### PR TITLE
feat(obs): add @observe root trace to RAG API endpoint

### DIFF
--- a/.claude/rules/observability.md
+++ b/.claude/rules/observability.md
@@ -129,6 +129,7 @@ Rule: `traced_pipeline` → `@observe(root)` → nested `@observe(children)`
 | Entry Point | File | session_id format |
 |-------------|------|-------------------|
 | Telegram bot | bot.py:handle_query | chat-{hash}-{YYYYMMDD} |
+| RAG API | src/api/main.py:query | api-{user_id} (or req.session_id) |
 | Validation | scripts/validate_traces.py | validate-{run_id[:8]} |
 | Smoke tests | tests/smoke/test_langgraph_smoke.py | smoke-test-{YYYYMMDD} |
 | Integration | tests/integration/test_graph_paths.py | test-{path-name} |

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -15,6 +15,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
 from src.api.schemas import QueryRequest, QueryResponse
+from telegram_bot.observability import observe
 
 
 logger = logging.getLogger(__name__)
@@ -101,6 +102,7 @@ async def health() -> dict[str, str]:
 
 
 @app.post("/query", response_model=QueryResponse)
+@observe(name="rag-api-query", capture_input=False, capture_output=False)
 async def query(req: QueryRequest) -> QueryResponse:
     """Run a RAG query through the LangGraph pipeline."""
     from telegram_bot.graph.state import make_initial_state
@@ -120,7 +122,7 @@ async def query(req: QueryRequest) -> QueryResponse:
     trace_kwargs: dict[str, Any] = {
         "session_id": session_id,
         "user_id": str(req.user_id),
-        "tags": [req.channel, "rag"],
+        "tags": ["api", "rag", req.channel],
     }
     if req.langfuse_trace_id:
         trace_kwargs["trace_id"] = req.langfuse_trace_id
@@ -128,9 +130,14 @@ async def query(req: QueryRequest) -> QueryResponse:
     with propagate_attributes(**trace_kwargs):
         result = await app.state.graph.ainvoke(state)
         lf = get_client()
+        # session_id/user_id/tags are also in propagate_attributes (for child spans);
+        # update_current_trace sets them on the root @observe trace itself.
         lf.update_current_trace(
             input=req.query,
             output=result.get("response", ""),
+            session_id=session_id,
+            user_id=str(req.user_id),
+            tags=["api", "rag", req.channel],
             metadata={
                 "source": req.channel,
                 "query_type": result.get("query_type", ""),

--- a/tests/unit/api/test_rag_api_runtime.py
+++ b/tests/unit/api/test_rag_api_runtime.py
@@ -73,6 +73,31 @@ async def test_query_writes_langfuse_scores() -> None:
     assert isinstance(call_args[0][1], dict)  # second arg: result dict
 
 
+async def test_query_observe_trace_sets_api_tags_and_ids() -> None:
+    """POST /query must set trace tags ["api", "rag", channel] and session/user IDs."""
+    graph = _DummyGraph()
+    app.state.graph = graph
+    app.state.max_rewrite_attempts = 1
+
+    lf = MagicMock()
+    lf.update_current_trace = MagicMock()
+
+    with (
+        patch("telegram_bot.observability.propagate_attributes", return_value=nullcontext()),
+        patch("telegram_bot.observability.get_client", return_value=lf),
+    ):
+        await query(QueryRequest(query="test", user_id=42, session_id="sess-1", channel="voice"))
+
+    lf.update_current_trace.assert_called_once()
+    call_kwargs = lf.update_current_trace.call_args.kwargs
+    assert "tags" in call_kwargs
+    assert "api" in call_kwargs["tags"]
+    assert "rag" in call_kwargs["tags"]
+    assert "voice" in call_kwargs["tags"]
+    assert call_kwargs["session_id"] == "sess-1"
+    assert call_kwargs["user_id"] == "42"
+
+
 async def test_lifespan_respects_rerank_provider_none() -> None:
     fake_cfg = SimpleNamespace(
         redis_url="redis://localhost:6379",


### PR DESCRIPTION
## Summary
- Add `@observe(name="rag-api-query")` to POST /query endpoint
- Set tags `["api", "rag", channel]` for Langfuse filtering
- Pass session_id/user_id/tags to `update_current_trace` for root trace metadata
- Update observability docs with RAG API entry point

Closes #528

## Test plan
- [x] New test `test_query_observe_trace_sets_api_tags_and_ids`
- [x] Existing API tests pass
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)