### PR TITLE
feat(bot): menu + i18n foundation (aiogram-dialog, fluentogram)

### DIFF
--- a/docker/postgres/init/00-init-databases.sql
+++ b/docker/postgres/init/00-init-databases.sql
@@ -14,3 +14,7 @@ GRANT ALL PRIVILEGES ON DATABASE mlflow TO postgres;
 -- Database for LiteLLM (LLM Gateway)
 CREATE DATABASE litellm;
 GRANT ALL PRIVILEGES ON DATABASE litellm TO postgres;
+
+-- Database for Real Estate CRM/Funnel
+CREATE DATABASE realestate;
+GRANT ALL PRIVILEGES ON DATABASE realestate TO postgres;

--- a/docker/postgres/init/05-realestate-schema.sql
+++ b/docker/postgres/init/05-realestate-schema.sql
@@ -1,0 +1,42 @@
+-- Real Estate: users, leads, funnel events
+-- Runs in default postgres DB (tables created there, not in realestate DB)
+-- because init scripts run against default DB
+
+\c realestate;
+
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    telegram_id BIGINT UNIQUE NOT NULL,
+    locale VARCHAR(5) DEFAULT 'ru',
+    role VARCHAR(20) DEFAULT 'client',
+    first_name VARCHAR(100),
+    telegram_language_code VARCHAR(10),
+    notifications_enabled BOOLEAN DEFAULT true,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS leads (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id),
+    stage VARCHAR(30) DEFAULT 'new',
+    score INTEGER DEFAULT 0,
+    preferences JSONB DEFAULT '{}',
+    kommo_lead_id BIGINT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS funnel_events (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id),
+    event_type VARCHAR(50) NOT NULL,
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_telegram_id ON users(telegram_id);
+CREATE INDEX IF NOT EXISTS idx_leads_user_id ON leads(user_id);
+CREATE INDEX IF NOT EXISTS idx_leads_stage ON leads(stage);
+CREATE INDEX IF NOT EXISTS idx_funnel_events_user_id ON funnel_events(user_id);
+CREATE INDEX IF NOT EXISTS idx_funnel_events_created ON funnel_events(created_at DESC);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
     "redis>=7.1.0",
     "redisvl>=0.13.2",
     "aiogram>=3.25.0",
+    "aiogram-dialog>=2.4.0",            # Dialog framework (menus, navigation, widgets)
+    "fluentogram>=1.2.0",               # i18n (Fluent .ftl files, stub generator)
     "asyncpg>=0.31.0",
     # Performance (2026-02-06)
     "uvloop>=0.21.0",                     # 2-4x faster asyncio event loop

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -216,6 +216,15 @@ class PropertyBot:
         # History service (initialized in start())
         self._history_service: HistoryService | None = None
 
+        # i18n hub (fluentogram) — initialized in start()
+        self._i18n_hub: Any = None
+
+        # User service (asyncpg) — initialized in start()
+        self._user_service: Any = None
+
+        # PostgreSQL pool — initialized in start()
+        self._pg_pool: Any = None
+
         # Track initialization state
         self._cache_initialized = False
 
@@ -244,17 +253,20 @@ class PropertyBot:
         self.dp.message(F.text)(self.handle_query)
         self.dp.callback_query(F.data.startswith("fb:"))(self.handle_feedback)
 
-    async def cmd_start(self, message: Message):
-        """Handle /start command."""
-        domain = self.config.domain
-        await message.answer(
-            f"Привет! Я бот-помощник по теме: {domain}.\n\n"
-            "Задавай вопросы вроде:\n"
-            "- Покажи квартиры дешевле 100 000 евро\n"
-            "- 3-комнатные в Солнечный берег\n"
-            "- Студии до 350м от моря\n\n"
-            "Используй /help для помощи."
-        )
+    async def cmd_start(self, message: Message, dialog_manager: Any = None):
+        """Handle /start command — launch menu dialog."""
+        if dialog_manager is not None:
+            from aiogram_dialog import StartMode
+
+            from .dialogs.states import ClientMenuSG
+
+            await dialog_manager.start(ClientMenuSG.main, mode=StartMode.RESET_STACK)
+        else:
+            # Fallback (dialog not initialized)
+            domain = self.config.domain
+            await message.answer(
+                f"Привет! Я бот-помощник по теме: {domain}.\nИспользуй /help для помощи."
+            )
 
     async def cmd_help(self, message: Message):
         """Handle /help command."""
@@ -916,6 +928,46 @@ class PropertyBot:
             logger.warning("History service init failed, /history disabled", exc_info=True)
             self._history_service = None
 
+        # Initialize PostgreSQL pool for realestate DB
+        try:
+            import asyncpg
+
+            self._pg_pool = await asyncpg.create_pool(
+                self.config.realestate_database_url,
+                min_size=0,
+                max_size=5,
+                timeout=5,
+            )
+            logger.info("PostgreSQL pool ready (realestate)")
+
+            from .services.user_service import UserService
+
+            self._user_service = UserService(pool=self._pg_pool)
+        except Exception:
+            logger.warning("PostgreSQL pool init failed, user features disabled", exc_info=True)
+
+        # Initialize i18n (fluentogram)
+        from .middlewares.i18n import create_translator_hub, setup_i18n_middleware
+
+        self._i18n_hub = create_translator_hub()
+        setup_i18n_middleware(self.dp, self._i18n_hub, self._user_service)
+        logger.info("i18n middleware ready")
+
+        # Setup aiogram-dialog
+        from aiogram_dialog import setup_dialogs as aiogram_setup_dialogs
+
+        from .dialogs.client_menu import client_menu_dialog
+        from .dialogs.faq import faq_dialog
+        from .dialogs.funnel import funnel_dialog
+        from .dialogs.settings import settings_dialog
+
+        self.dp.include_router(client_menu_dialog)
+        self.dp.include_router(settings_dialog)
+        self.dp.include_router(funnel_dialog)
+        self.dp.include_router(faq_dialog)
+        aiogram_setup_dialogs(self.dp)
+        logger.info("aiogram-dialog setup complete")
+
         # Preflight dependency checks
         from .preflight import check_dependencies
 
@@ -960,4 +1012,7 @@ class PropertyBot:
                 logger.warning("Failed to close checkpointer cleanly", exc_info=True)
             finally:
                 self._checkpointer = None
+        if self._pg_pool is not None:
+            await self._pg_pool.close()
+            logger.info("PostgreSQL pool closed")
         await self.bot.session.close()

--- a/telegram_bot/config.py
+++ b/telegram_bot/config.py
@@ -357,6 +357,37 @@ class BotConfig(BaseSettings):
         description="LLM model for judge evaluation",
     )
 
