### PR TITLE
fix(bot): add runtime fallback for Redis checkpointer failures

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -172,6 +172,37 @@ def _is_post_pipeline_cleanup_error(exc: Exception) -> bool:
     return False
 
 
+def _is_checkpointer_runtime_error(exc: Exception) -> bool:
+    """Detect runtime checkpointer/storage failures in text agent path."""
+    message = str(exc).lower()
+    checkpointer_markers = (
+        "checkpointer",
+        "checkpoint",
+        "aput",
+        "pregelloop.__aexit__",
+        "asyncpregelloop.__aexit__",
+    )
+    storage_markers = (
+        "serializ",
+        "json",
+        "msgpack",
+        "redis",
+        "connection",
+    )
+    if any(m in message for m in checkpointer_markers) and any(
+        m in message for m in storage_markers
+    ):
+        return True
+
+    tb = exc.__traceback__
+    while tb is not None:
+        filename = tb.tb_frame.f_code.co_filename.lower()
+        if "langgraph" in filename and "checkpoint" in filename:
+            return True
+        tb = tb.tb_next
+    return False
+
+
 class PropertyBot:
     """Telegram bot for domain-specific search (configurable via BOT_DOMAIN)."""
 
@@ -730,16 +761,14 @@ class PropertyBot:
             langfuse_handler = create_callback_handler()
             callbacks = [langfuse_handler] if langfuse_handler else []
             async with ChatActionSender.typing(bot=bot, chat_id=message.chat.id):
-                result = await agent.ainvoke(
-                    {"messages": [{"role": "user", "content": user_text}]},
-                    config={
-                        "callbacks": callbacks,
-                        "configurable": {
-                            "thread_id": _supervisor_thread_id(message.chat.id),
-                            "bot_context": ctx,
-                            "rag_result_store": rag_result_store,
-                        },
-                    },
+                result = await self._ainvoke_supervisor_with_recovery(
+                    agent=agent,
+                    tools=tools,
+                    user_text=user_text,
+                    chat_id=message.chat.id,
+                    callbacks=callbacks,
+                    bot_context=ctx,
+                    rag_result_store=rag_result_store,
                 )
 
             # Extract response from final message
@@ -890,6 +919,50 @@ class PropertyBot:
                         )
                 except Exception:
                     logger.warning("Failed to save history turn", exc_info=True)
