### PR TITLE
fix: dev setup + dirty-worktree preflight guard #165 #169

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --frozen --extra dev
+        run: uv sync --frozen
 
       - name: Ruff lint
         run: uv run ruff check src/ telegram_bot/ tests/ --output-format=github
@@ -50,7 +50,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --frozen --extra dev
+        run: uv sync --frozen
 
       - name: Run unit tests
         run: uv run pytest tests/unit/ -q -x -m "not legacy_api" --timeout=30
@@ -82,7 +82,7 @@ jobs:
 
       - name: Install dependencies
         if: env.LANGFUSE_AVAILABLE == 'true'
-        run: uv sync --frozen --extra dev
+        run: uv sync --frozen
 
       - name: Run baseline comparison
         if: env.LANGFUSE_AVAILABLE == 'true'

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ install-dev: ## Install development dependencies (linters, formatters, etc.)
 
 install-all: ## Install all dependencies (prod + dev + docs)
 	@echo "$(BLUE)Installing all dependencies...$(NC)"
-	uv sync --all-extras
+	uv sync --all-extras --all-groups
 	@echo "$(GREEN)✓ All dependencies installed$(NC)"
 
 # =============================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,24 +51,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# Development tools (linters, formatters, type checkers)
-dev = [
-    "ruff>=0.6.0",           # Fast linter + formatter
-    "mypy>=1.11.0",          # Type checking
-    "pylint>=3.2.0",         # Comprehensive linting
-    "bandit>=1.7.9",         # Security linting
-    "vulture>=2.11",         # Dead code detection
-    "pytest>=8.3.0",         # Testing framework
-    "pytest-cov>=5.0.0",     # Coverage plugin
-    "pytest-asyncio>=1.2.0", # Async testing
-    "pytest-httpx>=0.35.0",  # HTTPX mocking (2026 best practice)
-    "pytest-timeout>=2.4.0", # Per-test timeout
-    "pytest-xdist>=3.8.0",   # Parallel test execution
-    "opentelemetry-exporter-otlp-proto-grpc>=1.39.0",  # OTLP exporter for OTEL tests
-    "pre-commit>=3.8.0",     # Git hooks
-    "telethon>=1.42.0",      # E2E Telegram tests
-]
-
 # Documentation tools
 docs = [
     "mkdocs>=1.6.0",         # Documentation generator
@@ -91,7 +73,29 @@ voice = [
 
 # All optional dependencies
 all = [
-    "contextual-rag[dev,docs,voice]",
+    "contextual-rag[docs,voice]",
+]
+
+# =============================================================================
+# DEPENDENCY GROUPS (PEP 735) — dev tools installed by default with `uv sync`
+# =============================================================================
+
+[dependency-groups]
+dev = [
+    "ruff>=0.6.0",
+    "mypy>=1.11.0",
+    "pylint>=3.2.0",
+    "bandit>=1.7.9",
+    "vulture>=2.11",
+    "pytest>=8.3.0",
+    "pytest-cov>=5.0.0",
+    "pytest-asyncio>=1.2.0",
+    "pytest-httpx>=0.35.0",
+    "pytest-timeout>=2.4.0",
+    "pytest-xdist>=3.8.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.39.0",
+    "pre-commit>=3.8.0",
+    "telethon>=1.42.0",
 ]
 
 # =============================================================================

--- a/scripts/validate_traces.py
+++ b/scripts/validate_traces.py
@@ -150,6 +150,28 @@ def check_langfuse_config() -> None:
     logger.info("Langfuse config OK: host=%s", host)
 
 
+def check_worktree_clean(strict: bool = False) -> None:
+    """Preflight: warn or fail if git worktree has uncommitted changes.
+
+    Args:
+        strict: If True, exit on dirty worktree. If False, log warning only.
+    """
+    result = subprocess.run(
+        ["git", "diff", "--quiet", "HEAD"],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        msg = (
+            "Dirty worktree detected — uncommitted changes may cause "
+            "false positives in validation results"
+        )
+        if strict:
+            logger.error(msg)
+            sys.exit(1)
+        else:
+            logger.warning(msg)
+
+
 def detect_runner_mode(collection: str) -> str:
     """Detect runner mode based on collection embedding requirements.
 
@@ -1091,6 +1113,7 @@ async def run_validation(args: argparse.Namespace) -> None:
 
     config = GraphConfig.from_env()
     check_langfuse_config()  # fail fast if host/keys are missing
+    check_worktree_clean(strict=args.strict_worktree)
 
     run = ValidationRun(
         run_id=run_id,
@@ -1274,6 +1297,12 @@ def main() -> None:
         "--report",
         action="store_true",
         help="Generate markdown report",
+    )
+    parser.add_argument(
+        "--strict-worktree",
+        action="store_true",
+        default=False,
+        help="Fail if git worktree is dirty (default: warn only)",
     )
     args = parser.parse_args()
     asyncio.run(run_validation(args))

--- a/scripts/validate_traces.py
+++ b/scripts/validate_traces.py
@@ -157,10 +157,13 @@ def check_worktree_clean(strict: bool = False) -> None:
         strict: If True, exit on dirty worktree. If False, log warning only.
     """
     result = subprocess.run(
-        ["git", "diff", "--quiet", "HEAD"],
+        ["git", "status", "--porcelain", "--untracked-files=normal"],
         capture_output=True,
+        text=True,
+        check=False,
     )
-    if result.returncode != 0:
+    is_dirty = result.returncode != 0 or bool(result.stdout.strip())
+    if is_dirty:
         msg = (
             "Dirty worktree detected — uncommitted changes may cause "
             "false positives in validation results"

--- a/tests/baseline/cli.py
+++ b/tests/baseline/cli.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import click
 
+from scripts.validate_traces import check_worktree_clean
+
 from .collector import LangfuseMetricsCollector
 from .manager import BaselineManager
 
@@ -36,6 +38,7 @@ def cli():
 @click.option("--hours", default=24, help="Hours to look back for metrics")
 def compare(baseline: str, current: str, thresholds: str, hours: int):
     """Compare current run against baseline."""
+    check_worktree_clean(strict=False)
     collector = get_collector()
     manager = BaselineManager(
         collector=collector,

--- a/tests/unit/test_preflight_worktree.py
+++ b/tests/unit/test_preflight_worktree.py
@@ -1,0 +1,35 @@
+"""Tests for dirty-worktree preflight guard."""
+
+from unittest.mock import patch
+
+import pytest
+
+
+def test_clean_worktree_passes(tmp_path):
+    """Clean worktree should not raise."""
+    from scripts.validate_traces import check_worktree_clean
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        # Should not raise
+        check_worktree_clean(strict=True)
+
+
+def test_dirty_worktree_strict_fails(tmp_path):
+    """Dirty worktree in strict mode should exit."""
+    from scripts.validate_traces import check_worktree_clean
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 1
+        with pytest.raises(SystemExit):
+            check_worktree_clean(strict=True)
+
+
+def test_dirty_worktree_warn_only(tmp_path, caplog):
+    """Dirty worktree in warn mode should log warning but not exit."""
+    from scripts.validate_traces import check_worktree_clean
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 1
+        check_worktree_clean(strict=False)
+        assert "dirty worktree" in caplog.text.lower() or "uncommitted" in caplog.text.lower()

--- a/tests/unit/test_preflight_worktree.py
+++ b/tests/unit/test_preflight_worktree.py
@@ -11,6 +11,7 @@ def test_clean_worktree_passes(tmp_path):
 
     with patch("subprocess.run") as mock_run:
         mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = ""
         # Should not raise
         check_worktree_clean(strict=True)
 
@@ -21,6 +22,7 @@ def test_dirty_worktree_strict_fails(tmp_path):
 
     with patch("subprocess.run") as mock_run:
         mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = ""
         with pytest.raises(SystemExit):
             check_worktree_clean(strict=True)
 
@@ -31,5 +33,17 @@ def test_dirty_worktree_warn_only(tmp_path, caplog):
 
     with patch("subprocess.run") as mock_run:
         mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = ""
         check_worktree_clean(strict=False)
         assert "dirty worktree" in caplog.text.lower() or "uncommitted" in caplog.text.lower()
+
+
+def test_untracked_files_strict_fails(tmp_path):
+    """Untracked files should be treated as dirty worktree."""
+    from scripts.validate_traces import check_worktree_clean
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = "?? notes.txt\n"
+        with pytest.raises(SystemExit):
+            check_worktree_clean(strict=True)

--- a/uv.lock
+++ b/uv.lock
@@ -762,7 +762,6 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
-    { name = "bandit" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "livekit" },
@@ -772,38 +771,9 @@ all = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
-    { name = "mypy" },
-    { name = "opentelemetry-exporter-otlp-proto-grpc" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
-    { name = "pre-commit" },
-    { name = "pylint" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "pytest-httpx" },
-    { name = "pytest-timeout" },
-    { name = "pytest-xdist" },
-    { name = "ruff" },
-    { name = "telethon" },
     { name = "uvicorn" },
-    { name = "vulture" },
-]
-dev = [
-    { name = "bandit" },
-    { name = "mypy" },
-    { name = "opentelemetry-exporter-otlp-proto-grpc" },
-    { name = "pre-commit" },
-    { name = "pylint" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "pytest-httpx" },
-    { name = "pytest-timeout" },
-    { name = "pytest-xdist" },
-    { name = "ruff" },
-    { name = "telethon" },
-    { name = "vulture" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -822,15 +792,32 @@ voice = [
     { name = "uvicorn" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "bandit" },
+    { name = "mypy" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "pre-commit" },
+    { name = "pylint" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-httpx" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
+    { name = "ruff" },
+    { name = "telethon" },
+    { name = "vulture" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "aiogram", specifier = ">=3.22.0" },
     { name = "aiohttp" },
     { name = "anthropic" },
     { name = "asyncpg", specifier = ">=0.31.0" },
-    { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7.9" },
     { name = "cocoindex", specifier = ">=0.3.28" },
-    { name = "contextual-rag", extras = ["dev", "docs", "voice"], marker = "extra == 'all'" },
+    { name = "contextual-rag", extras = ["docs", "voice"], marker = "extra == 'all'" },
     { name = "datasets", specifier = ">=3.0.0" },
     { name = "docling", specifier = ">=2.70.0" },
     { name = "docling-core", specifier = ">=2.61.0" },
@@ -853,32 +840,20 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.25.0" },
     { name = "mlflow", specifier = ">=3.9.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
     { name = "numpy" },
     { name = "openai" },
-    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'dev'", specifier = ">=1.39.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'voice'", specifier = ">=1.39.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'voice'", specifier = ">=1.39.0" },
     { name = "pandas", specifier = ">=2.0.0" },
-    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.8.0" },
-    { name = "pylint", marker = "extra == 'dev'", specifier = ">=3.2.0" },
     { name = "pymupdf", specifier = ">=1.26.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.2.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
-    { name = "pytest-httpx", marker = "extra == 'dev'", specifier = ">=0.35.0" },
-    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.4.0" },
-    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.8.0" },
     { name = "python-dotenv" },
     { name = "qdrant-client", specifier = ">=1.16.2" },
     { name = "ragas", specifier = ">=0.4.3" },
     { name = "redis", specifier = ">=7.1.0" },
     { name = "redisvl", specifier = ">=0.13.2" },
     { name = "requests" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.0" },
     { name = "scipy" },
     { name = "sentence-transformers" },
-    { name = "telethon", marker = "extra == 'dev'", specifier = ">=1.42.0" },
     { name = "tenacity", specifier = ">=8.2.0" },
     { name = "torch", specifier = ">=2.0.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torchvision", specifier = ">=0.15.0", index = "https://download.pytorch.org/whl/cpu" },
@@ -886,9 +861,26 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'voice'", specifier = ">=0.30.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
     { name = "voyageai", specifier = ">=0.3.0" },
-    { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.11" },
 ]
-provides-extras = ["dev", "docs", "voice", "all"]
+provides-extras = ["docs", "voice", "all"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "bandit", specifier = ">=1.7.9" },
+    { name = "mypy", specifier = ">=1.11.0" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.39.0" },
+    { name = "pre-commit", specifier = ">=3.8.0" },
+    { name = "pylint", specifier = ">=3.2.0" },
+    { name = "pytest", specifier = ">=8.3.0" },
+    { name = "pytest-asyncio", specifier = ">=1.2.0" },
+    { name = "pytest-cov", specifier = ">=5.0.0" },
+    { name = "pytest-httpx", specifier = ">=0.35.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
+    { name = "ruff", specifier = ">=0.6.0" },
+    { name = "telethon", specifier = ">=1.42.0" },
+    { name = "vulture", specifier = ">=2.11" },
+]
 
 [[package]]
 name = "contourpy"


### PR DESCRIPTION
## Summary
- **#169**: Migrate dev dependencies from `[project.optional-dependencies].dev` to `[dependency-groups].dev` (PEP 735) — `uv sync` now installs pytest/ruff/mypy by default
- **#165**: Add `check_worktree_clean()` preflight guard to `validate_traces.py` and baseline CLI — warns on dirty worktree to prevent false positives

## Changes
| File | Change |
|------|--------|
| `pyproject.toml` | Move dev deps to `[dependency-groups]` |
| `Makefile` | Update `install-all` to `--all-extras --all-groups` |
| `.github/workflows/ci.yml` | Remove `--extra dev` (now default) |
| `uv.lock` | Regenerated |
| `scripts/validate_traces.py` | Add `check_worktree_clean()` + `--strict-worktree` flag |
| `tests/baseline/cli.py` | Add preflight call before compare |
| `tests/unit/test_preflight_worktree.py` | 3 unit tests |

## Test plan
- [x] `uv sync && uv run pytest --version` — installs pytest by default
- [x] `uv run pytest tests/unit/test_preflight_worktree.py -v` — 3 PASS
- [x] `uv run pytest tests/unit/test_validate_queries.py tests/unit/test_validate_aggregates.py -v` — PASS
- [ ] CI lint + test jobs pass

Closes #165, closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)