+    # Real Estate Database (realestate DB in shared Postgres)
+    realestate_database_url: str = Field(
+        default="postgresql://postgres:postgres@postgres:5432/realestate",
+        validation_alias=AliasChoices("realestate_database_url", "REALESTATE_DATABASE_URL"),
+    )
+
+    # i18n
+    supported_locales: list[str] = Field(
+        default=["ru", "en", "uk"],
+        validation_alias=AliasChoices("supported_locales", "SUPPORTED_LOCALES"),
+    )
+    default_locale: str = Field(
+        default="ru",
+        validation_alias=AliasChoices("default_locale", "DEFAULT_LOCALE"),
+    )
+
+    # Manager IDs (comma-separated Telegram user IDs)
+    manager_ids: list[int] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("manager_ids", "MANAGER_IDS"),
+    )
+
+    @field_validator("manager_ids", mode="before")
+    @classmethod
+    def parse_manager_ids(cls, v: object) -> list[int]:
+        if isinstance(v, str):
+            return [int(x.strip()) for x in v.split(",") if x.strip().isdigit()]
+        if isinstance(v, list):
+            return [int(x) for x in v]
+        return []
+
     def get_collection_name(self) -> str:
         """Get collection name based on quantization mode.
 

--- a/telegram_bot/dialogs/__init__.py
+++ b/telegram_bot/dialogs/__init__.py
@@ -1,0 +1,1 @@
+"""aiogram-dialog dialogs for PropertyBot."""

--- a/telegram_bot/dialogs/client_menu.py
+++ b/telegram_bot/dialogs/client_menu.py
@@ -1,0 +1,68 @@
+"""Client main menu dialog (aiogram-dialog)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aiogram_dialog import Dialog, LaunchMode, Window
+from aiogram_dialog.widgets.kbd import Column, Start
+from aiogram_dialog.widgets.text import Format
+
+from .states import ClientMenuSG, FaqSG, FunnelSG, SettingsSG
+
+
+async def get_menu_data(
+    callback: Any = None,
+    event_from_user: Any = None,
+    i18n: Any = None,
+    **kwargs: Any,
+) -> dict[str, str]:
+    """Getter: provide localized menu text."""
+    name = ""
+    if event_from_user is not None:
+        name = getattr(event_from_user, "first_name", "") or ""
+
+    if i18n is None:
+        # Fallback if i18n not injected (e.g., tests)
+        return {
+            "greeting": f"Привет, {name}!",
+            "btn_search": "Подобрать недвижимость",
+            "btn_faq": "Полезная информация",
+            "btn_settings": "Настройки",
+            "btn_manager": "Связаться с менеджером",
+        }
+
+    return {
+        "greeting": i18n.get("hello", name=name),
+        "btn_search": i18n.get("menu-search"),
+        "btn_faq": i18n.get("menu-faq"),
+        "btn_settings": i18n.get("menu-settings"),
+        "btn_manager": i18n.get("menu-manager"),
+    }
+
+
+client_menu_dialog = Dialog(
+    Window(
+        Format("{greeting}"),
+        Column(
+            Start(
+                Format("{btn_search}"),
+                id="funnel",
+                state=FunnelSG.property_type,
+            ),
+            Start(
+                Format("{btn_faq}"),
+                id="faq",
+                state=FaqSG.main,
+            ),
+            Start(
+                Format("{btn_settings}"),
+                id="settings",
+                state=SettingsSG.main,
+            ),
+        ),
+        getter=get_menu_data,
+        state=ClientMenuSG.main,
+    ),
+    launch_mode=LaunchMode.ROOT,
+)

--- a/telegram_bot/dialogs/faq.py
+++ b/telegram_bot/dialogs/faq.py
@@ -1,0 +1,31 @@
+"""FAQ dialog — static info pages (aiogram-dialog)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aiogram_dialog import Dialog, Window
+from aiogram_dialog.widgets.kbd import Cancel
+from aiogram_dialog.widgets.text import Format
+
+from .states import FaqSG
+
+
+async def get_faq_data(i18n: Any = None, **kwargs: Any) -> dict[str, str]:
+    """Getter for FAQ content."""
+    if i18n is None:
+        return {"title": "FAQ", "btn_back": "Назад"}
+    return {
+        "title": i18n.get("menu-faq"),
+        "btn_back": i18n.get("back"),
+    }
+
+
+faq_dialog = Dialog(
+    Window(
+        Format("{title}"),
+        Cancel(Format("{btn_back}")),
+        getter=get_faq_data,
+        state=FaqSG.main,
+    ),
+)

--- a/telegram_bot/dialogs/funnel.py
+++ b/telegram_bot/dialogs/funnel.py
@@ -1,0 +1,200 @@
+"""BANT sales funnel dialog (aiogram-dialog)."""
+
+from __future__ import annotations
+
+import operator
+from typing import Any
+
+from aiogram.types import CallbackQuery
+from aiogram_dialog import Dialog, DialogManager, Window
+from aiogram_dialog.widgets.kbd import Back, Cancel, Column, Select
+from aiogram_dialog.widgets.text import Format
+
+from .states import FunnelSG
+
+
+# --- Getters (provide data to windows) ---
+
+
+async def get_property_types(i18n: Any = None, **kwargs: Any) -> dict[str, Any]:
+    """Getter for property type selection."""
+    if i18n is None:
+        items = [
+            ("Купить квартиру", "apartment"),
+            ("Купить дом", "house"),
+            ("Арендовать", "rent"),
+            ("Просто посмотреть", "looking"),
+        ]
+    else:
+        items = [
+            (i18n.get("funnel-buy-apartment"), "apartment"),
+            (i18n.get("funnel-buy-house"), "house"),
+            (i18n.get("funnel-rent"), "rent"),
+            (i18n.get("funnel-just-looking"), "looking"),
+        ]
+
+    title = i18n.get("funnel-what-looking") if i18n else "Что вас интересует?"
+    back = i18n.get("back") if i18n else "Назад"
+    return {"title": title, "items": items, "btn_back": back}
+
+
+async def get_budget_options(i18n: Any = None, **kwargs: Any) -> dict[str, Any]:
+    """Getter for budget selection."""
+    if i18n is None:
+        items = [
+            ("До 50 000 €", "low"),
+            ("50 000 – 100 000 €", "mid"),
+            ("100 000 – 200 000 €", "high"),
+            ("Более 200 000 €", "premium"),
+        ]
+    else:
+        items = [
+            (i18n.get("funnel-budget-low"), "low"),
+            (i18n.get("funnel-budget-mid"), "mid"),
+            (i18n.get("funnel-budget-high"), "high"),
+            (i18n.get("funnel-budget-premium"), "premium"),
+        ]
+
+    title = i18n.get("funnel-budget") if i18n else "Какой бюджет?"
+    back = i18n.get("back") if i18n else "Назад"
+    return {"title": title, "items": items, "btn_back": back}
+
+
+async def get_timeline_options(i18n: Any = None, **kwargs: Any) -> dict[str, Any]:
+    """Getter for timeline selection."""
+    if i18n is None:
+        items = [
+            ("В ближайший месяц", "asap"),
+            ("В течение 3 месяцев", "3months"),
+            ("В течение полугода", "6months"),
+            ("Просто присматриваюсь", "looking"),
+        ]
+    else:
+        items = [
+            (i18n.get("funnel-timeline-asap"), "asap"),
+            (i18n.get("funnel-timeline-3m"), "3months"),
+            (i18n.get("funnel-timeline-6m"), "6months"),
+            (i18n.get("funnel-timeline-looking"), "looking"),
+        ]
+
+    title = i18n.get("funnel-timeline") if i18n else "Когда планируете?"
+    back = i18n.get("back") if i18n else "Назад"
+    return {"title": title, "items": items, "btn_back": back}
+
+
+async def get_results_data(
+    dialog_manager: DialogManager,
+    i18n: Any = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Getter for results window — compiles funnel answers."""
+    data = dialog_manager.dialog_data
+    title = i18n.get("funnel-results-title") if i18n else "Подобрали для вас:"
+    empty_msg = i18n.get("funnel-results-empty") if i18n else "Пока не нашли вариантов."
+    back = i18n.get("back") if i18n else "Назад"
+    return {
+        "title": title,
+        "property_type": data.get("property_type", ""),
+        "budget": data.get("budget", ""),
+        "timeline": data.get("timeline", ""),
+        "results_text": empty_msg,  # Placeholder — Phase 2 integrates RAG
+        "btn_back": back,
+    }
+
+
+# --- Handlers (on_click) ---
+
+
+async def on_property_type_selected(
+    callback: CallbackQuery,
+    widget: Select,
+    manager: DialogManager,
+    item_id: str,
+) -> None:
+    """Save property type and advance to budget."""
+    manager.dialog_data["property_type"] = item_id
+    await manager.switch_to(FunnelSG.budget)
+
+
+async def on_budget_selected(
+    callback: CallbackQuery,
+    widget: Select,
+    manager: DialogManager,
+    item_id: str,
+) -> None:
+    """Save budget and advance to timeline."""
+    manager.dialog_data["budget"] = item_id
+    await manager.switch_to(FunnelSG.timeline)
+
+
+async def on_timeline_selected(
+    callback: CallbackQuery,
+    widget: Select,
+    manager: DialogManager,
+    item_id: str,
+) -> None:
+    """Save timeline and show results."""
+    manager.dialog_data["timeline"] = item_id
+    await manager.switch_to(FunnelSG.results)
+
+
+# --- Dialog ---
+
+
+funnel_dialog = Dialog(
+    # Step 1: Property type (SPIN: Situation)
+    Window(
+        Format("{title}"),
+        Column(
+            Select(
+                Format("{item[0]}"),
+                id="property_type",
+                item_id_getter=operator.itemgetter(1),
+                items="items",
+                on_click=on_property_type_selected,
+            ),
+        ),
+        Cancel(Format("{btn_back}")),
+        getter=get_property_types,
+        state=FunnelSG.property_type,
+    ),
+    # Step 2: Budget (BANT: Budget)
+    Window(
+        Format("{title}"),
+        Column(
+            Select(
+                Format("{item[0]}"),
+                id="budget",
+                item_id_getter=operator.itemgetter(1),
+                items="items",
+                on_click=on_budget_selected,
+            ),
+        ),
+        Back(Format("{btn_back}")),
+        getter=get_budget_options,
+        state=FunnelSG.budget,
+    ),
+    # Step 3: Timeline (BANT: Timeline)
+    Window(
+        Format("{title}"),
+        Column(
+            Select(
+                Format("{item[0]}"),
+                id="timeline",
+                item_id_getter=operator.itemgetter(1),
+                items="items",
+                on_click=on_timeline_selected,
+            ),
+        ),
+        Back(Format("{btn_back}")),
+        getter=get_timeline_options,
+        state=FunnelSG.timeline,
+    ),
+    # Step 4: Results
+    Window(
+        Format("{title}\n\n{results_text}"),
+        Cancel(Format("{btn_back}")),
+        getter=get_results_data,
+        state=FunnelSG.results,
+    ),
+)

