### PR TITLE
fix(cache): prevent RedisVLError from losing voice pipeline response

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -190,6 +190,12 @@ def _is_post_pipeline_cleanup_error(exc: Exception) -> bool:
         "consuming input failed",
         "connection lost",
         "connection closed",
+        # RedisVL semantic cache errors (#524): index missing, schema mismatch,
+        # RediSearch module not loaded on plain Redis instance
+        "redisvlerror",
+        "redissearcherror",
+        "schemavalidationerror",
+        "redisvl",
     )
 
     if any(m in message for m in cleanup_markers) and any(m in message for m in storage_markers):

--- a/telegram_bot/graph/nodes/cache.py
+++ b/telegram_bot/graph/nodes/cache.py
@@ -210,13 +210,22 @@ async def cache_store_node(
     stored_semantic = False
     if response and embedding:
         if query_type in CACHEABLE_QUERY_TYPES:
-            await cache.store_semantic(
-                query=query,
-                response=response,
-                vector=embedding,
-                query_type=query_type,
-            )
-            stored_semantic = True
+            try:
+                await cache.store_semantic(
+                    query=query,
+                    response=response,
+                    vector=embedding,
+                    query_type=query_type,
+                )
+                stored_semantic = True
+            except Exception as exc:
+                # RedisVLError, RedisSearchError, SchemaValidationError, or any unexpected
+                # error from store_semantic must never lose the response (#524).
+                logger.warning(
+                    "cache_store: semantic store failed, response preserved: %s: %s",
+                    type(exc).__name__,
+                    exc,
+                )
 
         if stored_semantic:
             logger.info("cache_store: stored=semantic (type=%s)", query_type)
@@ -229,19 +238,24 @@ async def cache_store_node(
                 if latency_stages
                 else 0
             )
-            await event_stream.log_event(
-                "pipeline_result",
-                {
-                    "query": query[:200],
-                    "query_type": query_type,
-                    "latency_ms": round(total_latency * 1000) if total_latency else 0,
-                    "cache_hit": state.get("cache_hit", False),
-                    "search_count": state.get("search_results_count", 0),
-                    "rerank_applied": state.get("rerank_applied", False),
-                    "node_name": "cache_store",
-                    "user_id": user_id,
-                },
-            )
+            try:
+                await event_stream.log_event(
+                    "pipeline_result",
+                    {
+                        "query": query[:200],
+                        "query_type": query_type,
+                        "latency_ms": round(total_latency * 1000) if total_latency else 0,
+                        "cache_hit": state.get("cache_hit", False),
+                        "search_count": state.get("search_results_count", 0),
+                        "rerank_applied": state.get("rerank_applied", False),
+                        "node_name": "cache_store",
+                        "user_id": user_id,
+                    },
+                )
+            except Exception as exc:
+                logger.warning(
+                    "cache_store: event_stream.log_event failed: %s: %s", type(exc).__name__, exc
+                )
 
     latency = time.perf_counter() - start
     lf.update_current_span(

--- a/tests/unit/graph/test_cache_nodes.py
+++ b/tests/unit/graph/test_cache_nodes.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
+from redisvl.exceptions import RedisSearchError, RedisVLError, SchemaValidationError
 
 
 @pytest.fixture(autouse=True)
@@ -336,3 +337,70 @@ class TestCacheCheckEmbeddingError:
         assert result["embedding_error"] is False
         assert result["cache_hit"] is False
         embeddings.aembed_hybrid.assert_not_awaited()
+
+
+class TestCacheStoreNodeRedisVLErrorHandling:
+    """Test cache_store_node graceful degradation when RedisVL errors escape store_semantic.
+
+    Scenario: store_semantic's internal try/except is bypassed (e.g., via @observe decorator
+    cleanup, BaseException subclass, or future code changes). The node must always return
+    the response so the voice pipeline doesn't lose its output (#524).
+    """
+
+    async def test_store_node_preserves_response_on_redisvl_error(self):
+        """Response is returned even when store_semantic raises RedisVLError (#524)."""
+        state = make_initial_state(user_id=1, session_id="s1", query="test query")
+        state["query_type"] = "FAQ"
+        state["query_embedding"] = [0.1] * 1024
+        state["response"] = "generated voice response"
+
+        cache = AsyncMock()
+        cache.store_semantic = AsyncMock(side_effect=RedisVLError("index not found"))
+
+        result = await cache_store_node(state, cache=cache)
+
+        assert result["response"] == "generated voice response"
+
+    async def test_store_node_preserves_response_on_redis_search_error(self):
+        """Response is returned even when store_semantic raises RedisSearchError (#524)."""
+        state = make_initial_state(user_id=1, session_id="s1", query="test query")
+        state["query_type"] = "GENERAL"
+        state["query_embedding"] = [0.1] * 1024
+        state["response"] = "rag answer"
+
+        cache = AsyncMock()
+        cache.store_semantic = AsyncMock(side_effect=RedisSearchError("module not loaded"))
+
+        result = await cache_store_node(state, cache=cache)
+
+        assert result["response"] == "rag answer"
+
+    async def test_store_node_preserves_response_on_schema_validation_error(self):
+        """Response returned even when index schema mismatch causes SchemaValidationError (#524)."""
+        state = make_initial_state(user_id=1, session_id="s1", query="query")
+        state["query_type"] = "ENTITY"
+        state["query_embedding"] = [0.2] * 1024
+        state["response"] = "entity answer"
+
+        cache = AsyncMock()
+        cache.store_semantic = AsyncMock(
+            side_effect=SchemaValidationError("Schema validation failed: field mismatch")
+        )
+
+        result = await cache_store_node(state, cache=cache)
+
+        assert result["response"] == "entity answer"
+
+    async def test_store_node_preserves_response_on_generic_runtime_error(self):
+        """Response preserved for any unexpected store_semantic failure."""
+        state = make_initial_state(user_id=1, session_id="s1", query="query")
+        state["query_type"] = "STRUCTURED"
+        state["query_embedding"] = [0.3] * 1024
+        state["response"] = "structured answer"
+
+        cache = AsyncMock()
+        cache.store_semantic = AsyncMock(side_effect=RuntimeError("unexpected"))
+
+        result = await cache_store_node(state, cache=cache)
+
+        assert result["response"] == "structured answer"

--- a/tests/unit/integrations/test_cache_layers.py
+++ b/tests/unit/integrations/test_cache_layers.py
@@ -7,6 +7,7 @@ from types import ModuleType
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from redisvl.exceptions import RedisSearchError, RedisVLError, SchemaValidationError
 
 from telegram_bot.integrations.cache import (
     CACHE_VERSION,
@@ -244,6 +245,91 @@ class TestSemanticCache:
         assert call_kwargs["filters"]["user_id"] == "42"
         assert call_kwargs["filters"]["query_type"] == "FAQ"
         assert call_kwargs["filters"]["language"] == "ru"
+
+
+class TestSemanticCacheRedisVLErrors:
+    """Test CacheLayerManager graceful degradation on RedisVL errors (#524).
+
+    When Redis Stack modules are unavailable or the index schema is mismatched,
+    redisvl raises RedisVLError subclasses. Both store_semantic and check_semantic
+    must handle these without propagating exceptions to the caller.
+    """
+
+    async def test_store_semantic_handles_redisvl_error(self):
+        """store_semantic logs and swallows RedisVLError (Redis Stack missing)."""
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        mgr.semantic_cache = AsyncMock()
+        mgr.semantic_cache.astore = AsyncMock(side_effect=RedisVLError("index not found"))
+        mgr.cache_ttl = {"FAQ": 86400}
+
+        # Should not raise — graceful degradation
+        await mgr.store_semantic(
+            query="test",
+            response="answer",
+            vector=[0.1] * 1024,
+            query_type="FAQ",
+        )
+
+    async def test_store_semantic_handles_redis_search_error(self):
+        """store_semantic handles RedisSearchError (RediSearch module not loaded)."""
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        mgr.semantic_cache = AsyncMock()
+        mgr.semantic_cache.astore = AsyncMock(side_effect=RedisSearchError("ERR unknown command"))
+        mgr.cache_ttl = {"GENERAL": 3600}
+
+        await mgr.store_semantic(
+            query="test",
+            response="answer",
+            vector=[0.1] * 1024,
+            query_type="GENERAL",
+        )
+
+    async def test_store_semantic_handles_schema_validation_error(self):
+        """store_semantic handles SchemaValidationError (index schema mismatch)."""
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        mgr.semantic_cache = AsyncMock()
+        mgr.semantic_cache.astore = AsyncMock(
+            side_effect=SchemaValidationError("Schema validation failed: field mismatch")
+        )
+        mgr.cache_ttl = {"ENTITY": 3600}
+
+        await mgr.store_semantic(
+            query="test",
+            response="answer",
+            vector=[0.1] * 1024,
+            query_type="ENTITY",
+        )
+
+    async def test_check_semantic_handles_redisvl_error(self, _ensure_redisvl_filter_mock):
+        """check_semantic returns None on RedisVLError — miss path."""
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        mgr.semantic_cache = AsyncMock()
+        mgr.semantic_cache.acheck = AsyncMock(side_effect=RedisVLError("connection refused"))
+        mgr.cache_thresholds = {"GENERAL": 0.08}
+
+        result = await mgr.check_semantic(
+            query="test",
+            vector=[0.1] * 1024,
+            query_type="GENERAL",
+        )
+        assert result is None
+        assert mgr._metrics["semantic"]["misses"] == 1
+
+    async def test_check_semantic_handles_redis_search_error(self, _ensure_redisvl_filter_mock):
+        """check_semantic returns None on RedisSearchError."""
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        mgr.semantic_cache = AsyncMock()
+        mgr.semantic_cache.acheck = AsyncMock(
+            side_effect=RedisSearchError("ERR unknown command `FT.SEARCH`")
+        )
+        mgr.cache_thresholds = {"FAQ": 0.12}
+
+        result = await mgr.check_semantic(
+            query="test",
+            vector=[0.1] * 1024,
+            query_type="FAQ",
+        )
+        assert result is None
 
 
 class TestExactCaches:


### PR DESCRIPTION
## Summary
- Wrap `store_semantic` in try/except in `cache_store_node` — response is preserved even when Redis Stack is unavailable
- Add RedisVL error markers to `_is_post_pipeline_cleanup_error` for proper error classification
- Wrap `event_stream.log_event` in try/except for same resilience

Closes #524

## Root cause
`cache_store_node` had no error handling around `store_semantic()`. When RedisVL raised (index missing, RediSearch module not loaded, schema mismatch), the exception propagated through LangGraph `ainvoke()`, losing the generated response entirely.

## Test plan
- [x] 4 new tests in `test_cache_nodes.py` (RedisVLError, RedisSearchError, SchemaValidationError, RuntimeError)
- [x] 5 new tests in `test_cache_layers.py` (store + check graceful degradation)
- [x] 54/54 cache tests pass
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)