### PR TITLE
test(optimizer): split fast/full test gates and enforce marker tiering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-dev install-all lint format type-check security test test-cov clean all-checks \
+.PHONY: help install install-dev install-all lint format type-check security test test-full test-cov clean all-checks \
 	test-preflight test-smoke test-smoke-routing test-load test-load-ci test-load-eviction \
 	test-load-update-baseline test-all-smoke-load smoke-fast smoke-zoo \
 	monitoring-up monitoring-down monitoring-logs monitoring-status monitoring-test-alert \
@@ -131,10 +131,15 @@ all-checks: lint type-check security ## Run all code quality checks
 # TESTING
 # =============================================================================
 
-test: ## Run tests with pytest
-	@echo "$(BLUE)Running tests...$(NC)"
+test: ## Run fast deterministic PR/local gate (unit + critical graph paths)
+	@echo "$(BLUE)Running fast test gate (unit + graph_paths)...$(NC)"
+	PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/unit/ tests/integration/test_graph_paths.py -n auto --dist=worksteal -q --timeout=30 -m "not legacy_api and not requires_extras"
+	@echo "$(GREEN)✓ Fast test gate complete$(NC)"
+
+test-full: ## Run full test suite (all tiers)
+	@echo "$(BLUE)Running full test suite...$(NC)"
 	uv run pytest tests/
-	@echo "$(GREEN)✓ Tests complete$(NC)"
+	@echo "$(GREEN)✓ Full test suite complete$(NC)"
 
 test-cov: ## Run tests with coverage
 	@echo "$(BLUE)Running tests with coverage...$(NC)"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ uv sync
 make docker-up          # Start core (5 services, ~17s)
 make docker-full-up     # Start all (20 services)
 make check              # Lint + type check
-make test               # Run tests
+make test               # Fast deterministic gate
+make test-full          # Full test suite (all tiers)
 ```
 
 ## Documentation

--- a/docs/agent-rules/testing-and-validation.md
+++ b/docs/agent-rules/testing-and-validation.md
@@ -6,7 +6,7 @@ Run these for most code changes:
 - `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
 
 Run full test suite when touching cross-cutting logic:
-- `make test`
+- `make test-full`
 
 ## Bot And Graph Changes
 - Always run:

--- a/docs/agent-rules/workflow.md
+++ b/docs/agent-rules/workflow.md
@@ -10,7 +10,8 @@
 - Setup: `uv sync`
 - Quick gate: `make check`
 - Unit tests: `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
-- Full tests: `make test`
+- Fast gate tests: `make test`
+- Full tests: `make test-full`
 
 ## Service Stack Commands
 - Start core stack: `make docker-up`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import sys
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -38,6 +39,26 @@ for _logger_name in ("ragas", "ragas._analytics"):
 
 # Load environment variables before any imports
 load_dotenv()
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Apply stable directory-based markers for test tiering."""
+    root = Path(__file__).resolve().parent
+    path_to_marker = {
+        root / "unit": "unit",
+        root / "integration": "integration",
+        root / "smoke": "smoke",
+        root / "e2e": "e2e",
+        root / "chaos": "chaos",
+        root / "load": "load",
+        root / "benchmark": "benchmark",
+    }
+
+    for item in items:
+        item_path = Path(str(item.path)).resolve()
+        for directory, marker in path_to_marker.items():
+            if directory in item_path.parents:
+                item.add_marker(getattr(pytest.mark, marker))
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- split test execution into a fast deterministic gate (`make test`) and an explicit full run (`make test-full`)
- make fast gate run `tests/unit` + critical `tests/integration/test_graph_paths.py` with xdist worksteal
- keep full suite available unchanged via `make test-full`
- auto-apply directory-based pytest markers (`unit/integration/smoke/e2e/chaos/load/benchmark`) in `tests/conftest.py` for stable tiering

## Why
- reduce local/PR feedback time without losing full-suite coverage
- avoid env-sensitive integration/load/benchmark suites leaking into default developer loop

## Validation
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
- `make test`
- `make test-full`