--- a/telegram_bot/dialogs/settings.py
+++ b/telegram_bot/dialogs/settings.py
@@ -1,0 +1,98 @@
+"""Settings dialog: language switch, notifications (aiogram-dialog)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from aiogram.types import CallbackQuery
+from aiogram_dialog import Dialog, DialogManager, Window
+from aiogram_dialog.widgets.kbd import Button, Cancel, Column, SwitchTo
+from aiogram_dialog.widgets.text import Const, Format
+
+from .states import SettingsSG
+
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_LOCALES = [
+    ("ru", "lang-ru"),
+    ("en", "lang-en"),
+    ("uk", "lang-uk"),
+]
+
+
+async def get_settings_data(i18n: Any = None, **kwargs: Any) -> dict[str, str]:
+    """Getter for settings main window."""
+    if i18n is None:
+        return {"title": "Настройки", "btn_language": "Язык", "btn_back": "Назад"}
+    return {
+        "title": i18n.get("settings-title"),
+        "btn_language": i18n.get("settings-language"),
+        "btn_back": i18n.get("back"),
+    }
+
+
+async def get_language_data(i18n: Any = None, **kwargs: Any) -> dict[str, Any]:
+    """Getter for language selection window."""
+    if i18n is None:
+        return {"title": "Язык", "btn_back": "Назад", "languages": _SUPPORTED_LOCALES}
+
+    languages = [(code, i18n.get(label_key)) for code, label_key in _SUPPORTED_LOCALES]
+    return {
+        "title": i18n.get("settings-language"),
+        "btn_back": i18n.get("back"),
+        "languages": languages,
+    }
+
+
+async def on_language_selected(
+    callback: CallbackQuery,
+    button: Button,
+    manager: DialogManager,
+) -> None:
+    """Handle language selection button click."""
+    locale = button.widget_id  # widget_id = locale code (ru, en, uk)
+    user_service = manager.middleware_data.get("user_service")
+    if user_service is not None and callback.from_user:
+        try:
+            await user_service.set_locale(
+                telegram_id=callback.from_user.id,
+                locale=locale,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to save locale for user %s", callback.from_user.id, exc_info=True
+            )
+    # Restart dialog to apply new locale
+    await manager.done()
+
+
+settings_dialog = Dialog(
+    # Main settings window
+    Window(
+        Format("{title}"),
+        Column(
+            SwitchTo(
+                Format("{btn_language}"),
+                id="lang",
+                state=SettingsSG.language,
+            ),
+        ),
+        Cancel(Format("{btn_back}")),
+        getter=get_settings_data,
+        state=SettingsSG.main,
+    ),
+    # Language selection window
+    Window(
+        Format("{title}"),
+        Column(
+            Button(Const("Русский"), id="ru", on_click=on_language_selected),
+            Button(Const("English"), id="en", on_click=on_language_selected),
+            Button(Const("Українська"), id="uk", on_click=on_language_selected),
+        ),
+        SwitchTo(Format("{btn_back}"), id="back_to_settings", state=SettingsSG.main),
+        getter=get_language_data,
+        state=SettingsSG.language,
+    ),
+)

--- a/telegram_bot/dialogs/states.py
+++ b/telegram_bot/dialogs/states.py
@@ -26,7 +26,7 @@ class FunnelSG(StatesGroup):
     """BANT sales funnel."""
 
     property_type = State()
-    area = State()
+    area = State()  # Phase 3: area/location selection (deferred)
     budget = State()
     timeline = State()
     results = State()

--- a/telegram_bot/dialogs/states.py
+++ b/telegram_bot/dialogs/states.py
@@ -1,0 +1,38 @@
+"""FSM states for all dialogs (aiogram-dialog)."""
+
+from aiogram.fsm.state import State, StatesGroup
+
+
+class ClientMenuSG(StatesGroup):
+    """Client main menu."""
+
+    main = State()
+
+
+class ManagerMenuSG(StatesGroup):
+    """Manager main menu."""
+
+    main = State()
+
+
+class SettingsSG(StatesGroup):
+    """User settings dialog."""
+
+    main = State()
+    language = State()
+
+
+class FunnelSG(StatesGroup):
+    """BANT sales funnel."""
+
+    property_type = State()
+    area = State()
+    budget = State()
+    timeline = State()
+    results = State()
+
+
+class FaqSG(StatesGroup):
+    """FAQ submenu."""
+
+    main = State()

--- a/telegram_bot/locales/en/messages.ftl
+++ b/telegram_bot/locales/en/messages.ftl
@@ -1,0 +1,52 @@
+# Main menu
+hello = Hi, { $name }! I'm a real estate assistant for Bulgaria.
+menu-search = Find property
+menu-favorites = My selections
+menu-faq = Useful info
+menu-settings = Settings
+menu-manager = Contact manager
+
+# Settings
+settings-title = Settings
+settings-language = Language
+settings-notifications = Notifications
+settings-notifications-on = On
+settings-notifications-off = Off
+
+# Languages
+lang-ru = Русский
+lang-en = English
+lang-uk = Українська
+
+# Navigation
+back = Back
+close = Close
+
+# Funnel
+funnel-what-looking = What are you looking for?
+funnel-buy-apartment = Buy an apartment
+funnel-buy-house = Buy a house
+funnel-rent = Rent
+funnel-just-looking = Just browsing
+
+funnel-area = Which area interests you?
+funnel-budget = What is your budget?
+funnel-budget-low = Up to €50,000
+funnel-budget-mid = €50,000 – €100,000
+funnel-budget-high = €100,000 – €200,000
+funnel-budget-premium = Over €200,000
+
+funnel-timeline = When are you planning?
+funnel-timeline-asap = Within a month
+funnel-timeline-3m = Within 3 months
+funnel-timeline-6m = Within 6 months
+funnel-timeline-looking = Just looking around
+
+funnel-results-title = We found for you:
+funnel-results-empty = No matching properties found. Try changing your criteria.
+funnel-booking = Book a viewing
+funnel-subscribe = Subscribe to updates
+
+# Commands
+cmd-help = Ask questions about real estate or use the menu.
+cmd-clear-done = Chat history cleared.

--- a/telegram_bot/locales/ru/messages.ftl
+++ b/telegram_bot/locales/ru/messages.ftl
@@ -1,0 +1,52 @@
+# Главное меню
+hello = Привет, { $name }! Я бот-помощник по недвижимости в Болгарии.
+menu-search = Подобрать недвижимость
+menu-favorites = Мои подборки
+menu-faq = Полезная информация
+menu-settings = Настройки
+menu-manager = Связаться с менеджером
+
+# Настройки
+settings-title = Настройки
+settings-language = Язык
+settings-notifications = Уведомления
+settings-notifications-on = Вкл
+settings-notifications-off = Выкл
+
+# Языки
+lang-ru = Русский
+lang-en = English
+lang-uk = Українська
+
+# Навигация
+back = Назад
+close = Закрыть
+
+# Воронка
+funnel-what-looking = Что вас интересует?
+funnel-buy-apartment = Купить квартиру
+funnel-buy-house = Купить дом
+funnel-rent = Арендовать
+funnel-just-looking = Просто посмотреть
+
+funnel-area = Какой район интересует?
+funnel-budget = Какой бюджет рассматриваете?
+funnel-budget-low = До 50 000 €
+funnel-budget-mid = 50 000 – 100 000 €
+funnel-budget-high = 100 000 – 200 000 €
+funnel-budget-premium = Более 200 000 €
+
+funnel-timeline = Когда планируете?
+funnel-timeline-asap = В ближайший месяц
+funnel-timeline-3m = В течение 3 месяцев
+funnel-timeline-6m = В течение полугода
+funnel-timeline-looking = Просто присматриваюсь
+
+funnel-results-title = Подобрали для вас:
+funnel-results-empty = Пока не нашли подходящих вариантов. Попробуйте изменить параметры.
+funnel-booking = Записаться на показ
+funnel-subscribe = Подписаться на обновления
+
+# Команды
+cmd-help = Задавайте вопросы о недвижимости или используйте меню.
+cmd-clear-done = История диалога очищена.

--- a/telegram_bot/locales/uk/messages.ftl
+++ b/telegram_bot/locales/uk/messages.ftl
@@ -1,0 +1,52 @@
+# Головне меню
+hello = Привіт, { $name }! Я бот-помічник з нерухомості в Болгарії.
+menu-search = Підібрати нерухомість
+menu-favorites = Мої добірки
+menu-faq = Корисна інформація
+menu-settings = Налаштування
+menu-manager = Зв'язатися з менеджером
+
+# Налаштування
+settings-title = Налаштування
+settings-language = Мова
+settings-notifications = Сповіщення
+settings-notifications-on = Увімк
+settings-notifications-off = Вимк
+
+# Мови
+lang-ru = Русский
+lang-en = English
+lang-uk = Українська
+
+# Навігація
+back = Назад
+close = Закрити
+
+# Воронка
+funnel-what-looking = Що вас цікавить?
+funnel-buy-apartment = Купити квартиру
+funnel-buy-house = Купити будинок
+funnel-rent = Орендувати
+funnel-just-looking = Просто переглядаю
+
+funnel-area = Який район цікавить?
+funnel-budget = Який бюджет розглядаєте?
+funnel-budget-low = До 50 000 €
+funnel-budget-mid = 50 000 – 100 000 €
+funnel-budget-high = 100 000 – 200 000 €
+funnel-budget-premium = Понад 200 000 €
+
+funnel-timeline = Коли плануєте?
+funnel-timeline-asap = Найближчим часом
+funnel-timeline-3m = Протягом 3 місяців
+funnel-timeline-6m = Протягом півроку
+funnel-timeline-looking = Просто придивляюсь
+
+funnel-results-title = Підібрали для вас:
+funnel-results-empty = Поки не знайшли відповідних варіантів. Спробуйте змінити параметри.
+funnel-booking = Записатися на перегляд
+funnel-subscribe = Підписатися на оновлення
+
+# Команди
+cmd-help = Ставте питання про нерухомість або використовуйте меню.
+cmd-clear-done = Історію діалогу очищено.

--- a/telegram_bot/middlewares/__init__.py
+++ b/telegram_bot/middlewares/__init__.py
@@ -1,12 +1,16 @@
 """Middlewares for bot."""
 
 from .error_handler import ErrorHandlerMiddleware, setup_error_middleware
+from .i18n import I18nMiddleware, create_translator_hub, setup_i18n_middleware
 from .throttling import ThrottlingMiddleware, setup_throttling_middleware
 
 
 __all__ = [
     "ErrorHandlerMiddleware",
+    "I18nMiddleware",
     "ThrottlingMiddleware",
+    "create_translator_hub",
     "setup_error_middleware",
+    "setup_i18n_middleware",
     "setup_throttling_middleware",
 ]

--- a/telegram_bot/middlewares/i18n.py
+++ b/telegram_bot/middlewares/i18n.py
@@ -103,6 +103,7 @@ class I18nMiddleware(BaseMiddleware):
 
         data["i18n"] = self._hub.get_translator_by_locale(locale)
         data["locale"] = locale
+        data["user_service"] = self._user_service
         return await handler(event, data)
 
 

--- a/telegram_bot/middlewares/i18n.py
+++ b/telegram_bot/middlewares/i18n.py
@@ -1,0 +1,117 @@
+"""i18n middleware using fluentogram (Fluent .ftl files)."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from aiogram import BaseMiddleware, Dispatcher
+from fluent_compiler.bundle import FluentBundle
+from fluentogram import FluentTranslator, TranslatorHub
+
+
+if TYPE_CHECKING:
+    from aiogram.types import TelegramObject
+
+    from telegram_bot.services.user_service import UserService
+
+logger = logging.getLogger(__name__)
+
+
+def create_translator_hub(
+    *,
+    locales_dir: Path | None = None,
+) -> TranslatorHub:
+    """Create TranslatorHub with all supported locales.
+
+    Args:
+        locales_dir: Path to locales directory. Defaults to telegram_bot/locales/.
+    """
+    if locales_dir is None:
+        locales_dir = Path(__file__).resolve().parent.parent / "locales"
+
+    return TranslatorHub(
+        locales_map={
+            "en": ("en",),
+            "ru": ("ru", "en"),
+            "uk": ("uk", "ru", "en"),
+        },
+        translators=[
+            FluentTranslator(
+                locale="en",
+                translator=FluentBundle.from_files(
+                    "en-US",
+                    filenames=[str(p) for p in (locales_dir / "en").glob("*.ftl")],
+                ),
+            ),
+            FluentTranslator(
+                locale="ru",
+                translator=FluentBundle.from_files(
+                    "ru",
+                    filenames=[str(p) for p in (locales_dir / "ru").glob("*.ftl")],
+                ),
+            ),
+            FluentTranslator(
+                locale="uk",
+                translator=FluentBundle.from_files(
+                    "uk",
+                    filenames=[str(p) for p in (locales_dir / "uk").glob("*.ftl")],
+                ),
+            ),
+        ],
+    )
+
+
+class I18nMiddleware(BaseMiddleware):
+    """Inject translator (i18n) into handler data based on user locale."""
+
+    def __init__(
+        self,
+        hub: TranslatorHub,
+        user_service: UserService | None = None,
+        default_locale: str = "ru",
+    ) -> None:
+        super().__init__()
+        self._hub = hub
+        self._user_service = user_service
+        self._default_locale = default_locale
+
+    async def __call__(
+        self,
+        handler: Callable,
+        event: TelegramObject,
+        data: dict[str, Any],
+    ) -> Any:
+        user = data.get("event_from_user")
+        locale = self._default_locale
+
+        if user is not None:
+            # Try loading from DB/cache via UserService
+            if self._user_service is not None:
+                try:
+                    locale = await self._user_service.get_locale(telegram_id=user.id)
+                except Exception:
+                    logger.debug("Failed to get locale for user %s", user.id, exc_info=True)
+
+            # Fallback: detect from Telegram language_code
+            if locale == self._default_locale and user.language_code:
+                from telegram_bot.services.user_service import detect_locale
+
+                locale = detect_locale(user.language_code)
+
+        data["i18n"] = self._hub.get_translator_by_locale(locale)
+        data["locale"] = locale
+        return await handler(event, data)
+
+
+def setup_i18n_middleware(
+    dp: Dispatcher,
+    hub: TranslatorHub,
+    user_service: UserService | None = None,
+) -> None:
+    """Register i18n middleware on all routers."""
+    middleware = I18nMiddleware(hub=hub, user_service=user_service)
+    dp.message.outer_middleware(middleware)
+    dp.callback_query.outer_middleware(middleware)

