### PR TITLE
fix(tests): forbid module-level sys.modules monkeypatch

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -26,6 +26,23 @@ make test-cov                                          # Opens htmlcov/index.htm
 
 **pytest-timeout:** All tests have 30s default timeout (pyproject.toml). Override per-test with `@pytest.mark.timeout(60)`.
 
+## sys.modules Hygiene
+
+**Policy:** NEVER assign to `sys.modules` at module level in test files.
+
+| Pattern | Status |
+|---------|--------|
+| `sys.modules["foo"] = MagicMock()` at module level | **FORBIDDEN** |
+| `monkeypatch.setitem(sys.modules, "foo", mock)` in fixture | **OK** |
+| `pytest.MonkeyPatch.context()` in module-scoped fixture | **OK** |
+| `sys.modules["foo"] = mock` in `pytest_configure` (conftest) | **OK** (with `pytest_unconfigure` cleanup) |
+
+**Why:** Module-level patching leaks mocks into the session, breaks xdist isolation, and causes flaky tests from import-order dependencies.
+
+**For collection-time mocks** (heavy ML libs): use `pytest_configure` / `pytest_unconfigure` hooks in `conftest.py`.
+
+**Guard:** `test_module_pollution.py::test_no_module_level_sys_modules_assignment` scans all test files via AST and fails if bare module-level `sys.modules[...] = ...` is found.
+
 ## Integration Tests
 
 ### Graph Path Tests (no Docker required)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,45 +43,53 @@ load_dotenv()
 # =============================================================================
 # MOCK HEAVY IMPORTS FOR UNIT TESTS
 # =============================================================================
-# These modules are slow to import due to model loading. Mock them at startup
-# to allow fast unit test collection and execution.
+# These modules are slow to import due to model loading.  Mocks are installed
+# in ``pytest_configure`` (earliest hook, before collection) and removed in
+# ``pytest_unconfigure`` so that no MagicMock leaks into sys.modules after the
+# session ends.
+#
+# Policy: NEVER assign to sys.modules at module level.  Use
+# ``monkeypatch.setitem(sys.modules, ...)`` inside fixtures, or register mocks
+# via ``pytest_configure`` for collection-time needs.  See
+# ``.claude/rules/testing.md`` § "sys.modules hygiene".
+
+_saved_modules: dict[str, object] = {}
+_mocked_module_names: list[str] = []
 
 
-def _setup_mock_heavy_imports():
-    """Mock slow-to-import ML libraries at startup."""
-    # Skip if already mocked
-    if "sentence_transformers" in sys.modules and not isinstance(
+def pytest_configure(config):
+    """Install lightweight mocks for heavy ML libs before test collection."""
+    # -- sentence_transformers / FlagEmbedding (slow model loading) ----------
+    # Skip if: (a) real module already loaded, or (b) re-entry (already mocked).
+    _already_mocked = "sentence_transformers" in _mocked_module_names
+    _real_module_loaded = "sentence_transformers" in sys.modules and not isinstance(
         sys.modules["sentence_transformers"], MagicMock
-    ):
-        return
+    )
+    if not _already_mocked and not _real_module_loaded:
+        for mod_name in ("sentence_transformers", "FlagEmbedding"):
+            _saved_modules[mod_name] = sys.modules.get(mod_name)
 
-    # Mock sentence_transformers
-    mock_st = MagicMock()
-    mock_st.CrossEncoder = MagicMock()
-    mock_st.SentenceTransformer = MagicMock()
-    sys.modules["sentence_transformers"] = mock_st
+        mock_st = MagicMock()
+        mock_st.CrossEncoder = MagicMock()
+        mock_st.SentenceTransformer = MagicMock()
+        sys.modules["sentence_transformers"] = mock_st
+        _mocked_module_names.append("sentence_transformers")
 
-    # Mock FlagEmbedding
-    mock_flag = MagicMock()
-    mock_flag.BGEM3FlagModel = MagicMock()
-    sys.modules["FlagEmbedding"] = mock_flag
+        mock_flag = MagicMock()
+        mock_flag.BGEM3FlagModel = MagicMock()
+        sys.modules["FlagEmbedding"] = mock_flag
+        _mocked_module_names.append("FlagEmbedding")
 
