### PR TITLE
refactor(eval): migrate evaluation Qdrant to qdrant-client SDK (#314)

### DIFF
--- a/src/evaluation/extract_ground_truth.py
+++ b/src/evaluation/extract_ground_truth.py
@@ -8,7 +8,7 @@ import json
 import os
 from collections import defaultdict
 
-import requests  # type: ignore[import-untyped]
+from qdrant_client import QdrantClient
 
 from src.config import Settings
 
@@ -33,6 +33,15 @@ def _qdrant_api_key() -> str:
     return QDRANT_API_KEY or ""
 
 
+def _make_client() -> QdrantClient:
+    """Create a QdrantClient from resolved settings/environment."""
+    url = _qdrant_url()
+    api_key = _qdrant_api_key()
+    if api_key:
+        return QdrantClient(url=url, api_key=api_key)
+    return QdrantClient(url=url)
+
+
 def extract_articles(collection_name: str) -> dict[str, list[str]]:
     """
     Extract all articles and their chunk IDs from Qdrant collection.
@@ -40,7 +49,9 @@ def extract_articles(collection_name: str) -> dict[str, list[str]]:
     Returns:
         Dict mapping article_number to list of chunk IDs
     """
-    print(f"📊 Extracting articles from collection: {collection_name}")
+    print(f"Extracting articles from collection: {collection_name}")
+
+    client = _make_client()
 
     # Get all points from collection with scroll API
     offset = None
@@ -48,56 +59,45 @@ def extract_articles(collection_name: str) -> dict[str, list[str]]:
     total_points = 0
 
     while True:
-        # Scroll through collection
-        payload = {
-            "limit": 100,
-            "with_payload": ["article_number", "chunk_id", "text"],
-            "with_vector": False,
-        }
-
-        if offset:
-            payload["offset"] = offset
-
-        response = requests.post(
-            f"{_qdrant_url()}/collections/{collection_name}/points/scroll",
-            json=payload,
-            headers={"api-key": _qdrant_api_key()},
+        points, next_offset = client.scroll(
+            collection_name=collection_name,
+            offset=offset,
+            limit=100,
+            with_payload=["article_number", "chunk_id", "text"],
+            with_vectors=False,
         )
-        response.raise_for_status()
-
-        data = response.json()["result"]
-        points = data["points"]
 
         if not points:
             break
 
         # Process points
         for point in points:
-            article = point["payload"].get("article_number")
+            payload = point.payload or {}
+            article = payload.get("article_number")
             if article:
-                chunk_id = point["payload"].get("chunk_id", point["id"])
-                text_preview = point["payload"].get("text", "")[:100]
+                chunk_id = payload.get("chunk_id", point.id)
+                text_preview = payload.get("text", "")[:100]
 
                 articles[str(article)].append(
-                    {"chunk_id": chunk_id, "point_id": point["id"], "text_preview": text_preview}
+                    {"chunk_id": chunk_id, "point_id": point.id, "text_preview": text_preview}
                 )
                 total_points += 1
 
         # Check if there are more points
-        offset = data.get("next_page_offset")
+        offset = next_offset
         if offset is None:
             break
 
         print(f"  Processed {total_points} points...", end="\r")
 
-    print(f"\n✅ Extracted {len(articles)} articles from {total_points} chunks")
+    print(f"\nExtracted {len(articles)} articles from {total_points} chunks")
 
     return dict(articles)  # type: ignore[arg-type]
 
 
 def print_statistics(articles: dict[str, list[str]]):
     """Print statistics about the extracted articles."""
-    print("\n📈 Dataset Statistics:")
+    print("\nDataset Statistics:")
     print(f"  Total articles: {len(articles)}")
     print(f"  Total chunks: {sum(len(chunks) for chunks in articles.values())}")
 
@@ -109,7 +109,7 @@ def print_statistics(articles: dict[str, list[str]]):
     print(f"    Avg: {sum(chunks_per_article) / len(chunks_per_article):.1f}")
 
     # Sample articles
-    print("\n📝 Sample articles:")
+    print("\nSample articles:")
     for article_num in sorted(articles.keys(), key=lambda x: int(x))[:5]:
         print(f"    Article {article_num}: {len(articles[article_num])} chunks")
 
@@ -129,7 +129,7 @@ def main():
     with open(output_file, "w", encoding="utf-8") as f:
         json.dump(articles, f, ensure_ascii=False, indent=2)
 
-    print(f"\n💾 Saved to: {output_file}")
+    print(f"\nSaved to: {output_file}")
 
     # Create simplified mapping (article -> first chunk only) for quick tests
     simple_mapping = {article: chunks[0]["point_id"] for article, chunks in articles.items()}
@@ -137,8 +137,8 @@ def main():
     with open(simple_output, "w", encoding="utf-8") as f:
         json.dump(simple_mapping, f, ensure_ascii=False, indent=2)
 
-    print(f"💾 Simplified mapping saved to: {simple_output}")
-    print("\n✅ Ground truth extraction completed!")
+    print(f"Simplified mapping saved to: {simple_output}")
+    print("\nGround truth extraction completed!")
 
 
 if __name__ == "__main__":

--- a/src/evaluation/generate_test_queries.py
+++ b/src/evaluation/generate_test_queries.py
@@ -2,16 +2,16 @@
 """
 Generate test queries using LLM.
 Creates 3 types of queries for each article:
-1. Direct (точный запрос)
-2. Semantic (семантический вариант)
-3. Paraphrased (перефразированный)
+1. Direct (exact query)
+2. Semantic (semantic variant)
+3. Paraphrased (paraphrased)
 """
 
 import asyncio
 import json
 import sys
 
-import requests  # type: ignore[import-untyped]
+from qdrant_client import QdrantClient, models
 
 
 sys.path.append("/home/admin/contextual_rag")
@@ -26,6 +26,13 @@ QDRANT_URL = _settings.qdrant_url
 QDRANT_API_KEY = _settings.qdrant_api_key or ""
 
 
+def _make_client() -> QdrantClient:
+    """Create a QdrantClient from resolved settings."""
+    if QDRANT_API_KEY:
+        return QdrantClient(url=QDRANT_URL, api_key=QDRANT_API_KEY)
+    return QdrantClient(url=QDRANT_URL)
+
+
 def fetch_article_texts(collection_name: str, article_numbers: list[str]) -> dict[str, str]:
     """
     Fetch full texts for specified articles from Qdrant.
@@ -37,43 +44,39 @@ def fetch_article_texts(collection_name: str, article_numbers: list[str]) -> dic
     Returns:
         Dict mapping article_number (str) -> full_text
     """
-    print(f"📚 Fetching {len(article_numbers)} articles from Qdrant...")
+    print(f"Fetching {len(article_numbers)} articles from Qdrant...")
 
+    client = _make_client()
     articles = {}
 
     for article_num in article_numbers:
         # Search for article by article_number filter
         # IMPORTANT: Qdrant stores article_number as int, not string!
-        payload = {
-            "filter": {
-                "must": [
-                    {
-                        "key": "article_number",
-                        "match": {"value": int(article_num)},  # Convert to int!
-                    }
-                ]
-            },
-            "limit": 1,
-            "with_payload": True,
-            "with_vector": False,
-        }
-
-        response = requests.post(
-            f"{QDRANT_URL}/collections/{collection_name}/points/scroll",
-            json=payload,
-            headers={"api-key": QDRANT_API_KEY},
+        scroll_filter = models.Filter(
+            must=[
+                models.FieldCondition(
+                    key="article_number",
+                    match=models.MatchValue(value=int(article_num)),
+                )
+            ]
         )
-        response.raise_for_status()
 
-        points = response.json()["result"]["points"]
+        points, _ = client.scroll(
+            collection_name=collection_name,
+            scroll_filter=scroll_filter,
+            limit=1,
+            with_payload=True,
+            with_vectors=False,
+        )
+
         if points:
-            text = points[0]["payload"].get("text", "")
+            text = (points[0].payload or {}).get("text", "")
             articles[article_num] = text
-            print(f"  ✓ Article {article_num}: {len(text)} chars")
+            print(f"  Article {article_num}: {len(text)} chars")
         else:
-            print(f"  ✗ Article {article_num}: NOT FOUND")
+            print(f"  Article {article_num}: NOT FOUND")
 
-    print(f"✅ Fetched {len(articles)}/{len(article_numbers)} articles\n")
+    print(f"Fetched {len(articles)}/{len(article_numbers)} articles\n")
     return articles
 
 
@@ -182,7 +185,7 @@ async def generate_all_queries(
     Returns:
         List of all generated queries
     """
-    print(f"🤖 Generating queries with {model}...")
+    print(f"Generating queries with {model}...")
     print(f"   Max concurrent: {max_concurrent}")
     print(f"   Total articles: {len(article_texts)}\n")
 
@@ -204,12 +207,12 @@ async def generate_all_queries(
             queries = await task_coro
             all_queries.extend(queries)
             completed += 1
-            print(f"[{completed}/{len(tasks)}] Article {article_num}: ✓ 3 queries generated")
+            print(f"[{completed}/{len(tasks)}] Article {article_num}: 3 queries generated")
         except Exception as e:
-            print(f"[{completed}/{len(tasks)}] Article {article_num}: ✗ ERROR: {e}")
+            print(f"[{completed}/{len(tasks)}] Article {article_num}: ERROR: {e}")
             completed += 1
 
-    print(f"\n✅ Generated {len(all_queries)} queries total")
+    print(f"\nGenerated {len(all_queries)} queries total")
 
     # Print stats
     llm.print_stats()
@@ -238,7 +241,7 @@ def select_representative_articles(all_articles: dict[str, list], n: int = 50) -
     # Convert to int for display
     selected_ints = [int(a) for a in selected]
 
-    print(f"📊 Selected {len(selected)} articles:")
+    print(f"Selected {len(selected)} articles:")
     print(f"   Range: {min(selected_ints)} - {max(selected_ints)}")
     print(f"   Sample: {selected_ints[:10]}...")
 
@@ -248,7 +251,7 @@ def select_representative_articles(all_articles: dict[str, list], n: int = 50) -
 async def main():
     """Main entry point."""
     print("=" * 80)
-    print("🔬 TEST QUERY GENERATION - Criminal Code Ukraine")
+    print("TEST QUERY GENERATION - Criminal Code Ukraine")
     print("=" * 80)
 
     collection_name = "ukraine_criminal_code_zai_full"
@@ -260,15 +263,15 @@ async def main():
         all_articles = json.load(f)
 
     # Select representative articles
-    print(f"\n📌 Step 1: Select {num_articles} representative articles")
+    print(f"\nStep 1: Select {num_articles} representative articles")
     selected_articles = select_representative_articles(all_articles, n=num_articles)
 
     # Fetch article texts
-    print("\n📌 Step 2: Fetch article texts from Qdrant")
+    print("\nStep 2: Fetch article texts from Qdrant")
     article_texts = fetch_article_texts(collection_name, selected_articles)
 
     # Generate queries
-    print("📌 Step 3: Generate test queries with LLM")
+    print("Step 3: Generate test queries with LLM")
     queries = await generate_all_queries(
         article_texts,
         model="openai/gpt-oss-120b",  # 120B parameters, 100% accuracy
@@ -280,17 +283,17 @@ async def main():
     with open(output_file, "w", encoding="utf-8") as f:
         json.dump(queries, f, ensure_ascii=False, indent=2)
 
-    print(f"\n💾 Saved {len(queries)} queries to: {output_file}")
+    print(f"\nSaved {len(queries)} queries to: {output_file}")
 
     # Print summary
-    print("\n📊 Test Set Summary:")
+    print("\nTest Set Summary:")
     print(f"   Total queries: {len(queries)}")
     print(f"   Direct: {len([q for q in queries if q['type'] == 'direct'])}")
     print(f"   Semantic: {len([q for q in queries if q['type'] == 'semantic'])}")
     print(f"   Paraphrased: {len([q for q in queries if q['type'] == 'paraphrased'])}")
     print(f"   Articles covered: {len({q['expected_article'] for q in queries})}")
 
-    print("\n✅ Test query generation completed!")
+    print("\nTest query generation completed!")
 
 
 if __name__ == "__main__":

--- a/src/evaluation/search_engines.py
+++ b/src/evaluation/search_engines.py
@@ -9,7 +9,7 @@ import os
 from abc import ABC, abstractmethod
 
 import numpy as np
-import requests  # type: ignore[import-untyped]
+from qdrant_client import QdrantClient, models
 
 from src.config import HSNWParameters, RetrievalStages, Settings, ThresholdValues
 
@@ -57,13 +57,30 @@ def convert_to_python_types(obj):
     return obj
 
 
+def _lexical_weights_to_sparse(lexical_weights) -> models.SparseVector:
+    """Convert BGE-M3 lexical weights to Qdrant SparseVector."""
+    if hasattr(lexical_weights, "indices"):
+        # Scipy sparse format
+        sparse_indices = lexical_weights.indices.tolist()
+        sparse_values = lexical_weights.values.tolist()
+    else:
+        # Dict format - keys are strings, need to convert to ints
+        sparse_indices = [int(k) for k in lexical_weights]
+        sparse_values = list(lexical_weights.values())
+    return models.SparseVector(indices=sparse_indices, values=sparse_values)
+
+
 class SearchEngine(ABC):
     """Abstract base class for search engines."""
 
     def __init__(self, collection_name: str):
         self.collection_name = collection_name
-        self.qdrant_url = _qdrant_url()
-        self.headers = {"api-key": _qdrant_api_key()}
+        url = _qdrant_url()
+        api_key = _qdrant_api_key()
+        if api_key:
+            self.client = QdrantClient(url=url, api_key=api_key)
+        else:
+            self.client = QdrantClient(url=url)
 
     @abstractmethod
     def search(self, query: str, top_k: int = 10) -> list[dict]:
@@ -104,33 +121,25 @@ class BaselineSearchEngine(SearchEngine):
             query, return_dense=True, return_sparse=False, return_colbert_vecs=False
         )
 
-        # Search using dense vector only
-        search_payload = {
-            "vector": {"name": "dense", "vector": query_embedding["dense_vecs"].tolist()},
-            "limit": top_k,
-            "with_payload": True,
-            "with_vector": False,
-        }
+        dense_vector = convert_to_python_types(query_embedding["dense_vecs"])
 
-        response = requests.post(
-            f"{self.qdrant_url}/collections/{self.collection_name}/points/search",
-            json=search_payload,
-            headers=self.headers,
+        response = self.client.query_points(
+            collection_name=self.collection_name,
+            query=dense_vector,
+            using="dense",
+            limit=top_k,
+            with_payload=True,
         )
-        response.raise_for_status()
 
-        results = []
-        for point in response.json()["result"]:
-            results.append(
-                {
-                    "point_id": point["id"],
-                    "score": point["score"],
-                    "article_number": self._extract_article_number(point["payload"]),
-                    "text": point["payload"].get("text", "")[:200] + "...",
-                }
-            )
-
-        return results
+        return [
+            {
+                "point_id": point.id,
+                "score": point.score,
+                "article_number": self._extract_article_number(point.payload or {}),
+                "text": (point.payload or {}).get("text", "")[:200] + "...",
+            }
+            for point in response.points
+        ]
 
 
 class HybridSearchEngine(SearchEngine):
@@ -156,97 +165,39 @@ class HybridSearchEngine(SearchEngine):
         Uses Qdrant's query API with prefetch and RRF fusion:
         1. Dense vector search
         2. Sparse BM25 search
-        3. ColBERT multi-vector search
-        4. RRF combines all three result sets
+        3. RRF combines both result sets
         """
         # Generate all embeddings for query
         query_embeddings = self.embedding_model.encode(
             query, return_dense=True, return_sparse=True, return_colbert_vecs=True
         )
 
-        # Convert sparse to Qdrant format
-        # lexical_weights is a dict, need to convert to lists
-        lexical_weights = query_embeddings["lexical_weights"]
-        if hasattr(lexical_weights, "indices"):
-            # Scipy sparse format
-            sparse_indices = lexical_weights.indices.tolist()
-            sparse_values = lexical_weights.values.tolist()
-        else:
-            # Dict format - keys are strings, need to convert to ints!
-            sparse_indices = [int(k) for k in lexical_weights]
-            sparse_values = list(lexical_weights.values())
+        dense_vector = convert_to_python_types(query_embeddings["dense_vecs"])
+        sparse_vector = _lexical_weights_to_sparse(query_embeddings["lexical_weights"])
 
         # Build hybrid search with RRF using query API
-        # NOTE: Testing without ColBERT first - will add back if dense+sparse works
-        search_payload = {
-            "prefetch": [
-                # Prefetch 1: Dense vector search
-                {
-                    "query": query_embeddings["dense_vecs"].tolist(),
-                    "using": "dense",
-                    "limit": 100,  # Get more candidates for fusion
-                },
-                # Prefetch 2: Sparse BM25 search
-                {
-                    "query": {
-                        "values": sparse_values,  # values BEFORE indices (Qdrant API requirement)
-                        "indices": sparse_indices,
-                    },
-                    "using": "sparse",
-                    "limit": 100,
-                },
-                # Temporarily disabled ColBERT for testing
-                # {
-                #     "query": query_embeddings["colbert_vecs"].tolist(),
-                #     "using": "colbert",
-                #     "limit": 100
-                # }
-            ],
-            "query": {
-                "fusion": "rrf"  # Reciprocal Rank Fusion
-            },
-            "limit": top_k,
-            "with_payload": True,
-            "with_vector": False,
-        }
+        prefetch = [
+            models.Prefetch(query=dense_vector, using="dense", limit=100),
+            models.Prefetch(query=sparse_vector, using="sparse", limit=100),
+        ]
 
-        # Convert all numpy types to Python types for JSON serialization
-        search_payload = convert_to_python_types(search_payload)
-
-        response = requests.post(
-            f"{self.qdrant_url}/collections/{self.collection_name}/points/query",
-            json=search_payload,
-            headers=self.headers,
+        response = self.client.query_points(
+            collection_name=self.collection_name,
+            prefetch=prefetch,
+            query=models.FusionQuery(fusion=models.Fusion.RRF),
+            limit=top_k,
+            with_payload=True,
         )
 
-        if response.status_code != 200:
-            # Print detailed error for debugging
-            print(f"ERROR: {response.status_code} - {response.text}")
-
-        response.raise_for_status()
-
-        resp_data = response.json()
-
-        # Query API returns dict with 'points' key, not a list
-        if isinstance(resp_data["result"], dict):
-            points_list = resp_data["result"].get("points", [])
-        elif isinstance(resp_data["result"], list):
-            points_list = resp_data["result"]
-        else:
-            points_list = []
-
-        results = []
-        for point in points_list:
-            results.append(
-                {
-                    "point_id": point["id"],
-                    "score": point["score"],
-                    "article_number": self._extract_article_number(point["payload"]),
-                    "text": point["payload"].get("text", "")[:200] + "...",
-                }
-            )
-
-        return results
+        return [
+            {
+                "point_id": point.id,
+                "score": point.score,
+                "article_number": self._extract_article_number(point.payload or {}),
+                "text": (point.payload or {}).get("text", "")[:200] + "...",
+            }
+            for point in response.points
+        ]
 
 
 class HybridDBSFColBERTSearchEngine(SearchEngine):
@@ -254,9 +205,9 @@ class HybridDBSFColBERTSearchEngine(SearchEngine):
     Advanced hybrid search using DBSF fusion + ColBERT reranking (Qdrant 2025 Best Practices).
 
     3-Stage Retrieval Pipeline:
-    1. Prefetch: Dense + Sparse → 100 candidates each
+    1. Prefetch: Dense + Sparse -> 100 candidates each
     2. Fusion: DBSF (Distribution-Based Score Fusion) combines results
-    3. Rerank: ColBERT multivector server-side reranking → top-K
+    3. Rerank: ColBERT multivector server-side reranking -> top-K
 
     Based on official Qdrant documentation:
     - DBSF: https://qdrant.tech/articles/hybrid-search/
@@ -290,89 +241,39 @@ class HybridDBSFColBERTSearchEngine(SearchEngine):
             query, return_dense=True, return_sparse=True, return_colbert_vecs=True
         )
 
-        # Convert sparse to Qdrant format
-        lexical_weights = query_embeddings["lexical_weights"]
-        if hasattr(lexical_weights, "indices"):
-            # Scipy sparse format
-            sparse_indices = lexical_weights.indices.tolist()
-            sparse_values = lexical_weights.values.tolist()
-        else:
-            # Dict format - keys are strings, need to convert to ints
-            sparse_indices = [int(k) for k in lexical_weights]
-            sparse_values = list(lexical_weights.values())
+        dense_vector = convert_to_python_types(query_embeddings["dense_vecs"])
+        sparse_vector = _lexical_weights_to_sparse(query_embeddings["lexical_weights"])
+        colbert_vectors = convert_to_python_types(query_embeddings["colbert_vecs"])
 
         # Build 3-stage query with DBSF fusion + ColBERT reranking
-        search_payload = {
-            "prefetch": [
-                # Stage 1a: Dense vector search (prefetch 100 candidates)
-                {
-                    "prefetch": [
-                        {
-                            "query": query_embeddings["dense_vecs"].tolist(),
-                            "using": "dense",
-                            "limit": self.stage1_limit,
-                        },
-                        # Stage 1b: Sparse BM25 search (prefetch 100 candidates)
-                        {
-                            "query": {"values": sparse_values, "indices": sparse_indices},
-                            "using": "sparse",
-                            "limit": self.stage1_limit,
-                        },
-                    ],
-                    # Stage 2: DBSF fusion combines dense + sparse results
-                    "query": {
-                        "fusion": "dbsf"  # Distribution-Based Score Fusion
-                    },
-                }
+        dbsf_prefetch = models.Prefetch(
+            prefetch=[
+                models.Prefetch(query=dense_vector, using="dense", limit=self.stage1_limit),
+                models.Prefetch(query=sparse_vector, using="sparse", limit=self.stage1_limit),
             ],
-            # Stage 3: ColBERT multivector reranking on fused results
-            "query": query_embeddings["colbert_vecs"].tolist(),
-            "using": "colbert",
-            "limit": top_k,
-            "score_threshold": self.score_threshold,
-            "params": {
-                "hnsw_ef": self.hnsw_ef  # Higher precision for ColBERT search
-            },
-            "with_payload": self.payload_fields,
-            "with_vector": False,
-        }
-
-        # Convert numpy types to Python types
-        search_payload = convert_to_python_types(search_payload)
-
-        # Execute query using Qdrant Query API
-        response = requests.post(
-            f"{self.qdrant_url}/collections/{self.collection_name}/points/query",
-            json=search_payload,
-            headers=self.headers,
+            query=models.FusionQuery(fusion=models.Fusion.DBSF),
         )
 
-        if response.status_code != 200:
-            print(f"ERROR: {response.status_code} - {response.text}")
+        response = self.client.query_points(
+            collection_name=self.collection_name,
+            prefetch=[dbsf_prefetch],
+            query=colbert_vectors,
+            using="colbert",
+            limit=top_k,
+            score_threshold=self.score_threshold,
+            search_params=models.SearchParams(hnsw_ef=self.hnsw_ef),
+            with_payload=self.payload_fields,
+        )
 
-        response.raise_for_status()
-        resp_data = response.json()
-
-        # Parse response
-        if isinstance(resp_data["result"], dict):
-            points_list = resp_data["result"].get("points", [])
-        elif isinstance(resp_data["result"], list):
-            points_list = resp_data["result"]
-        else:
-            points_list = []
-
-        results = []
-        for point in points_list:
-            results.append(
-                {
-                    "point_id": point["id"],
-                    "score": point["score"],
-                    "article_number": self._extract_article_number(point["payload"]),
-                    "text": point["payload"].get("text", "")[:200] + "...",
-                }
-            )
-
-        return results
+        return [
+            {
+                "point_id": point.id,
+                "score": point.score,
+                "article_number": self._extract_article_number(point.payload or {}),
+                "text": (point.payload or {}).get("text", "")[:200] + "...",
+            }
+            for point in response.points
+        ]
 
 
 class HybridRRFColBERTSearchEngine(SearchEngine):
@@ -380,9 +281,9 @@ class HybridRRFColBERTSearchEngine(SearchEngine):
     Advanced hybrid search using RRF fusion + ColBERT reranking (Official Qdrant Method).
 
     3-Stage Retrieval Pipeline:
-    1. Prefetch: Dense + Sparse → 100 candidates each
+    1. Prefetch: Dense + Sparse -> 100 candidates each
     2. Fusion: RRF (Reciprocal Rank Fusion) combines results - OFFICIAL QDRANT METHOD
-    3. Rerank: ColBERT multivector server-side reranking → top-K
+    3. Rerank: ColBERT multivector server-side reranking -> top-K
 
     Based on official Qdrant documentation:
     - RRF: https://qdrant.tech/articles/hybrid-search/ (officially supported)
@@ -416,89 +317,39 @@ class HybridRRFColBERTSearchEngine(SearchEngine):
             query, return_dense=True, return_sparse=True, return_colbert_vecs=True
         )
 
-        # Convert sparse to Qdrant format
-        lexical_weights = query_embeddings["lexical_weights"]
-        if hasattr(lexical_weights, "indices"):
-            # Scipy sparse format
-            sparse_indices = lexical_weights.indices.tolist()
-            sparse_values = lexical_weights.values.tolist()
-        else:
-            # Dict format - keys are strings, need to convert to ints
-            sparse_indices = [int(k) for k in lexical_weights]
-            sparse_values = list(lexical_weights.values())
+        dense_vector = convert_to_python_types(query_embeddings["dense_vecs"])
+        sparse_vector = _lexical_weights_to_sparse(query_embeddings["lexical_weights"])
+        colbert_vectors = convert_to_python_types(query_embeddings["colbert_vecs"])
 
         # Build 3-stage query with RRF fusion + ColBERT reranking
-        search_payload = {
-            "prefetch": [
-                # Stage 1a: Dense vector search (prefetch 100 candidates)
-                {
-                    "prefetch": [
-                        {
-                            "query": query_embeddings["dense_vecs"].tolist(),
-                            "using": "dense",
-                            "limit": self.stage1_limit,
-                        },
-                        # Stage 1b: Sparse BM25 search (prefetch 100 candidates)
-                        {
-                            "query": {"values": sparse_values, "indices": sparse_indices},
-                            "using": "sparse",
-                            "limit": self.stage1_limit,
-                        },
-                    ],
-                    # Stage 2: RRF fusion combines dense + sparse results
-                    "query": {
-                        "fusion": "rrf"  # Reciprocal Rank Fusion (OFFICIAL METHOD)
-                    },
-                }
+        rrf_prefetch = models.Prefetch(
+            prefetch=[
+                models.Prefetch(query=dense_vector, using="dense", limit=self.stage1_limit),
+                models.Prefetch(query=sparse_vector, using="sparse", limit=self.stage1_limit),
             ],
-            # Stage 3: ColBERT multivector reranking on fused results
-            "query": query_embeddings["colbert_vecs"].tolist(),
-            "using": "colbert",
-            "limit": top_k,
-            "score_threshold": self.score_threshold,
-            "params": {
-                "hnsw_ef": self.hnsw_ef  # Higher precision for ColBERT search
-            },
-            "with_payload": self.payload_fields,
-            "with_vector": False,
-        }
-
-        # Convert numpy types to Python types
-        search_payload = convert_to_python_types(search_payload)
-
-        # Execute query using Qdrant Query API
-        response = requests.post(
-            f"{self.qdrant_url}/collections/{self.collection_name}/points/query",
-            json=search_payload,
-            headers=self.headers,
+            query=models.FusionQuery(fusion=models.Fusion.RRF),
         )
 
-        if response.status_code != 200:
-            print(f"ERROR: {response.status_code} - {response.text}")
+        response = self.client.query_points(
+            collection_name=self.collection_name,
+            prefetch=[rrf_prefetch],
+            query=colbert_vectors,
+            using="colbert",
+            limit=top_k,
+            score_threshold=self.score_threshold,
+            search_params=models.SearchParams(hnsw_ef=self.hnsw_ef),
+            with_payload=self.payload_fields,
+        )
 
-        response.raise_for_status()
-        resp_data = response.json()
-
-        # Parse response
-        if isinstance(resp_data["result"], dict):
-            points_list = resp_data["result"].get("points", [])
-        elif isinstance(resp_data["result"], list):
-            points_list = resp_data["result"]
-        else:
-            points_list = []
-
-        results = []
-        for point in points_list:
-            results.append(
-                {
-                    "point_id": point["id"],
-                    "score": point["score"],
-                    "article_number": self._extract_article_number(point["payload"]),
-                    "text": point["payload"].get("text", "")[:200] + "...",
-                }
-            )
-
-        return results
+        return [
+            {
+                "point_id": point.id,
+                "score": point.score,
+                "article_number": self._extract_article_number(point.payload or {}),
+                "text": (point.payload or {}).get("text", "")[:200] + "...",
+            }
+            for point in response.points
+        ]
 
 
 def create_search_engine(engine_type: str, collection_name: str, embedding_model) -> SearchEngine:

--- a/tests/unit/evaluation/test_extract_ground_truth.py
+++ b/tests/unit/evaluation/test_extract_ground_truth.py
@@ -7,67 +7,49 @@ from unittest.mock import MagicMock, mock_open, patch
 class TestExtractArticles:
     """Tests for extract_articles function."""
 
-    @patch("src.evaluation.extract_ground_truth.requests")
-    @patch("src.evaluation.extract_ground_truth._qdrant_api_key", new=lambda: "test_key")
-    @patch("src.evaluation.extract_ground_truth._qdrant_url", new=lambda: "http://localhost:6333")
-    def test_extract_articles_scrolls_collection(self, mock_requests):
+    @patch("src.evaluation.extract_ground_truth._make_client")
+    def test_extract_articles_scrolls_collection(self, mock_make_client):
         """Test extract_articles scrolls through Qdrant collection."""
-        # First response with points
-        first_response = MagicMock()
-        first_response.json.return_value = {
-            "result": {
-                "points": [
-                    {
-                        "id": "point-1",
-                        "payload": {
-                            "article_number": 121,
-                            "chunk_id": "chunk-1",
-                            "text": "Article 121 text",
-                        },
-                    }
-                ],
-                "next_page_offset": None,
-            }
+        mock_client = MagicMock()
+
+        # First scroll returns points, second returns empty
+        mock_point = MagicMock()
+        mock_point.id = "point-1"
+        mock_point.payload = {
+            "article_number": 121,
+            "chunk_id": "chunk-1",
+            "text": "Article 121 text",
         }
-        first_response.raise_for_status = MagicMock()
-        mock_requests.post.return_value = first_response
+
+        mock_client.scroll.return_value = ([mock_point], None)
+        mock_make_client.return_value = mock_client
 
         from src.evaluation.extract_ground_truth import extract_articles
 
         extract_articles("test_collection")
 
-        mock_requests.post.assert_called()
-        call_args = mock_requests.post.call_args
-        assert "test_collection" in call_args[0][0]
-        assert call_args[1]["headers"]["api-key"] == "test_key"
+        mock_client.scroll.assert_called()
+        call_kwargs = mock_client.scroll.call_args[1]
+        assert call_kwargs["collection_name"] == "test_collection"
 
-    @patch("src.evaluation.extract_ground_truth.requests")
-    @patch("src.evaluation.extract_ground_truth._qdrant_api_key", new=lambda: "")
-    @patch("src.evaluation.extract_ground_truth._qdrant_url", new=lambda: "http://localhost:6333")
-    def test_extract_articles_groups_by_article_number(self, mock_requests):
+    @patch("src.evaluation.extract_ground_truth._make_client")
+    def test_extract_articles_groups_by_article_number(self, mock_make_client):
         """Test extract_articles groups chunks by article number."""
-        response = MagicMock()
-        response.json.return_value = {
-            "result": {
-                "points": [
-                    {
-                        "id": "point-1",
-                        "payload": {"article_number": 121, "chunk_id": "chunk-1", "text": "A"},
-                    },
-                    {
-                        "id": "point-2",
-                        "payload": {"article_number": 121, "chunk_id": "chunk-2", "text": "B"},
-                    },
-                    {
-                        "id": "point-3",
-                        "payload": {"article_number": 122, "chunk_id": "chunk-3", "text": "C"},
-                    },
-                ],
-                "next_page_offset": None,
-            }
-        }
-        response.raise_for_status = MagicMock()
-        mock_requests.post.return_value = response
+        mock_client = MagicMock()
+
+        mock_points = []
+        for pid, article, chunk_id, text in [
+            ("point-1", 121, "chunk-1", "A"),
+            ("point-2", 121, "chunk-2", "B"),
+            ("point-3", 122, "chunk-3", "C"),
+        ]:
+            p = MagicMock()
+            p.id = pid
+            p.payload = {"article_number": article, "chunk_id": chunk_id, "text": text}
+            mock_points.append(p)
+
+        mock_client.scroll.return_value = (mock_points, None)
+        mock_make_client.return_value = mock_client
 
         from src.evaluation.extract_ground_truth import extract_articles
 
@@ -78,62 +60,50 @@ class TestExtractArticles:
         assert len(result["121"]) == 2
         assert len(result["122"]) == 1
 
-    @patch("src.evaluation.extract_ground_truth.requests")
-    @patch("src.evaluation.extract_ground_truth._qdrant_api_key", new=lambda: "")
-    @patch("src.evaluation.extract_ground_truth._qdrant_url", new=lambda: "http://localhost:6333")
-    def test_extract_articles_handles_pagination(self, mock_requests):
+    @patch("src.evaluation.extract_ground_truth._make_client")
+    def test_extract_articles_handles_pagination(self, mock_make_client):
         """Test extract_articles handles multiple pages."""
+        mock_client = MagicMock()
+
         # First page
-        first_response = MagicMock()
-        first_response.json.return_value = {
-            "result": {
-                "points": [
-                    {"id": "1", "payload": {"article_number": 1, "chunk_id": "c1", "text": "A"}}
-                ],
-                "next_page_offset": "offset-1",
-            }
-        }
-        first_response.raise_for_status = MagicMock()
+        p1 = MagicMock()
+        p1.id = "1"
+        p1.payload = {"article_number": 1, "chunk_id": "c1", "text": "A"}
 
         # Second page
-        second_response = MagicMock()
-        second_response.json.return_value = {
-            "result": {
-                "points": [
-                    {"id": "2", "payload": {"article_number": 2, "chunk_id": "c2", "text": "B"}}
-                ],
-                "next_page_offset": None,
-            }
-        }
-        second_response.raise_for_status = MagicMock()
+        p2 = MagicMock()
+        p2.id = "2"
+        p2.payload = {"article_number": 2, "chunk_id": "c2", "text": "B"}
 
-        mock_requests.post.side_effect = [first_response, second_response]
+        mock_client.scroll.side_effect = [
+            ([p1], "offset-1"),
+            ([p2], None),
+        ]
+        mock_make_client.return_value = mock_client
 
         from src.evaluation.extract_ground_truth import extract_articles
 
         result = extract_articles("test")
 
-        assert mock_requests.post.call_count == 2
+        assert mock_client.scroll.call_count == 2
         assert "1" in result
         assert "2" in result
 
-    @patch("src.evaluation.extract_ground_truth.requests")
-    @patch("src.evaluation.extract_ground_truth._qdrant_api_key", new=lambda: "")
-    @patch("src.evaluation.extract_ground_truth._qdrant_url", new=lambda: "http://localhost:6333")
-    def test_extract_articles_skips_points_without_article(self, mock_requests):
+    @patch("src.evaluation.extract_ground_truth._make_client")
+    def test_extract_articles_skips_points_without_article(self, mock_make_client):
         """Test extract_articles skips points without article_number."""
-        response = MagicMock()
-        response.json.return_value = {
-            "result": {
-                "points": [
-                    {"id": "1", "payload": {"article_number": 121, "text": "A"}},
-                    {"id": "2", "payload": {"text": "No article number"}},  # Missing article
-                ],
-                "next_page_offset": None,
-            }
-        }
-        response.raise_for_status = MagicMock()
-        mock_requests.post.return_value = response
+        mock_client = MagicMock()
+
+        p1 = MagicMock()
+        p1.id = "1"
+        p1.payload = {"article_number": 121, "text": "A"}
+
+        p2 = MagicMock()
+        p2.id = "2"
+        p2.payload = {"text": "No article number"}  # Missing article
+
+        mock_client.scroll.return_value = ([p1, p2], None)
+        mock_make_client.return_value = mock_client
 
         from src.evaluation.extract_ground_truth import extract_articles
 
@@ -142,22 +112,17 @@ class TestExtractArticles:
         assert "121" in result
         assert len(result) == 1  # Only one article extracted
 
-    @patch("src.evaluation.extract_ground_truth.requests")
-    @patch("src.evaluation.extract_ground_truth._qdrant_api_key", new=lambda: "")
-    @patch("src.evaluation.extract_ground_truth._qdrant_url", new=lambda: "http://localhost:6333")
-    def test_extract_articles_uses_point_id_as_fallback(self, mock_requests):
+    @patch("src.evaluation.extract_ground_truth._make_client")
+    def test_extract_articles_uses_point_id_as_fallback(self, mock_make_client):
         """Test extract_articles uses point ID when chunk_id missing."""
-        response = MagicMock()
-        response.json.return_value = {
-            "result": {
-                "points": [
-                    {"id": "point-123", "payload": {"article_number": 121, "text": "A"}},
-                ],
-                "next_page_offset": None,
-            }
-        }
-        response.raise_for_status = MagicMock()
-        mock_requests.post.return_value = response
+        mock_client = MagicMock()
+
+        p = MagicMock()
+        p.id = "point-123"
+        p.payload = {"article_number": 121, "text": "A"}
+
+        mock_client.scroll.return_value = ([p], None)
+        mock_make_client.return_value = mock_client
 
         from src.evaluation.extract_ground_truth import extract_articles
 
@@ -165,26 +130,18 @@ class TestExtractArticles:
 
         assert result["121"][0]["chunk_id"] == "point-123"
 
-    @patch("src.evaluation.extract_ground_truth.requests")
-    @patch("src.evaluation.extract_ground_truth._qdrant_api_key", new=lambda: "")
-    @patch("src.evaluation.extract_ground_truth._qdrant_url", new=lambda: "http://localhost:6333")
-    def test_extract_articles_stores_text_preview(self, mock_requests):
+    @patch("src.evaluation.extract_ground_truth._make_client")
+    def test_extract_articles_stores_text_preview(self, mock_make_client):
         """Test extract_articles stores truncated text preview."""
+        mock_client = MagicMock()
+
         long_text = "A" * 200  # Longer than 100 chars
-        response = MagicMock()
-        response.json.return_value = {
-            "result": {
-                "points": [
-                    {
-                        "id": "1",
-                        "payload": {"article_number": 121, "chunk_id": "c1", "text": long_text},
-                    }
-                ],
-                "next_page_offset": None,
-            }
-        }
-        response.raise_for_status = MagicMock()
-        mock_requests.post.return_value = response
+        p = MagicMock()
+        p.id = "1"
+        p.payload = {"article_number": 121, "chunk_id": "c1", "text": long_text}
+
+        mock_client.scroll.return_value = ([p], None)
+        mock_make_client.return_value = mock_client
 
         from src.evaluation.extract_ground_truth import extract_articles
 
@@ -193,20 +150,12 @@ class TestExtractArticles:
         # Text preview should be truncated to 100 chars
         assert len(result["121"][0]["text_preview"]) == 100
 
-    @patch("src.evaluation.extract_ground_truth.requests")
-    @patch("src.evaluation.extract_ground_truth._qdrant_api_key", new=lambda: "")
-    @patch("src.evaluation.extract_ground_truth._qdrant_url", new=lambda: "http://localhost:6333")
-    def test_extract_articles_empty_collection(self, mock_requests):
+    @patch("src.evaluation.extract_ground_truth._make_client")
+    def test_extract_articles_empty_collection(self, mock_make_client):
         """Test extract_articles handles empty collection."""
-        response = MagicMock()
-        response.json.return_value = {
-            "result": {
-                "points": [],
-                "next_page_offset": None,
-            }
-        }
-        response.raise_for_status = MagicMock()
-        mock_requests.post.return_value = response
+        mock_client = MagicMock()
+        mock_client.scroll.return_value = ([], None)
+        mock_make_client.return_value = mock_client
 
         from src.evaluation.extract_ground_truth import extract_articles
 

--- a/tests/unit/evaluation/test_generate_test_queries.py
+++ b/tests/unit/evaluation/test_generate_test_queries.py
@@ -19,7 +19,6 @@ import pytest
 @pytest.fixture(autouse=True)
 def mock_imports():
     """Mock external dependencies that won't pollute other tests."""
-    mock_requests = MagicMock()
     mock_contextualize = MagicMock()
     mock_settings = MagicMock()
 
@@ -42,7 +41,6 @@ def mock_imports():
     try:
         with patch("src.config.Settings", mock_settings):
             yield {
-                "requests": mock_requests,
                 "contextualize": mock_contextualize,
                 "settings": mock_settings,
             }
@@ -59,38 +57,21 @@ class TestFetchArticleTexts:
     """Tests for fetch_article_texts function."""
 
     def test_fetch_single_article(self, mock_imports):
-        """Test fetching a single article from Qdrant."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "result": {"points": [{"payload": {"text": "Article 115 text content"}}]}
-        }
-        mock_response.raise_for_status = MagicMock()
-        mock_imports["requests"].post.return_value = mock_response
+        """Test fetching a single article from Qdrant via SDK scroll."""
+        mock_client = MagicMock()
 
-        # Simulate fetch_article_texts behavior
-        article_numbers = ["115"]
-        articles = {}
+        # Mock scroll return: a point with text
+        mock_point = MagicMock()
+        mock_point.payload = {"text": "Article 115 text content"}
+        mock_client.scroll.return_value = ([mock_point], None)
 
-        for article_num in article_numbers:
-            response = mock_imports["requests"].post(
-                "http://localhost:6333/collections/test/points/scroll",
-                json={
-                    "filter": {
-                        "must": [{"key": "article_number", "match": {"value": int(article_num)}}]
-                    },
-                    "limit": 1,
-                    "with_payload": True,
-                    "with_vector": False,
-                },
-                headers={"api-key": "test-key"},
-            )
-            points = response.json()["result"]["points"]
-            if points:
-                text = points[0]["payload"].get("text", "")
-                articles[article_num] = text
+        with patch("src.evaluation.generate_test_queries._make_client", return_value=mock_client):
+            from src.evaluation.generate_test_queries import fetch_article_texts
 
-        assert "115" in articles
-        assert articles["115"] == "Article 115 text content"
+            result = fetch_article_texts("test_collection", ["115"])
+
+        assert "115" in result
+        assert result["115"] == "Article 115 text content"
 
     def test_fetch_multiple_articles(self, mock_imports):
         """Test fetching multiple articles."""
@@ -100,79 +81,59 @@ class TestFetchArticleTexts:
             "185": "Theft article text",
         }
 
-        def mock_post(url, json=None, headers=None):
-            article_num = json["filter"]["must"][0]["match"]["value"]
-            response = MagicMock()
-            response.json.return_value = {
-                "result": {
-                    "points": [{"payload": {"text": article_texts.get(str(article_num), "")}}]
-                    if str(article_num) in article_texts
-                    else []
-                }
-            }
-            response.raise_for_status = MagicMock()
-            return response
+        mock_client = MagicMock()
 
-        mock_imports["requests"].post.side_effect = mock_post
+        def mock_scroll(collection_name, scroll_filter, limit, with_payload, with_vectors):
+            # Extract article number from the filter
+            must = scroll_filter.must
+            value = must[0].match.value
+            article_num = str(value)
+            if article_num in article_texts:
+                p = MagicMock()
+                p.payload = {"text": article_texts[article_num]}
+                return ([p], None)
+            return ([], None)
 
-        # Fetch articles
-        fetched = {}
-        for num in ["115", "121", "185"]:
-            response = mock_imports["requests"].post(
-                "url",
-                json={
-                    "filter": {"must": [{"key": "article_number", "match": {"value": int(num)}}]}
-                },
-                headers={},
-            )
-            points = response.json()["result"]["points"]
-            if points:
-                fetched[num] = points[0]["payload"]["text"]
+        mock_client.scroll.side_effect = mock_scroll
 
-        assert len(fetched) == 3
-        assert fetched["115"] == "Murder article text"
+        with patch("src.evaluation.generate_test_queries._make_client", return_value=mock_client):
+            from src.evaluation.generate_test_queries import fetch_article_texts
+
+            result = fetch_article_texts("test_collection", ["115", "121", "185"])
+
+        assert len(result) == 3
+        assert result["115"] == "Murder article text"
 
     def test_fetch_article_not_found(self, mock_imports):
         """Test handling when article is not found."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"result": {"points": []}}
-        mock_response.raise_for_status = MagicMock()
-        mock_imports["requests"].post.return_value = mock_response
+        mock_client = MagicMock()
+        mock_client.scroll.return_value = ([], None)
 
-        article_numbers = ["999"]
-        articles = {}
+        with patch("src.evaluation.generate_test_queries._make_client", return_value=mock_client):
+            from src.evaluation.generate_test_queries import fetch_article_texts
 
-        for article_num in article_numbers:
-            response = mock_imports["requests"].post("url", json={}, headers={})
-            points = response.json()["result"]["points"]
-            if points:
-                articles[article_num] = points[0]["payload"]["text"]
+            result = fetch_article_texts("test_collection", ["999"])
 
-        assert "999" not in articles
-        assert len(articles) == 0
+        assert "999" not in result
+        assert len(result) == 0
 
-    def test_qdrant_request_payload_structure(self):
-        """Test Qdrant request payload is correctly structured."""
+    def test_qdrant_scroll_filter_structure(self, mock_imports):
+        """Test Qdrant scroll filter is correctly structured."""
+        from qdrant_client import models
+
         article_num = "115"
 
-        payload = {
-            "filter": {
-                "must": [
-                    {
-                        "key": "article_number",
-                        "match": {"value": int(article_num)},
-                    }
-                ]
-            },
-            "limit": 1,
-            "with_payload": True,
-            "with_vector": False,
-        }
+        scroll_filter = models.Filter(
+            must=[
+                models.FieldCondition(
+                    key="article_number",
+                    match=models.MatchValue(value=int(article_num)),
+                )
+            ]
+        )
 
-        assert payload["filter"]["must"][0]["match"]["value"] == 115
-        assert payload["limit"] == 1
-        assert payload["with_payload"] is True
-        assert payload["with_vector"] is False
+        assert scroll_filter.must[0].match.value == 115
+        assert scroll_filter.must[0].key == "article_number"
 
 
 class TestGenerateQueriesForArticle:
@@ -571,10 +532,16 @@ class TestErrorHandling:
 
     def test_qdrant_connection_error(self, mock_imports):
         """Test handling Qdrant connection errors."""
-        mock_imports["requests"].post.side_effect = ConnectionError("Connection refused")
+        mock_client = MagicMock()
+        mock_client.scroll.side_effect = ConnectionError("Connection refused")
 
-        with pytest.raises(ConnectionError):
-            mock_imports["requests"].post("http://localhost:6333/...")
+        with (
+            patch("src.evaluation.generate_test_queries._make_client", return_value=mock_client),
+            pytest.raises(ConnectionError),
+        ):
+            from src.evaluation.generate_test_queries import fetch_article_texts
+
+            fetch_article_texts("test_collection", ["115"])
 
     def test_invalid_json_response(self):
         """Test handling invalid JSON in LLM response."""

--- a/tests/unit/evaluation/test_search_engines_eval.py
+++ b/tests/unit/evaluation/test_search_engines_eval.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
+from qdrant_client import models
 
 
 class TestConvertToPythonTypes:
@@ -77,8 +78,9 @@ class TestConvertToPythonTypes:
 class TestSearchEngineBase:
     """Tests for SearchEngine base class."""
 
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_search_engine_init(self, mock_settings_cls):
+    def test_search_engine_init(self, mock_settings_cls, mock_qdrant):
         """Test SearchEngine initialization."""
         from src.evaluation.search_engines import SearchEngine
 
@@ -89,8 +91,9 @@ class TestSearchEngineBase:
         # Just verify the import works
         assert SearchEngine is not None
 
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_extract_article_number(self, mock_settings_cls):
+    def test_extract_article_number(self, mock_settings_cls, mock_qdrant):
         """Test _extract_article_number helper."""
         from src.evaluation.search_engines import BaselineSearchEngine
 
@@ -106,8 +109,9 @@ class TestSearchEngineBase:
         result = engine._extract_article_number(payload)
         assert result == "115"
 
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_extract_article_number_missing(self, mock_settings_cls):
+    def test_extract_article_number_missing(self, mock_settings_cls, mock_qdrant):
         """Test _extract_article_number with missing field."""
         from src.evaluation.search_engines import BaselineSearchEngine
 
@@ -125,8 +129,9 @@ class TestSearchEngineBase:
 class TestBaselineSearchEngine:
     """Tests for BaselineSearchEngine."""
 
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_baseline_init(self, mock_settings_cls):
+    def test_baseline_init(self, mock_settings_cls, mock_qdrant):
         """Test BaselineSearchEngine initialization."""
         from src.evaluation.search_engines import BaselineSearchEngine
 
@@ -139,9 +144,9 @@ class TestBaselineSearchEngine:
         assert engine.collection_name == "test_collection"
         assert engine.embedding_model == mock_model
 
-    @patch("src.evaluation.search_engines.requests")
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_baseline_search_generates_embedding(self, mock_settings_cls, mock_requests):
+    def test_baseline_search_generates_embedding(self, mock_settings_cls, mock_qdrant):
         """Test that search generates dense embedding."""
         from src.evaluation.search_engines import BaselineSearchEngine
 
@@ -153,10 +158,11 @@ class TestBaselineSearchEngine:
         mock_model = MagicMock()
         mock_model.encode.return_value = {"dense_vecs": np.array([0.1, 0.2, 0.3])}
 
+        mock_client = MagicMock()
         mock_response = MagicMock()
-        mock_response.json.return_value = {"result": []}
-        mock_response.raise_for_status = MagicMock()
-        mock_requests.post.return_value = mock_response
+        mock_response.points = []
+        mock_client.query_points.return_value = mock_response
+        mock_qdrant.return_value = mock_client
 
         engine = BaselineSearchEngine("test_collection", mock_model)
         engine.search("test query", top_k=5)
@@ -168,9 +174,9 @@ class TestBaselineSearchEngine:
             return_colbert_vecs=False,
         )
 
-    @patch("src.evaluation.search_engines.requests")
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_baseline_search_returns_results(self, mock_settings_cls, mock_requests):
+    def test_baseline_search_returns_results(self, mock_settings_cls, mock_qdrant):
         """Test that search returns formatted results."""
         from src.evaluation.search_engines import BaselineSearchEngine
 
@@ -182,21 +188,20 @@ class TestBaselineSearchEngine:
         mock_model = MagicMock()
         mock_model.encode.return_value = {"dense_vecs": np.array([0.1, 0.2, 0.3])}
 
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "result": [
-                {
-                    "id": 1,
-                    "score": 0.95,
-                    "payload": {
-                        "article_number": "115",
-                        "text": "Sample article text for testing",
-                    },
-                }
-            ]
+        # Create mock search result using SDK point format
+        mock_point = MagicMock()
+        mock_point.id = 1
+        mock_point.score = 0.95
+        mock_point.payload = {
+            "article_number": "115",
+            "text": "Sample article text for testing",
         }
-        mock_response.raise_for_status = MagicMock()
-        mock_requests.post.return_value = mock_response
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.points = [mock_point]
+        mock_client.query_points.return_value = mock_response
+        mock_qdrant.return_value = mock_client
 
         engine = BaselineSearchEngine("test_collection", mock_model)
         results = engine.search("test query", top_k=5)
@@ -205,12 +210,42 @@ class TestBaselineSearchEngine:
         assert results[0]["article_number"] == "115"
         assert results[0]["score"] == 0.95
 
+    @patch("src.evaluation.search_engines.QdrantClient")
+    @patch("src.evaluation.search_engines.Settings")
+    def test_baseline_search_calls_client(self, mock_settings_cls, mock_qdrant):
+        """Test that baseline search calls client.query_points with correct params."""
+        from src.evaluation.search_engines import BaselineSearchEngine
+
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings.qdrant_api_key = "test-key"
+        mock_settings_cls.return_value = mock_settings
+
+        mock_model = MagicMock()
+        mock_model.encode.return_value = {"dense_vecs": np.array([0.1, 0.2, 0.3])}
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.points = []
+        mock_client.query_points.return_value = mock_response
+        mock_qdrant.return_value = mock_client
+
+        engine = BaselineSearchEngine("test_collection", mock_model)
+        engine.search("test query", top_k=5)
+
+        mock_client.query_points.assert_called_once()
+        call_kwargs = mock_client.query_points.call_args[1]
+        assert call_kwargs["collection_name"] == "test_collection"
+        assert call_kwargs["limit"] == 5
+        assert call_kwargs["with_payload"] is True
+
 
 class TestHybridSearchEngine:
     """Tests for HybridSearchEngine."""
 
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_hybrid_init(self, mock_settings_cls):
+    def test_hybrid_init(self, mock_settings_cls, mock_qdrant):
         """Test HybridSearchEngine initialization."""
         from src.evaluation.search_engines import HybridSearchEngine
 
@@ -223,9 +258,9 @@ class TestHybridSearchEngine:
         assert engine.collection_name == "test_collection"
         assert engine.embedding_model == mock_model
 
-    @patch("src.evaluation.search_engines.requests")
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_hybrid_search_generates_all_embeddings(self, mock_settings_cls, mock_requests):
+    def test_hybrid_search_generates_all_embeddings(self, mock_settings_cls, mock_qdrant):
         """Test that hybrid search generates dense and sparse embeddings."""
         from src.evaluation.search_engines import HybridSearchEngine
 
@@ -241,11 +276,11 @@ class TestHybridSearchEngine:
             "colbert_vecs": np.array([[0.1, 0.2], [0.3, 0.4]]),
         }
 
+        mock_client = MagicMock()
         mock_response = MagicMock()
-        mock_response.json.return_value = {"result": {"points": []}}
-        mock_response.raise_for_status = MagicMock()
-        mock_response.status_code = 200
-        mock_requests.post.return_value = mock_response
+        mock_response.points = []
+        mock_client.query_points.return_value = mock_response
+        mock_qdrant.return_value = mock_client
 
         engine = HybridSearchEngine("test_collection", mock_model)
         engine.search("test query", top_k=5)
@@ -257,10 +292,10 @@ class TestHybridSearchEngine:
             return_colbert_vecs=True,
         )
 
-    @patch("src.evaluation.search_engines.requests")
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_hybrid_search_converts_sparse_indices(self, mock_settings_cls, mock_requests):
-        """Test that hybrid search converts sparse indices to ints."""
+    def test_hybrid_search_uses_query_points(self, mock_settings_cls, mock_qdrant):
+        """Test that hybrid search uses SDK query_points."""
         from src.evaluation.search_engines import HybridSearchEngine
 
         mock_settings = MagicMock()
@@ -269,34 +304,62 @@ class TestHybridSearchEngine:
         mock_settings_cls.return_value = mock_settings
 
         mock_model = MagicMock()
-        # Dict format with string keys (as BGE-M3 returns)
         mock_model.encode.return_value = {
             "dense_vecs": np.array([0.1, 0.2]),
             "lexical_weights": {"100": 0.5, "200": 0.8},
             "colbert_vecs": np.array([[0.1, 0.2]]),
         }
 
+        mock_client = MagicMock()
         mock_response = MagicMock()
-        mock_response.json.return_value = {"result": {"points": []}}
-        mock_response.raise_for_status = MagicMock()
-        mock_response.status_code = 200
-        mock_requests.post.return_value = mock_response
+        mock_response.points = []
+        mock_client.query_points.return_value = mock_response
+        mock_qdrant.return_value = mock_client
 
         engine = HybridSearchEngine("test_collection", mock_model)
         engine.search("test query", top_k=5)
 
-        # Verify the request was made with correct payload
-        call_args = mock_requests.post.call_args
-        payload = call_args[1]["json"]
+        mock_client.query_points.assert_called_once()
+        call_kwargs = mock_client.query_points.call_args[1]
+        assert call_kwargs["collection_name"] == "test_collection"
+        assert "prefetch" in call_kwargs
 
-        # Check that sparse indices are integers
-        prefetch = payload["prefetch"][1]  # Second prefetch is sparse
-        sparse_query = prefetch["query"]
-        assert all(isinstance(idx, int) for idx in sparse_query["indices"])
-
-    @patch("src.evaluation.search_engines.requests")
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_hybrid_search_handles_scipy_sparse(self, mock_settings_cls, mock_requests):
+    def test_hybrid_search_uses_rrf_fusion(self, mock_settings_cls, mock_qdrant):
+        """Test that hybrid search uses RRF fusion."""
+        from src.evaluation.search_engines import HybridSearchEngine
+
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings.qdrant_api_key = "test-key"
+        mock_settings_cls.return_value = mock_settings
+
+        mock_model = MagicMock()
+        mock_model.encode.return_value = {
+            "dense_vecs": np.array([0.1, 0.2]),
+            "lexical_weights": {"100": 0.5},
+            "colbert_vecs": np.array([[0.1, 0.2]]),
+        }
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.points = []
+        mock_client.query_points.return_value = mock_response
+        mock_qdrant.return_value = mock_client
+
+        engine = HybridSearchEngine("test_collection", mock_model)
+        engine.search("test query", top_k=5)
+
+        # Verify query_points was called with FusionQuery(RRF)
+        call_kwargs = mock_client.query_points.call_args[1]
+        query = call_kwargs["query"]
+        assert isinstance(query, models.FusionQuery)
+        assert query.fusion == models.Fusion.RRF
+
+    @patch("src.evaluation.search_engines.QdrantClient")
+    @patch("src.evaluation.search_engines.Settings")
+    def test_hybrid_search_handles_scipy_sparse(self, mock_settings_cls, mock_qdrant):
         """Test that hybrid search handles scipy sparse format."""
         from src.evaluation.search_engines import HybridSearchEngine
 
@@ -317,22 +380,22 @@ class TestHybridSearchEngine:
             "colbert_vecs": np.array([[0.1, 0.2]]),
         }
 
+        mock_client = MagicMock()
         mock_response = MagicMock()
-        mock_response.json.return_value = {"result": {"points": []}}
-        mock_response.raise_for_status = MagicMock()
-        mock_response.status_code = 200
-        mock_requests.post.return_value = mock_response
+        mock_response.points = []
+        mock_client.query_points.return_value = mock_response
+        mock_qdrant.return_value = mock_client
 
         engine = HybridSearchEngine("test_collection", mock_model)
         engine.search("test query", top_k=5)
 
         # Should not raise exception
-        mock_requests.post.assert_called_once()
+        mock_client.query_points.assert_called_once()
 
-    @patch("src.evaluation.search_engines.requests")
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_hybrid_search_uses_rrf_fusion(self, mock_settings_cls, mock_requests):
-        """Test that hybrid search uses RRF fusion."""
+    def test_hybrid_search_returns_results(self, mock_settings_cls, mock_qdrant):
+        """Test parsing response from query_points."""
         from src.evaluation.search_engines import HybridSearchEngine
 
         mock_settings = MagicMock()
@@ -347,26 +410,30 @@ class TestHybridSearchEngine:
             "colbert_vecs": np.array([[0.1, 0.2]]),
         }
 
+        mock_point = MagicMock()
+        mock_point.id = 1
+        mock_point.score = 0.95
+        mock_point.payload = {"article_number": "115", "text": "Test text"}
+
+        mock_client = MagicMock()
         mock_response = MagicMock()
-        mock_response.json.return_value = {"result": {"points": []}}
-        mock_response.raise_for_status = MagicMock()
-        mock_response.status_code = 200
-        mock_requests.post.return_value = mock_response
+        mock_response.points = [mock_point]
+        mock_client.query_points.return_value = mock_response
+        mock_qdrant.return_value = mock_client
 
         engine = HybridSearchEngine("test_collection", mock_model)
-        engine.search("test query", top_k=5)
+        results = engine.search("test", top_k=5)
 
-        # Verify RRF fusion is used
-        call_args = mock_requests.post.call_args
-        payload = call_args[1]["json"]
-        assert payload["query"]["fusion"] == "rrf"
+        assert len(results) == 1
+        assert results[0]["article_number"] == "115"
 
 
 class TestHybridDBSFColBERTSearchEngine:
     """Tests for HybridDBSFColBERTSearchEngine."""
 
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_dbsf_colbert_init(self, mock_settings_cls):
+    def test_dbsf_colbert_init(self, mock_settings_cls, mock_qdrant):
         """Test HybridDBSFColBERTSearchEngine initialization."""
         from src.evaluation.search_engines import HybridDBSFColBERTSearchEngine
 
@@ -378,9 +445,9 @@ class TestHybridDBSFColBERTSearchEngine:
 
         assert engine.collection_name == "test_collection"
 
-    @patch("src.evaluation.search_engines.requests")
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_dbsf_colbert_uses_dbsf_fusion(self, mock_settings_cls, mock_requests):
+    def test_dbsf_colbert_uses_dbsf_fusion(self, mock_settings_cls, mock_qdrant):
         """Test that DBSF+ColBERT search uses DBSF fusion."""
         from src.evaluation.search_engines import HybridDBSFColBERTSearchEngine
 
@@ -396,26 +463,33 @@ class TestHybridDBSFColBERTSearchEngine:
             "colbert_vecs": np.array([[0.1, 0.2]]),
         }
 
+        mock_client = MagicMock()
         mock_response = MagicMock()
-        mock_response.json.return_value = {"result": {"points": []}}
-        mock_response.raise_for_status = MagicMock()
-        mock_response.status_code = 200
-        mock_requests.post.return_value = mock_response
+        mock_response.points = []
+        mock_client.query_points.return_value = mock_response
+        mock_qdrant.return_value = mock_client
 
         engine = HybridDBSFColBERTSearchEngine("test_collection", mock_model)
         engine.search("test query", top_k=5)
 
-        # Verify DBSF fusion is used in inner prefetch
-        call_args = mock_requests.post.call_args
-        payload = call_args[1]["json"]
+        # Verify query_points was called
+        mock_client.query_points.assert_called_once()
+        call_kwargs = mock_client.query_points.call_args[1]
 
-        # Check nested prefetch structure
-        outer_prefetch = payload["prefetch"][0]
-        assert outer_prefetch["query"]["fusion"] == "dbsf"
+        # Verify uses colbert for reranking
+        assert call_kwargs["using"] == "colbert"
 
-    @patch("src.evaluation.search_engines.requests")
+        # Verify nested prefetch with DBSF fusion
+        prefetch = call_kwargs["prefetch"]
+        assert len(prefetch) == 1
+        inner_prefetch = prefetch[0]
+        assert isinstance(inner_prefetch, models.Prefetch)
+        assert isinstance(inner_prefetch.query, models.FusionQuery)
+        assert inner_prefetch.query.fusion == models.Fusion.DBSF
+
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_dbsf_colbert_uses_colbert_for_rerank(self, mock_settings_cls, mock_requests):
+    def test_dbsf_colbert_uses_colbert_for_rerank(self, mock_settings_cls, mock_qdrant):
         """Test that DBSF+ColBERT uses ColBERT for final reranking."""
         from src.evaluation.search_engines import HybridDBSFColBERTSearchEngine
 
@@ -431,27 +505,25 @@ class TestHybridDBSFColBERTSearchEngine:
             "colbert_vecs": np.array([[0.1, 0.2]]),
         }
 
+        mock_client = MagicMock()
         mock_response = MagicMock()
-        mock_response.json.return_value = {"result": {"points": []}}
-        mock_response.raise_for_status = MagicMock()
-        mock_response.status_code = 200
-        mock_requests.post.return_value = mock_response
+        mock_response.points = []
+        mock_client.query_points.return_value = mock_response
+        mock_qdrant.return_value = mock_client
 
         engine = HybridDBSFColBERTSearchEngine("test_collection", mock_model)
         engine.search("test query", top_k=5)
 
-        call_args = mock_requests.post.call_args
-        payload = call_args[1]["json"]
-
-        # Final query uses ColBERT
-        assert payload["using"] == "colbert"
+        call_kwargs = mock_client.query_points.call_args[1]
+        assert call_kwargs["using"] == "colbert"
 
 
 class TestHybridRRFColBERTSearchEngine:
     """Tests for HybridRRFColBERTSearchEngine."""
 
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_rrf_colbert_init(self, mock_settings_cls):
+    def test_rrf_colbert_init(self, mock_settings_cls, mock_qdrant):
         """Test HybridRRFColBERTSearchEngine initialization."""
         from src.evaluation.search_engines import HybridRRFColBERTSearchEngine
 
@@ -463,9 +535,9 @@ class TestHybridRRFColBERTSearchEngine:
 
         assert engine.collection_name == "test_collection"
 
-    @patch("src.evaluation.search_engines.requests")
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_rrf_colbert_uses_rrf_fusion(self, mock_settings_cls, mock_requests):
+    def test_rrf_colbert_uses_rrf_fusion(self, mock_settings_cls, mock_qdrant):
         """Test that RRF+ColBERT search uses RRF fusion."""
         from src.evaluation.search_engines import HybridRRFColBERTSearchEngine
 
@@ -481,28 +553,32 @@ class TestHybridRRFColBERTSearchEngine:
             "colbert_vecs": np.array([[0.1, 0.2]]),
         }
 
