### PR TITLE
test(vectorizers): harden redisvl optional-import gate against stubbed modules (#183)

### DIFF
--- a/tests/unit/test_vectorizers.py
+++ b/tests/unit/test_vectorizers.py
@@ -4,7 +4,7 @@ import pytest
 
 
 try:
-    import redisvl  # noqa: F401
+    from redisvl.utils.vectorize import BaseVectorizer  # noqa: F401
 except (ImportError, ModuleNotFoundError, ValueError):
     pytest.skip("redisvl not installed", allow_module_level=True)
 


### PR DESCRIPTION
## Summary
- change optional dependency gate in `tests/unit/test_vectorizers.py`
- verify exact production import path (`redisvl.utils.vectorize`) instead of only `import redisvl`
- keep module-level graceful skip behavior when redisvl extras are absent

## Validation
- `uv run pytest tests/unit/test_vectorizers.py -q` (13 passed)
- `uv run pytest tests/unit/ -q -x -m "not legacy_api" --timeout=30` (failed on unrelated env-gated test requiring `ANTHROPIC_API_KEY`, not on vectorizer test)

Closes #183