### PR TITLE
chore(docker): audit & cleanup unused dependencies and services

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,6 +228,9 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 "test_*.py" = ["E402", "T201", "SIM117"]  # Allow late imports, print(), nested with in tests
 "tests/**/*.py" = ["E402", "T201", "SIM117"]  # Same for tests/ directory
 "legacy/*.py" = ["ASYNC210"]      # Allow blocking HTTP calls in async functions (legacy code)
+"src/ingestion/docling_client.py" = ["ASYNC240"]  # Legacy ingestion (replaced by unified pipeline)
+"src/ingestion/gdrive_flow.py" = ["ASYNC240"]     # Legacy ingestion (replaced by unified pipeline)
+"src/ingestion/service.py" = ["ASYNC240"]          # Legacy ingestion (replaced by unified pipeline)
 "*.py" = ["ARG001"]               # Allow unused function arguments (common in callbacks)
 
 # Import sorting configuration (isort replacement)


### PR DESCRIPTION
## Summary

- Remove dead packages from bot deps (fastembed, langchain-text-splitters)
- Remove BM42 service directory and LightRAG from docker-compose
- Remove duplicate root Dockerfile
- Split eval (mlflow, ragas, datasets, pandas) and ingest (pymupdf, docling, cocoindex, fastembed) into optional dependency groups
- Update Dockerfile.ingestion to use `--extra ingest` with `--locked`
- Add `eval` profile to MLflow service
- Create follow-up issue #249 for model-stack optionalization (torch/sentence-transformers)

## Test plan

- [x] `uv lock --check` passes
- [x] `docker compose config --quiet` validates
- [x] `uv sync --extra eval` resolves + imports OK
- [x] `uv sync --extra ingest` resolves
- [x] Docker bot image builds successfully
- [x] Unit tests: 2290 passed (54 pre-existing failures unrelated to this PR)

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)