### PR TITLE
test(e2e): move Telethon E2E to canonical corpus scenarios

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -528,7 +528,8 @@ e2e-test-traces: ## Run E2E tests + validate Langfuse traces
 e2e-test-group: ## Run specific test group (usage: make e2e-test-group GROUP=filters)
 	uv run python scripts/e2e/runner.py --group $(GROUP)
 
-e2e-setup: e2e-install e2e-generate-data e2e-index-data ## Full E2E setup
+e2e-setup: e2e-install ## Full E2E setup on canonical collection
+	@echo "$(YELLOW)Using canonical collection via E2E_COLLECTION_NAME (default: gdrive_documents_bge)$(NC)"
 	@echo "$(GREEN)✓ E2E setup complete$(NC)"
 
 # =============================================================================

--- a/scripts/e2e/config.py
+++ b/scripts/e2e/config.py
@@ -34,8 +34,10 @@ class E2EConfig:
     # Thresholds
     pass_score: float = 6.0
 
-    # Qdrant test collection
-    test_collection: str = "contextual_bulgaria_test"
+    # Canonical Qdrant collection for current corpus
+    test_collection: str = field(
+        default_factory=lambda: os.getenv("E2E_COLLECTION_NAME", "gdrive_documents_bge")
+    )
 
     # Reports
     reports_dir: str = "reports"

--- a/scripts/e2e/test_scenarios.py
+++ b/scripts/e2e/test_scenarios.py
@@ -13,6 +13,7 @@ class TestGroup(Enum):
     ROOM_FILTERS = "room_filters"
     LOCATION_FILTERS = "location_filters"
     SEARCH = "search"
+    IMMIGRATION = "immigration"
     EDGE_CASES = "edge_cases"
 
 
@@ -44,6 +45,49 @@ class TestScenario:
 
 # All 25 test scenarios
 SCENARIOS: list[TestScenario] = [
+    # Group 0: Immigration corpus (6 tests)
+    TestScenario(
+        id="0.1",
+        name="Digital Nomad visa basics",
+        query="Какие требования для визы Digital Nomad в Болгарии?",
+        group=TestGroup.IMMIGRATION,
+        expected_keywords=["digital", "nomad", "виза", "болгар"],
+    ),
+    TestScenario(
+        id="0.2",
+        name="VNZ options",
+        query="Какие есть основные основания для ВНЖ в Болгарии?",
+        group=TestGroup.IMMIGRATION,
+        expected_keywords=["внж", "основан", "болгар"],
+    ),
+    TestScenario(
+        id="0.3",
+        name="PMJ path",
+        query="Через сколько лет после ВНЖ можно получить ПМЖ в Болгарии?",
+        group=TestGroup.IMMIGRATION,
+        expected_keywords=["пмж", "внж", "лет"],
+    ),
+    TestScenario(
+        id="0.4",
+        name="Immigration plus housing cross-question",
+        query="Можно ли получить ВНЖ через покупку недвижимости и какие есть риски?",
+        group=TestGroup.IMMIGRATION,
+        expected_keywords=["внж", "недвижим", "риск"],
+    ),
+    TestScenario(
+        id="0.5",
+        name="Document checklist",
+        query="Какие документы обычно нужны для подачи на ВНЖ?",
+        group=TestGroup.IMMIGRATION,
+        expected_keywords=["документ", "внж", "подач"],
+    ),
+    TestScenario(
+        id="0.6",
+        name="2026 rule changes",
+        query="Что изменилось в правилах ВНЖ/ПМЖ в Болгарии в 2026 году?",
+        group=TestGroup.IMMIGRATION,
+        expected_keywords=["2026", "внж", "пмж", "измен"],
+    ),
     # Group 1: Commands (4 tests)
     TestScenario(
         id="1.1",

--- a/tests/unit/e2e/test_corpus_e2e_config.py
+++ b/tests/unit/e2e/test_corpus_e2e_config.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from scripts.e2e.config import E2EConfig
+from scripts.e2e.test_scenarios import SCENARIOS
+from scripts.e2e.test_scenarios import TestGroup as _ScenarioGroup
+
+
+def test_e2e_config_defaults_to_canonical_collection() -> None:
+    cfg = E2EConfig()
+    assert cfg.test_collection == "gdrive_documents_bge"
+    assert cfg.test_collection != "contextual_bulgaria_test"
+
+
+def test_scenarios_include_immigration_corpus_coverage() -> None:
+    immigration = [s for s in SCENARIOS if s.group == _ScenarioGroup.IMMIGRATION]
+    assert len(immigration) >= 5
+
+    text = " ".join((s.query + " " + " ".join(s.expected_keywords)) for s in immigration).lower()
+    for token in ("внж", "пмж", "digital nomad", "виза"):
+        assert token in text


### PR DESCRIPTION
## Summary
- switch E2E default collection from legacy `contextual_bulgaria_test` to canonical `gdrive_documents_bge` via `E2E_COLLECTION_NAME`
- remove `e2e-setup` dependency on synthetic property generation/indexing
- expand `scripts/e2e/test_scenarios.py` with immigration-corpus coverage (ВНЖ/ПМЖ/Digital Nomad + cross questions)
- add unit contracts in `tests/unit/e2e/test_corpus_e2e_config.py` to prevent regression to legacy collection/scenarios

## Validation
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' uv run pytest tests/unit/e2e/test_corpus_e2e_config.py -q`
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`

Closes #491
