### PR TITLE
feat(bot): user feedback collection — like/dislike buttons (#229)

### DIFF
--- a/.claude/rules/features/telegram-bot.md
+++ b/.claude/rules/features/telegram-bot.md
@@ -89,6 +89,7 @@ START → classify → [CHITCHAT/OFF_TOPIC] → respond → END
 | `/clear` | cmd_clear | Clear conversation history |
 | `/stats` | cmd_stats | Cache tier hit rates |
 | `/metrics` | cmd_metrics | Pipeline p50/p95 timing |
+| (callback) | handle_feedback | Like/dislike feedback (#229) |
 
 ## Configuration (BotConfig)
 

--- a/.claude/rules/observability.md
+++ b/.claude/rules/observability.md
@@ -129,7 +129,7 @@ Usage:
 | generate_node | query_preview, query_hash, context_docs_count, streaming_enabled | response_length, llm_provider_model, llm_ttft_ms, token_usage, duration_ms |
 | cache_check_node | query_preview, query_hash, query_type | cache_hit, embeddings_cache_hit, hit_layer, duration_ms |
 | cache_store_node | query_preview, query_hash, response_length | stored, stored_semantic, stored_conversation, duration_ms |
-| respond_node | response_length, response_sent, has_message | respond_skipped, respond_delivered, used_markdown, duration_ms |
+| respond_node | response_length, response_sent, has_message, has_trace_id | respond_skipped, respond_delivered, used_markdown, feedback_buttons, duration_ms |
 | transcribe_node | audio_size_bytes, voice_language, stt_model, voice_duration_s | stt_duration_ms, text_length, text_preview |
 
 Light nodes (classify, grade, rerank, rewrite) keep default auto-capture — their state is small.
@@ -239,8 +239,9 @@ OTEL_SERVICE_NAME: rag-bot  # Set in docker-compose.dev.yml bot service
 | `hyde_used` | 0.0 | Not yet tracked in LangGraph state |
 | `llm_ttft_ms` | float | Time to first token (ms), streaming only |
 | `llm_response_duration_ms` | float | Full LLM response wall-time (ms) |
+| `user_feedback` | 0.0/1.0 | User like/dislike via inline button (#229) |
 
-**Implementation:** `get_client().score_current_trace(name=..., value=...)` (Langfuse SDK v3)
+**Implementation:** `get_client().score_current_trace(name=..., value=...)` (Langfuse SDK v3), `user_feedback` via `create_score(trace_id=...)` in callback handler
 
 ## Langfuse Prompt Management
 

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -882,10 +882,9 @@ class PropertyBot:
         # Update keyboard to confirmation
         liked = value > 0
         try:
-            if callback.message is not None:
-                await callback.message.edit_reply_markup(
-                    reply_markup=build_feedback_confirmation(liked=liked)
-                )
+            msg = callback.message
+            if msg is not None and hasattr(msg, "edit_reply_markup"):
+                await msg.edit_reply_markup(reply_markup=build_feedback_confirmation(liked=liked))
         except Exception:
             logger.debug("Failed to update feedback keyboard", exc_info=True)
 

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from aiogram import Bot, Dispatcher, F
 from aiogram.filters import Command
-from aiogram.types import BotCommand, Message
+from aiogram.types import BotCommand, CallbackQuery, Message
 from aiogram.utils.chat_action import ChatActionSender
 
 from .config import BotConfig
@@ -381,6 +381,7 @@ class PropertyBot:
         self.dp.message(Command("history"))(self.cmd_history)
         self.dp.message(F.voice)(self.handle_voice)
         self.dp.message(F.text)(self.handle_query)
+        self.dp.callback_query(F.data.startswith("fb:"))(self.handle_feedback)
 
     async def cmd_start(self, message: Message):
         """Handle /start command."""
@@ -845,6 +846,50 @@ class PropertyBot:
                     )
                 except Exception:
                     logger.warning("Failed to save voice history turn", exc_info=True)
+
+    async def handle_feedback(self, callback: CallbackQuery):
+        """Handle feedback button callback (#229)."""
+        from .feedback import build_feedback_confirmation, parse_feedback_callback
+
+        data = callback.data or ""
+
+        # Acknowledge "done" button silently
+        if data == "fb:done":
+            await callback.answer()
+            return
+
+        parsed = parse_feedback_callback(data)
+        if parsed is None:
+            await callback.answer()
+            return
+
+        value, trace_id = parsed
+        user_id = callback.from_user.id if callback.from_user else 0
+
+        # Write score to Langfuse
+        try:
+            lf = get_client()
+            lf.create_score(
+                trace_id=trace_id,
+                name="user_feedback",
+                value=value,
+                data_type="NUMERIC",
+                comment=f"user_id:{user_id}",
+            )
+        except Exception:
+            logger.debug("Failed to write feedback score to Langfuse", exc_info=True)
+
+        # Update keyboard to confirmation
+        liked = value > 0
+        try:
+            if callback.message is not None:
+                await callback.message.edit_reply_markup(
+                    reply_markup=build_feedback_confirmation(liked=liked)
+                )
+        except Exception:
+            logger.debug("Failed to update feedback keyboard", exc_info=True)
+
+        await callback.answer("Спасибо за отзыв!")
 
     async def start(self):
         """Start bot polling."""

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -600,6 +600,10 @@ class PropertyBot:
         )
         state["max_rewrite_attempts"] = self._graph_config.max_rewrite_attempts
 
+        # Inject Langfuse trace_id for feedback buttons (#229)
+        lf_pre = get_client()
+        state["trace_id"] = lf_pre.get_current_trace_id() or ""
+
         with propagate_attributes(
             session_id=state["session_id"],
             user_id=str(state["user_id"]),
@@ -701,6 +705,10 @@ class PropertyBot:
         state["voice_duration_s"] = float(voice.duration)
         state["input_type"] = "voice"
         state["max_rewrite_attempts"] = self._graph_config.max_rewrite_attempts
+
+        # Inject Langfuse trace_id for feedback buttons (#229)
+        lf_pre = get_client()
+        state["trace_id"] = lf_pre.get_current_trace_id() or ""
 
         with propagate_attributes(
             session_id=state["session_id"],

--- a/telegram_bot/feedback.py
+++ b/telegram_bot/feedback.py
@@ -1,0 +1,63 @@
+"""User feedback utilities — inline keyboard builder and callback parser (#229)."""
+
+from __future__ import annotations
+
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+
+_FB_PREFIX = "fb:"
+
+
+def build_feedback_keyboard(trace_id: str) -> InlineKeyboardMarkup:
+    """Build inline keyboard with like/dislike buttons encoding trace_id."""
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text="\U0001f44d Полезно",
+                    callback_data=f"{_FB_PREFIX}1:{trace_id}",
+                ),
+                InlineKeyboardButton(
+                    text="\U0001f44e Не помогло",
+                    callback_data=f"{_FB_PREFIX}0:{trace_id}",
+                ),
+            ]
+        ]
+    )
+
+
+def build_feedback_confirmation(*, liked: bool) -> InlineKeyboardMarkup:
+    """Build single-button confirmation keyboard after feedback submitted."""
+    emoji = "\u2705" if liked else "\U0001f4dd"
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text=f"{emoji} Спасибо за отзыв!",
+                    callback_data="fb:done",
+                ),
+            ]
+        ]
+    )
+
+
+def parse_feedback_callback(data: str) -> tuple[float, str] | None:
+    """Parse callback_data from feedback button.
+
+    Returns (value, trace_id) or None if not a feedback callback.
+    Format: fb:{0|1}:{trace_id}
+    """
+    if not data.startswith(_FB_PREFIX):
+        return None
+
+    parts = data.split(":", 2)  # ["fb", "0|1", "trace_id"]
+    if len(parts) != 3:
+        return None
+
+    value_str, trace_id = parts[1], parts[2]
+    if value_str not in ("0", "1"):
+        return None
+    if not trace_id:
+        return None
+
+    return float(value_str), trace_id

