### PR TITLE
fix(bot): make /history fail-soft for backend and malformed data

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -564,19 +564,39 @@ class PropertyBot:
             return
 
         query = parts[1]
-        results = await self._history_service.search_user_history(
-            user_id=message.from_user.id,
-            query=query,
-            limit=5,
-        )
+        try:
+            results = await self._history_service.search_user_history(
+                user_id=message.from_user.id,
+                query=query,
+                limit=5,
+            )
+        except Exception:
+            logger.exception("History search failed for user %s", message.from_user.id)
+            await message.answer("Произошла ошибка при поиске в истории. Попробуйте позже.")
+            return
 
         if not results:
             await message.answer(f"По запросу «{query}» ничего не найдено в истории.")
             return
 
-        lines = [f"📋 Найдено {len(results)} записей:\n"]
-        for i, r in enumerate(results, 1):
-            ts = r.get("timestamp", "")[:16].replace("T", " ")
+        valid = []
+        for r in results:
+            if not isinstance(r, dict):
+                continue
+            q = r.get("query")
+            resp = r.get("response")
+            if not isinstance(q, str) or not isinstance(resp, str):
+                continue
+            valid.append(r)
+
+        if not valid:
+            await message.answer(f"По запросу «{query}» ничего не найдено в истории.")
+            return
+
+        lines = [f"📋 Найдено {len(valid)} записей:\n"]
+        for i, r in enumerate(valid, 1):
+            ts = r.get("timestamp", "")
+            ts = ts[:16].replace("T", " ") if isinstance(ts, str) else ""
             lines.append(f"{i}. [{ts}]")
             lines.append(f"   В: {r['query']}")
             resp_preview = r["response"][:150]

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -544,6 +544,64 @@ class TestCmdHistory:
         bot, _ = _create_bot(mock_config)
         assert hasattr(bot, "cmd_history")
 
+    async def test_history_backend_exception_returns_safe_message(self, mock_config):
+        """Backend exception is caught and user gets a safe error message."""
+        bot, _ = _create_bot(mock_config)
+        bot._history_service = AsyncMock()
+        bot._history_service.search_user_history = AsyncMock(
+            side_effect=RuntimeError("connection lost")
+        )
+        message = _make_text_message("/history цены")
+
+        await bot.cmd_history(message)
+
+        message.answer.assert_called_once()
+        answer_text = message.answer.call_args[0][0]
+        assert "ошибка" in answer_text.lower()
+
+    async def test_history_malformed_payload_skips_bad_records(self, mock_config):
+        """Malformed results (None, str, dict without keys) are skipped; valid ones shown."""
+        bot, _ = _create_bot(mock_config)
+        bot._history_service = AsyncMock()
+        bot._history_service.search_user_history = AsyncMock(
+            return_value=[
+                None,
+                "not a dict",
+                {"query": 123, "response": "text"},
+                {"other_key": "value"},
+                {
+                    "query": "валидный вопрос",
+                    "response": "валидный ответ",
+                    "timestamp": "2026-02-13T10:00:00",
+                },
+            ]
+        )
+        message = _make_text_message("/history тест")
+
+        await bot.cmd_history(message)
+
+        message.answer.assert_called_once()
+        answer_text = message.answer.call_args[0][0]
+        assert "валидный вопрос" in answer_text
+        assert "валидный ответ" in answer_text
+        assert "1 записей" in answer_text
+        assert "1. [" in answer_text
+
+    async def test_history_all_malformed_returns_not_found(self, mock_config):
+        """When all results are malformed, user sees 'not found' fallback."""
+        bot, _ = _create_bot(mock_config)
+        bot._history_service = AsyncMock()
+        bot._history_service.search_user_history = AsyncMock(
+            return_value=[None, "bad", {"no_query": True}]
+        )
+        message = _make_text_message("/history тест")
+
+        await bot.cmd_history(message)
+
+        message.answer.assert_called_once()
+        answer_text = message.answer.call_args[0][0]
+        assert "не найден" in answer_text.lower() or "нет" in answer_text.lower()
+
 
 class TestCheckpointNamespace:
     """Test checkpoint namespace separation for text/voice."""


### PR DESCRIPTION
## Summary
- Wrap `search_user_history` call in `try/except` with `logger.exception` and safe user message
- Filter malformed result records (non-dict, missing/non-string `query`/`response`) before formatting
- Correct numbering and count based on valid records only

Closes #293

## Test plan
- [x] `test_history_backend_exception_returns_safe_message` — exception branch
- [x] `test_history_malformed_payload_skips_bad_records` — mixed valid/invalid records
- [x] `test_history_all_malformed_returns_not_found` — all-invalid fallback
- [x] `make check` green (ruff + mypy)
- [x] `pytest -k history -n auto` — 15/15 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)