### PR TITLE
Fix #585: add Qdrant ColBERT schema drift guardrails

### DIFF
--- a/docs/QDRANT_STACK.md
+++ b/docs/QDRANT_STACK.md
@@ -37,8 +37,14 @@ Payload indexes created by bootstrap include:
 # Create ingestion-ready collection if missing
 uv run python -m src.ingestion.unified.cli bootstrap
 
+# Fail-fast guard: require ColBERT in existing/new runtime schema
+uv run python -m src.ingestion.unified.cli bootstrap --require-colbert
+
+# Explicit drift check (non-zero exit on missing required vectors)
+uv run python -m src.ingestion.unified.cli schema-check --require-colbert
+
 # Check collection
-curl -fsS http://localhost:6333/collections/gdrive_documents_bge | python -m json.tool
+curl -fsS http://localhost:6333/collections/gdrive_documents_bge | python3 -m json.tool
 
 # Check service readiness
 curl -fsS http://localhost:6333/readyz
@@ -62,4 +68,5 @@ Snapshots are created via `scripts/qdrant_snapshot.py`.
 
 - Empty retrieval results: verify `QDRANT_COLLECTION` matches existing collection.
 - Ingestion writes fail: run `src.ingestion.unified.cli preflight` to confirm reachability.
+- ColBERT missing in runtime: run `src.ingestion.unified.cli schema-check --require-colbert`.
 - Slow queries: verify collection contains expected `dense`/`bm42` vectors and payload indexes.

--- a/src/ingestion/unified/cli.py
+++ b/src/ingestion/unified/cli.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 import sys
+from collections.abc import Mapping
 
 from dotenv import load_dotenv
 
@@ -152,6 +153,86 @@ async def cmd_preflight(args: argparse.Namespace) -> int:
     return 0 if all_ok else 1
 
 
+def _extract_vector_names(collection_info) -> tuple[set[str], set[str]]:
+    """Extract named dense/sparse vector names from a Qdrant collection."""
+    params = getattr(getattr(collection_info, "config", None), "params", None)
+    vectors = getattr(params, "vectors", {})
+    sparse_vectors = getattr(params, "sparse_vectors", {})
+
+    dense_names: set[str] = set()
+    sparse_names: set[str] = set()
+
+    if isinstance(vectors, Mapping) or hasattr(vectors, "keys"):
+        dense_names = set(vectors.keys())
+
+    if isinstance(sparse_vectors, Mapping) or hasattr(sparse_vectors, "keys"):
+        sparse_names = set(sparse_vectors.keys())
+
+    return dense_names, sparse_names
+
+
+def _schema_requirements_status(
+    collection_info,
+    *,
+    require_colbert: bool,
+) -> tuple[list[str], set[str], set[str]]:
+    """Validate required vector names and return missing requirements."""
+    dense_names, sparse_names = _extract_vector_names(collection_info)
+    missing: list[str] = []
+
+    if "dense" not in dense_names:
+        missing.append("dense")
+    if "bm42" not in sparse_names:
+        missing.append("bm42")
+    if require_colbert and "colbert" not in dense_names:
+        missing.append("colbert")
+
+    return missing, dense_names, sparse_names
+
+
+async def cmd_schema_check(args: argparse.Namespace) -> int:
+    """Validate Qdrant collection schema for required vector names."""
+    from qdrant_client import QdrantClient
+    from qdrant_client.http.exceptions import UnexpectedResponse
+
+    from src.ingestion.unified.config import UnifiedConfig
+
+    config = UnifiedConfig()
+    collection_name = config.collection_name
+
+    print(f"\n=== Schema Check: {collection_name} ===")
+
+    client = QdrantClient(
+        url=os.getenv("QDRANT_URL", "http://localhost:6333"),
+        api_key=os.getenv("QDRANT_API_KEY"),
+        timeout=60,
+    )
+
+    try:
+        info = client.get_collection(collection_name)
+    except UnexpectedResponse as exc:
+        print(f"  [FAIL] Cannot load collection '{collection_name}': {exc}")
+        return 1
+    except Exception as exc:
+        print(f"  [FAIL] Qdrant error while loading '{collection_name}': {exc}")
+        return 1
+
+    missing, dense_names, sparse_names = _schema_requirements_status(
+        info,
+        require_colbert=args.require_colbert,
+    )
+    if missing:
+        print(
+            "  [FAIL] Schema drift detected: missing "
+            f"{', '.join(sorted(missing))}. "
+            f"dense={sorted(dense_names)} sparse={sorted(sparse_names)}"
+        )
+        return 1
+
+    print(f"  [OK] Schema valid: dense={sorted(dense_names)} sparse={sorted(sparse_names)}")
+    return 0
+
+
 async def cmd_bootstrap(args: argparse.Namespace) -> int:
     """Create Qdrant collection if it doesn't exist."""
     from qdrant_client import QdrantClient