--- a/telegram_bot/graph/nodes/generate.py
+++ b/telegram_bot/graph/nodes/generate.py
@@ -49,6 +49,16 @@ _HISTORY_INSTRUCTION = (
 )
 
 
+def _extract_sent_message_ref(sent_msg: Any) -> dict[str, int] | None:
+    """Build serializable Telegram message reference for checkpointer state."""
+    chat = getattr(sent_msg, "chat", None)
+    chat_id = getattr(chat, "id", None)
+    message_id = getattr(sent_msg, "message_id", None)
+    if isinstance(chat_id, int) and isinstance(message_id, int):
+        return {"chat_id": chat_id, "message_id": message_id}
+    return None
+
+
 def _get_config() -> Any:
     """Get GraphConfig from environment."""
     from telegram_bot.graph.config import GraphConfig
@@ -473,10 +483,14 @@ async def generate_node(state: RAGState, *, message: Any | None = None) -> dict[
     ratio = answer_words / max(question_words, 1)
     response_policy_mode = "enforced" if use_style else ("shadow" if shadow_mode else "disabled")
 
+    sent_message_ref = (
+        _extract_sent_message_ref(sent_msg) if response_sent and sent_msg is not None else None
+    )
+
     return {
         "response": answer,
         "response_sent": response_sent,
-        "sent_message": sent_msg if response_sent else None,
+        "sent_message": sent_message_ref,
         "llm_provider_model": actual_model,
         "llm_ttft_ms": ttft_ms,
         "llm_response_duration_ms": elapsed * 1000,

--- a/telegram_bot/graph/nodes/generate.py
+++ b/telegram_bot/graph/nodes/generate.py
@@ -152,7 +152,7 @@ async def _generate_streaming(
     llm_messages: list[dict[str, str]],
     message: Any,
     max_tokens: int = 0,
-) -> tuple[str, str, float, int | None]:
+) -> tuple[str, str, float, int | None, Any]:
     """Stream LLM response directly to Telegram via message editing.
 
     Sends a placeholder message, then edits it with accumulated text as chunks
@@ -166,7 +166,7 @@ async def _generate_streaming(
         message: aiogram Message object for Telegram delivery.
 
     Returns:
-        Tuple of (response_text, actual_model, ttft_ms, completion_tokens).
+        Tuple of (response_text, actual_model, ttft_ms, completion_tokens, sent_msg).
 
     Raises:
         Exception: On any streaming failure (caller handles fallback).
@@ -233,7 +233,7 @@ async def _generate_streaming(
         except Exception:
             logger.warning("Failed to finalize streaming message")
 
-    return accumulated, actual_model, ttft_ms, completion_tokens
+    return accumulated, actual_model, ttft_ms, completion_tokens, sent_msg
 
 
 def _extract_queue_ms_from_provider_headers(response_obj: Any | None) -> float | None:
@@ -322,6 +322,7 @@ async def generate_node(state: RAGState, *, message: Any | None = None) -> dict[
     completion_tokens: int | None = None
     stream_recovery = False
     hard_timeout = False
+    sent_msg: Any = None
 
     # Curated span metadata
     lf = get_client()
@@ -341,7 +342,13 @@ async def generate_node(state: RAGState, *, message: Any | None = None) -> dict[
         # Streaming path: deliver directly to Telegram
         if message is not None and config.streaming_enabled:
             try:
-                answer, actual_model, ttft_ms, completion_tokens = await _generate_streaming(
+                (
+                    answer,
+                    actual_model,
+                    ttft_ms,
+                    completion_tokens,
+                    sent_msg,
+                ) = await _generate_streaming(
                     llm,
                     config,
                     llm_messages,
@@ -356,6 +363,7 @@ async def generate_node(state: RAGState, *, message: Any | None = None) -> dict[
                     len(e.partial_text),
                     exc_info=True,
                 )
+                sent_msg = e.sent_msg
                 response_obj = await llm.chat.completions.create(
                     model=config.llm_model,
                     messages=llm_messages,
@@ -468,6 +476,7 @@ async def generate_node(state: RAGState, *, message: Any | None = None) -> dict[
     return {
         "response": answer,
         "response_sent": response_sent,
+        "sent_message": sent_msg if response_sent else None,
         "llm_provider_model": actual_model,
         "llm_ttft_ms": ttft_ms,
         "llm_response_duration_ms": elapsed * 1000,

--- a/telegram_bot/graph/nodes/respond.py
+++ b/telegram_bot/graph/nodes/respond.py
@@ -25,6 +25,18 @@ def _build_reply_markup(trace_id: str) -> Any:
     return build_feedback_keyboard(trace_id)
 
 
+def _extract_sent_message_ref(state: dict[str, Any]) -> tuple[int, int] | None:
+    """Read serialized streamed-message reference from state."""
+    sent_message = state.get("sent_message")
+    if not isinstance(sent_message, dict):
+        return None
+    chat_id = sent_message.get("chat_id")
+    message_id = sent_message.get("message_id")
+    if isinstance(chat_id, int) and isinstance(message_id, int):
+        return chat_id, message_id
+    return None
+
+
 @observe(name="node-respond", capture_input=False, capture_output=False)
 async def respond_node(state: dict[str, Any]) -> dict[str, Any]:
     """LangGraph node: send response to the user.
@@ -59,10 +71,16 @@ async def respond_node(state: dict[str, Any]) -> dict[str, Any]:
 
     # Streaming path: response already delivered, just attach feedback buttons
     if response_sent:
-        sent_msg = state.get("sent_message")
-        if sent_msg is not None and reply_markup is not None:
+        sent_ref = _extract_sent_message_ref(state)
+        bot = getattr(message, "bot", None)
+        if sent_ref is not None and reply_markup is not None and bot is not None:
+            chat_id, message_id = sent_ref
             try:
-                await sent_msg.edit_reply_markup(reply_markup=reply_markup)
+                await bot.edit_message_reply_markup(
+                    chat_id=chat_id,
+                    message_id=message_id,
+                    reply_markup=reply_markup,
+                )
             except Exception:
                 logger.debug("Failed to attach feedback buttons to streamed message")
 

--- a/telegram_bot/graph/nodes/respond.py
+++ b/telegram_bot/graph/nodes/respond.py
@@ -1,6 +1,7 @@
 """respond_node — sends the final response to the user via Telegram.
 
 Sends with Markdown parse_mode, falls back to plain text on parse error.
+Attaches feedback buttons when trace_id is available (#229).
 """
 
 from __future__ import annotations
@@ -15,12 +16,22 @@ from telegram_bot.observability import get_client, observe
 logger = logging.getLogger(__name__)
 
 
+def _build_reply_markup(trace_id: str) -> Any:
+    """Build feedback keyboard if trace_id is available, else None."""
+    if not trace_id:
+        return None
+    from telegram_bot.feedback import build_feedback_keyboard
+
+    return build_feedback_keyboard(trace_id)
+
+
 @observe(name="node-respond", capture_input=False, capture_output=False)
 async def respond_node(state: dict[str, Any]) -> dict[str, Any]:
     """LangGraph node: send response to the user.
 
     Reads state["response"] and state["message"] (aiogram Message object),
     sends with Markdown formatting and falls back to plain text on failure.
+    Attaches feedback inline keyboard when trace_id is present (#229).
 
     Returns partial state update with latency_stages["respond"].
     """
@@ -30,6 +41,7 @@ async def respond_node(state: dict[str, Any]) -> dict[str, Any]:
     message = state.get("message")
     response = state.get("response", "")
     response_sent = state.get("response_sent", False)
+    trace_id = state.get("trace_id", "")
 
     if not response:
         response = "Извините, не удалось сформировать ответ. Попробуйте переформулировать вопрос."
@@ -39,17 +51,28 @@ async def respond_node(state: dict[str, Any]) -> dict[str, Any]:
             "response_length": len(response),
             "response_sent": bool(response_sent),
             "has_message": message is not None,
+            "has_trace_id": bool(trace_id),
         }
     )
 
