### PR TITLE
fix(docker): allow litellm startup writes under hardened compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -498,6 +498,9 @@ services:
 
   litellm:
     <<: *security-defaults
+    # LiteLLM writes migration/UI artifacts under site-packages at startup.
+    # Keep hardening defaults, but allow writes for this service.
+    read_only: false
     image: ghcr.io/berriai/litellm:main-v1.81.3-stable@sha256:3d80908e35230a0dfb58051ae4e2847371b2a327b44e105e79b8c4f67a65596c
     container_name: dev-litellm
     profiles: ["bot", "voice", "full"]


### PR DESCRIPTION
## Summary
- keep security defaults for `litellm` but override `read_only: false`
- fixes startup failure after #422 where LiteLLM writes migration/UI artifacts at boot

## Verification
- `docker compose --compatibility -f docker-compose.dev.yml --profile bot config --quiet`
- `make docker-bot-up` (bot + litellm healthy)