-
-# Run at conftest load time to prevent slow imports during test collection
-_setup_mock_heavy_imports()
-
-
-def _setup_mock_optional_telegram_deps():
-    """Mock optional Telegram deps (aiogram) when not installed.
-
-    Unit tests should not require Telegram runtime dependencies to be present.
-    """
+    # -- aiogram (optional Telegram runtime dep) -----------------------------
     try:
         import importlib.util
 
         if importlib.util.find_spec("aiogram") is None:
             raise ModuleNotFoundError("aiogram not installed")
     except ModuleNotFoundError:
+        for mod_name in ("aiogram", "aiogram.filters", "aiogram.types"):
+            _saved_modules[mod_name] = sys.modules.get(mod_name)
+
         mock_aiogram = MagicMock()
         mock_aiogram.Bot = MagicMock()
         mock_aiogram.Dispatcher = MagicMock()
@@ -96,9 +104,19 @@ def _setup_mock_optional_telegram_deps():
         sys.modules["aiogram"] = mock_aiogram
         sys.modules["aiogram.filters"] = mock_filters
         sys.modules["aiogram.types"] = mock_types
+        _mocked_module_names.extend(["aiogram", "aiogram.filters", "aiogram.types"])
 
 
-_setup_mock_optional_telegram_deps()
+def pytest_unconfigure(config):
+    """Restore original modules after test session."""
+    for mod_name in _mocked_module_names:
+        original = _saved_modules.get(mod_name)
+        if original is None:
+            sys.modules.pop(mod_name, None)
+        else:
+            sys.modules[mod_name] = original  # type: ignore[assignment]
+    _mocked_module_names.clear()
+    _saved_modules.clear()
 
 
 # =============================================================================

--- a/tests/unit/retrieval/conftest.py
+++ b/tests/unit/retrieval/conftest.py
@@ -7,11 +7,13 @@ import pytest
 
 
 @pytest.fixture
-def mock_cross_encoder():
+def mock_cross_encoder(monkeypatch):
     """Provide access to mocked CrossEncoder for assertions.
 
     Since reranker.py now uses lazy import, we need to ensure the mock
     is in sys.modules BEFORE the test imports reranker.
+
+    Uses monkeypatch.setitem for automatic teardown of sys.modules entries.
 
     Returns dict with:
     - encoder: Mock CrossEncoder instance
@@ -26,7 +28,7 @@ def mock_cross_encoder():
     mock_st = MagicMock()
     mock_encoder_instance = MagicMock()
     mock_st.CrossEncoder.return_value = mock_encoder_instance
-    sys.modules["sentence_transformers"] = mock_st
+    monkeypatch.setitem(sys.modules, "sentence_transformers", mock_st)
 
     # Now import reranker - it will use our mock
     from src.retrieval import reranker

--- a/tests/unit/test_bge_m3_endpoints.py
+++ b/tests/unit/test_bge_m3_endpoints.py
@@ -2,35 +2,24 @@
 
 Covers /encode/sparse, /encode/colbert, /encode/hybrid, /encode/dense,
 /health, /metrics, and config defaults.
+
+All sys.modules mocking is fixture-scoped (no module-level pollution).
 """
 
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import httpx
 import numpy as np
 import pytest
-
-
-# ── Mock heavy dependencies BEFORE importing app ──
-mock_flag = MagicMock()
-mock_prom = MagicMock()
-sys.modules["FlagEmbedding"] = mock_flag
-sys.modules["prometheus_client"] = mock_prom
-
-# pydantic_settings is available in test env, but config.py imports it;
-# also re-export make_asgi_app so app.py can mount metrics
-mock_prom.make_asgi_app = MagicMock(return_value=MagicMock())
-
-# Add service directory to path
-sys.path.insert(0, str(Path(__file__).parents[2] / "services" / "bge-m3-api"))
-
-import httpx
 
 
 # ── Fake model that returns deterministic numpy arrays ──
 _DENSE_DIM = 1024
 _COLBERT_DIM = 1024
+
+_BGE_SERVICE_DIR = str(Path(__file__).parents[2] / "services" / "bge-m3-api")
 
 
 def _make_fake_model():
@@ -64,25 +53,46 @@ def _make_fake_model():
     return model
 
 
