### PR TITLE
fix(voice): reuse httpx.AsyncClient with connection pooling (#369)

### DIFF
--- a/src/voice/agent.py
+++ b/src/voice/agent.py
@@ -34,6 +34,26 @@ logger = logging.getLogger(__name__)
 RAG_API_URL = os.getenv("RAG_API_URL", "http://rag-api:8080")
 DATABASE_URL = os.getenv("DATABASE_URL") or os.getenv("VOICE_DATABASE_URL", "")
 _transcript_store: TranscriptStore | None = None
+_http_client: httpx.AsyncClient | None = None
+
+
+def _get_http_client() -> httpx.AsyncClient:
+    """Return a shared httpx client with connection pooling."""
+    global _http_client
+    if _http_client is None:
+        _http_client = httpx.AsyncClient(
+            timeout=30.0,
+            limits=httpx.Limits(max_connections=10, max_keepalive_connections=5),
+        )
+    return _http_client
+
+
+async def _close_http_client() -> None:
+    """Close the shared httpx client (called on server shutdown)."""
+    global _http_client
+    if _http_client is not None:
+        await _http_client.aclose()
+        _http_client = None
 
 
 async def _get_transcript_store() -> TranscriptStore | None:
@@ -141,24 +161,24 @@ class VoiceBot(Agent):
         """
         await self._append_transcript("user", query)
         try:
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                payload: dict[str, Any] = {
-                    "query": query,
-                    "user_id": 0,
-                    "session_id": f"voice-{self._call_id}",
-                    "channel": "voice",
-                }
-                if self._langfuse_trace_id:
-                    payload["langfuse_trace_id"] = self._langfuse_trace_id
-                resp = await client.post(
-                    f"{RAG_API_URL}/query",
-                    json=payload,
-                )
-                resp.raise_for_status()
-                data = resp.json()
-                answer = str(data.get("response", "Информация не найдена."))
-                await self._append_transcript("bot", answer)
-                return answer
+            client = _get_http_client()
+            payload: dict[str, Any] = {
+                "query": query,
+                "user_id": 0,
+                "session_id": f"voice-{self._call_id}",
+                "channel": "voice",
+            }
+            if self._langfuse_trace_id:
+                payload["langfuse_trace_id"] = self._langfuse_trace_id
+            resp = await client.post(
+                f"{RAG_API_URL}/query",
+                json=payload,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            answer = str(data.get("response", "Информация не найдена."))
+            await self._append_transcript("bot", answer)
+            return answer
         except Exception:
             logger.exception("RAG API call failed")
             fallback = "Извините, не могу найти информацию сейчас."

--- a/tests/unit/voice/test_voice_agent.py
+++ b/tests/unit/voice/test_voice_agent.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 
@@ -98,11 +99,7 @@ async def test_search_tool_forwards_langfuse_trace_id():
     mock_client = MagicMock()
     mock_client.post = AsyncMock(return_value=mock_response)
 
-    client_cm = AsyncMock()
-    client_cm.__aenter__.return_value = mock_client
-    client_cm.__aexit__.return_value = None
-
-    with patch("src.voice.agent.httpx.AsyncClient", return_value=client_cm):
+    with patch("src.voice.agent._get_http_client", return_value=mock_client):
         await VoiceBot.search_knowledge_base.__wrapped__(agent, None, "test query")
 
     payload = mock_client.post.await_args.kwargs["json"]
@@ -123,11 +120,7 @@ async def test_search_tool_omits_langfuse_trace_id_when_none():
     mock_client = MagicMock()
     mock_client.post = AsyncMock(return_value=mock_response)
 
-    client_cm = AsyncMock()
-    client_cm.__aenter__.return_value = mock_client
-    client_cm.__aexit__.return_value = None
-
-    with patch("src.voice.agent.httpx.AsyncClient", return_value=client_cm):
+    with patch("src.voice.agent._get_http_client", return_value=mock_client):
         await VoiceBot.search_knowledge_base.__wrapped__(agent, None, "test query")
 
     payload = mock_client.post.await_args.kwargs["json"]
@@ -149,11 +142,7 @@ async def test_search_tool_appends_transcript_entries_with_store():
     mock_client = MagicMock()
     mock_client.post = AsyncMock(return_value=mock_response)
 
-    client_cm = AsyncMock()
-    client_cm.__aenter__.return_value = mock_client
-    client_cm.__aexit__.return_value = None
-
-    with patch("src.voice.agent.httpx.AsyncClient", return_value=client_cm):
+    with patch("src.voice.agent._get_http_client", return_value=mock_client):
         result = await VoiceBot.search_knowledge_base.__wrapped__(agent, None, "что есть в Несебре")
 
     assert result == "Найдено 3 варианта."
@@ -163,3 +152,48 @@ async def test_search_tool_appends_transcript_entries_with_store():
     assert first["call_id"] == "22222222-2222-2222-2222-222222222222"
     assert first["role"] == "user"
     assert second["role"] == "bot"
+
+
+def test_get_http_client_returns_shared_instance():
+    """_get_http_client returns the same AsyncClient on repeated calls (#369)."""
+    import src.voice.agent as mod
+
+    original = mod._http_client
+    try:
+        mod._http_client = None
+        first = mod._get_http_client()
+        second = mod._get_http_client()
+        assert first is second
+        assert isinstance(first, httpx.AsyncClient)
+    finally:
+        mod._http_client = original
+
+
+def test_get_http_client_has_pool_limits():
+    """Shared httpx client uses connection pool limits (#369)."""
+    import src.voice.agent as mod
+
+    original = mod._http_client
+    try:
+        mod._http_client = None
+        client = mod._get_http_client()
+        pool = client._transport._pool
+        assert pool._max_connections == 10
+        assert pool._max_keepalive_connections == 5
+    finally:
+        mod._http_client = original
+
+
+async def test_close_http_client():
+    """_close_http_client closes the client and resets the global (#369)."""
+    import src.voice.agent as mod
+
+    original = mod._http_client
+    try:
+        mod._http_client = None
+        mod._get_http_client()
+        assert mod._http_client is not None
+        await mod._close_http_client()
+        assert mod._http_client is None
+    finally:
+        mod._http_client = original


### PR DESCRIPTION
## Summary
- Replace per-call `httpx.AsyncClient` creation in `search_knowledge_base` with a module-level shared client
- Configure connection pool: `max_connections=10`, `max_keepalive_connections=5`
- Add `_get_http_client()` lazy singleton and `_close_http_client()` cleanup function
- Update 3 existing tests to mock `_get_http_client` instead of `httpx.AsyncClient` context manager
- Add 3 new tests: singleton behavior, pool limits, cleanup

Closes #369

## Test plan
- [x] All 14 voice agent tests pass
- [x] Ruff lint + format clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)