### PR TITLE
test(unit): add missing service-level tests for coverage gap

### DIFF
--- a/tests/unit/services/test_funnel_analytics_store.py
+++ b/tests/unit/services/test_funnel_analytics_store.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import AsyncMock
+
+import pytest
+
+from telegram_bot.services.funnel_analytics_store import FunnelAnalyticsStore
+
+
+@pytest.mark.asyncio
+async def test_fetch_stage_counts_queries_metric_date() -> None:
+    pool = AsyncMock()
+    rows = [{"stage_name": "inquiry", "entered_count": 10, "converted_count": 4}]
+    pool.fetch.return_value = rows
+
+    store = FunnelAnalyticsStore(pool=pool)
+    result = await store.fetch_stage_counts(dt.date(2026, 2, 19))
+
+    assert result == rows
+    pool.fetch.assert_awaited_once()
+    query, metric_date = pool.fetch.await_args.args
+    assert "FROM funnel_events" in query
+    assert metric_date == dt.date(2026, 2, 19)
+
+
+@pytest.mark.asyncio
+async def test_fetch_latest_summary_queries_daily_table() -> None:
+    pool = AsyncMock()
+    rows = [{"stage_name": "inquiry", "metric_date": dt.date(2026, 2, 19)}]
+    pool.fetch.return_value = rows
+
+    store = FunnelAnalyticsStore(pool=pool)
+    result = await store.fetch_latest_summary()
+
+    assert result == rows
+    pool.fetch.assert_awaited_once()
+    (query,) = pool.fetch.await_args.args
+    assert "FROM funnel_metrics_daily" in query
+    assert "MAX(metric_date)" in query

--- a/tests/unit/services/test_ingestion_cocoindex.py
+++ b/tests/unit/services/test_ingestion_cocoindex.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import telegram_bot.services.ingestion_cocoindex as cocoindex
+
+
+@pytest.mark.asyncio
+async def test_ingest_from_directory_delegates_to_ingestion_service(monkeypatch) -> None:
+    expected = SimpleNamespace(total_documents=1, indexed_nodes=2, duration_seconds=0.2, errors=[])
+    delegate = AsyncMock(return_value=expected)
+    monkeypatch.setattr(cocoindex, "_ingest_from_directory", delegate)
+
+    result = await cocoindex.ingest_from_directory("/tmp/docs", "unit_collection")
+
+    assert result is expected
+    delegate.assert_awaited_once_with("/tmp/docs", "unit_collection")
+
+
+@pytest.mark.asyncio
+async def test_get_ingestion_status_delegates(monkeypatch) -> None:
+    expected = {"points": 100, "collection": "documents"}
+    delegate = AsyncMock(return_value=expected)
+    monkeypatch.setattr(cocoindex, "_get_ingestion_status", delegate)
+
+    result = await cocoindex.get_ingestion_status("documents")
+
+    assert result == expected
+    delegate.assert_awaited_once_with("documents")
+
+
+def test_main_without_args_exits_with_usage(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cocoindex.sys, "argv", ["ingestion_cocoindex"])
+
+    with pytest.raises(SystemExit) as exc:
+        cocoindex.main()
+
+    assert exc.value.code == 1
+    output = capsys.readouterr().out
+    assert "Usage:" in output
+    assert "ingest-dir" in output
+
+
+def test_main_ingest_dir_without_path_exits(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cocoindex.sys, "argv", ["ingestion_cocoindex", "ingest-dir"])
+
+    with pytest.raises(SystemExit) as exc:
+        cocoindex.main()
+
+    assert exc.value.code == 1
+    assert "Directory path required" in capsys.readouterr().out
+
+
+def test_main_unknown_command_exits(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cocoindex.sys, "argv", ["ingestion_cocoindex", "bad-command"])
+
+    with pytest.raises(SystemExit) as exc:
+        cocoindex.main()
+
+    assert exc.value.code == 1
+    assert "Unknown command: bad-command" in capsys.readouterr().out

