### PR TITLE
fix(voice/infra): pass Redis auth to livekit-sip (#318)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -695,6 +695,7 @@ services:
         ws_url: ws://livekit-server:7880
         redis:
           address: redis:6379
+          password: ${REDIS_PASSWORD:-dev_redis_pass}
         sip_port: 5060
         rtp_port: 10000-10100
         use_external_ip: false


### PR DESCRIPTION
## Summary
- livekit-sip failed with `NOAUTH Authentication required` because Redis has `--requirepass` but SIP config had no password
- Added `password: ${REDIS_PASSWORD:-dev_redis_pass}` to redis section in `SIP_CONFIG_BODY`
- Uses same env var pattern as other services (bot, rag-api)

Closes #318

## Test plan
- [ ] `docker compose -f docker-compose.dev.yml --profile voice up -d` — verify livekit-sip connects to Redis without NOAUTH error
- [ ] Check `docker logs dev-livekit-sip` for successful Redis connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)