### PR TITLE
fix(infra): stabilize dev-litellm startup and prevent exit 255 (#319)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -453,6 +453,8 @@ services:
     image: ghcr.io/berriai/litellm:main-v1.81.3-stable@sha256:3d80908e35230a0dfb58051ae4e2847371b2a327b44e105e79b8c4f67a65596c
     container_name: dev-litellm
     profiles: ["bot", "voice", "full"]
+    restart: unless-stopped
+    logging: *default-logging
     ports:
       - "127.0.0.1:4000:4000"
     volumes:
@@ -462,8 +464,8 @@ services:
       LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:?LITELLM_MASTER_KEY is required}
       # LLM Providers
       CEREBRAS_API_KEY: ${CEREBRAS_API_KEY:-${LLM_API_KEY}}
-      GROQ_API_KEY: ${GROQ_API_KEY}
-      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      GROQ_API_KEY: ${GROQ_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       # Langfuse v3 OTEL (Docker internal network)
       LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-sk-lf-dev}
@@ -471,7 +473,7 @@ services:
       LANGFUSE_OTEL_HOST: http://langfuse:3000
       # Database for virtual keys
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/litellm
-    command: ["--config", "/app/config.yaml", "--detailed_debug"]
+    command: ["--config", "/app/config.yaml"]
     depends_on:
       postgres:
         condition: service_healthy
@@ -479,13 +481,8 @@ services:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:4000/health/liveliness', timeout=5)"]
       interval: 30s
       timeout: 10s
-      retries: 3
-      start_period: 30s
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "5"
+      retries: 5
+      start_period: 60s
     deploy:
       resources:
         limits:

--- a/docker/litellm/config.yaml
+++ b/docker/litellm/config.yaml
@@ -1,6 +1,6 @@
 # LiteLLM Proxy Configuration
 # Docs: https://docs.litellm.ai/docs/proxy/configs
-# Image: ghcr.io/berriai/litellm:main-v1.81.0-stable
+# Image: ghcr.io/berriai/litellm:main-v1.81.3-stable
 
 model_list:
   # Primary: gpt-oss-120b on Cerebras (3000 tok/s)


### PR DESCRIPTION
## Summary

- Add `restart: unless-stopped` — litellm was the only service without a restart policy, so any crash was permanent
- Remove `--detailed_debug` from command — config already has `json_logs: true` and `set_verbose: false`; debug flag inflated memory under 512M limit
- Increase health check `start_period` 30→60s, `retries` 3→5 — gives time for DB migrations on cold starts
- Use shared `*default-logging` anchor for consistency with the rest of the stack
- Add explicit `:-` defaults for optional `GROQ_API_KEY` / `OPENAI_API_KEY` env vars
- Fix config.yaml version comment drift (v1.81.0 → v1.81.3)

Closes #319

## Test plan

- [ ] `docker compose -f docker-compose.dev.yml config --quiet` passes
- [ ] `make docker-bot-up` → `dev-litellm` reaches `Up (healthy)` without manual restart
- [ ] 3 consecutive cold starts (`down -v && up -d`) all show litellm healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)