### PR TITLE
fix(scoring,retrieval,agent): batch 2 — observability gaps, embed optimization, sliding window

### DIFF
--- a/telegram_bot/agents/agent.py
+++ b/telegram_bot/agents/agent.py
@@ -13,6 +13,7 @@ from langchain.agents.middleware import AgentState, before_model
 from langchain_core.messages import RemoveMessage
 from langchain_core.messages.utils import trim_messages
 from langchain_openai import ChatOpenAI
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
 
 from telegram_bot.agents.context import BotContext
 from telegram_bot.integrations.prompt_manager import get_prompt
@@ -56,20 +57,18 @@ def _create_history_trimmer(max_messages: int) -> Any:
         if not to_keep:
             return None
 
-        keep_ids = {m.id for m in to_keep if m.id is not None}
-        # Only remove messages with a known id; id=None messages can't be targeted.
-        to_remove = [m for m in messages if m.id is not None and m.id not in keep_ids]
-        if not to_remove:
+        # No-op when trim result is effectively the same as input.
+        if len(to_keep) == len(messages):
             return None
 
         logger.debug(
-            "history_trimmer: removed %d messages (kept %d of %d, max=%d)",
-            len(to_remove),
+            "history_trimmer: trimmed history (kept %d of %d, max=%d)",
             len(to_keep),
             len(messages),
             max_messages,
         )
