### PR TITLE
test: stabilize local full-suite execution and retriever filter typing

### DIFF
--- a/src/ingestion/service.py
+++ b/src/ingestion/service.py
@@ -242,10 +242,24 @@ class IngestionService:
                     "error": "Collection not found",
                     "points_count": 0,
                 }
-            return {"error": str(e)}
+            return {
+                "name": self.collection_name,
+                "error": str(e),
+                "points_count": 0,
+            }
         except Exception as e:
+            if "not found" in str(e).lower() or getattr(e, "status_code", None) == 404:
+                return {
+                    "name": self.collection_name,
+                    "error": "Collection not found",
+                    "points_count": 0,
+                }
             logger.error(f"Error getting collection stats: {e}")
-            return {"error": str(e)}
+            return {
+                "name": self.collection_name,
+                "error": str(e),
+                "points_count": 0,
+            }
 
     async def close(self) -> None:
         """Close service connections."""

--- a/telegram_bot/services/retriever.py
+++ b/telegram_bot/services/retriever.py
@@ -1,9 +1,13 @@
 """Qdrant retrieval service."""
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from qdrant_client import QdrantClient, models
+from qdrant_client import QdrantClient
+
+
+if TYPE_CHECKING:
+    from qdrant_client.http.models.models import Filter as QdrantFilter
 
 
 logger = logging.getLogger(__name__)
@@ -105,7 +109,7 @@ class RetrieverService:
             self._is_healthy = False
             return []
 
-    def _build_base_filter(self) -> models.Filter | None:
+    def _build_base_filter(self) -> "QdrantFilter | None":
         """
         Build base Qdrant Filter.
 
@@ -118,7 +122,7 @@ class RetrieverService:
         # No base filter - search all documents in collection
         return None
 
-    def _build_filter(self, filters: dict[str, Any]) -> models.Filter | None:
+    def _build_filter(self, filters: dict[str, Any]) -> "QdrantFilter | None":
         """
         Build Qdrant Filter from extracted filters dict.
 
@@ -131,6 +135,9 @@ class RetrieverService:
         """
         if not filters:
             return None
+
+        # Import lazily so returned models stay consistent with current qdrant_client module state.
+        from qdrant_client import models
 
         conditions = []
 

--- a/tests/chaos/test_redis_failures.py
+++ b/tests/chaos/test_redis_failures.py
@@ -6,6 +6,14 @@ Tests verify graceful degradation when Redis is unavailable.
 import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+
+pytest.importorskip(
+    "telegram_bot.services.cache",
+    reason="telegram_bot.services.cache module removed in current architecture",
+)
+
 
 class TestRedisDisconnect:
     """Tests for Redis disconnection handling."""

--- a/tests/integration/test_infrastructure.py
+++ b/tests/integration/test_infrastructure.py
@@ -31,6 +31,8 @@ class TestQdrantInfrastructure:
     @pytest.fixture
     def qdrant_client(self):
         """Create Qdrant client."""
+        if not _check_tcp("localhost", 6333):
+            pytest.skip("Qdrant not running on localhost:6333")
         url = os.getenv("QDRANT_URL", "http://localhost:6333")
         api_key = os.getenv("QDRANT_API_KEY", "")
         if api_key:

--- a/tests/integration/test_qdrant_history.py
+++ b/tests/integration/test_qdrant_history.py
@@ -4,6 +4,7 @@ Requires a running Qdrant instance (make docker-up).
 """
 
 import contextlib
+import socket
 import uuid
 from unittest.mock import AsyncMock
 
@@ -21,9 +22,19 @@ from telegram_bot.services.history_service import HistoryService
 TEST_COLLECTION = f"test_history_{uuid.uuid4().hex[:8]}"
 
 
