### PR TITLE
feat(qdrant): add binary quantization support for 40x faster search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Contextual RAG Pipeline** - A production-grade Retrieval-Augmented Generation system for document search with hybrid vector search, ML platform integration, and Telegram bot interface.
 
-**Version:** 2.10.0 (VoyageService unified + voyage-4 models)
+**Version:** 2.11.0 (Binary Quantization + A/B testing)
 **Python:** 3.12+ (minimum 3.9)
 **LLM:** zai-glm-4.7 (GLM-4, OpenAI-compatible API)
 **Primary use cases:** Ukrainian Criminal Code search (1,294 documents), Bulgarian property catalogs
@@ -71,6 +71,7 @@ Input (PDF/CSV/DOCX) → Docling Parser → Chunker (1024 chars)
 | Service | Purpose |
 |---------|---------|
 | `VoyageService` | **Unified** embeddings + reranking (voyage-4-large/lite, rerank-2.5) |
+| `QdrantService` | Smart Gateway: RRF fusion, binary quantization, MMR diversity |
 | `RetrieverService` | Dense vector search in Qdrant with dynamic filters |
 | `HybridRetrieverService` | RRF fusion search (dense + sparse) |
 | `QueryPreprocessor` | Translit normalization (Latin→Cyrillic), dynamic RRF weights |
@@ -154,6 +155,41 @@ result = pp.analyze("apartments in Sunny Beach корпус 5")
 - **Semantic queries** (no IDs): RRF weights 0.6/0.4 (dense favored), cache threshold 0.10
 - **Exact queries** (IDs, corpus, floors): RRF weights 0.2/0.8 (sparse favored), cache threshold 0.05
 
+### Qdrant Binary Quantization (2026 Best Practice)
+```python
+from telegram_bot.services import QdrantService
+
+# QdrantService with quantization (default: enabled)
+qdrant = QdrantService(
+    url="http://localhost:6333",
+    collection_name="documents",
+    use_quantization=True,           # 40x faster search
+    quantization_rescore=True,       # Maintain accuracy
+    quantization_oversampling=2.0,   # Fetch 2x candidates, rescore top_k
+)
+
+# Hybrid search with RRF fusion
+results = await qdrant.hybrid_search_rrf(
+    dense_vector=query_embedding,
+    sparse_vector={"indices": [...], "values": [...]},
+    top_k=10,
+)
+
+# A/B testing: disable quantization per-request
+results_baseline = await qdrant.hybrid_search_rrf(
+    dense_vector=query_embedding,
+    quantization_ignore=True,  # Skip quantization for this request
+)
+
+# Enable binary quantization on collection (one-time setup)
+await qdrant.enable_binary_quantization(always_ram=True)
+```
+
+**Quantization benefits (dim >= 1024):**
+- 40x faster search
+- 75% less RAM
+- Rescore with oversampling maintains accuracy
+
 ## Code Style
 
 - **Line length:** 100 characters
@@ -198,8 +234,13 @@ Check these files for current project status:
    - `VOYAGE_MODEL_DOCS=voyage-4-large`
    - `VOYAGE_MODEL_QUERIES=voyage-4-lite`
    - `VOYAGE_RERANK_MODEL=rerank-2.5`
-5. Run `make install-dev`
-6. Start services: `docker compose -f docker-compose.dev.yml up -d` (full stack with bot)
+5. Qdrant quantization config (optional, defaults shown):
+   - `QDRANT_USE_QUANTIZATION=true` - Enable binary quantization
+   - `QDRANT_QUANTIZATION_RESCORE=true` - Rescore for accuracy
+   - `QDRANT_QUANTIZATION_OVERSAMPLING=2.0` - Candidate multiplier
+   - `QDRANT_QUANTIZATION_ALWAYS_RAM=true` - Keep quantized in RAM
+6. Run `make install-dev`
+7. Start services: `docker compose -f docker-compose.dev.yml up -d` (full stack with bot)
 
 ## Testing Notes
 

--- a/telegram_bot/config.py
+++ b/telegram_bot/config.py
@@ -77,3 +77,4 @@ class BotConfig:
     qdrant_use_quantization: bool = os.getenv("QDRANT_USE_QUANTIZATION", "true").lower() == "true"
     qdrant_quantization_rescore: bool = os.getenv("QDRANT_QUANTIZATION_RESCORE", "true").lower() == "true"
     qdrant_quantization_oversampling: float = float(os.getenv("QDRANT_QUANTIZATION_OVERSAMPLING", "2.0"))
+    qdrant_quantization_always_ram: bool = os.getenv("QDRANT_QUANTIZATION_ALWAYS_RAM", "true").lower() == "true"

