### PR TITLE
fix(infra): single-collection policy and production defaults

### DIFF
--- a/scripts/benchmark_acorn.py
+++ b/scripts/benchmark_acorn.py
@@ -146,7 +146,7 @@ def main():
     )
     parser.add_argument(
         "--collection",
-        default="contextual_bulgaria_voyage",
+        default="gdrive_documents_bge",
         help="Collection name to benchmark",
     )
     parser.add_argument(

--- a/scripts/index_test_properties_prod.py
+++ b/scripts/index_test_properties_prod.py
@@ -27,7 +27,7 @@ load_dotenv()
 QDRANT_URL = os.getenv("QDRANT_URL", "http://localhost:6333")
 QDRANT_API_KEY = os.getenv("QDRANT_API_KEY", "")
 VOYAGE_API_KEY = os.getenv("VOYAGE_API_KEY", "")
-COLLECTION_NAME = "contextual_bulgaria_voyage4"  # Production collection!
+COLLECTION_NAME = "gdrive_documents_bge"  # Production collection!
 ID_OFFSET = 900000  # Start IDs from 900000 to avoid conflicts
 
 

--- a/scripts/reindex_to_binary.py
+++ b/scripts/reindex_to_binary.py
@@ -233,7 +233,7 @@ Examples:
     parser.add_argument(
         "--source",
         "-s",
-        default=os.getenv("COLLECTION_NAME", "contextual_bulgaria_voyage"),
+        default=os.getenv("COLLECTION_NAME", "gdrive_documents_bge"),
         help="Source collection name (scalar quantized)",
     )
 

--- a/scripts/setup_binary_collection.py
+++ b/scripts/setup_binary_collection.py
@@ -427,7 +427,7 @@ Examples:
     parser.add_argument(
         "--source",
         "-s",
-        default=os.getenv("COLLECTION_NAME", "contextual_bulgaria_voyage"),
+        default=os.getenv("COLLECTION_NAME", "gdrive_documents_bge"),
         help="Source collection name (will add _binary suffix)",
     )
 

--- a/scripts/setup_scalar_collection.py
+++ b/scripts/setup_scalar_collection.py
@@ -414,7 +414,7 @@ Examples:
     parser.add_argument(
         "--source",
         "-s",
-        default=os.getenv("COLLECTION_NAME", "contextual_bulgaria_voyage"),
+        default=os.getenv("COLLECTION_NAME", "gdrive_documents_bge"),
         help="Source collection name (will add _scalar suffix)",
     )
 

--- a/scripts/test_int8_vs_binary.py
+++ b/scripts/test_int8_vs_binary.py
@@ -389,7 +389,7 @@ Examples:
     parser.add_argument(
         "--base",
         "-b",
-        default=os.getenv("COLLECTION_NAME", "contextual_bulgaria_voyage"),
+        default=os.getenv("COLLECTION_NAME", "gdrive_documents_bge"),
         help="Base collection name (without _scalar/_binary suffix)",
     )
 

--- a/scripts/validate_traces.py
+++ b/scripts/validate_traces.py
@@ -52,7 +52,16 @@ from scripts.validate_queries import (
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
-COLLECTIONS_TO_CHECK = ["gdrive_documents_bge", "contextual_bulgaria_voyage"]
+
+def _build_redis_url(redis_url: str) -> str:
+    """Inject REDIS_PASSWORD into URL if not already present."""
+    password = os.getenv("REDIS_PASSWORD", "")
+    if password and "@" not in redis_url:
+        redis_url = redis_url.replace("redis://", f"redis://:{password}@", 1)
+    return redis_url
+
+
+COLLECTIONS_TO_CHECK = ["gdrive_documents_bge"]
 # Base names used by discovery helper (kept as explicit alias for tests/backward compatibility).
 COLLECTION_BASE_NAMES = COLLECTIONS_TO_CHECK
 
@@ -352,7 +361,7 @@ async def init_services(collection: str) -> dict[str, Any]:
     # Override collection for this validation run
     config.qdrant_collection = collection
 
-    cache = CacheLayerManager(redis_url=config.redis_url)
+    cache = CacheLayerManager(redis_url=_build_redis_url(config.redis_url))
     await cache.initialize()
 
     hybrid = BGEM3HybridEmbeddings(base_url=config.bge_m3_url)

--- a/telegram_bot/config.py
+++ b/telegram_bot/config.py
@@ -35,7 +35,7 @@ class BotConfig(BaseSettings):
         default=None, validation_alias=AliasChoices("qdrant_api_key", "QDRANT_API_KEY")
     )
     qdrant_collection: str = Field(
-        default="contextual_bulgaria_voyage4",
+        default="gdrive_documents_bge",
         validation_alias=AliasChoices("qdrant_collection", "QDRANT_COLLECTION"),
     )
     qdrant_history_collection: str = Field(
@@ -122,13 +122,13 @@ class BotConfig(BaseSettings):
 
     # Retrieval provider (bge_m3_api | voyage)
     retrieval_dense_provider: str = Field(
-        default="voyage",
+        default="bge_m3_api",
         validation_alias=AliasChoices("retrieval_dense_provider", "RETRIEVAL_DENSE_PROVIDER"),
     )
 
     # Rerank provider (colbert | none | voyage)
     rerank_provider: str = Field(
-        default="voyage", validation_alias=AliasChoices("rerank_provider", "RERANK_PROVIDER")
+        default="colbert", validation_alias=AliasChoices("rerank_provider", "RERANK_PROVIDER")
     )
 
     # Hybrid Search Configuration

--- a/tests/integration/test_infrastructure.py
+++ b/tests/integration/test_infrastructure.py
@@ -44,16 +44,16 @@ class TestQdrantInfrastructure:
         collections = qdrant_client.get_collections().collections
         names = [c.name for c in collections]
 
-        assert "contextual_bulgaria_voyage" in names
+        assert "gdrive_documents_bge" in names
 
-    def test_collection_voyage_vector_config(self, qdrant_client):
-        """Voyage collection has correct vector config."""
-        info = qdrant_client.get_collection("contextual_bulgaria_voyage")
+    def test_collection_bge_vector_config(self, qdrant_client):
+        """BGE-M3 collection has correct vector config."""
+        info = qdrant_client.get_collection("gdrive_documents_bge")
 
         # Check dense vector config
         dense_config = info.config.params.vectors.get("dense")
         assert dense_config is not None
-        assert dense_config.size == 1024  # voyage-3-large
+        assert dense_config.size == 1024  # bge-m3
 
         # Check sparse vector exists (may be named 'sparse' or 'bm42')
         sparse_config = info.config.params.sparse_vectors
@@ -62,7 +62,7 @@ class TestQdrantInfrastructure:
 
     def test_collection_points_count(self, qdrant_client):
         """Collection has expected number of points."""
-        info = qdrant_client.get_collection("contextual_bulgaria_voyage")
+        info = qdrant_client.get_collection("gdrive_documents_bge")
         assert info.points_count >= 90
 
     def test_search_dense_returns_results(self, qdrant_client):
@@ -70,7 +70,7 @@ class TestQdrantInfrastructure:
         dummy_vector = [0.1] * 1024
 
         results = qdrant_client.query_points(
-            collection_name="contextual_bulgaria_voyage",
+            collection_name="gdrive_documents_bge",
             query=dummy_vector,
             using="dense",
             limit=5,
@@ -85,14 +85,14 @@ class TestQdrantInfrastructure:
         from qdrant_client.models import SparseVector
 
         # Get actual sparse vector name from collection config
-        info = qdrant_client.get_collection("contextual_bulgaria_voyage")
+        info = qdrant_client.get_collection("gdrive_documents_bge")
         sparse_names = list(info.config.params.sparse_vectors.keys())
         sparse_name = sparse_names[0] if sparse_names else "bm42"
 
         sparse = SparseVector(indices=[1, 2, 3], values=[0.5, 0.3, 0.2])
 
         results = qdrant_client.query_points(
-            collection_name="contextual_bulgaria_voyage",
+            collection_name="gdrive_documents_bge",
             query=sparse,
             using=sparse_name,
             limit=5,

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -77,7 +77,7 @@ async def qdrant_service():
     """QdrantService for search."""
     url = os.getenv("QDRANT_URL", "http://localhost:6333")
     api_key = os.getenv("QDRANT_API_KEY", "")
-    collection = os.getenv("QDRANT_COLLECTION", "contextual_bulgaria_voyage4")
+    collection = os.getenv("QDRANT_COLLECTION", "gdrive_documents_bge")
 
     service = QdrantService(
         url=url,

--- a/tests/smoke/test_preflight.py
+++ b/tests/smoke/test_preflight.py
@@ -66,7 +66,7 @@ def redis_url():
 
 @pytest.fixture(scope="module")
 def collection_name():
-    return os.getenv("QDRANT_COLLECTION", "contextual_bulgaria_voyage4")
+    return os.getenv("QDRANT_COLLECTION", "gdrive_documents_bge")
 
 
 class TestPreflightQdrant:

--- a/tests/smoke/test_smoke_quantization.py
+++ b/tests/smoke/test_smoke_quantization.py
@@ -33,7 +33,7 @@ async def qdrant_service():
 
     url = os.getenv("QDRANT_URL", "http://localhost:6333")
     api_key = os.getenv("QDRANT_API_KEY", "")
-    collection = os.getenv("QDRANT_COLLECTION", "contextual_bulgaria_voyage4")
+    collection = os.getenv("QDRANT_COLLECTION", "gdrive_documents_bge")
 
     service = QdrantService(url=url, api_key=api_key or None, collection_name=collection)
     yield service

--- a/tests/smoke/test_smoke_services.py
+++ b/tests/smoke/test_smoke_services.py
@@ -132,12 +132,12 @@ class TestSmokeServices:
     @pytest.mark.asyncio
     async def test_llm_api_health(self):
         """LLM API responds (minimal completion call)."""
-        api_key = os.getenv("OPENAI_API_KEY", "")
-        base_url = os.getenv("OPENAI_BASE_URL", "")
+        api_key = os.getenv("LLM_API_KEY", os.getenv("OPENAI_API_KEY", ""))
+        base_url = os.getenv("LLM_BASE_URL", os.getenv("OPENAI_BASE_URL", ""))
         model = os.getenv("LLM_MODEL", "")
 
         if not api_key:
-            pytest.skip("OPENAI_API_KEY not set")
+            pytest.skip("LLM_API_KEY not set")
 
         # If custom model but no custom base_url, skip (misconfigured)
         if model and not model.startswith("gpt") and not base_url:

--- a/tests/unit/test_validate_aggregates.py
+++ b/tests/unit/test_validate_aggregates.py
@@ -771,7 +771,7 @@ class TestCollectionResolution:
     """Report collections must reflect actually validated collections only."""
 
     def test_uses_only_collections_present_in_results(self):
-        discovered = ["gdrive_documents_bge", "contextual_bulgaria_voyage"]
+        discovered = ["gdrive_documents_bge"]
         results = [
             TraceResult(
                 trace_id="t1",
@@ -786,7 +786,7 @@ class TestCollectionResolution:
         assert resolve_report_collections(discovered, results) == ["gdrive_documents_bge"]
 
     def test_falls_back_to_discovered_if_results_empty(self):
-        discovered = ["gdrive_documents_bge", "contextual_bulgaria_voyage"]
+        discovered = ["gdrive_documents_bge"]
         assert resolve_report_collections(discovered, []) == discovered
 
 
@@ -802,18 +802,12 @@ class TestCollectionDiscovery:
         assert "gdrive_documents_bge" in result
 
     async def test_discovers_collection_with_quantization_suffix(self):
-        """Finds base collection even when stored with _scalar or _binary suffix."""
-        mock_client = _make_mock_qdrant_client(
-            ["gdrive_documents_bge_scalar", "contextual_bulgaria_voyage_binary"]
-        )
-        with (
-            patch("qdrant_client.AsyncQdrantClient", return_value=mock_client),
-            patch("scripts.validate_traces.check_voyage_available", return_value=True),
-        ):
+        """Finds base collection even when stored with _scalar suffix."""
+        mock_client = _make_mock_qdrant_client(["gdrive_documents_bge_scalar"])
+        with patch("qdrant_client.AsyncQdrantClient", return_value=mock_client):
             result = await discover_collections("http://localhost:6333")
 
         assert "gdrive_documents_bge_scalar" in result
-        assert "contextual_bulgaria_voyage_binary" in result
 
     async def test_prefers_exact_match_over_suffixed(self):
         """If both base and suffixed exist, prefer exact match."""
@@ -838,10 +832,8 @@ class TestCollectionDiscovery:
         assert result == []
 
     async def test_skips_voyage_collection_without_api_key(self):
-        """Voyage collections discovered but skipped if VOYAGE_API_KEY missing."""
-        mock_client = _make_mock_qdrant_client(
-            ["gdrive_documents_bge", "contextual_bulgaria_voyage"]
-        )
+        """BGE-M3 collection is discovered regardless of VOYAGE_API_KEY."""
+        mock_client = _make_mock_qdrant_client(["gdrive_documents_bge"])
         with (
             patch("qdrant_client.AsyncQdrantClient", return_value=mock_client),
             patch("scripts.validate_traces.check_voyage_available", return_value=False),
@@ -849,7 +841,6 @@ class TestCollectionDiscovery:
             result = await discover_collections("http://localhost:6333")
 
         assert "gdrive_documents_bge" in result
-        assert "contextual_bulgaria_voyage" not in result
 
     async def test_prefers_mode_suffix_when_quantization_enabled(self):
         """Quantization mode must influence discovered collection choice."""


### PR DESCRIPTION
## Summary
- Fix BotConfig defaults: `qdrant_collection` → `gdrive_documents_bge`, providers → `bge_m3_api`/`colbert` (#490, #497)
- Fix smoke test defaults and LLM health check env vars (#492, #496)
- Fix validate_traces: single collection + Redis password support (#495, #482)
- Remove all legacy `contextual_bulgaria_voyage*` references from scripts, smoke, integration tests (#493)

## Issues
Closes #490, Closes #492, Closes #493, Closes #495, Closes #496, Closes #497, Closes #482

Sprint: #510

## Test plan
- [x] 102 unit tests pass (`test_bot_config`, `test_validate_queries`, `test_validate_aggregates`, `config/`)
- [x] Ruff clean (check + format)
- [ ] Smoke tests with Docker (`make test-preflight`) — manual verification needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)