@@ -192,14 +273,31 @@ async def cmd_bootstrap(args: argparse.Namespace) -> int:
 
     # Check if collection already exists
     exists = False
+    existing_info = None
     try:
-        client.get_collection(collection_name)
+        existing_info = client.get_collection(collection_name)
         exists = True
     except (UnexpectedResponse, Exception):
         pass
 
     if exists:
-        print(f"  Collection '{collection_name}' already exists — nothing to do.")
+        print(f"  Collection '{collection_name}' already exists.")
+        if args.require_colbert:
+            missing, dense_names, sparse_names = _schema_requirements_status(
+                existing_info,
+                require_colbert=True,
+            )
+            if missing:
+                print(
+                    "  [FAIL] Existing collection schema drift: missing "
+                    f"{', '.join(sorted(missing))}. "
+                    "Recreate collection and run full reingest. "
+                    f"dense={sorted(dense_names)} sparse={sorted(sparse_names)}"
+                )
+                return 1
+            print("  [OK] Existing collection schema includes required vectors.")
+        else:
+            print("  Nothing to do.")
         return 0
 
     # Create collection
@@ -262,6 +360,20 @@ async def cmd_bootstrap(args: argparse.Namespace) -> int:
         except Exception as e:
             print(f"  Warning: Could not create index {field}: {e}")
 
+    if args.require_colbert:
+        info = client.get_collection(collection_name)
+        missing, dense_names, sparse_names = _schema_requirements_status(
+            info,
+            require_colbert=True,
+        )
+        if missing:
+            print(
+                "  [FAIL] Created collection schema drift: missing "
+                f"{', '.join(sorted(missing))}. "
+                f"dense={sorted(dense_names)} sparse={sorted(sparse_names)}"
+            )
+            return 1
+
     print(f"  Bootstrap completed: {collection_name}")
     return 0
 
@@ -323,7 +435,23 @@ def main() -> int:
     subparsers.add_parser("preflight", help="Check dependencies are reachable")
 
     # bootstrap
-    subparsers.add_parser("bootstrap", help="Create Qdrant collection if missing")
+    bootstrap_p = subparsers.add_parser("bootstrap", help="Create Qdrant collection if missing")
+    bootstrap_p.add_argument(
+        "--require-colbert",
+        action="store_true",
+        help="Fail if existing/new collection schema misses 'colbert' vector",
+    )
+
+    # schema-check
+    schema_check_p = subparsers.add_parser(
+        "schema-check",
+        help="Validate collection schema (dense/bm42 and optional colbert)",
+    )
+    schema_check_p.add_argument(
+        "--require-colbert",
+        action="store_true",
+        help="Require 'colbert' vector to be present",
+    )
 
     # reprocess
     reprocess_p = subparsers.add_parser("reprocess", help="Reprocess files")
@@ -341,6 +469,8 @@ def main() -> int:
         return asyncio.run(cmd_preflight(args))
     if args.command == "bootstrap":
         return asyncio.run(cmd_bootstrap(args))
+    if args.command == "schema-check":
+        return asyncio.run(cmd_schema_check(args))
     if args.command == "reprocess":
         return asyncio.run(cmd_reprocess(args))
 

--- a/telegram_bot/services/qdrant.py
+++ b/telegram_bot/services/qdrant.py
@@ -423,6 +423,29 @@ class QdrantService:
                 with_payload=True,
             )
             results = self._format_results(result.points)
+            if not results:
+                logger.warning(
+                    "Qdrant ColBERT returned 0 docs for collection %s, falling back to RRF",
+                    self._collection_name,
+                )
+                fallback = await self.hybrid_search_rrf(
+                    dense_vector=dense_vector,
+                    sparse_vector=sparse_vector,
+                    filters=filters,
+                    top_k=top_k,
+                    rrf_k=rrf_k,
+                    return_meta=return_meta,
+                )
+                fallback_results = fallback[0] if isinstance(fallback, tuple) else fallback
+                if fallback_results:
+                    self._colbert_available = False
+                    logger.info(
+                        "Qdrant ColBERT disabled for collection %s: no point-level "
+                        "ColBERT vectors detected (RRF returned %d docs)",
+                        self._collection_name,
+                        len(fallback_results),
+                    )
+                return fallback
             if return_meta:
                 return results, ok_meta
             return results