--- a/telegram_bot/config.py
+++ b/telegram_bot/config.py
@@ -71,3 +71,9 @@ class BotConfig:
     # MMR Diversity Configuration
     mmr_enabled: bool = os.getenv("MMR_ENABLED", "true").lower() == "true"
     mmr_lambda: float = float(os.getenv("MMR_LAMBDA", "0.7"))
+
+    # Qdrant Quantization Configuration (2026 best practice)
+    # Binary quantization: 40x faster, -75% RAM for dim >= 1024
+    qdrant_use_quantization: bool = os.getenv("QDRANT_USE_QUANTIZATION", "true").lower() == "true"
+    qdrant_quantization_rescore: bool = os.getenv("QDRANT_QUANTIZATION_RESCORE", "true").lower() == "true"
+    qdrant_quantization_oversampling: float = float(os.getenv("QDRANT_QUANTIZATION_OVERSAMPLING", "2.0"))

--- a/telegram_bot/services/qdrant.py
+++ b/telegram_bot/services/qdrant.py
@@ -1,7 +1,12 @@
-"""Qdrant service with Query API, Score Boosting, and MMR.
+"""Qdrant service with Query API, Score Boosting, MMR, and Quantization.
 
 Smart Gateway pattern for Qdrant vector database.
-Features: RRF fusion, freshness boosting, MMR diversity.
+Features: RRF fusion, freshness boosting, MMR diversity, binary quantization.
+
+2026 best practices:
+- Binary Quantization: 40x faster, -75% RAM (for dim >= 1024)
+- Prefetch: dense + sparse in single RPC
+- Rescore with oversampling for accuracy
 """
 
 import logging
@@ -32,6 +37,9 @@ class QdrantService:
         collection_name: str = "documents",
         dense_vector_name: str = "dense",
         sparse_vector_name: str = "bm42",
+        use_quantization: bool = True,
+        quantization_rescore: bool = True,
+        quantization_oversampling: float = 2.0,
     ):
         """Initialize Qdrant service.
 
@@ -41,13 +49,19 @@ class QdrantService:
             collection_name: Default collection name
             dense_vector_name: Name of dense vector field
             sparse_vector_name: Name of sparse vector field
+            use_quantization: Enable quantized search (faster, less accurate)
+            quantization_rescore: Rescore with original vectors for accuracy
+            quantization_oversampling: Fetch N*limit candidates, rescore top limit
         """
         self._client = AsyncQdrantClient(url=url, api_key=api_key)
         self._collection_name = collection_name
         self._dense_vector_name = dense_vector_name
         self._sparse_vector_name = sparse_vector_name
+        self._use_quantization = use_quantization
+        self._quantization_rescore = quantization_rescore
+        self._quantization_oversampling = quantization_oversampling
 
-        logger.info(f"QdrantService initialized: {collection_name}")
+        logger.info(f"QdrantService initialized: {collection_name} (quantization={use_quantization})")
 
     async def hybrid_search_rrf(
         self,
@@ -100,6 +114,16 @@ class QdrantService:
                 )
             )
 
+        # Build search params with quantization
+        search_params = None
+        if self._use_quantization:
+            search_params = models.SearchParams(
+                quantization=models.QuantizationSearchParams(
+                    rescore=self._quantization_rescore,
+                    oversampling=self._quantization_oversampling,
+                )
+            )
+
         # Execute RRF fusion search
         result = await self._client.query_points(
             collection_name=self._collection_name,
@@ -108,6 +132,7 @@ class QdrantService:
             query_filter=self._build_filter(filters),
             limit=top_k,
             with_payload=True,
+            search_params=search_params,
         )
 
         return self._format_results(result.points)
@@ -337,6 +362,62 @@ class QdrantService:
             }
             for p in points
         ]
+
+    async def enable_binary_quantization(
+        self,
+        collection_name: Optional[str] = None,
+        always_ram: bool = True,
+    ) -> bool:
+        """Enable binary quantization on collection for 40x faster search.
+
+        Binary quantization reduces each dimension to 1 bit, achieving:
+        - 32x memory compression
+        - Up to 40x faster search
+        - Works best with dim >= 1024 (voyage-4-large is 1024)
+
+        Args:
+            collection_name: Collection to update (default: self._collection_name)
+            always_ram: Keep quantized vectors in RAM for speed
+
+        Returns:
+            True if successful
+        """
+        coll = collection_name or self._collection_name
+        try:
+            await self._client.update_collection(
+                collection_name=coll,
+                quantization_config=models.BinaryQuantization(
+                    binary=models.BinaryQuantizationConfig(always_ram=always_ram),
+                ),
+            )
+            logger.info(f"Binary quantization enabled for {coll}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to enable binary quantization: {e}")
+            return False
+
+    async def get_collection_info(self, collection_name: Optional[str] = None) -> dict:
+        """Get collection info including quantization status.
+
+        Args:
+            collection_name: Collection to check
+
+        Returns:
+            Dict with collection info
+        """
+        coll = collection_name or self._collection_name
+        try:
+            info = await self._client.get_collection(collection_name=coll)
+            return {
+                "name": coll,
+                "points_count": info.points_count,
+                "vectors_count": info.vectors_count,
+                "status": info.status.value,
+                "quantization": str(info.config.quantization_config) if info.config.quantization_config else None,
+            }
+        except Exception as e:
+            logger.error(f"Failed to get collection info: {e}")
+            return {}
 
     async def close(self):
         """Close the client connection."""

--- a/telegram_bot/services/qdrant.py
+++ b/telegram_bot/services/qdrant.py
@@ -72,6 +72,7 @@ class QdrantService:
         dense_weight: float = 0.6,
         sparse_weight: float = 0.4,
         prefetch_multiplier: int = 3,
+        quantization_ignore: Optional[bool] = None,
     ) -> list[dict]:
         """Hybrid search with RRF fusion (dense + sparse).
 
