### PR TITLE
fix: eval scripts, call-limit propagation, and locale upsert

### DIFF
--- a/scripts/eval/goldset_sync.py
+++ b/scripts/eval/goldset_sync.py
@@ -37,16 +37,17 @@ def sync_to_langfuse(
     Returns number of items created.
     """
     try:
-        dataset = langfuse.get_dataset(dataset_name)
+        langfuse.get_dataset(dataset_name)
         logger.info("Found existing dataset: %s", dataset_name)
     except Exception:
-        dataset = langfuse.create_dataset(name=dataset_name)
+        langfuse.create_dataset(name=dataset_name)
         logger.info("Created new dataset: %s", dataset_name)
 
     created = 0
     for sample in samples:
         item_id = f"{dataset_name}-{sample.get('id', created)}"
-        dataset.create_item(
+        langfuse.create_dataset_item(
+            dataset_name=dataset_name,
             id=item_id,
             input={"question": sample["question"]},
             expected_output={"answer": sample["ground_truth"]},

--- a/scripts/eval/run_experiment.py
+++ b/scripts/eval/run_experiment.py
@@ -11,13 +11,78 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import sys
+import uuid
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_DATASET = "rag-gold-set"
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+
+class _NoopCache:
+    """Minimal async cache adapter for offline eval experiments."""
+
+    async def get_embedding(self, query: str) -> None:
+        return None
+
+    async def store_embedding(self, query: str, embedding: list[float]) -> None:
+        return None
+
+    async def get_sparse_embedding(self, query: str) -> None:
+        return None
+
+    async def store_sparse_embedding(self, query: str, sparse: dict[str, Any]) -> None:
+        return None
+
+    async def check_semantic(
+        self,
+        query: str,
+        vector: list[float],
+        query_type: str,
+        language: str = "ru",
+        user_id: int | None = None,
+    ) -> None:
+        return None
+
+    async def store_semantic(
+        self,
+        query: str,
+        response: str,
+        vector: list[float],
+        query_type: str,
+        language: str = "ru",
+        user_id: int | None = None,
+    ) -> None:
+        return None
+
+    async def get_search_results(self, dense_vector: list[float]) -> None:
+        return None
+
+    async def store_search_results(
+        self,
+        dense_vector: list[float],
+        filters: dict[str, Any] | None,
+        results: list[dict[str, Any]],
+    ) -> None:
+        return None
+
+
+def _build_eval_state(question: str) -> dict[str, Any]:
+    """Build valid RAG state for non-Telegram experiment execution."""
+    from telegram_bot.graph.state import make_initial_state
+
+    return make_initial_state(
+        user_id=0,
+        session_id=f"eval-{uuid.uuid4().hex[:12]}",
+        query=question,
+    )
 
 
 def build_rag_task(graph: Any) -> Any:
@@ -30,7 +95,7 @@ def build_rag_task(graph: Any) -> Any:
         question = (
             item.input.get("question", "") if isinstance(item.input, dict) else str(item.input)
         )
-        result = asyncio.run(graph.ainvoke({"query": question}))
+        result = asyncio.run(graph.ainvoke(_build_eval_state(question)))
         return {
             "answer": result.get("response", ""),
             "context": "\n".join(
@@ -50,21 +115,32 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
     from langfuse import Langfuse
-    from telegram_bot.services.qdrant_service import QdrantService
 
     from telegram_bot.config import BotConfig
     from telegram_bot.graph.graph import build_graph
-    from telegram_bot.services.bge_m3_client import BGEM3HybridEmbeddings, BGEM3SparseEmbeddings
+    from telegram_bot.integrations.embeddings import BGEM3HybridEmbeddings, BGEM3SparseEmbeddings
     from telegram_bot.services.colbert_reranker import ColbertRerankerService
+    from telegram_bot.services.qdrant import QdrantService
 
     config = BotConfig()
+    cache = _NoopCache()
     embeddings = BGEM3HybridEmbeddings(base_url=config.bge_m3_url)
     sparse = BGEM3SparseEmbeddings(base_url=config.bge_m3_url)
-    qdrant = QdrantService(url=config.qdrant_url, collection_name=config.get_collection_name())
-    reranker = ColbertRerankerService(base_url=config.bge_m3_url)
+    qdrant = QdrantService(
+        url=config.qdrant_url,
+        api_key=config.qdrant_api_key or None,
+        collection_name=config.qdrant_collection,
+        quantization_mode=config.qdrant_quantization_mode,
+        timeout=config.qdrant_timeout,
+    )
+    reranker = (
+        ColbertRerankerService(base_url=config.bge_m3_url)
+        if config.rerank_provider == "colbert"
+        else None
+    )
 
     graph = build_graph(
-        cache=None,
+        cache=cache,
         embeddings=embeddings,
         sparse_embeddings=sparse,
         qdrant=qdrant,
@@ -81,17 +157,19 @@ def main() -> None:
         "Running experiment '%s' on dataset '%s' (%d items)",
         exp_name,
         args.dataset,
-        len(dataset.items),
+        len(getattr(dataset, "items", [])),
     )
 
-    result = dataset.run_experiment(
-        name=exp_name,
-        task=task,
-    )
-
-    print(f"Experiment '{result.run_name}' complete")
-    print(f"URL: {result.dataset_run_url}")
-    langfuse.flush()
+    try:
+        result = dataset.run_experiment(
+            name=exp_name,
+            task=task,
+        )
+        print(f"Experiment '{result.run_name}' complete")
+        print(f"URL: {result.dataset_run_url}")
+    finally:
+        langfuse.flush()
+        asyncio.run(qdrant.close())
 
 
 if __name__ == "__main__":

--- a/telegram_bot/agents/rag_agent.py
+++ b/telegram_bot/agents/rag_agent.py
@@ -35,6 +35,9 @@ def create_rag_agent(
     guard_mode: str = "hard",
     guard_ml_enabled: bool = False,
     llm_guard_client: Any | None = None,
+    max_rewrite_attempts: int = 1,
+    show_sources: bool = True,
+    max_llm_calls: int = 5,
 ) -> Any:
     """Create RAG agent tool wrapping the existing LangGraph pipeline.
 
@@ -80,6 +83,9 @@ def create_rag_agent(
                 session_id=session_id or "",
                 query=query,
             )
+            state["max_rewrite_attempts"] = max_rewrite_attempts
+            state["show_sources"] = show_sources
+            state["max_llm_calls"] = max_llm_calls
             invoke_start = time.perf_counter()
             result = await graph.ainvoke(state)
             ainvoke_wall_ms = (time.perf_counter() - invoke_start) * 1000

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -557,6 +557,9 @@ class PropertyBot:
                 guard_mode=self.config.guard_mode,
                 guard_ml_enabled=self.config.guard_ml_enabled,
                 llm_guard_client=self._llm_guard_client,
+                max_rewrite_attempts=self._graph_config.max_rewrite_attempts,
+                show_sources=self._graph_config.show_sources,
+                max_llm_calls=self.config.max_llm_calls,
             ),
             direct_response,
         ]
