### PR TITLE
test(crm): add manager-id routing coverage for my leads

### DIFF
--- a/tests/unit/agents/test_crm_tools.py
+++ b/tests/unit/agents/test_crm_tools.py
@@ -454,6 +454,18 @@ async def test_crm_get_my_leads(bot_context, mock_kommo):
     mock_kommo.search_leads.assert_called_once_with(responsible_user_id=42, limit=20)
 
 
+async def test_crm_get_my_leads_uses_manager_id_not_telegram_user_id(bot_context, mock_kommo):
+    """Manager workflow must use ctx.manager_id for responsible_user_id filter."""
+    from telegram_bot.agents.crm_tools import crm_get_my_leads
+
+    bot_context.telegram_user_id = 999
+    bot_context.manager_id = 77
+
+    await crm_get_my_leads.ainvoke({}, config=_make_config(bot_context))
+
+    mock_kommo.search_leads.assert_called_once_with(responsible_user_id=77, limit=20)
+
+
 async def test_crm_get_my_leads_no_manager_id(bot_context_no_manager):
     """crm_get_my_leads returns error when manager_id is None."""
     from telegram_bot.agents.crm_tools import crm_get_my_leads


### PR DESCRIPTION
## Summary
- add focused manager-workflow test for `crm_get_my_leads`
- verify tool uses `bot_context.manager_id` (responsible manager) rather than `telegram_user_id`
- assert call to `search_leads` uses `responsible_user_id=<manager_id>`

## Validation
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' uv run pytest tests/unit/agents/test_crm_tools.py -k my_leads -q`
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`

Closes #536