@@ -83,6 +84,8 @@ class QdrantService:
             dense_weight: Weight for dense vector prefetch
             sparse_weight: Weight for sparse vector prefetch
             prefetch_multiplier: Multiplier for prefetch limits
+            quantization_ignore: Override quantization per-request (None=use default,
+                True=skip quantization, False=force quantization). Useful for A/B testing.
 
         Returns:
             List of results with id, score, text, metadata
@@ -115,13 +118,21 @@ class QdrantService:
             )
 
         # Build search params with quantization
+        # quantization_ignore: None=use default, True=skip quant, False=force quant
         search_params = None
-        if self._use_quantization:
+        use_quant = self._use_quantization if quantization_ignore is None else not quantization_ignore
+        if use_quant:
             search_params = models.SearchParams(
                 quantization=models.QuantizationSearchParams(
+                    ignore=False,  # Explicitly use quantization
                     rescore=self._quantization_rescore,
                     oversampling=self._quantization_oversampling,
                 )
+            )
+        elif quantization_ignore is True:
+            # Explicitly disable quantization for this request (A/B testing)
+            search_params = models.SearchParams(
+                quantization=models.QuantizationSearchParams(ignore=True)
             )
 
         # Execute RRF fusion search
@@ -145,6 +156,7 @@ class QdrantService:
         freshness_boost: bool = True,
         freshness_field: str = "created_at",
         freshness_scale_days: int = 7,
+        quantization_ignore: Optional[bool] = None,
     ) -> list[dict]:
         """Search with score boosting using Qdrant Query API.
 
@@ -157,10 +169,28 @@ class QdrantService:
             freshness_boost: Enable freshness boosting
             freshness_field: Payload field for datetime (e.g., "created_at")
             freshness_scale_days: Decay scale in days
+            quantization_ignore: Override quantization per-request (None=use default,
+                True=skip quantization, False=force quantization). Useful for A/B testing.
 
         Returns:
             List of results with boosted scores
         """
+        # Build search params with quantization
+        search_params = None
+        use_quant = self._use_quantization if quantization_ignore is None else not quantization_ignore
+        if use_quant:
+            search_params = models.SearchParams(
+                quantization=models.QuantizationSearchParams(
+                    ignore=False,
+                    rescore=self._quantization_rescore,
+                    oversampling=self._quantization_oversampling,
+                )
+            )
+        elif quantization_ignore is True:
+            search_params = models.SearchParams(
+                quantization=models.QuantizationSearchParams(ignore=True)
+            )
+
         # Base search without boosting
         if not freshness_boost:
             result = await self._client.query_points(
@@ -170,6 +200,7 @@ class QdrantService:
                 query_filter=self._build_filter(filters),
                 limit=top_k,
                 with_payload=True,
+                search_params=search_params,
             )
             return self._format_results(result.points)
 
@@ -184,6 +215,7 @@ class QdrantService:
                 query_filter=self._build_filter(filters),
                 limit=top_k * 2,  # Overfetch for boosting
                 with_payload=True,
+                search_params=search_params,
             )
 
             # Post-process with freshness boosting
@@ -230,6 +262,7 @@ class QdrantService:
                 query_filter=self._build_filter(filters),
                 limit=top_k,
                 with_payload=True,
+                search_params=search_params,
             )
             return self._format_results(result.points)
 


### PR DESCRIPTION
2026 best practice implementation:
- Add quantization search params (rescore + oversampling)
- Add enable_binary_quantization() method
- Add get_collection_info() for quantization status
- Config: QDRANT_USE_QUANTIZATION, QDRANT_QUANTIZATION_RESCORE, QDRANT_QUANTIZATION_OVERSAMPLING

Binary quantization: 32x memory compression, 40x faster search
for voyage-4-large (1024 dim)