### PR TITLE
test: follow-up autofix after full re-review of today's merged PRs

### DIFF
--- a/src/voice/sip_setup.py
+++ b/src/voice/sip_setup.py
@@ -2,18 +2,27 @@
 
 import asyncio
 import os
-from typing import Any, cast
+from importlib import import_module
+from typing import TYPE_CHECKING, Any, cast
 
-from livekit import api
 from livekit.protocol.sip import CreateSIPOutboundTrunkRequest, SIPOutboundTrunkInfo
+
+
+if TYPE_CHECKING:
+    from livekit.api import LiveKitAPI
+
+api = cast(Any, import_module("livekit.api"))
 
 
 async def setup_lifecell_trunk() -> str:
     """Create lifecell outbound SIP trunk. Returns trunk ID."""
-    lk = cast(Any, api).LiveKitAPI(
-        url=os.getenv("LIVEKIT_URL", "http://localhost:7880"),
-        api_key=os.getenv("LIVEKIT_API_KEY", "devkey"),
-        api_secret=os.getenv("LIVEKIT_API_SECRET", "secret"),
+    lk = cast(
+        "LiveKitAPI",
+        api.LiveKitAPI(
+            url=os.getenv("LIVEKIT_URL", "http://localhost:7880"),
+            api_key=os.getenv("LIVEKIT_API_KEY", "devkey"),
+            api_secret=os.getenv("LIVEKIT_API_SECRET", "secret"),
+        ),
     )
 
     sip_user = os.getenv("LIFECELL_SIP_USER", "")

--- a/tests/benchmark/test_colbert_rerank.py
+++ b/tests/benchmark/test_colbert_rerank.py
@@ -4,8 +4,12 @@ Test ColBERT multivector rerank in production code (Variant A - Complete).
 Verifies HybridRRFColBERTSearchEngine uses: Dense + Sparse + ColBERT rerank.
 """
 
+import socket
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
 
 
 # Add project root to path
@@ -16,8 +20,8 @@ from src.config import Settings
 from src.retrieval import HybridRRFColBERTSearchEngine
 
 
-def test_colbert_rerank():
-    """Test Variant A: Hybrid RRF + ColBERT rerank."""
+def _run_colbert_rerank() -> bool:
+    """Run Variant A benchmark flow and return success flag."""
 
     print("=" * 80)
     print("TEST: VARIANT A - HYBRID RRF + COLBERT RERANK")
@@ -100,6 +104,25 @@ def test_colbert_rerank():
     return True
 
 
+def _is_port_open(host: str, port: int, timeout: float = 1.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def test_colbert_rerank():
+    """Test Variant A: Hybrid RRF + ColBERT rerank."""
+    settings = Settings()
+    parsed = urlparse(settings.qdrant_url)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 6333
+    if not _is_port_open(host, port):
+        pytest.skip(f"Qdrant not running on {host}:{port}")
+    assert _run_colbert_rerank()
+
+
 if __name__ == "__main__":
-    success = test_colbert_rerank()
+    success = _run_colbert_rerank()
     sys.exit(0 if success else 1)

--- a/tests/benchmark/test_dbsf_colbert.py
+++ b/tests/benchmark/test_dbsf_colbert.py
@@ -4,8 +4,12 @@ Test DBSF + ColBERT multivector rerank in production code (Variant B).
 Verifies DBSFColBERTSearchEngine uses: Dense + Sparse + DBSF fusion + ColBERT rerank.
 """
 
+import socket
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
 
 
 # Add project root to path
@@ -16,8 +20,8 @@ from src.config import Settings
 from src.retrieval import DBSFColBERTSearchEngine
 
 
-def test_dbsf_colbert():
-    """Test Variant B: Hybrid DBSF + ColBERT rerank."""
+def _run_dbsf_colbert() -> tuple[bool, dict[str, list[dict[str, str | float | None]]] | None]:
+    """Run Variant B benchmark flow and return success flag with collected results."""
 
     print("=" * 80)
     print("TEST: VARIANT B - HYBRID DBSF + COLBERT RERANK")
@@ -114,8 +118,29 @@ def test_dbsf_colbert():
     return True, all_results
 
 
+def _is_port_open(host: str, port: int, timeout: float = 1.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def test_dbsf_colbert():
+    """Test Variant B: Hybrid DBSF + ColBERT rerank."""
+    settings = Settings()
+    parsed = urlparse(settings.qdrant_url)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 6333
+    if not _is_port_open(host, port):
+        pytest.skip(f"Qdrant not running on {host}:{port}")
+    success, results = _run_dbsf_colbert()
+    assert success
+    assert results is not None
+
+
 if __name__ == "__main__":
-    success, results = test_dbsf_colbert()
+    success, results = _run_dbsf_colbert()
 
     if success and results:
         # Save results for comparison with RRF

--- a/tests/benchmark/test_docling_vs_pymupdf.py
+++ b/tests/benchmark/test_docling_vs_pymupdf.py
@@ -7,6 +7,8 @@ Tests both approaches on the same Ukrainian legal document.
 import sys
 from pathlib import Path
 
+import pytest
+
 
 # Add paths
 sys.path.insert(0, str(Path(__file__).parent))
@@ -20,8 +22,8 @@ from transformers import AutoTokenizer
 from legacy.pymupdf_chunker import PyMuPDFChunker
 
 
-def test_pymupdf_approach():
-    """Test PyMuPDF regex-based chunking."""
+def _run_pymupdf_approach():
+    """Run PyMuPDF regex-based chunking flow."""
     print("=" * 80)
     print("🔧 APPROACH 1: PyMuPDF (Regex-based)")
     print("=" * 80)
@@ -59,8 +61,8 @@ def test_pymupdf_approach():
     return chunks
 
 
-def test_docling_approach():
-    """Test Docling HybridChunker with document structure."""
+def _run_docling_approach():
+    """Run Docling HybridChunker flow."""
     print("\n" + "=" * 80)
     print("🔧 APPROACH 2: Docling HybridChunker (Structure-aware)")
     print("=" * 80)
@@ -128,6 +130,22 @@ def test_docling_approach():
     return chunks
 
 
+def test_pymupdf_approach():
+    """Test PyMuPDF regex-based chunking."""
+    chunks = _run_pymupdf_approach()
+    if chunks is None:
+        pytest.skip("Source DOCX file not found for benchmark test")
+    assert chunks
+
+
+def test_docling_approach():
+    """Test Docling HybridChunker with document structure."""
+    chunks = _run_docling_approach()
+    if chunks is None:
+        pytest.skip("Source DOCX file not found for benchmark test")
+    assert chunks
+
+
 def compare_approaches():
     """Compare both approaches side by side."""
     print("\n\n")
@@ -135,8 +153,8 @@ def compare_approaches():
     print("║" + " " * 20 + "DOCLING vs PyMuPDF COMPARISON" + " " * 28 + "║")
     print("╚" + "═" * 78 + "╝")
 
-    pymupdf_chunks = test_pymupdf_approach()
-    docling_chunks = test_docling_approach()
+    pymupdf_chunks = _run_pymupdf_approach()
+    docling_chunks = _run_docling_approach()
 
     if pymupdf_chunks and docling_chunks:
         print("\n\n" + "=" * 80)

--- a/tests/integration/test_basic_connection.py
+++ b/tests/integration/test_basic_connection.py
@@ -6,8 +6,12 @@
 
 import json
 import os
+import socket
 import urllib.error
 import urllib.request
+from urllib.parse import urlparse
+
+import pytest
 
 
 # Настройки из .env
@@ -15,8 +19,8 @@ QDRANT_URL = os.getenv("QDRANT_URL", "http://localhost:6333")
 QDRANT_API_KEY = os.getenv("QDRANT_API_KEY", "")
 
 
-def test_qdrant_connection():
-    """Тест подключения к Qdrant."""
+def _run_qdrant_connection_checks() -> bool:
+    """Прогон проверок подключения к Qdrant."""
 
     print("=" * 80)
     print("ТЕСТ ПОДКЛЮЧЕНИЯ К QDRANT (базовый)")
@@ -105,8 +109,26 @@ def test_qdrant_connection():
     return True
 
 
+def _is_port_open(host: str, port: int, timeout: float = 1.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def test_qdrant_connection():
+    """Тест подключения к Qdrant."""
+    parsed = urlparse(QDRANT_URL)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 6333
+    if not _is_port_open(host, port):
+        pytest.skip(f"Qdrant not running on {host}:{port}")
+    assert _run_qdrant_connection_checks()
+
+
 if __name__ == "__main__":
     import sys
 
-    success = test_qdrant_connection()
+    success = _run_qdrant_connection_checks()
     sys.exit(0 if success else 1)

--- a/tests/integration/test_hybrid_search_sparse.py
+++ b/tests/integration/test_hybrid_search_sparse.py
@@ -4,8 +4,12 @@ Test hybrid search with sparse vectors in production code.
 Verifies that HybridRRFSearchEngine uses both dense and sparse vectors via RRF.
 """
 
+import socket
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
 
 
 # Add project root to path
@@ -16,8 +20,8 @@ from src.config import Settings
 from src.retrieval import HybridRRFSearchEngine
 
 
-def test_hybrid_search_with_sparse():
-    """Test hybrid search using dense + sparse vectors."""
+def _run_hybrid_search_with_sparse() -> bool:
+    """Run hybrid search flow using dense + sparse vectors."""
 
     print("=" * 80)
     print("TEST: HYBRID SEARCH WITH SPARSE VECTORS")
@@ -80,6 +84,25 @@ def test_hybrid_search_with_sparse():
     return True
 
 
+def _is_port_open(host: str, port: int, timeout: float = 1.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def test_hybrid_search_with_sparse():
+    """Test hybrid search using dense + sparse vectors."""
+    settings = Settings()
+    parsed = urlparse(settings.qdrant_url)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 6333
+    if not _is_port_open(host, port):
+        pytest.skip(f"Qdrant not running on {host}:{port}")
+    assert _run_hybrid_search_with_sparse()
+
+
 if __name__ == "__main__":
-    success = test_hybrid_search_with_sparse()
+    success = _run_hybrid_search_with_sparse()
     sys.exit(0 if success else 1)

--- a/tests/integration/test_qdrant_connection.py
+++ b/tests/integration/test_qdrant_connection.py
@@ -4,21 +4,24 @@
 Тестирует подключение и выводит информацию о коллекциях.
 """
 
+import socket
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 
 # Add project root to path
 project_root = Path(__file__).parent
 sys.path.insert(0, str(project_root))
 
+import pytest
 from qdrant_client import QdrantClient
 
 from src.config.settings import Settings
 
 
-def test_qdrant_connection():
-    """Проверка подключения к Qdrant."""
+def _run_qdrant_connection_checks() -> bool:
+    """Выполнить проверки подключения к Qdrant."""
 
     print("=" * 70)
     print("ТЕСТ ПОДКЛЮЧЕНИЯ К QDRANT")
@@ -74,6 +77,25 @@ def test_qdrant_connection():
         return False
 
 
+def _is_port_open(host: str, port: int, timeout: float = 1.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def test_qdrant_connection():
+    """Проверка подключения к Qdrant."""
+    settings = Settings()
+    parsed = urlparse(settings.qdrant_url)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 6333
+    if not _is_port_open(host, port):
+        pytest.skip(f"Qdrant not running on {host}:{port}")
+    assert _run_qdrant_connection_checks()
+
+
 if __name__ == "__main__":
-    success = test_qdrant_connection()
+    success = _run_qdrant_connection_checks()
     sys.exit(0 if success else 1)

--- a/tests/integration/test_qdrant_read.py
+++ b/tests/integration/test_qdrant_read.py
@@ -4,8 +4,10 @@
 Проверяет поиск и получение точек из существующей коллекции.
 """
 
+import socket
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 
 project_root = Path(__file__).parent
@@ -13,6 +15,7 @@ sys.path.insert(0, str(project_root))
 
 import os
 
+import pytest
 from dotenv import load_dotenv
 from qdrant_client import QdrantClient
 
@@ -24,8 +27,8 @@ QDRANT_URL = os.getenv("QDRANT_URL", "http://95.111.252.29:6333")
 QDRANT_API_KEY = os.getenv("QDRANT_API_KEY", "")
 
 
-def test_qdrant_read():
-    """Тест чтения из Qdrant."""
+def _run_qdrant_read_checks() -> bool:
+    """Выполнить проверки чтения из Qdrant."""
 
     print("=" * 80)
     print("ТЕСТ ЧТЕНИЯ ИЗ QDRANT")
@@ -123,6 +126,24 @@ def test_qdrant_read():
         return False
 
 
+def _is_port_open(host: str, port: int, timeout: float = 1.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def test_qdrant_read():
+    """Тест чтения из Qdrant."""
+    parsed = urlparse(QDRANT_URL)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 6333
+    if not _is_port_open(host, port):
+        pytest.skip(f"Qdrant not running on {host}:{port}")
+    assert _run_qdrant_read_checks()
+
+
 if __name__ == "__main__":
-    success = test_qdrant_read()
+    success = _run_qdrant_read_checks()
     sys.exit(0 if success else 1)

--- a/tests/unit/graph/test_summarize_node.py
+++ b/tests/unit/graph/test_summarize_node.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+import pytest
+
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Importing Send from langgraph.constants is deprecated.*"
+)
+
 
 class TestSummarizationNodeIntegration:
     def test_summarize_node_is_runnable(self):

--- a/tests/unit/ingestion/test_gdrive_flow.py
+++ b/tests/unit/ingestion/test_gdrive_flow.py
@@ -4,6 +4,13 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:This module is deprecated. Use src.ingestion.unified instead.:DeprecationWarning"
+)
+
 
 class TestGDriveFlowConfig:
     """Test flow configuration."""

--- a/tests/unit/ingestion/test_gdrive_flow_dotenv.py
+++ b/tests/unit/ingestion/test_gdrive_flow_dotenv.py
@@ -3,6 +3,13 @@
 import importlib
 from pathlib import Path
 
+import pytest
+
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:This module is deprecated. Use src.ingestion.unified instead.:DeprecationWarning"
+)
+
 
 class TestDotenvLoading:
     """Test that .env variables are loaded before config initialization."""

--- a/tests/unit/test_evaluator.py
+++ b/tests/unit/test_evaluator.py
@@ -310,6 +310,7 @@ class TestCompareEngines:
                 "relative_improvement_pct"
             ] == pytest.approx(12.5)
 
+    @pytest.mark.filterwarnings("ignore:.*sample.*too small.*")
     def test_compare_engines_failure_rate_improvement(self):
         """Test failure rate improvement (lower is better)."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:

--- a/tests/unit/test_qdrant_service.py
+++ b/tests/unit/test_qdrant_service.py
@@ -873,6 +873,7 @@ class TestQdrantServiceInit:
         ],
         ids=["defaults", "custom_vector_names", "with_api_key"],
     )
+    @pytest.mark.filterwarnings("ignore:Api key is used with an insecure connection.")
     def test_init(self, extra_kwargs, expected):
         """Test initialization with various configurations."""
         with patch("telegram_bot.services.qdrant.AsyncQdrantClient"):


### PR DESCRIPTION
## What this PR does
Follow-up autofix after re-review of all PRs merged on 2026-02-17 (`#251`..`#308`) on top of `origin/main`.

### 1) Removed warning-producing test anti-patterns
- converted tests that returned values into assertion-based tests via helper runners:
  - `tests/benchmark/test_colbert_rerank.py`
  - `tests/benchmark/test_dbsf_colbert.py`
  - `tests/integration/test_basic_connection.py`
  - `tests/integration/test_hybrid_search_sparse.py`
  - `tests/integration/test_qdrant_connection.py`
  - `tests/integration/test_qdrant_read.py`
- refactored `tests/benchmark/test_docling_vs_pymupdf.py` to avoid returning payloads from test functions.

### 2) Stabilized infra-dependent tests
- added explicit TCP preflight + `pytest.skip(...)` for Qdrant-dependent benchmark/integration checks when service is unavailable.

### 3) Silenced known external/legacy warning noise at test level
- added targeted warning filters for:
  - deprecated legacy ingestion module usage in gdrive-flow tests
  - external langgraph deprecation surfacing through langmem/trustcall
  - known statistical warning in evaluator comparison test
  - insecure API-key warning in qdrant init test

### 4) Fixed mypy regression discovered during review run
- `src/voice/sip_setup.py`: switched to mypy-safe dynamic `livekit.api` import while preserving `api.LiveKitAPI` patch point expected by unit tests.

## Validation
- `make check` ✅
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit` ✅ (`2477 passed, 7 skipped`)
- `make test` ✅ (`2662 passed, 98 skipped`)

## Full test duration
- full local `make test` runtime: **81.30s** (about **1m21s**)
