### PR TITLE
feat(obs): add @observe spans to nurturing/funnel/lead-scoring services

### DIFF
--- a/telegram_bot/services/funnel_analytics_service.py
+++ b/telegram_bot/services/funnel_analytics_service.py
@@ -6,6 +6,7 @@ import datetime as dt
 import logging
 from typing import Any
 
+from telegram_bot.observability import observe
 from telegram_bot.services.funnel_analytics_store import FunnelAnalyticsStore
 
 
@@ -19,6 +20,7 @@ class FunnelAnalyticsService:
         self._store = FunnelAnalyticsStore(pool=pool)
         self._pool = pool
 
+    @observe(name="funnel-rollup")
     async def build_daily_snapshot(self, *, metric_date: dt.date) -> list[dict[str, Any]]:
         """Compute conversion/dropoff for each stage on the given date."""
         rows = await self._store.fetch_stage_counts(metric_date)
@@ -40,6 +42,7 @@ class FunnelAnalyticsService:
             )
         return snapshots
 
+    @observe(name="funnel-store-upsert")
     async def persist_snapshots(self, *, snapshots: list[dict[str, Any]]) -> None:
         """Upsert daily snapshot rows via executemany."""
         records = [

--- a/telegram_bot/services/lead_scoring_store.py
+++ b/telegram_bot/services/lead_scoring_store.py
@@ -9,6 +9,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
+from telegram_bot.observability import observe
 from telegram_bot.services.lead_scoring_models import LeadScoreRecord
 
 
@@ -24,6 +25,7 @@ class LeadScoringStore:
     def __init__(self, *, pool: Any) -> None:
         self._pool = pool
 
+    @observe(name="lead-score-upsert")
     async def upsert_score(self, rec: LeadScoreRecord) -> None:
         """Insert or update a lead score (resets sync_status to pending)."""
         await self._pool.execute(

--- a/telegram_bot/services/nurturing_scheduler.py
+++ b/telegram_bot/services/nurturing_scheduler.py
@@ -19,6 +19,8 @@ from typing import Any
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
+from telegram_bot.observability import observe
+
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +79,7 @@ class NurturingScheduler:
         """Check if a job is registered."""
         return self._scheduler.get_job(job_id) is not None
 
+    @observe(name="nurturing-scheduler-tick")
     async def run_nurturing_batch(self) -> None:
         """Execute a single nurturing batch (called by scheduler)."""
         try:

--- a/telegram_bot/services/nurturing_service.py
+++ b/telegram_bot/services/nurturing_service.py
@@ -11,6 +11,8 @@ import logging
 from datetime import UTC, datetime
 from typing import Any
 
+from telegram_bot.observability import observe
+
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +103,7 @@ class NurturingService:
             records,
         )
 
+    @observe(name="nurturing-batch-run")
     async def run_once(self, *, limit: int = 100) -> int:
         """Select candidates, enqueue, return count."""
         candidates = await self.select_candidates(limit=limit)


### PR DESCRIPTION
## Summary
- Add `@observe` decorators to 5 key methods across 4 background services
- Services were previously invisible in Langfuse — no spans on internal operations

Closes #527

## Changes
| Service | Method | Span name |
|---------|--------|-----------|
| NurturingService | `run_once()` | `nurturing-batch-run` |
| NurturingScheduler | `run_nurturing_batch()` | `nurturing-scheduler-tick` |
| FunnelAnalyticsService | `build_daily_snapshot()` | `funnel-rollup` |
| FunnelAnalyticsService | `persist_snapshots()` | `funnel-store-upsert` |
| LeadScoringStore | `upsert_score()` | `lead-score-upsert` |

## Test plan
- [x] 16 existing tests pass
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)