### PR TITLE
fix(bot): restore streaming coordination — response_sent flag (#428)

### DIFF
--- a/telegram_bot/agents/context.py
+++ b/telegram_bot/agents/context.py
@@ -30,3 +30,6 @@ class BotContext:
     llm: Any  # AsyncOpenAI
     content_filter_enabled: bool = True
     guard_mode: str = "hard"
+    # Set to True by tools that deliver response directly (e.g. streaming) to prevent
+    # bot.py from sending the message a second time (#428).
+    response_sent: bool = False

--- a/telegram_bot/agents/rag_tool.py
+++ b/telegram_bot/agents/rag_tool.py
@@ -140,6 +140,13 @@ async def rag_search(
         )
         pipeline_wall_ms = (time.perf_counter() - invoke_start) * 1000
 
+        # Streaming hook (#428): when streaming is restored for the agent text path
+        # (i.e. the pipeline delivers the final answer directly to Telegram via
+        # generate_node with a live message object), set ctx.response_sent = True here
+        # so that _handle_query_supervisor in bot.py does not send the message again.
+        # Example: if result.get("response_sent") and ctx is not None:
+        #              ctx.response_sent = True
+
         if guard_result:
             if guard_result.get("injection_detected"):
                 result["injection_detected"] = True

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -693,8 +693,9 @@ class PropertyBot:
                 last_msg = messages[-1]
                 response_text = last_msg.content if hasattr(last_msg, "content") else str(last_msg)
 
-            # Send response with feedback buttons, sources, and Markdown (#426)
-            if response_text:
+            # Send response with feedback buttons, sources, and Markdown (#426).
+            # Skip if a tool already delivered the response via streaming (#428).
+            if response_text and not ctx.response_sent:
                 lf = get_client()
                 trace_id = lf.get_current_trace_id() or ""
                 query_type = rag_result_store.get("query_type", "")

--- a/tests/unit/agents/test_streaming.py
+++ b/tests/unit/agents/test_streaming.py
@@ -20,3 +20,51 @@ async def test_streaming_default_is_true():
 
     gc = GraphConfig()
     assert gc.streaming_enabled is True
+
+
+# --- BotContext.response_sent coordination tests (#428) ---
+
+
+async def test_bot_context_has_response_sent_field():
+    """BotContext has response_sent field defaulting to False (#428)."""
+    from unittest.mock import MagicMock
+
+    from telegram_bot.agents.context import BotContext
+
+    ctx = BotContext(
+        telegram_user_id=1,
+        session_id="s",
+        language="ru",
+        kommo_client=None,
+        history_service=MagicMock(),
+        embeddings=MagicMock(),
+        sparse_embeddings=MagicMock(),
+        qdrant=MagicMock(),
+        cache=MagicMock(),
+        reranker=None,
+        llm=MagicMock(),
+    )
+    assert ctx.response_sent is False
+
+
+async def test_bot_context_response_sent_mutable():
+    """BotContext.response_sent is mutable so streaming tools can set it (#428)."""
+    from unittest.mock import MagicMock
+
+    from telegram_bot.agents.context import BotContext
+
+    ctx = BotContext(
+        telegram_user_id=1,
+        session_id="s",
+        language="ru",
+        kommo_client=None,
+        history_service=MagicMock(),
+        embeddings=MagicMock(),
+        sparse_embeddings=MagicMock(),
+        qdrant=MagicMock(),
+        cache=MagicMock(),
+        reranker=None,
+        llm=MagicMock(),
+    )
+    ctx.response_sent = True
+    assert ctx.response_sent is True

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -1459,3 +1459,77 @@ class TestSdkAgentIntegration:
                 await bot.handle_query(message)
 
             mock_agent.ainvoke.assert_called_once()
+
+
+class TestStreamingCoordination:
+    """Test response_sent flag prevents double-sending after streaming (#428)."""
+
+    async def test_handle_query_skips_send_when_response_sent_flagged(self, mock_config):
+        """When ctx.response_sent=True, bot.py must NOT send again (#428)."""
+        bot, _ = _create_bot(mock_config)
+
+        async def _simulate_streaming(*args, **kwargs):
+            # Simulate a tool that streams the response and marks it as sent.
+            config_arg = kwargs.get("config", {})
+            ctx = config_arg.get("configurable", {}).get("bot_context")
+            if ctx is not None:
+                ctx.response_sent = True
+            return _mock_agent_result()
+
+        mock_agent = AsyncMock()
+        mock_agent.ainvoke = _simulate_streaming
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+        ):
+            message = _make_text_message("квартиры")
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        # Streaming already sent the message — bot.py must NOT send again.
+        message.answer.assert_not_called()
+
+    async def test_handle_query_sends_when_response_not_sent(self, mock_config):
+        """When ctx.response_sent=False (non-streaming), bot.py sends response (#428)."""
+        bot, _ = _create_bot(mock_config)
+
+        mock_agent = AsyncMock()
+        mock_agent.ainvoke = AsyncMock(return_value=_mock_agent_result())
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+        ):
+            message = _make_text_message("квартиры")
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        message.answer.assert_called()
+
+    def test_bot_context_response_sent_defaults_false(self, mock_config):
+        """BotContext.response_sent defaults to False (#428). Full field tests in test_streaming.py."""
+        from unittest.mock import MagicMock as _MagicMock
+
+        from telegram_bot.agents.context import BotContext
+
+        ctx = BotContext(
+            telegram_user_id=1,
+            session_id="s",
+            language="ru",
+            kommo_client=None,
+            history_service=_MagicMock(),
+            embeddings=_MagicMock(),
+            sparse_embeddings=_MagicMock(),
+            qdrant=_MagicMock(),
+            cache=_MagicMock(),
+            reranker=None,
+            llm=_MagicMock(),
+        )
+        assert ctx.response_sent is False


### PR DESCRIPTION
## Summary

- Adds `response_sent: bool = False` to `BotContext` — the DI context shared between agent tools and `bot.py`
- Guards the `message.answer()` call in `_handle_query_supervisor` with `not ctx.response_sent`, preventing double-send when a tool has already streamed the response directly to Telegram
- Documents the streaming hook in `rag_tool.py` with a comment showing exactly where `ctx.response_sent = True` must be set when streaming is restored for the text path

## Fixes

Closes #428

## Context

After the #413 migration to the `create_agent` SDK, `_handle_query_supervisor` sends the response unconditionally. The old supervisor checked `response_sent` from `RAGState`. This PR re-establishes that coordination via `BotContext` — the mutable DI object that survives the full agent invocation and is accessible in both `rag_tool.py` and `bot.py`.

Currently not visibly broken because `rag_pipeline` (post-#442) returns retrieved context only — streaming to Telegram does not yet happen in the agent text path. The guard is infrastructure to prevent double-sending when streaming is restored.

## Test plan

- [x] `TestStreamingCoordination.test_handle_query_skips_send_when_response_sent_flagged` — simulates tool setting flag, asserts `message.answer` not called
- [x] `TestStreamingCoordination.test_handle_query_sends_when_response_not_sent` — non-streaming path, asserts `message.answer` called normally
- [x] `TestStreamingCoordination.test_bot_context_response_sent_defaults_false` — field defaults correctly
- [x] `test_bot_context_has_response_sent_field` / `test_bot_context_response_sent_mutable` — field is mutable (tools can set it)
- [x] All 91 targeted unit tests pass: `pytest tests/unit/test_bot_handlers.py tests/unit/agents/test_streaming.py tests/unit/agents/test_rag_tool.py tests/unit/agents/test_context.py -n auto`
- [x] Lint: `ruff check` + `ruff format --check` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)