-    # Skip sending if streaming already delivered the response
+    reply_markup = _build_reply_markup(trace_id)
+
+    # Streaming path: response already delivered, just attach feedback buttons
     if response_sent:
+        sent_msg = state.get("sent_message")
+        if sent_msg is not None and reply_markup is not None:
+            try:
+                await sent_msg.edit_reply_markup(reply_markup=reply_markup)
+            except Exception:
+                logger.debug("Failed to attach feedback buttons to streamed message")
+
         elapsed = time.perf_counter() - t0
         lf.update_current_span(
             output={
                 "respond_skipped": True,
                 "respond_delivered": False,
                 "used_markdown": False,
+                "feedback_buttons": reply_markup is not None,
                 "duration_ms": round(elapsed * 1000, 1),
             }
         )
@@ -62,13 +85,13 @@ async def respond_node(state: dict[str, Any]) -> dict[str, Any]:
     used_markdown = False
     if message is not None:
         try:
-            await message.answer(response, parse_mode="Markdown")
+            await message.answer(response, parse_mode="Markdown", reply_markup=reply_markup)
             delivered = True
             used_markdown = True
         except Exception:
             logger.warning("Markdown parse failed, falling back to plain text")
             try:
-                await message.answer(response)
+                await message.answer(response, reply_markup=reply_markup)
                 delivered = True
             except Exception as e:
                 logger.exception("Failed to send response")
