### PR TITLE
chore(infra): bump Qdrant server image to v1.16.2

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -152,7 +152,7 @@ docker stats
 
 | Type | Strategy | Example |
 |------|----------|---------|
-| Stable 3rd-party | Versioned tag | `redis:8.4.0`, `qdrant/qdrant:v1.16`, `clickhouse:24.8` |
+| Stable 3rd-party | Versioned tag | `redis:8.4.0`, `qdrant/qdrant:v1.16.2`, `clickhouse:24.8` |
 | Floating tag only | Digest pin | `docling-serve-cpu@sha256:4e93e8e...` |
 | Self-built | Local build | `services/bm42/Dockerfile` |
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -60,7 +60,7 @@ services:
       retries: 3
 
   qdrant:
-    image: qdrant/qdrant:v1.16@sha256:0425e3e03e7fd9b3dc95c4214546afe19de2eb2e28ca621441a56663ac6e1f46
+    image: qdrant/qdrant:v1.16.2@sha256:dab6de32f7b2cc599985a7c764db3e8b062f70508fb85ca074aa856f829bf335
     container_name: dev-qdrant
     restart: unless-stopped
     logging: *default-logging

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,6 +1,6 @@
 services:
   qdrant:
-    image: qdrant/qdrant:v1.16@sha256:0425e3e03e7fd9b3dc95c4214546afe19de2eb2e28ca621441a56663ac6e1f46
+    image: qdrant/qdrant:v1.16.2@sha256:dab6de32f7b2cc599985a7c764db3e8b062f70508fb85ca074aa856f829bf335
     container_name: rag-qdrant-local
     ports:
       - "6333:6333"

--- a/docker-compose.vps.yml
+++ b/docker-compose.vps.yml
@@ -60,7 +60,7 @@ services:
           memory: 300M
 
   qdrant:
-    image: qdrant/qdrant:v1.16@sha256:0425e3e03e7fd9b3dc95c4214546afe19de2eb2e28ca621441a56663ac6e1f46
+    image: qdrant/qdrant:v1.16.2@sha256:dab6de32f7b2cc599985a7c764db3e8b062f70508fb85ca074aa856f829bf335
     container_name: vps-qdrant
     restart: unless-stopped
     logging: *default-logging

--- a/k8s/base/qdrant/deployment.yaml
+++ b/k8s/base/qdrant/deployment.yaml
@@ -20,7 +20,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: qdrant
-          image: qdrant/qdrant:v1.16
+          image: qdrant/qdrant:v1.16.2
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
## Summary
- Bumps Qdrant from `v1.16` to `v1.16.2` across all deployment targets
- Updates digest pins in 3 compose files (dev, vps, local)
- Updates k8s base deployment manifest
- Updates DOCKER.md docs reference

Closes #339

## Test plan
- [x] YAML syntax validated (all 3 compose files)
- [x] Pre-commit hooks pass (YAML check, trailing whitespace, etc.)
- [ ] `docker compose config --quiet` on dev machine with Docker available
- [ ] Verify Qdrant starts with new image: `docker compose up -d qdrant`

🤖 Generated with [Claude Code](https://claude.com/claude-code)