### PR TITLE
chore(infra): standardize uv version and add UV_COMPILE_BYTECODE=1 (#337)

### DIFF
--- a/Dockerfile.ingestion
+++ b/Dockerfile.ingestion
@@ -56,8 +56,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # Create non-root user BEFORE copying files
 RUN useradd -m -u 1000 ingestion
 
-# Copy uv binary
-COPY --from=ghcr.io/astral-sh/uv:0.10@sha256:94a23af2d50e97b87b522d3cea24aaf8a1faedec1344c952767434f69585cbf9 /uv /usr/local/bin/uv
+# Copy uv binary from builder (same version as build stage)
+COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
 
 # Copy venv with --chown (avoids 9GB duplicate layer from chown -R)
 COPY --from=builder --chown=ingestion:ingestion /app/.venv /app/.venv

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -1,14 +1,30 @@
+# syntax=docker/dockerfile:1@sha256:b6afd42430b15f2d2a4c5a02b919e98a525b785b1aaff16747d2f623364e39b6
+# RAG API — uv sync pattern (2026 best practices)
+
+# ====== BUILD STAGE ======
 FROM ghcr.io/astral-sh/uv:0.9-python3.12-bookworm-slim@sha256:e5b65587bce7de595f299855d7385fe7fca39b8a74baa261ba1b7147afa78e58 AS builder
 
 WORKDIR /app
 
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=0
+
+# Deps layer (cached separately from code)
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    uv sync --frozen --no-dev --extra voice --no-install-project
+
+# Code layer
 COPY pyproject.toml uv.lock ./
-RUN uv sync --frozen --no-dev --extra voice --no-install-project
+COPY src/ src/
+COPY telegram_bot/ telegram_bot/
 
-COPY . .
-RUN uv sync --frozen --no-dev --extra voice
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --extra voice
 
-
+# ====== RUNTIME STAGE ======
 FROM python:3.14-slim-bookworm@sha256:f0540d0436a220db0a576ccfe75631ab072391e43a24b88972ef9833f699095f AS runtime
 
 WORKDIR /app

--- a/src/voice/Dockerfile
+++ b/src/voice/Dockerfile
@@ -1,11 +1,30 @@
+# syntax=docker/dockerfile:1@sha256:b6afd42430b15f2d2a4c5a02b919e98a525b785b1aaff16747d2f623364e39b6
+# Voice Agent — uv sync pattern (2026 best practices)
+
+# ====== BUILD STAGE ======
 FROM ghcr.io/astral-sh/uv:0.9-python3.12-bookworm-slim@sha256:e5b65587bce7de595f299855d7385fe7fca39b8a74baa261ba1b7147afa78e58 AS builder
+
 WORKDIR /app
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=0
+
+# Deps layer (cached separately from code)
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    uv sync --frozen --no-dev --extra voice --no-install-project
+
+# Code layer
 COPY pyproject.toml uv.lock ./
-RUN uv sync --frozen --no-dev --extra voice --no-install-project
 COPY src/ src/
 COPY telegram_bot/ telegram_bot/
-RUN uv sync --frozen --no-dev --extra voice
 
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --extra voice
+
+# ====== RUNTIME STAGE ======
 FROM python:3.14-slim-bookworm@sha256:f0540d0436a220db0a576ccfe75631ab072391e43a24b88972ef9833f699095f AS runtime
 WORKDIR /app
 COPY --from=builder /app/.venv /app/.venv


### PR DESCRIPTION
## Summary
- Add `UV_COMPILE_BYTECODE=1`, `UV_LINK_MODE=copy`, `UV_PYTHON_DOWNLOADS=0` to `src/api/Dockerfile` and `src/voice/Dockerfile` builder stages
- Add syntax header, section comments, and cache mounts to match established patterns
- Fix uv version skew in `Dockerfile.ingestion`: runtime was copying uv 0.10 while builder uses 0.9; now copies from builder stage

## Test plan
- [ ] `docker compose -f docker-compose.dev.yml config --quiet` passes
- [ ] `docker compose build rag-api` succeeds
- [ ] `docker compose build voice-agent` succeeds
- [ ] `docker compose build ingestion` succeeds

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)