### PR TITLE
feat(eval): add Langfuse Experiments SDK runner (#383)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ dmypy.json
 logs/
 data/embeddings/
 data/evaluation/
+data/gold_set*.jsonl
 evaluation/results/
 evaluation/evaluation/
 *.tar.gz

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ make docker-full-up        # All services (17 containers)
 make eval-rag              # RAG evaluation (RAGAS faithfulness >= 0.8)
 make eval-goldset-sync     # Sync gold set to Langfuse dataset
 make eval-experiment       # Run RAG experiment on gold set
+make eval-gold-gen         # Generate gold set from Qdrant → Langfuse + JSONL
+make eval-sdk-experiment   # Run SDK experiment on gold set (DATASET=name)
 make validate-traces-fast  # Trace validation (cold+cache, Langfuse report)
 make monitoring-up         # Start alerting stack
 make ingest-unified        # Unified ingestion (CocoIndex v3.2.1); also: -watch, -status

--- a/Makefile
+++ b/Makefile
@@ -634,6 +634,24 @@ eval-experiment: ## Run RAG experiment on gold set
 	uv run python scripts/eval/run_experiment.py
 	@echo "$(GREEN)✓ Experiment complete$(NC)"
 
+.PHONY: eval-gold-gen eval-gold-gen-dry eval-sdk-experiment eval-sdk-experiment-named
+
+eval-gold-gen: ## Generate gold set from Qdrant → Langfuse Dataset + JSONL
+	@echo "$(BLUE)Generating gold set from Qdrant...$(NC)"
+	uv run python scripts/generate_gold_set.py --collection gdrive_documents_bge
+
+eval-gold-gen-dry: ## Dry-run gold set generation (JSONL only, no Langfuse)
+	@echo "$(BLUE)Generating gold set (dry-run)...$(NC)"
+	uv run python scripts/generate_gold_set.py --dry-run --output data/gold_set.jsonl
+
+eval-sdk-experiment: ## Run SDK experiment on gold set (DATASET=name required)
+	@echo "$(BLUE)Running SDK experiment on gold set...$(NC)"
+	uv run python scripts/run_experiment.py --dataset $(DATASET)
+
+eval-sdk-experiment-named: ## Run named SDK experiment (DATASET=name NAME=label required)
+	@echo "$(BLUE)Running SDK experiment '$(NAME)'...$(NC)"
+	uv run python scripts/run_experiment.py --dataset $(DATASET) --name $(NAME)
+
 # =============================================================================
 # MONITORING & ALERTING
 # =============================================================================

--- a/docs/plans/2026-02-18-langfuse-experiments-design.md
+++ b/docs/plans/2026-02-18-langfuse-experiments-design.md
@@ -1,0 +1,493 @@
+# Langfuse Experiments: Gold Set + Automated Regression Testing
+
+**Дата:** 2026-02-18
+**Статус:** Draft
+**Цель:** Синтетический gold set из Qdrant → Langfuse Dataset → `run_experiment()` для regression testing после изменений в RAG pipeline.
+
+---
+
+## Контекст
+
+### Текущее состояние
+
+| Компонент | Что есть | Чего нет |
+|-----------|----------|----------|
+| `scripts/export_traces_to_dataset.py` | Экспорт low-scoring traces в Langfuse Dataset | Экспорт high-scoring traces |
+| `telegram_bot/evaluation/judges.py` | RAG Triad (faithfulness, relevance, context) | Обёртка как experiment evaluators |
+| `scripts/validate_traces.py` | 4-phase validation с Go/No-Go | Прогон по фиксированному gold set |
+| `tests/baseline/` | Regression detection по метрикам | Regression detection по качеству ответов |
+| Langfuse SDK v3 | `create_dataset`, `create_dataset_item` | `run_experiment()`, versioned datasets |
+
+### Qdrant: gdrive_documents_bge
+
+- **278 чанков**, **14 документов** (болгарская недвижимость, ВНЖ, евро, фирмы)
+- Payload: `page_content`, `metadata.file_id`, `metadata.order`, `metadata.source`, `metadata.section`
+- Vectors: dense (BGE-M3, 1024-dim) + sparse (BM42)
+
+---
+
+## Архитектура
+
+```
+┌─────────────────────────────────────────────────────┐
+│                 GENERATION (однократно)               │
+│                                                       │
+│  Qdrant scroll (278 чанков)                          │
+│       ↓                                               │
+│  Группировка по file_id (14 документов)              │
+│       ↓                                               │
+│  LLM генерация per-document:                         │
+│    - N = max(3, round(chunks/4)) вопросов            │
+│    - Типы: factual, comparative, practical           │
+│    - Эталонные ответы строго из текста               │
+│       ↓                                               │
+│  Groundedness validation (LLM проверка)              │
+│       ↓                                               │
+│  Cross-document вопросы (5-10 штук)                  │
+│       ↓                                               │
+│  Upload → Langfuse Dataset + JSONL бэкап             │
+│  (~90-120 items)                                     │
+└─────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────┐
+│              EXPERIMENT RUN (после изменений)         │
+│                                                       │
+│  langfuse.get_dataset("rag-gold-set-v1")             │
+│       ↓                                               │
+│  dataset.run_experiment(                              │
+│      name="after-prompt-v2",                         │
+│      task=rag_task,           ← LangGraph pipeline   │
+│      evaluators=[                                     │
+│          faithfulness_eval,   ← обёртка judges.py    │
+│          relevance_eval,                              │
+│          context_eval,                                │
+│          retrieval_recall,    ← новый: нашли чанки?  │
+│      ],                                               │
+│      run_evaluators=[avg_scores],                    │
+│      max_concurrency=5,                               │
+│      metadata={...config...}                         │
+│  )                                                    │
+│       ↓                                               │
+│  result.format()  → CLI таблица                      │
+│  result.dataset_run_url → Langfuse UI сравнение      │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## Компонент 1: Gold Set Generator
+
+### Скрипт: `scripts/generate_gold_set.py`
+
+**Вход:** Qdrant collection `gdrive_documents_bge` (278 чанков, 14 документов)
+
+**Выход:** Langfuse Dataset + `data/gold_set.jsonl` бэкап
+
+### Алгоритм
+
+1. **Scroll** — вычитать все 278 чанков из Qdrant (без векторов, только payload)
+2. **Группировка** — собрать чанки по `metadata.file_id`, отсортировать по `metadata.order`
+3. **Склейка** — для каждого документа собрать полный текст из `page_content`
+4. **Генерация** — для каждого документа вызвать LLM:
+   - Количество вопросов: `N = max(3, round(chunk_count / 4))`
+   - Промпт генерирует JSON массив `[{query, answer, difficulty, type, source_chunks}]`
+   - Типы вопросов: `factual` (факт из текста), `comparative` (сравнение), `practical` (как сделать?)
+   - Difficulty: `easy` (прямой ответ из 1 чанка), `medium` (синтез 2-3 чанков), `hard` (требует понимания контекста)
+5. **Валидация** — LLM-проверка: "Ответ полностью следует из текста? Нет ли выдуманных фактов?"
+6. **Cross-document** — сгенерировать 5-10 вопросов, требующих информации из 2+ документов
+7. **Upload** — `langfuse.create_dataset()` + `create_dataset_item()` для каждого item
+8. **Бэкап** — сохранить в `data/gold_set.jsonl`
+
+### Масштабирование по размеру документа
+
+| Документ | Чанков | Вопросов |
+|----------|--------|----------|
+| AIRBNB/Booking запреты | 82 | ~20 |
+| Польша vs Болгария | 44 | ~11 |
+| ВНЖ/ПМЖ правила 2026 | 18 | ~5 |
+| Купить квартиру | 18 | ~5 |
+| Не потерять деньги | 15 | ~4 |
+| Digital Nomad виза | 15 | ~4 |
+| Евро прогноз | 14 | ~4 |
+| ВНЖ для иностранцев | 13 | ~3 |
+| Ошибка ценой в квартиру | 12 | ~3 |
+| Такса поддержки | 12 | ~3 |
+| Деньги на границе | 12 | ~3 |
+| Старите Къщи | 10 | ~3 |
+| Открыть фирму | 7 | ~3 |
+| Демо дом.xlsx | 6 | ~3 |
+| **Cross-document** | — | ~8 |
+| **Итого** | **278** | **~82 + 8 = ~90** |
+
+### Dataset Item Structure
+
+```python
+langfuse.create_dataset_item(
+    dataset_name="rag-gold-set-v1",
+    input={"query": "Какие документы нужны покупателю квартиры в Болгарии?"},
+    expected_output={
+        "answer": "Покупателю нужны: загранпаспорт, ИНН (ЕГН для иностранцев), ..."
+    },
+    metadata={
+        "source_doc": "Как купить квартиру в Болгарии...",
+        "source_file_id": "a1b2c3d4e5f6g7h8",
+        "source_chunks": ["seq_3", "seq_5", "seq_7"],
+        "difficulty": "medium",
+        "type": "factual",
+        "generated_by": "cerebras/llama-3.3-70b",
+        "generated_at": "2026-02-18T12:00:00Z"
+    }
+)
+```
+
+### CLI
+
+```bash
+# Полная генерация + upload в Langfuse
+python scripts/generate_gold_set.py --collection gdrive_documents_bge
+
+# Dry-run: генерация без upload, только JSONL
+python scripts/generate_gold_set.py --dry-run --output data/gold_set.jsonl
+
+# Дополнить существующий dataset (не пересоздавать)
+python scripts/generate_gold_set.py --append --dataset-name rag-gold-set-v1
+
+# Только cross-document вопросы
+python scripts/generate_gold_set.py --cross-document-only
+
+# Кастомное количество вопросов на документ
+python scripts/generate_gold_set.py --questions-per-doc 10
+```
+
+### LLM промпт для генерации
+
+```
+Ты эксперт по недвижимости и иммиграции в Болгарии.
+
+Ниже — текст документа. Сгенерируй {n} вопросов, которые клиент
+реально задал бы в Telegram-чате на русском языке.
+
+Требования:
+- Вопросы должны быть разнообразными: фактические, сравнительные, практические
+- Ответ СТРОГО на основе текста, никаких выдуманных фактов
+- Сложность: easy (1 чанк), medium (2-3 чанка), hard (весь документ)
+- source_chunks: список chunk_location тех чанков, где есть ответ
+
+Формат JSON:
+[
+  {
+    "query": "вопрос на русском",
+    "answer": "полный ответ на основе текста",
+    "difficulty": "easy|medium|hard",
+    "type": "factual|comparative|practical",
+    "source_chunks": ["seq_3", "seq_5"]
+  }
+]
+
+ТЕКСТ ДОКУМЕНТА:
+{document_text}
+```
+
+---
+
+## Компонент 2: Experiment Runner
+
+### Скрипт: `scripts/run_experiment.py`
+
+**Вход:** Langfuse Dataset name + конфигурация эксперимента
+
+**Выход:** Langfuse Dataset Run + CLI таблица результатов
+
+### Task Function
+
+```python
+from langfuse import get_client
+
+langfuse = get_client()
+
+async def rag_task(*, item, **kwargs):
+    """Прогоняет один item через RAG pipeline."""
+    query = item.input["query"]
+
+    # Вызов LangGraph pipeline (тот же что в боте)
+    result = await run_rag_pipeline(query)
+
+    return {
+        "response": result["response"],
+        "context": result.get("retrieved_context", []),
+        "scores": result.get("scores", {}),
+        "latency_ms": result.get("latency_ms"),
+    }
+```
+
+### Evaluators
+
+**Item-level** (оценка каждого Q&A):
+
+```python
+from langfuse import Evaluation
+
+def faithfulness_eval(*, input, output, expected_output, metadata, **kwargs):
+    """Обёртка над существующим judge_faithfulness из judges.py"""
+    score = call_judge(
+        judge_type="faithfulness",
+        query=input["query"],
+        answer=output["response"],
+        context=output.get("context", [])
+    )
+    return Evaluation(name="faithfulness", value=score)
+
+def answer_relevance_eval(*, input, output, expected_output, metadata, **kwargs):
+    """Обёртка над judge_answer_relevance"""
+    score = call_judge(
+        judge_type="answer_relevance",
+        query=input["query"],
+        answer=output["response"]
+    )
+    return Evaluation(name="answer_relevance", value=score)
+
+def context_relevance_eval(*, input, output, expected_output, metadata, **kwargs):
+    """Обёртка над judge_context_relevance"""
+    score = call_judge(
+        judge_type="context_relevance",
+        query=input["query"],
+        context=output.get("context", [])
+    )
+    return Evaluation(name="context_relevance", value=score)
+
+def retrieval_recall_eval(*, input, output, expected_output, metadata, **kwargs):
+    """Новый: проверяет нашёл ли retrieval нужные source_chunks."""
+    expected_chunks = set(metadata.get("source_chunks", []))
+    if not expected_chunks:
+        return Evaluation(name="retrieval_recall", value=1.0, comment="no expected chunks")
+
+    retrieved_chunks = set()
+    for doc in output.get("context", []):
+        loc = doc.get("metadata", {}).get("chunk_location", "")
+        if loc:
+            retrieved_chunks.add(loc)
+
+    found = expected_chunks & retrieved_chunks
+    recall = len(found) / len(expected_chunks)
+    return Evaluation(
+        name="retrieval_recall",
+        value=recall,
+        comment=f"Found {len(found)}/{len(expected_chunks)}: {found}"
+    )
+```
+
+**Run-level** (агрегация по всему эксперименту):
+
+```python
+def avg_scores_evaluator(*, item_results, **kwargs):
+    """Средние скоры по всем items."""
+    metrics = {}
+    for name in ["faithfulness", "answer_relevance", "context_relevance", "retrieval_recall"]:
+        values = [
+            e.value for r in item_results
+            for e in r.evaluations
+            if e.name == name and e.value is not None
+        ]
+        if values:
+            metrics[name] = sum(values) / len(values)
+
+    # Возвращаем composite score
+    avg_all = sum(metrics.values()) / len(metrics) if metrics else 0
+    return Evaluation(
+        name="composite_score",
+        value=round(avg_all, 3),
+        comment=f"Averages: {metrics}"
+    )
+```
+
+### Запуск эксперимента
+
+```python
+dataset = langfuse.get_dataset("rag-gold-set-v1")
+
+result = dataset.run_experiment(
+    name="after-prompt-change-v2",
+    description="Тест после изменения system prompt generate_node",
+    task=rag_task,
+    evaluators=[
+        faithfulness_eval,
+        answer_relevance_eval,
+        context_relevance_eval,
+        retrieval_recall_eval,
+    ],
+    run_evaluators=[avg_scores_evaluator],
+    max_concurrency=5,
+    metadata={
+        "model": "cerebras/llama-3.3-70b",
+        "change": "updated system prompt v2",
+        "collection": "gdrive_documents_bge",
+        "git_sha": get_git_sha(),
+    }
+)
+
+print(result.format())
+print(f"Langfuse UI: {result.dataset_run_url}")
+```
+
+### CLI
+
+```bash
+# Запуск эксперимента
+python scripts/run_experiment.py --dataset rag-gold-set-v1 --name "baseline-v1"
+
+# С описанием изменений
+python scripts/run_experiment.py \
+    --dataset rag-gold-set-v1 \
+    --name "prompt-v2" \
+    --description "Updated system prompt" \
+    --concurrency 3
+
+# На версированном датасете
+python scripts/run_experiment.py \
+    --dataset rag-gold-set-v1 \
+    --version "2026-02-18T12:00:00Z" \
+    --name "regression-check"
+```
+
+### Makefile
+
+```makefile
+eval-gold-gen:          ## Generate gold set from Qdrant → Langfuse Dataset
+	uv run python scripts/generate_gold_set.py --collection gdrive_documents_bge
+
+eval-gold-gen-dry:      ## Dry-run gold set generation (JSONL only)
+	uv run python scripts/generate_gold_set.py --dry-run --output data/gold_set.jsonl
+
+eval-experiment:        ## Run experiment on gold set
+	uv run python scripts/run_experiment.py --dataset rag-gold-set-v1
+
+eval-experiment-named:  ## Run named experiment (NAME=prompt-v2 make eval-experiment-named)
+	uv run python scripts/run_experiment.py --dataset rag-gold-set-v1 --name $(NAME)
+```
+
+---
+
+## Компонент 3: Интеграция с существующей инфраструктурой
+
+### Переиспользование кода
+
+| Существующий модуль | Как используем |
+|---------------------|----------------|
+| `telegram_bot/evaluation/judges.py` | `call_judge()` → обёртка в experiment evaluators |
+| `telegram_bot/evaluation/prompts.py` | Промпты для faithfulness/relevance/context judges |
+| `telegram_bot/services/qdrant.py` | `QdrantService` для scroll чанков при генерации gold set |
+| `telegram_bot/graph/` | LangGraph pipeline как `task` в `run_experiment()` |
+| `telegram_bot/integrations/langfuse.py` | Langfuse client init |
+| `tests/baseline/thresholds.yaml` | Пороги для judge scores |
+
+### Новые файлы
+
+```
+scripts/
+├── generate_gold_set.py    # Генерация gold set из Qdrant
+├── run_experiment.py       # Запуск экспериментов через Langfuse SDK
+data/
+├── gold_set.jsonl          # JSONL бэкап gold set (gitignored)
+```
+
+### Конфигурация (thresholds.yaml — дополнение)
+
+```yaml
+# Добавить в tests/baseline/thresholds.yaml
+experiment:
+  faithfulness_mean_gte: 0.75
+  answer_relevance_mean_gte: 0.70
+  context_relevance_mean_gte: 0.65
+  retrieval_recall_mean_gte: 0.60
+  composite_score_gte: 0.65
+```
+
+---
+
+## Компонент 4: Data Flow
+
+```
+                    GENERATION (once)
+                    ═══════════════
+
+  ┌──────────┐     ┌──────────────┐     ┌─────────────┐
+  │  Qdrant  │────→│ generate_    │────→│  Langfuse   │
+  │  278     │     │ gold_set.py  │     │  Dataset    │
+  │  chunks  │     │              │     │  ~90 items  │
+  └──────────┘     │  LLM gen +   │     └──────┬──────┘
+                   │  validation  │            │
+                   └──────┬───────┘            │
+                          │                    │
+                          ▼                    │
+                   ┌──────────────┐            │
+                   │ gold_set.    │            │
+                   │ jsonl        │            │
+                   │ (backup)     │            │
+                   └──────────────┘            │
+                                               │
+                    EXPERIMENT (per change)     │
+                    ══════════════════════      │
+                                               │
+  ┌──────────┐     ┌──────────────┐     ┌──────┴──────┐
+  │ RAG      │◄────│ run_         │◄────│  Dataset    │
+  │ Pipeline │     │ experiment.  │     │  items      │
+  │ LangGraph│     │ py           │     └─────────────┘
+  └──────────┘     │              │
+                   │  evaluators: │     ┌─────────────┐
+                   │  - faith.    │────→│  Langfuse   │
+                   │  - relevance │     │  Dataset    │
+                   │  - context   │     │  Run        │
+                   │  - recall    │     │  (compare   │
+                   └──────────────┘     │   in UI)    │
+                                        └─────────────┘
+```
+
+---
+
+## Workflow для разработчика
+
+```
+1. Изменил prompt / retrieval / model
+       ↓
+2. make eval-experiment  (или с именем: NAME=prompt-v2 make eval-experiment-named)
+       ↓
+3. CLI выводит таблицу:
+   ┌────────────────────┬───────┬────────┐
+   │ Metric             │ Value │ Status │
+   ├────────────────────┼───────┼────────┤
+   │ faithfulness (avg) │ 0.82  │ PASS   │
+   │ answer_relevance   │ 0.78  │ PASS   │
+   │ context_relevance  │ 0.71  │ PASS   │
+   │ retrieval_recall   │ 0.65  │ PASS   │
+   │ composite_score    │ 0.74  │ PASS   │
+   └────────────────────┴───────┴────────┘
+       ↓
+4. Langfuse UI → Datasets → rag-gold-set-v1 → Runs
+   Сравниваешь baseline-v1 vs prompt-v2 визуально
+```
+
+---
+
+## Ограничения и риски
+
+| Риск | Митигация |
+|------|-----------|
+| LLM генерирует некорректные ответы | Groundedness validation + ручная проверка первого батча |
+| Gold set устаревает при обновлении Qdrant | Регенерация: `make eval-gold-gen` после ingestion |
+| Evaluator LLM дорогой | Используем cerebras (бесплатный tier), max_concurrency=5 |
+| Experiment run долгий (~90 items × LLM) | ~15-20 минут, запуск в tmux |
+| Langfuse SDK breaking changes | Версия зафиксирована в pyproject.toml |
+
+---
+
+## Зависимости
+
+- `langfuse` Python SDK v3 (уже в проекте)
+- `qdrant-client` (уже в проекте)
+- LiteLLM для генерации и evaluation (уже в проекте)
+- Qdrant запущен с данными (`make docker-up`)
+
+## Тесты
+
+- `tests/unit/test_generate_gold_set.py` — генерация, группировка, валидация
+- `tests/unit/test_run_experiment.py` — evaluators, task function, CLI args

--- a/docs/plans/2026-02-18-langfuse-experiments-design.md
+++ b/docs/plans/2026-02-18-langfuse-experiments-design.md
@@ -6,6 +6,16 @@
 
 ---
 
+## Точечный Review Patch (2026-02-18)
+
+1. API `langfuse` сверен на версии из lockfile: для версионного датасета используется `langfuse.get_dataset(name=..., version=<UTC datetime>)`, а в `dataset.run_experiment(...)` доступны `run_name`, `max_concurrency`, `metadata`.
+2. Для `retrieval_recall` читаем `chunk_location` из top-level поля контекста (`doc["chunk_location"]`), так как именно его добавляем в API-ответ.
+3. Upload gold set должен быть idempotent: `create_dataset` вызывать только при отсутствии датасета, а `create_dataset_item` лучше делать со стабильным `id` для dedupe.
+4. В MVP этого issue не включаем CLI-флаги `--append` и `--cross-document-only` (вынести в follow-up после базового pipeline).
+5. В `Makefile` не хардкодим датасет по дате; передаём `DATASET=...` явно при запуске.
+
+---
+
 ## Контекст
 
 ### Текущее состояние
@@ -16,7 +26,7 @@
 | `telegram_bot/evaluation/judges.py` | RAG Triad (faithfulness, relevance, context) | Обёртка как experiment evaluators |
 | `scripts/validate_traces.py` | 4-phase validation с Go/No-Go | Прогон по фиксированному gold set |
 | `tests/baseline/` | Regression detection по метрикам | Regression detection по качеству ответов |
-| Langfuse SDK v3 | `create_dataset`, `create_dataset_item` | `run_experiment()`, versioned datasets |
+| Langfuse SDK v3 | `create_dataset`, `create_dataset_item`, `run_experiment()`, `get_dataset(version=...)` | стабильный процесс экспериментов для текущего проекта |
 
 ### Qdrant: gdrive_documents_bge
 
@@ -144,19 +154,13 @@ langfuse.create_dataset_item(
 
 ```bash
 # Полная генерация + upload в Langfuse
-python scripts/generate_gold_set.py --collection gdrive_documents_bge
+uv run python scripts/generate_gold_set.py --collection gdrive_documents_bge
 
 # Dry-run: генерация без upload, только JSONL
-python scripts/generate_gold_set.py --dry-run --output data/gold_set.jsonl
-
-# Дополнить существующий dataset (не пересоздавать)
-python scripts/generate_gold_set.py --append --dataset-name rag-gold-set-v1
-
-# Только cross-document вопросы
-python scripts/generate_gold_set.py --cross-document-only
+uv run python scripts/generate_gold_set.py --dry-run --output data/gold_set.jsonl
 
 # Кастомное количество вопросов на документ
-python scripts/generate_gold_set.py --questions-per-doc 10
+uv run python scripts/generate_gold_set.py --questions-per-doc 10
 ```
 
 ### LLM промпт для генерации
@@ -226,34 +230,49 @@ async def rag_task(*, item, **kwargs):
 
 ```python
 from langfuse import Evaluation
+from telegram_bot.evaluation.judges import (
+    judge_answer_relevance,
+    judge_context_relevance,
+    judge_faithfulness,
+)
 
-def faithfulness_eval(*, input, output, expected_output, metadata, **kwargs):
-    """Обёртка над существующим judge_faithfulness из judges.py"""
-    score = call_judge(
-        judge_type="faithfulness",
+def _context_to_text(context_items):
+    return "\n\n".join(
+        str(doc.get("content", ""))
+        for doc in context_items
+        if isinstance(doc, dict) and doc.get("content")
+    )
+
+async def faithfulness_eval(*, input, output, expected_output, metadata, **kwargs):
+    """Обёртка над существующим judge_faithfulness из judges.py."""
+    result = await judge_faithfulness(
+        client=judge_client,  # AsyncOpenAI/LiteLLM client
+        model=judge_model,
         query=input["query"],
         answer=output["response"],
-        context=output.get("context", [])
+        context=_context_to_text(output.get("context", [])),
     )
-    return Evaluation(name="faithfulness", value=score)
+    return Evaluation(name="faithfulness", value=result.score or 0.0, comment=result.reasoning)
 
-def answer_relevance_eval(*, input, output, expected_output, metadata, **kwargs):
-    """Обёртка над judge_answer_relevance"""
-    score = call_judge(
-        judge_type="answer_relevance",
+async def answer_relevance_eval(*, input, output, expected_output, metadata, **kwargs):
+    """Обёртка над judge_answer_relevance."""
+    result = await judge_answer_relevance(
+        client=judge_client,
+        model=judge_model,
         query=input["query"],
-        answer=output["response"]
+        answer=output["response"],
     )
-    return Evaluation(name="answer_relevance", value=score)
+    return Evaluation(name="answer_relevance", value=result.score or 0.0, comment=result.reasoning)
 
-def context_relevance_eval(*, input, output, expected_output, metadata, **kwargs):
-    """Обёртка над judge_context_relevance"""
-    score = call_judge(
-        judge_type="context_relevance",
+async def context_relevance_eval(*, input, output, expected_output, metadata, **kwargs):
+    """Обёртка над judge_context_relevance."""
+    result = await judge_context_relevance(
+        client=judge_client,
+        model=judge_model,
         query=input["query"],
-        context=output.get("context", [])
+        context=_context_to_text(output.get("context", [])),
     )
-    return Evaluation(name="context_relevance", value=score)
+    return Evaluation(name="context_relevance", value=result.score or 0.0, comment=result.reasoning)
 
 def retrieval_recall_eval(*, input, output, expected_output, metadata, **kwargs):
     """Новый: проверяет нашёл ли retrieval нужные source_chunks."""
@@ -263,7 +282,7 @@ def retrieval_recall_eval(*, input, output, expected_output, metadata, **kwargs)
 
     retrieved_chunks = set()
     for doc in output.get("context", []):
-        loc = doc.get("metadata", {}).get("chunk_location", "")
+        loc = doc.get("chunk_location", "")
         if loc:
             retrieved_chunks.add(loc)
 
@@ -333,17 +352,17 @@ print(f"Langfuse UI: {result.dataset_run_url}")
 
 ```bash
 # Запуск эксперимента
-python scripts/run_experiment.py --dataset rag-gold-set-v1 --name "baseline-v1"
+uv run python scripts/run_experiment.py --dataset rag-gold-set-v1 --name "baseline-v1"
 
 # С описанием изменений
-python scripts/run_experiment.py \
+uv run python scripts/run_experiment.py \
     --dataset rag-gold-set-v1 \
     --name "prompt-v2" \
     --description "Updated system prompt" \
     --concurrency 3
 
 # На версированном датасете
-python scripts/run_experiment.py \
+uv run python scripts/run_experiment.py \
     --dataset rag-gold-set-v1 \
     --version "2026-02-18T12:00:00Z" \
     --name "regression-check"
@@ -358,11 +377,11 @@ eval-gold-gen:          ## Generate gold set from Qdrant → Langfuse Dataset
 eval-gold-gen-dry:      ## Dry-run gold set generation (JSONL only)
 	uv run python scripts/generate_gold_set.py --dry-run --output data/gold_set.jsonl
 
-eval-experiment:        ## Run experiment on gold set
-	uv run python scripts/run_experiment.py --dataset rag-gold-set-v1
+eval-experiment:        ## Run experiment on gold set (usage: make eval-experiment DATASET=rag-gold-set-v1)
+	uv run python scripts/run_experiment.py --dataset $(DATASET)
 
 eval-experiment-named:  ## Run named experiment (NAME=prompt-v2 make eval-experiment-named)
-	uv run python scripts/run_experiment.py --dataset rag-gold-set-v1 --name $(NAME)
+	uv run python scripts/run_experiment.py --dataset $(DATASET) --name $(NAME)
 ```
 
 ---
@@ -373,7 +392,7 @@ eval-experiment-named:  ## Run named experiment (NAME=prompt-v2 make eval-experi
 
 | Существующий модуль | Как используем |
 |---------------------|----------------|
-| `telegram_bot/evaluation/judges.py` | `call_judge()` → обёртка в experiment evaluators |
+| `telegram_bot/evaluation/judges.py` | `judge_*()` async функции → обёртки в experiment evaluators |
 | `telegram_bot/evaluation/prompts.py` | Промпты для faithfulness/relevance/context judges |
 | `telegram_bot/services/qdrant.py` | `QdrantService` для scroll чанков при генерации gold set |
 | `telegram_bot/graph/` | LangGraph pipeline как `task` в `run_experiment()` |

--- a/docs/plans/2026-02-18-langfuse-experiments-impl.md
+++ b/docs/plans/2026-02-18-langfuse-experiments-impl.md
@@ -1,0 +1,1236 @@
+# Langfuse Experiments Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Синтетический gold set из Qdrant → Langfuse Dataset → `dataset.run_experiment()` для regression testing RAG pipeline.
+
+**Architecture:** Максимально SDK-based. `task` = HTTP POST к RAG API (:8080). Judge evaluators — Langfuse UI managed (0 кода). Единственный code evaluator — `retrieval_recall`. Gold set генерация — Qdrant scroll → LLM Q&A gen → groundedness validation → Langfuse Dataset + JSONL backup.
+
+**Tech Stack:** Langfuse Python SDK v3 (`get_client`, `Evaluation`, `run_experiment`), qdrant-client, httpx, LiteLLM (OpenAI SDK)
+
+**Issue:** #383 | **Design doc:** `docs/plans/2026-02-18-langfuse-experiments-design.md`
+
+**Worktree:** `.worktrees/langfuse-experiments-383` | **Branch:** `feat/langfuse-experiments-383`
+
+---
+
+## Task 1: Extend RAG API — add context to QueryResponse
+
+RAG API (`src/api/`) не возвращает `retrieved_context`. Нужен для `retrieval_recall` evaluator. Два изменения: (1) `_build_retrieved_context` добавить `chunk_location`, (2) `QueryResponse` добавить `context` поле.
+
+**Files:**
+- Modify: `telegram_bot/graph/nodes/retrieve.py:24-40`
+- Modify: `src/api/schemas.py:20-28`
+- Modify: `src/api/main.py:148-155`
+- Test: `tests/unit/api/test_rag_api.py` (существующие тесты)
+
+**Step 1: Write the failing test**
+
+File: `tests/unit/api/test_rag_api.py` — добавить тест на `context` поле:
+
+```python
+class TestQueryResponseContext:
+    """Test that QueryResponse includes retrieved context."""
+
+    def test_context_field_default_empty(self):
+        from src.api.schemas import QueryResponse
+
+        resp = QueryResponse(response="answer")
+        assert resp.context == []
+
+    def test_context_field_with_data(self):
+        from src.api.schemas import QueryResponse
+
+        ctx = [{"content": "text", "score": 0.5, "chunk_location": "seq_3"}]
+        resp = QueryResponse(response="answer", context=ctx)
+        assert len(resp.context) == 1
+        assert resp.context[0]["chunk_location"] == "seq_3"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/api/test_rag_api.py::TestQueryResponseContext -v`
+Expected: FAIL — `QueryResponse` has no field `context`
+
+**Step 3: Add `chunk_location` to `_build_retrieved_context`**
+
+File: `telegram_bot/graph/nodes/retrieve.py:24-40` — текущий код:
+
+```python
+def _build_retrieved_context(
+    results: list[dict[str, Any]],
+    limit: int = 5,
+) -> list[dict[str, str | float]]:
+    """Build curated context snippets for LLM-as-a-Judge evaluation."""
+    ctx: list[dict[str, str | float]] = []
+    for doc in results[:limit]:
+        if not isinstance(doc, dict):
+            continue
+        text = doc.get("text", "")
+        ctx.append(
+            {
+                "content": text[:_MAX_CONTEXT_SNIPPET],
+                "score": doc.get("score", 0),
+            }
+        )
+    return ctx
+```
+
+Заменить на:
+
+```python
+def _build_retrieved_context(
+    results: list[dict[str, Any]],
+    limit: int = 5,
+) -> list[dict[str, str | float]]:
+    """Build curated context snippets for LLM-as-a-Judge evaluation."""
+    ctx: list[dict[str, str | float]] = []
+    for doc in results[:limit]:
+        if not isinstance(doc, dict):
+            continue
+        text = doc.get("text", "")
+        meta = doc.get("metadata", {})
+        ctx.append(
+            {
+                "content": text[:_MAX_CONTEXT_SNIPPET],
+                "score": doc.get("score", 0),
+                "chunk_location": meta.get("chunk_location", ""),
+            }
+        )
+    return ctx
+```
+
+**Step 4: Add `context` field to `QueryResponse`**
+
+File: `src/api/schemas.py:20-28` — добавить поле после `latency_ms`:
+
+```python
+class QueryResponse(BaseModel):
+    """POST /query response body."""
+
+    response: str = Field(..., description="Generated answer")
+    query_type: str = Field(default="", description="Classified query type")
+    cache_hit: bool = Field(default=False, description="Whether semantic cache was hit")
+    documents_count: int = Field(default=0, description="Number of retrieved documents")
+    rerank_applied: bool = Field(default=False, description="Whether reranking was applied")
+    latency_ms: float = Field(default=0.0, description="Total pipeline latency in milliseconds")
+    context: list[dict] = Field(
+        default_factory=list,
+        description="Retrieved context documents (for evaluation)",
+    )
+```
+
+**Step 5: Populate `context` in API endpoint**
+
+File: `src/api/main.py:148-155` — текущий return:
+
+```python
+    return QueryResponse(
+        response=result.get("response", ""),
+        query_type=result.get("query_type", ""),
+        cache_hit=result.get("cache_hit", False),
+        documents_count=result.get("search_results_count", 0),
+        rerank_applied=result.get("rerank_applied", False),
+        latency_ms=round(elapsed_ms, 1),
+    )
+```
+
+Заменить на:
+
+```python
+    return QueryResponse(
+        response=result.get("response", ""),
+        query_type=result.get("query_type", ""),
+        cache_hit=result.get("cache_hit", False),
+        documents_count=result.get("search_results_count", 0),
+        rerank_applied=result.get("rerank_applied", False),
+        latency_ms=round(elapsed_ms, 1),
+        context=result.get("retrieved_context", []),
+    )
+```
+
+**Step 6: Run tests**
+
+Run: `uv run pytest tests/unit/api/ -v`
+Expected: All PASS
+
+**Step 7: Commit**
+
+```bash
+git add telegram_bot/graph/nodes/retrieve.py src/api/schemas.py src/api/main.py tests/unit/api/test_rag_api.py
+git commit -m "feat(api): add context field to QueryResponse for experiment evaluation (#383)"
+```
+
+---
+
+## Task 2: Experiment thresholds in thresholds.yaml
+
+**Files:**
+- Modify: `tests/baseline/thresholds.yaml` (append after `judge:` section, line 47)
+
+**Step 1: Add experiment section**
+
+Append to end of `tests/baseline/thresholds.yaml`:
+
+```yaml
+
+# Experiment quality thresholds (run_experiment evaluators)
+experiment:
+  faithfulness_mean_gte: 0.75
+  answer_relevance_mean_gte: 0.70
+  context_relevance_mean_gte: 0.65
+  retrieval_recall_mean_gte: 0.60
+  composite_score_gte: 0.65
+```
+
+**Step 2: Verify YAML is valid**
+
+Run: `python -c "import yaml; yaml.safe_load(open('tests/baseline/thresholds.yaml')); print('OK')"`
+Expected: `OK`
+
+**Step 3: Commit**
+
+```bash
+git add tests/baseline/thresholds.yaml
+git commit -m "feat(eval): add experiment quality thresholds (#383)"
+```
+
+---
+
+## Task 3: Gold set generator — tests
+
+**Files:**
+- Create: `tests/unit/test_generate_gold_set.py`
+
+**Step 1: Write all tests**
+
+File: `tests/unit/test_generate_gold_set.py`
+
+```python
+"""Tests for gold set generator."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _make_point(file_id: str, order: int, text: str, source: str = "doc.md") -> SimpleNamespace:
+    """Create a mock Qdrant point with payload."""
+    return SimpleNamespace(
+        payload={
+            "page_content": text,
+            "metadata": {
+                "file_id": file_id,
+                "order": order,
+                "source": source,
+                "chunk_location": f"seq_{order}",
+                "file_name": source,
+                "section": "",
+            },
+        },
+    )
+
+
+class TestScrollCollection:
+    async def test_returns_all_points(self):
+        from scripts.generate_gold_set import scroll_collection
+
+        mock_client = AsyncMock()
+        mock_client.scroll.return_value = (
+            [_make_point("f1", 0, "text1"), _make_point("f1", 1, "text2")],
+            None,
+        )
+        points = await scroll_collection(mock_client, "test_col")
+        assert len(points) == 2
+
+    async def test_pagination(self):
+        from scripts.generate_gold_set import scroll_collection
+
+        mock_client = AsyncMock()
+        mock_client.scroll.side_effect = [
+            ([_make_point("f1", 0, "t1")], "offset2"),
+            ([_make_point("f1", 1, "t2")], None),
+        ]
+        points = await scroll_collection(mock_client, "test_col", batch_size=1)
+        assert len(points) == 2
+        assert mock_client.scroll.call_count == 2
+
+
+class TestGroupByDocument:
+    def test_groups_and_sorts(self):
+        from scripts.generate_gold_set import group_by_document
+
+        points = [
+            _make_point("f1", 2, "C"),
+            _make_point("f1", 0, "A"),
+            _make_point("f2", 0, "X"),
+            _make_point("f1", 1, "B"),
+        ]
+        docs = group_by_document(points)
+        assert len(docs) == 2
+        assert [c["text"] for c in docs["f1"]["chunks"]] == ["A", "B", "C"]
+
+    def test_single_document(self):
+        from scripts.generate_gold_set import group_by_document
+
+        points = [_make_point("f1", 0, "only")]
+        docs = group_by_document(points)
+        assert len(docs) == 1
+        assert docs["f1"]["chunks"][0]["text"] == "only"
+
+
+class TestCalculateQuestionsCount:
+    @pytest.mark.parametrize(
+        ("chunks", "expected_min"),
+        [(1, 3), (6, 3), (12, 3), (20, 5), (44, 11), (82, 21)],
+    )
+    def test_formula_min_3(self, chunks: int, expected_min: int):
+        from scripts.generate_gold_set import calculate_questions_count
+
+        result = calculate_questions_count(chunks)
+        assert result >= 3
+        assert result >= expected_min
+
+
+class TestExportToJsonl:
+    def test_writes_valid_jsonl(self, tmp_path: Path):
+        from scripts.generate_gold_set import export_to_jsonl
+
+        items = [
+            {
+                "query": "Вопрос?",
+                "answer": "Ответ",
+                "source_doc": "doc.md",
+                "source_file_id": "f1",
+                "source_chunks": ["seq_0"],
+                "difficulty": "easy",
+                "type": "factual",
+            },
+        ]
+        out = tmp_path / "gold.jsonl"
+        export_to_jsonl(out, items)
+
+        lines = out.read_text().strip().split("\n")
+        assert len(lines) == 1
+        data = json.loads(lines[0])
+        assert data["input"]["query"] == "Вопрос?"
+        assert data["expected_output"]["answer"] == "Ответ"
+        assert data["metadata"]["source_chunks"] == ["seq_0"]
+
+    def test_multiple_items(self, tmp_path: Path):
+        from scripts.generate_gold_set import export_to_jsonl
+
+        items = [
+            {"query": f"q{i}", "answer": f"a{i}", "source_doc": "d", "source_file_id": "f",
+             "source_chunks": [], "difficulty": "easy", "type": "factual"}
+            for i in range(3)
+        ]
+        out = tmp_path / "gold.jsonl"
+        export_to_jsonl(out, items)
+        assert len(out.read_text().strip().split("\n")) == 3
+
+
+class TestUploadToLangfuse:
+    def test_creates_dataset_and_items(self):
+        from scripts.generate_gold_set import upload_to_langfuse
+
+        mock_lf = MagicMock()
+        items = [
+            {
+                "query": "q?",
+                "answer": "a",
+                "source_doc": "d",
+                "source_file_id": "f1",
+                "source_chunks": ["seq_0"],
+                "difficulty": "easy",
+                "type": "factual",
+            },
+        ]
+        count = upload_to_langfuse(mock_lf, "test-ds", items)
+        assert count == 1
+        mock_lf.create_dataset.assert_called_once_with(name="test-ds")
+        mock_lf.create_dataset_item.assert_called_once()
+
+    def test_empty_items(self):
+        from scripts.generate_gold_set import upload_to_langfuse
+
+        mock_lf = MagicMock()
+        count = upload_to_langfuse(mock_lf, "test-ds", [])
+        assert count == 0
+
+
+class TestAssembleDocumentText:
+    def test_joins_chunks(self):
+        from scripts.generate_gold_set import assemble_document_text
+
+        doc = {"chunks": [{"text": "A"}, {"text": "B"}, {"text": "C"}]}
+        result = assemble_document_text(doc)
+        assert result == "A\n\nB\n\nC"
+```
+
+**Step 2: Run tests — expect ImportError**
+
+Run: `uv run pytest tests/unit/test_generate_gold_set.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'scripts.generate_gold_set'`
+
+**Step 3: Commit test file**
+
+```bash
+git add tests/unit/test_generate_gold_set.py
+git commit -m "test(eval): add gold set generator tests — RED phase (#383)"
+```
+
+---
+
+## Task 4: Gold set generator — implementation
+
+**Files:**
+- Create: `scripts/generate_gold_set.py`
+
+**Step 1: Write implementation**
+
+File: `scripts/generate_gold_set.py`
+
+```python
+#!/usr/bin/env python3
+"""Generate synthetic gold set from Qdrant for Langfuse experiments.
+
+Scrolls chunks from Qdrant, groups by document, generates Q&A via LLM,
+validates groundedness, uploads to Langfuse Dataset + JSONL backup.
+
+Usage:
+    uv run python scripts/generate_gold_set.py --collection gdrive_documents_bge
+    uv run python scripts/generate_gold_set.py --dry-run --output data/gold_set.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+DEFAULT_COLLECTION = "gdrive_documents_bge"
+DEFAULT_DATASET_PREFIX = "rag-gold-set"
+SCROLL_BATCH_SIZE = 100
+
+# ---------------------------------------------------------------------------
+# LLM prompts
+# ---------------------------------------------------------------------------
+
+GENERATION_PROMPT = """\
+Ты эксперт по недвижимости и иммиграции в Болгарии.
+
+Ниже — текст документа. Сгенерируй {n} вопросов, которые клиент
+реально задал бы в Telegram-чате на русском языке.
+
+Требования:
+- Вопросы разнообразные: фактические, сравнительные, практические
+- Ответ СТРОГО на основе текста, никаких выдуманных фактов
+- Сложность: easy (1 чанк), medium (2-3 чанка), hard (весь документ)
+- source_chunks: список chunk_location тех чанков, где есть ответ
+
+Доступные chunk_location: {chunk_locations}
+
+Верни ТОЛЬКО JSON массив:
+[{{"query": "вопрос", "answer": "ответ", "difficulty": "easy|medium|hard", \
+"type": "factual|comparative|practical", "source_chunks": ["seq_3"]}}]
+
+ТЕКСТ ДОКУМЕНТА:
+{document_text}"""
+
+GROUNDEDNESS_PROMPT = """\
+Проверь, полностью ли ответ основан на тексте документа.
+
+ТЕКСТ: {document_text}
+
+ВОПРОС: {query}
+ОТВЕТ: {answer}
+
+Верни ТОЛЬКО JSON: {{"grounded": true|false, "reasoning": "1-2 предложения"}}"""
+
+
+# ---------------------------------------------------------------------------
+# Qdrant scroll
+# ---------------------------------------------------------------------------
+
+
+async def scroll_collection(
+    client: Any, collection_name: str, batch_size: int = SCROLL_BATCH_SIZE
+) -> list[Any]:
+    """Scroll all points from Qdrant (no vectors, payload only)."""
+    all_points: list[Any] = []
+    offset = None
+    while True:
+        points, next_offset = await client.scroll(
+            collection_name=collection_name,
+            limit=batch_size,
+            offset=offset,
+            with_payload=True,
+            with_vectors=False,
+        )
+        all_points.extend(points)
+        if next_offset is None:
+            break
+        offset = next_offset
+    logger.info("Scrolled %d points from '%s'", len(all_points), collection_name)
+    return all_points
+
+
+# ---------------------------------------------------------------------------
+# Group & assemble
+# ---------------------------------------------------------------------------
+
+
+def group_by_document(points: list[Any]) -> dict[str, dict[str, Any]]:
+    """Group points by file_id, sort chunks by order."""
+    docs: dict[str, dict[str, Any]] = {}
+    for point in points:
+        payload = point.payload if hasattr(point, "payload") else point
+        meta = payload.get("metadata", {})
+        fid = meta.get("file_id", "unknown")
+        if fid not in docs:
+            docs[fid] = {
+                "source": meta.get("source", "unknown"),
+                "file_id": fid,
+                "chunks": [],
+            }
+        docs[fid]["chunks"].append(
+            {
+                "text": payload.get("page_content", ""),
+                "order": meta.get("order", 0),
+                "chunk_location": meta.get("chunk_location", ""),
+                "section": meta.get("section", ""),
+            }
+        )
+    for doc in docs.values():
+        doc["chunks"].sort(key=lambda c: c["order"])
+    return docs
+
+
+def assemble_document_text(doc: dict[str, Any]) -> str:
+    """Join chunk texts into full document."""
+    return "\n\n".join(c["text"] for c in doc["chunks"])
+
+
+def calculate_questions_count(chunk_count: int) -> int:
+    """Scale questions by document size: max(3, round(chunks/4))."""
+    return max(3, round(chunk_count / 4))
+
+
+# ---------------------------------------------------------------------------
+# LLM generation
+# ---------------------------------------------------------------------------
+
+
+async def generate_qa_for_document(
+    client: Any, model: str, doc: dict[str, Any], n_questions: int
+) -> list[dict[str, Any]]:
+    """Generate Q&A pairs for a single document via LLM."""
+    doc_text = assemble_document_text(doc)
+    chunk_locations = [c["chunk_location"] for c in doc["chunks"]]
+    prompt = GENERATION_PROMPT.format(
+        n=n_questions,
+        chunk_locations=json.dumps(chunk_locations),
+        document_text=doc_text[:15000],
+    )
+
+    try:
+        response = await client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.7,
+            max_tokens=4096,
+            response_format={"type": "json_object"},
+        )
+        content = response.choices[0].message.content or "[]"
+    except Exception:
+        logger.warning("LLM generation failed for '%s'", doc.get("source"), exc_info=True)
+        return []
+
+    try:
+        parsed = json.loads(content)
+        if isinstance(parsed, dict):
+            parsed = parsed.get("items", parsed.get("questions", []))
+        if not isinstance(parsed, list):
+            return []
+    except json.JSONDecodeError:
+        return []
+
+    items = []
+    for qa in parsed:
+        if not isinstance(qa, dict) or not qa.get("query") or not qa.get("answer"):
+            continue
+        items.append(
+            {
+                "query": qa["query"],
+                "answer": qa["answer"],
+                "difficulty": qa.get("difficulty", "medium"),
+                "type": qa.get("type", "factual"),
+                "source_chunks": qa.get("source_chunks", []),
+                "source_doc": doc.get("source", ""),
+                "source_file_id": doc.get("file_id", ""),
+            }
+        )
+    logger.info(
+        "Generated %d/%d Q&A for '%s'", len(items), n_questions, doc.get("source", "?")
+    )
+    return items
+
+
+async def validate_groundedness(
+    client: Any, model: str, doc_text: str, items: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Filter items where answer is not grounded in document text."""
+    validated = []
+    for item in items:
+        prompt = GROUNDEDNESS_PROMPT.format(
+            document_text=doc_text[:10000], query=item["query"], answer=item["answer"]
+        )
+        try:
+            response = await client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0,
+                max_tokens=256,
+                response_format={"type": "json_object"},
+            )
+            result = json.loads(response.choices[0].message.content or "{}")
+            if result.get("grounded", False):
+                validated.append(item)
+            else:
+                logger.info(
+                    "Filtered: '%s' — %s",
+                    item["query"][:60],
+                    result.get("reasoning", ""),
+                )
+        except Exception:
+            validated.append(item)  # keep on error
+    logger.info("Groundedness: %d/%d passed", len(validated), len(items))
+    return validated
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+
+def export_to_jsonl(output_path: Path, items: list[dict[str, Any]]) -> None:
+    """Write items to JSONL file in Langfuse dataset format."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        for item in items:
+            f.write(
+                json.dumps(
+                    {
+                        "input": {"query": item["query"]},
+                        "expected_output": {"answer": item["answer"]},
+                        "metadata": {
+                            "source_doc": item.get("source_doc", ""),
+                            "source_file_id": item.get("source_file_id", ""),
+                            "source_chunks": item.get("source_chunks", []),
+                            "difficulty": item.get("difficulty", ""),
+                            "type": item.get("type", ""),
+                        },
+                    },
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
+    logger.info("Exported %d items to %s", len(items), output_path)
+
+
+def upload_to_langfuse(
+    langfuse: Any,
+    dataset_name: str,
+    items: list[dict[str, Any]],
+    model_name: str = "",
+) -> int:
+    """Upload items to Langfuse Dataset."""
+    if not items:
+        return 0
+    langfuse.create_dataset(name=dataset_name)
+    for item in items:
+        langfuse.create_dataset_item(
+            dataset_name=dataset_name,
+            input={"query": item["query"]},
+            expected_output={"answer": item["answer"]},
+            metadata={
+                "source_doc": item.get("source_doc", ""),
+                "source_file_id": item.get("source_file_id", ""),
+                "source_chunks": item.get("source_chunks", []),
+                "difficulty": item.get("difficulty", ""),
+                "type": item.get("type", ""),
+                "generated_by": model_name,
+                "generated_at": datetime.now(UTC).isoformat(),
+            },
+        )
+    langfuse.flush()
+    logger.info("Uploaded %d items to Langfuse '%s'", len(items), dataset_name)
+    return len(items)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def make_dataset_name(prefix: str = DEFAULT_DATASET_PREFIX) -> str:
+    """Generate versioned dataset name."""
+    return f"{prefix}-v{datetime.now(UTC).strftime('%Y%m%d')}"
+
+
+async def run_pipeline(args: argparse.Namespace) -> None:
+    """Main pipeline: scroll → group → generate → validate → export."""
+    from openai import AsyncOpenAI
+    from qdrant_client import AsyncQdrantClient
+
+    qdrant_url = os.getenv("QDRANT_URL", "http://localhost:6333")
+    llm_url = os.getenv("LITELLM_BASE_URL", "http://localhost:4000")
+    llm_model = os.getenv("JUDGE_MODEL", "gpt-4o-mini")
+
+    qdrant = AsyncQdrantClient(url=qdrant_url)
+    points = await scroll_collection(qdrant, args.collection)
+    await qdrant.close()
+    if not points:
+        logger.error("No points in '%s'", args.collection)
+        sys.exit(1)
+
+    docs = group_by_document(points)
+    logger.info("Found %d documents (%d chunks)", len(docs), len(points))
+
+    llm = AsyncOpenAI(api_key="not-needed", base_url=llm_url)
+    all_items: list[dict[str, Any]] = []
+
+    for doc in docs.values():
+        n = args.questions_per_doc or calculate_questions_count(len(doc["chunks"]))
+        items = await generate_qa_for_document(llm, llm_model, doc, n)
+        if items:
+            items = await validate_groundedness(
+                llm, llm_model, assemble_document_text(doc), items
+            )
+        all_items.extend(items)
+
+    logger.info("Total: %d items from %d documents", len(all_items), len(docs))
+    if not all_items:
+        logger.error("No items generated")
+        sys.exit(1)
+
+    export_to_jsonl(Path(args.output), all_items)
+
+    if not args.dry_run:
+        from langfuse import Langfuse
+
+        lf = Langfuse()
+        dataset_name = args.dataset_name or make_dataset_name()
+        upload_to_langfuse(lf, dataset_name, all_items, model_name=llm_model)
+    else:
+        logger.info("DRY RUN: %d items → %s (no Langfuse upload)", len(all_items), args.output)
+
+
+def main() -> None:
+    """CLI entry point."""
+    load_dotenv()
+    parser = argparse.ArgumentParser(description="Generate gold set from Qdrant")
+    parser.add_argument("--collection", default=DEFAULT_COLLECTION)
+    parser.add_argument("--dataset-name", default=None)
+    parser.add_argument("--output", default="data/gold_set.jsonl")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--questions-per-doc", type=int, default=None)
+    args = parser.parse_args()
+    asyncio.run(run_pipeline(args))
+
+
+if __name__ == "__main__":
+    main()
+```
+
+**Step 2: Run tests — expect PASS**
+
+Run: `uv run pytest tests/unit/test_generate_gold_set.py -v`
+Expected: All PASS
+
+**Step 3: Commit**
+
+```bash
+git add scripts/generate_gold_set.py
+git commit -m "feat(eval): add gold set generator — Qdrant scroll, LLM gen, groundedness (#383)"
+```
+
+---
+
+## Task 5: Experiment runner — tests
+
+**Files:**
+- Create: `tests/unit/test_run_experiment.py`
+
+**Step 1: Write all tests**
+
+File: `tests/unit/test_run_experiment.py`
+
+```python
+"""Tests for experiment runner evaluators."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+class TestRetrievalRecallEval:
+    def test_full_recall(self):
+        from scripts.run_experiment import retrieval_recall_eval
+
+        result = retrieval_recall_eval(
+            input={"query": "q"},
+            output={
+                "response": "a",
+                "context": [
+                    {"chunk_location": "seq_0", "content": "t", "score": 0.5},
+                    {"chunk_location": "seq_1", "content": "t", "score": 0.4},
+                ],
+            },
+            expected_output={"answer": "a"},
+            metadata={"source_chunks": ["seq_0", "seq_1"]},
+        )
+        assert result.value == 1.0
+        assert result.name == "retrieval_recall"
+
+    def test_partial_recall(self):
+        from scripts.run_experiment import retrieval_recall_eval
+
+        result = retrieval_recall_eval(
+            input={"query": "q"},
+            output={
+                "response": "a",
+                "context": [{"chunk_location": "seq_0", "content": "t", "score": 0.5}],
+            },
+            expected_output={"answer": "a"},
+            metadata={"source_chunks": ["seq_0", "seq_1"]},
+        )
+        assert result.value == 0.5
+
+    def test_zero_recall(self):
+        from scripts.run_experiment import retrieval_recall_eval
+
+        result = retrieval_recall_eval(
+            input={"query": "q"},
+            output={"response": "a", "context": [{"chunk_location": "seq_99"}]},
+            expected_output={"answer": "a"},
+            metadata={"source_chunks": ["seq_0", "seq_1"]},
+        )
+        assert result.value == 0.0
+
+    def test_no_expected_chunks(self):
+        from scripts.run_experiment import retrieval_recall_eval
+
+        result = retrieval_recall_eval(
+            input={"query": "q"},
+            output={"response": "a", "context": []},
+            expected_output={"answer": "a"},
+            metadata={},
+        )
+        assert result.value == 1.0
+
+
+class TestAvgScoresEvaluator:
+    def test_computes_average(self):
+        from scripts.run_experiment import avg_scores_evaluator
+
+        item_results = [
+            SimpleNamespace(
+                evaluations=[SimpleNamespace(name="retrieval_recall", value=1.0)]
+            ),
+            SimpleNamespace(
+                evaluations=[SimpleNamespace(name="retrieval_recall", value=0.5)]
+            ),
+        ]
+        result = avg_scores_evaluator(item_results=item_results)
+        assert result.name == "composite_score"
+        assert result.value == 0.75
+
+    def test_empty_results(self):
+        from scripts.run_experiment import avg_scores_evaluator
+
+        result = avg_scores_evaluator(item_results=[])
+        assert result.value == 0
+
+    def test_ignores_other_metrics(self):
+        from scripts.run_experiment import avg_scores_evaluator
+
+        item_results = [
+            SimpleNamespace(
+                evaluations=[
+                    SimpleNamespace(name="retrieval_recall", value=0.8),
+                    SimpleNamespace(name="other_metric", value=0.1),
+                ]
+            ),
+        ]
+        result = avg_scores_evaluator(item_results=item_results)
+        assert result.value == 0.8
+```
+
+**Step 2: Run tests — expect ImportError**
+
+Run: `uv run pytest tests/unit/test_run_experiment.py -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+**Step 3: Commit test file**
+
+```bash
+git add tests/unit/test_run_experiment.py
+git commit -m "test(eval): add experiment runner tests — RED phase (#383)"
+```
+
+---
+
+## Task 6: Experiment runner — implementation
+
+**Files:**
+- Create: `scripts/run_experiment.py`
+
+**Step 1: Write implementation**
+
+File: `scripts/run_experiment.py`
+
+```python
+#!/usr/bin/env python3
+"""Run Langfuse experiment on gold set — SDK-based.
+
+Task = HTTP POST to RAG API. Judge evaluators = Langfuse UI managed.
+Only retrieval_recall is a code evaluator.
+
+Usage:
+    uv run python scripts/run_experiment.py --dataset rag-gold-set-v20260218 --name baseline
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import subprocess
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+from dotenv import load_dotenv
+from langfuse import Evaluation
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Task: HTTP call to RAG API
+# ---------------------------------------------------------------------------
+
+
+def rag_task(*, item: Any, **kwargs: Any) -> dict[str, Any]:
+    """Call RAG API for each dataset item. Returns response + context."""
+    rag_api_url = os.getenv("RAG_API_URL", "http://localhost:8080")
+    query = item.input["query"] if hasattr(item, "input") else item["input"]["query"]
+
+    with httpx.Client(timeout=60.0) as client:
+        resp = client.post(
+            f"{rag_api_url}/query",
+            json={"query": query, "user_id": 0, "channel": "experiment"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+    return {
+        "response": data.get("response", ""),
+        "context": data.get("context", []),
+        "query_type": data.get("query_type", ""),
+        "cache_hit": data.get("cache_hit", False),
+        "documents_count": data.get("documents_count", 0),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Evaluators (only retrieval_recall in code; judges → Langfuse UI)
+# ---------------------------------------------------------------------------
+
+
+def retrieval_recall_eval(
+    *, input: dict, output: dict, expected_output: dict, metadata: dict, **kwargs: Any
+) -> Evaluation:
+    """Check if retrieval found the expected source_chunks."""
+    expected = set(metadata.get("source_chunks", []))
+    if not expected:
+        return Evaluation(
+            name="retrieval_recall", value=1.0, comment="no expected chunks"
+        )
+
+    found = {
+        doc.get("chunk_location", "")
+        for doc in output.get("context", [])
+        if isinstance(doc, dict)
+    }
+    recall = len(expected & found) / len(expected)
+    return Evaluation(
+        name="retrieval_recall",
+        value=recall,
+        comment=f"{len(expected & found)}/{len(expected)}",
+    )
+
+
+def avg_scores_evaluator(*, item_results: list[Any], **kwargs: Any) -> Evaluation:
+    """Run-level: average retrieval_recall across all items."""
+    values = [
+        e.value
+        for r in item_results
+        for e in r.evaluations
+        if e.name == "retrieval_recall" and e.value is not None
+    ]
+    avg = sum(values) / len(values) if values else 0
+    return Evaluation(
+        name="composite_score",
+        value=round(avg, 3),
+        comment=f"avg of {len(values)} items",
+    )
+
+
+def _git_sha() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], text=True, timeout=5
+        ).strip()
+    except Exception:
+        return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """CLI entry point."""
+    load_dotenv()
+    parser = argparse.ArgumentParser(description="Run Langfuse experiment on gold set")
+    parser.add_argument("--dataset", required=True, help="Langfuse dataset name")
+    parser.add_argument("--name", default=None, help="Experiment run name")
+    parser.add_argument("--description", default="", help="Description")
+    parser.add_argument("--concurrency", type=int, default=5)
+    args = parser.parse_args()
+
+    from langfuse import get_client
+
+    langfuse = get_client()
+    dataset = langfuse.get_dataset(name=args.dataset)
+    logger.info("Dataset '%s': %d items", args.dataset, len(dataset.items))
+
+    run_name = args.name or f"exp-{datetime.now(UTC).strftime('%Y%m%d-%H%M%S')}"
+
+    result = dataset.run_experiment(
+        name=run_name,
+        description=args.description or f"Experiment {run_name}",
+        task=rag_task,
+        evaluators=[retrieval_recall_eval],
+        run_evaluators=[avg_scores_evaluator],
+        metadata={
+            "model": os.getenv("LLM_MODEL", "gpt-4o-mini"),
+            "collection": os.getenv("QDRANT_COLLECTION", "gdrive_documents_bge"),
+            "git_sha": _git_sha(),
+        },
+    )
+
+    print(result.format())
+    logger.info("Experiment '%s' complete", run_name)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+**Step 2: Run tests — expect PASS**
+
+Run: `uv run pytest tests/unit/test_run_experiment.py -v`
+Expected: All PASS
+
+**Step 3: Commit**
+
+```bash
+git add scripts/run_experiment.py
+git commit -m "feat(eval): add SDK-based experiment runner — HTTP task + retrieval recall (#383)"
+```
+
+---
+
+## Task 7: Makefile targets + gitignore
+
+**Files:**
+- Modify: `Makefile` (append after `eval-judge-sample` target, ~line 633)
+- Modify: `.gitignore` (add `data/` if not covered)
+
+**Step 1: Add targets to Makefile**
+
+Найти строку `eval-judge-sample:` (line ~631) и после всего блока добавить:
+
+```makefile
+
+.PHONY: eval-gold-gen eval-gold-gen-dry eval-experiment eval-experiment-named
+
+eval-gold-gen: ## Generate gold set from Qdrant → Langfuse Dataset + JSONL
+	@echo "$(BLUE)Generating gold set from Qdrant...$(NC)"
+	uv run python scripts/generate_gold_set.py --collection gdrive_documents_bge
+
+eval-gold-gen-dry: ## Dry-run gold set generation (JSONL only, no Langfuse)
+	@echo "$(BLUE)Generating gold set (dry-run)...$(NC)"
+	uv run python scripts/generate_gold_set.py --dry-run --output data/gold_set.jsonl
+
+eval-experiment: ## Run experiment on latest gold set dataset
+	@echo "$(BLUE)Running experiment on gold set...$(NC)"
+	uv run python scripts/run_experiment.py --dataset $(or $(DATASET),rag-gold-set-v20260218)
+
+eval-experiment-named: ## Run named experiment (NAME=prompt-v2 make eval-experiment-named)
+	@echo "$(BLUE)Running experiment '$(NAME)'...$(NC)"
+	uv run python scripts/run_experiment.py --dataset $(or $(DATASET),rag-gold-set-v20260218) --name $(NAME)
+```
+
+**Step 2: Check `.gitignore` covers `data/`**
+
+Run: `grep -n "^data" .gitignore || echo "NOT FOUND"`
+
+Если `data/` не в `.gitignore`, добавить:
+
+```
+data/
+```
+
+**Step 3: Verify make targets parse**
+
+Run: `make -n eval-gold-gen-dry 2>&1 | head -3`
+Expected: Выводит команду без ошибок
+
+**Step 4: Commit**
+
+```bash
+git add Makefile .gitignore
+git commit -m "feat(eval): add Makefile targets — eval-gold-gen, eval-experiment (#383)"
+```
+
+---
+
+## Task 8: Lint + full test suite
+
+**Step 1: Lint new files**
+
+Run: `uv run ruff check scripts/generate_gold_set.py scripts/run_experiment.py --fix`
+Run: `uv run ruff format scripts/generate_gold_set.py scripts/run_experiment.py`
+
+**Step 2: Lint test files**
+
+Run: `uv run ruff check tests/unit/test_generate_gold_set.py tests/unit/test_run_experiment.py --fix`
+Run: `uv run ruff format tests/unit/test_generate_gold_set.py tests/unit/test_run_experiment.py`
+
+**Step 3: Run new tests**
+
+Run: `uv run pytest tests/unit/test_generate_gold_set.py tests/unit/test_run_experiment.py -v`
+Expected: All PASS
+
+**Step 4: Run full unit test suite (no regressions)**
+
+Run: `uv run pytest tests/unit/ -n auto --timeout=30 -q`
+Expected: All PASS, no regressions
+
+**Step 5: Commit lint fixes if any**
+
+```bash
+git add -u
+git diff --cached --stat
+git commit -m "style(eval): lint and format experiment scripts (#383)"
+```
+
+---
+
+## Task 9: Smoke test — gold set dry-run
+
+**Requires:** Docker services running (Qdrant + LiteLLM): `make docker-up`
+
+**Step 1: Run dry-run in tmux**
+
+```bash
+mkdir -p logs
+tmux new-window -n "W-GOLDSET" -c /home/user/projects/rag-fresh/.worktrees/langfuse-experiments-383
+tmux send-keys -t "W-GOLDSET" "uv run python scripts/generate_gold_set.py --dry-run 2>&1 | tee logs/gold-set-gen.log; echo '[COMPLETE]'" Enter
+```
+
+**Step 2: Monitor and verify**
+
+```bash
+tail -f logs/gold-set-gen.log
+# Expected output:
+# Scrolled 278 points from 'gdrive_documents_bge'
+# Found 14 documents (278 chunks)
+# Generated X/N Q&A for 'document_name'
+# Groundedness: X/Y passed
+# Total: ~90 items from 14 documents
+# Exported ~90 items to data/gold_set.jsonl
+# DRY RUN: ~90 items → data/gold_set.jsonl (no Langfuse upload)
+```
+
+**Step 3: Validate JSONL output**
+
+```bash
+wc -l data/gold_set.jsonl
+head -1 data/gold_set.jsonl | python3 -m json.tool
+```
+
+Expected: 60-120 lines, valid JSON with `input.query`, `expected_output.answer`, `metadata.source_chunks`
+
+---
+
+## Task 10: Configure Langfuse UI managed evaluators
+
+**No code.** Configure in Langfuse web UI (http://localhost:3001).
+
+**Step 1:** Open Langfuse UI → Settings → Evaluators
+
+**Step 2:** Create 3 managed evaluators:
+
+| Name | Type | Model | Threshold |
+|------|------|-------|-----------|
+| `faithfulness` | LLM-as-a-judge | gpt-4o-mini | ≥0.75 |
+| `answer_relevance` | LLM-as-a-judge | gpt-4o-mini | ≥0.70 |
+| `context_relevance` | LLM-as-a-judge | gpt-4o-mini | ≥0.65 |
+
+Use prompts from `telegram_bot/evaluation/prompts.py` (FAITHFULNESS_PROMPT, ANSWER_RELEVANCE_PROMPT, CONTEXT_RELEVANCE_PROMPT) adapted for Langfuse evaluator template format.
+
+These auto-run on experiment traces, scoring via the same prompts as `judges.py`.
+
+**Step 3:** Verify — run `make eval-experiment` and check scores appear in Langfuse UI.
+
+---
+
+## Summary
+
+| Task | What | Custom code | SDK calls |
+|------|------|-------------|-----------|
+| 1 | RAG API context field | ~10 lines | — |
+| 2 | Thresholds YAML | 6 lines | — |
+| 3 | Gold set tests | ~120 lines | — |
+| 4 | Gold set generator | ~180 lines | `create_dataset`, `create_dataset_item` |
+| 5 | Runner tests | ~90 lines | — |
+| 6 | Experiment runner | ~80 lines | `get_dataset`, `run_experiment`, `Evaluation` |
+| 7 | Makefile | 15 lines | — |
+| 8 | Lint + tests | — | — |
+| 9 | Smoke test | — | — |
+| 10 | Langfuse UI evaluators | **0 lines** | Managed evaluators |
+| **Total** | | **~500 lines** (incl. tests) | |

--- a/docs/plans/2026-02-18-langfuse-experiments-impl.md
+++ b/docs/plans/2026-02-18-langfuse-experiments-impl.md
@@ -1,16 +1,28 @@
 # Langfuse Experiments Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> **For Codex:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Синтетический gold set из Qdrant → Langfuse Dataset → `dataset.run_experiment()` для regression testing RAG pipeline.
 
-**Architecture:** Максимально SDK-based. `task` = HTTP POST к RAG API (:8080). Judge evaluators — Langfuse UI managed (0 кода). Единственный code evaluator — `retrieval_recall`. Gold set генерация — Qdrant scroll → LLM Q&A gen → groundedness validation → Langfuse Dataset + JSONL backup.
+**Architecture:** Максимально SDK-based. `task` = HTTP POST к RAG API (:8080). MVP-оценка в коде: `retrieval_recall` + run-level aggregate через `run_evaluators`. Managed evaluators в Langfuse UI — опциональный слой после базового SDK-пайплайна. Gold set генерация — Qdrant scroll → LLM Q&A gen → groundedness validation → Langfuse Dataset + JSONL backup.
 
 **Tech Stack:** Langfuse Python SDK v3 (`get_client`, `Evaluation`, `run_experiment`), qdrant-client, httpx, LiteLLM (OpenAI SDK)
 
 **Issue:** #383 | **Design doc:** `docs/plans/2026-02-18-langfuse-experiments-design.md`
 
 **Worktree:** `.worktrees/langfuse-experiments-383` | **Branch:** `feat/langfuse-experiments-383`
+
+---
+
+## Review Patch (2026-02-18)
+
+1. `langfuse` API в проекте проверен на версии из lockfile: для `dataset.run_experiment(...)` обязательно передавать `max_concurrency=args.concurrency`; для версионного прогона поддерживается `langfuse.get_dataset(name=..., version=<UTC datetime>)`.
+2. В `run_experiment` разделяем `name` (стабильное имя эксперимента) и `run_name` (конкретный запуск), чтобы сравнения в UI не фрагментировались.
+3. Формула `max(3, round(chunks / 4))` в Python даёт `20` для `82` чанков (`round(20.5) == 20`), поэтому тест-кейс на `82` корректируется.
+4. Upload gold set делаем idempotent: `create_dataset` только при отсутствии датасета, а `create_dataset_item` со стабильным `id` для dedupe/re-run.
+5. `Makefile` не должен содержать зашитую дату датасета; датасет передаётся через `DATASET=...`.
+6. В `.gitignore` добавляем только `data/gold_set*.jsonl`, а не `data/` целиком.
+7. Перед завершением обязателен репо-гейт из AGENTS: `make check` и `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`.
 
 ---
 
@@ -185,7 +197,7 @@ experiment:
 
 **Step 2: Verify YAML is valid**
 
-Run: `python -c "import yaml; yaml.safe_load(open('tests/baseline/thresholds.yaml')); print('OK')"`
+Run: `uv run python -c "import yaml; yaml.safe_load(open('tests/baseline/thresholds.yaml')); print('OK')"`
 Expected: `OK`
 
 **Step 3: Commit**
@@ -287,7 +299,7 @@ class TestGroupByDocument:
 class TestCalculateQuestionsCount:
     @pytest.mark.parametrize(
         ("chunks", "expected_min"),
-        [(1, 3), (6, 3), (12, 3), (20, 5), (44, 11), (82, 21)],
+        [(1, 3), (6, 3), (12, 3), (20, 5), (44, 11), (82, 20)],
     )
     def test_formula_min_3(self, chunks: int, expected_min: int):
         from scripts.generate_gold_set import calculate_questions_count
@@ -412,6 +424,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -664,12 +677,19 @@ def upload_to_langfuse(
     """Upload items to Langfuse Dataset."""
     if not items:
         return 0
-    langfuse.create_dataset(name=dataset_name)
+    try:
+        langfuse.get_dataset(name=dataset_name)
+    except Exception:
+        langfuse.create_dataset(name=dataset_name)
     for item in items:
         langfuse.create_dataset_item(
             dataset_name=dataset_name,
             input={"query": item["query"]},
             expected_output={"answer": item["answer"]},
+            id=(
+                f"{item.get('source_file_id', 'na')}::"
+                f"{hashlib.sha256(item['query'].encode()).hexdigest()[:16]}"
+            ),
             metadata={
                 "source_doc": item.get("source_doc", ""),
                 "source_file_id": item.get("source_file_id", ""),
@@ -915,7 +935,7 @@ Task = HTTP POST to RAG API. Judge evaluators = Langfuse UI managed.
 Only retrieval_recall is a code evaluator.
 
 Usage:
-    uv run python scripts/run_experiment.py --dataset rag-gold-set-v20260218 --name baseline
+    uv run python scripts/run_experiment.py --dataset rag-gold-set-v1 --name baseline
 """
 
 from __future__ import annotations
@@ -1028,22 +1048,33 @@ def main() -> None:
     parser.add_argument("--name", default=None, help="Experiment run name")
     parser.add_argument("--description", default="", help="Description")
     parser.add_argument("--concurrency", type=int, default=5)
+    parser.add_argument(
+        "--version",
+        default=None,
+        help="Dataset version timestamp in ISO 8601 UTC, e.g. 2026-02-18T12:00:00Z",
+    )
     args = parser.parse_args()
 
     from langfuse import get_client
 
     langfuse = get_client()
-    dataset = langfuse.get_dataset(name=args.dataset)
+    version_dt = None
+    if args.version:
+        version_dt = datetime.fromisoformat(args.version.replace("Z", "+00:00")).astimezone(UTC)
+
+    dataset = langfuse.get_dataset(name=args.dataset, version=version_dt)
     logger.info("Dataset '%s': %d items", args.dataset, len(dataset.items))
 
     run_name = args.name or f"exp-{datetime.now(UTC).strftime('%Y%m%d-%H%M%S')}"
 
     result = dataset.run_experiment(
-        name=run_name,
+        name="rag-gold-set-regression",
+        run_name=run_name,
         description=args.description or f"Experiment {run_name}",
         task=rag_task,
         evaluators=[retrieval_recall_eval],
         run_evaluators=[avg_scores_evaluator],
+        max_concurrency=args.concurrency,
         metadata={
             "model": os.getenv("LLM_MODEL", "gpt-4o-mini"),
             "collection": os.getenv("QDRANT_COLLECTION", "gdrive_documents_bge"),
@@ -1097,21 +1128,21 @@ eval-gold-gen-dry: ## Dry-run gold set generation (JSONL only, no Langfuse)
 
 eval-experiment: ## Run experiment on latest gold set dataset
 	@echo "$(BLUE)Running experiment on gold set...$(NC)"
-	uv run python scripts/run_experiment.py --dataset $(or $(DATASET),rag-gold-set-v20260218)
+	uv run python scripts/run_experiment.py --dataset $(DATASET)
 
 eval-experiment-named: ## Run named experiment (NAME=prompt-v2 make eval-experiment-named)
 	@echo "$(BLUE)Running experiment '$(NAME)'...$(NC)"
-	uv run python scripts/run_experiment.py --dataset $(or $(DATASET),rag-gold-set-v20260218) --name $(NAME)
+	uv run python scripts/run_experiment.py --dataset $(DATASET) --name $(NAME)
 ```
 
-**Step 2: Check `.gitignore` covers `data/`**
+**Step 2: Check `.gitignore` covers only generated gold-set artifacts**
 
 Run: `grep -n "^data" .gitignore || echo "NOT FOUND"`
 
-Если `data/` не в `.gitignore`, добавить:
+Добавить (если нет) именно этот паттерн:
 
 ```
-data/
+data/gold_set*.jsonl
 ```
 
 **Step 3: Verify make targets parse**
@@ -1145,10 +1176,11 @@ Run: `uv run ruff format tests/unit/test_generate_gold_set.py tests/unit/test_ru
 Run: `uv run pytest tests/unit/test_generate_gold_set.py tests/unit/test_run_experiment.py -v`
 Expected: All PASS
 
-**Step 4: Run full unit test suite (no regressions)**
+**Step 4: Run required repository gates (AGENTS minimum)**
 
-Run: `uv run pytest tests/unit/ -n auto --timeout=30 -q`
-Expected: All PASS, no regressions
+Run: `make check`
+Run: `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
+Expected: оба проходят
 
 **Step 5: Commit lint fixes if any**
 
@@ -1197,9 +1229,9 @@ Expected: 60-120 lines, valid JSON with `input.query`, `expected_output.answer`,
 
 ---
 
-## Task 10: Configure Langfuse UI managed evaluators
+## Task 10 (Optional): Configure Langfuse UI managed evaluators
 
-**No code.** Configure in Langfuse web UI (http://localhost:3001).
+**No code.** Опциональный слой после рабочего SDK/MVP-контура.
 
 **Step 1:** Open Langfuse UI → Settings → Evaluators
 
@@ -1211,9 +1243,9 @@ Expected: 60-120 lines, valid JSON with `input.query`, `expected_output.answer`,
 | `answer_relevance` | LLM-as-a-judge | gpt-4o-mini | ≥0.70 |
 | `context_relevance` | LLM-as-a-judge | gpt-4o-mini | ≥0.65 |
 
-Use prompts from `telegram_bot/evaluation/prompts.py` (FAITHFULNESS_PROMPT, ANSWER_RELEVANCE_PROMPT, CONTEXT_RELEVANCE_PROMPT) adapted for Langfuse evaluator template format.
+Use prompts from `telegram_bot/evaluation/prompts.py` (`FAITHFULNESS`, `ANSWER_RELEVANCE`, `CONTEXT_RELEVANCE`) adapted for Langfuse evaluator template format.
 
-These auto-run on experiment traces, scoring via the same prompts as `judges.py`.
+Использовать как дополнительный online-monitoring слой; gating в MVP остаётся на кодовых evaluators + thresholds из репозитория.
 
 **Step 3:** Verify — run `make eval-experiment` and check scores appear in Langfuse UI.
 
@@ -1232,5 +1264,5 @@ These auto-run on experiment traces, scoring via the same prompts as `judges.py`
 | 7 | Makefile | 15 lines | — |
 | 8 | Lint + tests | — | — |
 | 9 | Smoke test | — | — |
-| 10 | Langfuse UI evaluators | **0 lines** | Managed evaluators |
+| 10 (optional) | Langfuse UI evaluators | **0 lines** | Managed evaluators |
 | **Total** | | **~500 lines** (incl. tests) | |

--- a/scripts/generate_gold_set.py
+++ b/scripts/generate_gold_set.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Generate synthetic gold set from Qdrant for Langfuse experiments.
+
+Scrolls chunks from Qdrant, groups by document, generates Q&A via LLM,
+validates groundedness, uploads to Langfuse Dataset + JSONL backup.
+
+Usage:
+    uv run python scripts/generate_gold_set.py --collection gdrive_documents_bge
+    uv run python scripts/generate_gold_set.py --dry-run --output data/gold_set.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+DEFAULT_COLLECTION = "gdrive_documents_bge"
+DEFAULT_DATASET_PREFIX = "rag-gold-set"
+SCROLL_BATCH_SIZE = 100
+
+# ---------------------------------------------------------------------------
+# LLM prompts
+# ---------------------------------------------------------------------------
+
+GENERATION_PROMPT = """\
+Ты эксперт по недвижимости и иммиграции в Болгарии.
+
+Ниже — текст документа. Сгенерируй {n} вопросов, которые клиент
+реально задал бы в Telegram-чате на русском языке.
+
+Требования:
+- Вопросы разнообразные: фактические, сравнительные, практические
+- Ответ СТРОГО на основе текста, никаких выдуманных фактов
+- Сложность: easy (1 чанк), medium (2-3 чанка), hard (весь документ)
+- source_chunks: список chunk_location тех чанков, где есть ответ
+
+Доступные chunk_location: {chunk_locations}
+
+Верни ТОЛЬКО JSON массив:
+[{{"query": "вопрос", "answer": "ответ", "difficulty": "easy|medium|hard", \
+"type": "factual|comparative|practical", "source_chunks": ["seq_3"]}}]
+
+ТЕКСТ ДОКУМЕНТА:
+{document_text}"""
+
+GROUNDEDNESS_PROMPT = """\
+Проверь, полностью ли ответ основан на тексте документа.
+
+ТЕКСТ: {document_text}
+
+ВОПРОС: {query}
+ОТВЕТ: {answer}
+
+Верни ТОЛЬКО JSON: {{"grounded": true|false, "reasoning": "1-2 предложения"}}"""
+
+
+# ---------------------------------------------------------------------------
+# Qdrant scroll
+# ---------------------------------------------------------------------------
+
+
+async def scroll_collection(
+    client: Any, collection_name: str, batch_size: int = SCROLL_BATCH_SIZE
+) -> list[Any]:
+    """Scroll all points from Qdrant (no vectors, payload only)."""
+    all_points: list[Any] = []
+    offset = None
+    while True:
+        points, next_offset = await client.scroll(
+            collection_name=collection_name,
+            limit=batch_size,
+            offset=offset,
+            with_payload=True,
+            with_vectors=False,
+        )
+        all_points.extend(points)
+        if next_offset is None:
+            break
+        offset = next_offset
+    logger.info("Scrolled %d points from '%s'", len(all_points), collection_name)
+    return all_points
+
+
+# ---------------------------------------------------------------------------
+# Group & assemble
+# ---------------------------------------------------------------------------
+
+
+def group_by_document(points: list[Any]) -> dict[str, dict[str, Any]]:
+    """Group points by file_id, sort chunks by order."""
+    docs: dict[str, dict[str, Any]] = {}
+    for point in points:
+        payload = point.payload if hasattr(point, "payload") else point
+        meta = payload.get("metadata", {})
+        fid = meta.get("file_id", "unknown")
+        if fid not in docs:
+            docs[fid] = {
+                "source": meta.get("source", "unknown"),
+                "file_id": fid,
+                "chunks": [],
+            }
+        docs[fid]["chunks"].append(
+            {
+                "text": payload.get("page_content", ""),
+                "order": meta.get("order", 0),
+                "chunk_location": meta.get("chunk_location", ""),
+                "section": meta.get("section", ""),
+            }
+        )
+    for doc in docs.values():
+        doc["chunks"].sort(key=lambda c: c["order"])
+    return docs
+
+
+def assemble_document_text(doc: dict[str, Any]) -> str:
+    """Join chunk texts into full document."""
+    return "\n\n".join(c["text"] for c in doc["chunks"])
+
+
+def calculate_questions_count(chunk_count: int) -> int:
+    """Scale questions by document size: max(3, round(chunks/4))."""
+    return max(3, round(chunk_count / 4))
+
+
+# ---------------------------------------------------------------------------
+# LLM generation
+# ---------------------------------------------------------------------------
+
+
+async def generate_qa_for_document(
+    client: Any, model: str, doc: dict[str, Any], n_questions: int
+) -> list[dict[str, Any]]:
+    """Generate Q&A pairs for a single document via LLM."""
+    doc_text = assemble_document_text(doc)
+    chunk_locations = [c["chunk_location"] for c in doc["chunks"]]
+    prompt = GENERATION_PROMPT.format(
+        n=n_questions,
+        chunk_locations=json.dumps(chunk_locations),
+        document_text=doc_text[:15000],
+    )
+
+    try:
+        response = await client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.7,
+            max_tokens=4096,
+            response_format={"type": "json_object"},
+        )
+        content = response.choices[0].message.content or "[]"
+    except Exception:
+        logger.warning("LLM generation failed for '%s'", doc.get("source"), exc_info=True)
+        return []
+
+    try:
+        parsed = json.loads(content)
+        if isinstance(parsed, dict):
+            parsed = parsed.get("items", parsed.get("questions", []))
+        if not isinstance(parsed, list):
+            return []
+    except json.JSONDecodeError:
+        return []
+
+    items = []
+    for qa in parsed:
+        if not isinstance(qa, dict) or not qa.get("query") or not qa.get("answer"):
+            continue
+        items.append(
+            {
+                "query": qa["query"],
+                "answer": qa["answer"],
+                "difficulty": qa.get("difficulty", "medium"),
+                "type": qa.get("type", "factual"),
+                "source_chunks": qa.get("source_chunks", []),
+                "source_doc": doc.get("source", ""),
+                "source_file_id": doc.get("file_id", ""),
+            }
+        )
+    logger.info("Generated %d/%d Q&A for '%s'", len(items), n_questions, doc.get("source", "?"))
+    return items
+
+
+async def validate_groundedness(
+    client: Any, model: str, doc_text: str, items: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Filter items where answer is not grounded in document text."""
+    validated = []
+    for item in items:
+        prompt = GROUNDEDNESS_PROMPT.format(
+            document_text=doc_text[:10000], query=item["query"], answer=item["answer"]
+        )
+        try:
+            response = await client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0,
+                max_tokens=256,
+                response_format={"type": "json_object"},
+            )
+            result = json.loads(response.choices[0].message.content or "{}")
+            if result.get("grounded", False):
+                validated.append(item)
+            else:
+                logger.info(
+                    "Filtered: '%s' — %s",
+                    item["query"][:60],
+                    result.get("reasoning", ""),
+                )
+        except Exception:
+            validated.append(item)  # keep on error
+    logger.info("Groundedness: %d/%d passed", len(validated), len(items))
+    return validated
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+
+def export_to_jsonl(output_path: Path, items: list[dict[str, Any]]) -> None:
+    """Write items to JSONL file in Langfuse dataset format."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        f.writelines(
+            json.dumps(
+                {
+                    "input": {"query": item["query"]},
+                    "expected_output": {"answer": item["answer"]},
+                    "metadata": {
+                        "source_doc": item.get("source_doc", ""),
+                        "source_file_id": item.get("source_file_id", ""),
+                        "source_chunks": item.get("source_chunks", []),
+                        "difficulty": item.get("difficulty", ""),
+                        "type": item.get("type", ""),
+                    },
+                },
+                ensure_ascii=False,
+            )
+            + "\n"
+            for item in items
+        )
+    logger.info("Exported %d items to %s", len(items), output_path)
+
+
+def upload_to_langfuse(
+    langfuse: Any,
+    dataset_name: str,
+    items: list[dict[str, Any]],
+    model_name: str = "",
+) -> int:
+    """Upload items to Langfuse Dataset."""
+    if not items:
+        return 0
+    try:
+        langfuse.get_dataset(name=dataset_name)
+    except Exception:
+        langfuse.create_dataset(name=dataset_name)
+    for item in items:
+        langfuse.create_dataset_item(
+            dataset_name=dataset_name,
+            input={"query": item["query"]},
+            expected_output={"answer": item["answer"]},
+            id=(
+                f"{item.get('source_file_id', 'na')}::"
+                f"{hashlib.sha256(item['query'].encode()).hexdigest()[:16]}"
+            ),
+            metadata={
+                "source_doc": item.get("source_doc", ""),
+                "source_file_id": item.get("source_file_id", ""),
+                "source_chunks": item.get("source_chunks", []),
+                "difficulty": item.get("difficulty", ""),
+                "type": item.get("type", ""),
+                "generated_by": model_name,
+                "generated_at": datetime.now(UTC).isoformat(),
+            },
+        )
+    langfuse.flush()
+    logger.info("Uploaded %d items to Langfuse '%s'", len(items), dataset_name)
+    return len(items)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def make_dataset_name(prefix: str = DEFAULT_DATASET_PREFIX) -> str:
+    """Generate versioned dataset name."""
+    return f"{prefix}-v{datetime.now(UTC).strftime('%Y%m%d')}"
+
+
+async def run_pipeline(args: argparse.Namespace) -> None:
+    """Main pipeline: scroll → group → generate → validate → export."""
+    from openai import AsyncOpenAI
+    from qdrant_client import AsyncQdrantClient
+
+    qdrant_url = os.getenv("QDRANT_URL", "http://localhost:6333")
+    llm_url = os.getenv("LITELLM_BASE_URL", "http://localhost:4000")
+    llm_model = os.getenv("JUDGE_MODEL", "gpt-4o-mini")
+
+    qdrant = AsyncQdrantClient(url=qdrant_url)
+    points = await scroll_collection(qdrant, args.collection)
+    await qdrant.close()
+    if not points:
+        logger.error("No points in '%s'", args.collection)
+        sys.exit(1)
+
+    docs = group_by_document(points)
+    logger.info("Found %d documents (%d chunks)", len(docs), len(points))
+
+    llm = AsyncOpenAI(api_key="not-needed", base_url=llm_url)
+    all_items: list[dict[str, Any]] = []
+
+    for doc in docs.values():
+        n = args.questions_per_doc or calculate_questions_count(len(doc["chunks"]))
+        items = await generate_qa_for_document(llm, llm_model, doc, n)
+        if items:
+            items = await validate_groundedness(llm, llm_model, assemble_document_text(doc), items)
+        all_items.extend(items)
+
+    logger.info("Total: %d items from %d documents", len(all_items), len(docs))
+    if not all_items:
+        logger.error("No items generated")
+        sys.exit(1)
+
+    export_to_jsonl(Path(args.output), all_items)
+
+    if not args.dry_run:
+        from langfuse import Langfuse
+
+        lf = Langfuse()
+        dataset_name = args.dataset_name or make_dataset_name()
+        upload_to_langfuse(lf, dataset_name, all_items, model_name=llm_model)
+    else:
+        logger.info("DRY RUN: %d items → %s (no Langfuse upload)", len(all_items), args.output)
+
+
+def main() -> None:
+    """CLI entry point."""
+    load_dotenv()
+    parser = argparse.ArgumentParser(description="Generate gold set from Qdrant")
+    parser.add_argument("--collection", default=DEFAULT_COLLECTION)
+    parser.add_argument("--dataset-name", default=None)
+    parser.add_argument("--output", default="data/gold_set.jsonl")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--questions-per-doc", type=int, default=None)
+    args = parser.parse_args()
+    asyncio.run(run_pipeline(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Run Langfuse experiment on gold set — SDK-based.
+
+Task = HTTP POST to RAG API. Judge evaluators = Langfuse UI managed.
+Only retrieval_recall is a code evaluator.
+
+Usage:
+    uv run python scripts/run_experiment.py --dataset rag-gold-set-v1 --name baseline
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import subprocess
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+from dotenv import load_dotenv
+from langfuse import Evaluation
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Task: HTTP call to RAG API
+# ---------------------------------------------------------------------------
+
+
+def rag_task(*, item: Any, **kwargs: Any) -> dict[str, Any]:
+    """Call RAG API for each dataset item. Returns response + context."""
+    rag_api_url = os.getenv("RAG_API_URL", "http://localhost:8080")
+    query = item.input["query"] if hasattr(item, "input") else item["input"]["query"]
+
+    with httpx.Client(timeout=60.0) as client:
+        resp = client.post(
+            f"{rag_api_url}/query",
+            json={"query": query, "user_id": 0, "channel": "experiment"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+    return {
+        "response": data.get("response", ""),
+        "context": data.get("context", []),
+        "query_type": data.get("query_type", ""),
+        "cache_hit": data.get("cache_hit", False),
+        "documents_count": data.get("documents_count", 0),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Evaluators (only retrieval_recall in code; judges → Langfuse UI)
+# ---------------------------------------------------------------------------
+
+
+def retrieval_recall_eval(
+    *, input: dict, output: dict, expected_output: dict, metadata: dict, **kwargs: Any
+) -> Evaluation:
+    """Check if retrieval found the expected source_chunks."""
+    expected = set(metadata.get("source_chunks", []))
+    if not expected:
+        return Evaluation(name="retrieval_recall", value=1.0, comment="no expected chunks")
+
+    found = {
+        doc.get("chunk_location", "") for doc in output.get("context", []) if isinstance(doc, dict)
+    }
+    recall = len(expected & found) / len(expected)
+    return Evaluation(
+        name="retrieval_recall",
+        value=recall,
+        comment=f"{len(expected & found)}/{len(expected)}",
+    )
+
+
+def avg_scores_evaluator(*, item_results: list[Any], **kwargs: Any) -> Evaluation:
+    """Run-level: average retrieval_recall across all items."""
+    values = [
+        e.value
+        for r in item_results
+        for e in r.evaluations
+        if e.name == "retrieval_recall" and e.value is not None
+    ]
+    avg = sum(values) / len(values) if values else 0
+    return Evaluation(
+        name="composite_score",
+        value=round(avg, 3),
+        comment=f"avg of {len(values)} items",
+    )
+
+
+def _git_sha() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], text=True, timeout=5
+        ).strip()
+    except Exception:
+        return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """CLI entry point."""
+    load_dotenv()
+    parser = argparse.ArgumentParser(description="Run Langfuse experiment on gold set")
+    parser.add_argument("--dataset", required=True, help="Langfuse dataset name")
+    parser.add_argument("--name", default=None, help="Experiment run name")
+    parser.add_argument("--description", default="", help="Description")
+    parser.add_argument("--concurrency", type=int, default=5)
+    parser.add_argument(
+        "--version",
+        default=None,
+        help="Dataset version timestamp in ISO 8601 UTC, e.g. 2026-02-18T12:00:00Z",
+    )
+    args = parser.parse_args()
+
+    from langfuse import get_client
+
+    langfuse = get_client()
+    version_dt = None
+    if args.version:
+        version_dt = datetime.fromisoformat(args.version).astimezone(UTC)
+
+    dataset = langfuse.get_dataset(name=args.dataset, version=version_dt)
+    logger.info("Dataset '%s': %d items", args.dataset, len(dataset.items))
+
+    run_name = args.name or f"exp-{datetime.now(UTC).strftime('%Y%m%d-%H%M%S')}"
+
+    result = dataset.run_experiment(
+        name="rag-gold-set-regression",
+        run_name=run_name,
+        description=args.description or f"Experiment {run_name}",
+        task=rag_task,
+        evaluators=[retrieval_recall_eval],
+        run_evaluators=[avg_scores_evaluator],
+        max_concurrency=args.concurrency,
+        metadata={
+            "model": os.getenv("LLM_MODEL", "gpt-4o-mini"),
+            "collection": os.getenv("QDRANT_COLLECTION", "gdrive_documents_bge"),
+            "git_sha": _git_sha(),
+        },
+    )
+
+    print(result.format())
+    logger.info("Experiment '%s' complete", run_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -152,4 +152,5 @@ async def query(req: QueryRequest) -> QueryResponse:
         documents_count=result.get("search_results_count", 0),
         rerank_applied=result.get("rerank_applied", False),
         latency_ms=round(elapsed_ms, 1),
+        context=result.get("retrieved_context", []),
     )

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel, Field
 
 
@@ -26,7 +28,7 @@ class QueryResponse(BaseModel):
     documents_count: int = Field(default=0, description="Number of retrieved documents")
     rerank_applied: bool = Field(default=False, description="Whether reranking was applied")
     latency_ms: float = Field(default=0.0, description="Total pipeline latency in milliseconds")
-    context: list[dict] = Field(
+    context: list[dict[str, Any]] = Field(
         default_factory=list,
         description="Retrieved context documents (for evaluation)",
     )

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -26,3 +26,7 @@ class QueryResponse(BaseModel):
     documents_count: int = Field(default=0, description="Number of retrieved documents")
     rerank_applied: bool = Field(default=False, description="Whether reranking was applied")
     latency_ms: float = Field(default=0.0, description="Total pipeline latency in milliseconds")
+    context: list[dict] = Field(
+        default_factory=list,
+        description="Retrieved context documents (for evaluation)",
+    )

--- a/telegram_bot/graph/nodes/retrieve.py
+++ b/telegram_bot/graph/nodes/retrieve.py
@@ -31,10 +31,12 @@ def _build_retrieved_context(
         if not isinstance(doc, dict):
             continue
         text = doc.get("text", "")
+        meta = doc.get("metadata", {})
         ctx.append(
             {
                 "content": text[:_MAX_CONTEXT_SNIPPET],
                 "score": doc.get("score", 0),
+                "chunk_location": meta.get("chunk_location", ""),
             }
         )
     return ctx

--- a/tests/baseline/thresholds.yaml
+++ b/tests/baseline/thresholds.yaml
@@ -44,3 +44,11 @@ judge:
   faithfulness_mean_gte: 0.75
   answer_relevance_mean_gte: 0.70
   context_relevance_mean_gte: 0.65
+
+# Experiment quality thresholds (run_experiment evaluators)
+experiment:
+  faithfulness_mean_gte: 0.75
+  answer_relevance_mean_gte: 0.70
+  context_relevance_mean_gte: 0.65
+  retrieval_recall_mean_gte: 0.60
+  composite_score_gte: 0.65

--- a/tests/unit/api/test_rag_api.py
+++ b/tests/unit/api/test_rag_api.py
@@ -75,3 +75,17 @@ class TestQueryResponse:
     def test_response_required(self):
         with pytest.raises(ValidationError):
             QueryResponse()  # type: ignore[call-arg]
+
+
+class TestQueryResponseContext:
+    """Test that QueryResponse includes retrieved context."""
+
+    def test_context_field_default_empty(self):
+        resp = QueryResponse(response="answer")
+        assert resp.context == []
+
+    def test_context_field_with_data(self):
+        ctx = [{"content": "text", "score": 0.5, "chunk_location": "seq_3"}]
+        resp = QueryResponse(response="answer", context=ctx)
+        assert len(resp.context) == 1
+        assert resp.context[0]["chunk_location"] == "seq_3"

--- a/tests/unit/test_generate_gold_set.py
+++ b/tests/unit/test_generate_gold_set.py
@@ -155,6 +155,26 @@ class TestUploadToLangfuse:
         mock_lf.create_dataset.assert_called_once_with(name="test-ds")
         mock_lf.create_dataset_item.assert_called_once()
 
+    def test_reuses_existing_dataset(self):
+        from scripts.generate_gold_set import upload_to_langfuse
+
+        mock_lf = MagicMock()
+        mock_lf.get_dataset.return_value = MagicMock()  # dataset exists
+        items = [
+            {
+                "query": "q?",
+                "answer": "a",
+                "source_doc": "d",
+                "source_file_id": "f1",
+                "source_chunks": ["seq_0"],
+                "difficulty": "easy",
+                "type": "factual",
+            },
+        ]
+        count = upload_to_langfuse(mock_lf, "test-ds", items)
+        assert count == 1
+        mock_lf.create_dataset.assert_not_called()
+
     def test_empty_items(self):
         from scripts.generate_gold_set import upload_to_langfuse
 

--- a/tests/unit/test_generate_gold_set.py
+++ b/tests/unit/test_generate_gold_set.py
@@ -1,0 +1,172 @@
+"""Tests for gold set generator."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _make_point(file_id: str, order: int, text: str, source: str = "doc.md") -> SimpleNamespace:
+    """Create a mock Qdrant point with payload."""
+    return SimpleNamespace(
+        payload={
+            "page_content": text,
+            "metadata": {
+                "file_id": file_id,
+                "order": order,
+                "source": source,
+                "chunk_location": f"seq_{order}",
+                "file_name": source,
+                "section": "",
+            },
+        },
+    )
+
+
+class TestScrollCollection:
+    async def test_returns_all_points(self):
+        from scripts.generate_gold_set import scroll_collection
+
+        mock_client = AsyncMock()
+        mock_client.scroll.return_value = (
+            [_make_point("f1", 0, "text1"), _make_point("f1", 1, "text2")],
+            None,
+        )
+        points = await scroll_collection(mock_client, "test_col")
+        assert len(points) == 2
+
+    async def test_pagination(self):
+        from scripts.generate_gold_set import scroll_collection
+
+        mock_client = AsyncMock()
+        mock_client.scroll.side_effect = [
+            ([_make_point("f1", 0, "t1")], "offset2"),
+            ([_make_point("f1", 1, "t2")], None),
+        ]
+        points = await scroll_collection(mock_client, "test_col", batch_size=1)
+        assert len(points) == 2
+        assert mock_client.scroll.call_count == 2
+
+
+class TestGroupByDocument:
+    def test_groups_and_sorts(self):
+        from scripts.generate_gold_set import group_by_document
+
+        points = [
+            _make_point("f1", 2, "C"),
+            _make_point("f1", 0, "A"),
+            _make_point("f2", 0, "X"),
+            _make_point("f1", 1, "B"),
+        ]
+        docs = group_by_document(points)
+        assert len(docs) == 2
+        assert [c["text"] for c in docs["f1"]["chunks"]] == ["A", "B", "C"]
+
+    def test_single_document(self):
+        from scripts.generate_gold_set import group_by_document
+
+        points = [_make_point("f1", 0, "only")]
+        docs = group_by_document(points)
+        assert len(docs) == 1
+        assert docs["f1"]["chunks"][0]["text"] == "only"
+
+
+class TestCalculateQuestionsCount:
+    @pytest.mark.parametrize(
+        ("chunks", "expected_min"),
+        [(1, 3), (6, 3), (12, 3), (20, 5), (44, 11), (82, 20)],
+    )
+    def test_formula_min_3(self, chunks: int, expected_min: int):
+        from scripts.generate_gold_set import calculate_questions_count
+
+        result = calculate_questions_count(chunks)
+        assert result >= 3
+        assert result >= expected_min
+
+
+class TestExportToJsonl:
+    def test_writes_valid_jsonl(self, tmp_path: Path):
+        from scripts.generate_gold_set import export_to_jsonl
+
+        items = [
+            {
+                "query": "Вопрос?",
+                "answer": "Ответ",
+                "source_doc": "doc.md",
+                "source_file_id": "f1",
+                "source_chunks": ["seq_0"],
+                "difficulty": "easy",
+                "type": "factual",
+            },
+        ]
+        out = tmp_path / "gold.jsonl"
+        export_to_jsonl(out, items)
+
+        lines = out.read_text().strip().split("\n")
+        assert len(lines) == 1
+        data = json.loads(lines[0])
+        assert data["input"]["query"] == "Вопрос?"
+        assert data["expected_output"]["answer"] == "Ответ"
+        assert data["metadata"]["source_chunks"] == ["seq_0"]
+
+    def test_multiple_items(self, tmp_path: Path):
+        from scripts.generate_gold_set import export_to_jsonl
+
+        items = [
+            {
+                "query": f"q{i}",
+                "answer": f"a{i}",
+                "source_doc": "d",
+                "source_file_id": "f",
+                "source_chunks": [],
+                "difficulty": "easy",
+                "type": "factual",
+            }
+            for i in range(3)
+        ]
+        out = tmp_path / "gold.jsonl"
+        export_to_jsonl(out, items)
+        assert len(out.read_text().strip().split("\n")) == 3
+
+
+class TestUploadToLangfuse:
+    def test_creates_dataset_and_items(self):
+        from scripts.generate_gold_set import upload_to_langfuse
+
+        mock_lf = MagicMock()
+        mock_lf.get_dataset.side_effect = Exception("not found")
+        items = [
+            {
+                "query": "q?",
+                "answer": "a",
+                "source_doc": "d",
+                "source_file_id": "f1",
+                "source_chunks": ["seq_0"],
+                "difficulty": "easy",
+                "type": "factual",
+            },
+        ]
+        count = upload_to_langfuse(mock_lf, "test-ds", items)
+        assert count == 1
+        mock_lf.create_dataset.assert_called_once_with(name="test-ds")
+        mock_lf.create_dataset_item.assert_called_once()
+
+    def test_empty_items(self):
+        from scripts.generate_gold_set import upload_to_langfuse
+
+        mock_lf = MagicMock()
+        count = upload_to_langfuse(mock_lf, "test-ds", [])
+        assert count == 0
+
+
+class TestAssembleDocumentText:
+    def test_joins_chunks(self):
+        from scripts.generate_gold_set import assemble_document_text
+
+        doc = {"chunks": [{"text": "A"}, {"text": "B"}, {"text": "C"}]}
+        result = assemble_document_text(doc)
+        assert result == "A\n\nB\n\nC"

--- a/tests/unit/test_run_experiment.py
+++ b/tests/unit/test_run_experiment.py
@@ -1,0 +1,94 @@
+"""Tests for experiment runner evaluators."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+class TestRetrievalRecallEval:
+    def test_full_recall(self):
+        from scripts.run_experiment import retrieval_recall_eval
+
+        result = retrieval_recall_eval(
+            input={"query": "q"},
+            output={
+                "response": "a",
+                "context": [
+                    {"chunk_location": "seq_0", "content": "t", "score": 0.5},
+                    {"chunk_location": "seq_1", "content": "t", "score": 0.4},
+                ],
+            },
+            expected_output={"answer": "a"},
+            metadata={"source_chunks": ["seq_0", "seq_1"]},
+        )
+        assert result.value == 1.0
+        assert result.name == "retrieval_recall"
+
+    def test_partial_recall(self):
+        from scripts.run_experiment import retrieval_recall_eval
+
+        result = retrieval_recall_eval(
+            input={"query": "q"},
+            output={
+                "response": "a",
+                "context": [{"chunk_location": "seq_0", "content": "t", "score": 0.5}],
+            },
+            expected_output={"answer": "a"},
+            metadata={"source_chunks": ["seq_0", "seq_1"]},
+        )
+        assert result.value == 0.5
+
+    def test_zero_recall(self):
+        from scripts.run_experiment import retrieval_recall_eval
+
+        result = retrieval_recall_eval(
+            input={"query": "q"},
+            output={"response": "a", "context": [{"chunk_location": "seq_99"}]},
+            expected_output={"answer": "a"},
+            metadata={"source_chunks": ["seq_0", "seq_1"]},
+        )
+        assert result.value == 0.0
+
+    def test_no_expected_chunks(self):
+        from scripts.run_experiment import retrieval_recall_eval
+
+        result = retrieval_recall_eval(
+            input={"query": "q"},
+            output={"response": "a", "context": []},
+            expected_output={"answer": "a"},
+            metadata={},
+        )
+        assert result.value == 1.0
+
+
+class TestAvgScoresEvaluator:
+    def test_computes_average(self):
+        from scripts.run_experiment import avg_scores_evaluator
+
+        item_results = [
+            SimpleNamespace(evaluations=[SimpleNamespace(name="retrieval_recall", value=1.0)]),
+            SimpleNamespace(evaluations=[SimpleNamespace(name="retrieval_recall", value=0.5)]),
+        ]
+        result = avg_scores_evaluator(item_results=item_results)
+        assert result.name == "composite_score"
+        assert result.value == 0.75
+
+    def test_empty_results(self):
+        from scripts.run_experiment import avg_scores_evaluator
+
+        result = avg_scores_evaluator(item_results=[])
+        assert result.value == 0
+
+    def test_ignores_other_metrics(self):
+        from scripts.run_experiment import avg_scores_evaluator
+
+        item_results = [
+            SimpleNamespace(
+                evaluations=[
+                    SimpleNamespace(name="retrieval_recall", value=0.8),
+                    SimpleNamespace(name="other_metric", value=0.1),
+                ]
+            ),
+        ]
+        result = avg_scores_evaluator(item_results=item_results)
+        assert result.value == 0.8


### PR DESCRIPTION
## Summary
- Add `QueryResponse.context` field to RAG API for experiment evaluation (chunk_location passthrough)
- Add gold set generator (`scripts/generate_gold_set.py`): Qdrant scroll → LLM Q&A gen → groundedness validation → Langfuse Dataset + JSONL backup
- Add SDK experiment runner (`scripts/run_experiment.py`): HTTP task → `retrieval_recall` evaluator → `composite_score` run-level aggregate
- Add experiment quality thresholds in `tests/baseline/thresholds.yaml`
- Add Makefile targets: `eval-gold-gen`, `eval-gold-gen-dry`, `eval-sdk-experiment`, `eval-sdk-experiment-named`
- 33 new unit tests (16 gold set + 7 runner + 10 API schema tests)

## Test plan
- [x] 33/33 new tests pass
- [x] 2386 existing unit tests pass (0 failures)
- [x] `make check` passes (ruff + mypy)
- [x] Pre-commit hooks pass on all commits
- [ ] Smoke test: `make eval-gold-gen-dry` with Docker services (requires Qdrant + LiteLLM)
- [ ] Full experiment: `DATASET=rag-gold-set-v1 make eval-sdk-experiment` with RAG API running

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)