@@ -83,6 +106,7 @@ async def respond_node(state: dict[str, Any]) -> dict[str, Any]:
             "respond_skipped": False,
             "respond_delivered": delivered,
             "used_markdown": used_markdown,
+            "feedback_buttons": reply_markup is not None,
             "duration_ms": round(elapsed * 1000, 1),
         }
     )

--- a/telegram_bot/graph/state.py
+++ b/telegram_bot/graph/state.py
@@ -67,7 +67,7 @@ class RAGState(TypedDict):
     input_type: str  # "text" or "voice"
     # User feedback (#229)
     trace_id: str
-    sent_message: Any | None  # Streamed message ref for feedback buttons
+    sent_message: dict[str, int] | None  # {"chat_id": int, "message_id": int}
 
 
 def make_initial_state(user_id: int, session_id: str, query: str) -> dict[str, Any]:

--- a/telegram_bot/graph/state.py
+++ b/telegram_bot/graph/state.py
@@ -65,6 +65,9 @@ class RAGState(TypedDict):
     stt_text: str | None
     stt_duration_ms: float | None
     input_type: str  # "text" or "voice"
+    # User feedback (#229)
+    trace_id: str
+    sent_message: Any | None  # Streamed message ref for feedback buttons
 
 
 def make_initial_state(user_id: int, session_id: str, query: str) -> dict[str, Any]:
@@ -122,4 +125,7 @@ def make_initial_state(user_id: int, session_id: str, query: str) -> dict[str, A
         "stt_text": None,
         "stt_duration_ms": None,
         "input_type": "text",
+        # User feedback (#229)
+        "trace_id": "",
+        "sent_message": None,
     }

--- a/telegram_bot/observability.py
+++ b/telegram_bot/observability.py
@@ -74,6 +74,12 @@ class _NullLangfuseClient:
     def score_current_trace(self, **kwargs: Any) -> None:
         pass
 
+    def create_score(self, **kwargs: Any) -> None:
+        pass
+
+    def get_current_trace_id(self) -> str:
+        return ""
+
     def flush(self) -> None:
         pass
 

--- a/tests/unit/graph/test_generate_node.py
+++ b/tests/unit/graph/test_generate_node.py
@@ -468,6 +468,44 @@ class TestGenerateNodeStreaming:
         assert create_kwargs["stream"] is True
 
     @pytest.mark.asyncio
+    async def test_streaming_returns_serializable_sent_message_ref(self) -> None:
+        """Streaming path stores serializable message reference for checkpointer safety."""
+        from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+
+        from telegram_bot.graph.nodes.generate import generate_node
+
+        chunks = ["Ответ ", "готов."]
+        mock_client = _make_streaming_client(chunks)
+
+        mock_config = MagicMock()
+        mock_config.domain = "недвижимость"
+        mock_config.llm_model = "gpt-4o-mini"
+        mock_config.llm_temperature = 0.7
+        mock_config.generate_max_tokens = 2048
+        mock_config.streaming_enabled = True
+        mock_config.create_llm.return_value = mock_client
+
+        sent_msg = AsyncMock()
+        sent_msg.edit_text = AsyncMock()
+        sent_msg.message_id = 77
+        sent_msg.chat = MagicMock(id=12345)
+        message = AsyncMock()
+        message.answer = AsyncMock(return_value=sent_msg)
+
+        state = _make_state_with_docs()
+
+        with patch(
+            "telegram_bot.graph.nodes.generate._get_config",
+            return_value=mock_config,
+        ):
+            result = await generate_node(state, message=message)
+
+        assert result["response_sent"] is True
+        assert result["sent_message"] == {"chat_id": 12345, "message_id": 77}
+        # Regression guard: this value is persisted by checkpointer and must be msgpack-safe.
+        JsonPlusSerializer().dumps_typed(result["sent_message"])
+
+    @pytest.mark.asyncio
     async def test_streaming_fallback_on_stream_error(self) -> None:
         """When streaming fails, falls back to non-streaming LLM call."""
         from telegram_bot.graph.nodes.generate import generate_node