-# Add config for defaults test
-import app as app_module
+@pytest.fixture(scope="module")
+def bge_app():
+    """Mock heavy deps, import bge-m3-api app, install fake model.
 
-# Import app and patch model
-from app import app as fastapi_app
+    Uses MonkeyPatch.context() for automatic teardown of sys.modules entries.
+    """
+    with pytest.MonkeyPatch.context() as mp:
+        mock_flag = MagicMock()
+        mock_prom = MagicMock()
+        mock_prom.make_asgi_app = MagicMock(return_value=MagicMock())
 
-import config as _cfg
+        mp.setitem(sys.modules, "FlagEmbedding", mock_flag)
+        mp.setitem(sys.modules, "prometheus_client", mock_prom)
+        mp.syspath_prepend(_BGE_SERVICE_DIR)
+
+        import app as app_module
+        from app import app as fastapi_app
+
+        import config as _cfg
+
+        fake_model = _make_fake_model()
+        app_module._model = fake_model
+        app_module.get_model = MagicMock(return_value=fake_model)
+
+        yield {
+            "app": fastapi_app,
+            "app_module": app_module,
+            "config": _cfg,
+            "fake_model": fake_model,
+        }
+
+        # Clean up cached service imports (not mocks — real modules imported
+        # via syspath_prepend that shouldn't leak to other test files).
+        for mod_name in ("app", "config"):
+            sys.modules.pop(mod_name, None)
 
 
-# Install fake model
-_fake_model = _make_fake_model()
-app_module._model = _fake_model
-app_module.get_model = MagicMock(return_value=_fake_model)
-
-
-# ── Async client fixture ──
 @pytest.fixture
-def client():
-    transport = httpx.ASGITransport(app=fastapi_app)
+def client(bge_app):
+    transport = httpx.ASGITransport(app=bge_app["app"])
     return httpx.AsyncClient(transport=transport, base_url="http://test")
 
 
@@ -152,7 +162,8 @@ class TestMetrics:
 
 
 class TestConfigDefaults:
-    def test_settings_defaults(self):
+    def test_settings_defaults(self, bge_app):
+        _cfg = bge_app["config"]
         assert _cfg.settings.MAX_LENGTH == 2048
         assert _cfg.settings.BATCH_SIZE == 12
         assert _cfg.settings.USE_FP16 is True

--- a/tests/unit/test_bge_m3_rerank.py
+++ b/tests/unit/test_bge_m3_rerank.py
@@ -1,24 +1,37 @@
-"""Tests for bge-m3-api /rerank endpoint."""
+"""Tests for bge-m3-api /rerank endpoint.
+
+All sys.modules mocking is fixture-scoped (no module-level pollution).
+"""
 
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import numpy as np
+import pytest
 
 
-# Mock heavy dependencies before importing app
-sys.modules["FlagEmbedding"] = MagicMock()
-sys.modules["prometheus_client"] = MagicMock()
+_BGE_SERVICE_DIR = str(Path(__file__).parents[2] / "services" / "bge-m3-api")
 
-# Add services/bge-m3-api to path for imports
-sys.path.insert(0, str(Path(__file__).parents[2] / "services" / "bge-m3-api"))
+
+@pytest.fixture(scope="module")
+def bge_rerank_app():
+    """Mock heavy deps and add bge-m3-api to sys.path for imports."""
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setitem(sys.modules, "FlagEmbedding", MagicMock())
+        mp.setitem(sys.modules, "prometheus_client", MagicMock())
+        mp.syspath_prepend(_BGE_SERVICE_DIR)
+        yield
+        # Clean up cached service imports (not mocks — real modules imported
+        # via syspath_prepend that shouldn't leak to other test files).
+        for mod in ("app", "config"):
+            sys.modules.pop(mod, None)
 
 
 class TestRerankEndpoint:
     """Tests for ColBERT MaxSim rerank endpoint."""
 
-    def test_rerank_request_model_validation(self):
+    def test_rerank_request_model_validation(self, bge_rerank_app):
         """Test RerankRequest validates input."""
         from app import RerankRequest
 
@@ -32,7 +45,7 @@ class TestRerankEndpoint:
         assert len(req.documents) == 2
         assert req.top_k == 2
 