--- a/telegram_bot/models/__init__.py
+++ b/telegram_bot/models/__init__.py
@@ -1,0 +1,1 @@
+"""Data models for real estate bot."""

--- a/telegram_bot/models/user.py
+++ b/telegram_bot/models/user.py
@@ -1,0 +1,30 @@
+"""User and Lead data models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class User:
+    """Bot user (client or manager)."""
+
+    telegram_id: int
+    id: int | None = None
+    locale: str = "ru"
+    role: str = "client"  # client, manager, admin
+    first_name: str | None = None
+    telegram_language_code: str | None = None
+    notifications_enabled: bool = True
+
+
+@dataclass
+class Lead:
+    """Sales lead with qualification data."""
+
+    user_id: int
+    id: int | None = None
+    stage: str = "new"  # new, qualified, hot, warm, cold, converted
+    score: int = 0
+    preferences: dict = field(default_factory=dict)
+    kommo_lead_id: int | None = None

--- a/telegram_bot/services/lead_scoring.py
+++ b/telegram_bot/services/lead_scoring.py
@@ -1,0 +1,45 @@
+"""Rule-based lead scoring for sales funnel."""
+
+from __future__ import annotations
+
+
+# Points per funnel answer
+_TIMELINE_SCORES = {
+    "asap": 40,
+    "3months": 25,
+    "6months": 15,
+    "looking": 5,
+}
+
+_BUDGET_BONUS = 20  # Any defined budget
+_TYPE_BONUS = 10  # Any defined property type (not "looking")
+
+
+def compute_lead_score(
+    *,
+    property_type: str | None = None,
+    budget: str | None = None,
+    timeline: str | None = None,
+) -> int:
+    """Compute lead score (0-100) from funnel answers."""
+    score = 0
+
+    if timeline:
+        score += _TIMELINE_SCORES.get(timeline, 0)
+
+    if budget:
+        score += _BUDGET_BONUS
+
+    if property_type and property_type != "looking":
+        score += _TYPE_BONUS
+
+    return min(score, 100)
+
+
+def classify_lead(score: int) -> str:
+    """Classify lead by score: hot (>=60), warm (30-59), cold (<30)."""
+    if score >= 60:
+        return "hot"
+    if score >= 30:
+        return "warm"
+    return "cold"

--- a/telegram_bot/services/user_service.py
+++ b/telegram_bot/services/user_service.py
@@ -21,6 +21,7 @@ _LOCALE_MAP = {
     "be": "ru",  # Belarusian → Russian fallback
 }
 _DEFAULT_LOCALE = "ru"
+_SUPPORTED_LOCALES = frozenset({"ru", "en", "uk"})
 
 
 def detect_locale(language_code: str | None) -> str:
@@ -84,6 +85,9 @@ class UserService:
 
     async def set_locale(self, *, telegram_id: int, locale: str) -> None:
         """Update user locale."""
+        if locale not in _SUPPORTED_LOCALES:
+            msg = f"Unsupported locale: {locale}"
+            raise ValueError(msg)
         await self._pool.execute(
             "UPDATE users SET locale = $1, updated_at = NOW() WHERE telegram_id = $2",
             locale,

--- a/telegram_bot/services/user_service.py
+++ b/telegram_bot/services/user_service.py
@@ -1,0 +1,104 @@
+"""User CRUD service (asyncpg)."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from telegram_bot.models.user import User
+
+
+if TYPE_CHECKING:
+    import asyncpg
+
+logger = logging.getLogger(__name__)
+
+# Locale detection from Telegram language_code
+_LOCALE_MAP = {
+    "ru": "ru",
+    "uk": "uk",
+    "en": "en",
+    "be": "ru",  # Belarusian → Russian fallback
+}
+_DEFAULT_LOCALE = "ru"
+
+
+def detect_locale(language_code: str | None) -> str:
+    """Detect locale from Telegram API language_code."""
+    if not language_code:
+        return _DEFAULT_LOCALE
+    # Try exact match, then 2-char prefix
+    code = language_code.lower().strip()
+    return _LOCALE_MAP.get(code, _LOCALE_MAP.get(code[:2], _DEFAULT_LOCALE))
+
+
+class UserService:
+    """CRUD operations for users table (asyncpg)."""
+
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        self._pool = pool
+
+    async def get_or_create(
+        self,
+        *,
+        telegram_id: int,
+        first_name: str | None = None,
+        language_code: str | None = None,
+    ) -> User:
+        """Get existing user or create new one."""
+        row = await self._pool.fetchrow(
+            "SELECT * FROM users WHERE telegram_id = $1",
+            telegram_id,
+        )
+        if row is not None:
+            return self._row_to_user(row)
+
+        locale = detect_locale(language_code)
+        row = await self._pool.fetchrow(
+            """INSERT INTO users (telegram_id, locale, first_name, telegram_language_code)
+               VALUES ($1, $2, $3, $4)
+               ON CONFLICT (telegram_id) DO UPDATE SET updated_at = NOW()
+               RETURNING *""",
+            telegram_id,
+            locale,
+            first_name,
+            language_code,
+        )
+        return self._row_to_user(row)
+
+    async def get_role(self, *, telegram_id: int) -> str:
+        """Get user role. Returns 'client' for unknown users."""
+        role = await self._pool.fetchval(
+            "SELECT role FROM users WHERE telegram_id = $1",
+            telegram_id,
+        )
+        return role or "client"
+
+    async def get_locale(self, *, telegram_id: int) -> str:
+        """Get user locale. Returns 'ru' for unknown users."""
+        locale = await self._pool.fetchval(
+            "SELECT locale FROM users WHERE telegram_id = $1",
+            telegram_id,
+        )
+        return locale or _DEFAULT_LOCALE
+
+    async def set_locale(self, *, telegram_id: int, locale: str) -> None:
+        """Update user locale."""
+        await self._pool.execute(
+            "UPDATE users SET locale = $1, updated_at = NOW() WHERE telegram_id = $2",
+            locale,
+            telegram_id,
+        )
+
+    @staticmethod
+    def _row_to_user(row: Any) -> User:
+        """Convert asyncpg Row to User dataclass."""
+        return User(
+            id=row["id"],
+            telegram_id=row["telegram_id"],
+            locale=row["locale"],
+            role=row["role"],
+            first_name=row["first_name"],
+            telegram_language_code=row.get("telegram_language_code"),
+            notifications_enabled=row["notifications_enabled"],
+        )