--- a/tests/unit/graph/test_respond_node.py
+++ b/tests/unit/graph/test_respond_node.py
@@ -17,7 +17,9 @@ class TestRespondNode:
 
         result = await respond_node(state)
 
-        message.answer.assert_awaited_once_with("**Bold** answer", parse_mode="Markdown")
+        message.answer.assert_awaited_once_with(
+            "**Bold** answer", parse_mode="Markdown", reply_markup=None
+        )
         assert "respond" in result["latency_stages"]
 
     async def test_fallback_to_plain_text(self):
@@ -32,7 +34,7 @@ class TestRespondNode:
 
         assert message.answer.await_count == 2
         # Second call should be plain text (no parse_mode)
-        message.answer.assert_awaited_with("bad *markdown")
+        message.answer.assert_awaited_with("bad *markdown", reply_markup=None)
         assert "respond" in result["latency_stages"]
 
     async def test_empty_response_gets_default(self):
@@ -105,3 +107,47 @@ class TestRespondNodeSavesAssistantMessage:
         msg = result["messages"][0]
         assert msg["role"] == "assistant"
         assert "Извините" in msg["content"]
+
+
+class TestRespondNodeFeedbackButtons:
+    async def test_sends_with_feedback_keyboard(self):
+        """respond_node attaches feedback buttons when trace_id present."""
+        message = AsyncMock()
+        state = make_initial_state(user_id=1, session_id="s", query="test")
+        state["response"] = "Answer text"
+        state["message"] = message
+        state["trace_id"] = "abc123def456"
+
+        await respond_node(state)
+
+        call_kwargs = message.answer.call_args
+        assert call_kwargs.kwargs.get("reply_markup") is not None
+
+    async def test_no_buttons_when_trace_id_empty(self):
+        """respond_node sends without buttons when trace_id is empty."""
+        message = AsyncMock()
+        state = make_initial_state(user_id=1, session_id="s", query="test")
+        state["response"] = "Answer text"
+        state["message"] = message
+        # trace_id is "" by default
+
+        await respond_node(state)
+
+        call_kwargs = message.answer.call_args
+        assert call_kwargs.kwargs.get("reply_markup") is None
+
+    async def test_streaming_adds_reply_markup_via_edit(self):
+        """When response_sent=True, respond_node edits markup on streamed message."""
+        message = AsyncMock()
+        sent_msg = AsyncMock()
+        state = make_initial_state(user_id=1, session_id="s", query="test")
+        state["response"] = "Streamed answer"
+        state["message"] = message
+        state["response_sent"] = True
+        state["trace_id"] = "trace123"
+        state["sent_message"] = sent_msg
+
+        await respond_node(state)
+
+        message.answer.assert_not_called()
+        sent_msg.edit_reply_markup.assert_awaited_once()

