### PR TITLE
test(observability): add trace contract test suite (#499)

### DIFF
--- a/tests/unit/observability/test_score_coverage.py
+++ b/tests/unit/observability/test_score_coverage.py
@@ -1,0 +1,340 @@
+"""Score coverage contract — parametrized verification of each score name and type.
+
+Verifies scoring.py covers all documented scores:
+  - 14 core RAG scores (write_langfuse_scores)
+  - Always-written supplementary scores (BOOLEAN/CATEGORICAL)
+  - 4 history scores (write_history_scores)
+  - 4 CRM tool scores (write_crm_scores)
+  - Supervisor score names present as string literals in bot.py
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+_TRACE_ID = "trace-coverage-001"
+
+_FULL_RESULT: dict = {
+    "query_type": "STRUCTURED",
+    "cache_hit": False,
+    "embeddings_cache_hit": False,
+    "search_cache_hit": False,
+    "search_results_count": 5,
+    "rerank_applied": True,
+    "grade_confidence": 0.85,
+    "pipeline_wall_ms": 862.0,
+    "latency_stages": {
+        "cache_check": 0.050,
+        "retrieve": 0.200,
+        "generate": 0.500,
+    },
+    "llm_ttft_ms": 150.0,
+    "llm_response_duration_ms": 450.0,
+    "llm_decode_ms": 300.0,
+    "llm_tps": 42.5,
+    "llm_queue_ms": None,
+    "llm_timeout": False,
+    "llm_stream_recovery": False,
+    "streaming_enabled": True,
+    "answer_words": 12,
+    "answer_chars": 65,
+    "answer_to_question_ratio": 2.4,
+    "response_policy_mode": "enforced",
+    "response_style": "balanced",
+    "sources_count": 3,
+    "messages": [{"role": "user"}, {"role": "assistant"}],
+    "input_type": "text",
+}
+
+
+@pytest.fixture()
+def all_rag_scores() -> dict[str, dict]:
+    from telegram_bot.scoring import write_langfuse_scores
+
+    lf = MagicMock()
+    write_langfuse_scores(lf, _FULL_RESULT, trace_id=_TRACE_ID)
+    return {c.kwargs["name"]: c.kwargs for c in lf.create_score.call_args_list}
+
+
+# ---------------------------------------------------------------------------
+# Core RAG scores (14) — documented table in observability.md
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "score_name",
+    [
+        "query_type",
+        "latency_total_ms",
+        "semantic_cache_hit",
+        "embeddings_cache_hit",
+        "search_cache_hit",
+        "rerank_applied",
+        "rerank_cache_hit",
+        "results_count",
+        "no_results",
+        "llm_used",
+        "confidence_score",
+        "hyde_used",
+        "llm_ttft_ms",
+        "llm_response_duration_ms",
+    ],
+)
+def test_core_rag_score_is_written(score_name: str, all_rag_scores: dict) -> None:
+    assert score_name in all_rag_scores, f"Core RAG score '{score_name}' not written"
+
+
+# ---------------------------------------------------------------------------
+# Core RAG scores — numeric value type
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "score_name",
+    [
+        "latency_total_ms",
+        "semantic_cache_hit",
+        "embeddings_cache_hit",
+        "search_cache_hit",
+        "rerank_applied",
+        "rerank_cache_hit",
+        "results_count",
+        "no_results",
+        "llm_used",
+        "confidence_score",
+        "hyde_used",
+        "llm_ttft_ms",
+        "llm_response_duration_ms",
+    ],
+)
+def test_core_rag_score_value_is_numeric(score_name: str, all_rag_scores: dict) -> None:
+    val = all_rag_scores[score_name]["value"]
+    assert isinstance(val, (int, float)), (
+        f"Score '{score_name}' value must be numeric, got {type(val)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# BOOLEAN scores — must carry data_type="BOOLEAN"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "score_name",
+    [
+        "streaming_enabled",
+        "llm_timeout",
+        "llm_stream_recovery",
+        "bge_embed_error",
+        "security_alert",
+        "guard_ml_available",
+        "summarization_triggered",
+    ],
+)
+def test_boolean_score_has_boolean_data_type(score_name: str, all_rag_scores: dict) -> None:
+    assert score_name in all_rag_scores, f"BOOLEAN score '{score_name}' not written"
+    assert all_rag_scores[score_name].get("data_type") == "BOOLEAN", (
+        f"Score '{score_name}' should have data_type='BOOLEAN'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CATEGORICAL scores
+# ---------------------------------------------------------------------------
+
+
+def test_input_type_is_categorical(all_rag_scores: dict) -> None:
+    assert "input_type" in all_rag_scores
+    assert all_rag_scores["input_type"]["data_type"] == "CATEGORICAL"
+
+
+def test_input_type_text_value_for_text_result(all_rag_scores: dict) -> None:
+    assert all_rag_scores["input_type"]["value"] == "text"
+
+
+def test_input_type_voice_for_voice_result() -> None:
+    from telegram_bot.scoring import write_langfuse_scores
+
+    lf = MagicMock()
+    write_langfuse_scores(lf, {**_FULL_RESULT, "input_type": "voice"}, trace_id=_TRACE_ID)
+    scores = {c.kwargs["name"]: c.kwargs for c in lf.create_score.call_args_list}
+    assert scores["input_type"]["value"] == "voice"
+
+
+# ---------------------------------------------------------------------------
+# memory_messages_count — always written
+# ---------------------------------------------------------------------------
+
+
+def test_memory_messages_count_always_written(all_rag_scores: dict) -> None:
+    assert "memory_messages_count" in all_rag_scores
+
+
+def test_memory_messages_count_value_matches_messages(all_rag_scores: dict) -> None:
+    # _FULL_RESULT has 2 messages
+    assert all_rag_scores["memory_messages_count"]["value"] == 2.0
+
+
+# ---------------------------------------------------------------------------
+# Streaming path scores — llm_decode_ms, llm_tps when available
+# ---------------------------------------------------------------------------
+
+
+def test_llm_decode_ms_written_when_available(all_rag_scores: dict) -> None:
+    # _FULL_RESULT has llm_decode_ms=300.0
+    assert "llm_decode_ms" in all_rag_scores
+    assert all_rag_scores["llm_decode_ms"]["value"] == 300.0
+
+
+def test_llm_tps_written_when_available(all_rag_scores: dict) -> None:
+    assert "llm_tps" in all_rag_scores
+    assert all_rag_scores["llm_tps"]["value"] == 42.5
+
+
+def test_llm_decode_unavailable_written_when_none() -> None:
+    from telegram_bot.scoring import write_langfuse_scores
+
+    lf = MagicMock()
+    result = {**_FULL_RESULT, "llm_decode_ms": None, "llm_tps": None}
+    del result["llm_decode_ms"]
+    del result["llm_tps"]
+    write_langfuse_scores(lf, result, trace_id=_TRACE_ID)
+    scores = {c.kwargs["name"]: c.kwargs for c in lf.create_score.call_args_list}
+    assert "llm_decode_unavailable" in scores
+    assert scores["llm_decode_unavailable"]["data_type"] == "BOOLEAN"
+    assert "llm_tps_unavailable" in scores
+
+
+# ---------------------------------------------------------------------------
+# History scores (4) — write_history_scores
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def history_scores() -> dict[str, dict]:
+    from telegram_bot.scoring import write_history_scores
+
+    lf = MagicMock()
+    write_history_scores(lf, _TRACE_ID, count=5, latency_ms=75.0, backend="qdrant")
+    return {c.kwargs["name"]: c.kwargs for c in lf.create_score.call_args_list}
+
+
+@pytest.mark.parametrize(
+    "score_name",
+    [
+        "history_search_count",
+        "history_search_latency_ms",
+        "history_search_empty",
+        "history_backend",
+    ],
+)
+def test_history_score_is_written(score_name: str, history_scores: dict) -> None:
+    assert score_name in history_scores, f"History score '{score_name}' not written"
+
+
+def test_history_search_count_is_numeric(history_scores: dict) -> None:
+    val = history_scores["history_search_count"]["value"]
+    assert isinstance(val, (int, float))
+
+
+def test_history_backend_is_categorical(history_scores: dict) -> None:
+    assert history_scores["history_backend"]["data_type"] == "CATEGORICAL"
+
+
+def test_history_search_latency_is_numeric(history_scores: dict) -> None:
+    val = history_scores["history_search_latency_ms"]["value"]
+    assert isinstance(val, float)
+
+
+# ---------------------------------------------------------------------------
+# CRM scores (4) — write_crm_scores
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def crm_scores() -> dict[str, dict]:
+    from telegram_bot.scoring import write_crm_scores
+
+    lf = MagicMock()
+    write_crm_scores(lf, [], trace_id=_TRACE_ID)
+    return {c.kwargs["name"]: c.kwargs for c in lf.create_score.call_args_list}
+
+
+@pytest.mark.parametrize(
+    "score_name",
+    [
+        "crm_tool_used",
+        "crm_tools_count",
+        "crm_tools_success",
+        "crm_tools_error",
+    ],
+)
+def test_crm_score_is_written(score_name: str, crm_scores: dict) -> None:
+    """Each CRM score name must be written (parametrized for individual failure messages)."""
+    assert score_name in crm_scores, f"CRM score '{score_name}' not written"
+    # Type/schema contracts are in test_trace_contracts.py::TestWriteCrmScoresContract
+
+
+# ---------------------------------------------------------------------------
+# Supervisor scores — verify names appear as string literals in bot.py
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "score_name",
+    [
+        "supervisor_model",
+        "user_role",
+        "history_save_success",
+        "tool_calls_total",
+    ],
+)
+def test_supervisor_score_name_in_bot_source(score_name: str) -> None:
+    """Supervisor score names must appear as string literals in bot.py."""
+    from pathlib import Path
+
+    bot_py = Path(__file__).resolve().parents[3] / "telegram_bot" / "bot.py"
+    bot_source = bot_py.read_text(encoding="utf-8")
+    assert f'"{score_name}"' in bot_source or f"'{score_name}'" in bot_source, (
+        f"Supervisor score '{score_name}' not found as string literal in bot.py"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Response-length control scores — conditional on enforced policy
+# ---------------------------------------------------------------------------
+
+
+def test_response_style_applied_written_for_enforced_policy(all_rag_scores: dict) -> None:
+    # _FULL_RESULT has response_policy_mode="enforced", response_style="balanced"
+    assert "response_style_applied" in all_rag_scores
+
+
+def test_response_style_applied_not_written_for_shadow_policy() -> None:
+    from telegram_bot.scoring import write_langfuse_scores
+
+    lf = MagicMock()
+    result = {**_FULL_RESULT, "response_policy_mode": "shadow", "response_style": "short"}
+    write_langfuse_scores(lf, result, trace_id=_TRACE_ID)
+    scores = {c.kwargs["name"] for c in lf.create_score.call_args_list}
+    assert "response_style_applied" not in scores
+
+
+# ---------------------------------------------------------------------------
+# Source attribution scores — conditional on sources_count > 0
+# ---------------------------------------------------------------------------
+
+
+def test_sources_shown_boolean_written_when_sources_present(all_rag_scores: dict) -> None:
+    # _FULL_RESULT has sources_count=3
+    assert "sources_shown" in all_rag_scores
+    assert all_rag_scores["sources_shown"]["data_type"] == "BOOLEAN"
+    assert all_rag_scores["sources_shown"]["value"] == 1
+
+
+def test_sources_count_written_when_sources_present(all_rag_scores: dict) -> None:
+    assert "sources_count" in all_rag_scores
+    assert all_rag_scores["sources_count"]["value"] == 3.0

--- a/tests/unit/observability/test_trace_contracts.py
+++ b/tests/unit/observability/test_trace_contracts.py
@@ -1,0 +1,367 @@
+"""Trace contract tests — verify score writing and update_current_trace shapes.
+
+Contracts tested:
+  - score() must use create_score with trace_id and score_id idempotency key
+  - write_langfuse_scores must write all 14 core RAG scores on every call
+  - write_history_scores must write all 4 history scores (latency conditional)
+  - write_crm_scores must write all 4 CRM scores unconditionally
+  - _build_trace_metadata must include required keys for voice/text paths
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+_TRACE_ID = "trace-contract-abc"
+
+# Minimal state dict that exercises all 14 core RAG scores.
+_MINIMAL_RESULT: dict = {
+    "query_type": "SIMPLE",
+    "cache_hit": False,
+    "embeddings_cache_hit": False,
+    "search_cache_hit": False,
+    "search_results_count": 3,
+    "rerank_applied": False,
+    "grade_confidence": 0.7,
+    "pipeline_wall_ms": 500.0,
+    "latency_stages": {"generate": 0.3},
+    "llm_ttft_ms": 100.0,
+    "llm_response_duration_ms": 300.0,
+    "llm_timeout": False,
+    "llm_stream_recovery": False,
+    "streaming_enabled": False,
+    "messages": [],
+}
+
+# 14 core RAG scores from observability.md § "Langfuse Scores" table
+_CORE_RAG_SCORES = [
+    "query_type",
+    "latency_total_ms",
+    "semantic_cache_hit",
+    "embeddings_cache_hit",
+    "search_cache_hit",
+    "rerank_applied",
+    "rerank_cache_hit",
+    "results_count",
+    "no_results",
+    "llm_used",
+    "confidence_score",
+    "hyde_used",
+    "llm_ttft_ms",
+    "llm_response_duration_ms",
+]
+
+
+# ---------------------------------------------------------------------------
+# score() function signature contract
+# ---------------------------------------------------------------------------
+
+
+class TestScoreSignatureContract:
+    """score() must wrap create_score with trace_id + score_id idempotency key."""
+
+    def test_routes_through_create_score_not_score_current_trace(self):
+        from telegram_bot.scoring import score
+
+        lf = MagicMock()
+        score(lf, _TRACE_ID, name="my_metric", value=1.0)
+
+        lf.create_score.assert_called_once()
+        lf.score_current_trace.assert_not_called()
+
+    def test_passes_trace_id_name_value(self):
+        from telegram_bot.scoring import score
+
+        lf = MagicMock()
+        score(lf, _TRACE_ID, name="latency_ms", value=42.5)
+
+        call = lf.create_score.call_args
+        assert call.kwargs["trace_id"] == _TRACE_ID
+        assert call.kwargs["name"] == "latency_ms"
+        assert call.kwargs["value"] == 42.5
+
+    def test_sets_idempotency_score_id(self):
+        from telegram_bot.scoring import score
+
+        lf = MagicMock()
+        score(lf, _TRACE_ID, name="cache_hit", value=1.0)
+
+        call = lf.create_score.call_args
+        assert call.kwargs["score_id"] == f"{_TRACE_ID}-cache_hit"
+
+    def test_forwards_data_type_kwarg(self):
+        from telegram_bot.scoring import score
+
+        lf = MagicMock()
+        score(lf, _TRACE_ID, name="flag", value=1, data_type="BOOLEAN")
+
+        call = lf.create_score.call_args
+        assert call.kwargs.get("data_type") == "BOOLEAN"
+
+    def test_accepts_categorical_string_value(self):
+        from telegram_bot.scoring import score
+
+        lf = MagicMock()
+        score(lf, _TRACE_ID, name="input_type", value="voice", data_type="CATEGORICAL")
+
+        call = lf.create_score.call_args
+        assert call.kwargs["value"] == "voice"
+        assert call.kwargs["data_type"] == "CATEGORICAL"
+
+    def test_empty_trace_id_still_calls_create_score(self):
+        """score() does not guard on empty trace_id — callers are responsible."""
+        from telegram_bot.scoring import score
+
+        lf = MagicMock()
+        score(lf, "", name="metric", value=1.0)
+
+        lf.create_score.assert_called_once()
+        assert lf.create_score.call_args.kwargs["trace_id"] == ""
+
+
+# ---------------------------------------------------------------------------
+# write_langfuse_scores: 14 core RAG scores contract
+# ---------------------------------------------------------------------------
+
+
+class TestWriteLangfuseScoresContract:
+    """write_langfuse_scores must write all 14 core RAG scores."""
+
+    def _written_scores(self, result: dict) -> dict[str, dict]:
+        from telegram_bot.scoring import write_langfuse_scores
+
+        lf = MagicMock()
+        write_langfuse_scores(lf, result, trace_id=_TRACE_ID)
+        return {c.kwargs["name"]: c.kwargs for c in lf.create_score.call_args_list}
+
+    def test_all_14_core_scores_present(self):
+        scores = self._written_scores(_MINIMAL_RESULT)
+        missing = [s for s in _CORE_RAG_SCORES if s not in scores]
+        assert not missing, f"Missing core RAG scores: {missing}"
+
+    def test_all_scores_use_explicit_trace_id(self):
+        from telegram_bot.scoring import write_langfuse_scores
+
+        lf = MagicMock()
+        write_langfuse_scores(lf, _MINIMAL_RESULT, trace_id=_TRACE_ID)
+
+        for call in lf.create_score.call_args_list:
+            assert call.kwargs["trace_id"] == _TRACE_ID
+
+    def test_all_scores_have_score_id(self):
+        from telegram_bot.scoring import write_langfuse_scores
+
+        lf = MagicMock()
+        write_langfuse_scores(lf, _MINIMAL_RESULT, trace_id=_TRACE_ID)
+
+        for call in lf.create_score.call_args_list:
+            name = call.kwargs["name"]
+            expected_id = f"{_TRACE_ID}-{name}"
+            assert call.kwargs["score_id"] == expected_id, f"Score '{name}' has wrong score_id"
+
+    def test_skip_all_when_no_trace_and_no_context(self):
+        from telegram_bot.scoring import write_langfuse_scores
+
+        lf = MagicMock()
+        lf.get_current_trace_id = MagicMock(return_value="")
+        write_langfuse_scores(lf, _MINIMAL_RESULT, trace_id="")
+
+        lf.create_score.assert_not_called()
+
+    def test_fallback_to_context_trace_id_when_empty(self):
+        """Falls back to lf.get_current_trace_id() when trace_id=''."""
+        from telegram_bot.scoring import write_langfuse_scores
+
+        lf = MagicMock()
+        lf.get_current_trace_id = MagicMock(return_value="ctx-trace-xyz")
+        write_langfuse_scores(lf, _MINIMAL_RESULT, trace_id="")
+
+        lf.get_current_trace_id.assert_called()
+        assert lf.create_score.call_count > 0
+
+    def test_query_type_chitchat_maps_to_zero(self):
+        scores = self._written_scores({**_MINIMAL_RESULT, "query_type": "CHITCHAT"})
+        assert scores["query_type"]["value"] == 0.0
+
+    def test_query_type_structured_maps_to_two(self):
+        scores = self._written_scores({**_MINIMAL_RESULT, "query_type": "STRUCTURED"})
+        assert scores["query_type"]["value"] == 2.0
+
+    def test_semantic_cache_hit_when_true(self):
+        scores = self._written_scores({**_MINIMAL_RESULT, "cache_hit": True})
+        assert scores["semantic_cache_hit"]["value"] == 1.0
+
+    def test_semantic_cache_hit_when_false(self):
+        scores = self._written_scores({**_MINIMAL_RESULT, "cache_hit": False})
+        assert scores["semantic_cache_hit"]["value"] == 0.0
+
+    def test_llm_used_when_generate_stage_present(self):
+        scores = self._written_scores(_MINIMAL_RESULT)  # has "generate" in latency_stages
+        assert scores["llm_used"]["value"] == 1.0
+
+    def test_llm_used_zero_when_no_generate_stage(self):
+        result = {**_MINIMAL_RESULT, "latency_stages": {"cache_check": 0.01}}
+        scores = self._written_scores(result)
+        assert scores["llm_used"]["value"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# write_history_scores: 4 history scores contract
+# ---------------------------------------------------------------------------
+
+_HISTORY_SCORES_ALWAYS = [
+    "history_search_count",
+    "history_search_empty",
+    "history_backend",
+]
+
+
+class TestWriteHistoryScoresContract:
+    """write_history_scores must write all 4 history scores (latency conditional)."""
+
+    def _written(self, **kwargs) -> dict[str, dict]:
+        from telegram_bot.scoring import write_history_scores
+
+        lf = MagicMock()
+        write_history_scores(lf, _TRACE_ID, **kwargs)
+        return {c.kwargs["name"]: c.kwargs for c in lf.create_score.call_args_list}
+
+    def test_always_written_3_scores_present(self):
+        scores = self._written(count=3, backend="qdrant")
+        for name in _HISTORY_SCORES_ALWAYS:
+            assert name in scores, f"Expected history score '{name}' not written"
+
+    def test_latency_written_when_positive(self):
+        scores = self._written(count=1, latency_ms=50.0)
+        assert "history_search_latency_ms" in scores
+        assert scores["history_search_latency_ms"]["value"] == 50.0
+
+    def test_latency_not_written_when_zero(self):
+        scores = self._written(count=0, latency_ms=0.0)
+        assert "history_search_latency_ms" not in scores
+
+    def test_empty_flag_one_for_zero_count(self):
+        scores = self._written(count=0)
+        assert scores["history_search_empty"]["value"] == 1.0
+
+    def test_empty_flag_zero_for_nonzero_count(self):
+        scores = self._written(count=5)
+        assert scores["history_search_empty"]["value"] == 0.0
+
+    def test_backend_is_categorical(self):
+        scores = self._written(count=1, backend="qdrant")
+        assert scores["history_backend"]["data_type"] == "CATEGORICAL"
+        assert scores["history_backend"]["value"] == "qdrant"
+
+    def test_empty_trace_id_writes_nothing(self):
+        from telegram_bot.scoring import write_history_scores
+
+        lf = MagicMock()
+        write_history_scores(lf, "", count=5, latency_ms=100.0)
+        lf.create_score.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# write_crm_scores: 4 CRM scores contract
+# NOTE: Behavioural tests (tool message parsing, success/error counting, score_id pattern,
+#       empty trace_id skip) live in tests/unit/test_crm_scores.py.
+#       This class tests SCHEMA contracts only: all 4 names present, value types.
+# ---------------------------------------------------------------------------
+
+_CRM_SCORES = ["crm_tool_used", "crm_tools_count", "crm_tools_success", "crm_tools_error"]
+
+
+class TestWriteCrmScoresContract:
+    """Schema contract: write_crm_scores must write all 4 CRM scores with correct types."""
+
+    def _written(self, messages, *, trace_id: str = _TRACE_ID) -> dict[str, dict]:
+        from telegram_bot.scoring import write_crm_scores
+
+        lf = MagicMock()
+        write_crm_scores(lf, messages, trace_id=trace_id)
+        return {c.kwargs["name"]: c.kwargs for c in lf.create_score.call_args_list}
+
+    def test_all_4_scores_present(self):
+        """All 4 CRM score names must always be written (contract: complete schema)."""
+        scores = self._written([])
+        missing = [s for s in _CRM_SCORES if s not in scores]
+        assert not missing, f"Missing CRM scores: {missing}"
+
+    def test_crm_tool_used_is_boolean(self):
+        scores = self._written([])
+        assert scores["crm_tool_used"]["data_type"] == "BOOLEAN"
+
+    def test_counts_are_numeric_float(self):
+        """All three count scores must be float (allows arithmetic in dashboards)."""
+        scores = self._written([])
+        for name in ["crm_tools_count", "crm_tools_success", "crm_tools_error"]:
+            assert isinstance(scores[name]["value"], float), f"{name} value should be float"
+
+
+# ---------------------------------------------------------------------------
+# _build_trace_metadata: shape contract (requires aiogram for bot.py import)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTraceMetadataContract:
+    """_build_trace_metadata must include required keys for voice/text paths."""
+
+    _REQUIRED_KEYS = {
+        "input_type",
+        "query_type",
+        "cache_hit",
+        "search_results_count",
+        "rerank_applied",
+        "embedding_error",
+        "memory_messages_count",
+    }
+
+    @pytest.fixture(autouse=True)
+    def _require_aiogram(self):
+        pytest.importorskip("aiogram", reason="bot.py requires aiogram")
+
+    def test_all_required_keys_present(self):
+        from telegram_bot.bot import _build_trace_metadata
+
+        result = {
+            "input_type": "text",
+            "query_type": "SIMPLE",
+            "cache_hit": False,
+            "search_results_count": 3,
+            "rerank_applied": False,
+            "messages": [],
+        }
+        metadata = _build_trace_metadata(result)
+        missing = self._REQUIRED_KEYS - set(metadata.keys())
+        assert not missing, f"Missing metadata keys: {missing}"
+
+    def test_voice_specific_keys_propagate(self):
+        from telegram_bot.bot import _build_trace_metadata
+
+        result = {
+            "input_type": "voice",
+            "stt_duration_ms": 200.0,
+            "messages": [],
+        }
+        metadata = _build_trace_metadata(result)
+        assert metadata["input_type"] == "voice"
+        assert metadata["stt_duration_ms"] == 200.0
+
+    def test_defaults_for_minimal_result(self):
+        from telegram_bot.bot import _build_trace_metadata
+
+        metadata = _build_trace_metadata({})
+        assert metadata["input_type"] == "text"
+        assert metadata["cache_hit"] is False
+        assert metadata["embedding_error"] is False
+        assert metadata["memory_messages_count"] == 0
+
+    def test_memory_messages_count_from_messages_list(self):
+        from telegram_bot.bot import _build_trace_metadata
+
+        result = {"messages": [{"role": "user"}, {"role": "assistant"}, {"role": "user"}]}
+        metadata = _build_trace_metadata(result)
+        assert metadata["memory_messages_count"] == 3

--- a/tests/unit/observability/test_trace_resilience.py
+++ b/tests/unit/observability/test_trace_resilience.py
@@ -1,0 +1,311 @@
+"""Trace resilience contracts — verify graceful degradation when Langfuse is unavailable.
+
+Contracts:
+  - _NullLangfuseClient: all methods callable, no exceptions raised
+  - write_langfuse_scores: empty trace_id → silent no-op
+  - write_history_scores / write_crm_scores: empty trace_id → silent no-op
+  - scoring functions work transparently with _NullLangfuseClient
+  - _write_voice_error_scores: graceful handling of empty trace_id
+  - bot.py wraps scoring calls in try/except (static contract)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+_TRACE_ID = "trace-resilience-001"
+
+_MINIMAL_RESULT: dict = {
+    "query_type": "SIMPLE",
+    "cache_hit": False,
+    "search_results_count": 0,
+    "rerank_applied": False,
+    "grade_confidence": 0.0,
+    "pipeline_wall_ms": 100.0,
+    "latency_stages": {},
+    "llm_ttft_ms": 0.0,
+    "llm_response_duration_ms": 0.0,
+    "llm_timeout": False,
+    "llm_stream_recovery": False,
+    "streaming_enabled": False,
+    "messages": [],
+}
+
+
+# ---------------------------------------------------------------------------
+# _NullLangfuseClient: all public methods must be callable without raising
+# ---------------------------------------------------------------------------
+
+
+class TestNullLangfuseClientResilience:
+    """_NullLangfuseClient: every method must be a no-op that never raises."""
+
+    def test_update_current_trace_no_raise(self):
+        from telegram_bot.observability import _NullLangfuseClient
+
+        _NullLangfuseClient().update_current_trace(
+            input={"query": "test"}, output={"response": "ok"}, metadata={"k": "v"}
+        )
+
+    def test_update_current_span_no_raise(self):
+        from telegram_bot.observability import _NullLangfuseClient
+
+        _NullLangfuseClient().update_current_span(
+            input={"x": 1}, output={"y": 2}, level="WARNING", status_message="msg"
+        )
+
+    def test_update_current_generation_no_raise(self):
+        from telegram_bot.observability import _NullLangfuseClient
+
+        _NullLangfuseClient().update_current_generation(model="gpt-4", usage={"tokens": 100})
+
+    def test_score_current_trace_no_raise(self):
+        from telegram_bot.observability import _NullLangfuseClient
+
+        _NullLangfuseClient().score_current_trace(
+            name="hitl_action", value="approve", data_type="CATEGORICAL"
+        )
+
+    def test_create_score_no_raise(self):
+        from telegram_bot.observability import _NullLangfuseClient
+
+        _NullLangfuseClient().create_score(
+            trace_id="abc",
+            name="metric",
+            value=1.0,
+            score_id="abc-metric",
+            data_type="NUMERIC",
+        )
+
+    def test_get_current_trace_id_returns_empty_string(self):
+        from telegram_bot.observability import _NullLangfuseClient
+
+        result = _NullLangfuseClient().get_current_trace_id()
+        assert result == ""
+        assert isinstance(result, str)
+
+    def test_flush_no_raise(self):
+        from telegram_bot.observability import _NullLangfuseClient
+
+        _NullLangfuseClient().flush()
+
+    def test_write_langfuse_scores_with_null_client_no_raise(self):
+        """write_langfuse_scores with _NullLangfuseClient and explicit trace_id must not raise."""
+        from telegram_bot.observability import _NullLangfuseClient
+        from telegram_bot.scoring import write_langfuse_scores
+
+        write_langfuse_scores(_NullLangfuseClient(), _MINIMAL_RESULT, trace_id=_TRACE_ID)
+
+    def test_write_history_scores_with_null_client_no_raise(self):
+        from telegram_bot.observability import _NullLangfuseClient
+        from telegram_bot.scoring import write_history_scores
+
+        write_history_scores(_NullLangfuseClient(), _TRACE_ID, count=0)
+
+    def test_write_crm_scores_with_null_client_no_raise(self):
+        from telegram_bot.observability import _NullLangfuseClient
+        from telegram_bot.scoring import write_crm_scores
+
+        write_crm_scores(_NullLangfuseClient(), [], trace_id=_TRACE_ID)
+
+
+# ---------------------------------------------------------------------------
+# Empty trace_id: all scoring functions silently skip
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyTraceIdSilentSkip:
+    """Empty trace_id → no scores written, no exceptions."""
+
+    def test_write_langfuse_scores_no_trace_id_no_calls(self):
+        from telegram_bot.scoring import write_langfuse_scores
+
+        lf = MagicMock()
+        lf.get_current_trace_id = MagicMock(return_value="")
+        write_langfuse_scores(lf, _MINIMAL_RESULT, trace_id="")
+
+        lf.create_score.assert_not_called()
+
+    def test_write_history_scores_no_trace_id_no_calls(self):
+        from telegram_bot.scoring import write_history_scores
+
+        lf = MagicMock()
+        write_history_scores(lf, "", count=5, latency_ms=100.0)
+
+        lf.create_score.assert_not_called()
+
+    def test_write_crm_scores_no_trace_id_no_calls(self):
+        from telegram_bot.scoring import write_crm_scores
+
+        lf = MagicMock()
+        write_crm_scores(lf, [], trace_id="")
+
+        lf.create_score.assert_not_called()
+
+    def test_write_langfuse_scores_empty_trace_no_raise(self):
+        """Must not raise even when trace_id is empty and get_current_trace_id returns ''."""
+        from telegram_bot.scoring import write_langfuse_scores
+
+        lf = MagicMock()
+        lf.get_current_trace_id = MagicMock(return_value="")
+        # Must complete without raising
+        write_langfuse_scores(lf, _MINIMAL_RESULT, trace_id="")
+
+
+# ---------------------------------------------------------------------------
+# _write_voice_error_scores: graceful behavior
+# ---------------------------------------------------------------------------
+
+
+class TestVoiceErrorScoresResilience:
+    """_write_voice_error_scores must handle missing trace_id gracefully."""
+
+    @pytest.fixture(autouse=True)
+    def _require_aiogram(self):
+        pytest.importorskip("aiogram", reason="bot.py requires aiogram")
+
+    def test_empty_trace_id_writes_nothing(self):
+        from telegram_bot.bot import _write_voice_error_scores
+
+        lf = MagicMock()
+        lf.get_current_trace_id = MagicMock(return_value="")
+        _write_voice_error_scores(lf, trace_id="", voice_duration_s=5.0)
+
+        lf.create_score.assert_not_called()
+
+    def test_with_trace_id_writes_input_type_and_error_reason(self):
+        from telegram_bot.bot import _write_voice_error_scores
+
+        lf = MagicMock()
+        _write_voice_error_scores(
+            lf,
+            trace_id=_TRACE_ID,
+            voice_duration_s=5.0,
+            error_reason="empty_transcription",
+        )
+        written = {c.kwargs["name"] for c in lf.create_score.call_args_list}
+        assert "input_type" in written
+        assert "voice_error_reason" in written
+        assert "voice_duration_s" in written
+
+    def test_input_type_is_voice_categorical(self):
+        from telegram_bot.bot import _write_voice_error_scores
+
+        lf = MagicMock()
+        _write_voice_error_scores(lf, trace_id=_TRACE_ID)
+        scores = {c.kwargs["name"]: c.kwargs for c in lf.create_score.call_args_list}
+        assert scores["input_type"]["value"] == "voice"
+        assert scores["input_type"]["data_type"] == "CATEGORICAL"
+
+    def test_voice_duration_omitted_when_none(self):
+        from telegram_bot.bot import _write_voice_error_scores
+
+        lf = MagicMock()
+        _write_voice_error_scores(lf, trace_id=_TRACE_ID, voice_duration_s=None)
+        written = {c.kwargs["name"] for c in lf.create_score.call_args_list}
+        assert "voice_duration_s" not in written
+
+    def test_fallback_to_get_current_trace_id_when_no_explicit(self):
+        """Falls back to lf.get_current_trace_id() when trace_id not passed."""
+        from telegram_bot.bot import _write_voice_error_scores
+
+        lf = MagicMock()
+        lf.get_current_trace_id = MagicMock(return_value=_TRACE_ID)
+        _write_voice_error_scores(lf, trace_id="")
+
+        lf.get_current_trace_id.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# Static contract: bot.py wraps scoring calls in try/except
+# ---------------------------------------------------------------------------
+
+
+class TestBotScoringTryCatchContract:
+    """bot.py must wrap write_langfuse_scores and update_current_trace in try/except."""
+
+    def _bot_source(self) -> str:
+        from pathlib import Path
+
+        return (Path(__file__).resolve().parents[3] / "telegram_bot" / "bot.py").read_text(
+            encoding="utf-8"
+        )
+
+    def test_write_langfuse_scores_wrapped_in_try_except(self):
+        """write_langfuse_scores must be called inside a try block in handle_voice."""
+        source = self._bot_source()
+        assert "write_langfuse_scores" in source
+        # Both try and write_langfuse_scores exist together in the voice handler
+        assert "Failed to write Langfuse voice scores" in source
+
+    def test_update_current_trace_failure_logged_not_raised(self):
+        """Failed update_current_trace must be caught and logged, not re-raised."""
+        source = self._bot_source()
+        assert "Failed to update Langfuse voice trace metadata" in source
+
+    def test_voice_error_scores_wrapped_in_try_except(self):
+        """_write_voice_error_scores calls must be wrapped in try/except in handle_voice."""
+        source = self._bot_source()
+        assert "Failed to write voice error scores" in source
+
+    def test_scoring_exception_does_not_produce_double_error_message(self):
+        """No user-facing error message is emitted from the scoring try/except blocks.
+
+        Scoring-specific handlers are identified by the logger messages they contain as
+        direct string-literal arguments (not nested code). This avoids false positives
+        from outer handlers that wrap scoring calls AND legitimately call message.answer.
+        """
+        import ast
+        from pathlib import Path
+
+        source = (Path(__file__).resolve().parents[3] / "telegram_bot" / "bot.py").read_text(
+            encoding="utf-8"
+        )
+        tree = ast.parse(source)
+
+        _SCORING_LOG_MARKERS = (
+            "Failed to write Langfuse voice scores",
+            "Failed to update Langfuse voice trace metadata",
+            "Failed to write voice error scores",
+        )
+
+        def _direct_string_literals(stmts: list) -> list[str]:
+            """Collect string constants from direct (non-nested) expression statements."""
+            literals = []
+            for stmt in stmts:
+                if not isinstance(stmt, ast.Expr):
+                    continue
+                for node in ast.walk(stmt.value):
+                    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                        literals.append(node.value)
+            return literals
+
+        def _direct_has_message_answer(stmts: list) -> bool:
+            """Check direct body for await message.answer() calls (not nested)."""
+            for stmt in stmts:
+                # Await expression: await message.answer(...)
+                if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Await):
+                    call = stmt.value.value
+                    if isinstance(call, ast.Call) and "message.answer" in ast.unparse(call.func):
+                        return True
+            return False
+
+        # Find except handlers whose DIRECT body contains a scoring log marker
+        score_handlers = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ExceptHandler):
+                continue
+            literals = _direct_string_literals(node.body)
+            if any(any(m in lit for m in _SCORING_LOG_MARKERS) for lit in literals):
+                score_handlers.append(node)
+
+        assert score_handlers, "Expected at least one scoring-specific except handler in bot.py"
+
+        # Each scoring-specific handler must NOT directly call message.answer
+        for handler in score_handlers:
+            assert not _direct_has_message_answer(handler.body), (
+                "Scoring error handler must not send user messages"
+            )


### PR DESCRIPTION
## Summary
- 3 new test modules in `tests/unit/observability/`:
  - `test_trace_contracts.py` — trace update calls, score() signatures, scoring function coverage (14 RAG + 4 history + 4 CRM scores)
  - `test_score_coverage.py` — parametrized tests for all 25 score names, value types (NUMERIC/CATEGORICAL/BOOLEAN)
  - `test_trace_resilience.py` — graceful degradation: Langfuse down, score write exceptions, NullLangfuseClient
- 151 tests pass

## Test plan
- [x] `uv run pytest tests/unit/observability/ tests/unit/test_bot_scores.py -v -n auto` — 151 passed
- [x] Merged with main (includes audit report + menu expansion)

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)