+
+    async def _ainvoke_supervisor_with_recovery(
+        self,
+        *,
+        agent: Any,
+        tools: list[Any],
+        user_text: str,
+        chat_id: int,
+        callbacks: list[Any],
+        bot_context: BotContext,
+        rag_result_store: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Invoke supervisor agent and retry once with MemorySaver on checkpointer failures."""
+        payload = {"messages": [{"role": "user", "content": user_text}]}
+        config = {
+            "callbacks": callbacks,
+            "configurable": {
+                "thread_id": _supervisor_thread_id(chat_id),
+                "bot_context": bot_context,
+                "rag_result_store": rag_result_store,
+            },
+        }
+        try:
+            return await agent.ainvoke(payload, config=config)
+        except Exception as exc:
+            if not _is_checkpointer_runtime_error(exc):
+                raise
+            logger.exception(
+                "Supervisor ainvoke failed due to checkpointer runtime error; "
+                "retrying once with MemorySaver"
+            )
+
+        from .integrations.memory import create_fallback_checkpointer
+
+        self._agent_checkpointer = create_fallback_checkpointer()
+        fallback_agent = create_bot_agent(
+            model=self.config.supervisor_model,
+            tools=tools,
+            checkpointer=self._agent_checkpointer,
+            language=self.config.domain_language,
+            base_url=self.config.llm_base_url,
+            api_key=self.config.llm_api_key,
+        )
+        return await fallback_agent.ainvoke(payload, config=config)
 
     @observe(name="telegram-rag-voice")
     async def handle_voice(self, message: Message):

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -764,6 +764,7 @@ class PropertyBot:
                 result = await self._ainvoke_supervisor_with_recovery(
                     agent=agent,
                     tools=tools,
+                    role=role,
                     user_text=user_text,
                     chat_id=message.chat.id,
                     callbacks=callbacks,
@@ -925,6 +926,7 @@ class PropertyBot:
         *,
         agent: Any,
         tools: list[Any],
+        role: str,
         user_text: str,
         chat_id: int,
         callbacks: list[Any],
@@ -945,6 +947,15 @@ class PropertyBot:
             return await agent.ainvoke(payload, config=config)
         except Exception as exc:
             if not _is_checkpointer_runtime_error(exc):
+                raise
+            if role in {"manager", "admin"}:
+                # Manager toolsets include write-side effects (CRM/nurturing).
+                # Retrying the full agent run can duplicate external actions.
+                logger.exception(
+                    "Supervisor ainvoke failed with checkpointer runtime error; "
+                    "skip retry for role=%s to avoid duplicate side effects",
+                    role,
+                )
                 raise
             logger.exception(
                 "Supervisor ainvoke failed due to checkpointer runtime error; "

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -350,6 +350,67 @@ class TestHandleQuery:
 
             mock_agent.ainvoke.assert_called_once()
 
+    async def test_handle_query_retries_with_memory_on_checkpointer_runtime_error(
+        self, mock_config
+    ):
+        """Text path retries once with MemorySaver when checkpointer write fails (#466)."""
+        bot, _ = _create_bot(mock_config)
+
+        failing_agent = AsyncMock()
+        failing_agent.ainvoke = AsyncMock(
+            side_effect=RuntimeError("checkpointer aput not JSON serializable")
+        )
+        fallback_agent = AsyncMock()
+        fallback_agent.ainvoke = AsyncMock(return_value=_mock_agent_result())
+        fallback_cp = MagicMock(name="memory-saver-fallback")
+
+        with (
+            patch(
+                "telegram_bot.bot.create_bot_agent",
+                side_effect=[failing_agent, fallback_agent],
+            ) as mock_factory,
+            patch(
+                "telegram_bot.integrations.memory.create_fallback_checkpointer",
+                return_value=fallback_cp,
+            ) as mock_create_fallback_cp,
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+        ):
+            message = _make_text_message("квартиры в Несебр")
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        assert failing_agent.ainvoke.await_count == 1
+        assert fallback_agent.ainvoke.await_count == 1
+        assert mock_factory.call_count == 2
+        assert mock_factory.call_args_list[1].kwargs["checkpointer"] is fallback_cp
+        assert bot._agent_checkpointer is fallback_cp
+        assert mock_create_fallback_cp.call_count == 1
+
+    async def test_handle_query_does_not_retry_on_non_checkpointer_error(self, mock_config):
+        """Non-checkpointer failures should bubble up without fallback retry."""
+        bot, _ = _create_bot(mock_config)
+
+        failing_agent = AsyncMock()
+        failing_agent.ainvoke = AsyncMock(side_effect=RuntimeError("upstream llm timeout"))
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=failing_agent) as mock_factory,
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+        ):
+            message = _make_text_message("квартиры в Несебр")
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                with pytest.raises(RuntimeError, match="upstream llm timeout"):
+                    await bot.handle_query(message)
+
+        assert failing_agent.ainvoke.await_count == 1
+        assert mock_factory.call_count == 1
+
     async def test_handle_query_sends_typing(self, mock_config):
         """Typing action is sent early."""
         bot, _ = _create_bot(mock_config)

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -411,6 +411,35 @@ class TestHandleQuery:
         assert failing_agent.ainvoke.await_count == 1
         assert mock_factory.call_count == 1
 
+    async def test_handle_query_manager_skips_retry_on_checkpointer_error(self, mock_config):
+        """Manager path should not retry to avoid duplicate write-side effects."""
+        mock_config.manager_ids = [12345]
+        bot, _ = _create_bot(mock_config)
+
+        failing_agent = AsyncMock()
+        failing_agent.ainvoke = AsyncMock(
+            side_effect=RuntimeError("checkpointer aput not JSON serializable")
+        )
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=failing_agent) as mock_factory,
+            patch(
+                "telegram_bot.integrations.memory.create_fallback_checkpointer"
+            ) as mock_create_fallback_cp,
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+        ):
+            message = _make_text_message("квартиры в Несебр", user_id=12345)
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                with pytest.raises(RuntimeError, match="checkpointer aput"):
+                    await bot.handle_query(message)
+
+        assert failing_agent.ainvoke.await_count == 1
+        assert mock_factory.call_count == 1
+        assert mock_create_fallback_cp.call_count == 0
+
     async def test_handle_query_sends_typing(self, mock_config):
         """Typing action is sent early."""
         bot, _ = _create_bot(mock_config)


### PR DESCRIPTION
## Summary
- add checkpointer runtime error detector for text supervisor path
- add guarded retry path: on checkpointer/serialization/storage runtime failure, switch to MemorySaver and retry once
- keep non-checkpointer failures unchanged (bubble up)
- add regression unit tests for retry/no-retry behavior

## Why
Issue #466 highlights a gap: startup fallback covers Redis init failures, but runtime serializer/storage failures at `agent.ainvoke()` could still break user flow.

## Fixes
- Refs #466

## Verification
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
- `uv run pytest tests/integration/test_graph_paths.py -v`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' uv run pytest tests/unit/test_bot_handlers.py -q`

## Staging rebuild & validation (required for closing #466)
Because bot image has not been rebuilt recently, validate on fresh image:
1. `make docker-bot-down`
2. `make docker-bot-up` (or equivalent with image rebuild in your env)
3. Send 5-10 text queries in one chat
4. Send 2-3 follow-up queries in same chat
5. Run `/clear`
6. Check logs for `checkpointer`, `aput`, `not JSON serializable`, `AsyncPregelLoop.__aexit__`, `Redis`
7. Confirm no generic middleware error was sent to users
