### PR TITLE
fix(bot): resolve #420 runtime crashes — LiteLLM routing, checkpoint serde, DB/CRM fail-safe

### DIFF
--- a/telegram_bot/agents/agent.py
+++ b/telegram_bot/agents/agent.py
@@ -9,6 +9,7 @@ import logging
 from typing import Any
 
 from langchain.agents import create_agent
+from langchain_openai import ChatOpenAI
 
 from telegram_bot.agents.context import BotContext
 
@@ -47,6 +48,8 @@ def create_bot_agent(
     checkpointer: Any | None = None,
     system_prompt: str | None = None,
     language: str = "русском языке",
+    base_url: str | None = None,
+    api_key: str | None = None,
 ) -> Any:
     """Create the bot agent using langchain create_agent SDK.
 
@@ -55,14 +58,31 @@ def create_bot_agent(
         tools: List of @tool decorated functions.
         checkpointer: AsyncRedisSaver or None.
         system_prompt: Override default system prompt.
+        language: Response language.
+        base_url: OpenAI-compatible API base URL (e.g. LiteLLM proxy).
+        api_key: API key for the LLM provider.
 
     Returns:
         Compiled agent graph ready for .ainvoke() / .astream().
     """
     prompt = system_prompt or DEFAULT_SYSTEM_PROMPT.format(language=language)
 
