### PR TITLE
feat(bot): nurturing + funnel analytics (#390)

### DIFF
--- a/docker/postgres/init/06-lead-scoring-sync.sql
+++ b/docker/postgres/init/06-lead-scoring-sync.sql
@@ -35,3 +35,6 @@ CREATE TABLE IF NOT EXISTS lead_score_sync_audit (
 
 CREATE INDEX IF NOT EXISTS idx_lead_scores_pending_sync
     ON lead_scores (sync_status, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_lead_scores_band_sync
+    ON lead_scores (score_band, sync_status, updated_at DESC);

--- a/docker/postgres/init/07-nurturing-funnel-analytics.sql
+++ b/docker/postgres/init/07-nurturing-funnel-analytics.sql
@@ -1,0 +1,45 @@
+-- Nurturing Jobs + Funnel Analytics (#390)
+-- Depends on: 05-realestate-schema.sql (funnel_events), 06-lead-scoring-sync.sql (lead_scores)
+
+\c realestate;
+
+CREATE TABLE IF NOT EXISTS nurturing_jobs (
+    id BIGSERIAL PRIMARY KEY,
+    lead_score_id BIGINT NOT NULL REFERENCES lead_scores(id) ON DELETE CASCADE,
+    scheduled_for TIMESTAMPTZ NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'running', 'sent', 'failed', 'skipped')),
+    channel TEXT NOT NULL DEFAULT 'telegram',
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    sent_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (lead_score_id, scheduled_for)
+);
+
+CREATE TABLE IF NOT EXISTS funnel_metrics_daily (
+    id BIGSERIAL PRIMARY KEY,
+    metric_date DATE NOT NULL,
+    stage_name TEXT NOT NULL,
+    entered_count INTEGER NOT NULL DEFAULT 0,
+    converted_count INTEGER NOT NULL DEFAULT 0,
+    dropoff_count INTEGER NOT NULL DEFAULT 0,
+    conversion_rate NUMERIC(6,4) NOT NULL DEFAULT 0,
+    prev_stage_count INTEGER NOT NULL DEFAULT 0,
+    step_conversion_rate NUMERIC(6,4) NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (metric_date, stage_name)
+);
+
+CREATE TABLE IF NOT EXISTS scheduler_leases (
+    lease_name TEXT PRIMARY KEY,
+    owner_id TEXT NOT NULL,
+    lease_until TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_nurturing_jobs_pending
+    ON nurturing_jobs (status, scheduled_for ASC);
+
+CREATE INDEX IF NOT EXISTS idx_funnel_events_date_stage
+    ON funnel_events (DATE(created_at), stage_name);

--- a/docker/postgres/init/07-nurturing-funnel-analytics.sql
+++ b/docker/postgres/init/07-nurturing-funnel-analytics.sql
@@ -41,5 +41,8 @@ CREATE TABLE IF NOT EXISTS scheduler_leases (
 CREATE INDEX IF NOT EXISTS idx_nurturing_jobs_pending
     ON nurturing_jobs (status, scheduled_for ASC);
 
+-- Add stage_name to funnel_events (#387 dependency — needed by analytics queries)
+ALTER TABLE funnel_events ADD COLUMN IF NOT EXISTS stage_name TEXT;
+
 CREATE INDEX IF NOT EXISTS idx_funnel_events_date_stage
     ON funnel_events (DATE(created_at), stage_name);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
     # Conversation memory (#154)
     "langgraph-checkpoint-redis>=0.2.0",  # Redis checkpointer for LangGraph
     "langmem>=0.0.30",                    # SummarizationNode for conversation compression
+    # Scheduled nurturing + analytics (#390)
+    "apscheduler>=3.11.2,<4.0",           # Async job scheduling (v3 API)
 ]
 
 [project.optional-dependencies]

--- a/telegram_bot/agents/tools.py
+++ b/telegram_bot/agents/tools.py
@@ -198,6 +198,38 @@ def create_crm_score_sync_tool(
     return crm_sync_lead_score
 
 
+def create_manager_nurturing_tools(*, analytics_service: Any, nurturing_service: Any) -> list[Any]:
+    """Create manager-only nurturing + analytics tools (#390)."""
+
+    @tool
+    async def manager_get_funnel_analytics(query: str, config: RunnableConfig) -> str:
+        """Get funnel conversion analytics for manager review.
+
+        Returns the latest daily funnel metrics including conversion rates,
+        dropoff counts, and stage-level performance data.
+        """
+        role = (config or {}).get("configurable", {}).get("role", "client")
+        if role not in {"manager", "admin"}:
+            return "Access denied"
+        report = await analytics_service.get_latest_summary()
+        return str(report)
+
+    @tool
+    async def manager_run_nurturing_batch(query: str, config: RunnableConfig) -> str:
+        """Execute an on-demand nurturing batch for warm/cold leads.
+
+        Selects eligible leads and enqueues nurturing messages.
+        Manager-only operation.
+        """
+        role = (config or {}).get("configurable", {}).get("role", "client")
+        if role not in {"manager", "admin"}:
+            return "Access denied"
+        count = await nurturing_service.run_once(limit=100)
+        return f"Nurturing batch executed: {count} leads"
+
+    return [manager_get_funnel_analytics, manager_run_nurturing_batch]
+
+
 @tool
 @observe(name="tool-direct-response")
 async def direct_response(message: str) -> str:

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -674,6 +674,7 @@ class PropertyBot:
             "configurable": {
                 "user_id": user_id,
                 "session_id": session_id,
+                "role": role,
                 "llm_base_url": self.config.llm_base_url,
             }
         }

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -232,6 +232,9 @@ class PropertyBot:
         # Lead scoring store (initialized in start() with pg_pool)
         self._lead_scoring_store: Any | None = None
 
+        # Nurturing scheduler (initialized in start() if enabled)
+        self._nurturing_scheduler: Any | None = None
+
         # Track initialization state
         self._cache_initialized = False
 
@@ -565,6 +568,7 @@ class PropertyBot:
             build_tools_for_role,
             create_crm_score_sync_tool,
             create_history_search_tool,
+            create_manager_nurturing_tools,
             direct_response,
         )
         from .graph.supervisor_state import make_supervisor_state
@@ -605,6 +609,17 @@ class PropertyBot:
         _lead_svc = getattr(self, "_lead_service", None)
         if _lead_svc is not None:
             manager_tools = create_manager_tools(lead_service=_lead_svc)
+        # Nurturing + analytics tools (#390) — manager-only
+        if self.config.nurturing_enabled and self._pg_pool is not None:
+            from .services.funnel_analytics_service import FunnelAnalyticsService
+            from .services.nurturing_service import NurturingService
+
+            manager_tools.extend(
+                create_manager_nurturing_tools(
+                    analytics_service=FunnelAnalyticsService(pool=self._pg_pool),
+                    nurturing_service=NurturingService(pool=self._pg_pool),
+                )
+            )
         tools = build_tools_for_role(role=role, base_tools=base_tools, manager_tools=manager_tools)
 
         # CRM tools are manager-only (issue #389).
@@ -1063,6 +1078,26 @@ class PropertyBot:
 
             self._lead_scoring_store = LeadScoringStore(pool=self._pg_pool)
             logger.info("Lead scoring store ready")
+
+            # Initialize nurturing scheduler (#390)
+            if self.config.nurturing_enabled:
+                try:
+                    from .services.funnel_analytics_service import FunnelAnalyticsService
+                    from .services.nurturing_scheduler import NurturingScheduler
+                    from .services.nurturing_service import NurturingService
+
+                    nurturing_svc = NurturingService(pool=self._pg_pool)
+                    analytics_svc = FunnelAnalyticsService(pool=self._pg_pool)
+                    self._nurturing_scheduler = NurturingScheduler(
+                        nurturing_service=nurturing_svc,
+                        analytics_service=analytics_svc,
+                        lease_store=None,
+                        config=self.config,
+                    )
+                    await self._nurturing_scheduler.start()
+                    logger.info("Nurturing scheduler started")
+                except Exception:
+                    logger.exception("Failed to start nurturing scheduler")
         except Exception:
             logger.warning("PostgreSQL pool init failed, user features disabled", exc_info=True)
 
@@ -1135,6 +1170,9 @@ class PropertyBot:
                 logger.warning("Failed to close checkpointer cleanly", exc_info=True)
             finally:
                 self._checkpointer = None
+        if self._nurturing_scheduler is not None:
+            await self._nurturing_scheduler.stop()
+            self._nurturing_scheduler = None
         if self._pg_pool is not None:
             await self._pg_pool.close()
             logger.info("PostgreSQL pool closed")

--- a/telegram_bot/config.py
+++ b/telegram_bot/config.py
@@ -381,6 +381,20 @@ class BotConfig(BaseSettings):
         validation_alias=AliasChoices("kommo_lead_band_field_id", "KOMMO_LEAD_BAND_FIELD_ID"),
     )
 
+    # Nurturing + funnel analytics (#390)
+    nurturing_enabled: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("nurturing_enabled", "NURTURING_ENABLED"),
+    )
+    nurturing_interval_minutes: int = Field(
+        default=60,
+        validation_alias=AliasChoices("nurturing_interval_minutes", "NURTURING_INTERVAL_MINUTES"),
+    )
+    funnel_rollup_cron: str = Field(
+        default="15 * * * *",
+        validation_alias=AliasChoices("funnel_rollup_cron", "FUNNEL_ROLLUP_CRON"),
+    )
+
     # Call limits (#374)
     max_llm_calls: int = Field(
         default=5,

--- a/telegram_bot/scoring.py
+++ b/telegram_bot/scoring.py
@@ -195,6 +195,24 @@ def write_langfuse_scores(lf: Any, result: dict) -> None:
             value=float(result["checkpointer_overhead_proxy_ms"]),
         )
 
+    # --- Nurturing + funnel analytics (#390) ---
+    if "nurturing_batch_size" in result:
+        lf.score_current_trace(
+            name="nurturing_batch_size", value=float(result["nurturing_batch_size"])
+        )
+    if "nurturing_sent_count" in result:
+        lf.score_current_trace(
+            name="nurturing_sent_count", value=float(result["nurturing_sent_count"])
+        )
+    if "funnel_conversion_rate" in result:
+        lf.score_current_trace(
+            name="funnel_conversion_rate", value=float(result["funnel_conversion_rate"])
+        )
+    if "funnel_dropoff_rate" in result:
+        lf.score_current_trace(
+            name="funnel_dropoff_rate", value=float(result["funnel_dropoff_rate"])
+        )
+
     # --- Source attribution (#225) ---
     sources_count = int(result.get("sources_count", 0) or 0)
     lf.score_current_trace(

--- a/telegram_bot/services/funnel_analytics_service.py
+++ b/telegram_bot/services/funnel_analytics_service.py
@@ -1,0 +1,73 @@
+"""Funnel analytics service: daily snapshot computation and persistence (#390)."""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from typing import Any
+
+from telegram_bot.services.funnel_analytics_store import FunnelAnalyticsStore
+
+
+logger = logging.getLogger(__name__)
+
+
+class FunnelAnalyticsService:
+    """Compute and persist funnel conversion/dropoff metrics."""
+
+    def __init__(self, *, pool: Any) -> None:
+        self._store = FunnelAnalyticsStore(pool=pool)
+        self._pool = pool
+
+    async def build_daily_snapshot(self, *, metric_date: dt.date) -> list[dict[str, Any]]:
+        """Compute conversion/dropoff for each stage on the given date."""
+        rows = await self._store.fetch_stage_counts(metric_date)
+        snapshots: list[dict[str, Any]] = []
+        for r in rows:
+            entered = int(r["entered_count"] or 0)
+            converted = int(r["converted_count"] or 0)
+            dropoff = max(entered - converted, 0)
+            rate = (converted / entered) if entered else 0.0
+            snapshots.append(
+                {
+                    "metric_date": metric_date,
+                    "stage_name": r["stage_name"],
+                    "entered_count": entered,
+                    "converted_count": converted,
+                    "dropoff_count": dropoff,
+                    "conversion_rate": round(rate, 4),
+                }
+            )
+        return snapshots
+
+    async def persist_snapshots(self, *, snapshots: list[dict[str, Any]]) -> None:
+        """Upsert daily snapshot rows via executemany."""
+        records = [
+            (
+                s["metric_date"],
+                s["stage_name"],
+                s["entered_count"],
+                s["converted_count"],
+                s["dropoff_count"],
+                s["conversion_rate"],
+            )
+            for s in snapshots
+        ]
+        await self._pool.executemany(
+            """
+            INSERT INTO funnel_metrics_daily
+                (metric_date, stage_name, entered_count, converted_count,
+                 dropoff_count, conversion_rate)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            ON CONFLICT (metric_date, stage_name) DO UPDATE SET
+                entered_count = EXCLUDED.entered_count,
+                converted_count = EXCLUDED.converted_count,
+                dropoff_count = EXCLUDED.dropoff_count,
+                conversion_rate = EXCLUDED.conversion_rate
+            """,
+            records,
+        )
+
+    async def get_latest_summary(self) -> list[Any]:
+        """Return latest daily snapshot for display / tool output."""
+        return await self._store.fetch_latest_summary()

--- a/telegram_bot/services/funnel_analytics_store.py
+++ b/telegram_bot/services/funnel_analytics_store.py
@@ -1,0 +1,39 @@
+"""Postgres store for funnel analytics queries (#390)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+
+class FunnelAnalyticsStore:
+    """Read funnel event counts and persist daily metric snapshots."""
+
+    def __init__(self, *, pool: Any) -> None:
+        self._pool = pool
+
+    async def fetch_stage_counts(self, metric_date: dt.date) -> list[Any]:
+        """Aggregate entered/converted counts per stage for a given date."""
+        return await self._pool.fetch(
+            """
+            SELECT stage_name,
+                   COUNT(*) FILTER (WHERE event_type = 'entered') AS entered_count,
+                   COUNT(*) FILTER (WHERE event_type = 'converted') AS converted_count
+            FROM funnel_events
+            WHERE DATE(created_at) = $1
+            GROUP BY stage_name
+            """,
+            metric_date,
+        )
+
+    async def fetch_latest_summary(self) -> list[Any]:
+        """Return the most recent daily snapshot rows."""
+        return await self._pool.fetch(
+            """
+            SELECT stage_name, entered_count, converted_count, dropoff_count,
+                   conversion_rate, metric_date
+            FROM funnel_metrics_daily
+            WHERE metric_date = (SELECT MAX(metric_date) FROM funnel_metrics_daily)
+            ORDER BY stage_name
+            """
+        )

--- a/telegram_bot/services/funnel_analytics_store.py
+++ b/telegram_bot/services/funnel_analytics_store.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
-from typing import Any
+from typing import Any, cast
 
 
 class FunnelAnalyticsStore:
@@ -14,7 +14,7 @@ class FunnelAnalyticsStore:
 
     async def fetch_stage_counts(self, metric_date: dt.date) -> list[Any]:
         """Aggregate entered/converted counts per stage for a given date."""
-        return await self._pool.fetch(
+        rows = await self._pool.fetch(
             """
             SELECT stage_name,
                    COUNT(*) FILTER (WHERE event_type = 'entered') AS entered_count,
@@ -25,10 +25,11 @@ class FunnelAnalyticsStore:
             """,
             metric_date,
         )
+        return cast(list[Any], rows)
 
     async def fetch_latest_summary(self) -> list[Any]:
         """Return the most recent daily snapshot rows."""
-        return await self._pool.fetch(
+        rows = await self._pool.fetch(
             """
             SELECT stage_name, entered_count, converted_count, dropoff_count,
                    conversion_rate, metric_date
@@ -37,3 +38,4 @@ class FunnelAnalyticsStore:
             ORDER BY stage_name
             """
         )
+        return cast(list[Any], rows)

--- a/telegram_bot/services/nurturing_scheduler.py
+++ b/telegram_bot/services/nurturing_scheduler.py
@@ -17,6 +17,7 @@ import logging
 from typing import Any
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
 
 
 logger = logging.getLogger(__name__)
@@ -57,8 +58,7 @@ class NurturingScheduler:
         )
         self._scheduler.add_job(
             self.run_funnel_rollup,
-            "cron",
-            minute=15,
+            trigger=CronTrigger.from_crontab(self._config.funnel_rollup_cron),
             id="funnel-analytics-rollup",
             replace_existing=True,
         )

--- a/telegram_bot/services/nurturing_scheduler.py
+++ b/telegram_bot/services/nurturing_scheduler.py
@@ -1,0 +1,99 @@
+"""APScheduler-based nurturing + funnel analytics scheduler (#390).
+
+Uses APScheduler v3 AsyncIOScheduler with:
+- coalesce=True: collapse missed runs into one
+- max_instances=1: prevent concurrent duplicate runs
+- misfire_grace_time=300: 5-min grace window for late execution
+
+TODO(#390): Migrate to APScheduler v4 when stable (currently alpha 4.0.0a6).
+  v4 changes: AsyncScheduler, AnyIO, add_schedule(IntervalTrigger),
+  CoalescePolicy.latest, misfire_grace_time=timedelta(minutes=5).
+  See research notes in docs/plans/2026-02-18-nurturing-funnel-390-plan.md.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+
+logger = logging.getLogger(__name__)
+
+
+class NurturingScheduler:
+    """Manage scheduled nurturing batches and funnel analytics rollups."""
+
+    def __init__(
+        self,
+        *,
+        nurturing_service: Any,
+        analytics_service: Any,
+        lease_store: Any,
+        config: Any,
+    ) -> None:
+        self._scheduler = AsyncIOScheduler(
+            job_defaults={
+                "coalesce": True,
+                "max_instances": 1,
+                "misfire_grace_time": 300,
+            }
+        )
+        self._nurturing = nurturing_service
+        self._analytics = analytics_service
+        self._lease_store = lease_store
+        self._config = config
+        self._started = False
+
+    async def start(self) -> None:
+        """Register jobs and start the scheduler."""
+        self._scheduler.add_job(
+            self.run_nurturing_batch,
+            "interval",
+            minutes=self._config.nurturing_interval_minutes,
+            id="nurturing-batch",
+            replace_existing=True,
+        )
+        self._scheduler.add_job(
+            self.run_funnel_rollup,
+            "cron",
+            minute=15,
+            id="funnel-analytics-rollup",
+            replace_existing=True,
+        )
+        self._scheduler.start()
+        self._started = True
+        logger.info("NurturingScheduler started")
+
+    async def stop(self) -> None:
+        """Shutdown the scheduler if running."""
+        if self._started:
+            self._scheduler.shutdown(wait=False)
+            self._started = False
+            logger.info("NurturingScheduler stopped")
+
+    def has_job(self, job_id: str) -> bool:
+        """Check if a job is registered."""
+        return self._scheduler.get_job(job_id) is not None
+
+    async def run_nurturing_batch(self) -> None:
+        """Execute a single nurturing batch (called by scheduler)."""
+        try:
+            count = await self._nurturing.run_once(limit=100)
+            logger.info("Nurturing batch completed: %d candidates", count)
+        except Exception:
+            logger.exception("Nurturing batch failed")
+
+    async def run_funnel_rollup(self) -> None:
+        """Compute and persist daily funnel metrics (called by scheduler)."""
+        import datetime as dt
+
+        try:
+            today = dt.date.today()
+            snapshots = await self._analytics.build_daily_snapshot(metric_date=today)
+            if snapshots:
+                await self._analytics.persist_snapshots(snapshots=snapshots)
+            logger.info("Funnel rollup completed: %d stages", len(snapshots))
+        except Exception:
+            logger.exception("Funnel rollup failed")

--- a/telegram_bot/services/nurturing_service.py
+++ b/telegram_bot/services/nurturing_service.py
@@ -1,0 +1,96 @@
+"""Nurturing service: candidate selection + batch enqueue (#390).
+
+Consumes #384 lead_scores (score_band, sync_status) for targeting.
+Uses executemany for bulk insert performance.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+
+
+class _Candidate:
+    """Lightweight candidate DTO from lead_scores + leads join."""
+
+    __slots__ = (
+        "id",
+        "kommo_lead_id",
+        "lead_id",
+        "preferences",
+        "score_band",
+        "sync_status",
+        "user_id",
+    )
+
+    def __init__(self, row: Any) -> None:
+        self.id: int = row["id"]
+        self.lead_id: int = row["lead_id"]
+        self.score_band: str = row["score_band"]
+        self.sync_status: str = row["sync_status"]
+        self.kommo_lead_id: int | None = row["kommo_lead_id"]
+        self.user_id: int = row["user_id"]
+        self.preferences: dict[str, Any] = row["preferences"] or {}
+
+
+class NurturingService:
+    """Select warm/cold leads and enqueue nurturing jobs."""
+
+    def __init__(self, *, pool: Any) -> None:
+        self._pool = pool
+
+    async def select_candidates(self, *, limit: int) -> list[_Candidate]:
+        """Fetch warm/cold synced leads eligible for nurturing."""
+        rows = await self._pool.fetch(
+            """
+            SELECT ls.id, ls.lead_id, ls.score_band, ls.sync_status, ls.kommo_lead_id,
+                   l.user_id, l.preferences
+            FROM lead_scores ls
+            JOIN leads l ON l.id = ls.lead_id
+            WHERE ls.score_band IN ('warm', 'cold')
+              AND ls.sync_status = 'synced'
+            ORDER BY ls.updated_at DESC
+            LIMIT $1
+            """,
+            limit,
+        )
+        return [_Candidate(r) for r in rows]
+
+    async def enqueue_updates(
+        self,
+        *,
+        candidates: list[_Candidate],
+        scheduled_for: datetime,
+    ) -> None:
+        """Bulk-insert nurturing jobs using executemany (asyncpg optimised)."""
+        records = [
+            (
+                c.id,
+                scheduled_for,
+                json.dumps({"user_id": c.user_id, "preferences": c.preferences}),
+            )
+            for c in candidates
+        ]
+        await self._pool.executemany(
+            """
+            INSERT INTO nurturing_jobs (lead_score_id, scheduled_for, payload)
+            VALUES ($1, $2, $3::jsonb)
+            ON CONFLICT (lead_score_id, scheduled_for) DO NOTHING
+            """,
+            records,
+        )
+
+    async def run_once(self, *, limit: int = 100) -> int:
+        """Select candidates, enqueue, return count."""
+        candidates = await self.select_candidates(limit=limit)
+        if not candidates:
+            return 0
+        scheduled_for = datetime.now(UTC)
+        await self.enqueue_updates(candidates=candidates, scheduled_for=scheduled_for)
+        logger.info("Nurturing batch enqueued: %d candidates", len(candidates))
+        return len(candidates)

--- a/telegram_bot/services/nurturing_service.py
+++ b/telegram_bot/services/nurturing_service.py
@@ -44,8 +44,24 @@ class NurturingService:
     def __init__(self, *, pool: Any) -> None:
         self._pool = pool
 
+    async def _assert_384_contract(self) -> None:
+        """Fail fast if lead_scores table is missing #384 columns."""
+        row = await self._pool.fetchrow(
+            """
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_name = 'lead_scores'
+              AND column_name IN ('score_band', 'sync_status', 'kommo_lead_id')
+            GROUP BY table_name
+            HAVING COUNT(*) = 3
+            """
+        )
+        if row is None:
+            raise RuntimeError("lead_scores contract from #384 is missing")
+
     async def select_candidates(self, *, limit: int) -> list[_Candidate]:
         """Fetch warm/cold synced leads eligible for nurturing."""
+        await self._assert_384_contract()
         rows = await self._pool.fetch(
             """
             SELECT ls.id, ls.lead_id, ls.score_band, ls.sync_status, ls.kommo_lead_id,

--- a/tests/unit/agents/test_nurturing_analytics_tools.py
+++ b/tests/unit/agents/test_nurturing_analytics_tools.py
@@ -1,0 +1,88 @@
+"""Tests for role-gated nurturing + analytics tools (#390)."""
+
+from unittest.mock import AsyncMock
+
+from langchain_core.tools import tool
+
+from telegram_bot.agents.tools import (
+    build_tools_for_role,
+    create_manager_nurturing_tools,
+)
+
+
+@tool
+async def base_tool(message: str) -> str:
+    """Base tool for role-selection tests."""
+    return message
+
+
+async def test_manager_tools_hidden_for_client_role():
+    nurturing_tools = create_manager_nurturing_tools(
+        analytics_service=AsyncMock(),
+        nurturing_service=AsyncMock(),
+    )
+    client_tools = build_tools_for_role(
+        role="client",
+        base_tools=[base_tool],
+        manager_tools=nurturing_tools,
+    )
+    manager_tools = build_tools_for_role(
+        role="manager",
+        base_tools=[base_tool],
+        manager_tools=nurturing_tools,
+    )
+
+    client_names = {t.name for t in client_tools}
+    manager_names = {t.name for t in manager_tools}
+
+    assert "manager_get_funnel_analytics" not in client_names
+    assert "manager_run_nurturing_batch" not in client_names
+    assert "manager_get_funnel_analytics" in manager_names
+    assert "manager_run_nurturing_batch" in manager_names
+
+
+async def test_manager_get_funnel_analytics_returns_report():
+    analytics_service = AsyncMock()
+    analytics_service.get_latest_summary = AsyncMock(
+        return_value=[{"stage": "inquiry", "rate": 0.4}]
+    )
+    tools = create_manager_nurturing_tools(
+        analytics_service=analytics_service,
+        nurturing_service=AsyncMock(),
+    )
+    analytics_tool = next(t for t in tools if t.name == "manager_get_funnel_analytics")
+
+    config = {"configurable": {"role": "manager"}}
+    result = await analytics_tool.ainvoke({"query": "show funnel"}, config=config)
+
+    assert "inquiry" in result
+    analytics_service.get_latest_summary.assert_called_once()
+
+
+async def test_manager_get_funnel_analytics_denies_client():
+    tools = create_manager_nurturing_tools(
+        analytics_service=AsyncMock(),
+        nurturing_service=AsyncMock(),
+    )
+    analytics_tool = next(t for t in tools if t.name == "manager_get_funnel_analytics")
+
+    config = {"configurable": {"role": "client"}}
+    result = await analytics_tool.ainvoke({"query": "show funnel"}, config=config)
+
+    assert "Access denied" in result
+
+
+async def test_manager_run_nurturing_batch_returns_count():
+    nurturing_service = AsyncMock()
+    nurturing_service.run_once = AsyncMock(return_value=15)
+    tools = create_manager_nurturing_tools(
+        analytics_service=AsyncMock(),
+        nurturing_service=nurturing_service,
+    )
+    batch_tool = next(t for t in tools if t.name == "manager_run_nurturing_batch")
+
+    config = {"configurable": {"role": "manager"}}
+    result = await batch_tool.ainvoke({"query": "run now"}, config=config)
+
+    assert "15" in result
+    nurturing_service.run_once.assert_called_once()

--- a/tests/unit/agents/test_nurturing_observability.py
+++ b/tests/unit/agents/test_nurturing_observability.py
@@ -1,0 +1,49 @@
+"""Tests for nurturing + funnel Langfuse scores (#390)."""
+
+from telegram_bot.scoring import write_langfuse_scores
+
+
+class FakeLangfuse:
+    """Minimal fake Langfuse client that records score_current_trace calls."""
+
+    def __init__(self):
+        self._scores: dict[str, object] = {}
+
+    def score_current_trace(self, *, name: str, value: object, **kwargs: object) -> None:
+        self._scores[name] = value
+
+    def has_score(self, name: str) -> bool:
+        return name in self._scores
+
+    def get_score(self, name: str) -> object:
+        return self._scores.get(name)
+
+
+def test_write_langfuse_scores_includes_nurturing_and_funnel_metrics():
+    lf = FakeLangfuse()
+    result = {
+        "nurturing_batch_size": 12,
+        "nurturing_sent_count": 9,
+        "funnel_conversion_rate": 0.31,
+        "funnel_dropoff_rate": 0.69,
+        "latency_stages": {},
+    }
+    write_langfuse_scores(lf, result)
+
+    assert lf.has_score("nurturing_batch_size")
+    assert lf.get_score("nurturing_batch_size") == 12.0
+    assert lf.has_score("nurturing_sent_count")
+    assert lf.get_score("nurturing_sent_count") == 9.0
+    assert lf.has_score("funnel_conversion_rate")
+    assert lf.get_score("funnel_conversion_rate") == 0.31
+    assert lf.has_score("funnel_dropoff_rate")
+    assert lf.get_score("funnel_dropoff_rate") == 0.69
+
+
+def test_write_langfuse_scores_skips_missing_nurturing_keys():
+    lf = FakeLangfuse()
+    result = {"latency_stages": {}}
+    write_langfuse_scores(lf, result)
+
+    assert not lf.has_score("nurturing_batch_size")
+    assert not lf.has_score("funnel_conversion_rate")

--- a/tests/unit/services/test_funnel_analytics_service.py
+++ b/tests/unit/services/test_funnel_analytics_service.py
@@ -1,0 +1,109 @@
+"""Tests for FunnelAnalyticsService (#390)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from telegram_bot.services.funnel_analytics_service import FunnelAnalyticsService
+
+
+def _make_row(**kwargs):
+    """Create a dict-like mock mimicking asyncpg Record."""
+    row = MagicMock()
+    row.__getitem__ = lambda _self, k: kwargs[k]
+    row.keys = lambda: kwargs.keys()
+    return row
+
+
+@pytest.fixture
+def fake_pool():
+    pool = AsyncMock()
+    pool.fetch = AsyncMock(
+        return_value=[
+            _make_row(stage_name="inquiry", entered_count=100, converted_count=40),
+            _make_row(stage_name="viewing", entered_count=40, converted_count=10),
+        ]
+    )
+    pool.execute = AsyncMock()
+    pool.executemany = AsyncMock()
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_daily_snapshot_computes_conversion_and_dropoff(fake_pool):
+    svc = FunnelAnalyticsService(pool=fake_pool)
+    snapshots = await svc.build_daily_snapshot(metric_date=dt.date(2026, 2, 18))
+
+    assert len(snapshots) == 2
+    first = snapshots[0]
+    assert first["stage_name"] == "inquiry"
+    assert first["entered_count"] == 100
+    assert first["converted_count"] == 40
+    assert first["dropoff_count"] == 60
+    assert 0 <= first["conversion_rate"] <= 1
+
+
+@pytest.mark.asyncio
+async def test_daily_snapshot_empty_returns_empty_list(fake_pool):
+    fake_pool.fetch = AsyncMock(return_value=[])
+    svc = FunnelAnalyticsService(pool=fake_pool)
+    snapshots = await svc.build_daily_snapshot(metric_date=dt.date(2026, 2, 18))
+
+    assert snapshots == []
+
+
+@pytest.mark.asyncio
+async def test_daily_snapshot_zero_entered_gives_zero_rate(fake_pool):
+    fake_pool.fetch = AsyncMock(
+        return_value=[_make_row(stage_name="demo", entered_count=0, converted_count=0)]
+    )
+    svc = FunnelAnalyticsService(pool=fake_pool)
+    snapshots = await svc.build_daily_snapshot(metric_date=dt.date(2026, 2, 18))
+
+    assert len(snapshots) == 1
+    assert snapshots[0]["conversion_rate"] == 0.0
+    assert snapshots[0]["dropoff_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_persist_snapshots_calls_executemany(fake_pool):
+    svc = FunnelAnalyticsService(pool=fake_pool)
+    snapshots = [
+        {
+            "metric_date": dt.date(2026, 2, 18),
+            "stage_name": "inquiry",
+            "entered_count": 100,
+            "converted_count": 40,
+            "dropoff_count": 60,
+            "conversion_rate": 0.4,
+        }
+    ]
+    await svc.persist_snapshots(snapshots=snapshots)
+
+    fake_pool.executemany.assert_called_once()
+    sql = fake_pool.executemany.call_args[0][0]
+    assert "funnel_metrics_daily" in sql
+
+
+@pytest.mark.asyncio
+async def test_get_latest_summary_delegates_to_store(fake_pool):
+    fake_pool.fetch = AsyncMock(
+        return_value=[
+            _make_row(
+                stage_name="inquiry",
+                entered_count=100,
+                converted_count=40,
+                dropoff_count=60,
+                conversion_rate=0.4,
+                metric_date=dt.date(2026, 2, 18),
+            )
+        ]
+    )
+    svc = FunnelAnalyticsService(pool=fake_pool)
+    summary = await svc.get_latest_summary()
+
+    assert len(summary) >= 1
+    fake_pool.fetch.assert_called_once()

--- a/tests/unit/services/test_nurturing_dependency_contracts.py
+++ b/tests/unit/services/test_nurturing_dependency_contracts.py
@@ -1,0 +1,69 @@
+"""Tests for #384 dependency contract enforcement in NurturingService (#390)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from telegram_bot.services.nurturing_service import NurturingService
+
+
+def _make_row(**kwargs):
+    row = MagicMock()
+    row.__getitem__ = lambda _self, k: kwargs[k]
+    row.keys = lambda: kwargs.keys()
+    return row
+
+
+@pytest.fixture
+def fake_pool_without_384_columns():
+    """Pool where information_schema query returns None (columns missing)."""
+    pool = AsyncMock()
+    pool.fetchrow = AsyncMock(return_value=None)
+    pool.fetch = AsyncMock(return_value=[])
+    pool.executemany = AsyncMock()
+    return pool
+
+
+@pytest.fixture
+def fake_pool_with_384_columns():
+    """Pool where information_schema query confirms columns exist."""
+    pool = AsyncMock()
+    pool.fetchrow = AsyncMock(return_value={"count": 3})
+    pool.fetch = AsyncMock(
+        return_value=[
+            _make_row(
+                id=1,
+                lead_id=10,
+                score_band="warm",
+                sync_status="synced",
+                kommo_lead_id=5001,
+                user_id=99,
+                preferences={},
+            )
+        ]
+    )
+    pool.executemany = AsyncMock()
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_nurturing_service_fails_fast_when_384_columns_missing(
+    fake_pool_without_384_columns,
+):
+    svc = NurturingService(pool=fake_pool_without_384_columns)
+
+    with pytest.raises(RuntimeError, match="lead_scores contract from #384 is missing"):
+        await svc.select_candidates(limit=10)
+
+
+@pytest.mark.asyncio
+async def test_nurturing_service_succeeds_when_384_columns_present(
+    fake_pool_with_384_columns,
+):
+    svc = NurturingService(pool=fake_pool_with_384_columns)
+    candidates = await svc.select_candidates(limit=10)
+
+    assert len(candidates) == 1
+    assert candidates[0].score_band == "warm"

--- a/tests/unit/services/test_nurturing_funnel_schema_sql.py
+++ b/tests/unit/services/test_nurturing_funnel_schema_sql.py
@@ -23,6 +23,11 @@ def test_nurturing_schema_has_step_conversion_columns():
     assert "step_conversion_rate" in ddl
 
 
+def test_funnel_events_stage_name_column_added():
+    ddl = Path("docker/postgres/init/07-nurturing-funnel-analytics.sql").read_text(encoding="utf-8")
+    assert "ADD COLUMN IF NOT EXISTS stage_name" in ddl
+
+
 def test_lead_scores_band_sync_index():
     ddl = Path("docker/postgres/init/06-lead-scoring-sync.sql").read_text(encoding="utf-8")
     assert "idx_lead_scores_band_sync" in ddl

--- a/tests/unit/services/test_nurturing_funnel_schema_sql.py
+++ b/tests/unit/services/test_nurturing_funnel_schema_sql.py
@@ -1,0 +1,28 @@
+"""Tests for nurturing jobs + funnel analytics SQL schema (#390)."""
+
+from pathlib import Path
+
+
+def test_nurturing_schema_has_jobs_metrics_and_leases():
+    ddl = Path("docker/postgres/init/07-nurturing-funnel-analytics.sql").read_text(encoding="utf-8")
+    assert "CREATE TABLE IF NOT EXISTS nurturing_jobs" in ddl
+    assert "CREATE TABLE IF NOT EXISTS funnel_metrics_daily" in ddl
+    assert "CREATE TABLE IF NOT EXISTS scheduler_leases" in ddl
+    assert "REFERENCES lead_scores(id)" in ddl
+
+
+def test_nurturing_schema_has_required_indexes():
+    ddl = Path("docker/postgres/init/07-nurturing-funnel-analytics.sql").read_text(encoding="utf-8")
+    assert "idx_nurturing_jobs_pending" in ddl
+    assert "idx_funnel_events_date_stage" in ddl
+
+
+def test_nurturing_schema_has_step_conversion_columns():
+    ddl = Path("docker/postgres/init/07-nurturing-funnel-analytics.sql").read_text(encoding="utf-8")
+    assert "prev_stage_count" in ddl
+    assert "step_conversion_rate" in ddl
+
+
+def test_lead_scores_band_sync_index():
+    ddl = Path("docker/postgres/init/06-lead-scoring-sync.sql").read_text(encoding="utf-8")
+    assert "idx_lead_scores_band_sync" in ddl

--- a/tests/unit/services/test_nurturing_scheduler.py
+++ b/tests/unit/services/test_nurturing_scheduler.py
@@ -1,0 +1,50 @@
+"""Tests for NurturingScheduler (#390)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from telegram_bot.services.nurturing_scheduler import NurturingScheduler
+
+
+@pytest.fixture
+def fake_services():
+    config = MagicMock()
+    config.nurturing_interval_minutes = 60
+    config.funnel_rollup_cron = "15 * * * *"
+    return {
+        "nurturing_service": AsyncMock(),
+        "analytics_service": AsyncMock(),
+        "lease_store": AsyncMock(),
+        "config": config,
+    }
+
+
+@pytest.mark.asyncio
+async def test_scheduler_configures_single_instance_coalesced_jobs(fake_services):
+    scheduler = NurturingScheduler(**fake_services)
+    await scheduler.start()
+
+    assert scheduler.has_job("nurturing-batch")
+    assert scheduler.has_job("funnel-analytics-rollup")
+
+    await scheduler.stop()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_has_no_jobs_before_start(fake_services):
+    scheduler = NurturingScheduler(**fake_services)
+
+    assert not scheduler.has_job("nurturing-batch")
+    assert not scheduler.has_job("funnel-analytics-rollup")
+
+
+@pytest.mark.asyncio
+async def test_scheduler_stop_is_idempotent(fake_services):
+    scheduler = NurturingScheduler(**fake_services)
+    await scheduler.start()
+    await scheduler.stop()
+    # Second stop should not raise
+    await scheduler.stop()

--- a/tests/unit/services/test_nurturing_scheduler.py
+++ b/tests/unit/services/test_nurturing_scheduler.py
@@ -48,3 +48,16 @@ async def test_scheduler_stop_is_idempotent(fake_services):
     await scheduler.stop()
     # Second stop should not raise
     await scheduler.stop()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_uses_funnel_rollup_cron_from_config(fake_services):
+    fake_services["config"].funnel_rollup_cron = "7 * * * *"
+    scheduler = NurturingScheduler(**fake_services)
+    await scheduler.start()
+
+    job = scheduler._scheduler.get_job("funnel-analytics-rollup")
+    assert job is not None
+    assert "minute='7'" in str(job.trigger)
+
+    await scheduler.stop()

--- a/tests/unit/services/test_nurturing_service.py
+++ b/tests/unit/services/test_nurturing_service.py
@@ -1,0 +1,90 @@
+"""Tests for NurturingService (#390)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from telegram_bot.services.nurturing_service import NurturingService
+
+
+def _make_row(**kwargs):
+    """Create a dict-like mock mimicking asyncpg Record."""
+    row = MagicMock()
+    row.__getitem__ = lambda _self, k: kwargs[k]
+    row.keys = lambda: kwargs.keys()
+    return row
+
+
+@pytest.fixture
+def fake_pool():
+    pool = AsyncMock()
+    pool.fetch = AsyncMock(
+        return_value=[
+            _make_row(
+                id=1,
+                lead_id=10,
+                score_band="warm",
+                sync_status="synced",
+                kommo_lead_id=5001,
+                user_id=99,
+                preferences={"budget": "100k"},
+            ),
+            _make_row(
+                id=2,
+                lead_id=20,
+                score_band="cold",
+                sync_status="synced",
+                kommo_lead_id=5002,
+                user_id=100,
+                preferences={},
+            ),
+        ]
+    )
+    pool.execute = AsyncMock()
+    pool.executemany = AsyncMock()
+    pool.fetchrow = AsyncMock(return_value={"count": 3})
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_select_candidates_uses_warm_and_cold_synced_scores(fake_pool):
+    svc = NurturingService(pool=fake_pool)
+    candidates = await svc.select_candidates(limit=25)
+
+    assert len(candidates) == 2
+    assert all(c.score_band in {"warm", "cold"} for c in candidates)
+    assert all(c.sync_status == "synced" for c in candidates)
+
+    sql = fake_pool.fetch.call_args[0][0]
+    assert "score_band IN ('warm', 'cold')" in sql
+    assert "sync_status = 'synced'" in sql
+
+
+@pytest.mark.asyncio
+async def test_enqueue_updates_uses_executemany(fake_pool):
+    svc = NurturingService(pool=fake_pool)
+    candidates = await svc.select_candidates(limit=25)
+
+    scheduled_for = dt.datetime(2026, 2, 18, 12, 0, tzinfo=dt.UTC)
+    await svc.enqueue_updates(candidates=candidates, scheduled_for=scheduled_for)
+
+    fake_pool.executemany.assert_called_once()
+    sql = fake_pool.executemany.call_args[0][0]
+    assert "nurturing_jobs" in sql
+    assert "ON CONFLICT" in sql
+
+    records = fake_pool.executemany.call_args[0][1]
+    assert len(records) == 2
+
+
+@pytest.mark.asyncio
+async def test_run_once_selects_and_enqueues(fake_pool):
+    svc = NurturingService(pool=fake_pool)
+    count = await svc.run_once(limit=25)
+
+    assert count == 2
+    fake_pool.fetch.assert_called_once()
+    fake_pool.executemany.assert_called_once()

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -441,6 +441,27 @@ class TestHandleQuery:
         state_arg = mock_graph.ainvoke.call_args.args[0]
         assert state_arg["max_tool_calls"] == 9
 
+    async def test_handle_query_passes_role_in_configurable(self, mock_config):
+        """Supervisor config should include resolved role for role-aware tools (#390)."""
+        bot, _ = _create_bot(mock_config)
+        bot._resolve_user_role = AsyncMock(return_value="manager")
+
+        mock_graph = AsyncMock()
+        mock_graph.ainvoke = AsyncMock(return_value=_mock_supervisor_result())
+
+        with (
+            patch("telegram_bot.bot.build_supervisor_graph", return_value=mock_graph),
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+        ):
+            message = _make_text_message("квартиры")
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        cfg = mock_graph.ainvoke.call_args.kwargs["config"]["configurable"]
+        assert cfg["role"] == "manager"
+
     async def test_handle_query_skips_crm_tools_for_client_role(self, mock_config):
         """CRM tools are not injected for non-manager users (#389)."""
         mock_config.kommo_enabled = True

--- a/uv.lock
+++ b/uv.lock
@@ -284,6 +284,18 @@ wheels = [
 ]
 
 [[package]]
+name = "apscheduler"
+version = "3.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
+]
+
+[[package]]
 name = "astroid"
 version = "4.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -730,6 +742,7 @@ dependencies = [
     { name = "aiogram-dialog" },
     { name = "aiohttp" },
     { name = "anthropic" },
+    { name = "apscheduler" },
     { name = "asyncpg" },
     { name = "cachetools" },
     { name = "fluentogram" },
@@ -851,6 +864,7 @@ requires-dist = [
     { name = "aiogram-dialog", specifier = ">=2.4.0" },
     { name = "aiohttp" },
     { name = "anthropic" },
+    { name = "apscheduler", specifier = ">=3.11.2,<4.0" },
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "cachetools", specifier = ">=5.0.0" },
     { name = "cocoindex", marker = "extra == 'ingest'", specifier = ">=0.3.28" },
@@ -7177,6 +7191,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Postgres schema: `nurturing_jobs`, `funnel_metrics_daily`, `scheduler_leases` tables
- `FunnelAnalyticsService` — daily conversion/dropoff snapshots from funnel_events
- `NurturingService` — candidate selection (warm/cold synced leads), bulk enqueue via `executemany`
- `NurturingScheduler` — APScheduler v3 with coalesce, max_instances=1, misfire grace
- Role-gated manager tools: `manager_get_funnel_analytics`, `manager_run_nurturing_batch`
- 4 new Langfuse scores: nurturing_batch_size, nurturing_sent_count, funnel_conversion_rate, funnel_dropoff_rate
- Explicit #384 dependency contract test (fail-fast if lead_scores schema missing)
- 24 new unit tests, 2510 total pass

## Stacked on

- PR #407 (`feat/lead-scoring-sync-384`) — merge #407 first, then rebase this PR onto main

## Test plan

- [x] `make check` (ruff + mypy clean)
- [x] `uv run pytest tests/unit/ -n auto` (2510 pass, 0 fail)
- [x] TDD: all 7 tasks written test-first

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>