-    def test_rerank_response_model(self):
+    def test_rerank_response_model(self, bge_rerank_app):
         """Test RerankResponse structure."""
         from app import RerankResponse, RerankResult
 
@@ -42,7 +55,7 @@ class TestRerankEndpoint:
         assert response.results[0].index == 0
         assert response.results[0].score == 0.95
 
-    def test_maxsim_score_calculation(self):
+    def test_maxsim_score_calculation(self, bge_rerank_app):
         """Test MaxSim scoring function."""
         from app import compute_maxsim_scores
 

--- a/tests/unit/test_module_pollution.py
+++ b/tests/unit/test_module_pollution.py
@@ -1,9 +1,20 @@
-"""Test that no global sys.modules pollution occurs during test runs."""
+"""Test that no global sys.modules pollution occurs during test runs.
 
+Policy: NEVER assign to sys.modules at module level in test files.
+Use ``monkeypatch.setitem(sys.modules, ...)`` inside fixtures, or register
+mocks via ``pytest_configure`` in conftest.py for collection-time needs.
+"""
+
+import ast
 import sys
+from pathlib import Path
 from types import ModuleType
+from unittest.mock import MagicMock
 
 import pytest
+
+
+_TESTS_ROOT = Path(__file__).resolve().parents[1]  # tests/
 
 
 def test_no_global_sys_modules_patching():
@@ -43,3 +54,55 @@ def test_langfuse_not_globally_mocked():
                 "Global langfuse mock detected. Use @pytest.fixture(autouse=True) "
                 "with monkeypatch.setitem(sys.modules, ...) instead."
             )
+
+
+def test_prometheus_client_not_globally_mocked():
+    """prometheus_client mock must be fixture-scoped, not global."""
+    if "prometheus_client" in sys.modules:
+        module = sys.modules["prometheus_client"]
+        if isinstance(module, MagicMock):
+            pytest.fail(
+                "Global prometheus_client mock detected. "
+                "Use @pytest.fixture with monkeypatch.setitem instead."
+            )
+
+
+def test_no_module_level_sys_modules_assignment():
+    """Static guard: scan test files for module-level ``sys.modules[...] = ...``.
+
+    Conftest files using ``pytest_configure`` are allowed.
+    Assignments inside functions, fixtures, and classes are fine.
+    Only bare module-level assignments are forbidden.
+    """
+    violations: list[str] = []
+
+    for py_file in sorted(_TESTS_ROOT.rglob("*.py")):
+        # conftest.py files may use pytest_configure for collection-time mocks
+        if py_file.name == "conftest.py":
+            continue
+
+        source = py_file.read_text(encoding="utf-8")
+        try:
+            tree = ast.parse(source, filename=str(py_file))
+        except SyntaxError:
+            continue
+
+        for node in ast.iter_child_nodes(tree):
+            # Only check top-level statements (module body)
+            if not isinstance(node, (ast.Assign, ast.Expr)):
+                continue
+
+            source_line = ast.get_source_segment(source, node) or ""
+
+            if "sys.modules[" in source_line and "=" in source_line:
+                rel = py_file.relative_to(_TESTS_ROOT)
+                violations.append(f"{rel}:{node.lineno}")
+
+    if violations:
+        pytest.fail(
+            f"Module-level sys.modules assignment detected in {len(violations)} "
+            f"location(s):\n"
+            + "\n".join(f"  - {v}" for v in violations)
+            + "\n\nUse monkeypatch.setitem(sys.modules, ...) in a fixture instead. "
+            "See .claude/rules/testing.md § 'sys.modules hygiene'."
+        )

--- a/tests/unit/test_userbase_endpoints.py
+++ b/tests/unit/test_userbase_endpoints.py
@@ -1,56 +1,68 @@
 """Tests for USER2-base FastAPI endpoints (services/user-base/main.py).
 
-Mocks SentenceTransformer before importing app to avoid model download.
+Mocks SentenceTransformer via fixture before importing app to avoid model download.
 Uses httpx.AsyncClient + ASGITransport for async endpoint testing.
+
+All sys.modules mocking is fixture-scoped (no module-level pollution).
 """
 
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import httpx
 import numpy as np
 import pytest
 
 
