### PR TITLE
fix(embeddings): BGE-M3 retry resilience + graceful fallback #210

### DIFF
--- a/docker/monitoring/rules/infrastructure.yaml
+++ b/docker/monitoring/rules/infrastructure.yaml
@@ -201,6 +201,29 @@ groups:
           summary: "Embedding service errors"
           description: "Errors detected in embedding services"
 
+      # BGE-M3 embedding retries and failures (from bot logs, #210)
+      - alert: BGEEmbedRetryFromBot
+        expr: |
+          count_over_time({container="dev-bot"} |= "Retrying telegram_bot.integrations.embeddings" [5m]) > 3
+        for: 3m
+        labels:
+          severity: warning
+          service: bge-m3
+        annotations:
+          summary: "BGE-M3 embedding retries detected in bot"
+          description: "Bot is retrying BGE-M3 embedding calls — service may be degraded"
+
+      - alert: BGEEmbedErrorFromBot
+        expr: |
+          count_over_time({container="dev-bot"} |= "Embedding failed after retries" [5m]) > 0
+        for: 1m
+        labels:
+          severity: critical
+          service: bge-m3
+        annotations:
+          summary: "BGE-M3 embedding failures in bot"
+          description: "Bot embedding calls failing after all retries exhausted"
+
       # =============================================================================
       # DATABASE
       # =============================================================================

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -153,6 +153,19 @@ def _write_langfuse_scores(lf: Any, result: dict) -> None:
     if voice_dur is not None:
         lf.score_current_trace(name="voice_duration_s", value=float(voice_dur))
 
+    # --- Embedding resilience (#210) ---
+    lf.score_current_trace(
+        name="bge_embed_error",
+        value=1 if result.get("embedding_error") else 0,
+        data_type="BOOLEAN",
+    )
+    cache_check_s = result.get("latency_stages", {}).get("cache_check")
+    if cache_check_s is not None:
+        lf.score_current_trace(
+            name="bge_embed_latency_ms",
+            value=round(cache_check_s * 1000, 1),
+        )
+
     # --- Conversation memory (#154, #159) ---
     summarize_ms = result.get("latency_stages", {}).get("summarize", 0) * 1000
     if summarize_ms > 0:

