### PR TITLE
chore(deps): pin langgraph<2.0 upper bound (#335)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # Performance (2026-02-06)
     "uvloop>=0.21.0",                     # 2-4x faster asyncio event loop
     # LangGraph Pipeline (2026-02-09)
-    "langgraph>=1.0.3",                   # State graph for RAG pipeline
+    "langgraph>=1.0.3,<2.0",               # State graph for RAG pipeline
     "langchain-core>=1.2",                # Core abstractions (Embeddings, etc.)
     "langgraph-checkpoint-postgres>=2.0", # Postgres checkpointing for LangGraph
     # Conversation memory (#154)

--- a/uv.lock
+++ b/uv.lock
@@ -837,7 +837,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'voice'", specifier = ">=0.27.0" },
     { name = "langchain-core", specifier = ">=1.2" },
     { name = "langfuse", specifier = ">=3.0.0" },
-    { name = "langgraph", specifier = ">=1.0.3" },
+    { name = "langgraph", specifier = ">=1.0.3,<2.0" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=2.0" },
     { name = "langgraph-checkpoint-redis", specifier = ">=0.2.0" },
     { name = "langmem", specifier = ">=0.0.30" },


### PR DESCRIPTION
## Summary
- Pin `langgraph` dependency to `>=1.0.3,<2.0` to prevent breaking changes from a future v2.0 release
- Regenerated `uv.lock` to reflect the updated constraint

Closes #335

## Test plan
- [x] `uv lock` succeeds
- [x] `uv run pytest tests/unit/ -n auto` — 2217 passed, 1 pre-existing failure (unrelated)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)