### PR TITLE
fix(observability): SDK audit remediation — docs sync (#224)

### DIFF
--- a/docs/PROJECT_STACK.md
+++ b/docs/PROJECT_STACK.md
@@ -50,7 +50,7 @@
 | Technology | Version | Purpose |
 |------------|---------|---------|
 | Qdrant | v1.16 | Vector DB (gRPC + HTTP, hybrid search) |
-| Redis | 8.4.0 | 6-tier cache (volatile-lfu, 512MB) |
+| Redis | 8.4.0 | 6-tier cache (volatile-lfu, 512MB, `REDIS_PASSWORD` required) |
 | PostgreSQL | 17 (pgvector) | Langfuse, MLflow, CocoIndex state, transcripts |
 | redisvl | >=0.13.2 | Semantic cache (RedisVL) |
 
@@ -426,6 +426,8 @@ Without `traced_pipeline`, each `@observe` creates a separate root trace.
 | k3s overhead | ~1.6GB | System |
 
 **k3s overlays:** core (11 resources) → bot (19) → ingest (17) → full (23)
+
+**Redis auth:** All profiles (local, VPS, k3s) require `REDIS_PASSWORD`. Redis runs with `--requirepass`, app services use `REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379`.
 
 ### Monitoring Stack
 

--- a/tests/unit/security/test_secret_hygiene.py
+++ b/tests/unit/security/test_secret_hygiene.py
@@ -77,6 +77,18 @@ def test_compose_redis_uses_requirepass():
 
 
 @pytest.mark.timeout(0)
+def test_stack_doc_mentions_redis_auth_requirement():
+    """Ensure PROJECT_STACK.md documents the REDIS_PASSWORD requirement."""
+    from pathlib import Path
+
+    content = (Path(__file__).parent.parent.parent.parent / "docs" / "PROJECT_STACK.md").read_text()
+    assert "REDIS_PASSWORD" in content, (
+        "docs/PROJECT_STACK.md must document the REDIS_PASSWORD requirement. "
+        "Redis auth is enforced in compose and k8s — the stack doc should reflect this."
+    )
+
+
+@pytest.mark.timeout(0)
 def test_k8s_bot_redis_password_declared_before_redis_url():
     """K8s expands $(VAR) only from previously declared env vars in the same list."""
     from pathlib import Path


### PR DESCRIPTION
## Summary

Closes #224

Completes the final task (Task 8: documentation sync) from the SDK audit remediation plan. Tasks 1-7 were already merged via prior PRs:

- **Task 1** (hardcoded Qdrant secret) — already fixed on main
- **Task 2** (trace validator alignment) — already fixed on main
- **Task 3** (cache version drift) — already fixed on main
- **Task 4** (Langfuse score parity) — already fixed on main
- **Task 5** (sys.modules pollution) — PR #281 / #326
- **Task 6** (/stats denominator) — already fixed on main
- **Task 7** (Redis auth hardening) — already fixed on main

### This PR adds:
- `REDIS_PASSWORD` requirement documented in `docs/PROJECT_STACK.md` (Database & Cache table + Infrastructure section)
- Guard test `test_stack_doc_mentions_redis_auth_requirement` in `tests/unit/security/test_secret_hygiene.py`

## Test plan

- [x] 2201 unit tests pass (`uv run pytest tests/unit/ -n auto`)
- [x] All 5 security/e2e tests pass
- [x] Ruff lint + format clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)