--- a/telegram_bot/graph/edges.py
+++ b/telegram_bot/graph/edges.py
@@ -34,7 +34,9 @@ def route_by_query_type(
 def route_cache(
     state: dict[str, Any],
 ) -> Literal["respond", "retrieve"]:
-    """Route after cache check: hit → respond, miss → retrieve."""
+    """Route after cache check: embedding error/hit → respond, miss → retrieve."""
+    if state.get("embedding_error", False):
+        return "respond"
     if state.get("cache_hit", False):
         return "respond"
     return "retrieve"

--- a/telegram_bot/graph/nodes/cache.py
+++ b/telegram_bot/graph/nodes/cache.py
@@ -63,18 +63,49 @@ async def cache_check_node(
     # Step 1: Get or compute dense embedding (prefer hybrid for efficiency)
     embedding = await cache.get_embedding(query)
     embeddings_cache_hit = embedding is not None
+    embedding_error = False
+    embedding_error_type: str | None = None
+
     if embedding is None:
-        _has_hybrid = callable(
-            getattr(embeddings, "aembed_hybrid", None)
-        ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid)
-        if _has_hybrid:
-            # Hybrid: get both dense + sparse in one call, cache both
-            embedding, sparse = await embeddings.aembed_hybrid(query)
-            await cache.store_embedding(query, embedding)
-            await cache.store_sparse_embedding(query, sparse)
-        else:
-            embedding = await embeddings.aembed_query(query)
-            await cache.store_embedding(query, embedding)
+        try:
+            _has_hybrid = callable(
+                getattr(embeddings, "aembed_hybrid", None)
+            ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid)
+            if _has_hybrid:
+                # Hybrid: get both dense + sparse in one call, cache both
+                embedding, sparse = await embeddings.aembed_hybrid(query)
+                await cache.store_embedding(query, embedding)
+                await cache.store_sparse_embedding(query, sparse)
+            else:
+                embedding = await embeddings.aembed_query(query)
+                await cache.store_embedding(query, embedding)
+        except Exception as exc:
+            embedding_error = True
+            embedding_error_type = type(exc).__name__
+            logger.error("Embedding failed after retries: %s: %s", embedding_error_type, exc)
+            latency = time.perf_counter() - start
+            lf.update_current_span(
+                level="ERROR",
+                output={
+                    "embedding_error": True,
+                    "embedding_error_type": embedding_error_type,
+                    "error_message": str(exc)[:200],
+                    "duration_ms": round(latency * 1000, 1),
+                },
+            )
+            return {
+                "cache_hit": False,
+                "cached_response": None,
+                "query_embedding": None,
+                "embeddings_cache_hit": False,
+                "embedding_error": True,
+                "embedding_error_type": embedding_error_type,
+                "response": "Сервис временно недоступен. Пожалуйста, повторите через минуту.",
+                "latency_stages": {
+                    **state.get("latency_stages", {}),
+                    "cache_check": latency,
+                },
+            }
 
     # Step 2: Check semantic cache with query-type threshold (allowlisted types only)
     cached = None
@@ -104,6 +135,8 @@ async def cache_check_node(
             "query_embedding": embedding,
             "response": cached,
             "embeddings_cache_hit": embeddings_cache_hit,
+            "embedding_error": False,
+            "embedding_error_type": None,
             "latency_stages": {**state.get("latency_stages", {}), "cache_check": latency},
         }
 
@@ -121,6 +154,8 @@ async def cache_check_node(
         "cached_response": None,
         "query_embedding": embedding,
         "embeddings_cache_hit": embeddings_cache_hit,
+        "embedding_error": embedding_error,
+        "embedding_error_type": embedding_error_type,
         "latency_stages": {**state.get("latency_stages", {}), "cache_check": latency},
     }
 

--- a/telegram_bot/graph/state.py
+++ b/telegram_bot/graph/state.py
@@ -38,6 +38,9 @@ class RAGState(TypedDict):
     score_improved: bool
     retrieval_backend_error: bool
     retrieval_error_type: str | None
+    # Embedding resilience (#210)
+    embedding_error: bool
+    embedding_error_type: str | None
     rewrite_provider_model: str
     llm_provider_model: str
     llm_ttft_ms: float
@@ -92,6 +95,9 @@ def make_initial_state(user_id: int, session_id: str, query: str) -> dict[str, A
         "score_improved": True,
         "retrieval_backend_error": False,
         "retrieval_error_type": None,
+        # Embedding resilience (#210)
+        "embedding_error": False,
+        "embedding_error_type": None,
         "rewrite_provider_model": "",
         "llm_provider_model": "",
         "llm_ttft_ms": 0.0,

--- a/telegram_bot/integrations/embeddings.py
+++ b/telegram_bot/integrations/embeddings.py
@@ -12,11 +12,34 @@ from typing import Any
 
 import httpx
 from langchain_core.embeddings import Embeddings
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
 
 from telegram_bot.observability import observe
 
 
 logger = logging.getLogger(__name__)
+
+# Transient transport errors worth retrying
+_RETRYABLE_ERRORS = (
+    httpx.RemoteProtocolError,
+    httpx.ConnectError,
+    httpx.ReadTimeout,
+    httpx.ConnectTimeout,
+)
+
+_embed_retry = retry(
+    retry=retry_if_exception_type(_RETRYABLE_ERRORS),
+    wait=wait_exponential_jitter(initial=0.5, max=4, jitter=1),
+    stop=stop_after_attempt(3),
+    before_sleep=before_sleep_log(logger, logging.WARNING),
+    reraise=True,
+)
 
 
 class BGEM3Embeddings(Embeddings):
@@ -120,23 +143,30 @@ class BGEM3HybridEmbeddings(Embeddings):
     def __init__(
         self,
         base_url: str = "http://bge-m3:8000",
-        timeout: float = 120.0,
+        timeout: float | httpx.Timeout | None = None,
         max_length: int = 512,
     ) -> None:
         self.base_url = base_url.rstrip("/")
-        self.timeout = timeout
         self.max_length = max_length
+        if timeout is None:
+            self._timeout = httpx.Timeout(connect=5.0, read=30.0, write=5.0, pool=5.0)
+        elif isinstance(timeout, (int, float)):
+            self._timeout = httpx.Timeout(timeout)
+        else:
+            self._timeout = timeout
         self._client: httpx.AsyncClient | None = None
 
     def _get_client(self) -> httpx.AsyncClient:
         if self._client is None or self._client.is_closed:
             self._client = httpx.AsyncClient(
-                timeout=self.timeout,
+                timeout=self._timeout,
+                transport=httpx.AsyncHTTPTransport(retries=1),
                 limits=httpx.Limits(max_connections=20, max_keepalive_connections=10),
             )
         return self._client
 
     @observe(name="bge-m3-hybrid-embed")
+    @_embed_retry
     async def aembed_hybrid(self, text: str) -> tuple[list[float], dict[str, Any]]:
         """Embed text via /encode/hybrid, returning (dense, sparse)."""
         client = self._get_client()
@@ -151,6 +181,7 @@ class BGEM3HybridEmbeddings(Embeddings):
         return dense, sparse
 
     @observe(name="bge-m3-hybrid-embed-batch")
+    @_embed_retry
     async def aembed_hybrid_batch(
         self, texts: list[str]
     ) -> tuple[list[list[float]], list[dict[str, Any]]]:

--- a/tests/unit/graph/test_cache_nodes.py
+++ b/tests/unit/graph/test_cache_nodes.py
@@ -4,6 +4,7 @@ import sys
 from types import ModuleType
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 
@@ -262,3 +263,66 @@ class TestCacheableQueryTypes:
         assert "GENERAL" not in CACHEABLE_QUERY_TYPES
         assert "CHITCHAT" not in CACHEABLE_QUERY_TYPES
         assert "OFF_TOPIC" not in CACHEABLE_QUERY_TYPES
+
+
+class TestCacheCheckEmbeddingError:
+    """Test cache_check_node graceful fallback on embedding failure."""
+
+    @pytest.mark.asyncio
+    async def test_embedding_error_sets_error_state(self):
+        """When embedding fails, sets embedding_error and user-friendly response."""
+        state = make_initial_state(user_id=1, session_id="s1", query="test query")
+        state["query_type"] = "FAQ"
+
+        cache = AsyncMock()
+        cache.get_embedding = AsyncMock(return_value=None)  # cache miss
+
+        embeddings = MagicMock()
+        embeddings.aembed_hybrid = AsyncMock(
+            side_effect=httpx.RemoteProtocolError("Server disconnected")
+        )
+
+        result = await cache_check_node(state, cache=cache, embeddings=embeddings)
+
+        assert result["embedding_error"] is True
+        assert result["embedding_error_type"] == "RemoteProtocolError"
+        assert result["cache_hit"] is False
+        assert "недоступен" in result["response"]
+        assert result["query_embedding"] is None
+
+    @pytest.mark.asyncio
+    async def test_embedding_error_on_read_timeout(self):
+        """ReadTimeout also triggers graceful fallback."""
+        state = make_initial_state(user_id=1, session_id="s1", query="test query")
+        state["query_type"] = "GENERAL"
+
+        cache = AsyncMock()
+        cache.get_embedding = AsyncMock(return_value=None)
+
+        embeddings = MagicMock()
+        embeddings.aembed_hybrid = AsyncMock(side_effect=httpx.ReadTimeout("Read timed out"))
+
+        result = await cache_check_node(state, cache=cache, embeddings=embeddings)
+
+        assert result["embedding_error"] is True
+        assert result["cache_hit"] is False
+
+    @pytest.mark.asyncio
+    async def test_cached_embedding_skips_bge_call(self):
+        """When embedding cache hits, no BGE-M3 call — no error possible."""
+        state = make_initial_state(user_id=1, session_id="s1", query="test query")
+        state["query_type"] = "FAQ"
+
+        cache = AsyncMock()
+        cache.get_embedding = AsyncMock(return_value=[0.1] * 1024)
+        cache.check_semantic = AsyncMock(return_value=None)
+
+        embeddings = MagicMock()
+        # aembed_hybrid should NOT be called
+        embeddings.aembed_hybrid = AsyncMock(side_effect=Exception("should not be called"))
+
+        result = await cache_check_node(state, cache=cache, embeddings=embeddings)
+
+        assert result["embedding_error"] is False
+        assert result["cache_hit"] is False
+        embeddings.aembed_hybrid.assert_not_awaited()

--- a/tests/unit/graph/test_edges.py
+++ b/tests/unit/graph/test_edges.py
@@ -71,6 +71,12 @@ class TestRouteCache:
         state["cache_hit"] = False
         assert route_cache(state) == "retrieve"
 
+    def test_embedding_error_routes_to_respond(self):
+        state = make_initial_state(user_id=1, session_id="s", query="test")
+        state["embedding_error"] = True
+        state["cache_hit"] = False
+        assert route_cache(state) == "respond"
+
 
 class TestRouteGrade:
     def test_relevant_routes_to_rerank(self):

--- a/tests/unit/integrations/test_embeddings.py
+++ b/tests/unit/integrations/test_embeddings.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, patch
 
 import httpx
+import pytest
 from langchain_core.embeddings import Embeddings
 
-from telegram_bot.integrations.embeddings import BGEM3Embeddings, BGEM3SparseEmbeddings
+from telegram_bot.integrations.embeddings import (
+    BGEM3Embeddings,
+    BGEM3HybridEmbeddings,
+    BGEM3SparseEmbeddings,
+)
 
 
 class TestBGEM3Embeddings:
@@ -142,8 +147,6 @@ class TestBGEM3HybridEmbeddings:
             request=httpx.Request("POST", "http://fake:8000/encode/hybrid"),
         )
         with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response):
-            from telegram_bot.integrations.embeddings import BGEM3HybridEmbeddings
-
             emb = BGEM3HybridEmbeddings(base_url="http://fake:8000")
             dense, sparse = await emb.aembed_hybrid("test query")
         assert dense == [0.1, 0.2, 0.3]
@@ -162,8 +165,6 @@ class TestBGEM3HybridEmbeddings:
         with patch(
             "httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response
         ) as mock_post:
-            from telegram_bot.integrations.embeddings import BGEM3HybridEmbeddings
-
             emb = BGEM3HybridEmbeddings(base_url="http://fake:8000")
             await emb.aembed_hybrid("test")
             mock_post.assert_called_once()
@@ -182,8 +183,6 @@ class TestBGEM3HybridEmbeddings:
             request=httpx.Request("POST", "http://fake:8000/encode/hybrid"),
         )
         with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response):