-# Mock SentenceTransformer BEFORE importing the app module
-_mock_st_class = MagicMock()
-_mock_model_instance = MagicMock()
-_mock_model_instance.get_sentence_embedding_dimension.return_value = 768
-_mock_model_instance.encode.side_effect = lambda text, **_kw: (
-    np.random.rand(768).astype(np.float32)
-    if isinstance(text, str)
-    else np.random.rand(len(text), 768).astype(np.float32)
-)
-_mock_st_class.return_value = _mock_model_instance
-
-_mock_module = MagicMock()
-_mock_module.SentenceTransformer = _mock_st_class
-sys.modules["sentence_transformers"] = _mock_module
-
-# Import main.py from services/user-base/ (not a Python package due to hyphen)
-_service_dir = str(Path(__file__).resolve().parents[2] / "services" / "user-base")
-sys.path.insert(0, _service_dir)
-import main as userbase_main
+_USERBASE_SERVICE_DIR = str(Path(__file__).resolve().parents[2] / "services" / "user-base")
 
 
-app = userbase_main.app
-sys.path.pop(0)
+@pytest.fixture(scope="module")
+def userbase_env():
+    """Mock sentence_transformers & import user-base app.
 
-import httpx
+    Returns dict with app, main module, mock class and mock model instance.
+    """
+    mock_st_class = MagicMock()
+    mock_model_instance = MagicMock()
+    mock_model_instance.get_sentence_embedding_dimension.return_value = 768
+    mock_model_instance.encode.side_effect = lambda text, **_kw: (
+        np.random.rand(768).astype(np.float32)
+        if isinstance(text, str)
+        else np.random.rand(len(text), 768).astype(np.float32)
+    )
+    mock_st_class.return_value = mock_model_instance
+
+    mock_module = MagicMock()
+    mock_module.SentenceTransformer = mock_st_class
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setitem(sys.modules, "sentence_transformers", mock_module)
+        mp.syspath_prepend(_USERBASE_SERVICE_DIR)
+
+        import main as userbase_main
+
+        yield {
+            "main": userbase_main,
+            "app": userbase_main.app,
+            "mock_st_class": mock_st_class,
+            "mock_model_instance": mock_model_instance,
+        }
+
+        # Clean up cached service import (not a mock — real module imported
+        # via syspath_prepend that shouldn't leak to other test files).
+        sys.modules.pop("main", None)
 
 
 @pytest.fixture
-async def client():
-    """Create async test client with ASGI transport.
-
-    Sets the module-level model to the mock instance since lifespan
-    doesn't run with ASGITransport.
-    """
-    userbase_main.model = _mock_model_instance
-    transport = httpx.ASGITransport(app=app)
+async def client(userbase_env):
+    """Create async test client with ASGI transport."""
+    userbase_env["main"].model = userbase_env["mock_model_instance"]
+    transport = httpx.ASGITransport(app=userbase_env["app"])
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
         yield c
-    userbase_main.model = None
+    userbase_env["main"].model = None
 
 
 class TestHealthEndpoint:
@@ -135,46 +147,55 @@ class TestEmbedBatchEndpoint:
 class TestLoadModelBackend:
     """Tests for _load_model backend selection and fallback."""
 
-    def test_default_backend_is_pytorch(self):
+    def test_default_backend_is_pytorch(self, userbase_env):
         """Default EMBEDDING_BACKEND loads pytorch."""
-        with patch.object(userbase_main, "EMBEDDING_BACKEND", "pytorch"):
-            model = userbase_main._load_model()
-            assert userbase_main._active_backend == "pytorch"
-            assert model is _mock_model_instance
+        ub = userbase_env["main"]
+        mock_model = userbase_env["mock_model_instance"]
+        with patch.object(ub, "EMBEDDING_BACKEND", "pytorch"):
+            model = ub._load_model()
+            assert ub._active_backend == "pytorch"
+            assert model is mock_model
 
-    def test_onnx_backend_falls_back_on_import_error(self):
+    def test_onnx_backend_falls_back_on_import_error(self, userbase_env):
         """ONNX backend falls back to pytorch when onnxruntime not installed."""
+        ub = userbase_env["main"]
+        mock_model = userbase_env["mock_model_instance"]
         with (
-            patch.object(userbase_main, "EMBEDDING_BACKEND", "onnx"),
+            patch.object(ub, "EMBEDDING_BACKEND", "onnx"),
             patch.dict(sys.modules, {"onnxruntime": None}),
         ):