@@ -578,6 +581,7 @@ class PropertyBot:
             session_id=session_id,
             query=message.text or "",
         )
+        state["max_tool_calls"] = self.config.max_tool_calls
         config = {
             "configurable": {
                 "user_id": user_id,
@@ -688,6 +692,7 @@ class PropertyBot:
         state["input_type"] = "voice"
         state["max_rewrite_attempts"] = self._graph_config.max_rewrite_attempts
         state["show_sources"] = self._graph_config.show_sources
+        state["max_llm_calls"] = self.config.max_llm_calls
 
         with propagate_attributes(
             session_id=state["session_id"],

--- a/telegram_bot/services/user_service.py
+++ b/telegram_bot/services/user_service.py
@@ -89,9 +89,12 @@ class UserService:
             msg = f"Unsupported locale: {locale}"
             raise ValueError(msg)
         await self._pool.execute(
-            "UPDATE users SET locale = $1, updated_at = NOW() WHERE telegram_id = $2",
-            locale,
+            """INSERT INTO users (telegram_id, locale)
+               VALUES ($1, $2)
+               ON CONFLICT (telegram_id)
+               DO UPDATE SET locale = EXCLUDED.locale, updated_at = NOW()""",
             telegram_id,
+            locale,
         )
 
     @staticmethod

--- a/tests/unit/agents/test_rag_agent_tool.py
+++ b/tests/unit/agents/test_rag_agent_tool.py
@@ -107,3 +107,53 @@ async def test_rag_agent_passes_guard_config_to_graph():
     assert kwargs["guard_mode"] == "soft"
     assert kwargs["guard_ml_enabled"] is True
     assert kwargs["llm_guard_client"] is services["llm_guard_client"]
+
+
+async def test_rag_agent_applies_state_overrides():
+    """RAG agent applies max_rewrite_attempts/show_sources to state."""
+    from telegram_bot.agents.rag_agent import create_rag_agent
+
+    mock_graph = AsyncMock()
+    mock_graph.ainvoke = AsyncMock(return_value={"response": "ok"})
+
+    services = {
+        "cache": AsyncMock(),
+        "embeddings": AsyncMock(),
+        "sparse_embeddings": AsyncMock(),
+        "qdrant": AsyncMock(),
+        "max_rewrite_attempts": 3,
+        "show_sources": False,
+    }
+    agent = create_rag_agent(**services)
+    config = RunnableConfig(configurable={"user_id": 7, "session_id": "s-7"})
+
+    with patch("telegram_bot.graph.graph.build_graph", return_value=mock_graph):
+        await agent.ainvoke({"query": "test"}, config=config)
+
+    state = mock_graph.ainvoke.call_args[0][0]
+    assert state["max_rewrite_attempts"] == 3
+    assert state["show_sources"] is False
+
+
+async def test_rag_agent_applies_max_llm_calls_override():
+    """RAG agent applies max_llm_calls limit to pipeline state."""
+    from telegram_bot.agents.rag_agent import create_rag_agent
+
+    mock_graph = AsyncMock()
+    mock_graph.ainvoke = AsyncMock(return_value={"response": "ok"})
+
+    services = {
+        "cache": AsyncMock(),
+        "embeddings": AsyncMock(),
+        "sparse_embeddings": AsyncMock(),
+        "qdrant": AsyncMock(),
+        "max_llm_calls": 12,
+    }
+    agent = create_rag_agent(**services)
+    config = RunnableConfig(configurable={"user_id": 5, "session_id": "s-5"})
+
+    with patch("telegram_bot.graph.graph.build_graph", return_value=mock_graph):
+        await agent.ainvoke({"query": "test"}, config=config)
+
+    state = mock_graph.ainvoke.call_args[0][0]
+    assert state["max_llm_calls"] == 12

--- a/tests/unit/evaluation/test_goldset_sync.py
+++ b/tests/unit/evaluation/test_goldset_sync.py
@@ -32,7 +32,7 @@ def test_sync_creates_dataset_when_not_exists():
     count = sync_to_langfuse(mock_langfuse, "test-dataset", samples)
 
     mock_langfuse.create_dataset.assert_called_once_with(name="test-dataset")
-    mock_dataset.create_item.assert_called_once()
+    mock_langfuse.create_dataset_item.assert_called_once()
     assert count == 1
 
 
@@ -48,5 +48,5 @@ def test_sync_uses_existing_dataset():
     count = sync_to_langfuse(mock_langfuse, "existing-dataset", samples)
 
     mock_langfuse.create_dataset.assert_not_called()
-    assert mock_dataset.create_item.call_count == 2
+    assert mock_langfuse.create_dataset_item.call_count == 2
     assert count == 2

--- a/tests/unit/evaluation/test_run_experiment.py
+++ b/tests/unit/evaluation/test_run_experiment.py
@@ -13,6 +13,15 @@ def test_build_rag_task_returns_callable():
     assert callable(task)
 
 
+def test_build_eval_state_contains_required_rag_fields():
+    from scripts.eval.run_experiment import _build_eval_state
+
+    state = _build_eval_state("What is X?")
+    assert state["messages"][-1]["content"] == "What is X?"
+    assert state["user_id"] == 0
+    assert state["session_id"].startswith("eval-")
+
+
 def test_build_rag_task_invokes_graph():
     from scripts.eval.run_experiment import build_rag_task
 
@@ -32,3 +41,5 @@ def test_build_rag_task_invokes_graph():
 
     assert result["answer"] == "Test answer"
     assert "Doc 1" in result["context"]
+    called_state = mock_graph.ainvoke.await_args.args[0]
+    assert called_state["messages"][-1]["content"] == "What is X?"

--- a/tests/unit/services/test_user_service.py
+++ b/tests/unit/services/test_user_service.py
@@ -84,6 +84,9 @@ async def test_set_locale(service, mock_pool):
     mock_pool.execute.return_value = "UPDATE 1"
     await service.set_locale(telegram_id=123, locale="en")
     mock_pool.execute.assert_called_once()
+    sql = mock_pool.execute.call_args.args[0]
+    assert "INSERT INTO users" in sql
+    assert "ON CONFLICT (telegram_id)" in sql
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -366,8 +366,11 @@ class TestHandleQuery:
         mock_config.content_filter_enabled = False
         mock_config.guard_mode = "soft"
         mock_config.guard_ml_enabled = True
+        mock_config.max_llm_calls = 11
         bot, _ = _create_bot(mock_config)
         bot._llm_guard_client = MagicMock()
+        bot._graph_config.max_rewrite_attempts = 4
+        bot._graph_config.show_sources = False
 
         mock_graph = AsyncMock()
         mock_graph.ainvoke = AsyncMock(return_value=_mock_supervisor_result())
@@ -391,6 +394,30 @@ class TestHandleQuery:
         assert kwargs["guard_mode"] == "soft"
         assert kwargs["guard_ml_enabled"] is True
         assert kwargs["llm_guard_client"] is bot._llm_guard_client
+        assert kwargs["max_rewrite_attempts"] == 4
+        assert kwargs["show_sources"] is False
+        assert kwargs["max_llm_calls"] == 11
+
+    async def test_handle_query_passes_max_tool_calls_to_supervisor_state(self, mock_config):
+        """Supervisor invocation state uses configured max_tool_calls."""
+        mock_config.max_tool_calls = 9
+        bot, _ = _create_bot(mock_config)
+
+        mock_graph = AsyncMock()
+        mock_graph.ainvoke = AsyncMock(return_value=_mock_supervisor_result())
+
+        with (
+            patch("telegram_bot.bot.build_supervisor_graph", return_value=mock_graph),
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+        ):
+            message = _make_text_message("квартиры")
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        state_arg = mock_graph.ainvoke.call_args.args[0]
+        assert state_arg["max_tool_calls"] == 9
 
 
 class TestHistorySaveOnResponse:


### PR DESCRIPTION
## Summary
- repair `scripts/eval/run_experiment.py` runtime wiring (imports, state shape, noop cache, qdrant config, cleanup)
- switch `scripts/eval/goldset_sync.py` to SDK-correct `langfuse.create_dataset_item(...)`
- propagate `max_llm_calls` / `max_tool_calls` and state overrides through supervisor + rag agent paths
- make `UserService.set_locale` idempotent with upsert
- add regression tests for all above

## Validation
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
- `uv run pytest tests/integration/test_graph_paths.py -n auto --dist=worksteal -q`
