### PR TITLE
fix(bot): wire runtime lead scoring sync + hot lead notifier

### DIFF
--- a/telegram_bot/agents/manager_tools.py
+++ b/telegram_bot/agents/manager_tools.py
@@ -1,0 +1,104 @@
+"""Manager-only tools and role-gating helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import tool
+
+from telegram_bot.observability import observe
+from telegram_bot.services.lead_score_sync import sync_pending_lead_scores
+
+
+def _resolve_role(config: RunnableConfig) -> str:
+    configurable = (config or {}).get("configurable", {})
+    role = configurable.get("role")
+    if isinstance(role, str) and role.strip():
+        return role.strip().lower()
+    ctx = configurable.get("bot_context")
+    ctx_role = getattr(ctx, "role", None)
+    if isinstance(ctx_role, str) and ctx_role.strip():
+        return ctx_role.strip().lower()
+    return "client"
+
+
+def _get_user_context(config: RunnableConfig) -> tuple[int | None, str | None]:
+    configurable = (config or {}).get("configurable", {})
+    user_id = configurable.get("user_id")
+    session_id = configurable.get("session_id")
+    return user_id, session_id
+
+
+def build_tools_for_role(
+    *, role: str, base_tools: list[Any], manager_tools: Iterable[Any]
+) -> list[Any]:
+    """Select tools based on user role."""
+    tools = list(base_tools)
+    if role == "manager":
+        tools.extend(list(manager_tools))
+    return tools
+
+
+def create_manager_nurturing_tools(*, analytics_service: Any, nurturing_service: Any) -> list[Any]:
+    """Create manager-only nurturing + analytics tools."""
+
+    @tool
+    @observe(name="manager-get-funnel-analytics")
+    async def manager_get_funnel_analytics(query: str, config: RunnableConfig) -> str:
+        """Get funnel conversion analytics for manager review."""
+        role = _resolve_role(config)
+        if role not in {"manager", "admin"}:
+            return "Access denied"
+        if analytics_service is None:
+            return "Analytics service unavailable"
+        report = await analytics_service.get_latest_summary()
+        return str(report)
+
+    @tool
+    @observe(name="manager-run-nurturing-batch")
+    async def manager_run_nurturing_batch(query: str, config: RunnableConfig) -> str:
+        """Execute an on-demand nurturing batch for warm/cold leads."""
+        role = _resolve_role(config)
+        if role not in {"manager", "admin"}:
+            return "Access denied"
+        if nurturing_service is None:
+            return "Nurturing service unavailable"
+        count = await nurturing_service.run_once(limit=100)
+        return f"Nurturing batch executed: {count} leads"
+
+    return [manager_get_funnel_analytics, manager_run_nurturing_batch]
+
+
+def create_crm_score_sync_tool(
+    *,
+    scoring_store: Any,
+    kommo_client: Any,
+    score_field_id: int,
+    band_field_id: int,
+) -> Any:
+    """Create crm_sync_lead_score production tool."""
+
+    @tool
+    @observe(name="tool-crm-sync-lead-score")
+    async def crm_sync_lead_score(query: str, config: RunnableConfig) -> str:
+        """Sync pending lead scores to Kommo CRM."""
+        role = _resolve_role(config)
+        if role not in {"manager", "admin"}:
+            return "Access denied"
+
+        user_id, session_id = _get_user_context(config)
+        result = await sync_pending_lead_scores(
+            scoring_store=scoring_store,
+            kommo_client=kommo_client,
+            score_field_id=score_field_id,
+            band_field_id=band_field_id,
+            limit=20,
+        )
+        return (
+            f"CRM score sync completed: synced {result['synced']}, failed {result['failed']}, "
+            f"skipped {result['skipped']} (user {user_id}, session {session_id})"
+        )
+
+    return crm_sync_lead_score

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -274,6 +274,10 @@ class PropertyBot:
         # Nurturing scheduler (initialized in start() if enabled)
         self._nurturing_scheduler: Any | None = None
 
+        # Manager runtime services (initialized in start() if enabled)
+        self._nurturing_service: Any | None = None
+        self._funnel_analytics_service: Any | None = None
+
         # Hot lead notifier (initialized in start() when manager_ids configured)
         self._hot_lead_notifier: Any | None = None
 
@@ -622,20 +626,51 @@ class PropertyBot:
         session_id = make_session_id("chat", message.chat.id)
         role = await self._resolve_user_role(user_id)
 
-        # Build tools list
-        tools: list[Any] = [rag_search]
+        # Build base tools list
+        base_tools: list[Any] = [rag_search]
         if self._history_service is not None:
-            tools.append(history_search)
+            base_tools.append(history_search)
 
-        # Add CRM tools conditionally
-        if (
-            role == "manager"
-            and getattr(self.config, "kommo_enabled", False)
-            and getattr(self, "_kommo_client", None)
-        ):
-            from .agents.crm_tools import get_crm_tools
+        manager_tools: list[Any] = []
+        if role == "manager":
+            from .agents.manager_tools import (
+                build_tools_for_role,
+                create_crm_score_sync_tool,
+                create_manager_nurturing_tools,
+            )
 
-            tools.extend(get_crm_tools())
+            manager_tools.extend(
+                create_manager_nurturing_tools(
+                    analytics_service=self._funnel_analytics_service,
+                    nurturing_service=self._nurturing_service,
+                )
+            )
+
+            if self._lead_scoring_store is not None:
+                manager_tools.append(
+                    create_crm_score_sync_tool(
+                        scoring_store=self._lead_scoring_store,
+                        kommo_client=getattr(self, "_kommo_client", None),
+                        score_field_id=self.config.kommo_lead_score_field_id,
+                        band_field_id=self.config.kommo_lead_band_field_id,
+                    )
+                )
+
+            # Add direct CRM tools conditionally
+            if getattr(self.config, "kommo_enabled", False) and getattr(
+                self, "_kommo_client", None
+            ):
+                from .agents.crm_tools import get_crm_tools
+
+                manager_tools.extend(get_crm_tools())
+
+            tools = build_tools_for_role(
+                role=role,
+                base_tools=base_tools,
+                manager_tools=manager_tools,
+            )
+        else:
+            tools = base_tools
 
         # Create agent via SDK — route through LiteLLM proxy (#420)
         agent = create_bot_agent(
@@ -1272,6 +1307,8 @@ class PropertyBot:
 
                     nurturing_svc = NurturingService(pool=self._pg_pool)
                     analytics_svc = FunnelAnalyticsService(pool=self._pg_pool)
+                    self._nurturing_service = nurturing_svc
+                    self._funnel_analytics_service = analytics_svc
                     self._nurturing_scheduler = NurturingScheduler(
                         nurturing_service=nurturing_svc,
                         analytics_service=analytics_svc,
@@ -1289,7 +1326,16 @@ class PropertyBot:
         from .middlewares.i18n import create_translator_hub, setup_i18n_middleware
 
         self._i18n_hub = create_translator_hub()
-        setup_i18n_middleware(self.dp, self._i18n_hub, self._user_service)
+        setup_i18n_middleware(
+            self.dp,
+            self._i18n_hub,
+            self._user_service,
+            lead_scoring_store=self._lead_scoring_store,
+            hot_lead_notifier=self._hot_lead_notifier,
+            kommo_client=self._kommo_client,
+            pg_pool=self._pg_pool,
+            bot_config=self.config,
+        )
         logger.info("i18n middleware ready")
 
         # Setup aiogram-dialog
@@ -1365,6 +1411,8 @@ class PropertyBot:
         if self._nurturing_scheduler is not None:
             await self._nurturing_scheduler.stop()
             self._nurturing_scheduler = None
+        self._nurturing_service = None
+        self._funnel_analytics_service = None
         if self._pg_pool is not None:
             await self._pg_pool.close()
             logger.info("PostgreSQL pool closed")

--- a/telegram_bot/dialogs/funnel.py
+++ b/telegram_bot/dialogs/funnel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import operator
 from typing import Any
@@ -15,6 +16,25 @@ from .states import FunnelSG
 
 
 logger = logging.getLogger(__name__)
+_BACKGROUND_TASKS: set[asyncio.Task[Any]] = set()
+
+
+async def _persist_funnel_lead_score_safe(**kwargs: Any) -> None:
+    """Persist/sync funnel score without breaking callback flow."""
+    try:
+        from telegram_bot.services.funnel_lead_scoring import persist_and_sync_funnel_lead_score
+
+        await persist_and_sync_funnel_lead_score(**kwargs)
+    except Exception:
+        logger.exception("Failed to persist/sync funnel lead score")
+
+
+def _spawn_persist_funnel_lead_score(**kwargs: Any) -> None:
+    """Run heavy side effects in the background to keep callback responsive."""
+    task = asyncio.create_task(_persist_funnel_lead_score_safe(**kwargs))
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_TASKS.discard)
+
 
 # --- Getters (provide data to windows) ---
 
@@ -139,14 +159,13 @@ async def on_timeline_selected(
     """Save timeline and show results."""
     manager.dialog_data["timeline"] = item_id
 
-    # Persist scoring + CRM sync on completed funnel answers.
+    # Persist scoring + CRM sync asynchronously on completed funnel answers.
     try:
         from telegram_bot.bot import make_session_id
-        from telegram_bot.services.funnel_lead_scoring import persist_and_sync_funnel_lead_score
 
         if callback.from_user is not None:
             data = manager.dialog_data
-            await persist_and_sync_funnel_lead_score(
+            _spawn_persist_funnel_lead_score(
                 telegram_user_id=callback.from_user.id,
                 session_id=make_session_id("chat", callback.message.chat.id)
                 if callback.message is not None
@@ -162,7 +181,7 @@ async def on_timeline_selected(
                 config=manager.middleware_data.get("bot_config"),
             )
     except Exception:
-        logger.exception("Failed to persist/sync funnel lead score")
+        logger.exception("Failed to schedule funnel lead score persistence")
 
     await manager.switch_to(FunnelSG.results)
 

--- a/telegram_bot/dialogs/funnel.py
+++ b/telegram_bot/dialogs/funnel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import operator
 from typing import Any
 
@@ -12,6 +13,8 @@ from aiogram_dialog.widgets.text import Format
 
 from .states import FunnelSG
 
+
+logger = logging.getLogger(__name__)
 
 # --- Getters (provide data to windows) ---
 
@@ -135,6 +138,32 @@ async def on_timeline_selected(
 ) -> None:
     """Save timeline and show results."""
     manager.dialog_data["timeline"] = item_id
+
+    # Persist scoring + CRM sync on completed funnel answers.
+    try:
+        from telegram_bot.bot import make_session_id
+        from telegram_bot.services.funnel_lead_scoring import persist_and_sync_funnel_lead_score
+
+        if callback.from_user is not None:
+            data = manager.dialog_data
+            await persist_and_sync_funnel_lead_score(
+                telegram_user_id=callback.from_user.id,
+                session_id=make_session_id("chat", callback.message.chat.id)
+                if callback.message is not None
+                else make_session_id("chat", callback.from_user.id),
+                property_type=data.get("property_type"),
+                budget=data.get("budget"),
+                timeline=data.get("timeline"),
+                user_service=manager.middleware_data.get("user_service"),
+                pg_pool=manager.middleware_data.get("pg_pool"),
+                lead_scoring_store=manager.middleware_data.get("lead_scoring_store"),
+                kommo_client=manager.middleware_data.get("kommo_client"),
+                hot_lead_notifier=manager.middleware_data.get("hot_lead_notifier"),
+                config=manager.middleware_data.get("bot_config"),
+            )
+    except Exception:
+        logger.exception("Failed to persist/sync funnel lead score")
+
     await manager.switch_to(FunnelSG.results)
 
 

--- a/telegram_bot/middlewares/i18n.py
+++ b/telegram_bot/middlewares/i18n.py
@@ -71,11 +71,21 @@ class I18nMiddleware(BaseMiddleware):
         self,
         hub: TranslatorHub,
         user_service: UserService | None = None,
+        lead_scoring_store: Any | None = None,
+        hot_lead_notifier: Any | None = None,
+        kommo_client: Any | None = None,
+        pg_pool: Any | None = None,
+        bot_config: Any | None = None,
         default_locale: str = "ru",
     ) -> None:
         super().__init__()
         self._hub = hub
         self._user_service = user_service
+        self._lead_scoring_store = lead_scoring_store
+        self._hot_lead_notifier = hot_lead_notifier
+        self._kommo_client = kommo_client
+        self._pg_pool = pg_pool
+        self._bot_config = bot_config
         self._default_locale = default_locale
 
     async def __call__(
@@ -104,6 +114,11 @@ class I18nMiddleware(BaseMiddleware):
         data["i18n"] = self._hub.get_translator_by_locale(locale)
         data["locale"] = locale
         data["user_service"] = self._user_service
+        data["lead_scoring_store"] = self._lead_scoring_store
+        data["hot_lead_notifier"] = self._hot_lead_notifier
+        data["kommo_client"] = self._kommo_client
+        data["pg_pool"] = self._pg_pool
+        data["bot_config"] = self._bot_config
         return await handler(event, data)
 
 
@@ -111,8 +126,21 @@ def setup_i18n_middleware(
     dp: Dispatcher,
     hub: TranslatorHub,
     user_service: UserService | None = None,
+    lead_scoring_store: Any | None = None,
+    hot_lead_notifier: Any | None = None,
+    kommo_client: Any | None = None,
+    pg_pool: Any | None = None,
+    bot_config: Any | None = None,
 ) -> None:
     """Register i18n middleware on all routers."""
-    middleware = I18nMiddleware(hub=hub, user_service=user_service)
+    middleware = I18nMiddleware(
+        hub=hub,
+        user_service=user_service,
+        lead_scoring_store=lead_scoring_store,
+        hot_lead_notifier=hot_lead_notifier,
+        kommo_client=kommo_client,
+        pg_pool=pg_pool,
+        bot_config=bot_config,
+    )
     dp.message.outer_middleware(middleware)
     dp.callback_query.outer_middleware(middleware)

--- a/telegram_bot/services/funnel_lead_scoring.py
+++ b/telegram_bot/services/funnel_lead_scoring.py
@@ -1,0 +1,143 @@
+"""Persist lead score from funnel answers and run side effects."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from telegram_bot.services.lead_score_sync import sync_pending_lead_scores
+from telegram_bot.services.lead_scoring import classify_lead, compute_lead_score
+from telegram_bot.services.lead_scoring_models import LeadScoreRecord
+
+
+logger = logging.getLogger(__name__)
+
+
+def _build_reason_codes(
+    *, property_type: str | None, budget: str | None, timeline: str | None
+) -> list[str]:
+    codes: list[str] = []
+    if timeline:
+        codes.append(f"timeline_{timeline}")
+    if budget:
+        codes.append("budget_defined")
+    if property_type and property_type != "looking":
+        codes.append(f"property_type_{property_type}")
+    return codes
+
+
+async def persist_and_sync_funnel_lead_score(
+    *,
+    telegram_user_id: int,
+    session_id: str,
+    property_type: str | None,
+    budget: str | None,
+    timeline: str | None,
+    user_service: Any,
+    pg_pool: Any,
+    lead_scoring_store: Any,
+    kommo_client: Any,
+    hot_lead_notifier: Any,
+    config: Any,
+) -> dict[str, Any]:
+    """Compute score from funnel data, persist it, sync it, and notify managers."""
+    if user_service is None or pg_pool is None or lead_scoring_store is None:
+        return {"persisted": False}
+
+    user = await user_service.get_or_create(telegram_id=telegram_user_id)
+    user_id = getattr(user, "id", None)
+    if user_id is None:
+        return {"persisted": False}
+
+    score_value = compute_lead_score(property_type=property_type, budget=budget, timeline=timeline)
+    score_band = classify_lead(score_value)
+    reason_codes = _build_reason_codes(
+        property_type=property_type, budget=budget, timeline=timeline
+    )
+    preferences = {
+        "property_type": property_type,
+        "budget": budget,
+        "timeline": timeline,
+    }
+
+    row = await pg_pool.fetchrow(
+        """
+        SELECT id, kommo_lead_id
+        FROM leads
+        WHERE user_id = $1
+        ORDER BY updated_at DESC
+        LIMIT 1
+        """,
+        user_id,
+    )
+    if row is None:
+        row = await pg_pool.fetchrow(
+            """
+            INSERT INTO leads (user_id, stage, score, preferences)
+            VALUES ($1, $2, $3, $4::jsonb)
+            RETURNING id, kommo_lead_id
+            """,
+            user_id,
+            score_band,
+            score_value,
+            json.dumps(preferences),
+        )
+    else:
+        row = await pg_pool.fetchrow(
+            """
+            UPDATE leads
+            SET stage = $2,
+                score = $3,
+                preferences = COALESCE(preferences, '{}'::jsonb) || $4::jsonb,
+                updated_at = now()
+            WHERE id = $1
+            RETURNING id, kommo_lead_id
+            """,
+            int(row["id"]),
+            score_band,
+            score_value,
+            json.dumps(preferences),
+        )
+
+    lead_id = int(row["id"])
+    kommo_lead_id = row["kommo_lead_id"]
+
+    await lead_scoring_store.upsert_score(
+        LeadScoreRecord(
+            lead_id=lead_id,
+            user_id=int(user_id),
+            session_id=session_id,
+            score_value=score_value,
+            score_band=score_band,
+            reason_codes=reason_codes,
+            kommo_lead_id=int(kommo_lead_id) if kommo_lead_id is not None else None,
+        )
+    )
+
+    sync_result = await sync_pending_lead_scores(
+        scoring_store=lead_scoring_store,
+        kommo_client=kommo_client,
+        score_field_id=int(getattr(config, "kommo_lead_score_field_id", 0) or 0),
+        band_field_id=int(getattr(config, "kommo_lead_band_field_id", 0) or 0),
+        limit=20,
+    )
+
+    notified = False
+    threshold = int(getattr(config, "manager_hot_lead_threshold", 60) or 60)
+    if hot_lead_notifier is not None and score_value >= threshold:
+        try:
+            notified = await hot_lead_notifier.notify_if_hot(
+                {"lead_id": lead_id, "score": score_value, "session_id": session_id}
+            )
+        except Exception:
+            logger.exception("Failed to notify managers for hot lead %s", lead_id)
+
+    return {
+        "persisted": True,
+        "lead_id": lead_id,
+        "score_value": score_value,
+        "score_band": score_band,
+        "notified": notified,
+        **sync_result,
+    }