+    # Build a ChatOpenAI instance routed through LiteLLM proxy (#420).
+    # Passing a string model name to create_agent triggers init_chat_model()
+    # which defaults to OpenAI and requires OPENAI_API_KEY.
+    model_kwargs: dict[str, Any] = {"model": model}
+    if base_url:
+        model_kwargs["base_url"] = base_url
+    if api_key:
+        model_kwargs["api_key"] = api_key
+    else:
+        # Dummy key — LiteLLM proxy doesn't need a real OpenAI key
+        model_kwargs["api_key"] = "sk-not-needed"
+
+    llm = ChatOpenAI(**model_kwargs)
+
     agent = create_agent(
-        model=model,
+        model=llm,
         tools=tools,
         system_prompt=prompt,
         context_schema=BotContext,
@@ -70,8 +90,9 @@ def create_bot_agent(
     )
 
     logger.info(
-        "Created bot agent: model=%s, tools=%d, checkpointer=%s",
+        "Created bot agent: model=%s, base_url=%s, tools=%d, checkpointer=%s",
         model,
+        base_url or "default",
         len(tools),
         type(checkpointer).__name__ if checkpointer else "None",
     )

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -343,12 +343,26 @@ class PropertyBot:
         user_id = message.from_user.id
         checkpointer_cleared = True
         thread_id = _supervisor_thread_id(message.chat.id)
-
-        if self._checkpointer is not None:
+        seen_checkpointers: set[int] = set()
+        for cp_name, checkpointer in (
+            ("conversation", self._checkpointer),
+            ("agent", self._agent_checkpointer),
+        ):
+            if checkpointer is None:
+                continue
+            cp_id = id(checkpointer)
+            if cp_id in seen_checkpointers:
+                continue
+            seen_checkpointers.add(cp_id)
             try:
-                await self._checkpointer.adelete_thread(thread_id)
+                await checkpointer.adelete_thread(thread_id)
             except Exception:
-                logger.warning("Failed to clear checkpointer thread %s", thread_id, exc_info=True)
+                logger.warning(
+                    "Failed to clear %s checkpointer thread %s",
+                    cp_name,
+                    thread_id,
+                    exc_info=True,
+                )
                 checkpointer_cleared = False
 
         await self._cache.clear_conversation(user_id)

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -226,6 +226,10 @@ class PropertyBot:
         # Conversation memory checkpointer (initialized in start())
         self._checkpointer: Any = None
 
+        # Agent checkpointer — MemorySaver to avoid Redis JSON serialization
+        # issues with LangChain Message objects (#420)
+        self._agent_checkpointer: Any = None
+
         # History service (initialized in start())
         self._history_service: HistoryService | None = None
 
@@ -603,12 +607,14 @@ class PropertyBot:
 
             tools.extend(get_crm_tools())
 
-        # Create agent via SDK
+        # Create agent via SDK — route through LiteLLM proxy (#420)
         agent = create_bot_agent(
             model=self.config.supervisor_model,
             tools=tools,
-            checkpointer=self._checkpointer,
+            checkpointer=self._agent_checkpointer,
             language=self.config.domain_language,
+            base_url=self.config.llm_base_url,
+            api_key=self.config.llm_api_key,
         )
 
         # Build context for tool DI
@@ -966,6 +972,11 @@ class PropertyBot:
             logger.warning("Redis checkpointer init failed, using in-memory", exc_info=True)
             self._checkpointer = create_fallback_checkpointer()
 
+        # Agent checkpointer — MemorySaver avoids redisvl JSON serialization
+        # errors with LangChain Message objects (HumanMessage, AIMessage) (#420).
+        # Voice pipeline keeps AsyncRedisSaver (graph state uses simple dicts).
+        self._agent_checkpointer = create_fallback_checkpointer()
+
         # Initialize history service (Qdrant-backed Q&A history)
         try:
             self._history_service = HistoryService(
@@ -979,35 +990,36 @@ class PropertyBot:
             logger.warning("History service init failed, /history disabled", exc_info=True)
             self._history_service = None
 
-        # Initialize Kommo CRM client if enabled
+        # Initialize Kommo CRM client if enabled (#420: fail-safe, must not block startup)
         if self.config.kommo_enabled and self.config.kommo_subdomain:
             try:
                 from .services.kommo_client import KommoClient
                 from .services.kommo_tokens import KommoTokenStore
 
                 if self._cache.redis is None:
-                    raise RuntimeError("Cache redis client is not initialized")
+                    logger.warning("Kommo CRM skipped: Redis client not initialized")
+                    self._kommo_client = None
+                else:
+                    token_store = KommoTokenStore(
+                        redis=self._cache.redis,
+                        client_id=self.config.kommo_client_id,
+                        client_secret=self.config.kommo_client_secret.get_secret_value(),
+                        subdomain=self.config.kommo_subdomain,
+                        redirect_uri=self.config.kommo_redirect_uri,
+                    )
+                    auth_code = self.config.kommo_auth_code or None
+                    await token_store.initialize(authorization_code=auth_code)
 
-                token_store = KommoTokenStore(
-                    redis=self._cache.redis,
-                    client_id=self.config.kommo_client_id,
-                    client_secret=self.config.kommo_client_secret.get_secret_value(),
-                    subdomain=self.config.kommo_subdomain,
-                    redirect_uri=self.config.kommo_redirect_uri,
-                )
-                auth_code = self.config.kommo_auth_code or None
-                await token_store.initialize(authorization_code=auth_code)
-
-                self._kommo_client = KommoClient(
-                    subdomain=self.config.kommo_subdomain,
-                    token_store=token_store,
-                )
-                logger.info(
-                    "Kommo CRM client initialized (subdomain=%s)",
-                    self.config.kommo_subdomain,
-                )
+                    self._kommo_client = KommoClient(
+                        subdomain=self.config.kommo_subdomain,
+                        token_store=token_store,
+                    )
+                    logger.info(
+                        "Kommo CRM client initialized (subdomain=%s)",
+                        self.config.kommo_subdomain,
+                    )
             except Exception:
-                logger.exception("Failed to initialize Kommo CRM client")
+                logger.warning("Kommo CRM init failed — CRM features disabled", exc_info=True)
                 self._kommo_client = None
 
         # Initialize PostgreSQL pool for realestate DB
@@ -1138,6 +1150,7 @@ class PropertyBot:
                 logger.warning("Failed to close checkpointer cleanly", exc_info=True)
             finally:
                 self._checkpointer = None
+        self._agent_checkpointer = None
         if self._nurturing_scheduler is not None:
             await self._nurturing_scheduler.stop()
             self._nurturing_scheduler = None

--- a/telegram_bot/services/user_service.py
+++ b/telegram_bot/services/user_service.py
@@ -45,43 +45,55 @@ class UserService:
         telegram_id: int,
         first_name: str | None = None,
         language_code: str | None = None,
-    ) -> User:
-        """Get existing user or create new one."""
-        row = await self._pool.fetchrow(
-            "SELECT * FROM users WHERE telegram_id = $1",
-            telegram_id,
-        )
-        if row is not None:
-            return self._row_to_user(row)
+    ) -> User | None:
+        """Get existing user or create new one. Returns None on DB errors (#420)."""
+        try:
+            row = await self._pool.fetchrow(
+                "SELECT * FROM users WHERE telegram_id = $1",
+                telegram_id,
+            )
+            if row is not None:
+                return self._row_to_user(row)
 