--- a/tests/unit/dialogs/test_client_menu.py
+++ b/tests/unit/dialogs/test_client_menu.py
@@ -1,0 +1,18 @@
+"""Tests for client menu dialog."""
+
+from telegram_bot.dialogs.client_menu import client_menu_dialog
+from telegram_bot.dialogs.states import ClientMenuSG
+
+
+def test_client_menu_dialog_exists():
+    """Client menu dialog is a valid Dialog."""
+    from aiogram_dialog import Dialog
+
+    assert isinstance(client_menu_dialog, Dialog)
+
+
+def test_client_menu_has_main_window():
+    """Client menu has window for ClientMenuSG.main state."""
+    windows = client_menu_dialog.windows
+    states = [w.get_state() for w in windows.values()]
+    assert ClientMenuSG.main in states

--- a/tests/unit/dialogs/test_faq.py
+++ b/tests/unit/dialogs/test_faq.py
@@ -1,0 +1,16 @@
+"""Tests for FAQ dialog."""
+
+from telegram_bot.dialogs.faq import faq_dialog
+from telegram_bot.dialogs.states import FaqSG
+
+
+def test_faq_dialog_exists():
+    from aiogram_dialog import Dialog
+
+    assert isinstance(faq_dialog, Dialog)
+
+
+def test_faq_has_main_window():
+    windows = faq_dialog.windows
+    states = [w.get_state() for w in windows.values()]
+    assert FaqSG.main in states

