### PR TITLE
fix(eval): guard empty inputs and remove hardcoded paths

### DIFF
--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -224,6 +224,14 @@ class RAGPipeline:
         Returns:
             Evaluation metrics
         """
+        if not queries:
+            return {
+                "total_queries": 0,
+                "average_latency": 0.0,
+                "results": [],
+                "metrics": {},
+            }
+
         results = []
         for query in queries:
             result = await self.search(query)

--- a/src/evaluation/extract_ground_truth.py
+++ b/src/evaluation/extract_ground_truth.py
@@ -101,6 +101,10 @@ def print_statistics(articles: dict[str, list[str]]):
     print(f"  Total articles: {len(articles)}")
     print(f"  Total chunks: {sum(len(chunks) for chunks in articles.values())}")
 
+    if not articles:
+        print("  No articles to analyze.")
+        return
+
     # Article distribution
     chunks_per_article = [len(chunks) for chunks in articles.values()]
     print("  Chunks per article:")
@@ -124,8 +128,11 @@ def main():
     # Print statistics
     print_statistics(articles)
 
-    # Save to file
-    output_file = "/home/admin/contextual_rag/evaluation/data/ground_truth_articles.json"
+    # Save to file (relative to project root)
+    data_dir = os.path.join(os.path.dirname(__file__), "data")
+    os.makedirs(data_dir, exist_ok=True)
+
+    output_file = os.path.join(data_dir, "ground_truth_articles.json")
     with open(output_file, "w", encoding="utf-8") as f:
         json.dump(articles, f, ensure_ascii=False, indent=2)
 
@@ -133,7 +140,7 @@ def main():
 
     # Create simplified mapping (article -> first chunk only) for quick tests
     simple_mapping = {article: chunks[0]["point_id"] for article, chunks in articles.items()}
-    simple_output = "/home/admin/contextual_rag/evaluation/data/article_to_chunk_mapping.json"
+    simple_output = os.path.join(data_dir, "article_to_chunk_mapping.json")
     with open(simple_output, "w", encoding="utf-8") as f:
         json.dump(simple_mapping, f, ensure_ascii=False, indent=2)
 

--- a/src/evaluation/generate_test_queries.py
+++ b/src/evaluation/generate_test_queries.py
@@ -9,15 +9,26 @@ Creates 3 types of queries for each article:
 
 import asyncio
 import json
+from typing import Protocol, cast
 
 from qdrant_client import QdrantClient, models
 
 from src.config import Settings
 
 
-# ContextualRetrievalGroqAsync lives in legacy/ (not a package).
-# Import deferred to generate_all_queries() to avoid hard dependency.
-ContextualRetrievalGroqAsync = None  # type: ignore[assignment]
+class ContextualRetrievalGroqAsyncProtocol(Protocol):
+    api_url: str
+    api_key: str
+    model: str
+    max_tokens: int
+
+    def print_stats(self) -> None: ...
+
+
+class ContextualRetrievalGroqAsyncFactoryProtocol(Protocol):
+    def __call__(
+        self, *, model: str, max_concurrent: int
+    ) -> ContextualRetrievalGroqAsyncProtocol: ...
 
 
 # Load settings
@@ -81,7 +92,7 @@ def fetch_article_texts(collection_name: str, article_numbers: list[str]) -> dic
 
 
 async def generate_queries_for_article(
-    llm: ContextualRetrievalGroqAsync, article_num: str, article_text: str
+    llm: ContextualRetrievalGroqAsyncProtocol, article_num: str, article_text: str
 ) -> list[dict]:
     """
     Generate 3 types of queries for a single article.
