### PR TITLE
chore(wave-5): audit follow-up fixes — docker, bot, CRM (#560)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -222,7 +222,7 @@ services:
   clickhouse:
     image: clickhouse/clickhouse-server:26.1@sha256:be0cb54cf637cf6132081882bfdb33adc9826e4d87ec6fb65c8ab4e27fa91cbf
     container_name: dev-clickhouse
-    profiles: ["ml", "full"]
+    profiles: ["bot", "ml", "full"]
     restart: unless-stopped
     user: "101:101"
     environment:
@@ -246,7 +246,7 @@ services:
   minio:
     image: minio/minio:RELEASE.2024-12-18T13-15-44Z@sha256:1dce27c494a16bae114774f1cec295493f3613142713130c2d22dd5696be6ad3
     container_name: dev-minio
-    profiles: ["ml", "full"]
+    profiles: ["bot", "ml", "full"]
     restart: unless-stopped
     entrypoint: sh
     command: -c 'mkdir -p /data/langfuse && minio server --address ":9000" --console-address ":9001" /data'
@@ -269,7 +269,7 @@ services:
   redis-langfuse:
     image: redis:8.6.0@sha256:7b6fb55d8b0adcd77269dc52b3cfffe5f59ca5d43dec3c90dbe18aacce7942e1
     container_name: dev-redis-langfuse
-    profiles: ["ml", "full"]
+    profiles: ["bot", "ml", "full"]
     restart: unless-stopped
     ports:
       - "127.0.0.1:6380:6379"
@@ -284,7 +284,7 @@ services:
   langfuse-worker:
     image: langfuse/langfuse-worker:3.150.0@sha256:e4c98263d86593e2ba76e104c7e62e1c0c306785b84d83e21f74ef9f2d9bd0c9
     container_name: dev-langfuse-worker
-    profiles: ["ml", "full"]
+    profiles: ["bot", "ml", "full"]
     restart: always
     depends_on:
       postgres:
@@ -341,7 +341,7 @@ services:
   langfuse:
     image: langfuse/langfuse:3.150.0@sha256:7f47fd823a5d6f8b1195e0ca6830f8f99e78a659b150ccdb077d188674efb1b6
     container_name: dev-langfuse
-    profiles: ["ml", "full"]
+    profiles: ["bot", "ml", "full"]
     restart: always
     depends_on:
       postgres:

--- a/telegram_bot/agents/crm_tools.py
+++ b/telegram_bot/agents/crm_tools.py
@@ -307,7 +307,7 @@ async def crm_search_leads(query: str, config: RunnableConfig) -> str:
         if not leads:
             return f"Сделки по запросу «{query}» не найдены."
         lines = []
-        for lead in leads:
+        for lead in leads[:10]:
             budget_str = f", бюджет: {lead.budget}" if lead.budget else ""
             lines.append(f"- {lead.name or 'Без названия'} (ID: {lead.id}{budget_str})")
         return "\n".join(lines)

--- a/telegram_bot/agents/history_tool.py
+++ b/telegram_bot/agents/history_tool.py
@@ -136,14 +136,19 @@ async def history_search(
 
             # Step 3: Store summary in semantic cache for future hits
             if cache is not None and embedding is not None and summary:
-                await cache.store_semantic(
-                    query,
-                    summary,
-                    vector=embedding,
-                    query_type="ENTITY",
-                    user_id=user_id_val,
-                    cache_scope="history",
-                )
+                try:
+                    await cache.store_semantic(
+                        query,
+                        summary,
+                        vector=embedding,
+                        query_type="ENTITY",
+                        user_id=user_id_val,
+                        cache_scope="history",
+                    )
+                except Exception:
+                    logger.warning(
+                        "History cache: store_semantic failed, continuing without cache store"
+                    )
 
             lf.update_current_span(
                 output={"summary_length": len(summary), "history_cache_hit": False}

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -1512,8 +1512,11 @@ class PropertyBot:
             for chunk in _split_telegram_response(response_text):
                 await bot.send_message(chat_id=chat_id, text=chunk)
 
-        lf = get_client()
-        lf.score_current_trace(name="hitl_action", value=action, data_type="CATEGORICAL")
+        try:
+            lf = get_client()
+            lf.score_current_trace(name="hitl_action", value=action, data_type="CATEGORICAL")
+        except Exception:
+            logger.warning("Failed to write hitl_action score to Langfuse", exc_info=True)
 
     async def handle_feedback(self, callback: CallbackQuery):
         """Handle feedback button callback (#229)."""

--- a/telegram_bot/scoring.py
+++ b/telegram_bot/scoring.py
@@ -317,6 +317,7 @@ def write_crm_scores(lf: Any, messages: list, *, trace_id: str) -> None:
     crm_total = 0
     crm_success = 0
     crm_error = 0
+    per_tool_results: list[tuple[str, str]] = []
 
     for msg in messages:
         if getattr(msg, "type", None) != "tool":
@@ -329,9 +330,11 @@ def write_crm_scores(lf: Any, messages: list, *, trace_id: str) -> None:
         status = str(getattr(msg, "status", "") or "").lower()
         if status == "error":
             crm_error += 1
+            per_tool_results.append((name, "error"))
             continue
         if status == "success":
             crm_success += 1
+            per_tool_results.append((name, "success"))
             continue
 
         # Fallback for legacy/adapter messages where status is absent.
@@ -343,10 +346,16 @@ def write_crm_scores(lf: Any, messages: list, *, trace_id: str) -> None:
             or content_text == "CRM недоступен. Обратитесь к администратору."
         ):
             crm_error += 1
+            per_tool_results.append((name, "error"))
         else:
             crm_success += 1
+            per_tool_results.append((name, "success"))
 
     score(lf, trace_id, name="crm_tool_used", value=1 if crm_total > 0 else 0, data_type="BOOLEAN")
     score(lf, trace_id, name="crm_tools_count", value=float(crm_total))
     score(lf, trace_id, name="crm_tools_success", value=float(crm_success))
     score(lf, trace_id, name="crm_tools_error", value=float(crm_error))
+
+    # Per-tool result scores (#541)
+    for tool_name, tool_result in per_tool_results:
+        score(lf, trace_id, name=f"{tool_name}_result", value=tool_result, data_type="CATEGORICAL")

--- a/telegram_bot/scoring.py
+++ b/telegram_bot/scoring.py
@@ -301,10 +301,10 @@ def write_history_scores(
 
 
 def write_crm_scores(lf: Any, messages: list, *, trace_id: str) -> None:
-    """Write CRM tool usage scores from agent result messages (#440).
+    """Write CRM tool usage scores from agent result messages (#440, #541).
 
     Inspects ToolMessage objects for CRM tool calls (name starts with ``crm_``),
-    counts successes vs errors, and writes 4 Langfuse scores.
+    counts successes vs errors, and writes 4 aggregate scores + per-tool result scores.
 
     Args:
         lf: Langfuse client.

--- a/tests/unit/agents/test_crm_tools.py
+++ b/tests/unit/agents/test_crm_tools.py
@@ -537,3 +537,164 @@ async def test_get_crm_tools_count():
 
     tools = get_crm_tools()
     assert len(tools) == 12
+
+
+# --- Task 1: crm_get_my_leads manager_id resolution (#536) ---
+
+
+async def test_crm_get_my_leads_manager_context(mock_kommo):
+    """crm_get_my_leads uses manager_id=12345 from context and returns lead name."""
+    from telegram_bot.agents.crm_tools import crm_get_my_leads
+
+    mock_kommo.search_leads.return_value = [Lead(id=1, name="Test")]
+    ctx = BotContext(
+        telegram_user_id=99,
+        session_id="s-mgr",
+        language="ru",
+        kommo_client=mock_kommo,
+        history_service=AsyncMock(),
+        embeddings=AsyncMock(),
+        sparse_embeddings=AsyncMock(),
+        qdrant=AsyncMock(),
+        cache=AsyncMock(),
+        reranker=None,
+        llm=MagicMock(),
+        content_filter_enabled=True,
+        guard_mode="hard",
+        manager_id=12345,
+    )
+    result = await crm_get_my_leads.ainvoke({}, config=_make_config(ctx))
+    mock_kommo.search_leads.assert_called_once_with(responsible_user_id=12345, limit=20)
+    assert "Test" in result
+    assert "1" in result
+
+
+async def test_crm_get_my_leads_no_manager_id_explicit(mock_kommo):
+    """crm_get_my_leads returns error message when manager_id is None."""
+    from telegram_bot.agents.crm_tools import crm_get_my_leads
+
+    ctx = BotContext(
+        telegram_user_id=99,
+        session_id="s-no-mgr",
+        language="ru",
+        kommo_client=mock_kommo,
+        history_service=AsyncMock(),
+        embeddings=AsyncMock(),
+        sparse_embeddings=AsyncMock(),
+        qdrant=AsyncMock(),
+        cache=AsyncMock(),
+        reranker=None,
+        llm=MagicMock(),
+        content_filter_enabled=True,
+        guard_mode="hard",
+    )
+    result = await crm_get_my_leads.ainvoke({}, config=_make_config(ctx))
+    assert "manager_id" in result.lower()
+
+
+# --- Task 2: crm_get_my_tasks overdue flagging (#537) ---
+
+
+async def test_crm_get_my_tasks_overdue(mock_kommo):
+    """crm_get_my_tasks marks past-due incomplete tasks as ПРОСРОЧЕНО."""
+    import time
+
+    from telegram_bot.agents.crm_tools import crm_get_my_tasks
+
+    mock_kommo.get_tasks.return_value = [
+        Task(id=400, text="Overdue task", complete_till=int(time.time()) - 3600, is_completed=False)
+    ]
+    ctx = BotContext(
+        telegram_user_id=1,
+        session_id="s",
+        language="ru",
+        kommo_client=mock_kommo,
+        history_service=AsyncMock(),
+        embeddings=AsyncMock(),
+        sparse_embeddings=AsyncMock(),
+        qdrant=AsyncMock(),
+        cache=AsyncMock(),
+        reranker=None,
+        llm=MagicMock(),
+        manager_id=10,
+    )
+    result = await crm_get_my_tasks.ainvoke({}, config=_make_config(ctx))
+    assert "ПРОСРОЧЕНО" in result
+
+
+async def test_crm_get_my_tasks_not_overdue(mock_kommo):
+    """crm_get_my_tasks does NOT mark future tasks as ПРОСРОЧЕНО."""
+    import time
+
+    from telegram_bot.agents.crm_tools import crm_get_my_tasks
+
+    mock_kommo.get_tasks.return_value = [
+        Task(id=401, text="Future task", complete_till=int(time.time()) + 3600, is_completed=False)
+    ]
+    ctx = BotContext(
+        telegram_user_id=1,
+        session_id="s",
+        language="ru",
+        kommo_client=mock_kommo,
+        history_service=AsyncMock(),
+        embeddings=AsyncMock(),
+        sparse_embeddings=AsyncMock(),
+        qdrant=AsyncMock(),
+        cache=AsyncMock(),
+        reranker=None,
+        llm=MagicMock(),
+        manager_id=10,
+    )
+    result = await crm_get_my_tasks.ainvoke({}, config=_make_config(ctx))
+    assert "ПРОСРОЧЕНО" not in result
+
+
+async def test_crm_get_my_tasks_completed_not_flagged(mock_kommo):
+    """crm_get_my_tasks does NOT mark completed tasks as ПРОСРОЧЕНО even if past due."""
+    import time
+
+    from telegram_bot.agents.crm_tools import crm_get_my_tasks
+
+    mock_kommo.get_tasks.return_value = [
+        Task(
+            id=402,
+            text="Done task",
+            complete_till=int(time.time()) - 3600,
+            is_completed=True,
+        )
+    ]
+    ctx = BotContext(
+        telegram_user_id=1,
+        session_id="s",
+        language="ru",
+        kommo_client=mock_kommo,
+        history_service=AsyncMock(),
+        embeddings=AsyncMock(),
+        sparse_embeddings=AsyncMock(),
+        qdrant=AsyncMock(),
+        cache=AsyncMock(),
+        reranker=None,
+        llm=MagicMock(),
+        manager_id=10,
+    )
+    result = await crm_get_my_tasks.ainvoke({}, config=_make_config(ctx))
+    assert "ПРОСРОЧЕНО" not in result
+
+
+# --- Task 3: crm_search_leads truncation (#543) ---
+
+
+async def test_crm_search_leads_truncation(bot_context, mock_kommo):
+    """crm_search_leads shows only first 10 results when more are returned."""
+    from telegram_bot.agents.crm_tools import crm_search_leads
+
+    mock_kommo.search_leads.return_value = [Lead(id=i, name=f"Deal {i}") for i in range(15)]
+    result = await crm_search_leads.ainvoke(
+        {"query": "Deal"},
+        config=_make_config(bot_context),
+    )
+    lines = [line for line in result.split("\n") if line.strip().startswith("-")]
+    assert len(lines) == 10
+    assert "Deal 0" in result
+    assert "Deal 9" in result
+    assert "Deal 10" not in result

--- a/tests/unit/agents/test_history_tool.py
+++ b/tests/unit/agents/test_history_tool.py
@@ -250,6 +250,37 @@ async def test_history_search_sets_reply_markup_on_success(bot_context):
     assert isinstance(bot_context.history_reply_markup, InlineKeyboardMarkup)
 
 
+async def test_history_search_cache_store_semantic_error_returns_result(bot_context, caplog):
+    """cache.store_semantic failure is logged and does not prevent returning summary (#542)."""
+    import logging
+
+    from telegram_bot.agents.history_tool import history_search
+
+    mock_graph = AsyncMock()
+    mock_graph.ainvoke = AsyncMock(
+        return_value={
+            "summary": "Вы спрашивали о ценах",
+            "results": [],
+            "results_relevant": True,
+            "rewrite_count": 0,
+            "latency_stages": {},
+        }
+    )
+    bot_context.cache.get_embedding = AsyncMock(return_value=[0.1] * 10)
+    bot_context.cache.check_semantic = AsyncMock(return_value=None)
+    bot_context.cache.store_semantic = AsyncMock(side_effect=Exception("Redis connection error"))
+
+    with caplog.at_level(logging.WARNING, logger="telegram_bot.agents.history_tool"):
+        with patch("telegram_bot.agents.history_tool.build_history_graph", return_value=mock_graph):
+            result = await history_search.ainvoke(
+                {"query": "цены"},
+                config=_make_config(bot_context),
+            )
+
+    assert result == "Вы спрашивали о ценах"
+    assert any("store_semantic" in record.message for record in caplog.records)
+
+
 async def test_history_search_no_reply_markup_on_empty_summary(bot_context):
     """history_search does not set reply_markup when summary is empty (#434)."""
     from telegram_bot.agents.history_tool import history_search

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -2293,3 +2293,46 @@ class TestHITLBotHandler:
         callback.answer.assert_called_once_with("Отменено")
         command = mock_agent.ainvoke.call_args[0][0]
         assert command.resume == {"action": "cancel"}
+
+    async def test_handle_hitl_callback_stale_trace(self, mock_config):
+        """Langfuse score_current_trace failure (stale trace_id) does not crash callback (#545)."""
+        bot, _ = _create_bot(mock_config)
+        bot._history_service = None
+        callback = _make_callback_query("hitl:approve", user_id=12345, chat_id=12345)
+
+        mock_agent = AsyncMock()
+        mock_agent.ainvoke = AsyncMock(return_value=_mock_agent_result())
+
+        lf_client = MagicMock()
+        lf_client.score_current_trace.side_effect = Exception("Langfuse trace expired")
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.get_client", return_value=lf_client),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+            patch("telegram_bot.bot.PropertyBot._resolve_user_role", return_value="manager"),
+        ):
+            await bot.handle_hitl_callback(callback)
+
+        callback.answer.assert_called_once_with("Принято")
+        lf_client.score_current_trace.assert_called_once()
+
+
+class TestHandleFeedback:
+    """Tests for handle_feedback callback handler (#539)."""
+
+    async def test_handle_feedback_langfuse_failure(self, mock_config):
+        """Langfuse create_score failure does not crash handle_feedback (#539)."""
+        bot, _ = _create_bot(mock_config)
+        trace_id = "trace-abc-123"
+        callback = _make_callback_query(f"fb:1:{trace_id}", user_id=12345, chat_id=12345)
+
+        lf_client = MagicMock()
+        lf_client.create_score.side_effect = Exception("Langfuse unavailable")
+
+        with patch("telegram_bot.bot.get_langfuse_client", return_value=lf_client):
+            await bot.handle_feedback(callback)
+
+        callback.answer.assert_called_once_with("Спасибо за отзыв!")
+        callback.message.edit_reply_markup.assert_called_once()

--- a/tests/unit/test_crm_scores.py
+++ b/tests/unit/test_crm_scores.py
@@ -154,3 +154,78 @@ class TestWriteCrmScores:
         assert calls["crm_tools_count"] == 1.0
         assert calls["crm_tools_success"] == 1.0
         assert calls["crm_tools_error"] == 0.0
+
+
+class TestWriteCrmScoresPerTool:
+    """Per-tool result score tests (#541)."""
+
+    def test_per_tool_success_score(self):
+        """Successful CRM call writes per-tool _result=success CATEGORICAL score."""
+        lf = _make_lf()
+        messages = [
+            _tool_msg("crm_create_lead", "Сделка создана: ID 1, New"),
+        ]
+
+        write_crm_scores(lf, messages, trace_id="t-pt-1")
+
+        calls = {c.kwargs["name"]: c.kwargs["value"] for c in lf.create_score.call_args_list}
+        assert calls["crm_create_lead_result"] == "success"
+        # Verify data_type=CATEGORICAL
+        dt_calls = {
+            c.kwargs["name"]: c.kwargs.get("data_type") for c in lf.create_score.call_args_list
+        }
+        assert dt_calls["crm_create_lead_result"] == "CATEGORICAL"
+
+    def test_per_tool_error_score(self):
+        """Failed CRM call writes per-tool _result=error CATEGORICAL score."""
+        lf = _make_lf()
+        messages = [
+            _tool_msg("crm_get_deal", "Ошибка при получении сделки: timeout"),
+        ]
+
+        write_crm_scores(lf, messages, trace_id="t-pt-2")
+
+        calls = {c.kwargs["name"]: c.kwargs["value"] for c in lf.create_score.call_args_list}
+        assert calls["crm_get_deal_result"] == "error"
+
+    def test_per_tool_mixed_results(self):
+        """Multiple CRM calls write separate per-tool scores."""
+        lf = _make_lf()
+        messages = [
+            _tool_msg("crm_create_lead", "Сделка создана: ID 1, New"),
+            _tool_msg("crm_add_note", "Ошибка при добавлении заметки: 500"),
+            _tool_msg("crm_get_contacts", "- Ivan Petrov (ID: 10)"),
+        ]
+
+        write_crm_scores(lf, messages, trace_id="t-pt-3")
+
+        calls = {c.kwargs["name"]: c.kwargs["value"] for c in lf.create_score.call_args_list}
+        assert calls["crm_create_lead_result"] == "success"
+        assert calls["crm_add_note_result"] == "error"
+        assert calls["crm_get_contacts_result"] == "success"
+
+    def test_per_tool_status_field_used(self):
+        """status field on ToolMessage takes priority for per-tool score."""
+        lf = _make_lf()
+        messages = [
+            _tool_msg("crm_get_deal", "some content", status="error"),
+        ]
+
+        write_crm_scores(lf, messages, trace_id="t-pt-4")
+
+        calls = {c.kwargs["name"]: c.kwargs["value"] for c in lf.create_score.call_args_list}
+        assert calls["crm_get_deal_result"] == "error"
+
+    def test_no_per_tool_scores_when_no_crm_messages(self):
+        """No per-tool scores when no CRM tool messages present."""
+        lf = _make_lf()
+        messages = [
+            _tool_msg("rag_search", "RAG results"),
+            _human_msg("hello"),
+        ]
+
+        write_crm_scores(lf, messages, trace_id="t-pt-5")
+
+        score_names = {c.kwargs["name"] for c in lf.create_score.call_args_list}
+        per_tool = {n for n in score_names if n.endswith("_result")}
+        assert per_tool == set()


### PR DESCRIPTION
## Summary
- **Docker (#535):** Added `bot` profile to 5 Langfuse services so `make docker-bot-up` starts the full Langfuse stack
- **Bot (#539, #545):** Wrapped `hitl_action` Langfuse score write in try-except for graceful degradation on stale traces; added error-path tests for both HITL and feedback handlers
- **History (#542):** Wrapped `cache.store_semantic` in try-except so history search returns results even on Redis failure
- **CRM tests (#536, #537, #543):** Added tests for `crm_get_my_leads` manager_id resolution, `crm_get_my_tasks` overdue flagging, `crm_search_leads` truncation
- **CRM scores (#541):** Added per-tool Langfuse CATEGORICAL scores (`{tool_name}_result`) alongside existing 4 aggregate scores

## Test plan
- [x] 38 targeted tests pass (history_tool, crm_tools, crm_scores, bot_handlers)
- [x] `docker compose --profile bot config --quiet` validates
- [x] `ruff check` + `ruff format` clean
- [x] Opus code review: 0 MUST-FIX issues

Closes #535, closes #536, closes #537, closes #539, closes #541, closes #542, closes #543, closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)