--- a/tests/unit/dialogs/test_funnel.py
+++ b/tests/unit/dialogs/test_funnel.py
@@ -1,0 +1,19 @@
+"""Tests for BANT funnel dialog."""
+
+from telegram_bot.dialogs.funnel import funnel_dialog
+from telegram_bot.dialogs.states import FunnelSG
+
+
+def test_funnel_dialog_exists():
+    from aiogram_dialog import Dialog
+
+    assert isinstance(funnel_dialog, Dialog)
+
+
+def test_funnel_has_all_windows():
+    windows = funnel_dialog.windows
+    states = [w.get_state() for w in windows.values()]
+    assert FunnelSG.property_type in states
+    assert FunnelSG.budget in states
+    assert FunnelSG.timeline in states
+    assert FunnelSG.results in states

--- a/tests/unit/dialogs/test_settings.py
+++ b/tests/unit/dialogs/test_settings.py
@@ -1,0 +1,17 @@
+"""Tests for settings dialog."""
+
+from telegram_bot.dialogs.settings import settings_dialog
+from telegram_bot.dialogs.states import SettingsSG
+
+
+def test_settings_dialog_exists():
+    from aiogram_dialog import Dialog
+
+    assert isinstance(settings_dialog, Dialog)
+
+
+def test_settings_has_main_and_language():
+    windows = settings_dialog.windows
+    states = [w.get_state() for w in windows.values()]
+    assert SettingsSG.main in states
+    assert SettingsSG.language in states

