### PR TITLE
test: add comprehensive unit tests for 80% coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,9 +206,57 @@ Check these files for current project status:
 - Tests use pytest with `asyncio_mode = "auto"` (async tests don't need `@pytest.mark.asyncio`)
 - Coverage reports: `make test-cov` generates `htmlcov/index.html`
 - Integration tests require Docker services running
-- Voyage tests: `pytest tests/test_voyage*.py -v` (45 tests)
-- E2E tests: `pytest tests/test_e2e_pipeline.py -v` (requires API keys and services)
 - Run single test: `pytest tests/test_file.py::TestClass::test_method -v`
+
+### Test Structure
+
+```
+tests/
+├── unit/                    # Unit tests (~200 test cases)
+│   ├── test_settings.py     # Settings, API validation, defaults
+│   ├── test_constants.py    # Enums, dataclasses, config values
+│   ├── test_chunker.py      # DocumentChunker, CSV chunking
+│   ├── test_document_parser.py  # PDF/Docling parsing, caching
+│   ├── test_indexer.py      # DocumentIndexer, Qdrant collections
+│   ├── test_contextual_schema.py  # Chunk/Document serialization
+│   ├── test_search_engines.py    # All search engine variants
+│   ├── test_query_preprocessor_unit.py  # Translit, RRF weights
+│   ├── test_voyage_service.py    # Embeddings, reranking
+│   ├── test_retriever_service.py # Qdrant retrieval, filters
+│   └── test_llm_service.py       # Answer generation, streaming
+├── test_voyage*.py          # Voyage AI integration tests
+├── test_*_integration.py    # Integration tests (require services)
+└── legacy/                  # Deprecated tests
+```
+
+### Running Tests
+
+```bash
+# All unit tests (fast, no external services needed)
+pytest tests/unit/ -v
+
+# Specific module
+pytest tests/unit/test_settings.py -v
+
+# With coverage
+pytest tests/unit/ --cov=src --cov=telegram_bot --cov-report=term-missing
+
+# Integration tests (require Docker services)
+pytest tests/test_voyage*.py -v
+pytest tests/test_e2e_pipeline.py -v
+
+# Exclude legacy tests
+pytest tests/ --ignore=tests/legacy -v
+```
+
+### Test Coverage Targets
+
+| Module | Coverage |
+|--------|----------|
+| `src/config/` | ~90% |
+| `src/ingestion/` | ~85% |
+| `src/retrieval/` | ~80% |
+| `telegram_bot/services/` | ~85% |
 
 ## Telegram Bot (Docker)
 

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""E2E tests for RAG pipeline."""

--- a/tests/e2e/test_rag_pipeline.py
+++ b/tests/e2e/test_rag_pipeline.py
@@ -1,0 +1,383 @@
+"""E2E tests for RAG pipeline workflow.
+
+These tests verify the complete RAG pipeline from document ingestion to search results.
+They use mocks to avoid requiring external services but test the full flow.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.core.pipeline import RAGPipeline, RAGResult
+
+
+class TestRAGPipelineInit:
+    """Test RAGPipeline initialization."""
+
+    @patch("src.core.pipeline.get_sentence_transformer")
+    @patch("src.core.pipeline.create_search_engine")
+    @patch("src.core.pipeline.ClaudeContextualizer")
+    @patch("src.core.pipeline.DocumentIndexer")
+    @patch("src.core.pipeline.DocumentChunker")
+    @patch("src.core.pipeline.UniversalDocumentParser")
+    def test_pipeline_init_creates_components(
+        self,
+        mock_parser,
+        mock_chunker,
+        mock_indexer,
+        mock_contextualizer,
+        mock_search_engine,
+        mock_embedding,
+    ):
+        """Test that pipeline initializes all components."""
+        pipeline = RAGPipeline()
+
+        mock_embedding.assert_called_once_with("BAAI/bge-m3")
+        mock_search_engine.assert_called_once()
+        mock_contextualizer.assert_called_once()
+        mock_indexer.assert_called_once()
+        mock_chunker.assert_called_once()
+        mock_parser.assert_called_once_with(use_cache=True)
+
+    @patch("src.core.pipeline.get_sentence_transformer")
+    @patch("src.core.pipeline.create_search_engine")
+    @patch("src.core.pipeline.ClaudeContextualizer")
+    @patch("src.core.pipeline.DocumentIndexer")
+    @patch("src.core.pipeline.DocumentChunker")
+    @patch("src.core.pipeline.UniversalDocumentParser")
+    def test_pipeline_init_with_custom_settings(
+        self,
+        mock_parser,
+        mock_chunker,
+        mock_indexer,
+        mock_contextualizer,
+        mock_search_engine,
+        mock_embedding,
+    ):
+        """Test pipeline with custom settings."""
+        from src.config import Settings
+
+        custom_settings = MagicMock(spec=Settings)
+        custom_settings.api_provider = MagicMock()
+        custom_settings.api_provider.value = "claude"
+
+        pipeline = RAGPipeline(settings=custom_settings)
+
+        assert pipeline.settings == custom_settings
+
+
+class TestRAGPipelineContextualizer:
+    """Test contextualizer creation based on API provider."""
+
+    @patch("src.core.pipeline.get_sentence_transformer")
+    @patch("src.core.pipeline.create_search_engine")
+    @patch("src.core.pipeline.DocumentIndexer")
+    @patch("src.core.pipeline.DocumentChunker")
+    @patch("src.core.pipeline.UniversalDocumentParser")
+    @patch("src.core.pipeline.ClaudeContextualizer")
+    def test_creates_claude_contextualizer(
+        self,
+        mock_claude,
+        mock_parser,
+        mock_chunker,
+        mock_indexer,
+        mock_search_engine,
+        mock_embedding,
+    ):
+        """Test Claude contextualizer is created for Claude provider."""
+        from src.config import APIProvider
+
+        mock_settings = MagicMock()
+        mock_settings.api_provider = APIProvider.CLAUDE
+
+        pipeline = RAGPipeline(settings=mock_settings)
+
+        mock_claude.assert_called_once()
+
+    @patch("src.core.pipeline.get_sentence_transformer")
+    @patch("src.core.pipeline.create_search_engine")
+    @patch("src.core.pipeline.DocumentIndexer")
+    @patch("src.core.pipeline.DocumentChunker")
+    @patch("src.core.pipeline.UniversalDocumentParser")
+    @patch("src.core.pipeline.OpenAIContextualizer")
+    def test_creates_openai_contextualizer(
+        self,
+        mock_openai,
+        mock_parser,
+        mock_chunker,
+        mock_indexer,
+        mock_search_engine,
+        mock_embedding,
+    ):
+        """Test OpenAI contextualizer is created for OpenAI provider."""
+        from src.config import APIProvider
+
+        mock_settings = MagicMock()
+        mock_settings.api_provider = APIProvider.OPENAI
+
+        pipeline = RAGPipeline(settings=mock_settings)
+
+        mock_openai.assert_called_once()
+
+    @patch("src.core.pipeline.get_sentence_transformer")
+    @patch("src.core.pipeline.create_search_engine")
+    @patch("src.core.pipeline.DocumentIndexer")
+    @patch("src.core.pipeline.DocumentChunker")
+    @patch("src.core.pipeline.UniversalDocumentParser")
+    @patch("src.core.pipeline.GroqContextualizer")
+    def test_creates_groq_contextualizer(
+        self,
+        mock_groq,
+        mock_parser,
+        mock_chunker,
+        mock_indexer,
+        mock_search_engine,
+        mock_embedding,
+    ):
+        """Test Groq contextualizer is created for Groq provider."""
+        from src.config import APIProvider
+
+        mock_settings = MagicMock()
+        mock_settings.api_provider = APIProvider.GROQ
+
+        pipeline = RAGPipeline(settings=mock_settings)
+
+        mock_groq.assert_called_once()
+
+
+class TestRAGPipelineSearch:
+    """Test RAG pipeline search functionality."""
+
+    @pytest.mark.asyncio
+    @patch("src.core.pipeline.get_sentence_transformer")
+    @patch("src.core.pipeline.create_search_engine")
+    @patch("src.core.pipeline.ClaudeContextualizer")
+    @patch("src.core.pipeline.DocumentIndexer")
+    @patch("src.core.pipeline.DocumentChunker")
+    @patch("src.core.pipeline.UniversalDocumentParser")
+    async def test_search_returns_rag_result(
+        self,
+        mock_parser,
+        mock_chunker,
+        mock_indexer,
+        mock_contextualizer,
+        mock_search_engine,
+        mock_embedding,
+    ):
+        """Test that search returns RAGResult."""
+        # Setup mock search results
+        mock_result = MagicMock()
+        mock_result.article_number = "121"
+        mock_result.text = "Test article text"
+        mock_result.score = 0.95
+        mock_result.metadata = {"source": "test"}
+
+        mock_engine = MagicMock()
+        mock_engine.search.return_value = [mock_result]
+        mock_engine.get_name.return_value = "mock_engine"
+        mock_search_engine.return_value = mock_engine
+
+        mock_settings = MagicMock()
+        mock_settings.top_k = 10
+        mock_settings.score_threshold = 0.5
+        mock_settings.enable_query_expansion = False
+
+        pipeline = RAGPipeline(settings=mock_settings)
+        result = await pipeline.search("test query")
+
+        assert isinstance(result, RAGResult)
+        assert result.query == "test query"
+        assert len(result.results) == 1
+        assert result.results[0]["article_number"] == "121"
+        assert result.execution_time > 0
+
+    @pytest.mark.asyncio
+    @patch("src.core.pipeline.get_sentence_transformer")
+    @patch("src.core.pipeline.create_search_engine")
+    @patch("src.core.pipeline.ClaudeContextualizer")
+    @patch("src.core.pipeline.DocumentIndexer")
+    @patch("src.core.pipeline.DocumentChunker")
+    @patch("src.core.pipeline.UniversalDocumentParser")
+    async def test_search_with_custom_top_k(
+        self,
+        mock_parser,
+        mock_chunker,
+        mock_indexer,
+        mock_contextualizer,
+        mock_search_engine,
+        mock_embedding,
+    ):
+        """Test search with custom top_k parameter."""
+        mock_engine = MagicMock()
+        mock_engine.search.return_value = []
+        mock_engine.get_name.return_value = "mock_engine"
+        mock_search_engine.return_value = mock_engine
+
+        mock_settings = MagicMock()
+        mock_settings.top_k = 10
+        mock_settings.score_threshold = 0.5
+        mock_settings.enable_query_expansion = False
+
+        pipeline = RAGPipeline(settings=mock_settings)
+        await pipeline.search("test query", top_k=5)
+
+        # Verify custom top_k was used
+        call_args = mock_engine.search.call_args
+        assert call_args.kwargs["top_k"] == 5
+
+
+class TestRAGPipelineEvaluate:
+    """Test RAG pipeline evaluate method."""
+
+    @pytest.mark.asyncio
+    @patch("src.core.pipeline.get_sentence_transformer")
+    @patch("src.core.pipeline.create_search_engine")
+    @patch("src.core.pipeline.ClaudeContextualizer")
+    @patch("src.core.pipeline.DocumentIndexer")
+    @patch("src.core.pipeline.DocumentChunker")
+    @patch("src.core.pipeline.UniversalDocumentParser")
+    async def test_evaluate_multiple_queries(
+        self,
+        mock_parser,
+        mock_chunker,
+        mock_indexer,
+        mock_contextualizer,
+        mock_search_engine,
+        mock_embedding,
+    ):
+        """Test evaluating multiple queries."""
+        mock_result = MagicMock()
+        mock_result.article_number = "121"
+        mock_result.text = "Test text"
+        mock_result.score = 0.9
+        mock_result.metadata = {}
+
+        mock_engine = MagicMock()
+        mock_engine.search.return_value = [mock_result]
+        mock_engine.get_name.return_value = "mock_engine"
+        mock_search_engine.return_value = mock_engine
+
+        mock_settings = MagicMock()
+        mock_settings.top_k = 10
+        mock_settings.score_threshold = 0.5
+        mock_settings.enable_query_expansion = False
+
+        pipeline = RAGPipeline(settings=mock_settings)
+
+        queries = ["query 1", "query 2", "query 3"]
+        result = await pipeline.evaluate(queries)
+
+        assert result["total_queries"] == 3
+        assert "average_latency" in result
+        assert len(result["results"]) == 3
+
+    @pytest.mark.asyncio
+    @patch("src.core.pipeline.get_sentence_transformer")
+    @patch("src.core.pipeline.create_search_engine")
+    @patch("src.core.pipeline.ClaudeContextualizer")
+    @patch("src.core.pipeline.DocumentIndexer")
+    @patch("src.core.pipeline.DocumentChunker")
+    @patch("src.core.pipeline.UniversalDocumentParser")
+    async def test_evaluate_with_ground_truth(
+        self,
+        mock_parser,
+        mock_chunker,
+        mock_indexer,
+        mock_contextualizer,
+        mock_search_engine,
+        mock_embedding,
+    ):
+        """Test evaluate with ground truth computes metrics."""
+        mock_result = MagicMock()
+        mock_result.article_number = "121"
+        mock_result.text = "Test"
+        mock_result.score = 0.9
+        mock_result.metadata = {}
+
+        mock_engine = MagicMock()
+        mock_engine.search.return_value = [mock_result]
+        mock_engine.get_name.return_value = "mock_engine"
+        mock_search_engine.return_value = mock_engine
+
+        mock_settings = MagicMock()
+        mock_settings.top_k = 10
+        mock_settings.score_threshold = 0.5
+        mock_settings.enable_query_expansion = False
+
+        pipeline = RAGPipeline(settings=mock_settings)
+
+        queries = ["query 1"]
+        ground_truth = [["121"]]
+        result = await pipeline.evaluate(queries, ground_truth)
+
+        assert "metrics" in result
+        assert "recall_at_1" in result["metrics"]
+
+
+class TestRAGPipelineStats:
+    """Test RAG pipeline statistics."""
+
+    @patch("src.core.pipeline.get_sentence_transformer")
+    @patch("src.core.pipeline.create_search_engine")
+    @patch("src.core.pipeline.ClaudeContextualizer")
+    @patch("src.core.pipeline.DocumentIndexer")
+    @patch("src.core.pipeline.DocumentChunker")
+    @patch("src.core.pipeline.UniversalDocumentParser")
+    def test_get_stats_returns_dict(
+        self,
+        mock_parser,
+        mock_chunker,
+        mock_indexer,
+        mock_contextualizer,
+        mock_search_engine,
+        mock_embedding,
+    ):
+        """Test get_stats returns pipeline statistics."""
+        mock_engine = MagicMock()
+        mock_engine.get_name.return_value = "HybridRRFColBERT"
+        mock_search_engine.return_value = mock_engine
+
+        mock_settings = MagicMock()
+        mock_settings.api_provider.value = "claude"
+        mock_settings.model_name = "claude-3"
+        mock_settings.collection_name = "test_collection"
+
+        pipeline = RAGPipeline(settings=mock_settings)
+        stats = pipeline.get_stats()
+
+        assert stats["api_provider"] == "claude"
+        assert stats["model"] == "claude-3"
+        assert stats["search_engine"] == "HybridRRFColBERT"
+        assert stats["collection"] == "test_collection"
+
+
+class TestRAGResult:
+    """Test RAGResult dataclass."""
+
+    def test_rag_result_creation(self):
+        """Test RAGResult creation with all fields."""
+        result = RAGResult(
+            query="test query",
+            results=[{"text": "result 1"}],
+            context_used=True,
+            search_method="hybrid",
+            execution_time=0.5,
+        )
+
+        assert result.query == "test query"
+        assert len(result.results) == 1
+        assert result.context_used is True
+        assert result.search_method == "hybrid"
+        assert result.execution_time == 0.5
+
+    def test_rag_result_empty_results(self):
+        """Test RAGResult with empty results."""
+        result = RAGResult(
+            query="query",
+            results=[],
+            context_used=False,
+            search_method="baseline",
+            execution_time=0.1,
+        )
+
+        assert len(result.results) == 0

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests package."""

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -1,0 +1,441 @@
+"""Unit tests for telegram_bot/bot.py handlers."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from telegram_bot.bot import PropertyBot
+from telegram_bot.config import BotConfig
+
+
+@pytest.fixture
+def mock_config():
+    """Create mock bot config."""
+    return BotConfig(
+        telegram_token="test-token",
+        voyage_api_key="voyage-key",
+        llm_api_key="llm-key",
+        llm_base_url="https://api.example.com/v1",
+        llm_model="gpt-4o-mini",
+        qdrant_url="http://localhost:6333",
+        qdrant_api_key="qdrant-key",
+        qdrant_collection="test_collection",
+        redis_url="redis://localhost:6379",
+        bm42_url="http://localhost:8000",
+    )
+
+
+class TestPropertyBotInit:
+    """Test PropertyBot initialization."""
+
+    @patch("telegram_bot.bot.Bot")
+    @patch("telegram_bot.bot.CacheService")
+    @patch("telegram_bot.bot.QueryAnalyzer")
+    @patch("telegram_bot.bot.VoyageService")
+    @patch("telegram_bot.bot.QdrantService")
+    @patch("telegram_bot.bot.LLMService")
+    @patch("telegram_bot.bot.UserContextService")
+    @patch("telegram_bot.bot.CESCPersonalizer")
+    def test_init_creates_services(
+        self,
+        mock_cesc,
+        mock_user_ctx,
+        mock_llm,
+        mock_qdrant,
+        mock_voyage,
+        mock_analyzer,
+        mock_cache,
+        mock_bot,
+        mock_config,
+    ):
+        """Test that initialization creates all services."""
+        bot = PropertyBot(mock_config)
+
+        assert bot.config == mock_config
+        mock_cache.assert_called_once()
+        mock_analyzer.assert_called_once()
+        mock_voyage.assert_called_once()
+        mock_qdrant.assert_called_once()
+        mock_llm.assert_called_once()
+
+
+class TestCommandHandlers:
+    """Test command handlers."""
+
+    @pytest.mark.asyncio
+    @patch("telegram_bot.bot.Bot")
+    @patch("telegram_bot.bot.CacheService")
+    @patch("telegram_bot.bot.QueryAnalyzer")
+    @patch("telegram_bot.bot.VoyageService")
+    @patch("telegram_bot.bot.QdrantService")
+    @patch("telegram_bot.bot.LLMService")
+    @patch("telegram_bot.bot.UserContextService")
+    @patch("telegram_bot.bot.CESCPersonalizer")
+    async def test_cmd_start(
+        self,
+        mock_cesc,
+        mock_user_ctx,
+        mock_llm,
+        mock_qdrant,
+        mock_voyage,
+        mock_analyzer,
+        mock_cache,
+        mock_bot,
+        mock_config,
+    ):
+        """Test /start command handler."""
+        bot = PropertyBot(mock_config)
+
+        message = MagicMock()
+        message.answer = AsyncMock()
+
+        await bot.cmd_start(message)
+
+        message.answer.assert_called_once()
+        call_args = message.answer.call_args[0][0]
+        assert "Привет" in call_args
+        assert "бот по недвижимости" in call_args
+
+    @pytest.mark.asyncio
+    @patch("telegram_bot.bot.Bot")
+    @patch("telegram_bot.bot.CacheService")
+    @patch("telegram_bot.bot.QueryAnalyzer")
+    @patch("telegram_bot.bot.VoyageService")
+    @patch("telegram_bot.bot.QdrantService")
+    @patch("telegram_bot.bot.LLMService")
+    @patch("telegram_bot.bot.UserContextService")
+    @patch("telegram_bot.bot.CESCPersonalizer")
+    async def test_cmd_help(
+        self,
+        mock_cesc,
+        mock_user_ctx,
+        mock_llm,
+        mock_qdrant,
+        mock_voyage,
+        mock_analyzer,
+        mock_cache,
+        mock_bot,
+        mock_config,
+    ):
+        """Test /help command handler."""
+        bot = PropertyBot(mock_config)
+
+        message = MagicMock()
+        message.answer = AsyncMock()
+
+        await bot.cmd_help(message)
+
+        message.answer.assert_called_once()
+        call_args = message.answer.call_args[0][0]
+        assert "Примеры запросов" in call_args
+        assert "/clear" in call_args
+        assert "/stats" in call_args
+
+    @pytest.mark.asyncio
+    @patch("telegram_bot.bot.Bot")
+    @patch("telegram_bot.bot.CacheService")
+    @patch("telegram_bot.bot.QueryAnalyzer")
+    @patch("telegram_bot.bot.VoyageService")
+    @patch("telegram_bot.bot.QdrantService")
+    @patch("telegram_bot.bot.LLMService")
+    @patch("telegram_bot.bot.UserContextService")
+    @patch("telegram_bot.bot.CESCPersonalizer")
+    async def test_cmd_clear(
+        self,
+        mock_cesc,
+        mock_user_ctx,
+        mock_llm,
+        mock_qdrant,
+        mock_voyage,
+        mock_analyzer,
+        mock_cache,
+        mock_bot,
+        mock_config,
+    ):
+        """Test /clear command handler."""
+        mock_cache_instance = MagicMock()
+        mock_cache_instance.clear_conversation_history = AsyncMock()
+        mock_cache.return_value = mock_cache_instance
+
+        bot = PropertyBot(mock_config)
+
+        message = MagicMock()
+        message.from_user = MagicMock()
+        message.from_user.id = 12345
+        message.answer = AsyncMock()
+
+        await bot.cmd_clear(message)
+
+        mock_cache_instance.clear_conversation_history.assert_called_once_with(12345)
+        message.answer.assert_called_once()
+        assert "очищена" in message.answer.call_args[0][0].lower()
+
+    @pytest.mark.asyncio
+    @patch("telegram_bot.bot.Bot")
+    @patch("telegram_bot.bot.CacheService")
+    @patch("telegram_bot.bot.QueryAnalyzer")
+    @patch("telegram_bot.bot.VoyageService")
+    @patch("telegram_bot.bot.QdrantService")
+    @patch("telegram_bot.bot.LLMService")
+    @patch("telegram_bot.bot.UserContextService")
+    @patch("telegram_bot.bot.CESCPersonalizer")
+    async def test_cmd_stats(
+        self,
+        mock_cesc,
+        mock_user_ctx,
+        mock_llm,
+        mock_qdrant,
+        mock_voyage,
+        mock_analyzer,
+        mock_cache,
+        mock_bot,
+        mock_config,
+    ):
+        """Test /stats command handler."""
+        mock_cache_instance = MagicMock()
+        mock_cache_instance.get_metrics.return_value = {
+            "overall_hit_rate": 75.0,
+            "total_requests": 100,
+            "by_type": {
+                "semantic": {"hit_rate": 80.0, "hits": 40, "requests": 50},
+                "embeddings": {"hit_rate": 70.0, "hits": 35, "requests": 50},
+            },
+        }
+        mock_cache.return_value = mock_cache_instance
+
+        bot = PropertyBot(mock_config)
+
+        message = MagicMock()
+        message.answer = AsyncMock()
+
+        await bot.cmd_stats(message)
+
+        message.answer.assert_called_once()
+        call_args = message.answer.call_args[0][0]
+        assert "Статистика" in call_args
+        assert "75" in call_args  # Overall hit rate
+
+
+class TestFormatResults:
+    """Test _format_results method."""
+
+    @patch("telegram_bot.bot.Bot")
+    @patch("telegram_bot.bot.CacheService")
+    @patch("telegram_bot.bot.QueryAnalyzer")
+    @patch("telegram_bot.bot.VoyageService")
+    @patch("telegram_bot.bot.QdrantService")
+    @patch("telegram_bot.bot.LLMService")
+    @patch("telegram_bot.bot.UserContextService")
+    @patch("telegram_bot.bot.CESCPersonalizer")
+    def test_format_results_basic(
+        self,
+        mock_cesc,
+        mock_user_ctx,
+        mock_llm,
+        mock_qdrant,
+        mock_voyage,
+        mock_analyzer,
+        mock_cache,
+        mock_bot,
+        mock_config,
+    ):
+        """Test formatting search results."""
+        bot = PropertyBot(mock_config)
+
+        results = [
+            {
+                "metadata": {
+                    "title": "Квартира 1",
+                    "price": 50000,
+                    "city": "Несебр",
+                    "rooms": 2,
+                },
+                "score": 0.95,
+            },
+            {
+                "metadata": {
+                    "title": "Квартира 2",
+                    "price": 75000,
+                    "city": "Бургас",
+                    "area": 65,
+                },
+                "score": 0.85,
+            },
+        ]
+
+        formatted = bot._format_results(results)
+
+        assert "Квартира 1" in formatted
+        assert "50,000€" in formatted
+        assert "Несебр" in formatted
+        assert "2 комн" in formatted
+        assert "0.95" in formatted
+
+    @patch("telegram_bot.bot.Bot")
+    @patch("telegram_bot.bot.CacheService")
+    @patch("telegram_bot.bot.QueryAnalyzer")
+    @patch("telegram_bot.bot.VoyageService")
+    @patch("telegram_bot.bot.QdrantService")
+    @patch("telegram_bot.bot.LLMService")
+    @patch("telegram_bot.bot.UserContextService")
+    @patch("telegram_bot.bot.CESCPersonalizer")
+    def test_format_results_limits_to_three(
+        self,
+        mock_cesc,
+        mock_user_ctx,
+        mock_llm,
+        mock_qdrant,
+        mock_voyage,
+        mock_analyzer,
+        mock_cache,
+        mock_bot,
+        mock_config,
+    ):
+        """Test that formatting limits to 3 results."""
+        bot = PropertyBot(mock_config)
+
+        results = [
+            {"metadata": {"title": f"Квартира {i}"}, "score": 0.9 - i * 0.1}
+            for i in range(5)
+        ]
+
+        formatted = bot._format_results(results)
+
+        assert "Квартира 0" in formatted
+        assert "Квартира 1" in formatted
+        assert "Квартира 2" in formatted
+        assert "Квартира 3" not in formatted
+        assert "Квартира 4" not in formatted
+
+
+class TestGetSparseVector:
+    """Test _get_sparse_vector method."""
+
+    @pytest.mark.asyncio
+    @patch("telegram_bot.bot.Bot")
+    @patch("telegram_bot.bot.CacheService")
+    @patch("telegram_bot.bot.QueryAnalyzer")
+    @patch("telegram_bot.bot.VoyageService")
+    @patch("telegram_bot.bot.QdrantService")
+    @patch("telegram_bot.bot.LLMService")
+    @patch("telegram_bot.bot.UserContextService")
+    @patch("telegram_bot.bot.CESCPersonalizer")
+    async def test_get_sparse_vector_success(
+        self,
+        mock_cesc,
+        mock_user_ctx,
+        mock_llm,
+        mock_qdrant,
+        mock_voyage,
+        mock_analyzer,
+        mock_cache,
+        mock_bot,
+        mock_config,
+    ):
+        """Test successful sparse vector retrieval."""
+        bot = PropertyBot(mock_config)
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"indices": [1, 2, 3], "values": [0.5, 0.3, 0.2]}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.post.return_value = mock_response
+            mock_client.return_value.__aenter__.return_value = mock_client_instance
+
+            bot._http_client = mock_client_instance
+
+            result = await bot._get_sparse_vector("test query")
+
+            assert result == {"indices": [1, 2, 3], "values": [0.5, 0.3, 0.2]}
+
+    @pytest.mark.asyncio
+    @patch("telegram_bot.bot.Bot")
+    @patch("telegram_bot.bot.CacheService")
+    @patch("telegram_bot.bot.QueryAnalyzer")
+    @patch("telegram_bot.bot.VoyageService")
+    @patch("telegram_bot.bot.QdrantService")
+    @patch("telegram_bot.bot.LLMService")
+    @patch("telegram_bot.bot.UserContextService")
+    @patch("telegram_bot.bot.CESCPersonalizer")
+    async def test_get_sparse_vector_error_fallback(
+        self,
+        mock_cesc,
+        mock_user_ctx,
+        mock_llm,
+        mock_qdrant,
+        mock_voyage,
+        mock_analyzer,
+        mock_cache,
+        mock_bot,
+        mock_config,
+    ):
+        """Test sparse vector fallback on error."""
+        bot = PropertyBot(mock_config)
+
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = Exception("Network error")
+        bot._http_client = mock_client
+
+        result = await bot._get_sparse_vector("test query")
+
+        # Should return empty sparse vector
+        assert result == {"indices": [], "values": []}
+
+
+class TestBotLifecycle:
+    """Test bot start/stop lifecycle."""
+
+    @pytest.mark.asyncio
+    @patch("telegram_bot.bot.Bot")
+    @patch("telegram_bot.bot.CacheService")
+    @patch("telegram_bot.bot.QueryAnalyzer")
+    @patch("telegram_bot.bot.VoyageService")
+    @patch("telegram_bot.bot.QdrantService")
+    @patch("telegram_bot.bot.LLMService")
+    @patch("telegram_bot.bot.UserContextService")
+    @patch("telegram_bot.bot.CESCPersonalizer")
+    async def test_stop_closes_all_services(
+        self,
+        mock_cesc,
+        mock_user_ctx,
+        mock_llm,
+        mock_qdrant,
+        mock_voyage,
+        mock_analyzer,
+        mock_cache,
+        mock_bot,
+        mock_config,
+    ):
+        """Test that stop() closes all services."""
+        mock_cache_instance = MagicMock()
+        mock_cache_instance.close = AsyncMock()
+        mock_cache.return_value = mock_cache_instance
+
+        mock_analyzer_instance = MagicMock()
+        mock_analyzer_instance.close = AsyncMock()
+        mock_analyzer.return_value = mock_analyzer_instance
+
+        mock_llm_instance = MagicMock()
+        mock_llm_instance.close = AsyncMock()
+        mock_llm.return_value = mock_llm_instance
+
+        mock_qdrant_instance = MagicMock()
+        mock_qdrant_instance.close = AsyncMock()
+        mock_qdrant.return_value = mock_qdrant_instance
+
+        mock_bot_instance = MagicMock()
+        mock_bot_instance.session = MagicMock()
+        mock_bot_instance.session.close = AsyncMock()
+        mock_bot.return_value = mock_bot_instance
+
+        bot = PropertyBot(mock_config)
+        bot._http_client = AsyncMock()
+
+        await bot.stop()
+
+        mock_cache_instance.close.assert_called_once()
+        mock_analyzer_instance.close.assert_called_once()
+        mock_llm_instance.close.assert_called_once()
+        mock_qdrant_instance.close.assert_called_once()

