### PR TITLE
fix(observability): reduce Langfuse payload bloat + correct TTFT semantics (#143)

### DIFF
--- a/.claude/rules/observability.md
+++ b/.claude/rules/observability.md
@@ -118,6 +118,31 @@ Usage:
 | rewrite_node | `node-rewrite` |
 | respond_node | `node-respond` |
 
+### Payload Bloat Prevention (#143)
+
+4 heavy nodes use `@observe(capture_input=False, capture_output=False)` to disable auto-capture of full LangGraph state (documents, embeddings, messages). Instead, they log curated metadata via `get_client().update_current_span(input={...}, output={...})`.
+
+| Heavy Node | Curated Input | Curated Output |
+|------------|---------------|----------------|
+| retrieve_node | query_preview, query_hash, query_type, top_k | results_count, top_score, min_score, search_cache_hit, duration_ms |
+| generate_node | query_preview, query_hash, context_docs_count, streaming_enabled | response_length, llm_provider_model, llm_ttft_ms, token_usage, duration_ms |
+| cache_check_node | query_preview, query_hash, query_type | cache_hit, embeddings_cache_hit, hit_layer, duration_ms |
+| cache_store_node | query_preview, query_hash, response_length | stored, stored_semantic, stored_conversation, duration_ms |
+
+Light nodes (classify, grade, rerank, rewrite, respond) keep default auto-capture — their state is small.
+
+**Pattern:**
+```python
+@observe(name="node-retrieve", capture_input=False, capture_output=False)
+async def retrieve_node(state, ...):
+    lf = get_client()
+    lf.update_current_span(input={"query_preview": query[:120], ...})
+    # ... node logic ...
+    lf.update_current_span(output={"results_count": len(results), ...})
+```
+
+**Forbidden keys** in curated spans: `documents`, `query_embedding`, `sparse_embedding`, `state`, `messages`.
+
 ### Error Span Tracking (#103 P1.2)
 
 4 nodes call `get_client().update_current_span(level=..., status_message=...)` on failure:
@@ -247,9 +272,11 @@ LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
 LANGFUSE_HOST: http://langfuse:3000
 ```
 
-## Trace Validation (#110)
+## Trace Validation (#110, #143)
 
 `scripts/validate_traces.py` uses `@observe`, `propagate_attributes`, `update_current_trace` for headless LangGraph runs. After flush, `enrich_results_from_langfuse()` fetches scores + node spans by trace_id via Langfuse API. Reference trace `c2b95d86` — anomalous (5213s), not reproducible.
+
+Go/No-Go criterion `generate_p50_lt_2s` (renamed from `ttft_p50_lt_2s` in #143) measures full generation latency in non-streaming validation mode. True TTFT requires a streaming phase (see #144).
 
 ## Baseline Module
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Bot:       Query → LangGraph StateGraph (9 nodes) → classify → cache_check
 
 **Services:** Qdrant:6333 (gRPC:6334), Redis:6379, LiteLLM:4000, Langfuse:3001
 
-**Observability:** Langfuse v3 — 35 observations/trace, 14 scores (incl. TTFT, provider metadata), error spans on 4 nodes, traced_pipeline for orphan prevention → see `.claude/rules/observability.md`
+**Observability:** Langfuse v3 — 35 observations/trace, 14 scores, curated spans on 4 heavy nodes (no auto-capture), error spans on 4 nodes, traced_pipeline for orphan prevention → see `.claude/rules/observability.md`
 
 **Docker Profiles:** `core` (5 svc, ~17s) | `bot` | `ml` | `obs` | `ai` | `ingest` | `full` (19 svc) → see `.claude/rules/docker.md`
 

--- a/docs/plans/2026-02-11-payload-bloat-ttft-design.md
+++ b/docs/plans/2026-02-11-payload-bloat-ttft-design.md
@@ -1,0 +1,121 @@
+# fix(observability): reduce Langfuse node payload bloat + correct TTFT semantics
+
+**Issue:** [#143](https://github.com/yastman/rag/issues/143)
+**Date:** 2026-02-11
+
+## Problem
+
+1. **Payload bloat** — `@observe` on 9 LangGraph nodes auto-captures full `state` dict (documents, embeddings) as span input/output. `node-retrieve` alone is ~337 KB per trace.
+2. **TTFT metric mismatch** — validation runs `message=None` → non-streaming → `llm_ttft_ms` always `0.0`. Go/No-Go uses generate node span duration as "TTFT proxy" under misleading name `ttft_p50_lt_2s`.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Payload control | `@observe(capture_input=False, capture_output=False)` on heavy nodes + `update_current_span()` for curated metadata | Надёжно отрубает авто-слив, прозрачный контракт, проще ревью |
+| Which nodes are "heavy" | retrieve, generate, cache_check, cache_store | Measured: 337/49/28/54 KB respectively |
+| Light nodes | classify, grade, rerank, rewrite, respond — keep default `@observe` | Payloads small, auto-capture useful for debugging |
+| TTFT rename | `ttft_p50_lt_2s` → `generate_p50_lt_2s` now; real streaming TTFT as follow-up | Минимальный риск, честная семантика |
+| `_query_preview` util | Inline in each node first, extract to `_utils.py` only if duplication grows | Минимум связности |
+| Tests | Runtime mock of `observe`, not regex/AST | Устойчиво к рефакторингу |
+
+## Scope
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `telegram_bot/graph/nodes/retrieve.py` | `capture_input/output=False` + curated metadata |
+| `telegram_bot/graph/nodes/generate.py` | Same |
+| `telegram_bot/graph/nodes/cache.py` | Same (both cache_check and cache_store) |
+| `scripts/validate_traces.py` | Rename criterion `ttft_p50_lt_2s` → `generate_p50_lt_2s` + footnote in report |
+| `tests/unit/test_observe_payloads.py` | New: 3 test cases |
+
+### Files NOT changed
+
+- Light nodes (classify, grade, rerank, rewrite, respond)
+- `telegram_bot/observability.py`
+- `telegram_bot/bot.py` (score writing reads from state, not spans)
+- State schema (`graph/state.py`) — `llm_ttft_ms` field untouched
+
+## Implementation
+
+### 1. Heavy nodes: disable auto-capture + curated metadata
+
+Pattern (same for all 4 nodes):
+
+```python
+@observe(name="node-retrieve", capture_input=False, capture_output=False)
+async def retrieve_node(state: dict[str, Any], *, ...):
+    query = state.get("query") or state["messages"][-1].content  # safe extraction
+    lf = get_client()
+    lf.update_current_span(input={
+        "query_preview": query[:120],
+        "query_len": len(query),
+        "query_hash": hashlib.sha256(query.encode()).hexdigest()[:8],
+        ...
+    })
+    # ... existing logic ...
+    lf.update_current_span(output={...})
+```
+
+### Curated fields per node
+
+**node-retrieve**
+- input: `query_preview`, `query_len`, `query_hash`, `query_type`, `top_k`
+- output: `results_count`, `top_score`, `min_score`, `retrieval_backend_error`, `retrieval_error_type`, `duration_ms`
+
+**node-generate**
+- input: `query_preview`, `context_docs_count`, `streaming_enabled`
+- output: `response_length`, `llm_provider_model`, `llm_ttft_ms` (or null), `llm_response_duration_ms`, `fallback_used`, `response_sent`, `token_usage` (optional, only if present)
+
+**node-cache-check**
+- input: `query_preview`, `query_type`
+- output: `cache_hit`, `embeddings_cache_hit`, `hit_layer` (semantic|none), `duration_ms`
+
+**node-cache-store**
+- input: `query_preview`, `response_length`, `search_results_count`
+- output: `stored`, `stored_semantic`, `stored_conversation`, `duration_ms`
+
+### 2. TTFT criterion rename
+
+In `scripts/validate_traces.py`:
+
+```python
+# Before:
+criteria["ttft_p50_lt_2s"] = { "target": "< 2000 ms", ... }
+
+# After:
+criteria["generate_p50_lt_2s"] = { "target": "< 2000 ms", ... }
+```
+
+Footnote in markdown report: "generate_p50 measures full generation latency in non-streaming (headless) mode. For real TTFT measurement, see follow-up issue."
+
+`llm_ttft_ms` score in `bot.py` and state schema — unchanged.
+
+### 3. Tests
+
+**test_heavy_nodes_disable_auto_capture** (runtime)
+- Mock `telegram_bot.observability.observe` before importing node modules
+- Assert `observe` was called with `capture_input=False, capture_output=False` for each heavy node function
+
+**test_go_no_go_uses_generate_p50_key**
+- Run the criteria-building code with mock data
+- Assert `generate_p50_lt_2s` in criteria keys
+- Assert `ttft_p50_lt_2s` NOT in criteria keys
+
+**test_curated_span_payload_no_heavy_fields** (retrieve + generate)
+- Mock `get_client()` → mock `update_current_span`
+- Run node with test state containing documents/embeddings
+- Assert `update_current_span` calls do NOT contain keys: `documents`, `query_embedding`, `sparse_embedding`, `state`
+
+### 4. Follow-up issue
+
+After merge, create: "feat(validation): add streaming phase for real TTFT measurement" linked to #143.
+
+## Acceptance Criteria (from issue)
+
+- [ ] p95 payload size for `node-retrieve` reduced by at least 80% vs current run
+- [ ] No full documents/embeddings in node-level trace input/output for validation mode
+- [ ] TTFT/latency metric naming and computation are mode-correct and documented
+- [ ] Validation report reflects the corrected metric semantics

--- a/docs/plans/2026-02-11-payload-bloat-ttft-impl.md
+++ b/docs/plans/2026-02-11-payload-bloat-ttft-impl.md
@@ -1,10 +1,10 @@
 # Payload Bloat + TTFT Rename Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> **For Codex:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Reduce Langfuse node payload bloat by 80%+ and rename TTFT criterion to honest semantics.
 
-**Architecture:** Disable auto-capture on 4 heavy LangGraph nodes (`@observe(capture_input=False, capture_output=False)`), replace with curated metadata via `get_client().update_current_span()`. Rename `ttft_p50_lt_2s` → `generate_p50_lt_2s` in validation Go/No-Go.
+**Architecture:** Disable auto-capture on 4 heavy LangGraph nodes (`@observe(capture_input=False, capture_output=False)`), replace with curated metadata via `get_client().update_current_span()` (no full state, documents, or embeddings in spans). Rename `ttft_p50_lt_2s` → `generate_p50_lt_2s` in validation Go/No-Go and add a report footnote clarifying this is full generation latency in non-streaming mode.
 
 **Tech Stack:** Python 3.12, Langfuse SDK v3 (`@observe`, `get_client`), pytest, hashlib
 
@@ -196,6 +196,8 @@ class TestCuratedSpanPayloads:
         input_payload = payloads[0]
         assert "query_preview" in input_payload
         assert len(input_payload["query_preview"]) <= 120
+        assert "query_hash" in input_payload
+        assert len(input_payload["query_hash"]) == 8
 
     @pytest.mark.asyncio
     async def test_generate_node_curated_payload(self):
@@ -329,11 +331,19 @@ from telegram_bot.observability import observe
 from telegram_bot.observability import get_client, observe
 ```
 
-**Step 3: Add curated input span after query extraction (after line 54)**
+**Step 3: Harden query extraction from `messages` + add curated input span (after line 54)**
 
-Insert after the `query` extraction block (after line 54):
+Replace direct `state["messages"][-1]` indexing with a safe extraction, then add span input metadata:
 
 ```python
+    messages = state.get("messages") or []
+    last_msg = messages[-1] if messages else {}
+    query = (
+        last_msg.content
+        if hasattr(last_msg, "content")
+        else (last_msg.get("content", "") if isinstance(last_msg, dict) else "")
+    )
+
     # Curated span metadata (replaces auto-captured full state)
     lf = get_client()
     lf.update_current_span(input={
@@ -412,26 +422,37 @@ Insert after `ttft_ms = 0.0` (line 248):
     lf = get_client()
     lf.update_current_span(input={
         "query_preview": query[:120],
+        "query_len": len(query),
+        "query_hash": hashlib.sha256(query.encode()).hexdigest()[:8],
         "context_docs_count": len(documents),
         "streaming_enabled": bool(message is not None and config.streaming_enabled),
     })
 ```
 
-Note: `get_client` is already imported in generate.py (line 20).
+Note: `get_client` is already imported in generate.py (line 20). Add `import hashlib` if missing.
 
 **Step 3: Add curated output span before the final return (before `return` around line 333)**
 
 Insert before the final `return {` block:
 
 ```python
-    lf.update_current_span(output={
+    span_output = {
         "response_length": len(answer),
         "llm_provider_model": actual_model,
         "llm_ttft_ms": ttft_ms if ttft_ms > 0 else None,
         "llm_response_duration_ms": round(elapsed * 1000, 1),
         "fallback_used": actual_model == "fallback",
         "response_sent": response_sent,
-    })
+    }
+    if "response" in locals():
+        usage = getattr(response, "usage", None)
+        if usage is not None:
+            span_output["token_usage"] = {
+                "prompt_tokens": getattr(usage, "prompt_tokens", None),
+                "completion_tokens": getattr(usage, "completion_tokens", None),
+                "total_tokens": getattr(usage, "total_tokens", None),
+            }
+    lf.update_current_span(output=span_output)
 ```
 
 **Step 4: Run tests**
@@ -475,14 +496,24 @@ from telegram_bot.observability import get_client, observe
 @observe(name="node-cache-check", capture_input=False, capture_output=False)
 ```
 
-**Step 3: Add curated input span in cache_check_node (after line 42)**
+**Step 3: Harden query extraction from `messages` + add curated input span in cache_check_node (after line 42)**
 
 Insert after `query_type = state.get("query_type", "GENERAL")`:
 
 ```python
+    messages = state.get("messages") or []
+    last_msg = messages[-1] if messages else {}
+    query = (
+        last_msg.content
+        if hasattr(last_msg, "content")
+        else (last_msg.get("content", "") if isinstance(last_msg, dict) else "")
+    )
+
     lf = get_client()
     lf.update_current_span(input={
         "query_preview": query[:120],
+        "query_len": len(query),
+        "query_hash": hashlib.sha256(query.encode()).hexdigest()[:8],
         "query_type": query_type,
     })
 ```
@@ -531,6 +562,8 @@ Insert after `user_id = state.get("user_id", 0)`:
     lf = get_client()
     lf.update_current_span(input={
         "query_preview": query[:120],
+        "query_len": len(query),
+        "query_hash": hashlib.sha256(query.encode()).hexdigest()[:8],
         "response_length": len(response),
         "search_results_count": state.get("search_results_count", 0),
     })
@@ -543,13 +576,17 @@ The current code has two paths: (1) `if response and embedding:` stores data, (2
 After the `if response and embedding:` block, before `return {"response": response}`:
 
 ```python
+    latency = time.perf_counter() - start
     stored = bool(response and embedding)
     lf.update_current_span(output={
         "stored": stored,
         "stored_semantic": stored,
         "stored_conversation": stored,
+        "duration_ms": round(latency * 1000, 1),
     })
 ```
+
+Note: initialize `start = time.perf_counter()` near node start to keep duration semantics consistent.
 
 **Step 9: Run tests**
 
@@ -570,7 +607,7 @@ git commit -m "fix(observability): disable auto-capture on cache nodes, add cura
 **Files:**
 - Modify: `scripts/validate_traces.py:539-545`
 
-**Step 1: Rename the criterion key and comment**
+**Step 1: Rename the criterion key and comment (no `note` field inside criteria dict)**
 
 Change lines 539-545 from:
 
@@ -596,12 +633,26 @@ To:
     }
 ```
 
-**Step 2: Run tests**
+**Step 2: Add report footnote clarifying metric semantics**
+
+In `generate_report()` after the Go/No-Go criteria table, append:
+
+```python
+        lines.append(
+            "_Note: `generate_p50_lt_2s` measures full generation latency in "
+            "non-streaming validation mode; true TTFT requires a streaming phase._"
+        )
+        lines.append("")
+```
+
+This keeps the renderer stable and avoids changing criteria object shape.
+
+**Step 3: Run tests**
 
 Run: `uv run pytest tests/unit/test_validate_aggregates.py -v`
 Expected: All PASS (including the new `test_uses_generate_p50_key_not_ttft`)
 
-**Step 3: Commit**
+**Step 4: Commit**
 
 ```bash
 git add scripts/validate_traces.py
@@ -652,7 +703,7 @@ git commit -m "style: format after payload bloat fix #143"
 
 **Files:** None (GitHub only)
 
-**Step 1: Create follow-up issue linked to #143**
+**Step 1: Create follow-up issue linked as child/follow-up of #143**
 
 Run:
 
@@ -673,7 +724,7 @@ Follow-up to #143. The `generate_p50_lt_2s` criterion measures full generation l
 
 ## Parent Issue
 
-Linked to #143 (payload bloat + TTFT rename).
+Parent: #143 (payload bloat + TTFT rename).
 EOF
 )" \
   --label "next"

--- a/docs/plans/2026-02-11-payload-bloat-ttft-impl.md
+++ b/docs/plans/2026-02-11-payload-bloat-ttft-impl.md
@@ -1,0 +1,684 @@
+# Payload Bloat + TTFT Rename Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Reduce Langfuse node payload bloat by 80%+ and rename TTFT criterion to honest semantics.
+
+**Architecture:** Disable auto-capture on 4 heavy LangGraph nodes (`@observe(capture_input=False, capture_output=False)`), replace with curated metadata via `get_client().update_current_span()`. Rename `ttft_p50_lt_2s` → `generate_p50_lt_2s` in validation Go/No-Go.
+
+**Tech Stack:** Python 3.12, Langfuse SDK v3 (`@observe`, `get_client`), pytest, hashlib
+
+**Issue:** [#143](https://github.com/yastman/rag/issues/143)
+**Design:** `docs/plans/2026-02-11-payload-bloat-ttft-design.md`
+
+---
+
+### Task 1: Write failing tests for heavy node auto-capture flags
+
+**Files:**
+- Create: `tests/unit/graph/test_observe_payloads.py`
+
+**Step 1: Write the test file**
+
+```python
+"""Tests: heavy nodes disable @observe auto-capture, curated span has no heavy fields."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import sys
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Heavy nodes use capture_input=False, capture_output=False
+# ---------------------------------------------------------------------------
+
+
+class TestHeavyNodesDisableAutoCapture:
+    """Verify @observe(capture_input=False, capture_output=False) on heavy nodes."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_observe(self):
+        """Mock observe decorator before importing node modules.
+
+        Replaces telegram_bot.observability.observe with a mock that records
+        the kwargs passed to @observe(...) and returns the original function.
+        """
+        self.observe_calls: dict[str, dict] = {}
+        original_modules: dict[str, object] = {}
+
+        # Remove cached node modules so re-import picks up our mock
+        node_modules = [
+            "telegram_bot.graph.nodes.retrieve",
+            "telegram_bot.graph.nodes.generate",
+            "telegram_bot.graph.nodes.cache",
+        ]
+        for mod in node_modules:
+            if mod in sys.modules:
+                original_modules[mod] = sys.modules.pop(mod)
+
+        def fake_observe(**kwargs):
+            def decorator(func):
+                self.observe_calls[kwargs.get("name", func.__name__)] = kwargs
+                return func
+            return decorator
+
+        with patch("telegram_bot.observability.observe", side_effect=fake_observe):
+            # Force re-import with our mocked observe
+            for mod in node_modules:
+                importlib.import_module(mod)
+            yield
+
+        # Restore original modules
+        for mod in node_modules:
+            sys.modules.pop(mod, None)
+        for mod, original in original_modules.items():
+            sys.modules[mod] = original  # type: ignore[assignment]
+
+    def test_retrieve_node_disables_auto_capture(self):
+        kwargs = self.observe_calls.get("node-retrieve", {})
+        assert kwargs.get("capture_input") is False, "node-retrieve must set capture_input=False"
+        assert kwargs.get("capture_output") is False, "node-retrieve must set capture_output=False"
+
+    def test_generate_node_disables_auto_capture(self):
+        kwargs = self.observe_calls.get("node-generate", {})
+        assert kwargs.get("capture_input") is False, "node-generate must set capture_input=False"
+        assert kwargs.get("capture_output") is False, "node-generate must set capture_output=False"
+
+    def test_cache_check_node_disables_auto_capture(self):
+        kwargs = self.observe_calls.get("node-cache-check", {})
+        assert kwargs.get("capture_input") is False, "node-cache-check must set capture_input=False"
+        assert kwargs.get("capture_output") is False, "node-cache-check must set capture_output=False"
+
+    def test_cache_store_node_disables_auto_capture(self):
+        kwargs = self.observe_calls.get("node-cache-store", {})
+        assert kwargs.get("capture_input") is False, "node-cache-store must set capture_input=False"
+        assert kwargs.get("capture_output") is False, "node-cache-store must set capture_output=False"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/graph/test_observe_payloads.py::TestHeavyNodesDisableAutoCapture -v`
+Expected: FAIL — `capture_input` is not in kwargs (current decorators don't pass these)
+
+**Step 3: Commit failing tests**
+
+```bash
+git add tests/unit/graph/test_observe_payloads.py
+git commit -m "test(observability): add failing tests for heavy node auto-capture flags #143"
+```
+
+---
+
+### Task 2: Write failing tests for curated span payloads (no heavy fields)
+
+**Files:**
+- Modify: `tests/unit/graph/test_observe_payloads.py`
+
+**Step 1: Add curated payload tests to the same file**
+
+Append after `TestHeavyNodesDisableAutoCapture`:
+
+```python
+# ---------------------------------------------------------------------------
+# Test 2: Curated span payloads contain no heavy fields
+# ---------------------------------------------------------------------------
+
+# Forbidden keys — these must NEVER appear in update_current_span input/output
+_FORBIDDEN_KEYS = {"documents", "query_embedding", "sparse_embedding", "state", "messages"}
+
+
+def _extract_span_payloads(mock_lf_client: MagicMock) -> list[dict]:
+    """Collect all input/output dicts from update_current_span calls."""
+    payloads: list[dict] = []
+    for c in mock_lf_client.update_current_span.call_args_list:
+        kwargs = c.kwargs if c.kwargs else {}
+        if "input" in kwargs and isinstance(kwargs["input"], dict):
+            payloads.append(kwargs["input"])
+        if "output" in kwargs and isinstance(kwargs["output"], dict):
+            payloads.append(kwargs["output"])
+    return payloads
+
+
+def _assert_no_forbidden_keys(payloads: list[dict], node_name: str) -> None:
+    """Assert none of the payloads contain forbidden heavy keys."""
+    for payload in payloads:
+        for key in _FORBIDDEN_KEYS:
+            assert key not in payload, (
+                f"{node_name}: update_current_span must not contain '{key}', "
+                f"found in payload keys: {list(payload.keys())}"
+            )
+
+
+class TestCuratedSpanPayloads:
+    """Verify update_current_span calls contain only curated metadata."""
+
+    @pytest.mark.asyncio
+    async def test_retrieve_node_curated_payload(self):
+        from telegram_bot.graph.nodes.retrieve import retrieve_node
+        from telegram_bot.graph.state import make_initial_state
+
+        state = make_initial_state(user_id=1, session_id="s1", query="test query text")
+        state["query_type"] = "GENERAL"
+        state["query_embedding"] = [0.1] * 1024
+
+        docs = [
+            {"id": "1", "text": "Doc content " * 100, "score": 0.9, "metadata": {}},
+            {"id": "2", "text": "More content " * 100, "score": 0.7, "metadata": {}},
+        ]
+        ok_meta = {"backend_error": False, "error_type": None, "error_message": None}
+
+        cache = AsyncMock()
+        cache.get_search_results = AsyncMock(return_value=None)
+        cache.get_sparse_embedding = AsyncMock(return_value=None)
+        cache.store_sparse_embedding = AsyncMock()
+        cache.store_search_results = AsyncMock()
+
+        sparse = AsyncMock()
+        sparse.aembed_query = AsyncMock(return_value={"indices": [1], "values": [0.5]})
+
+        qdrant = AsyncMock()
+        qdrant.hybrid_search_rrf = AsyncMock(return_value=(docs, ok_meta))
+
+        mock_lf = MagicMock()
+        with patch("telegram_bot.graph.nodes.retrieve.get_client", return_value=mock_lf):
+            await retrieve_node(state, cache=cache, sparse_embeddings=sparse, qdrant=qdrant)
+
+        payloads = _extract_span_payloads(mock_lf)
+        assert len(payloads) >= 2, "retrieve_node must call update_current_span for input and output"
+        _assert_no_forbidden_keys(payloads, "node-retrieve")
+
+        # Verify expected curated keys exist in input
+        input_payload = payloads[0]
+        assert "query_preview" in input_payload
+        assert len(input_payload["query_preview"]) <= 120
+
+    @pytest.mark.asyncio
+    async def test_generate_node_curated_payload(self):
+        from unittest.mock import patch as _patch
+
+        from telegram_bot.graph.nodes.generate import generate_node
+        from telegram_bot.graph.state import make_initial_state
+
+        state = make_initial_state(user_id=1, session_id="s1", query="test query")
+        state["query_type"] = "GENERAL"
+        state["documents"] = [
+            {"text": "Large doc " * 200, "score": 0.9, "metadata": {"title": "Test"}},
+        ]
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Answer."
+        mock_response = MagicMock(choices=[mock_choice])
+        mock_response.model = "gpt-4o-mini"
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        mock_config = MagicMock()
+        mock_config.domain = "test"
+        mock_config.llm_model = "gpt-4o-mini"
+        mock_config.llm_temperature = 0.7
+        mock_config.generate_max_tokens = 2048
+        mock_config.streaming_enabled = False
+        mock_config.create_llm.return_value = mock_client
+
+        mock_lf = MagicMock()
+        with (
+            _patch("telegram_bot.graph.nodes.generate._get_config", return_value=mock_config),
+            _patch("telegram_bot.graph.nodes.generate.get_client", return_value=mock_lf),
+        ):
+            await generate_node(state)
+
+        payloads = _extract_span_payloads(mock_lf)
+        assert len(payloads) >= 2, "generate_node must call update_current_span for input and output"
+        _assert_no_forbidden_keys(payloads, "node-generate")
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/graph/test_observe_payloads.py::TestCuratedSpanPayloads -v`
+Expected: FAIL — nodes don't call `update_current_span` yet (or `get_client` not imported in retrieve)
+
+**Step 3: Commit**
+
+```bash
+git add tests/unit/graph/test_observe_payloads.py
+git commit -m "test(observability): add failing tests for curated span payloads #143"
+```
+
+---
+
+### Task 3: Write failing test for TTFT criterion rename
+
+**Files:**
+- Modify: `tests/unit/test_validate_aggregates.py`
+
+**Step 1: Add test to existing file**
+
+Append to `TestEvaluateGoNoGo` class in `tests/unit/test_validate_aggregates.py`:
+
+```python
+    def test_uses_generate_p50_key_not_ttft(self):
+        """Go/No-Go must use 'generate_p50_lt_2s', not 'ttft_p50_lt_2s'."""
+        aggregates = {
+            "cold": {
+                "latency_p50": 3000,
+                "latency_p95": 5000,
+                "node_p50": {"generate": 1500},
+            },
+            "cache_hit": {"latency_p50": 500},
+        }
+        results = [_make_result(phase="cold", latency=3000)]
+        criteria = evaluate_go_no_go(aggregates, results, orphan_rate=0.0)
+
+        assert "generate_p50_lt_2s" in criteria, "Criterion must be named 'generate_p50_lt_2s'"
+        assert "ttft_p50_lt_2s" not in criteria, "Old 'ttft_p50_lt_2s' key must not exist"
+        assert criteria["generate_p50_lt_2s"]["passed"] is True  # 1500 < 2000
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_validate_aggregates.py::TestEvaluateGoNoGo::test_uses_generate_p50_key_not_ttft -v`
+Expected: FAIL — `generate_p50_lt_2s` not in criteria (still named `ttft_p50_lt_2s`)
+
+**Step 3: Commit**
+
+```bash
+git add tests/unit/test_validate_aggregates.py
+git commit -m "test(validation): add failing test for TTFT criterion rename #143"
+```
+
+---
+
+### Task 4: Implement payload bloat fix for retrieve_node
+
+**Files:**
+- Modify: `telegram_bot/graph/nodes/retrieve.py:1-15,21`
+
+**Step 1: Add hashlib import and update decorator**
+
+At the top of `retrieve.py`, add `hashlib` to imports:
+
+```python
+import hashlib
+```
+
+Change the decorator on line 21:
+
+```python
+# Before:
+@observe(name="node-retrieve")
+
+# After:
+@observe(name="node-retrieve", capture_input=False, capture_output=False)
+```
+
+**Step 2: Add `get_client` import**
+
+Change line 15:
+
+```python
+# Before:
+from telegram_bot.observability import observe
+
+# After:
+from telegram_bot.observability import get_client, observe
+```
+
+**Step 3: Add curated input span after query extraction (after line 54)**
+
+Insert after the `query` extraction block (after line 54):
+
+```python
+    # Curated span metadata (replaces auto-captured full state)
+    lf = get_client()
+    lf.update_current_span(input={
+        "query_preview": query[:120],
+        "query_len": len(query),
+        "query_hash": hashlib.sha256(query.encode()).hexdigest()[:8],
+        "query_type": state.get("query_type"),
+        "top_k": top_k,
+    })
+```
+
+**Step 4: Add curated output span in the search-cache-hit return (before `return` around line 99)**
+
+In the cache-hit early return block (around line 99), insert before the `return`:
+
+```python
+        lf.update_current_span(output={
+            "results_count": len(cached_results),
+            "search_cache_hit": True,
+            "duration_ms": round(latency * 1000, 1),
+        })
+```
+
+**Step 5: Add curated output span in the main return (before the `return update` around line 149)**
+
+Insert before `return update`:
+
+```python
+    scores = [d.get("score", 0) for d in results if isinstance(d, dict)]
+    lf.update_current_span(output={
+        "results_count": len(results),
+        "top_score": round(scores[0], 4) if scores else None,
+        "min_score": round(scores[-1], 4) if scores else None,
+        "search_cache_hit": False,
+        "retrieval_backend_error": search_meta.get("backend_error", False),
+        "retrieval_error_type": search_meta.get("error_type"),
+        "duration_ms": round(latency * 1000, 1),
+    })
+```
+
+**Step 6: Run tests**
+
+Run: `uv run pytest tests/unit/graph/test_observe_payloads.py::TestHeavyNodesDisableAutoCapture::test_retrieve_node_disables_auto_capture tests/unit/graph/test_observe_payloads.py::TestCuratedSpanPayloads::test_retrieve_node_curated_payload tests/unit/graph/test_retrieve_node.py -v`
+Expected: All PASS
+
+**Step 7: Commit**
+
+```bash
+git add telegram_bot/graph/nodes/retrieve.py
+git commit -m "fix(observability): disable auto-capture on retrieve_node, add curated metadata #143"
+```
+
+---
+
+### Task 5: Implement payload bloat fix for generate_node
+
+**Files:**
+- Modify: `telegram_bot/graph/nodes/generate.py:196,210-248,332-340`
+
+**Step 1: Update decorator on line 196**
+
+```python
+# Before:
+@observe(name="node-generate")
+
+# After:
+@observe(name="node-generate", capture_input=False, capture_output=False)
+```
+
+**Step 2: Add curated input span after state extraction (after line 248, before the `try`)**
+
+Insert after `ttft_ms = 0.0` (line 248):
+
+```python
+    # Curated span metadata
+    lf = get_client()
+    lf.update_current_span(input={
+        "query_preview": query[:120],
+        "context_docs_count": len(documents),
+        "streaming_enabled": bool(message is not None and config.streaming_enabled),
+    })
+```
+
+Note: `get_client` is already imported in generate.py (line 20).
+
+**Step 3: Add curated output span before the final return (before `return` around line 333)**
+
+Insert before the final `return {` block:
+
+```python
+    lf.update_current_span(output={
+        "response_length": len(answer),
+        "llm_provider_model": actual_model,
+        "llm_ttft_ms": ttft_ms if ttft_ms > 0 else None,
+        "llm_response_duration_ms": round(elapsed * 1000, 1),
+        "fallback_used": actual_model == "fallback",
+        "response_sent": response_sent,
+    })
+```
+
+**Step 4: Run tests**
+
+Run: `uv run pytest tests/unit/graph/test_observe_payloads.py::TestHeavyNodesDisableAutoCapture::test_generate_node_disables_auto_capture tests/unit/graph/test_observe_payloads.py::TestCuratedSpanPayloads::test_generate_node_curated_payload tests/unit/graph/test_generate_node.py -v`
+Expected: All PASS
+
+**Step 5: Commit**
+
+```bash
+git add telegram_bot/graph/nodes/generate.py
+git commit -m "fix(observability): disable auto-capture on generate_node, add curated metadata #143"
+```
+
+---
+
+### Task 6: Implement payload bloat fix for cache nodes
+
+**Files:**
+- Modify: `telegram_bot/graph/nodes/cache.py:14,20,92`
+
+**Step 1: Add imports**
+
+Change line 14:
+
+```python
+# Before:
+from telegram_bot.observability import observe
+
+# After:
+from telegram_bot.observability import get_client, observe
+```
+
+**Step 2: Update cache_check_node decorator (line 20)**
+
+```python
+# Before:
+@observe(name="node-cache-check")
+
+# After:
+@observe(name="node-cache-check", capture_input=False, capture_output=False)
+```
+
+**Step 3: Add curated input span in cache_check_node (after line 42)**
+
+Insert after `query_type = state.get("query_type", "GENERAL")`:
+
+```python
+    lf = get_client()
+    lf.update_current_span(input={
+        "query_preview": query[:120],
+        "query_type": query_type,
+    })
+```
+
+**Step 4: Add curated output span in cache_check_node HIT path (before `return` around line 73)**
+
+Insert before the hit-path `return`:
+
+```python
+        lf.update_current_span(output={
+            "cache_hit": True,
+            "embeddings_cache_hit": embeddings_cache_hit,
+            "hit_layer": "semantic",
+            "duration_ms": round(latency * 1000, 1),
+        })
+```
+
+**Step 5: Add curated output span in cache_check_node MISS path (before `return` around line 83)**
+
+Insert before the miss-path `return`:
+
+```python
+    lf.update_current_span(output={
+        "cache_hit": False,
+        "embeddings_cache_hit": embeddings_cache_hit,
+        "hit_layer": "none",
+        "duration_ms": round(latency * 1000, 1),
+    })
+```
+
+**Step 6: Update cache_store_node decorator (line 92)**
+
+```python
+# Before:
+@observe(name="node-cache-store")
+
+# After:
+@observe(name="node-cache-store", capture_input=False, capture_output=False)
+```
+
+**Step 7: Add curated input span in cache_store_node (after line 117, after `user_id` extraction)**
+
+Insert after `user_id = state.get("user_id", 0)`:
+
+```python
+    lf = get_client()
+    lf.update_current_span(input={
+        "query_preview": query[:120],
+        "response_length": len(response),
+        "search_results_count": state.get("search_results_count", 0),
+    })
+```
+
+**Step 8: Add curated output span in cache_store_node (before `return` at end)**
+
+The current code has two paths: (1) `if response and embedding:` stores data, (2) falls through.
+
+After the `if response and embedding:` block, before `return {"response": response}`:
+
+```python
+    stored = bool(response and embedding)
+    lf.update_current_span(output={
+        "stored": stored,
+        "stored_semantic": stored,
+        "stored_conversation": stored,
+    })
+```
+
+**Step 9: Run tests**
+
+Run: `uv run pytest tests/unit/graph/test_observe_payloads.py::TestHeavyNodesDisableAutoCapture::test_cache_check_node_disables_auto_capture tests/unit/graph/test_observe_payloads.py::TestHeavyNodesDisableAutoCapture::test_cache_store_node_disables_auto_capture tests/unit/graph/test_cache_nodes.py -v`
+Expected: All PASS
+
+**Step 10: Commit**
+
+```bash
+git add telegram_bot/graph/nodes/cache.py
+git commit -m "fix(observability): disable auto-capture on cache nodes, add curated metadata #143"
+```
+
+---
+
+### Task 7: Implement TTFT criterion rename
+
+**Files:**
+- Modify: `scripts/validate_traces.py:539-545`
+
+**Step 1: Rename the criterion key and comment**
+
+Change lines 539-545 from:
+
+```python
+    # 5. TTFT p50 (generate node start) < 2s
+    generate_p50 = cold.get("node_p50", {}).get("generate", 99999)
+    criteria["ttft_p50_lt_2s"] = {
+        "target": "< 2000 ms",
+        "actual": f"{generate_p50:.0f} ms",
+        "passed": generate_p50 < 2000,
+    }
+```
+
+To:
+
+```python
+    # 5. Generate node p50 < 2s (full generation latency, non-streaming mode)
+    generate_p50 = cold.get("node_p50", {}).get("generate", 99999)
+    criteria["generate_p50_lt_2s"] = {
+        "target": "< 2000 ms",
+        "actual": f"{generate_p50:.0f} ms",
+        "passed": generate_p50 < 2000,
+    }
+```
+
+**Step 2: Run tests**
+
+Run: `uv run pytest tests/unit/test_validate_aggregates.py -v`
+Expected: All PASS (including the new `test_uses_generate_p50_key_not_ttft`)
+
+**Step 3: Commit**
+
+```bash
+git add scripts/validate_traces.py
+git commit -m "fix(validation): rename ttft_p50_lt_2s → generate_p50_lt_2s for honest semantics #143"
+```
+
+---
+
+### Task 8: Run full test suite and lint
+
+**Files:** None (verification only)
+
+**Step 1: Run linter**
+
+Run: `uv run ruff check telegram_bot/graph/nodes/retrieve.py telegram_bot/graph/nodes/generate.py telegram_bot/graph/nodes/cache.py scripts/validate_traces.py tests/unit/graph/test_observe_payloads.py tests/unit/test_validate_aggregates.py`
+Expected: No errors
+
+**Step 2: Run formatter**
+
+Run: `uv run ruff format telegram_bot/graph/nodes/retrieve.py telegram_bot/graph/nodes/generate.py telegram_bot/graph/nodes/cache.py tests/unit/graph/test_observe_payloads.py`
+Expected: Files formatted (or already formatted)
+
+**Step 3: Run type check on changed files**
+
+Run: `uv run mypy telegram_bot/graph/nodes/retrieve.py telegram_bot/graph/nodes/generate.py telegram_bot/graph/nodes/cache.py --ignore-missing-imports`
+Expected: No type errors
+
+**Step 4: Run all related unit tests**
+
+Run: `uv run pytest tests/unit/graph/test_observe_payloads.py tests/unit/graph/test_retrieve_node.py tests/unit/graph/test_generate_node.py tests/unit/graph/test_cache_nodes.py tests/unit/test_validate_aggregates.py -v`
+Expected: All PASS
+
+**Step 5: Run graph path integration tests (quick sanity)**
+
+Run: `uv run pytest tests/integration/test_graph_paths.py -v`
+Expected: All 6 PASS (~5s)
+
+**Step 6: Commit lint/format fixes if any**
+
+```bash
+git add -u
+git commit -m "style: format after payload bloat fix #143"
+```
+
+---
+
+### Task 9: Create follow-up issue for streaming TTFT
+
+**Files:** None (GitHub only)
+
+**Step 1: Create follow-up issue linked to #143**
+
+Run:
+
+```bash
+gh issue create \
+  --title "feat(validation): add streaming phase for real TTFT measurement" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Follow-up to #143. The `generate_p50_lt_2s` criterion measures full generation latency in non-streaming (headless) mode. For true TTFT measurement, validation needs a streaming phase.
+
+## Proposed Approach
+
+1. Add a `--streaming` flag to `validate_traces.py`
+2. Inject a mock `message` object that records TTFT without Telegram delivery
+3. Add `ttft_p50_lt_Xms` criterion using real streaming TTFT data
+4. Run streaming phase after cold phase (subset of queries)
+
+## Parent Issue
+
+Linked to #143 (payload bloat + TTFT rename).
+EOF
+)" \
+  --label "next"
+```
+
+Expected: Issue created successfully
+
+**Step 2: Done — no commit needed**

--- a/scripts/validate_traces.py
+++ b/scripts/validate_traces.py
@@ -536,9 +536,9 @@ def evaluate_go_no_go(
         "passed": cache_p50 < 1500,
     }
 
-    # 5. TTFT p50 (generate node start) < 2s
+    # 5. Generate node p50 < 2s (full generation latency, non-streaming mode)
     generate_p50 = cold.get("node_p50", {}).get("generate", 99999)
-    criteria["ttft_p50_lt_2s"] = {
+    criteria["generate_p50_lt_2s"] = {
         "target": "< 2000 ms",
         "actual": f"{generate_p50:.0f} ms",
         "passed": generate_p50 < 2000,
@@ -810,6 +810,11 @@ def generate_report(
         lines.append("")
         passed = sum(1 for c in go_no_go.values() if c["passed"])
         lines.append(f"**Score: {passed}/{len(go_no_go)} criteria passed**")
+        lines.append("")
+        lines.append(
+            "_Note: `generate_p50_lt_2s` measures full generation latency in "
+            "non-streaming validation mode; true TTFT requires a streaming phase._"
+        )
     else:
         lines.append("<!-- Go/No-Go data not available — run with --report -->")
     lines.append("")

--- a/telegram_bot/graph/nodes/cache.py
+++ b/telegram_bot/graph/nodes/cache.py
@@ -7,17 +7,18 @@ cache_store_node: store response in semantic cache + conversation history.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import time
 from typing import Any
 
-from telegram_bot.observability import observe
+from telegram_bot.observability import get_client, observe
 
 
 logger = logging.getLogger(__name__)
 
 
-@observe(name="node-cache-check")
+@observe(name="node-cache-check", capture_input=False, capture_output=False)
 async def cache_check_node(
     state: dict[str, Any],
     *,
@@ -34,12 +35,24 @@ async def cache_check_node(
     Returns:
         State update with cache_hit, cached_response, query_embedding
     """
+    messages = state.get("messages") or []
+    last_msg = messages[-1] if messages else {}
     query = (
-        state["messages"][-1].content
-        if hasattr(state["messages"][-1], "content")
-        else state["messages"][-1]["content"]
+        last_msg.content
+        if hasattr(last_msg, "content")
+        else (last_msg.get("content", "") if isinstance(last_msg, dict) else "")
     )
     query_type = state.get("query_type", "GENERAL")
+
+    lf = get_client()
+    lf.update_current_span(
+        input={
+            "query_preview": query[:120],
+            "query_len": len(query),
+            "query_hash": hashlib.sha256(query.encode()).hexdigest()[:8],
+            "query_type": query_type,
+        }
+    )
 
     start = time.perf_counter()
 
@@ -70,6 +83,14 @@ async def cache_check_node(
 
     if cached:
         logger.info("cache_check HIT (%.3fs, type=%s)", latency, query_type)
+        lf.update_current_span(
+            output={
+                "cache_hit": True,
+                "embeddings_cache_hit": embeddings_cache_hit,
+                "hit_layer": "semantic",
+                "duration_ms": round(latency * 1000, 1),
+            }
+        )
         return {
             "cache_hit": True,
             "cached_response": cached,
@@ -80,6 +101,14 @@ async def cache_check_node(
         }
 
     logger.info("cache_check MISS (%.3fs, type=%s)", latency, query_type)
+    lf.update_current_span(
+        output={
+            "cache_hit": False,
+            "embeddings_cache_hit": embeddings_cache_hit,
+            "hit_layer": "none",
+            "duration_ms": round(latency * 1000, 1),
+        }
+    )
     return {
         "cache_hit": False,
         "cached_response": None,
@@ -89,7 +118,7 @@ async def cache_check_node(
     }
 
 
-@observe(name="node-cache-store")
+@observe(name="node-cache-store", capture_input=False, capture_output=False)
 async def cache_store_node(
     state: dict[str, Any],
     *,
@@ -106,15 +135,29 @@ async def cache_store_node(
     Returns:
         State update (pass-through response)
     """
+    start = time.perf_counter()
     response = state.get("response", "")
     embedding = state.get("query_embedding")
     query_type = state.get("query_type", "GENERAL")
+    messages = state.get("messages") or []
+    last_msg = messages[-1] if messages else {}
     query = (
-        state["messages"][-1].content
-        if hasattr(state["messages"][-1], "content")
-        else state["messages"][-1]["content"]
+        last_msg.content
+        if hasattr(last_msg, "content")
+        else (last_msg.get("content", "") if isinstance(last_msg, dict) else "")
     )
     user_id = state.get("user_id", 0)
+
+    lf = get_client()
+    lf.update_current_span(
+        input={
+            "query_preview": query[:120],
+            "query_len": len(query),
+            "query_hash": hashlib.sha256(query.encode()).hexdigest()[:8],
+            "response_length": len(response),
+            "search_results_count": state.get("search_results_count", 0),
+        }
+    )
 
     # Store in semantic cache if we have both response and embedding
     if response and embedding:
@@ -154,5 +197,16 @@ async def cache_store_node(
                     "user_id": user_id,
                 },
             )
+
+    latency = time.perf_counter() - start
+    stored = bool(response and embedding)
+    lf.update_current_span(
+        output={
+            "stored": stored,
+            "stored_semantic": stored,
+            "stored_conversation": stored,
+            "duration_ms": round(latency * 1000, 1),
+        }
+    )
 
     return {"response": response}

--- a/telegram_bot/graph/nodes/generate.py
+++ b/telegram_bot/graph/nodes/generate.py
@@ -11,6 +11,7 @@ edits with accumulated chunks (throttled 300ms), finalizes with Markdown.
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import logging
 import time
 from typing import Any
@@ -193,7 +194,7 @@ async def _generate_streaming(
     return accumulated, actual_model, ttft_ms
 
 
-@observe(name="node-generate")
+@observe(name="node-generate", capture_input=False, capture_output=False)
 async def generate_node(state: RAGState, *, message: Any | None = None) -> dict[str, Any]:
     """Generate an answer from retrieved documents using LLM.
 
@@ -246,6 +247,18 @@ async def generate_node(state: RAGState, *, message: Any | None = None) -> dict[
     response_sent = False
     actual_model = config.llm_model
     ttft_ms = 0.0
+
+    # Curated span metadata
+    lf = get_client()
+    lf.update_current_span(
+        input={
+            "query_preview": query[:120],
+            "query_len": len(query),
+            "query_hash": hashlib.sha256(query.encode()).hexdigest()[:8],
+            "context_docs_count": len(documents),
+            "streaming_enabled": bool(message is not None and config.streaming_enabled),
+        }
+    )
 
     try:
         llm = config.create_llm()
@@ -330,6 +343,25 @@ async def generate_node(state: RAGState, *, message: Any | None = None) -> dict[
         ttft_ms = 0.0
 
     elapsed = time.monotonic() - t0
+
+    span_output: dict[str, Any] = {
+        "response_length": len(answer),
+        "llm_provider_model": actual_model,
+        "llm_ttft_ms": ttft_ms if ttft_ms > 0 else None,
+        "llm_response_duration_ms": round(elapsed * 1000, 1),
+        "fallback_used": actual_model == "fallback",
+        "response_sent": response_sent,
+    }
+    if "response" in locals():
+        usage = getattr(response, "usage", None)
+        if usage is not None:
+            span_output["token_usage"] = {
+                "prompt_tokens": getattr(usage, "prompt_tokens", None),
+                "completion_tokens": getattr(usage, "completion_tokens", None),
+                "total_tokens": getattr(usage, "total_tokens", None),
+            }
+    lf.update_current_span(output=span_output)
+
     return {
         "response": answer,
         "response_sent": response_sent,

--- a/telegram_bot/graph/nodes/retrieve.py
+++ b/telegram_bot/graph/nodes/retrieve.py
@@ -8,17 +8,18 @@ prefetch, FusionQuery, and ColBERT reranking.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import time
 from typing import Any
 
-from telegram_bot.observability import observe
+from telegram_bot.observability import get_client, observe
 
 
 logger = logging.getLogger(__name__)
 
 
-@observe(name="node-retrieve")
+@observe(name="node-retrieve", capture_input=False, capture_output=False)
 async def retrieve_node(
     state: dict[str, Any],
     *,
@@ -47,11 +48,26 @@ async def retrieve_node(
     Returns:
         State update with documents, search_results_count, sparse_embedding
     """
+    messages = state.get("messages") or []
+    last_msg = messages[-1] if messages else {}
     query = (
-        state["messages"][-1].content
-        if hasattr(state["messages"][-1], "content")
-        else state["messages"][-1]["content"]
+        last_msg.content
+        if hasattr(last_msg, "content")
+        else (last_msg.get("content", "") if isinstance(last_msg, dict) else "")
     )
+
+    # Curated span metadata (replaces auto-captured full state)
+    lf = get_client()
+    lf.update_current_span(
+        input={
+            "query_preview": query[:120],
+            "query_len": len(query),
+            "query_hash": hashlib.sha256(query.encode()).hexdigest()[:8],
+            "query_type": state.get("query_type"),
+            "top_k": top_k,
+        }
+    )
+
     dense_vector = state.get("query_embedding")
     sparse_vector: Any = None
 
@@ -96,6 +112,13 @@ async def retrieve_node(
     if cached_results is not None:
         latency = time.perf_counter() - start
         logger.info("retrieve HIT search cache (%.3fs, %d docs)", latency, len(cached_results))
+        lf.update_current_span(
+            output={
+                "results_count": len(cached_results),
+                "search_cache_hit": True,
+                "duration_ms": round(latency * 1000, 1),
+            }
+        )
         return {
             "documents": cached_results,
             "search_results_count": len(cached_results),
@@ -133,6 +156,19 @@ async def retrieve_node(
 
     latency = time.perf_counter() - start
     logger.info("retrieve done (%.3fs, %d docs)", latency, len(results))
+
+    scores = [d.get("score", 0) for d in results if isinstance(d, dict)]
+    lf.update_current_span(
+        output={
+            "results_count": len(results),
+            "top_score": round(scores[0], 4) if scores else None,
+            "min_score": round(scores[-1], 4) if scores else None,
+            "search_cache_hit": False,
+            "retrieval_backend_error": search_meta.get("backend_error", False),
+            "retrieval_error_type": search_meta.get("error_type"),
+            "duration_ms": round(latency * 1000, 1),
+        }
+    )
 
     update: dict[str, Any] = {
         "documents": results,

--- a/tests/unit/graph/test_observe_payloads.py
+++ b/tests/unit/graph/test_observe_payloads.py
@@ -1,0 +1,201 @@
+"""Tests: heavy nodes disable @observe auto-capture, curated span has no heavy fields."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Heavy nodes use capture_input=False, capture_output=False
+# ---------------------------------------------------------------------------
+
+
+class TestHeavyNodesDisableAutoCapture:
+    """Verify @observe(capture_input=False, capture_output=False) on heavy nodes."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_observe(self):
+        """Mock observe decorator before importing node modules.
+
+        Replaces telegram_bot.observability.observe with a mock that records
+        the kwargs passed to @observe(...) and returns the original function.
+        """
+        self.observe_calls: dict[str, dict] = {}
+        original_modules: dict[str, object] = {}
+
+        # Remove cached node modules so re-import picks up our mock
+        node_modules = [
+            "telegram_bot.graph.nodes.retrieve",
+            "telegram_bot.graph.nodes.generate",
+            "telegram_bot.graph.nodes.cache",
+        ]
+        for mod in node_modules:
+            if mod in sys.modules:
+                original_modules[mod] = sys.modules.pop(mod)
+
+        def fake_observe(**kwargs):
+            def decorator(func):
+                self.observe_calls[kwargs.get("name", func.__name__)] = kwargs
+                return func
+
+            return decorator
+
+        with patch("telegram_bot.observability.observe", side_effect=fake_observe):
+            # Force re-import with our mocked observe
+            for mod in node_modules:
+                importlib.import_module(mod)
+            yield
+
+        # Restore original modules
+        for mod in node_modules:
+            sys.modules.pop(mod, None)
+        for mod, original in original_modules.items():
+            sys.modules[mod] = original  # type: ignore[assignment]
+
+    def test_retrieve_node_disables_auto_capture(self):
+        kwargs = self.observe_calls.get("node-retrieve", {})
+        assert kwargs.get("capture_input") is False, "node-retrieve must set capture_input=False"
+        assert kwargs.get("capture_output") is False, "node-retrieve must set capture_output=False"
+
+    def test_generate_node_disables_auto_capture(self):
+        kwargs = self.observe_calls.get("node-generate", {})
+        assert kwargs.get("capture_input") is False, "node-generate must set capture_input=False"
+        assert kwargs.get("capture_output") is False, "node-generate must set capture_output=False"
+
+    def test_cache_check_node_disables_auto_capture(self):
+        kwargs = self.observe_calls.get("node-cache-check", {})
+        assert kwargs.get("capture_input") is False, "node-cache-check must set capture_input=False"
+        assert kwargs.get("capture_output") is False, (
+            "node-cache-check must set capture_output=False"
+        )
+
+    def test_cache_store_node_disables_auto_capture(self):
+        kwargs = self.observe_calls.get("node-cache-store", {})
+        assert kwargs.get("capture_input") is False, "node-cache-store must set capture_input=False"
+        assert kwargs.get("capture_output") is False, (
+            "node-cache-store must set capture_output=False"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Curated span payloads contain no heavy fields
+# ---------------------------------------------------------------------------
+
+# Forbidden keys — these must NEVER appear in update_current_span input/output
+_FORBIDDEN_KEYS = {"documents", "query_embedding", "sparse_embedding", "state", "messages"}
+
+
+def _extract_span_payloads(mock_lf_client: MagicMock) -> list[dict]:
+    """Collect all input/output dicts from update_current_span calls."""
+    payloads: list[dict] = []
+    for c in mock_lf_client.update_current_span.call_args_list:
+        kwargs = c.kwargs if c.kwargs else {}
+        if "input" in kwargs and isinstance(kwargs["input"], dict):
+            payloads.append(kwargs["input"])
+        if "output" in kwargs and isinstance(kwargs["output"], dict):
+            payloads.append(kwargs["output"])
+    return payloads
+
+
+def _assert_no_forbidden_keys(payloads: list[dict], node_name: str) -> None:
+    """Assert none of the payloads contain forbidden heavy keys."""
+    for payload in payloads:
+        for key in _FORBIDDEN_KEYS:
+            assert key not in payload, (
+                f"{node_name}: update_current_span must not contain '{key}', "
+                f"found in payload keys: {list(payload.keys())}"
+            )
+
+
+class TestCuratedSpanPayloads:
+    """Verify update_current_span calls contain only curated metadata."""
+
+    @pytest.mark.asyncio
+    async def test_retrieve_node_curated_payload(self):
+        from telegram_bot.graph.nodes.retrieve import retrieve_node
+        from telegram_bot.graph.state import make_initial_state
+
+        state = make_initial_state(user_id=1, session_id="s1", query="test query text")
+        state["query_type"] = "GENERAL"
+        state["query_embedding"] = [0.1] * 1024
+
+        docs = [
+            {"id": "1", "text": "Doc content " * 100, "score": 0.9, "metadata": {}},
+            {"id": "2", "text": "More content " * 100, "score": 0.7, "metadata": {}},
+        ]
+        ok_meta = {"backend_error": False, "error_type": None, "error_message": None}
+
+        cache = AsyncMock()
+        cache.get_search_results = AsyncMock(return_value=None)
+        cache.get_sparse_embedding = AsyncMock(return_value=None)
+        cache.store_sparse_embedding = AsyncMock()
+        cache.store_search_results = AsyncMock()
+
+        sparse = AsyncMock()
+        sparse.aembed_query = AsyncMock(return_value={"indices": [1], "values": [0.5]})
+
+        qdrant = AsyncMock()
+        qdrant.hybrid_search_rrf = AsyncMock(return_value=(docs, ok_meta))
+
+        mock_lf = MagicMock()
+        with patch("telegram_bot.graph.nodes.retrieve.get_client", return_value=mock_lf):
+            await retrieve_node(state, cache=cache, sparse_embeddings=sparse, qdrant=qdrant)
+
+        payloads = _extract_span_payloads(mock_lf)
+        assert len(payloads) >= 2, (
+            "retrieve_node must call update_current_span for input and output"
+        )
+        _assert_no_forbidden_keys(payloads, "node-retrieve")
+
+        # Verify expected curated keys exist in input
+        input_payload = payloads[0]
+        assert "query_preview" in input_payload
+        assert len(input_payload["query_preview"]) <= 120
+        assert "query_hash" in input_payload
+        assert len(input_payload["query_hash"]) == 8
+
+    @pytest.mark.asyncio
+    async def test_generate_node_curated_payload(self):
+        from unittest.mock import patch as _patch
+
+        from telegram_bot.graph.nodes.generate import generate_node
+        from telegram_bot.graph.state import make_initial_state
+
+        state = make_initial_state(user_id=1, session_id="s1", query="test query")
+        state["query_type"] = "GENERAL"
+        state["documents"] = [
+            {"text": "Large doc " * 200, "score": 0.9, "metadata": {"title": "Test"}},
+        ]
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Answer."
+        mock_response = MagicMock(choices=[mock_choice])
+        mock_response.model = "gpt-4o-mini"
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        mock_config = MagicMock()
+        mock_config.domain = "test"
+        mock_config.llm_model = "gpt-4o-mini"
+        mock_config.llm_temperature = 0.7
+        mock_config.generate_max_tokens = 2048
+        mock_config.streaming_enabled = False
+        mock_config.create_llm.return_value = mock_client
+
+        mock_lf = MagicMock()
+        with (
+            _patch("telegram_bot.graph.nodes.generate._get_config", return_value=mock_config),
+            _patch("telegram_bot.graph.nodes.generate.get_client", return_value=mock_lf),
+        ):
+            await generate_node(state)
+
+        payloads = _extract_span_payloads(mock_lf)
+        assert len(payloads) >= 2, (
+            "generate_node must call update_current_span for input and output"
+        )
+        _assert_no_forbidden_keys(payloads, "node-generate")

--- a/tests/unit/test_validate_aggregates.py
+++ b/tests/unit/test_validate_aggregates.py
@@ -111,3 +111,20 @@ class TestEvaluateGoNoGo:
         )
         assert criteria["cold_over_10s_lt_15pct"]["actual"] == "0.0% (0/0)"
         assert criteria["orphan_traces_zero"]["passed"] is True
+
+    def test_uses_generate_p50_key_not_ttft(self):
+        """Go/No-Go must use 'generate_p50_lt_2s', not 'ttft_p50_lt_2s'."""
+        aggregates = {
+            "cold": {
+                "latency_p50": 3000,
+                "latency_p95": 5000,
+                "node_p50": {"generate": 1500},
+            },
+            "cache_hit": {"latency_p50": 500},
+        }
+        results = [_make_result(phase="cold", latency=3000)]
+        criteria = evaluate_go_no_go(aggregates, results, orphan_rate=0.0)
+
+        assert "generate_p50_lt_2s" in criteria, "Criterion must be named 'generate_p50_lt_2s'"
+        assert "ttft_p50_lt_2s" not in criteria, "Old 'ttft_p50_lt_2s' key must not exist"
+        assert criteria["generate_p50_lt_2s"]["passed"] is True  # 1500 < 2000


### PR DESCRIPTION
## Summary
- Disable Langfuse auto-capture on heavy nodes: `node-retrieve`, `node-generate`, `node-cache-check`, `node-cache-store`
- Add curated `update_current_span()` payloads (query preview/hash + compact scalar outputs)
- Rename validation Go/No-Go criterion from `ttft_p50_lt_2s` to `generate_p50_lt_2s`
- Add report footnote clarifying non-streaming validation semantics
- Add/extend tests for decorator flags, curated payload keys, and criterion rename

## Validation
- Worker payload run completed: `logs/worker-payload-bloat.log`
- Unit/integration tests green in worker run
- Live Langfuse check on fresh trace `ab88a1f694ee411d8fd50ff2eeb442ff`:
  - `node-cache-check` payload: 248 bytes
  - `node-retrieve` payload: 341 bytes
  - `node-generate` payload: 438 bytes
  - `node-cache-store` payload: 270 bytes

## Follow-ups
- Streaming TTFT validation tracked in #144

Closes #143
