### PR TITLE
fix(voice): keep Langfuse trace/scores on cleanup-error without result

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -212,6 +212,9 @@ def _build_trace_metadata(result: dict[str, Any]) -> dict[str, Any]:
         # Conversation memory (#159)
         "memory_messages_count": len(result.get("messages", [])),
         "checkpointer_overhead_proxy_ms": result.get("checkpointer_overhead_proxy_ms"),
+        # Voice post-pipeline cleanup diagnostics (#205)
+        "pipeline_cleanup_error": result.get("pipeline_cleanup_error", False),
+        "pipeline_cleanup_error_type": result.get("pipeline_cleanup_error_type"),
     }
 
 
@@ -646,19 +649,32 @@ class PropertyBot:
                             "Voice pipeline cleanup failed after execution (no extra user error)",
                             exc_info=True,
                         )
-                        return
+                        # Preserve observability even without returned graph state.
+                        result = {
+                            "response": state.get("response", ""),
+                            "stt_text": state.get("stt_text", ""),
+                            "stt_duration_ms": state.get("stt_duration_ms"),
+                            "input_type": "voice",
+                            "voice_duration_s": float(voice.duration),
+                            "latency_stages": state.get("latency_stages", {}),
+                            "messages": state.get("messages", []),
+                            "pipeline_cleanup_error": True,
+                            "pipeline_cleanup_error_type": type(e).__name__,
+                        }
                     # Pipeline never returned — genuine failure
-                    logger.exception("Voice pipeline failed (no result)")
-                    await message.answer(
-                        "Не удалось распознать голосовое сообщение. Попробуйте отправить текстом."
-                    )
-                    return
+                    else:
+                        logger.exception("Voice pipeline failed (no result)")
+                        await message.answer(
+                            "Не удалось распознать голосовое сообщение. Попробуйте отправить текстом."
+                        )
+                        return
                 # Pipeline succeeded but post-invoke cleanup failed (#201)
                 # Answer already delivered via streaming/respond — don't confuse user
-                logger.warning(
-                    "Post-pipeline error in voice handler (answer already delivered)",
-                    exc_info=True,
-                )
+                else:
+                    logger.warning(
+                        "Post-pipeline error in voice handler (answer already delivered)",
+                        exc_info=True,
+                    )
 
             result["pipeline_wall_ms"] = (time.perf_counter() - pipeline_start) * 1000
             # User-perceived latency excludes post-respond summarization

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -636,11 +636,12 @@ class TestHandleVoiceExceptionHandling:
                 "AsyncPregelLoop.__aexit__ failed: psycopg.OperationalError: connection lost"
             )
         )
+        mock_lf = MagicMock()
 
         with (
             patch("telegram_bot.bot.build_graph", return_value=mock_graph),
-            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
-            patch("telegram_bot.bot._write_langfuse_scores"),
+            patch("telegram_bot.bot.get_client", return_value=mock_lf),
+            patch("telegram_bot.bot._write_langfuse_scores") as mock_write_scores,
             patch("telegram_bot.bot.propagate_attributes"),
         ):
             message = self._make_voice_message()
@@ -658,6 +659,9 @@ class TestHandleVoiceExceptionHandling:
                 "Не удалось распознать" in str(call) for call in message.answer.call_args_list
             )
             assert not error_sent
+            # #205: even on cleanup failure, trace metadata and scores must be persisted.
+            mock_lf.update_current_trace.assert_called_once()
+            mock_write_scores.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_scores_written_even_if_trace_update_fails(self, mock_config):


### PR DESCRIPTION
## Summary
- preserve observability writes when graph cleanup fails after pipeline execution and no result object is returned
- synthesize minimal result payload from available state to keep trace metadata and scores
- add cleanup diagnostics metadata fields: pipeline_cleanup_error, pipeline_cleanup_error_type
- add regression assertion to ensure trace + scores are still written in cleanup-error/no-result path

Closes #205

## Verification
- uv run pytest tests/unit/test_bot_handlers.py -q -k cleanup_error_with_no_result_does_not_send_false_error
- uv run pytest tests/unit/test_bot_scores.py -q
- uv run pytest tests/unit/test_bot_observability.py -q
- uv run pytest tests/unit/graph/test_error_spans.py -q