### PR TITLE
fix(ci): install all extras in test jobs to resolve missing deps

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -105,6 +105,17 @@ strategy:
 # Each shard: --splits 4 --group ${{ matrix.group }} -n auto --dist loadscope
 ```
 
+### CI Dependency Profile
+
+Unit/integration/baseline CI jobs must install optional runtime dependencies used by imports in the test graph:
+
+```bash
+uv sync --frozen --extra voice --extra ingest --extra eval
+```
+
+Do not use `--all-extras` for this profile unless docs tooling is required.
+If new imports are added to the suite, update the preflight module list in `.github/workflows/ci.yml`.
+
 ### Updating `.test_durations`
 
 Regenerate after adding/removing tests or significant refactors:

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -84,19 +84,6 @@ uv run pytest tests/unit/test_validate_queries.py tests/unit/test_validate_aggre
 | `test_validate_queries.py` | 10 | Query sets, collection mapping, warmup/cache selection |
 | `test_validate_aggregates.py` | 8 | p50/p95, phase split, score_rate, node latencies |
 
-## CI Dependency Profile
-
-CI installs **all extras** (`uv sync --frozen --all-extras`) because unit tests import source modules that depend on optional packages:
-
-| Extra | Packages needed by tests | Source modules |
-|-------|--------------------------|----------------|
-| `voice` | fastapi, uvicorn, httpx | `src/api/main` |
-| `ingest` | pymupdf, fastembed, docling | `src/ingestion/*` |
-| `eval` | mlflow, ragas, datasets | `telegram_bot/evaluation/*` |
-| (base) | pydantic-settings, cachetools | `telegram_bot/config`, `telegram_bot/middlewares/*` |
-
-A **preflight import check** step runs before pytest to catch missing deps early.
-
 ## CI Pipeline: Sharded Unit Tests (pytest-split)
 
 CI splits unit tests into **4 parallel shards** using `pytest-split` for ~4x faster feedback.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -84,6 +84,19 @@ uv run pytest tests/unit/test_validate_queries.py tests/unit/test_validate_aggre
 | `test_validate_queries.py` | 10 | Query sets, collection mapping, warmup/cache selection |
 | `test_validate_aggregates.py` | 8 | p50/p95, phase split, score_rate, node latencies |
 
+## CI Dependency Profile
+
+CI installs **all extras** (`uv sync --frozen --all-extras`) because unit tests import source modules that depend on optional packages:
+
+| Extra | Packages needed by tests | Source modules |
+|-------|--------------------------|----------------|
+| `voice` | fastapi, uvicorn, httpx | `src/api/main` |
+| `ingest` | pymupdf, fastembed, docling | `src/ingestion/*` |
+| `eval` | mlflow, ragas, datasets | `telegram_bot/evaluation/*` |
+| (base) | pydantic-settings, cachetools | `telegram_bot/config`, `telegram_bot/middlewares/*` |
+
+A **preflight import check** step runs before pytest to catch missing deps early.
+
 ## CI Pipeline: Sharded Unit Tests (pytest-split)
 
 CI splits unit tests into **4 parallel shards** using `pytest-split` for ~4x faster feedback.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,39 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --frozen
+        run: uv sync --frozen --extra voice --extra ingest --extra eval
+
+      - name: Preflight imports (unit profile)
+        run: |
+          uv run python - <<'PY'
+          import importlib
+          import sys
+
+          required_modules = [
+              "fastapi",
+              "pydantic_settings",
+              "pymupdf",
+              "mlflow",
+              "ragas",
+              "fastembed",
+              "cachetools",
+          ]
+
+          failed = []
+          for module_name in required_modules:
+              try:
+                  importlib.import_module(module_name)
+              except Exception as exc:
+                  failed.append((module_name, exc))
+
+          if failed:
+              print("CI dependency preflight failed:")
+              for module_name, exc in failed:
+                  print(f" - {module_name}: {exc!r}")
+              sys.exit(1)
+
+          print("CI dependency preflight passed.")
+          PY
 
       - name: Cache test durations
         uses: actions/cache@v4
@@ -116,7 +148,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --frozen
+        run: uv sync --frozen --extra voice --extra ingest --extra eval
 
       - name: Run integration tests
         run: uv run pytest tests/integration/test_graph_paths.py -v --timeout=30
@@ -147,7 +179,7 @@ jobs:
 
       - name: Install dependencies
         if: env.LANGFUSE_AVAILABLE == 'true'
-        run: uv sync --frozen
+        run: uv sync --frozen --extra voice --extra ingest --extra eval
 
       - name: Run baseline comparison
         if: env.LANGFUSE_AVAILABLE == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,31 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
-      - name: Install dependencies
-        run: uv sync --frozen
+      - name: Install dependencies (all extras for full test coverage)
+        run: uv sync --frozen --all-extras
+
+      - name: Preflight import check
+        run: |
+          uv run python -c "
+          import importlib, sys
+          modules = [
+              'pydantic_settings', 'cachetools',
+              'fastapi', 'pymupdf', 'fastembed',
+              'mlflow', 'ragas',
+          ]
+          failed = []
+          for m in modules:
+              try:
+                  importlib.import_module(m)
+              except ImportError as e:
+                  failed.append(f'{m}: {e}')
+          if failed:
+              print('Missing CI dependencies:', file=sys.stderr)
+              for f in failed:
+                  print(f'  - {f}', file=sys.stderr)
+              sys.exit(1)
+          print(f'All {len(modules)} preflight imports OK')
+          "
 
       - name: Cache test durations
         uses: actions/cache@v4
@@ -115,8 +138,8 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
-      - name: Install dependencies
-        run: uv sync --frozen
+      - name: Install dependencies (all extras for full test coverage)
+        run: uv sync --frozen --all-extras
 
       - name: Run integration tests
         run: uv run pytest tests/integration/test_graph_paths.py -v --timeout=30
@@ -145,9 +168,9 @@ jobs:
         if: env.LANGFUSE_AVAILABLE == 'true'
         run: uv python install 3.12
 
-      - name: Install dependencies
+      - name: Install dependencies (all extras)
         if: env.LANGFUSE_AVAILABLE == 'true'
-        run: uv sync --frozen
+        run: uv sync --frozen --all-extras
 
       - name: Run baseline comparison
         if: env.LANGFUSE_AVAILABLE == 'true'

--- a/tests/unit/test_small_to_big.py
+++ b/tests/unit/test_small_to_big.py
@@ -271,13 +271,16 @@ class TestSmallToBigSettings:
         with patch.dict(
             "os.environ",
             {
+                # Isolate from runner secrets/default provider selection
+                "API_PROVIDER": "groq",
+                "GROQ_API_KEY": "test-groq-key",
                 "SMALL_TO_BIG_MODE": "on",
                 "SMALL_TO_BIG_WINDOW_BEFORE": "2",
                 "SMALL_TO_BIG_WINDOW_AFTER": "3",
                 "MAX_EXPANDED_CHUNKS": "15",
                 "MAX_CONTEXT_TOKENS": "10000",
             },
-            clear=False,
+            clear=True,
         ):
             # Import after patching env
             from src.config.settings import Settings
@@ -295,8 +298,12 @@ class TestSmallToBigSettings:
         """Test default values for small-to-big settings."""
         with patch.dict(
             "os.environ",
-            {},
-            clear=False,
+            {
+                # Ensure Settings() is valid regardless of host environment
+                "API_PROVIDER": "groq",
+                "GROQ_API_KEY": "test-groq-key",
+            },
+            clear=True,
         ):
             from src.config.settings import Settings
 
@@ -310,16 +317,24 @@ class TestSmallToBigSettings:
 
     def test_settings_to_dict_includes_small_to_big(self):
         """Test that to_dict includes small-to-big settings."""
-        from src.config.settings import Settings
+        with patch.dict(
+            "os.environ",
+            {
+                "API_PROVIDER": "groq",
+                "GROQ_API_KEY": "test-groq-key",
+            },
+            clear=True,
+        ):
+            from src.config.settings import Settings
 
-        settings = Settings()
-        settings_dict = settings.to_dict()
+            settings = Settings()
+            settings_dict = settings.to_dict()
 
-        assert "small_to_big_mode" in settings_dict
-        assert "small_to_big_window_before" in settings_dict
-        assert "small_to_big_window_after" in settings_dict
-        assert "max_expanded_chunks" in settings_dict
-        assert "max_context_tokens" in settings_dict
+            assert "small_to_big_mode" in settings_dict
+            assert "small_to_big_window_before" in settings_dict
+            assert "small_to_big_window_after" in settings_dict
+            assert "max_expanded_chunks" in settings_dict
+            assert "max_context_tokens" in settings_dict
 
 
 class TestIndexerMetadataFields:


### PR DESCRIPTION
## Summary
- Switch `uv sync --frozen` to `uv sync --frozen --all-extras` in test, integration, and baseline CI jobs
- Add preflight import check step (7 modules) before pytest for early failure on missing deps
- Document CI dependency profile in `.claude/rules/testing.md`

Fixes unit shard failures on main caused by missing optional deps (fastapi, pydantic_settings, pymupdf, mlflow, ragas, fastembed).

## Test plan
- [x] YAML syntax validated (`yaml.safe_load`)
- [x] `make check` green (ruff + mypy)
- [x] Lint job unchanged (no extras needed for ruff/mypy)
- [ ] CI green after merge (verifies the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)