### PR TITLE
chore(docs): align history plan docs with Qdrant-first architecture

### DIFF
--- a/docs/plans/2026-02-11-conversation-memory-design.md
+++ b/docs/plans/2026-02-11-conversation-memory-design.md
@@ -1,9 +1,15 @@
 # Conversation Memory — Design Document
 
 **Date:** 2026-02-11
-**Status:** Draft
-**Issue:** TBD
+**Status:** Partially Implemented (see note below)
+**Issue:** #239
 **Scope:** Хранение истории переписки с клиентом + семантический поиск
+
+> **2026-02-17 Alignment Note (#243):**
+> - **Qdrant `conversation_history`** — IMPLEMENTED in `telegram_bot/services/history_service.py`.
+> - **PostgresSaver** — NOT IMPLEMENTED, superseded by Redis checkpointer (already in use).
+> - **LangMem** — deferred to future phase.
+> - Canonical architecture: see `telegram_bot/agents/` (#240) and `telegram_bot/services/history_service.py` (#239).
 
 ## Проблема
 

--- a/docs/plans/2026-02-11-conversation-memory-plan.md
+++ b/docs/plans/2026-02-11-conversation-memory-plan.md
@@ -2,11 +2,16 @@
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Add persistent conversation memory with semantic search — store Q&A history in Qdrant, replace MemorySaver with PostgresSaver, enable bot auto-recall and manager search.
+> **2026-02-17 Alignment Note (#243):**
+> PostgresSaver tasks (1-2) were NOT implemented — Redis checkpointer remains the thread state backend.
+> Qdrant `conversation_history` (tasks 3+) was implemented in #239. History agent integrated in #240.
+> This plan is partially superseded. See actual implementation in `telegram_bot/services/history_service.py`.
 
-**Architecture:** PostgresSaver for thread persistence (replaces MemorySaver), new Qdrant collection `conversation_history` for Q&A pairs with hybrid search (BGE-M3 dense+sparse), two new graph nodes (history_recall + history_store). LangMem for background fact extraction deferred to Phase 2.
+**Goal:** Add persistent conversation memory with semantic search — store Q&A history in Qdrant ~~, replace MemorySaver with PostgresSaver,~~ enable bot auto-recall and manager search.
 
-**Tech Stack:** langgraph-checkpoint-postgres, psycopg[binary,pool], qdrant-client (existing), BGE-M3 (existing)
+**Architecture:** ~~PostgresSaver for thread persistence (replaces MemorySaver),~~ Redis checkpointer for thread state (existing), new Qdrant collection `conversation_history` for Q&A pairs with dense search (BGE-M3), `/history` command + supervisor `history_search` tool. LangMem for background fact extraction deferred to Phase 2.
+
+**Tech Stack:** ~~langgraph-checkpoint-postgres, psycopg[binary,pool],~~ qdrant-client (existing), BGE-M3 (existing)
 
 **Design Doc:** `docs/plans/2026-02-11-conversation-memory-design.md`
 

--- a/docs/plans/2026-02-11-postgres-saver-plan.md
+++ b/docs/plans/2026-02-11-postgres-saver-plan.md
@@ -1,8 +1,13 @@
 # PostgresSaver for LangGraph Persistence — Implementation Plan
 
+> **2026-02-17 Alignment Note (#243):**
+> This plan was NOT implemented. Redis checkpointer is used for thread state.
+> Conversation history is stored in Qdrant (`conversation_history` collection) via `HistoryService` (#239).
+> PostgresSaver is no longer planned. See `telegram_bot/services/history_service.py`.
+
 **Issue:** [#74](https://github.com/yastman/rag/issues/74) feat: enable PostgresSaver for LangGraph persistence
-**Priority:** P0 | **Effort:** Low (~30 min)
-**Milestone:** Deferred: Post-Baseline
+**Priority:** ~~P0~~ Superseded | **Effort:** Low (~30 min)
+**Milestone:** ~~Deferred: Post-Baseline~~ Not Implemented
 
 ## Goal
 


### PR DESCRIPTION
## Summary

Closes #243

Align outdated plan docs with the current Qdrant-first history design. Issues #239 and #240 were already updated (bodies reference Qdrant/HistoryService), but plan docs still referenced PostgresSaver.

## Changes

**Plan docs (this PR):**
- `docs/plans/2026-02-11-conversation-memory-design.md` — status Draft → Partially Implemented, alignment note
- `docs/plans/2026-02-11-conversation-memory-plan.md` — strikethrough PostgresSaver tasks, note Redis checkpointer in use
- `docs/plans/2026-02-11-postgres-saver-plan.md` — marked as Superseded/Not Implemented

**GitHub issues (via gh CLI, already applied):**
- #239: removed stale `in-progress` label, added alignment comment
- #240: removed stale `blocked` + `P2-backlog` labels, added alignment comment

## Verification

| Criteria | Status |
|----------|--------|
| #239/#240 don't reference PostgresStore as mandatory | PASS (refs are "out of scope") |
| Dependency chain reflects actual path | PASS (labels cleaned) |
| No PostgresStore in source code | PASS (0 matches) |
| Plan docs updated with alignment notes | PASS (3 files) |

## Test plan

- [x] Docs-only change — no code impact, no tests needed
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)