--- a/tests/unit/services/test_lead_score_sync.py
+++ b/tests/unit/services/test_lead_score_sync.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from telegram_bot.services.lead_score_sync import sync_pending_lead_scores
+
+
+@pytest.mark.asyncio
+async def test_sync_pending_lead_scores_returns_zero_when_dependencies_missing() -> None:
+    result = await sync_pending_lead_scores(
+        scoring_store=None,
+        kommo_client=None,
+        score_field_id=1,
+        band_field_id=2,
+    )
+
+    assert result == {"synced": 0, "failed": 0, "skipped": 0}
+
+
+@pytest.mark.asyncio
+async def test_sync_pending_lead_scores_skips_invalid_field_ids() -> None:
+    scoring_store = AsyncMock()
+    kommo_client = AsyncMock()
+
+    result = await sync_pending_lead_scores(
+        scoring_store=scoring_store,
+        kommo_client=kommo_client,
+        score_field_id=0,
+        band_field_id=2,
+    )
+
+    assert result == {"synced": 0, "failed": 0, "skipped": 0}
+    scoring_store.list_pending_sync.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sync_pending_lead_scores_marks_synced_and_skipped() -> None:
+    scoring_store = AsyncMock()
+    kommo_client = AsyncMock()
+    scoring_store.list_pending_sync.return_value = [
+        SimpleNamespace(
+            lead_id=11,
+            session_id="s1",
+            score_value=87,
+            score_band="hot",
+            kommo_lead_id=9011,
+        ),
+        SimpleNamespace(
+            lead_id=12,
+            session_id="s2",
+            score_value=12,
+            score_band="cold",
+            kommo_lead_id=None,
+        ),
+    ]
+
+    result = await sync_pending_lead_scores(
+        scoring_store=scoring_store,
+        kommo_client=kommo_client,
+        score_field_id=1001,
+        band_field_id=1002,
+        limit=5,
+    )
+
+    assert result == {"synced": 1, "failed": 0, "skipped": 1}
+    scoring_store.list_pending_sync.assert_awaited_once_with(limit=5)
+    kommo_client.update_lead_score.assert_awaited_once()
+    call = kommo_client.update_lead_score.await_args.kwargs
+    assert call["lead_id"] == 9011
+    assert call["idempotency_key"] == "lead-score:11:s1:87:hot"
+    assert "custom_fields_values" in call["payload"]
+    scoring_store.mark_synced.assert_awaited_once_with(lead_id=11)
+    scoring_store.mark_failed.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sync_pending_lead_scores_marks_failed_on_kommo_error() -> None:
+    scoring_store = AsyncMock()
+    kommo_client = AsyncMock()
+    scoring_store.list_pending_sync.return_value = [
+        SimpleNamespace(
+            lead_id=42,
+            session_id="s3",
+            score_value=50,
+            score_band="warm",
+            kommo_lead_id=9042,
+        )
+    ]
+    kommo_client.update_lead_score.side_effect = RuntimeError("kommo down")
+
+    result = await sync_pending_lead_scores(
+        scoring_store=scoring_store,
+        kommo_client=kommo_client,
+        score_field_id=1001,
+        band_field_id=1002,
+    )
+
+    assert result == {"synced": 0, "failed": 1, "skipped": 0}
+    scoring_store.mark_failed.assert_awaited_once_with(lead_id=42, error="kommo_error")
+    scoring_store.mark_synced.assert_not_called()


### PR DESCRIPTION
## Summary
- add unit tests for `FunnelAnalyticsStore` SQL delegation paths
- add unit tests for `sync_pending_lead_scores` success/skip/failure branches
- add unit tests for `ingestion_cocoindex` async delegates and CLI error branches

## Validation
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' uv run pytest tests/unit/services/test_funnel_analytics_store.py tests/unit/services/test_lead_score_sync.py tests/unit/services/test_ingestion_cocoindex.py -q`
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`

Closes #552