### PR TITLE
fix(observability): replace id= with score_id= in Langfuse create_score

### DIFF
--- a/telegram_bot/agents/history_graph/nodes.py
+++ b/telegram_bot/agents/history_graph/nodes.py
@@ -410,29 +410,29 @@ def write_history_scores(lf: Any, result: dict[str, Any], *, trace_id: str = "")
         trace_id=trace_id,
         name="history_results_count",
         value=len(results),
-        id=f"{trace_id}-history_results_count",
+        score_id=f"{trace_id}-history_results_count",
     )
     lf.create_score(
         trace_id=trace_id,
         name="history_relevance",
         value=1.0 if result.get("results_relevant") else 0.0,
-        id=f"{trace_id}-history_relevance",
+        score_id=f"{trace_id}-history_relevance",
     )
     lf.create_score(
         trace_id=trace_id,
         name="history_rewrite_count",
         value=result.get("rewrite_count", 0),
-        id=f"{trace_id}-history_rewrite_count",
+        score_id=f"{trace_id}-history_rewrite_count",
     )
     lf.create_score(
         trace_id=trace_id,
         name="history_latency_ms",
         value=round(total_ms, 1),
-        id=f"{trace_id}-history_latency_ms",
+        score_id=f"{trace_id}-history_latency_ms",
     )
     lf.create_score(
         trace_id=trace_id,
         name="history_cache_hit",
         value=1.0 if result.get("history_cache_hit") else 0.0,
-        id=f"{trace_id}-history_cache_hit",
+        score_id=f"{trace_id}-history_cache_hit",
     )

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -907,7 +907,7 @@ class PropertyBot:
                     name="supervisor_model",
                     value=self.config.supervisor_model,
                     data_type="CATEGORICAL",
-                    id=f"{tid}-supervisor_model",
+                    score_id=f"{tid}-supervisor_model",
                 )
                 # User role score (#388)
                 lf.create_score(
@@ -915,7 +915,7 @@ class PropertyBot:
                     name="user_role",
                     value=role,
                     data_type="CATEGORICAL",
-                    id=f"{tid}-user_role",
+                    score_id=f"{tid}-user_role",
                 )
                 # Tool call count (#374): count actual tool calls, not just messages.
                 tool_calls = sum(
@@ -928,7 +928,7 @@ class PropertyBot:
                         trace_id=tid,
                         name="tool_calls_total",
                         value=float(tool_calls),
-                        id=f"{tid}-tool_calls_total",
+                        score_id=f"{tid}-tool_calls_total",
                     )
 
                 # CRM tool usage scores (#440)
@@ -952,7 +952,7 @@ class PropertyBot:
                             name="history_save_success",
                             value=1 if saved else 0,
                             data_type="BOOLEAN",
-                            id=f"{tid}-history_save_success",
+                            score_id=f"{tid}-history_save_success",
                         )
                 except Exception:
                     logger.warning("Failed to save history turn", exc_info=True)
@@ -1191,14 +1191,14 @@ class PropertyBot:
                             name="history_save_success",
                             value=1 if saved else 0,
                             data_type="BOOLEAN",
-                            id=f"{tid}-history_save_success",
+                            score_id=f"{tid}-history_save_success",
                         )
                         lf.create_score(
                             trace_id=tid,
                             name="history_backend",
                             value="qdrant",
                             data_type="CATEGORICAL",
-                            id=f"{tid}-history_backend",
+                            score_id=f"{tid}-history_backend",
                         )
                 except Exception:
                     logger.warning("Failed to save voice history turn", exc_info=True)

--- a/telegram_bot/scoring.py
+++ b/telegram_bot/scoring.py
@@ -38,7 +38,7 @@ def score(lf: Any, trace_id: str, *, name: str, value: Any, **kwargs: Any) -> No
         trace_id=trace_id,
         name=name,
         value=value,
-        id=f"{trace_id}-{name}",
+        score_id=f"{trace_id}-{name}",
         **kwargs,
     )
 

--- a/tests/unit/test_bot_scores.py
+++ b/tests/unit/test_bot_scores.py
@@ -704,7 +704,7 @@ class TestScoreIsolation:
             assert call.kwargs["trace_id"] == _TEST_TRACE_ID
             # Idempotency key format: {trace_id}-{name}
             expected_id = f"{_TEST_TRACE_ID}-{call.kwargs['name']}"
-            assert call.kwargs["id"] == expected_id
+            assert call.kwargs["score_id"] == expected_id
 
         # score_current_trace must NOT be used
         assert mock_lf.score_current_trace.call_count == 0
@@ -724,10 +724,38 @@ class TestScoreIsolation:
         assert "user_role" in score_names
         for call in mock_lf.create_score.call_args_list:
             assert call.kwargs["trace_id"] == "trace-xyz"
-            assert "id" in call.kwargs  # idempotency key
+            assert "score_id" in call.kwargs  # idempotency key
 
         # score_current_trace must NOT be used
         assert mock_lf.score_current_trace.call_count == 0
+
+
+class TestCreateScoreNoBarId:
+    """Regression guard: create_score must use score_id=, never id= (#480)."""
+
+    def test_no_bare_id_kwarg_in_create_score_calls(self):
+        """All create_score() calls use score_id= for idempotency, not id=."""
+        import ast
+        from pathlib import Path
+
+        targets = [
+            Path("telegram_bot/scoring.py"),
+            Path("telegram_bot/bot.py"),
+            Path("telegram_bot/agents/history_graph/nodes.py"),
+        ]
+        violations = []
+        for path in targets:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                # Match *.create_score(...) calls
+                if isinstance(func, ast.Attribute) and func.attr == "create_score":
+                    for kw in node.keywords:
+                        if kw.arg == "id":
+                            violations.append(f"{path}:{node.lineno}")
+        assert not violations, f"create_score() uses bare id= (should be score_id=): {violations}"
 
 
 class TestTextPathFeedbackButtons:

--- a/tests/unit/test_crm_scores.py
+++ b/tests/unit/test_crm_scores.py
@@ -123,7 +123,7 @@ class TestWriteCrmScores:
         write_crm_scores(lf, [], trace_id="abc-123")
 
         for call in lf.create_score.call_args_list:
-            score_id = call.kwargs["id"]
+            score_id = call.kwargs["score_id"]
             score_name = call.kwargs["name"]
             assert score_id == f"abc-123-{score_name}"
 


### PR DESCRIPTION
## Summary
- Replace unsupported `id=` kwarg with `score_id=` in all `create_score()` calls (Langfuse SDK v3)
- Fix false "Произошла ошибка" message sent to users after every successful response
- Add AST regression guard to prevent `id=` from returning

## Files changed (5)
- `telegram_bot/scoring.py` — central `score()` helper
- `telegram_bot/bot.py` — 6 direct `create_score()` calls (supervisor + history)
- `telegram_bot/agents/history_graph/nodes.py` — 5 direct calls
- `tests/unit/test_bot_scores.py` — updated assertions + AST regression test
- `tests/unit/test_crm_scores.py` — updated assertion

## Test plan
- [x] 70 tests pass (test_bot_scores + test_crm_scores + test_history_graph_nodes)
- [x] Ruff lint + format pass
- [x] Grep confirms zero `id=` in `create_score` calls
- [x] AST guard test prevents regression

Closes #480, closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)