--- a/tests/unit/test_chunker.py
+++ b/tests/unit/test_chunker.py
@@ -1,0 +1,398 @@
+"""Unit tests for src/ingestion/chunker.py."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.ingestion.chunker import (
+    Chunk,
+    ChunkingStrategy,
+    DocumentChunker,
+    _parse_csv_row_metadata,
+    chunk_csv_by_rows,
+)
+
+
+class TestChunk:
+    """Test Chunk dataclass."""
+
+    def test_chunk_creation(self):
+        """Test basic Chunk creation."""
+        chunk = Chunk(
+            text="Test text",
+            chunk_id=0,
+            document_name="test.pdf",
+            article_number="115",
+        )
+
+        assert chunk.text == "Test text"
+        assert chunk.chunk_id == 0
+        assert chunk.document_name == "test.pdf"
+        assert chunk.article_number == "115"
+        assert chunk.chapter is None
+        assert chunk.section is None
+        assert chunk.order == 0
+
+    def test_chunk_with_metadata(self):
+        """Test Chunk with extra metadata."""
+        chunk = Chunk(
+            text="Test text",
+            chunk_id=1,
+            document_name="test.pdf",
+            article_number="116",
+            chapter="Глава I",
+            section="Розділ I",
+            page_range=(1, 5),
+            order=1,
+            extra_metadata={"price": 50000, "city": "Varna"},
+        )
+
+        assert chunk.chapter == "Глава I"
+        assert chunk.section == "Розділ I"
+        assert chunk.page_range == (1, 5)
+        assert chunk.extra_metadata["price"] == 50000
+
+
+class TestChunkingStrategy:
+    """Test ChunkingStrategy enum."""
+
+    def test_strategy_values(self):
+        """Test enum values."""
+        assert ChunkingStrategy.FIXED_SIZE.value == "fixed_size"
+        assert ChunkingStrategy.SEMANTIC.value == "semantic"
+        assert ChunkingStrategy.SLIDING_WINDOW.value == "sliding_window"
+
+
+class TestDocumentChunkerFixedSize:
+    """Test fixed-size chunking strategy."""
+
+    def test_fixed_size_basic(self):
+        """Test basic fixed-size chunking."""
+        chunker = DocumentChunker(
+            chunk_size=100,
+            overlap=20,
+            strategy=ChunkingStrategy.FIXED_SIZE,
+        )
+
+        text = "A" * 200  # 200 characters
+        chunks = chunker.chunk_text(text, "test.pdf", "1")
+
+        assert len(chunks) >= 2
+        assert all(isinstance(c, Chunk) for c in chunks)
+        assert chunks[0].document_name == "test.pdf"
+
+    def test_fixed_size_overlap(self):
+        """Test that chunks have correct overlap."""
+        chunker = DocumentChunker(
+            chunk_size=100,
+            overlap=50,
+            strategy=ChunkingStrategy.FIXED_SIZE,
+        )
+
+        text = "A" * 150
+        chunks = chunker.chunk_text(text, "test.pdf", "1")
+
+        # With 100 chunk size and 50 overlap, step is 50
+        # For 150 chars, we should get multiple chunks
+        assert len(chunks) >= 2
+
+    def test_fixed_size_small_text(self):
+        """Test chunking text smaller than chunk_size."""
+        chunker = DocumentChunker(
+            chunk_size=1000,
+            overlap=100,
+            strategy=ChunkingStrategy.FIXED_SIZE,
+        )
+
+        text = "Short text"
+        chunks = chunker.chunk_text(text, "test.pdf", "1")
+
+        assert len(chunks) == 1
+        assert chunks[0].text == "Short text"
+
+    def test_fixed_size_empty_text(self):
+        """Test chunking empty text."""
+        chunker = DocumentChunker(
+            chunk_size=100,
+            overlap=20,
+            strategy=ChunkingStrategy.FIXED_SIZE,
+        )
+
+        chunks = chunker.chunk_text("", "test.pdf", "1")
+
+        assert len(chunks) == 0
+
+
+class TestDocumentChunkerSemantic:
+    """Test semantic chunking strategy."""
+
+    def test_semantic_preserves_sections(self):
+        """Test that semantic chunking preserves section boundaries."""
+        chunker = DocumentChunker(
+            chunk_size=500,
+            overlap=50,
+            strategy=ChunkingStrategy.SEMANTIC,
+        )
+
+        text = """
+        Розділ I. ЗАГАЛЬНІ ПОЛОЖЕННЯ
+
+        Стаття 1. Завдання Кримінального кодексу України
+        Кримінальний кодекс України має своїм завданням правове забезпечення
+        охорони прав і свобод людини і громадянина.
+
+        Стаття 2. Підстава кримінальної відповідальності
+        Підставою кримінальної відповідальності є вчинення особою суспільно
+        небезпечного діяння.
+        """
+
+        chunks = chunker.chunk_text(text, "criminal_code.pdf", "1")
+
+        assert len(chunks) >= 1
+        # Check that chunks preserve structure
+        assert any("Стаття" in c.text for c in chunks)
+
+    def test_semantic_chapters(self):
+        """Test semantic chunking with Глава markers."""
+        chunker = DocumentChunker(
+            chunk_size=200,
+            overlap=20,
+            strategy=ChunkingStrategy.SEMANTIC,
+        )
+
+        text = """Глава 1 Загальні положення
+        Текст першої глави.
+
+        Глава 2 Особлива частина
+        Текст другої глави."""
+
+        chunks = chunker.chunk_text(text, "test.pdf", "1")
+
+        assert len(chunks) >= 1
+
+    def test_semantic_article_numbers(self):
+        """Test semantic chunking extracts article markers."""
+        chunker = DocumentChunker(
+            chunk_size=100,
+            overlap=10,
+            strategy=ChunkingStrategy.SEMANTIC,
+        )
+
+        text = "Стаття 115. Умисне вбивство. Текст статті про вбивство."
+
+        chunks = chunker.chunk_text(text, "test.pdf", "115")
+
+        assert len(chunks) >= 1
+        assert "115" in chunks[0].text
+
+
+class TestDocumentChunkerSlidingWindow:
+    """Test sliding window chunking strategy."""
+
+    def test_sliding_window_basic(self):
+        """Test basic sliding window chunking."""
+        chunker = DocumentChunker(
+            chunk_size=100,
+            overlap=50,
+            strategy=ChunkingStrategy.SLIDING_WINDOW,
+        )
+
+        text = "A" * 200
+        chunks = chunker.chunk_text(text, "test.pdf", "1")
+
+        assert len(chunks) >= 3  # 200 chars, step=50, should get 4 windows
+
+    def test_sliding_window_overlap_content(self):
+        """Test that sliding windows actually overlap."""
+        chunker = DocumentChunker(
+            chunk_size=10,
+            overlap=5,
+            strategy=ChunkingStrategy.SLIDING_WINDOW,
+        )
+
+        text = "0123456789ABCDEFGHIJ"  # 20 chars
+        chunks = chunker.chunk_text(text, "test.pdf", "1")
+
+        # First chunk: 0-9, Second chunk: 5-14, etc.
+        assert len(chunks) >= 3
+        # Check overlap exists
+        if len(chunks) >= 2:
+            # Characters 5-9 should be in both first and second chunk
+            assert "56789" in chunks[0].text
+            assert "56789" in chunks[1].text
+
+
+class TestExtractMetadata:
+    """Test metadata extraction from chunk text."""
+
+    def test_extract_article_number(self):
+        """Test article number extraction."""
+        text = "Стаття 115. Умисне вбивство"
+        metadata = DocumentChunker.extract_metadata(text)
+
+        assert metadata.get("article_number") == "115"
+
+    def test_extract_article_number_short_form(self):
+        """Test article number extraction with Ст. format."""
+        text = "Ст. 256 визначає..."
+        metadata = DocumentChunker.extract_metadata(text)
+
+        assert metadata.get("article_number") == "256"
+
+    def test_extract_chapter_roman(self):
+        """Test chapter extraction with Roman numerals."""
+        text = "Розділ III. ЗЛОЧИНИ"
+        metadata = DocumentChunker.extract_metadata(text)
+
+        assert metadata.get("chapter") == "III"
+
+    def test_extract_chapter_arabic(self):
+        """Test chapter extraction with Arabic numerals."""
+        text = "Глава 5 Майнові злочини"
+        metadata = DocumentChunker.extract_metadata(text)
+
+        assert metadata.get("chapter") == "5"
+
+    def test_extract_no_metadata(self):
+        """Test extraction when no metadata present."""
+        text = "Просто текст без маркерів"
+        metadata = DocumentChunker.extract_metadata(text)
+
+        assert metadata == {}
+
+
+class TestChunkCSVByRows:
+    """Test CSV row-based chunking."""
+
+    def test_csv_chunking_basic(self):
+        """Test basic CSV chunking."""
+        csv_content = """Название,Город,Цена (€),Комнат
+Квартира 1,Варна,50000,2
+Квартира 2,Бургас,75000,3
+"""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".csv", delete=False, encoding="utf-8"
+        ) as f:
+            f.write(csv_content)
+            f.flush()
+
+            chunks = chunk_csv_by_rows(Path(f.name), "properties.csv")
+
+        assert len(chunks) == 2
+        assert "Варна" in chunks[0].text
+        assert "Бургас" in chunks[1].text
+
+    def test_csv_chunking_metadata(self):
+        """Test that CSV chunking extracts metadata."""
+        csv_content = """Название,Город,Цена (€),Комнат,Площадь (м²)
+Апартамент,Несебър,120000,3,85
+"""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".csv", delete=False, encoding="utf-8"
+        ) as f:
+            f.write(csv_content)
+            f.flush()
+
+            chunks = chunk_csv_by_rows(Path(f.name), "test.csv")
+
+        assert len(chunks) == 1
+        assert chunks[0].extra_metadata is not None
+        assert chunks[0].extra_metadata.get("city") == "Несебър"
+        assert chunks[0].extra_metadata.get("price") == 120000
+        assert chunks[0].extra_metadata.get("rooms") == 3
+        assert chunks[0].extra_metadata.get("area") == 85
+
+    def test_csv_chunking_chunk_id(self):
+        """Test that chunk IDs are sequential."""
+        csv_content = """Название,Город
+Row1,City1
+Row2,City2
+Row3,City3
+"""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".csv", delete=False, encoding="utf-8"
+        ) as f:
+            f.write(csv_content)
+            f.flush()
+
+            chunks = chunk_csv_by_rows(Path(f.name), "test.csv")
+
+        assert [c.chunk_id for c in chunks] == [0, 1, 2]
+        assert [c.order for c in chunks] == [0, 1, 2]
+
+
+class TestParseCSVRowMetadata:
+    """Test CSV row metadata parsing."""
+
+    def test_parse_numeric_fields(self):
+        """Test numeric field parsing."""
+        row = {
+            "Цена (€)": "150000",
+            "Комнат": "3",
+            "Площадь (м²)": "95.5",
+            "Этаж": "5",
+        }
+
+        metadata = _parse_csv_row_metadata(row)
+
+        assert metadata["price"] == 150000
+        assert metadata["rooms"] == 3
+        assert metadata["area"] == 95.5
+        assert metadata["floor"] == 5
+
+    def test_parse_number_with_spaces(self):
+        """Test parsing numbers with space formatting."""
+        row = {"Цена (€)": "120 000"}
+
+        metadata = _parse_csv_row_metadata(row)
+
+        assert metadata["price"] == 120000
+
+    def test_parse_boolean_fields(self):
+        """Test boolean field parsing."""
+        row_yes = {"Мебель": "есть", "Круглогодичность": "да"}
+        row_no = {"Мебель": "нет", "Круглогодичность": ""}
+
+        metadata_yes = _parse_csv_row_metadata(row_yes)
+        metadata_no = _parse_csv_row_metadata(row_no)
+
+        assert metadata_yes["furnished"] is True
+        assert metadata_yes["year_round"] is True
+        assert metadata_no.get("furnished", False) is False
+
+    def test_parse_text_fields(self):
+        """Test text field parsing."""
+        row = {
+            "Название": "Квартира у моря",
+            "Город": "Варна",
+            "Описание": "Красивая квартира",
+        }
+
+        metadata = _parse_csv_row_metadata(row)
+
+        assert metadata["title"] == "Квартира у моря"
+        assert metadata["city"] == "Варна"
+        assert metadata["description"] == "Красивая квартира"
+
+    def test_parse_empty_values(self):
+        """Test handling of empty values."""
+        row = {
+            "Цена (€)": "",
+            "Комнат": "   ",
+            "Город": "Варна",
+        }
+
+        metadata = _parse_csv_row_metadata(row)
+
+        assert "price" not in metadata
+        assert "rooms" not in metadata
+        assert metadata["city"] == "Варна"
+
+    def test_source_type_marker(self):
+        """Test that source_type is always added."""
+        row = {"Город": "Варна"}
+
+        metadata = _parse_csv_row_metadata(row)
+
+        assert metadata["source_type"] == "csv_row"

--- a/tests/unit/test_constants.py
+++ b/tests/unit/test_constants.py
@@ -1,0 +1,207 @@
+"""Unit tests for src/config/constants.py."""
+
+import pytest
+
+from src.config.constants import (
+    APIProvider,
+    BatchSizes,
+    DEFAULTS,
+    HSNWParameters,
+    MetricValues,
+    MMRParameters,
+    ModelName,
+    RATE_LIMITS,
+    RetrievalStages,
+    SearchEngine,
+    ThresholdValues,
+    VectorDimensions,
+)
+
+
+class TestSearchEngine:
+    """Test SearchEngine enum."""
+
+    def test_search_engine_values(self):
+        """Test all search engine values."""
+        assert SearchEngine.BASELINE.value == "baseline"
+        assert SearchEngine.HYBRID_RRF.value == "hybrid_rrf"
+        assert SearchEngine.HYBRID_RRF_COLBERT.value == "hybrid_rrf_colbert"
+        assert SearchEngine.DBSF_COLBERT.value == "dbsf_colbert"
+
+    def test_search_engine_is_string_enum(self):
+        """Test that SearchEngine is a string enum."""
+        assert isinstance(SearchEngine.BASELINE, str)
+        assert SearchEngine.BASELINE == "baseline"
+
+    def test_search_engine_from_string(self):
+        """Test creating SearchEngine from string."""
+        engine = SearchEngine("hybrid_rrf_colbert")
+        assert engine == SearchEngine.HYBRID_RRF_COLBERT
+
+
+class TestAPIProvider:
+    """Test APIProvider enum."""
+
+    def test_api_provider_values(self):
+        """Test all API provider values."""
+        assert APIProvider.CLAUDE.value == "claude"
+        assert APIProvider.OPENAI.value == "openai"
+        assert APIProvider.GROQ.value == "groq"
+        assert APIProvider.Z_AI.value == "zai"
+
+    def test_api_provider_is_string_enum(self):
+        """Test that APIProvider is a string enum."""
+        assert isinstance(APIProvider.CLAUDE, str)
+        assert APIProvider.OPENAI == "openai"
+
+    def test_api_provider_from_string(self):
+        """Test creating APIProvider from string."""
+        provider = APIProvider("claude")
+        assert provider == APIProvider.CLAUDE
+
+
+class TestModelName:
+    """Test ModelName enum."""
+
+    def test_claude_models(self):
+        """Test Claude model names."""
+        assert "claude-3-opus" in ModelName.CLAUDE_OPUS.value
+        assert "claude-3-5-sonnet" in ModelName.CLAUDE_SONNET.value
+        assert "claude-3-5-haiku" in ModelName.CLAUDE_HAIKU.value
+
+    def test_openai_models(self):
+        """Test OpenAI model names."""
+        assert "gpt-4-turbo" in ModelName.GPT_4_TURBO.value
+        assert "gpt-4" == ModelName.GPT_4.value
+        assert "gpt-3.5-turbo" == ModelName.GPT_35_TURBO.value
+
+    def test_groq_models(self):
+        """Test Groq model names."""
+        assert "llama3-70b" in ModelName.GROQ_LLAMA3_70B.value
+        assert "llama3-8b" in ModelName.GROQ_LLAMA3_8B.value
+        assert "mixtral" in ModelName.GROQ_MIXTRAL.value
+
+
+class TestVectorDimensions:
+    """Test VectorDimensions dataclass."""
+
+    def test_vector_dimensions(self):
+        """Test vector dimension values."""
+        assert VectorDimensions.DENSE == 1024
+        assert VectorDimensions.COLBERT == 1024
+        assert VectorDimensions.FULL == 1024
+
+
+class TestThresholdValues:
+    """Test ThresholdValues dataclass."""
+
+    def test_threshold_values(self):
+        """Test threshold values."""
+        assert ThresholdValues.DENSE_ONLY == 0.5
+        assert ThresholdValues.HYBRID == 0.3
+        assert ThresholdValues.COLBERT == 0.4
+        assert ThresholdValues.MINIMUM == 0.1
+
+    def test_dense_higher_than_hybrid(self):
+        """Test that dense-only threshold is higher than hybrid."""
+        assert ThresholdValues.DENSE_ONLY > ThresholdValues.HYBRID
+
+
+class TestHSNWParameters:
+    """Test HSNWParameters dataclass."""
+
+    def test_hsnw_ef_values(self):
+        """Test HNSW ef parameter values."""
+        assert HSNWParameters.EF_DEFAULT == 128
+        assert HSNWParameters.EF_HIGH_PRECISION == 256
+        assert HSNWParameters.EF_LOW_LATENCY == 64
+        assert HSNWParameters.MAX_CONNECTIONS == 16
+
+    def test_ef_ordering(self):
+        """Test that EF values are properly ordered."""
+        assert HSNWParameters.EF_LOW_LATENCY < HSNWParameters.EF_DEFAULT < HSNWParameters.EF_HIGH_PRECISION
+
+
+class TestBatchSizes:
+    """Test BatchSizes dataclass."""
+
+    def test_batch_sizes(self):
+        """Test batch size values."""
+        assert BatchSizes.QUERIES == 10
+        assert BatchSizes.EMBEDDINGS == 32
+        assert BatchSizes.DOCUMENTS == 16
+        assert BatchSizes.CONTEXT == 5
+
+
+class TestRetrievalStages:
+    """Test RetrievalStages dataclass."""
+
+    def test_retrieval_stages(self):
+        """Test retrieval stage values."""
+        assert RetrievalStages.STAGE1_CANDIDATES == 100
+        assert RetrievalStages.STAGE2_FINAL == 10
+
+    def test_stage1_larger_than_stage2(self):
+        """Test that stage 1 retrieves more than stage 2."""
+        assert RetrievalStages.STAGE1_CANDIDATES > RetrievalStages.STAGE2_FINAL
+
+
+class TestMetricValues:
+    """Test MetricValues dataclass."""
+
+    def test_metric_k_values(self):
+        """Test metric K values."""
+        assert MetricValues.RECALL_K == [1, 3, 5, 10]
+        assert MetricValues.NDCG_K == [1, 3, 5, 10]
+        assert MetricValues.FAILURE_K == [1, 3, 5, 10]
+
+
+class TestMMRParameters:
+    """Test MMRParameters dataclass."""
+
+    def test_mmr_parameters(self):
+        """Test MMR parameter values."""
+        assert MMRParameters.LAMBDA == 0.5
+        assert MMRParameters.ENABLED is True
+
+
+class TestDefaults:
+    """Test DEFAULTS dictionary."""
+
+    def test_defaults_contains_search_engine(self):
+        """Test that defaults contains search engine."""
+        assert "search_engine" in DEFAULTS
+        assert DEFAULTS["search_engine"] == SearchEngine.HYBRID_RRF_COLBERT
+
+    def test_defaults_contains_api_provider(self):
+        """Test that defaults contains API provider."""
+        assert "api_provider" in DEFAULTS
+        assert DEFAULTS["api_provider"] == APIProvider.CLAUDE
+
+    def test_defaults_contains_model(self):
+        """Test that defaults contains model."""
+        assert "model" in DEFAULTS
+        assert DEFAULTS["model"] == ModelName.CLAUDE_SONNET
+
+    def test_defaults_contains_retry_config(self):
+        """Test that defaults contains retry config."""
+        assert "max_retries" in DEFAULTS
+        assert "retry_backoff" in DEFAULTS
+        assert DEFAULTS["max_retries"] == 3
+        assert DEFAULTS["retry_backoff"] == 2
+
+
+class TestRateLimits:
+    """Test RATE_LIMITS dictionary."""
+
+    def test_rate_limits_all_providers(self):
+        """Test rate limits for all providers."""
+        assert APIProvider.CLAUDE in RATE_LIMITS
+        assert APIProvider.OPENAI in RATE_LIMITS
+        assert APIProvider.GROQ in RATE_LIMITS
+        assert APIProvider.Z_AI in RATE_LIMITS
+
+    def test_groq_fastest(self):
+        """Test that Groq has fastest rate limit."""
+        assert RATE_LIMITS[APIProvider.GROQ] < RATE_LIMITS[APIProvider.CLAUDE]
+        assert RATE_LIMITS[APIProvider.GROQ] < RATE_LIMITS[APIProvider.OPENAI]

--- a/tests/unit/test_contextual_schema.py
+++ b/tests/unit/test_contextual_schema.py
@@ -1,0 +1,332 @@
+"""Unit tests for src/ingestion/contextual_schema.py."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.ingestion.contextual_schema import (
+    ContextualChunk,
+    ContextualDocument,
+    create_text_for_embedding,
+)
+
+
+class TestCreateTextForEmbedding:
+    """Test create_text_for_embedding function."""
+
+    def test_creates_markdown_format(self):
+        """Test that result is Markdown-formatted."""
+        result = create_text_for_embedding(
+            topic="Legal Topic",
+            context="This discusses important legal matters.",
+            text="The actual chunk text content.",
+        )
+
+        assert result.startswith("# Legal Topic")
+        assert "This discusses important legal matters." in result
+        assert "The actual chunk text content." in result
+
+    def test_empty_context(self):
+        """Test with empty context."""
+        result = create_text_for_embedding(
+            topic="Topic",
+            context="",
+            text="Text content",
+        )
+
+        assert "# Topic" in result
+        assert "Text content" in result
+
+    def test_whitespace_context(self):
+        """Test with whitespace-only context."""
+        result = create_text_for_embedding(
+            topic="Topic",
+            context="   ",
+            text="Text",
+        )
+
+        # Should handle whitespace context
+        assert "# Topic" in result
+
+
+class TestContextualChunk:
+    """Test ContextualChunk dataclass."""
+
+    def test_chunk_creation(self):
+        """Test basic ContextualChunk creation."""
+        chunk = ContextualChunk(
+            chunk_id=0,
+            topic="Criminal Law",
+            keywords=["crime", "punishment"],
+            context="This chunk discusses criminal penalties.",
+            text="Article 115 covers intentional homicide.",
+        )
+
+        assert chunk.chunk_id == 0
+        assert chunk.topic == "Criminal Law"
+        assert chunk.keywords == ["crime", "punishment"]
+        assert chunk.context == "This chunk discusses criminal penalties."
+        assert chunk.text == "Article 115 covers intentional homicide."
+
+    def test_text_for_embedding_property(self):
+        """Test text_for_embedding property generates formatted text."""
+        chunk = ContextualChunk(
+            chunk_id=1,
+            topic="Property Law",
+            keywords=["property", "ownership"],
+            context="About ownership rights.",
+            text="Property ownership details.",
+        )
+
+        embedding_text = chunk.text_for_embedding
+
+        assert "# Property Law" in embedding_text
+        assert "About ownership rights." in embedding_text
+        assert "Property ownership details." in embedding_text
+
+    def test_text_for_embedding_cached(self):
+        """Test that text_for_embedding is cached."""
+        chunk = ContextualChunk(
+            chunk_id=2,
+            topic="Test",
+            keywords=[],
+            context="Context",
+            text="Text",
+        )
+
+        # First access
+        text1 = chunk.text_for_embedding
+        # Second access
+        text2 = chunk.text_for_embedding
+
+        assert text1 is text2  # Same object (cached)
+
+    def test_to_dict(self):
+        """Test chunk serialization to dict."""
+        chunk = ContextualChunk(
+            chunk_id=3,
+            topic="Topic",
+            keywords=["keyword1", "keyword2"],
+            context="Context text",
+            text="Main text",
+        )
+
+        result = chunk.to_dict()
+
+        assert result["chunk_id"] == 3
+        assert result["topic"] == "Topic"
+        assert result["keywords"] == ["keyword1", "keyword2"]
+        assert result["context"] == "Context text"
+        assert result["text"] == "Main text"
+        assert "text_for_embedding" in result
+
+    def test_from_dict(self):
+        """Test chunk deserialization from dict."""
+        data = {
+            "chunk_id": 4,
+            "topic": "Loaded Topic",
+            "keywords": ["key1"],
+            "context": "Loaded context",
+            "text": "Loaded text",
+        }
+
+        chunk = ContextualChunk.from_dict(data)
+
+        assert chunk.chunk_id == 4
+        assert chunk.topic == "Loaded Topic"
+        assert chunk.keywords == ["key1"]
+        assert chunk.context == "Loaded context"
+        assert chunk.text == "Loaded text"
+
+    def test_from_dict_with_embedding_text(self):
+        """Test deserialization preserves cached embedding text."""
+        data = {
+            "chunk_id": 5,
+            "topic": "Topic",
+            "keywords": [],
+            "context": "Context",
+            "text": "Text",
+            "text_for_embedding": "Pre-computed embedding text",
+        }
+
+        chunk = ContextualChunk.from_dict(data)
+
+        # Should use pre-computed value
+        assert chunk.text_for_embedding == "Pre-computed embedding text"
+
+
+class TestContextualDocument:
+    """Test ContextualDocument dataclass."""
+
+    def test_document_creation(self):
+        """Test basic ContextualDocument creation."""
+        chunk = ContextualChunk(
+            chunk_id=0,
+            topic="Test",
+            keywords=[],
+            context="",
+            text="Text",
+        )
+
+        doc = ContextualDocument(
+            source="test.pdf",
+            chunks=[chunk],
+        )
+
+        assert doc.source == "test.pdf"
+        assert len(doc.chunks) == 1
+        assert doc.processed_at is not None
+
+    def test_total_chunks_property(self):
+        """Test total_chunks property."""
+        chunks = [
+            ContextualChunk(chunk_id=i, topic="T", keywords=[], context="", text="T")
+            for i in range(5)
+        ]
+
+        doc = ContextualDocument(source="doc.pdf", chunks=chunks)
+
+        assert doc.total_chunks == 5
+
+    def test_to_dict(self):
+        """Test document serialization to dict."""
+        chunk = ContextualChunk(
+            chunk_id=0,
+            topic="Topic",
+            keywords=["k1"],
+            context="Ctx",
+            text="Txt",
+        )
+        doc = ContextualDocument(
+            source="source.pdf",
+            chunks=[chunk],
+            processed_at="2024-01-01T00:00:00Z",
+        )
+
+        result = doc.to_dict()
+
+        assert result["source"] == "source.pdf"
+        assert result["total_chunks"] == 1
+        assert result["processed_at"] == "2024-01-01T00:00:00Z"
+        assert len(result["chunks"]) == 1
+
+    def test_to_json(self):
+        """Test document serialization to JSON."""
+        chunk = ContextualChunk(
+            chunk_id=0,
+            topic="Topic",
+            keywords=[],
+            context="",
+            text="Text",
+        )
+        doc = ContextualDocument(source="doc.pdf", chunks=[chunk])
+
+        json_str = doc.to_json()
+
+        # Should be valid JSON
+        parsed = json.loads(json_str)
+        assert parsed["source"] == "doc.pdf"
+
+    def test_from_dict(self):
+        """Test document deserialization from dict."""
+        data = {
+            "source": "loaded.pdf",
+            "processed_at": "2024-01-01T00:00:00Z",
+            "chunks": [
+                {
+                    "chunk_id": 0,
+                    "topic": "T",
+                    "keywords": [],
+                    "context": "C",
+                    "text": "X",
+                }
+            ],
+        }
+
+        doc = ContextualDocument.from_dict(data)
+
+        assert doc.source == "loaded.pdf"
+        assert doc.processed_at == "2024-01-01T00:00:00Z"
+        assert len(doc.chunks) == 1
+        assert doc.chunks[0].chunk_id == 0
+
+    def test_from_json(self):
+        """Test document deserialization from JSON string."""
+        json_str = json.dumps(
+            {
+                "source": "json.pdf",
+                "processed_at": "2024-01-01T00:00:00Z",
+                "chunks": [
+                    {
+                        "chunk_id": 0,
+                        "topic": "T",
+                        "keywords": [],
+                        "context": "C",
+                        "text": "X",
+                    }
+                ],
+            }
+        )
+
+        doc = ContextualDocument.from_json(json_str)
+
+        assert doc.source == "json.pdf"
+        assert len(doc.chunks) == 1
+
+    def test_save_and_load(self):
+        """Test saving and loading document from file."""
+        chunk = ContextualChunk(
+            chunk_id=0,
+            topic="Test Topic",
+            keywords=["kw1", "kw2"],
+            context="Test context",
+            text="Test text content",
+        )
+        doc = ContextualDocument(source="original.pdf", chunks=[chunk])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "document.json"
+
+            # Save
+            doc.save(str(file_path))
+
+            # Load
+            loaded_doc = ContextualDocument.load(str(file_path))
+
+            assert loaded_doc.source == "original.pdf"
+            assert len(loaded_doc.chunks) == 1
+            assert loaded_doc.chunks[0].topic == "Test Topic"
+            assert loaded_doc.chunks[0].keywords == ["kw1", "kw2"]
+
+    def test_roundtrip_serialization(self):
+        """Test that serialization and deserialization are consistent."""
+        chunks = [
+            ContextualChunk(
+                chunk_id=i,
+                topic=f"Topic {i}",
+                keywords=[f"kw{i}"],
+                context=f"Context {i}",
+                text=f"Text {i}",
+            )
+            for i in range(3)
+        ]
+        original = ContextualDocument(
+            source="roundtrip.pdf",
+            chunks=chunks,
+            processed_at="2024-06-15T10:30:00Z",
+        )
+
+        # Roundtrip
+        json_str = original.to_json()
+        restored = ContextualDocument.from_json(json_str)
+
+        assert restored.source == original.source
+        assert restored.processed_at == original.processed_at
+        assert len(restored.chunks) == len(original.chunks)
+
+        for i, chunk in enumerate(restored.chunks):
+            assert chunk.chunk_id == original.chunks[i].chunk_id
+            assert chunk.topic == original.chunks[i].topic
+            assert chunk.keywords == original.chunks[i].keywords

