### PR TITLE
docs(observability): Langfuse latency dashboard design and runbook #147

### DIFF
--- a/docs/plans/2026-02-12-langfuse-dashboards-design.md
+++ b/docs/plans/2026-02-12-langfuse-dashboards-design.md
@@ -1,0 +1,246 @@
+# Langfuse Dashboards Design: LLM Latency Breakdown (#147)
+
+**Date:** 2026-02-12
+**Branch:** `chore/parallel-backlog/langfuse-147`
+**Status:** Implementation
+
+## Context
+
+Issue #147 tracks slow-thinking latency breakdown. The runtime scores are already written to Langfuse traces:
+
+| Score Name | Type | Source | When Written |
+|------------|------|--------|--------------|
+| `llm_queue_ms` | NUMERIC | `_extract_queue_ms_from_provider_headers()` | Provider reports queue time |
+| `llm_ttft_ms` | NUMERIC | `generate_node` streaming timer | Always (0.0 if non-streaming) |
+| `llm_decode_ms` | NUMERIC | `response_duration_ms - ttft_ms` | Streaming only, ttft > 0 |
+| `llm_tps` | NUMERIC | `completion_tokens / (decode_ms / 1000)` | Streaming + decode > 0 |
+| `llm_timeout` | BOOLEAN | Hard LLM failure flag | Always |
+| `streaming_enabled` | BOOLEAN | Config check | Always |
+| `llm_stream_recovery` | BOOLEAN | Streaming fallback to non-streaming | Always |
+| `llm_queue_unavailable` | BOOLEAN | Paired flag when queue_ms is None | When queue_ms absent |
+| `llm_decode_unavailable` | BOOLEAN | Paired flag when decode_ms is None | When decode_ms absent |
+| `llm_tps_unavailable` | BOOLEAN | Paired flag when tps is None | When tps absent |
+
+**What remains:** Dashboards, alerts, classification guide, investigation runbook.
+
+## 1. Dashboard Layout
+
+### Dashboard 1: LLM Latency Breakdown (Primary)
+
+**Purpose:** At-a-glance view of where LLM time is spent.
+
+| Panel | Chart Type | View | Metric | Dimensions | Filter |
+|-------|-----------|------|--------|------------|--------|
+| TTFT p95 Trend | Line (time series) | `scores-numeric` | `value` / `p95` | `timeDimension: day` | `name = llm_ttft_ms` |
+| Decode p95 Trend | Line (time series) | `scores-numeric` | `value` / `p95` | `timeDimension: day` | `name = llm_decode_ms` |
+| Queue p95 Trend | Line (time series) | `scores-numeric` | `value` / `p95` | `timeDimension: day` | `name = llm_queue_ms` |
+| TPS Trend (avg) | Line (time series) | `scores-numeric` | `value` / `avg` | `timeDimension: day` | `name = llm_tps` |
+| Timeout Rate | Bar (time series) | `scores-numeric` | `value` / `avg` | `timeDimension: day` | `name = llm_timeout` |
+| Stream Recovery Rate | Bar (time series) | `scores-numeric` | `value` / `avg` | `timeDimension: day` | `name = llm_stream_recovery` |
+
+### Dashboard 2: End-to-End Pipeline Latency
+
+**Purpose:** Total latency with node-level breakdown context.
+
+| Panel | Chart Type | View | Metric | Dimensions | Filter |
+|-------|-----------|------|--------|------------|--------|
+| Total Latency p50/p95 | Line (dual) | `scores-numeric` | `value` / `p50`, `p95` | `timeDimension: day` | `name = latency_total_ms` |
+| Generate Node Latency | Line | `observations` | `latency` / `p95` | `timeDimension: day` | `name = node-generate` |
+| Retrieve Node Latency | Line | `observations` | `latency` / `p95` | `timeDimension: day` | `name = node-retrieve` |
+| Cache Hit Rate | Line | `scores-numeric` | `value` / `avg` | `timeDimension: day` | `name = semantic_cache_hit` |
+
+### Dashboard 3: Availability & Reliability
+
+| Panel | Chart Type | Metric | Filter |
+|-------|-----------|--------|--------|
+| Timeout % (daily) | Bar | `llm_timeout` avg | `streaming_enabled = 1` |
+| Data Availability | Stacked bar | `llm_decode_unavailable` count | — |
+| Queue Unavailable % | Bar | `llm_queue_unavailable` avg | — |
+
+## 2. Alert Rules
+
+Langfuse v3 Custom Dashboards do not have built-in alerting. Alerts are implemented via:
+1. **Metrics API polling script** (`scripts/setup_langfuse_dashboards.py`) — runs on schedule
+2. **Existing Telegram alerting stack** (`make monitoring-up`) — receives threshold violations
+
+### Threshold Definitions
+
+| Alert | Score | Aggregation | Threshold | Window | Severity |
+|-------|-------|-------------|-----------|--------|----------|
+| TTFT p95 High | `llm_ttft_ms` | p95 | > 2000 ms | 1 hour | WARNING |
+| TTFT p95 Critical | `llm_ttft_ms` | p95 | > 5000 ms | 1 hour | CRITICAL |
+| Decode p95 High | `llm_decode_ms` | p95 | > 3000 ms | 1 hour | WARNING |
+| Queue p95 High | `llm_queue_ms` | p95 | > 1000 ms | 1 hour | WARNING |
+| Queue p95 Critical | `llm_queue_ms` | p95 | > 3000 ms | 1 hour | CRITICAL |
+| Timeout Rate | `llm_timeout` | avg | > 0.05 (5%) | 1 hour | CRITICAL |
+| TPS Degradation | `llm_tps` | p50 | < 20 tps | 1 hour | WARNING |
+| Stream Recovery Spike | `llm_stream_recovery` | avg | > 0.10 (10%) | 1 hour | WARNING |
+
+### Rationale
+
+- **TTFT 2s WARNING:** Current gate is `generate_p50_lt_2s` for full generation. TTFT should be well under that.
+- **Queue 1s WARNING:** Queue time is provider-side. >1s indicates Cerebras/LiteLLM congestion.
+- **Timeout 5%:** Any LLM hard failure rate above 5% is production-critical.
+- **TPS 20:** Below 20 tokens/second indicates model slowdown (normal range: 40-80 tps for Cerebras).
+
+## 3. Classification Guide: Queue-Bound vs Model-Bound
+
+### Decision Tree
+
+```
+Slow trace detected (latency_total_ms p95 > threshold)
+│
+├─ llm_timeout = true?
+│  └─ YES → Hard failure. Check LiteLLM logs, provider status page.
+│
+├─ llm_queue_ms available?
+│  ├─ YES and queue_ms > 1000ms → QUEUE-BOUND
+│  │  └─ Provider queue congestion. Consider:
+│  │     - Different time window (off-peak)
+│  │     - Fallback model in LiteLLM
+│  │     - Rate limiting on bot side
+│  │
+│  └─ YES and queue_ms < 500ms → Not queue-bound, continue below
+│
+├─ llm_ttft_ms > 2000ms?
+│  └─ YES → MODEL-BOUND (prefill phase)
+│     └─ Slow prompt processing. Consider:
+│        - Reduce context_docs_count (currently top-5)
+│        - Shorten system prompt
+│        - Check prompt token count in trace metadata
+│
+├─ llm_decode_ms > 3000ms AND llm_tps < 20?
+│  └─ YES → MODEL-BOUND (decode phase)
+│     └─ Slow token generation. Consider:
+│        - Model load issues (cold start)
+│        - Provider throttling
+│        - Switch to faster model variant
+│
+├─ llm_decode_ms > 3000ms AND llm_tps >= 20?
+│  └─ YES → RESPONSE-LENGTH-BOUND
+│     └─ Normal speed, just long output. Consider:
+│        - Reduce GENERATE_MAX_TOKENS
+│        - Tighter response length policy (#129)
+│
+└─ All LLM metrics normal?
+   └─ Check non-LLM nodes: retrieve, rerank, embeddings
+      - node-retrieve p95 > 500ms → Qdrant/embedding bottleneck
+      - node-rerank p95 > 500ms → ColBERT reranker bottleneck
+      - cache miss → Expected for cold queries
+```
+
+### Summary Table
+
+| Classification | Key Indicator | Root Cause | Action |
+|---------------|---------------|------------|--------|
+| Queue-Bound | `llm_queue_ms` > 1000ms | Provider queue congestion | Fallback model, rate limit, off-peak |
+| TTFT-Bound (Prefill) | `llm_ttft_ms` > 2000ms, queue low | Slow prompt processing | Reduce context, shorter prompts |
+| Decode-Bound (Slow) | `llm_decode_ms` high, `llm_tps` < 20 | Model generation slow | Provider issue, model switch |
+| Response-Length-Bound | `llm_decode_ms` high, `llm_tps` >= 20 | Long output at normal speed | Reduce max_tokens, style policy |
+| Retrieval-Bound | LLM metrics normal, node-retrieve slow | Qdrant/embedding latency | Check Qdrant, BGE-M3 service |
+| Timeout | `llm_timeout` = true | Hard LLM failure | Check LiteLLM, provider status |
+
+## 4. Langfuse Metrics API Queries
+
+### Query: TTFT p95 (last 24 hours)
+
+```json
+{
+  "view": "scores-numeric",
+  "metrics": [{"measure": "value", "aggregation": "p95"}],
+  "dimensions": [],
+  "filters": [
+    {"column": "name", "operator": "=", "value": "llm_ttft_ms", "type": "string"}
+  ],
+  "fromTimestamp": "2026-02-11T00:00:00Z",
+  "toTimestamp": "2026-02-12T00:00:00Z"
+}
+```
+
+### Query: All Latency Breakdown p95 (grouped by score name)
+
+```json
+{
+  "view": "scores-numeric",
+  "metrics": [
+    {"measure": "value", "aggregation": "p95"},
+    {"measure": "value", "aggregation": "p50"},
+    {"measure": "count", "aggregation": "count"}
+  ],
+  "dimensions": [{"field": "name"}],
+  "filters": [
+    {"column": "name", "operator": "anyOf", "value": ["llm_ttft_ms", "llm_decode_ms", "llm_queue_ms", "llm_tps"], "type": "stringList"}
+  ],
+  "fromTimestamp": "2026-02-11T00:00:00Z",
+  "toTimestamp": "2026-02-12T00:00:00Z"
+}
+```
+
+### Query: Timeout Rate (daily trend)
+
+```json
+{
+  "view": "scores-numeric",
+  "metrics": [
+    {"measure": "value", "aggregation": "avg"},
+    {"measure": "count", "aggregation": "count"}
+  ],
+  "dimensions": [],
+  "timeDimension": {"granularity": "day"},
+  "filters": [
+    {"column": "name", "operator": "=", "value": "llm_timeout", "type": "string"}
+  ],
+  "fromTimestamp": "2026-02-05T00:00:00Z",
+  "toTimestamp": "2026-02-12T00:00:00Z"
+}
+```
+
+## 5. UI Steps for Custom Dashboard Creation
+
+### Step-by-Step (Langfuse UI)
+
+1. Navigate to **Dashboards** in left sidebar
+2. Click **+ New Dashboard**, name it "LLM Latency Breakdown"
+3. Click **+ Add Widget**
+4. Configure first widget (TTFT p95 Trend):
+   - **Chart type:** Line
+   - **View:** scores-numeric
+   - **Metric:** value / p95
+   - **Filter:** name = llm_ttft_ms
+   - **Time dimension:** day
+   - **Time range:** Last 7 days
+5. Save widget, repeat for each panel from Dashboard 1 layout above
+6. Arrange widgets using drag-and-drop layout
+7. Repeat for Dashboard 2 (Pipeline Latency) and Dashboard 3 (Availability)
+
+### Curated Dashboard Baseline
+
+Langfuse provides curated dashboards for Latency and Cost. Start with the curated "Latency" dashboard, then customize by adding score-based widgets for the breakdown metrics.
+
+## 6. Integration with Existing Infrastructure
+
+### Existing Gates (from `validate_traces.py`)
+
+| Gate | Current | Enhancement |
+|------|---------|-------------|
+| `generate_p50_lt_2s` | Full generation p50 < 2000ms | Add TTFT-specific gate when streaming validation available (#144) |
+| `ttft_p50_lt_1000ms` | Streaming TTFT p50 < 1000ms | Already implemented, skipped when sample < 3 |
+
+### Baseline Module Integration
+
+The `tests/baseline/` module computes per-trace metrics. The latency breakdown scores (`llm_ttft_ms`, `llm_decode_ms`, `llm_queue_ms`) are already included in traces via `_write_langfuse_scores()` and picked up by `enrich_results_from_langfuse()`.
+
+### Monitoring Stack
+
+- `make monitoring-up` starts alerting stack
+- `make monitoring-test-alert` validates Telegram alerting
+- The metrics query script can be integrated as a periodic check
+
+## 7. Data Availability Notes
+
+- **`llm_queue_ms`:** Currently always `None` — `_extract_queue_ms_from_provider_headers()` returns `None` (stub). Will become available when Cerebras/LiteLLM exposes queue time headers.
+- **`llm_decode_ms`:** Available only when streaming is enabled AND `ttft_ms > 0`.
+- **`llm_tps`:** Available only when `decode_ms > 0` AND `completion_tokens` is reported.
+- **`llm_ttft_ms`:** Written as 0.0 for non-streaming; meaningful values only from streaming runs.
+
+Dashboard widgets should handle missing data gracefully (empty charts rather than errors).

--- a/docs/runbooks/latency-investigation.md
+++ b/docs/runbooks/latency-investigation.md
@@ -1,0 +1,193 @@
+# Runbook: LLM Latency Investigation
+
+**Issue:** #147 — Slow-thinking latency breakdown
+**Last Updated:** 2026-02-12
+
+## Quick Commands
+
+```bash
+# Check latency metrics (last 24h)
+uv run python scripts/setup_langfuse_dashboards.py
+
+# Check with alert thresholds
+uv run python scripts/setup_langfuse_dashboards.py --check-alerts
+
+# JSON output for automation
+uv run python scripts/setup_langfuse_dashboards.py --json --hours 6
+
+# Run trace validation (full pipeline)
+uv run python scripts/validate_traces.py --report
+```
+
+## Step 1: Detect — Is There a Latency Problem?
+
+### Automated Detection
+
+The metrics script checks these thresholds:
+
+| Metric | WARNING | CRITICAL |
+|--------|---------|----------|
+| `llm_ttft_ms` p95 | > 2000 ms | > 5000 ms |
+| `llm_decode_ms` p95 | > 3000 ms | — |
+| `llm_queue_ms` p95 | > 1000 ms | > 3000 ms |
+| `llm_tps` p50 | < 20 tps | — |
+| `llm_timeout` avg | — | > 5% |
+| `llm_stream_recovery` avg | > 10% | — |
+
+### Manual Detection (Langfuse UI)
+
+1. Open Langfuse: http://localhost:3001 (local) or cloud URL
+2. Go to **Dashboards** → "LLM Latency Breakdown"
+3. Look for spikes in TTFT, Decode, or Queue p95 trend lines
+4. Check Timeout Rate bar chart for red bars
+
+## Step 2: Find the Slow Trace
+
+### Via Langfuse UI
+
+1. **Traces** → Filter by time range of the spike
+2. Sort by **Duration** (descending)
+3. Look for traces with `latency_total_ms` score > 5000
+4. Click on the trace to see timeline
+
+### Via Langfuse API
+
+```python
+from langfuse import Langfuse
+lf = Langfuse()
+# List recent traces sorted by latency
+traces = lf.api.trace.list(order_by="latency", order="DESC", limit=10)
+for t in traces.data:
+    print(f"{t.id}: {t.latency}ms - {t.input}")
+```
+
+### Via Scores Filter
+
+1. **Scores** → Filter: `name = llm_ttft_ms`, sort by value DESC
+2. Click trace_id to navigate to the slow trace
+
+## Step 3: Determine the Bottleneck
+
+Open the slow trace and check these scores:
+
+```
+Trace scores:
+├── llm_timeout        → true = hard failure (go to Step 4a)
+├── llm_queue_ms       → value present? Check magnitude
+├── llm_ttft_ms        → time to first token
+├── llm_decode_ms      → token generation time
+├── llm_tps            → tokens per second
+├── streaming_enabled  → was streaming active?
+└── llm_stream_recovery → did streaming fall back?
+```
+
+### Decision Matrix
+
+| llm_queue_ms | llm_ttft_ms | llm_decode_ms | llm_tps | Classification |
+|-------------|-------------|---------------|---------|----------------|
+| > 1000ms | any | any | any | **Queue-Bound** |
+| < 500ms | > 2000ms | any | any | **TTFT-Bound (Prefill)** |
+| < 500ms | < 2000ms | > 3000ms | < 20 | **Decode-Bound (Slow Model)** |
+| < 500ms | < 2000ms | > 3000ms | >= 20 | **Response-Length-Bound** |
+| < 500ms | < 2000ms | < 3000ms | >= 20 | **Not LLM — Check Retrieval** |
+| N/A | 0.0 | N/A | N/A | **Non-streaming — Check node-generate span** |
+
+### Non-LLM Bottlenecks
+
+If LLM metrics are all normal, expand the trace timeline and check:
+
+| Span | Normal p95 | If Slow |
+|------|-----------|---------|
+| `node-retrieve` | < 500ms | Qdrant timeout, BGE-M3 cold start |
+| `node-rerank` | < 300ms | ColBERT service overloaded |
+| `bge-m3-hybrid-embed` | < 200ms | BGE-M3 API timeout, cold start |
+| `cache-semantic-check` | < 50ms | Redis connection issue |
+
+## Step 4: Root Cause & Action
+
+### 4a. Hard Timeout (`llm_timeout = true`)
+
+**Symptoms:** `llm_timeout` = 1, no response generated, fallback answer used.
+
+**Actions:**
+1. Check LiteLLM proxy logs: `docker logs dev-litellm --tail 100`
+2. Check provider status page (Cerebras)
+3. Check `QDRANT_TIMEOUT` setting (default 30s)
+4. If persistent: increase `GENERATE_MAX_TOKENS` timeout or switch model in LiteLLM config
+
+### 4b. Queue-Bound (`llm_queue_ms > 1000ms`)
+
+**Symptoms:** High queue time, normal TTFT and decode.
+
+**Actions:**
+1. Check LiteLLM rate limits: `curl http://localhost:4000/health`
+2. Check if Cerebras is experiencing high demand (status page)
+3. Consider off-peak scheduling for batch operations
+4. Fallback: configure secondary model in LiteLLM routing
+
+### 4c. TTFT-Bound (`llm_ttft_ms > 2000ms`, queue low)
+
+**Symptoms:** Slow first token, but decode speed normal once started.
+
+**Actions:**
+1. Check input token count in trace metadata (`prompt_tokens`)
+2. Review `context_docs_count` — are too many documents in context?
+3. Check system prompt length via Langfuse Prompt Management
+4. If context is bloated: lower `TOP_K` or tighten relevance thresholds
+
+### 4d. Decode-Bound (`llm_tps < 20`)
+
+**Symptoms:** Low tokens-per-second, high decode time.
+
+**Actions:**
+1. Check if model is under load (LiteLLM `/health` endpoint)
+2. Compare with historical TPS trend in dashboard
+3. Cold start? Check if first request after idle period
+4. If persistent: escalate to provider or switch model
+
+### 4e. Response-Length-Bound (`llm_tps >= 20`, decode > 3s)
+
+**Symptoms:** Good speed but very long response.
+
+**Actions:**
+1. Check `answer_words` and `answer_chars` scores
+2. Check `answer_to_question_ratio` — is response disproportionately long?
+3. Review response length policy settings (#129)
+4. Consider reducing `GENERATE_MAX_TOKENS` (default: 2048)
+
+### 4f. Stream Recovery (`llm_stream_recovery = true`)
+
+**Symptoms:** Streaming started but failed, fell back to non-streaming.
+
+**Actions:**
+1. Check trace for ERROR span on `node-generate`
+2. Common cause: Telegram API rate limit on `edit_text` (300ms throttle)
+3. Network interruption between bot and LiteLLM
+4. If frequent: check Telegram bot error logs
+
+## Step 5: Verify Fix
+
+After applying fix:
+
+1. Run validation: `uv run python scripts/validate_traces.py --report`
+2. Check latency report: `uv run python scripts/setup_langfuse_dashboards.py`
+3. Compare with baseline: `make baseline-compare`
+4. Monitor dashboard for 24h to confirm regression resolved
+
+## Escalation Criteria
+
+| Condition | Action |
+|-----------|--------|
+| Timeout rate > 10% for > 1 hour | Page on-call, check provider |
+| TTFT p95 > 5s for > 30 min | Investigate immediately |
+| Queue p95 > 3s sustained | Contact provider support |
+| TPS dropped to 0 | LiteLLM/provider outage, enable fallback model |
+| All metrics normal but users report slow | Check Telegram delivery (`respond_node` span), network |
+
+## Related Resources
+
+- Design doc: `docs/plans/2026-02-12-langfuse-dashboards-design.md`
+- Observability rules: `.claude/rules/observability.md`
+- Trace validation: `scripts/validate_traces.py`
+- Baseline module: `tests/baseline/`
+- Alerting: `docs/ALERTING.md`

--- a/scripts/setup_langfuse_dashboards.py
+++ b/scripts/setup_langfuse_dashboards.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Langfuse Metrics API: LLM latency breakdown report (#147).
+
+Queries Langfuse scores-numeric view for latency breakdown metrics
+(llm_ttft_ms, llm_decode_ms, llm_queue_ms, llm_tps, llm_timeout)
+and checks thresholds. Outputs human-readable report or JSON.
+
+Usage:
+    uv run python scripts/setup_langfuse_dashboards.py
+    uv run python scripts/setup_langfuse_dashboards.py --hours 24 --json
+    uv run python scripts/setup_langfuse_dashboards.py --check-alerts
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from dotenv import load_dotenv
+from langfuse import Langfuse
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Alert thresholds (from design doc)
+# ---------------------------------------------------------------------------
+
+ALERT_THRESHOLDS: dict[str, list[dict[str, Any]]] = {
+    "llm_ttft_ms": [
+        {"aggregation": "p95", "threshold": 2000, "severity": "WARNING", "label": "TTFT p95 high"},
+        {
+            "aggregation": "p95",
+            "threshold": 5000,
+            "severity": "CRITICAL",
+            "label": "TTFT p95 critical",
+        },
+    ],
+    "llm_decode_ms": [
+        {
+            "aggregation": "p95",
+            "threshold": 3000,
+            "severity": "WARNING",
+            "label": "Decode p95 high",
+        },
+    ],
+    "llm_queue_ms": [
+        {"aggregation": "p95", "threshold": 1000, "severity": "WARNING", "label": "Queue p95 high"},
+        {
+            "aggregation": "p95",
+            "threshold": 3000,
+            "severity": "CRITICAL",
+            "label": "Queue p95 critical",
+        },
+    ],
+    "llm_timeout": [
+        {
+            "aggregation": "avg",
+            "threshold": 0.05,
+            "severity": "CRITICAL",
+            "label": "Timeout rate > 5%",
+        },
+    ],
+    "llm_tps": [
+        {
+            "aggregation": "p50",
+            "threshold": 20,
+            "severity": "WARNING",
+            "label": "TPS p50 low",
+            "below": True,
+        },
+    ],
+    "llm_stream_recovery": [
+        {
+            "aggregation": "avg",
+            "threshold": 0.10,
+            "severity": "WARNING",
+            "label": "Stream recovery > 10%",
+        },
+    ],
+}
+
+# Scores to query and their aggregations
+LATENCY_SCORES = [
+    "llm_ttft_ms",
+    "llm_decode_ms",
+    "llm_queue_ms",
+    "llm_tps",
+    "llm_timeout",
+    "streaming_enabled",
+    "llm_stream_recovery",
+]
+
+
+def _build_query(
+    score_name: str,
+    from_ts: str,
+    to_ts: str,
+    aggregations: list[str] | None = None,
+) -> str:
+    """Build Metrics API JSON query for a single score."""
+    if aggregations is None:
+        aggregations = ["p50", "p95", "avg", "count", "max"]
+
+    metrics = [{"measure": "value", "aggregation": agg} for agg in aggregations]
+    metrics.append({"measure": "count", "aggregation": "count"})
+
+    query = {
+        "view": "scores-numeric",
+        "metrics": metrics,
+        "dimensions": [],
+        "filters": [
+            {"column": "name", "operator": "=", "value": score_name, "type": "string"},
+        ],
+        "fromTimestamp": from_ts,
+        "toTimestamp": to_ts,
+    }
+    return json.dumps(query)
+
+
+def query_score_metrics(
+    lf: Langfuse,
+    score_name: str,
+    from_ts: str,
+    to_ts: str,
+) -> dict[str, Any]:
+    """Query Langfuse Metrics API for a single score's aggregates."""
+    query_str = _build_query(score_name, from_ts, to_ts)
+    try:
+        result = lf.api.metrics.metrics(query=query_str)
+        data = getattr(result, "data", [])
+        if data and len(data) > 0:
+            row = data[0]
+            # Extract values from response row
+            parsed: dict[str, Any] = {}
+            if hasattr(row, "__dict__"):
+                for key, val in row.__dict__.items():
+                    if val is not None:
+                        parsed[key] = float(val) if isinstance(val, (int, float, str)) else val
+            elif isinstance(row, dict):
+                parsed = {
+                    k: float(v) if isinstance(v, (int, float, str)) else v
+                    for k, v in row.items()
+                    if v is not None
+                }
+            return parsed
+        return {}
+    except Exception as e:
+        logger.warning("Metrics API query failed for %s: %s", score_name, e)
+        return {"error": str(e)}
+
+
+def check_alerts(metrics: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    """Check metrics against alert thresholds. Returns list of fired alerts."""
+    fired: list[dict[str, Any]] = []
+
+    for score_name, thresholds in ALERT_THRESHOLDS.items():
+        score_data = metrics.get(score_name, {})
+        if not score_data or "error" in score_data:
+            continue
+
+        for rule in thresholds:
+            agg_key = f"value_{rule['aggregation']}"
+            actual = score_data.get(agg_key)
+            if actual is None:
+                continue
+
+            actual_float = float(actual)
+            is_below = rule.get("below", False)
+
+            if is_below:
+                triggered = actual_float < rule["threshold"]
+            else:
+                triggered = actual_float > rule["threshold"]
+
+            if triggered:
+                fired.append(
+                    {
+                        "score": score_name,
+                        "label": rule["label"],
+                        "severity": rule["severity"],
+                        "aggregation": rule["aggregation"],
+                        "threshold": rule["threshold"],
+                        "actual": actual_float,
+                        "direction": "below" if is_below else "above",
+                    }
+                )
+
+    return fired
+
+
+def format_report(
+    metrics: dict[str, dict[str, Any]],
+    alerts: list[dict[str, Any]],
+    from_ts: str,
+    to_ts: str,
+) -> str:
+    """Format human-readable latency breakdown report."""
+    lines: list[str] = []
+    lines.append("=" * 60)
+    lines.append("LLM Latency Breakdown Report (#147)")
+    lines.append(f"Period: {from_ts} — {to_ts}")
+    lines.append("=" * 60)
+    lines.append("")
+
+    lines.append("Score               | Count | p50      | p95      | Avg      | Max")
+    lines.append("-" * 80)
+
+    for score_name in LATENCY_SCORES:
+        data = metrics.get(score_name, {})
+        if not data or "error" in data:
+            lines.append(f"{score_name:<20}| {'N/A (no data or error)':>57}")
+            continue
+
+        count = data.get("count_count", data.get("count", "?"))
+        p50 = data.get("value_p50", "—")
+        p95 = data.get("value_p95", "—")
+        avg = data.get("value_avg", "—")
+        mx = data.get("value_max", "—")
+
+        def fmt(v: Any) -> str:
+            if isinstance(v, float):
+                return f"{v:.1f}"
+            return str(v)
+
+        lines.append(
+            f"{score_name:<20}| {fmt(count):>5} | {fmt(p50):>8} | {fmt(p95):>8} | {fmt(avg):>8} | {fmt(mx):>8}"
+        )
+
+    lines.append("")
+
+    if alerts:
+        lines.append("ALERTS FIRED:")
+        for a in alerts:
+            lines.append(
+                f"  [{a['severity']}] {a['label']}: {a['actual']:.1f} "
+                f"({a['direction']} threshold {a['threshold']})"
+            )
+    else:
+        lines.append("No alerts fired.")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    load_dotenv()
+
+    parser = argparse.ArgumentParser(description="Langfuse LLM latency breakdown report")
+    parser.add_argument(
+        "--hours", type=int, default=24, help="Lookback window in hours (default: 24)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.add_argument(
+        "--check-alerts",
+        action="store_true",
+        help="Check alert thresholds and exit with code 1 if any fire",
+    )
+    args = parser.parse_args()
+
+    to_dt = datetime.now(UTC)
+    from_dt = to_dt - timedelta(hours=args.hours)
+    from_ts = from_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    to_ts = to_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    logger.info("Querying Langfuse Metrics API: %s — %s", from_ts, to_ts)
+
+    try:
+        lf = Langfuse()
+    except Exception as e:
+        logger.error("Failed to initialize Langfuse client: %s", e)
+        sys.exit(1)
+
+    metrics: dict[str, dict[str, Any]] = {}
+    for score_name in LATENCY_SCORES:
+        metrics[score_name] = query_score_metrics(lf, score_name, from_ts, to_ts)
+
+    alerts = check_alerts(metrics)
+
+    if args.json:
+        output = {
+            "period": {"from": from_ts, "to": to_ts, "hours": args.hours},
+            "metrics": metrics,
+            "alerts": alerts,
+            "alerts_fired": len(alerts),
+        }
+        print(json.dumps(output, indent=2, default=str))
+    else:
+        print(format_report(metrics, alerts, from_ts, to_ts))
+
+    if args.check_alerts and alerts:
+        critical = [a for a in alerts if a["severity"] == "CRITICAL"]
+        if critical:
+            logger.error("%d CRITICAL alert(s) fired", len(critical))
+            sys.exit(1)
+        logger.warning("%d WARNING alert(s) fired", len(alerts))
+
+    lf.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup_langfuse_dashboards.py
+++ b/scripts/setup_langfuse_dashboards.py
@@ -202,6 +202,13 @@ def check_alerts(metrics: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
     return fired
 
 
+def has_query_errors(metrics: dict[str, dict[str, Any]]) -> bool:
+    """Return True when any score query failed."""
+    return any(
+        isinstance(score_data, dict) and "error" in score_data for score_data in metrics.values()
+    )
+
+
 def format_report(
     metrics: dict[str, dict[str, Any]],
     alerts: list[dict[str, Any]],
@@ -267,7 +274,7 @@ def main() -> None:
     parser.add_argument(
         "--check-alerts",
         action="store_true",
-        help="Check alert thresholds and exit with code 1 if any fire",
+        help="Check alert thresholds/query errors and exit with code 1 on failure",
     )
     args = parser.parse_args()
 
@@ -301,12 +308,17 @@ def main() -> None:
     else:
         print(format_report(metrics, alerts, from_ts, to_ts))
 
-    if args.check_alerts and alerts:
-        critical = [a for a in alerts if a["severity"] == "CRITICAL"]
-        if critical:
-            logger.error("%d CRITICAL alert(s) fired", len(critical))
+    if args.check_alerts:
+        if has_query_errors(metrics):
+            logger.error("One or more Metrics API queries failed")
             sys.exit(1)
-        logger.warning("%d WARNING alert(s) fired", len(alerts))
+
+        if alerts:
+            critical = [a for a in alerts if a["severity"] == "CRITICAL"]
+            if critical:
+                logger.error("%d CRITICAL alert(s) fired", len(critical))
+                sys.exit(1)
+            logger.warning("%d WARNING alert(s) fired", len(alerts))
 
     lf.flush()
 

--- a/scripts/setup_langfuse_dashboards.py
+++ b/scripts/setup_langfuse_dashboards.py
@@ -97,6 +97,18 @@ LATENCY_SCORES = [
 ]
 
 
+def _safe_float(val: Any) -> Any:
+    """Convert to float if numeric, otherwise return as-is."""
+    if isinstance(val, (int, float)):
+        return float(val)
+    if isinstance(val, str):
+        try:
+            return float(val)
+        except ValueError:
+            return val
+    return val
+
+
 def _build_query(
     score_name: str,
     from_ts: str,
@@ -105,7 +117,7 @@ def _build_query(
 ) -> str:
     """Build Metrics API JSON query for a single score."""
     if aggregations is None:
-        aggregations = ["p50", "p95", "avg", "count", "max"]
+        aggregations = ["p50", "p95", "avg", "max"]
 
     metrics = [{"measure": "value", "aggregation": agg} for agg in aggregations]
     metrics.append({"measure": "count", "aggregation": "count"})
@@ -141,13 +153,9 @@ def query_score_metrics(
             if hasattr(row, "__dict__"):
                 for key, val in row.__dict__.items():
                     if val is not None:
-                        parsed[key] = float(val) if isinstance(val, (int, float, str)) else val
+                        parsed[key] = _safe_float(val)
             elif isinstance(row, dict):
-                parsed = {
-                    k: float(v) if isinstance(v, (int, float, str)) else v
-                    for k, v in row.items()
-                    if v is not None
-                }
+                parsed = {k: _safe_float(v) for k, v in row.items() if v is not None}
             return parsed
         return {}
     except Exception as e:

--- a/tests/unit/test_setup_langfuse_dashboards.py
+++ b/tests/unit/test_setup_langfuse_dashboards.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_script_module():
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / "setup_langfuse_dashboards.py"
+    spec = importlib.util.spec_from_file_location("setup_langfuse_dashboards", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_has_query_errors_detects_api_error():
+    module = _load_script_module()
+    metrics = {
+        "llm_ttft_ms": {"error": "auth failed"},
+        "llm_decode_ms": {"value_p95": 1200.0},
+    }
+    assert module.has_query_errors(metrics) is True
+
+
+def test_has_query_errors_false_on_clean_data():
+    module = _load_script_module()
+    metrics = {
+        "llm_ttft_ms": {"value_p95": 1200.0, "count_count": 10.0},
+        "llm_decode_ms": {"value_p95": 800.0, "count_count": 10.0},
+    }
+    assert module.has_query_errors(metrics) is False


### PR DESCRIPTION
## Summary
- Dashboard design doc with Metrics API queries for llm_ttft_ms, llm_decode_ms, llm_queue_ms p95
- Alert thresholds and queue-bound vs model-bound classification guide
- Investigation runbook: `docs/runbooks/latency-investigation.md`
- Metrics query script: `scripts/setup_langfuse_dashboards.py`
- Code review fix: removed duplicate count metric, added safe float conversion

## Test plan
- [x] `ruff check` + `ruff format` — clean
- [x] `mypy` — no issues
- [x] Langfuse MetricsClient API verified against SDK v3.12.1
- [x] Code review findings fixed (2 issues resolved)

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)