-            model = userbase_main._load_model()
-            assert userbase_main._active_backend == "pytorch"
-            assert model is _mock_model_instance
+            model = ub._load_model()
+            assert ub._active_backend == "pytorch"
+            assert model is mock_model
 
-    def test_onnx_backend_loads_when_available(self):
+    def test_onnx_backend_loads_when_available(self, userbase_env):
         """ONNX backend used when onnxruntime is importable."""
+        ub = userbase_env["main"]
+        mock_st = userbase_env["mock_st_class"]
         mock_ort = MagicMock()
         with (
-            patch.object(userbase_main, "EMBEDDING_BACKEND", "onnx"),
+            patch.object(ub, "EMBEDDING_BACKEND", "onnx"),
             patch.dict(sys.modules, {"onnxruntime": mock_ort}),
         ):
-            userbase_main._load_model()
-            assert userbase_main._active_backend == "onnx"
-            _mock_st_class.assert_called_with("deepvk/USER2-base", backend="onnx")
+            ub._load_model()
+            assert ub._active_backend == "onnx"
+            mock_st.assert_called_with("deepvk/USER2-base", backend="onnx")
 
-    def test_onnx_backend_falls_back_on_exception(self):
+    def test_onnx_backend_falls_back_on_exception(self, userbase_env):
         """ONNX backend falls back to pytorch on any SentenceTransformer error."""
+        ub = userbase_env["main"]
+        mock_st = userbase_env["mock_st_class"]
+        mock_model = userbase_env["mock_model_instance"]
         mock_ort = MagicMock()
-        _mock_st_class.side_effect = [RuntimeError("ONNX export failed"), _mock_model_instance]
+        mock_st.side_effect = [RuntimeError("ONNX export failed"), mock_model]
         try:
             with (
-                patch.object(userbase_main, "EMBEDDING_BACKEND", "onnx"),
+                patch.object(ub, "EMBEDDING_BACKEND", "onnx"),
                 patch.dict(sys.modules, {"onnxruntime": mock_ort}),
             ):
-                model = userbase_main._load_model()
-                assert userbase_main._active_backend == "pytorch"
-                assert model is _mock_model_instance
+                model = ub._load_model()
+                assert ub._active_backend == "pytorch"
+                assert model is mock_model
         finally:
-            _mock_st_class.side_effect = None
-            _mock_st_class.return_value = _mock_model_instance
+            mock_st.side_effect = None
+            mock_st.return_value = mock_model


### PR DESCRIPTION
## Summary

- Migrate all module-level `sys.modules[...] = MagicMock()` to fixture-scoped `monkeypatch.setitem()` (function-scope) or `MonkeyPatch.context()` (module-scope) with automatic teardown
- Convert root conftest mock installs to `pytest_configure`/`pytest_unconfigure` hooks with save/restore and re-entry guard
- Add AST-based static guard (`test_no_module_level_sys_modules_assignment`) that scans all test files and fails CI if bare module-level `sys.modules` assignments are found
- Document `sys.modules` hygiene policy in `.claude/rules/testing.md`

## Files changed (7)

| File | Change |
|------|--------|
| `tests/conftest.py` | `pytest_configure`/`pytest_unconfigure` hooks with save/restore |
| `tests/unit/test_bge_m3_endpoints.py` | Module-scoped `bge_app` fixture |
| `tests/unit/test_bge_m3_rerank.py` | Module-scoped `bge_rerank_app` fixture |
| `tests/unit/test_userbase_endpoints.py` | Module-scoped `userbase_env` fixture |
| `tests/unit/retrieval/conftest.py` | `monkeypatch.setitem` for sentence_transformers |
| `tests/unit/test_module_pollution.py` | AST guard + prometheus runtime check |
| `.claude/rules/testing.md` | Policy documentation |

## Test plan

- [x] Full test suite: 2479 passed, 7 skipped, 0 failures (`-n auto`)
- [x] Ruff lint + format clean
- [x] Pre-commit hooks pass
- [x] AST guard catches violations (tested manually)
- [x] Verified flaky `test_target_sync_execution` is pre-existing (passes on main)

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)