### PR TITLE
fix(validation): use active CACHE_VERSION in cold flush patterns (#176)

### DIFF
--- a/scripts/validate_traces.py
+++ b/scripts/validate_traces.py
@@ -199,6 +199,17 @@ def get_git_sha() -> str:
     return result.stdout.strip()
 
 
+def _get_cache_version() -> str:
+    """Resolve exact-cache key version from cache integration module."""
+    try:
+        from telegram_bot.integrations.cache import CACHE_VERSION
+
+        return str(CACHE_VERSION)
+    except Exception as e:
+        logger.warning("Failed to resolve CACHE_VERSION, fallback to v3: %s", e)
+        return "v3"
+
+
 async def check_collection_available(qdrant_url: str, collection_name: str) -> bool:
     """Check if Qdrant collection exists."""
     from qdrant_client import AsyncQdrantClient
@@ -403,12 +414,13 @@ async def _flush_redis_caches(cache: Any) -> None:
         return
 
     deleted = 0
+    cache_version = _get_cache_version()
     patterns = [
-        "embeddings:v3:*",
-        "sparse:v3:*",
-        "analysis:v3:*",
-        "search:v3:*",
-        "rerank:v3:*",
+        f"embeddings:{cache_version}:*",
+        f"sparse:{cache_version}:*",
+        f"analysis:{cache_version}:*",
+        f"search:{cache_version}:*",
+        f"rerank:{cache_version}:*",
         "conversation:*",
     ]
     for pattern in patterns:

--- a/tests/unit/test_validate_aggregates.py
+++ b/tests/unit/test_validate_aggregates.py
@@ -3,13 +3,14 @@
 import contextlib
 import sys
 import types
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from scripts.validate_traces import (
     TraceResult,
     ValidationRun,
+    _flush_redis_caches,
     aggregate_node_payloads,
     check_langfuse_config,
     compute_aggregates,
@@ -427,6 +428,38 @@ class TestReportAndSummary:
 
         assert "[-] SKIP" in text
         assert "[x] PASS" in text
+
+
+class TestRedisFlushPatterns:
+    """Redis flush should use active cache version for exact-cache prefixes."""
+
+    @pytest.mark.asyncio
+    async def test_flush_uses_cache_version_prefix(self, monkeypatch: pytest.MonkeyPatch):
+        seen_matches: list[str] = []
+
+        async def fake_scan_iter(match=None, count=100):
+            if match is not None:
+                seen_matches.append(match)
+            if False:
+                yield None
+
+        mock_redis = AsyncMock()
+        mock_redis.scan_iter = fake_scan_iter
+        mock_redis.delete = AsyncMock()
+
+        mock_cache = MagicMock()
+        mock_cache.redis = mock_redis
+        mock_cache.semantic_cache = None
+
+        monkeypatch.setattr("scripts.validate_traces._get_cache_version", lambda: "v9")
+
+        await _flush_redis_caches(mock_cache)
+
+        assert "embeddings:v9:*" in seen_matches
+        assert "sparse:v9:*" in seen_matches
+        assert "analysis:v9:*" in seen_matches
+        assert "search:v9:*" in seen_matches
+        assert "rerank:v9:*" in seen_matches
 
     def test_report_includes_streaming_ttft_section(self, tmp_path):
         """Report includes Streaming TTFT section when streaming aggregates exist."""


### PR DESCRIPTION
## Summary
- Replace hardcoded `v3` exact-cache flush patterns in `scripts/validate_traces.py` with dynamic version resolution from cache integration (`CACHE_VERSION`).
- Add `_get_cache_version()` helper with safe fallback to `v3` if import fails.
- Add unit test to ensure `_flush_redis_caches()` uses the active cache version prefix.

## Why
`CACHE_VERSION` is currently `v4`, but cold validation flush scanned `v3` keys only. This could leave warm exact-cache keys and skew cold-phase metrics.

## Validation
- `uv run python -m pytest tests/unit/test_validate_aggregates.py tests/unit/test_validate_queries.py -q`
- `uv run ruff check scripts/validate_traces.py tests/unit/test_validate_aggregates.py`
- `uv run ruff format --check scripts/validate_traces.py tests/unit/test_validate_aggregates.py`

Closes #176
