### PR TITLE
feat(guards): add tool/model call limits per request

### DIFF
--- a/telegram_bot/agents/supervisor.py
+++ b/telegram_bot/agents/supervisor.py
@@ -7,22 +7,49 @@ The supervisor loop:
 1. Supervisor LLM decides which tool to call (via bind_tools)
 2. ToolNode executes the selected tool
 3. If the LLM returns a final message (no tool call), the loop ends
+4. Tool call limit (#374): stops loop when tool_call_count >= max_tool_calls
 """
 
 from __future__ import annotations
 
 import logging
 import time
-from typing import Any
+from typing import Any, Literal
 
-from langgraph.graph import START, StateGraph
-from langgraph.prebuilt import ToolNode, tools_condition
+from langgraph.graph import END, START, StateGraph
+from langgraph.prebuilt import ToolNode
 
 from telegram_bot.graph.supervisor_state import SupervisorState
 from telegram_bot.observability import get_client, observe
 
 
 logger = logging.getLogger(__name__)
+
+
+def route_supervisor(state: dict[str, Any]) -> Literal["tools", "__end__"]:
+    """Route after supervisor node: check tool call limit, then tool calls.
+
+    Returns "__end__" when:
+    - tool_call_count >= max_tool_calls (limit reached)
+    - LLM returned final answer (no tool calls)
+
+    Returns "tools" when LLM requested a tool call and limit not reached.
+    """
+    max_tool_calls = state.get("max_tool_calls", 5)
+    tool_count = state.get("tool_call_count", 0)
+    if tool_count >= max_tool_calls:
+        logger.warning(
+            "Tool call limit reached (%d/%d), ending supervisor loop", tool_count, max_tool_calls
+        )
+        return "__end__"
+
+    messages = state.get("messages", [])
+    if messages:
+        last = messages[-1]
+        if hasattr(last, "tool_calls") and last.tool_calls:
+            return "tools"
+
+    return "__end__"
 
 
 def build_supervisor_graph(
@@ -66,6 +93,8 @@ def build_supervisor_graph(
         if hasattr(response, "tool_calls") and response.tool_calls:
             tool_name = response.tool_calls[0]["name"]
             update["agent_used"] = tool_name
+            # Increment tool call count (#374)
+            update["tool_call_count"] = state.get("tool_call_count", 0) + 1
 
         lf.update_current_span(
             output={
@@ -81,7 +110,11 @@ def build_supervisor_graph(
     workflow.add_node("tools", ToolNode(tools))
 
     workflow.add_edge(START, "supervisor")
-    workflow.add_conditional_edges("supervisor", tools_condition)
+    workflow.add_conditional_edges(
+        "supervisor",
+        route_supervisor,
+        {"tools": "tools", "__end__": END},
+    )
     workflow.add_edge("tools", "supervisor")
 
     return workflow.compile()

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -618,6 +618,10 @@ class PropertyBot:
             lf.score_current_trace(
                 name="supervisor_model", value=self.config.supervisor_model, data_type="CATEGORICAL"
             )
+            # Tool call count (#374)
+            tool_calls = result.get("tool_call_count", 0)
+            if tool_calls > 0:
+                lf.score_current_trace(name="tool_calls_total", value=float(tool_calls))
 
             # Persist Q&A to history (#310 — ported from monolith path)
             if self._history_service and response_text:

--- a/telegram_bot/config.py
+++ b/telegram_bot/config.py
@@ -345,6 +345,18 @@ class BotConfig(BaseSettings):
         validation_alias=AliasChoices("kommo_telegram_field_id", "KOMMO_TELEGRAM_FIELD_ID"),
     )
 
+    # Call limits (#374)
+    max_llm_calls: int = Field(
+        default=5,
+        ge=1,
+        validation_alias=AliasChoices("max_llm_calls", "MAX_LLM_CALLS"),
+    )
+    max_tool_calls: int = Field(
+        default=5,
+        ge=1,
+        validation_alias=AliasChoices("max_tool_calls", "MAX_TOOL_CALLS"),
+    )
+
     # LLM-as-a-Judge online sampling
     judge_sample_rate: float = Field(
         default=0.0,

--- a/telegram_bot/graph/edges.py
+++ b/telegram_bot/graph/edges.py
@@ -10,7 +10,11 @@ Five routing functions that control the graph flow:
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Literal
+
+
+logger = logging.getLogger(__name__)
 
 
 def route_start(
@@ -55,11 +59,23 @@ def route_cache(
 def route_grade(
     state: dict[str, Any],
 ) -> Literal["rerank", "rewrite", "generate"]:
-    """Route after grading: skip_rerank → generate, relevant → rerank, not relevant + retries → rewrite/generate."""
+    """Route after grading: skip_rerank → generate, relevant → rerank, not relevant + retries → rewrite/generate.
+
+    Also enforces LLM call limit (#374): when llm_call_count >= max_llm_calls,
+    prevents further rewrites and routes to generate instead.
+    """
     if state.get("documents_relevant", False):
         if state.get("skip_rerank", False):
             return "generate"
         return "rerank"
+
+    # LLM call limit check (#374) — prevent rewrite loops
+    max_llm = state.get("max_llm_calls", 5)
+    llm_count = state.get("llm_call_count", 0)
+    if llm_count >= max_llm:
+        logger.warning("LLM call limit reached (%d/%d), skipping rewrite", llm_count, max_llm)
+        return "generate"
+
     max_attempts = state.get("max_rewrite_attempts", 1)
     if (
         state.get("rewrite_count", 0) < max_attempts

--- a/telegram_bot/graph/graph.py
+++ b/telegram_bot/graph/graph.py
@@ -254,7 +254,8 @@ def build_graph(
     else:
         workflow.add_edge("respond", END)
 
-    return workflow.compile(checkpointer=checkpointer)
+    compiled = workflow.compile(checkpointer=checkpointer)
+    return compiled.with_config(recursion_limit=15)
 
 
 async def retrieve_node_wrapper(

--- a/telegram_bot/graph/nodes/classify.py
+++ b/telegram_bot/graph/nodes/classify.py
@@ -281,6 +281,7 @@ async def classify_node(state: dict[str, Any]) -> dict[str, Any]:
 
     result: dict[str, Any] = {
         "query_type": query_type,
+        "llm_call_count": state.get("llm_call_count", 0) + 1,
         "latency_stages": {**state.get("latency_stages", {}), "classify": time.perf_counter() - t0},
     }
 

--- a/telegram_bot/graph/nodes/generate.py
+++ b/telegram_bot/graph/nodes/generate.py
@@ -504,6 +504,7 @@ async def generate_node(state: RAGState, *, message: Any | None = None) -> dict[
         "llm_provider_model": actual_model,
         "llm_ttft_ms": ttft_ms,
         "llm_response_duration_ms": elapsed * 1000,
+        "llm_call_count": state.get("llm_call_count", 0) + 1,
         "latency_stages": {**state.get("latency_stages", {}), "generate": elapsed},
         # Latency breakdown (#147)
         "llm_decode_ms": llm_decode_ms,

--- a/telegram_bot/graph/nodes/rerank.py
+++ b/telegram_bot/graph/nodes/rerank.py
@@ -38,11 +38,14 @@ async def rerank_node(
     t0 = time.perf_counter()
 
     documents = state.get("documents", [])
+    llm_call_count = state.get("llm_call_count", 0) + 1
+
     if not documents:
         elapsed = time.perf_counter() - t0
         return {
             "documents": [],
             "rerank_applied": False,
+            "llm_call_count": llm_call_count,
             "latency_stages": {**state.get("latency_stages", {}), "rerank": elapsed},
         }
 
@@ -74,6 +77,7 @@ async def rerank_node(
             return {
                 "documents": reranked,
                 "rerank_applied": True,
+                "llm_call_count": llm_call_count,
                 "latency_stages": {**state.get("latency_stages", {}), "rerank": elapsed},
             }
         except Exception as e:
@@ -96,5 +100,6 @@ async def rerank_node(
     return {
         "documents": sorted_docs,
         "rerank_applied": False,
+        "llm_call_count": llm_call_count,
         "latency_stages": {**state.get("latency_stages", {}), "rerank": elapsed},
     }

--- a/telegram_bot/graph/nodes/rewrite.py
+++ b/telegram_bot/graph/nodes/rewrite.py
@@ -105,5 +105,6 @@ async def rewrite_node(
         "query_embedding": None,
         "sparse_embedding": None,
         "rewrite_provider_model": rewrite_actual_model,
+        "llm_call_count": state.get("llm_call_count", 0) + 1,
         "latency_stages": {**state.get("latency_stages", {}), "rewrite": elapsed},
     }

--- a/telegram_bot/graph/state.py
+++ b/telegram_bot/graph/state.py
@@ -83,6 +83,9 @@ class RAGState(TypedDict):
     # Guard ML classifier (#226 Phase 2)
     guard_ml_score: float
     guard_ml_latency_ms: float
+    # Call limits (#374)
+    llm_call_count: int
+    max_llm_calls: int
 
 
 def make_initial_state(user_id: int, session_id: str, query: str) -> dict[str, Any]:
@@ -158,4 +161,7 @@ def make_initial_state(user_id: int, session_id: str, query: str) -> dict[str, A
         # Guard ML classifier (#226 Phase 2)
         "guard_ml_score": 0.0,
         "guard_ml_latency_ms": 0.0,
+        # Call limits (#374)
+        "llm_call_count": 0,
+        "max_llm_calls": 5,
     }

--- a/telegram_bot/graph/supervisor_state.py
+++ b/telegram_bot/graph/supervisor_state.py
@@ -27,6 +27,9 @@ class SupervisorState(TypedDict):
     session_id: str
     agent_used: str
     latency_stages: dict[str, float]
+    # Call limits (#374)
+    tool_call_count: int
+    max_tool_calls: int
 
 
 def make_supervisor_state(
@@ -41,4 +44,7 @@ def make_supervisor_state(
         "session_id": session_id,
         "agent_used": "",
         "latency_stages": {},
+        # Call limits (#374)
+        "tool_call_count": 0,
+        "max_tool_calls": 5,
     }

--- a/telegram_bot/scoring.py
+++ b/telegram_bot/scoring.py
@@ -169,6 +169,11 @@ def write_langfuse_scores(lf: Any, result: dict) -> None:
         data_type="BOOLEAN",
     )
 
+    # --- Call limits (#374) ---
+    llm_calls = result.get("llm_call_count", 0)
+    if llm_calls > 0:
+        lf.score_current_trace(name="llm_calls_total", value=float(llm_calls))
+
     # --- Conversation memory (#154, #159) ---
     summarize_ms = result.get("latency_stages", {}).get("summarize", 0) * 1000
     if summarize_ms > 0:

--- a/tests/unit/agents/test_supervisor_call_limits.py
+++ b/tests/unit/agents/test_supervisor_call_limits.py
@@ -1,0 +1,154 @@
+"""Tests for supervisor tool call limits (#374).
+
+Verifies tool_call_count tracking and routing in supervisor graph.
+"""
+
+from __future__ import annotations
+
+from typing import get_type_hints
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from telegram_bot.graph.supervisor_state import SupervisorState, make_supervisor_state
+
+
+class TestSupervisorStateToolCallCount:
+    """SupervisorState must have tool_call_count field."""
+
+    def test_has_tool_call_count_annotation(self):
+        hints = get_type_hints(SupervisorState)
+        assert "tool_call_count" in hints, "SupervisorState must have tool_call_count"
+
+    def test_initial_state_has_tool_call_count_zero(self):
+        state = make_supervisor_state(user_id=1, session_id="s", query="test")
+        assert state["tool_call_count"] == 0
+
+    def test_has_max_tool_calls_annotation(self):
+        hints = get_type_hints(SupervisorState)
+        assert "max_tool_calls" in hints, "SupervisorState must have max_tool_calls"
+
+    def test_initial_state_has_max_tool_calls_default(self):
+        state = make_supervisor_state(user_id=1, session_id="s", query="test")
+        assert state["max_tool_calls"] == 5
+
+
+class TestSupervisorToolCallRouting:
+    """Supervisor must route to END when tool_call_count >= max_tool_calls."""
+
+    def test_route_supervisor_tools_when_under_limit(self):
+        """When tool_call_count < max, route to tools if LLM requested tool call."""
+        from telegram_bot.agents.supervisor import route_supervisor
+
+        mock_msg = MagicMock()
+        mock_msg.tool_calls = [{"name": "rag_search", "args": {}}]
+
+        state = {
+            "messages": [mock_msg],
+            "tool_call_count": 2,
+            "max_tool_calls": 5,
+        }
+        assert route_supervisor(state) == "tools"
+
+    def test_route_supervisor_end_when_limit_reached(self):
+        """When tool_call_count >= max, route to __end__ regardless of tool calls."""
+        from telegram_bot.agents.supervisor import route_supervisor
+
+        mock_msg = MagicMock()
+        mock_msg.tool_calls = [{"name": "rag_search", "args": {}}]
+
+        state = {
+            "messages": [mock_msg],
+            "tool_call_count": 5,
+            "max_tool_calls": 5,
+        }
+        assert route_supervisor(state) == "__end__"
+
+    def test_route_supervisor_end_when_no_tool_calls(self):
+        """When LLM returns final answer (no tool calls), route to __end__."""
+        from telegram_bot.agents.supervisor import route_supervisor
+
+        mock_msg = MagicMock()
+        mock_msg.tool_calls = []
+
+        state = {
+            "messages": [mock_msg],
+            "tool_call_count": 1,
+            "max_tool_calls": 5,
+        }
+        assert route_supervisor(state) == "__end__"
+
+    def test_route_supervisor_end_when_no_tool_calls_attr(self):
+        """When LLM message has no tool_calls attribute, route to __end__."""
+        from telegram_bot.agents.supervisor import route_supervisor
+
+        mock_msg = MagicMock(spec=[])  # no tool_calls attribute
+
+        state = {
+            "messages": [mock_msg],
+            "tool_call_count": 0,
+            "max_tool_calls": 5,
+        }
+        assert route_supervisor(state) == "__end__"
+
+
+class TestSupervisorNodeToolCallIncrement:
+    """supervisor_node must increment tool_call_count when tool calls are made."""
+
+    @pytest.mark.asyncio
+    async def test_supervisor_node_increments_tool_call_count(self):
+        """When supervisor LLM selects a tool, tool_call_count increments.
+
+        Tested indirectly via route_supervisor: tool_call_count in state
+        must increment for the routing to eventually stop.
+        """
+        from telegram_bot.agents.supervisor import route_supervisor
+
+        # Simulate state after supervisor_node incremented tool_call_count
+        mock_msg = MagicMock()
+        mock_msg.tool_calls = [{"name": "rag_search", "args": {}}]
+        state = {"messages": [mock_msg], "tool_call_count": 4, "max_tool_calls": 5}
+        assert route_supervisor(state) == "tools"
+
+        # After one more increment, limit reached
+        state["tool_call_count"] = 5
+        assert route_supervisor(state) == "__end__"
+
+    @pytest.mark.asyncio
+    async def test_supervisor_node_no_increment_on_final_answer(self):
+        """When supervisor returns final answer (no tools), tool_call_count unchanged."""
+        from telegram_bot.agents.supervisor import route_supervisor
+
+        mock_msg = MagicMock()
+        mock_msg.tool_calls = []
+        state = {"messages": [mock_msg], "tool_call_count": 0, "max_tool_calls": 5}
+        assert route_supervisor(state) == "__end__"
+
+
+class TestSupervisorGraphCompilation:
+    """Supervisor graph must use custom routing with tool call limits."""
+
+    def test_supervisor_graph_uses_route_supervisor(self):
+        """build_supervisor_graph must use route_supervisor for conditional edges."""
+        from telegram_bot.agents.supervisor import route_supervisor
+
+        mock_llm = MagicMock()
+        mock_llm.bind_tools = MagicMock(return_value=mock_llm)
+
+        with (
+            patch("telegram_bot.agents.supervisor.StateGraph") as mock_sg_cls,
+            patch("telegram_bot.agents.supervisor.ToolNode"),
+            patch("telegram_bot.agents.supervisor.get_client"),
+            patch("telegram_bot.agents.supervisor.observe", lambda **_kw: lambda f: f),
+        ):
+            mock_workflow = MagicMock()
+            mock_sg_cls.return_value = mock_workflow
+
+            from telegram_bot.agents.supervisor import build_supervisor_graph
+
+            build_supervisor_graph(supervisor_llm=mock_llm, tools=[])
+
+            # Verify add_conditional_edges was called with route_supervisor
+            mock_workflow.add_conditional_edges.assert_called_once()
+            call_args = mock_workflow.add_conditional_edges.call_args
+            assert call_args[0][1] is route_supervisor

--- a/tests/unit/graph/test_call_limits.py
+++ b/tests/unit/graph/test_call_limits.py
@@ -1,0 +1,270 @@
+"""Tests for LLM call limits in RAG pipeline (#374).
+
+3-tier protection:
+- Graph recursion_limit=15 (LangGraph built-in)
+- llm_call_count field + route_grade limit check
+- Config: MAX_LLM_CALLS env var
+"""
+
+from __future__ import annotations
+
+from typing import get_type_hints
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestRAGStateLLMCallCount:
+    """RAGState must have llm_call_count field."""
+
+    def test_rag_state_has_llm_call_count_annotation(self):
+        from telegram_bot.graph.state import RAGState
+
+        hints = get_type_hints(RAGState)
+        assert "llm_call_count" in hints, "RAGState must have llm_call_count field"
+
+    def test_initial_state_has_llm_call_count_zero(self):
+        from telegram_bot.graph.state import make_initial_state
+
+        state = make_initial_state(user_id=1, session_id="s", query="test")
+        assert state["llm_call_count"] == 0
+
+    def test_rag_state_has_max_llm_calls_annotation(self):
+        from telegram_bot.graph.state import RAGState
+
+        hints = get_type_hints(RAGState)
+        assert "max_llm_calls" in hints, "RAGState must have max_llm_calls field"
+
+    def test_initial_state_has_max_llm_calls_default(self):
+        from telegram_bot.graph.state import make_initial_state
+
+        state = make_initial_state(user_id=1, session_id="s", query="test")
+        assert state["max_llm_calls"] == 5
+
+
+class TestRouteGradeLLMCallLimit:
+    """route_grade must respect llm_call_count limit."""
+
+    def test_llm_limit_reached_prevents_rewrite(self):
+        """When llm_call_count >= max_llm_calls, rewrite is blocked → generate."""
+        from telegram_bot.graph.edges import route_grade
+
+        state = {
+            "documents_relevant": False,
+            "rewrite_count": 0,
+            "max_rewrite_attempts": 3,
+            "rewrite_effective": True,
+            "score_improved": True,
+            "llm_call_count": 5,
+            "max_llm_calls": 5,
+        }
+        assert route_grade(state) == "generate"
+
+    def test_llm_limit_not_reached_allows_rewrite(self):
+        """When llm_call_count < max_llm_calls, rewrite is allowed."""
+        from telegram_bot.graph.edges import route_grade
+
+        state = {
+            "documents_relevant": False,
+            "rewrite_count": 0,
+            "max_rewrite_attempts": 3,
+            "rewrite_effective": True,
+            "score_improved": True,
+            "llm_call_count": 2,
+            "max_llm_calls": 5,
+        }
+        assert route_grade(state) == "rewrite"
+
+    def test_llm_limit_exceeded_prevents_rewrite(self):
+        """When llm_call_count > max_llm_calls, rewrite is blocked → generate."""
+        from telegram_bot.graph.edges import route_grade
+
+        state = {
+            "documents_relevant": False,
+            "rewrite_count": 0,
+            "max_rewrite_attempts": 3,
+            "rewrite_effective": True,
+            "score_improved": True,
+            "llm_call_count": 7,
+            "max_llm_calls": 5,
+        }
+        assert route_grade(state) == "generate"
+
+    def test_llm_limit_does_not_affect_relevant_docs_rerank(self):
+        """When documents are relevant, rerank still works regardless of llm_call_count."""
+        from telegram_bot.graph.edges import route_grade
+
+        state = {
+            "documents_relevant": True,
+            "skip_rerank": False,
+            "llm_call_count": 10,
+            "max_llm_calls": 5,
+        }
+        assert route_grade(state) == "rerank"
+
+    def test_llm_limit_does_not_affect_relevant_docs_generate(self):
+        """When documents are relevant and skip_rerank, generate works regardless."""
+        from telegram_bot.graph.edges import route_grade
+
+        state = {
+            "documents_relevant": True,
+            "skip_rerank": True,
+            "llm_call_count": 10,
+            "max_llm_calls": 5,
+        }
+        assert route_grade(state) == "generate"
+
+    def test_default_max_llm_calls(self):
+        """Missing max_llm_calls defaults to 5."""
+        from telegram_bot.graph.edges import route_grade
+
+        state = {
+            "documents_relevant": False,
+            "rewrite_count": 0,
+            "max_rewrite_attempts": 3,
+            "rewrite_effective": True,
+            "score_improved": True,
+            "llm_call_count": 5,
+            # no max_llm_calls key
+        }
+        assert route_grade(state) == "generate"
+
+
+class TestNodeLLMCallCountIncrement:
+    """Nodes must increment llm_call_count in their state updates."""
+
+    @pytest.mark.asyncio
+    async def test_classify_node_increments_llm_call_count(self):
+        from telegram_bot.graph.nodes.classify import classify_node
+        from telegram_bot.graph.state import make_initial_state
+
+        state = make_initial_state(user_id=1, session_id="s", query="квартира в Несебре")
+        result = await classify_node(state)
+        assert result["llm_call_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_rewrite_node_increments_llm_call_count(self):
+        from unittest.mock import AsyncMock
+
+        from telegram_bot.graph.nodes.rewrite import rewrite_node
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "rewritten query"
+        mock_response.model = "test-model"
+
+        mock_llm = MagicMock()
+        mock_llm.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        state = {
+            "messages": [{"role": "user", "content": "test query"}],
+            "rewrite_count": 0,
+            "llm_call_count": 2,
+            "latency_stages": {},
+        }
+
+        with patch("telegram_bot.graph.config.GraphConfig") as mock_config_cls:
+            mock_config = MagicMock()
+            mock_config.rewrite_model = "test-model"
+            mock_config.rewrite_max_tokens = 100
+            mock_config.create_llm.return_value = mock_llm
+            mock_config_cls.from_env.return_value = mock_config
+
+            result = await rewrite_node(state, llm=mock_llm)
+
+        assert result["llm_call_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_rerank_node_increments_llm_call_count(self):
+        from telegram_bot.graph.nodes.rerank import rerank_node
+
+        state = {
+            "messages": [{"role": "user", "content": "test"}],
+            "documents": [{"text": "doc1", "score": 0.9}],
+            "llm_call_count": 1,
+            "latency_stages": {},
+        }
+
+        result = await rerank_node(state, reranker=None)
+        assert result["llm_call_count"] == 2
+
+
+class TestBotConfigCallLimits:
+    """BotConfig must have MAX_LLM_CALLS and MAX_TOOL_CALLS settings."""
+
+    def test_max_llm_calls_default(self):
+        from telegram_bot.config import BotConfig
+
+        config = BotConfig()
+        assert config.max_llm_calls == 5
+
+    def test_max_tool_calls_default(self):
+        from telegram_bot.config import BotConfig
+
+        config = BotConfig()
+        assert config.max_tool_calls == 5
+
+    def test_max_llm_calls_from_env(self, monkeypatch):
+        monkeypatch.setenv("MAX_LLM_CALLS", "10")
+        from telegram_bot.config import BotConfig
+
+        config = BotConfig()
+        assert config.max_llm_calls == 10
+
+    def test_max_tool_calls_from_env(self, monkeypatch):
+        monkeypatch.setenv("MAX_TOOL_CALLS", "8")
+        from telegram_bot.config import BotConfig
+
+        config = BotConfig()
+        assert config.max_tool_calls == 8
+
+
+class TestGraphRecursionLimit:
+    """Graph must have recursion_limit=15 via with_config."""
+
+    def test_graph_has_recursion_limit(self):
+        """build_graph should set recursion_limit=15 via with_config."""
+
+        mock_cache = MagicMock()
+        mock_embeddings = MagicMock()
+        mock_sparse = MagicMock()
+        mock_qdrant = MagicMock()
+
+        with patch("telegram_bot.graph.graph.StateGraph") as mock_sg_cls:
+            mock_workflow = MagicMock()
+            mock_compiled = MagicMock()
+            mock_workflow.compile.return_value = mock_compiled
+            mock_sg_cls.return_value = mock_workflow
+
+            from telegram_bot.graph.graph import build_graph
+
+            build_graph(
+                cache=mock_cache,
+                embeddings=mock_embeddings,
+                sparse_embeddings=mock_sparse,
+                qdrant=mock_qdrant,
+            )
+
+            mock_compiled.with_config.assert_called_once_with(recursion_limit=15)
+
+
+class TestScoringCallLimits:
+    """Langfuse scores must include llm_calls_total and tool_calls_total."""
+
+    def test_write_langfuse_scores_includes_llm_calls_total(self):
+        from telegram_bot.scoring import write_langfuse_scores
+
+        mock_lf = MagicMock()
+        result = {
+            "query_type": "GENERAL",
+            "latency_stages": {},
+            "llm_call_count": 3,
+        }
+        write_langfuse_scores(mock_lf, result)
+
+        # Find call with name="llm_calls_total"
+        found = any(
+            c.kwargs.get("name") == "llm_calls_total" or (c.args and c.args[0] == "llm_calls_total")
+            for c in mock_lf.score_current_trace.call_args_list
+        )
+        assert found, "write_langfuse_scores must write llm_calls_total score"


### PR DESCRIPTION
## Summary
- **Graph recursion:** `recursion_limit=15` via `with_config()` on compiled graph
- **LLM call limit:** `llm_call_count` in RAGState, incremented in classify/generate/rewrite/rerank nodes, blocks rewrite loops when exceeded
- **Tool call limit:** `tool_call_count` in SupervisorState, incremented in `supervisor_node`, routes to END when limit reached
- **Config:** `MAX_LLM_CALLS` / `MAX_TOOL_CALLS` env vars (default 5)
- **Observability:** `llm_calls_total` + `tool_calls_total` Langfuse scores

## Test plan
- [x] 30 new unit tests (all pass)
- [x] 349 existing graph+agents tests pass (0 regressions)
- [x] Ruff lint + MyPy clean
- [ ] Follow-up: wire BotConfig max values to state at bot.py invocation sites

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>