--- a/tests/unit/ingestion/test_unified_cli.py
+++ b/tests/unit/ingestion/test_unified_cli.py
@@ -34,7 +34,11 @@ class TestArgParsing:
 
         subparsers.add_parser("status")
         subparsers.add_parser("preflight")
-        subparsers.add_parser("bootstrap")
+        bootstrap_p = subparsers.add_parser("bootstrap")
+        bootstrap_p.add_argument("--require-colbert", action="store_true")
+
+        schema_check_p = subparsers.add_parser("schema-check")
+        schema_check_p.add_argument("--require-colbert", action="store_true")
 
         reprocess_p = subparsers.add_parser("reprocess")
         reprocess_p.add_argument("--file-id")
@@ -66,6 +70,22 @@ class TestArgParsing:
     def test_bootstrap(self):
         args = self._parse("bootstrap")
         assert args.command == "bootstrap"
+        assert args.require_colbert is False
+
+    def test_bootstrap_require_colbert(self):
+        args = self._parse("bootstrap", "--require-colbert")
+        assert args.command == "bootstrap"
+        assert args.require_colbert is True
+
+    def test_schema_check(self):
+        args = self._parse("schema-check")
+        assert args.command == "schema-check"
+        assert args.require_colbert is False
+
+    def test_schema_check_require_colbert(self):
+        args = self._parse("schema-check", "--require-colbert")
+        assert args.command == "schema-check"
+        assert args.require_colbert is True
 
     def test_reprocess_file_id(self):
         args = self._parse("reprocess", "--file-id", "abc123")
@@ -525,7 +545,7 @@ class TestCmdBootstrap:
 
     @pytest.fixture
     def args(self):
-        return argparse.Namespace(command="bootstrap", verbose=False)
+        return argparse.Namespace(command="bootstrap", verbose=False, require_colbert=False)
 
     async def test_collection_already_exists(self, args, capsys):
         config = _make_config(collection_name="existing_col")
@@ -545,6 +565,30 @@ class TestCmdBootstrap:
         output = capsys.readouterr().out
         assert "already exists" in output
         client.create_collection.assert_not_called()
+
+    async def test_collection_exists_require_colbert_fails_on_drift(self, capsys):
+        config = _make_config(collection_name="existing_col")
+        client = MagicMock()
+        client.get_collections.return_value = MagicMock()
+        collection_info = MagicMock()
+        collection_info.config.params.vectors = {"dense": MagicMock()}
+        collection_info.config.params.sparse_vectors = {"bm42": MagicMock()}
+        client.get_collection.return_value = collection_info
+
+        with (
+            patch("src.ingestion.unified.config.UnifiedConfig", return_value=config),
+            patch("qdrant_client.QdrantClient", return_value=client),
+        ):
+            from src.ingestion.unified.cli import cmd_bootstrap
+
+            result = await cmd_bootstrap(
+                argparse.Namespace(command="bootstrap", verbose=False, require_colbert=True)
+            )
+
+        assert result == 1
+        output = capsys.readouterr().out
+        assert "schema drift" in output.lower()
+        assert "colbert" in output
 
     async def test_connection_failure(self, args, capsys):
         config = _make_config(collection_name="new_col")
@@ -585,6 +629,55 @@ class TestCmdBootstrap:
         client.create_collection.assert_called_once()
         output = capsys.readouterr().out
         assert "Bootstrap completed" in output
