### PR TITLE
feat(config): session summary + Kommo CRM feature flags (#305)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,3 +137,13 @@ LIFECELL_SIP_USER=
 LIFECELL_SIP_PASS=
 RAG_API_URL=http://rag-api:8080
 VOICE_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/postgres
+
+# =============================================================================
+# SESSION SUMMARY + CRM (#305)
+# =============================================================================
+SESSION_SUMMARY_ENABLED=false
+SESSION_TIMEOUT_MINUTES=30
+KOMMO_ENABLED=false
+KOMMO_SUBDOMAIN=
+KOMMO_ACCESS_TOKEN=
+KOMMO_TELEGRAM_FIELD_ID=0

--- a/telegram_bot/config.py
+++ b/telegram_bot/config.py
@@ -1,6 +1,6 @@
 """Bot configuration."""
 
-from pydantic import AliasChoices, Field, field_validator
+from pydantic import AliasChoices, Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -322,8 +322,8 @@ class BotConfig(BaseSettings):
         default="",
         validation_alias=AliasChoices("kommo_subdomain", "KOMMO_SUBDOMAIN"),
     )
-    kommo_access_token: str = Field(
-        default="",
+    kommo_access_token: SecretStr = Field(
+        default=SecretStr(""),
         validation_alias=AliasChoices("kommo_access_token", "KOMMO_ACCESS_TOKEN"),
     )
     kommo_telegram_field_id: int = Field(

--- a/telegram_bot/config.py
+++ b/telegram_bot/config.py
@@ -305,6 +305,32 @@ class BotConfig(BaseSettings):
         validation_alias=AliasChoices("supervisor_model", "SUPERVISOR_MODEL"),
     )
 
+    # Session summary + CRM (#305)
+    session_summary_enabled: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("session_summary_enabled", "SESSION_SUMMARY_ENABLED"),
+    )
+    session_timeout_minutes: int = Field(
+        default=30,
+        validation_alias=AliasChoices("session_timeout_minutes", "SESSION_TIMEOUT_MINUTES"),
+    )
+    kommo_enabled: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("kommo_enabled", "KOMMO_ENABLED"),
+    )
+    kommo_subdomain: str = Field(
+        default="",
+        validation_alias=AliasChoices("kommo_subdomain", "KOMMO_SUBDOMAIN"),
+    )
+    kommo_access_token: str = Field(
+        default="",
+        validation_alias=AliasChoices("kommo_access_token", "KOMMO_ACCESS_TOKEN"),
+    )
+    kommo_telegram_field_id: int = Field(
+        default=0,
+        validation_alias=AliasChoices("kommo_telegram_field_id", "KOMMO_TELEGRAM_FIELD_ID"),
+    )
+
     # LLM-as-a-Judge online sampling
     judge_sample_rate: float = Field(
         default=0.0,

--- a/telegram_bot/services/__init__.py
+++ b/telegram_bot/services/__init__.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from .query_analyzer import QueryAnalyzer
     from .query_preprocessor import HyDEGenerator, QueryPreprocessor
     from .retriever import RetrieverService
+    from .session_summary import SessionSummary, format_summary_as_note, generate_summary
     from .small_to_big import ExpandedChunk, SmallToBigService
     from .vectorizers import UserBaseVectorizer
     from .voyage import VoyageService
@@ -39,9 +40,12 @@ __all__ = [
     "QueryAnalyzer",
     "QueryPreprocessor",
     "RetrieverService",
+    "SessionSummary",
     "SmallToBigService",
     "UserBaseVectorizer",
     "VoyageService",
+    "format_summary_as_note",
+    "generate_summary",
 ]
 
 # Lazy import mapping
@@ -53,6 +57,7 @@ _IMPORT_MAP = {
     "ExpandedChunk": ".small_to_big",
     "HistoryService": ".history_service",
     "HyDEGenerator": ".query_preprocessor",
+    "SessionSummary": ".session_summary",
     "LLMService": ".llm",
     "LOW_CONFIDENCE_THRESHOLD": ".llm",
     "PipelineMetrics": ".metrics",
@@ -63,6 +68,8 @@ _IMPORT_MAP = {
     "SmallToBigService": ".small_to_big",
     "UserBaseVectorizer": ".vectorizers",
     "VoyageService": ".voyage",
+    "format_summary_as_note": ".session_summary",
+    "generate_summary": ".session_summary",
 }
 
 


### PR DESCRIPTION
## Summary

Completes Phase 1 scope for #305 by adding missing config flags and code review fixes.

**PR #309** (already merged) implemented the core deliverables:
- `get_session_turns()` in HistoryService
- `SessionSummary` Pydantic model
- `generate_summary()` with LLM structured output
- `format_summary_as_note()` for CRM output
- 37 unit tests

**This PR** adds the remaining items identified in code review:
- `SESSION_SUMMARY_ENABLED`, `SESSION_TIMEOUT_MINUTES`, `KOMMO_ENABLED` feature flags in BotConfig (all `False` by default)
- `KOMMO_SUBDOMAIN`, `KOMMO_ACCESS_TOKEN` (SecretStr), `KOMMO_TELEGRAM_FIELD_ID` config fields
- Lazy exports for `SessionSummary`, `generate_summary`, `format_summary_as_note` in `services/__init__.py`
- `.env.example` documentation for all new vars

## Review Findings Addressed

| Finding | Status |
|---------|--------|
| 1. No `get_session_turns()` | Done in PR #309 |
| 2. No `session_summary.py` | Done in PR #309 |
| 3. No tests | Done in PR #309 (37 tests) |
| 4. No config flags | **This PR** |
| 5. Dual-path active | Out of scope (epic #263) |
| 6. #305 closed manually | Reopened |

## Test plan

- [x] `make check` — Ruff + MyPy clean (70 files, 0 issues)
- [x] `uv run pytest tests/unit/ -n auto` — 2522 passed, 7 skipped
- [x] Phase 1 tests: 37/37 pass
- [x] Lazy imports verified: `from telegram_bot.services import SessionSummary` works
- [x] `SecretStr` verified: `kommo_access_token` prints as `SecretStr('')`
- [x] All flags default to `False`

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)