--- a/telegram_bot/services/lead_score_sync.py
+++ b/telegram_bot/services/lead_score_sync.py
@@ -1,0 +1,56 @@
+"""Runtime helpers for syncing pending lead scores to Kommo CRM."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from telegram_bot.services.kommo_models import LeadScoreSyncPayload
+
+
+logger = logging.getLogger(__name__)
+
+
+async def sync_pending_lead_scores(
+    *,
+    scoring_store: Any,
+    kommo_client: Any,
+    score_field_id: int,
+    band_field_id: int,
+    limit: int = 20,
+) -> dict[str, int]:
+    """Sync pending lead scores to Kommo and return counters."""
+    if scoring_store is None or kommo_client is None:
+        return {"synced": 0, "failed": 0, "skipped": 0}
+    if score_field_id <= 0 or band_field_id <= 0:
+        return {"synced": 0, "failed": 0, "skipped": 0}
+
+    pending = await scoring_store.list_pending_sync(limit=limit)
+    synced = 0
+    failed = 0
+    skipped = 0
+
+    for rec in pending:
+        if rec.kommo_lead_id is None:
+            skipped += 1
+            continue
+        key = f"lead-score:{rec.lead_id}:{rec.session_id}:{rec.score_value}:{rec.score_band}"
+        payload = LeadScoreSyncPayload.from_record(
+            rec,
+            score_field_id=score_field_id,
+            band_field_id=band_field_id,
+        ).to_kommo_payload()
+        try:
+            await kommo_client.update_lead_score(
+                lead_id=rec.kommo_lead_id,
+                payload=payload,
+                idempotency_key=key,
+            )
+            await scoring_store.mark_synced(lead_id=rec.lead_id)
+            synced += 1
+        except Exception:
+            logger.exception("CRM score sync failed for lead %s", rec.lead_id)
+            await scoring_store.mark_failed(lead_id=rec.lead_id, error="kommo_error")
+            failed += 1
+
+    return {"synced": synced, "failed": failed, "skipped": skipped}

--- a/tests/smoke/test_manager_flow.py
+++ b/tests/smoke/test_manager_flow.py
@@ -6,21 +6,11 @@ No Docker required — uses mocked services.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-
-def build_tools_for_role(
-    *, role: str, base_tools: list[Any], manager_tools: Iterable[Any]
-) -> list[Any]:
-    """Select tools based on user role (#388)."""
-    tools = list(base_tools)
-    if role == "manager":
-        tools.extend(list(manager_tools))
-    return tools
+from telegram_bot.agents.manager_tools import build_tools_for_role
 
 
 @pytest.fixture

--- a/tests/unit/agents/test_lead_score_sync_tool.py
+++ b/tests/unit/agents/test_lead_score_sync_tool.py
@@ -3,77 +3,15 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
-from langchain_core.runnables import RunnableConfig
-from langchain_core.tools import tool
 
-from telegram_bot.observability import observe
-from telegram_bot.services.kommo_models import LeadScoreSyncPayload
+from telegram_bot.agents.manager_tools import create_crm_score_sync_tool
 from telegram_bot.services.lead_scoring_models import LeadScoreRecord
 
 
 logger = logging.getLogger(__name__)
-
-
-def _get_user_context(config: RunnableConfig) -> tuple[int | None, str | None]:
-    """Extract user_id and session_id from RunnableConfig."""
-    configurable = (config or {}).get("configurable", {})
-    user_id = configurable.get("user_id")
-    session_id = configurable.get("session_id")
-    return user_id, session_id
-
-
-def create_crm_score_sync_tool(
-    *,
-    scoring_store: Any,
-    kommo_client: Any,
-    score_field_id: int,
-    band_field_id: int,
-) -> Any:
-    """Create crm_sync_lead_score tool for supervisor (#384)."""
-
-    @tool
-    @observe(name="tool-crm-sync-lead-score")
-    async def crm_sync_lead_score(query: str, config: RunnableConfig) -> str:
-        """Sync pending lead scores to Kommo CRM."""
-        user_id, session_id = _get_user_context(config)
-        pending = await scoring_store.list_pending_sync(limit=20)
-        synced = 0
-        failed = 0
-        skipped = 0
-
-        for rec in pending:
-            if rec.kommo_lead_id is None:
-                skipped += 1
-                continue
-            key = f"lead-score:{rec.lead_id}:{rec.session_id}:{rec.score_value}:{rec.score_band}"
-            payload = LeadScoreSyncPayload.from_record(
-                rec,
-                score_field_id=score_field_id,
-                band_field_id=band_field_id,
-            ).to_kommo_payload()
-            try:
-                await kommo_client.update_lead_score(
-                    lead_id=rec.kommo_lead_id,
-                    payload=payload,
-                    idempotency_key=key,
-                )
-                await scoring_store.mark_synced(lead_id=rec.lead_id)
-                synced += 1
-            except Exception:
-                logger.exception("CRM score sync failed for lead %s", rec.lead_id)
-                await scoring_store.mark_failed(lead_id=rec.lead_id, error="kommo_error")
-                failed += 1
-
-        return (
-            f"CRM score sync completed: synced {synced}, failed {failed}, "
-            f"skipped {skipped} (user {user_id}, session {session_id})"
-        )
-
-    return crm_sync_lead_score
 
 
 @pytest.fixture
@@ -113,7 +51,7 @@ def mock_kommo_client_error():
 
 @pytest.fixture
 def runnable_config():
-    return {"configurable": {"user_id": 99, "session_id": "chat-1"}}
+    return {"configurable": {"user_id": 99, "session_id": "chat-1", "role": "manager"}}
 
 
 class TestCrmSyncLeadScoreTool:

--- a/tests/unit/agents/test_nurturing_analytics_tools.py
+++ b/tests/unit/agents/test_nurturing_analytics_tools.py
@@ -2,46 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-from typing import Any
 from unittest.mock import AsyncMock
 
-from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 
-
-def build_tools_for_role(
-    *, role: str, base_tools: list[Any], manager_tools: Iterable[Any]
-) -> list[Any]:
-    """Select tools based on user role (#388)."""
-    tools = list(base_tools)
-    if role == "manager":
-        tools.extend(list(manager_tools))
-    return tools
-
-
-def create_manager_nurturing_tools(*, analytics_service: Any, nurturing_service: Any) -> list[Any]:
-    """Create manager-only nurturing + analytics tools (#390)."""
-
-    @tool
-    async def manager_get_funnel_analytics(query: str, config: RunnableConfig) -> str:
-        """Get funnel conversion analytics for manager review."""
-        role = (config or {}).get("configurable", {}).get("role", "client")
-        if role not in {"manager", "admin"}:
-            return "Access denied"
-        report = await analytics_service.get_latest_summary()
-        return str(report)
-
-    @tool
-    async def manager_run_nurturing_batch(query: str, config: RunnableConfig) -> str:
-        """Execute an on-demand nurturing batch for warm/cold leads."""
-        role = (config or {}).get("configurable", {}).get("role", "client")
-        if role not in {"manager", "admin"}:
-            return "Access denied"
-        count = await nurturing_service.run_once(limit=100)
-        return f"Nurturing batch executed: {count} leads"
-
-    return [manager_get_funnel_analytics, manager_run_nurturing_batch]
+from telegram_bot.agents.manager_tools import build_tools_for_role, create_manager_nurturing_tools
 
 
 @tool

--- a/tests/unit/dialogs/test_funnel.py
+++ b/tests/unit/dialogs/test_funnel.py
@@ -1,5 +1,11 @@
 """Tests for BANT funnel dialog."""
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import telegram_bot.dialogs.funnel as funnel_module
 from telegram_bot.dialogs.funnel import funnel_dialog
 from telegram_bot.dialogs.states import FunnelSG
 
@@ -17,3 +23,67 @@ def test_funnel_has_all_windows():
     assert FunnelSG.budget in states
     assert FunnelSG.timeline in states
     assert FunnelSG.results in states
+
+
+@pytest.mark.asyncio
+async def test_timeline_selection_schedules_background_persist_and_switches(monkeypatch):
+    spawn_mock = MagicMock()
+    monkeypatch.setattr(funnel_module, "_spawn_persist_funnel_lead_score", spawn_mock)
+
+    callback = SimpleNamespace(
+        from_user=SimpleNamespace(id=12345),
+        message=SimpleNamespace(chat=SimpleNamespace(id=777)),
+    )
+    manager = SimpleNamespace(
+        dialog_data={"property_type": "apartment", "budget": "mid"},
+        middleware_data={
+            "user_service": object(),
+            "pg_pool": object(),
+            "lead_scoring_store": object(),
+            "kommo_client": object(),
+            "hot_lead_notifier": object(),
+            "bot_config": object(),
+        },
+        switch_to=AsyncMock(),
+    )
+
+    await funnel_module.on_timeline_selected(
+        callback=callback,
+        widget=SimpleNamespace(),
+        manager=manager,
+        item_id="asap",
+    )
+
+    spawn_mock.assert_called_once()
+    assert spawn_mock.call_args.kwargs["telegram_user_id"] == 12345
+    assert spawn_mock.call_args.kwargs["property_type"] == "apartment"
+    assert spawn_mock.call_args.kwargs["budget"] == "mid"
+    assert spawn_mock.call_args.kwargs["timeline"] == "asap"
+    manager.switch_to.assert_awaited_once_with(FunnelSG.results)
+
+
+@pytest.mark.asyncio
+async def test_timeline_selection_fail_soft_when_schedule_raises(monkeypatch):
+    def _raise_on_schedule(**kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(funnel_module, "_spawn_persist_funnel_lead_score", _raise_on_schedule)
+
+    callback = SimpleNamespace(
+        from_user=SimpleNamespace(id=1),
+        message=SimpleNamespace(chat=SimpleNamespace(id=2)),
+    )
+    manager = SimpleNamespace(
+        dialog_data={},
+        middleware_data={},
+        switch_to=AsyncMock(),
+    )
+
+    await funnel_module.on_timeline_selected(
+        callback=callback,
+        widget=SimpleNamespace(),
+        manager=manager,
+        item_id="3months",
+    )
+
+    manager.switch_to.assert_awaited_once_with(FunnelSG.results)

--- a/tests/unit/services/test_funnel_lead_scoring.py
+++ b/tests/unit/services/test_funnel_lead_scoring.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from telegram_bot.services.funnel_lead_scoring import persist_and_sync_funnel_lead_score
+
+
+@pytest.mark.asyncio
+async def test_persist_and_sync_calls_hot_lead_notifier_for_hot_score():
+    user_service = AsyncMock()
+    user_service.get_or_create = AsyncMock(return_value=SimpleNamespace(id=7))
+
+    pg_pool = AsyncMock()
+    pg_pool.fetchrow = AsyncMock(
+        side_effect=[
+            None,
+            {"id": 11, "kommo_lead_id": 5001},
+        ]
+    )
+
+    lead_scoring_store = AsyncMock()
+    lead_scoring_store.upsert_score = AsyncMock()
+    lead_scoring_store.list_pending_sync = AsyncMock(
+        return_value=[
+            SimpleNamespace(
+                lead_id=11,
+                user_id=7,
+                session_id="chat-1",
+                score_value=70,
+                score_band="hot",
+                reason_codes=["timeline_asap"],
+                kommo_lead_id=5001,
+            )
+        ]
+    )
+    lead_scoring_store.mark_synced = AsyncMock()
+    lead_scoring_store.mark_failed = AsyncMock()
+
+    kommo_client = AsyncMock()
+    kommo_client.update_lead_score = AsyncMock(return_value={"id": 5001})
+
+    hot_lead_notifier = AsyncMock()
+    hot_lead_notifier.notify_if_hot = AsyncMock(return_value=True)
+
+    config = SimpleNamespace(
+        kommo_lead_score_field_id=701,
+        kommo_lead_band_field_id=702,
+        manager_hot_lead_threshold=60,
+    )
+
+    result = await persist_and_sync_funnel_lead_score(
+        telegram_user_id=12345,
+        session_id="chat-1",
+        property_type="apartment",
+        budget="mid",
+        timeline="asap",
+        user_service=user_service,
+        pg_pool=pg_pool,
+        lead_scoring_store=lead_scoring_store,
+        kommo_client=kommo_client,
+        hot_lead_notifier=hot_lead_notifier,
+        config=config,
+    )
+
+    assert result["persisted"] is True
+    assert result["score_band"] == "hot"
+    lead_scoring_store.upsert_score.assert_called_once()
+    kommo_client.update_lead_score.assert_called_once()
+    hot_lead_notifier.notify_if_hot.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_persist_and_sync_skips_if_runtime_services_missing():
+    result = await persist_and_sync_funnel_lead_score(
+        telegram_user_id=1,
+        session_id="chat-1",
+        property_type="apartment",
+        budget="mid",
+        timeline="asap",
+        user_service=None,
+        pg_pool=None,
+        lead_scoring_store=None,
+        kommo_client=None,
+        hot_lead_notifier=None,
+        config=SimpleNamespace(),
+    )
+
+    assert result == {"persisted": False}


### PR DESCRIPTION
## Summary\n- wire production manager tools into supervisor runtime (role gating, nurturing/analytics, crm score sync)\n- add funnel completion runtime path to compute/persist lead score, sync pending scores to Kommo, and trigger hot lead notifications\n- inject runtime services into dialog middleware context so funnel callbacks use real production deps\n- replace test-local helper implementations with imports from production modules\n\n## Fixes\n- Closes #467\n- Closes #468\n- Closes #469\n\n## Verification\n- make check\n- PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit\n- uv run pytest tests/integration/test_graph_paths.py -v\n- PYTEST_ADDOPTS='-n auto --dist=worksteal' uv run pytest tests/unit/agents/test_lead_score_sync_tool.py tests/unit/agents/test_nurturing_analytics_tools.py tests/unit/services/test_funnel_lead_scoring.py tests/smoke/test_manager_flow.py tests/unit/dialogs/test_funnel.py -q