### PR TITLE
feat(crm): internal lead scoring in Postgres with Kommo sync (#384)

### DIFF
--- a/docker/postgres/init/06-lead-scoring-sync.sql
+++ b/docker/postgres/init/06-lead-scoring-sync.sql
@@ -1,0 +1,37 @@
+-- Lead Scoring + Kommo CRM Sync State (#384)
+-- Depends on: 05-realestate-schema.sql (leads table)
+
+\c realestate;
+
+CREATE TABLE IF NOT EXISTS lead_scores (
+    id BIGSERIAL PRIMARY KEY,
+    lead_id BIGINT NOT NULL REFERENCES leads(id) ON DELETE CASCADE,
+    user_id BIGINT NOT NULL,
+    session_id TEXT NOT NULL,
+    -- score_value: rule-based 0-100 now; ML model probability * 100 in v2
+    score_value INTEGER NOT NULL CHECK (score_value BETWEEN 0 AND 100),
+    score_band TEXT NOT NULL CHECK (score_band IN ('hot', 'warm', 'cold')),
+    -- reason_codes: rule-based codes now; SHAP feature importances in ML v2
+    reason_codes JSONB NOT NULL DEFAULT '[]'::jsonb,
+    kommo_lead_id BIGINT,
+    sync_status TEXT NOT NULL DEFAULT 'pending' CHECK (sync_status IN ('pending', 'synced', 'failed')),
+    sync_attempts INTEGER NOT NULL DEFAULT 0,
+    last_synced_at TIMESTAMPTZ,
+    sync_error TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (lead_id)
+);
+
+CREATE TABLE IF NOT EXISTS lead_score_sync_audit (
+    id BIGSERIAL PRIMARY KEY,
+    lead_score_id BIGINT NOT NULL REFERENCES lead_scores(id) ON DELETE CASCADE,
+    idempotency_key TEXT NOT NULL,
+    sync_status TEXT NOT NULL,
+    http_status INTEGER,
+    response_excerpt TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_lead_scores_pending_sync
+    ON lead_scores (sync_status, updated_at DESC);

--- a/telegram_bot/agents/tools.py
+++ b/telegram_bot/agents/tools.py
@@ -143,6 +143,61 @@ def build_tools_for_role(
     return tools
 
 
+def create_crm_score_sync_tool(
+    *,
+    scoring_store: Any,
+    kommo_client: Any,
+    score_field_id: int,
+    band_field_id: int,
+) -> Any:
+    """Create crm_sync_lead_score tool for supervisor (#384)."""
+
+    @tool
+    @observe(name="tool-crm-sync-lead-score")
+    async def crm_sync_lead_score(query: str, config: RunnableConfig) -> str:
+        """Sync pending lead scores to Kommo CRM.
+
+        Use this tool to push scored leads to the CRM system.
+        Handles retries and idempotency automatically.
+        """
+        user_id, session_id = _get_user_context(config)
+        pending = await scoring_store.list_pending_sync(limit=20)
+        synced = 0
+        failed = 0
+        skipped = 0
+
+        for rec in pending:
+            if rec.kommo_lead_id is None:
+                skipped += 1
+                continue
+            key = f"lead-score:{rec.lead_id}:{rec.session_id}:{rec.score_value}"
+            payload = {
+                "custom_fields_values": [
+                    {"field_id": score_field_id, "values": [{"value": rec.score_value}]},
+                    {"field_id": band_field_id, "values": [{"value": rec.score_band}]},
+                ]
+            }
+            try:
+                await kommo_client.update_lead_score(
+                    lead_id=rec.kommo_lead_id,
+                    payload=payload,
+                    idempotency_key=key,
+                )
+                await scoring_store.mark_synced(lead_id=rec.lead_id)
+                synced += 1
+            except Exception:
+                logger.exception("CRM score sync failed for lead %s", rec.lead_id)
+                await scoring_store.mark_failed(lead_id=rec.lead_id, error="kommo_error")
+                failed += 1
+
+        return (
+            f"CRM score sync completed: synced {synced}, failed {failed}, "
+            f"skipped {skipped} (user {user_id}, session {session_id})"
+        )
+
+    return crm_sync_lead_score
+
+
 @tool
 @observe(name="tool-direct-response")
 async def direct_response(message: str) -> str:

--- a/telegram_bot/agents/tools.py
+++ b/telegram_bot/agents/tools.py
@@ -14,6 +14,7 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 
 from telegram_bot.observability import observe
+from telegram_bot.services.kommo_models import LeadScoreSyncPayload
 
 
 logger = logging.getLogger(__name__)
@@ -170,13 +171,12 @@ def create_crm_score_sync_tool(
             if rec.kommo_lead_id is None:
                 skipped += 1
                 continue
-            key = f"lead-score:{rec.lead_id}:{rec.session_id}:{rec.score_value}"
-            payload = {
-                "custom_fields_values": [
-                    {"field_id": score_field_id, "values": [{"value": rec.score_value}]},
-                    {"field_id": band_field_id, "values": [{"value": rec.score_band}]},
-                ]
-            }
+            key = f"lead-score:{rec.lead_id}:{rec.session_id}:{rec.score_value}:{rec.score_band}"
+            payload = LeadScoreSyncPayload.from_record(
+                rec,
+                score_field_id=score_field_id,
+                band_field_id=band_field_id,
+            ).to_kommo_payload()
             try:
                 await kommo_client.update_lead_score(
                     lead_id=rec.kommo_lead_id,

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -229,6 +229,9 @@ class PropertyBot:
         # Kommo CRM client (initialized in start() if enabled)
         self._kommo_client: Any | None = None
 
+        # Lead scoring store (initialized in start() with pg_pool)
+        self._lead_scoring_store: Any | None = None
+
         # Track initialization state
         self._cache_initialized = False
 
@@ -558,7 +561,12 @@ class PropertyBot:
         """Handle query via supervisor graph (#240, #310 — primary query path)."""
         from .agents.manager_tools import create_manager_tools
         from .agents.rag_agent import create_rag_agent
-        from .agents.tools import build_tools_for_role, create_history_search_tool, direct_response
+        from .agents.tools import (
+            build_tools_for_role,
+            create_crm_score_sync_tool,
+            create_history_search_tool,
+            direct_response,
+        )
         from .graph.supervisor_state import make_supervisor_state
 
         assert message.bot is not None
@@ -612,6 +620,22 @@ class PropertyBot:
                     responsible_user_id=self.config.kommo_responsible_user_id,
                     session_field_id=self.config.kommo_session_field_id,
                     idempotency_store=self._cache.redis,
+                )
+            )
+
+        # Lead score sync tool (#384) — available when scoring store is initialized
+        _scoring_store = getattr(self, "_lead_scoring_store", None)
+        if (
+            self.config.kommo_enabled
+            and self._kommo_client is not None
+            and _scoring_store is not None
+        ):
+            tools.append(
+                create_crm_score_sync_tool(
+                    scoring_store=_scoring_store,
+                    kommo_client=self._kommo_client,
+                    score_field_id=self.config.kommo_lead_score_field_id,
+                    band_field_id=self.config.kommo_lead_band_field_id,
                 )
             )
 
@@ -1033,6 +1057,12 @@ class PropertyBot:
             from .services.user_service import UserService
 
             self._user_service = UserService(pool=self._pg_pool)
+
+            # Initialize lead scoring store (#384)
+            from .services.lead_scoring_store import LeadScoringStore
+
+            self._lead_scoring_store = LeadScoringStore(pool=self._pg_pool)
+            logger.info("Lead scoring store ready")
         except Exception:
             logger.warning("PostgreSQL pool init failed, user features disabled", exc_info=True)
 

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -626,9 +626,12 @@ class PropertyBot:
         # Lead score sync tool (#384) — available when scoring store is initialized
         _scoring_store = getattr(self, "_lead_scoring_store", None)
         if (
-            self.config.kommo_enabled
+            role == "manager"
+            and self.config.kommo_enabled
             and self._kommo_client is not None
             and _scoring_store is not None
+            and self.config.kommo_lead_score_field_id > 0
+            and self.config.kommo_lead_band_field_id > 0
         ):
             tools.append(
                 create_crm_score_sync_tool(

--- a/telegram_bot/config.py
+++ b/telegram_bot/config.py
@@ -372,6 +372,14 @@ class BotConfig(BaseSettings):
         default=0,
         validation_alias=AliasChoices("kommo_session_field_id", "KOMMO_SESSION_FIELD_ID"),
     )
+    kommo_lead_score_field_id: int = Field(
+        default=0,
+        validation_alias=AliasChoices("kommo_lead_score_field_id", "KOMMO_LEAD_SCORE_FIELD_ID"),
+    )
+    kommo_lead_band_field_id: int = Field(
+        default=0,
+        validation_alias=AliasChoices("kommo_lead_band_field_id", "KOMMO_LEAD_BAND_FIELD_ID"),
+    )
 
     # Call limits (#374)
     max_llm_calls: int = Field(

--- a/telegram_bot/services/__init__.py
+++ b/telegram_bot/services/__init__.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from .bge_m3_client import BGEM3Client, BGEM3SyncClient
     from .colbert_reranker import ColbertRerankerService
     from .history_service import HistoryService
+    from .lead_scoring_store import LeadScoringStore
     from .llm import LOW_CONFIDENCE_THRESHOLD, ConfidenceResult, LLMService
     from .metrics import PipelineMetrics
     from .qdrant import QdrantService
@@ -38,6 +39,7 @@ __all__ = [
     "HistoryService",
     "HyDEGenerator",
     "LLMService",
+    "LeadScoringStore",
     "PipelineMetrics",
     "QdrantService",
     "QueryAnalyzer",
@@ -60,6 +62,7 @@ _IMPORT_MAP = {
     "ExpandedChunk": ".small_to_big",
     "HistoryService": ".history_service",
     "HyDEGenerator": ".query_preprocessor",
+    "LeadScoringStore": ".lead_scoring_store",
     "SessionSummary": ".session_summary",
     "check_responses_parse_compat": ".session_summary",
     "LLMService": ".llm",

--- a/telegram_bot/services/kommo_client.py
+++ b/telegram_bot/services/kommo_client.py
@@ -71,7 +71,8 @@ class KommoClient:
     async def _request(self, method: str, path: str, **kwargs: Any) -> dict:
         """Execute authenticated request with auto-refresh on 401."""
         token = await self._token_store.get_valid_token()
-        headers = {"Authorization": f"Bearer {token}"}
+        extra_headers = kwargs.pop("headers", None) or {}
+        headers = {"Authorization": f"Bearer {token}", **extra_headers}
         response = await self._client.request(method, path, headers=headers, **kwargs)
 
         # Retry once on 401 with refreshed token
@@ -146,6 +147,21 @@ class KommoClient:
         resp = await self._request("POST", "/tasks", json=[payload])
         t = resp["_embedded"]["tasks"][0]
         return TaskResponse(id=t["id"], text=task.text)
+
+    # --- Lead Scores (#384) ---
+
+    async def update_lead_score(self, *, lead_id: int, payload: dict, idempotency_key: str) -> dict:
+        """PATCH /leads/{id} — update lead custom fields with score data.
+
+        Idempotency key prevents duplicate writes on retries.
+        Retries are handled by _request's existing retry policy.
+        """
+        return await self._request(
+            "PATCH",
+            f"/leads/{lead_id}",
+            json=payload,
+            headers={"X-Idempotency-Key": idempotency_key},
+        )
 
     # --- Lifecycle ---
 

--- a/telegram_bot/services/kommo_client.py
+++ b/telegram_bot/services/kommo_client.py
@@ -31,7 +31,7 @@ from telegram_bot.services.kommo_models import (
 
 if TYPE_CHECKING:
     from telegram_bot.services.kommo_models import ContactCreate
-    from telegram_bot.services.kommo_tokens import KommoTokenStore
+    from telegram_bot.services.kommo_tokens import KommoTokenStoreProtocol
 
 
 logger = logging.getLogger(__name__)
@@ -57,7 +57,7 @@ _kommo_retry = retry(
 class KommoClient:
     """Async Kommo CRM API client."""
 
-    def __init__(self, subdomain: str, token_store: KommoTokenStore) -> None:
+    def __init__(self, subdomain: str, token_store: KommoTokenStoreProtocol) -> None:
         self._base_url = f"https://{subdomain}.kommo.com/api/v4"
         self._token_store = token_store
         self._client = httpx.AsyncClient(

--- a/telegram_bot/services/kommo_models.py
+++ b/telegram_bot/services/kommo_models.py
@@ -148,3 +148,42 @@ class NoteResponse(BaseModel):
     """Kommo note from API response."""
 
     id: int
+
+
+# --- Lead Score Sync (#384) ---
+
+
+class LeadScoreSyncPayload(BaseModel):
+    """Payload for syncing a lead score to Kommo custom fields."""
+
+    kommo_lead_id: int
+    score_value: int
+    score_band: str
+    score_field_id: int
+    band_field_id: int
+
+    @classmethod
+    def from_record(
+        cls,
+        rec: object,
+        *,
+        score_field_id: int,
+        band_field_id: int,
+    ) -> LeadScoreSyncPayload:
+        """Build from a LeadScoreRecord (avoids circular import)."""
+        return cls(
+            kommo_lead_id=int(getattr(rec, "kommo_lead_id", 0) or 0),
+            score_value=getattr(rec, "score_value", 0),
+            score_band=getattr(rec, "score_band", ""),
+            score_field_id=score_field_id,
+            band_field_id=band_field_id,
+        )
+
+    def to_kommo_payload(self) -> dict:
+        """Convert to Kommo API PATCH body for custom fields."""
+        return {
+            "custom_fields_values": [
+                {"field_id": self.score_field_id, "values": [{"value": self.score_value}]},
+                {"field_id": self.band_field_id, "values": [{"value": self.score_band}]},
+            ]
+        }

--- a/telegram_bot/services/kommo_tokens.py
+++ b/telegram_bot/services/kommo_tokens.py
@@ -8,12 +8,22 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Any, cast
+from typing import Any, Protocol, cast, runtime_checkable
 
 import httpx
 
 
 logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class KommoTokenStoreProtocol(Protocol):
+    """Abstract token store contract for future Postgres migration (#384)."""
+
+    async def get_valid_token(self) -> str: ...
+
+    async def force_refresh(self) -> str: ...
+
 
 REDIS_KEY = "kommo:oauth:tokens"
 REFRESH_BUFFER_SEC = 300  # refresh 5 min before expiry

--- a/telegram_bot/services/lead_scoring_models.py
+++ b/telegram_bot/services/lead_scoring_models.py
@@ -1,0 +1,17 @@
+"""Pydantic models for lead scoring persistence (#384)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class LeadScoreRecord(BaseModel):
+    """A scored lead ready for persistence and CRM sync."""
+
+    lead_id: int
+    user_id: int
+    session_id: str
+    score_value: int = Field(ge=0, le=100)
+    score_band: str
+    reason_codes: list[str] = Field(default_factory=list)
+    kommo_lead_id: int | None = None

--- a/telegram_bot/services/lead_scoring_store.py
+++ b/telegram_bot/services/lead_scoring_store.py
@@ -1,0 +1,107 @@
+"""Postgres store for lead scoring persistence and sync queue (#384).
+
+Pool callers should configure command_timeout=30 to prevent runaway queries.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from telegram_bot.services.lead_scoring_models import LeadScoreRecord
+
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+class LeadScoringStore:
+    """Upsert scores and manage the pending-sync queue."""
+
+    def __init__(self, *, pool: Any) -> None:
+        self._pool = pool
+
+    async def upsert_score(self, rec: LeadScoreRecord) -> None:
+        """Insert or update a lead score (resets sync_status to pending)."""
+        await self._pool.execute(
+            """
+            INSERT INTO lead_scores
+                (lead_id, user_id, session_id, score_value, score_band,
+                 reason_codes, kommo_lead_id)
+            VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7)
+            ON CONFLICT (lead_id) DO UPDATE SET
+                score_value = EXCLUDED.score_value,
+                score_band = EXCLUDED.score_band,
+                reason_codes = EXCLUDED.reason_codes,
+                kommo_lead_id = EXCLUDED.kommo_lead_id,
+                sync_status = 'pending',
+                updated_at = now();
+            """,
+            rec.lead_id,
+            rec.user_id,
+            rec.session_id,
+            rec.score_value,
+            rec.score_band,
+            json.dumps(rec.reason_codes),
+            rec.kommo_lead_id,
+        )
+
+    async def list_pending_sync(self, *, limit: int) -> list[LeadScoreRecord]:
+        """Return up to *limit* scores awaiting Kommo sync."""
+        rows = await self._pool.fetch(
+            """
+            SELECT lead_id, user_id, session_id, score_value, score_band,
+                   reason_codes, kommo_lead_id
+            FROM lead_scores
+            WHERE sync_status = 'pending'
+            ORDER BY updated_at ASC
+            LIMIT $1
+            """,
+            limit,
+        )
+        results: list[LeadScoreRecord] = []
+        for r in rows:
+            raw_codes = r["reason_codes"]
+            if isinstance(raw_codes, str):
+                raw_codes = json.loads(raw_codes)
+            results.append(
+                LeadScoreRecord(
+                    lead_id=r["lead_id"],
+                    user_id=r["user_id"],
+                    session_id=r["session_id"],
+                    score_value=r["score_value"],
+                    score_band=r["score_band"],
+                    reason_codes=raw_codes,
+                    kommo_lead_id=r["kommo_lead_id"],
+                )
+            )
+        return results
+
+    async def mark_synced(self, *, lead_id: int) -> None:
+        """Mark a score as successfully synced to Kommo."""
+        await self._pool.execute(
+            """
+            UPDATE lead_scores
+            SET sync_status = 'synced', last_synced_at = now(), updated_at = now()
+            WHERE lead_id = $1;
+            """,
+            lead_id,
+        )
+
+    async def mark_failed(self, *, lead_id: int, error: str) -> None:
+        """Mark a score sync as failed."""
+        await self._pool.execute(
+            """
+            UPDATE lead_scores
+            SET sync_status = 'failed',
+                sync_attempts = sync_attempts + 1,
+                sync_error = $2,
+                updated_at = now()
+            WHERE lead_id = $1;
+            """,
+            lead_id,
+            error,
+        )

--- a/tests/unit/agents/test_lead_score_sync_tool.py
+++ b/tests/unit/agents/test_lead_score_sync_tool.py
@@ -127,4 +127,4 @@ class TestCrmSyncLeadScoreTool:
 
         call_kwargs = mock_kommo_client.update_lead_score.call_args[1]
         key = call_kwargs["idempotency_key"]
-        assert key == "lead-score:11:chat-1:74"
+        assert key == "lead-score:11:chat-1:74:hot"

--- a/tests/unit/agents/test_lead_score_sync_tool.py
+++ b/tests/unit/agents/test_lead_score_sync_tool.py
@@ -1,0 +1,130 @@
+"""Tests for crm_sync_lead_score supervisor tool (#384)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from telegram_bot.services.lead_scoring_models import LeadScoreRecord
+
+
+@pytest.fixture
+def mock_scoring_store():
+    store = AsyncMock()
+    store.list_pending_sync = AsyncMock(
+        return_value=[
+            LeadScoreRecord(
+                lead_id=11,
+                user_id=99,
+                session_id="chat-1",
+                score_value=74,
+                score_band="hot",
+                reason_codes=["timeline_asap"],
+                kommo_lead_id=5001,
+            ),
+        ]
+    )
+    store.mark_synced = AsyncMock()
+    store.mark_failed = AsyncMock()
+    return store
+
+
+@pytest.fixture
+def mock_kommo_client():
+    client = AsyncMock()
+    client.update_lead_score = AsyncMock(return_value={"id": 5001})
+    return client
+
+
+@pytest.fixture
+def mock_kommo_client_error():
+    client = AsyncMock()
+    client.update_lead_score = AsyncMock(side_effect=RuntimeError("kommo outage"))
+    return client
+
+
+@pytest.fixture
+def runnable_config():
+    return {"configurable": {"user_id": 99, "session_id": "chat-1"}}
+
+
+class TestCrmSyncLeadScoreTool:
+    async def test_syncs_pending_scores(
+        self, mock_scoring_store, mock_kommo_client, runnable_config
+    ):
+        from telegram_bot.agents.tools import create_crm_score_sync_tool
+
+        tool = create_crm_score_sync_tool(
+            scoring_store=mock_scoring_store,
+            kommo_client=mock_kommo_client,
+            score_field_id=701,
+            band_field_id=702,
+        )
+        result = await tool.ainvoke({"query": "sync scores"}, config=runnable_config)
+
+        assert "synced 1" in result.lower() or "completed" in result.lower()
+        mock_kommo_client.update_lead_score.assert_called_once()
+        mock_scoring_store.mark_synced.assert_called_once_with(lead_id=11)
+
+    async def test_fail_soft_on_kommo_error(
+        self, mock_scoring_store, mock_kommo_client_error, runnable_config
+    ):
+        from telegram_bot.agents.tools import create_crm_score_sync_tool
+
+        tool = create_crm_score_sync_tool(
+            scoring_store=mock_scoring_store,
+            kommo_client=mock_kommo_client_error,
+            score_field_id=701,
+            band_field_id=702,
+        )
+        result = await tool.ainvoke({"query": "sync scores"}, config=runnable_config)
+
+        assert "failed" in result.lower() or "error" in result.lower()
+        mock_scoring_store.mark_failed.assert_called_once()
+
+    async def test_skips_records_without_kommo_lead_id(self, mock_kommo_client, runnable_config):
+        from telegram_bot.agents.tools import create_crm_score_sync_tool
+
+        store = AsyncMock()
+        store.list_pending_sync = AsyncMock(
+            return_value=[
+                LeadScoreRecord(
+                    lead_id=22,
+                    user_id=99,
+                    session_id="chat-1",
+                    score_value=30,
+                    score_band="cold",
+                    kommo_lead_id=None,
+                ),
+            ]
+        )
+        store.mark_synced = AsyncMock()
+
+        tool = create_crm_score_sync_tool(
+            scoring_store=store,
+            kommo_client=mock_kommo_client,
+            score_field_id=701,
+            band_field_id=702,
+        )
+        result = await tool.ainvoke({"query": "sync scores"}, config=runnable_config)
+
+        mock_kommo_client.update_lead_score.assert_not_called()
+        assert "skipped" in result.lower() or "0" in result or "no" in result.lower()
+
+    async def test_idempotency_key_includes_score_value(
+        self, mock_scoring_store, mock_kommo_client, runnable_config
+    ):
+        from telegram_bot.agents.tools import create_crm_score_sync_tool
+
+        tool = create_crm_score_sync_tool(
+            scoring_store=mock_scoring_store,
+            kommo_client=mock_kommo_client,
+            score_field_id=701,
+            band_field_id=702,
+        )
+        await tool.ainvoke({"query": "sync scores"}, config=runnable_config)
+
+        call_kwargs = mock_kommo_client.update_lead_score.call_args[1]
+        key = call_kwargs["idempotency_key"]
+        assert key == "lead-score:11:chat-1:74"

--- a/tests/unit/config/test_bot_config_kommo_scoring.py
+++ b/tests/unit/config/test_bot_config_kommo_scoring.py
@@ -1,0 +1,20 @@
+"""Tests for Kommo lead scoring config fields (#384)."""
+
+from telegram_bot.config import BotConfig
+
+
+def test_config_reads_kommo_scoring_field_ids(monkeypatch):
+    monkeypatch.setenv("KOMMO_LEAD_SCORE_FIELD_ID", "701")
+    monkeypatch.setenv("KOMMO_LEAD_BAND_FIELD_ID", "702")
+
+    cfg = BotConfig()
+
+    assert cfg.kommo_lead_score_field_id == 701
+    assert cfg.kommo_lead_band_field_id == 702
+
+
+def test_config_kommo_scoring_fields_default_to_zero():
+    cfg = BotConfig()
+
+    assert cfg.kommo_lead_score_field_id == 0
+    assert cfg.kommo_lead_band_field_id == 0

--- a/tests/unit/services/test_kommo_client_lead_score_sync.py
+++ b/tests/unit/services/test_kommo_client_lead_score_sync.py
@@ -1,0 +1,74 @@
+"""Tests for KommoClient.update_lead_score (#384)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+
+_DUMMY_REQ = httpx.Request("PATCH", "https://testcompany.kommo.com/api/v4/leads/5001")
+
+
+@pytest.fixture
+def mock_token_store():
+    store = AsyncMock()
+    store.get_valid_token = AsyncMock(return_value="test_access_token")
+    store.force_refresh = AsyncMock(return_value="refreshed_token")
+    return store
+
+
+@pytest.fixture
+def kommo_client(mock_token_store):
+    from telegram_bot.services.kommo_client import KommoClient
+
+    return KommoClient(subdomain="testcompany", token_store=mock_token_store)
+
+
+class TestUpdateLeadScore:
+    async def test_update_lead_score_sends_patch(self, kommo_client):
+        mock_resp = httpx.Response(200, json={"id": 5001}, request=_DUMMY_REQ)
+        with patch.object(kommo_client._client, "request", return_value=mock_resp) as mock_req:
+            payload = {
+                "custom_fields_values": [
+                    {"field_id": 701, "values": [{"value": 74}]},
+                    {"field_id": 702, "values": [{"value": "hot"}]},
+                ]
+            }
+            result = await kommo_client.update_lead_score(
+                lead_id=5001,
+                payload=payload,
+                idempotency_key="lead-score:11:chat-1:74",
+            )
+
+            assert result["id"] == 5001
+            call_args = mock_req.call_args
+            # Verify PATCH method
+            assert call_args[0][0] == "PATCH"
+            # Verify idempotency key header
+            headers = call_args[1].get("headers", {})
+            assert headers.get("X-Idempotency-Key") == "lead-score:11:chat-1:74"
+
+    async def test_update_lead_score_retries_on_429(self, kommo_client):
+        """429 should be retried via existing _request retry policy."""
+        resp_429 = httpx.Response(429, headers={"Retry-After": "1"}, request=_DUMMY_REQ)
+        resp_200 = httpx.Response(200, json={"id": 5001}, request=_DUMMY_REQ)
+        with patch.object(kommo_client._client, "request", side_effect=[resp_429, resp_200]):
+            result = await kommo_client.update_lead_score(
+                lead_id=5001,
+                payload={"custom_fields_values": []},
+                idempotency_key="lead-score:11:chat-1:74",
+            )
+            assert result["id"] == 5001
+
+    async def test_update_lead_score_retries_on_5xx(self, kommo_client):
+        resp_503 = httpx.Response(503, request=_DUMMY_REQ)
+        resp_200 = httpx.Response(200, json={"id": 5001}, request=_DUMMY_REQ)
+        with patch.object(kommo_client._client, "request", side_effect=[resp_503, resp_200]):
+            result = await kommo_client.update_lead_score(
+                lead_id=5001,
+                payload={"custom_fields_values": []},
+                idempotency_key="lead-score:11:chat-1:74",
+            )
+            assert result["id"] == 5001

--- a/tests/unit/services/test_kommo_token_store_protocol.py
+++ b/tests/unit/services/test_kommo_token_store_protocol.py
@@ -1,0 +1,21 @@
+"""Tests for KommoTokenStoreProtocol abstraction (#384)."""
+
+from typing import Protocol
+
+from telegram_bot.services.kommo_tokens import KommoTokenStore, KommoTokenStoreProtocol
+
+
+def test_token_store_contract_is_protocol():
+    assert issubclass(KommoTokenStoreProtocol, Protocol)
+
+
+def test_token_store_protocol_is_runtime_checkable():
+    assert getattr(KommoTokenStoreProtocol, "__protocol_attrs__", None) is not None or hasattr(
+        KommoTokenStoreProtocol, "__subclasshook__"
+    )
+
+
+def test_redis_token_store_satisfies_protocol():
+    # KommoTokenStore should structurally match KommoTokenStoreProtocol
+    assert hasattr(KommoTokenStore, "get_valid_token")
+    assert hasattr(KommoTokenStore, "force_refresh")

--- a/tests/unit/services/test_lead_scoring_models.py
+++ b/tests/unit/services/test_lead_scoring_models.py
@@ -1,0 +1,78 @@
+"""Tests for lead scoring models and Kommo payload contract (#384)."""
+
+import pytest
+
+
+def test_lead_score_record_validates_score_range():
+    from telegram_bot.services.lead_scoring_models import LeadScoreRecord
+
+    rec = LeadScoreRecord(
+        lead_id=11,
+        user_id=99,
+        session_id="chat-1",
+        score_value=74,
+        score_band="hot",
+        reason_codes=["timeline_asap", "budget_defined"],
+        kommo_lead_id=5001,
+    )
+    assert rec.score_value == 74
+    assert rec.score_band == "hot"
+
+
+def test_lead_score_record_rejects_invalid_score():
+    from telegram_bot.services.lead_scoring_models import LeadScoreRecord
+
+    with pytest.raises(ValueError):
+        LeadScoreRecord(
+            lead_id=11,
+            user_id=99,
+            session_id="chat-1",
+            score_value=101,
+            score_band="hot",
+        )
+
+
+def test_lead_score_payload_uses_field_id_not_field_name():
+    from telegram_bot.services.kommo_models import LeadScoreSyncPayload
+    from telegram_bot.services.lead_scoring_models import LeadScoreRecord
+
+    rec = LeadScoreRecord(
+        lead_id=11,
+        user_id=99,
+        session_id="chat-1",
+        score_value=74,
+        score_band="hot",
+        reason_codes=["timeline_asap", "budget_defined"],
+        kommo_lead_id=5001,
+    )
+
+    payload = LeadScoreSyncPayload.from_record(
+        rec,
+        score_field_id=701,
+        band_field_id=702,
+    ).to_kommo_payload()
+
+    assert payload["custom_fields_values"][0]["field_id"] == 701
+    assert "field_name" not in payload["custom_fields_values"][0]
+    assert payload["custom_fields_values"][1]["field_id"] == 702
+    assert payload["custom_fields_values"][1]["values"][0]["value"] == "hot"
+
+
+def test_lead_score_payload_score_value_in_values():
+    from telegram_bot.services.kommo_models import LeadScoreSyncPayload
+    from telegram_bot.services.lead_scoring_models import LeadScoreRecord
+
+    rec = LeadScoreRecord(
+        lead_id=11,
+        user_id=99,
+        session_id="chat-1",
+        score_value=50,
+        score_band="warm",
+        kommo_lead_id=5001,
+    )
+
+    payload = LeadScoreSyncPayload.from_record(
+        rec, score_field_id=701, band_field_id=702
+    ).to_kommo_payload()
+
+    assert payload["custom_fields_values"][0]["values"][0]["value"] == 50

--- a/tests/unit/services/test_lead_scoring_store.py
+++ b/tests/unit/services/test_lead_scoring_store.py
@@ -1,0 +1,102 @@
+"""Tests for LeadScoringStore (#384)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from telegram_bot.services.lead_scoring_models import LeadScoreRecord
+from telegram_bot.services.lead_scoring_store import LeadScoringStore
+
+
+@pytest.fixture
+def fake_pool():
+    """Minimal asyncpg pool mock."""
+    pool = AsyncMock()
+    pool.execute = AsyncMock()
+
+    # Return rows that look like asyncpg Records
+    def _make_row(**kwargs):
+        row = MagicMock()
+        row.__getitem__ = lambda _self, k: kwargs[k]
+        row.keys = lambda: kwargs.keys()
+        # Allow dict(row) to work
+        row.__iter__ = lambda _self: iter(kwargs.keys())
+        # Make dict() constructor work via mapping protocol
+        items = list(kwargs.items())
+        row.items = lambda: items
+        row.values = lambda: list(kwargs.values())
+        return row
+
+    pending_row = _make_row(
+        lead_id=11,
+        user_id=99,
+        session_id="chat-1",
+        score_value=74,
+        score_band="hot",
+        reason_codes=json.dumps(["timeline_asap"]),
+        kommo_lead_id=5001,
+    )
+    pool.fetch = AsyncMock(return_value=[pending_row])
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_upsert_score_calls_execute(fake_pool):
+    store = LeadScoringStore(pool=fake_pool)
+
+    rec = LeadScoreRecord(
+        lead_id=11,
+        user_id=99,
+        session_id="chat-1",
+        score_value=74,
+        score_band="hot",
+        reason_codes=["timeline_asap"],
+        kommo_lead_id=5001,
+    )
+    await store.upsert_score(rec)
+
+    fake_pool.execute.assert_called_once()
+    call_args = fake_pool.execute.call_args
+    sql = call_args[0][0]
+    assert "INSERT INTO lead_scores" in sql
+    assert "ON CONFLICT" in sql
+
+
+@pytest.mark.asyncio
+async def test_list_pending_sync_returns_records(fake_pool):
+    store = LeadScoringStore(pool=fake_pool)
+
+    rows = await store.list_pending_sync(limit=10)
+
+    assert len(rows) == 1
+    assert rows[0].lead_id == 11
+    assert rows[0].score_value == 74
+    fake_pool.fetch.assert_called_once()
+    sql = fake_pool.fetch.call_args[0][0]
+    assert "sync_status = 'pending'" in sql
+
+
+@pytest.mark.asyncio
+async def test_mark_synced_updates_status(fake_pool):
+    store = LeadScoringStore(pool=fake_pool)
+
+    await store.mark_synced(lead_id=11)
+
+    fake_pool.execute.assert_called_once()
+    sql = fake_pool.execute.call_args[0][0]
+    assert "sync_status" in sql
+    assert "'synced'" in sql
+
+
+@pytest.mark.asyncio
+async def test_mark_failed_updates_status(fake_pool):
+    store = LeadScoringStore(pool=fake_pool)
+
+    await store.mark_failed(lead_id=11, error="timeout")
+
+    fake_pool.execute.assert_called_once()
+    sql = fake_pool.execute.call_args[0][0]
+    assert "'failed'" in sql

--- a/tests/unit/services/test_lead_scoring_sync_schema_sql.py
+++ b/tests/unit/services/test_lead_scoring_sync_schema_sql.py
@@ -1,0 +1,18 @@
+"""Tests for lead scoring + kommo sync SQL schema."""
+
+from pathlib import Path
+
+
+def test_lead_scoring_schema_contains_required_tables_and_indexes():
+    ddl = Path("docker/postgres/init/06-lead-scoring-sync.sql").read_text(encoding="utf-8")
+    assert "CREATE TABLE IF NOT EXISTS lead_scores" in ddl
+    assert "CREATE TABLE IF NOT EXISTS lead_score_sync_audit" in ddl
+    assert "REFERENCES leads(id)" in ddl
+    assert "idx_lead_scores_pending_sync" in ddl
+
+
+def test_lead_scoring_schema_ml_upgrade_comments():
+    ddl = Path("docker/postgres/init/06-lead-scoring-sync.sql").read_text(encoding="utf-8")
+    assert "reason_codes" in ddl
+    assert "SHAP" in ddl
+    assert "ML" in ddl

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -501,6 +501,105 @@ class TestHandleQuery:
         tools_passed = build_graph.call_args.kwargs["tools"]
         assert crm_tool in tools_passed
 
+    async def test_handle_query_skips_score_sync_tool_for_client_role(self, mock_config):
+        """Lead score sync tool is manager-only (#384)."""
+        mock_config.kommo_enabled = True
+        mock_config.kommo_lead_score_field_id = 701
+        mock_config.kommo_lead_band_field_id = 702
+        bot, _ = _create_bot(mock_config)
+        bot._kommo_client = AsyncMock()
+        bot._lead_scoring_store = AsyncMock()
+        bot._resolve_user_role = AsyncMock(return_value="client")
+
+        score_tool = MagicMock()
+        mock_graph = AsyncMock()
+        mock_graph.ainvoke = AsyncMock(return_value=_mock_supervisor_result())
+
+        with (
+            patch(
+                "telegram_bot.agents.tools.create_crm_score_sync_tool", return_value=score_tool
+            ) as score_factory,
+            patch(
+                "telegram_bot.bot.build_supervisor_graph", return_value=mock_graph
+            ) as build_graph,
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+        ):
+            message = _make_text_message("квартиры")
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        score_factory.assert_not_called()
+        tools_passed = build_graph.call_args.kwargs["tools"]
+        assert score_tool not in tools_passed
+
+    async def test_handle_query_adds_score_sync_tool_for_manager_with_fields(self, mock_config):
+        """Lead score sync tool is added for manager when Kommo field ids are configured."""
+        mock_config.kommo_enabled = True
+        mock_config.kommo_lead_score_field_id = 701
+        mock_config.kommo_lead_band_field_id = 702
+        bot, _ = _create_bot(mock_config)
+        bot._kommo_client = AsyncMock()
+        bot._lead_scoring_store = AsyncMock()
+        bot._resolve_user_role = AsyncMock(return_value="manager")
+
+        score_tool = MagicMock()
+        mock_graph = AsyncMock()
+        mock_graph.ainvoke = AsyncMock(return_value=_mock_supervisor_result())
+
+        with (
+            patch(
+                "telegram_bot.agents.tools.create_crm_score_sync_tool", return_value=score_tool
+            ) as score_factory,
+            patch(
+                "telegram_bot.bot.build_supervisor_graph", return_value=mock_graph
+            ) as build_graph,
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+        ):
+            message = _make_text_message("квартиры")
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        score_factory.assert_called_once()
+        tools_passed = build_graph.call_args.kwargs["tools"]
+        assert score_tool in tools_passed
+
+    async def test_handle_query_skips_score_sync_tool_when_field_ids_missing(self, mock_config):
+        """Lead score sync tool is not added when Kommo field ids are unset."""
+        mock_config.kommo_enabled = True
+        mock_config.kommo_lead_score_field_id = 0
+        mock_config.kommo_lead_band_field_id = 0
+        bot, _ = _create_bot(mock_config)
+        bot._kommo_client = AsyncMock()
+        bot._lead_scoring_store = AsyncMock()
+        bot._resolve_user_role = AsyncMock(return_value="manager")
+
+        score_tool = MagicMock()
+        mock_graph = AsyncMock()
+        mock_graph.ainvoke = AsyncMock(return_value=_mock_supervisor_result())
+
+        with (
+            patch(
+                "telegram_bot.agents.tools.create_crm_score_sync_tool", return_value=score_tool
+            ) as score_factory,
+            patch(
+                "telegram_bot.bot.build_supervisor_graph", return_value=mock_graph
+            ) as build_graph,
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+        ):
+            message = _make_text_message("квартиры")
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        score_factory.assert_not_called()
+        tools_passed = build_graph.call_args.kwargs["tools"]
+        assert score_tool not in tools_passed
+
 
 class TestHistorySaveOnResponse:
     """Test Q&A history persistence after successful responses."""


### PR DESCRIPTION
## Summary

- Postgres-backed lead scoring model (`lead_scores` + `lead_score_sync_audit` tables)
- `LeadScoreRecord` + `LeadScoreSyncPayload` pydantic models with Kommo custom fields format
- `LeadScoringStore` for upsert/pending-sync queue via asyncpg
- `KommoClient.update_lead_score()` with idempotency key headers
- `crm_sync_lead_score` supervisor tool (fail-soft, conditional on kommo_enabled)
- `KommoTokenStoreProtocol` for future Postgres migration seam
- 24 new unit tests, 2486 total pass

## Test plan

- [x] `make check` (ruff + mypy clean)
- [x] `uv run pytest tests/unit/ -n auto` (2486 pass, 0 fail)
- [x] TDD: all 7 tasks written test-first

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>