### PR TITLE
test(optimizer): remove sleeps and tighten fixture isolation

### DIFF
--- a/tests/unit/evaluation/test_generate_test_queries.py
+++ b/tests/unit/evaluation/test_generate_test_queries.py
@@ -17,7 +17,7 @@ import pytest
 # Note: We don't mock 'aiohttp' or 'requests' in sys.modules because they're used
 # by httpx internally and mocking them causes test pollution in other test modules.
 @pytest.fixture(autouse=True)
-def mock_imports():
+def mock_imports(monkeypatch: pytest.MonkeyPatch):
     """Mock external dependencies that won't pollute other tests."""
     mock_contextualize = MagicMock()
     mock_settings = MagicMock()
@@ -29,28 +29,13 @@ def mock_imports():
     mock_settings.return_value = mock_settings_instance
 
     # Only mock modules that won't affect other parts of the codebase
-    mock_keys = ["contextualize_groq_async"]
-    original_modules = {k: sys.modules.get(k) for k in mock_keys}
+    monkeypatch.setitem(sys.modules, "contextualize_groq_async", mock_contextualize)
 
-    # Apply mocks
-    mocks = {
-        "contextualize_groq_async": mock_contextualize,
-    }
-    sys.modules.update(mocks)
-
-    try:
-        with patch("src.config.Settings", mock_settings):
-            yield {
-                "contextualize": mock_contextualize,
-                "settings": mock_settings,
-            }
-    finally:
-        # Restore original state
-        for key, value in original_modules.items():
-            if value is None:
-                sys.modules.pop(key, None)
-            else:
-                sys.modules[key] = value
+    with patch("src.config.Settings", mock_settings):
+        yield {
+            "contextualize": mock_contextualize,
+            "settings": mock_settings,
+        }
 
 
 class TestFetchArticleTexts:

--- a/tests/unit/evaluation/test_judges.py
+++ b/tests/unit/evaluation/test_judges.py
@@ -1,6 +1,6 @@
 """Tests for LLM-as-a-Judge evaluators."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -102,12 +102,14 @@ class TestJudgeFunctions:
     async def test_judge_handles_llm_error(self):
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(side_effect=Exception("API error"))
-        result = await judge_faithfulness(
-            client=mock_client,
-            model="test-model",
-            query="q",
-            answer="a",
-            context="c",
-        )
+        with patch("telegram_bot.evaluation.judges.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            result = await judge_faithfulness(
+                client=mock_client,
+                model="test-model",
+                query="q",
+                answer="a",
+                context="c",
+            )
         assert result.score is None
         assert "error" in result.reasoning.lower()
+        assert mock_sleep.await_count == 2

--- a/tests/unit/evaluation/test_langfuse_integration.py
+++ b/tests/unit/evaluation/test_langfuse_integration.py
@@ -16,7 +16,7 @@ import pytest
 
 # Mock langfuse module before any imports
 @pytest.fixture(autouse=True)
-def mock_langfuse_module():
+def mock_langfuse_module(monkeypatch: pytest.MonkeyPatch):
     """Mock langfuse module and its components."""
 
     # Configure observe to return a pass-through decorator
@@ -49,29 +49,16 @@ def mock_langfuse_module():
     mock_langfuse_mod.get_client = MagicMock(return_value=mock_client_instance)
     mock_langfuse_mod.observe = observe_passthrough
 
-    # Save original state
-    mock_keys = ["langfuse"]
-    original_modules = {k: sys.modules.get(k) for k in mock_keys}
+    monkeypatch.setitem(sys.modules, "langfuse", mock_langfuse_mod)
 
-    # Apply mock
-    sys.modules["langfuse"] = mock_langfuse_mod
-
-    try:
-        yield {
-            "Langfuse": mock_langfuse_class,
-            "client_instance": mock_client_instance,
-            "get_client": mock_langfuse_mod.get_client,
-            "observe": observe_passthrough,
-            "span": mock_span,
-            "module": mock_langfuse_mod,
-        }
-    finally:
-        # Restore original state
-        for key, value in original_modules.items():
-            if value is None:
-                sys.modules.pop(key, None)
-            else:
-                sys.modules[key] = value
+    yield {
+        "Langfuse": mock_langfuse_class,
+        "client_instance": mock_client_instance,
+        "get_client": mock_langfuse_mod.get_client,
+        "observe": observe_passthrough,
+        "span": mock_span,
+        "module": mock_langfuse_mod,
+    }
 
 
 class TestInitializeLangfuse:
@@ -229,12 +216,13 @@ class TestTraceSearchWithDecorator:
         """Test latency is measured during search."""
 
         def mock_search(query: str) -> list:
-            time.sleep(0.01)  # 10ms simulated latency
+            _ = query
             return []
 
-        start_time = time.time()
-        mock_search("test")
-        latency_ms = (time.time() - start_time) * 1000
+        with patch("time.time", side_effect=[100.0, 100.012]):
+            start_time = time.time()
+            mock_search("test")
+            latency_ms = (time.time() - start_time) * 1000
 
         assert latency_ms >= 10
         assert latency_ms < 100  # Should be under 100ms
@@ -396,9 +384,9 @@ class TestMetricsCalculation:
 
     def test_latency_calculation(self):
         """Test latency is calculated correctly in milliseconds."""
-        start_time = time.time()
-        time.sleep(0.05)  # 50ms
-        latency_ms = (time.time() - start_time) * 1000
+        with patch("time.time", side_effect=[200.0, 200.05]):
+            start_time = time.time()
+            latency_ms = (time.time() - start_time) * 1000
 
         assert 45 < latency_ms < 100  # Allow some tolerance
 

--- a/tests/unit/ingestion/test_unified_metrics.py
+++ b/tests/unit/ingestion/test_unified_metrics.py
@@ -2,7 +2,6 @@
 """Tests for unified ingestion metrics: structured logging and timing."""
 
 import logging
-import time
 from datetime import UTC, datetime
 
 import pytest
@@ -96,26 +95,32 @@ class TestToStructuredLog:
 class TestTimedOperation:
     """Test timed_operation() context manager."""
 
-    def test_records_docling_duration(self):
+    @pytest.mark.parametrize(
+        ("operation", "attr", "start", "end"),
+        [
+            ("docling", "docling_duration_ms", 100.0, 100.011),
+            ("voyage", "voyage_duration_ms", 200.0, 200.022),
+            ("qdrant", "qdrant_duration_ms", 300.0, 300.033),
+        ],
+    )
+    def test_records_duration_for_operation(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        operation: str,
+        attr: str,
+        start: float,
+        end: float,
+    ):
         """timed_operation stores elapsed time in the correct attr."""
+        values = iter([start, end])
+        monkeypatch.setattr(
+            "src.ingestion.unified.metrics.time.perf_counter",
+            lambda: next(values),
+        )
         m = IngestionMetrics(file_id="f1", source_path="x.pdf")
-        with timed_operation(m, "docling"):
-            time.sleep(0.01)
-        assert m.docling_duration_ms > 0
-
-    def test_records_voyage_duration(self):
-        """Voyage timing is recorded."""
-        m = IngestionMetrics(file_id="f1", source_path="x.pdf")
-        with timed_operation(m, "voyage"):
-            time.sleep(0.01)
-        assert m.voyage_duration_ms > 0
-
-    def test_records_qdrant_duration(self):
-        """Qdrant timing is recorded."""
-        m = IngestionMetrics(file_id="f1", source_path="x.pdf")
-        with timed_operation(m, "qdrant"):
-            time.sleep(0.01)
-        assert m.qdrant_duration_ms > 0
+        with timed_operation(m, operation):
+            pass
+        assert getattr(m, attr) == pytest.approx((end - start) * 1000)
 
     def test_unknown_operation_is_noop(self):
         """Unknown operation name does not crash."""
@@ -124,13 +129,18 @@ class TestTimedOperation:
             pass
         # No crash, no attr set
 
-    def test_timing_on_exception(self):
+    def test_timing_on_exception(self, monkeypatch: pytest.MonkeyPatch):
         """Duration is still recorded even if the block raises."""
+        values = iter([400.0, 400.005])
+        monkeypatch.setattr(
+            "src.ingestion.unified.metrics.time.perf_counter",
+            lambda: next(values),
+        )
         m = IngestionMetrics(file_id="f1", source_path="x.pdf")
         with pytest.raises(ValueError, match="boom"):
             with timed_operation(m, "docling"):
                 raise ValueError("boom")
-        assert m.docling_duration_ms > 0
+        assert m.docling_duration_ms == pytest.approx(5.0)
 
 
 class TestLogIngestionResult:

--- a/tests/unit/test_retriever_service.py
+++ b/tests/unit/test_retriever_service.py
@@ -1,50 +1,44 @@
 # tests/test_retriever_service.py
 """Tests for RetrieverService."""
 
-from unittest.mock import patch
+import pytest
+
+from telegram_bot.services.retriever import RetrieverService
+
+
+@pytest.fixture
+def retriever() -> RetrieverService:
+    """Create RetrieverService instance without running network-bound __init__."""
+    instance = RetrieverService.__new__(RetrieverService)
+    instance.url = "http://localhost:6333"
+    instance.api_key = ""
+    instance.collection_name = "test"
+    instance.client = None
+    instance._is_healthy = False
+    return instance
 
 
 class TestRetrieverServiceFilters:
     """Test filter building logic."""
 
-    def test_build_filter_returns_none_for_empty_dict(self):
+    def test_build_filter_returns_none_for_empty_dict(self, retriever):
         """Empty filters should return None, not empty Filter."""
-        from telegram_bot.services import RetrieverService
+        result = retriever._build_filter({})
 
-        with patch.object(RetrieverService, "__init__", lambda _s, *_a, **_kw: None):
-            retriever = RetrieverService.__new__(RetrieverService)
-            retriever.url = "http://localhost:6333"
-            retriever.api_key = ""
-            retriever.collection_name = "test"
-            retriever.client = None
-            retriever._is_healthy = False
+        assert result is None, "Empty filters should return None"
 
-            result = retriever._build_filter({})
-
-            assert result is None, "Empty filters should return None"
-
-    def test_build_filter_returns_filter_for_city(self):
+    def test_build_filter_returns_filter_for_city(self, retriever):
         """Filter with city should return proper Filter object."""
         from qdrant_client import models
 
-        from telegram_bot.services import RetrieverService
+        result = retriever._build_filter({"city": "Несебр"})
 
-        with patch.object(RetrieverService, "__init__", lambda _s, *_a, **_kw: None):
-            retriever = RetrieverService.__new__(RetrieverService)
+        assert result is not None
+        assert isinstance(result, models.Filter)
+        assert len(result.must) == 1
 
-            result = retriever._build_filter({"city": "Несебр"})
-
-            assert result is not None
-            assert isinstance(result, models.Filter)
-            assert len(result.must) == 1
-
-    def test_build_base_filter_returns_none(self):
+    def test_build_base_filter_returns_none(self, retriever):
         """Base filter should return None (search all documents)."""
-        from telegram_bot.services import RetrieverService
+        result = retriever._build_base_filter()
 
-        with patch.object(RetrieverService, "__init__", lambda _s, *_a, **_kw: None):
-            retriever = RetrieverService.__new__(RetrieverService)
-
-            result = retriever._build_base_filter()
-
-            assert result is None
+        assert result is None


### PR DESCRIPTION
## Summary
- removed artificial sleeps from unit tests and switched to deterministic clock patching
- eliminated retry backoff delay in `test_judges` by patching async sleep
- tightened fixture/module mocking hygiene with `monkeypatch.setitem(sys.modules, ...)`
- simplified `RetrieverService` unit tests with a lightweight fixture (no network-bound init)

## Why
This keeps behavior coverage while improving determinism and reducing unnecessary runtime overhead in local/CI parallel runs.

## Files
- `tests/unit/evaluation/test_judges.py`
- `tests/unit/ingestion/test_unified_metrics.py`
- `tests/unit/evaluation/test_langfuse_integration.py`
- `tests/unit/evaluation/test_generate_test_queries.py`
- `tests/unit/test_retriever_service.py`

## Verification
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
- `make test`
- `make test-full`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' uv run pytest tests/unit/evaluation/test_judges.py tests/unit/ingestion/test_unified_metrics.py tests/unit/evaluation/test_langfuse_integration.py tests/unit/test_retriever_service.py --durations=20 --durations-min=0.05 -q`

## Follow-up tracking
- Refs #363
