### PR TITLE
fix(ci): install required test extras and add import preflight

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -105,6 +105,17 @@ strategy:
 # Each shard: --splits 4 --group ${{ matrix.group }} -n auto --dist loadscope
 ```
 
+### CI Dependency Profile
+
+Unit/integration/baseline CI jobs must install optional runtime dependencies used by imports in the test graph:
+
+```bash
+uv sync --frozen --extra voice --extra ingest --extra eval
+```
+
+Do not use `--all-extras` for this profile unless docs tooling is required.
+If new imports are added to the suite, update the preflight module list in `.github/workflows/ci.yml`.
+
 ### Updating `.test_durations`
 
 Regenerate after adding/removing tests or significant refactors:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,39 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --frozen
+        run: uv sync --frozen --extra voice --extra ingest --extra eval
+
+      - name: Preflight imports (unit profile)
+        run: |
+          uv run python - <<'PY'
+          import importlib
+          import sys
+
+          required_modules = [
+              "fastapi",
+              "pydantic_settings",
+              "pymupdf",
+              "mlflow",
+              "ragas",
+              "fastembed",
+              "cachetools",
+          ]
+
+          failed = []
+          for module_name in required_modules:
+              try:
+                  importlib.import_module(module_name)
+              except Exception as exc:
+                  failed.append((module_name, exc))
+
+          if failed:
+              print("CI dependency preflight failed:")
+              for module_name, exc in failed:
+                  print(f" - {module_name}: {exc!r}")
+              sys.exit(1)
+
+          print("CI dependency preflight passed.")
+          PY
 
       - name: Cache test durations
         uses: actions/cache@v4
@@ -116,7 +148,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --frozen
+        run: uv sync --frozen --extra voice --extra ingest --extra eval
 
       - name: Run integration tests
         run: uv run pytest tests/integration/test_graph_paths.py -v --timeout=30
@@ -147,7 +179,7 @@ jobs:
 
       - name: Install dependencies
         if: env.LANGFUSE_AVAILABLE == 'true'
-        run: uv sync --frozen
+        run: uv sync --frozen --extra voice --extra ingest --extra eval
 
       - name: Run baseline comparison
         if: env.LANGFUSE_AVAILABLE == 'true'


### PR DESCRIPTION
## Summary
- install CI dependencies for test-bearing jobs with explicit extras: `voice`, `ingest`, `eval`
- keep `lint` job on `uv sync --frozen` (no extras)
- add preflight import check in unit-test job for optional modules required by test import graph
- document CI dependency profile in `.claude/rules/testing.md`

## Why
Unit test shards were failing on missing optional modules (`fastapi`, `pydantic_settings`, `pymupdf`, `mlflow`, `ragas`, `fastembed`, `cachetools`).

## Validation
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
- `uv run pytest tests/unit/test_bot_handlers.py -k history -n auto --dist=worksteal -q`
- `uv run python` preflight import check for 7 modules