-        return {"messages": [RemoveMessage(id=m.id) for m in to_remove]}
+        # Reset message list and re-add only the kept window.
+        return {"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), *to_keep]}
 
     return _trim_history
 

--- a/telegram_bot/agents/agent.py
+++ b/telegram_bot/agents/agent.py
@@ -9,6 +9,9 @@ import logging
 from typing import Any
 
 from langchain.agents import create_agent
+from langchain.agents.middleware import AgentState, before_model
+from langchain_core.messages import RemoveMessage
+from langchain_core.messages.utils import trim_messages
 from langchain_openai import ChatOpenAI
 
 from telegram_bot.agents.context import BotContext
@@ -16,6 +19,60 @@ from telegram_bot.integrations.prompt_manager import get_prompt
 
 
 logger = logging.getLogger(__name__)
+
+
+def _create_history_trimmer(max_messages: int) -> Any:
+    """Return a before_model middleware that enforces a sliding-window history.
+
+    Removes oldest messages from checkpointed state so the LLM never sees more
+    than *max_messages* turns.  Uses RemoveMessage so the add_messages reducer
+    actually deletes them (not just hides them).  trim_messages with
+    start_on="human" ensures the remaining window starts on a clean turn
+    boundary (no orphaned ToolMessages).
+
+    Args:
+        max_messages: Maximum number of messages kept in state.
+
+    Returns:
+        A before_model middleware callable.
+    """
+
+    @before_model
+    def _trim_history(state: AgentState, runtime: Any) -> dict[str, Any] | None:
+        messages = state.get("messages", [])
+        if len(messages) <= max_messages:
+            return None
+
+        to_keep = trim_messages(
+            messages,
+            strategy="last",
+            max_tokens=max_messages,
+            token_counter=len,
+            start_on="human",
+        )
+
+        # Guard: if trim_messages returns nothing (e.g. no HumanMessage fits the
+        # window), skip the trim entirely rather than wiping the whole history.
+        if not to_keep:
+            return None
+
+        keep_ids = {m.id for m in to_keep if m.id is not None}
+        # Only remove messages with a known id; id=None messages can't be targeted.
+        to_remove = [m for m in messages if m.id is not None and m.id not in keep_ids]
+        if not to_remove:
+            return None
+
+        logger.debug(
+            "history_trimmer: removed %d messages (kept %d of %d, max=%d)",
+            len(to_remove),
+            len(to_keep),
+            len(messages),
+            max_messages,
+        )
+        return {"messages": [RemoveMessage(id=m.id) for m in to_remove]}
+
+    return _trim_history
+
 
 DEFAULT_SYSTEM_PROMPT = """Ты — AI-ассистент агентства недвижимости в Болгарии.
 Работаешь в Telegram. Отвечай на {{language}}.
@@ -90,6 +147,7 @@ def create_bot_agent(
     language: str = "русском языке",
     base_url: str | None = None,
     api_key: str | None = None,
+    max_history_messages: int = 15,
 ) -> Any:
     """Create the bot agent using langchain create_agent SDK.
 
@@ -101,6 +159,9 @@ def create_bot_agent(
         language: Response language.
         base_url: OpenAI-compatible API base URL (e.g. LiteLLM proxy).
         api_key: API key for the LLM provider.
+        max_history_messages: Sliding-window cap on checkpointed message count.
+            Old messages beyond this limit are removed from state via
+            RemoveMessage before each LLM call (#519).
 
     Returns:
         Compiled agent graph ready for .ainvoke() / .astream().
@@ -125,20 +186,28 @@ def create_bot_agent(
 
     llm = ChatOpenAI(**model_kwargs)
 
+    # Only install the trimmer when a checkpointer is active; without one the
+    # agent starts each invoke with a single message (no accumulated history).
+    middleware: list[Any] = []
+    if checkpointer is not None:
+        middleware.append(_create_history_trimmer(max_history_messages))
+
     agent = create_agent(
         model=llm,
         tools=tools,
         system_prompt=prompt,
         context_schema=BotContext,
         checkpointer=checkpointer,
+        middleware=middleware,
     )
 
     logger.info(
-        "Created bot agent: model=%s, base_url=%s, tools=%d, checkpointer=%s",
+        "Created bot agent: model=%s, base_url=%s, tools=%d, checkpointer=%s, max_history=%d",
         model,
         base_url or "default",
         len(tools),
         type(checkpointer).__name__ if checkpointer else "None",
+        max_history_messages,
     )
 
     return agent

--- a/telegram_bot/agents/rag_pipeline.py
+++ b/telegram_bot/agents/rag_pipeline.py
@@ -734,9 +734,15 @@ async def rag_pipeline(
         }
 
     # For retrieval, use reformulated query embedding.
-    # If cache_key differs from query (agent reformulated), we must re-embed query
-    # so retrieval uses the reformulated form (better recall).
-    query_embedding = None if cache_key != query else cache_embedding
+    # If cache_key differs from query (agent reformulated), pre-fetch the
+    # reformulated query embedding for the FIRST retrieval attempt. This avoids a
+    # redundant BGE-M3 call in _hybrid_retrieve on warm requests (#513).
+    # Subsequent iterations after _rewrite_query set query_embedding = None and
+    # let _hybrid_retrieve handle cache lookup for those new rewritten queries.
+    if cache_key != query:
+        query_embedding = await cache.get_embedding(query)
+    else:
+        query_embedding = cache_embedding
 
     # Retrieve → grade → (rerank | rewrite loop)
     for _attempt in range(config.max_rewrite_attempts + 1):

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -658,10 +658,11 @@ class PropertyBot:
         bot = message.bot
         await bot.send_chat_action(chat_id=message.chat.id, action="typing")
 
-        await self._handle_query_supervisor(message, pipeline_start)
+        response_text = await self._handle_query_supervisor(message, pipeline_start)
+        get_client().update_current_trace(output={"response": response_text or ""})
 
     @observe(name="telegram-rag-supervisor")
-    async def _handle_query_supervisor(self, message: Message, pipeline_start: float) -> None:
+    async def _handle_query_supervisor(self, message: Message, pipeline_start: float) -> str:
         """Handle query via create_agent SDK (#413 — replaces build_supervisor_graph)."""
         from .agents.history_tool import history_search
         from .agents.rag_tool import rag_search
@@ -799,7 +800,7 @@ class PropertyBot:
                                 value=pattern or "unknown",
                                 data_type="CATEGORICAL",
                             )
-                        return
+                        return _BLOCKED_RESPONSE
                     # soft/log mode: log but don't block
                     logger.warning(
                         "Pre-agent guard detected (mode=%s, score=%.2f, pattern=%s): %.80s",
@@ -831,6 +832,30 @@ class PropertyBot:
                 last_msg = messages[-1]
                 response_text = last_msg.content if hasattr(last_msg, "content") else str(last_msg)
 
+            # Extract LLM metrics from supervisor agent response (#515)
+            if messages:
+                last_ai = next(
+                    (
+                        m
+                        for m in reversed(messages)
+                        if hasattr(m, "response_metadata") and m.response_metadata
+                    ),
+                    None,
+                )
+                if last_ai:
+                    token_usage = last_ai.response_metadata.get("token_usage", {}) or {}
+                    decode_time = token_usage.get("completion_time")
+                    if decode_time is not None and float(decode_time) > 0:
+                        rag_result_store["llm_decode_ms"] = round(float(decode_time) * 1000, 1)
+                        completion_tokens = token_usage.get("completion_tokens")
+                        if completion_tokens and int(completion_tokens) > 0:
+                            rag_result_store["llm_tps"] = round(
+                                float(completion_tokens) / float(decode_time), 1
+                            )
+                    queue_time = token_usage.get("queue_time")
+                    if queue_time is not None:
+                        rag_result_store["llm_queue_ms"] = round(float(queue_time) * 1000, 1)
+
             # Send response with feedback buttons, sources, and Markdown (#426).
             # Skip if a tool already delivered the response via streaming (#428).
             if response_text and not ctx.response_sent:
@@ -861,9 +886,10 @@ class PropertyBot:
                         "OFF_TOPIC",
                     }
                 ):
-                    from telegram_bot.graph.nodes.respond import format_sources
+                    from telegram_bot.graph.nodes.respond import _MAX_SOURCES, format_sources
 
                     sources_text = format_sources(documents)
+                    rag_result_store["sources_count"] = min(len(documents), _MAX_SOURCES)
 
                 full_response = response_text + sources_text if sources_text else response_text
 
@@ -910,7 +936,6 @@ class PropertyBot:
             lf = get_client()
             lf.update_current_trace(
                 input={"query": message.text},
-                output={"response": response_text},
                 metadata={
                     "pipeline_mode": "sdk_agent",
                     "pipeline_wall_ms": wall_ms,
@@ -952,6 +977,11 @@ class PropertyBot:
                 from telegram_bot.scoring import write_crm_scores
 
                 write_crm_scores(lf, current_turn_msgs, trace_id=tid)
+                # Overwrite sources_shown/sources_count with actual post-send values (#514)
+                sources_count_actual = int(rag_result_store.get("sources_count", 0) or 0)
+                if sources_count_actual > 0:
+                    score(lf, tid, name="sources_shown", value=1, data_type="BOOLEAN")
+                    score(lf, tid, name="sources_count", value=float(sources_count_actual))
 
             # Persist Q&A to history
             if self._history_service and response_text:
@@ -973,6 +1003,8 @@ class PropertyBot:
                         )
                 except Exception:
                     logger.warning("Failed to save history turn", exc_info=True)
+
+        return response_text
 
     async def _ainvoke_supervisor_with_recovery(
         self,

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -727,6 +727,7 @@ class PropertyBot:
             language=self.config.domain_language,
             base_url=self.config.llm_base_url,
             api_key=self.config.llm_api_key,
+            max_history_messages=self.config.agent_max_history_messages,
         )
 
         # Build context for tool DI

--- a/telegram_bot/config.py
+++ b/telegram_bot/config.py
@@ -429,6 +429,13 @@ class BotConfig(BaseSettings):
         ),
     )
 
+    # Sliding window for agent history (#519)
+    agent_max_history_messages: int = Field(
+        default=15,
+        ge=1,
+        validation_alias=AliasChoices("agent_max_history_messages", "AGENT_MAX_HISTORY_MESSAGES"),
+    )
+
     # Real Estate Database (realestate DB in shared Postgres)
     realestate_database_url: str = Field(
         default="postgresql://postgres:postgres@postgres:5432/realestate",

--- a/tests/unit/agents/test_agent_factory.py
+++ b/tests/unit/agents/test_agent_factory.py
@@ -136,3 +136,160 @@ def test_default_system_prompt_contains_safety_instructions():
     assert "Безопасность" in DEFAULT_SYSTEM_PROMPT
     # Must enforce rag_search for property questions
     assert "rag_search" in DEFAULT_SYSTEM_PROMPT
+
+
+# --- #519: Sliding-window history trimmer ---
+
+
+def test_create_bot_agent_passes_history_trimmer_middleware():
+    """create_bot_agent injects a before_model history-trimmer when checkpointer set (#519)."""
+    from langchain.agents.middleware import AgentMiddleware
+
+    from telegram_bot.agents.agent import create_bot_agent
+
+    with patch("telegram_bot.agents.agent.create_agent") as mock_ca:
+        create_bot_agent(
+            model="openai/gpt-4o-mini",
+            tools=[],
+            checkpointer=MagicMock(),  # non-None checkpointer
+            max_history_messages=10,
+        )
+        call_kwargs = mock_ca.call_args[1]
+        middleware = call_kwargs.get("middleware", [])
+        assert len(middleware) == 1, "Exactly one middleware expected (history trimmer)"
+        assert isinstance(middleware[0], AgentMiddleware)
+        assert callable(middleware[0].before_model)
+
+
+def test_create_bot_agent_no_middleware_without_checkpointer():
+    """create_bot_agent skips history-trimmer middleware when checkpointer=None (#519)."""
+    from telegram_bot.agents.agent import create_bot_agent
+
+    with patch("telegram_bot.agents.agent.create_agent") as mock_ca:
+        create_bot_agent(
+            model="openai/gpt-4o-mini",
+            tools=[],
+            checkpointer=None,
+            max_history_messages=10,
+        )
+        call_kwargs = mock_ca.call_args[1]
+        middleware = call_kwargs.get("middleware", [])
+        assert len(middleware) == 0, "No middleware expected without checkpointer"
+
+
+def test_create_bot_agent_default_max_history_messages():
+    """create_bot_agent defaults to max_history_messages=15 (#519)."""
+    from telegram_bot.agents.agent import create_bot_agent
+
+    with patch("telegram_bot.agents.agent.create_agent") as mock_ca:
+        create_bot_agent(
+            model="openai/gpt-4o-mini",
+            tools=[],
+            checkpointer=MagicMock(),  # non-None to get middleware
+        )
+        call_kwargs = mock_ca.call_args[1]
+        # Middleware must still be present with default window
+        assert len(call_kwargs.get("middleware", [])) == 1
+
+
+def test_history_trimmer_noop_when_within_limit():
+    """_create_history_trimmer returns None when messages <= max_messages (#519)."""
+    from unittest.mock import MagicMock
+
+    from langchain_core.messages import AIMessage, HumanMessage
+
+    from telegram_bot.agents.agent import _create_history_trimmer
+
+    trimmer = _create_history_trimmer(max_messages=10)
+    state = {
+        "messages": [
+            HumanMessage(content="hi", id="h1"),
+            AIMessage(content="hello", id="a1"),
+        ]
+    }
+    result = trimmer.before_model(state, MagicMock())
+    assert result is None, "Should be a no-op when history is short"
+
+
+def test_history_trimmer_removes_old_messages_when_over_limit():
+    """_create_history_trimmer returns RemoveMessage for oldest messages (#519)."""
+    from unittest.mock import MagicMock
+
+    from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage
+
+    from telegram_bot.agents.agent import _create_history_trimmer
+
+    trimmer = _create_history_trimmer(max_messages=4)
+
+    # Build 6 messages: 3 turns (H, AI) — oldest turn should be removed
+    messages = [
+        HumanMessage(content="q1", id="h1"),
+        AIMessage(content="a1", id="a1"),
+        HumanMessage(content="q2", id="h2"),
+        AIMessage(content="a2", id="a2"),
+        HumanMessage(content="q3", id="h3"),
+        AIMessage(content="a3", id="a3"),
+    ]
+    state = {"messages": messages}
+    result = trimmer.before_model(state, MagicMock())
+
+    assert result is not None, "Should return a state update"
+    assert "messages" in result
+    remove_msgs = result["messages"]
+    assert all(isinstance(m, RemoveMessage) for m in remove_msgs)
+
+    # Oldest 2 messages should be removed (keep last 4 starting on human)
+    removed_ids = {m.id for m in remove_msgs}
+    assert "h1" in removed_ids
+    assert "a1" in removed_ids
+    # Kept messages should not be in remove list
+    assert "h2" not in removed_ids
+    assert "h3" not in removed_ids
+    assert "a3" not in removed_ids
+
+
+def test_history_trimmer_respects_start_on_human():
+    """Trimmer never starts window on a non-human message (#519)."""
+    from unittest.mock import MagicMock
+
+    from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage
+
+    from telegram_bot.agents.agent import _create_history_trimmer
+
+    # 5 messages, max=3 — naive cut would start on AIMessage
+    # start_on="human" must push window start to the next HumanMessage
+    trimmer = _create_history_trimmer(max_messages=3)
+    messages = [
+        HumanMessage(content="q1", id="h1"),
+        AIMessage(content="a1", id="a1"),
+        HumanMessage(content="q2", id="h2"),
+        AIMessage(content="a2", id="a2"),
+        HumanMessage(content="q3", id="h3"),
+    ]
+    state = {"messages": messages}
+    result = trimmer.before_model(state, MagicMock())
+
+    assert result is not None
+    removed_ids = {m.id for m in result["messages"] if isinstance(m, RemoveMessage)}
+    # Window must start on h2 or later — both h2, a2, h3 should be kept
+    assert "h2" not in removed_ids and "a2" not in removed_ids and "h3" not in removed_ids
+    # First kept message must be a HumanMessage (start_on constraint)
+    kept = [m for m in messages if m.id not in removed_ids]
+    assert isinstance(kept[0], HumanMessage), f"Window starts on {type(kept[0])}"
+
+
+def test_history_trimmer_noop_when_no_human_message_fits_window():
+    """Trimmer returns None when trim_messages produces an empty window (#519)."""
+    from unittest.mock import MagicMock
+
+    from langchain_core.messages import AIMessage
+
+    from telegram_bot.agents.agent import _create_history_trimmer
+
+    # 5 consecutive AI messages — start_on="human" finds no valid boundary,
+    # so trim_messages returns []. The trimmer must not wipe the whole state.
+    trimmer = _create_history_trimmer(max_messages=2)
+    messages = [AIMessage(content=f"a{i}", id=f"a{i}") for i in range(5)]
+    state = {"messages": messages}
+    result = trimmer.before_model(state, MagicMock())
+    assert result is None, "Should be a no-op rather than wiping all messages"

--- a/tests/unit/agents/test_agent_factory.py
+++ b/tests/unit/agents/test_agent_factory.py
@@ -212,10 +212,11 @@ def test_history_trimmer_noop_when_within_limit():
 
 
 def test_history_trimmer_removes_old_messages_when_over_limit():
-    """_create_history_trimmer returns RemoveMessage for oldest messages (#519)."""
+    """_create_history_trimmer resets state and re-adds trimmed window (#519)."""
     from unittest.mock import MagicMock
 
     from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage
+    from langgraph.graph.message import REMOVE_ALL_MESSAGES
 
     from telegram_bot.agents.agent import _create_history_trimmer
 
@@ -235,24 +236,18 @@ def test_history_trimmer_removes_old_messages_when_over_limit():
 
     assert result is not None, "Should return a state update"
     assert "messages" in result
-    remove_msgs = result["messages"]
-    assert all(isinstance(m, RemoveMessage) for m in remove_msgs)
-
-    # Oldest 2 messages should be removed (keep last 4 starting on human)
-    removed_ids = {m.id for m in remove_msgs}
-    assert "h1" in removed_ids
-    assert "a1" in removed_ids
-    # Kept messages should not be in remove list
-    assert "h2" not in removed_ids
-    assert "h3" not in removed_ids
-    assert "a3" not in removed_ids
+    updates = result["messages"]
+    assert isinstance(updates[0], RemoveMessage)
+    assert updates[0].id == REMOVE_ALL_MESSAGES
+    kept_ids = [m.id for m in updates[1:]]
+    assert kept_ids == ["h2", "a2", "h3", "a3"]
 
 
 def test_history_trimmer_respects_start_on_human():
     """Trimmer never starts window on a non-human message (#519)."""
     from unittest.mock import MagicMock
 
-    from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage
+    from langchain_core.messages import AIMessage, HumanMessage
 
     from telegram_bot.agents.agent import _create_history_trimmer
 
@@ -270,12 +265,10 @@ def test_history_trimmer_respects_start_on_human():
     result = trimmer.before_model(state, MagicMock())
 
     assert result is not None
-    removed_ids = {m.id for m in result["messages"] if isinstance(m, RemoveMessage)}
-    # Window must start on h2 or later — both h2, a2, h3 should be kept
-    assert "h2" not in removed_ids and "a2" not in removed_ids and "h3" not in removed_ids
-    # First kept message must be a HumanMessage (start_on constraint)
-    kept = [m for m in messages if m.id not in removed_ids]
+    kept = result["messages"][1:]  # first element is RemoveMessage(REMOVE_ALL_MESSAGES)
+    assert kept, "Expected non-empty kept window"
     assert isinstance(kept[0], HumanMessage), f"Window starts on {type(kept[0])}"
+    assert [m.id for m in kept] == ["h2", "a2", "h3"]
 
 
 def test_history_trimmer_noop_when_no_human_message_fits_window():
@@ -293,3 +286,28 @@ def test_history_trimmer_noop_when_no_human_message_fits_window():
     state = {"messages": messages}
     result = trimmer.before_model(state, MagicMock())
     assert result is None, "Should be a no-op rather than wiping all messages"
+
+
+def test_history_trimmer_handles_messages_without_ids():
+    """Trimmer still works when messages have id=None by resetting full state."""
+    from unittest.mock import MagicMock
+
+    from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage
+    from langgraph.graph.message import REMOVE_ALL_MESSAGES
+
+    from telegram_bot.agents.agent import _create_history_trimmer
+
+    trimmer = _create_history_trimmer(max_messages=3)
+    messages = [
+        HumanMessage(content="q1"),  # id=None
+        AIMessage(content="a1"),  # id=None
+        HumanMessage(content="q2"),  # id=None
+        AIMessage(content="a2"),  # id=None
+    ]
+    result = trimmer.before_model({"messages": messages}, MagicMock())
+
+    assert result is not None
+    updates = result["messages"]
+    assert isinstance(updates[0], RemoveMessage)
+    assert updates[0].id == REMOVE_ALL_MESSAGES
+    assert len(updates[1:]) <= 3

--- a/tests/unit/agents/test_rag_pipeline.py
+++ b/tests/unit/agents/test_rag_pipeline.py
@@ -583,6 +583,54 @@ async def test_pipeline_cache_miss_when_different_original_query(
     mock_qdrant.hybrid_search_rrf.assert_called_once()
 
 
+async def test_pipeline_reformulation_skips_embed_on_warm_cache(
+    mock_cache, mock_embeddings, mock_sparse, mock_qdrant
+):
+    """Reformulated query embedding in cache prevents a redundant BGE-M3 call (#513).
+
+    Scenario: embeddings_cache_hit=True for original query, but the agent reformulated.
+    On the second+ request the reformulated embedding is also cached — aembed_hybrid
+    must NOT be called (no 'bge-m3-hybrid-embed' span).
+    """
+    from telegram_bot.agents.rag_pipeline import rag_pipeline
+
+    original_emb = [0.1] * 1024
+    reform_emb = [0.2] * 1024  # distinct embedding for reformulated query
+
+    def _get_embedding(text: str):
+        if "квартиры" in text:
+            return original_emb  # original query — warm
+        if "apartments" in text:
+            return reform_emb  # reformulated query — warm
+        return None
+
+    mock_cache.get_embedding = AsyncMock(side_effect=_get_embedding)
+    mock_cache.check_semantic = AsyncMock(return_value=None)  # semantic miss → full retrieval
+    mock_cache.get_sparse_embedding = AsyncMock(return_value={"indices": [1], "values": [0.5]})
+
+    result = await rag_pipeline(
+        "apartments in Nesebar",  # agent-reformulated query
+        original_query="квартиры в Несебре",  # original user query
+        user_id=42,
+        session_id="test",
+        query_type="GENERAL",
+        cache=mock_cache,
+        embeddings=mock_embeddings,
+        sparse_embeddings=mock_sparse,
+        qdrant=mock_qdrant,
+    )
+
+    # Reformulated embedding was in cache — BGE-M3 must NOT be called
+    mock_embeddings.aembed_hybrid.assert_not_called()
+    mock_embeddings.aembed_query.assert_not_called()
+    assert result["cache_hit"] is False
+    mock_qdrant.hybrid_search_rrf.assert_called_once()
+    # Verify the orchestrator pre-fetched the reformulated query embedding from
+    # cache (the mechanism of the fix — not just the observable BGE-M3 side-effect).
+    get_embedding_calls = [str(c.args[0]) for c in mock_cache.get_embedding.call_args_list]
+    assert any("apartments" in c for c in get_embedding_calls)
+
+
 async def test_pipeline_embedding_error(mock_cache, mock_sparse, mock_qdrant):
     from telegram_bot.agents.rag_pipeline import rag_pipeline
 

--- a/tests/unit/agents/test_supervisor_observability.py
+++ b/tests/unit/agents/test_supervisor_observability.py
@@ -111,10 +111,11 @@ async def test_supervisor_trace_has_pipeline_mode_metadata(supervisor_config):
             mock_cas.typing.return_value = _make_typing_cm()
             await bot.handle_query(message)
 
-    trace_call = mock_lf.update_current_trace.call_args
-    assert trace_call is not None
-    metadata = trace_call[1]["metadata"]
-    assert metadata["pipeline_mode"] == "sdk_agent"
+    trace_calls = mock_lf.update_current_trace.call_args_list
+    assert trace_calls, "update_current_trace was never called"
+    meta_call = next((c for c in trace_calls if "metadata" in c[1]), None)
+    assert meta_call is not None, "no update_current_trace call contains metadata"
+    assert meta_call[1]["metadata"]["pipeline_mode"] == "sdk_agent"
 
 
 # --- #242: @observe decorator presence tests ---
@@ -219,9 +220,9 @@ async def test_supervisor_curated_span_metadata_on_routing(supervisor_config):
             mock_cas.typing.return_value = _make_typing_cm()
             await bot.handle_query(message)
 
-    trace_call = mock_lf.update_current_trace.call_args
-    assert trace_call is not None
-    assert "input" in trace_call[1] or "metadata" in trace_call[1]
+    trace_calls = mock_lf.update_current_trace.call_args_list
+    assert trace_calls, "update_current_trace was never called"
+    assert any("input" in c[1] or "metadata" in c[1] for c in trace_calls)
 
 
 async def test_agent_ainvoke_receives_bot_context(supervisor_config):

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -479,8 +479,9 @@ class TestHandleQuery:
                 mock_cas.typing.return_value = _make_typing_cm()
                 await bot.handle_query(message)
 
-            mock_lf.update_current_trace.assert_called_once()
-            trace_kwargs = mock_lf.update_current_trace.call_args.kwargs
+            # Child span call (first) carries metadata; root span call (second) carries output (#511)
+            assert mock_lf.update_current_trace.call_count >= 1
+            trace_kwargs = mock_lf.update_current_trace.call_args_list[0].kwargs
             assert trace_kwargs["metadata"]["pipeline_mode"] == "sdk_agent"
 
     async def test_handle_query_writes_supervisor_model_score(self, mock_config):
@@ -1698,8 +1699,9 @@ class TestPreAgentGuard:
                 await bot.handle_query(message)
 
         # Verify trace metadata
-        mock_lf.update_current_trace.assert_called_once()
-        trace_meta = mock_lf.update_current_trace.call_args.kwargs["metadata"]
+        # Guard metadata is in the child span call (first); root span call (second) has output (#511)
+        assert mock_lf.update_current_trace.call_count >= 1
+        trace_meta = mock_lf.update_current_trace.call_args_list[0].kwargs["metadata"]
         assert trace_meta["guard_blocked"] is True
         assert trace_meta["injection_pattern"] == "system_prompt_leak"
 

--- a/tests/unit/test_bot_observability.py
+++ b/tests/unit/test_bot_observability.py
@@ -84,10 +84,12 @@ class TestHandleQueryObservability:
 
             await bot.handle_query(mock_message)
 
-        mock_lf.update_current_trace.assert_called_once()
-        kwargs = mock_lf.update_current_trace.call_args.kwargs
-        assert kwargs["input"]["query"] == "квартиры до 100000 евро"
-        assert kwargs["output"]["response"] == "ok"
+        # Two calls: child span (input+metadata) + root span (output only) — #511
+        assert mock_lf.update_current_trace.call_count == 2
+        child_kwargs = mock_lf.update_current_trace.call_args_list[0].kwargs
+        assert child_kwargs["input"]["query"] == "квартиры до 100000 евро"
+        root_kwargs = mock_lf.update_current_trace.call_args_list[1].kwargs
+        assert root_kwargs["output"]["response"] == "ok"
 
     async def test_handle_query_includes_expected_metadata_fields(
         self,
@@ -114,6 +116,7 @@ class TestHandleQueryObservability:
 
             await bot.handle_query(mock_message)
 
-        metadata = mock_lf.update_current_trace.call_args.kwargs["metadata"]
+        # Metadata is in the child span call (first call) — #511
+        metadata = mock_lf.update_current_trace.call_args_list[0].kwargs["metadata"]
         assert metadata["pipeline_mode"] == "sdk_agent"
         assert "pipeline_wall_ms" in metadata


### PR DESCRIPTION
## Summary
- **#511**: Fix trace output=null — moved `update_current_trace(output=...)` to root span `handle_query` (was lost in child span context)
- **#512**: Confirmed design gap — text agent path has no summarize node, `summarization_triggered=0` is expected
- **#513**: Fix redundant BGE-M3 embed on cache hit — pre-fetch reformulated query embedding from Redis instead of unconditional `query_embedding=None`
- **#514**: Fix sources_shown=0 — write `sources_count` to `rag_result_store` after `format_sources()`, overwrite score after send
- **#515**: Fix LLM metrics unavailable — extract `llm_decode_ms`, `llm_tps`, `llm_queue_ms` from `AIMessage.response_metadata.token_usage`
- **#519**: Add sliding window to checkpointer — `@before_model` middleware with `RemoveMessage` + `trim_messages(strategy="last", start_on="human")`, configurable via `AGENT_MAX_HISTORY_MESSAGES=15`

## Changes
| File | Changes |
|------|---------|
| `telegram_bot/bot.py` | trace output on root span, sources_count, LLM metrics extraction, max_history_messages passthrough |
| `telegram_bot/agents/agent.py` | `_create_history_trimmer()` middleware, `max_history_messages` param |
| `telegram_bot/agents/rag_pipeline.py` | pre-fetch reformulated embedding from cache |
| `telegram_bot/config.py` | `agent_max_history_messages` field |
| `tests/unit/agents/test_agent_factory.py` | 7 new tests for sliding window |
| `tests/unit/agents/test_rag_pipeline.py` | 1 new test for embed cache hit |
| `tests/unit/agents/test_supervisor_observability.py` | fix assertions for split trace calls |
| `tests/unit/test_bot_handlers.py` | updated for return type change |
| `tests/unit/test_bot_observability.py` | updated for output split |

## Test plan
- [x] 201 affected tests pass (`-n auto`, 12.77s)
- [x] ruff check + format clean
- [ ] Verify trace output in Langfuse after deploy
- [ ] Verify LLM metrics (tps, decode_ms) appear in scores
- [ ] Verify sources_count > 0 for RAG queries with sources

Closes #513, Closes #514, Closes #515, Closes #519, Ref #511, Ref #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)