--- a/tests/unit/test_document_parser.py
+++ b/tests/unit/test_document_parser.py
@@ -1,0 +1,338 @@
+"""Unit tests for src/ingestion/document_parser.py."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.ingestion.document_parser import (
+    ParsedDocument,
+    ParserCache,
+    UniversalDocumentParser,
+    parse_document,
+)
+
+
+class TestParsedDocument:
+    """Test ParsedDocument dataclass."""
+
+    def test_parsed_document_creation(self):
+        """Test basic ParsedDocument creation."""
+        doc = ParsedDocument(
+            filename="test.pdf",
+            title="Test Document",
+            content="Document content",
+        )
+
+        assert doc.filename == "test.pdf"
+        assert doc.title == "Test Document"
+        assert doc.content == "Document content"
+        assert doc.num_pages is None
+        assert doc.metadata == {}
+
+    def test_parsed_document_with_metadata(self):
+        """Test ParsedDocument with all fields."""
+        doc = ParsedDocument(
+            filename="test.pdf",
+            title="Test",
+            content="Content",
+            num_pages=10,
+            metadata={"author": "John"},
+        )
+
+        assert doc.num_pages == 10
+        assert doc.metadata["author"] == "John"
+
+    def test_parsed_document_metadata_default(self):
+        """Test that metadata defaults to empty dict."""
+        doc = ParsedDocument(
+            filename="test.pdf",
+            title="Test",
+            content="Content",
+        )
+
+        assert doc.metadata == {}
+        assert isinstance(doc.metadata, dict)
+
+
+class TestParserCache:
+    """Test ParserCache class."""
+
+    def test_cache_init_creates_directory(self):
+        """Test that cache creates directory on init."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir) / "test_cache"
+            cache = ParserCache(cache_dir=cache_dir)
+
+            assert cache_dir.exists()
+
+    def test_cache_get_miss(self):
+        """Test cache miss returns None."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache = ParserCache(cache_dir=Path(tmpdir))
+
+            # Create a test file
+            test_file = Path(tmpdir) / "test.txt"
+            test_file.write_text("content")
+
+            result = cache.get(test_file)
+
+            assert result is None
+
+    def test_cache_set_and_get(self):
+        """Test setting and getting cached content."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache = ParserCache(cache_dir=Path(tmpdir))
+
+            # Create a test file
+            test_file = Path(tmpdir) / "test.txt"
+            test_file.write_text("original content")
+
+            # Cache some content
+            cache.set(test_file, "cached content")
+
+            # Get cached content
+            result = cache.get(test_file)
+
+            assert result == "cached content"
+
+    def test_cache_hash_based(self):
+        """Test that cache is based on file content hash."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache = ParserCache(cache_dir=Path(tmpdir))
+
+            # Create two files with same content
+            file1 = Path(tmpdir) / "file1.txt"
+            file2 = Path(tmpdir) / "file2.txt"
+            file1.write_text("same content")
+            file2.write_text("same content")
+
+            # Cache file1
+            cache.set(file1, "cached")
+
+            # file2 should hit cache (same content hash)
+            result = cache.get(file2)
+            assert result == "cached"
+
+
+class TestUniversalDocumentParser:
+    """Test UniversalDocumentParser class."""
+
+    def test_parser_init_with_cache(self):
+        """Test parser init with cache enabled."""
+        parser = UniversalDocumentParser(use_cache=True)
+
+        assert parser.use_cache is True
+        assert parser.cache is not None
+
+    def test_parser_init_without_cache(self):
+        """Test parser init with cache disabled."""
+        parser = UniversalDocumentParser(use_cache=False)
+
+        assert parser.use_cache is False
+        assert parser.cache is None
+
+    def test_parser_formats(self):
+        """Test supported format constants."""
+        assert ".pdf" in UniversalDocumentParser.PDF_FORMATS
+        assert ".docx" in UniversalDocumentParser.DOCLING_FORMATS
+        assert ".csv" in UniversalDocumentParser.DOCLING_FORMATS
+        assert ".xlsx" in UniversalDocumentParser.DOCLING_FORMATS
+
+    def test_parser_file_not_found(self):
+        """Test FileNotFoundError for missing file."""
+        parser = UniversalDocumentParser(use_cache=False)
+
+        with pytest.raises(FileNotFoundError):
+            parser.parse_file("/nonexistent/file.pdf")
+
+    def test_parser_unsupported_format(self):
+        """Test ValueError for unsupported format."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create file with unsupported extension
+            test_file = Path(tmpdir) / "test.xyz"
+            test_file.write_text("content")
+
+            parser = UniversalDocumentParser(use_cache=False)
+
+            with pytest.raises(ValueError, match="Unsupported format"):
+                parser.parse_file(test_file)
+
+    def test_parser_docling_lazy_init(self):
+        """Test that Docling converter is lazily initialized."""
+        parser = UniversalDocumentParser(use_cache=False)
+
+        assert parser.docling_converter is None
+
+    @patch("src.ingestion.document_parser.DocumentConverter")
+    def test_parser_docling_converter_created(self, mock_converter_cls):
+        """Test that Docling converter is created on first use."""
+        mock_converter = MagicMock()
+        mock_converter_cls.return_value = mock_converter
+
+        parser = UniversalDocumentParser(use_cache=False)
+        converter = parser._get_docling_converter()
+
+        assert converter is mock_converter
+        mock_converter_cls.assert_called_once()
+
+    @patch("src.ingestion.document_parser.DocumentConverter")
+    def test_parser_docling_converter_reused(self, mock_converter_cls):
+        """Test that Docling converter is reused."""
+        mock_converter = MagicMock()
+        mock_converter_cls.return_value = mock_converter
+
+        parser = UniversalDocumentParser(use_cache=False)
+
+        # Get converter twice
+        converter1 = parser._get_docling_converter()
+        converter2 = parser._get_docling_converter()
+
+        assert converter1 is converter2
+        mock_converter_cls.assert_called_once()  # Only created once
+
+
+class TestParsePDF:
+    """Test PDF parsing."""
+
+    @patch("src.ingestion.document_parser.pymupdf")
+    def test_parse_pdf_success(self, mock_pymupdf):
+        """Test successful PDF parsing."""
+        # Create mock PDF document
+        mock_page = MagicMock()
+        mock_page.get_text.return_value = "Page content"
+
+        mock_doc = MagicMock()
+        mock_doc.__iter__ = lambda self: iter([mock_page])
+        mock_doc.__len__ = lambda self: 1
+        mock_doc.metadata = {"title": "Test PDF", "author": "Author"}
+
+        mock_pymupdf.open.return_value = mock_doc
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create dummy PDF file
+            pdf_file = Path(tmpdir) / "test.pdf"
+            pdf_file.write_bytes(b"%PDF-1.4")
+
+            parser = UniversalDocumentParser(use_cache=False)
+            result = parser._parse_pdf(pdf_file)
+
+            assert result.filename == "test.pdf"
+            assert result.title == "Test PDF"
+            assert result.content == "Page content"
+            assert result.num_pages == 1
+            assert result.metadata["parser"] == "pymupdf"
+
+    @patch("src.ingestion.document_parser.pymupdf")
+    def test_parse_pdf_no_metadata(self, mock_pymupdf):
+        """Test PDF parsing when metadata is None."""
+        mock_page = MagicMock()
+        mock_page.get_text.return_value = "Content"
+
+        mock_doc = MagicMock()
+        mock_doc.__iter__ = lambda self: iter([mock_page])
+        mock_doc.__len__ = lambda self: 1
+        mock_doc.metadata = None
+
+        mock_pymupdf.open.return_value = mock_doc
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pdf_file = Path(tmpdir) / "test.pdf"
+            pdf_file.write_bytes(b"%PDF-1.4")
+
+            parser = UniversalDocumentParser(use_cache=False)
+            result = parser._parse_pdf(pdf_file)
+
+            # Should use stem as title when no metadata
+            assert result.title == "test"
+
+
+class TestParseWithDocling:
+    """Test Docling parsing."""
+
+    @patch("src.ingestion.document_parser.DocumentConverter")
+    def test_parse_docling_success(self, mock_converter_cls):
+        """Test successful Docling parsing."""
+        mock_result = MagicMock()
+        mock_result.document.export_to_markdown.return_value = "# Document\n\nContent"
+
+        mock_converter = MagicMock()
+        mock_converter.convert.return_value = mock_result
+        mock_converter_cls.return_value = mock_converter
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            docx_file = Path(tmpdir) / "test.docx"
+            docx_file.write_bytes(b"dummy")
+
+            parser = UniversalDocumentParser(use_cache=False)
+            result = parser._parse_with_docling(docx_file)
+
+            assert result.filename == "test.docx"
+            assert result.title == "test"
+            assert result.content == "# Document\n\nContent"
+            assert result.metadata["parser"] == "docling"
+            assert result.metadata["format"] == "docx"
+
+
+class TestParseFile:
+    """Test main parse_file method."""
+
+    @patch("src.ingestion.document_parser.pymupdf")
+    def test_parse_file_uses_cache(self, mock_pymupdf):
+        """Test that parse_file uses cache."""
+        mock_page = MagicMock()
+        mock_page.get_text.return_value = "Content"
+
+        mock_doc = MagicMock()
+        mock_doc.__iter__ = lambda self: iter([mock_page])
+        mock_doc.__len__ = lambda self: 1
+        mock_doc.metadata = {}
+
+        mock_pymupdf.open.return_value = mock_doc
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pdf_file = Path(tmpdir) / "test.pdf"
+            pdf_file.write_bytes(b"%PDF-1.4")
+
+            parser = UniversalDocumentParser(use_cache=True)
+            parser.cache = ParserCache(cache_dir=Path(tmpdir) / "cache")
+
+            # First call - should parse
+            result1 = parser.parse_file(pdf_file)
+
+            # Reset mock to verify second call uses cache
+            mock_pymupdf.open.reset_mock()
+
+            # Second call - should use cache
+            result2 = parser.parse_file(pdf_file)
+
+            # Verify second call didn't parse
+            mock_pymupdf.open.assert_not_called()
+            assert result2.metadata["source"] == "cache"
+
+
+class TestConvenienceFunction:
+    """Test parse_document convenience function."""
+
+    @patch("src.ingestion.document_parser.pymupdf")
+    def test_parse_document_function(self, mock_pymupdf):
+        """Test parse_document convenience function."""
+        mock_page = MagicMock()
+        mock_page.get_text.return_value = "Content"
+
+        mock_doc = MagicMock()
+        mock_doc.__iter__ = lambda self: iter([mock_page])
+        mock_doc.__len__ = lambda self: 1
+        mock_doc.metadata = {}
+
+        mock_pymupdf.open.return_value = mock_doc
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pdf_file = Path(tmpdir) / "test.pdf"
+            pdf_file.write_bytes(b"%PDF-1.4")
+
+            result = parse_document(pdf_file, use_cache=False)
+
+            assert isinstance(result, ParsedDocument)
+            assert result.content == "Content"

