### PR TITLE
perf: Sprint 1 — latency & correctness fixes (#125)

### DIFF
--- a/.claude/rules/features/embeddings.md
+++ b/.claude/rules/features/embeddings.md
@@ -24,15 +24,16 @@ Dev:
   Cache:  USER-base (768-dim)
 
 LangGraph Pipeline (via integrations/embeddings.py):
-  BGEM3Embeddings (dense, LangChain Embeddings)
-  BGEM3SparseEmbeddings (sparse, custom wrapper)
+  BGEM3HybridEmbeddings (dense+sparse in 1 call, shared httpx.AsyncClient)
+  BGEM3Embeddings (dense only, LangChain Embeddings) — legacy
+  BGEM3SparseEmbeddings (sparse only, custom wrapper) — legacy
 ```
 
 ## Key Files
 
 | File | Description |
 |------|-------------|
-| `telegram_bot/integrations/embeddings.py` | BGEM3Embeddings + BGEM3SparseEmbeddings (LangChain-compatible) |
+| `telegram_bot/integrations/embeddings.py` | BGEM3HybridEmbeddings (preferred) + legacy BGEM3Embeddings/BGEM3SparseEmbeddings |
 | `telegram_bot/services/voyage.py` | VoyageService class |
 | `telegram_bot/services/vectorizers.py` | UserBaseVectorizer + BgeM3CacheVectorizer |
 | `telegram_bot/services/colbert_reranker.py` | ColbertRerankerService |
@@ -41,7 +42,22 @@ LangGraph Pipeline (via integrations/embeddings.py):
 
 ## LangChain Wrappers (LangGraph integration)
 
-### BGEM3Embeddings (dense)
+### BGEM3HybridEmbeddings (preferred — single API call)
+
+```python
+from telegram_bot.integrations.embeddings import BGEM3HybridEmbeddings
+
+emb = BGEM3HybridEmbeddings(base_url="http://bge-m3:8000", timeout=120.0)
+# Shared httpx.AsyncClient with connection pooling (reused across calls)
+
+# Returns (dense, sparse) tuple in one /encode/hybrid call
+dense, sparse = await emb.aembed_hybrid("search text")    # (list[float], dict)
+
+# Also works as LangChain Embeddings (dense only)
+vector = await emb.aembed_query("search text")             # list[float], 1024-dim
+```
+
+### BGEM3Embeddings (dense) — legacy, use BGEM3HybridEmbeddings instead
 
 ```python
 from telegram_bot.integrations.embeddings import BGEM3Embeddings
@@ -58,7 +74,7 @@ vector = emb.embed_query("search text")
 
 Wraps BGE-M3 `/encode/dense` endpoint (fixed from legacy `/encode`). Batching via `batch_size=32`.
 
-### BGEM3SparseEmbeddings (sparse)
+### BGEM3SparseEmbeddings (sparse) — legacy, use BGEM3HybridEmbeddings instead
 
 ```python
 from telegram_bot.integrations.embeddings import BGEM3SparseEmbeddings
@@ -88,7 +104,7 @@ Wraps BGE-M3 `/encode/sparse` endpoint (fixed from legacy `/encode`). Returns `l
 |----------|---------|---------|
 | `/encode/dense` | `dense_vecs` | BGEM3Embeddings |
 | `/encode/sparse` | `lexical_weights` | BGEM3SparseEmbeddings |
-| `/encode/hybrid` | all three | Direct API calls |
+| `/encode/hybrid` | `dense_vecs` + `lexical_weights` | BGEM3HybridEmbeddings (preferred) |
 | `/rerank` | ColBERT scores | ColbertRerankerService |
 
 ## Dependencies

--- a/.claude/rules/features/search-retrieval.md
+++ b/.claude/rules/features/search-retrieval.md
@@ -31,7 +31,7 @@ Dev:  Voyage dense + BM42 sparse + Voyage rerank (API)
 | `src/retrieval/search_engines.py` | BaseSearchEngine ABC + variants |
 | `telegram_bot/services/qdrant.py` | QdrantService (async, gRPC, batch, group_by) |
 | `telegram_bot/graph/nodes/retrieve.py` | LangGraph retrieve_node (hybrid RRF + cache) |
-| `telegram_bot/graph/nodes/grade.py` | Score-based relevance grading (threshold 0.3) |
+| `telegram_bot/graph/nodes/grade.py` | Score-based relevance grading (RRF threshold 0.005) |
 | `telegram_bot/graph/nodes/rerank.py` | Optional ColBERT + score-sort fallback, top-5 |
 | `telegram_bot/graph/nodes/rewrite.py` | LLM query reformulation, max 2 retries |
 
@@ -53,7 +53,7 @@ Dense embedding comes from `state["query_embedding"]` (set by cache_check_node).
 
 ### grade_node
 
-Score-based heuristic: `top_score > 0.3` → documents relevant. Also sets `grade_confidence` (= top_score) and `skip_rerank` (true when `top_score >= skip_rerank_threshold`).
+Score-based heuristic: `top_score > relevance_threshold_rrf` (default 0.005, env `RELEVANCE_THRESHOLD_RRF`) → documents relevant. RRF scores use scale `1/(k+rank)` where k=60, so typical scores are 0.001–0.016. Also sets `grade_confidence` (= top_score) and `skip_rerank` (true when `top_score >= skip_rerank_threshold`).
 
 ### rerank_node
 
@@ -78,7 +78,8 @@ LLM reformulation via OpenAI SDK (`GraphConfig.create_llm()`). Increments `rewri
 |-----------|---------|-------------|
 | `dense_weight` | 0.6 | RRF weight for dense vectors |
 | `sparse_weight` | 0.4 | RRF weight for sparse vectors |
-| `rrf_k` | 60 | RRF constant (configurable) |
+| `rrf_k` | 60 | RRF constant, scores = 1/(k+rank) |
+| `relevance_threshold_rrf` | 0.005 | Grade threshold for RRF scores (env `RELEVANCE_THRESHOLD_RRF`) |
 | `prefetch_multiplier` | 3 | Overfetch ratio for RRF |
 | `quantization_mode` | binary | off/scalar/binary (32x compression) |
 | `quantization_rescore` | true | Rescore with full vectors |

--- a/.claude/rules/observability.md
+++ b/.claude/rules/observability.md
@@ -145,21 +145,21 @@ OTEL_SERVICE_NAME: rag-bot  # Set in docker-compose.dev.yml bot service
 
 12 scores written via `_write_langfuse_scores(lf, result)` in `bot.py` after `graph.ainvoke()`:
 
-**Latency convention:** All `latency_stages` values are in **seconds** (float). The score writer computes `latency_total_ms = sum(stages.values()) * 1000`.
+**Latency convention:** `latency_total_ms` is **wall-time** measured via `time.perf_counter` in `handle_query` (pipeline_wall_ms), NOT sum of stages. All `latency_stages` values are in **seconds** (float) for per-stage breakdown only.
 
 | Score | Values | Purpose |
 |-------|--------|---------|
 | `query_type` | 0/1/2 | CHITCHAT/SIMPLE/COMPLEX (via `_QUERY_TYPE_SCORE` mapping) |
-| `latency_total_ms` | float | End-to-end request latency (sum of seconds * 1000) |
+| `latency_total_ms` | float | End-to-end wall-time latency (perf_counter, ms) |
 | `semantic_cache_hit` | 0.0/1.0 | Semantic cache effectiveness |
-| `embeddings_cache_hit` | 0.0/1.0 | Embeddings cache (not yet tracked in state, default 0.0) |
-| `search_cache_hit` | 0.0/1.0 | Search results cache (not yet tracked in state, default 0.0) |
+| `embeddings_cache_hit` | 0.0/1.0 | Embeddings cache (real value from state) |
+| `search_cache_hit` | 0.0/1.0 | Search results cache (real value from state) |
 | `rerank_applied` | 0.0/1.0 | Whether reranking was performed |
 | `rerank_cache_hit` | 0.0/1.0 | Rerank cache (not yet tracked in state, default 0.0) |
 | `results_count` | 0-N | Number of retrieved documents |
 | `no_results` | 0.0/1.0 | Query returned empty results |
 | `llm_used` | 0.0/1.0 | LLM generation was invoked |
-| `confidence_score` | 0.0 | Not yet tracked in LangGraph state |
+| `confidence_score` | 0.0-1.0 | Grade confidence (real value from state) |
 | `hyde_used` | 0.0 | Not yet tracked in LangGraph state |
 
 **Implementation:** `get_client().score_current_trace(name=..., value=...)` (Langfuse SDK v3)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ make ingest-unified-status # Show ingestion stats from Postgres
 ```
 Ingestion: Docling Parser → Chunker → BGE-M3 Dense + Sparse → Qdrant
 Bot:       Query → LangGraph StateGraph (9 nodes) → classify → cache_check
-           → retrieve (RRF) → grade → rerank (ColBERT) → generate → respond
+           → retrieve (RRF, hybrid embed 1-call) → grade → rerank (ColBERT) → generate → respond
 ```
 
 | Module | Purpose |
@@ -107,7 +107,7 @@ CLAUDE_CODE_TASK_LIST_ID=my-project claude
 | `legal_documents` | Ukrainian Criminal Code (1,294 docs) | BGE-M3 | Dev |
 | `gdrive_documents_scalar` | Google Drive docs | Voyage | Dev |
 
-**Settings:** `quantization_mode=off|scalar|binary`, `small_to_big_mode=off|on|auto`, `use_hyde=true|false`, `STREAMING_ENABLED=true|false`
+**Settings:** `quantization_mode=off|scalar|binary`, `small_to_big_mode=off|on|auto`, `use_hyde=true|false`, `STREAMING_ENABLED=true|false`, `RELEVANCE_THRESHOLD_RRF=0.005`
 
 ## Deployment
 
@@ -179,7 +179,7 @@ See `.claude/rules/` for domain-specific documentation:
 | `features/query-processing.md` | HyDE, preprocessing, routing | `**/query*.py` |
 | `features/evaluation.md` | RAGAS, metrics, A/B tests | `src/evaluation/**` |
 | `features/caching.md` | 6-tier cache, Redis pipelines, TTL | `**/cache*.py` |
-| `features/embeddings.md` | BGE-M3 (/encode/dense, /encode/sparse), Voyage | `**/embed*.py` |
+| `features/embeddings.md` | BGE-M3 (/encode/hybrid, dense, sparse), Voyage | `**/embed*.py` |
 | `features/llm-integration.md` | LiteLLM, guardrails, fallbacks | `**/llm*.py` |
 | `features/ingestion.md` | CocoIndex, Docling, parsing | `src/ingestion/**` |
 | `features/telegram-bot.md` | LangGraph pipeline, bot, middlewares | `telegram_bot/*.py` |

--- a/docs/plans/2026-02-10-issue120-umbrella-execution.md
+++ b/docs/plans/2026-02-10-issue120-umbrella-execution.md
@@ -697,7 +697,7 @@ Expected: collected (with legacy_api marker), no import error during collection.
 **Step 3: Verify it's excluded in CI mode**
 
 ```bash
-uv run pytest tests/integration/test_redis_cache.py -m "not legacy_api" --collect-only
+uv run pytest tests/integration/test_redis_cache.py -m "not legacy_api" --collect-only || true
 ```
 
 Expected: 0 tests collected.

--- a/docs/plans/2026-02-10-issue120-umbrella-execution.md
+++ b/docs/plans/2026-02-10-issue120-umbrella-execution.md
@@ -1,10 +1,10 @@
 # #120 Umbrella: P0 Fixes → Local Validation → P1/P2
 
-**Goal:** Закрыть все дефекты из аудита PR #111, провести локальную валидацию бота, собрать Langfuse трейсы, принять Go/No-Go по latency issues.
+**Goal:** Закрыть все дефекты из аудита PR #111, провести локальную валидацию бота, собрать Langfuse трейсы, выполнить глубокий аудит Qdrant/Redis/BGE-M3 latency и принять Go/No-Go по ONNX migration spike.
 
-**Architecture:** 6 фаз: подготовка → P0 фиксы (4 issues) → gate → docker rebuild + traces → P1/P2 фиксы (4 issues) → final gate. Исполнение: 1 issue = 1 branch = 1 PR (без прямых коммитов в `main`). TDD для #114 и #117.
+**Architecture:** 7 фаз: подготовка → P0 фиксы (4 issues) → gate → docker rebuild + traces → deep audit (Qdrant/Redis/BGE/ONNX) → P1/P2 фиксы (4 issues) → final gate. Исполнение: 1 issue = 1 branch = 1 PR (без прямых коммитов в `main`). TDD для #114 и #117.
 
-**Tech Stack:** pytest, ruff, mypy, monkeypatch, Docker Compose, Langfuse SDK, Qdrant Python SDK, gh CLI, Context7
+**Tech Stack:** pytest, ruff, mypy, monkeypatch, Docker Compose, Langfuse SDK, Qdrant Python SDK, RedisVL SDK, Sentence-Transformers/Optimum (ONNX spike), gh CLI, Context7
 
 ---
 
@@ -40,6 +40,13 @@ gh issue edit 120 --body "$(gh issue view 120 --json body -q '.body')
 - [ ] Full E2E (25 scenarios)
 - [ ] Go/No-Go decision
 
+### Deep Audit (Qdrant/Redis/BGE/ONNX)
+- [ ] Trace-level latency breakdown documented (incl. `c2b95d86aa1f643b79016dd611c4691f`)
+- [ ] BGE endpoint benchmark (dense/sparse/hybrid, p50/p95)
+- [ ] Qdrant benchmark (query_points RRF, p50/p95)
+- [ ] Redis benchmark + eviction/hit-rate snapshot
+- [ ] ONNX spike decision (dense-only vs full BGE-M3 tri-vector parity)
+
 ### P1/P2
 - [ ] #116 sync rewrite_max_tokens
 - [ ] #118 test_redis_cache legacy imports
@@ -65,6 +72,8 @@ Expected: #120 body обновлён, checklist виден в UI.
 - Использовать официальные SDK, не raw HTTP, где есть стабильный клиент.
 - Для tracing/LLM вызовов: `langfuse-python` (`/langfuse/langfuse-python` в Context7), в т.ч. `from langfuse.openai import AsyncOpenAI`, `@observe`, `update_current_trace`, `score_current_trace`.
 - Для векторного поиска: `qdrant-client` (`/qdrant/qdrant-client` в Context7), в т.ч. `AsyncQdrantClient` + `query_points`.
+- Для semantic cache: `redis-vl-python` (`/redis/redis-vl-python` в Context7), в т.ч. `SemanticCache(redis_url=...)`, `acheck/astore`, filterable fields.
+- Для ONNX spike: `sentence-transformers` (`/huggingface/sentence-transformers` в Context7) + `optimum` (экспорт/оптимизация), без ad-hoc кастомных рантаймов на первом шаге.
 
 **Step 2: Проверять в code review каждого PR**
 
@@ -339,7 +348,7 @@ Closes #113"
 **Files:**
 - Edit: `telegram_bot/graph/nodes/generate.py:221-261`
 - Read: `telegram_bot/graph/nodes/respond.py` (already handles `response_sent`)
-- Create: `tests/unit/graph/test_streaming_fallback.py`
+- Edit: `tests/unit/graph/test_generate_node.py`
 
 **Analysis of the bug:**
 
@@ -360,203 +369,38 @@ try:
 
 The bug: if `_generate_streaming` sent partial chunks (placeholder + some edits) but then raised, `response_sent` stays `False`. The fallback generates a new answer, and `respond_node` sends it as a NEW message. User sees: partial streamed text + full new message = duplicate.
 
-**The fix:** Track whether the streaming placeholder was sent. If it was, the fallback should edit that message instead of letting respond_node send a new one.
+**Important correction:** нельзя просто выставлять `response_sent=True` на любой streaming-error. Если стрим упал до первого user-visible chunk, пользователь может остаться только с placeholder.
 
-However, the simplest correct fix per issue scope: if streaming started (placeholder sent), set `response_sent = True` after fallback too, because the user already has a message being edited. The fallback should edit the existing placeholder message.
+**Step 1: Add/adjust tests in existing suite**
 
-Looking at `_generate_streaming`:
-- Line 127: `sent_msg = await message.answer(_STREAM_PLACEHOLDER)` — sends placeholder
-- If error occurs after this, placeholder message exists in Telegram
+В `tests/unit/graph/test_generate_node.py` добавить 2 явных кейса:
+- `stream_error_before_visible_output` -> `response_sent=False` (final send делает `respond_node`);
+- `stream_error_after_visible_output` -> fallback редактирует уже отправленное сообщение и `response_sent=True`.
 
-**Simplest fix:** After fallback LLM call, edit the existing placeholder if streaming was attempted. But we don't have `sent_msg` in the outer scope.
-
-**Better fix:** Restructure to catch errors inside `_generate_streaming` more granularly, or pass a mutable container.
-
-**Simplest correct fix:** Wrap the streaming+fallback logic so that if streaming was attempted (placeholder sent), the fallback response is delivered via edit_text on the placeholder, and `response_sent = True`.
-
-**Step 1: Write the failing test**
-
-Create `tests/unit/graph/test_streaming_fallback.py`:
-
-```python
-"""Tests for streaming fallback duplicate prevention in generate_node."""
-
-from unittest.mock import AsyncMock, MagicMock, patch
-
-import pytest
-
-
-@pytest.fixture
-def mock_message():
-    """Create mock aiogram Message."""
-    msg = MagicMock()
-    sent_placeholder = MagicMock()
-    sent_placeholder.edit_text = AsyncMock()
-    sent_placeholder.delete = AsyncMock()
-    msg.answer = AsyncMock(return_value=sent_placeholder)
-    msg.chat = MagicMock(id=12345)
-    return msg
-
-
-@pytest.fixture
-def mock_config():
-    """Create mock GraphConfig for streaming."""
-    gc = MagicMock()
-    gc.domain = "недвижимость"
-    gc.llm_model = "test-model"
-    gc.llm_temperature = 0.7
-    gc.generate_max_tokens = 2048
-    gc.streaming_enabled = True
-    gc.create_llm.return_value = MagicMock()
-    return gc
-
-
-def _make_state(query: str = "квартиры в Несебре") -> dict:
-    """Create minimal state for generate_node."""
-    return {
-        "documents": [
-            {"text": "Квартира 85000 евро", "score": 0.9, "metadata": {"title": "Квартира"}},
-        ],
-        "messages": [{"role": "user", "content": query}],
-        "latency_stages": {},
-    }
-
-
-class TestStreamingFallbackNoDuplicate:
-    """Verify that streaming failure + fallback does not cause duplicate sends."""
-
-    @pytest.mark.asyncio
-    async def test_fallback_sets_response_sent_true(self, mock_message, mock_config):
-        """After streaming fails and fallback succeeds, response_sent must be True.
-
-        This prevents respond_node from sending a duplicate message.
-        """
-        from telegram_bot.graph.nodes.generate import _make_llm_completion
-
-        fallback_completion = MagicMock()
-        fallback_completion.choices = [MagicMock(message=MagicMock(content="Fallback answer"))]
-
-        mock_llm = MagicMock()
-        mock_llm.chat.completions.create = AsyncMock(return_value=fallback_completion)
-
-        with (
-            patch(
-                "telegram_bot.graph.nodes.generate._get_config", return_value=mock_config,
-            ),
-            patch(
-                "telegram_bot.graph.nodes.generate._generate_streaming",
-                side_effect=RuntimeError("stream broken"),
-            ),
-        ):
-            mock_config.create_llm.return_value = mock_llm
-            state = _make_state()
-
-            from telegram_bot.graph.nodes.generate import generate_node
-
-            result = await generate_node(state, message=mock_message)
-
-        assert result["response"] == "Fallback answer"
-        # Key assertion: response_sent should be True if streaming was attempted
-        # so respond_node does not send a duplicate
-        assert result["response_sent"] is True
-
-    @pytest.mark.asyncio
-    async def test_non_streaming_response_sent_false(self, mock_message, mock_config):
-        """Non-streaming path should leave response_sent=False for respond_node."""
-        mock_config.streaming_enabled = False
-
-        completion = MagicMock()
-        completion.choices = [MagicMock(message=MagicMock(content="Normal answer"))]
-
-        mock_llm = MagicMock()
-        mock_llm.chat.completions.create = AsyncMock(return_value=completion)
-
-        with patch(
-            "telegram_bot.graph.nodes.generate._get_config", return_value=mock_config,
-        ):
-            mock_config.create_llm.return_value = mock_llm
-            state = _make_state()
-
-            from telegram_bot.graph.nodes.generate import generate_node
-
-            result = await generate_node(state, message=mock_message)
-
-        assert result["response"] == "Normal answer"
-        assert result["response_sent"] is False
-```
-
-**Step 2: Run test to verify it fails**
+**Step 2: Run tests in red state**
 
 ```bash
-uv run pytest tests/unit/graph/test_streaming_fallback.py -v
+uv run pytest tests/unit/graph/test_generate_node.py -k "streaming_fallback or stream_error" -v
 ```
 
-Expected: `test_fallback_sets_response_sent_true` FAILS (response_sent is False).
+Expected: минимум один тест падает до фикса.
 
-**Step 3: Fix generate_node streaming fallback**
+**Step 3: Fix generate_node streaming fallback safely**
 
-In `telegram_bot/graph/nodes/generate.py`, replace lines 221-261 (the `response_sent = False` through end of function):
+В `telegram_bot/graph/nodes/generate.py`:
+- Ввести явный сигнал частичной пользовательской доставки из `_generate_streaming` (например custom exception `StreamingPartialDeliveryError`, содержащий ссылку на `sent_msg`).
+- В `generate_node` на fallback:
+  - если partial delivery уже была -> отдать fallback через `edit_text` того же сообщения и поставить `response_sent=True`;
+  - если partial delivery не было -> оставить `response_sent=False`, чтобы `respond_node` отправил ответ.
+- Не ломать текущий контракт non-streaming пути.
 
-```python
-    response_sent = False
-
-    try:
-        llm = config.create_llm()
-
-        # Streaming path: deliver directly to Telegram
-        if message is not None and config.streaming_enabled:
-            streaming_attempted = False
-            try:
-                answer = await _generate_streaming(llm, config, llm_messages, message)
-                response_sent = True
-            except Exception:
-                streaming_attempted = True
-                logger.warning("Streaming failed, falling back to non-streaming", exc_info=True)
-                # Fall back to non-streaming
-                response = await llm.chat.completions.create(
-                    model=config.llm_model,
-                    messages=llm_messages,
-                    temperature=config.llm_temperature,
-                    max_tokens=config.generate_max_tokens,
-                    name="generate-answer",  # type: ignore[call-overload]
-                )
-                answer = response.choices[0].message.content or ""
-                # Streaming was attempted — a placeholder message exists in Telegram.
-                # Mark response_sent so respond_node does not send a duplicate.
-                response_sent = True
-        else:
-            # Non-streaming path (original)
-            response = await llm.chat.completions.create(
-                model=config.llm_model,
-                messages=llm_messages,
-                temperature=config.llm_temperature,
-                max_tokens=config.generate_max_tokens,
-                name="generate-answer",  # type: ignore[call-overload]  # langfuse kwarg
-            )
-            answer = response.choices[0].message.content or ""
-    except Exception:
-        logger.exception("generate_node: LLM call failed, using fallback")
-        answer = _build_fallback_response(documents)
-
-    elapsed = time.monotonic() - t0
-    return {
-        "response": answer,
-        "response_sent": response_sent,
-        "latency_stages": {**state.get("latency_stages", {}), "generate": elapsed},
-    }
-```
-
-Key change: after streaming exception + fallback LLM call, set `response_sent = True` because a placeholder message already exists in the chat. `respond_node` will skip the duplicate send (it already checks `state.get("response_sent", False)` at line 36).
-
-**Note:** The `streaming_attempted` variable is kept for clarity but currently unused. Remove if ruff complains (F841).
-
-**Step 4: Run test to verify it passes**
+**Step 4: Run tests to green**
 
 ```bash
-uv run pytest tests/unit/graph/test_streaming_fallback.py -v
+uv run pytest tests/unit/graph/test_generate_node.py -k "streaming_fallback or stream_error" -v
 ```
 
-Expected: both tests green.
+Expected: новые/обновлённые кейсы зелёные.
 
 **Step 5: Run graph integration tests (regression)**
 
@@ -570,12 +414,13 @@ Expected: all green (path tests use `streaming_enabled=False`).
 **Step 6: Lint + commit**
 
 ```bash
-uv run ruff check telegram_bot/graph/nodes/generate.py tests/unit/graph/test_streaming_fallback.py --output-format=concise
-git add telegram_bot/graph/nodes/generate.py tests/unit/graph/test_streaming_fallback.py
+uv run ruff check telegram_bot/graph/nodes/generate.py tests/unit/graph/test_generate_node.py --output-format=concise
+git add telegram_bot/graph/nodes/generate.py tests/unit/graph/test_generate_node.py
 git commit -m "fix(graph): prevent duplicate response on streaming fallback
 
-When streaming fails after placeholder sent, mark response_sent=True
-so respond_node skips redundant message.send(). Adds test coverage.
+Track partial streaming delivery and route fallback safely:
+edit existing message when partial output was visible, otherwise let
+respond_node deliver final answer.
 
 Closes #114"
 ```
@@ -653,7 +498,7 @@ Send to bot in Telegram:
 Open Langfuse UI. Find traces from smoke test. Check:
 - Node spans: node-classify, node-cache-check, node-retrieve, node-grade, node-generate, node-respond
 - Scores: latency_total_ms, semantic_cache_hit, search_results_count, rerank_applied
-- response_sent score present
+- `response_sent` проверяется как поле state/output в trace metadata/span (не как score, если отдельно не добавлено)
 
 Record trace IDs.
 
@@ -676,6 +521,81 @@ Expected: pass rate >= 80%.
 ### Task 3.6: Go/No-Go
 
 Compare with problem trace `c2b95d86aa1f643b79016dd611c4691f` from #105. Post results to #120.
+
+---
+
+## Phase 3.7: Deep Audit (Qdrant + Redis + BGE-M3 + ONNX)
+
+### Task 3.7.1: Trace-first baseline (Langfuse SDK)
+
+**Step 1: Зафиксировать baseline по проблемному trace**
+
+Снять из trace:
+- total latency
+- суммарный вклад `node-retrieve`, `bge-m3-dense-embed`, `bge-m3-sparse-embed`, `qdrant-hybrid-search-rrf`
+- число rewrite-итераций
+
+Expected: подтверждено, где compute bottleneck (BGE/LLM/Qdrant/looping).
+
+### Task 3.7.2: BGE-M3 bottleneck isolation
+
+**Step 1: Benchmark `/encode/dense`, `/encode/sparse`, `/encode/hybrid` (p50/p95)**
+
+Expected:
+- `hybrid` не хуже суммы `dense+sparse` (обычно существенно лучше двух последовательных вызовов).
+- зафиксировать tail latency при concurrency 1/2/4/8.
+
+**Step 2: Проверить runtime-конфиг BGE**
+
+Проверить:
+- `workers`, `limit-concurrency`
+- `OMP_NUM_THREADS`, `MKL_NUM_THREADS`
+- модельные лимиты (`max_length`, batch)
+
+Expected: задокументирован план тюнинга без регресса стабильности.
+
+### Task 3.7.3: Qdrant deep check (SDK-only)
+
+**Step 1: Benchmark `query_points` RRF (dense+sparse prefetch)**
+
+Expected: p50/p95 и доля в E2E latency.
+
+**Step 2: Проверить collection config**
+
+Проверить:
+- `quantization_config`
+- `optimizer_status`
+- `segments_count`, `indexed_vectors_count`
+- наличие payload indexes для фильтров
+
+Expected: решение по quantization/optimizer для текущего датасета.
+
+### Task 3.7.4: Redis deep check
+
+**Step 1: Snapshot метрик Redis**
+
+Проверить:
+- `keyspace_hits/misses`
+- `evicted_keys`
+- `used_memory/maxmemory`
+- policy (`volatile-lfu`)
+
+**Step 2: Micro-benchmark GET/SET**
+
+Expected: Redis latency << BGE/LLM latency; если нет — отдельный issue на Redis.
+
+### Task 3.7.5: ONNX migration spike (decision gate)
+
+**Scope:**
+- Spike only for dense embedding path first (не сразу весь tri-vector pipeline).
+- Проверить качество/совместимость и throughput.
+
+**Decision rule:**
+- Если ONNX даёт >=20-30% выигрыш на dense path без заметной quality деградации, открыть implementation issue.
+- Если нет стабильного выигрыша/паритета для BGE-M3 tri-vector, оставить PyTorch для sparse/colbert и использовать гибридную схему.
+
+Deliverable:
+- комментарий в #120 с таблицей baseline vs candidate (p50/p95/quality).
 
 ---
 
@@ -797,142 +717,65 @@ Closes #118"
 
 ---
 
-### Task 4.3: #117 — Qdrant error vs no-results
+### Task 4.3: #117 — Qdrant error vs no-results (без shared mutable state)
 
 **Files:**
-- Edit: `telegram_bot/services/qdrant.py:251-254`
+- Edit: `telegram_bot/services/qdrant.py`
+- Edit: `telegram_bot/graph/nodes/retrieve.py`
+- Edit: `telegram_bot/graph/state.py`
 - Create: `tests/unit/test_qdrant_error_signal.py`
 
-**Step 1: Write the failing test**
+**Step 1: Write failing tests (service + retrieve node)**
 
-Create `tests/unit/test_qdrant_error_signal.py`:
+Покрыть два сценария:
+- backend exception -> `backend_error=True` + `error_type` заполнен;
+- genuine empty results -> `backend_error=False`.
 
-```python
-"""Tests for Qdrant error signal distinction from empty results."""
+Примечание: следуем SDK-first (Context7): используем `AsyncQdrantClient` и его вызовы/исключения, без raw HTTP.
 
-from unittest.mock import AsyncMock, MagicMock, patch
-
-import pytest
-
-
-@pytest.fixture
-def qdrant_service():
-    """Create QdrantService with mocked client."""
-    with patch("telegram_bot.services.qdrant.AsyncQdrantClient") as mock_client_cls:
-        mock_client = AsyncMock()
-        mock_client_cls.return_value = mock_client
-
-        from telegram_bot.services.qdrant import QdrantService
-
-        svc = QdrantService(
-            url="http://localhost:6333",
-            collection_name="test_collection",
-        )
-        svc._client = mock_client
-        svc._collection_verified = True
-        yield svc, mock_client
-
-
-class TestQdrantErrorSignal:
-    """Verify error vs empty-results distinction."""
-
-    @pytest.mark.asyncio
-    async def test_search_error_returns_empty_with_error_flag(self, qdrant_service):
-        """When Qdrant raises, result is [] but qdrant_error metadata is set."""
-        svc, mock_client = qdrant_service
-        mock_client.query_points = AsyncMock(side_effect=RuntimeError("connection refused"))
-
-        results = await svc.hybrid_search_rrf(
-            dense_vector=[0.1] * 1024,
-            sparse_vector={"indices": [1], "values": [0.5]},
-        )
-        assert results == []
-        assert svc.last_search_error is True
-
-    @pytest.mark.asyncio
-    async def test_empty_results_no_error_flag(self, qdrant_service):
-        """When Qdrant returns empty, no error flag."""
-        svc, mock_client = qdrant_service
-        mock_result = MagicMock()
-        mock_result.points = []
-        mock_client.query_points = AsyncMock(return_value=mock_result)
-
-        results = await svc.hybrid_search_rrf(
-            dense_vector=[0.1] * 1024,
-            sparse_vector={"indices": [1], "values": [0.5]},
-        )
-        assert results == []
-        assert svc.last_search_error is False
-```
-
-**Step 2: Run test to verify it fails**
+**Step 2: Run tests in red state**
 
 ```bash
 uv run pytest tests/unit/test_qdrant_error_signal.py -v
 ```
 
-Expected: FAIL (no `last_search_error` attribute).
+Expected: FAIL (сигнал backend_error ещё не реализован).
 
-**Step 3: Add error tracking to QdrantService**
+**Step 3: Add per-call meta signal**
 
-In `telegram_bot/services/qdrant.py`:
+В `telegram_bot/services/qdrant.py`:
+- Добавить opt-in API: `hybrid_search_rrf(..., return_meta: bool = False)`.
+- Если `return_meta=False`: сохранить текущий контракт `list[dict]`.
+- Если `return_meta=True`: возвращать `(results, meta)` где:
+  - `backend_error: bool`
+  - `error_type: str | None`
+  - `error_message: str | None`
 
-Add to `__init__` (after other instance vars):
+В `telegram_bot/graph/nodes/retrieve.py`:
+- Вызывать `hybrid_search_rrf(..., return_meta=True)`;
+- сохранять в state: `retrieval_backend_error`, `retrieval_error_type`.
 
-```python
-        self.last_search_error: bool = False
-```
-
-In `hybrid_search_rrf` method, before the try block add:
-
-```python
-        self.last_search_error = False
-```
-
-In the except block (line 251-254), change:
-
-```python
-        except Exception as e:
-            # Graceful degradation: return empty list on any Qdrant error
-            logger.error(f"Qdrant search failed (graceful degradation): {e}")
-            self.last_search_error = True
-            return []
-```
-
-Do the same for `batch_search_rrf` except block (line 349-351):
-
-```python
-        except Exception as e:
-            logger.error(f"Qdrant batch search failed (graceful degradation): {e}")
-            self.last_search_error = True
-            return []
-```
+В `telegram_bot/graph/state.py`:
+- Добавить новые поля в `RAGState`.
 
 **Step 4: Run tests**
 
 ```bash
 uv run pytest tests/unit/test_qdrant_error_signal.py -v
+uv run pytest tests/unit/test_qdrant_service.py tests/unit/graph/test_retrieve_node.py -q
 ```
 
-Expected: both green.
+Expected: green, контракт для текущих call-sites не ломается.
 
-**Step 5: Run existing qdrant tests (regression)**
-
-```bash
-uv run pytest tests/unit/test_qdrant_service.py -q
-```
-
-Expected: green.
-
-**Step 6: Lint + commit**
+**Step 5: Lint + commit**
 
 ```bash
-uv run ruff check telegram_bot/services/qdrant.py tests/unit/test_qdrant_error_signal.py --output-format=concise
-git add telegram_bot/services/qdrant.py tests/unit/test_qdrant_error_signal.py
-git commit -m "feat(qdrant): add last_search_error flag for error observability
+uv run ruff check telegram_bot/services/qdrant.py telegram_bot/graph/nodes/retrieve.py telegram_bot/graph/state.py tests/unit/test_qdrant_error_signal.py --output-format=concise
+git add telegram_bot/services/qdrant.py telegram_bot/graph/nodes/retrieve.py telegram_bot/graph/state.py tests/unit/test_qdrant_error_signal.py
+git commit -m "feat(qdrant): add per-call backend_error meta for retrieval observability
 
-Distinguish backend errors from genuine empty results. Graceful
-degradation preserved (still returns []). Flag readable by pipeline.
+Differentiate backend failures from genuine empty search results while
+preserving graceful degradation and existing default API contract.
 
 Closes #117"
 ```
@@ -942,46 +785,51 @@ Closes #117"
 ### Task 4.4: #119 — mypy duplicate module name
 
 **Files:**
-- Edit: `pyproject.toml:237-274` (mypy config section)
+- Edit: `pyproject.toml` (точечно, только если реально нужно)
 
 **Problem:** `services/user-base/main.py` and `services/bm42/main.py` both resolve as module `main` — mypy duplicate-module-name error.
 
-**Step 1: Add exclude pattern to mypy config**
-
-In `pyproject.toml`, after line 242 (`ignore_missing_imports = true`), add:
-
-```toml
-exclude = [
-    "services/user-base/",
-    "services/bm42/",
-]
-```
-
-**Step 2: Verify**
-
-```bash
-uv run mypy src telegram_bot --ignore-missing-imports 2>&1 | grep -i "duplicate"
-```
-
-Expected: no duplicate module errors.
-
-**Step 3: Full mypy run**
+**Step 1: Reproduce with CI-aligned commands**
 
 ```bash
 uv run mypy src telegram_bot --ignore-missing-imports
 ```
 
-Expected: clean (or only pre-existing warnings, no new errors).
+Expected: если duplicate не воспроизводится в этом контуре, config не менять.
 
-**Step 4: Lint + commit**
+**Step 2: Reproduce service-only issue отдельно**
+
+```bash
+uv run mypy services --ignore-missing-imports
+```
+
+Expected: duplicate error воспроизводится только для standalone services.
+
+**Step 3: Fix минимально-инвазивно**
+
+Предпочтительно:
+- Для service-only typecheck использовать `--explicit-package-bases`, либо
+- добавить отдельную команду/target для `services/*`, не затрагивая основной CI path.
+
+Избегать широкого global `exclude`, если проблема не влияет на `src telegram_bot`.
+
+**Step 4: Verify**
+
+```bash
+uv run mypy src telegram_bot --ignore-missing-imports
+uv run mypy services --ignore-missing-imports --explicit-package-bases
+```
+
+Expected: нет duplicate-module ошибок в обоих контурах.
+
+**Step 5: Commit**
 
 ```bash
 git add pyproject.toml
-git commit -m "fix(mypy): exclude standalone services with duplicate main.py
+git commit -m "fix(mypy): resolve duplicate module names in standalone services
 
-services/user-base/ and services/bm42/ each have main.py, causing
-duplicate module name errors. These are standalone FastAPI services,
-not part of the main package.
+Align mypy configuration/commands so standalone service entrypoints
+do not conflict while preserving main CI typecheck scope.
 
 Closes #119"
 ```

--- a/docs/plans/2026-02-10-issue120-umbrella-execution.md
+++ b/docs/plans/2026-02-10-issue120-umbrella-execution.md
@@ -1,0 +1,1053 @@
+# #120 Umbrella: P0 Fixes → Local Validation → P1/P2
+
+**Goal:** Закрыть все дефекты из аудита PR #111, провести локальную валидацию бота, собрать Langfuse трейсы, принять Go/No-Go по latency issues.
+
+**Architecture:** 6 фаз: подготовка → P0 фиксы (4 issues) → gate → docker rebuild + traces → P1/P2 фиксы (4 issues) → final gate. Исполнение: 1 issue = 1 branch = 1 PR (без прямых коммитов в `main`). TDD для #114 и #117.
+
+**Tech Stack:** pytest, ruff, mypy, monkeypatch, Docker Compose, Langfuse SDK, Qdrant Python SDK, gh CLI, Context7
+
+---
+
+## Phase 0: Подготовка
+
+### Task 0.1: Обновить #120 checklist
+
+**Files:**
+- N/A (GitHub API only)
+
+**Step 1: Добавить checklist подзадач в #120**
+
+```bash
+gh issue edit 120 --body "$(gh issue view 120 --json body -q '.body')
+
+## Execution Checklist
+
+### P0 (blockers)
+- [ ] #115 cross-test pollution (sys.modules)
+- [ ] #112 test_bot_handlers (legacy API patch)
+- [ ] #113 test_graph_paths (GraphConfig mocks)
+- [ ] #114 streaming fallback duplicate response
+
+### P0 Gate
+- [ ] All P0 target tests green
+- [ ] ruff check clean
+
+### Local Validation
+- [ ] docker-bot-up healthy
+- [ ] Telegram smoke: /start, RAG, /stats
+- [ ] Langfuse traces captured
+- [ ] E2E dry run (scenario 1.1)
+- [ ] Full E2E (25 scenarios)
+- [ ] Go/No-Go decision
+
+### P1/P2
+- [ ] #116 sync rewrite_max_tokens
+- [ ] #118 test_redis_cache legacy imports
+- [ ] #117 qdrant error vs no-results
+- [ ] #119 mypy duplicate module
+
+### Final Gate
+- [ ] Full lint/type/test suite green
+- [ ] Merged PRs listed
+- [ ] Trace IDs documented
+"
+```
+
+Expected: #120 body обновлён, checklist виден в UI.
+
+---
+
+### Task 0.2: SDK-first правило (Context7)
+
+**Step 1: Зафиксировать policy в #120 и PR descriptions**
+
+Принцип:
+- Использовать официальные SDK, не raw HTTP, где есть стабильный клиент.
+- Для tracing/LLM вызовов: `langfuse-python` (`/langfuse/langfuse-python` в Context7), в т.ч. `from langfuse.openai import AsyncOpenAI`, `@observe`, `update_current_trace`, `score_current_trace`.
+- Для векторного поиска: `qdrant-client` (`/qdrant/qdrant-client` в Context7), в т.ч. `AsyncQdrantClient` + `query_points`.
+
+**Step 2: Проверять в code review каждого PR**
+
+Acceptance:
+- Нет новых `requests/httpx` вызовов к Langfuse/Qdrant там, где есть SDK-эквивалент.
+- В PR описано, какой SDK использован и почему.
+
+---
+
+## Phase 1: P0 Fixes (blockers)
+
+### Task 1.1: #115 — Cross-test pollution (sys.modules["redisvl"])
+
+**Files:**
+- Edit: `tests/unit/test_redis_semantic_cache.py:1-18`
+- Verify: `tests/unit/test_vectorizers.py`
+
+**Step 1: Убрать cross-test pollution, сохранив изоляцию импорта**
+
+В `tests/unit/test_redis_semantic_cache.py` использовать `sys.modules` mock только на время импорта `RedisSemanticCache`, затем сразу восстановить исходные модули.
+
+Рабочий шаблон:
+
+```python
+import json
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_MOCKED_MODULES = [
+    "redis", "redis.asyncio",
+    "opentelemetry", "opentelemetry.trace",
+    "redisvl", "redisvl.extensions.message_history",
+    "redisvl.query.filter", "redisvl.utils.vectorize",
+]
+_saved = {name: sys.modules.get(name) for name in _MOCKED_MODULES}
+for name in _MOCKED_MODULES:
+    sys.modules[name] = MagicMock()
+
+from src.cache.redis_semantic_cache import RedisSemanticCache
+
+for name in _MOCKED_MODULES:
+    if _saved[name] is None:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = _saved[name]
+
+del _saved
+```
+
+Ключевой принцип: мок нужен только в момент импорта тестируемого модуля.
+
+**Step 2: Run target tests**
+
+```bash
+uv run pytest tests/unit/test_redis_semantic_cache.py tests/unit/test_vectorizers.py -q
+```
+
+Expected: both green, no collection errors.
+
+**Step 3: Lint**
+
+```bash
+uv run ruff check tests/unit/test_redis_semantic_cache.py --output-format=concise
+```
+
+Expected: clean.
+
+**Step 4: Commit**
+
+```bash
+git add tests/unit/test_redis_semantic_cache.py
+git commit -m "fix(tests): restore sys.modules after redisvl mock import
+
+Mock modules only during RedisSemanticCache import, then immediately
+restore. Prevents cross-test pollution in test_vectorizers.
+
+Closes #115"
+```
+
+---
+
+### Task 1.2: #112 — test_bot_handlers под новый Langfuse API
+
+**Files:**
+- Edit: `tests/unit/test_bot_handlers.py:241-305`
+- Read: `telegram_bot/bot.py:226-274` (current handle_query contract)
+
+The current `handle_query` (bot.py:226-274):
+1. Calls `build_graph()` → `graph.ainvoke(state)`
+2. Calls `get_client().update_current_trace(input=..., output=..., metadata=...)`
+3. Calls `_write_langfuse_scores(lf, result)`
+4. NO `create_langfuse_handler` — removed
+
+Two broken tests:
+- `test_handle_query_passes_langfuse_handler` (line 241): patches `telegram_bot.bot.create_langfuse_handler`
+- `test_handle_query_no_langfuse` (line 275): patches `telegram_bot.bot.create_langfuse_handler`
+
+**Step 1: Replace test_handle_query_passes_langfuse_handler**
+
+Replace the test at lines 241-272 with:
+
+```python
+    @pytest.mark.asyncio
+    async def test_handle_query_writes_langfuse_trace(self, mock_config):
+        """Test that handle_query updates Langfuse trace and writes scores."""
+        bot, _ = _create_bot(mock_config)
+
+        mock_graph = AsyncMock()
+        mock_graph.ainvoke = AsyncMock(
+            return_value={"response": "ok", "query_type": "GENERAL", "latency_stages": {}}
+        )
+        mock_lf = MagicMock()
+
+        with (
+            patch("telegram_bot.bot.build_graph", return_value=mock_graph),
+            patch("telegram_bot.bot.get_client", return_value=mock_lf),
+            patch("telegram_bot.bot._write_langfuse_scores") as mock_write_scores,
+            patch("telegram_bot.bot.propagate_attributes"),
+        ):
+            message = MagicMock()
+            message.text = "test"
+            message.from_user = MagicMock()
+            message.from_user.id = 12345
+            message.chat = MagicMock()
+            message.chat.id = 12345
+            message.bot = MagicMock()
+            message.bot.send_chat_action = AsyncMock()
+
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cm = AsyncMock()
+                mock_cm.__aenter__ = AsyncMock()
+                mock_cm.__aexit__ = AsyncMock()
+                mock_cas.typing.return_value = mock_cm
+
+                await bot.handle_query(message)
+
+            mock_lf.update_current_trace.assert_called_once()
+            mock_write_scores.assert_called_once_with(mock_lf, mock_graph.ainvoke.return_value)
+```
+
+**Step 2: Replace test_handle_query_no_langfuse**
+
+Replace lines 274-305 with:
+
+```python
+    @pytest.mark.asyncio
+    async def test_handle_query_passes_state_to_graph(self, mock_config):
+        """Test that handle_query passes correct initial state to graph."""
+        bot, _ = _create_bot(mock_config)
+
+        mock_graph = AsyncMock()
+        mock_graph.ainvoke = AsyncMock(
+            return_value={"response": "ok", "query_type": "GENERAL", "latency_stages": {}}
+        )
+
+        with (
+            patch("telegram_bot.bot.build_graph", return_value=mock_graph),
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot._write_langfuse_scores"),
+            patch("telegram_bot.bot.propagate_attributes"),
+        ):
+            message = MagicMock()
+            message.text = "квартиры"
+            message.from_user = MagicMock()
+            message.from_user.id = 12345
+            message.chat = MagicMock()
+            message.chat.id = 12345
+            message.bot = MagicMock()
+            message.bot.send_chat_action = AsyncMock()
+
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cm = AsyncMock()
+                mock_cm.__aenter__ = AsyncMock()
+                mock_cm.__aexit__ = AsyncMock()
+                mock_cas.typing.return_value = mock_cm
+
+                await bot.handle_query(message)
+
+            state_arg = mock_graph.ainvoke.call_args[0][0]
+            assert state_arg["user_id"] == 12345
+            assert "квартиры" in str(state_arg["messages"])
+```
+
+**Step 3: Run tests**
+
+```bash
+uv run pytest tests/unit/test_bot_handlers.py -q
+```
+
+Expected: all green, no `create_langfuse_handler` references.
+
+**Step 4: Verify no leftover references**
+
+```bash
+grep -r "create_langfuse_handler" tests/
+```
+
+Expected: no output.
+
+**Step 5: Lint + commit**
+
+```bash
+uv run ruff check tests/unit/test_bot_handlers.py --output-format=concise
+git add tests/unit/test_bot_handlers.py
+git commit -m "fix(tests): update bot handler tests to current Langfuse API
+
+Replace create_langfuse_handler patches with get_client/update_current_trace
+and _write_langfuse_scores mocks matching current bot.py contract.
+
+Closes #112"
+```
+
+---
+
+### Task 1.3: #113 — test_graph_paths (GraphConfig mocks)
+
+**Files:**
+- Edit: `tests/integration/test_graph_paths.py:125-135`
+
+The problem: `_make_mock_graph_config()` returns a `MagicMock` without typed fields. `grade_node` (grade.py:48-51) calls `GraphConfig.from_env()` and reads `config.skip_rerank_threshold` — but the test patches `GraphConfig.from_env` to return this mock, so it gets `MagicMock()` instead of `float`.
+
+**Step 1: Add missing typed fields to _make_mock_graph_config**
+
+Replace `_make_mock_graph_config` function (lines 125-135):
+
+```python
+def _make_mock_graph_config(llm_mock: MagicMock) -> MagicMock:
+    """Create a mock GraphConfig with all required typed fields."""
+    gc = MagicMock()
+    gc.domain = "недвижимость"
+    gc.llm_model = "test-model"
+    gc.llm_temperature = 0.7
+    gc.llm_max_tokens = 4096
+    gc.generate_max_tokens = 2048
+    gc.rewrite_model = "test-model"
+    gc.rewrite_max_tokens = 64
+    gc.skip_rerank_threshold = 0.85
+    gc.streaming_enabled = False
+    gc.create_llm.return_value = llm_mock
+    return gc
+```
+
+Changes: added `gc.generate_max_tokens = 2048`, `gc.skip_rerank_threshold = 0.85`, `gc.streaming_enabled = False`.
+
+**Step 2: Run tests**
+
+```bash
+uv run pytest tests/integration/test_graph_paths.py -v
+```
+
+Expected: all 6 path tests green, no TypeError.
+
+**Step 3: Lint + commit**
+
+```bash
+uv run ruff check tests/integration/test_graph_paths.py --output-format=concise
+git add tests/integration/test_graph_paths.py
+git commit -m "fix(tests): add typed fields to GraphConfig mock in path tests
+
+Add skip_rerank_threshold, generate_max_tokens, streaming_enabled to
+_make_mock_graph_config. Prevents TypeError in grade_node comparisons.
+
+Closes #113"
+```
+
+---
+
+### Task 1.4: #114 — Streaming fallback duplicate response
+
+**Files:**
+- Edit: `telegram_bot/graph/nodes/generate.py:221-261`
+- Read: `telegram_bot/graph/nodes/respond.py` (already handles `response_sent`)
+- Create: `tests/unit/graph/test_streaming_fallback.py`
+
+**Analysis of the bug:**
+
+In `generate.py:221-241`:
+```python
+response_sent = False
+try:
+    if message is not None and config.streaming_enabled:
+        try:
+            answer = await _generate_streaming(...)
+            response_sent = True        # ← only set on SUCCESS
+        except Exception:
+            # Falls back to non-streaming LLM call
+            response = await llm.chat.completions.create(...)
+            answer = response.choices[0].message.content or ""
+            # response_sent stays False → respond_node will send again!
+```
+
+The bug: if `_generate_streaming` sent partial chunks (placeholder + some edits) but then raised, `response_sent` stays `False`. The fallback generates a new answer, and `respond_node` sends it as a NEW message. User sees: partial streamed text + full new message = duplicate.
+
+**The fix:** Track whether the streaming placeholder was sent. If it was, the fallback should edit that message instead of letting respond_node send a new one.
+
+However, the simplest correct fix per issue scope: if streaming started (placeholder sent), set `response_sent = True` after fallback too, because the user already has a message being edited. The fallback should edit the existing placeholder message.
+
+Looking at `_generate_streaming`:
+- Line 127: `sent_msg = await message.answer(_STREAM_PLACEHOLDER)` — sends placeholder
+- If error occurs after this, placeholder message exists in Telegram
+
+**Simplest fix:** After fallback LLM call, edit the existing placeholder if streaming was attempted. But we don't have `sent_msg` in the outer scope.
+
+**Better fix:** Restructure to catch errors inside `_generate_streaming` more granularly, or pass a mutable container.
+
+**Simplest correct fix:** Wrap the streaming+fallback logic so that if streaming was attempted (placeholder sent), the fallback response is delivered via edit_text on the placeholder, and `response_sent = True`.
+
+**Step 1: Write the failing test**
+
+Create `tests/unit/graph/test_streaming_fallback.py`:
+
+```python
+"""Tests for streaming fallback duplicate prevention in generate_node."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_message():
+    """Create mock aiogram Message."""
+    msg = MagicMock()
+    sent_placeholder = MagicMock()
+    sent_placeholder.edit_text = AsyncMock()
+    sent_placeholder.delete = AsyncMock()
+    msg.answer = AsyncMock(return_value=sent_placeholder)
+    msg.chat = MagicMock(id=12345)
+    return msg
+
+
+@pytest.fixture
+def mock_config():
+    """Create mock GraphConfig for streaming."""
+    gc = MagicMock()
+    gc.domain = "недвижимость"
+    gc.llm_model = "test-model"
+    gc.llm_temperature = 0.7
+    gc.generate_max_tokens = 2048
+    gc.streaming_enabled = True
+    gc.create_llm.return_value = MagicMock()
+    return gc
+
+
+def _make_state(query: str = "квартиры в Несебре") -> dict:
+    """Create minimal state for generate_node."""
+    return {
+        "documents": [
+            {"text": "Квартира 85000 евро", "score": 0.9, "metadata": {"title": "Квартира"}},
+        ],
+        "messages": [{"role": "user", "content": query}],
+        "latency_stages": {},
+    }
+
+
+class TestStreamingFallbackNoDuplicate:
+    """Verify that streaming failure + fallback does not cause duplicate sends."""
+
+    @pytest.mark.asyncio
+    async def test_fallback_sets_response_sent_true(self, mock_message, mock_config):
+        """After streaming fails and fallback succeeds, response_sent must be True.
+
+        This prevents respond_node from sending a duplicate message.
+        """
+        from telegram_bot.graph.nodes.generate import _make_llm_completion
+
+        fallback_completion = MagicMock()
+        fallback_completion.choices = [MagicMock(message=MagicMock(content="Fallback answer"))]
+
+        mock_llm = MagicMock()
+        mock_llm.chat.completions.create = AsyncMock(return_value=fallback_completion)
+
+        with (
+            patch(
+                "telegram_bot.graph.nodes.generate._get_config", return_value=mock_config,
+            ),
+            patch(
+                "telegram_bot.graph.nodes.generate._generate_streaming",
+                side_effect=RuntimeError("stream broken"),
+            ),
+        ):
+            mock_config.create_llm.return_value = mock_llm
+            state = _make_state()
+
+            from telegram_bot.graph.nodes.generate import generate_node
+
+            result = await generate_node(state, message=mock_message)
+
+        assert result["response"] == "Fallback answer"
+        # Key assertion: response_sent should be True if streaming was attempted
+        # so respond_node does not send a duplicate
+        assert result["response_sent"] is True
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_response_sent_false(self, mock_message, mock_config):
+        """Non-streaming path should leave response_sent=False for respond_node."""
+        mock_config.streaming_enabled = False
+
+        completion = MagicMock()
+        completion.choices = [MagicMock(message=MagicMock(content="Normal answer"))]
+
+        mock_llm = MagicMock()
+        mock_llm.chat.completions.create = AsyncMock(return_value=completion)
+
+        with patch(
+            "telegram_bot.graph.nodes.generate._get_config", return_value=mock_config,
+        ):
+            mock_config.create_llm.return_value = mock_llm
+            state = _make_state()
+
+            from telegram_bot.graph.nodes.generate import generate_node
+
+            result = await generate_node(state, message=mock_message)
+
+        assert result["response"] == "Normal answer"
+        assert result["response_sent"] is False
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+uv run pytest tests/unit/graph/test_streaming_fallback.py -v
+```
+
+Expected: `test_fallback_sets_response_sent_true` FAILS (response_sent is False).
+
+**Step 3: Fix generate_node streaming fallback**
+
+In `telegram_bot/graph/nodes/generate.py`, replace lines 221-261 (the `response_sent = False` through end of function):
+
+```python
+    response_sent = False
+
+    try:
+        llm = config.create_llm()
+
+        # Streaming path: deliver directly to Telegram
+        if message is not None and config.streaming_enabled:
+            streaming_attempted = False
+            try:
+                answer = await _generate_streaming(llm, config, llm_messages, message)
+                response_sent = True
+            except Exception:
+                streaming_attempted = True
+                logger.warning("Streaming failed, falling back to non-streaming", exc_info=True)
+                # Fall back to non-streaming
+                response = await llm.chat.completions.create(
+                    model=config.llm_model,
+                    messages=llm_messages,
+                    temperature=config.llm_temperature,
+                    max_tokens=config.generate_max_tokens,
+                    name="generate-answer",  # type: ignore[call-overload]
+                )
+                answer = response.choices[0].message.content or ""
+                # Streaming was attempted — a placeholder message exists in Telegram.
+                # Mark response_sent so respond_node does not send a duplicate.
+                response_sent = True
+        else:
+            # Non-streaming path (original)
+            response = await llm.chat.completions.create(
+                model=config.llm_model,
+                messages=llm_messages,
+                temperature=config.llm_temperature,
+                max_tokens=config.generate_max_tokens,
+                name="generate-answer",  # type: ignore[call-overload]  # langfuse kwarg
+            )
+            answer = response.choices[0].message.content or ""
+    except Exception:
+        logger.exception("generate_node: LLM call failed, using fallback")
+        answer = _build_fallback_response(documents)
+
+    elapsed = time.monotonic() - t0
+    return {
+        "response": answer,
+        "response_sent": response_sent,
+        "latency_stages": {**state.get("latency_stages", {}), "generate": elapsed},
+    }
+```
+
+Key change: after streaming exception + fallback LLM call, set `response_sent = True` because a placeholder message already exists in the chat. `respond_node` will skip the duplicate send (it already checks `state.get("response_sent", False)` at line 36).
+
+**Note:** The `streaming_attempted` variable is kept for clarity but currently unused. Remove if ruff complains (F841).
+
+**Step 4: Run test to verify it passes**
+
+```bash
+uv run pytest tests/unit/graph/test_streaming_fallback.py -v
+```
+
+Expected: both tests green.
+
+**Step 5: Run graph integration tests (regression)**
+
+```bash
+uv run pytest tests/integration/test_graph_paths.py -v
+uv run pytest tests/unit/graph/ -q
+```
+
+Expected: all green (path tests use `streaming_enabled=False`).
+
+**Step 6: Lint + commit**
+
+```bash
+uv run ruff check telegram_bot/graph/nodes/generate.py tests/unit/graph/test_streaming_fallback.py --output-format=concise
+git add telegram_bot/graph/nodes/generate.py tests/unit/graph/test_streaming_fallback.py
+git commit -m "fix(graph): prevent duplicate response on streaming fallback
+
+When streaming fails after placeholder sent, mark response_sent=True
+so respond_node skips redundant message.send(). Adds test coverage.
+
+Closes #114"
+```
+
+---
+
+## Phase 2: P0 Gate
+
+### Task 2.1: Verify all P0 fixes together
+
+**Files:**
+- N/A (verification only)
+
+**Step 1: Run all target tests**
+
+```bash
+uv run pytest tests/unit/test_redis_semantic_cache.py tests/unit/test_vectorizers.py -q
+uv run pytest tests/unit/test_bot_handlers.py -q
+uv run pytest tests/integration/test_graph_paths.py -q
+uv run pytest tests/unit/graph -q
+```
+
+Expected: all green.
+
+**Step 2: Run lint**
+
+```bash
+uv run ruff check src telegram_bot tests services --output-format=concise
+```
+
+Expected: clean.
+
+**Step 3: STOP if any red. Fix before proceeding.**
+
+---
+
+## Phase 3: Local Validation (rebuild + traces)
+
+> Full steps in `docs/plans/2026-02-10-local-validation-design.md`.
+> This phase is largely manual (Telegram interaction + Langfuse UI).
+
+### Task 3.1: Docker bot rebuild
+
+**Step 1: Start bot stack**
+
+```bash
+make docker-bot-up
+```
+
+**Step 2: Wait for healthy**
+
+```bash
+docker compose -f docker-compose.dev.yml ps
+```
+
+Expected: postgres, redis, qdrant, bge-m3, litellm, bot all healthy/running.
+
+**Step 3: Check bot logs**
+
+```bash
+docker logs --tail 30 dev-bot
+```
+
+Expected: `Preflight checks passed`, no errors.
+
+### Task 3.2: Telegram smoke test (manual)
+
+Send to bot in Telegram:
+1. `/start` → expect greeting with domain
+2. `Какие квартиры в Несебре?` → expect streaming response (text appears in chunks)
+3. `/stats` → expect cache stats
+
+### Task 3.3: Langfuse traces (manual)
+
+Open Langfuse UI. Find traces from smoke test. Check:
+- Node spans: node-classify, node-cache-check, node-retrieve, node-grade, node-generate, node-respond
+- Scores: latency_total_ms, semantic_cache_hit, search_results_count, rerank_applied
+- response_sent score present
+
+Record trace IDs.
+
+### Task 3.4: E2E dry run
+
+```bash
+uv run python scripts/e2e/runner.py --scenario 1.1
+```
+
+Expected: PASS.
+
+### Task 3.5: Full E2E (25 scenarios)
+
+```bash
+make e2e-test
+```
+
+Expected: pass rate >= 80%.
+
+### Task 3.6: Go/No-Go
+
+Compare with problem trace `c2b95d86aa1f643b79016dd611c4691f` from #105. Post results to #120.
+
+---
+
+## Phase 4: P1/P2 Fixes
+
+### Task 4.1: #116 — Sync rewrite_max_tokens default
+
+**Files:**
+- Edit: `telegram_bot/graph/config.py:70`
+
+**Step 1: Fix the mismatch**
+
+In `telegram_bot/graph/config.py`, line 70:
+
+```python
+# Before:
+            rewrite_max_tokens=int(os.getenv("REWRITE_MAX_TOKENS", "200")),
+# After:
+            rewrite_max_tokens=int(os.getenv("REWRITE_MAX_TOKENS", "64")),
+```
+
+**Step 2: Run config tests**
+
+```bash
+uv run pytest tests/ -k "config" -q
+```
+
+Expected: green.
+
+**Step 3: Verify consistency**
+
+```bash
+grep -n "rewrite_max_tokens" telegram_bot/graph/config.py
+```
+
+Expected: line 24 shows `rewrite_max_tokens: int = 64`, line 70 shows fallback `"64"`.
+
+**Step 4: Lint + commit**
+
+```bash
+uv run ruff check telegram_bot/graph/config.py --output-format=concise
+git add telegram_bot/graph/config.py
+git commit -m "fix(config): sync rewrite_max_tokens env fallback to 64
+
+Dataclass default is 64, but from_env fallback was '200'. Now consistent.
+
+Closes #116"
+```
+
+---
+
+### Task 4.2: #118 — test_redis_cache legacy imports
+
+**Files:**
+- Edit: `tests/integration/test_redis_cache.py`
+
+**Analysis:** This file (163 lines) is a standalone script (`__name__ == "__main__"`), not a pytest test module. It uses `sys.path.insert` to import `src.cache.redis_semantic_cache` directly. It requires a live Redis connection. It should be marked as legacy and excluded from pytest collection.
+
+**Step 1: Add legacy_api marker and skip**
+
+Add at the top of `tests/integration/test_redis_cache.py` (after the docstring, before imports):
+
+Replace lines 1-13:
+
+```python
+#!/usr/bin/env python3
+"""Test Redis semantic cache connectivity and basic operations.
+
+Legacy integration test — requires live Redis. Run manually:
+    python tests/integration/test_redis_cache.py
+
+Excluded from CI via @pytest.mark.legacy_api marker.
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Mark entire module as legacy (skipped in CI: -m "not legacy_api")
+pytestmark = pytest.mark.legacy_api
+
+# Add src to path for legacy import
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from cache.redis_semantic_cache import RedisSemanticCache  # noqa: E402
+```
+
+**Step 2: Verify collection works**
+
+```bash
+uv run pytest tests/integration/test_redis_cache.py --collect-only
+```
+
+Expected: collected (with legacy_api marker), no import error during collection.
+
+**Step 3: Verify it's excluded in CI mode**
+
+```bash
+uv run pytest tests/integration/test_redis_cache.py -m "not legacy_api" --collect-only
+```
+
+Expected: 0 tests collected.
+
+**Step 4: Lint + commit**
+
+```bash
+uv run ruff check tests/integration/test_redis_cache.py --output-format=concise
+git add tests/integration/test_redis_cache.py
+git commit -m "fix(tests): mark test_redis_cache as legacy_api
+
+Add pytestmark so CI skips it (-m 'not legacy_api'). Fix sys.path
+to use correct relative path.
+
+Closes #118"
+```
+
+---
+
+### Task 4.3: #117 — Qdrant error vs no-results
+
+**Files:**
+- Edit: `telegram_bot/services/qdrant.py:251-254`
+- Create: `tests/unit/test_qdrant_error_signal.py`
+
+**Step 1: Write the failing test**
+
+Create `tests/unit/test_qdrant_error_signal.py`:
+
+```python
+"""Tests for Qdrant error signal distinction from empty results."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def qdrant_service():
+    """Create QdrantService with mocked client."""
+    with patch("telegram_bot.services.qdrant.AsyncQdrantClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client_cls.return_value = mock_client
+
+        from telegram_bot.services.qdrant import QdrantService
+
+        svc = QdrantService(
+            url="http://localhost:6333",
+            collection_name="test_collection",
+        )
+        svc._client = mock_client
+        svc._collection_verified = True
+        yield svc, mock_client
+
+
+class TestQdrantErrorSignal:
+    """Verify error vs empty-results distinction."""
+
+    @pytest.mark.asyncio
+    async def test_search_error_returns_empty_with_error_flag(self, qdrant_service):
+        """When Qdrant raises, result is [] but qdrant_error metadata is set."""
+        svc, mock_client = qdrant_service
+        mock_client.query_points = AsyncMock(side_effect=RuntimeError("connection refused"))
+
+        results = await svc.hybrid_search_rrf(
+            dense_vector=[0.1] * 1024,
+            sparse_vector={"indices": [1], "values": [0.5]},
+        )
+        assert results == []
+        assert svc.last_search_error is True
+
+    @pytest.mark.asyncio
+    async def test_empty_results_no_error_flag(self, qdrant_service):
+        """When Qdrant returns empty, no error flag."""
+        svc, mock_client = qdrant_service
+        mock_result = MagicMock()
+        mock_result.points = []
+        mock_client.query_points = AsyncMock(return_value=mock_result)
+
+        results = await svc.hybrid_search_rrf(
+            dense_vector=[0.1] * 1024,
+            sparse_vector={"indices": [1], "values": [0.5]},
+        )
+        assert results == []
+        assert svc.last_search_error is False
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+uv run pytest tests/unit/test_qdrant_error_signal.py -v
+```
+
+Expected: FAIL (no `last_search_error` attribute).
+
+**Step 3: Add error tracking to QdrantService**
+
+In `telegram_bot/services/qdrant.py`:
+
+Add to `__init__` (after other instance vars):
+
+```python
+        self.last_search_error: bool = False
+```
+
+In `hybrid_search_rrf` method, before the try block add:
+
+```python
+        self.last_search_error = False
+```
+
+In the except block (line 251-254), change:
+
+```python
+        except Exception as e:
+            # Graceful degradation: return empty list on any Qdrant error
+            logger.error(f"Qdrant search failed (graceful degradation): {e}")
+            self.last_search_error = True
+            return []
+```
+
+Do the same for `batch_search_rrf` except block (line 349-351):
+
+```python
+        except Exception as e:
+            logger.error(f"Qdrant batch search failed (graceful degradation): {e}")
+            self.last_search_error = True
+            return []
+```
+
+**Step 4: Run tests**
+
+```bash
+uv run pytest tests/unit/test_qdrant_error_signal.py -v
+```
+
+Expected: both green.
+
+**Step 5: Run existing qdrant tests (regression)**
+
+```bash
+uv run pytest tests/unit/test_qdrant_service.py -q
+```
+
+Expected: green.
+
+**Step 6: Lint + commit**
+
+```bash
+uv run ruff check telegram_bot/services/qdrant.py tests/unit/test_qdrant_error_signal.py --output-format=concise
+git add telegram_bot/services/qdrant.py tests/unit/test_qdrant_error_signal.py
+git commit -m "feat(qdrant): add last_search_error flag for error observability
+
+Distinguish backend errors from genuine empty results. Graceful
+degradation preserved (still returns []). Flag readable by pipeline.
+
+Closes #117"
+```
+
+---
+
+### Task 4.4: #119 — mypy duplicate module name
+
+**Files:**
+- Edit: `pyproject.toml:237-274` (mypy config section)
+
+**Problem:** `services/user-base/main.py` and `services/bm42/main.py` both resolve as module `main` — mypy duplicate-module-name error.
+
+**Step 1: Add exclude pattern to mypy config**
+
+In `pyproject.toml`, after line 242 (`ignore_missing_imports = true`), add:
+
+```toml
+exclude = [
+    "services/user-base/",
+    "services/bm42/",
+]
+```
+
+**Step 2: Verify**
+
+```bash
+uv run mypy src telegram_bot --ignore-missing-imports 2>&1 | grep -i "duplicate"
+```
+
+Expected: no duplicate module errors.
+
+**Step 3: Full mypy run**
+
+```bash
+uv run mypy src telegram_bot --ignore-missing-imports
+```
+
+Expected: clean (or only pre-existing warnings, no new errors).
+
+**Step 4: Lint + commit**
+
+```bash
+git add pyproject.toml
+git commit -m "fix(mypy): exclude standalone services with duplicate main.py
+
+services/user-base/ and services/bm42/ each have main.py, causing
+duplicate module name errors. These are standalone FastAPI services,
+not part of the main package.
+
+Closes #119"
+```
+
+---
+
+## Phase 5: Final Gate
+
+### Task 5.1: Full verification suite
+
+**Step 1: Lint + types**
+
+```bash
+uv run ruff check src telegram_bot tests services --output-format=concise
+uv run mypy src telegram_bot --ignore-missing-imports
+```
+
+Expected: both clean.
+
+**Step 2: All target tests**
+
+```bash
+uv run pytest tests/unit/test_redis_semantic_cache.py tests/unit/test_vectorizers.py -q
+uv run pytest tests/unit/test_bot_handlers.py -q
+uv run pytest tests/integration/test_graph_paths.py -q
+uv run pytest tests/unit/graph -q
+uv run pytest tests/unit/test_qdrant_error_signal.py -q
+```
+
+Expected: all green.
+
+**Step 3: Full unit suite**
+
+```bash
+uv run pytest tests/unit/ -n auto -q
+```
+
+Expected: all green.
+
+**Step 4: Post results to #120**
+
+```bash
+gh issue comment 120 --body "## Final Gate Results
+
+### Merged Commits
+- #115 cross-test pollution ✅
+- #112 bot handler tests ✅
+- #113 graph path mocks ✅
+- #114 streaming fallback ✅
+- #116 rewrite_max_tokens default ✅
+- #118 redis cache legacy marker ✅
+- #117 qdrant error signal ✅
+- #119 mypy duplicate module ✅
+
+### Test Results
+<paste output from step 3>
+
+### Trace IDs
+<paste from Phase 3>
+
+### Go/No-Go
+<decision + reasoning>"
+```
+
+**Step 5: Close #120**
+
+```bash
+gh issue close 120 --reason completed
+```

--- a/docs/plans/2026-02-10-local-validation-design.md
+++ b/docs/plans/2026-02-10-local-validation-design.md
@@ -1,0 +1,201 @@
+# Local Validation: Rebuild Bot + Capture Traces
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Убедиться что бот работает локально после merge в main (streaming, latency phase 2, rewrite control), собрать трейсы в Langfuse.
+
+**Architecture:** Поднимаем Docker bot profile локально, прогоняем smoke-тест вручную, проверяем трейсы в Langfuse, затем запускаем E2E runner (25 сценариев).
+
+**Tech Stack:** Docker Compose (bot profile), Telegram, Langfuse, Telethon (E2E)
+
+---
+
+### Task 1: Поднять Docker bot stack
+
+**Files:**
+- Check: `docker-compose.dev.yml`
+- Check: `.env`
+
+**Step 1: Убедиться что .env содержит нужные переменные**
+
+```bash
+grep -E "TELEGRAM_BOT_TOKEN|CEREBRAS_API_KEY|LANGFUSE_" .env | head -10
+```
+
+Expected: ключи заданы (не пустые).
+
+**Step 2: Поднять bot profile**
+
+```bash
+make docker-bot-up
+```
+
+Expected: `docker compose --profile bot up -d` стартует сервисы.
+
+**Step 3: Дождаться healthy**
+
+```bash
+docker compose -f docker-compose.dev.yml ps
+```
+
+Expected: все контейнеры `healthy` или `running` (postgres, redis, qdrant, bge-m3, litellm, bot).
+
+**Step 4: Проверить логи бота**
+
+```bash
+docker logs --tail 30 dev-bot
+```
+
+Expected: `Preflight checks passed`, бот стартовал без ошибок. Новые env defaults работают:
+- `MAX_REWRITE_ATTEMPTS=1`
+- `GENERATE_MAX_TOKENS=2048`
+- `STREAMING_ENABLED=true`
+
+---
+
+### Task 2: Smoke-тест через Telegram
+
+**Ручной тест — отправить боту в Telegram:**
+
+**Step 1: /start**
+
+Отправить `/start` боту. Expected: приветственное сообщение с доменом.
+
+**Step 2: RAG-запрос**
+
+Отправить: `Какие квартиры в Несебре?`
+
+Expected:
+- Видны edit_text обновления (streaming — текст появляется порциями)
+- Финальный ответ с Markdown форматированием
+- Ответ содержит релевантную информацию
+
+**Step 3: /stats**
+
+Отправить `/stats`. Expected: статистика кеша (hit rates по тирам).
+
+**Step 4: Проверить логи**
+
+```bash
+docker logs --tail 50 dev-bot
+```
+
+Expected: нет ошибок, видны node spans (classify, retrieve, grade, generate, respond).
+
+---
+
+### Task 3: Проверить Langfuse трейсы
+
+**Step 1: Открыть Langfuse UI**
+
+URL: `http://localhost:3001` (если Langfuse поднят локально) или VPS Langfuse.
+
+**Step 2: Найти трейс от smoke-запроса**
+
+Проверить что трейс содержит:
+- Node spans: `node-classify`, `node-cache-check`, `node-retrieve`, `node-grade`, `node-generate`, `node-respond`
+- Scores: `latency_total_ms`, `semantic_cache_hit`, `search_results_count`, `rerank_applied`
+- `response_sent=true` (streaming доставил ответ)
+
+**Step 3: Записать trace ID**
+
+Сохранить trace ID для сравнения с проблемным трейсом `c2b95d86aa1f643b79016dd611c4691f` из #105.
+
+---
+
+### Task 4: Проверить E2E runner работает
+
+**Files:**
+- Check: `scripts/e2e/runner.py`
+- Check: `scripts/e2e/test_scenarios.py`
+- Check: `.env` (TELEGRAM_API_ID, TELEGRAM_API_HASH, E2E_BOT_USERNAME)
+
+**Step 1: Проверить E2E env vars**
+
+```bash
+grep -E "TELEGRAM_API_ID|TELEGRAM_API_HASH|E2E_BOT_USERNAME" .env
+```
+
+Expected: все три заданы. Если нет — добавить из https://my.telegram.org.
+
+**Step 2: Установить E2E зависимости**
+
+```bash
+make e2e-install
+```
+
+Expected: `uv sync --group e2e` — Telethon и зависимости установлены.
+
+**Step 3: Dry run — один сценарий**
+
+```bash
+uv run python scripts/e2e/runner.py --scenario 1.1
+```
+
+Expected: один тест проходит (команда `/start`), результат PASS/FAIL.
+
+**Step 4: Если сломано — дебажить**
+
+Частые проблемы:
+- `TELEGRAM_API_ID not set` → добавить в `.env`
+- `FloodWaitError` → подождать, уменьшить `between_tests_delay`
+- `AuthKeyError` → удалить сессию Telethon, перелогиниться
+
+---
+
+### Task 5: Полный E2E прогон
+
+**Step 1: Запустить все 25 сценариев**
+
+```bash
+make e2e-test
+```
+
+Expected: runner прогоняет все сценарии, генерирует отчёт.
+
+**Step 2: Проверить отчёт**
+
+```bash
+ls -la reports/e2e_*.json reports/e2e_*.html
+```
+
+Открыть HTML отчёт, проверить:
+- Pass rate >= 80%
+- Avg score
+- Какие тесты упали и почему
+
+**Step 3: Проверить трейсы в Langfuse**
+
+25 трейсов должны появиться. Проверить:
+- `latency_total_ms` — разброс значений
+- `rerank_applied` — true/false корректно
+- Нет rewrite-циклов > 1 (MAX_REWRITE_ATTEMPTS=1)
+- Streaming работает (response_sent=true)
+
+---
+
+### Task 6: Go/No-Go отчёт
+
+**Step 1: Сравнить с проблемным трейсом**
+
+Проблемный трейс из #105: `c2b95d86aa1f643b79016dd611c4691f`
+
+Проверить:
+- [ ] `latency_total_ms` корректный (не NaN, не отрицательный)
+- [ ] Нет ложных rewrite-циклов (grade не отправляет на rewrite при relevance > 0.3)
+- [ ] `rerank_applied` корректно отражает skip_rerank logic
+- [ ] Node-level latency stages записаны
+
+**Step 2: Решение**
+
+- **Баги воспроизводятся** → идём фиксить #107 → #108 → #109
+- **Баги НЕ воспроизводятся** → закрываем #105/#107/#108/#109 с evidence (trace IDs)
+- **Частично** → сужаем scope оставшихся issues
+
+**Step 3: Записать результат**
+
+Обновить issue #110 с результатами:
+
+```bash
+gh issue comment 110 --body "## Validation Results\n\n- Traces: [IDs]\n- Pass rate: X%\n- Reproducible: yes/no\n- Next: ..."
+```

--- a/docs/plans/2026-02-10-pr111-fixes-tz.md
+++ b/docs/plans/2026-02-10-pr111-fixes-tz.md
@@ -1,0 +1,151 @@
+# ТЗ на фиксы по итогам глубинного аудита PR #111
+
+Дата: 2026-02-10
+PR: https://github.com/yastman/rag/pull/111
+Ветка: `chore/mypy-hardening`
+
+## 1. Что проверено
+- Diff `origin/main...HEAD` (181 файл, код + тесты + CI + infra manifests).
+- Статпроверки: `ruff`, `mypy` (частично), выборочные `pytest` (unit/integration/smoke).
+- Построчный аудит ключевых runtime-файлов (`telegram_bot/graph/*`, `telegram_bot/bot.py`, `telegram_bot/services/qdrant.py`) и обновлённых тестов.
+
+## 2. Критичные дефекты (P0)
+
+### P0.1 Сломаны unit-тесты `bot handlers` (устаревший patch API)
+Проблема:
+- Тесты патчат несуществующий символ `create_langfuse_handler`, которого больше нет в `telegram_bot/bot.py`.
+
+Файлы:
+- `tests/unit/test_bot_handlers.py:249`
+- `tests/unit/test_bot_handlers.py:282`
+- `telegram_bot/bot.py:261`
+
+Требование:
+- Удалить patch `telegram_bot.bot.create_langfuse_handler`.
+- Проверять текущий контракт: `get_client().update_current_trace` и `_write_langfuse_scores`.
+
+Критерий приёмки:
+- `uv run pytest tests/unit/test_bot_handlers.py -q` зелёный.
+
+---
+
+### P0.2 Сломаны integration path tests из-за несовместимых моков `GraphConfig`
+Проблема:
+- В `grade_node` используется `skip_rerank_threshold`, но мок-конфиг не задаёт корректный float (получается `MagicMock`, `TypeError`).
+
+Файлы:
+- `telegram_bot/graph/nodes/grade.py:50`
+- `telegram_bot/graph/nodes/grade.py:51`
+- `tests/integration/test_graph_paths.py:125`
+
+Требование:
+- В `_make_mock_graph_config()` явно задать:
+  - `skip_rerank_threshold: float`
+  - `generate_max_tokens: int`
+  - `streaming_enabled: bool`
+
+Критерий приёмки:
+- `uv run pytest tests/integration/test_graph_paths.py -q` зелёный.
+
+---
+
+### P0.3 Риск двойной генерации при streaming fallback
+Проблема:
+- При ошибке стриминга вызывается fallback non-stream, что даёт второй вызов LLM и потенциальный дубль отправки/контента.
+- Видно по падениям path tests с ожиданием одного LLM call.
+
+Файлы:
+- `telegram_bot/graph/nodes/generate.py:227`
+- `telegram_bot/graph/nodes/generate.py:232`
+- `telegram_bot/graph/nodes/respond.py:36`
+
+Требование:
+- Ввести явный статус стрима в state (например `streaming_started`, `streaming_partial_sent`).
+- Если был partial output, запрещать повторную полную отправку через `respond_node`.
+- Для тестов с обычным completion-моком отключать streaming (`streaming_enabled=False`) либо мокать stream-ответ корректно.
+
+Критерий приёмки:
+- Нет дублирования сообщений в ручном сценарии “stream partial -> stream error”.
+- Новый тест на duplicate-guard зелёный.
+
+---
+
+### P0.4 Cross-test pollution: глобальное мокирование `sys.modules["redisvl"]`
+Проблема:
+- `tests/unit/test_redis_semantic_cache.py` пишет в `sys.modules` на уровне модуля.
+- Ломает последующие тесты (`tests/unit/test_vectorizers.py`), где импортируется фейковый `redisvl` вместо реального/отсутствующего пакета.
+
+Файлы:
+- `tests/unit/test_redis_semantic_cache.py:13`
+- `tests/unit/test_redis_semantic_cache.py:16`
+- `tests/unit/test_vectorizers.py:15`
+
+Требование:
+- Заменить модульное вмешательство в `sys.modules` на fixture `monkeypatch` с восстановлением состояния.
+- Локализовать моки внутри тестов/фикстур, не оставляя глобальный side-effect.
+
+Критерий приёмки:
+- `uv run pytest tests/unit/test_redis_semantic_cache.py tests/unit/test_vectorizers.py -q` зелёный.
+
+## 3. Важные дефекты (P1)
+
+### P1.1 Несогласован default `rewrite_max_tokens`
+Проблема:
+- Dataclass default `rewrite_max_tokens=64`, но fallback из env всё ещё `"200"`.
+
+Файлы:
+- `telegram_bot/graph/config.py:24`
+- `telegram_bot/graph/config.py:70`
+
+Требование:
+- Синхронизировать fallback до `"64"` и обновить тесты defaults.
+
+---
+
+### P1.2 Грейсфул-деградация Qdrant скрывает operational проблемы
+Проблема:
+- В `QdrantService` исключения глушатся с `return []`, что маскирует инфраструктурные ошибки как “пустая выдача”.
+- В smoke логах есть `RuntimeWarning` и `Event loop is closed`, но бизнес-пайплайн продолжает путь как “нет документов”.
+
+Файлы:
+- `telegram_bot/services/qdrant.py:120`
+- `telegram_bot/services/qdrant.py:253`
+
+Требование:
+- Разделить “пустой результат” и “ошибка backend” (state flag/metric).
+- В trace/метриках фиксировать код ошибки backend отдельно от `search_results_count=0`.
+
+---
+
+### P1.3 Интеграционный тест устарел по структуре проекта
+Проблема:
+- `tests/integration/test_redis_cache.py` импортирует `cache.redis_semantic_cache` через ручной `sys.path` hack на `tests/src` и падает на collection.
+
+Файл:
+- `tests/integration/test_redis_cache.py:11`
+- `tests/integration/test_redis_cache.py:13`
+
+Требование:
+- Перевести импорт на актуальный пакетный путь или вынести тест в legacy/disabled suite.
+
+## 4. Низкий приоритет (P2)
+
+### P2.1 Mypy: конфликт имён модулей `main.py` в сервисах
+Проблема:
+- При запуске mypy на `services/` возникает duplicate module name (`services/user-base/main.py` и `services/bm42/main.py`).
+
+Требование:
+- Либо добавить пакетную структуру (`__init__.py`), либо настроить `explicit_package_bases`/исключения mypy.
+
+## 5. Прогон после фиксов (gate)
+
+```bash
+uv run ruff check src telegram_bot tests services --output-format=concise
+uv run pytest tests/unit/test_bot_handlers.py -q
+uv run pytest tests/integration/test_graph_paths.py -q
+uv run pytest tests/unit/test_redis_semantic_cache.py tests/unit/test_vectorizers.py -q
+uv run pytest tests/unit/graph -q
+uv run mypy src telegram_bot --ignore-missing-imports
+```
+
+Merge допускается только при зелёном результате всех пунктов.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,6 +240,7 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false  # Set to true for strict mode
 ignore_missing_imports = true  # Ignore missing stubs for now
+explicit_package_bases = true  # Resolve duplicate module names in services/
 
 # Per-module overrides
 [[tool.mypy.overrides]]

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -50,15 +50,15 @@ def _write_langfuse_scores(lf: Any, result: dict) -> None:
         "query_type": _QUERY_TYPE_SCORE.get(result.get("query_type", ""), 1.0),
         "latency_total_ms": total_ms,
         "semantic_cache_hit": 1.0 if result.get("cache_hit") else 0.0,
-        "embeddings_cache_hit": 0.0,  # Not tracked in LangGraph state
-        "search_cache_hit": 0.0,  # Not tracked in LangGraph state
+        "embeddings_cache_hit": 1.0 if result.get("embeddings_cache_hit") else 0.0,
+        "search_cache_hit": 1.0 if result.get("search_cache_hit") else 0.0,
         "rerank_applied": 1.0 if result.get("rerank_applied") else 0.0,
-        "rerank_cache_hit": 0.0,  # Not tracked in LangGraph state
+        "rerank_cache_hit": 0.0,  # Tracked when rerank cache implemented
         "results_count": float(result.get("search_results_count", 0)),
         "no_results": 1.0 if result.get("search_results_count", 0) == 0 else 0.0,
         "llm_used": 1.0 if "generate" in latency_stages else 0.0,
-        "confidence_score": 0.0,  # Not tracked in LangGraph state
-        "hyde_used": 0.0,  # Not tracked in LangGraph state
+        "confidence_score": float(result.get("grade_confidence", 0.0)),
+        "hyde_used": 0.0,  # HyDE not implemented in current pipeline
     }
 
     for name, value in scores.items():

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import logging
+import time
 from datetime import UTC, datetime
 from typing import Any
 
@@ -43,7 +44,7 @@ def _write_langfuse_scores(lf: Any, result: dict) -> None:
         result: State dict returned by graph.ainvoke().
     """
     latency_stages = result.get("latency_stages", {})
-    total_ms = sum(latency_stages.values()) * 1000
+    total_ms = result.get("pipeline_wall_ms", 0.0)
 
     scores = {
         "query_type": _QUERY_TYPE_SCORE.get(result.get("query_type", ""), 1.0),
@@ -226,6 +227,7 @@ class PropertyBot:
     @observe(name="telegram-rag-query")
     async def handle_query(self, message: Message):
         """Handle user query via LangGraph RAG pipeline."""
+        pipeline_start = time.perf_counter()
         # Early typing ACK — user sees "typing..." immediately
         assert message.bot is not None
         assert message.from_user is not None
@@ -256,6 +258,9 @@ class PropertyBot:
 
             async with ChatActionSender.typing(bot=bot, chat_id=message.chat.id):
                 result = await graph.ainvoke(state)
+
+            # Wall-time for accurate latency_total_ms
+            result["pipeline_wall_ms"] = (time.perf_counter() - pipeline_start) * 1000
 
             # Update trace with input/output and metadata
             lf = get_client()

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -105,13 +105,15 @@ class PropertyBot:
 
         # Initialize LangGraph service dependencies
         from .integrations.cache import CacheLayerManager
-        from .integrations.embeddings import BGEM3Embeddings, BGEM3SparseEmbeddings
+        from .integrations.embeddings import BGEM3HybridEmbeddings, BGEM3SparseEmbeddings
         from .services.qdrant import QdrantService
 
         self._cache = CacheLayerManager(redis_url=config.redis_url)
-        self._embeddings = BGEM3Embeddings(
+        self._hybrid = BGEM3HybridEmbeddings(
             base_url=config.bge_m3_url,
         )
+        # Use hybrid as primary embeddings provider
+        self._embeddings = self._hybrid
         self._sparse = BGEM3SparseEmbeddings(
             base_url=config.bge_m3_url,
         )
@@ -305,6 +307,10 @@ class PropertyBot:
         await self._redis_monitor.stop()
         await self._cache.close()
         await self._qdrant.close()
+        if hasattr(self._embeddings, "aclose"):
+            await self._embeddings.aclose()
+        if hasattr(self._sparse, "aclose"):
+            await self._sparse.aclose()
         if self._reranker and hasattr(self._reranker, "close"):
             await self._reranker.close()
         await self.bot.session.close()

--- a/telegram_bot/graph/config.py
+++ b/telegram_bot/graph/config.py
@@ -37,6 +37,7 @@ class GraphConfig:
 
     max_rewrite_attempts: int = 1
     skip_rerank_threshold: float = 0.85
+    relevance_threshold_rrf: float = 0.005
     streaming_enabled: bool = True
 
     cache_thresholds: dict[str, float] = field(
@@ -79,6 +80,7 @@ class GraphConfig:
             domain_language=os.getenv("BOT_LANGUAGE", "ru"),
             max_rewrite_attempts=int(os.getenv("MAX_REWRITE_ATTEMPTS", "1")),
             skip_rerank_threshold=float(os.getenv("SKIP_RERANK_THRESHOLD", "0.85")),
+            relevance_threshold_rrf=float(os.getenv("RELEVANCE_THRESHOLD_RRF", "0.005")),
             streaming_enabled=os.getenv("STREAMING_ENABLED", "true").lower() == "true",
         )
 

--- a/telegram_bot/graph/config.py
+++ b/telegram_bot/graph/config.py
@@ -67,7 +67,7 @@ class GraphConfig:
             ),  # LLM_API_KEY preferred
             llm_model=os.getenv("LLM_MODEL", "gpt-4o-mini"),
             rewrite_model=os.getenv("REWRITE_MODEL", os.getenv("LLM_MODEL", "gpt-4o-mini")),
-            rewrite_max_tokens=int(os.getenv("REWRITE_MAX_TOKENS", "200")),
+            rewrite_max_tokens=int(os.getenv("REWRITE_MAX_TOKENS", "64")),
             generate_max_tokens=int(os.getenv("GENERATE_MAX_TOKENS", "2048")),
             bge_m3_url=os.getenv("BGE_M3_URL", "http://bge-m3:8000"),
             bge_m3_timeout=float(os.getenv("BGE_M3_TIMEOUT", "120.0")),

--- a/telegram_bot/graph/config.py
+++ b/telegram_bot/graph/config.py
@@ -112,3 +112,12 @@ class GraphConfig:
             base_url=self.bge_m3_url,
             timeout=self.bge_m3_timeout,
         )
+
+    def create_hybrid_embeddings(self) -> Any:
+        """Create BGEM3HybridEmbeddings instance."""
+        from telegram_bot.integrations.embeddings import BGEM3HybridEmbeddings
+
+        return BGEM3HybridEmbeddings(
+            base_url=self.bge_m3_url,
+            timeout=self.bge_m3_timeout,
+        )

--- a/telegram_bot/graph/nodes/cache.py
+++ b/telegram_bot/graph/nodes/cache.py
@@ -10,6 +10,7 @@ import logging
 import time
 from typing import Any
 
+from telegram_bot.integrations.embeddings import BGEM3HybridEmbeddings
 from telegram_bot.observability import observe
 
 
@@ -46,7 +47,7 @@ async def cache_check_node(
     embedding = await cache.get_embedding(query)
     embeddings_cache_hit = embedding is not None
     if embedding is None:
-        if hasattr(embeddings, "aembed_hybrid"):
+        if isinstance(embeddings, BGEM3HybridEmbeddings):
             # Hybrid: get both dense + sparse in one call, cache both
             embedding, sparse = await embeddings.aembed_hybrid(query)
             await cache.store_embedding(query, embedding)

--- a/telegram_bot/graph/nodes/cache.py
+++ b/telegram_bot/graph/nodes/cache.py
@@ -42,11 +42,17 @@ async def cache_check_node(
 
     start = time.perf_counter()
 
-    # Step 1: Get or compute dense embedding
+    # Step 1: Get or compute dense embedding (prefer hybrid for efficiency)
     embedding = await cache.get_embedding(query)
     if embedding is None:
-        embedding = await embeddings.aembed_query(query)
-        await cache.store_embedding(query, embedding)
+        if hasattr(embeddings, "aembed_hybrid"):
+            # Hybrid: get both dense + sparse in one call, cache both
+            embedding, sparse = await embeddings.aembed_hybrid(query)
+            await cache.store_embedding(query, embedding)
+            await cache.store_sparse_embedding(query, sparse)
+        else:
+            embedding = await embeddings.aembed_query(query)
+            await cache.store_embedding(query, embedding)
 
     # Step 2: Check semantic cache with query-type threshold
     cached = await cache.check_semantic(

--- a/telegram_bot/graph/nodes/cache.py
+++ b/telegram_bot/graph/nodes/cache.py
@@ -44,6 +44,7 @@ async def cache_check_node(
 
     # Step 1: Get or compute dense embedding (prefer hybrid for efficiency)
     embedding = await cache.get_embedding(query)
+    embeddings_cache_hit = embedding is not None
     if embedding is None:
         if hasattr(embeddings, "aembed_hybrid"):
             # Hybrid: get both dense + sparse in one call, cache both
@@ -70,6 +71,7 @@ async def cache_check_node(
             "cached_response": cached,
             "query_embedding": embedding,
             "response": cached,
+            "embeddings_cache_hit": embeddings_cache_hit,
             "latency_stages": {**state.get("latency_stages", {}), "cache_check": latency},
         }
 
@@ -78,6 +80,7 @@ async def cache_check_node(
         "cache_hit": False,
         "cached_response": None,
         "query_embedding": embedding,
+        "embeddings_cache_hit": embeddings_cache_hit,
         "latency_stages": {**state.get("latency_stages", {}), "cache_check": latency},
     }
 

--- a/telegram_bot/graph/nodes/generate.py
+++ b/telegram_bot/graph/nodes/generate.py
@@ -22,6 +22,16 @@ from telegram_bot.observability import observe
 
 logger = logging.getLogger(__name__)
 
+
+class StreamingPartialDeliveryError(Exception):
+    """Raised when streaming delivered partial content to user then failed."""
+
+    def __init__(self, sent_msg: Any, partial_text: str):
+        self.sent_msg = sent_msg
+        self.partial_text = partial_text
+        super().__init__(f"Streaming failed after delivering {len(partial_text)} chars")
+
+
 _MAX_CONTEXT_DOCS = 5
 _STREAM_EDIT_INTERVAL = 0.3  # 300ms throttle for Telegram edit_text
 _STREAM_PLACEHOLDER = "⏳ Генерирую ответ..."
@@ -138,17 +148,25 @@ async def _generate_streaming(
         name="generate-answer",  # type: ignore[call-overload]  # langfuse kwarg
     )
 
-    async for chunk in stream:
-        if not chunk.choices:
-            continue
-        delta = chunk.choices[0].delta
-        if delta and delta.content:
-            accumulated += delta.content
-            now = time.monotonic()
-            if now - last_edit >= _STREAM_EDIT_INTERVAL:
-                with contextlib.suppress(Exception):
-                    await sent_msg.edit_text(accumulated)
-                last_edit = now
+    try:
+        async for chunk in stream:
+            if not chunk.choices:
+                continue
+            delta = chunk.choices[0].delta
+            if delta and delta.content:
+                accumulated += delta.content
+                now = time.monotonic()
+                if now - last_edit >= _STREAM_EDIT_INTERVAL:
+                    with contextlib.suppress(Exception):
+                        await sent_msg.edit_text(accumulated)
+                    last_edit = now
+    except Exception:
+        if accumulated:
+            raise StreamingPartialDeliveryError(sent_msg, accumulated) from None
+        # No real content delivered — clean up placeholder
+        with contextlib.suppress(Exception):
+            await sent_msg.delete()
+        raise
 
     if not accumulated:
         # Stream produced no content — clean up placeholder
@@ -227,6 +245,28 @@ async def generate_node(state: RAGState, *, message: Any | None = None) -> dict[
         if message is not None and config.streaming_enabled:
             try:
                 answer = await _generate_streaming(llm, config, llm_messages, message)
+                response_sent = True
+            except StreamingPartialDeliveryError as e:
+                logger.warning(
+                    "Streaming failed after partial delivery (%d chars), "
+                    "falling back to non-streaming with edit",
+                    len(e.partial_text),
+                    exc_info=True,
+                )
+                response = await llm.chat.completions.create(
+                    model=config.llm_model,
+                    messages=llm_messages,
+                    temperature=config.llm_temperature,
+                    max_tokens=config.generate_max_tokens,
+                    name="generate-answer",  # type: ignore[call-overload]
+                )
+                answer = response.choices[0].message.content or ""
+                # Edit existing message with fallback answer
+                try:
+                    await e.sent_msg.edit_text(answer, parse_mode="Markdown")
+                except Exception:
+                    with contextlib.suppress(Exception):
+                        await e.sent_msg.edit_text(answer)
                 response_sent = True
             except Exception:
                 logger.warning("Streaming failed, falling back to non-streaming", exc_info=True)

--- a/telegram_bot/graph/nodes/generate.py
+++ b/telegram_bot/graph/nodes/generate.py
@@ -262,12 +262,21 @@ async def generate_node(state: RAGState, *, message: Any | None = None) -> dict[
                 )
                 answer = response.choices[0].message.content or ""
                 # Edit existing message with fallback answer
+                delivered = False
                 try:
                     await e.sent_msg.edit_text(answer, parse_mode="Markdown")
+                    delivered = True
                 except Exception:
-                    with contextlib.suppress(Exception):
+                    try:
                         await e.sent_msg.edit_text(answer)
-                response_sent = True
+                        delivered = True
+                    except Exception:
+                        logger.warning(
+                            "Failed to deliver fallback edit after partial stream; "
+                            "respond_node will send final answer",
+                            exc_info=True,
+                        )
+                response_sent = delivered
             except Exception:
                 logger.warning("Streaming failed, falling back to non-streaming", exc_info=True)
                 # Fall back to non-streaming

--- a/telegram_bot/graph/nodes/grade.py
+++ b/telegram_bot/graph/nodes/grade.py
@@ -15,8 +15,6 @@ from telegram_bot.observability import observe
 
 logger = logging.getLogger(__name__)
 
-RELEVANCE_THRESHOLD = 0.3
-
 
 @observe(name="node-grade")
 async def grade_node(state: dict[str, Any]) -> dict[str, Any]:
@@ -42,19 +40,23 @@ async def grade_node(state: dict[str, Any]) -> dict[str, Any]:
         }
 
     top_score = max(doc.get("score", 0) for doc in documents)
-    relevant = top_score > RELEVANCE_THRESHOLD
 
-    # Early termination: skip rerank when confidence is high enough
+    # RRF scores = 1/(k+rank), k=60 → rank 1 = ~0.016, rank 10 = ~0.014
+    # Threshold must be below typical top-1 RRF score
     from telegram_bot.graph.config import GraphConfig
 
     config = GraphConfig.from_env()
+    relevance_threshold = config.relevance_threshold_rrf
+    relevant = top_score > relevance_threshold
+
+    # Early termination: skip rerank when confidence is high enough
     skip_rerank = relevant and top_score >= config.skip_rerank_threshold
 
     elapsed = time.perf_counter() - t0
     logger.info(
         "grade: top_score=%.3f threshold=%.3f relevant=%s skip_rerank=%s (%d docs, %.3fs)",
         top_score,
-        RELEVANCE_THRESHOLD,
+        relevance_threshold,
         relevant,
         skip_rerank,
         len(documents),

--- a/telegram_bot/graph/nodes/retrieve.py
+++ b/telegram_bot/graph/nodes/retrieve.py
@@ -58,24 +58,32 @@ async def retrieve_node(
     if dense_vector is None and embeddings is not None:
         dense_vector = await cache.get_embedding(query)
         if dense_vector is None:
-            # Parallel: compute dense + sparse simultaneously (saves ~0.5-1s)
-            import asyncio
-
             sparse_cached = await cache.get_sparse_embedding(query)
+            if sparse_cached is not None:
+                # Dense miss, sparse cached → just compute dense
+                dense_vector = await embeddings.aembed_query(query)
+                await cache.store_embedding(query, dense_vector)
+                sparse_vector = sparse_cached
+            elif hasattr(embeddings, "aembed_hybrid"):
+                # Hybrid: single call for both dense + sparse
+                dense_vector, sparse_vector = await embeddings.aembed_hybrid(query)
+                await cache.store_embedding(query, dense_vector)
+                await cache.store_sparse_embedding(query, sparse_vector)
+            else:
+                # Fallback: parallel dense + sparse (old path)
+                import asyncio
 
-            async def _get_dense() -> list[float]:
-                vec: list[float] = await embeddings.aembed_query(query)
-                await cache.store_embedding(query, vec)
-                return vec
+                async def _get_dense() -> list[float]:
+                    vec: list[float] = await embeddings.aembed_query(query)
+                    await cache.store_embedding(query, vec)
+                    return vec
 
-            async def _get_sparse() -> Any:
-                if sparse_cached is not None:
-                    return sparse_cached
-                vec = await sparse_embeddings.aembed_query(query)
-                await cache.store_sparse_embedding(query, vec)
-                return vec
+                async def _get_sparse() -> Any:
+                    vec = await sparse_embeddings.aembed_query(query)
+                    await cache.store_sparse_embedding(query, vec)
+                    return vec
 
-            dense_vector, sparse_vector = await asyncio.gather(_get_dense(), _get_sparse())
+                dense_vector, sparse_vector = await asyncio.gather(_get_dense(), _get_sparse())
 
     if not dense_vector:
         dense_vector = []

--- a/telegram_bot/graph/nodes/retrieve.py
+++ b/telegram_bot/graph/nodes/retrieve.py
@@ -91,6 +91,9 @@ async def retrieve_node(
             "documents": cached_results,
             "search_results_count": len(cached_results),
             "latency_stages": {**state.get("latency_stages", {}), "retrieve": latency},
+            # Clear stale backend-error markers from previous turns/branches.
+            "retrieval_backend_error": False,
+            "retrieval_error_type": None,
         }
 
     # Step 2: Get sparse embedding (cached or compute)

--- a/telegram_bot/graph/nodes/retrieve.py
+++ b/telegram_bot/graph/nodes/retrieve.py
@@ -101,14 +101,15 @@ async def retrieve_node(
             await cache.store_sparse_embedding(query, sparse_vector)
 
     # Step 3: Hybrid search via Qdrant SDK (RRF fusion)
-    results = await qdrant.hybrid_search_rrf(
+    results, search_meta = await qdrant.hybrid_search_rrf(
         dense_vector=dense_vector,
         sparse_vector=sparse_vector,
         top_k=top_k,
+        return_meta=True,
     )
 
-    # Step 4: Cache results
-    if results:
+    # Step 4: Cache results (only on successful backend response)
+    if results and not search_meta["backend_error"]:
         await cache.store_search_results(dense_vector, None, results)
 
     latency = time.perf_counter() - start
@@ -119,6 +120,8 @@ async def retrieve_node(
         "search_results_count": len(results),
         "sparse_embedding": sparse_vector,
         "latency_stages": {**state.get("latency_stages", {}), "retrieve": latency},
+        "retrieval_backend_error": search_meta["backend_error"],
+        "retrieval_error_type": search_meta.get("error_type"),
     }
     # Persist re-computed embedding for downstream nodes (grade, cache_store)
     if state.get("query_embedding") is None and dense_vector:

--- a/telegram_bot/graph/nodes/retrieve.py
+++ b/telegram_bot/graph/nodes/retrieve.py
@@ -11,6 +11,7 @@ import logging
 import time
 from typing import Any
 
+from telegram_bot.integrations.embeddings import BGEM3HybridEmbeddings
 from telegram_bot.observability import observe
 
 
@@ -64,7 +65,7 @@ async def retrieve_node(
                 dense_vector = await embeddings.aembed_query(query)
                 await cache.store_embedding(query, dense_vector)
                 sparse_vector = sparse_cached
-            elif hasattr(embeddings, "aembed_hybrid"):
+            elif isinstance(embeddings, BGEM3HybridEmbeddings):
                 # Hybrid: single call for both dense + sparse
                 dense_vector, sparse_vector = await embeddings.aembed_hybrid(query)
                 await cache.store_embedding(query, dense_vector)

--- a/telegram_bot/graph/nodes/retrieve.py
+++ b/telegram_bot/graph/nodes/retrieve.py
@@ -98,6 +98,7 @@ async def retrieve_node(
         return {
             "documents": cached_results,
             "search_results_count": len(cached_results),
+            "search_cache_hit": True,
             "latency_stages": {**state.get("latency_stages", {}), "retrieve": latency},
             # Clear stale backend-error markers from previous turns/branches.
             "retrieval_backend_error": False,
@@ -129,6 +130,7 @@ async def retrieve_node(
     update: dict[str, Any] = {
         "documents": results,
         "search_results_count": len(results),
+        "search_cache_hit": False,
         "sparse_embedding": sparse_vector,
         "latency_stages": {**state.get("latency_stages", {}), "retrieve": latency},
         "retrieval_backend_error": search_meta["backend_error"],

--- a/telegram_bot/graph/state.py
+++ b/telegram_bot/graph/state.py
@@ -33,6 +33,8 @@ class RAGState(TypedDict):
     grade_confidence: float
     skip_rerank: bool
     response_sent: bool
+    embeddings_cache_hit: bool
+    search_cache_hit: bool
     retrieval_backend_error: bool
     retrieval_error_type: str | None
 
@@ -60,6 +62,8 @@ def make_initial_state(user_id: int, session_id: str, query: str) -> dict[str, A
         "grade_confidence": 0.0,
         "skip_rerank": False,
         "response_sent": False,
+        "embeddings_cache_hit": False,
+        "search_cache_hit": False,
         "retrieval_backend_error": False,
         "retrieval_error_type": None,
     }

--- a/telegram_bot/graph/state.py
+++ b/telegram_bot/graph/state.py
@@ -33,6 +33,8 @@ class RAGState(TypedDict):
     grade_confidence: float
     skip_rerank: bool
     response_sent: bool
+    retrieval_backend_error: bool
+    retrieval_error_type: str | None
 
 
 def make_initial_state(user_id: int, session_id: str, query: str) -> dict[str, Any]:
@@ -58,4 +60,6 @@ def make_initial_state(user_id: int, session_id: str, query: str) -> dict[str, A
         "grade_confidence": 0.0,
         "skip_rerank": False,
         "response_sent": False,
+        "retrieval_backend_error": False,
+        "retrieval_error_type": None,
     }

--- a/telegram_bot/integrations/embeddings.py
+++ b/telegram_bot/integrations/embeddings.py
@@ -108,3 +108,80 @@ class BGEM3SparseEmbeddings:
             response.raise_for_status()
             data: dict[str, list[dict[str, Any]]] = response.json()
             return data["lexical_weights"]
+
+
+class BGEM3HybridEmbeddings(Embeddings):
+    """Combined dense+sparse embedding via BGE-M3 /encode/hybrid.
+
+    Single HTTP call returns both dense and sparse vectors.
+    Uses shared httpx.AsyncClient for connection pooling.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "http://bge-m3:8000",
+        timeout: float = 120.0,
+        max_length: int = 512,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.max_length = max_length
+        self._client: httpx.AsyncClient | None = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                timeout=self.timeout,
+                limits=httpx.Limits(max_connections=20, max_keepalive_connections=10),
+            )
+        return self._client
+
+    @observe(name="bge-m3-hybrid-embed")
+    async def aembed_hybrid(self, text: str) -> tuple[list[float], dict[str, Any]]:
+        """Embed text via /encode/hybrid, returning (dense, sparse)."""
+        client = self._get_client()
+        response = await client.post(
+            f"{self.base_url}/encode/hybrid",
+            json={"texts": [text], "max_length": self.max_length},
+        )
+        response.raise_for_status()
+        data = response.json()
+        dense = data["dense_vecs"][0]
+        sparse = data["lexical_weights"][0]
+        return dense, sparse
+
+    @observe(name="bge-m3-hybrid-embed-batch")
+    async def aembed_hybrid_batch(
+        self, texts: list[str]
+    ) -> tuple[list[list[float]], list[dict[str, Any]]]:
+        """Batch embed via /encode/hybrid."""
+        if not texts:
+            return [], []
+        client = self._get_client()
+        response = await client.post(
+            f"{self.base_url}/encode/hybrid",
+            json={"texts": texts, "max_length": self.max_length},
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data["dense_vecs"], data["lexical_weights"]
+
+    async def aembed_query(self, text: str) -> list[float]:
+        dense, _ = await self.aembed_hybrid(text)
+        return dense
+
+    async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
+        dense_vecs, _ = await self.aembed_hybrid_batch(texts)
+        return dense_vecs
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return asyncio.get_event_loop().run_until_complete(self.aembed_documents(texts))
+
+    def embed_query(self, text: str) -> list[float]:
+        return asyncio.get_event_loop().run_until_complete(self.aembed_query(text))
+
+    async def aclose(self) -> None:
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()

--- a/telegram_bot/services/qdrant.py
+++ b/telegram_bot/services/qdrant.py
@@ -160,7 +160,9 @@ class QdrantService:
         # Grouping for diverse results
         group_by: str | None = None,
         group_size: int = 2,
-    ) -> list[dict]:
+        # Per-call error meta (#117)
+        return_meta: bool = False,
+    ) -> list[dict] | tuple[list[dict], dict[str, Any]]:
         """Hybrid search with RRF fusion (dense + sparse).
 
         Args:
@@ -177,9 +179,12 @@ class QdrantService:
             rrf_k: RRF constant k (higher = more weight to lower-ranked results).
             group_by: Optional payload field to group results by (e.g. "metadata.doc_id").
             group_size: Max points per group when group_by is set.
+            return_meta: If True, return (results, meta) tuple with backend_error info.
 
         Returns:
-            List of results with id, score, text, metadata
+            If return_meta=False: list of results (backward compatible).
+            If return_meta=True: (results, meta) where meta has
+                backend_error, error_type, error_message.
         """
         await self.ensure_collection()
         # Build prefetch queries
@@ -221,6 +226,11 @@ class QdrantService:
             )
 
         rrf_query = models.RrfQuery(rrf=models.Rrf(k=rrf_k))
+        ok_meta: dict[str, Any] = {
+            "backend_error": False,
+            "error_type": None,
+            "error_message": None,
+        }
 
         # Execute RRF fusion search with graceful degradation
         try:
@@ -236,7 +246,10 @@ class QdrantService:
                     with_payload=True,
                     search_params=search_params,
                 )
-                return self._format_group_results(group_result)
+                results = self._format_group_results(group_result)
+                if return_meta:
+                    return results, ok_meta
+                return results
 
             result = await self._client.query_points(
                 collection_name=self._collection_name,
@@ -247,10 +260,19 @@ class QdrantService:
                 with_payload=True,
                 search_params=search_params,
             )
-            return self._format_results(result.points)
+            results = self._format_results(result.points)
+            if return_meta:
+                return results, ok_meta
+            return results
         except Exception as e:
             # Graceful degradation: return empty list on any Qdrant error
             logger.error(f"Qdrant search failed (graceful degradation): {e}")
+            if return_meta:
+                return [], {
+                    "backend_error": True,
+                    "error_type": type(e).__name__,
+                    "error_message": str(e),
+                }
             return []
 
     @observe(name="qdrant-batch-search-rrf")

--- a/tests/integration/test_graph_paths.py
+++ b/tests/integration/test_graph_paths.py
@@ -133,6 +133,7 @@ def _make_mock_graph_config(llm_mock: MagicMock) -> MagicMock:
     gc.rewrite_model = "test-model"
     gc.rewrite_max_tokens = 64
     gc.skip_rerank_threshold = 0.95
+    gc.relevance_threshold_rrf = 0.005
     gc.streaming_enabled = False
     gc.create_llm.return_value = llm_mock
     return gc
@@ -299,7 +300,7 @@ async def test_path_happy_retrieve_rerank_generate():
 async def test_path_rewrite_loop_then_success():
     """Irrelevant docs trigger rewrite, second retrieve finds relevant docs."""
     irrelevant_docs = [
-        {"text": "Нерелевантный текст", "score": 0.1, "id": "x1", "metadata": {}},
+        {"text": "Нерелевантный текст", "score": 0.003, "id": "x1", "metadata": {}},
     ]
     relevant_docs = [
         {
@@ -369,7 +370,7 @@ async def test_path_rewrite_loop_then_success():
 async def test_path_rewrite_exhausted_fallback():
     """When rewrite_count >= 2, skip rewrite and go straight to generate."""
     irrelevant_docs = [
-        {"text": "Не очень релевантный текст", "score": 0.15, "id": "z1", "metadata": {}},
+        {"text": "Не очень релевантный текст", "score": 0.003, "id": "z1", "metadata": {}},
     ]
     mocks = _make_graph_mocks(
         qdrant_results=irrelevant_docs,
@@ -418,7 +419,7 @@ async def test_path_rewrite_exhausted_fallback():
 async def test_path_rewrite_ineffective_fallback():
     """When rewrite_effective=False (even with retries left), skip rewrite → generate."""
     irrelevant_docs = [
-        {"text": "Не очень релевантный текст", "score": 0.15, "id": "z1", "metadata": {}},
+        {"text": "Не очень релевантный текст", "score": 0.003, "id": "z1", "metadata": {}},
     ]
     mocks = _make_graph_mocks(
         qdrant_results=irrelevant_docs,

--- a/tests/integration/test_graph_paths.py
+++ b/tests/integration/test_graph_paths.py
@@ -123,14 +123,17 @@ def _make_graph_mocks(
 
 
 def _make_mock_graph_config(llm_mock: MagicMock) -> MagicMock:
-    """Create a mock GraphConfig with all required fields."""
+    """Create a mock GraphConfig with all required typed fields."""
     gc = MagicMock()
     gc.domain = "недвижимость"
     gc.llm_model = "test-model"
     gc.llm_temperature = 0.7
     gc.llm_max_tokens = 4096
+    gc.generate_max_tokens = 2048
     gc.rewrite_model = "test-model"
     gc.rewrite_max_tokens = 64
+    gc.skip_rerank_threshold = 0.95
+    gc.streaming_enabled = False
     gc.create_llm.return_value = llm_mock
     return gc
 

--- a/tests/integration/test_graph_paths.py
+++ b/tests/integration/test_graph_paths.py
@@ -90,10 +90,10 @@ def _make_graph_mocks(
             "metadata": {"title": "Студия", "city": "Солнечный берег", "price": 60000},
         },
     ]
+    _ok_meta = {"backend_error": False, "error_type": None, "error_message": None}
+    _docs = qdrant_results if qdrant_results is not None else default_docs
     qdrant = MagicMock()
-    qdrant.hybrid_search_rrf = AsyncMock(
-        return_value=qdrant_results if qdrant_results is not None else default_docs
-    )
+    qdrant.hybrid_search_rrf = AsyncMock(return_value=(_docs, _ok_meta))
 
     # -- Reranker (ColBERT) --
     reranker = MagicMock()
@@ -313,7 +313,10 @@ async def test_path_rewrite_loop_then_success():
     mocks = _make_graph_mocks()
 
     # Qdrant: 1st call → irrelevant, 2nd call → relevant
-    mocks["qdrant"].hybrid_search_rrf = AsyncMock(side_effect=[irrelevant_docs, relevant_docs])
+    _ok_meta = {"backend_error": False, "error_type": None, "error_message": None}
+    mocks["qdrant"].hybrid_search_rrf = AsyncMock(
+        side_effect=[(irrelevant_docs, _ok_meta), (relevant_docs, _ok_meta)]
+    )
 
     # LLM: 1st call → rewrite query, 2nd call → generate answer
     rewrite_completion = _make_llm_completion("квартира Несебр недорого")

--- a/tests/integration/test_redis_cache.py
+++ b/tests/integration/test_redis_cache.py
@@ -1,14 +1,25 @@
 #!/usr/bin/env python3
-"""Test Redis semantic cache connectivity and basic operations."""
+"""Test Redis semantic cache connectivity and basic operations.
+
+Legacy integration test — requires live Redis. Run manually:
+    python tests/integration/test_redis_cache.py
+
+Excluded from CI via @pytest.mark.legacy_api marker.
+"""
 
 import asyncio
 import os
 import sys
 from pathlib import Path
 
+import pytest
 
-# Add src to path
-sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+# Mark entire module as legacy (skipped in CI: -m "not legacy_api")
+pytestmark = pytest.mark.legacy_api
+
+# Add src to path for legacy import
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
 from cache.redis_semantic_cache import RedisSemanticCache
 

--- a/tests/unit/graph/test_agentic_nodes.py
+++ b/tests/unit/graph/test_agentic_nodes.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -29,13 +29,13 @@ class TestGradeNode:
 
     @pytest.mark.asyncio
     async def test_not_relevant_documents(self):
-        """Documents with top score <= 0.3 are not relevant."""
+        """Documents with top score <= 0.005 are not relevant."""
         from telegram_bot.graph.nodes.grade import grade_node
 
         state = make_initial_state(user_id=1, session_id="s", query="test")
         state["documents"] = [
-            {"text": "doc1", "score": 0.2},
-            {"text": "doc2", "score": 0.1},
+            {"text": "doc1", "score": 0.003},
+            {"text": "doc2", "score": 0.001},
         ]
         result = await grade_node(state)
         assert result["documents_relevant"] is False
@@ -52,13 +52,52 @@ class TestGradeNode:
 
     @pytest.mark.asyncio
     async def test_threshold_boundary(self):
-        """Score exactly at threshold (0.3) is NOT relevant (strictly >)."""
+        """Score exactly at threshold (0.005) is NOT relevant (strictly >)."""
         from telegram_bot.graph.nodes.grade import grade_node
 
         state = make_initial_state(user_id=1, session_id="s", query="test")
-        state["documents"] = [{"text": "doc1", "score": 0.3}]
+        state["documents"] = [{"text": "doc1", "score": 0.005}]
         result = await grade_node(state)
         assert result["documents_relevant"] is False
+
+
+class TestGradeNodeRRFScores:
+    @pytest.mark.asyncio
+    async def test_rrf_scores_are_relevant(self):
+        """RRF scores ~0.016 should be considered relevant (not irrelevant)."""
+        from telegram_bot.graph.nodes.grade import grade_node
+
+        state = make_initial_state(user_id=1, session_id="s", query="квартиры")
+        state["documents"] = [
+            {"score": 0.016, "text": "doc1"},  # RRF rank 1: 1/61 ≈ 0.016
+            {"score": 0.015, "text": "doc2"},
+            {"score": 0.014, "text": "doc3"},
+        ]
+        result = await grade_node(state)
+        assert result["documents_relevant"] is True
+
+    @pytest.mark.asyncio
+    async def test_very_low_scores_are_not_relevant(self):
+        """Scores near zero should still be irrelevant."""
+        from telegram_bot.graph.nodes.grade import grade_node
+
+        state = make_initial_state(user_id=1, session_id="s", query="test")
+        state["documents"] = [
+            {"score": 0.001, "text": "garbage"},
+        ]
+        result = await grade_node(state)
+        assert result["documents_relevant"] is False
+
+    @pytest.mark.asyncio
+    async def test_threshold_configurable_via_env(self):
+        """RELEVANCE_THRESHOLD_RRF env var should override default."""
+        from telegram_bot.graph.nodes.grade import grade_node
+
+        state = make_initial_state(user_id=1, session_id="s", query="test")
+        state["documents"] = [{"score": 0.008, "text": "doc1"}]
+        with patch.dict("os.environ", {"RELEVANCE_THRESHOLD_RRF": "0.01"}):
+            result = await grade_node(state)
+        assert result["documents_relevant"] is False  # 0.008 < 0.01
 
 
 # --- rerank_node tests ---

--- a/tests/unit/graph/test_cache_nodes.py
+++ b/tests/unit/graph/test_cache_nodes.py
@@ -54,7 +54,8 @@ class TestCacheCheckNode:
         cache.check_semantic = AsyncMock(return_value=None)
         cache.get_embedding = AsyncMock(return_value=None)
 
-        embeddings = AsyncMock()
+        # Non-hybrid embeddings (no aembed_hybrid attr)
+        embeddings = AsyncMock(spec=["aembed_query"])
         embeddings.aembed_query = AsyncMock(return_value=[0.1] * 1024)
 
         result = await cache_check_node(state, cache=cache, embeddings=embeddings)
@@ -93,12 +94,34 @@ class TestCacheCheckNode:
         cache.check_semantic = AsyncMock(return_value=None)
         cache.store_embedding = AsyncMock()
 
-        embeddings = AsyncMock()
+        # Non-hybrid embeddings (no aembed_hybrid attr)
+        embeddings = AsyncMock(spec=["aembed_query"])
         embeddings.aembed_query = AsyncMock(return_value=[0.3] * 1024)
 
         await cache_check_node(state, cache=cache, embeddings=embeddings)
 
         cache.store_embedding.assert_awaited_once_with("new query", [0.3] * 1024)
+
+    @pytest.mark.asyncio
+    async def test_hybrid_stores_both_embeddings(self):
+        """When hybrid embeddings available, cache both dense and sparse."""
+        state = make_initial_state(user_id=1, session_id="s1", query="hybrid query")
+        state["query_type"] = "GENERAL"
+
+        cache = AsyncMock()
+        cache.get_embedding = AsyncMock(return_value=None)
+        cache.check_semantic = AsyncMock(return_value=None)
+        cache.store_embedding = AsyncMock()
+        cache.store_sparse_embedding = AsyncMock()
+
+        sparse_vec = {"indices": [1, 5], "values": [0.1, 0.5]}
+        embeddings = AsyncMock()
+        embeddings.aembed_hybrid = AsyncMock(return_value=([0.3] * 1024, sparse_vec))
+
+        await cache_check_node(state, cache=cache, embeddings=embeddings)
+
+        cache.store_embedding.assert_awaited_once_with("hybrid query", [0.3] * 1024)
+        cache.store_sparse_embedding.assert_awaited_once_with("hybrid query", sparse_vec)
 
 
 class TestCacheStoreNode:

--- a/tests/unit/graph/test_cache_nodes.py
+++ b/tests/unit/graph/test_cache_nodes.py
@@ -31,6 +31,7 @@ _ensure_redisvl_mock()
 
 from telegram_bot.graph.nodes.cache import cache_check_node, cache_store_node
 from telegram_bot.graph.state import make_initial_state
+from telegram_bot.integrations.embeddings import BGEM3HybridEmbeddings
 
 
 def _make_mock_config():
@@ -115,7 +116,7 @@ class TestCacheCheckNode:
         cache.store_sparse_embedding = AsyncMock()
 
         sparse_vec = {"indices": [1, 5], "values": [0.1, 0.5]}
-        embeddings = AsyncMock()
+        embeddings = AsyncMock(spec=BGEM3HybridEmbeddings)
         embeddings.aembed_hybrid = AsyncMock(return_value=([0.3] * 1024, sparse_vec))
 
         await cache_check_node(state, cache=cache, embeddings=embeddings)

--- a/tests/unit/graph/test_generate_node.py
+++ b/tests/unit/graph/test_generate_node.py
@@ -61,6 +61,24 @@ class _MockAsyncStream:
         return chunk
 
 
+class _MockFailingStream:
+    """Async iterator that yields some chunks then raises RuntimeError."""
+
+    def __init__(self, good_texts: list[str]):
+        self._chunks = [_MockStreamChunk(t) for t in good_texts]
+        self._index = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._index >= len(self._chunks):
+            raise RuntimeError("stream connection lost")
+        chunk = self._chunks[self._index]
+        self._index += 1
+        return chunk
+
+
 def _make_streaming_client(chunks: list[str]) -> MagicMock:
     """Create mock client that returns a streaming response."""
     mock_client = MagicMock()
@@ -423,3 +441,90 @@ class TestGenerateNodeStreaming:
 
         assert result["response"] == "Fallback from empty stream."
         assert result["response_sent"] is False
+
+    @pytest.mark.asyncio
+    async def test_stream_error_before_visible_output(self) -> None:
+        """Stream fails before any real content is visible: response_sent=False."""
+        from telegram_bot.graph.nodes.generate import generate_node
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Fallback answer."
+        mock_fallback_response = MagicMock(choices=[mock_choice])
+
+        mock_client = MagicMock()
+        # Stream fails immediately (no chunks delivered), then fallback succeeds
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=[_MockFailingStream([]), mock_fallback_response],
+        )
+
+        mock_config = MagicMock()
+        mock_config.domain = "недвижимость"
+        mock_config.llm_model = "gpt-4o-mini"
+        mock_config.llm_temperature = 0.7
+        mock_config.generate_max_tokens = 2048
+        mock_config.streaming_enabled = True
+        mock_config.create_llm.return_value = mock_client
+
+        sent_msg = AsyncMock()
+        sent_msg.edit_text = AsyncMock()
+        sent_msg.delete = AsyncMock()
+        message = AsyncMock()
+        message.answer = AsyncMock(return_value=sent_msg)
+
+        state = _make_state_with_docs()
+
+        with patch(
+            "telegram_bot.graph.nodes.generate._get_config",
+            return_value=mock_config,
+        ):
+            result = await generate_node(state, message=message)
+
+        assert result["response"] == "Fallback answer."
+        assert result["response_sent"] is False
+
+    @pytest.mark.asyncio
+    async def test_stream_error_after_visible_output(self) -> None:
+        """Stream delivers partial content then fails: edits existing msg, response_sent=True."""
+        from telegram_bot.graph.nodes.generate import generate_node
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Fallback complete answer."
+        mock_fallback_response = MagicMock(choices=[mock_choice])
+
+        mock_client = MagicMock()
+        # Stream yields real chunks then fails, then fallback succeeds
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=[
+                _MockFailingStream(["Квартира ", "в Несебре "]),
+                mock_fallback_response,
+            ],
+        )
+
+        mock_config = MagicMock()
+        mock_config.domain = "недвижимость"
+        mock_config.llm_model = "gpt-4o-mini"
+        mock_config.llm_temperature = 0.7
+        mock_config.generate_max_tokens = 2048
+        mock_config.streaming_enabled = True
+        mock_config.create_llm.return_value = mock_client
+
+        sent_msg = AsyncMock()
+        sent_msg.edit_text = AsyncMock()
+        message = AsyncMock()
+        message.answer = AsyncMock(return_value=sent_msg)
+
+        state = _make_state_with_docs()
+
+        with patch(
+            "telegram_bot.graph.nodes.generate._get_config",
+            return_value=mock_config,
+        ):
+            result = await generate_node(state, message=message)
+
+        # Fallback answer is the response
+        assert result["response"] == "Fallback complete answer."
+        # KEY: response_sent=True because partial content was already visible
+        assert result["response_sent"] is True
+        # Fallback was edited into existing message (last edit_text call)
+        last_edit_call = sent_msg.edit_text.call_args_list[-1]
+        assert last_edit_call.args[0] == "Fallback complete answer."

--- a/tests/unit/graph/test_generate_node.py
+++ b/tests/unit/graph/test_generate_node.py
@@ -528,3 +528,45 @@ class TestGenerateNodeStreaming:
         # Fallback was edited into existing message (last edit_text call)
         last_edit_call = sent_msg.edit_text.call_args_list[-1]
         assert last_edit_call.args[0] == "Fallback complete answer."
+
+    @pytest.mark.asyncio
+    async def test_stream_error_partial_and_edit_fails_falls_back_to_respond_node(self) -> None:
+        """If fallback edit fails after partial stream, respond_node must send final answer."""
+        from telegram_bot.graph.nodes.generate import generate_node
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Final fallback answer."
+        mock_fallback_response = MagicMock(choices=[mock_choice])
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=[
+                _MockFailingStream(["partial "]),
+                mock_fallback_response,
+            ],
+        )
+
+        mock_config = MagicMock()
+        mock_config.domain = "недвижимость"
+        mock_config.llm_model = "gpt-4o-mini"
+        mock_config.llm_temperature = 0.7
+        mock_config.generate_max_tokens = 2048
+        mock_config.streaming_enabled = True
+        mock_config.create_llm.return_value = mock_client
+
+        sent_msg = AsyncMock()
+        # First call may happen during stream; subsequent fallback edits fail.
+        sent_msg.edit_text = AsyncMock(side_effect=Exception("edit failed"))
+        message = AsyncMock()
+        message.answer = AsyncMock(return_value=sent_msg)
+
+        state = _make_state_with_docs()
+
+        with patch(
+            "telegram_bot.graph.nodes.generate._get_config",
+            return_value=mock_config,
+        ):
+            result = await generate_node(state, message=message)
+
+        assert result["response"] == "Final fallback answer."
+        assert result["response_sent"] is False

--- a/tests/unit/graph/test_retrieve_node.py
+++ b/tests/unit/graph/test_retrieve_node.py
@@ -82,6 +82,30 @@ class TestRetrieveNode:
         qdrant.hybrid_search_rrf.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_cache_hit_clears_stale_backend_error_flags(self):
+        state = make_initial_state(user_id=1, session_id="s1", query="cached query")
+        state["query_type"] = "FAQ"
+        state["query_embedding"] = [0.2] * 1024
+        state["retrieval_backend_error"] = True
+        state["retrieval_error_type"] = "TimeoutError"
+
+        cached_docs = _make_docs(1)
+        cache = AsyncMock()
+        cache.get_search_results = AsyncMock(return_value=cached_docs)
+        qdrant = AsyncMock()
+        sparse_embeddings = AsyncMock()
+
+        result = await retrieve_node(
+            state,
+            cache=cache,
+            sparse_embeddings=sparse_embeddings,
+            qdrant=qdrant,
+        )
+
+        assert result["retrieval_backend_error"] is False
+        assert result["retrieval_error_type"] is None
+
+    @pytest.mark.asyncio
     async def test_handles_empty_results(self):
         state = make_initial_state(user_id=1, session_id="s1", query="obscure query")
         state["query_type"] = "GENERAL"

--- a/tests/unit/graph/test_retrieve_node.py
+++ b/tests/unit/graph/test_retrieve_node.py
@@ -6,6 +6,7 @@ import pytest
 
 from telegram_bot.graph.nodes.retrieve import retrieve_node
 from telegram_bot.graph.state import make_initial_state
+from telegram_bot.integrations.embeddings import BGEM3HybridEmbeddings
 
 
 _OK_META = {"backend_error": False, "error_type": None, "error_message": None}
@@ -266,7 +267,7 @@ class TestRetrieveNode:
         cache.store_search_results = AsyncMock()
 
         sparse_vec = {"indices": [1, 2], "values": [0.5, 0.3]}
-        embeddings = AsyncMock()
+        embeddings = AsyncMock(spec=BGEM3HybridEmbeddings)
         embeddings.aembed_hybrid = AsyncMock(return_value=([0.1] * 1024, sparse_vec))
 
         sparse_embeddings = AsyncMock()

--- a/tests/unit/graph/test_retrieve_node.py
+++ b/tests/unit/graph/test_retrieve_node.py
@@ -8,6 +8,9 @@ from telegram_bot.graph.nodes.retrieve import retrieve_node
 from telegram_bot.graph.state import make_initial_state
 
 
+_OK_META = {"backend_error": False, "error_type": None, "error_message": None}
+
+
 def _make_docs(n: int = 3) -> list[dict]:
     """Create mock search results."""
     return [
@@ -39,7 +42,7 @@ class TestRetrieveNode:
         )
 
         qdrant = AsyncMock()
-        qdrant.hybrid_search_rrf = AsyncMock(return_value=mock_docs)
+        qdrant.hybrid_search_rrf = AsyncMock(return_value=(mock_docs, _OK_META))
 
         result = await retrieve_node(
             state,
@@ -94,7 +97,7 @@ class TestRetrieveNode:
         sparse_embeddings.aembed_query = AsyncMock(return_value={"indices": [1], "values": [0.1]})
 
         qdrant = AsyncMock()
-        qdrant.hybrid_search_rrf = AsyncMock(return_value=[])
+        qdrant.hybrid_search_rrf = AsyncMock(return_value=([], _OK_META))
 
         result = await retrieve_node(
             state,
@@ -121,7 +124,7 @@ class TestRetrieveNode:
 
         sparse_embeddings = AsyncMock()
         qdrant = AsyncMock()
-        qdrant.hybrid_search_rrf = AsyncMock(return_value=_make_docs(2))
+        qdrant.hybrid_search_rrf = AsyncMock(return_value=(_make_docs(2), _OK_META))
 
         await retrieve_node(
             state,
@@ -154,7 +157,7 @@ class TestRetrieveNode:
         sparse_embeddings.aembed_query = AsyncMock(return_value={"indices": [1], "values": [0.5]})
 
         qdrant = AsyncMock()
-        qdrant.hybrid_search_rrf = AsyncMock(return_value=mock_docs)
+        qdrant.hybrid_search_rrf = AsyncMock(return_value=(mock_docs, _OK_META))
 
         await retrieve_node(
             state,
@@ -204,7 +207,7 @@ class TestRetrieveNode:
         sparse_embeddings.aembed_query = AsyncMock(side_effect=mock_sparse_embed)
 
         qdrant = AsyncMock()
-        qdrant.hybrid_search_rrf = AsyncMock(return_value=_make_docs(3))
+        qdrant.hybrid_search_rrf = AsyncMock(return_value=(_make_docs(3), _OK_META))
 
         result = await retrieve_node(
             state,

--- a/tests/unit/graph/test_retrieve_node.py
+++ b/tests/unit/graph/test_retrieve_node.py
@@ -195,7 +195,7 @@ class TestRetrieveNode:
 
     @pytest.mark.asyncio
     async def test_parallel_embeddings_after_rewrite(self):
-        """After rewrite (query_embedding=None), dense+sparse fetched in parallel."""
+        """After rewrite (query_embedding=None), fallback parallel dense+sparse."""
         import asyncio
 
         state = make_initial_state(user_id=1, session_id="s1", query="rewritten query")
@@ -224,7 +224,8 @@ class TestRetrieveNode:
         cache.store_sparse_embedding = AsyncMock()
         cache.store_search_results = AsyncMock()
 
-        embeddings = AsyncMock()
+        # Non-hybrid embeddings → falls through to parallel path
+        embeddings = AsyncMock(spec=["aembed_query"])
         embeddings.aembed_query = AsyncMock(side_effect=mock_dense_embed)
 
         sparse_embeddings = AsyncMock()
@@ -248,3 +249,42 @@ class TestRetrieveNode:
         # Check parallel execution: sparse_start should appear before dense_end
         assert "sparse_start" in call_order
         assert "dense_start" in call_order
+
+    @pytest.mark.asyncio
+    async def test_hybrid_embedding_after_rewrite(self):
+        """After rewrite, hybrid embeddings uses single /encode/hybrid call."""
+        state = make_initial_state(user_id=1, session_id="s1", query="rewritten query")
+        state["query_type"] = "GENERAL"
+        state["query_embedding"] = None  # simulates post-rewrite
+
+        cache = AsyncMock()
+        cache.get_embedding = AsyncMock(return_value=None)
+        cache.store_embedding = AsyncMock()
+        cache.get_search_results = AsyncMock(return_value=None)
+        cache.get_sparse_embedding = AsyncMock(return_value=None)
+        cache.store_sparse_embedding = AsyncMock()
+        cache.store_search_results = AsyncMock()
+
+        sparse_vec = {"indices": [1, 2], "values": [0.5, 0.3]}
+        embeddings = AsyncMock()
+        embeddings.aembed_hybrid = AsyncMock(return_value=([0.1] * 1024, sparse_vec))
+
+        sparse_embeddings = AsyncMock()
+
+        qdrant = AsyncMock()
+        qdrant.hybrid_search_rrf = AsyncMock(return_value=(_make_docs(3), _OK_META))
+
+        result = await retrieve_node(
+            state,
+            cache=cache,
+            embeddings=embeddings,
+            sparse_embeddings=sparse_embeddings,
+            qdrant=qdrant,
+        )
+
+        assert len(result["documents"]) == 3
+        embeddings.aembed_hybrid.assert_awaited_once_with("rewritten query")
+        cache.store_embedding.assert_awaited_once()
+        cache.store_sparse_embedding.assert_awaited_once()
+        # sparse_embeddings should NOT be called — hybrid provided both
+        sparse_embeddings.aembed_query.assert_not_awaited()

--- a/tests/unit/integrations/test_embeddings.py
+++ b/tests/unit/integrations/test_embeddings.py
@@ -127,3 +127,83 @@ class TestBGEM3SparseEmbeddings:
             mock_post.assert_called_once()
             call_args = mock_post.call_args
             assert "/encode/sparse" in call_args[0][0]
+
+
+class TestBGEM3HybridEmbeddings:
+    async def test_aembed_hybrid_returns_dense_and_sparse(self):
+        """Hybrid embed returns both dense_vecs and lexical_weights from one call."""
+        hybrid_response = {
+            "dense_vecs": [[0.1, 0.2, 0.3]],
+            "lexical_weights": [{"indices": [1, 5], "values": [0.1, 0.5]}],
+        }
+        mock_response = httpx.Response(
+            200,
+            json=hybrid_response,
+            request=httpx.Request("POST", "http://fake:8000/encode/hybrid"),
+        )
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response):
+            from telegram_bot.integrations.embeddings import BGEM3HybridEmbeddings
+
+            emb = BGEM3HybridEmbeddings(base_url="http://fake:8000")
+            dense, sparse = await emb.aembed_hybrid("test query")
+        assert dense == [0.1, 0.2, 0.3]
+        assert sparse == {"indices": [1, 5], "values": [0.1, 0.5]}
+
+    async def test_posts_to_hybrid_endpoint(self):
+        hybrid_response = {
+            "dense_vecs": [[0.1]],
+            "lexical_weights": [{"indices": [1], "values": [0.1]}],
+        }
+        mock_response = httpx.Response(
+            200,
+            json=hybrid_response,
+            request=httpx.Request("POST", "http://fake:8000/encode/hybrid"),
+        )
+        with patch(
+            "httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response
+        ) as mock_post:
+            from telegram_bot.integrations.embeddings import BGEM3HybridEmbeddings
+
+            emb = BGEM3HybridEmbeddings(base_url="http://fake:8000")
+            await emb.aembed_hybrid("test")
+            mock_post.assert_called_once()
+            call_args = mock_post.call_args
+            assert "/encode/hybrid" in call_args[0][0]
+
+    async def test_shared_client_reused(self):
+        """Client is created once and reused across calls."""
+        hybrid_response = {
+            "dense_vecs": [[0.1]],
+            "lexical_weights": [{"indices": [1], "values": [0.1]}],
+        }
+        mock_response = httpx.Response(
+            200,
+            json=hybrid_response,
+            request=httpx.Request("POST", "http://fake:8000/encode/hybrid"),
+        )
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response):
+            from telegram_bot.integrations.embeddings import BGEM3HybridEmbeddings
+
+            emb = BGEM3HybridEmbeddings(base_url="http://fake:8000")
+            await emb.aembed_hybrid("test1")
+            await emb.aembed_hybrid("test2")
+            # Same client instance used (shared)
+            assert emb._client is not None
+
+    async def test_aembed_query_delegates_to_hybrid(self):
+        """aembed_query returns only dense part from hybrid call."""
+        hybrid_response = {
+            "dense_vecs": [[0.1, 0.2]],
+            "lexical_weights": [{"indices": [1], "values": [0.5]}],
+        }
+        mock_response = httpx.Response(
+            200,
+            json=hybrid_response,
+            request=httpx.Request("POST", "http://fake:8000/encode/hybrid"),
+        )
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response):
+            from telegram_bot.integrations.embeddings import BGEM3HybridEmbeddings
+
+            emb = BGEM3HybridEmbeddings(base_url="http://fake:8000")
+            result = await emb.aembed_query("test")
+        assert result == [0.1, 0.2]

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -476,6 +476,30 @@ class TestWriteLangfuseScores:
         }
         assert calls["latency_total_ms"] == 0.0
 
+    def test_real_scores_from_state(self):
+        """Hardcoded scores should now use real state values."""
+        from telegram_bot.bot import _write_langfuse_scores
+
+        mock_lf = MagicMock()
+        result = {
+            "query_type": "FAQ",
+            "cache_hit": False,
+            "search_results_count": 20,
+            "rerank_applied": True,
+            "latency_stages": {"generate": 1.0},
+            "pipeline_wall_ms": 5000.0,
+            "embeddings_cache_hit": True,
+            "search_cache_hit": False,
+            "grade_confidence": 0.016,
+        }
+        _write_langfuse_scores(mock_lf, result)
+        calls = {
+            c.kwargs["name"]: c.kwargs["value"] for c in mock_lf.score_current_trace.call_args_list
+        }
+        assert calls["embeddings_cache_hit"] == 1.0
+        assert calls["search_cache_hit"] == 0.0
+        assert calls["confidence_score"] == 0.016
+
 
 class TestMakeSessionId:
     """Test make_session_id utility function."""

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -435,6 +435,42 @@ class TestRegisterHandlers:
         assert hasattr(bot, "handle_query")
 
 
+class TestWriteLangfuseScores:
+    """Test _write_langfuse_scores score writing."""
+
+    def test_latency_total_ms_uses_wall_time(self):
+        """latency_total_ms should use pipeline_wall_ms from state, not sum of stages."""
+        from telegram_bot.bot import _write_langfuse_scores
+
+        mock_lf = MagicMock()
+        result = {
+            "query_type": "GENERAL",
+            "cache_hit": False,
+            "search_results_count": 20,
+            "rerank_applied": False,
+            "latency_stages": {"cache_check": 5.0, "retrieve": 8.0, "generate": 3.0},
+            "pipeline_wall_ms": 7500.0,  # wall-time set by handle_query
+        }
+        _write_langfuse_scores(mock_lf, result)
+        # Find the latency_total_ms call
+        calls = {
+            c.kwargs["name"]: c.kwargs["value"] for c in mock_lf.score_current_trace.call_args_list
+        }
+        assert calls["latency_total_ms"] == 7500.0
+
+    def test_latency_total_ms_fallback_zero(self):
+        """Without pipeline_wall_ms, latency_total_ms should be 0."""
+        from telegram_bot.bot import _write_langfuse_scores
+
+        mock_lf = MagicMock()
+        result = {"query_type": "FAQ", "latency_stages": {}}
+        _write_langfuse_scores(mock_lf, result)
+        calls = {
+            c.kwargs["name"]: c.kwargs["value"] for c in mock_lf.score_current_trace.call_args_list
+        }
+        assert calls["latency_total_ms"] == 0.0
+
+
 class TestMakeSessionId:
     """Test make_session_id utility function."""
 

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -238,17 +238,21 @@ class TestHandleQuery:
             message.bot.send_chat_action.assert_called_once_with(chat_id=12345, action="typing")
 
     @pytest.mark.asyncio
-    async def test_handle_query_passes_langfuse_handler(self, mock_config):
-        """Test that Langfuse handler is created and passed to graph."""
+    async def test_handle_query_writes_langfuse_trace(self, mock_config):
+        """Test that handle_query updates Langfuse trace and writes scores."""
         bot, _ = _create_bot(mock_config)
 
         mock_graph = AsyncMock()
-        mock_graph.ainvoke = AsyncMock(return_value={"response": "ok"})
-        mock_handler = MagicMock()
+        mock_graph.ainvoke = AsyncMock(
+            return_value={"response": "ok", "query_type": "GENERAL", "latency_stages": {}}
+        )
+        mock_lf = MagicMock()
 
         with (
             patch("telegram_bot.bot.build_graph", return_value=mock_graph),
-            patch("telegram_bot.bot.create_langfuse_handler", return_value=mock_handler),
+            patch("telegram_bot.bot.get_client", return_value=mock_lf),
+            patch("telegram_bot.bot._write_langfuse_scores") as mock_write_scores,
+            patch("telegram_bot.bot.propagate_attributes"),
         ):
             message = MagicMock()
             message.text = "test"
@@ -267,24 +271,27 @@ class TestHandleQuery:
 
                 await bot.handle_query(message)
 
-            # Check that callbacks were passed
-            call_config = mock_graph.ainvoke.call_args[1].get("config", {})
-            assert mock_handler in call_config.get("callbacks", [])
+            mock_lf.update_current_trace.assert_called_once()
+            mock_write_scores.assert_called_once_with(mock_lf, mock_graph.ainvoke.return_value)
 
     @pytest.mark.asyncio
-    async def test_handle_query_no_langfuse(self, mock_config):
-        """Test handle_query works without Langfuse."""
+    async def test_handle_query_passes_state_to_graph(self, mock_config):
+        """Test that handle_query passes correct initial state to graph."""
         bot, _ = _create_bot(mock_config)
 
         mock_graph = AsyncMock()
-        mock_graph.ainvoke = AsyncMock(return_value={"response": "ok"})
+        mock_graph.ainvoke = AsyncMock(
+            return_value={"response": "ok", "query_type": "GENERAL", "latency_stages": {}}
+        )
 
         with (
             patch("telegram_bot.bot.build_graph", return_value=mock_graph),
-            patch("telegram_bot.bot.create_langfuse_handler", return_value=None),
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot._write_langfuse_scores"),
+            patch("telegram_bot.bot.propagate_attributes"),
         ):
             message = MagicMock()
-            message.text = "test"
+            message.text = "квартиры"
             message.from_user = MagicMock()
             message.from_user.id = 12345
             message.chat = MagicMock()
@@ -300,9 +307,9 @@ class TestHandleQuery:
 
                 await bot.handle_query(message)
 
-            # Empty config when no handler
-            call_config = mock_graph.ainvoke.call_args[1].get("config", {})
-            assert call_config == {}
+            state_arg = mock_graph.ainvoke.call_args[0][0]
+            assert state_arg["user_id"] == 12345
+            assert "квартиры" in str(state_arg["messages"])
 
     @pytest.mark.asyncio
     async def test_handle_query_passes_max_rewrite_attempts(self, mock_config):

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -33,7 +33,7 @@ def mock_config():
 BOT_INIT_PATCHES = [
     "telegram_bot.bot.Bot",
     "telegram_bot.integrations.cache.CacheLayerManager",
-    "telegram_bot.integrations.embeddings.BGEM3Embeddings",
+    "telegram_bot.integrations.embeddings.BGEM3HybridEmbeddings",
     "telegram_bot.integrations.embeddings.BGEM3SparseEmbeddings",
     "telegram_bot.services.qdrant.QdrantService",
     "telegram_bot.graph.config.GraphConfig.create_llm",
@@ -46,7 +46,7 @@ def _create_bot(mock_config):
     with (
         patch("telegram_bot.bot.Bot") as mock_bot,
         patch("telegram_bot.integrations.cache.CacheLayerManager") as mock_cache,
-        patch("telegram_bot.integrations.embeddings.BGEM3Embeddings") as mock_emb,
+        patch("telegram_bot.integrations.embeddings.BGEM3HybridEmbeddings") as mock_emb,
         patch("telegram_bot.integrations.embeddings.BGEM3SparseEmbeddings") as mock_sparse,
         patch("telegram_bot.services.qdrant.QdrantService") as mock_qdrant,
         patch("telegram_bot.graph.config.GraphConfig.create_llm") as mock_llm,
@@ -71,7 +71,7 @@ class TestPropertyBotInit:
         with (
             patch("telegram_bot.bot.Bot"),
             patch("telegram_bot.integrations.cache.CacheLayerManager") as mock_cache,
-            patch("telegram_bot.integrations.embeddings.BGEM3Embeddings") as mock_emb,
+            patch("telegram_bot.integrations.embeddings.BGEM3HybridEmbeddings") as mock_emb,
             patch("telegram_bot.integrations.embeddings.BGEM3SparseEmbeddings") as mock_sparse,
             patch("telegram_bot.services.qdrant.QdrantService") as mock_qdrant,
             patch("telegram_bot.graph.config.GraphConfig.create_llm"),
@@ -387,6 +387,10 @@ class TestBotLifecycle:
         bot._cache.close = AsyncMock()
         bot._qdrant = MagicMock()
         bot._qdrant.close = AsyncMock()
+        bot._embeddings = MagicMock()
+        bot._embeddings.aclose = AsyncMock()
+        bot._sparse = MagicMock()
+        bot._sparse.aclose = AsyncMock()
         bot._reranker = None
         bot.bot = MagicMock()
         bot.bot.session = MagicMock()
@@ -398,6 +402,8 @@ class TestBotLifecycle:
 
         bot._cache.close.assert_called_once()
         bot._qdrant.close.assert_called_once()
+        bot._embeddings.aclose.assert_awaited_once()
+        bot._sparse.aclose.assert_awaited_once()
 
 
 class TestSetupMiddlewares:
@@ -410,7 +416,7 @@ class TestSetupMiddlewares:
         with (
             patch("telegram_bot.bot.Bot"),
             patch("telegram_bot.integrations.cache.CacheLayerManager"),
-            patch("telegram_bot.integrations.embeddings.BGEM3Embeddings"),
+            patch("telegram_bot.integrations.embeddings.BGEM3HybridEmbeddings"),
             patch("telegram_bot.integrations.embeddings.BGEM3SparseEmbeddings"),
             patch("telegram_bot.services.qdrant.QdrantService"),
             patch("telegram_bot.graph.config.GraphConfig.create_llm"),

--- a/tests/unit/test_bot_scores.py
+++ b/tests/unit/test_bot_scores.py
@@ -66,6 +66,10 @@ FULL_PIPELINE_RESULT = {
     "search_results_count": 5,
     "rerank_applied": True,
     "documents_relevant": True,
+    "embeddings_cache_hit": False,
+    "search_cache_hit": False,
+    "grade_confidence": 0.85,
+    "pipeline_wall_ms": 862.0,
     "latency_stages": {
         "classify": 0.001,
         "cache_check": 0.050,
@@ -186,9 +190,12 @@ class TestScoreWriting:
         assert scores["no_results"] == 0.0
         # generate in latency_stages → LLM used
         assert scores["llm_used"] == 1.0
-        # latency_total_ms = sum of stages * 1000
-        expected_latency = sum(FULL_PIPELINE_RESULT["latency_stages"].values()) * 1000
-        assert abs(scores["latency_total_ms"] - expected_latency) < 0.01
+        # latency_total_ms = pipeline_wall_ms (wall-time, not sum of stages)
+        assert abs(scores["latency_total_ms"] - FULL_PIPELINE_RESULT["pipeline_wall_ms"]) < 0.01
+        # embeddings/search cache misses, confidence from grade
+        assert scores["embeddings_cache_hit"] == 0.0
+        assert scores["search_cache_hit"] == 0.0
+        assert scores["confidence_score"] == 0.85
 
     @pytest.mark.asyncio
     async def test_score_values_cache_hit(self, mock_config):

--- a/tests/unit/test_latency_units.py
+++ b/tests/unit/test_latency_units.py
@@ -89,6 +89,7 @@ class TestLatencyUnitsConsistency:
             "cache_hit": False,
             "rerank_applied": False,
             "search_results_count": 5,
+            "pipeline_wall_ms": 2862.0,  # wall-time, not sum of stages
             "latency_stages": {
                 "classify": 0.001,  # 1ms
                 "cache_check": 0.050,  # 50ms
@@ -102,9 +103,8 @@ class TestLatencyUnitsConsistency:
 
         _write_langfuse_scores(mock_lf, result)
 
-        # sum = 2.862s → 2862ms
-        expected_ms = sum(result["latency_stages"].values()) * 1000
-        assert abs(expected_ms - 2862.0) < 1.0
+        # latency_total_ms reads pipeline_wall_ms directly (wall-time)
+        expected_ms = result["pipeline_wall_ms"]
 
         # Verify the actual score value matches
         calls = mock_lf.score_current_trace.call_args_list

--- a/tests/unit/test_qdrant_error_signal.py
+++ b/tests/unit/test_qdrant_error_signal.py
@@ -1,0 +1,124 @@
+"""Tests for Qdrant backend_error meta signal (#117).
+
+Verifies that hybrid_search_rrf with return_meta=True distinguishes
+backend failures from genuine empty search results.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from qdrant_client.http.exceptions import ResponseHandlingException, UnexpectedResponse
+
+from telegram_bot.services.qdrant import QdrantService
+
+
+@pytest.fixture
+def service():
+    """Create QdrantService with mocked client."""
+    with patch("telegram_bot.services.qdrant.AsyncQdrantClient"):
+        svc = QdrantService(
+            url="http://localhost:6333",
+            collection_name="test_collection",
+        )
+        svc._client = AsyncMock()
+        svc._collection_validated = True
+        return svc
+
+
+class TestQdrantErrorSignal:
+    """Test per-call backend_error meta from hybrid_search_rrf."""
+
+    @pytest.mark.asyncio
+    async def test_backend_exception_returns_error_meta(self, service):
+        """Qdrant SDK exception -> backend_error=True, error_type filled."""
+        service._client.query_points = AsyncMock(
+            side_effect=ResponseHandlingException("connection reset")
+        )
+
+        results, meta = await service.hybrid_search_rrf(
+            dense_vector=[0.1] * 1024,
+            return_meta=True,
+        )
+
+        assert results == []
+        assert meta["backend_error"] is True
+        assert meta["error_type"] == "ResponseHandlingException"
+        assert "connection reset" in meta["error_message"]
+
+    @pytest.mark.asyncio
+    async def test_empty_results_returns_no_error(self, service):
+        """Genuine empty search -> backend_error=False."""
+        service._client.query_points = AsyncMock(return_value=MagicMock(points=[]))
+
+        results, meta = await service.hybrid_search_rrf(
+            dense_vector=[0.1] * 1024,
+            return_meta=True,
+        )
+
+        assert results == []
+        assert meta["backend_error"] is False
+        assert meta["error_type"] is None
+        assert meta["error_message"] is None
+
+    @pytest.mark.asyncio
+    async def test_unexpected_response_returns_error_meta(self, service):
+        """UnexpectedResponse exception -> backend_error=True."""
+        import httpx
+
+        service._client.query_points = AsyncMock(
+            side_effect=UnexpectedResponse(
+                status_code=503,
+                reason_phrase="Service Unavailable",
+                content=b"overloaded",
+                headers=httpx.Headers(),
+            )
+        )
+
+        results, meta = await service.hybrid_search_rrf(
+            dense_vector=[0.1] * 1024,
+            return_meta=True,
+        )
+
+        assert results == []
+        assert meta["backend_error"] is True
+        assert meta["error_type"] == "UnexpectedResponse"
+
+    @pytest.mark.asyncio
+    async def test_return_meta_false_preserves_old_contract(self, service):
+        """Default return_meta=False returns list[dict] (backward compat)."""
+        mock_point = MagicMock()
+        mock_point.id = "1"
+        mock_point.score = 0.9
+        mock_point.payload = {"page_content": "test", "metadata": {}}
+
+        service._client.query_points = AsyncMock(return_value=MagicMock(points=[mock_point]))
+
+        result = await service.hybrid_search_rrf(
+            dense_vector=[0.1] * 1024,
+            return_meta=False,
+        )
+
+        # Old contract: plain list, not tuple
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["id"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_success_with_results_meta(self, service):
+        """Successful search with results -> backend_error=False, results populated."""
+        mock_point = MagicMock()
+        mock_point.id = "doc_1"
+        mock_point.score = 0.95
+        mock_point.payload = {"page_content": "content", "metadata": {}}
+
+        service._client.query_points = AsyncMock(return_value=MagicMock(points=[mock_point]))
+
+        results, meta = await service.hybrid_search_rrf(
+            dense_vector=[0.1] * 1024,
+            return_meta=True,
+        )
+
+        assert len(results) == 1
+        assert results[0]["id"] == "doc_1"
+        assert meta["backend_error"] is False
+        assert meta["error_type"] is None

--- a/tests/unit/test_redis_semantic_cache.py
+++ b/tests/unit/test_redis_semantic_cache.py
@@ -5,17 +5,30 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
-# Pre-mock dependencies to avoid runtime overhead/connection attempts
-sys.modules["redis"] = MagicMock()
-sys.modules["redis.asyncio"] = MagicMock()
-sys.modules["opentelemetry"] = MagicMock()
-sys.modules["opentelemetry.trace"] = MagicMock()
-sys.modules["redisvl"] = MagicMock()
-sys.modules["redisvl.extensions.message_history"] = MagicMock()
-sys.modules["redisvl.query.filter"] = MagicMock()
-sys.modules["redisvl.utils.vectorize"] = MagicMock()
+_MOCKED_MODULES = [
+    "redis",
+    "redis.asyncio",
+    "opentelemetry",
+    "opentelemetry.trace",
+    "redisvl",
+    "redisvl.extensions.message_history",
+    "redisvl.query.filter",
+    "redisvl.utils.vectorize",
+]
+_saved = {name: sys.modules.get(name) for name in _MOCKED_MODULES}
+for name in _MOCKED_MODULES:
+    sys.modules[name] = MagicMock()
 
 from src.cache.redis_semantic_cache import RedisSemanticCache
+
+
+for name in _MOCKED_MODULES:
+    if _saved[name] is None:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = _saved[name]
+
+del _saved
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- **perf(embeddings):** BGEM3HybridEmbeddings — single `/encode/hybrid` call instead of separate dense+sparse (2x speedup), shared httpx.AsyncClient connection pooling
- **fix(observability):** `latency_total_ms` now uses wall-time (`time.perf_counter`) instead of inflated `sum(latency_stages)` (was 300x+ on rewrite loops)
- **fix(grade):** Recalibrate `RELEVANCE_THRESHOLD` from 0.3 to 0.005 for RRF score scale (`1/(k+rank)`) — eliminates infinite rewrite loops
- **feat(observability):** Replace 3 hardcoded 0.0 Langfuse scores with real values: `embeddings_cache_hit`, `search_cache_hit`, `confidence_score`
- **docs:** Update CLAUDE.md and rules files to reflect Sprint 1 changes
- **fix(tests):** Resolve regressions (isinstance check for hybrid embeddings, score contract updates)

Also includes prior #120 umbrella fixes (P0+P1/P2): streaming fallback, GraphConfig mocks, sys.modules cleanup, rewrite_max_tokens sync, qdrant error signal, mypy duplicate modules, legacy test markers.

## Commits (Sprint 1)
- `acf3361` fix(observability): use wall-time for latency_total_ms score
- `1e5fa50` fix(grade): recalibrate RELEVANCE_THRESHOLD for RRF score scale
- `e4862d3` perf(embeddings): add BGEM3HybridEmbeddings with /encode/hybrid + connection pooling
- `69c2863` feat(observability): implement real Langfuse scores for cache hits and confidence
- `76a9fda` docs: update CLAUDE.md and rules for Sprint 1 changes
- `f2f4961` fix(tests): resolve Sprint 1 test regressions

## Test plan
- [x] 103 Sprint 1 affected tests pass (integration + unit)
- [x] Ruff lint clean on all changed files
- [ ] Full unit suite (`uv run pytest tests/unit/ -n auto`)
- [ ] Docker bot rebuild + Telegram smoke test
- [ ] Langfuse trace verification (wall-time latency, real scores)

Closes #107, #109
Refs #103, #105, #106, #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)