### PR TITLE
chore(ci): split fast PR gate vs nightly heavy test tier (#267)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         id: markers
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "expr=not legacy_api and not requires_extras" >> "$GITHUB_OUTPUT"
+            echo "expr=not legacy_api and not requires_extras and not slow" >> "$GITHUB_OUTPUT"
           else
             echo "expr=not legacy_api" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/nightly-heavy.yml
+++ b/.github/workflows/nightly-heavy.yml
@@ -10,8 +10,51 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # All unit tests (including slow, requires_extras) — full tier
+  # ---------------------------------------------------------------------------
+  unit-full:
+    name: Unit Tests (full tier)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra voice --extra ingest --extra eval
+
+      - name: Run all unit tests (full tier)
+        run: |
+          uv run pytest tests/unit/ \
+            -n auto --dist loadscope \
+            --timeout=30 \
+            -m "not legacy_api" \
+            --durations=20 --durations-min=1.0 \
+            -q
+
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: unit-full-results
+          path: |
+            .pytest_cache/
+            reports/
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------
+  # Heavy suites: chaos, smoke, slow unit tests
+  # ---------------------------------------------------------------------------
   heavy:
-    name: Heavy Test Tier
+    name: Heavy Test Tier (chaos, smoke, slow)
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -26,11 +69,24 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --frozen
+        run: uv sync --frozen --extra voice --extra ingest --extra eval
 
       - name: Run nightly heavy suites
         run: make test-nightly
 
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: heavy-tier-results
+          path: |
+            .pytest_cache/
+            reports/
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------
+  # Baseline regression — nightly cadence
+  # ---------------------------------------------------------------------------
   baseline-nightly:
     name: Baseline Regression (nightly)
     runs-on: ubuntu-latest
@@ -48,7 +104,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --frozen
+        run: uv sync --frozen --extra voice --extra ingest --extra eval
 
       - name: Run baseline comparison
         env:

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ test-unit: ## Run unit tests locally in parallel (xdist worksteal)
 
 test-unit-core: ## Run core unit tests (no optional deps needed, PR gate)
 	@echo "$(BLUE)Running core unit tests (no optional deps)...$(NC)"
-	PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/unit/ -n auto --dist=worksteal -q --timeout=30 -m "not legacy_api and not requires_extras"
+	PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/unit/ -n auto --dist=worksteal -q --timeout=30 -m "not legacy_api and not requires_extras and not slow"
 	@echo "$(GREEN)✓ Core unit tests complete$(NC)"
 
 test-unit-full: ## Run all unit tests including optional-dep tests (nightly/main)
@@ -192,10 +192,10 @@ test-integration-full: ## Run ALL integration tests (requires Docker)
 	uv run pytest tests/integration/ -v --timeout=60
 	@echo "$(GREEN)✓ Full integration tests complete$(NC)"
 
-test-nightly: ## Run heavy test suites (e2e, chaos, baseline, load) — schedule overnight
+test-nightly: ## Run heavy test suites (chaos, smoke, slow unit) — schedule overnight
 	@echo "$(BLUE)Running nightly test suite...$(NC)"
-	uv run pytest tests/chaos/ -v --timeout=60 -n auto
-	uv run pytest tests/smoke/ -v --timeout=60
+	uv run pytest tests/chaos/ -v --timeout=60 -n auto -m "not legacy_api"
+	uv run pytest tests/smoke/ -v --timeout=60 -m "not legacy_api"
 	uv run pytest tests/unit/ -n auto --timeout=30 -m "slow" -q
 	@echo "$(GREEN)✓ Nightly tests complete$(NC)"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -378,8 +378,12 @@ markers = [
     "unit: Unit tests with mocks (fast, no external deps)",
     "integration: Integration tests (requires Docker/API keys)",
     "slow: Tests taking > 5 seconds",
-    "legacy_api: tests for pre-LangGraph API (may need rewrite)",
+    "chaos: Chaos/resilience tests (service failures, fallbacks)",
+    "load: Load/performance tests (concurrent users, throughput)",
+    "e2e: End-to-end pipeline tests (require live services)",
     "smoke: Smoke tests (requires running services)",
+    "benchmark: Benchmark tests (parser/reranker comparisons)",
+    "legacy_api: tests for pre-LangGraph API (may need rewrite)",
     "requires_extras: Tests needing optional deps (voice/ingest/eval); skipped in core tier",
     "xdist_group: Group tests onto same xdist worker (prevents global registry collisions)",
 ]

--- a/tests/benchmark/__init__.py
+++ b/tests/benchmark/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark tests for parser/reranker comparisons."""

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -1,0 +1,16 @@
+# tests/benchmark/conftest.py
+"""Benchmark test configuration."""
+
+from pathlib import Path
+
+import pytest
+
+
+_THIS_DIR = Path(__file__).parent
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Auto-apply 'benchmark' marker to all tests in this directory."""
+    for item in items:
+        if item.path.parent == _THIS_DIR or _THIS_DIR in item.path.parents:
+            item.add_marker(pytest.mark.benchmark)

--- a/tests/chaos/conftest.py
+++ b/tests/chaos/conftest.py
@@ -1,6 +1,18 @@
 """Pytest configuration for chaos tests."""
 
+from pathlib import Path
+
 import pytest
+
+
+_THIS_DIR = Path(__file__).parent
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Auto-apply 'chaos' marker to all tests in this directory."""
+    for item in items:
+        if item.path.parent == _THIS_DIR or _THIS_DIR in item.path.parents:
+            item.add_marker(pytest.mark.chaos)
 
 
 @pytest.fixture

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,16 @@
+# tests/e2e/conftest.py
+"""E2E test configuration."""
+
+from pathlib import Path
+
+import pytest
+
+
+_THIS_DIR = Path(__file__).parent
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Auto-apply 'e2e' marker to all tests in this directory."""
+    for item in items:
+        if item.path.parent == _THIS_DIR or _THIS_DIR in item.path.parents:
+            item.add_marker(pytest.mark.e2e)

--- a/tests/load/conftest.py
+++ b/tests/load/conftest.py
@@ -2,9 +2,20 @@
 """Load test fixtures - support live/mock toggle."""
 
 import os
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
+
+
+_THIS_DIR = Path(__file__).parent
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Auto-apply 'load' marker to all tests in this directory."""
+    for item in items:
+        if item.path.parent == _THIS_DIR or _THIS_DIR in item.path.parents:
+            item.add_marker(pytest.mark.load)
 
 
 def use_mocks() -> bool:

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import os
+from pathlib import Path
 
 import httpx
 import pytest
@@ -11,6 +12,16 @@ import redis.asyncio as redis
 from telegram_bot.integrations.cache import CacheLayerManager
 from telegram_bot.services.qdrant import QdrantService
 from telegram_bot.services.voyage import VoyageService
+
+
+_THIS_DIR = Path(__file__).parent
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Auto-apply 'smoke' marker to all tests in this directory."""
+    for item in items:
+        if item.path.parent == _THIS_DIR or _THIS_DIR in item.path.parents:
+            item.add_marker(pytest.mark.smoke)
 
 
 def _build_redis_url() -> str:


### PR DESCRIPTION
## Summary
- PR gate now excludes `slow`-marked tests (in addition to `legacy_api` and `requires_extras`) for faster CI feedback (~4-5 min target)
- Nightly workflow expanded with `unit-full` job (all extras installed), `heavy` suite (chaos, smoke, slow unit), and `baseline-nightly` regression
- Auto-marker `conftest.py` hooks added for `chaos`, `load`, `smoke`, `benchmark`, and `e2e` test directories
- All new markers registered in `pyproject.toml` with `--strict-markers`
- Makefile targets `test-unit-core` and `test-nightly` updated to match CI expressions

## Test plan
- [x] `uv run ruff check` — 0 errors
- [x] `uv run ruff format --check` — all files formatted
- [x] Unit tests (PR gate expression): 2200 passed, 18 skipped
- [x] Auto-marker verified: `pytest tests/chaos/ -m chaos --co` collects 29 tests
- [x] YAML validity checked via `yaml.safe_load`
- [x] Pre-commit hooks all passed

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)