-        locale = detect_locale(language_code)
-        row = await self._pool.fetchrow(
-            """INSERT INTO users (telegram_id, locale, first_name, telegram_language_code)
-               VALUES ($1, $2, $3, $4)
-               ON CONFLICT (telegram_id) DO UPDATE SET updated_at = NOW()
-               RETURNING *""",
-            telegram_id,
-            locale,
-            first_name,
-            language_code,
-        )
-        return self._row_to_user(row)
+            locale = detect_locale(language_code)
+            row = await self._pool.fetchrow(
+                """INSERT INTO users (telegram_id, locale, first_name, telegram_language_code)
+                   VALUES ($1, $2, $3, $4)
+                   ON CONFLICT (telegram_id) DO UPDATE SET updated_at = NOW()
+                   RETURNING *""",
+                telegram_id,
+                locale,
+                first_name,
+                language_code,
+            )
+            return self._row_to_user(row)
+        except Exception:
+            logger.warning("get_or_create DB query failed", exc_info=True)
+            return None
 
     async def get_role(self, *, telegram_id: int) -> str:
-        """Get user role. Returns 'client' for unknown users."""
-        role = await self._pool.fetchval(
-            "SELECT role FROM users WHERE telegram_id = $1",
-            telegram_id,
-        )
-        return role or "client"
+        """Get user role. Returns 'client' on DB errors or unknown users (#420)."""
+        try:
+            role = await self._pool.fetchval(
+                "SELECT role FROM users WHERE telegram_id = $1",
+                telegram_id,
+            )
+            return role or "client"
+        except Exception:
+            logger.warning("get_role DB query failed, returning default", exc_info=True)
+            return "client"
 
     async def get_locale(self, *, telegram_id: int) -> str:
-        """Get user locale. Returns 'ru' for unknown users."""
-        locale = await self._pool.fetchval(
-            "SELECT locale FROM users WHERE telegram_id = $1",
-            telegram_id,
-        )
-        return locale or _DEFAULT_LOCALE
+        """Get user locale. Returns 'ru' on DB errors or unknown users (#420)."""
+        try:
+            locale = await self._pool.fetchval(
+                "SELECT locale FROM users WHERE telegram_id = $1",
+                telegram_id,
+            )
+            return locale or _DEFAULT_LOCALE
+        except Exception:
+            logger.warning("get_locale DB query failed, returning default", exc_info=True)
+            return _DEFAULT_LOCALE
 
     async def set_locale(self, *, telegram_id: int, locale: str) -> None:
         """Update user locale."""

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -196,11 +196,13 @@ class TestCommandHandlers:
         bot._cache = MagicMock()
         bot._cache.clear_conversation = AsyncMock()
         bot._checkpointer = AsyncMock()
+        bot._agent_checkpointer = AsyncMock()
         message = _make_text_message()
 
         await bot.cmd_clear(message)
 
         bot._checkpointer.adelete_thread.assert_awaited_once_with("tg_12345")
+        bot._agent_checkpointer.adelete_thread.assert_awaited_once_with("tg_12345")
         bot._cache.clear_conversation.assert_awaited_once_with(12345)
 
     async def test_cmd_clear_uses_chat_id_for_thread_namespace(self, mock_config):
