### PR TITLE
fix(voice): resolve mypy LiveKitAPI attr-defined under all-extras

### DIFF
--- a/src/voice/sip_setup.py
+++ b/src/voice/sip_setup.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+from typing import Any, cast
 
 from livekit import api
 from livekit.protocol.sip import CreateSIPOutboundTrunkRequest, SIPOutboundTrunkInfo
@@ -9,7 +10,7 @@ from livekit.protocol.sip import CreateSIPOutboundTrunkRequest, SIPOutboundTrunk
 
 async def setup_lifecell_trunk() -> str:
     """Create lifecell outbound SIP trunk. Returns trunk ID."""
-    lk = api.LiveKitAPI(
+    lk = cast(Any, api).LiveKitAPI(
         url=os.getenv("LIVEKIT_URL", "http://localhost:7880"),
         api_key=os.getenv("LIVEKIT_API_KEY", "devkey"),
         api_secret=os.getenv("LIVEKIT_API_SECRET", "secret"),


### PR DESCRIPTION
## Summary
Fixes issue #298 by removing mypy `attr-defined` failure in `src/voice/sip_setup.py` when optional extras are installed.

- keeps runtime behavior unchanged
- keeps existing test patching path (`src.voice.sip_setup.api.LiveKitAPI`) intact
- makes type-check robust with `--all-extras` profile

## Change
- `src/voice/sip_setup.py`
  - add `from typing import Any, cast`
  - use `cast(Any, api).LiveKitAPI(...)`

## Verification
- `uv sync --frozen && make check`
- `uv sync --frozen --all-extras && make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`

## Notes
During validation, observed one intermittent xdist failure in ingestion unit tests; tracked separately in issue #303.

Closes #298
