### PR TITLE
perf(pipeline): fix 5 latency/quality issues from trace analysis

### DIFF
--- a/.claude/rules/features/search-retrieval.md
+++ b/.claude/rules/features/search-retrieval.md
@@ -88,7 +88,7 @@ LLM reformulation via OpenAI SDK (`GraphConfig.create_llm()`). Increments `rewri
 | `acorn_mode` | off | off/on/auto (filtered search optimization) |
 | `skip_rerank_threshold` | 0.018 | Skip ColBERT rerank when grade confidence >= threshold (RRF scale; must be > 1/61≈0.016) |
 | `score_improvement_delta` | 0.001 | Minimum score delta vs prev confidence to count as improvement |
-| `generate_max_tokens` | 2048 | Token cap for LLM generation (env: `GENERATE_MAX_TOKENS`) |
+| `generate_max_tokens` | 4096 | Token cap for LLM generation (env: `GENERATE_MAX_TOKENS`) |
 
 ## RRF Weights by Query Type
 

--- a/.claude/rules/features/telegram-bot.md
+++ b/.claude/rules/features/telegram-bot.md
@@ -168,7 +168,7 @@ pydantic-settings `BaseSettings` with `.env` file support and `AliasChoices` for
 |-----------|---------|---------|-------------|
 | `skip_rerank_threshold` | `SKIP_RERANK_THRESHOLD` | `0.018` | Skip rerank when grade confidence >= threshold (RRF scale; must be > 1/61≈0.016 to ensure ColBERT runs) |
 | `max_rewrite_attempts` | `MAX_REWRITE_ATTEMPTS` | `1` | Max query rewrites before fallback |
-| `generate_max_tokens` | `GENERATE_MAX_TOKENS` | `2048` | Token cap for LLM generation |
+| `generate_max_tokens` | `GENERATE_MAX_TOKENS` | `4096` | Token cap for LLM generation |
 | `rewrite_max_tokens` | `REWRITE_MAX_TOKENS` | `64` | Token budget for rewrite LLM call |
 | `rewrite_model` | `REWRITE_MODEL` | `gpt-4o-mini` | Model for rewrites |
 | `bge_m3_timeout` | `BGE_M3_TIMEOUT` | `120.0` | BGE-M3 API timeout (seconds) |
@@ -238,9 +238,11 @@ run_client_pipeline(user_text, user_id, session_id, message, cache, ...) → Pip
      → if intent: return PipelineResult(needs_agent=True, agent_intent=intent)
   3. Cache check: semantic cache for CACHEABLE types → hit: return early
   4. RAG pipeline: rag_pipeline(skip_rewrite=True for FAQ)
-  5. Generate: generate_response() with streaming
-  6. Post-process: cache store (with confidence/source/contextual guards), history save, Langfuse scores
+  5. Generate: generate_response(message=message) with streaming (#571: message forwarded for chunked edits)
+  6. Post-process: double-send guard (response_sent), cache store (confidence/source/contextual guards), history save, Langfuse scores
 ```
