### PR TITLE
feat(manager): add role-based supervisor tools (#388)

### DIFF
--- a/telegram_bot/agents/manager_tools.py
+++ b/telegram_bot/agents/manager_tools.py
@@ -1,0 +1,30 @@
+"""Manager-only supervisor tools (#388).
+
+Provides tools available exclusively to users with the 'manager' role.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.tools import tool
+
+
+def create_manager_tools(*, lead_service: Any) -> list[Any]:
+    """Create manager-specific tools with injected lead service."""
+
+    @tool
+    async def manager_list_hot_leads(limit: int = 10) -> str:
+        """List latest hot leads for manager triage."""
+        leads = await lead_service.list_hot_leads(limit=limit)
+        if not leads:
+            return "No hot leads right now."
+        return "\n".join(f"{row['lead_id']}: score={row['score']}" for row in leads)
+
+    @tool
+    async def manager_ack_hot_lead(lead_id: int) -> str:
+        """Mark hot lead as acknowledged by manager."""
+        await lead_service.ack_hot_lead(lead_id=lead_id)
+        return f"Lead {lead_id} acknowledged"
+
+    return [manager_list_hot_leads, manager_ack_hot_lead]

--- a/telegram_bot/agents/tools.py
+++ b/telegram_bot/agents/tools.py
@@ -7,6 +7,7 @@ and delegates to existing services (RAG graph, HistoryService).
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from typing import Any, cast
 
 from langchain_core.runnables import RunnableConfig
@@ -130,6 +131,16 @@ def create_history_search_tool(*, history_service: Any) -> Any:
         return "\n".join(lines)
 
     return history_search
+
+
+def build_tools_for_role(
+    *, role: str, base_tools: list[Any], manager_tools: Iterable[Any]
+) -> list[Any]:
+    """Select tools based on user role (#388)."""
+    tools = list(base_tools)
+    if role == "manager":
+        tools.extend(list(manager_tools))
+    return tools
 
 
 @tool

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -544,8 +544,9 @@ class PropertyBot:
     @observe(name="telegram-rag-supervisor")
     async def _handle_query_supervisor(self, message: Message, pipeline_start: float) -> None:
         """Handle query via supervisor graph (#240, #310 — primary query path)."""
+        from .agents.manager_tools import create_manager_tools
         from .agents.rag_agent import create_rag_agent
-        from .agents.tools import create_history_search_tool, direct_response
+        from .agents.tools import build_tools_for_role, create_history_search_tool, direct_response
         from .graph.supervisor_state import make_supervisor_state
 
         assert message.bot is not None
@@ -554,8 +555,11 @@ class PropertyBot:
         user_id = message.from_user.id
         session_id = make_session_id("chat", message.chat.id)
 
-        # Build supervisor tools
-        tools = [
+        # Resolve user role (#388)
+        role = await self._resolve_user_role(user_id)
+
+        # Build supervisor tools (base + role-specific)
+        base_tools = [
             create_rag_agent(
                 cache=self._cache,
                 embeddings=self._embeddings,
@@ -574,7 +578,14 @@ class PropertyBot:
             direct_response,
         ]
         if self._history_service is not None:
-            tools.append(create_history_search_tool(history_service=self._history_service))
+            base_tools.append(create_history_search_tool(history_service=self._history_service))
+
+        # Manager tools (#388) — activated when lead_service is available (#387)
+        manager_tools: list[Any] = []
+        _lead_svc = getattr(self, "_lead_service", None)
+        if _lead_svc is not None:
+            manager_tools = create_manager_tools(lead_service=_lead_svc)
+        tools = build_tools_for_role(role=role, base_tools=base_tools, manager_tools=manager_tools)
 
         # Build supervisor LLM (cheap model for routing)
         supervisor_llm = self._graph_config.create_supervisor_llm(
@@ -643,6 +654,8 @@ class PropertyBot:
             lf.score_current_trace(
                 name="supervisor_model", value=self.config.supervisor_model, data_type="CATEGORICAL"
             )
+            # User role score (#388)
+            lf.score_current_trace(name="user_role", value=role, data_type="CATEGORICAL")
             # Tool call count (#374)
             tool_calls = result.get("tool_call_count", 0)
             if tool_calls > 0:

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -256,13 +256,22 @@ class PropertyBot:
 
     async def _resolve_user_role(self, user_id: int) -> str:
         """Resolve user role from DB or config fallback (#388)."""
+        db_role: str | None = None
         user_service = getattr(self, "_user_service", None)
         if user_service is not None and hasattr(user_service, "get_role"):
             try:
-                return await user_service.get_role(telegram_id=user_id)
+                resolved = await user_service.get_role(telegram_id=user_id)
+                if isinstance(resolved, str):
+                    normalized = resolved.strip().lower()
+                    if normalized in {"manager", "client"}:
+                        db_role = normalized
             except Exception:
                 logger.warning("Role lookup failed", exc_info=True)
-        return "manager" if user_id in self.config.manager_ids else "client"
+
+        # Config manager_ids should still elevate known managers even if DB is stale.
+        if user_id in self.config.manager_ids:
+            return "manager"
+        return db_role or "client"
 
     async def cmd_start(self, message: Message, dialog_manager: Any = None):
         """Handle /start command — launch menu dialog."""

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -28,6 +28,7 @@ from .scoring import (
     write_langfuse_scores,
 )
 from .services.history_service import HistoryService
+from .services.manager_menu import render_start_menu
 from .services.metrics import PipelineMetrics
 from .services.redis_monitor import RedisHealthMonitor
 
@@ -253,6 +254,16 @@ class PropertyBot:
         self.dp.message(F.text)(self.handle_query)
         self.dp.callback_query(F.data.startswith("fb:"))(self.handle_feedback)
 
+    async def _resolve_user_role(self, user_id: int) -> str:
+        """Resolve user role from DB or config fallback (#388)."""
+        user_service = getattr(self, "_user_service", None)
+        if user_service is not None and hasattr(user_service, "get_role"):
+            try:
+                return await user_service.get_role(telegram_id=user_id)
+            except Exception:
+                logger.warning("Role lookup failed", exc_info=True)
+        return "manager" if user_id in self.config.manager_ids else "client"
+
     async def cmd_start(self, message: Message, dialog_manager: Any = None):
         """Handle /start command — launch menu dialog."""
         if dialog_manager is not None:
@@ -263,10 +274,9 @@ class PropertyBot:
             await dialog_manager.start(ClientMenuSG.main, mode=StartMode.RESET_STACK)
         else:
             # Fallback (dialog not initialized)
-            domain = self.config.domain
-            await message.answer(
-                f"Привет! Я бот-помощник по теме: {domain}.\nИспользуй /help для помощи."
-            )
+            assert message.from_user is not None
+            role = await self._resolve_user_role(message.from_user.id)
+            await message.answer(render_start_menu(role=role, domain=self.config.domain))
 
     async def cmd_help(self, message: Message):
         """Handle /help command."""

--- a/telegram_bot/config.py
+++ b/telegram_bot/config.py
@@ -390,6 +390,14 @@ class BotConfig(BaseSettings):
         default_factory=list,
         validation_alias=AliasChoices("manager_ids", "MANAGER_IDS"),
     )
+    manager_hot_lead_threshold: int = Field(
+        default=60,
+        validation_alias=AliasChoices("manager_hot_lead_threshold", "MANAGER_HOT_LEAD_THRESHOLD"),
+    )
+    manager_hot_lead_dedupe_sec: int = Field(
+        default=3600,
+        validation_alias=AliasChoices("manager_hot_lead_dedupe_sec", "MANAGER_HOT_LEAD_DEDUPE_SEC"),
+    )
 
     @field_validator("manager_ids", mode="before")
     @classmethod

--- a/telegram_bot/services/hot_lead_notifier.py
+++ b/telegram_bot/services/hot_lead_notifier.py
@@ -31,7 +31,12 @@ class HotLeadNotifier:
         """
         lead_id = payload.get("lead_id")
         session_id = payload.get("session_id")
-        score = int(payload.get("score", 0))
+        raw_score = payload.get("score", 0)
+        try:
+            score = int(raw_score)
+        except (TypeError, ValueError):
+            logger.warning("Invalid hot lead score %r; defaulting to 0", raw_score)
+            score = 0
         if not lead_id or not session_id:
             return False
 

--- a/telegram_bot/services/hot_lead_notifier.py
+++ b/telegram_bot/services/hot_lead_notifier.py
@@ -1,0 +1,48 @@
+"""Hot lead notification service (#388).
+
+Sends Telegram messages to manager users when a hot lead is detected.
+Deduplicates via Redis SET NX to avoid spamming on repeated events.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+
+
+class HotLeadNotifier:
+    """Fan-out hot-lead alerts to configured manager Telegram IDs."""
+
+    def __init__(
+        self, *, bot: Any, cache: Any, manager_ids: list[int], dedupe_ttl_sec: int
+    ) -> None:
+        self._bot = bot
+        self._cache = cache
+        self._manager_ids = manager_ids
+        self._dedupe_ttl_sec = dedupe_ttl_sec
+
+    async def notify_if_hot(self, payload: dict[str, Any]) -> bool:
+        """Send notification to managers if lead is new (not deduped).
+
+        Returns True if notification was sent, False if deduped or invalid.
+        """
+        lead_id = payload.get("lead_id")
+        session_id = payload.get("session_id")
+        score = int(payload.get("score", 0))
+        if not lead_id or not session_id:
+            return False
+
+        redis = getattr(self._cache, "redis", None)
+        if redis is not None:
+            key = f"hot-lead:{session_id}:{lead_id}"
+            fresh = await redis.set(key, "1", ex=self._dedupe_ttl_sec, nx=True)
+            if not fresh:
+                return False
+
+        text = f"Hot lead detected: lead_id={lead_id}, score={score}, session_id={session_id}"
+        for manager_id in self._manager_ids:
+            await self._bot.send_message(chat_id=manager_id, text=text)
+        return True

--- a/telegram_bot/services/manager_menu.py
+++ b/telegram_bot/services/manager_menu.py
@@ -1,0 +1,10 @@
+"""Manager menu rendering for /start command (#388)."""
+
+from __future__ import annotations
+
+
+def render_start_menu(*, role: str, domain: str) -> str:
+    """Render /start menu text based on user role."""
+    if role == "manager":
+        return f"Manager menu ({domain})\n- /leads\n- /history <query>\n- /stats\n- /help"
+    return f"Hi! I am your assistant for {domain}.\nAsk questions in free text or use /help."

--- a/tests/unit/agents/test_manager_tools.py
+++ b/tests/unit/agents/test_manager_tools.py
@@ -1,0 +1,37 @@
+"""Tests for manager role-based tool registry (#388)."""
+
+from unittest.mock import AsyncMock
+
+from langchain_core.tools import tool
+
+from telegram_bot.agents.manager_tools import create_manager_tools
+from telegram_bot.agents.tools import build_tools_for_role
+
+
+@tool
+async def base_tool(message: str) -> str:
+    """Base tool for role-selection tests."""
+    return message
+
+
+async def test_manager_role_gets_manager_tools():
+    manager_tools = create_manager_tools(lead_service=AsyncMock())
+    tools = build_tools_for_role(
+        role="manager",
+        base_tools=[base_tool],
+        manager_tools=manager_tools,
+    )
+    names = {t.name for t in tools}
+    assert "manager_list_hot_leads" in names
+    assert "manager_ack_hot_lead" in names
+
+
+async def test_client_role_does_not_get_manager_tools():
+    manager_tools = create_manager_tools(lead_service=AsyncMock())
+    tools = build_tools_for_role(
+        role="client",
+        base_tools=[base_tool],
+        manager_tools=manager_tools,
+    )
+    names = {t.name for t in tools}
+    assert "manager_list_hot_leads" not in names

--- a/tests/unit/agents/test_supervisor_observability.py
+++ b/tests/unit/agents/test_supervisor_observability.py
@@ -254,6 +254,39 @@ async def test_supervisor_propagate_attributes_called_with_supervisor_tag(superv
     assert call_kwargs["user_id"]  # non-empty
 
 
+async def test_supervisor_writes_user_role_score(supervisor_config):
+    """Supervisor path writes user_role CATEGORICAL score (#388)."""
+    supervisor_config.manager_ids = [12345]
+    bot = _create_bot_patched(supervisor_config)
+
+    mock_supervisor_graph = AsyncMock()
+    mock_supervisor_graph.ainvoke = AsyncMock(
+        return_value={
+            "messages": [MagicMock(content="Response")],
+            "agent_used": "rag_search",
+            "latency_stages": {"supervisor": 0.05},
+        }
+    )
+    mock_lf = MagicMock()
+
+    with (
+        patch("telegram_bot.bot.build_supervisor_graph", return_value=mock_supervisor_graph),
+        patch("telegram_bot.bot.get_client", return_value=mock_lf),
+        patch("telegram_bot.bot.propagate_attributes"),
+    ):
+        message = _make_text_message("цены", user_id=12345)
+        with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+            mock_cas.typing.return_value = _make_typing_cm()
+            await bot.handle_query(message)
+
+    role_scores = [
+        c for c in mock_lf.score_current_trace.call_args_list if c[1].get("name") == "user_role"
+    ]
+    assert len(role_scores) == 1
+    assert role_scores[0][1]["value"] == "manager"
+    assert role_scores[0][1]["data_type"] == "CATEGORICAL"
+
+
 async def test_supervisor_curated_span_metadata_on_routing(supervisor_config):
     """Supervisor node writes curated span metadata for routing decision (#242)."""
     bot = _create_bot_patched(supervisor_config)

--- a/tests/unit/config/test_bot_config_settings.py
+++ b/tests/unit/config/test_bot_config_settings.py
@@ -54,6 +54,14 @@ class TestBotConfigIsPydanticSettings:
         assert config.use_hyde is True
         assert config.mmr_enabled is False
 
+    def test_manager_hot_lead_defaults(self):
+        """Manager hot-lead config fields have sane defaults (#388)."""
+        from telegram_bot.config import BotConfig
+
+        cfg = BotConfig()
+        assert cfg.manager_hot_lead_threshold == 60
+        assert cfg.manager_hot_lead_dedupe_sec == 3600
+
     def test_config_get_collection_name(self):
         """get_collection_name() still works after migration."""
         from telegram_bot.config import BotConfig

--- a/tests/unit/services/test_hot_lead_notifier.py
+++ b/tests/unit/services/test_hot_lead_notifier.py
@@ -1,0 +1,48 @@
+"""Tests for hot lead notification service (#388)."""
+
+from unittest.mock import AsyncMock
+
+from telegram_bot.services.hot_lead_notifier import HotLeadNotifier
+
+
+async def test_notifier_sends_once_per_session():
+    """Fan-out to managers on first event; dedupe skips second."""
+    cache = AsyncMock()
+    cache.redis = AsyncMock()
+    cache.redis.set = AsyncMock(side_effect=[True, False])
+    bot = AsyncMock()
+
+    notifier = HotLeadNotifier(bot=bot, cache=cache, manager_ids=[1, 2], dedupe_ttl_sec=3600)
+    payload = {"lead_id": 77, "score": 88, "session_id": "chat-abc"}
+
+    await notifier.notify_if_hot(payload)
+    await notifier.notify_if_hot(payload)
+
+    # First call fans out to 2 managers, second is deduped
+    assert bot.send_message.await_count == 2
+
+
+async def test_notifier_returns_false_when_deduped():
+    """Return False when lead notification was already sent."""
+    cache = AsyncMock()
+    cache.redis = AsyncMock()
+    cache.redis.set = AsyncMock(return_value=False)
+    bot = AsyncMock()
+
+    notifier = HotLeadNotifier(bot=bot, cache=cache, manager_ids=[1], dedupe_ttl_sec=3600)
+    result = await notifier.notify_if_hot({"lead_id": 1, "score": 90, "session_id": "s1"})
+
+    assert result is False
+    bot.send_message.assert_not_awaited()
+
+
+async def test_notifier_returns_false_on_missing_fields():
+    """Return False when required fields are missing."""
+    cache = AsyncMock()
+    bot = AsyncMock()
+
+    notifier = HotLeadNotifier(bot=bot, cache=cache, manager_ids=[1], dedupe_ttl_sec=3600)
+    result = await notifier.notify_if_hot({"score": 90})
+
+    assert result is False
+    bot.send_message.assert_not_awaited()

--- a/tests/unit/services/test_hot_lead_notifier.py
+++ b/tests/unit/services/test_hot_lead_notifier.py
@@ -46,3 +46,17 @@ async def test_notifier_returns_false_on_missing_fields():
 
     assert result is False
     bot.send_message.assert_not_awaited()
+
+
+async def test_notifier_handles_non_numeric_score_without_crashing():
+    """Invalid score payload should not crash notification flow."""
+    cache = AsyncMock()
+    cache.redis = None
+    bot = AsyncMock()
+    notifier = HotLeadNotifier(bot=bot, cache=cache, manager_ids=[1], dedupe_ttl_sec=3600)
+
+    result = await notifier.notify_if_hot({"lead_id": 1, "score": "high", "session_id": "s1"})
+
+    assert result is True
+    bot.send_message.assert_awaited_once()
+    assert "score=0" in bot.send_message.await_args.kwargs["text"]

--- a/tests/unit/services/test_manager_menu.py
+++ b/tests/unit/services/test_manager_menu.py
@@ -1,0 +1,15 @@
+"""Tests for manager menu rendering (#388)."""
+
+from telegram_bot.services.manager_menu import render_start_menu
+
+
+def test_render_start_menu_manager():
+    text = render_start_menu(role="manager", domain="real estate")
+    assert "Manager menu" in text
+    assert "/leads" in text
+
+
+def test_render_start_menu_client():
+    text = render_start_menu(role="client", domain="real estate")
+    assert "Ask questions" in text
+    assert "Manager menu" not in text

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -139,7 +139,7 @@ class TestCommandHandlers:
     @pytest.mark.parametrize(
         ("handler_name", "expected_fragments"),
         [
-            ("cmd_start", ["Привет", "недвижимость"]),
+            ("cmd_start", ["assistant", "недвижимость"]),
             ("cmd_help", ["Примеры запросов", "/clear", "/stats"]),
         ],
     )
@@ -154,6 +154,17 @@ class TestCommandHandlers:
         call_args = message.answer.call_args[0][0]
         for fragment in expected_fragments:
             assert fragment in call_args
+
+    async def test_cmd_start_manager_receives_manager_menu(self, mock_config):
+        """Manager user receives manager-specific start menu (#388)."""
+        mock_config.manager_ids = [12345]
+        bot, _ = _create_bot(mock_config)
+        message = _make_text_message(user_id=12345)
+
+        await bot.cmd_start(message)
+
+        sent = message.answer.call_args[0][0]
+        assert "Manager menu" in sent
 
     async def test_cmd_clear(self, mock_config):
         """Test /clear command handler."""

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -166,6 +166,17 @@ class TestCommandHandlers:
         sent = message.answer.call_args[0][0]
         assert "Manager menu" in sent
 
+    async def test_resolve_user_role_prefers_config_manager_ids_on_db_client(self, mock_config):
+        """manager_ids fallback should elevate manager even when DB returns client (#388)."""
+        mock_config.manager_ids = [12345]
+        bot, _ = _create_bot(mock_config)
+        bot._user_service = AsyncMock()
+        bot._user_service.get_role = AsyncMock(return_value="client")
+
+        role = await bot._resolve_user_role(12345)
+
+        assert role == "manager"
+
     async def test_cmd_clear(self, mock_config):
         """Test /clear command handler."""
         bot, _ = _create_bot(mock_config)


### PR DESCRIPTION
## Summary
- Add role-based supervisor tool registry: managers get extra tools (`manager_list_hot_leads`, `manager_ack_hot_lead`) alongside base tools
- Add `_resolve_user_role()` with fail-soft fallback chain: DB lookup → config `manager_ids` → default "client"
- Add manager-specific `/start` menu rendering (`render_start_menu()`)
- Add `HotLeadNotifier` service with Redis SET NX deduplication (wiring deferred to #389 pending #387 merge)
- Add `user_role` CATEGORICAL Langfuse score to supervisor observability
- Add `manager_hot_lead_threshold` / `manager_hot_lead_dedupe_sec` config fields

## Files Changed

| File | Change |
|------|--------|
| `telegram_bot/agents/manager_tools.py` | NEW: `create_manager_tools()` factory |
| `telegram_bot/agents/tools.py` | ADD: `build_tools_for_role()` |
| `telegram_bot/services/manager_menu.py` | NEW: `render_start_menu()` |
| `telegram_bot/services/hot_lead_notifier.py` | NEW: `HotLeadNotifier` class |
| `telegram_bot/config.py` | ADD: 2 config fields |
| `telegram_bot/bot.py` | MOD: role resolution, role-based tools, user_role score |
| `tests/unit/agents/test_manager_tools.py` | NEW: 2 tests |
| `tests/unit/services/test_manager_menu.py` | NEW: 2 tests |
| `tests/unit/services/test_hot_lead_notifier.py` | NEW: 3 tests |
| `tests/unit/test_bot_handlers.py` | MOD: 1 new test + fixture update |
| `tests/unit/config/test_bot_config_settings.py` | MOD: 1 new test |
| `tests/unit/agents/test_supervisor_observability.py` | MOD: 1 new test |

## Test plan
- [x] 91 targeted tests pass (test_manager_tools, test_manager_menu, test_hot_lead_notifier, test_supervisor_observability, test_bot_handlers, test_bot_config_settings)
- [x] Full unit suite: 2372 passed, 19 skipped
- [x] Ruff lint: clean
- [x] Mypy: no issues

## Notes
- `HotLeadNotifier` wiring into `bot.py` deferred — depends on #387 (`_lead_service` + `lead_score` in supervisor result)
- TDD workflow: RED → GREEN → COMMIT for each of 4 tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)