--- a/tests/unit/middlewares/test_i18n.py
+++ b/tests/unit/middlewares/test_i18n.py
@@ -1,0 +1,61 @@
+"""Tests for i18n middleware (fluentogram)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from telegram_bot.middlewares.i18n import (
+    create_translator_hub,
+)
+
+
+@pytest.fixture
+def locales_dir():
+    return Path(__file__).resolve().parents[3] / "telegram_bot" / "locales"
+
+
+@pytest.fixture
+def hub(locales_dir):
+    return create_translator_hub(locales_dir=locales_dir)
+
+
+def test_create_translator_hub(hub):
+    """TranslatorHub created with 3 locales."""
+    translator = hub.get_translator_by_locale("ru")
+    assert translator is not None
+
+
+def test_translator_ru(hub):
+    """Russian translation works."""
+    t = hub.get_translator_by_locale("ru")
+    result = t.get("hello", name="Тест")
+    assert "Тест" in result
+    assert "бот-помощник" in result
+
+
+def test_translator_en(hub):
+    """English translation works."""
+    t = hub.get_translator_by_locale("en")
+    result = t.get("hello", name="Test")
+    assert "Test" in result
+    assert "real estate" in result
+
+
+def test_translator_uk(hub):
+    """Ukrainian translation works."""
+    t = hub.get_translator_by_locale("uk")
+    result = t.get("hello", name="Тест")
+    assert "Тест" in result
+    assert "бот-помічник" in result
+
+
+def test_translator_menu_keys(hub):
+    """All menu keys exist in all locales."""
+    keys = ["menu-search", "menu-settings", "menu-faq", "back", "close"]
+    for locale in ("ru", "en", "uk"):
+        t = hub.get_translator_by_locale(locale)
+        for key in keys:
+            result = t.get(key)
+            assert result, f"Missing key '{key}' in locale '{locale}'"

--- a/tests/unit/models/test_user_model.py
+++ b/tests/unit/models/test_user_model.py
@@ -1,0 +1,43 @@
+"""Tests for user model dataclasses."""
+
+from telegram_bot.models.user import Lead, User
+
+
+def test_user_defaults():
+    user = User(telegram_id=123456)
+    assert user.locale == "ru"
+    assert user.role == "client"
+    assert user.notifications_enabled is True
+    assert user.id is None
+
+
+def test_user_with_all_fields():
+    user = User(
+        id=1,
+        telegram_id=123456,
+        locale="uk",
+        role="manager",
+        first_name="Ярослав",
+        telegram_language_code="uk",
+        notifications_enabled=False,
+    )
+    assert user.role == "manager"
+    assert user.first_name == "Ярослав"
+
+
+def test_lead_defaults():
+    lead = Lead(user_id=1)
+    assert lead.stage == "new"
+    assert lead.score == 0
+    assert lead.preferences == {}
+
+
+def test_lead_with_preferences():
+    lead = Lead(
+        user_id=1,
+        stage="qualified",
+        score=65,
+        preferences={"type": "apartment", "area": "Sunny Beach", "budget": "80000"},
+    )
+    assert lead.score == 65
+    assert lead.preferences["type"] == "apartment"

--- a/tests/unit/services/test_lead_scoring.py
+++ b/tests/unit/services/test_lead_scoring.py
@@ -1,0 +1,45 @@
+"""Tests for lead scoring (rule-based)."""
+
+from telegram_bot.services.lead_scoring import classify_lead, compute_lead_score
+
+
+def test_hot_lead():
+    """ASAP timeline + defined budget + type = hot."""
+    score = compute_lead_score(
+        property_type="apartment",
+        budget="mid",
+        timeline="asap",
+    )
+    assert score >= 60  # Hot threshold
+
+
+def test_cold_lead():
+    """Just looking = cold."""
+    score = compute_lead_score(
+        property_type="looking",
+        budget=None,
+        timeline="looking",
+    )
+    assert score < 30
+
+
+def test_warm_lead():
+    """Defined type + 3 months = warm."""
+    score = compute_lead_score(
+        property_type="house",
+        budget="high",
+        timeline="3months",
+    )
+    assert 30 <= score < 60 or score >= 60  # warm or hot
+
+
+def test_classify_hot():
+    assert classify_lead(65) == "hot"
+
+
+def test_classify_warm():
+    assert classify_lead(45) == "warm"
+
+
+def test_classify_cold():
+    assert classify_lead(15) == "cold"

--- a/tests/unit/services/test_lead_scoring.py
+++ b/tests/unit/services/test_lead_scoring.py
@@ -30,7 +30,7 @@ def test_warm_lead():
         budget="high",
         timeline="3months",
     )
-    assert 30 <= score < 60 or score >= 60  # warm or hot
+    assert score == 55  # house(10) + high budget(20) + 3months(25)
 
 
 def test_classify_hot():

--- a/tests/unit/services/test_user_service.py
+++ b/tests/unit/services/test_user_service.py
@@ -100,3 +100,10 @@ async def test_get_locale_default(service, mock_pool):
     mock_pool.fetchval.return_value = None
     locale = await service.get_locale(telegram_id=999)
     assert locale == "ru"
+
+
+@pytest.mark.asyncio
+async def test_set_locale_rejects_unsupported(service):
+    """set_locale raises ValueError for unsupported locale."""
+    with pytest.raises(ValueError, match="Unsupported locale"):
+        await service.set_locale(telegram_id=123, locale="fr")

--- a/tests/unit/services/test_user_service.py
+++ b/tests/unit/services/test_user_service.py
@@ -1,0 +1,102 @@
+"""Tests for UserService (asyncpg CRUD)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from telegram_bot.services.user_service import UserService
+
+
+@pytest.fixture
+def mock_pool():
+    return AsyncMock()
+
+
+@pytest.fixture
+def service(mock_pool):
+    return UserService(pool=mock_pool)
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_existing_user(service, mock_pool):
+    """Existing user returned from DB."""
+    row = {
+        "id": 1,
+        "telegram_id": 123,
+        "locale": "uk",
+        "role": "client",
+        "first_name": "Test",
+        "telegram_language_code": "uk",
+        "notifications_enabled": True,
+    }
+    mock_pool.fetchrow.return_value = row
+
+    user = await service.get_or_create(telegram_id=123, first_name="Test")
+    assert user.telegram_id == 123
+    assert user.locale == "uk"
+    mock_pool.fetchrow.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_new_user(service, mock_pool):
+    """New user created when not found."""
+    # First call (SELECT) returns None, second call (INSERT) returns new row
+    mock_pool.fetchrow.side_effect = [
+        None,  # SELECT
+        {
+            "id": 2,
+            "telegram_id": 456,
+            "locale": "ru",
+            "role": "client",
+            "first_name": "New",
+            "telegram_language_code": "ru",
+            "notifications_enabled": True,
+        },  # INSERT ... RETURNING
+    ]
+
+    user = await service.get_or_create(telegram_id=456, first_name="New", language_code="ru")
+    assert user.telegram_id == 456
+    assert user.locale == "ru"
+    assert mock_pool.fetchrow.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_role(service, mock_pool):
+    """Get user role by telegram_id."""
+    mock_pool.fetchval.return_value = "manager"
+    role = await service.get_role(telegram_id=123)
+    assert role == "manager"
+
+
+@pytest.mark.asyncio
+async def test_get_role_unknown_user(service, mock_pool):
+    """Unknown user returns 'client' as default."""
+    mock_pool.fetchval.return_value = None
+    role = await service.get_role(telegram_id=999)
+    assert role == "client"
+
+
+@pytest.mark.asyncio
+async def test_set_locale(service, mock_pool):
+    """Set user locale (PG + Redis cache concept)."""
+    mock_pool.execute.return_value = "UPDATE 1"
+    await service.set_locale(telegram_id=123, locale="en")
+    mock_pool.execute.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_locale(service, mock_pool):
+    """Get user locale."""
+    mock_pool.fetchval.return_value = "uk"
+    locale = await service.get_locale(telegram_id=123)
+    assert locale == "uk"
+
+
+@pytest.mark.asyncio
+async def test_get_locale_default(service, mock_pool):
+    """Unknown user returns default locale."""
+    mock_pool.fetchval.return_value = None
+    locale = await service.get_locale(telegram_id=999)
+    assert locale == "ru"