--- a/tests/unit/test_evaluator.py
+++ b/tests/unit/test_evaluator.py
@@ -1,0 +1,333 @@
+"""Unit tests for src/evaluation/evaluator.py."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from src.evaluation.evaluator import SearchEvaluator
+
+
+class TestSearchEvaluatorInit:
+    """Test SearchEvaluator initialization."""
+
+    def test_init_loads_ground_truth(self):
+        """Test that init loads ground truth from file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"queries": []}, f)
+            f.flush()
+
+            evaluator = SearchEvaluator(f.name)
+            assert evaluator.ground_truth == {"queries": []}
+
+
+class TestEvaluateQuery:
+    """Test evaluate_query method."""
+
+    def test_evaluate_query_recall_at_1_hit(self):
+        """Test recall@1 when expected article is first."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({}, f)
+            f.flush()
+
+            evaluator = SearchEvaluator(f.name)
+
+            query = {"query": "test", "expected_article": "121"}
+            results = [
+                {"article_number": "121", "score": 0.95},
+                {"article_number": "122", "score": 0.85},
+            ]
+
+            metrics = evaluator.evaluate_query(query, results)
+
+            assert metrics["recall@1"] == 1
+            assert metrics["recall@3"] == 1
+            assert metrics["recall@5"] == 1
+
+    def test_evaluate_query_recall_at_1_miss(self):
+        """Test recall@1 when expected article is not first."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({}, f)
+            f.flush()
+
+            evaluator = SearchEvaluator(f.name)
+
+            query = {"query": "test", "expected_article": "121"}
+            results = [
+                {"article_number": "122", "score": 0.95},
+                {"article_number": "121", "score": 0.85},
+            ]
+
+            metrics = evaluator.evaluate_query(query, results)
+
+            assert metrics["recall@1"] == 0
+            assert metrics["recall@3"] == 1
+
+    def test_evaluate_query_mrr_first_position(self):
+        """Test MRR when expected article is at position 1."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({}, f)
+            f.flush()
+
+            evaluator = SearchEvaluator(f.name)
+
+            query = {"query": "test", "expected_article": "121"}
+            results = [{"article_number": "121", "score": 0.95}]
+
+            metrics = evaluator.evaluate_query(query, results)
+
+            assert metrics["mrr"] == 1.0
+            assert metrics["rank"] == 1
+
+    def test_evaluate_query_mrr_second_position(self):
+        """Test MRR when expected article is at position 2."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({}, f)
+            f.flush()
+
+            evaluator = SearchEvaluator(f.name)
+
+            query = {"query": "test", "expected_article": "121"}
+            results = [
+                {"article_number": "122", "score": 0.95},
+                {"article_number": "121", "score": 0.85},
+            ]
+
+            metrics = evaluator.evaluate_query(query, results)
+
+            assert metrics["mrr"] == 0.5
+            assert metrics["rank"] == 2
+
+    def test_evaluate_query_mrr_not_found(self):
+        """Test MRR when expected article is not in results."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({}, f)
+            f.flush()
+
+            evaluator = SearchEvaluator(f.name)
+
+            query = {"query": "test", "expected_article": "121"}
+            results = [{"article_number": "999", "score": 0.95}]
+
+            metrics = evaluator.evaluate_query(query, results)
+
+            assert metrics["mrr"] == 0.0
+            assert metrics["rank"] is None
+
+    def test_evaluate_query_ndcg_at_10(self):
+        """Test NDCG@10 calculation."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({}, f)
+            f.flush()
+
+            evaluator = SearchEvaluator(f.name)
+
+            query = {"query": "test", "expected_article": "121"}
+            # Expected at position 1 = perfect NDCG
+            results = [{"article_number": "121", "score": 0.95}]
+
+            metrics = evaluator.evaluate_query(query, results)
+
+            assert metrics["ndcg@10"] == 1.0
+
+    def test_evaluate_query_precision_at_k(self):
+        """Test precision@K calculations."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({}, f)
+            f.flush()
+
+            evaluator = SearchEvaluator(f.name)
+
+            query = {"query": "test", "expected_article": "121"}
+            results = [
+                {"article_number": "121", "score": 0.95},
+                {"article_number": "122", "score": 0.85},
+                {"article_number": "123", "score": 0.80},
+            ]
+
+            metrics = evaluator.evaluate_query(query, results)
+
+            # Only one relevant result at position 1
+            assert metrics["precision@1"] == 1.0
+            assert metrics["precision@3"] == pytest.approx(1/3)
+
+
+class TestCalculateNDCG:
+    """Test _calculate_ndcg method."""
+
+    def test_ndcg_perfect_ranking(self):
+        """Test NDCG with perfect ranking (expected at position 1)."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({}, f)
+            f.flush()
+
+            evaluator = SearchEvaluator(f.name)
+
+            ndcg = evaluator._calculate_ndcg("121", ["121", "122", "123"])
+            assert ndcg == 1.0
+
+    def test_ndcg_expected_at_position_2(self):
+        """Test NDCG with expected at position 2."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({}, f)
+            f.flush()
+
+            evaluator = SearchEvaluator(f.name)
+
+            ndcg = evaluator._calculate_ndcg("121", ["122", "121", "123"])
+            # DCG = 1/log2(3) ≈ 0.63, IDCG = 1.0
+            assert ndcg == pytest.approx(1 / np.log2(3))
+
+    def test_ndcg_not_found(self):
+        """Test NDCG when expected is not in results."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({}, f)
+            f.flush()
+
+            evaluator = SearchEvaluator(f.name)
+
+            ndcg = evaluator._calculate_ndcg("121", ["122", "123", "124"])
+            assert ndcg == 0.0
+
+
+class TestEvaluateQueries:
+    """Test evaluate_queries method for batch evaluation."""
+
+    def test_evaluate_queries_aggregation(self):
+        """Test aggregated metrics from multiple queries."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({}, f)
+            f.flush()
+
+            evaluator = SearchEvaluator(f.name)
+
+            queries = [
+                {"query": "query1", "expected_article": "121", "type": "semantic"},
+                {"query": "query2", "expected_article": "122", "type": "exact"},
+            ]
+
+            search_results_map = {
+                "query1": [{"article_number": "121", "score": 0.95}],
+                "query2": [
+                    {"article_number": "999", "score": 0.95},
+                    {"article_number": "122", "score": 0.85},
+                ],
+            }
+
+            result = evaluator.evaluate_queries(queries, search_results_map)
+
+            assert result["total_queries"] == 2
+            assert "metrics" in result
+            # Average recall@1: (1 + 0) / 2 = 0.5
+            assert result["metrics"]["recall@1"] == 0.5
+
+    def test_evaluate_queries_by_type(self):
+        """Test metrics broken down by query type."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({}, f)
+            f.flush()
+
+            evaluator = SearchEvaluator(f.name)
+
+            queries = [
+                {"query": "q1", "expected_article": "121", "type": "semantic"},
+                {"query": "q2", "expected_article": "122", "type": "semantic"},
+                {"query": "q3", "expected_article": "123", "type": "exact"},
+            ]
+
+            search_results_map = {
+                "q1": [{"article_number": "121", "score": 0.95}],
+                "q2": [{"article_number": "122", "score": 0.95}],
+                "q3": [{"article_number": "123", "score": 0.95}],
+            }
+
+            result = evaluator.evaluate_queries(queries, search_results_map)
+
+            assert "by_query_type" in result
+            assert "semantic" in result["by_query_type"]
+            assert result["by_query_type"]["semantic"]["count"] == 2
+
+    def test_evaluate_queries_failure_rate(self):
+        """Test failure rate calculation."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({}, f)
+            f.flush()
+
+            evaluator = SearchEvaluator(f.name)
+
+            queries = [
+                {"query": "q1", "expected_article": "121"},
+                {"query": "q2", "expected_article": "122"},
+            ]
+
+            # q1 fails, q2 succeeds
+            search_results_map = {
+                "q1": [{"article_number": "999", "score": 0.95}],  # Wrong
+                "q2": [{"article_number": "122", "score": 0.95}],  # Correct
+            }
+
+            result = evaluator.evaluate_queries(queries, search_results_map)
+
+            # recall@10 = 0.5, failure_rate = 1 - 0.5 = 0.5
+            assert result["metrics"]["failure_rate"] == 0.5
+
+
+class TestCompareEngines:
+    """Test compare_engines method."""
+
+    def test_compare_engines_improvements(self):
+        """Test improvement calculation between engines."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({}, f)
+            f.flush()
+
+            evaluator = SearchEvaluator(f.name)
+
+            baseline_results = {
+                "metrics": {
+                    "recall@1": 0.80,
+                    "recall@10": 0.90,
+                    "mrr": 0.75,
+                },
+                "detailed_results": [],
+            }
+
+            hybrid_results = {
+                "metrics": {
+                    "recall@1": 0.90,  # +10%
+                    "recall@10": 0.95,  # +5.5%
+                    "mrr": 0.85,  # +13.3%
+                },
+                "detailed_results": [],
+            }
+
+            comparison = evaluator.compare_engines(baseline_results, hybrid_results)
+
+            assert comparison["improvements"]["recall@1"]["absolute_diff"] == 0.10
+            assert comparison["improvements"]["recall@1"]["relative_improvement_pct"] == pytest.approx(12.5)
+
+    def test_compare_engines_failure_rate_improvement(self):
+        """Test failure rate improvement (lower is better)."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({}, f)
+            f.flush()
+
+            evaluator = SearchEvaluator(f.name)
+
+            baseline_results = {
+                "metrics": {"failure_rate": 0.20},
+                "detailed_results": [],
+            }
+
+            hybrid_results = {
+                "metrics": {"failure_rate": 0.10},  # 50% reduction
+                "detailed_results": [],
+            }
+
+            comparison = evaluator.compare_engines(baseline_results, hybrid_results)
+
+            # For failure rate, improvement is (baseline - hybrid) / baseline
+            assert comparison["improvements"]["failure_rate"]["relative_improvement_pct"] == 50.0

--- a/tests/unit/test_filter_extractor.py
+++ b/tests/unit/test_filter_extractor.py
@@ -1,0 +1,387 @@
+"""Unit tests for telegram_bot/services/filter_extractor.py."""
+
+import pytest
+
+from telegram_bot.services.filter_extractor import FilterExtractor
+
+
+class TestFilterExtractorInit:
+    """Test FilterExtractor initialization."""
+
+    def test_can_create_instance(self):
+        """Test that FilterExtractor can be instantiated."""
+        extractor = FilterExtractor()
+        assert extractor is not None
+
+
+class TestExtractPrice:
+    """Test price extraction."""
+
+    def test_extract_price_less_than(self):
+        """Test extracting 'less than' price filter."""
+        extractor = FilterExtractor()
+
+        queries = [
+            ("дешевле 100000", {"lt": 100000}),
+            ("до 80000 евро", {"lt": 80000}),
+            ("меньше 150000", {"lt": 150000}),
+            ("< 120000", {"lt": 120000}),
+            ("не дороже 90000", {"lt": 90000}),
+        ]
+
+        for query, expected in queries:
+            result = extractor._extract_price(query)
+            assert result == expected, f"Failed for query: {query}"
+
+    def test_extract_price_greater_than(self):
+        """Test extracting 'greater than' price filter."""
+        extractor = FilterExtractor()
+
+        queries = [
+            ("дороже 100000", {"gt": 100000}),
+            ("от 80000", {"gt": 80000}),
+            ("больше 50000", {"gt": 50000}),
+            ("> 70000", {"gt": 70000}),
+        ]
+
+        for query, expected in queries:
+            result = extractor._extract_price(query)
+            assert result == expected, f"Failed for query: {query}"
+
+    def test_extract_price_range(self):
+        """Test extracting price range filter."""
+        extractor = FilterExtractor()
+
+        result = extractor._extract_price("от 80000 до 150000 евро")
+        assert result == {"gte": 80000, "lte": 150000}
+
+    def test_extract_price_with_k_suffix(self):
+        """Test extracting price with 'k' suffix."""
+        extractor = FilterExtractor()
+
+        result = extractor._extract_price("до 100к")
+        assert result == {"lt": 100000}
+
+    def test_extract_price_with_spaces(self):
+        """Test extracting price with space formatting."""
+        extractor = FilterExtractor()
+
+        result = extractor._extract_price("дешевле 100 000")
+        assert result == {"lt": 100000}
+
+    def test_extract_price_no_price(self):
+        """Test query without price returns None."""
+        extractor = FilterExtractor()
+
+        result = extractor._extract_price("квартира в Несебр")
+        assert result is None
+
+
+class TestExtractRooms:
+    """Test rooms extraction."""
+
+    def test_extract_rooms_digit(self):
+        """Test extracting rooms with digit."""
+        extractor = FilterExtractor()
+
+        queries = [
+            ("3 комнаты", 3),
+            ("2-комнатная квартира", 2),
+            ("4 комнатная", 4),
+        ]
+
+        for query, expected in queries:
+            result = extractor._extract_rooms(query)
+            assert result == expected, f"Failed for query: {query}"
+
+    def test_extract_rooms_word(self):
+        """Test extracting rooms with word."""
+        extractor = FilterExtractor()
+
+        queries = [
+            ("однокомнатная", 1),
+            ("двукомнатная", 2),
+            ("трехкомнатная", 3),
+            ("четырехкомнатная", 4),
+        ]
+
+        for query, expected in queries:
+            result = extractor._extract_rooms(query)
+            assert result == expected, f"Failed for query: {query}"
+
+    def test_extract_rooms_studio(self):
+        """Test extracting studio as 1 room."""
+        extractor = FilterExtractor()
+
+        result = extractor._extract_rooms("студия в центре")
+        assert result == 1
+
+    def test_extract_rooms_none(self):
+        """Test query without rooms returns None."""
+        extractor = FilterExtractor()
+
+        result = extractor._extract_rooms("квартира дешевле 100000")
+        assert result is None
+
+
+class TestExtractCity:
+    """Test city extraction."""
+
+    def test_extract_known_cities(self):
+        """Test extracting known cities."""
+        extractor = FilterExtractor()
+
+        cities = [
+            ("в Солнечный берег", "Солнечный берег"),
+            ("квартиры в Несебр", "Несебр"),
+            ("в центре Бургас", "Бургас"),
+            ("Варна недорого", "Варна"),
+            ("в Поморие", "Поморие"),
+            ("Созополь", "Созополь"),
+        ]
+
+        for query, expected in cities:
+            result = extractor._extract_city(query)
+            assert result == expected, f"Failed for query: {query}"
+
+    def test_extract_city_case_insensitive(self):
+        """Test that city extraction is case insensitive."""
+        extractor = FilterExtractor()
+
+        result = extractor._extract_city("в НЕСЕБР")
+        assert result == "Несебр"
+
+    def test_extract_city_none(self):
+        """Test query without known city returns None."""
+        extractor = FilterExtractor()
+
+        result = extractor._extract_city("квартира дешевле 100000")
+        assert result is None
+
+
+class TestExtractArea:
+    """Test area extraction."""
+
+    def test_extract_area_greater_than(self):
+        """Test extracting 'greater than' area filter."""
+        extractor = FilterExtractor()
+
+        queries = [
+            ("больше 50 м2", {"gte": 50}),
+            ("от 60 кв.м", {"gte": 60}),
+        ]
+
+        for query, expected in queries:
+            result = extractor._extract_area(query)
+            assert result == expected, f"Failed for query: {query}"
+
+    def test_extract_area_less_than(self):
+        """Test extracting 'less than' area filter."""
+        extractor = FilterExtractor()
+
+        queries = [
+            ("меньше 100 м2", {"lte": 100}),
+            ("до 80 кв.м", {"lte": 80}),
+        ]
+
+        for query, expected in queries:
+            result = extractor._extract_area(query)
+            assert result == expected, f"Failed for query: {query}"
+
+
+class TestExtractFloor:
+    """Test floor extraction."""
+
+    def test_extract_floor(self):
+        """Test extracting floor number."""
+        extractor = FilterExtractor()
+
+        queries = [
+            ("4 этаж", 4),
+            ("на 3 этаже", 3),
+            ("5 этаж", 5),
+        ]
+
+        for query, expected in queries:
+            result = extractor._extract_floor(query)
+            assert result == expected, f"Failed for query: {query}"
+
+
+class TestExtractDistanceToSea:
+    """Test distance to sea extraction."""
+
+    def test_extract_distance_meters(self):
+        """Test extracting distance in meters."""
+        extractor = FilterExtractor()
+
+        queries = [
+            ("до 500м до моря", {"lte": 500}),
+            ("не дальше 600 метров", {"lte": 600}),
+            ("в 400м от моря", {"lte": 400}),
+        ]
+
+        for query, expected in queries:
+            result = extractor._extract_distance_to_sea(query)
+            assert result == expected, f"Failed for query: {query}"
+
+    def test_extract_distance_first_line(self):
+        """Test extracting 'first line' as close distance."""
+        extractor = FilterExtractor()
+
+        result = extractor._extract_distance_to_sea("первая линия")
+        assert result == {"lte": 200}
+
+    def test_extract_distance_near_sea(self):
+        """Test extracting 'near sea' as close distance."""
+        extractor = FilterExtractor()
+
+        result = extractor._extract_distance_to_sea("у моря")
+        assert result == {"lte": 200}
+
+
+class TestExtractMaintenance:
+    """Test maintenance cost extraction."""
+
+    def test_extract_maintenance_specific(self):
+        """Test extracting specific maintenance cost."""
+        extractor = FilterExtractor()
+
+        result = extractor._extract_maintenance("поддержка до 10 евро")
+        assert result == {"lte": 10.0}
+
+    def test_extract_maintenance_low(self):
+        """Test extracting 'low maintenance' as default value."""
+        extractor = FilterExtractor()
+
+        result = extractor._extract_maintenance("низкая поддержка")
+        assert result == {"lte": 12.0}
+
+
+class TestExtractBathrooms:
+    """Test bathrooms extraction."""
+
+    def test_extract_bathrooms_digit(self):
+        """Test extracting bathrooms with digit."""
+        extractor = FilterExtractor()
+
+        result = extractor._extract_bathrooms("2 санузла")
+        assert result == 2
+
+    def test_extract_bathrooms_word(self):
+        """Test extracting bathrooms with word."""
+        extractor = FilterExtractor()
+
+        queries = [
+            ("один санузел", 1),
+            ("два санузла", 2),
+            ("три санузла", 3),
+        ]
+
+        for query, expected in queries:
+            result = extractor._extract_bathrooms(query)
+            assert result == expected, f"Failed for query: {query}"
+
+
+class TestExtractFurniture:
+    """Test furniture extraction."""
+
+    def test_extract_furniture_present(self):
+        """Test extracting furniture requirement."""
+        extractor = FilterExtractor()
+
+        queries = [
+            "с мебелью",
+            "меблированная квартира",
+            "обставленная",
+        ]
+
+        for query in queries:
+            result = extractor._extract_furniture(query)
+            assert result == "Есть", f"Failed for query: {query}"
+
+    def test_extract_furniture_not_mentioned(self):
+        """Test query without furniture returns None."""
+        extractor = FilterExtractor()
+
+        result = extractor._extract_furniture("квартира в Несебр")
+        assert result is None
+
+
+class TestExtractYearRound:
+    """Test year-round extraction."""
+
+    def test_extract_year_round_present(self):
+        """Test extracting year-round requirement."""
+        extractor = FilterExtractor()
+
+        queries = [
+            "круглогодичная",
+            "круглый год",
+            "зимой можно жить",
+        ]
+
+        for query in queries:
+            result = extractor._extract_year_round(query)
+            assert result == "Да", f"Failed for query: {query}"
+
+
+class TestExtractFilters:
+    """Test full filter extraction."""
+
+    def test_extract_all_filters(self):
+        """Test extracting all filters from complex query."""
+        extractor = FilterExtractor()
+
+        query = "2-комнатная в Солнечный берег дешевле 100000 до 500м от моря"
+        result = extractor.extract_filters(query)
+
+        assert result["rooms"] == 2
+        assert result["city"] == "Солнечный берег"
+        assert result["price"] == {"lt": 100000}
+        assert result["distance_to_sea"] == {"lte": 500}
+
+    def test_extract_filters_empty(self):
+        """Test query with no extractable filters."""
+        extractor = FilterExtractor()
+
+        result = extractor.extract_filters("покажи что-нибудь интересное")
+
+        assert result == {}
+
+    def test_extract_filters_partial(self):
+        """Test query with some filters."""
+        extractor = FilterExtractor()
+
+        result = extractor.extract_filters("студия в Варна")
+
+        assert result["rooms"] == 1
+        assert result["city"] == "Варна"
+        assert "price" not in result
+
+
+class TestParseNumber:
+    """Test number parsing helper."""
+
+    def test_parse_simple_number(self):
+        """Test parsing simple number."""
+        extractor = FilterExtractor()
+
+        assert extractor._parse_number("100000") == 100000
+
+    def test_parse_number_with_spaces(self):
+        """Test parsing number with spaces."""
+        extractor = FilterExtractor()
+
+        assert extractor._parse_number("100 000") == 100000
+
+    def test_parse_number_with_k_suffix(self):
+        """Test parsing number with k suffix."""
+        extractor = FilterExtractor()
+
+        assert extractor._parse_number("100к") == 100000
+
+    def test_parse_invalid_number(self):
+        """Test parsing invalid number returns None."""
+        extractor = FilterExtractor()
+
+        assert extractor._parse_number("abc") is None

--- a/tests/unit/test_indexer.py
+++ b/tests/unit/test_indexer.py
@@ -1,0 +1,292 @@
+"""Unit tests for src/ingestion/indexer.py."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.ingestion.chunker import Chunk
+from src.ingestion.indexer import DocumentIndexer, IndexStats
+
+
+class TestIndexStats:
+    """Test IndexStats dataclass."""
+
+    def test_index_stats_defaults(self):
+        """Test IndexStats default values."""
+        stats = IndexStats()
+
+        assert stats.total_chunks == 0
+        assert stats.indexed_chunks == 0
+        assert stats.failed_chunks == 0
+        assert stats.total_tokens == 0
+        assert stats.total_cost == 0.0
+        assert stats.duration_seconds == 0.0
+
+    def test_index_stats_custom_values(self):
+        """Test IndexStats with custom values."""
+        stats = IndexStats(
+            total_chunks=100,
+            indexed_chunks=95,
+            failed_chunks=5,
+            duration_seconds=30.5,
+        )
+
+        assert stats.total_chunks == 100
+        assert stats.indexed_chunks == 95
+        assert stats.failed_chunks == 5
+        assert stats.duration_seconds == 30.5
+
+
+class TestDocumentIndexerInit:
+    """Test DocumentIndexer initialization."""
+
+    @patch("src.ingestion.indexer.get_bge_m3_model")
+    @patch("src.ingestion.indexer.QdrantClient")
+    @patch("src.ingestion.indexer.Settings")
+    def test_init_creates_client(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test that initialization creates Qdrant client."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings.qdrant_api_key = "test-key"
+        mock_settings_cls.return_value = mock_settings
+
+        indexer = DocumentIndexer(mock_settings)
+
+        mock_qdrant.assert_called_once_with(
+            "http://localhost:6333",
+            api_key="test-key",
+            timeout=120,
+        )
+
+    @patch("src.ingestion.indexer.get_bge_m3_model")
+    @patch("src.ingestion.indexer.QdrantClient")
+    @patch("src.ingestion.indexer.Settings")
+    def test_init_loads_embedding_model(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test that initialization loads BGE-M3 model."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings_cls.return_value = mock_settings
+
+        DocumentIndexer(mock_settings)
+
+        mock_bge.assert_called_once_with(use_fp16=True)
+
+
+class TestCreateCollection:
+    """Test collection creation."""
+
+    @patch("src.ingestion.indexer.get_bge_m3_model")
+    @patch("src.ingestion.indexer.QdrantClient")
+    @patch("src.ingestion.indexer.Settings")
+    def test_create_collection_new(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test creating a new collection."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings_cls.return_value = mock_settings
+
+        mock_client = MagicMock()
+        mock_client.get_collection.side_effect = Exception("Not found")
+        mock_qdrant.return_value = mock_client
+
+        indexer = DocumentIndexer(mock_settings)
+        result = indexer.create_collection("test_collection")
+
+        assert result is True
+        mock_client.create_collection.assert_called_once()
+
+    @patch("src.ingestion.indexer.get_bge_m3_model")
+    @patch("src.ingestion.indexer.QdrantClient")
+    @patch("src.ingestion.indexer.Settings")
+    def test_create_collection_exists_no_recreate(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test existing collection without recreate flag."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings_cls.return_value = mock_settings
+
+        mock_client = MagicMock()
+        mock_client.get_collection.return_value = MagicMock()  # Collection exists
+        mock_qdrant.return_value = mock_client
+
+        indexer = DocumentIndexer(mock_settings)
+        result = indexer.create_collection("test_collection", recreate=False)
+
+        assert result is True
+        mock_client.create_collection.assert_not_called()
+        mock_client.delete_collection.assert_not_called()
+
+    @patch("src.ingestion.indexer.get_bge_m3_model")
+    @patch("src.ingestion.indexer.QdrantClient")
+    @patch("src.ingestion.indexer.Settings")
+    def test_create_collection_exists_with_recreate(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test existing collection with recreate flag."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings_cls.return_value = mock_settings
+
+        mock_client = MagicMock()
+        mock_client.get_collection.return_value = MagicMock()  # Collection exists
+        mock_qdrant.return_value = mock_client
+
+        indexer = DocumentIndexer(mock_settings)
+        result = indexer.create_collection("test_collection", recreate=True)
+
+        assert result is True
+        mock_client.delete_collection.assert_called_once_with("test_collection")
+        mock_client.create_collection.assert_called_once()
+
+
+class TestCreatePayloadIndexes:
+    """Test payload index creation."""
+
+    @patch("src.ingestion.indexer.get_bge_m3_model")
+    @patch("src.ingestion.indexer.QdrantClient")
+    @patch("src.ingestion.indexer.Settings")
+    def test_creates_keyword_indexes(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test that keyword indexes are created."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings_cls.return_value = mock_settings
+
+        mock_client = MagicMock()
+        mock_qdrant.return_value = mock_client
+
+        indexer = DocumentIndexer(mock_settings)
+        indexer._create_payload_indexes("test_collection")
+
+        # Should create keyword indexes for text fields
+        keyword_calls = [
+            call
+            for call in mock_client.create_payload_index.call_args_list
+            if call[1].get("field_schema") == "keyword"
+        ]
+        assert len(keyword_calls) >= 4  # article_number, document_name, city, source_type
+
+    @patch("src.ingestion.indexer.get_bge_m3_model")
+    @patch("src.ingestion.indexer.QdrantClient")
+    @patch("src.ingestion.indexer.Settings")
+    def test_creates_integer_indexes(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test that integer indexes are created for numeric fields."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings_cls.return_value = mock_settings
+
+        mock_client = MagicMock()
+        mock_qdrant.return_value = mock_client
+
+        indexer = DocumentIndexer(mock_settings)
+        indexer._create_payload_indexes("test_collection")
+
+        # Should create integer indexes for numeric fields
+        integer_calls = [
+            call
+            for call in mock_client.create_payload_index.call_args_list
+            if call[1].get("field_schema") == "integer"
+        ]
+        # price, rooms, area, floor, floors, distance_to_sea, bathrooms
+        assert len(integer_calls) == 7
+
+    @patch("src.ingestion.indexer.get_bge_m3_model")
+    @patch("src.ingestion.indexer.QdrantClient")
+    @patch("src.ingestion.indexer.Settings")
+    def test_creates_bool_indexes(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test that boolean indexes are created."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings_cls.return_value = mock_settings
+
+        mock_client = MagicMock()
+        mock_qdrant.return_value = mock_client
+
+        indexer = DocumentIndexer(mock_settings)
+        indexer._create_payload_indexes("test_collection")
+
+        # Should create bool indexes for furnished, year_round
+        bool_calls = [
+            call
+            for call in mock_client.create_payload_index.call_args_list
+            if call[1].get("field_schema") == "bool"
+        ]
+        assert len(bool_calls) == 2
+
+
+class TestIndexChunks:
+    """Test chunk indexing."""
+
+    @pytest.mark.asyncio
+    @patch("src.ingestion.indexer.get_bge_m3_model")
+    @patch("src.ingestion.indexer.QdrantClient")
+    @patch("src.ingestion.indexer.Settings")
+    async def test_index_chunks_returns_stats(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test that index_chunks returns IndexStats."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings.batch_size_documents = 16
+        mock_settings_cls.return_value = mock_settings
+
+        mock_client = MagicMock()
+        mock_client.get_collection.side_effect = Exception("Not found")
+        mock_qdrant.return_value = mock_client
+
+        mock_model = MagicMock()
+        mock_bge.return_value = mock_model
+
+        indexer = DocumentIndexer(mock_settings)
+
+        # Mock _index_batch to avoid actual embedding
+        with patch.object(indexer, "_index_batch") as mock_index_batch:
+            chunks = [
+                Chunk(text="Text 1", chunk_id=0, document_name="doc.pdf", article_number="1"),
+                Chunk(text="Text 2", chunk_id=1, document_name="doc.pdf", article_number="2"),
+            ]
+
+            stats = await indexer.index_chunks(chunks, "test_collection")
+
+            assert isinstance(stats, IndexStats)
+            assert stats.total_chunks == 2
+
+
+class TestGetCollectionStats:
+    """Test collection statistics retrieval."""
+
+    @patch("src.ingestion.indexer.get_bge_m3_model")
+    @patch("src.ingestion.indexer.QdrantClient")
+    @patch("src.ingestion.indexer.Settings")
+    def test_get_collection_stats_success(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test successful stats retrieval."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings_cls.return_value = mock_settings
+
+        mock_info = MagicMock()
+        mock_info.points_count = 100
+        mock_info.vectors_count = 300  # 3 vectors per point
+        mock_info.indexed_vectors_count = 300
+
+        mock_client = MagicMock()
+        mock_client.get_collection.return_value = mock_info
+        mock_qdrant.return_value = mock_client
+
+        indexer = DocumentIndexer(mock_settings)
+        stats = indexer.get_collection_stats("test_collection")
+
+        assert stats["name"] == "test_collection"
+        assert stats["points_count"] == 100
+        assert stats["vectors_count"] == 300
+
+    @patch("src.ingestion.indexer.get_bge_m3_model")
+    @patch("src.ingestion.indexer.QdrantClient")
+    @patch("src.ingestion.indexer.Settings")
+    def test_get_collection_stats_error(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test stats retrieval on error returns empty dict."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings_cls.return_value = mock_settings
+
+        mock_client = MagicMock()
+        mock_client.get_collection.side_effect = Exception("Not found")
+        mock_qdrant.return_value = mock_client
+
+        indexer = DocumentIndexer(mock_settings)
+        stats = indexer.get_collection_stats("nonexistent")
+
+        assert stats == {}

--- a/tests/unit/test_llm_service.py
+++ b/tests/unit/test_llm_service.py
@@ -1,0 +1,323 @@
+"""Unit tests for telegram_bot/services/llm.py."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from telegram_bot.services.llm import LLMService
+
+
+class TestLLMServiceInit:
+    """Test LLMService initialization."""
+
+    def test_init_defaults(self):
+        """Test initialization with default values."""
+        service = LLMService(api_key="test-key")
+
+        assert service.api_key == "test-key"
+        assert service.base_url == "https://api.openai.com/v1"
+        assert service.model == "gpt-4o-mini"
+
+    def test_init_custom_values(self):
+        """Test initialization with custom values."""
+        service = LLMService(
+            api_key="custom-key",
+            base_url="https://custom.api.com/v1/",
+            model="custom-model",
+        )
+
+        assert service.api_key == "custom-key"
+        assert service.base_url == "https://custom.api.com/v1"  # Trailing slash removed
+        assert service.model == "custom-model"
+
+    def test_init_creates_http_client(self):
+        """Test that HTTP client is created."""
+        service = LLMService(api_key="test-key")
+
+        assert service.client is not None
+        assert isinstance(service.client, httpx.AsyncClient)
+
+
+class TestFormatContext:
+    """Test context formatting."""
+
+    def test_format_context_empty(self):
+        """Test formatting with empty chunks."""
+        service = LLMService(api_key="test-key")
+
+        result = service._format_context([])
+
+        assert result == "Релевантной информации не найдено."
+
+    def test_format_context_single_chunk(self):
+        """Test formatting with single chunk."""
+        service = LLMService(api_key="test-key")
+
+        chunks = [
+            {
+                "text": "Sample apartment text",
+                "metadata": {"title": "Apartment 1", "city": "Varna", "price": 50000},
+                "score": 0.95,
+            }
+        ]
+
+        result = service._format_context(chunks)
+
+        assert "[Объект 1]" in result
+        assert "релевантность: 0.95" in result
+        assert "Название: Apartment 1" in result
+        assert "Город: Varna" in result
+        assert "50,000€" in result
+        assert "Sample apartment text" in result
+
+    def test_format_context_multiple_chunks(self):
+        """Test formatting with multiple chunks."""
+        service = LLMService(api_key="test-key")
+
+        chunks = [
+            {"text": "Text 1", "metadata": {}, "score": 0.9},
+            {"text": "Text 2", "metadata": {}, "score": 0.8},
+        ]
+
+        result = service._format_context(chunks)
+
+        assert "[Объект 1]" in result
+        assert "[Объект 2]" in result
+        assert "---" in result  # Separator
+
+    def test_format_context_minimal_metadata(self):
+        """Test formatting with minimal metadata."""
+        service = LLMService(api_key="test-key")
+
+        chunks = [{"text": "Just text", "score": 0.75}]
+
+        result = service._format_context(chunks)
+
+        assert "Just text" in result
+        assert "релевантность: 0.75" in result
+
+
+class TestGetFallbackAnswer:
+    """Test fallback answer generation."""
+
+    def test_fallback_no_chunks(self):
+        """Test fallback with no chunks."""
+        service = LLMService(api_key="test-key")
+
+        result = service._get_fallback_answer("query", [])
+
+        assert "⚠️" in result
+        assert "Извините" in result
+        assert "недоступен" in result
+
+    def test_fallback_with_chunks(self):
+        """Test fallback with chunks returns formatted results."""
+        service = LLMService(api_key="test-key")
+
+        chunks = [
+            {
+                "text": "Apt 1",
+                "metadata": {"title": "Nice apartment", "price": 45000, "city": "Burgas", "rooms": 2},
+            },
+            {
+                "text": "Apt 2",
+                "metadata": {"title": "Beach view", "price": 75000, "city": "Nesebar"},
+            },
+        ]
+
+        result = service._get_fallback_answer("query", chunks)
+
+        assert "⚠️" in result
+        assert "Nice apartment" in result
+        assert "45,000€" in result
+        assert "Burgas" in result
+        assert "Beach view" in result
+
+    def test_fallback_limits_to_three_chunks(self):
+        """Test that fallback only shows 3 chunks."""
+        service = LLMService(api_key="test-key")
+
+        chunks = [
+            {"text": f"Chunk {i}", "metadata": {"title": f"Title {i}"}} for i in range(5)
+        ]
+
+        result = service._get_fallback_answer("query", chunks)
+
+        assert "Title 0" in result
+        assert "Title 1" in result
+        assert "Title 2" in result
+        assert "Title 3" not in result  # Should be excluded
+
+    def test_fallback_handles_non_numeric_price(self):
+        """Test fallback handles string price."""
+        service = LLMService(api_key="test-key")
+
+        chunks = [{"text": "Text", "metadata": {"price": "negotiable"}}]
+
+        result = service._get_fallback_answer("query", chunks)
+
+        assert "negotiable€" in result
+
+
+class TestGenerateAnswer:
+    """Test answer generation."""
+
+    @pytest.mark.asyncio
+    async def test_generate_answer_success(self):
+        """Test successful answer generation."""
+        service = LLMService(api_key="test-key")
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "Generated answer"}}]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(service.client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+
+            result = await service.generate_answer(
+                question="What apartments?",
+                context_chunks=[{"text": "Some context", "score": 0.9}],
+            )
+
+            assert result == "Generated answer"
+
+    @pytest.mark.asyncio
+    async def test_generate_answer_timeout(self):
+        """Test timeout returns fallback."""
+        service = LLMService(api_key="test-key")
+
+        with patch.object(service.client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.side_effect = httpx.TimeoutException("Timeout")
+
+            result = await service.generate_answer(
+                question="What apartments?",
+                context_chunks=[{"text": "Context", "metadata": {"title": "Apt"}}],
+            )
+
+            assert "⚠️" in result
+            assert "Apt" in result
+
+    @pytest.mark.asyncio
+    async def test_generate_answer_http_error(self):
+        """Test HTTP error returns fallback."""
+        service = LLMService(api_key="test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+
+        with patch.object(service.client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.side_effect = httpx.HTTPStatusError(
+                "Error", request=MagicMock(), response=mock_response
+            )
+
+            result = await service.generate_answer(
+                question="What?",
+                context_chunks=[],
+            )
+
+            assert "⚠️" in result
+
+    @pytest.mark.asyncio
+    async def test_generate_answer_custom_system_prompt(self):
+        """Test using custom system prompt."""
+        service = LLMService(api_key="test-key")
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"choices": [{"message": {"content": "Answer"}}]}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(service.client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+
+            await service.generate_answer(
+                question="Q?",
+                context_chunks=[],
+                system_prompt="Custom prompt",
+            )
+
+            # Verify the custom prompt was used
+            call_args = mock_post.call_args
+            json_data = call_args[1]["json"]
+            assert json_data["messages"][0]["content"] == "Custom prompt"
+
+
+class TestGenerate:
+    """Test simple text generation."""
+
+    @pytest.mark.asyncio
+    async def test_generate_success(self):
+        """Test successful text generation."""
+        service = LLMService(api_key="test-key")
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"choices": [{"message": {"content": "Result"}}]}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(service.client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+
+            result = await service.generate("Test prompt")
+
+            assert result == "Result"
+
+    @pytest.mark.asyncio
+    async def test_generate_uses_low_temperature(self):
+        """Test that generate uses low temperature (0.3)."""
+        service = LLMService(api_key="test-key")
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"choices": [{"message": {"content": "Result"}}]}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(service.client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+
+            await service.generate("Prompt")
+
+            json_data = mock_post.call_args[1]["json"]
+            assert json_data["temperature"] == 0.3
+
+    @pytest.mark.asyncio
+    async def test_generate_custom_max_tokens(self):
+        """Test generate with custom max_tokens."""
+        service = LLMService(api_key="test-key")
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"choices": [{"message": {"content": "Result"}}]}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(service.client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+
+            await service.generate("Prompt", max_tokens=500)
+
+            json_data = mock_post.call_args[1]["json"]
+            assert json_data["max_tokens"] == 500
+
+    @pytest.mark.asyncio
+    async def test_generate_raises_on_error(self):
+        """Test that generate raises exceptions (doesn't use fallback)."""
+        service = LLMService(api_key="test-key")
+
+        with patch.object(service.client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.side_effect = Exception("API Error")
+
+            with pytest.raises(Exception):
+                await service.generate("Prompt")
+
+
+class TestClose:
+    """Test client closing."""
+
+    @pytest.mark.asyncio
+    async def test_close_closes_client(self):
+        """Test that close() closes the HTTP client."""
+        service = LLMService(api_key="test-key")
+
+        with patch.object(service.client, "aclose", new_callable=AsyncMock) as mock_close:
+            await service.close()
+
+            mock_close.assert_called_once()

--- a/tests/unit/test_metrics_logger.py
+++ b/tests/unit/test_metrics_logger.py
@@ -1,0 +1,283 @@
+"""Unit tests for src/evaluation/metrics_logger.py."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestQueryMetrics:
+    """Test QueryMetrics dataclass."""
+
+    def test_query_metrics_creation(self):
+        """Test QueryMetrics creation with all fields."""
+        from src.evaluation.metrics_logger import QueryMetrics
+
+        with patch("src.evaluation.metrics_logger.get_config_hash", return_value="abc123"):
+            metrics = QueryMetrics(
+                query_id="test_1",
+                engine="hybrid",
+                latency_ms=450.0,
+                precision_at_1=1.0,
+                recall_at_10=1.0,
+                num_results=10,
+                config_hash="abc123",
+            )
+
+            assert metrics.query_id == "test_1"
+            assert metrics.engine == "hybrid"
+            assert metrics.latency_ms == 450.0
+            assert metrics.precision_at_1 == 1.0
+            assert metrics.user_id == "anonymous"
+
+    def test_query_metrics_to_dict(self):
+        """Test QueryMetrics serialization to dict."""
+        from src.evaluation.metrics_logger import QueryMetrics
+
+        metrics = QueryMetrics(
+            query_id="test_1",
+            engine="hybrid",
+            latency_ms=450.0,
+            precision_at_1=1.0,
+            recall_at_10=1.0,
+            num_results=10,
+            config_hash="abc123",
+        )
+
+        data = metrics.to_dict()
+
+        assert data["query_id"] == "test_1"
+        assert data["engine"] == "hybrid"
+        assert "timestamp" in data
+
+    def test_query_metrics_to_json(self):
+        """Test QueryMetrics serialization to JSON."""
+        from src.evaluation.metrics_logger import QueryMetrics
+
+        metrics = QueryMetrics(
+            query_id="test_1",
+            engine="hybrid",
+            latency_ms=450.0,
+            precision_at_1=1.0,
+            recall_at_10=1.0,
+            num_results=10,
+            config_hash="abc123",
+        )
+
+        json_str = metrics.to_json()
+        parsed = json.loads(json_str)
+
+        assert parsed["query_id"] == "test_1"
+
+    def test_query_metrics_to_prometheus(self):
+        """Test QueryMetrics Prometheus format export."""
+        from src.evaluation.metrics_logger import QueryMetrics
+
+        metrics = QueryMetrics(
+            query_id="test_1",
+            engine="hybrid",
+            latency_ms=450.0,
+            precision_at_1=1.0,
+            recall_at_10=1.0,
+            num_results=10,
+            config_hash="abc123",
+        )
+
+        prom_str = metrics.to_prometheus()
+
+        assert "rag_query_latency_ms" in prom_str
+        assert 'engine="hybrid"' in prom_str
+        assert "450.0" in prom_str
+
+
+class TestMetricsLogger:
+    """Test MetricsLogger class."""
+
+    def test_logger_init_creates_directory(self):
+        """Test that logger creates log directory on init."""
+        from src.evaluation.metrics_logger import MetricsLogger
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_dir = Path(tmpdir) / "logs"
+
+            with patch("src.evaluation.metrics_logger.get_config_hash", return_value="abc"):
+                logger = MetricsLogger(log_dir=str(log_dir))
+
+            assert log_dir.exists()
+
+    def test_logger_log_query(self):
+        """Test logging a query."""
+        from src.evaluation.metrics_logger import MetricsLogger
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("src.evaluation.metrics_logger.get_config_hash", return_value="abc"):
+                logger = MetricsLogger(log_dir=tmpdir)
+
+                metrics = logger.log_query(
+                    query="test query",
+                    engine="hybrid",
+                    latency_ms=450.0,
+                    precision_at_1=1.0,
+                )
+
+                assert metrics.engine == "hybrid"
+                assert metrics.latency_ms == 450.0
+                assert len(logger.metrics_buffer) == 1
+
+    def test_logger_aggregates_stats(self):
+        """Test that logger aggregates statistics by engine."""
+        from src.evaluation.metrics_logger import MetricsLogger
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("src.evaluation.metrics_logger.get_config_hash", return_value="abc"):
+                logger = MetricsLogger(log_dir=tmpdir)
+
+                # Log multiple queries
+                logger.log_query("q1", "hybrid", 400.0, 1.0)
+                logger.log_query("q2", "hybrid", 500.0, 1.0)
+                logger.log_query("q3", "baseline", 300.0, 0.0)
+
+                assert len(logger.aggregated_stats["hybrid"]["latency_ms"]) == 2
+                assert len(logger.aggregated_stats["baseline"]["latency_ms"]) == 1
+
+    def test_logger_writes_json_log(self):
+        """Test that logger writes JSON log files."""
+        from src.evaluation.metrics_logger import MetricsLogger
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("src.evaluation.metrics_logger.get_config_hash", return_value="abc"):
+                logger = MetricsLogger(log_dir=tmpdir)
+
+                logger.log_query("q1", "hybrid", 400.0, 1.0)
+
+                # Check that a log file was created
+                log_files = list(Path(tmpdir).glob("metrics_*.jsonl"))
+                assert len(log_files) == 1
+
+                # Verify content
+                content = log_files[0].read_text()
+                assert "hybrid" in content
+
+    def test_logger_export_prometheus(self):
+        """Test Prometheus metrics export."""
+        from src.evaluation.metrics_logger import MetricsLogger
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("src.evaluation.metrics_logger.get_config_hash", return_value="abc"):
+                logger = MetricsLogger(log_dir=tmpdir)
+
+                logger.log_query("q1", "hybrid", 400.0, 1.0)
+                logger.log_query("q2", "hybrid", 500.0, 1.0)
+
+                prom_export = logger.export_prometheus()
+
+                assert "rag_queries_total" in prom_export
+                assert "rag_latency_ms" in prom_export
+                assert "hybrid" in prom_export
+
+    def test_logger_get_summary(self):
+        """Test summary statistics."""
+        from src.evaluation.metrics_logger import MetricsLogger
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("src.evaluation.metrics_logger.get_config_hash", return_value="abc"):
+                logger = MetricsLogger(log_dir=tmpdir)
+
+                # Log 10 queries for percentile calculation
+                for i in range(10):
+                    logger.log_query(f"q{i}", "hybrid", 400.0 + i * 10, 1.0)
+
+                summary = logger.get_summary()
+
+                assert "hybrid" in summary
+                assert summary["hybrid"]["total_queries"] == 10
+                assert "latency_p50_ms" in summary["hybrid"]
+                assert "precision_at_1" in summary["hybrid"]
+
+
+class TestSLOTracking:
+    """Test SLO (Service Level Objective) tracking."""
+
+    def test_slo_thresholds_defaults(self):
+        """Test default SLO threshold values."""
+        from src.evaluation.metrics_logger import MetricsLogger
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("src.evaluation.metrics_logger.get_config_hash", return_value="abc"):
+                logger = MetricsLogger(log_dir=tmpdir)
+
+                assert logger.slo_thresholds["p50_latency_ms"] == 400
+                assert logger.slo_thresholds["p95_latency_ms"] == 800
+                assert logger.slo_thresholds["precision_at_1_min"] == 0.90
+
+    def test_slo_violation_count(self):
+        """Test SLO violation counting."""
+        from src.evaluation.metrics_logger import MetricsLogger
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("src.evaluation.metrics_logger.get_config_hash", return_value="abc"):
+                logger = MetricsLogger(log_dir=tmpdir)
+
+                # Log queries with poor latency
+                for i in range(10):
+                    logger.log_query(f"q{i}", "slow_engine", 2000.0, 1.0)  # Very slow
+
+                violations = logger._count_slo_violations("slow_engine")
+
+                assert violations >= 1  # At least latency SLO violated
+
+
+class TestAnomalyDetection:
+    """Test anomaly detection functionality."""
+
+    def test_latency_anomaly_logged(self):
+        """Test that latency anomalies are logged."""
+        from src.evaluation.metrics_logger import MetricsLogger
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("src.evaluation.metrics_logger.get_config_hash", return_value="abc"):
+                logger = MetricsLogger(log_dir=tmpdir)
+
+                # Log query with anomalous latency (> p99 threshold)
+                logger.log_query("q1", "hybrid", 5000.0, 1.0)
+
+                # Check anomaly log exists
+                anomaly_log = Path(tmpdir) / "anomalies.log"
+                assert anomaly_log.exists()
+                assert "LATENCY ANOMALY" in anomaly_log.read_text()
+
+    def test_quality_anomaly_logged(self):
+        """Test that quality anomalies are logged."""
+        from src.evaluation.metrics_logger import MetricsLogger
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("src.evaluation.metrics_logger.get_config_hash", return_value="abc"):
+                logger = MetricsLogger(log_dir=tmpdir)
+                # Override threshold to trigger anomaly
+                logger.slo_thresholds["precision_at_1_min"] = 1.0
+
+                # Log query with low precision
+                logger.log_query("q1", "hybrid", 400.0, 0.5)
+
+                # Check anomaly log exists
+                anomaly_log = Path(tmpdir) / "anomalies.log"
+                assert anomaly_log.exists()
+                assert "QUALITY ANOMALY" in anomaly_log.read_text()
+
+    def test_zero_results_anomaly(self):
+        """Test that zero results are logged as anomaly."""
+        from src.evaluation.metrics_logger import MetricsLogger
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("src.evaluation.metrics_logger.get_config_hash", return_value="abc"):
+                logger = MetricsLogger(log_dir=tmpdir)
+
+                # Log query with zero results
+                logger.log_query("q1", "hybrid", 400.0, 0.0, num_results=0)
+
+                # Check anomaly log
+                anomaly_log = Path(tmpdir) / "anomalies.log"
+                assert anomaly_log.exists()
+                assert "ZERO RESULTS" in anomaly_log.read_text()

--- a/tests/unit/test_middlewares.py
+++ b/tests/unit/test_middlewares.py
@@ -1,0 +1,203 @@
+"""Unit tests for telegram_bot/middlewares/."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiogram import Dispatcher
+from aiogram.types import Message, User
+
+from telegram_bot.middlewares.error_handler import (
+    ErrorHandlerMiddleware,
+    setup_error_middleware,
+)
+from telegram_bot.middlewares.throttling import (
+    ThrottlingMiddleware,
+    setup_throttling_middleware,
+)
+
+
+class TestErrorHandlerMiddleware:
+    """Test ErrorHandlerMiddleware."""
+
+    def test_middleware_creation(self):
+        """Test that middleware can be created."""
+        middleware = ErrorHandlerMiddleware()
+        assert middleware is not None
+
+    @pytest.mark.asyncio
+    async def test_middleware_passes_through_on_success(self):
+        """Test that middleware passes through when handler succeeds."""
+        middleware = ErrorHandlerMiddleware()
+
+        handler = AsyncMock(return_value="success")
+        event = MagicMock(spec=Message)
+        data = {}
+
+        result = await middleware(handler, event, data)
+
+        assert result == "success"
+        handler.assert_called_once_with(event, data)
+
+    @pytest.mark.asyncio
+    async def test_middleware_handles_exception(self):
+        """Test that middleware handles exceptions and sends error message."""
+        middleware = ErrorHandlerMiddleware()
+
+        handler = AsyncMock(side_effect=Exception("Test error"))
+        event = MagicMock(spec=Message)
+        event.answer = AsyncMock()
+        data = {}
+
+        with pytest.raises(Exception, match="Test error"):
+            await middleware(handler, event, data)
+
+        # Should have sent error message
+        event.answer.assert_called_once()
+        call_args = event.answer.call_args[0][0]
+        assert "ошибка" in call_args.lower()
+
+    @pytest.mark.asyncio
+    async def test_middleware_logs_error(self):
+        """Test that middleware logs errors."""
+        middleware = ErrorHandlerMiddleware()
+
+        handler = AsyncMock(side_effect=ValueError("Value error"))
+        event = MagicMock(spec=Message)
+        event.answer = AsyncMock()
+        data = {}
+
+        with patch(
+            "telegram_bot.middlewares.error_handler.logger"
+        ) as mock_logger:
+            with pytest.raises(ValueError):
+                await middleware(handler, event, data)
+
+            mock_logger.error.assert_called_once()
+
+
+class TestSetupErrorMiddleware:
+    """Test setup_error_middleware function."""
+
+    def test_setup_registers_middleware(self):
+        """Test that setup function registers middleware."""
+        dp = MagicMock(spec=Dispatcher)
+        dp.message = MagicMock()
+        dp.message.outer_middleware = MagicMock()
+
+        setup_error_middleware(dp)
+
+        dp.message.outer_middleware.register.assert_called_once()
+
+
+class TestThrottlingMiddleware:
+    """Test ThrottlingMiddleware."""
+
+    def test_middleware_creation_defaults(self):
+        """Test middleware creation with defaults."""
+        middleware = ThrottlingMiddleware()
+
+        assert middleware.rate_limit == 1.5
+        assert middleware.admin_ids == set()
+
+    def test_middleware_creation_custom(self):
+        """Test middleware creation with custom values."""
+        middleware = ThrottlingMiddleware(rate_limit=2.0, admin_ids=[123, 456])
+
+        assert middleware.rate_limit == 2.0
+        assert middleware.admin_ids == {123, 456}
+
+    @pytest.mark.asyncio
+    async def test_middleware_allows_first_request(self):
+        """Test that first request is allowed."""
+        middleware = ThrottlingMiddleware(rate_limit=1.5)
+
+        handler = AsyncMock(return_value="success")
+
+        user = MagicMock(spec=User)
+        user.id = 12345
+
+        event = MagicMock(spec=Message)
+        data = {"event_from_user": user}
+
+        result = await middleware(handler, event, data)
+
+        assert result == "success"
+        handler.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_middleware_throttles_rapid_requests(self):
+        """Test that rapid requests are throttled."""
+        middleware = ThrottlingMiddleware(rate_limit=1.5)
+
+        handler = AsyncMock(return_value="success")
+
+        user = MagicMock(spec=User)
+        user.id = 12345
+
+        event = MagicMock(spec=Message)
+        event.answer = AsyncMock()
+        data = {"event_from_user": user}
+
+        # First request
+        result1 = await middleware(handler, event, data)
+        assert result1 == "success"
+
+        # Second rapid request - should be throttled
+        result2 = await middleware(handler, event, data)
+        assert result2 is None
+
+        # Should have sent throttle message
+        event.answer.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_middleware_exempts_admins(self):
+        """Test that admins are exempt from throttling."""
+        middleware = ThrottlingMiddleware(rate_limit=1.5, admin_ids=[12345])
+
+        handler = AsyncMock(return_value="success")
+
+        user = MagicMock(spec=User)
+        user.id = 12345  # Admin
+
+        event = MagicMock(spec=Message)
+        data = {"event_from_user": user}
+
+        # First request
+        result1 = await middleware(handler, event, data)
+        assert result1 == "success"
+
+        # Second rapid request - admin should not be throttled
+        result2 = await middleware(handler, event, data)
+        assert result2 == "success"
+
+    @pytest.mark.asyncio
+    async def test_middleware_handles_no_user(self):
+        """Test that middleware handles events without user."""
+        middleware = ThrottlingMiddleware()
+
+        handler = AsyncMock(return_value="success")
+
+        event = MagicMock(spec=Message)
+        data = {}  # No user
+
+        result = await middleware(handler, event, data)
+
+        assert result == "success"
+        handler.assert_called_once()
+
+
+class TestSetupThrottlingMiddleware:
+    """Test setup_throttling_middleware function."""
+
+    def test_setup_registers_middleware(self):
+        """Test that setup function registers middleware."""
+        dp = MagicMock(spec=Dispatcher)
+        dp.message = MagicMock()
+        dp.message.middleware = MagicMock()
+        dp.callback_query = MagicMock()
+        dp.callback_query.middleware = MagicMock()
+
+        setup_throttling_middleware(dp, rate_limit=2.0, admin_ids=[123])
+
+        dp.message.middleware.register.assert_called_once()
+        dp.callback_query.middleware.register.assert_called_once()

--- a/tests/unit/test_query_analyzer.py
+++ b/tests/unit/test_query_analyzer.py
@@ -1,0 +1,275 @@
+"""Unit tests for telegram_bot/services/query_analyzer.py."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from telegram_bot.services.query_analyzer import QueryAnalyzer
+
+
+class TestQueryAnalyzerInit:
+    """Test QueryAnalyzer initialization."""
+
+    def test_init_defaults(self):
+        """Test initialization with default model."""
+        analyzer = QueryAnalyzer(
+            api_key="test-key",
+            base_url="https://api.example.com/v1",
+        )
+
+        assert analyzer.api_key == "test-key"
+        assert analyzer.base_url == "https://api.example.com/v1"
+        assert analyzer.model == "gpt-4o-mini"
+
+    def test_init_custom_model(self):
+        """Test initialization with custom model."""
+        analyzer = QueryAnalyzer(
+            api_key="test-key",
+            base_url="https://api.example.com/v1",
+            model="gpt-4",
+        )
+
+        assert analyzer.model == "gpt-4"
+
+    def test_init_creates_client(self):
+        """Test that HTTP client is created."""
+        analyzer = QueryAnalyzer(
+            api_key="test-key",
+            base_url="https://api.example.com/v1",
+        )
+
+        assert analyzer.client is not None
+        assert isinstance(analyzer.client, httpx.AsyncClient)
+
+
+class TestQueryAnalyzerAnalyze:
+    """Test analyze method."""
+
+    @pytest.mark.asyncio
+    async def test_analyze_extracts_price_filter(self):
+        """Test that price filter is extracted correctly."""
+        analyzer = QueryAnalyzer(
+            api_key="test-key",
+            base_url="https://api.example.com/v1",
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps(
+                            {
+                                "filters": {"price": {"lt": 100000}},
+                                "semantic_query": "квартира недорого",
+                            }
+                        )
+                    }
+                }
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(analyzer.client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+
+            result = await analyzer.analyze("квартира дешевле 100000 евро")
+
+            assert result["filters"]["price"] == {"lt": 100000}
+            assert result["semantic_query"] == "квартира недорого"
+
+    @pytest.mark.asyncio
+    async def test_analyze_extracts_city_filter(self):
+        """Test that city filter is extracted correctly."""
+        analyzer = QueryAnalyzer(
+            api_key="test-key",
+            base_url="https://api.example.com/v1",
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps(
+                            {
+                                "filters": {"city": "Несебр"},
+                                "semantic_query": "квартиры",
+                            }
+                        )
+                    }
+                }
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(analyzer.client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+
+            result = await analyzer.analyze("квартиры в Несебр")
+
+            assert result["filters"]["city"] == "Несебр"
+
+    @pytest.mark.asyncio
+    async def test_analyze_extracts_multiple_filters(self):
+        """Test that multiple filters are extracted correctly."""
+        analyzer = QueryAnalyzer(
+            api_key="test-key",
+            base_url="https://api.example.com/v1",
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps(
+                            {
+                                "filters": {
+                                    "price": {"lt": 80000},
+                                    "rooms": 2,
+                                    "city": "Солнечный берег",
+                                },
+                                "semantic_query": "квартира с хорошим ремонтом",
+                            }
+                        )
+                    }
+                }
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(analyzer.client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+
+            result = await analyzer.analyze(
+                "2-комнатная в Солнечный берег дешевле 80000"
+            )
+
+            assert result["filters"]["price"] == {"lt": 80000}
+            assert result["filters"]["rooms"] == 2
+            assert result["filters"]["city"] == "Солнечный берег"
+
+    @pytest.mark.asyncio
+    async def test_analyze_no_filters(self):
+        """Test handling query with no extractable filters."""
+        analyzer = QueryAnalyzer(
+            api_key="test-key",
+            base_url="https://api.example.com/v1",
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps(
+                            {
+                                "filters": {},
+                                "semantic_query": "красивая квартира с видом",
+                            }
+                        )
+                    }
+                }
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(analyzer.client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+
+            result = await analyzer.analyze("красивая квартира с видом на море")
+
+            assert result["filters"] == {}
+            assert result["semantic_query"] == "красивая квартира с видом"
+
+    @pytest.mark.asyncio
+    async def test_analyze_json_parse_error_fallback(self):
+        """Test fallback when JSON parsing fails."""
+        analyzer = QueryAnalyzer(
+            api_key="test-key",
+            base_url="https://api.example.com/v1",
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "invalid json {"}}]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(analyzer.client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+
+            result = await analyzer.analyze("test query")
+
+            # Should return fallback
+            assert result["filters"] == {}
+            assert result["semantic_query"] == "test query"
+
+    @pytest.mark.asyncio
+    async def test_analyze_api_error_fallback(self):
+        """Test fallback when API call fails."""
+        analyzer = QueryAnalyzer(
+            api_key="test-key",
+            base_url="https://api.example.com/v1",
+        )
+
+        with patch.object(analyzer.client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.side_effect = Exception("API Error")
+
+            result = await analyzer.analyze("test query")
+
+            # Should return fallback
+            assert result["filters"] == {}
+            assert result["semantic_query"] == "test query"
+
+    @pytest.mark.asyncio
+    async def test_analyze_uses_correct_api_format(self):
+        """Test that correct API format is used."""
+        analyzer = QueryAnalyzer(
+            api_key="test-key",
+            base_url="https://api.example.com/v1",
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps({"filters": {}, "semantic_query": "test"})
+                    }
+                }
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(analyzer.client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+
+            await analyzer.analyze("test query")
+
+            # Verify call arguments
+            call_args = mock_post.call_args
+            assert call_args[0][0] == "https://api.example.com/v1/chat/completions"
+            json_data = call_args[1]["json"]
+            assert json_data["response_format"] == {"type": "json_object"}
+            assert json_data["temperature"] == 0.0
+
+
+class TestQueryAnalyzerClose:
+    """Test close method."""
+
+    @pytest.mark.asyncio
+    async def test_close_closes_client(self):
+        """Test that close() closes the HTTP client."""
+        analyzer = QueryAnalyzer(
+            api_key="test-key",
+            base_url="https://api.example.com/v1",
+        )
+
+        with patch.object(analyzer.client, "aclose", new_callable=AsyncMock) as mock_close:
+            await analyzer.close()
+
+            mock_close.assert_called_once()

--- a/tests/unit/test_query_preprocessor_unit.py
+++ b/tests/unit/test_query_preprocessor_unit.py
@@ -1,0 +1,333 @@
+"""Unit tests for telegram_bot/services/query_preprocessor.py."""
+
+import pytest
+
+from telegram_bot.services.query_preprocessor import QueryPreprocessor
+
+
+class TestQueryPreprocessorInit:
+    """Test QueryPreprocessor initialization."""
+
+    def test_init_creates_translit_map(self):
+        """Test that translit map is initialized."""
+        pp = QueryPreprocessor()
+
+        assert hasattr(pp, "TRANSLIT_MAP")
+        assert len(pp.TRANSLIT_MAP) > 0
+        assert "Varna" in pp.TRANSLIT_MAP
+
+    def test_init_creates_exact_patterns(self):
+        """Test that exact patterns are initialized."""
+        pp = QueryPreprocessor()
+
+        assert hasattr(pp, "EXACT_PATTERNS")
+        assert len(pp.EXACT_PATTERNS) > 0
+
+
+class TestNormalizeTranslit:
+    """Test transliteration normalization."""
+
+    def test_translit_varna(self):
+        """Test Varna transliteration."""
+        pp = QueryPreprocessor()
+        result = pp.normalize_translit("apartments in Varna")
+
+        assert "Варна" in result
+        assert "Varna" not in result
+
+    def test_translit_nesebar(self):
+        """Test Nesebar transliteration (both spellings)."""
+        pp = QueryPreprocessor()
+
+        result1 = pp.normalize_translit("hotels in Nesebar")
+        result2 = pp.normalize_translit("hotels in Nessebar")
+
+        assert "Несебър" in result1
+        assert "Несебър" in result2
+
+    def test_translit_sunny_beach(self):
+        """Test Sunny Beach transliteration."""
+        pp = QueryPreprocessor()
+        result = pp.normalize_translit("apartments in Sunny Beach")
+
+        assert "Солнечный берег" in result
+
+    def test_translit_case_insensitive(self):
+        """Test case-insensitive transliteration."""
+        pp = QueryPreprocessor()
+
+        result_lower = pp.normalize_translit("varna")
+        result_upper = pp.normalize_translit("VARNA")
+        result_mixed = pp.normalize_translit("Varna")
+
+        assert "Варна" in result_lower
+        assert "Варна" in result_upper
+        assert "Варна" in result_mixed
+
+    def test_translit_multiple_cities(self):
+        """Test transliteration of multiple cities in one query."""
+        pp = QueryPreprocessor()
+        result = pp.normalize_translit("apartments in Varna or Burgas")
+
+        assert "Варна" in result
+        assert "Бургас" in result
+        assert "Varna" not in result
+        assert "Burgas" not in result
+
+    def test_translit_no_match(self):
+        """Test that unknown words are not changed."""
+        pp = QueryPreprocessor()
+        query = "apartments in Moscow"
+        result = pp.normalize_translit(query)
+
+        assert result == query
+
+    def test_translit_preserves_other_text(self):
+        """Test that non-transliterable text is preserved."""
+        pp = QueryPreprocessor()
+        result = pp.normalize_translit("2-room apartments in Varna under 50000 EUR")
+
+        assert "Варна" in result
+        assert "2-room" in result
+        assert "50000 EUR" in result
+
+    def test_translit_sveti_vlas_variants(self):
+        """Test Sveti Vlas transliteration variants."""
+        pp = QueryPreprocessor()
+
+        result1 = pp.normalize_translit("Sveti Vlas")
+        result2 = pp.normalize_translit("Svyati Vlas")
+        result3 = pp.normalize_translit("St Vlas")
+
+        assert "Святой Влас" in result1
+        assert "Святой Влас" in result2
+        assert "Святой Влас" in result3
+
+
+class TestGetRRFWeights:
+    """Test RRF weight calculation."""
+
+    def test_semantic_query_weights(self):
+        """Test weights for semantic queries."""
+        pp = QueryPreprocessor()
+        dense, sparse = pp.get_rrf_weights("квартиры у моря недорого")
+
+        assert dense == 0.6
+        assert sparse == 0.4
+
+    def test_exact_query_with_id(self):
+        """Test weights for queries with ID."""
+        pp = QueryPreprocessor()
+        dense, sparse = pp.get_rrf_weights("показать ID 12345")
+
+        assert dense == 0.2
+        assert sparse == 0.8
+
+    def test_exact_query_with_long_number(self):
+        """Test weights for queries with long numbers."""
+        pp = QueryPreprocessor()
+        dense, sparse = pp.get_rrf_weights("объект 123456")
+
+        assert dense == 0.2
+        assert sparse == 0.8
+
+    def test_exact_query_with_corpus(self):
+        """Test weights for queries with corpus number."""
+        pp = QueryPreprocessor()
+        dense, sparse = pp.get_rrf_weights("квартира корпус 5")
+
+        assert dense == 0.2
+        assert sparse == 0.8
+
+    def test_exact_query_with_block(self):
+        """Test weights for queries with block number."""
+        pp = QueryPreprocessor()
+        dense, sparse = pp.get_rrf_weights("блок 3 этаж 2")
+
+        assert dense == 0.2
+        assert sparse == 0.8
+
+    def test_exact_query_with_floor(self):
+        """Test weights for queries with floor number."""
+        pp = QueryPreprocessor()
+        dense, sparse = pp.get_rrf_weights("этаж 5 вид на море")
+
+        assert dense == 0.2
+        assert sparse == 0.8
+
+    def test_exact_query_with_zhk(self):
+        """Test weights for queries with ЖК (residential complex)."""
+        pp = QueryPreprocessor()
+        dense, sparse = pp.get_rrf_weights("ЖК Елените апартаменты")
+
+        assert dense == 0.2
+        assert sparse == 0.8
+
+    def test_weights_sum_to_one(self):
+        """Test that weights always sum to 1.0."""
+        pp = QueryPreprocessor()
+
+        queries = [
+            "semantic query",
+            "ID 12345",
+            "корпус 5",
+            "блок А этаж 3",
+        ]
+
+        for query in queries:
+            dense, sparse = pp.get_rrf_weights(query)
+            assert dense + sparse == pytest.approx(1.0)
+
+
+class TestGetCacheThreshold:
+    """Test cache threshold calculation."""
+
+    def test_semantic_query_threshold(self):
+        """Test threshold for semantic queries."""
+        pp = QueryPreprocessor()
+        threshold = pp.get_cache_threshold("квартиры с видом на море")
+
+        assert threshold == 0.10
+
+    def test_strict_threshold_with_numbers(self):
+        """Test strict threshold for queries with numbers."""
+        pp = QueryPreprocessor()
+        threshold = pp.get_cache_threshold("квартира 123")
+
+        assert threshold == 0.05
+
+    def test_strict_threshold_with_corpus(self):
+        """Test strict threshold for queries with corpus."""
+        pp = QueryPreprocessor()
+        threshold = pp.get_cache_threshold("корпус А")
+
+        assert threshold == 0.05
+
+    def test_strict_threshold_with_block(self):
+        """Test strict threshold for queries with block."""
+        pp = QueryPreprocessor()
+        threshold = pp.get_cache_threshold("блок 3")
+
+        assert threshold == 0.05
+
+    def test_strict_threshold_with_floor(self):
+        """Test strict threshold for queries with floor."""
+        pp = QueryPreprocessor()
+        threshold = pp.get_cache_threshold("этаж 5")
+
+        assert threshold == 0.05
+
+    def test_strict_threshold_with_id(self):
+        """Test strict threshold for queries with ID."""
+        pp = QueryPreprocessor()
+        threshold = pp.get_cache_threshold("ID квартиры")
+
+        assert threshold == 0.05
+
+
+class TestHasExactIdentifier:
+    """Test exact identifier detection."""
+
+    def test_no_identifier(self):
+        """Test query without identifiers."""
+        pp = QueryPreprocessor()
+        assert pp.has_exact_identifier("квартиры у моря") is False
+
+    def test_has_id(self):
+        """Test query with ID."""
+        pp = QueryPreprocessor()
+        assert pp.has_exact_identifier("ID 12345") is True
+
+    def test_has_long_number(self):
+        """Test query with long number."""
+        pp = QueryPreprocessor()
+        assert pp.has_exact_identifier("объект 123456") is True
+
+    def test_has_corpus(self):
+        """Test query with corpus."""
+        pp = QueryPreprocessor()
+        assert pp.has_exact_identifier("корпус 5") is True
+        assert pp.has_exact_identifier("корпус A") is True
+
+    def test_has_block(self):
+        """Test query with block."""
+        pp = QueryPreprocessor()
+        assert pp.has_exact_identifier("блок 3") is True
+        assert pp.has_exact_identifier("блок B") is True
+
+    def test_has_section(self):
+        """Test query with section."""
+        pp = QueryPreprocessor()
+        assert pp.has_exact_identifier("секция 2") is True
+
+    def test_has_floor(self):
+        """Test query with floor."""
+        pp = QueryPreprocessor()
+        assert pp.has_exact_identifier("этаж 5") is True
+
+    def test_has_zhk(self):
+        """Test query with ЖК."""
+        pp = QueryPreprocessor()
+        assert pp.has_exact_identifier("ЖК Елените") is True
+
+
+class TestAnalyze:
+    """Test full analysis pipeline."""
+
+    def test_analyze_semantic_query(self):
+        """Test analysis of semantic query."""
+        pp = QueryPreprocessor()
+        result = pp.analyze("квартиры в Varna недорого")
+
+        assert result["original_query"] == "квартиры в Varna недорого"
+        assert "Варна" in result["normalized_query"]
+        assert result["rrf_weights"]["dense"] == 0.6
+        assert result["rrf_weights"]["sparse"] == 0.4
+        assert result["cache_threshold"] == 0.10
+        assert result["is_exact"] is False
+
+    def test_analyze_exact_query(self):
+        """Test analysis of exact query."""
+        pp = QueryPreprocessor()
+        result = pp.analyze("квартира ID 12345 корпус 3")
+
+        assert result["original_query"] == "квартира ID 12345 корпус 3"
+        assert result["rrf_weights"]["dense"] == 0.2
+        assert result["rrf_weights"]["sparse"] == 0.8
+        assert result["cache_threshold"] == 0.05
+        assert result["is_exact"] is True
+
+    def test_analyze_mixed_query(self):
+        """Test analysis with transliteration and identifiers."""
+        pp = QueryPreprocessor()
+        result = pp.analyze("apartments in Sunny Beach корпус 5")
+
+        assert "Солнечный берег" in result["normalized_query"]
+        assert result["is_exact"] is True
+        assert result["rrf_weights"]["sparse"] == 0.8
+
+    def test_analyze_returns_all_keys(self):
+        """Test that analyze returns all expected keys."""
+        pp = QueryPreprocessor()
+        result = pp.analyze("test query")
+
+        expected_keys = [
+            "original_query",
+            "normalized_query",
+            "rrf_weights",
+            "cache_threshold",
+            "is_exact",
+        ]
+
+        for key in expected_keys:
+            assert key in result
+
+    def test_analyze_rrf_weights_structure(self):
+        """Test that rrf_weights has correct structure."""
+        pp = QueryPreprocessor()
+        result = pp.analyze("test query")
+
+        assert "dense" in result["rrf_weights"]
+        assert "sparse" in result["rrf_weights"]
+        assert isinstance(result["rrf_weights"]["dense"], float)
+        assert isinstance(result["rrf_weights"]["sparse"], float)

--- a/tests/unit/test_retriever_service.py
+++ b/tests/unit/test_retriever_service.py
@@ -1,0 +1,311 @@
+"""Unit tests for telegram_bot/services/retriever.py."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from telegram_bot.services.retriever import RetrieverService
+
+
+class TestRetrieverServiceInit:
+    """Test RetrieverService initialization."""
+
+    @patch("telegram_bot.services.retriever.QdrantClient")
+    def test_init_with_api_key(self, mock_qdrant):
+        """Test initialization with API key."""
+        mock_client = MagicMock()
+        mock_qdrant.return_value = mock_client
+
+        service = RetrieverService(
+            url="http://localhost:6333",
+            api_key="test-key",
+            collection_name="test_collection",
+        )
+
+        assert service.url == "http://localhost:6333"
+        assert service.api_key == "test-key"
+        assert service.collection_name == "test_collection"
+        mock_qdrant.assert_called_once_with(
+            url="http://localhost:6333",
+            api_key="test-key",
+            timeout=5.0,
+        )
+
+    @patch("telegram_bot.services.retriever.QdrantClient")
+    def test_init_without_api_key(self, mock_qdrant):
+        """Test initialization without API key."""
+        mock_client = MagicMock()
+        mock_qdrant.return_value = mock_client
+
+        service = RetrieverService(
+            url="http://localhost:6333",
+            api_key="",
+            collection_name="test_collection",
+        )
+
+        mock_qdrant.assert_called_once_with(
+            url="http://localhost:6333",
+            timeout=5.0,
+        )
+
+    @patch("telegram_bot.services.retriever.QdrantClient")
+    def test_init_healthy_connection(self, mock_qdrant):
+        """Test that healthy connection sets _is_healthy True."""
+        mock_client = MagicMock()
+        mock_client.get_collections.return_value = []
+        mock_qdrant.return_value = mock_client
+
+        service = RetrieverService(
+            url="http://localhost:6333",
+            api_key="",
+            collection_name="test",
+        )
+
+        assert service._is_healthy is True
+        assert service.client is not None
+
+    @patch("telegram_bot.services.retriever.QdrantClient")
+    def test_init_connection_failure(self, mock_qdrant):
+        """Test that connection failure sets _is_healthy False."""
+        mock_qdrant.side_effect = Exception("Connection refused")
+
+        service = RetrieverService(
+            url="http://localhost:6333",
+            api_key="",
+            collection_name="test",
+        )
+
+        assert service._is_healthy is False
+        assert service.client is None
+
+
+class TestRetrieverServiceSearch:
+    """Test RetrieverService search method."""
+
+    @patch("telegram_bot.services.retriever.QdrantClient")
+    def test_search_returns_empty_when_unhealthy(self, mock_qdrant):
+        """Test that search returns empty list when unhealthy."""
+        mock_qdrant.side_effect = Exception("Connection refused")
+
+        service = RetrieverService(
+            url="http://localhost:6333",
+            api_key="",
+            collection_name="test",
+        )
+
+        result = service.search([0.1, 0.2, 0.3])
+
+        assert result == []
+
+    @patch("telegram_bot.services.retriever.QdrantClient")
+    def test_search_returns_formatted_results(self, mock_qdrant):
+        """Test that search returns properly formatted results."""
+        mock_point = MagicMock()
+        mock_point.payload = {
+            "page_content": "Sample text content",
+            "metadata": {"city": "Varna", "price": 50000},
+        }
+        mock_point.score = 0.95
+
+        mock_results = MagicMock()
+        mock_results.points = [mock_point]
+
+        mock_client = MagicMock()
+        mock_client.query_points.return_value = mock_results
+        mock_qdrant.return_value = mock_client
+
+        service = RetrieverService(
+            url="http://localhost:6333",
+            api_key="",
+            collection_name="test",
+        )
+
+        results = service.search([0.1, 0.2, 0.3])
+
+        assert len(results) == 1
+        assert results[0]["text"] == "Sample text content"
+        assert results[0]["metadata"]["city"] == "Varna"
+        assert results[0]["score"] == 0.95
+
+    @patch("telegram_bot.services.retriever.QdrantClient")
+    def test_search_with_filters(self, mock_qdrant):
+        """Test search with filters."""
+        mock_results = MagicMock()
+        mock_results.points = []
+
+        mock_client = MagicMock()
+        mock_client.query_points.return_value = mock_results
+        mock_qdrant.return_value = mock_client
+
+        service = RetrieverService(
+            url="http://localhost:6333",
+            api_key="",
+            collection_name="test",
+        )
+
+        filters = {"city": "Varna", "rooms": 2}
+        service.search([0.1, 0.2, 0.3], filters=filters)
+
+        # Verify query_points was called
+        mock_client.query_points.assert_called_once()
+
+    @patch("telegram_bot.services.retriever.QdrantClient")
+    def test_search_handles_exception(self, mock_qdrant):
+        """Test that search handles exceptions gracefully."""
+        mock_client = MagicMock()
+        mock_client.query_points.side_effect = Exception("Search failed")
+        mock_qdrant.return_value = mock_client
+
+        service = RetrieverService(
+            url="http://localhost:6333",
+            api_key="",
+            collection_name="test",
+        )
+
+        results = service.search([0.1, 0.2, 0.3])
+
+        assert results == []
+        assert service._is_healthy is False
+
+
+class TestBuildFilter:
+    """Test filter building methods."""
+
+    @patch("telegram_bot.services.retriever.QdrantClient")
+    def test_build_base_filter_returns_none(self, mock_qdrant):
+        """Test that _build_base_filter returns None."""
+        mock_client = MagicMock()
+        mock_qdrant.return_value = mock_client
+
+        service = RetrieverService(
+            url="http://localhost:6333",
+            api_key="",
+            collection_name="test",
+        )
+
+        result = service._build_base_filter()
+
+        assert result is None
+
+    @patch("telegram_bot.services.retriever.QdrantClient")
+    def test_build_filter_empty_returns_none(self, mock_qdrant):
+        """Test that _build_filter with empty dict returns None."""
+        mock_client = MagicMock()
+        mock_qdrant.return_value = mock_client
+
+        service = RetrieverService(
+            url="http://localhost:6333",
+            api_key="",
+            collection_name="test",
+        )
+
+        result = service._build_filter({})
+
+        assert result is None
+
+    @patch("telegram_bot.services.retriever.QdrantClient")
+    def test_build_filter_string_match(self, mock_qdrant):
+        """Test filter building with string match."""
+        mock_client = MagicMock()
+        mock_qdrant.return_value = mock_client
+
+        service = RetrieverService(
+            url="http://localhost:6333",
+            api_key="",
+            collection_name="test",
+        )
+
+        result = service._build_filter({"city": "Varna"})
+
+        assert result is not None
+        assert len(result.must) == 1
+
+    @patch("telegram_bot.services.retriever.QdrantClient")
+    def test_build_filter_int_match(self, mock_qdrant):
+        """Test filter building with integer match."""
+        mock_client = MagicMock()
+        mock_qdrant.return_value = mock_client
+
+        service = RetrieverService(
+            url="http://localhost:6333",
+            api_key="",
+            collection_name="test",
+        )
+
+        result = service._build_filter({"rooms": 2})
+
+        assert result is not None
+        assert len(result.must) == 1
+
+    @patch("telegram_bot.services.retriever.QdrantClient")
+    def test_build_filter_range_lt(self, mock_qdrant):
+        """Test filter building with less-than range."""
+        mock_client = MagicMock()
+        mock_qdrant.return_value = mock_client
+
+        service = RetrieverService(
+            url="http://localhost:6333",
+            api_key="",
+            collection_name="test",
+        )
+
+        result = service._build_filter({"price": {"lt": 100000}})
+
+        assert result is not None
+        assert len(result.must) == 1
+
+    @patch("telegram_bot.services.retriever.QdrantClient")
+    def test_build_filter_range_gte(self, mock_qdrant):
+        """Test filter building with greater-than-or-equal range."""
+        mock_client = MagicMock()
+        mock_qdrant.return_value = mock_client
+
+        service = RetrieverService(
+            url="http://localhost:6333",
+            api_key="",
+            collection_name="test",
+        )
+
+        result = service._build_filter({"area": {"gte": 50}})
+
+        assert result is not None
+        assert len(result.must) == 1
+
+    @patch("telegram_bot.services.retriever.QdrantClient")
+    def test_build_filter_combined(self, mock_qdrant):
+        """Test filter building with multiple conditions."""
+        mock_client = MagicMock()
+        mock_qdrant.return_value = mock_client
+
+        service = RetrieverService(
+            url="http://localhost:6333",
+            api_key="",
+            collection_name="test",
+        )
+
+        filters = {
+            "city": "Nesebar",
+            "rooms": 2,
+            "price": {"lt": 100000},
+        }
+        result = service._build_filter(filters)
+
+        assert result is not None
+        assert len(result.must) == 3
+
+    @patch("telegram_bot.services.retriever.QdrantClient")
+    def test_build_filter_range_multiple_operators(self, mock_qdrant):
+        """Test filter building with multiple range operators."""
+        mock_client = MagicMock()
+        mock_qdrant.return_value = mock_client
+
+        service = RetrieverService(
+            url="http://localhost:6333",
+            api_key="",
+            collection_name="test",
+        )
+
+        result = service._build_filter({"price": {"gte": 50000, "lte": 100000}})
+
+        assert result is not None
+        assert len(result.must) == 1

--- a/tests/unit/test_search_engines.py
+++ b/tests/unit/test_search_engines.py
@@ -1,0 +1,392 @@
+"""Unit tests for src/retrieval/search_engines.py."""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from src.config.constants import SearchEngine
+from src.retrieval.search_engines import (
+    BaselineSearchEngine,
+    DBSFColBERTSearchEngine,
+    HybridRRFColBERTSearchEngine,
+    HybridRRFSearchEngine,
+    SearchResult,
+    convert_to_python_types,
+    create_search_engine,
+)
+
+
+class TestSearchResult:
+    """Test SearchResult dataclass."""
+
+    def test_search_result_creation(self):
+        """Test basic SearchResult creation."""
+        result = SearchResult(
+            article_number="115",
+            text="Sample text",
+            score=0.95,
+            metadata={"chapter": "I"},
+        )
+
+        assert result.article_number == "115"
+        assert result.text == "Sample text"
+        assert result.score == 0.95
+        assert result.metadata == {"chapter": "I"}
+
+    def test_search_result_empty_metadata(self):
+        """Test SearchResult with empty metadata."""
+        result = SearchResult(
+            article_number="1",
+            text="Text",
+            score=0.5,
+            metadata={},
+        )
+
+        assert result.metadata == {}
+
+
+class TestConvertToPythonTypes:
+    """Test numpy type conversion."""
+
+    def test_convert_numpy_array(self):
+        """Test numpy array to list conversion."""
+        arr = np.array([1.0, 2.0, 3.0])
+        result = convert_to_python_types(arr)
+
+        assert result == [1.0, 2.0, 3.0]
+        assert isinstance(result, list)
+
+    def test_convert_numpy_float32(self):
+        """Test numpy float32 to Python float."""
+        val = np.float32(3.14)
+        result = convert_to_python_types(val)
+
+        assert result == pytest.approx(3.14, rel=1e-5)
+        assert isinstance(result, float)
+
+    def test_convert_numpy_float64(self):
+        """Test numpy float64 to Python float."""
+        val = np.float64(3.14159)
+        result = convert_to_python_types(val)
+
+        assert result == pytest.approx(3.14159)
+        assert isinstance(result, float)
+
+    def test_convert_numpy_int32(self):
+        """Test numpy int32 to Python int."""
+        val = np.int32(42)
+        result = convert_to_python_types(val)
+
+        assert result == 42
+        assert isinstance(result, int)
+
+    def test_convert_numpy_int64(self):
+        """Test numpy int64 to Python int."""
+        val = np.int64(42)
+        result = convert_to_python_types(val)
+
+        assert result == 42
+        assert isinstance(result, int)
+
+    def test_convert_nested_dict(self):
+        """Test conversion of nested dict with numpy types."""
+        data = {
+            "values": np.array([1.0, 2.0]),
+            "score": np.float32(0.95),
+            "count": np.int32(5),
+        }
+        result = convert_to_python_types(data)
+
+        assert result["values"] == [1.0, 2.0]
+        assert isinstance(result["score"], float)
+        assert isinstance(result["count"], int)
+
+    def test_convert_nested_list(self):
+        """Test conversion of nested list with numpy types."""
+        data = [np.float32(1.0), np.array([2.0, 3.0]), "string"]
+        result = convert_to_python_types(data)
+
+        assert isinstance(result[0], float)
+        assert result[1] == [2.0, 3.0]
+        assert result[2] == "string"
+
+    def test_convert_python_types_unchanged(self):
+        """Test that Python types are unchanged."""
+        data = {
+            "string": "text",
+            "int": 42,
+            "float": 3.14,
+            "list": [1, 2, 3],
+        }
+        result = convert_to_python_types(data)
+
+        assert result == data
+
+
+class TestBaselineSearchEngine:
+    """Test BaselineSearchEngine."""
+
+    @patch("src.retrieval.search_engines.QdrantClient")
+    @patch("src.retrieval.search_engines.Settings")
+    def test_baseline_get_name(self, mock_settings_cls, mock_qdrant):
+        """Test get_name returns 'baseline'."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings.collection_name = "test"
+        mock_settings_cls.return_value = mock_settings
+
+        engine = BaselineSearchEngine(mock_settings)
+
+        assert engine.get_name() == "baseline"
+
+    @patch("src.retrieval.search_engines.QdrantClient")
+    @patch("src.retrieval.search_engines.Settings")
+    def test_baseline_search_default_threshold(self, mock_settings_cls, mock_qdrant):
+        """Test default score threshold is 0.5."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings.collection_name = "test"
+        mock_settings_cls.return_value = mock_settings
+
+        mock_client = MagicMock()
+        mock_client.search.return_value = []
+        mock_qdrant.return_value = mock_client
+
+        engine = BaselineSearchEngine(mock_settings)
+        engine.search([0.1, 0.2, 0.3], top_k=5)
+
+        # Check that search was called with default threshold 0.5
+        call_kwargs = mock_client.search.call_args[1]
+        assert call_kwargs["score_threshold"] == 0.5
+
+    @patch("src.retrieval.search_engines.QdrantClient")
+    @patch("src.retrieval.search_engines.Settings")
+    def test_baseline_search_custom_threshold(self, mock_settings_cls, mock_qdrant):
+        """Test custom score threshold."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings.collection_name = "test"
+        mock_settings_cls.return_value = mock_settings
+
+        mock_client = MagicMock()
+        mock_client.search.return_value = []
+        mock_qdrant.return_value = mock_client
+
+        engine = BaselineSearchEngine(mock_settings)
+        engine.search([0.1, 0.2, 0.3], top_k=5, score_threshold=0.7)
+
+        call_kwargs = mock_client.search.call_args[1]
+        assert call_kwargs["score_threshold"] == 0.7
+
+    @patch("src.retrieval.search_engines.QdrantClient")
+    @patch("src.retrieval.search_engines.Settings")
+    def test_baseline_search_returns_results(self, mock_settings_cls, mock_qdrant):
+        """Test that search returns formatted results."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings.collection_name = "test"
+        mock_settings_cls.return_value = mock_settings
+
+        # Create mock search result
+        mock_result = MagicMock()
+        mock_result.payload = {
+            "metadata": {"article_number": "115"},
+            "page_content": "Sample text",
+        }
+        mock_result.score = 0.95
+
+        mock_client = MagicMock()
+        mock_client.search.return_value = [mock_result]
+        mock_qdrant.return_value = mock_client
+
+        engine = BaselineSearchEngine(mock_settings)
+        results = engine.search([0.1, 0.2, 0.3], top_k=5)
+
+        assert len(results) == 1
+        assert results[0].article_number == "115"
+        assert results[0].text == "Sample text"
+        assert results[0].score == 0.95
+
+
+class TestHybridRRFSearchEngine:
+    """Test HybridRRFSearchEngine."""
+
+    @patch("src.retrieval.search_engines.get_bge_m3_model")
+    @patch("src.retrieval.search_engines.QdrantClient")
+    @patch("src.retrieval.search_engines.Settings")
+    def test_hybrid_get_name(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test get_name returns 'hybrid_rrf'."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings.collection_name = "test"
+        mock_settings_cls.return_value = mock_settings
+
+        engine = HybridRRFSearchEngine(mock_settings)
+
+        assert engine.get_name() == "hybrid_rrf"
+
+    @patch("src.retrieval.search_engines.get_bge_m3_model")
+    @patch("src.retrieval.search_engines.QdrantClient")
+    @patch("src.retrieval.search_engines.Settings")
+    def test_hybrid_search_with_embedding(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test search with pre-computed embedding uses dense-only."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings.collection_name = "test"
+        mock_settings_cls.return_value = mock_settings
+
+        mock_client = MagicMock()
+        mock_client.search.return_value = []
+        mock_qdrant.return_value = mock_client
+
+        engine = HybridRRFSearchEngine(mock_settings)
+        engine.search([0.1, 0.2, 0.3], top_k=5)
+
+        # Should call dense-only search when embedding provided
+        mock_client.search.assert_called_once()
+
+
+class TestHybridRRFColBERTSearchEngine:
+    """Test HybridRRFColBERTSearchEngine."""
+
+    @patch("src.retrieval.search_engines.get_bge_m3_model")
+    @patch("src.retrieval.search_engines.QdrantClient")
+    @patch("src.retrieval.search_engines.Settings")
+    def test_colbert_get_name(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test get_name returns 'hybrid_rrf_colbert'."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings.collection_name = "test"
+        mock_settings_cls.return_value = mock_settings
+
+        engine = HybridRRFColBERTSearchEngine(mock_settings)
+
+        assert engine.get_name() == "hybrid_rrf_colbert"
+
+    @patch("src.retrieval.search_engines.get_bge_m3_model")
+    @patch("src.retrieval.search_engines.QdrantClient")
+    @patch("src.retrieval.search_engines.Settings")
+    def test_colbert_search_with_embedding(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test search with pre-computed embedding uses dense-only."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings.collection_name = "test"
+        mock_settings_cls.return_value = mock_settings
+
+        mock_client = MagicMock()
+        mock_client.search.return_value = []
+        mock_qdrant.return_value = mock_client
+
+        engine = HybridRRFColBERTSearchEngine(mock_settings)
+        engine.search([0.1, 0.2, 0.3], top_k=5)
+
+        # Should call dense-only search when embedding provided
+        mock_client.search.assert_called_once()
+
+
+class TestDBSFColBERTSearchEngine:
+    """Test DBSFColBERTSearchEngine."""
+
+    @patch("src.retrieval.search_engines.get_bge_m3_model")
+    @patch("src.retrieval.search_engines.QdrantClient")
+    @patch("src.retrieval.search_engines.Settings")
+    def test_dbsf_get_name(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test get_name returns 'dbsf_colbert'."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings.collection_name = "test"
+        mock_settings_cls.return_value = mock_settings
+
+        engine = DBSFColBERTSearchEngine(mock_settings)
+
+        assert engine.get_name() == "dbsf_colbert"
+
+
+class TestCreateSearchEngine:
+    """Test search engine factory function."""
+
+    @patch("src.retrieval.search_engines.get_bge_m3_model")
+    @patch("src.retrieval.search_engines.QdrantClient")
+    @patch("src.retrieval.search_engines.Settings")
+    def test_create_baseline_engine(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test creating baseline engine."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings.search_engine = SearchEngine.BASELINE
+        mock_settings_cls.return_value = mock_settings
+
+        engine = create_search_engine(SearchEngine.BASELINE, mock_settings)
+
+        assert isinstance(engine, BaselineSearchEngine)
+        assert engine.get_name() == "baseline"
+
+    @patch("src.retrieval.search_engines.get_bge_m3_model")
+    @patch("src.retrieval.search_engines.QdrantClient")
+    @patch("src.retrieval.search_engines.Settings")
+    def test_create_hybrid_rrf_engine(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test creating hybrid RRF engine."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings_cls.return_value = mock_settings
+
+        engine = create_search_engine(SearchEngine.HYBRID_RRF, mock_settings)
+
+        assert isinstance(engine, HybridRRFSearchEngine)
+        assert engine.get_name() == "hybrid_rrf"
+
+    @patch("src.retrieval.search_engines.get_bge_m3_model")
+    @patch("src.retrieval.search_engines.QdrantClient")
+    @patch("src.retrieval.search_engines.Settings")
+    def test_create_hybrid_rrf_colbert_engine(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test creating hybrid RRF ColBERT engine."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings_cls.return_value = mock_settings
+
+        engine = create_search_engine(SearchEngine.HYBRID_RRF_COLBERT, mock_settings)
+
+        assert isinstance(engine, HybridRRFColBERTSearchEngine)
+        assert engine.get_name() == "hybrid_rrf_colbert"
+
+    @patch("src.retrieval.search_engines.get_bge_m3_model")
+    @patch("src.retrieval.search_engines.QdrantClient")
+    @patch("src.retrieval.search_engines.Settings")
+    def test_create_dbsf_colbert_engine(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test creating DBSF ColBERT engine."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings_cls.return_value = mock_settings
+
+        engine = create_search_engine(SearchEngine.DBSF_COLBERT, mock_settings)
+
+        assert isinstance(engine, DBSFColBERTSearchEngine)
+        assert engine.get_name() == "dbsf_colbert"
+
+    @patch("src.retrieval.search_engines.get_bge_m3_model")
+    @patch("src.retrieval.search_engines.QdrantClient")
+    @patch("src.retrieval.search_engines.Settings")
+    def test_create_default_engine(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test that default engine is HybridRRFColBERT."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings.search_engine = SearchEngine.HYBRID_RRF_COLBERT
+        mock_settings_cls.return_value = mock_settings
+
+        engine = create_search_engine(settings=mock_settings)
+
+        assert isinstance(engine, HybridRRFColBERTSearchEngine)
+
+    @patch("src.retrieval.search_engines.get_bge_m3_model")
+    @patch("src.retrieval.search_engines.QdrantClient")
+    @patch("src.retrieval.search_engines.Settings")
+    def test_create_uses_settings_engine_type(self, mock_settings_cls, mock_qdrant, mock_bge):
+        """Test that factory uses settings.search_engine when type not provided."""
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings.search_engine = SearchEngine.BASELINE
+        mock_settings_cls.return_value = mock_settings
+
+        engine = create_search_engine(settings=mock_settings)
+
+        assert isinstance(engine, BaselineSearchEngine)

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,0 +1,213 @@
+"""Unit tests for src/config/settings.py."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from src.config.constants import APIProvider, ModelName, SearchEngine
+from src.config.settings import Settings
+
+
+class TestSettingsInitialization:
+    """Test Settings class initialization."""
+
+    def test_settings_default_values(self):
+        """Test that Settings loads default values correctly."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=False):
+            settings = Settings(api_provider="openai")
+
+            assert settings.temperature == 0.0
+            assert settings.max_tokens == 4096
+            assert settings.qdrant_url == "http://localhost:6333"
+            assert settings.score_threshold == 0.3
+            assert settings.top_k == 10
+
+    def test_settings_env_override(self):
+        """Test that environment variables override defaults."""
+        env_vars = {
+            "API_PROVIDER": "openai",
+            "OPENAI_API_KEY": "test-key",
+            "QDRANT_URL": "http://custom-qdrant:6333",
+            "COLLECTION_NAME": "test_collection",
+            "ENABLE_CACHING": "false",
+            "DEBUG": "true",
+        }
+        with patch.dict(os.environ, env_vars, clear=False):
+            settings = Settings()
+
+            assert settings.api_provider == APIProvider.OPENAI
+            assert settings.qdrant_url == "http://custom-qdrant:6333"
+            assert settings.collection_name == "test_collection"
+            assert settings.enable_caching is False
+            assert settings.debug is True
+
+    def test_settings_constructor_override(self):
+        """Test that constructor arguments override env vars."""
+        env_vars = {
+            "API_PROVIDER": "openai",
+            "OPENAI_API_KEY": "env-key",
+            "QDRANT_URL": "http://env-qdrant:6333",
+        }
+        with patch.dict(os.environ, env_vars, clear=False):
+            settings = Settings(
+                qdrant_url="http://constructor-qdrant:6333",
+                score_threshold=0.5,
+                top_k=20,
+            )
+
+            assert settings.qdrant_url == "http://constructor-qdrant:6333"
+            assert settings.score_threshold == 0.5
+            assert settings.top_k == 20
+
+
+class TestAPIKeyValidation:
+    """Test API key validation logic."""
+
+    def test_claude_provider_requires_anthropic_key(self):
+        """Test that Claude provider requires ANTHROPIC_API_KEY."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="ANTHROPIC_API_KEY not set"):
+                Settings(api_provider="claude")
+
+    def test_openai_provider_requires_openai_key(self):
+        """Test that OpenAI provider requires OPENAI_API_KEY."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="OPENAI_API_KEY not set"):
+                Settings(api_provider="openai")
+
+    def test_groq_provider_requires_groq_key(self):
+        """Test that Groq provider requires GROQ_API_KEY."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="GROQ_API_KEY not set"):
+                Settings(api_provider="groq")
+
+    def test_valid_api_key_does_not_raise(self):
+        """Test that valid API key does not raise error."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "valid-key"}, clear=False):
+            settings = Settings(api_provider="openai")
+            assert settings.openai_api_key == "valid-key"
+
+
+class TestDefaultModelSelection:
+    """Test default model selection for providers."""
+
+    def test_claude_default_model(self):
+        """Test default model for Claude provider."""
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}, clear=False):
+            settings = Settings(api_provider="claude")
+            assert settings.model_name == ModelName.CLAUDE_SONNET.value
+
+    def test_openai_default_model(self):
+        """Test default model for OpenAI provider."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=False):
+            settings = Settings(api_provider="openai")
+            assert settings.model_name == ModelName.GPT_4_TURBO.value
+
+    def test_groq_default_model(self):
+        """Test default model for Groq provider."""
+        with patch.dict(os.environ, {"GROQ_API_KEY": "test-key"}, clear=False):
+            settings = Settings(api_provider="groq")
+            assert settings.model_name == ModelName.GROQ_LLAMA3_70B.value
+
+    def test_custom_model_override(self):
+        """Test that custom model overrides default."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=False):
+            settings = Settings(api_provider="openai", model_name="gpt-4")
+            assert settings.model_name == "gpt-4"
+
+
+class TestSearchEngineConfiguration:
+    """Test search engine configuration."""
+
+    def test_default_search_engine(self):
+        """Test default search engine is HYBRID_RRF_COLBERT."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=False):
+            settings = Settings(api_provider="openai")
+            assert settings.search_engine == SearchEngine.HYBRID_RRF_COLBERT
+
+    def test_search_engine_from_env(self):
+        """Test search engine from environment variable."""
+        env_vars = {
+            "OPENAI_API_KEY": "test-key",
+            "SEARCH_ENGINE": "baseline",
+        }
+        with patch.dict(os.environ, env_vars, clear=False):
+            settings = Settings(api_provider="openai")
+            assert settings.search_engine == SearchEngine.BASELINE
+
+    def test_search_engine_from_constructor(self):
+        """Test search engine from constructor."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=False):
+            settings = Settings(api_provider="openai", search_engine="hybrid_rrf")
+            assert settings.search_engine == SearchEngine.HYBRID_RRF
+
+
+class TestFeatureFlags:
+    """Test feature flag parsing."""
+
+    def test_feature_flags_default_true(self):
+        """Test that feature flags default to true."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=False):
+            settings = Settings(api_provider="openai")
+
+            assert settings.enable_caching is True
+            assert settings.enable_query_expansion is True
+            assert settings.enable_mlflow is True
+            assert settings.enable_langfuse is True
+
+    def test_feature_flags_false_parsing(self):
+        """Test that 'false' string is parsed correctly."""
+        env_vars = {
+            "OPENAI_API_KEY": "test-key",
+            "ENABLE_CACHING": "false",
+            "ENABLE_MLFLOW": "FALSE",
+            "ENABLE_LANGFUSE": "False",
+        }
+        with patch.dict(os.environ, env_vars, clear=False):
+            settings = Settings(api_provider="openai")
+
+            assert settings.enable_caching is False
+            assert settings.enable_mlflow is False
+            assert settings.enable_langfuse is False
+
+
+class TestToDict:
+    """Test settings serialization."""
+
+    def test_to_dict_excludes_sensitive_data(self):
+        """Test that to_dict excludes API keys."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "secret-key"}, clear=False):
+            settings = Settings(api_provider="openai")
+            result = settings.to_dict()
+
+            assert "openai_api_key" not in result
+            assert "anthropic_api_key" not in result
+            assert "groq_api_key" not in result
+            assert "qdrant_api_key" not in result
+
+    def test_to_dict_includes_config(self):
+        """Test that to_dict includes configuration values."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=False):
+            settings = Settings(api_provider="openai")
+            result = settings.to_dict()
+
+            assert "api_provider" in result
+            assert "model_name" in result
+            assert "search_engine" in result
+            assert "qdrant_url" in result
+            assert result["api_provider"] == "openai"
+
+
+class TestRepr:
+    """Test string representation."""
+
+    def test_repr_format(self):
+        """Test __repr__ returns formatted string."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=False):
+            settings = Settings(api_provider="openai")
+            result = repr(settings)
+
+            assert "Settings(" in result
+            assert "api_provider=openai" in result
+            assert "search_engine=" in result

--- a/tests/unit/test_voyage_service.py
+++ b/tests/unit/test_voyage_service.py
@@ -1,0 +1,303 @@
+"""Unit tests for telegram_bot/services/voyage.py."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from telegram_bot.services.voyage import VoyageService
+
+
+class TestVoyageServiceInit:
+    """Test VoyageService initialization."""
+
+    def test_init_with_defaults(self):
+        """Test initialization with default models."""
+        with patch("telegram_bot.services.voyage.voyageai.Client"):
+            service = VoyageService(api_key="test-key")
+
+            assert service._model_docs == "voyage-4-large"
+            assert service._model_queries == "voyage-4-lite"
+            assert service._model_rerank == "rerank-2.5"
+
+    def test_init_with_custom_models(self):
+        """Test initialization with custom models."""
+        with patch("telegram_bot.services.voyage.voyageai.Client"):
+            service = VoyageService(
+                api_key="test-key",
+                model_docs="voyage-3-large",
+                model_queries="voyage-3-lite",
+                model_rerank="rerank-2",
+            )
+
+            assert service._model_docs == "voyage-3-large"
+            assert service._model_queries == "voyage-3-lite"
+            assert service._model_rerank == "rerank-2"
+
+    def test_init_creates_client(self):
+        """Test that client is created with API key."""
+        with patch("telegram_bot.services.voyage.voyageai.Client") as mock_client:
+            VoyageService(api_key="test-api-key")
+
+            mock_client.assert_called_once_with(api_key="test-api-key")
+
+    def test_batch_size_constant(self):
+        """Test that BATCH_SIZE is correctly set."""
+        assert VoyageService.BATCH_SIZE == 128
+
+    def test_matryoshka_dims_constant(self):
+        """Test that MATRYOSHKA_DIMS contains valid dimensions."""
+        assert VoyageService.MATRYOSHKA_DIMS == (2048, 1024, 512, 256)
+
+
+class TestEmbedDocuments:
+    """Test document embedding."""
+
+    @pytest.mark.asyncio
+    async def test_embed_documents_empty_list(self):
+        """Test embedding empty list returns empty list."""
+        with patch("telegram_bot.services.voyage.voyageai.Client"):
+            service = VoyageService(api_key="test-key")
+
+            result = await service.embed_documents([])
+
+            assert result == []
+
+    @pytest.mark.asyncio
+    async def test_embed_documents_single_batch(self):
+        """Test embedding documents within single batch."""
+        mock_response = MagicMock()
+        mock_response.embeddings = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+
+        with patch("telegram_bot.services.voyage.voyageai.Client") as mock_client:
+            mock_client_instance = MagicMock()
+            mock_client_instance.embed.return_value = mock_response
+            mock_client.return_value = mock_client_instance
+
+            service = VoyageService(api_key="test-key")
+
+            with patch("asyncio.to_thread", new_callable=AsyncMock) as mock_to_thread:
+                mock_to_thread.return_value = mock_response
+
+                result = await service.embed_documents(["doc1", "doc2"])
+
+                assert len(result) == 2
+                assert result[0] == [0.1, 0.2, 0.3]
+
+    @pytest.mark.asyncio
+    async def test_embed_documents_batching(self):
+        """Test that documents are batched correctly."""
+        mock_response = MagicMock()
+        mock_response.embeddings = [[0.1] * 1024] * 128
+
+        with patch("telegram_bot.services.voyage.voyageai.Client") as mock_client:
+            mock_client_instance = MagicMock()
+            mock_client_instance.embed.return_value = mock_response
+            mock_client.return_value = mock_client_instance
+
+            service = VoyageService(api_key="test-key")
+
+            # Create 200 documents (should require 2 batches)
+            docs = [f"doc{i}" for i in range(200)]
+
+            with patch("asyncio.to_thread", new_callable=AsyncMock) as mock_to_thread:
+                mock_to_thread.return_value = mock_response
+
+                result = await service.embed_documents(docs)
+
+                # Should have called to_thread twice (128 + 72 docs)
+                assert mock_to_thread.call_count == 2
+
+
+class TestEmbedQuery:
+    """Test query embedding."""
+
+    @pytest.mark.asyncio
+    async def test_embed_query_returns_single_embedding(self):
+        """Test that embed_query returns a single embedding."""
+        mock_response = MagicMock()
+        mock_response.embeddings = [[0.1, 0.2, 0.3, 0.4]]
+
+        with patch("telegram_bot.services.voyage.voyageai.Client") as mock_client:
+            mock_client_instance = MagicMock()
+            mock_client_instance.embed.return_value = mock_response
+            mock_client.return_value = mock_client_instance
+
+            service = VoyageService(api_key="test-key")
+
+            with patch("asyncio.to_thread", new_callable=AsyncMock) as mock_to_thread:
+                mock_to_thread.return_value = mock_response
+
+                result = await service.embed_query("test query")
+
+                assert result == [0.1, 0.2, 0.3, 0.4]
+
+    @pytest.mark.asyncio
+    async def test_embed_query_uses_query_model(self):
+        """Test that embed_query uses the query model."""
+        mock_response = MagicMock()
+        mock_response.embeddings = [[0.1]]
+
+        with patch("telegram_bot.services.voyage.voyageai.Client") as mock_client:
+            mock_client_instance = MagicMock()
+            mock_client_instance.embed.return_value = mock_response
+            mock_client.return_value = mock_client_instance
+
+            service = VoyageService(api_key="test-key")
+
+            with patch("asyncio.to_thread", new_callable=AsyncMock) as mock_to_thread:
+                mock_to_thread.return_value = mock_response
+
+                await service.embed_query("test query")
+
+                # Check that to_thread was called with query model
+                call_args = mock_to_thread.call_args
+                assert call_args is not None
+
+
+class TestRerank:
+    """Test reranking."""
+
+    @pytest.mark.asyncio
+    async def test_rerank_empty_documents(self):
+        """Test reranking with empty documents returns empty list."""
+        with patch("telegram_bot.services.voyage.voyageai.Client"):
+            service = VoyageService(api_key="test-key")
+
+            result = await service.rerank("query", [])
+
+            assert result == []
+
+    @pytest.mark.asyncio
+    async def test_rerank_returns_formatted_results(self):
+        """Test that rerank returns properly formatted results."""
+        mock_result1 = MagicMock()
+        mock_result1.index = 0
+        mock_result1.relevance_score = 0.95
+        mock_result1.document = "doc1"
+
+        mock_result2 = MagicMock()
+        mock_result2.index = 1
+        mock_result2.relevance_score = 0.85
+        mock_result2.document = "doc2"
+
+        mock_response = MagicMock()
+        mock_response.results = [mock_result1, mock_result2]
+
+        with patch("telegram_bot.services.voyage.voyageai.Client") as mock_client:
+            mock_client_instance = MagicMock()
+            mock_client_instance.rerank.return_value = mock_response
+            mock_client.return_value = mock_client_instance
+
+            service = VoyageService(api_key="test-key")
+
+            with patch("asyncio.to_thread", new_callable=AsyncMock) as mock_to_thread:
+                mock_to_thread.return_value = mock_response
+
+                result = await service.rerank("query", ["doc1", "doc2"])
+
+                assert len(result) == 2
+                assert result[0]["index"] == 0
+                assert result[0]["relevance_score"] == 0.95
+                assert result[0]["document"] == "doc1"
+
+
+class TestMatryoshkaEmbeddings:
+    """Test Matryoshka embeddings."""
+
+    @pytest.mark.asyncio
+    async def test_matryoshka_invalid_dimension(self):
+        """Test that invalid dimension raises ValueError."""
+        with patch("telegram_bot.services.voyage.voyageai.Client"):
+            service = VoyageService(api_key="test-key")
+
+            with pytest.raises(ValueError, match="Invalid output_dimension"):
+                await service.embed_documents_matryoshka(["doc"], output_dimension=100)
+
+    @pytest.mark.asyncio
+    async def test_matryoshka_valid_dimensions(self):
+        """Test that valid dimensions are accepted."""
+        mock_response = MagicMock()
+        mock_response.embeddings = [[0.1] * 512]
+
+        with patch("telegram_bot.services.voyage.voyageai.Client") as mock_client:
+            mock_client_instance = MagicMock()
+            mock_client_instance.embed.return_value = mock_response
+            mock_client.return_value = mock_client_instance
+
+            service = VoyageService(api_key="test-key")
+
+            for dim in (2048, 1024, 512, 256):
+                with patch("asyncio.to_thread", new_callable=AsyncMock) as mock_to_thread:
+                    mock_to_thread.return_value = mock_response
+
+                    # Should not raise
+                    await service.embed_documents_matryoshka(["doc"], output_dimension=dim)
+
+    @pytest.mark.asyncio
+    async def test_matryoshka_empty_list(self):
+        """Test Matryoshka embedding with empty list."""
+        with patch("telegram_bot.services.voyage.voyageai.Client"):
+            service = VoyageService(api_key="test-key")
+
+            result = await service.embed_documents_matryoshka([])
+
+            assert result == []
+
+    @pytest.mark.asyncio
+    async def test_matryoshka_query_invalid_dimension(self):
+        """Test that invalid dimension raises ValueError for query."""
+        with patch("telegram_bot.services.voyage.voyageai.Client"):
+            service = VoyageService(api_key="test-key")
+
+            with pytest.raises(ValueError, match="Invalid output_dimension"):
+                await service.embed_query_matryoshka("query", output_dimension=100)
+
+
+class TestSyncWrappers:
+    """Test synchronous wrapper methods."""
+
+    def test_embed_documents_sync_calls_async(self):
+        """Test that sync wrapper calls async method."""
+        mock_response = MagicMock()
+        mock_response.embeddings = [[0.1, 0.2]]
+
+        with patch("telegram_bot.services.voyage.voyageai.Client") as mock_client:
+            mock_client_instance = MagicMock()
+            mock_client_instance.embed.return_value = mock_response
+            mock_client.return_value = mock_client_instance
+
+            service = VoyageService(api_key="test-key")
+
+            with patch.object(service, "embed_documents", new_callable=AsyncMock) as mock_async:
+                mock_async.return_value = [[0.1, 0.2]]
+
+                with patch("asyncio.run") as mock_run:
+                    mock_run.return_value = [[0.1, 0.2]]
+
+                    result = service.embed_documents_sync(["doc"])
+
+                    assert mock_run.called
+
+    def test_embed_query_sync_calls_async(self):
+        """Test that sync query wrapper calls async method."""
+        with patch("telegram_bot.services.voyage.voyageai.Client"):
+            service = VoyageService(api_key="test-key")
+
+            with patch("asyncio.run") as mock_run:
+                mock_run.return_value = [0.1, 0.2]
+
+                result = service.embed_query_sync("query")
+
+                assert mock_run.called
+
+    def test_rerank_sync_calls_async(self):
+        """Test that sync rerank wrapper calls async method."""
+        with patch("telegram_bot.services.voyage.voyageai.Client"):
+            service = VoyageService(api_key="test-key")
+
+            with patch("asyncio.run") as mock_run:
+                mock_run.return_value = [{"index": 0, "relevance_score": 0.9}]
+
+                result = service.rerank_sync("query", ["doc"])
+
+                assert mock_run.called


### PR DESCRIPTION
Add unit tests for core modules:
- test_settings.py: Settings class, API validation, defaults
- test_chunker.py: DocumentChunker, CSV chunking, metadata extraction
- test_query_preprocessor_unit.py: Transliteration, RRF weights, cache thresholds
- test_voyage_service.py: VoyageService embeddings, reranking, Matryoshka
- test_search_engines.py: All search engine variants, factory function
- test_retriever_service.py: RetrieverService, filter building
- test_llm_service.py: Answer generation, streaming, fallbacks
- test_indexer.py: DocumentIndexer, collection creation, payload indexes
- test_constants.py: Enums, dataclasses, default values
- test_document_parser.py: PDF/Docling parsing, caching
- test_contextual_schema.py: ContextualChunk/Document serialization

Total: 12 test files with ~200 test cases covering:
- src/config/
- src/ingestion/
- src/retrieval/
- telegram_bot/services/