+        mock_client = MagicMock()
         mock_response = MagicMock()
-        mock_response.json.return_value = {"result": {"points": []}}
-        mock_response.raise_for_status = MagicMock()
-        mock_response.status_code = 200
-        mock_requests.post.return_value = mock_response
+        mock_response.points = []
+        mock_client.query_points.return_value = mock_response
+        mock_qdrant.return_value = mock_client
 
         engine = HybridRRFColBERTSearchEngine("test_collection", mock_model)
         engine.search("test query", top_k=5)
 
-        call_args = mock_requests.post.call_args
-        payload = call_args[1]["json"]
+        call_kwargs = mock_client.query_points.call_args[1]
 
-        # Check nested prefetch structure uses RRF
-        outer_prefetch = payload["prefetch"][0]
-        assert outer_prefetch["query"]["fusion"] == "rrf"
+        # Verify nested prefetch with RRF fusion
+        prefetch = call_kwargs["prefetch"]
+        assert len(prefetch) == 1
+        inner_prefetch = prefetch[0]
+        assert isinstance(inner_prefetch, models.Prefetch)
+        assert isinstance(inner_prefetch.query, models.FusionQuery)
+        assert inner_prefetch.query.fusion == models.Fusion.RRF
 
 
 class TestCreateSearchEngine:
     """Tests for create_search_engine factory function."""
 
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_create_baseline_engine(self, mock_settings_cls):
+    def test_create_baseline_engine(self, mock_settings_cls, mock_qdrant):
         """Test creating baseline engine."""
         from src.evaluation.search_engines import (
             BaselineSearchEngine,
@@ -517,8 +593,9 @@ class TestCreateSearchEngine:
 
         assert isinstance(engine, BaselineSearchEngine)
 
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_create_hybrid_engine(self, mock_settings_cls):
+    def test_create_hybrid_engine(self, mock_settings_cls, mock_qdrant):
         """Test creating hybrid engine."""
         from src.evaluation.search_engines import (
             HybridSearchEngine,
@@ -533,8 +610,9 @@ class TestCreateSearchEngine:
 
         assert isinstance(engine, HybridSearchEngine)
 
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_create_dbsf_colbert_engine(self, mock_settings_cls):
+    def test_create_dbsf_colbert_engine(self, mock_settings_cls, mock_qdrant):
         """Test creating DBSF+ColBERT engine."""
         from src.evaluation.search_engines import (
             HybridDBSFColBERTSearchEngine,
@@ -549,8 +627,9 @@ class TestCreateSearchEngine:
 
         assert isinstance(engine, HybridDBSFColBERTSearchEngine)
 
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_create_rrf_colbert_engine(self, mock_settings_cls):
+    def test_create_rrf_colbert_engine(self, mock_settings_cls, mock_qdrant):
         """Test creating RRF+ColBERT engine."""
         from src.evaluation.search_engines import (
             HybridRRFColBERTSearchEngine,
@@ -565,8 +644,9 @@ class TestCreateSearchEngine:
 
         assert isinstance(engine, HybridRRFColBERTSearchEngine)
 
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_create_unknown_engine_raises_error(self, mock_settings_cls):
+    def test_create_unknown_engine_raises_error(self, mock_settings_cls, mock_qdrant):
         """Test that unknown engine type raises ValueError."""
         from src.evaluation.search_engines import create_search_engine
 
@@ -582,10 +662,10 @@ class TestCreateSearchEngine:
 class TestSearchEngineResponseParsing:
     """Tests for response parsing in search engines."""
 
-    @patch("src.evaluation.search_engines.requests")
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_parse_dict_result_format(self, mock_settings_cls, mock_requests):
-        """Test parsing response with dict result format."""
+    def test_parse_query_points_response(self, mock_settings_cls, mock_qdrant):
+        """Test parsing response from query_points."""
         from src.evaluation.search_engines import HybridSearchEngine
 
         mock_settings = MagicMock()
@@ -600,21 +680,16 @@ class TestSearchEngineResponseParsing:
             "colbert_vecs": np.array([[0.1, 0.2]]),
         }
 
+        mock_point = MagicMock()
+        mock_point.id = 1
+        mock_point.score = 0.95
+        mock_point.payload = {"article_number": "115", "text": "Test text"}
+
+        mock_client = MagicMock()
         mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "result": {
-                "points": [
-                    {
-                        "id": 1,
-                        "score": 0.95,
-                        "payload": {"article_number": "115", "text": "Test text"},
-                    }
-                ]
-            }
-        }
-        mock_response.raise_for_status = MagicMock()
-        mock_response.status_code = 200
-        mock_requests.post.return_value = mock_response
+        mock_response.points = [mock_point]
+        mock_client.query_points.return_value = mock_response
+        mock_qdrant.return_value = mock_client
 
         engine = HybridSearchEngine("test_collection", mock_model)
         results = engine.search("test", top_k=5)
@@ -622,47 +697,9 @@ class TestSearchEngineResponseParsing:
         assert len(results) == 1
         assert results[0]["article_number"] == "115"
 
-    @patch("src.evaluation.search_engines.requests")
+    @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
-    def test_parse_list_result_format(self, mock_settings_cls, mock_requests):
-        """Test parsing response with list result format."""
-        from src.evaluation.search_engines import HybridSearchEngine
-
-        mock_settings = MagicMock()
-        mock_settings.qdrant_url = "http://localhost:6333"
-        mock_settings.qdrant_api_key = "test-key"
-        mock_settings_cls.return_value = mock_settings
-
-        mock_model = MagicMock()
-        mock_model.encode.return_value = {
-            "dense_vecs": np.array([0.1, 0.2]),
-            "lexical_weights": {"100": 0.5},
-            "colbert_vecs": np.array([[0.1, 0.2]]),
-        }
-
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "result": [
-                {
-                    "id": 1,
-                    "score": 0.95,
-                    "payload": {"article_number": "115", "text": "Test text"},
-                }
-            ]
-        }
-        mock_response.raise_for_status = MagicMock()
-        mock_response.status_code = 200
-        mock_requests.post.return_value = mock_response
-
-        engine = HybridSearchEngine("test_collection", mock_model)
-        results = engine.search("test", top_k=5)
-
-        assert len(results) == 1
-        assert results[0]["article_number"] == "115"
-
-    @patch("src.evaluation.search_engines.requests")
-    @patch("src.evaluation.search_engines.Settings")
-    def test_parse_empty_result(self, mock_settings_cls, mock_requests):
+    def test_parse_empty_result(self, mock_settings_cls, mock_qdrant):
         """Test parsing empty result."""
         from src.evaluation.search_engines import HybridSearchEngine
 
@@ -678,13 +715,42 @@ class TestSearchEngineResponseParsing:
             "colbert_vecs": np.array([[0.1, 0.2]]),
         }
 
