### PR TITLE
test(e2e): add voice transcription scenario group

### DIFF
--- a/scripts/e2e/test_scenarios.py
+++ b/scripts/e2e/test_scenarios.py
@@ -14,6 +14,7 @@ class TestGroup(Enum):
     LOCATION_FILTERS = "location_filters"
     SEARCH = "search"
     EDGE_CASES = "edge_cases"
+    VOICE_TRANSCRIPTION = "voice_transcription"
 
 
 @dataclass
@@ -42,7 +43,7 @@ class TestScenario:
     timeout: int = 60
 
 
-# All 25 test scenarios
+# All 28 test scenarios
 SCENARIOS: list[TestScenario] = [
     # Group 1: Commands (4 tests)
     TestScenario(
@@ -237,6 +238,31 @@ SCENARIOS: list[TestScenario] = [
         query="квартира <script>alert(1)</script>",
         group=TestGroup.EDGE_CASES,
         description="Should handle safely without XSS",
+    ),
+    # Group 8: Voice transcription (3 tests)
+    TestScenario(
+        id="8.1",
+        name="Voice transcription + property search",
+        query="(voice) найди квартиру у моря до 120 тысяч",
+        group=TestGroup.VOICE_TRANSCRIPTION,
+        description="Voice message should transcribe and run property search flow.",
+        expected_keywords=["квартир", "мор", "120"],
+    ),
+    TestScenario(
+        id="8.2",
+        name="Voice transcription + CRM lookup",
+        query="(voice) покажи мои сделки в crm",
+        group=TestGroup.VOICE_TRANSCRIPTION,
+        description="Voice message should transcribe and route to CRM tool path.",
+        expected_keywords=["сделк", "crm", "ID"],
+    ),
+    TestScenario(
+        id="8.3",
+        name="Voice transcription timeout handling",
+        query="(voice) [simulate timeout]",
+        group=TestGroup.VOICE_TRANSCRIPTION,
+        description="Voice transcription timeout should return graceful fallback.",
+        expected_keywords=["не удалось", "попробуйте", "голос"],
     ),
 ]
 

--- a/tests/unit/e2e/test_voice_transcription_scenarios.py
+++ b/tests/unit/e2e/test_voice_transcription_scenarios.py
@@ -1,0 +1,14 @@
+"""Unit checks for voice-transcription E2E scenario catalog (#538)."""
+
+from scripts.e2e import test_scenarios as scenarios
+
+
+def test_voice_transcription_group_has_three_scenarios():
+    group_scenarios = scenarios.get_scenarios_by_group(scenarios.TestGroup.VOICE_TRANSCRIPTION)
+    assert len(group_scenarios) == 3
+
+
+def test_voice_transcription_scenarios_have_expected_ids():
+    group_scenarios = scenarios.get_scenarios_by_group(scenarios.TestGroup.VOICE_TRANSCRIPTION)
+    scenario_ids = {s.id for s in group_scenarios}
+    assert scenario_ids == {"8.1", "8.2", "8.3"}


### PR DESCRIPTION
## Summary
- add new `VOICE_TRANSCRIPTION` scenario group in `scripts/e2e/test_scenarios.py`
- add 3 voice E2E scenarios requested by audit:
  - voice transcription + property search
  - voice transcription + CRM lookup
  - voice transcription timeout/error handling
- add unit test coverage for scenario catalog integrity (group size + IDs)

## Validation
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' uv run pytest tests/unit/e2e/test_voice_transcription_scenarios.py -q`
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`

Closes #538
