### PR TITLE
fix(kommo): URL normalization, API payload fixes, live tests (#411, #409)

### DIFF
--- a/docs/PROJECT_STACK.md
+++ b/docs/PROJECT_STACK.md
@@ -29,7 +29,7 @@ Current stack snapshot for this repository as of 2026-02-18.
 | Service | Purpose |
 | --- | --- |
 | Qdrant | Hybrid dense+sparse retrieval storage |
-| Redis | Cache and runtime state |
+| Redis | Cache and runtime state (`REDIS_PASSWORD` is required in compose/k8s deployments) |
 | PostgreSQL (pgvector image) | App/ingestion/observability state |
 | BGE-M3 API | Local dense/sparse embeddings and rerank endpoint |
 | Docling | Document parsing/chunk extraction |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -392,6 +392,7 @@ markers = [
     "benchmark: Benchmark tests (parser/reranker comparisons)",
     "legacy_api: tests for pre-LangGraph API (may need rewrite)",
     "requires_extras: Tests needing optional deps (voice/ingest/eval); skipped in core tier",
+    "kommo: Live Kommo CRM API tests (requires KOMMO_ACCESS_TOKEN)",
     "xdist_group: Group tests onto same xdist worker (prevents global registry collisions)",
 ]
 filterwarnings = [

--- a/telegram_bot/observability.py
+++ b/telegram_bot/observability.py
@@ -125,7 +125,7 @@ if LANGFUSE_ENABLED:
 
     def create_callback_handler(
         *,
-        trace_context: dict | None = None,
+        trace_context: Any | None = None,
         update_trace: bool = False,
     ):
         """Create a Langfuse CallbackHandler for create_agent integration.

--- a/telegram_bot/services/kommo_client.py
+++ b/telegram_bot/services/kommo_client.py
@@ -35,6 +35,7 @@ class KommoClient:
     """Async Kommo CRM API adapter with auto-refresh OAuth2."""
 
     def __init__(self, *, subdomain: str, token_store: KommoTokenStore):
+        subdomain = subdomain.removesuffix(".kommo.com")
         self._base_url = f"https://{subdomain}.kommo.com/api/v4"
         self._token_store = token_store
         self._client = httpx.AsyncClient(
@@ -56,6 +57,9 @@ class KommoClient:
             response = await self._client.request(method, path, headers=headers, **kwargs)
 
         response.raise_for_status()
+        # Kommo returns 204/empty body for some endpoints (e.g. GET /contacts with no results)
+        if response.status_code == 204 or not response.content:
+            return {}
         return response.json()
 
     # --- Leads ---
@@ -63,7 +67,9 @@ class KommoClient:
     @observe(name="kommo-create-lead")
     async def create_lead(self, lead: LeadCreate) -> Lead:
         """POST /api/v4/leads."""
-        data = await self._request("POST", "/leads", json=[lead.model_dump(exclude_none=True)])
+        data = await self._request(
+            "POST", "/leads", json=[lead.model_dump(exclude_none=True, by_alias=True)]
+        )
         item = data["_embedded"]["leads"][0]
         return Lead(**item)
 
@@ -77,7 +83,7 @@ class KommoClient:
     async def update_lead(self, lead_id: int, update: LeadUpdate) -> Lead:
         """PATCH /api/v4/leads/{id}."""
         data = await self._request(
-            "PATCH", f"/leads/{lead_id}", json=update.model_dump(exclude_none=True)
+            "PATCH", f"/leads/{lead_id}", json=update.model_dump(exclude_none=True, by_alias=True)
         )
         return Lead(**data)
 

--- a/telegram_bot/services/kommo_models.py
+++ b/telegram_bot/services/kommo_models.py
@@ -1,12 +1,13 @@
 """Pydantic v2 models for Kommo CRM API (#413).
 
 Models match Kommo API v4 payloads.
+Kommo API uses "price" for deal value; Python code uses "budget" for readability.
 Ref: https://www.kommo.com/developers/content/api/
 """
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 
 # --- Request models (Create/Update) ---
@@ -15,8 +16,10 @@ from pydantic import BaseModel
 class LeadCreate(BaseModel):
     """POST /api/v4/leads payload."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     name: str
-    budget: int | None = None
+    budget: int | None = Field(None, serialization_alias="price", validation_alias="price")
     pipeline_id: int | None = None
     status_id: int | None = None
     custom_fields_values: list[dict] | None = None
@@ -25,8 +28,10 @@ class LeadCreate(BaseModel):
 class LeadUpdate(BaseModel):
     """PATCH /api/v4/leads/{id} payload."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     name: str | None = None
-    budget: int | None = None
+    budget: int | None = Field(None, serialization_alias="price", validation_alias="price")
     status_id: int | None = None
     custom_fields_values: list[dict] | None = None
 
@@ -55,11 +60,18 @@ class TaskCreate(BaseModel):
 
 
 class Lead(BaseModel):
-    """Lead from Kommo API response."""
+    """Lead from Kommo API response.
+
+    Note: POST /leads returns minimal response (id only).
+    Full fields available via GET /leads/{id}.
+    Kommo API field "price" maps to "budget" in Python.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
 
     id: int
-    name: str
-    budget: int | None = None
+    name: str | None = None
+    budget: int | None = Field(None, validation_alias="price")
     status_id: int | None = None
     pipeline_id: int | None = None
     created_at: int | None = None

--- a/tests/integration/test_kommo_live.py
+++ b/tests/integration/test_kommo_live.py
@@ -1,0 +1,152 @@
+"""Live integration tests for Kommo CRM API (#409).
+
+Requires real credentials:
+  KOMMO_SUBDOMAIN, KOMMO_ACCESS_TOKEN
+
+Run: uv run pytest tests/integration/test_kommo_live.py -v
+Skip when creds missing (CI).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+
+# Skip entire module if creds missing
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.kommo,
+    pytest.mark.skipif(
+        not os.getenv("KOMMO_ACCESS_TOKEN"),
+        reason="KOMMO_ACCESS_TOKEN not set",
+    ),
+]
+
+
+class _StaticTokenStore:
+    """Minimal token store returning a static access token for live tests."""
+
+    def __init__(self, token: str):
+        self._token = token
+
+    async def get_valid_token(self) -> str:
+        return self._token
+
+    async def force_refresh(self) -> str:
+        return self._token
+
+
+def _make_client():
+    """Create fresh KommoClient (new httpx session per test)."""
+    from telegram_bot.services.kommo_client import KommoClient
+
+    return KommoClient(
+        subdomain=os.environ["KOMMO_SUBDOMAIN"],
+        token_store=_StaticTokenStore(os.environ["KOMMO_ACCESS_TOKEN"]),  # type: ignore[arg-type]
+    )
+
+
+# Shared state for ordered tests
+_RUN_ID = f"ci-{int(time.time())}"
+
+
+class TestKommoLiveCRUD:
+    """Full CRUD lifecycle against real Kommo API."""
+
+    _lead_id: int | None = None
+    _contact_id: int | None = None
+
+    async def test_01_create_lead(self):
+        """Create a test lead."""
+        from telegram_bot.services.kommo_models import LeadCreate
+
+        client = _make_client()
+        lead = await client.create_lead(LeadCreate(name=f"[CI] {_RUN_ID}", budget=1000))
+        assert lead.id > 0
+        TestKommoLiveCRUD._lead_id = lead.id
+
+    async def test_02_get_lead(self):
+        """Verify created lead via GET returns full fields."""
+        assert self._lead_id, "test_01 must run first"
+
+        client = _make_client()
+        lead = await client.get_lead(self._lead_id)
+        assert lead.id == self._lead_id
+        assert lead.name == f"[CI] {_RUN_ID}"
+        assert lead.budget == 1000
+
+    async def test_03_update_lead(self):
+        """Update lead budget and verify."""
+        assert self._lead_id, "test_01 must run first"
+
+        from telegram_bot.services.kommo_models import LeadUpdate
+
+        client = _make_client()
+        await client.update_lead(self._lead_id, LeadUpdate(budget=2000))
+
+        refreshed = await client.get_lead(self._lead_id)
+        assert refreshed.budget == 2000
+
+    async def test_04_add_note(self):
+        """Add note to lead."""
+        assert self._lead_id, "test_01 must run first"
+
+        client = _make_client()
+        note = await client.add_note("leads", self._lead_id, f"Note {_RUN_ID}")
+        assert note.id > 0
+
+    async def test_05_create_task(self):
+        """Create task linked to lead."""
+        assert self._lead_id, "test_01 must run first"
+
+        from telegram_bot.services.kommo_models import TaskCreate
+
+        client = _make_client()
+        due = int(time.time()) + 86400
+        task = await client.create_task(
+            TaskCreate(
+                text=f"Task {_RUN_ID}",
+                entity_id=self._lead_id,
+                entity_type="leads",
+                complete_till=due,
+            )
+        )
+        assert task.id > 0
+
+    async def test_06_upsert_contact(self):
+        """Create a test contact via upsert."""
+        from telegram_bot.services.kommo_models import ContactCreate
+
+        client = _make_client()
+        phone = f"+38099{_RUN_ID[-7:]}"
+        contact = await client.upsert_contact(
+            phone,
+            ContactCreate(first_name="CI", last_name=_RUN_ID, phone=phone),
+        )
+        assert contact.id > 0
+        TestKommoLiveCRUD._contact_id = contact.id
+
+    async def test_07_link_contact_to_lead(self):
+        """Link contact to lead."""
+        assert self._lead_id, "test_01 must run first"
+        assert self._contact_id, "test_06 must run first"
+
+        client = _make_client()
+        await client.link_contact_to_lead(self._lead_id, self._contact_id)
+
+    async def test_08_list_pipelines(self):
+        """List pipelines (smoke test)."""
+        client = _make_client()
+        pipelines = await client.list_pipelines()
+        assert len(pipelines) > 0
+        assert pipelines[0].id > 0
+        assert pipelines[0].name
+
+    async def test_09_get_contacts(self):
+        """Search contacts by query."""
+        client = _make_client()
+        contacts = await client.get_contacts("CI")
+        assert isinstance(contacts, list)

--- a/tests/unit/agents/test_agent_factory.py
+++ b/tests/unit/agents/test_agent_factory.py
@@ -50,6 +50,22 @@ def test_create_bot_agent_passes_system_prompt():
         assert "Custom prompt" in call_kwargs["system_prompt"]
 
 
+def test_create_bot_agent_interpolates_language_in_default_prompt():
+    """Default prompt must interpolate {language} placeholder."""
+    from telegram_bot.agents.agent import create_bot_agent
+
+    with patch("telegram_bot.agents.agent.create_agent") as mock_ca:
+        create_bot_agent(
+            model="openai/gpt-oss-120b",
+            tools=[],
+            checkpointer=None,
+            language="английском языке",
+        )
+        prompt = mock_ca.call_args[1]["system_prompt"]
+        assert "английском языке" in prompt
+        assert "{language}" not in prompt
+
+
 def test_create_bot_agent_passes_checkpointer():
     """create_bot_agent passes checkpointer for conversation persistence."""
     from telegram_bot.agents.agent import create_bot_agent

--- a/tests/unit/services/test_kommo_client.py
+++ b/tests/unit/services/test_kommo_client.py
@@ -95,3 +95,30 @@ async def test_upsert_contact_find_existing(kommo_client, httpx_mock):
         ContactCreate(first_name="Иван", phone="+359888123456"),
     )
     assert contact.id == 456
+
+
+# --- URL normalization (#411) ---
+
+
+def test_subdomain_plain(mock_token_store):
+    """Plain subdomain builds correct base URL."""
+    from telegram_bot.services.kommo_client import KommoClient
+
+    client = KommoClient(subdomain="linhminhphung1", token_store=mock_token_store)
+    assert client._base_url == "https://linhminhphung1.kommo.com/api/v4"
+
+
+def test_subdomain_with_kommo_suffix(mock_token_store):
+    """Subdomain with .kommo.com suffix doesn't produce double domain (#411)."""
+    from telegram_bot.services.kommo_client import KommoClient
+
+    client = KommoClient(subdomain="linhminhphung1.kommo.com", token_store=mock_token_store)
+    assert client._base_url == "https://linhminhphung1.kommo.com/api/v4"
+
+
+def test_subdomain_with_dots(mock_token_store):
+    """Subdomain containing dots (but not .kommo.com) works correctly."""
+    from telegram_bot.services.kommo_client import KommoClient
+
+    client = KommoClient(subdomain="api-c", token_store=mock_token_store)
+    assert client._base_url == "https://api-c.kommo.com/api/v4"

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -178,8 +178,21 @@ class TestCommandHandlers:
 
         await bot.cmd_clear(message)
 
-        bot._checkpointer.adelete_thread.assert_awaited_once_with("12345")
+        bot._checkpointer.adelete_thread.assert_awaited_once_with("tg_12345")
         bot._cache.clear_conversation.assert_awaited_once_with(12345)
+
+    async def test_cmd_clear_uses_chat_id_for_thread_namespace(self, mock_config):
+        """Thread cleanup must target chat-scoped SDK thread_id."""
+        bot, _ = _create_bot(mock_config)
+        bot._cache = MagicMock()
+        bot._cache.clear_conversation = AsyncMock()
+        bot._checkpointer = AsyncMock()
+        message = _make_text_message(user_id=777, chat_id=42)
+
+        await bot.cmd_clear(message)
+
+        bot._checkpointer.adelete_thread.assert_awaited_once_with("tg_42")
+        bot._cache.clear_conversation.assert_awaited_once_with(777)
 
     async def test_cmd_clear_handles_no_checkpointer(self, mock_config):
         """Test /clear works when checkpointer is None (fallback)."""
@@ -206,7 +219,7 @@ class TestCommandHandlers:
         await bot.cmd_clear(message)
 
         bot._cache.clear_conversation.assert_awaited_once_with(12345)
-        bot._checkpointer.adelete_thread.assert_awaited_once_with("12345")
+        bot._checkpointer.adelete_thread.assert_awaited_once_with("tg_12345")
         message.answer.assert_awaited_once()
         answer_text = message.answer.await_args.args[0]
         assert "частично" in answer_text.lower()
@@ -384,6 +397,27 @@ class TestHandleQuery:
 
             config_arg = mock_agent.ainvoke.call_args[1]["config"]
             assert "bot_context" in config_arg["configurable"]
+
+    async def test_handle_query_uses_chat_scoped_thread_id(self, mock_config):
+        """SDK agent checkpointer thread_id uses chat namespace prefix."""
+        bot, _ = _create_bot(mock_config)
+
+        mock_agent = AsyncMock()
+        mock_agent.ainvoke = AsyncMock(return_value=_mock_agent_result())
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+        ):
+            message = _make_text_message("квартиры", user_id=777, chat_id=42)
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        config_arg = mock_agent.ainvoke.call_args[1]["config"]
+        assert config_arg["configurable"]["thread_id"] == "tg_42"
 
     async def test_handle_query_passes_guard_config_in_bot_context(self, mock_config):
         """SDK agent path forwards guard settings via BotContext (#413)."""


### PR DESCRIPTION
## Summary

- Fix KommoClient double-domain URL when subdomain contains `.kommo.com` (#411)
- Add 9 live integration tests for Kommo CRM API (#409)
- Fix bugs found during live testing

## Fixes

| Bug | Fix |
|-----|-----|
| `KommoClient("x.kommo.com")` → `x.kommo.com.kommo.com` | `subdomain.removesuffix(".kommo.com")` |
| `Lead.name` required but POST returns only `id` | `name: str \| None = None` |
| `budget` field ignored by API (expects `price`) | Pydantic `validation_alias="price"` + `by_alias=True` |
| GET /contacts returns empty body (204) | `_request()` returns `{}` for empty responses |

## Live tests (`tests/integration/test_kommo_live.py`)

9 tests against real Kommo API:
1. Create lead
2. GET lead (verify name, budget)
3. Update lead budget
4. Add note to lead
5. Create task on lead
6. Upsert contact
7. Link contact to lead
8. List pipelines
9. Search contacts

Markers: `@pytest.mark.integration`, `@pytest.mark.kommo` — skipped when `KOMMO_ACCESS_TOKEN` not set.

## Test plan

- [x] 8 unit tests (KommoClient + URL normalization)
- [x] 7 model tests
- [x] 4 CRM tool tests
- [x] 9 live Kommo integration tests
- [x] 447 agent/bot/service tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)