### PR TITLE
chore(deps): optionalize model-stack with lazy imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             uv sync --frozen
           else
-            uv sync --frozen --extra voice --extra ingest --extra eval
+            uv sync --frozen --extra voice --extra ingest --extra eval --extra ml-local
           fi
 
       - name: Preflight imports (full tier only)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,7 @@ dependencies = [
     "numpy",
     "aiohttp",
     "requests",
-    "FlagEmbedding",
-    "scipy",
-    "sentence-transformers",  # BGE-M3 embeddings
     "qdrant-client>=1.16.2",  # Vector database client (v1.15+ for BM42 support)
-    "transformers>=4.30.0",   # For HuggingFace tokenizers in HybridChunker
     "langfuse>=3.0.0",        # LLM observability & tracing
     # Voyage AI Integration (2026-01-21)
     "voyageai>=0.3.0",        # Voyage AI embeddings and reranking
@@ -25,9 +21,6 @@ dependencies = [
     "redis>=7.1.0",
     "redisvl>=0.13.2",
     "aiogram>=3.22.0",
-    # PyTorch CPU-only (forced via [tool.uv.sources] → pytorch-cpu index)
-    "torch>=2.0.0",
-    "torchvision>=0.15.0",  # Must be direct dep for [tool.uv.sources] to apply CPU index
     "asyncpg>=0.31.0",
     # Performance (2026-02-06)
     "uvloop>=0.21.0",                     # 2-4x faster asyncio event loop
@@ -41,6 +34,19 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Local ML models (torch, FlagEmbedding, sentence-transformers)
+# Only needed when running local model inference (BGE-M3, cross-encoder, etc.)
+# Install: uv sync --extra ml-local
+ml-local = [
+    "FlagEmbedding",
+    "scipy",
+    "sentence-transformers",
+    # PyTorch CPU-only (forced via [tool.uv.sources] → pytorch-cpu index)
+    "torch>=2.0.0",
+    "torchvision>=0.15.0",  # Must be direct dep for [tool.uv.sources] to apply CPU index
+    "transformers>=4.30.0", # For HuggingFace tokenizers in HybridChunker
+]
+
 # Documentation tools
 docs = [
     "mkdocs>=1.6.0",         # Documentation generator
@@ -80,7 +86,7 @@ eval = [
 
 # All optional dependencies
 all = [
-    "contextual-rag[docs,voice,eval,ingest]",
+    "contextual-rag[docs,voice,eval,ingest,ml-local]",
 ]
 
 # =============================================================================

--- a/src/evaluation/run_ab_test.py
+++ b/src/evaluation/run_ab_test.py
@@ -20,8 +20,6 @@ import sys
 import time
 from datetime import datetime
 
-from FlagEmbedding import BGEM3FlagModel
-
 
 sys.path.append("/home/admin/contextual_rag")
 
@@ -67,6 +65,13 @@ def run_ab_test(
     print()
 
     # Initialize embedding model
+    try:
+        from FlagEmbedding import BGEM3FlagModel
+    except ImportError as e:
+        raise ImportError(
+            "FlagEmbedding is not installed. Install ml-local extra: uv sync --extra ml-local"
+        ) from e
+
     print("🤖 Loading BGE-M3 embedding model...")
     start_time = time.time()
     model = BGEM3FlagModel("BAAI/bge-m3", use_fp16=True)

--- a/src/evaluation/search_engines_rerank.py
+++ b/src/evaluation/search_engines_rerank.py
@@ -7,8 +7,6 @@ Search engine with reranker for 2-stage retrieval:
 
 import sys
 
-from FlagEmbedding import FlagReranker
-
 
 sys.path.append("/home/admin/contextual_rag")
 
@@ -50,6 +48,13 @@ class RerankSearchEngine:
         self.baseline_engine = BaselineSearchEngine(collection_name, embedding_model)
 
         # Stage 2: Reranker (multilingual BGE-reranker-v2-m3)
+        try:
+            from FlagEmbedding import FlagReranker
+        except ImportError as e:
+            raise ImportError(
+                "FlagEmbedding is not installed. Install ml-local extra: uv sync --extra ml-local"
+            ) from e
+
         print(f"Loading reranker: {reranker_model_name}...")
         self.reranker = FlagReranker(
             reranker_model_name,
@@ -112,7 +117,10 @@ def create_rerank_search_engine(
 
 if __name__ == "__main__":
     # Quick test
-    from FlagEmbedding import BGEM3FlagModel
+    try:
+        from FlagEmbedding import BGEM3FlagModel
+    except ImportError:
+        raise SystemExit("FlagEmbedding is not installed. Run: uv sync --extra ml-local")
 
     print("Loading BGE-M3 model...")
     model = BGEM3FlagModel("BAAI/bge-m3", use_fp16=True)

--- a/src/models/embedding_model.py
+++ b/src/models/embedding_model.py
@@ -2,19 +2,29 @@
 
 Loading BGE-M3 multiple times wastes 4-6GB RAM per instance.
 This module ensures only ONE model instance exists in memory.
+
+NOTE: FlagEmbedding and sentence_transformers are imported lazily to avoid
+pulling torch at import time. Install with: uv sync --extra ml-local
 """
 
-import logging
+from __future__ import annotations
 
-from FlagEmbedding import BGEM3FlagModel
-from sentence_transformers import SentenceTransformer
+import logging
+from typing import TYPE_CHECKING, Any
+
+
+if TYPE_CHECKING:
+    from FlagEmbedding import BGEM3FlagModel
+    from sentence_transformers import SentenceTransformer
 
 
 logger = logging.getLogger(__name__)
 
-# Global singleton instances
-_bge_m3_model: BGEM3FlagModel | None = None
-_sentence_transformer: SentenceTransformer | None = None
+# Global singleton instances (typed as Any to avoid import at module level)
+_bge_m3_model: Any | None = None
+_sentence_transformer: Any | None = None
+
+_INSTALL_HINT = "Install ml-local extra: uv sync --extra ml-local"
 
 
 def get_bge_m3_model(use_fp16: bool = True, device: str | None = None) -> BGEM3FlagModel:
@@ -30,12 +40,20 @@ def get_bge_m3_model(use_fp16: bool = True, device: str | None = None) -> BGEM3F
 
     Returns:
         Shared BGEM3FlagModel instance
+
+    Raises:
+        ImportError: If FlagEmbedding is not installed
     """
     global _bge_m3_model
 
     if _bge_m3_model is None:
+        try:
+            from FlagEmbedding import BGEM3FlagModel as _BGEM3
+        except ImportError as e:
+            raise ImportError(f"FlagEmbedding is not installed. {_INSTALL_HINT}") from e
+
         logger.info("Loading BGE-M3 model (FlagEmbedding) - first initialization")
-        _bge_m3_model = BGEM3FlagModel(
+        _bge_m3_model = _BGEM3(
             "BAAI/bge-m3",
             use_fp16=use_fp16,
             device=device,
@@ -59,12 +77,20 @@ def get_sentence_transformer(model_name: str = "BAAI/bge-m3") -> SentenceTransfo
 
     Returns:
         Shared SentenceTransformer instance
+
+    Raises:
+        ImportError: If sentence_transformers is not installed
     """
     global _sentence_transformer
 
     if _sentence_transformer is None:
+        try:
+            from sentence_transformers import SentenceTransformer as _ST
+        except ImportError as e:
+            raise ImportError(f"sentence_transformers is not installed. {_INSTALL_HINT}") from e
+
         logger.info(f"Loading SentenceTransformer ({model_name}) - first initialization")
-        _sentence_transformer = SentenceTransformer(model_name)
+        _sentence_transformer = _ST(model_name)
         logger.info("SentenceTransformer loaded successfully (singleton)")
     else:
         logger.debug("Using existing SentenceTransformer instance (singleton)")

--- a/src/retrieval/reranker.py
+++ b/src/retrieval/reranker.py
@@ -4,7 +4,7 @@ Reranking improves retrieval accuracy by 10-15% NDCG.
 Uses lightweight cross-encoder for CPU inference (~50-100ms latency).
 
 NOTE: sentence_transformers is imported lazily to avoid pulling torch
-for bot runtime. Install with: uv sync --group indexing
+for bot runtime. Install with: uv sync --extra ml-local
 """
 
 import logging
@@ -46,8 +46,8 @@ def get_cross_encoder(model_name: str = "cross-encoder/ms-marco-MiniLM-L-6-v2") 
             from sentence_transformers import CrossEncoder
         except ImportError as e:
             raise ImportError(
-                "sentence_transformers not installed. This is a heavy ML package. "
-                "Run: uv sync --group indexing"
+                "sentence_transformers is not installed. "
+                "Install ml-local extra: uv sync --extra ml-local"
             ) from e
 
         logger.info(f"Loading cross-encoder: {model_name}")

--- a/tests/unit/utils/test_embedding_model.py
+++ b/tests/unit/utils/test_embedding_model.py
@@ -6,116 +6,119 @@ Tests verify that:
 3. Models have expected attributes after initialization
 4. clear_models() properly resets state
 5. Edge cases are handled properly
+
+NOTE: FlagEmbedding and sentence_transformers are optional (ml-local extra).
+Tests mock them via sys.modules to work without the actual packages.
 """
 
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    """Reset singleton state before and after each test."""
+    import src.models.embedding_model as embedding_module
+
+    embedding_module._bge_m3_model = None
+    embedding_module._sentence_transformer = None
+    yield
+    embedding_module._bge_m3_model = None
+    embedding_module._sentence_transformer = None
+
+
+@pytest.fixture()
+def mock_flag_embedding():
+    """Mock FlagEmbedding module in sys.modules for lazy import."""
+    mock_module = MagicMock()
+    mock_cls = MagicMock()
+    mock_module.BGEM3FlagModel = mock_cls
+    with patch.dict(sys.modules, {"FlagEmbedding": mock_module}):
+        yield mock_cls
+
+
+@pytest.fixture()
+def mock_sentence_transformers():
+    """Mock sentence_transformers module in sys.modules for lazy import."""
+    mock_module = MagicMock()
+    mock_cls = MagicMock()
+    mock_module.SentenceTransformer = mock_cls
+    with patch.dict(sys.modules, {"sentence_transformers": mock_module}):
+        yield mock_cls
+
+
 class TestGetBgeM3Model:
     """Tests for get_bge_m3_model() singleton function."""
 
-    @pytest.fixture(autouse=True)
-    def reset_singleton(self):
-        """Reset singleton state before and after each test."""
-        # Import here to access the module-level variables
-        import src.models.embedding_model as embedding_module
-
-        # Clear before test
-        embedding_module._bge_m3_model = None
-        embedding_module._sentence_transformer = None
-        yield
-        # Clear after test
-        embedding_module._bge_m3_model = None
-        embedding_module._sentence_transformer = None
-
-    @patch("src.models.embedding_model.BGEM3FlagModel")
-    def test_singleton_returns_same_instance(self, mock_model_class):
+    def test_singleton_returns_same_instance(self, mock_flag_embedding):
         """Test that get_bge_m3_model returns the same instance on multiple calls."""
         from src.models.embedding_model import get_bge_m3_model
 
-        # Setup mock
         mock_instance = MagicMock()
-        mock_model_class.return_value = mock_instance
+        mock_flag_embedding.return_value = mock_instance
 
-        # First call - should create instance
         model1 = get_bge_m3_model()
-        # Second call - should return same instance
         model2 = get_bge_m3_model()
-        # Third call - should return same instance
         model3 = get_bge_m3_model()
 
-        # All should be the exact same object
         assert model1 is model2
         assert model2 is model3
-        # Model class should only be instantiated once
-        assert mock_model_class.call_count == 1
+        assert mock_flag_embedding.call_count == 1
 
-    @patch("src.models.embedding_model.BGEM3FlagModel")
-    def test_default_initialization_parameters(self, mock_model_class):
+    def test_default_initialization_parameters(self, mock_flag_embedding):
         """Test that default parameters are passed correctly to the model."""
         from src.models.embedding_model import get_bge_m3_model
 
-        mock_instance = MagicMock()
-        mock_model_class.return_value = mock_instance
+        mock_flag_embedding.return_value = MagicMock()
 
         get_bge_m3_model()
 
-        # Check default parameters
-        mock_model_class.assert_called_once_with(
+        mock_flag_embedding.assert_called_once_with(
             "BAAI/bge-m3",
             use_fp16=True,
             device=None,
         )
 
-    @patch("src.models.embedding_model.BGEM3FlagModel")
-    def test_custom_initialization_parameters(self, mock_model_class):
+    def test_custom_initialization_parameters(self, mock_flag_embedding):
         """Test that custom parameters are passed correctly to the model."""
         from src.models.embedding_model import get_bge_m3_model
 
-        mock_instance = MagicMock()
-        mock_model_class.return_value = mock_instance
+        mock_flag_embedding.return_value = MagicMock()
 
         get_bge_m3_model(use_fp16=False, device="cuda")
 
-        mock_model_class.assert_called_once_with(
+        mock_flag_embedding.assert_called_once_with(
             "BAAI/bge-m3",
             use_fp16=False,
             device="cuda",
         )
 
-    @patch("src.models.embedding_model.BGEM3FlagModel")
-    def test_subsequent_calls_ignore_parameters(self, mock_model_class):
+    def test_subsequent_calls_ignore_parameters(self, mock_flag_embedding):
         """Test that parameters on subsequent calls are ignored (singleton already created)."""
         from src.models.embedding_model import get_bge_m3_model
 
         mock_instance = MagicMock()
-        mock_model_class.return_value = mock_instance
+        mock_flag_embedding.return_value = mock_instance
 
-        # First call with default params
         model1 = get_bge_m3_model(use_fp16=True, device="cpu")
-
-        # Second call with different params - should be ignored
         model2 = get_bge_m3_model(use_fp16=False, device="cuda")
 
-        # Should still be the same instance
         assert model1 is model2
-        # Model should only be created once with first call's params
-        mock_model_class.assert_called_once_with(
+        mock_flag_embedding.assert_called_once_with(
             "BAAI/bge-m3",
             use_fp16=True,
             device="cpu",
         )
 
-    @patch("src.models.embedding_model.BGEM3FlagModel")
-    def test_returns_bgem3flagmodel_instance(self, mock_model_class):
+    def test_returns_bgem3flagmodel_instance(self, mock_flag_embedding):
         """Test that the returned object is the BGEM3FlagModel mock."""
         from src.models.embedding_model import get_bge_m3_model
 
         mock_instance = MagicMock()
         mock_instance.some_attribute = "test_value"
-        mock_model_class.return_value = mock_instance
+        mock_flag_embedding.return_value = mock_instance
 
         model = get_bge_m3_model()
 
@@ -126,160 +129,114 @@ class TestGetBgeM3Model:
 class TestGetSentenceTransformer:
     """Tests for get_sentence_transformer() singleton function."""
 
-    @pytest.fixture(autouse=True)
-    def reset_singleton(self):
-        """Reset singleton state before and after each test."""
-        import src.models.embedding_model as embedding_module
-
-        embedding_module._bge_m3_model = None
-        embedding_module._sentence_transformer = None
-        yield
-        embedding_module._bge_m3_model = None
-        embedding_module._sentence_transformer = None
-
-    @patch("src.models.embedding_model.SentenceTransformer")
-    def test_singleton_returns_same_instance(self, mock_st_class):
+    def test_singleton_returns_same_instance(self, mock_sentence_transformers):
         """Test that get_sentence_transformer returns the same instance on multiple calls."""
         from src.models.embedding_model import get_sentence_transformer
 
         mock_instance = MagicMock()
-        mock_st_class.return_value = mock_instance
+        mock_sentence_transformers.return_value = mock_instance
 
-        # Multiple calls should return same instance
         st1 = get_sentence_transformer()
         st2 = get_sentence_transformer()
         st3 = get_sentence_transformer()
 
         assert st1 is st2
         assert st2 is st3
-        assert mock_st_class.call_count == 1
+        assert mock_sentence_transformers.call_count == 1
 
-    @patch("src.models.embedding_model.SentenceTransformer")
-    def test_default_model_name(self, mock_st_class):
+    def test_default_model_name(self, mock_sentence_transformers):
         """Test that default model name is BAAI/bge-m3."""
         from src.models.embedding_model import get_sentence_transformer
 
-        mock_instance = MagicMock()
-        mock_st_class.return_value = mock_instance
+        mock_sentence_transformers.return_value = MagicMock()
 
         get_sentence_transformer()
 
-        mock_st_class.assert_called_once_with("BAAI/bge-m3")
+        mock_sentence_transformers.assert_called_once_with("BAAI/bge-m3")
 
-    @patch("src.models.embedding_model.SentenceTransformer")
-    def test_custom_model_name(self, mock_st_class):
+    def test_custom_model_name(self, mock_sentence_transformers):
         """Test that custom model name is used on first call."""
         from src.models.embedding_model import get_sentence_transformer
 
-        mock_instance = MagicMock()
-        mock_st_class.return_value = mock_instance
+        mock_sentence_transformers.return_value = MagicMock()
 
         get_sentence_transformer(model_name="sentence-transformers/all-MiniLM-L6-v2")
 
-        mock_st_class.assert_called_once_with("sentence-transformers/all-MiniLM-L6-v2")
+        mock_sentence_transformers.assert_called_once_with("sentence-transformers/all-MiniLM-L6-v2")
 
-    @patch("src.models.embedding_model.SentenceTransformer")
-    def test_subsequent_calls_ignore_model_name(self, mock_st_class):
+    def test_subsequent_calls_ignore_model_name(self, mock_sentence_transformers):
         """Test that model_name on subsequent calls is ignored."""
         from src.models.embedding_model import get_sentence_transformer
 
         mock_instance = MagicMock()
-        mock_st_class.return_value = mock_instance
+        mock_sentence_transformers.return_value = mock_instance
 
         st1 = get_sentence_transformer(model_name="model-a")
         st2 = get_sentence_transformer(model_name="model-b")
 
         assert st1 is st2
-        mock_st_class.assert_called_once_with("model-a")
+        mock_sentence_transformers.assert_called_once_with("model-a")
 
 
 class TestClearModels:
     """Tests for clear_models() utility function."""
 
-    @pytest.fixture(autouse=True)
-    def reset_singleton(self):
-        """Reset singleton state before and after each test."""
-        import src.models.embedding_model as embedding_module
-
-        embedding_module._bge_m3_model = None
-        embedding_module._sentence_transformer = None
-        yield
-        embedding_module._bge_m3_model = None
-        embedding_module._sentence_transformer = None
-
-    @patch("src.models.embedding_model.BGEM3FlagModel")
-    @patch("src.models.embedding_model.SentenceTransformer")
-    def test_clear_models_resets_bge_m3(self, mock_st_class, mock_bge_class):
+    def test_clear_models_resets_bge_m3(self, mock_flag_embedding, mock_sentence_transformers):
         """Test that clear_models() clears the BGE-M3 singleton."""
         import src.models.embedding_model as embedding_module
         from src.models.embedding_model import clear_models, get_bge_m3_model
 
-        mock_bge_class.return_value = MagicMock()
-        mock_st_class.return_value = MagicMock()
+        mock_flag_embedding.return_value = MagicMock()
 
-        # Create instance
         get_bge_m3_model()
         assert embedding_module._bge_m3_model is not None
 
-        # Clear
         with patch("gc.collect", return_value=0):
             clear_models()
         assert embedding_module._bge_m3_model is None
 
-    @patch("src.models.embedding_model.BGEM3FlagModel")
-    @patch("src.models.embedding_model.SentenceTransformer")
-    def test_clear_models_resets_sentence_transformer(self, mock_st_class, mock_bge_class):
+    def test_clear_models_resets_sentence_transformer(
+        self, mock_flag_embedding, mock_sentence_transformers
+    ):
         """Test that clear_models() clears the SentenceTransformer singleton."""
         import src.models.embedding_model as embedding_module
         from src.models.embedding_model import clear_models, get_sentence_transformer
 
-        mock_bge_class.return_value = MagicMock()
-        mock_st_class.return_value = MagicMock()
+        mock_sentence_transformers.return_value = MagicMock()
 
-        # Create instance
         get_sentence_transformer()
         assert embedding_module._sentence_transformer is not None
 
-        # Clear
         with patch("gc.collect", return_value=0):
             clear_models()
         assert embedding_module._sentence_transformer is None
 
-    @patch("src.models.embedding_model.BGEM3FlagModel")
-    @patch("src.models.embedding_model.SentenceTransformer")
-    def test_clear_models_allows_new_initialization(self, mock_st_class, mock_bge_class):
+    def test_clear_models_allows_new_initialization(
+        self, mock_flag_embedding, mock_sentence_transformers
+    ):
         """Test that after clear_models(), new instances can be created."""
         from src.models.embedding_model import clear_models, get_bge_m3_model
 
         mock_instance_1 = MagicMock(name="instance1")
         mock_instance_2 = MagicMock(name="instance2")
-        mock_bge_class.side_effect = [mock_instance_1, mock_instance_2]
-        mock_st_class.return_value = MagicMock()
+        mock_flag_embedding.side_effect = [mock_instance_1, mock_instance_2]
 
-        # First initialization
         model1 = get_bge_m3_model()
         assert model1 is mock_instance_1
 
-        # Clear
         with patch("gc.collect", return_value=0):
             clear_models()
 
-        # Second initialization - should create new instance
         model2 = get_bge_m3_model()
         assert model2 is mock_instance_2
         assert model1 is not model2
+        assert mock_flag_embedding.call_count == 2
 
-        # Model class should be called twice
-        assert mock_bge_class.call_count == 2
-
-    @patch("src.models.embedding_model.BGEM3FlagModel")
-    @patch("src.models.embedding_model.SentenceTransformer")
-    def test_clear_models_calls_gc_collect(self, mock_st_class, mock_bge_class):
+    def test_clear_models_calls_gc_collect(self, mock_flag_embedding, mock_sentence_transformers):
         """Test that clear_models() triggers garbage collection."""
         from src.models.embedding_model import clear_models, get_bge_m3_model
 
-        mock_bge_class.return_value = MagicMock()
-        mock_st_class.return_value = MagicMock()
+        mock_flag_embedding.return_value = MagicMock()
 
         get_bge_m3_model()
 
@@ -292,15 +249,12 @@ class TestClearModels:
         import src.models.embedding_model as embedding_module
         from src.models.embedding_model import clear_models
 
-        # Ensure both are None
         assert embedding_module._bge_m3_model is None
         assert embedding_module._sentence_transformer is None
 
-        # Should not raise any exception
         with patch("gc.collect", return_value=0):
             clear_models()
 
-        # Should still be None
         assert embedding_module._bge_m3_model is None
         assert embedding_module._sentence_transformer is None
 
@@ -308,27 +262,14 @@ class TestClearModels:
 class TestSingletonIsolation:
     """Tests for isolation between the two singletons."""
 
-    @pytest.fixture(autouse=True)
-    def reset_singleton(self):
-        """Reset singleton state before and after each test."""
-        import src.models.embedding_model as embedding_module
-
-        embedding_module._bge_m3_model = None
-        embedding_module._sentence_transformer = None
-        yield
-        embedding_module._bge_m3_model = None
-        embedding_module._sentence_transformer = None
-
-    @patch("src.models.embedding_model.BGEM3FlagModel")
-    @patch("src.models.embedding_model.SentenceTransformer")
-    def test_singletons_are_independent(self, mock_st_class, mock_bge_class):
+    def test_singletons_are_independent(self, mock_flag_embedding, mock_sentence_transformers):
         """Test that BGE-M3 and SentenceTransformer singletons are separate."""
         from src.models.embedding_model import get_bge_m3_model, get_sentence_transformer
 
         mock_bge_instance = MagicMock(name="bge_model")
         mock_st_instance = MagicMock(name="st_model")
-        mock_bge_class.return_value = mock_bge_instance
-        mock_st_class.return_value = mock_st_instance
+        mock_flag_embedding.return_value = mock_bge_instance
+        mock_sentence_transformers.return_value = mock_st_instance
 
         bge_model = get_bge_m3_model()
         st_model = get_sentence_transformer()
@@ -337,9 +278,7 @@ class TestSingletonIsolation:
         assert bge_model is mock_bge_instance
         assert st_model is mock_st_instance
 
-    @patch("src.models.embedding_model.BGEM3FlagModel")
-    @patch("src.models.embedding_model.SentenceTransformer")
-    def test_clear_affects_both_singletons(self, mock_st_class, mock_bge_class):
+    def test_clear_affects_both_singletons(self, mock_flag_embedding, mock_sentence_transformers):
         """Test that clear_models() clears both singletons at once."""
         import src.models.embedding_model as embedding_module
         from src.models.embedding_model import (
@@ -348,17 +287,15 @@ class TestSingletonIsolation:
             get_sentence_transformer,
         )
 
-        mock_bge_class.return_value = MagicMock()
-        mock_st_class.return_value = MagicMock()
+        mock_flag_embedding.return_value = MagicMock()
+        mock_sentence_transformers.return_value = MagicMock()
 
-        # Create both
         get_bge_m3_model()
         get_sentence_transformer()
 
         assert embedding_module._bge_m3_model is not None
         assert embedding_module._sentence_transformer is not None
 
-        # Clear both
         with patch("gc.collect", return_value=0):
             clear_models()
 
@@ -369,169 +306,138 @@ class TestSingletonIsolation:
 class TestLogging:
     """Tests for logging behavior in the singleton functions."""
 
-    @pytest.fixture(autouse=True)
-    def reset_singleton(self):
-        """Reset singleton state before and after each test."""
-        import src.models.embedding_model as embedding_module
-
-        embedding_module._bge_m3_model = None
-        embedding_module._sentence_transformer = None
-        yield
-        embedding_module._bge_m3_model = None
-        embedding_module._sentence_transformer = None
-
-    @patch("src.models.embedding_model.BGEM3FlagModel")
-    @patch("src.models.embedding_model.logger")
-    def test_logs_info_on_first_initialization(self, mock_logger, mock_model_class):
+    def test_logs_info_on_first_initialization(self, mock_flag_embedding):
         """Test that info is logged on first model initialization."""
         from src.models.embedding_model import get_bge_m3_model
 
-        mock_model_class.return_value = MagicMock()
+        mock_flag_embedding.return_value = MagicMock()
 
-        get_bge_m3_model()
+        with patch("src.models.embedding_model.logger") as mock_logger:
+            get_bge_m3_model()
 
-        # Check that info was logged for loading and success
-        assert mock_logger.info.call_count == 2
-        # First call should be about loading
-        first_call_args = mock_logger.info.call_args_list[0][0][0]
-        assert "Loading BGE-M3 model" in first_call_args
-        # Second call should be about success
-        second_call_args = mock_logger.info.call_args_list[1][0][0]
-        assert "loaded successfully" in second_call_args
+            assert mock_logger.info.call_count == 2
+            first_call_args = mock_logger.info.call_args_list[0][0][0]
+            assert "Loading BGE-M3 model" in first_call_args
+            second_call_args = mock_logger.info.call_args_list[1][0][0]
+            assert "loaded successfully" in second_call_args
 
-    @patch("src.models.embedding_model.BGEM3FlagModel")
-    @patch("src.models.embedding_model.logger")
-    def test_logs_debug_on_subsequent_calls(self, mock_logger, mock_model_class):
+    def test_logs_debug_on_subsequent_calls(self, mock_flag_embedding):
         """Test that debug is logged on subsequent calls (existing instance)."""
         from src.models.embedding_model import get_bge_m3_model
 
-        mock_model_class.return_value = MagicMock()
+        mock_flag_embedding.return_value = MagicMock()
 
-        # First call
-        get_bge_m3_model()
-        mock_logger.reset_mock()
-
-        # Second call
         get_bge_m3_model()
 
-        # Should log debug, not info
-        mock_logger.debug.assert_called_once()
-        assert "existing" in mock_logger.debug.call_args[0][0].lower()
+        with patch("src.models.embedding_model.logger") as mock_logger:
+            get_bge_m3_model()
+            mock_logger.debug.assert_called_once()
+            assert "existing" in mock_logger.debug.call_args[0][0].lower()
 
-    @patch("src.models.embedding_model.BGEM3FlagModel")
-    @patch("src.models.embedding_model.SentenceTransformer")
-    @patch("src.models.embedding_model.logger")
-    def test_logs_info_on_clear(self, mock_logger, mock_st_class, mock_bge_class):
+    def test_logs_info_on_clear(self, mock_flag_embedding, mock_sentence_transformers):
         """Test that info is logged when clearing models."""
         from src.models.embedding_model import clear_models, get_bge_m3_model
 
-        mock_bge_class.return_value = MagicMock()
-        mock_st_class.return_value = MagicMock()
+        mock_flag_embedding.return_value = MagicMock()
 
         get_bge_m3_model()
-        mock_logger.reset_mock()
 
-        with patch("gc.collect", return_value=0):
+        with (
+            patch("src.models.embedding_model.logger") as mock_logger,
+            patch("gc.collect", return_value=0),
+        ):
             clear_models()
-
-        # Should log clearing BGE-M3
-        mock_logger.info.assert_called()
-        clear_call_args = mock_logger.info.call_args[0][0]
-        assert "Clearing" in clear_call_args
+            mock_logger.info.assert_called()
+            clear_call_args = mock_logger.info.call_args[0][0]
+            assert "Clearing" in clear_call_args
 
 
 class TestEdgeCases:
     """Tests for edge cases and error handling."""
 
-    @pytest.fixture(autouse=True)
-    def reset_singleton(self):
-        """Reset singleton state before and after each test."""
-        import src.models.embedding_model as embedding_module
-
-        embedding_module._bge_m3_model = None
-        embedding_module._sentence_transformer = None
-        yield
-        embedding_module._bge_m3_model = None
-        embedding_module._sentence_transformer = None
-
-    @patch("src.models.embedding_model.BGEM3FlagModel")
-    def test_model_initialization_error_propagates(self, mock_model_class):
+    def test_model_initialization_error_propagates(self, mock_flag_embedding):
         """Test that exceptions during model initialization are propagated."""
         from src.models.embedding_model import get_bge_m3_model
 
-        mock_model_class.side_effect = RuntimeError("CUDA out of memory")
+        mock_flag_embedding.side_effect = RuntimeError("CUDA out of memory")
 
         with pytest.raises(RuntimeError, match="CUDA out of memory"):
             get_bge_m3_model()
 
-    @patch("src.models.embedding_model.BGEM3FlagModel")
-    def test_singleton_state_after_failed_init(self, mock_model_class):
+    def test_singleton_state_after_failed_init(self, mock_flag_embedding):
         """Test that singleton remains None after failed initialization."""
         import src.models.embedding_model as embedding_module
         from src.models.embedding_model import get_bge_m3_model
 
-        mock_model_class.side_effect = RuntimeError("Model load failed")
+        mock_flag_embedding.side_effect = RuntimeError("Model load failed")
 
         with pytest.raises(RuntimeError):
             get_bge_m3_model()
 
-        # Singleton should still be None (not set to failed instance)
         assert embedding_module._bge_m3_model is None
 
-    @patch("src.models.embedding_model.BGEM3FlagModel")
-    def test_retry_after_failed_initialization(self, mock_model_class):
+    def test_retry_after_failed_initialization(self, mock_flag_embedding):
         """Test that initialization can be retried after a failure."""
         import src.models.embedding_model as embedding_module
         from src.models.embedding_model import get_bge_m3_model
 
         mock_instance = MagicMock()
-        # First call fails, second succeeds
-        mock_model_class.side_effect = [RuntimeError("First fail"), mock_instance]
+        mock_flag_embedding.side_effect = [RuntimeError("First fail"), mock_instance]
 
-        # First call fails
         with pytest.raises(RuntimeError):
             get_bge_m3_model()
 
         assert embedding_module._bge_m3_model is None
 
-        # Second call succeeds
         result = get_bge_m3_model()
         assert result is mock_instance
         assert embedding_module._bge_m3_model is mock_instance
 
-    @patch("src.models.embedding_model.BGEM3FlagModel")
-    def test_device_parameter_none_is_auto(self, mock_model_class):
+    def test_device_parameter_none_is_auto(self, mock_flag_embedding):
         """Test that device=None means auto-detection."""
         from src.models.embedding_model import get_bge_m3_model
 
-        mock_model_class.return_value = MagicMock()
+        mock_flag_embedding.return_value = MagicMock()
 
         get_bge_m3_model(device=None)
 
-        # Should be called with device=None (auto)
-        call_kwargs = mock_model_class.call_args[1]
+        call_kwargs = mock_flag_embedding.call_args[1]
         assert call_kwargs["device"] is None
 
-    @patch("src.models.embedding_model.BGEM3FlagModel")
-    def test_use_fp16_false(self, mock_model_class):
+    def test_use_fp16_false(self, mock_flag_embedding):
         """Test that use_fp16=False is passed correctly."""
         from src.models.embedding_model import get_bge_m3_model
 
-        mock_model_class.return_value = MagicMock()
+        mock_flag_embedding.return_value = MagicMock()
 
         get_bge_m3_model(use_fp16=False)
 
-        call_kwargs = mock_model_class.call_args[1]
+        call_kwargs = mock_flag_embedding.call_args[1]
         assert call_kwargs["use_fp16"] is False
 
-    @patch("src.models.embedding_model.SentenceTransformer")
-    def test_empty_model_name_passed_through(self, mock_st_class):
+    def test_empty_model_name_passed_through(self, mock_sentence_transformers):
         """Test that empty string model name is passed (may fail in real code)."""
         from src.models.embedding_model import get_sentence_transformer
 
-        mock_st_class.return_value = MagicMock()
+        mock_sentence_transformers.return_value = MagicMock()
 
-        # Empty string should still be passed through
         get_sentence_transformer(model_name="")
 
-        mock_st_class.assert_called_once_with("")
+        mock_sentence_transformers.assert_called_once_with("")
+
+    def test_import_error_when_flagembedding_missing(self):
+        """Test that ImportError is raised with helpful message when FlagEmbedding is absent."""
+        from src.models.embedding_model import get_bge_m3_model
+
+        # Ensure FlagEmbedding is NOT in sys.modules
+        with patch.dict(sys.modules, {"FlagEmbedding": None}):
+            with pytest.raises(ImportError, match="ml-local"):
+                get_bge_m3_model()
+
+    def test_import_error_when_sentence_transformers_missing(self):
+        """Test that ImportError is raised with helpful message when sentence_transformers absent."""
+        from src.models.embedding_model import get_sentence_transformer
+
+        with patch.dict(sys.modules, {"sentence_transformers": None}):
+            with pytest.raises(ImportError, match="ml-local"):
+                get_sentence_transformer()

--- a/uv.lock
+++ b/uv.lock
@@ -717,7 +717,6 @@ dependencies = [
     { name = "anthropic" },
     { name = "asyncpg" },
     { name = "cachetools" },
-    { name = "flagembedding" },
     { name = "groq" },
     { name = "langchain-core" },
     { name = "langfuse" },
@@ -733,14 +732,7 @@ dependencies = [
     { name = "redis" },
     { name = "redisvl" },
     { name = "requests" },
-    { name = "scipy" },
-    { name = "sentence-transformers" },
     { name = "tenacity" },
-    { name = "torch", version = "2.10.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
-    { name = "torchvision", version = "0.25.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
-    { name = "torchvision", version = "0.25.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
-    { name = "transformers" },
     { name = "uvloop" },
     { name = "voyageai" },
 ]
@@ -753,6 +745,7 @@ all = [
     { name = "docling-core" },
     { name = "fastapi" },
     { name = "fastembed" },
+    { name = "flagembedding" },
     { name = "httpx" },
     { name = "livekit" },
     { name = "livekit-agents", extra = ["silero", "turn-detector"] },
@@ -767,6 +760,13 @@ all = [
     { name = "pandas" },
     { name = "pymupdf" },
     { name = "ragas" },
+    { name = "scipy" },
+    { name = "sentence-transformers" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torchvision", version = "0.25.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torchvision", version = "0.25.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "transformers" },
     { name = "uvicorn" },
 ]
 docs = [
@@ -786,6 +786,16 @@ ingest = [
     { name = "docling-core" },
     { name = "fastembed" },
     { name = "pymupdf" },
+]
+ml-local = [
+    { name = "flagembedding" },
+    { name = "scipy" },
+    { name = "sentence-transformers" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torchvision", version = "0.25.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torchvision", version = "0.25.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "transformers" },
 ]
 voice = [
     { name = "fastapi" },
@@ -826,13 +836,13 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "cachetools", specifier = ">=5.0.0" },
     { name = "cocoindex", marker = "extra == 'ingest'", specifier = ">=0.3.28" },
-    { name = "contextual-rag", extras = ["docs", "voice", "eval", "ingest"], marker = "extra == 'all'" },
+    { name = "contextual-rag", extras = ["docs", "voice", "eval", "ingest", "ml-local"], marker = "extra == 'all'" },
     { name = "datasets", marker = "extra == 'eval'", specifier = ">=3.0.0" },
     { name = "docling", marker = "extra == 'ingest'", specifier = ">=2.70.0" },
     { name = "docling-core", marker = "extra == 'ingest'", specifier = ">=2.61.0" },
     { name = "fastapi", marker = "extra == 'voice'", specifier = ">=0.115.0" },
     { name = "fastembed", marker = "extra == 'ingest'", specifier = ">=0.7.4" },
-    { name = "flagembedding" },
+    { name = "flagembedding", marker = "extra == 'ml-local'" },
     { name = "groq" },
     { name = "httpx", marker = "extra == 'voice'", specifier = ">=0.27.0" },
     { name = "langchain-core", specifier = ">=1.2" },
@@ -862,17 +872,17 @@ requires-dist = [
     { name = "redis", specifier = ">=7.1.0" },
     { name = "redisvl", specifier = ">=0.13.2" },
     { name = "requests" },
-    { name = "scipy" },
-    { name = "sentence-transformers" },
+    { name = "scipy", marker = "extra == 'ml-local'" },
+    { name = "sentence-transformers", marker = "extra == 'ml-local'" },
     { name = "tenacity", specifier = ">=8.2.0" },
-    { name = "torch", specifier = ">=2.0.0", index = "https://download.pytorch.org/whl/cpu" },
-    { name = "torchvision", specifier = ">=0.15.0", index = "https://download.pytorch.org/whl/cpu" },
-    { name = "transformers", specifier = ">=4.30.0" },
+    { name = "torch", marker = "extra == 'ml-local'", specifier = ">=2.0.0", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torchvision", marker = "extra == 'ml-local'", specifier = ">=0.15.0", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "transformers", marker = "extra == 'ml-local'", specifier = ">=4.30.0" },
     { name = "uvicorn", marker = "extra == 'voice'", specifier = ">=0.30.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
     { name = "voyageai", specifier = ">=0.3.0" },
 ]
-provides-extras = ["docs", "voice", "ingest", "eval", "all"]
+provides-extras = ["ml-local", "docs", "voice", "ingest", "eval", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Closes #249

- Move heavy ML packages (torch, FlagEmbedding, sentence-transformers, torchvision, transformers) from core deps to optional `[ml-local]` extra — bot container no longer needs ~2GB of ML packages
- Add lazy imports with clear `ImportError` messages pointing to `uv sync --extra ml-local`
- Rewrite embedding model tests to use `sys.modules` mocking (work without ML packages installed)
- Add `--extra ml-local` to CI main-branch install for full test coverage

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | Move 5 ML packages to `[ml-local]` extra, add to `[all]` |
| `src/models/embedding_model.py` | Lazy import with `TYPE_CHECKING` + runtime `try/except` |
| `src/retrieval/reranker.py` | Update install hint message |
| `src/evaluation/run_ab_test.py` | Lazy import FlagEmbedding |
| `src/evaluation/search_engines_rerank.py` | Lazy import FlagReranker + `__main__` guard |
| `tests/unit/utils/test_embedding_model.py` | Rewrite mocking via `sys.modules` fixtures, +2 new tests |
| `.github/workflows/ci.yml` | Add `--extra ml-local` to main-branch install |
| `uv.lock` | Regenerated |

## Test plan

- [x] `uv run ruff check` — all checks passed
- [x] `uv run ruff format --check` — all formatted
- [x] `uv run mypy` — no issues in 4 source files
- [x] `uv run pytest tests/unit/ -n auto` — 2203 passed, 18 skipped
- [x] 27/27 embedding model tests pass (including 2 new import-error tests)
- [x] Pre-commit hooks passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)