### PR TITLE
chore(docker): cleanup and harden compose (#419)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,11 +3,20 @@
 # Stop:  docker compose -f docker-compose.dev.yml down
 # Reset: docker compose -f docker-compose.dev.yml down -v
 
+name: rag-fresh
+
 x-logging: &default-logging
   driver: json-file
   options:
     max-size: "10m"
     max-file: "3"
+
+x-security-defaults: &security-defaults
+  security_opt: ["no-new-privileges:true"]
+  cap_drop: ["ALL"]
+  read_only: true
+  tmpfs:
+    - /tmp
 
 services:
   # =============================================================================
@@ -83,6 +92,7 @@ services:
   # =============================================================================
 
   bge-m3:
+    <<: *security-defaults
     build:
       context: ./services/bge-m3-api
       dockerfile: Dockerfile
@@ -109,6 +119,7 @@ services:
       resources:
         limits:
           memory: 4G
+          pids: 200
 
   llm-guard:
     build:
@@ -143,6 +154,7 @@ services:
           memory: 2G
 
   user-base:
+    <<: *security-defaults
     build:
       context: ./services/user-base
       dockerfile: Dockerfile
@@ -167,8 +179,10 @@ services:
       resources:
         limits:
           memory: 2G
+          pids: 100
 
   docling:
+    <<: *security-defaults
     build:
       context: ./services/docling
       dockerfile: Dockerfile
@@ -197,6 +211,7 @@ services:
       resources:
         limits:
           memory: 4G
+          pids: 200
 
   # =============================================================================
   # ML PLATFORM
@@ -482,6 +497,7 @@ services:
       start_period: 10s
 
   litellm:
+    <<: *security-defaults
     image: ghcr.io/berriai/litellm:main-v1.81.3-stable@sha256:3d80908e35230a0dfb58051ae4e2847371b2a327b44e105e79b8c4f67a65596c
     container_name: dev-litellm
     profiles: ["bot", "voice", "full"]
@@ -519,12 +535,14 @@ services:
       resources:
         limits:
           memory: 512M
+          pids: 100
 
   # =============================================================================
   # TELEGRAM BOT (Local BGE-M3 embeddings — matches VPS production)
   # =============================================================================
 
   bot:
+    <<: *security-defaults
     build:
       context: .
       dockerfile: telegram_bot/Dockerfile
@@ -606,6 +624,7 @@ services:
       resources:
         limits:
           memory: 512M
+          pids: 100
 
 # =============================================================================
   # UNIFIED INGESTION PIPELINE (v3.2.1)

--- a/services/llm-guard-api/Dockerfile
+++ b/services/llm-guard-api/Dockerfile
@@ -13,14 +13,16 @@ WORKDIR /app
 # Deps layer
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --frozen --no-dev --no-install-project || uv sync --no-dev --no-install-project
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    uv sync --frozen --no-dev --no-install-project
 
 # Code layer
 COPY pyproject.toml ./
 COPY config.py app.py ./
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev || uv sync --no-dev
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    uv sync --frozen --no-dev
 
 # ====== RUNTIME STAGE ======
 FROM python:3.12-slim-bookworm AS runtime


### PR DESCRIPTION
## Summary
- **Naming normalization:** Added `name: rag-fresh` top-level in docker-compose.dev.yml — eliminates `rag-fresh-*` vs `rag-fresh_*` duplicate naming
- **Security baseline:** Added `x-security-defaults` anchor (`no-new-privileges`, `cap_drop ALL`, `read_only`, `tmpfs /tmp`) applied to 5 stateless services: bot, litellm, bge-m3, user-base, docling
- **PIDs limits:** Added `pids` limits via `deploy.resources.limits` (200 for ML/OMP services, 100 for others)
- **llm-guard reproducibility:** Removed `|| uv sync` fallbacks, added `uv.lock` bind-mount so `--frozen` is the only install path

## Files changed
- `docker-compose.dev.yml` — naming, security defaults, pids limits
- `services/llm-guard-api/Dockerfile` — lockfile-only builds

## Test plan
- [x] `docker compose config --quiet` — exits 0
- [x] Pre-commit hooks passed
- [ ] Runtime verify: `read_only: true` on 5 services (model-loading writes to volume-mounted paths, rootfs writes will fail as expected)

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)