--- a/uv.lock
+++ b/uv.lock
@@ -58,6 +58,20 @@ wheels = [
 ]
 
 [[package]]
+name = "aiogram-dialog"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiogram" },
+    { name = "cachetools" },
+    { name = "jinja2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/b9/cfadb823578f9aff44f10928f8020dc4abda82078fba62295aae8869e894/aiogram_dialog-2.4.0.tar.gz", hash = "sha256:e8f0a811be3a58d1e48dfb9dd79108fd0e25c8ab7f8067c31c49f2f583ba4ecc", size = 80359, upload-time = "2025-07-08T22:41:41.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/d0/1c6511eb6840d06efbfba12cf6e59f688f9e314ab90af34027fa8069af75/aiogram_dialog-2.4.0-py3-none-any.whl", hash = "sha256:4e5fd8f7db66b6d252983c4025968b379069f4a2022db60bde36e5b91268b6ad", size = 112911, upload-time = "2025-07-08T22:41:47.61Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -465,11 +479,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "6.2.6"
+version = "5.5.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/39/91/d9ae9a66b01102a18cd16db0cf4cd54187ffe10f0865cc80071a4104fbb3/cachetools-6.2.6.tar.gz", hash = "sha256:16c33e1f276b9a9c0b49ab5782d901e3ad3de0dd6da9bf9bcd29ac5672f2f9e6", size = 32363, upload-time = "2026-01-27T20:32:59.956Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380, upload-time = "2025-02-20T21:01:19.524Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/45/f458fa2c388e79dd9d8b9b0c99f1d31b568f27388f2fdba7bb66bbc0c6ed/cachetools-6.2.6-py3-none-any.whl", hash = "sha256:8c9717235b3c651603fff0076db52d6acbfd1b338b8ed50256092f7ce9c85bda", size = 11668, upload-time = "2026-01-27T20:32:58.527Z" },
+    { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080, upload-time = "2025-02-20T21:01:16.647Z" },
 ]
 
 [[package]]
@@ -713,10 +727,12 @@ version = "2.14.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiogram" },
+    { name = "aiogram-dialog" },
     { name = "aiohttp" },
     { name = "anthropic" },
     { name = "asyncpg" },
     { name = "cachetools" },
+    { name = "fluentogram" },
     { name = "groq" },
     { name = "langchain-core" },
     { name = "langfuse" },
@@ -832,6 +848,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiogram", specifier = ">=3.25.0" },
+    { name = "aiogram-dialog", specifier = ">=2.4.0" },
     { name = "aiohttp" },
     { name = "anthropic" },
     { name = "asyncpg", specifier = ">=0.31.0" },
@@ -844,6 +861,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'voice'", specifier = ">=0.115.0" },
     { name = "fastembed", marker = "extra == 'ingest'", specifier = ">=0.7.4" },
     { name = "flagembedding", marker = "extra == 'ml-local'" },
+    { name = "fluentogram", specifier = ">=1.2.0" },
     { name = "groq" },
     { name = "httpx", marker = "extra == 'voice'", specifier = ">=0.27.0" },
     { name = "langchain-core", specifier = ">=1.2" },
@@ -1562,6 +1580,45 @@ version = "25.12.19"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
+name = "fluent-compiler"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "babel" },
+    { name = "fluent-syntax" },
+    { name = "pytz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/32/b51e4b5708412ccd3bec1060216c711a5a36da3814346b1799652a9051af/fluent_compiler-1.1.tar.gz", hash = "sha256:7ab34182b7ef616233457bc7d17eca830aa8faa4685eed7e4498968d63cdf14e", size = 83700, upload-time = "2024-04-02T18:53:09.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/5c/f6fcde75c59a54209ee3a109d84506e82f55e24e77a3df0e2d5755b8a4b9/fluent_compiler-1.1-py3-none-any.whl", hash = "sha256:67486e9e12394c9c38c89705171ee965ca8163684ebaeff019d0fa23945e9827", size = 37272, upload-time = "2024-04-02T18:53:07.795Z" },
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/52/de75f2faf499ed5a089acff2ab8bda5fc3b8db8a3f1615428ef9ccbf1917/fluent.syntax-0.19.0.tar.gz", hash = "sha256:920326d7f46864b9758f0044e9968e3112198bc826acee16ddd8f11d359004fd", size = 15039, upload-time = "2023-03-16T11:03:24.023Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/28/475734afb670bf7932caa1828183a4687cac51111950b9fb633c4f976afc/fluent.syntax-0.19.0-py2.py3-none-any.whl", hash = "sha256:b352b3475fac6c6ed5f06527921f432aac073d764445508ee5218aeccc7cc5c4", size = 16432, upload-time = "2023-03-16T11:03:21.934Z" },
+]
+
+[[package]]
+name = "fluentogram"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fluent-compiler" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/f9/3903da5928f70740705d1c26554b2e5a75363ec2dd34f4b09357131aa63a/fluentogram-1.2.1.tar.gz", hash = "sha256:9ce201756be93dc43f98358325948237fa007921357ccd4c4d934522d4b01e09", size = 19682, upload-time = "2025-07-20T04:08:02.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/4a/1172202174b80348a4887d35430e0a2e8726e173901404d2589550500dd2/fluentogram-1.2.1-py3-none-any.whl", hash = "sha256:f4edd0aab253f35e59262680beb0a65aae281598ca57182cab3797828449e6b3", size = 21638, upload-time = "2025-07-20T04:08:01.288Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- **aiogram-dialog 2.4 + fluentogram 1.2** — interactive menu framework + i18n
- **PostgreSQL schema** — `users`, `leads`, `funnel_events` tables (realestate DB)
- **User/Lead models** — dataclasses with CRUD via asyncpg `UserService`
- **i18n** — 3 locales (ru/en/uk) via Fluent .ftl files + `I18nMiddleware`
- **4 dialogs** — client menu, settings (language switch), FAQ, BANT funnel (4 steps)
- **Lead scoring** — rule-based BANT scoring (hot/warm/cold classification)
- **Bot integration** — PG pool, i18n middleware, aiogram-dialog setup in `PropertyBot`

## Test plan
- [x] 32 new unit tests (models, services, middlewares, dialogs, scoring)
- [x] 2333 total tests pass (`-n auto`), 0 regressions
- [x] Ruff lint + MyPy clean
- [x] 14 conventional commits

Closes #385
Unblocks #387, #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>