### PR TITLE
feat: Chat History Session Summary + CRM Foundation (Phase 1)

### DIFF
--- a/telegram_bot/services/history_service.py
+++ b/telegram_bot/services/history_service.py
@@ -183,17 +183,30 @@ class HistoryService:
 
             turns: list[dict[str, Any]] = []
             for p in all_points:
-                meta = (p.payload or {}).get("metadata", {})
+                payload = p.payload if isinstance(p.payload, dict) else {}
+                meta = payload.get("metadata", {})
+                if not isinstance(meta, dict):
+                    continue
+
                 query = meta.get("query", "")
                 response = meta.get("response", "")
+                query = query if isinstance(query, str) else str(query or "")
+                response = response if isinstance(response, str) else str(response or "")
                 if not query and not response:
                     continue
+
+                timestamp = meta.get("timestamp", "")
+                timestamp = timestamp if isinstance(timestamp, str) else str(timestamp or "")
+
+                input_type = meta.get("input_type", "text")
+                input_type = input_type if isinstance(input_type, str) else "text"
+
                 turns.append(
                     {
                         "query": query,
                         "response": response,
-                        "timestamp": meta.get("timestamp", ""),
-                        "input_type": meta.get("input_type", "text"),
+                        "timestamp": timestamp,
+                        "input_type": input_type,
                     }
                 )
 

--- a/telegram_bot/services/history_service.py
+++ b/telegram_bot/services/history_service.py
@@ -136,3 +136,74 @@ class HistoryService:
         except Exception:
             logger.warning("Failed to search history", exc_info=True)
             return []
