### PR TITLE
fix(infra): correct livekit-server bind-mount path (#320)

### DIFF
--- a/.claude/rules/docker.md
+++ b/.claude/rules/docker.md
@@ -34,6 +34,7 @@ paths: "docker/**/*.*, docker-compose*.yml, **/monitoring/**"
 | `make docker-ai-up` | core + bge-m3, user-base | Heavy AI models |
 | `make docker-eval-up` | core + mlflow | Evaluation (RAGAS, A/B tests) |
 | `make docker-ingest-up` | core + ingestion | Ingestion container |
+| `make docker-voice-up` | core + livekit, sip, voice-agent | Voice/SIP dev (preflight check) |
 | `make docker-full-up` | everything (14+ services) | Full stack |
 
 ### Combining Profiles

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ uv run pytest tests/unit/ -n auto  # Parallel (4x faster, ~5 min)
 uv run pytest tests/integration/ -v  # Integration tests (~5s, no Docker)
 make docker-up             # Start core services (5 containers, ~17s)
 make docker-bot-up         # Core + bot/litellm
+make docker-voice-up       # Core + LiveKit/SIP/voice-agent (preflight)
 make docker-full-up        # All services (17 containers)
 make eval-rag              # RAG evaluation (RAGAS faithfulness >= 0.8)
 make eval-judge            # LLM-as-a-Judge batch (24h traces, RAG Triad)

--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,7 @@ clean: ## Clean up cache files and build artifacts
 # Common compose command with --compatibility to enforce deploy.resources.limits
 COMPOSE_CMD := docker compose --compatibility -f docker-compose.dev.yml
 
-.PHONY: docker-core-up docker-bot-up docker-obs-up docker-ml-up docker-ai-up docker-ingest-up docker-full-up docker-down docker-ps
+.PHONY: docker-core-up docker-bot-up docker-obs-up docker-ml-up docker-ai-up docker-ingest-up docker-voice-up docker-full-up docker-down docker-ps
 
 docker-core-up: ## Start core services (postgres, qdrant, redis, docling)
 	@echo "$(BLUE)Starting core services...$(NC)"
@@ -361,6 +361,13 @@ docker-ingest-up: ## Start core + ingestion service
 	@echo "$(BLUE)Starting ingestion service...$(NC)"
 	$(COMPOSE_CMD) --profile ingest up -d
 	@echo "$(GREEN)✓ Ingestion service started$(NC)"
+
+docker-voice-up: ## Start core + voice services (livekit, sip, voice-agent)
+	@echo "$(BLUE)Preflight: checking livekit config...$(NC)"
+	@test -f docker/livekit/livekit.yaml || { echo "$(RED)✗ docker/livekit/livekit.yaml not found$(NC)"; exit 1; }
+	@echo "$(BLUE)Starting voice services...$(NC)"
+	$(COMPOSE_CMD) --profile voice up -d
+	@echo "$(GREEN)✓ Voice services started$(NC)"
 
 docker-full-up: ## Start all services (full stack)
 	@echo "$(BLUE)Starting full stack...$(NC)"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -662,8 +662,8 @@ services:
       - "7881:7881"
       - "50000-50100:50000-50100/udp"
     volumes:
-      - ./docker/livekit/livekit.yaml:/etc/livekit.yaml:ro
-    command: --config /etc/livekit.yaml --dev
+      - ./docker/livekit:/etc/livekit:ro
+    command: --config /etc/livekit/livekit.yaml --dev
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:7880 || exit 1"]
       interval: 15s


### PR DESCRIPTION
## Summary

- Mount `./docker/livekit` directory instead of single file `./docker/livekit/livekit.yaml` to prevent Docker from creating a directory at the source path when the file is absent (stale worktree, cleanup, etc.)
- Add `make docker-voice-up` Makefile target with preflight check for `docker/livekit/livekit.yaml` existence
- Document voice profile in `CLAUDE.md` and `.claude/rules/docker.md`

## Root Cause

Docker bind-mounts create a **directory** at the source path when the file doesn't exist. This directory then can't be mounted onto a file path in the container → OCI error: `not a directory: Are you trying to mount a directory onto a file (or vice-versa)?`

## Changes

| File | Change |
|------|--------|
| `docker-compose.dev.yml` | `./docker/livekit/livekit.yaml:/etc/livekit.yaml` → `./docker/livekit:/etc/livekit` (directory mount) |
| `Makefile` | Add `docker-voice-up` with preflight file check |
| `CLAUDE.md` | Add `make docker-voice-up` to Quick Reference |
| `.claude/rules/docker.md` | Add voice profile to profiles table |

## Test plan

- [ ] `make docker-voice-up` preflight passes when `docker/livekit/livekit.yaml` exists
- [ ] `docker compose -f docker-compose.dev.yml --profile voice up -d livekit-server` starts without mount error
- [ ] `docker compose -f docker-compose.dev.yml --profile voice ps` shows `livekit-server` healthy

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)