+
+
+class TestCmdSchemaCheck:
+    """Test schema-check command."""
+
+    async def test_schema_check_passes_when_requirements_met(self, capsys):
+        config = _make_config(collection_name="existing_col")
+        client = MagicMock()
+        collection_info = MagicMock()
+        collection_info.config.params.vectors = {"dense": MagicMock(), "colbert": MagicMock()}
+        collection_info.config.params.sparse_vectors = {"bm42": MagicMock()}
+        client.get_collection.return_value = collection_info
+
+        with (
+            patch("src.ingestion.unified.config.UnifiedConfig", return_value=config),
+            patch("qdrant_client.QdrantClient", return_value=client),
+        ):
+            from src.ingestion.unified.cli import cmd_schema_check
+
+            result = await cmd_schema_check(
+                argparse.Namespace(command="schema-check", verbose=False, require_colbert=True)
+            )
+
+        assert result == 0
+        output = capsys.readouterr().out
+        assert "Schema valid" in output
+
+    async def test_schema_check_fails_when_colbert_missing(self, capsys):
+        config = _make_config(collection_name="existing_col")
+        client = MagicMock()
+        collection_info = MagicMock()
+        collection_info.config.params.vectors = {"dense": MagicMock()}
+        collection_info.config.params.sparse_vectors = {"bm42": MagicMock()}
+        client.get_collection.return_value = collection_info
+
+        with (
+            patch("src.ingestion.unified.config.UnifiedConfig", return_value=config),
+            patch("qdrant_client.QdrantClient", return_value=client),
+        ):
+            from src.ingestion.unified.cli import cmd_schema_check
+
+            result = await cmd_schema_check(
+                argparse.Namespace(command="schema-check", verbose=False, require_colbert=True)
+            )
+
+        assert result == 1
+        output = capsys.readouterr().out
+        assert "Schema drift" in output
+        assert "colbert" in output
 
 
 # ---------------------------------------------------------------------------
@@ -648,6 +741,18 @@ class TestMainDispatch:
     @patch("src.ingestion.unified.cli.load_dotenv")
     def test_main_dispatches_reprocess(self, mock_dotenv, mock_logging, mock_cmd, monkeypatch):
         monkeypatch.setattr("sys.argv", ["cli", "reprocess", "--errors"])
+
+        from src.ingestion.unified.cli import main
+
+        result = main()
+        assert result == 0
+        mock_cmd.assert_awaited_once()
+
+    @patch("src.ingestion.unified.cli.cmd_schema_check", new_callable=AsyncMock, return_value=0)
+    @patch("src.ingestion.unified.cli.setup_logging")
+    @patch("src.ingestion.unified.cli.load_dotenv")
+    def test_main_dispatches_schema_check(self, mock_dotenv, mock_logging, mock_cmd, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["cli", "schema-check", "--require-colbert"])
 
         from src.ingestion.unified.cli import main
 

--- a/tests/unit/test_qdrant_service.py
+++ b/tests/unit/test_qdrant_service.py
@@ -933,6 +933,26 @@ class TestQdrantServiceHybridSearchColbert:
         assert meta["backend_error"] is False
         service.hybrid_search_rrf.assert_awaited_once()
 
+    async def test_colbert_empty_results_falls_back_and_disables_feature(self, service):
+        """Empty ColBERT result set should fallback to RRF and disable ColBERT runtime path."""
+        service._client.query_points = AsyncMock(return_value=MagicMock(points=[]))
+        service.hybrid_search_rrf = AsyncMock(
+            return_value=[{"id": "fallback_1", "score": 0.9, "text": "fallback", "metadata": {}}]
+        )
+
+        colbert_query = [[0.1] * 1024] * 3
+
+        results = await service.hybrid_search_rrf_colbert(
+            dense_vector=[0.1] * 1024,
+            colbert_query=colbert_query,
+            top_k=5,
+        )
+
+        assert len(results) == 1
+        assert results[0]["id"] == "fallback_1"
+        assert service._colbert_available is False
+        service.hybrid_search_rrf.assert_awaited_once()
+
     async def test_colbert_search_with_filters(self, service, mock_point):
         """Filters are passed through to query_points."""
         service._client.query_points = AsyncMock(return_value=MagicMock(points=[mock_point]))


### PR DESCRIPTION
## Summary
- add `schema-check` command in unified ingestion CLI to validate required vector names (`dense`, `bm42`, optional `colbert`)
- add `--require-colbert` guard to `bootstrap` so existing schema drift fails fast with non-zero exit
- update Qdrant runbook with fail-fast commands for ColBERT schema validation
- expand unit tests for arg parsing, bootstrap drift behavior, schema-check command, and main dispatch

## Runtime validation (local)
- recreated `gdrive_documents_bge` and reingested content
- schema now contains `dense` + `colbert` and sparse `bm42`
- bot startup log no longer shows `missing 'colbert' vector` fallback message

## Verification
- `uv run pytest tests/unit/ingestion/test_unified_cli.py -q`
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
- `uv run python -m src.ingestion.unified.cli schema-check --require-colbert`

Closes #585