+
+**Embedding passthrough (#571):** Pre-agent computes dense+sparse+ColBERT in one `aembed_hybrid_with_colbert()` call. All three are stashed in `rag_result_store` (on both HIT and MISS) and passed to `rag_pipeline()` via `pre_computed_sparse`/`pre_computed_colbert` params, eliminating redundant BGE-M3 calls.
 
 **`detect_agent_intent()`**: Regex/keyword detector for intents not covered by `classify_query()`:
 - "ипотек", "кредит", "рассрочка" → `"mortgage"`

--- a/.claude/rules/observability.md
+++ b/.claude/rules/observability.md
@@ -234,7 +234,8 @@ except Exception as e:
 | `llm_used` | 0.0/1.0 | LLM generation was invoked |
 | `confidence_score` | 0.0-1.0 | Grade confidence (real value from state) |
 | `hyde_used` | 0.0 | Not yet tracked in LangGraph state |
-| `llm_ttft_ms` | float | Time to first token (ms), streaming only |
+| `llm_ttft_ms` | float | Time to first token (ms); streaming: first chunk, non-streaming: total LLM call time (#571) |
+| `llm_tps` | float/None | Tokens per second; streaming: from decode phase, non-streaming: from total call + usage.completion_tokens (#571) |
 | `llm_response_duration_ms` | float | Full LLM response wall-time (ms) |
 | `user_feedback` | 0.0/1.0 | User like/dislike via inline button (#229) |
 

--- a/telegram_bot/agents/rag_pipeline.py
+++ b/telegram_bot/agents/rag_pipeline.py
@@ -55,10 +55,13 @@ async def _cache_check(
     latency_stages: dict[str, float],
     agent_role: str | None = None,
     pre_computed_embedding: list[float] | None = None,
+    pre_computed_sparse: Any = None,
+    pre_computed_colbert: list[list[float]] | None = None,
 ) -> dict[str, Any]:
     """Compute embedding and check semantic cache.
 
-    Returns dict with cache_hit, cached_response, query_embedding, and latency.
+    Returns dict with cache_hit, cached_response, query_embedding, sparse_embedding,
+    colbert_query, and latency.
     """
     lf = get_client()
     lf.update_current_span(
@@ -77,6 +80,7 @@ async def _cache_check(
     embedding_error: bool = False
     embedding_error_type: str | None = None
     colbert_query: list[list[float]] | None = None
+    sparse: Any = None  # tracked for return so _hybrid_retrieve can skip re-fetch
 
     if pre_computed_embedding:
         logger.debug(
@@ -86,6 +90,12 @@ async def _cache_check(
         embeddings_cache_hit = False  # embedding came from caller, not Redis
         # Still warm the embedding cache so downstream hits benefit
         await cache.store_embedding(query, embedding)
+        # Reuse pre-computed sparse + colbert so rag_pipeline avoids redundant BGE-M3 calls (#571)
+        if pre_computed_sparse is not None:
+            await cache.store_sparse_embedding(query, pre_computed_sparse)
+            sparse = pre_computed_sparse
+        if pre_computed_colbert is not None:
+            colbert_query = pre_computed_colbert
     else:
         embedding = await cache.get_embedding(query)
         embeddings_cache_hit = embedding is not None
@@ -130,6 +140,7 @@ async def _cache_check(
                 "cache_hit": False,
                 "cached_response": None,
                 "query_embedding": None,
+                "sparse_embedding": None,
                 "embeddings_cache_hit": False,
                 "embedding_error": True,
                 "embedding_error_type": embedding_error_type,
@@ -172,6 +183,7 @@ async def _cache_check(
             "cache_hit": True,
             "cached_response": cached,
             "query_embedding": embedding,
+            "sparse_embedding": sparse,
             "embeddings_cache_hit": embeddings_cache_hit,
             "embedding_error": False,
             "embedding_error_type": None,
@@ -192,6 +204,7 @@ async def _cache_check(
         "cache_hit": False,
         "cached_response": None,
         "query_embedding": embedding,
+        "sparse_embedding": sparse,
         "embeddings_cache_hit": embeddings_cache_hit,
         "embedding_error": embedding_error,
         "embedding_error_type": embedding_error_type,
@@ -236,6 +249,7 @@ async def _hybrid_retrieve(
     qdrant: Any,
     embeddings: Any | None = None,
     colbert_query: list[list[float]] | None = None,
+    sparse_embedding: Any = None,
     top_k: int = 20,
     latency_stages: dict[str, float],
 ) -> dict[str, Any]:
@@ -254,7 +268,8 @@ async def _hybrid_retrieve(
     )
 
     dense_vector = query_embedding
-    sparse_vector: Any = None
+    # Initialize with pre-computed sparse from _cache_check to avoid redundant BGE-M3 call (#571)
+    sparse_vector: Any = sparse_embedding
 
     # After rewrite, query_embedding is None — re-embed the rewritten query
     if dense_vector is None and embeddings is not None:
@@ -713,6 +728,8 @@ async def rag_pipeline(
     llm: Any | None = None,
     agent_role: str | None = None,
     pre_computed_embedding: list[float] | None = None,
+    pre_computed_sparse: Any = None,
+    pre_computed_colbert: list[list[float]] | None = None,
     skip_rewrite: bool = False,
 ) -> dict[str, Any]:
     """Execute RAG pipeline: cache → retrieve → grade → rerank → rewrite loop → cache_store.
@@ -764,9 +781,12 @@ async def rag_pipeline(
         latency_stages=latency_stages,
         agent_role=agent_role,
         pre_computed_embedding=pre_computed_embedding,
+        pre_computed_sparse=pre_computed_sparse,
+        pre_computed_colbert=pre_computed_colbert,
     )
     # Embedding of cache_key — kept separately for _cache_store so rewrites don't overwrite it
     cache_embedding: list[float] | None = cache_result.get("query_embedding")
+    cache_sparse: Any = cache_result.get("sparse_embedding")
     latency_stages = cache_result["latency_stages"]
     colbert_query: list[list[float]] | None = cache_result.get("colbert_query")
 
@@ -815,6 +835,7 @@ async def rag_pipeline(
         # cache_result.colbert_query was computed for cache_key (original user text).
         # Reset and re-encode for the actual retrieval query to avoid query mismatch.
         colbert_query = None
+        query_sparse: Any = None  # pre-computed sparse is for cache_key, not reformulated query
         if (
             query_embedding is not None
             and callable(getattr(embeddings, "aembed_hybrid_with_colbert", None))
@@ -828,6 +849,7 @@ async def rag_pipeline(
                 )
     else:
         query_embedding = cache_embedding
+        query_sparse = cache_sparse  # reuse sparse from _cache_check for this query (#571)
 
     # Retrieve → grade → (rerank | rewrite loop)
     for _attempt in range(config.max_rewrite_attempts + 1):
@@ -840,6 +862,7 @@ async def rag_pipeline(
             qdrant=qdrant,
             embeddings=embeddings,
             colbert_query=colbert_query,
+            sparse_embedding=query_sparse,
             latency_stages=latency_stages,
         )
         latency_stages = retrieve_result["latency_stages"]
@@ -929,6 +952,7 @@ async def rag_pipeline(
         rewrite_effective = rewrite_result["rewrite_effective"]
         query_embedding = None  # Force re-embed on next retrieve
         colbert_query = None  # Force re-encode ColBERT on next retrieve
+        query_sparse = None  # Force re-compute sparse on next retrieve (query changed)
 
     # Fallback: ran out of rewrites, return best docs with rerank
     rerank_from_retrieve = retrieve_result.get("rerank_applied", False)

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -896,8 +896,22 @@ class PropertyBot:
             query_type = classify_query(user_text)
             if query_type in CACHEABLE_QUERY_TYPES:
                 try:
-                    embedding = await self._embeddings.aembed_query(user_text)
+                    _has_hybrid_colbert = callable(
+                        getattr(self._embeddings, "aembed_hybrid_with_colbert", None)
+                    ) and asyncio.iscoroutinefunction(self._embeddings.aembed_hybrid_with_colbert)
+                    if _has_hybrid_colbert:
+                        # Single call yields dense + sparse + colbert — stash all three (#571)
+                        dense, sparse, colbert = await self._embeddings.aembed_hybrid_with_colbert(
+                            user_text
+                        )
+                        embedding = dense
+                    else:
+                        embedding = await self._embeddings.aembed_query(user_text)
+                        sparse = None
+                        colbert = None
                     await self._cache.store_embedding(user_text, embedding)
+                    if sparse is not None:
+                        await self._cache.store_sparse_embedding(user_text, sparse)
                     cached = await self._cache.check_semantic(
                         query=user_text,
                         vector=embedding,
@@ -910,6 +924,8 @@ class PropertyBot:
                         rag_result_store["cache_hit"] = True
                         rag_result_store["query_type"] = query_type
                         rag_result_store["cache_key_embedding"] = embedding
+                        rag_result_store["cache_key_sparse"] = sparse
+                        rag_result_store["cache_key_colbert"] = colbert
                         # Write Langfuse scores and trace metadata
                         lf = get_client()
                         lf.update_current_trace(
@@ -942,9 +958,11 @@ class PropertyBot:
                         if root_trace_metadata is not None:
                             root_trace_metadata.update({"pipeline_mode": "pre_agent_cache"})
                         return cached
-                    # MISS: stash embedding so rag_pipeline can skip recomputation
+                    # MISS: stash all embeddings so rag_pipeline can skip recomputation (#571)
                     logger.debug("Pre-agent cache MISS (type=%s): %.60s", query_type, user_text)
                     rag_result_store["cache_key_embedding"] = embedding
+                    rag_result_store["cache_key_sparse"] = sparse
+                    rag_result_store["cache_key_colbert"] = colbert
                     rag_result_store["query_type"] = query_type
                 except Exception:
                     logger.warning(

--- a/telegram_bot/graph/config.py
+++ b/telegram_bot/graph/config.py
@@ -19,7 +19,7 @@ class GraphConfig:
     llm_model: str = "gpt-4o-mini"
     llm_temperature: float = 0.7
     llm_max_tokens: int = 4096
-    generate_max_tokens: int = 2048
+    generate_max_tokens: int = 4096
     rewrite_model: str = "gpt-4o-mini"
     rewrite_max_tokens: int = 64
 
@@ -86,7 +86,7 @@ class GraphConfig:
             llm_model=os.getenv("LLM_MODEL", "gpt-4o-mini"),
             rewrite_model=os.getenv("REWRITE_MODEL", os.getenv("LLM_MODEL", "gpt-4o-mini")),
             rewrite_max_tokens=int(os.getenv("REWRITE_MAX_TOKENS", "64")),
-            generate_max_tokens=int(os.getenv("GENERATE_MAX_TOKENS", "2048")),
+            generate_max_tokens=int(os.getenv("GENERATE_MAX_TOKENS", "4096")),
             bge_m3_url=os.getenv("BGE_M3_URL", "http://bge-m3:8000"),
             bge_m3_timeout=float(os.getenv("BGE_M3_TIMEOUT", "120.0")),
             qdrant_url=os.getenv("QDRANT_URL", "http://qdrant:6333"),

--- a/telegram_bot/pipelines/client.py
+++ b/telegram_bot/pipelines/client.py
@@ -216,7 +216,10 @@ async def run_client_pipeline(
         "messages": [{"role": "user", "content": user_text}],
     }
 
-    pre_computed = (rag_result_store or {}).get("cache_key_embedding")
+    _store = rag_result_store or {}
+    pre_computed = _store.get("cache_key_embedding")
+    pre_computed_sparse = _store.get("cache_key_sparse")
+    pre_computed_colbert = _store.get("cache_key_colbert")
 
     pipeline_result = await rag_pipeline(
         user_text,
@@ -232,6 +235,8 @@ async def run_client_pipeline(
         llm=llm,
         agent_role=role,
         pre_computed_embedding=pre_computed,
+        pre_computed_sparse=pre_computed_sparse,
+        pre_computed_colbert=pre_computed_colbert,
     )
     result.update(pipeline_result)
     response_text = str(pipeline_result.get("response", "") or "")

--- a/telegram_bot/pipelines/client.py
+++ b/telegram_bot/pipelines/client.py
@@ -246,6 +246,7 @@ async def run_client_pipeline(
             latency_stages=result.get("latency_stages", {}),
             llm_call_count=int(result.get("llm_call_count", 0) or 0),
             config=config,
+            message=message,
         )
         result.update(generated)
         response_text = str(generated.get("response", "") or "")
@@ -266,8 +267,14 @@ async def run_client_pipeline(
         sources_text = format_sources(documents_list)
         result["sources_count"] = min(len(documents_list), _MAX_SOURCES)
 
-    full_response = response_text + sources_text if sources_text else response_text
-    await _send_markdown_chunks(message, full_response, reply_markup=reply_markup)
+    response_already_sent = result.get("response_sent", False)
+    if response_already_sent:
+        # Streaming already delivered the main response; only send sources if applicable.
+        if sources_text:
+            await _send_markdown_chunks(message, sources_text, reply_markup=reply_markup)
+    else:
+        full_response = response_text + sources_text if sources_text else response_text
+        await _send_markdown_chunks(message, full_response, reply_markup=reply_markup)
 
     # --- Step f) Post-process ---
     wall_ms = (time.perf_counter() - pipeline_start) * 1000

--- a/telegram_bot/services/generate_response.py
+++ b/telegram_bot/services/generate_response.py
@@ -422,6 +422,7 @@ async def generate_response(
                     stream_recovery = True
         else:
             # Non-streaming path
+            t_llm_start = time.monotonic()
             response_obj = await llm.chat.completions.create(
                 model=config.llm_model,
                 messages=llm_messages,
@@ -429,8 +430,14 @@ async def generate_response(
                 max_tokens=max_tokens,
                 name="generate-answer",  # type: ignore[call-overload]  # langfuse kwarg
             )
+            t_llm_end = time.monotonic()
             answer = response_obj.choices[0].message.content or ""
             actual_model = getattr(response_obj, "model", config.llm_model) or config.llm_model
+            # For non-streaming: TTFT = entire call duration (one-shot completion)
+            ttft_ms = (t_llm_end - t_llm_start) * 1000
+            usage = getattr(response_obj, "usage", None)
+            if usage is not None:
+                completion_tokens = getattr(usage, "completion_tokens", None)
     except Exception as e:
         logger.exception("generate_response: LLM call failed, using fallback")
         lf_client.update_current_span(
@@ -488,6 +495,10 @@ async def generate_response(
             llm_decode_ms = 0.0
         if completion_tokens is not None and llm_decode_ms > 0:
             llm_tps = completion_tokens / (llm_decode_ms / 1000)
+    elif not streaming_was_enabled and ttft_ms > 0:
+        # Non-streaming: no decode/prefill distinction; compute TPS from total call time
+        if completion_tokens is not None and ttft_ms > 0:
+            llm_tps = completion_tokens / (ttft_ms / 1000)
 
     # Response length metrics (#129)
     answer_words = len(answer.split())

--- a/tests/unit/agents/test_rag_pipeline.py
+++ b/tests/unit/agents/test_rag_pipeline.py
@@ -1109,3 +1109,174 @@ async def test_rag_pipeline_recomputes_colbert_for_reformulated_query(mock_cache
     assert called_colbert_query == reformulated_colbert
     assert called_colbert_query != original_colbert
     assert result["documents"]
+
+
+# ---------------------------------------------------------------------------
+# Pre-computed sparse + colbert passthrough (#571)
+# ---------------------------------------------------------------------------
+
+
+async def test_cache_check_uses_pre_computed_sparse(mock_cache):
+    """_cache_check stores pre_computed_sparse in Redis and returns it as sparse_embedding."""
+    from unittest.mock import AsyncMock
+
+    from telegram_bot.agents.rag_pipeline import _cache_check
+
+    dense = [0.1] * 1024
+    sparse = {"indices": [1, 2], "values": [0.5, 0.3]}
+
+    mock_embeddings = AsyncMock()
+    mock_embeddings.aembed_hybrid_with_colbert = None  # not available
+
+    result = await _cache_check(
+        "test query",
+        "GENERAL",
+        42,
+        cache=mock_cache,
+        embeddings=mock_embeddings,
+        latency_stages={},
+        pre_computed_embedding=dense,
+        pre_computed_sparse=sparse,
+    )
+
+    assert result["sparse_embedding"] == sparse
+    mock_cache.store_sparse_embedding.assert_awaited_once_with("test query", sparse)
+    assert result["cache_hit"] is False
+    assert result["query_embedding"] == dense
+
+
+async def test_cache_check_uses_pre_computed_colbert_skips_reencode(mock_cache):
+    """_cache_check uses pre_computed_colbert and does NOT call aembed_hybrid_with_colbert."""
+    from unittest.mock import AsyncMock
+
+    from telegram_bot.agents.rag_pipeline import _cache_check
+
+    dense = [0.1] * 1024
+    colbert = [[0.2] * 1024] * 3
+
+    mock_embeddings = AsyncMock()
+    mock_embeddings.aembed_hybrid_with_colbert = AsyncMock(
+        return_value=(dense, {"indices": [1], "values": [0.5]}, colbert)
+    )
+
+    result = await _cache_check(
+        "test query",
+        "GENERAL",
+        42,
+        cache=mock_cache,
+        embeddings=mock_embeddings,
+        latency_stages={},
+        pre_computed_embedding=dense,
+        pre_computed_colbert=colbert,
+    )
+
+    assert result["colbert_query"] == colbert
+    # Must NOT call aembed_hybrid_with_colbert since colbert was pre-computed
+    mock_embeddings.aembed_hybrid_with_colbert.assert_not_awaited()
+
+
+async def test_cache_check_returns_sparse_embedding_in_all_paths(mock_cache):
+    """_cache_check returns sparse_embedding key in result for both HIT and MISS."""
+    from unittest.mock import AsyncMock
+
+    from telegram_bot.agents.rag_pipeline import _cache_check
+
+    dense = [0.1] * 1024
+    sparse = {"indices": [1], "values": [0.5]}
+
+    mock_embeddings = AsyncMock()
+    mock_embeddings.aembed_hybrid_with_colbert = None
+
+    # MISS path
+    result_miss = await _cache_check(
+        "miss query",
+        "GENERAL",
+        42,
+        cache=mock_cache,
+        embeddings=mock_embeddings,
+        latency_stages={},
+        pre_computed_embedding=dense,
+        pre_computed_sparse=sparse,
+    )
+    assert "sparse_embedding" in result_miss
+
+    # HIT path
+    mock_cache.check_semantic = AsyncMock(return_value="cached answer")
+    result_hit = await _cache_check(
+        "hit query",
+        "FAQ",
+        42,
+        cache=mock_cache,
+        embeddings=mock_embeddings,
+        latency_stages={},
+        pre_computed_embedding=dense,
+        pre_computed_sparse=sparse,
+    )
+    assert "sparse_embedding" in result_hit
+    assert result_hit["sparse_embedding"] == sparse
+
+
+async def test_hybrid_retrieve_uses_pre_computed_sparse(mock_cache, mock_sparse, mock_qdrant):
+    """_hybrid_retrieve uses sparse_embedding param and skips cache fetch + recompute."""
+    from telegram_bot.agents.rag_pipeline import _hybrid_retrieve
+
+    pre_sparse = {"indices": [5], "values": [0.9]}
+    dense = [0.1] * 1024
+
+    result = await _hybrid_retrieve(
+        "test query",
+        dense,
+        cache=mock_cache,
+        sparse_embeddings=mock_sparse,
+        qdrant=mock_qdrant,
+        sparse_embedding=pre_sparse,
+        latency_stages={},
+    )
+
+    # Sparse cache and recompute must NOT be called — pre-computed sparse was provided
+    mock_cache.get_sparse_embedding.assert_not_awaited()
+    mock_sparse.aembed_query.assert_not_awaited()
+    assert result["documents"]
+
+
+async def test_rag_pipeline_passes_pre_computed_sparse_to_retrieve(mock_cache, mock_sparse):
+    """rag_pipeline passes pre_computed_sparse through _cache_check to _hybrid_retrieve."""
+    from unittest.mock import AsyncMock
+
+    from telegram_bot.agents.rag_pipeline import rag_pipeline
+
+    dense = [0.1] * 1024
+    sparse = {"indices": [3], "values": [0.7]}
+
+    mock_embeddings = AsyncMock()
+    mock_embeddings.aembed_hybrid_with_colbert = None  # disable colbert
+    mock_embeddings.aembed_hybrid = None  # disable hybrid
+
+    mock_qdrant = AsyncMock()
+    mock_qdrant.hybrid_search_rrf_colbert = None  # ensure plain RRF path
+    mock_qdrant.hybrid_search_rrf = AsyncMock(
+        return_value=(
+            [{"text": "doc", "score": 0.9, "metadata": {}}],
+            {"backend_error": False, "error_type": None, "error_message": None},
+        )
+    )
+
+    result = await rag_pipeline(
+        "test query",
+        user_id=1,
+        session_id="s1",
+        query_type="GENERAL",
+        cache=mock_cache,
+        embeddings=mock_embeddings,
+        sparse_embeddings=mock_sparse,
+        qdrant=mock_qdrant,
+        reranker=None,
+        pre_computed_embedding=dense,
+        pre_computed_sparse=sparse,
+    )
+
+    # sparse_embeddings.aembed_query must NOT be called — sparse was pre-computed
+    mock_sparse.aembed_query.assert_not_awaited()
+    # cache get_sparse_embedding must NOT be called either
+    mock_cache.get_sparse_embedding.assert_not_awaited()
+    assert result["documents"]

--- a/tests/unit/pipelines/test_client_pipeline.py
+++ b/tests/unit/pipelines/test_client_pipeline.py
@@ -408,6 +408,103 @@ class TestPipelineFullFlow:
         assert pipeline_call is not None, "update_current_trace with pipeline_mode not found"
         assert pipeline_call.kwargs.get("tags") == ["telegram", "rag", "client_direct"]
 
+    async def test_pipeline_passes_message_to_generate_response(self):
+        """generate_response must receive message= so streaming can be enabled (#571)."""
+        msg = _make_message()
+        lf = _make_lf_client()
+
+        rag_result = {
+            "response": "",
+            "cache_hit": False,
+            "documents": [{"metadata": {"title": "Doc"}, "score": 0.9}],
+            "grade_confidence": 0.7,
+            "llm_call_count": 0,
+            "latency_stages": {},
+            "query_embedding": [0.1, 0.2],
+            "cache_key_embedding": [0.1, 0.2],
+        }
+        gen_result = {
+            "response": "Streamed answer",
+            "response_sent": False,
+            "llm_call_count": 1,
+        }
+
+        mock_gen = AsyncMock(return_value=gen_result)
+        with (
+            _patch_observability(lf),
+            _patch_rag_pipeline(rag_result),
+            patch("telegram_bot.pipelines.client.generate_response", mock_gen),
+            patch("telegram_bot.pipelines.client.write_langfuse_scores"),
+            patch("telegram_bot.pipelines.client.score"),
+        ):
+            await run_client_pipeline(
+                user_text="Какие документы для ВНЖ?",
+                user_id=1,
+                session_id="s1",
+                message=msg,
+                cache=AsyncMock(),
+                embeddings=MagicMock(),
+                sparse_embeddings=MagicMock(),
+                qdrant=MagicMock(),
+                reranker=None,
+                llm=None,
+                config=_make_config(streaming_enabled=True),
+                query_type="FAQ",
+            )
+
+        # message= must be forwarded so streaming can activate
+        call_kwargs = mock_gen.call_args.kwargs
+        assert call_kwargs.get("message") is msg, "message not forwarded to generate_response"
+
+    async def test_pipeline_no_double_send_when_streaming_delivers(self):
+        """When streaming delivers the response (response_sent=True), _send_markdown_chunks
+        must NOT send the main body again (#571)."""
+        msg = _make_message()
+        lf = _make_lf_client()
+
+        rag_result = {
+            "response": "",
+            "cache_hit": False,
+            "documents": [{"metadata": {"title": "Doc"}, "score": 0.9}],
+            "grade_confidence": 0.7,
+            "llm_call_count": 0,
+            "latency_stages": {},
+            "query_embedding": [0.1, 0.2],
+            "cache_key_embedding": [0.1, 0.2],
+        }
+        # Streaming delivered the response — response_sent=True
+        gen_result = {
+            "response": "Streaming delivered this",
+            "response_sent": True,
+            "llm_call_count": 1,
+        }
+
+        with (
+            _patch_observability(lf),
+            _patch_rag_pipeline(rag_result),
+            _patch_generate_response(gen_result),
+            patch("telegram_bot.pipelines.client.write_langfuse_scores"),
+            patch("telegram_bot.pipelines.client.score"),
+        ):
+            result = await run_client_pipeline(
+                user_text="Какие документы для ВНЖ?",
+                user_id=1,
+                session_id="s1",
+                message=msg,
+                cache=AsyncMock(),
+                embeddings=MagicMock(),
+                sparse_embeddings=MagicMock(),
+                qdrant=MagicMock(),
+                reranker=None,
+                llm=None,
+                config=_make_config(streaming_enabled=True),
+                query_type="FAQ",
+            )
+
+        # message.answer() must NOT be called again (streaming already sent)
+        msg.answer.assert_not_called()
+        assert result.answer == "Streaming delivered this"
+
     async def test_pipeline_propagates_exception_to_caller(self):
         """When rag_pipeline raises an exception, it propagates to the caller."""
         msg = _make_message()

--- a/tests/unit/pipelines/test_client_pipeline.py
+++ b/tests/unit/pipelines/test_client_pipeline.py
@@ -754,3 +754,111 @@ class TestHistorySave:
 
         assert result.answer == "Answer text"
         assert result.response_sent is True
+
+
+# ---------------------------------------------------------------------------
+# Pre-computed sparse + colbert passthrough (#571)
+# ---------------------------------------------------------------------------
+
+
+class TestPreComputedEmbeddingPassthrough:
+    """Verify all three pre-computed embeddings are passed to rag_pipeline (#571)."""
+
+    async def test_passes_sparse_and_colbert_from_rag_result_store(self):
+        """pre_computed_sparse and pre_computed_colbert from rag_result_store reach rag_pipeline."""
+        msg = _make_message()
+        lf = _make_lf_client()
+
+        dense = [0.1] * 1024
+        sparse = {"indices": [1], "values": [0.5]}
+        colbert = [[0.2] * 1024] * 2
+
+        rag_result = {
+            "response": "Есть студии",
+            "cache_hit": False,
+            "documents": [],
+            "grade_confidence": 0.9,
+            "llm_call_count": 0,
+            "latency_stages": {},
+        }
+
+        captured_kwargs: dict = {}
+
+        async def _capture_rag(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return rag_result
+
+        with (
+            _patch_observability(lf),
+            patch("telegram_bot.pipelines.client.rag_pipeline", side_effect=_capture_rag),
+            patch("telegram_bot.pipelines.client.write_langfuse_scores"),
+            patch("telegram_bot.pipelines.client.score"),
+        ):
+            await run_client_pipeline(
+                user_text="Какие квартиры есть?",
+                user_id=1,
+                session_id="s1",
+                message=msg,
+                cache=AsyncMock(),
+                embeddings=MagicMock(),
+                sparse_embeddings=MagicMock(),
+                qdrant=MagicMock(),
+                reranker=None,
+                llm=None,
+                config=_make_config(),
+                query_type="GENERAL",
+                rag_result_store={
+                    "cache_key_embedding": dense,
+                    "cache_key_sparse": sparse,
+                    "cache_key_colbert": colbert,
+                },
+            )
+
+        assert captured_kwargs.get("pre_computed_embedding") == dense
+        assert captured_kwargs.get("pre_computed_sparse") == sparse
+        assert captured_kwargs.get("pre_computed_colbert") == colbert
+
+    async def test_passes_none_when_embeddings_absent_from_store(self):
+        """When rag_result_store lacks sparse/colbert, None is passed to rag_pipeline."""
+        msg = _make_message()
+        lf = _make_lf_client()
+
+        rag_result = {
+            "response": "ok",
+            "cache_hit": False,
+            "documents": [],
+            "grade_confidence": 0.9,
+            "llm_call_count": 0,
+            "latency_stages": {},
+        }
+
+        captured_kwargs: dict = {}
+
+        async def _capture_rag(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return rag_result
+
+        with (
+            _patch_observability(lf),
+            patch("telegram_bot.pipelines.client.rag_pipeline", side_effect=_capture_rag),
+            patch("telegram_bot.pipelines.client.write_langfuse_scores"),
+            patch("telegram_bot.pipelines.client.score"),
+        ):
+            await run_client_pipeline(
+                user_text="тест",
+                user_id=1,
+                session_id="s1",
+                message=msg,
+                cache=AsyncMock(),
+                embeddings=MagicMock(),
+                sparse_embeddings=MagicMock(),
+                qdrant=MagicMock(),
+                reranker=None,
+                llm=None,
+                config=_make_config(),
+                query_type="GENERAL",
+                rag_result_store={"cache_key_embedding": [0.1]},
+            )
+
+        assert captured_kwargs.get("pre_computed_sparse") is None
+        assert captured_kwargs.get("pre_computed_colbert") is None

--- a/tests/unit/services/test_generate_response.py
+++ b/tests/unit/services/test_generate_response.py
@@ -127,3 +127,86 @@ async def test_generate_response_streaming_sets_response_sent_and_message_ref() 
     assert result["response"] == "Часть 1 Часть 2"
     assert result["response_sent"] is True
     assert result["sent_message"] == {"chat_id": 555, "message_id": 777}
+
+
+@pytest.mark.asyncio
+async def test_generate_response_non_streaming_has_ttft_ms() -> None:
+    """Non-streaming path must report ttft_ms > 0 from LLM call wall time (#571)."""
+    config, _client = _make_non_streaming_config(answer="Ответ без стриминга")
+    lf = MagicMock()
+
+    result = await generate_response(
+        query="Тест таймингов",
+        documents=[{"text": "Контекст", "score": 0.8, "metadata": {}}],
+        config=config,
+        lf_client=lf,
+    )
+
+    # ttft_ms must be populated (non-zero) in non-streaming mode
+    assert result["llm_ttft_ms"] > 0, "ttft_ms should be > 0 in non-streaming mode"
+    # llm_decode_ms is None for non-streaming (no decode/prefill distinction)
+    assert result["llm_decode_ms"] is None
+    # streaming_enabled must be False
+    assert result["streaming_enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_generate_response_non_streaming_computes_tps_from_usage() -> None:
+    """Non-streaming path computes llm_tps when completion_tokens available (#571)."""
+    mock_choice = MagicMock()
+    mock_choice.message.content = "Ответ с 10 токенами"
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    mock_response.model = "gpt-4o-mini"
+    mock_usage = MagicMock()
+    mock_usage.completion_tokens = 10
+    mock_response.usage = mock_usage
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+    mock_config = MagicMock()
+    mock_config.domain = "недвижимость"
+    mock_config.llm_model = "gpt-4o-mini"
+    mock_config.llm_temperature = 0.1
+    mock_config.generate_max_tokens = 128
+    mock_config.streaming_enabled = False
+    mock_config.show_sources = False
+    mock_config.response_style_enabled = False
+    mock_config.response_style_shadow_mode = False
+    mock_config.create_llm.return_value = mock_client
+
+    lf = MagicMock()
+
+    result = await generate_response(
+        query="Тест TPS",
+        documents=[{"text": "Контекст", "score": 0.8, "metadata": {}}],
+        config=mock_config,
+        lf_client=lf,
+    )
+
+    assert result["llm_ttft_ms"] > 0
+    # TPS = completion_tokens / (ttft_ms / 1000)
+    assert result["llm_tps"] is not None
+    assert result["llm_tps"] > 0
+    # decode_ms is None for non-streaming
+    assert result["llm_decode_ms"] is None
+
+
+@pytest.mark.asyncio
+async def test_generate_response_non_streaming_tps_none_when_no_usage() -> None:
+    """Non-streaming path sets llm_tps=None when usage is not available (#571)."""
+    config, _client = _make_non_streaming_config(answer="Ответ")
+    # usage=None set in _make_non_streaming_config already
+    lf = MagicMock()
+
+    result = await generate_response(
+        query="Тест без usage",
+        documents=[{"text": "Контекст", "score": 0.8, "metadata": {}}],
+        config=config,
+        lf_client=lf,
+    )
+
+    # No usage → no TPS, fallback to llm_tps_unavailable score
+    assert result["llm_tps"] is None
+    assert result["llm_decode_ms"] is None

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -2697,6 +2697,132 @@ class TestPreAgentCacheCheck:
         bot._cache.check_semantic.assert_not_called()
         mock_agent.ainvoke.assert_called_once()
 
+    async def test_pre_agent_uses_hybrid_colbert_when_available(self, mock_config):
+        """When aembed_hybrid_with_colbert exists, all three embeddings are stashed (#571)."""
+        bot, _ = _create_bot(mock_config)
+
+        dense = [0.5] * 10
+        sparse = {"indices": [1], "values": [0.7]}
+        colbert = [[0.3] * 10] * 2
+
+        bot._embeddings.aembed_hybrid_with_colbert = AsyncMock(
+            return_value=(dense, sparse, colbert)
+        )
+        bot._embeddings.aembed_query = AsyncMock()  # should NOT be called
+        bot._cache.store_embedding = AsyncMock()
+        bot._cache.store_sparse_embedding = AsyncMock()
+        bot._cache.check_semantic = AsyncMock(return_value=None)
+
+        stashed_store: dict = {}
+        invoke_count = 0
+
+        async def _capture_invoke(*args, **kwargs):
+            nonlocal invoke_count
+            invoke_count += 1
+            stashed_store.update(kwargs["config"]["configurable"]["rag_result_store"])
+            return _mock_agent_result()
+
+        mock_agent = AsyncMock()
+        mock_agent.ainvoke = _capture_invoke
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+            patch("telegram_bot.bot.classify_query", return_value="FAQ"),
+        ):
+            message = _make_text_message("как оформить покупку")
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        # hybrid_with_colbert must be called; aembed_query must NOT be called
+        bot._embeddings.aembed_hybrid_with_colbert.assert_awaited_once()
+        bot._embeddings.aembed_query.assert_not_called()
+        # sparse must be stored in cache
+        bot._cache.store_sparse_embedding.assert_awaited_once()
+        # all three embeddings must be stashed
+        assert stashed_store.get("cache_key_embedding") == dense
+        assert stashed_store.get("cache_key_sparse") == sparse
+        assert stashed_store.get("cache_key_colbert") == colbert
+
+    async def test_pre_agent_fallback_to_aembed_query_when_no_hybrid_colbert(self, mock_config):
+        """Fallback to aembed_query when aembed_hybrid_with_colbert is not available (#571)."""
+        bot, _ = _create_bot(mock_config)
+        test_embedding = [0.5] * 10
+
+        bot._embeddings.aembed_query = AsyncMock(return_value=test_embedding)
+        bot._embeddings.aembed_hybrid_with_colbert = None  # not available
+        bot._cache.store_embedding = AsyncMock()
+        bot._cache.store_sparse_embedding = AsyncMock()
+        bot._cache.check_semantic = AsyncMock(return_value=None)
+
+        stashed_store: dict = {}
+
+        async def _capture_invoke(*args, **kwargs):
+            stashed_store.update(kwargs["config"]["configurable"]["rag_result_store"])
+            return _mock_agent_result()
+
+        mock_agent = AsyncMock()
+        mock_agent.ainvoke = _capture_invoke
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+            patch("telegram_bot.bot.classify_query", return_value="FAQ"),
+        ):
+            message = _make_text_message("как оформить покупку")
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        # aembed_query must be called; sparse must NOT be stored
+        bot._embeddings.aembed_query.assert_awaited_once()
+        bot._cache.store_sparse_embedding.assert_not_awaited()
+        # sparse and colbert must be None in stashed store
+        assert stashed_store.get("cache_key_embedding") == test_embedding
+        assert stashed_store.get("cache_key_sparse") is None
+        assert stashed_store.get("cache_key_colbert") is None
+
+    async def test_pre_agent_hybrid_colbert_stash_on_cache_hit(self, mock_config):
+        """On cache HIT with hybrid_with_colbert, sparse is stored in cache (#571)."""
+        bot, _ = _create_bot(mock_config)
+
+        dense = [0.5] * 10
+        sparse = {"indices": [2], "values": [0.8]}
+        colbert = [[0.4] * 10] * 3
+
+        bot._embeddings.aembed_hybrid_with_colbert = AsyncMock(
+            return_value=(dense, sparse, colbert)
+        )
+        bot._cache.store_embedding = AsyncMock()
+        bot._cache.store_sparse_embedding = AsyncMock()
+        bot._cache.check_semantic = AsyncMock(return_value="Cached answer")
+
+        mock_lf = MagicMock()
+        mock_lf.get_current_trace_id = MagicMock(return_value="trace-123")
+        mock_agent = AsyncMock()
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.get_client", return_value=mock_lf),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+            patch("telegram_bot.bot.classify_query", return_value="FAQ"),
+            patch("telegram_bot.bot.score"),
+        ):
+            message = _make_text_message("как оформить покупку")
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        # On cache HIT, agent is NOT called but sparse must still be stored
+        mock_agent.ainvoke.assert_not_called()
+        bot._cache.store_sparse_embedding.assert_awaited_once()
+
     async def test_pre_agent_cache_hit_respects_role_isolation(self, mock_config):
         """Cache check passes correct agent_role to check_semantic (#563)."""
         bot, _ = _create_bot(mock_config)


### PR DESCRIPTION
## Summary
- **Eliminate redundant BGE-M3 calls** — pre-agent now computes dense+sparse+ColBERT in one call, passes all three through pipeline. Saves ~300-600ms per query.
- **Fix sparse embedding passthrough** — `_cache_check` returns sparse to `_hybrid_retrieve`, avoiding redundant sparse recompute (+320ms saved).
- **Enable streaming in client_direct pipeline** — pass `message` to `generate_response()`, guard against double-send when streaming delivers.
- **Increase max_tokens 2048→4096** — prevents answer truncation for long responses.
- **Add LLM timing for non-streaming** — TTFT and TPS metrics now computed in non-streaming path.

Closes #571

## Changes

| File | Change |
|------|--------|
| `bot.py` | Pre-agent: `aembed_query()` → `aembed_hybrid_with_colbert()`, always stash all embeddings |
| `pipelines/client.py` | Pass sparse+colbert to `rag_pipeline()`, pass `message` to `generate_response()`, double-send guard |
| `agents/rag_pipeline.py` | Accept/return pre-computed sparse+colbert, fix sparse passthrough in `_hybrid_retrieve` |
| `services/generate_response.py` | Non-streaming: `t_llm_start`/`t_llm_end` timing, TPS from `usage.completion_tokens` |
| `graph/config.py` | `generate_max_tokens`: 2048 → 4096 |

## Test plan
- [x] 198 tests pass (all affected test files)
- [x] 15 new tests covering all 5 fixes
- [x] Ruff lint clean
- [x] Auto-merge of two parallel worker branches (no conflicts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)