### PR TITLE
fix(ci): eliminate cache save race between test shards

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,54 @@
+---
+paths: ".github/**,renovate.json"
+---
+
+# Git & PR Workflow
+
+## PR Discipline
+
+| Rule | Standard |
+|------|----------|
+| **Size** | < 400 lines changed (ideal: < 200). Split larger work into stacked PRs |
+| **Scope** | One issue per PR. Title: `type(scope): description` matching commit convention |
+| **Linking** | Always include `Closes #N` or `Related #N` in PR body |
+| **Branch naming** | `feat/`, `fix/`, `chore/`, `docs/` prefix matching commit type |
+| **Rebase policy** | Rebase on `main` before push. Use `--force-with-lease` (never `--force`) |
+| **Stale branches** | Delete after merge. `make git-hygiene` for audit |
+
+## Merge Discipline
+
+- PRs merge only with green CI (lint + unit shards + integration)
+- Rebase-merge preferred (clean linear history)
+- No self-merge for non-trivial changes without review or CI pass
+- Renovate PRs: batch during stable CI windows (see below)
+
+## Renovate PR Handling
+
+Current config: `renovate.json` | Schedule: Monday before 9:00 Kyiv
+
+| Update Type | Strategy | Auto-merge |
+|-------------|----------|------------|
+| **Patch** (all) | Individual PR | Yes |
+| **Minor** (databases, core libs, pre-commit) | Grouped PR | Yes |
+| **Minor** (ML, RAG stack, bot) | Grouped PR | No — review changelogs |
+| **Major** (all) | Individual PR | No — manual review required |
+| **Lock maintenance** | Weekly Monday 5am | Yes |
+
+**Batching strategy:**
+- `platformAutomerge: true` — GitHub merges automatically after CI passes
+- `prHourlyLimit: 5` — prevents PR flood
+- Groups: databases, ml-platform, ai-services, monitoring, python-core-libs, python-ml-libs, python-rag-stack, python-bot, python-dev-tools, github-actions
+- Review with `/deps` skill for audit workflow
+
+**When CI is red:** Do not merge Renovate PRs. Fix CI first, then let automerge catch up.
+
+## Branch Cleanup
+
+```bash
+make git-hygiene          # Audit report: stale branches, orphan worktrees
+make git-hygiene-fix      # Auto-cleanup merged branches
+```
+
+- Merged branches: delete immediately after merge
+- Stale feature branches (> 30 days, no activity): close PR with comment, delete branch
+- Worktrees: clean up after feature completion

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -15,6 +15,17 @@ paths: ".github/**,renovate.json"
 | **Rebase policy** | Rebase on `main` before push. Use `--force-with-lease` (never `--force`) |
 | **Stale branches** | Delete after merge. `make git-hygiene` for audit |
 
+## Bug Handling During PR Review
+
+| Found during review | Action |
+|---------------------|--------|
+| Bug **in PR code** (new/changed lines) | PR review comment → author fixes in same PR |
+| **Pre-existing** bug (existed before PR) | New issue with `Found during #PR` in description |
+| **CI flake** (unrelated to PR) | New issue with label `flaky-test` |
+| **Conflict** with another PR | PR comment, coordinate merge order |
+
+**Rule:** PR fixes only what's in scope. Everything else → separate issue. Don't bloat PRs with unrelated fixes.
+
 ## Merge Discipline
 
 - PRs merge only with green CI (lint + unit shards + integration)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,8 @@ jobs:
           print("CI dependency preflight passed.")
           PY
 
-      - name: Cache test durations
-        uses: actions/cache@v4
+      - name: Restore test durations
+        uses: actions/cache/restore@v4
         with:
           path: .test_durations
           key: test-durations-${{ github.sha }}
@@ -113,8 +113,8 @@ jobs:
             --durations=20 --durations-min=1.0 \
             -q
 
-      - name: Store durations (main only)
-        if: github.ref == 'refs/heads/main'
+      - name: Store durations (main only, shard 1)
+        if: github.ref == 'refs/heads/main' && matrix.group == 1
         run: |
           uv run pytest tests/unit/ \
             --store-durations \
@@ -122,8 +122,8 @@ jobs:
             -m "not legacy_api" \
             -q || true
 
-      - name: Upload durations
-        if: always() && github.ref == 'refs/heads/main'
+      - name: Upload durations (main only, shard 1)
+        if: always() && github.ref == 'refs/heads/main' && matrix.group == 1
         uses: actions/cache/save@v4
         with:
           path: .test_durations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ Voice Bot:  /call → LiveKit Agent (ElevenLabs STT/TTS) → @function_tool → 
 - **Config:** `renovate.json` | Schedule: Monday before 9:00 Kyiv
 - **Skill:** `/deps` — review and merge updates
 - **Lock maintenance:** `uv.lock` refreshed weekly via Renovate
+- **PR workflow:** `.claude/rules/git-workflow.md` — PR size limits, merge discipline, Renovate batching
 
 ## Task Management
 
@@ -198,4 +199,5 @@ See `.claude/rules/` for domain-specific documentation:
 | `k3s.md` | k3s manifests, deployment, VPS | `k8s/**` |
 | `testing.md` | Unit tests, chaos tests, E2E | `tests/**` |
 | `skills.md` | Superpowers workflow | `docs/plans/**` |
+| `git-workflow.md` | PR discipline, merge rules, Renovate strategy | `.github/**, renovate.json` |
 | `shared-tasks.md` | Shared task list between terminals | — |


### PR DESCRIPTION
## Summary
- Fix intermittent "Cache save failed" warnings in CI unit test shards
- Root cause: all 4 shards competed to write the same immutable cache key `test-durations-{sha}`
- `actions/cache@v4` → `actions/cache/restore@v4` (restore-only, no implicit save)
- Store + Upload durations restricted to shard 1 only (single writer)

Closes #300

## Test plan
- [ ] CI runs without "Cache save failed" annotations
- [ ] All 4 shards still restore durations correctly
- [ ] Shard 1 stores and uploads durations on main branch pushes
- [ ] Criterion: 3 consecutive clean runs on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)