--- a/tests/unit/graph/test_respond_node.py
+++ b/tests/unit/graph/test_respond_node.py
@@ -139,15 +139,15 @@ class TestRespondNodeFeedbackButtons:
     async def test_streaming_adds_reply_markup_via_edit(self):
         """When response_sent=True, respond_node edits markup on streamed message."""
         message = AsyncMock()
-        sent_msg = AsyncMock()
+        message.bot = AsyncMock()
         state = make_initial_state(user_id=1, session_id="s", query="test")
         state["response"] = "Streamed answer"
         state["message"] = message
         state["response_sent"] = True
         state["trace_id"] = "trace123"
-        state["sent_message"] = sent_msg
+        state["sent_message"] = {"chat_id": 12345, "message_id": 77}
 
         await respond_node(state)
 
         message.answer.assert_not_called()
-        sent_msg.edit_reply_markup.assert_awaited_once()
+        message.bot.edit_message_reply_markup.assert_awaited_once()

--- a/tests/unit/graph/test_state.py
+++ b/tests/unit/graph/test_state.py
@@ -79,3 +79,17 @@ class TestRAGState:
 
         state = make_initial_state(user_id=1, session_id="s", query="test")
         assert state["grade_confidence"] == 0.0
+
+    def test_has_trace_id(self):
+        from telegram_bot.graph.state import make_initial_state
+
+        state = make_initial_state(user_id=123, session_id="s-test", query="hello")
+        assert "trace_id" in state
+        assert state["trace_id"] == ""
+
+    def test_has_sent_message(self):
+        from telegram_bot.graph.state import make_initial_state
+
+        state = make_initial_state(user_id=123, session_id="s-test", query="hello")
+        assert "sent_message" in state
+        assert state["sent_message"] is None

--- a/tests/unit/test_feedback.py
+++ b/tests/unit/test_feedback.py
@@ -1,0 +1,78 @@
+"""Tests for user feedback utilities (#229)."""
+
+
+class TestBuildFeedbackKeyboard:
+    def test_returns_inline_keyboard_markup(self):
+        from telegram_bot.feedback import build_feedback_keyboard
+
+        kb = build_feedback_keyboard("abc123def456")
+        assert len(kb.inline_keyboard) == 1
+        assert len(kb.inline_keyboard[0]) == 2
+
+    def test_button_callback_data_format(self):
+        from telegram_bot.feedback import build_feedback_keyboard
+
+        kb = build_feedback_keyboard("abc123def456")
+        like_btn, dislike_btn = kb.inline_keyboard[0]
+        assert like_btn.callback_data == "fb:1:abc123def456"
+        assert dislike_btn.callback_data == "fb:0:abc123def456"
+
+    def test_button_labels(self):
+        from telegram_bot.feedback import build_feedback_keyboard
+
+        kb = build_feedback_keyboard("abc123def456")
+        like_btn, dislike_btn = kb.inline_keyboard[0]
+        assert "Полезно" in like_btn.text
+        assert "Не помогло" in dislike_btn.text
+
+    def test_callback_data_within_64_bytes(self):
+        from telegram_bot.feedback import build_feedback_keyboard
+
+        trace_id = "a" * 32  # max W3C Trace Context
+        kb = build_feedback_keyboard(trace_id)
+        for btn in kb.inline_keyboard[0]:
+            assert len(btn.callback_data.encode()) <= 64
+
+
+class TestParseFeedbackCallback:
+    def test_parses_like(self):
+        from telegram_bot.feedback import parse_feedback_callback
+
+        assert parse_feedback_callback("fb:1:abc123def456") == (1.0, "abc123def456")
+
+    def test_parses_dislike(self):
+        from telegram_bot.feedback import parse_feedback_callback
+
+        assert parse_feedback_callback("fb:0:abc123def456") == (0.0, "abc123def456")
+
+    def test_invalid_prefix_returns_none(self):
+        from telegram_bot.feedback import parse_feedback_callback
+
+        assert parse_feedback_callback("other:data") is None
+
+    def test_invalid_value_returns_none(self):
+        from telegram_bot.feedback import parse_feedback_callback
+
+        assert parse_feedback_callback("fb:x:abc123") is None
+
+    def test_missing_trace_id_returns_none(self):
+        from telegram_bot.feedback import parse_feedback_callback
+
+        assert parse_feedback_callback("fb:1:") is None
+
+
+class TestBuildFeedbackConfirmation:
+    def test_like_confirmation(self):
+        from telegram_bot.feedback import build_feedback_confirmation
+
+        kb = build_feedback_confirmation(liked=True)
+        assert len(kb.inline_keyboard) == 1
+        btn = kb.inline_keyboard[0][0]
+        assert "Спасибо" in btn.text
+
+    def test_dislike_confirmation(self):
+        from telegram_bot.feedback import build_feedback_confirmation
+
+        kb = build_feedback_confirmation(liked=False)
+        btn = kb.inline_keyboard[0][0]
+        assert "Спасибо" in btn.text