-            from telegram_bot.integrations.embeddings import BGEM3HybridEmbeddings
-
             emb = BGEM3HybridEmbeddings(base_url="http://fake:8000")
             await emb.aembed_hybrid("test1")
             await emb.aembed_hybrid("test2")
@@ -202,8 +201,115 @@ class TestBGEM3HybridEmbeddings:
             request=httpx.Request("POST", "http://fake:8000/encode/hybrid"),
         )
         with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response):
-            from telegram_bot.integrations.embeddings import BGEM3HybridEmbeddings
-
             emb = BGEM3HybridEmbeddings(base_url="http://fake:8000")
             result = await emb.aembed_query("test")
         assert result == [0.1, 0.2]
+
+
+class TestBGEM3HybridRetry:
+    """Tests for retry behavior on transient errors."""
+
+    async def test_retries_on_remote_protocol_error(self):
+        """Retries on RemoteProtocolError and succeeds on second attempt."""
+        hybrid_ok = {
+            "dense_vecs": [[0.1, 0.2]],
+            "lexical_weights": [{"1": 0.5}],
+        }
+        ok_response = httpx.Response(
+            200,
+            json=hybrid_ok,
+            request=httpx.Request("POST", "http://fake:8000/encode/hybrid"),
+        )
+        call_count = 0
+
+        async def mock_post(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise httpx.RemoteProtocolError("Server disconnected without sending a response")
+            return ok_response
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            emb = BGEM3HybridEmbeddings(base_url="http://fake:8000")
+            dense, _sparse = await emb.aembed_hybrid("test")
+
+        assert dense == [0.1, 0.2]
+        assert call_count == 2  # 1 fail + 1 success
+
+    async def test_raises_after_max_retries(self):
+        """Raises original exception after all retries exhausted."""
+
+        async def always_fail(*args, **kwargs):
+            raise httpx.RemoteProtocolError("Server disconnected without sending a response")
+
+        with patch("httpx.AsyncClient.post", side_effect=always_fail):
+            emb = BGEM3HybridEmbeddings(base_url="http://fake:8000")
+            with pytest.raises(httpx.RemoteProtocolError):
+                await emb.aembed_hybrid("test")
+
+    async def test_no_retry_on_http_status_error(self):
+        """Does NOT retry on HTTP 500 (status error = not transient transport)."""
+        call_count = 0
+
+        async def mock_post(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            response = httpx.Response(
+                500,
+                request=httpx.Request("POST", "http://fake:8000/encode/hybrid"),
+            )
+            response.raise_for_status()
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            emb = BGEM3HybridEmbeddings(base_url="http://fake:8000")
+            with pytest.raises(httpx.HTTPStatusError):
+                await emb.aembed_hybrid("test")
+
+        assert call_count == 1  # No retries
+
+    async def test_retries_on_connect_timeout(self):
+        """Retries on ConnectTimeout."""
+        hybrid_ok = {
+            "dense_vecs": [[0.1]],
+            "lexical_weights": [{"1": 0.5}],
+        }
+        ok_response = httpx.Response(
+            200,
+            json=hybrid_ok,
+            request=httpx.Request("POST", "http://fake:8000/encode/hybrid"),
+        )
+        call_count = 0
+
+        async def mock_post(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise httpx.ConnectTimeout("Connection timed out")
+            return ok_response
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            emb = BGEM3HybridEmbeddings(base_url="http://fake:8000")
+            _dense, _sparse = await emb.aembed_hybrid("test")
+
+        assert call_count == 2
+
+
+class TestBGEM3HybridTimeout:
+    """Tests for granular timeout configuration."""
+
+    async def test_uses_granular_timeout(self):
+        """Client uses httpx.Timeout with separate connect/read values."""
+        emb = BGEM3HybridEmbeddings(base_url="http://fake:8000")
+        client = emb._get_client()
+        timeout = client.timeout
+        assert timeout.connect == 5.0
+        assert timeout.read == 30.0
+        assert timeout.write == 5.0
+        assert timeout.pool == 5.0
+
+    async def test_custom_timeout_override(self):
+        """Custom timeout parameter is respected (backward compat)."""
+        emb = BGEM3HybridEmbeddings(base_url="http://fake:8000", timeout=60.0)
+        client = emb._get_client()
+        # When float is passed, all components use that value
+        assert client.timeout.read == 60.0

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -930,6 +930,30 @@ class TestWriteLangfuseScores:
         assert calls["llm_ttft_ms"] == 450.0
         assert calls["llm_response_duration_ms"] == 2500.0
 
+    def test_writes_embedding_error_score(self):
+        """_write_langfuse_scores writes bge_embed_error when embedding failed."""
+        from telegram_bot.bot import _write_langfuse_scores
+
+        mock_lf = MagicMock()
+        result = {
+            "query_type": "FAQ",
+            "cache_hit": True,
+            "embedding_error": True,
+            "embedding_error_type": "RemoteProtocolError",
+            "latency_stages": {"cache_check": 5.123},
+            "pipeline_wall_ms": 5200.0,
+            "user_perceived_wall_ms": 5200.0,
+        }
+        _write_langfuse_scores(mock_lf, result)
+
+        calls = {
+            c.kwargs["name"]: c.kwargs.get("value")
+            for c in mock_lf.score_current_trace.call_args_list
+            if "name" in c.kwargs
+        }
+        assert calls["bge_embed_error"] == 1
+        assert "bge_embed_latency_ms" in calls
+
 
 class TestMakeSessionId:
     """Test make_session_id utility function."""


### PR DESCRIPTION
## Summary
- **Tenacity retry** with exponential backoff + jitter on `BGEM3HybridEmbeddings` (3 attempts, transient errors only: `RemoteProtocolError`, `ConnectError`, `ReadTimeout`, `ConnectTimeout`)
- **Granular httpx.Timeout** replacing flat 120s with `connect=5/read=30/write=5/pool=5`
- **Graceful fallback** in `cache_check_node`: embedding failures → user-friendly error message, explicit `embedding_error` state (no false `cache_hit` pollution)
- **Langfuse scores**: `bge_embed_error` (BOOLEAN) + `bge_embed_latency_ms` (NUMERIC)
- **Loki alert rules**: `BGEEmbedRetryFromBot` (warning) + `BGEEmbedErrorFromBot` (critical)

## Changed files

| File | Change |
|------|--------|
| `telegram_bot/integrations/embeddings.py` | tenacity retry + granular timeout |
| `telegram_bot/graph/state.py` | `embedding_error`, `embedding_error_type` fields |
| `telegram_bot/graph/nodes/cache.py` | try/except fallback on embedding failure |
| `telegram_bot/graph/edges.py` | `route_cache` checks `embedding_error` first |
| `telegram_bot/bot.py` | 2 new Langfuse scores |
| `docker/monitoring/rules/infrastructure.yaml` | 2 Loki alert rules |
| `tests/unit/integrations/test_embeddings.py` | 6 new tests (retry + timeout) |
| `tests/unit/graph/test_cache_nodes.py` | 3 new tests (embedding error fallback) |
| `tests/unit/graph/test_edges.py` | 1 new test (embedding_error route) |
| `tests/unit/test_bot_handlers.py` | 1 new test (score writing) |

## Test plan
- [x] 100 unit tests pass (all modified test files)
- [x] 11 graph path integration tests pass
- [x] Ruff lint + format clean
- [x] YAML syntax valid
- [x] No file overlap between tasks (parallel worker execution)

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)