### PR TITLE
fix(bot): fallback to delete_thread when adelete_thread is unavailable

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import hashlib
+import inspect
 import io
 import json
 import logging
@@ -70,6 +71,23 @@ def make_session_id(session_type: str, identifier: int | str) -> str:
 def _supervisor_thread_id(chat_id: int | str) -> str:
     """Build checkpointer thread id for text-agent conversations."""
     return f"tg_{chat_id}"
+
+
+async def _delete_checkpointer_thread(checkpointer: Any, thread_id: str) -> None:
+    """Delete checkpointer thread via async or sync SDK API."""
+    adelete_thread = getattr(checkpointer, "adelete_thread", None)
+    if callable(adelete_thread):
+        await adelete_thread(thread_id)
+        return
+
+    delete_thread = getattr(checkpointer, "delete_thread", None)
+    if callable(delete_thread):
+        result = delete_thread(thread_id)
+        if inspect.isawaitable(result):
+            await result
+        return
+
+    raise AttributeError("checkpointer does not expose delete_thread/adelete_thread")
 
 
 def _split_telegram_response(text: str, limit: int = _TELEGRAM_MESSAGE_LIMIT) -> list[str]:
@@ -432,7 +450,7 @@ class PropertyBot:
             seen_checkpointers.add(cp_id)
             for thread_id in (text_thread_id, voice_thread_id):
                 try:
-                    await checkpointer.adelete_thread(thread_id)
+                    await _delete_checkpointer_thread(checkpointer, thread_id)
                 except Exception:
                     logger.warning(
                         "Failed to clear %s checkpointer thread %s",

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -248,6 +248,31 @@ class TestCommandHandlers:
 
         bot._cache.clear_conversation.assert_awaited_once_with(12345)
 
+    async def test_cmd_clear_falls_back_to_sync_delete_thread(self, mock_config):
+        """Test /clear supports sync checkpointers exposing delete_thread only."""
+
+        class SyncCheckpointer:
+            def __init__(self):
+                self.calls = []
+
+            def delete_thread(self, thread_id):
+                self.calls.append(thread_id)
+
+        bot, _ = _create_bot(mock_config)
+        bot._cache = MagicMock()
+        bot._cache.clear_conversation = AsyncMock()
+        bot._checkpointer = SyncCheckpointer()
+        bot._agent_checkpointer = SyncCheckpointer()
+        message = _make_text_message()
+
+        await bot.cmd_clear(message)
+
+        assert set(bot._checkpointer.calls) == {"tg_12345", "12345"}
+        assert set(bot._agent_checkpointer.calls) == {"tg_12345", "12345"}
+        bot._cache.clear_conversation.assert_awaited_once_with(12345)
+        message.answer.assert_awaited_once()
+        assert "очищена" in message.answer.await_args.args[0].lower()
+
     async def test_cmd_clear_uses_chat_id_for_thread_namespace(self, mock_config):
         """Thread cleanup targets chat-scoped text thread and user-scoped voice thread."""
         bot, _ = _create_bot(mock_config)


### PR DESCRIPTION
## Summary
- add `_delete_checkpointer_thread` helper to support both async `adelete_thread` and sync `delete_thread` checkpointer APIs
- use helper in `/clear` thread cleanup loop
- add unit test for sync-only checkpointer fallback

## Validation
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
- `uv run pytest tests/unit/test_bot_handlers.py -k "cmd_clear" -n auto --dist=worksteal -q`