+
+    async def get_session_turns(
+        self,
+        user_id: int,
+        session_id: str,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Get session Q&A turns ordered by timestamp ascending."""
+        if limit <= 0:
+            return []
+
+        try:
+            all_points: list[Any] = []
+            offset: Any = None
+            remaining = min(limit, 500)  # hard cap to keep summary bounded
+
+            while remaining > 0:
+                page_limit = min(remaining, 100)
+                points, next_offset = await self._client.scroll(
+                    collection_name=self._collection_name,
+                    scroll_filter=models.Filter(
+                        must=[
+                            models.FieldCondition(
+                                key="metadata.user_id",
+                                match=models.MatchValue(value=user_id),
+                            ),
+                            models.FieldCondition(
+                                key="metadata.session_id",
+                                match=models.MatchValue(value=session_id),
+                            ),
+                        ]
+                    ),
+                    limit=page_limit,
+                    offset=offset,
+                    with_payload=True,
+                    with_vectors=False,
+                )
+                if not points:
+                    break
+                all_points.extend(points)
+                remaining -= len(points)
+                if next_offset is None:
+                    break
+                offset = next_offset
+
+            turns: list[dict[str, Any]] = []
+            for p in all_points:
+                meta = (p.payload or {}).get("metadata", {})
+                query = meta.get("query", "")
+                response = meta.get("response", "")
+                if not query and not response:
+                    continue
+                turns.append(
+                    {
+                        "query": query,
+                        "response": response,
+                        "timestamp": meta.get("timestamp", ""),
+                        "input_type": meta.get("input_type", "text"),
+                    }
+                )
+
+            turns.sort(key=lambda t: t["timestamp"])
+            return turns
+        except Exception:
+            logger.warning(
+                "Failed to get session turns: user_id=%s session_id=%s",
+                user_id,
+                session_id,
+                exc_info=True,
+            )
+            return []

--- a/telegram_bot/services/session_summary.py
+++ b/telegram_bot/services/session_summary.py
@@ -1,0 +1,37 @@
+"""Session summary generation for CRM integration.
+
+Generates structured summaries from Q&A dialog turns using LLM.
+"""
+
+import logging
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+logger = logging.getLogger(__name__)
+
+
+class SessionSummary(BaseModel):
+    """Structured summary of a bot-client dialog session.
+
+    Used for CRM note generation (Kommo) and manager context.
+    """
+
+    brief: str
+    """1-2 sentences summarizing the main topic and outcome."""
+
+    client_needs: list[str]
+    """What the client is looking for (extracted needs)."""
+
+    budget: str | None = None
+    """Budget if mentioned by client, None otherwise."""
+
+    preferences: list[str]
+    """Client preferences: location, floor, area, amenities, etc."""
+
+    next_steps: list[str]
+    """Agreed next actions or follow-ups."""
+
+    sentiment: Literal["positive", "neutral", "negative"]
+    """Overall conversation tone."""

--- a/telegram_bot/services/session_summary.py
+++ b/telegram_bot/services/session_summary.py
@@ -99,7 +99,7 @@ async def generate_summary(
 
     try:
         if hasattr(llm, "responses") and hasattr(llm.responses, "parse"):
-            response = await llm.responses.parse(  # type: ignore[union-attr]
+            response = await llm.responses.parse(  # type: ignore[attr-defined]
                 model=model,
                 input=[
                     {"role": "system", "content": _SUMMARY_SYSTEM_PROMPT},
@@ -111,7 +111,7 @@ async def generate_summary(
             return getattr(response, "output_parsed", None)
 
         # Fallback for wrappers that expose only Chat Completions parse
-        completion = await llm.beta.chat.completions.parse(  # type: ignore[union-attr]
+        completion = await llm.beta.chat.completions.parse(  # type: ignore[attr-defined]
             model=model,
             messages=[
                 {"role": "system", "content": _SUMMARY_SYSTEM_PROMPT},

--- a/telegram_bot/services/session_summary.py
+++ b/telegram_bot/services/session_summary.py
@@ -5,7 +5,7 @@ Generates structured summaries from Q&A dialog turns using LLM.
 
 import logging
 from datetime import UTC, datetime
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel
 
@@ -76,14 +76,15 @@ def _trim_turns_for_summary(turns: list[dict]) -> list[dict]:
 async def generate_summary(
     *,
     turns: list[dict],
-    llm: object,
+    llm: Any,
     model: str = "gpt-4o-mini",
 ) -> SessionSummary | None:
     """Generate structured session summary from Q&A turns.
 
     Args:
         turns: List of Q&A dicts with query, response, timestamp, input_type.
-        llm: AsyncOpenAI client (langfuse.openai.AsyncOpenAI or compatible).
+        llm: AsyncOpenAI-compatible client with responses.parse or
+            beta.chat.completions.parse method.
         model: LLM model name for summary generation.
 
     Returns:

--- a/telegram_bot/services/session_summary.py
+++ b/telegram_bot/services/session_summary.py
@@ -35,3 +35,91 @@ class SessionSummary(BaseModel):
 
     sentiment: Literal["positive", "neutral", "negative"]
     """Overall conversation tone."""
+
+
+_SUMMARY_SYSTEM_PROMPT = """\
+Ты — ассистент риелторского агентства. Проанализируй диалог бота с клиентом \
+и создай structured summary для карточки сделки в CRM.
+
+Правила:
+- brief: 1-2 предложения, главная тема и итог разговора
+- client_needs: конкретные запросы клиента (тип жилья, количество комнат, расположение)
+- budget: точная сумма если озвучена, иначе null
+- preferences: детали предпочтений (район, этаж, площадь, особенности)
+- next_steps: что договорились сделать дальше
+- sentiment: общий тон разговора (positive/neutral/negative)
+
+Извлекай только факты из диалога. Не додумывай."""
+
+_MAX_TURNS_FOR_SUMMARY = 40
+_MAX_DIALOG_CHARS = 12_000
+
+
+def format_turns_for_prompt(turns: list[dict]) -> str:
+    """Format Q&A turns as readable dialog for LLM prompt."""
+    if not turns:
+        return ""
+    lines = []
+    for turn in turns:
+        lines.append(f"Клиент: {turn['query']}")
+        lines.append(f"Бот: {turn['response']}")
+    return "\n".join(lines)
+
+
+def _trim_turns_for_summary(turns: list[dict]) -> list[dict]:
+    """Drop empty turns and cap dialog size for stable LLM latency."""
+    cleaned = [t for t in turns if t.get("query") or t.get("response")]
+    return cleaned[-_MAX_TURNS_FOR_SUMMARY:]
+
+
+async def generate_summary(
+    *,
+    turns: list[dict],
+    llm: object,
+    model: str = "gpt-4o-mini",
+) -> SessionSummary | None:
+    """Generate structured session summary from Q&A turns.
+
+    Args:
+        turns: List of Q&A dicts with query, response, timestamp, input_type.
+        llm: AsyncOpenAI client (langfuse.openai.AsyncOpenAI or compatible).
+        model: LLM model name for summary generation.
+
+    Returns:
+        SessionSummary on success, None on empty input or error.
+    """
+    trimmed_turns = _trim_turns_for_summary(turns)
+    if not trimmed_turns:
+        return None
+
+    dialog = format_turns_for_prompt(trimmed_turns)
+    if len(dialog) > _MAX_DIALOG_CHARS:
+        dialog = dialog[-_MAX_DIALOG_CHARS:]
+
+    try:
+        if hasattr(llm, "responses") and hasattr(llm.responses, "parse"):
+            response = await llm.responses.parse(  # type: ignore[union-attr]
+                model=model,
+                input=[
+                    {"role": "system", "content": _SUMMARY_SYSTEM_PROMPT},
+                    {"role": "user", "content": f"Диалог:\n{dialog}"},
+                ],
+                text_format=SessionSummary,
+                temperature=0.0,
+            )
+            return getattr(response, "output_parsed", None)
+
+        # Fallback for wrappers that expose only Chat Completions parse
+        completion = await llm.beta.chat.completions.parse(  # type: ignore[union-attr]
+            model=model,
+            messages=[
+                {"role": "system", "content": _SUMMARY_SYSTEM_PROMPT},
+                {"role": "user", "content": f"Диалог:\n{dialog}"},
+            ],
+            response_format=SessionSummary,
+            temperature=0.0,
+        )
+        return getattr(completion.choices[0].message, "parsed", None)
+    except Exception:
+        logger.warning("Failed to generate session summary", exc_info=True)
+        return None

--- a/telegram_bot/services/session_summary.py
+++ b/telegram_bot/services/session_summary.py
@@ -62,8 +62,8 @@ def format_turns_for_prompt(turns: list[dict]) -> str:
         return ""
     lines = []
     for turn in turns:
-        lines.append(f"Клиент: {turn['query']}")
-        lines.append(f"Бот: {turn['response']}")
+        lines.append(f"Клиент: {turn.get('query', '')}")
+        lines.append(f"Бот: {turn.get('response', '')}")
     return "\n".join(lines)
 
 
@@ -97,6 +97,9 @@ async def generate_summary(
     dialog = format_turns_for_prompt(trimmed_turns)
     if len(dialog) > _MAX_DIALOG_CHARS:
         dialog = dialog[-_MAX_DIALOG_CHARS:]
+        newline_idx = dialog.find("\n")
+        if newline_idx > 0:
+            dialog = dialog[newline_idx + 1 :]
 
     try:
         if hasattr(llm, "responses") and hasattr(llm.responses, "parse"):
@@ -130,7 +133,7 @@ async def generate_summary(
 def format_summary_as_note(summary: SessionSummary) -> str:
     """Format SessionSummary as a readable CRM note text.
 
-    Output is designed for Kommo lead notes (plain text with emoji markers).
+    Output is designed for Kommo lead notes (plain text with labeled sections).
     """
     lines = [f"AI Summary ({datetime.now(UTC).strftime('%Y-%m-%d')})", ""]
     lines.append(summary.brief)

--- a/telegram_bot/services/session_summary.py
+++ b/telegram_bot/services/session_summary.py
@@ -4,6 +4,7 @@ Generates structured summaries from Q&A dialog turns using LLM.
 """
 
 import logging
+from datetime import UTC, datetime
 from typing import Literal
 
 from pydantic import BaseModel
@@ -123,3 +124,24 @@ async def generate_summary(
     except Exception:
         logger.warning("Failed to generate session summary", exc_info=True)
         return None
+
+
+def format_summary_as_note(summary: SessionSummary) -> str:
+    """Format SessionSummary as a readable CRM note text.
+
+    Output is designed for Kommo lead notes (plain text with emoji markers).
+    """
+    lines = [f"AI Summary ({datetime.now(UTC).strftime('%Y-%m-%d')})", ""]
+    lines.append(summary.brief)
+    lines.append("")
+
+    if summary.client_needs:
+        lines.append("Потребности: " + ", ".join(summary.client_needs))
+    if summary.budget:
+        lines.append(f"Бюджет: {summary.budget}")
+    if summary.preferences:
+        lines.append("Предпочтения: " + ", ".join(summary.preferences))
+    if summary.next_steps:
+        lines.append("Следующие шаги: " + ", ".join(summary.next_steps))
+
+    return "\n".join(lines)

--- a/tests/unit/services/test_history_service.py
+++ b/tests/unit/services/test_history_service.py
@@ -204,3 +204,113 @@ class TestSearchUserHistory:
         results = await service.search_user_history(user_id=1, query="test", limit=5)
 
         assert results == []
+
+
+class TestGetSessionTurns:
+    """Test get_session_turns retrieves Q&A pairs by session_id."""
+
+    async def test_returns_turns_ordered_by_timestamp(self, service, mock_client):
+        """get_session_turns returns turns sorted by timestamp ascending."""
+        point1 = MagicMock()
+        point1.id = "p1"
+        point1.payload = {
+            "metadata": {
+                "user_id": 100,
+                "session_id": "chat-abc-20260217",
+                "query": "первый вопрос",
+                "response": "первый ответ",
+                "timestamp": "2026-02-17T10:00:00+00:00",
+                "input_type": "text",
+            }
+        }
+        point2 = MagicMock()
+        point2.id = "p2"
+        point2.payload = {
+            "metadata": {
+                "user_id": 100,
+                "session_id": "chat-abc-20260217",
+                "query": "второй вопрос",
+                "response": "второй ответ",
+                "timestamp": "2026-02-17T10:05:00+00:00",
+                "input_type": "text",
+            }
+        }
+        mock_client.scroll = AsyncMock(return_value=([point2, point1], None))  # unordered
+
+        turns = await service.get_session_turns(user_id=100, session_id="chat-abc-20260217")
+
+        assert len(turns) == 2
+        assert turns[0]["query"] == "первый вопрос"
+        assert turns[1]["query"] == "второй вопрос"
+        assert turns[0]["timestamp"] < turns[1]["timestamp"]
+
+    async def test_filters_by_user_and_session(self, service, mock_client):
+        """get_session_turns passes correct filters to Qdrant scroll."""
+        mock_client.scroll = AsyncMock(return_value=([], None))
+
+        await service.get_session_turns(user_id=100, session_id="chat-abc-20260217")
+
+        mock_client.scroll.assert_awaited_once()
+        call_kwargs = mock_client.scroll.call_args.kwargs
+        assert call_kwargs["collection_name"] == "test_history"
+        scroll_filter = call_kwargs["scroll_filter"]
+        filter_keys = [c.key for c in scroll_filter.must]
+        assert "metadata.user_id" in filter_keys
+        assert "metadata.session_id" in filter_keys
+
+    async def test_returns_empty_on_no_turns(self, service, mock_client):
+        """get_session_turns returns empty list when no points match."""
+        mock_client.scroll = AsyncMock(return_value=([], None))
+
+        turns = await service.get_session_turns(user_id=100, session_id="chat-nonexistent")
+
+        assert turns == []
+
+    async def test_graceful_on_qdrant_error(self, service, mock_client):
+        """get_session_turns returns empty list on Qdrant exception."""
+        mock_client.scroll = AsyncMock(side_effect=RuntimeError("connection lost"))
+
+        turns = await service.get_session_turns(user_id=100, session_id="s")
+
+        assert turns == []
+
+    async def test_respects_limit(self, service, mock_client):
+        """get_session_turns passes limit to Qdrant scroll."""
+        mock_client.scroll = AsyncMock(return_value=([], None))
+
+        await service.get_session_turns(user_id=100, session_id="s", limit=10)
+
+        call_kwargs = mock_client.scroll.call_args.kwargs
+        assert call_kwargs["limit"] == 10
+
+    async def test_paginates_until_next_page_offset_is_none(self, service, mock_client):
+        """get_session_turns aggregates pages while next_page_offset exists."""
+        p1 = MagicMock()
+        p1.payload = {
+            "metadata": {
+                "query": "q1",
+                "response": "r1",
+                "timestamp": "2026-02-17T10:00:00+00:00",
+            }
+        }
+        p2 = MagicMock()
+        p2.payload = {
+            "metadata": {
+                "query": "q2",
+                "response": "r2",
+                "timestamp": "2026-02-17T10:01:00+00:00",
+            }
+        }
+
+        mock_client.scroll = AsyncMock(
+            side_effect=[
+                ([p1], "offset-1"),
+                ([p2], None),
+            ]
+        )
+
+        turns = await service.get_session_turns(
+            user_id=100, session_id="chat-abc-20260217", limit=50
+        )
+        assert [t["query"] for t in turns] == ["q1", "q2"]
+        assert mock_client.scroll.await_count == 2

--- a/tests/unit/services/test_history_service.py
+++ b/tests/unit/services/test_history_service.py
@@ -330,3 +330,25 @@ class TestGetSessionTurns:
 
         assert turns == []
         mock_client.scroll.assert_not_called()
+
+    async def test_skips_malformed_metadata_and_keeps_valid_turns(self, service, mock_client):
+        """Malformed payload metadata should be skipped without dropping valid turns."""
+        bad_point = MagicMock()
+        bad_point.payload = {"metadata": "corrupted"}
+
+        good_point = MagicMock()
+        good_point.payload = {
+            "metadata": {
+                "query": "валидный вопрос",
+                "response": "валидный ответ",
+                "timestamp": "2026-02-17T10:01:00+00:00",
+                "input_type": "text",
+            }
+        }
+
+        mock_client.scroll = AsyncMock(return_value=([bad_point, good_point], None))
+
+        turns = await service.get_session_turns(user_id=100, session_id="chat-abc-20260217")
+
+        assert len(turns) == 1
+        assert turns[0]["query"] == "валидный вопрос"

--- a/tests/unit/services/test_history_service.py
+++ b/tests/unit/services/test_history_service.py
@@ -314,3 +314,19 @@ class TestGetSessionTurns:
         )
         assert [t["query"] for t in turns] == ["q1", "q2"]
         assert mock_client.scroll.await_count == 2
+        second_call_kwargs = mock_client.scroll.call_args_list[1].kwargs
+        assert second_call_kwargs["offset"] == "offset-1"
+
+    async def test_returns_empty_on_zero_limit(self, service, mock_client):
+        """get_session_turns returns empty list when limit <= 0."""
+        turns = await service.get_session_turns(user_id=100, session_id="s", limit=0)
+
+        assert turns == []
+        mock_client.scroll.assert_not_called()
+
+    async def test_returns_empty_on_negative_limit(self, service, mock_client):
+        """get_session_turns returns empty list when limit is negative."""
+        turns = await service.get_session_turns(user_id=100, session_id="s", limit=-5)
+
+        assert turns == []
+        mock_client.scroll.assert_not_called()

--- a/tests/unit/services/test_session_summary.py
+++ b/tests/unit/services/test_session_summary.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from telegram_bot.services.session_summary import (
     SessionSummary,
+    format_summary_as_note,
     format_turns_for_prompt,
     generate_summary,
 )
@@ -173,3 +174,42 @@ class TestGenerateSummary:
         )
 
         assert result is None
+
+
+class TestFormatSummaryAsNote:
+    """Test CRM note formatting."""
+
+    def test_formats_full_summary(self):
+        """format_summary_as_note produces readable CRM note."""
+        summary = SessionSummary(
+            brief="Клиент ищет квартиру у моря.",
+            client_needs=["2-комнатная квартира", "вид на море"],
+            budget="$80,000",
+            preferences=["Sunny Beach", "не выше 5 этажа"],
+            next_steps=["подобрать 3 варианта", "назначить показ"],
+            sentiment="positive",
+        )
+        note = format_summary_as_note(summary)
+
+        assert "AI Summary" in note
+        assert "Клиент ищет квартиру у моря." in note
+        assert "2-комнатная квартира" in note
+        assert "$80,000" in note
+        assert "Sunny Beach" in note
+        assert "подобрать 3 варианта" in note
+
+    def test_formats_minimal_summary(self):
+        """format_summary_as_note handles empty optional fields."""
+        summary = SessionSummary(
+            brief="Короткий разговор.",
+            client_needs=[],
+            budget=None,
+            preferences=[],
+            next_steps=[],
+            sentiment="neutral",
+        )
+        note = format_summary_as_note(summary)
+
+        assert "Короткий разговор." in note
+        # No budget section when None
+        assert "Бюджет" not in note

--- a/tests/unit/services/test_session_summary.py
+++ b/tests/unit/services/test_session_summary.py
@@ -1,9 +1,11 @@
 """Unit tests for SessionSummary model and generate_summary()."""
 
-from unittest.mock import AsyncMock, MagicMock
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from telegram_bot.services.session_summary import (
     SessionSummary,
+    _trim_turns_for_summary,
     format_summary_as_note,
     format_turns_for_prompt,
     generate_summary,
@@ -175,12 +177,93 @@ class TestGenerateSummary:
 
         assert result is None
 
+    async def test_fallback_to_chat_completions_parse(self):
+        """generate_summary uses beta.chat.completions.parse when responses API unavailable."""
+        mock_llm = MagicMock(spec=[])  # no 'responses' attribute
+        expected = SessionSummary(
+            brief="Fallback test.",
+            client_needs=[],
+            budget=None,
+            preferences=[],
+            next_steps=[],
+            sentiment="neutral",
+        )
+        mock_message = MagicMock()
+        mock_message.parsed = expected
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+        mock_completion = MagicMock()
+        mock_completion.choices = [mock_choice]
+        mock_llm.beta = MagicMock()
+        mock_llm.beta.chat.completions.parse = AsyncMock(return_value=mock_completion)
+
+        result = await generate_summary(
+            turns=[{"query": "q", "response": "r", "timestamp": "t", "input_type": "text"}],
+            llm=mock_llm,
+        )
+
+        assert result == expected
+        mock_llm.beta.chat.completions.parse.assert_awaited_once()
+        call_kwargs = mock_llm.beta.chat.completions.parse.call_args.kwargs
+        assert call_kwargs["response_format"] is SessionSummary
+        assert call_kwargs["temperature"] == 0.0
+
+    async def test_fallback_error_returns_none(self):
+        """generate_summary returns None when fallback path also fails."""
+        mock_llm = MagicMock(spec=[])  # no 'responses' attribute
+        mock_llm.beta = MagicMock()
+        mock_llm.beta.chat.completions.parse = AsyncMock(side_effect=RuntimeError("fallback error"))
+
+        result = await generate_summary(
+            turns=[{"query": "q", "response": "r", "timestamp": "t", "input_type": "text"}],
+            llm=mock_llm,
+        )
+
+        assert result is None
+
+
+class TestTrimTurnsForSummary:
+    """Test _trim_turns_for_summary internal function."""
+
+    def test_filters_empty_turns(self):
+        """_trim_turns_for_summary removes turns with no query and no response."""
+        turns = [
+            {"query": "q1", "response": "r1"},
+            {"query": "", "response": ""},
+            {"query": "q2", "response": "r2"},
+        ]
+        result = _trim_turns_for_summary(turns)
+        assert len(result) == 2
+        assert result[0]["query"] == "q1"
+        assert result[1]["query"] == "q2"
+
+    def test_caps_at_max_turns(self):
+        """_trim_turns_for_summary keeps only last 40 turns."""
+        turns = [{"query": f"q{i}", "response": f"r{i}"} for i in range(60)]
+        result = _trim_turns_for_summary(turns)
+        assert len(result) == 40
+        assert result[0]["query"] == "q20"
+        assert result[-1]["query"] == "q59"
+
+    def test_returns_empty_for_empty_input(self):
+        """_trim_turns_for_summary returns empty list for no turns."""
+        assert _trim_turns_for_summary([]) == []
+
+    def test_keeps_turns_with_only_query(self):
+        """_trim_turns_for_summary keeps turns that have only query."""
+        turns = [{"query": "q1", "response": ""}]
+        result = _trim_turns_for_summary(turns)
+        assert len(result) == 1
+
 
 class TestFormatSummaryAsNote:
     """Test CRM note formatting."""
 
-    def test_formats_full_summary(self):
-        """format_summary_as_note produces readable CRM note."""
+    @patch("telegram_bot.services.session_summary.datetime")
+    def test_formats_full_summary(self, mock_dt):
+        """format_summary_as_note produces readable CRM note with date."""
+        mock_dt.now.return_value = datetime(2026, 2, 17, tzinfo=UTC)
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
         summary = SessionSummary(
             brief="Клиент ищет квартиру у моря.",
             client_needs=["2-комнатная квартира", "вид на море"],
@@ -191,7 +274,7 @@ class TestFormatSummaryAsNote:
         )
         note = format_summary_as_note(summary)
 
-        assert "AI Summary" in note
+        assert "AI Summary (2026-02-17)" in note
         assert "Клиент ищет квартиру у моря." in note
         assert "2-комнатная квартира" in note
         assert "$80,000" in note

--- a/tests/unit/services/test_session_summary.py
+++ b/tests/unit/services/test_session_summary.py
@@ -1,6 +1,12 @@
 """Unit tests for SessionSummary model and generate_summary()."""
 
-from telegram_bot.services.session_summary import SessionSummary
+from unittest.mock import AsyncMock, MagicMock
+
+from telegram_bot.services.session_summary import (
+    SessionSummary,
+    format_turns_for_prompt,
+    generate_summary,
+)
 
 
 class TestSessionSummaryModel:
@@ -45,3 +51,125 @@ class TestSessionSummaryModel:
                 sentiment=sentiment,
             )
             assert summary.sentiment == sentiment
+
+
+class TestFormatTurnsForPrompt:
+    """Test turns formatting for LLM prompt."""
+
+    def test_formats_turns_as_dialog(self):
+        """format_turns_for_prompt renders Q&A pairs as readable dialog."""
+        turns = [
+            {
+                "query": "Какие квартиры у моря?",
+                "response": "Есть варианты в Sunny Beach от $50K.",
+                "timestamp": "2026-02-17T10:00:00+00:00",
+                "input_type": "text",
+            },
+            {
+                "query": "А с двумя комнатами?",
+                "response": "2-комнатные от $75K, есть 3 варианта.",
+                "timestamp": "2026-02-17T10:02:00+00:00",
+                "input_type": "text",
+            },
+        ]
+        result = format_turns_for_prompt(turns)
+
+        assert "Клиент: Какие квартиры у моря?" in result
+        assert "Бот: Есть варианты в Sunny Beach от $50K." in result
+        assert "Клиент: А с двумя комнатами?" in result
+
+    def test_empty_turns(self):
+        """format_turns_for_prompt returns empty string for no turns."""
+        assert format_turns_for_prompt([]) == ""
+
+
+class TestGenerateSummary:
+    """Test generate_summary() with mocked LLM."""
+
+    async def test_returns_session_summary(self):
+        """generate_summary returns SessionSummary from LLM response."""
+        mock_llm = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.output_parsed = SessionSummary(
+            brief="Клиент ищет квартиру у моря.",
+            client_needs=["2-комнатная", "вид на море"],
+            budget="$80,000",
+            preferences=["Sunny Beach"],
+            next_steps=["подобрать варианты"],
+            sentiment="positive",
+        )
+        mock_llm.responses.parse = AsyncMock(return_value=mock_response)
+
+        turns = [
+            {
+                "query": "Ищу квартиру у моря",
+                "response": "Есть варианты от $50K",
+                "timestamp": "2026-02-17T10:00:00+00:00",
+                "input_type": "text",
+            }
+        ]
+
+        result = await generate_summary(turns=turns, llm=mock_llm)
+
+        assert isinstance(result, SessionSummary)
+        assert result.brief == "Клиент ищет квартиру у моря."
+        assert result.budget == "$80,000"
+        mock_llm.responses.parse.assert_awaited_once()
+
+    async def test_passes_model_parameter(self):
+        """generate_summary uses provided model name."""
+        mock_llm = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.output_parsed = SessionSummary(
+            brief="Test.",
+            client_needs=[],
+            budget=None,
+            preferences=[],
+            next_steps=[],
+            sentiment="neutral",
+        )
+        mock_llm.responses.parse = AsyncMock(return_value=mock_response)
+
+        await generate_summary(
+            turns=[{"query": "q", "response": "r", "timestamp": "t", "input_type": "text"}],
+            llm=mock_llm,
+            model="gpt-4o-mini",
+        )
+
+        call_kwargs = mock_llm.responses.parse.call_args.kwargs
+        assert call_kwargs["model"] == "gpt-4o-mini"
+
+    async def test_returns_none_on_empty_turns(self):
+        """generate_summary returns None when no turns provided."""
+        mock_llm = AsyncMock()
+
+        result = await generate_summary(turns=[], llm=mock_llm)
+
+        assert result is None
+        mock_llm.responses.parse.assert_not_called()
+
+    async def test_returns_none_on_llm_error(self):
+        """generate_summary returns None on LLM exception."""
+        mock_llm = AsyncMock()
+        mock_llm.responses.parse = AsyncMock(side_effect=RuntimeError("API error"))
+
+        result = await generate_summary(
+            turns=[{"query": "q", "response": "r", "timestamp": "t", "input_type": "text"}],
+            llm=mock_llm,
+        )
+
+        assert result is None
+
+    async def test_returns_none_on_refusal_or_unparsed_output(self):
+        """generate_summary returns None when model does not produce parsed payload."""
+        mock_llm = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.output_parsed = None
+        mock_llm.responses.parse = AsyncMock(return_value=mock_response)
+
+        result = await generate_summary(
+            turns=[{"query": "q", "response": "r", "timestamp": "t", "input_type": "text"}],
+            llm=mock_llm,
+        )
+
+        assert result is None

--- a/tests/unit/services/test_session_summary.py
+++ b/tests/unit/services/test_session_summary.py
@@ -1,0 +1,47 @@
+"""Unit tests for SessionSummary model and generate_summary()."""
+
+from telegram_bot.services.session_summary import SessionSummary
+
+
+class TestSessionSummaryModel:
+    """Test SessionSummary Pydantic model."""
+
+    def test_valid_summary(self):
+        """SessionSummary accepts valid data."""
+        summary = SessionSummary(
+            brief="Клиент интересовался квартирами у моря.",
+            client_needs=["2-комнатная квартира", "вид на море"],
+            budget="$80,000",
+            preferences=["район Sunny Beach", "не выше 5 этажа"],
+            next_steps=["подобрать 3 варианта"],
+            sentiment="positive",
+        )
+        assert summary.brief == "Клиент интересовался квартирами у моря."
+        assert len(summary.client_needs) == 2
+        assert summary.budget == "$80,000"
+        assert summary.sentiment == "positive"
+
+    def test_optional_budget(self):
+        """SessionSummary allows None budget."""
+        summary = SessionSummary(
+            brief="Общий разговор.",
+            client_needs=[],
+            budget=None,
+            preferences=[],
+            next_steps=[],
+            sentiment="neutral",
+        )
+        assert summary.budget is None
+
+    def test_sentiment_values(self):
+        """SessionSummary accepts valid sentiment values."""
+        for sentiment in ("positive", "neutral", "negative"):
+            summary = SessionSummary(
+                brief="Test.",
+                client_needs=[],
+                budget=None,
+                preferences=[],
+                next_steps=[],
+                sentiment=sentiment,
+            )
+            assert summary.sentiment == sentiment


### PR DESCRIPTION
## Summary

Phase 1 Foundation для session summary + CRM integration (#305).

- **get_session_turns()** — Qdrant scroll по session_id с пагинацией, ascending timestamp sort, graceful error handling, hard cap 500
- **SessionSummary** — Pydantic v2 model (brief, client_needs, budget, preferences, next_steps, sentiment)
- **generate_summary()** — LLM structured output: Responses API primary + Chat Completions fallback, temperature=0.0, trim 40 turns / 12K chars
- **format_summary_as_note()** — plain text CRM note formatter для Kommo (labeled sections)

## Files Changed (4 files, +646 lines)

| File | Change |
|------|--------|
| telegram_bot/services/history_service.py | +get_session_turns() method with pagination |
| telegram_bot/services/session_summary.py | NEW: model + generate + format + trim |
| tests/unit/services/test_history_service.py | +8 tests (TestGetSessionTurns) |
| tests/unit/services/test_session_summary.py | NEW: 18 tests (6 classes) |

## Test Results

- 36/36 tests pass (-n auto, 3.54s)
- make check passes (ruff + mypy, 0 errors)
- Code review: 2 rounds, all issues addressed

## Test plan

- [x] Unit tests: 36/36 pass
- [x] Lint + types: make check clean
- [x] Code review: 2 rounds done
- [x] Verification gate: fresh evidence
- [ ] CI pipeline (auto on PR)

Closes #305