### PR TITLE
fix(cache): make RAG semantic cache global, not per-user

### DIFF
--- a/telegram_bot/agents/rag_pipeline.py
+++ b/telegram_bot/agents/rag_pipeline.py
@@ -120,7 +120,6 @@ async def _cache_check(
             query=query,
             vector=embedding,
             query_type=query_type,
-            user_id=user_id,
         )
 
     latency = time.perf_counter() - start
@@ -606,7 +605,6 @@ async def _cache_store(
                 response=response,
                 vector=query_embedding,
                 query_type=query_type,
-                user_id=user_id,
             )
             stored_semantic = True
 

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -966,7 +966,6 @@ class PropertyBot:
                             response=response_text,
                             vector=store_vector,
                             query_type=query_type,
-                            user_id=user_id,
                         )
                     except Exception:
                         logger.warning("Failed to store semantic cache in text path", exc_info=True)

--- a/telegram_bot/graph/nodes/cache.py
+++ b/telegram_bot/graph/nodes/cache.py
@@ -115,7 +115,6 @@ async def cache_check_node(
             query=query,
             vector=embedding,
             query_type=query_type,
-            user_id=state.get("user_id"),
         )
 
     latency = time.perf_counter() - start
@@ -216,7 +215,6 @@ async def cache_store_node(
                 response=response,
                 vector=embedding,
                 query_type=query_type,
-                user_id=user_id,
             )
             stored_semantic = True
 

--- a/tests/unit/agents/test_rag_pipeline.py
+++ b/tests/unit/agents/test_rag_pipeline.py
@@ -144,7 +144,7 @@ async def test_cache_check_uses_semantic_for_general(mock_cache, mock_embeddings
     mock_cache.check_semantic.assert_awaited_once()
     call_kwargs = mock_cache.check_semantic.call_args.kwargs
     assert call_kwargs["query_type"] == "GENERAL"
-    assert call_kwargs["user_id"] == 42
+    assert "user_id" not in call_kwargs
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/graph/test_cache_nodes.py
+++ b/tests/unit/graph/test_cache_nodes.py
@@ -109,8 +109,8 @@ class TestCacheCheckNode:
         # Should use cached embedding, not recompute
         embeddings.aembed_query.assert_not_awaited()
 
-    async def test_check_passes_user_id_to_cache(self):
-        """cache_check_node passes state['user_id'] to check_semantic."""
+    async def test_check_does_not_pass_user_id_to_cache(self):
+        """cache_check_node does NOT pass user_id to check_semantic (global cache)."""
         state = make_initial_state(user_id=99, session_id="s1", query="test query")
         state["query_type"] = "FAQ"
 
@@ -123,7 +123,7 @@ class TestCacheCheckNode:
         await cache_check_node(state, cache=cache, embeddings=embeddings)
 
         call_kwargs = cache.check_semantic.call_args[1]
-        assert call_kwargs["user_id"] == 99
+        assert "user_id" not in call_kwargs
 
     async def test_stores_new_embedding_in_cache(self):
         state = make_initial_state(user_id=1, session_id="s1", query="new query")
@@ -167,7 +167,7 @@ class TestCacheStoreNode:
     """Test cache_store_node."""
 
     async def test_stores_response_in_semantic_cache(self):
-        """FAQ (allowlisted) stores to semantic cache with user_id."""
+        """FAQ (allowlisted) stores to semantic cache without user_id (global)."""
         state = make_initial_state(user_id=1, session_id="s1", query="test query")
         state["query_type"] = "FAQ"
         state["query_embedding"] = [0.1] * 1024
@@ -183,7 +183,6 @@ class TestCacheStoreNode:
             response="generated answer",
             vector=[0.1] * 1024,
             query_type="FAQ",
-            user_id=1,
         )
         assert result["response"] == "generated answer"
 
@@ -203,7 +202,7 @@ class TestCacheStoreNode:
         assert result["response"] == "generated answer"
 
     async def test_store_passes_user_id_to_cache(self):
-        """cache_store_node passes state['user_id'] to store_semantic."""
+        """cache_store_node does NOT pass user_id to store_semantic (global cache)."""
         state = make_initial_state(user_id=99, session_id="s1", query="test query")
         state["query_type"] = "FAQ"
         state["query_embedding"] = [0.1] * 1024
@@ -215,7 +214,7 @@ class TestCacheStoreNode:
         await cache_store_node(state, cache=cache)
 
         call_kwargs = cache.store_semantic.call_args[1]
-        assert call_kwargs["user_id"] == 99
+        assert "user_id" not in call_kwargs
 
     async def test_skips_store_if_no_response(self):
         state = make_initial_state(user_id=1, session_id="s1", query="test query")


### PR DESCRIPTION
## Summary
- Remove `user_id` from semantic cache calls in RAG pipeline (voice graph, text pipeline, bot fallback)
- Keep `user_id` scoping only in `history_tool.py` (history summaries are per-user)
- Update 3 unit tests to verify `user_id` is no longer passed

Closes #525

## Root Cause
`check_semantic()` / `store_semantic()` used `Tag("user_id")` filter — identical queries from different users never hit the cache. Discovered via Langfuse traces: same query "Какие варианты рассрочек есть в Болгарии?" from two users, second trace missed cache despite first storing successfully.

## Changes
| File | Change |
|------|--------|
| `telegram_bot/graph/nodes/cache.py` | Remove `user_id` from check + store (voice path) |
| `telegram_bot/agents/rag_pipeline.py` | Remove `user_id` from check + store (text path) |
| `telegram_bot/bot.py` | Remove `user_id` from store (text fallback) |
| `tests/unit/graph/test_cache_nodes.py` | Assert `user_id` NOT in call kwargs |
| `tests/unit/agents/test_rag_pipeline.py` | Assert `user_id` NOT in call kwargs |

## Test plan
- [x] `tests/unit/graph/test_cache_nodes.py` — 12 passed
- [x] `tests/unit/agents/test_rag_pipeline.py` — 40 passed
- [x] `tests/integration/test_graph_paths.py` — 12 passed
- [ ] Deploy and verify semantic cache HIT in Langfuse for cross-user same query

🤖 Generated with [Claude Code](https://claude.com/claude-code)