+        mock_client = MagicMock()
         mock_response = MagicMock()
-        mock_response.json.return_value = {"result": None}
-        mock_response.raise_for_status = MagicMock()
-        mock_response.status_code = 200
-        mock_requests.post.return_value = mock_response
+        mock_response.points = []
+        mock_client.query_points.return_value = mock_response
+        mock_qdrant.return_value = mock_client
 
         engine = HybridSearchEngine("test_collection", mock_model)
         results = engine.search("test", top_k=5)
 
         assert len(results) == 0
+
+
+class TestLexicalWeightsToSparse:
+    """Tests for _lexical_weights_to_sparse helper."""
+
+    def test_dict_format(self):
+        """Test converting dict lexical weights to SparseVector."""
+        from src.evaluation.search_engines import _lexical_weights_to_sparse
+
+        weights = {"100": 0.5, "200": 0.8, "300": 0.3}
+        sparse = _lexical_weights_to_sparse(weights)
+
+        assert isinstance(sparse, models.SparseVector)
+        assert sparse.indices == [100, 200, 300]
+        assert sparse.values == [0.5, 0.8, 0.3]
+
+    def test_scipy_sparse_format(self):
+        """Test converting scipy sparse format to SparseVector."""
+        from src.evaluation.search_engines import _lexical_weights_to_sparse
+
+        mock_sparse = MagicMock()
+        mock_sparse.indices = np.array([100, 200])
+        mock_sparse.values = np.array([0.5, 0.8])
+
+        sparse = _lexical_weights_to_sparse(mock_sparse)
+
+        assert isinstance(sparse, models.SparseVector)
+        assert sparse.indices == [100, 200]
+        assert sparse.values == pytest.approx([0.5, 0.8])


### PR DESCRIPTION
## Summary
- Replace raw `requests.post` calls to Qdrant REST API with `qdrant-client` SDK in 3 eval modules
- `search_engines.py`: All 4 search engine classes (Baseline, Hybrid, DBSF+ColBERT, RRF+ColBERT) now use `QdrantClient.query_points()` with `models.Prefetch`, `models.FusionQuery`, `models.SparseVector`
- `extract_ground_truth.py`: Uses `QdrantClient.scroll()` for collection traversal
- `generate_test_queries.py`: Uses `QdrantClient.scroll()` with `models.Filter`/`models.FieldCondition`/`models.MatchValue` for article filtering
- All 3 test files updated to mock SDK methods; net reduction of 164 lines

Closes #314

## Test plan
- [x] 77/77 evaluation unit tests pass
- [x] 201/201 full evaluation test suite passes (3 skipped: optional deps)
- [x] Ruff lint + format clean
- [x] Pre-commit hooks pass
- [x] No raw `requests` references to Qdrant remain in target files
- [x] Code review caught and fixed critical bug: `BaselineSearchEngine` was using non-existent `client.search()` instead of `client.query_points()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)