@@ -209,11 +211,13 @@ class TestCommandHandlers:
         bot._cache = MagicMock()
         bot._cache.clear_conversation = AsyncMock()
         bot._checkpointer = AsyncMock()
+        bot._agent_checkpointer = AsyncMock()
         message = _make_text_message(user_id=777, chat_id=42)
 
         await bot.cmd_clear(message)
 
         bot._checkpointer.adelete_thread.assert_awaited_once_with("tg_42")
+        bot._agent_checkpointer.adelete_thread.assert_awaited_once_with("tg_42")
         bot._cache.clear_conversation.assert_awaited_once_with(777)
 
     async def test_cmd_clear_handles_no_checkpointer(self, mock_config):
@@ -222,6 +226,7 @@ class TestCommandHandlers:
         bot._cache = MagicMock()
         bot._cache.clear_conversation = AsyncMock()
         bot._checkpointer = None
+        bot._agent_checkpointer = None
         message = _make_text_message()
 
         await bot.cmd_clear(message)
@@ -236,15 +241,32 @@ class TestCommandHandlers:
         bot._cache.clear_conversation = AsyncMock()
         bot._checkpointer = AsyncMock()
         bot._checkpointer.adelete_thread = AsyncMock(side_effect=RuntimeError("redis down"))
+        bot._agent_checkpointer = AsyncMock()
         message = _make_text_message()
 
         await bot.cmd_clear(message)
 
         bot._cache.clear_conversation.assert_awaited_once_with(12345)
         bot._checkpointer.adelete_thread.assert_awaited_once_with("tg_12345")
+        bot._agent_checkpointer.adelete_thread.assert_awaited_once_with("tg_12345")
         message.answer.assert_awaited_once()
         answer_text = message.answer.await_args.args[0]
         assert "частично" in answer_text.lower()
+
+    async def test_cmd_clear_deduplicates_same_checkpointer_instance(self, mock_config):
+        """When both checkpointer refs point to one object, thread delete is called once."""
+        bot, _ = _create_bot(mock_config)
+        bot._cache = MagicMock()
+        bot._cache.clear_conversation = AsyncMock()
+        shared_cp = AsyncMock()
+        bot._checkpointer = shared_cp
+        bot._agent_checkpointer = shared_cp
+        message = _make_text_message()
+
+        await bot.cmd_clear(message)
+
+        shared_cp.adelete_thread.assert_awaited_once_with("tg_12345")
+        bot._cache.clear_conversation.assert_awaited_once_with(12345)
 
     async def test_cmd_stats(self, mock_config):
         """Test /stats command handler."""


### PR DESCRIPTION
## Summary
- **OPENAI_API_KEY fix:** `create_bot_agent()` now builds `ChatOpenAI(base_url=litellm_url, api_key=...)` instead of passing model string to `init_chat_model()`. Routes through LiteLLM proxy.
- **HumanMessage serialization fix:** Agent uses `MemorySaver` instead of `AsyncRedisSaver` — avoids redisvl JSON serialization failure with LangChain Message objects. Voice pipeline keeps Redis checkpointer (simple dicts).
- **"realestate" DB fix:** `UserService.get_role()`, `get_locale()`, `get_or_create()` wrapped in try/except with safe defaults ("client", "ru", None).
- **Kommo CRM fail-safe:** Replaced `raise RuntimeError` with `logger.warning` + `self._kommo_client = None`. CRM features gracefully disabled when no tokens.

## Files changed
- `telegram_bot/agents/agent.py` — ChatOpenAI with explicit base_url/api_key
- `telegram_bot/bot.py` — MemorySaver for agent, Kommo fail-safe init
- `telegram_bot/services/user_service.py` — DB error handling with safe defaults

## Test plan
- [x] `ruff check .` — clean
- [x] `mypy telegram_bot/ src/` — 167 files, no issues
- [x] `pytest tests/unit/ -n auto` — 2579 passed, 3 pre-existing flaky (xdist isinstance)
- [ ] Docker runtime smoke: `make docker-bot-up` + send message to bot

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)