--- a/tests/unit/test_feedback_handler.py
+++ b/tests/unit/test_feedback_handler.py
@@ -1,0 +1,20 @@
+"""Tests for feedback callback_query handler (#229)."""
+
+from __future__ import annotations
+
+from telegram_bot.feedback import parse_feedback_callback
+
+
+class TestParseFeedbackIntegration:
+    async def test_parses_like_callback(self):
+        parsed = parse_feedback_callback("fb:1:abc123def456789012345678901234")
+        assert parsed is not None
+        value, trace_id = parsed
+        assert value == 1.0
+        assert trace_id == "abc123def456789012345678901234"
+
+    async def test_invalid_callback_ignored(self):
+        assert parse_feedback_callback("not_feedback") is None
+
+    async def test_done_callback_returns_none(self):
+        assert parse_feedback_callback("fb:done") is None

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -78,3 +78,18 @@ class TestTracedPipeline:
 
         with traced_pipeline(session_id="s", user_id="u", tags=["a", "b"]):
             pass
+
+
+class TestNullLangfuseClient:
+    def test_create_score_is_noop(self):
+        from telegram_bot.observability import _NullLangfuseClient
+
+        client = _NullLangfuseClient()
+        client.create_score(trace_id="abc123", name="user_feedback", value=1.0, data_type="NUMERIC")
+
+    def test_get_current_trace_id_returns_empty(self):
+        from telegram_bot.observability import _NullLangfuseClient
+
+        client = _NullLangfuseClient()
+        result = client.get_current_trace_id()
+        assert result == ""


### PR DESCRIPTION
## Summary

- Add binary like/dislike feedback buttons (👍/👎) after every bot response
- Buttons encode Langfuse `trace_id` in callback_data for stateless feedback tracking
- Callback handler writes `user_feedback` score (0.0/1.0) to Langfuse via `create_score()`
- Buttons replaced with "Спасибо за отзыв!" confirmation after click
- Supports both streaming (edit_reply_markup) and non-streaming (reply_markup) paths

### Changes by file

| File | Change |
|------|--------|
| `telegram_bot/graph/state.py` | +`trace_id: str`, `sent_message: Any \| None` fields |
| `telegram_bot/feedback.py` | New: keyboard builder, callback parser, confirmation builder |
| `telegram_bot/graph/nodes/respond.py` | Attach feedback buttons when trace_id present |
| `telegram_bot/observability.py` | +`create_score()`, `get_current_trace_id()` stubs |
| `telegram_bot/bot.py` | Inject trace_id, register callback handler, `handle_feedback()` |
| `telegram_bot/graph/nodes/generate.py` | Pass `sent_message` from streaming for button attachment |
| `.claude/rules/observability.md` | Document `user_feedback` score |
| `.claude/rules/features/telegram-bot.md` | Document `handle_feedback` handler |

## Test plan

- [x] 44 unit tests pass (feedback, respond_node, state, observability, callback handler)
- [x] 11 integration tests pass (graph paths)
- [x] Ruff check + format clean
- [x] MyPy passes on all modified files
- [ ] Manual: send message to bot, verify buttons appear, click like/dislike

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)