+def _is_port_open(host: str, port: int, timeout: float = 1.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
 @pytest.fixture
 async def qdrant_client():
     """Create async Qdrant client for testing."""
+    if not _is_port_open("localhost", 6333):
+        pytest.skip("Qdrant not running on localhost:6333")
     client = AsyncQdrantClient(url="http://localhost:6333")
     try:
         yield client
@@ -54,10 +65,6 @@ async def service(qdrant_client, mock_embeddings):
     return svc
 
 
-@pytest.mark.skipif(
-    not pytest.importorskip("qdrant_client", reason="qdrant not available"),
-    reason="Qdrant not available",
-)
 class TestQdrantHistoryIntegration:
     """Integration tests requiring live Qdrant."""
 

--- a/tests/integration/test_voyage_embeddings.py
+++ b/tests/integration/test_voyage_embeddings.py
@@ -2,6 +2,14 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+
+pytest.importorskip(
+    "telegram_bot.services.voyage_embeddings",
+    reason="telegram_bot.services.voyage_embeddings module removed",
+)
+
 
 class TestVoyageEmbeddingServiceUnit:
     """Unit tests for VoyageEmbeddingService."""

--- a/tests/integration/test_voyage_reranker.py
+++ b/tests/integration/test_voyage_reranker.py
@@ -2,6 +2,14 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+
+pytest.importorskip(
+    "telegram_bot.services.voyage_reranker",
+    reason="telegram_bot.services.voyage_reranker module removed",
+)
+
 
 class TestVoyageRerankerServiceUnit:
     """Unit tests for VoyageRerankerService."""

--- a/tests/load/test_load_redis_eviction.py
+++ b/tests/load/test_load_redis_eviction.py
@@ -4,6 +4,7 @@
 import json
 import os
 import random
+import socket
 import time
 from pathlib import Path
 
@@ -14,12 +15,22 @@ import redis.asyncio as redis
 REPORTS_DIR = Path(__file__).parent.parent.parent / "reports"
 
 
+def _is_port_open(host: str, port: int, timeout: float = 1.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
 @pytest.mark.skipif(not os.getenv("REDIS_URL"), reason="REDIS_URL not set")
 class TestLoadRedisEviction:
     """Test Redis eviction behavior under load."""
 
     @pytest.fixture
     async def redis_client(self):
+        if not _is_port_open("localhost", 6379):
+            pytest.skip("Redis not running on localhost:6379")
         client = redis.from_url(
             os.getenv("REDIS_URL", "redis://localhost:6379"),
             decode_responses=True,

--- a/tests/smoke/test_preflight.py
+++ b/tests/smoke/test_preflight.py
@@ -7,6 +7,7 @@ not just declared in code. Run before any other smoke/load tests.
 
 import json
 import os
+import socket
 from pathlib import Path
 
 import httpx
@@ -17,8 +18,20 @@ import redis.asyncio as redis
 REPORTS_DIR = Path(__file__).parent.parent.parent / "reports"
 
 
+def _check_tcp(host: str, port: int, timeout: float = 2.0) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(timeout)
+        try:
+            s.connect((host, port))
+            return True
+        except OSError:
+            return False
+
+
 @pytest.fixture(scope="module")
 def qdrant_url():
+    if not _check_tcp("localhost", 6333):
+        pytest.skip("Qdrant not running on localhost:6333")
     return os.getenv("QDRANT_URL", "http://localhost:6333")
 
 
@@ -77,6 +90,8 @@ class TestPreflightRedis:
 
     @pytest.fixture
     async def redis_client(self, redis_url):
+        if not _check_tcp("localhost", 6379):
+            pytest.skip("Redis not running on localhost:6379")
         client = redis.from_url(redis_url, decode_responses=True)
         yield client
         await client.close()
@@ -160,6 +175,8 @@ class TestPreflightReport:
 
     async def test_generate_preflight_report(self, qdrant_url, redis_url, collection_name):
         """Generate reports/preflight.json with all config values."""
+        if not _check_tcp("localhost", 6333) or not _check_tcp("localhost", 6379):
+            pytest.skip("Qdrant/Redis not running locally")
         report = {
             "qdrant": {},
             "redis": {},

--- a/tests/smoke/test_smoke_quantization.py
+++ b/tests/smoke/test_smoke_quantization.py
@@ -2,10 +2,19 @@
 """Smoke tests for Qdrant quantization A/B testing."""
 
 import os
+import socket
 import time
 
 import numpy as np
 import pytest
+
+
+def _is_port_open(host: str, port: int, timeout: float = 1.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
 
 
 @pytest.fixture
@@ -31,7 +40,7 @@ async def qdrant_service():
     await service.close()
 
 
-@pytest.mark.skipif(not os.getenv("QDRANT_URL"), reason="QDRANT_URL not set")
+@pytest.mark.skipif(not _is_port_open("localhost", 6333), reason="Qdrant not running (6333)")
 class TestSmokeQuantization:
     """Test quantization A/B switching."""
 

--- a/tests/smoke/test_smoke_services.py
+++ b/tests/smoke/test_smoke_services.py
@@ -21,6 +21,7 @@ class TestSmokeServices:
     """Verify all services are alive and responding."""
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(not _is_port_open("localhost", 6333), reason="Qdrant not running (6333)")
     async def test_qdrant_health(self):
         """Qdrant responds to health check."""
         url = os.getenv("QDRANT_URL", "http://localhost:6333")
@@ -29,6 +30,7 @@ class TestSmokeServices:
             assert response.status_code == 200
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(not _is_port_open("localhost", 6379), reason="Redis not running (6379)")
     async def test_redis_health(self):
         """Redis responds to PING."""
         url = os.getenv("REDIS_URL", "redis://localhost:6379")

--- a/tests/smoke/test_zoo_smoke.py
+++ b/tests/smoke/test_zoo_smoke.py
@@ -147,6 +147,9 @@ class TestZooCache:
         """CacheLayerManager for testing."""
         from telegram_bot.integrations.cache import CacheLayerManager
 
+        if not _is_port_open("localhost", 6379):
+            pytest.skip("Redis not running (port 6379)")
+
         redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
         password = os.getenv("REDIS_PASSWORD", "")
         if password and "@" not in redis_url:
@@ -180,6 +183,9 @@ class TestZooEndToEnd:
     async def cache_service(self):
         """CacheLayerManager for testing."""
         from telegram_bot.integrations.cache import CacheLayerManager
+
+        if not _is_port_open("localhost", 6379):
+            pytest.skip("Redis not running (port 6379)")
 
         redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
         password = os.getenv("REDIS_PASSWORD", "")


### PR DESCRIPTION
## Summary
- stabilize `IngestionService.get_collection_stats()` fallback payload for not-found/error paths
- fix `RetrieverService._build_filter()` Qdrant `Filter` type identity flake by lazy-loading `qdrant_client.models`
- convert removed-module tests to explicit `importorskip`
- add local service availability guards for Redis/Qdrant dependent integration/smoke/load tests

## Validation
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
- `make test`

## Results
- full local suite: `2668 passed, 92 skipped, 14 warnings`
- previously failing `tests/unit/test_retriever_service.py::TestRetrieverServiceFilters::test_build_filter_returns_filter_for_city` is stable in full run

## Follow-up issues
- opened: #306 (trustcall/langgraph deprecation warning)
- existing related: #268, #276