@@ -204,7 +215,10 @@ async def generate_all_queries(
     _mod = importlib.util.module_from_spec(_spec)
     _spec.loader.exec_module(_mod)
 
-    llm = _mod.ContextualRetrievalGroqAsync(model=model, max_concurrent=max_concurrent)
+    llm_factory = cast(
+        ContextualRetrievalGroqAsyncFactoryProtocol, _mod.ContextualRetrievalGroqAsync
+    )
+    llm = llm_factory(model=model, max_concurrent=max_concurrent)
 
     all_queries = []
     completed = 0

--- a/src/evaluation/generate_test_queries.py
+++ b/src/evaluation/generate_test_queries.py
@@ -9,15 +9,15 @@ Creates 3 types of queries for each article:
 
 import asyncio
 import json
-import sys
 
 from qdrant_client import QdrantClient, models
 
-
-sys.path.append("/home/admin/contextual_rag")
-from contextualize_groq_async import ContextualRetrievalGroqAsync
-
 from src.config import Settings
+
+
+# ContextualRetrievalGroqAsync lives in legacy/ (not a package).
+# Import deferred to generate_all_queries() to avoid hard dependency.
+ContextualRetrievalGroqAsync = None  # type: ignore[assignment]
 
 
 # Load settings
@@ -189,8 +189,22 @@ async def generate_all_queries(
     print(f"   Max concurrent: {max_concurrent}")
     print(f"   Total articles: {len(article_texts)}\n")
 
-    # Initialize LLM
-    llm = ContextualRetrievalGroqAsync(model=model, max_concurrent=max_concurrent)
+    # Lazy import — legacy module not on sys.path by default
+    import importlib.util
+    import os
+
+    _spec = importlib.util.spec_from_file_location(
+        "contextualize_groq_async",
+        os.path.join(
+            os.path.dirname(__file__), "..", "..", "legacy", "contextualize_groq_async.py"
+        ),
+    )
+    if _spec is None or _spec.loader is None:
+        raise ImportError("legacy/contextualize_groq_async.py not found")
+    _mod = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_mod)
+
+    llm = _mod.ContextualRetrievalGroqAsync(model=model, max_concurrent=max_concurrent)
 
     all_queries = []
     completed = 0

--- a/src/evaluation/ragas_evaluation.py
+++ b/src/evaluation/ragas_evaluation.py
@@ -33,7 +33,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from datasets import Dataset
 from openai import OpenAI
 from ragas import evaluate
 from ragas.llms import llm_factory
@@ -46,6 +45,7 @@ from ragas.metrics.collections import (
     Faithfulness,
 )
 
+from datasets import Dataset
 from src.evaluation.mlflow_integration import MLflowRAGLogger
 
 

--- a/src/evaluation/run_ab_test.py
+++ b/src/evaluation/run_ab_test.py
@@ -16,15 +16,11 @@ Steps:
 """
 
 import json
-import sys
 import time
 from datetime import datetime
 
-
-sys.path.append("/home/admin/contextual_rag")
-
-from evaluator import SearchEvaluator
-from search_engines import create_search_engine
+from src.evaluation.evaluator import SearchEvaluator
+from src.evaluation.search_engines import create_search_engine
 
 
 # MLflow integration (optional - gracefully handles if not available)
@@ -62,6 +58,11 @@ def run_ab_test(
     with open(queries_file, encoding="utf-8") as f:
         queries = json.load(f)
     print(f"   Loaded {len(queries)} test queries")
+
+    if not queries:
+        print("⚠️  No queries found. Aborting A/B test.")
+        return {"baseline": {}, "hybrid": {}, "dbsf_colbert": {}, "comparisons": {}, "reports": {}}
+
     print()
 
     # Initialize embedding model

--- a/src/evaluation/search_engines_rerank.py
+++ b/src/evaluation/search_engines_rerank.py
@@ -5,22 +5,7 @@ Search engine with reranker for 2-stage retrieval:
 2. Reranker reranks to top-K final results
 """
 
-import sys
-
-
-sys.path.append("/home/admin/contextual_rag")
-
-# Import from same directory
-import importlib.util
-import os
-
-
-spec = importlib.util.spec_from_file_location(
-    "search_engines", os.path.join(os.path.dirname(__file__), "search_engines.py")
-)
-search_engines = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
-spec.loader.exec_module(search_engines)  # type: ignore[union-attr]
-BaselineSearchEngine = search_engines.BaselineSearchEngine
+from src.evaluation.search_engines import BaselineSearchEngine
 
 
 class RerankSearchEngine:

--- a/tests/unit/core/test_pipeline.py
+++ b/tests/unit/core/test_pipeline.py
@@ -368,3 +368,12 @@ class TestRAGPipelineEvaluate:
         assert "average_latency" in results
         assert "metrics" in results
         assert "recall_at_1" in results["metrics"]
+
+    async def test_evaluate_empty_queries(self, mock_pipeline):
+        """Test evaluate handles empty queries without ZeroDivisionError."""
+        results = await mock_pipeline.evaluate([])
+
+        assert results["total_queries"] == 0
+        assert results["average_latency"] == 0.0
+        assert results["results"] == []
+        assert results["metrics"] == {}

--- a/tests/unit/evaluation/test_extract_ground_truth.py
+++ b/tests/unit/evaluation/test_extract_ground_truth.py
@@ -216,6 +216,16 @@ class TestPrintStatistics:
         assert "Sample articles" in captured.out
         assert "Article 1" in captured.out
 
+    def test_print_statistics_empty_dataset(self, capsys):
+        """Test print_statistics handles empty dataset without crashing."""
+        from src.evaluation.extract_ground_truth import print_statistics
+
+        print_statistics({})
+
+        captured = capsys.readouterr()
+        assert "Total articles: 0" in captured.out
+        assert "No articles to analyze" in captured.out
+
 
 class TestMain:
     """Tests for main function."""
@@ -223,7 +233,8 @@ class TestMain:
     @patch("src.evaluation.extract_ground_truth.extract_articles")
     @patch("src.evaluation.extract_ground_truth.print_statistics")
     @patch("builtins.open", new_callable=mock_open)
-    def test_main_extracts_and_saves(self, mock_file, mock_stats, mock_extract):
+    @patch("os.makedirs")
+    def test_main_extracts_and_saves(self, mock_makedirs, mock_file, mock_stats, mock_extract):
         """Test main extracts articles and saves to files."""
         mock_extract.return_value = {
             "121": [{"chunk_id": "c1", "point_id": "p1", "text_preview": "text"}],
@@ -238,18 +249,18 @@ class TestMain:
         mock_stats.assert_called_once()
 
         opened_paths = [call.args[0] for call in mock_file.call_args_list]
-        assert (
-            "/home/admin/contextual_rag/evaluation/data/ground_truth_articles.json" in opened_paths
-        )
-        assert (
-            "/home/admin/contextual_rag/evaluation/data/article_to_chunk_mapping.json"
-            in opened_paths
-        )
+        assert any("ground_truth_articles.json" in p for p in opened_paths)
+        assert any("article_to_chunk_mapping.json" in p for p in opened_paths)
+        # Verify no hardcoded /home/admin paths
+        assert all("/home/admin" not in p for p in opened_paths)
 
     @patch("src.evaluation.extract_ground_truth.extract_articles")
     @patch("src.evaluation.extract_ground_truth.print_statistics")
     @patch("builtins.open", new_callable=mock_open)
-    def test_main_creates_simplified_mapping(self, mock_file, mock_stats, mock_extract):
+    @patch("os.makedirs")
+    def test_main_creates_simplified_mapping(
+        self, mock_makedirs, mock_file, mock_stats, mock_extract
+    ):
         """Test main creates simplified article-to-chunk mapping."""
         mock_extract.return_value = {
             "121": [
@@ -271,7 +282,10 @@ class TestMain:
     @patch("src.evaluation.extract_ground_truth.extract_articles")
     @patch("src.evaluation.extract_ground_truth.print_statistics")
     @patch("builtins.open", new_callable=mock_open)
-    def test_main_prints_completion_message(self, mock_file, mock_stats, mock_extract, capsys):
+    @patch("os.makedirs")
+    def test_main_prints_completion_message(
+        self, mock_makedirs, mock_file, mock_stats, mock_extract, capsys
+    ):
         """Test main prints completion message."""
         mock_extract.return_value = {"121": [{"point_id": "p1"}]}
 
@@ -285,7 +299,8 @@ class TestMain:
     @patch("src.evaluation.extract_ground_truth.extract_articles")
     @patch("src.evaluation.extract_ground_truth.print_statistics")
     @patch("builtins.open", new_callable=mock_open)
-    def test_main_uses_correct_collection(self, mock_file, mock_stats, mock_extract):
+    @patch("os.makedirs")
+    def test_main_uses_correct_collection(self, mock_makedirs, mock_file, mock_stats, mock_extract):
         """Test main uses correct collection name."""
         mock_extract.return_value = {}
 

--- a/tests/unit/test_evaluator.py
+++ b/tests/unit/test_evaluator.py
@@ -6,6 +6,9 @@ import tempfile
 import numpy as np
 import pytest
 
+
+pytest.importorskip("pandas", reason="pandas not installed (eval extra)")
+
 from src.evaluation.evaluator import SearchEvaluator
 
 


### PR DESCRIPTION
## Summary
- **#367** — `RAGPipeline.evaluate()` early return on empty queries (ZeroDivisionError)
- **#368** — `print_statistics()` guard for empty dataset (min/max crash)
- **#370** — Remove `sys.path.append("/home/admin/...")` from 3 eval scripts, use proper imports
- **#372** — `run_ab_test()` early return on empty query-set (ZeroDivisionError)

## Changes
| File | Change |
|------|--------|
| `src/core/pipeline.py` | Early return in `evaluate()` for empty queries |
| `src/evaluation/extract_ground_truth.py` | Guard in `print_statistics()` + relative paths in `main()` |
| `src/evaluation/run_ab_test.py` | Early return for empty queries + proper imports |
| `src/evaluation/generate_test_queries.py` | Remove `sys.path.append`, lazy import for legacy module |
| `src/evaluation/search_engines_rerank.py` | Replace importlib hack with proper import |
| `tests/unit/core/test_pipeline.py` | Add `test_evaluate_empty_queries` |
| `tests/unit/evaluation/test_extract_ground_truth.py` | Add `test_print_statistics_empty_dataset` + fix main mocks |

## Test plan
- [x] `uv run pytest tests/unit/ -n auto` — 2278 passed, 18 skipped (optional extras)
- [x] `ruff check` + `ruff format --check` — all clean
- [x] Pre-commit hooks pass
- [x] No `/home/admin` paths remain in `.py` files
- [x] No `sys.path.append` remains in `src/evaluation/`

Closes #367, closes #368, closes #370, closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)