### PR TITLE
feat: backfill ColBERT multivectors and coverage checks (#599)

### DIFF
--- a/docs/QDRANT_STACK.md
+++ b/docs/QDRANT_STACK.md
@@ -37,6 +37,18 @@ Payload indexes created by bootstrap include:
 # Create ingestion-ready collection if missing
 uv run python -m src.ingestion.unified.cli bootstrap
 
+# Validate vector schema (fail if colbert missing)
+uv run python -m src.ingestion.unified.cli schema-check --require-colbert
+
+# Check point-level ColBERT coverage (>=99.5% recommended, 100% target)
+uv run python -m src.ingestion.unified.cli coverage-check --min-ratio 0.995
+
+# Backfill missing point-level ColBERT vectors
+uv run python -m src.ingestion.unified.cli backfill-colbert --batch-size 32 --resume
+
+# Dry-run sample before writes
+uv run python -m src.ingestion.unified.cli backfill-colbert --dry-run --limit 1000
+
 # Check collection
 curl -fsS http://localhost:6333/collections/gdrive_documents_bge | python -m json.tool
 
@@ -62,4 +74,7 @@ Snapshots are created via `scripts/qdrant_snapshot.py`.
 
 - Empty retrieval results: verify `QDRANT_COLLECTION` matches existing collection.
 - Ingestion writes fail: run `src.ingestion.unified.cli preflight` to confirm reachability.
+- ColBERT schema drift: run `src.ingestion.unified.cli schema-check --require-colbert`.
+- Low ColBERT coverage: run `src.ingestion.unified.cli coverage-check --min-ratio 0.995`.
+- Interrupted backfill: rerun `src.ingestion.unified.cli backfill-colbert --resume` to continue from `.colbert_backfill_checkpoint.json`.
 - Slow queries: verify collection contains expected `dense`/`bm42` vectors and payload indexes.

--- a/src/ingestion/unified/cli.py
+++ b/src/ingestion/unified/cli.py
@@ -6,8 +6,15 @@ import asyncio
 import logging
 import os
 import sys
+from collections.abc import Mapping
 
 from dotenv import load_dotenv
+
+from src.ingestion.unified.colbert_backfill import (
+    ColbertBackfillRunner,
+    compute_colbert_coverage,
+    inspect_collection_schema,
+)
 
 
 def setup_logging(verbose: bool = False) -> None:
@@ -152,6 +159,84 @@ async def cmd_preflight(args: argparse.Namespace) -> int:
     return 0 if all_ok else 1
 
 
+def _extract_vector_names(collection_info) -> tuple[set[str], set[str]]:
+    """Extract named dense/sparse vector names from a Qdrant collection."""
+    params = getattr(getattr(collection_info, "config", None), "params", None)
+    vectors = getattr(params, "vectors", {})
+    sparse_vectors = getattr(params, "sparse_vectors", {})
+
+    dense_names: set[str] = set()
+    sparse_names: set[str] = set()
+
+    if isinstance(vectors, Mapping) or hasattr(vectors, "keys"):
+        dense_names = set(vectors.keys())
+
+    if isinstance(sparse_vectors, Mapping) or hasattr(sparse_vectors, "keys"):
+        sparse_names = set(sparse_vectors.keys())
+
+    return dense_names, sparse_names
+
+
+def _schema_requirements_status(
+    collection_info,
+    *,
+    require_colbert: bool,
+) -> tuple[list[str], set[str], set[str]]:
+    """Validate required vector names and return missing requirements."""
+    dense_names, sparse_names = _extract_vector_names(collection_info)
+    missing: list[str] = []
+
+    if "dense" not in dense_names:
+        missing.append("dense")
+    if "bm42" not in sparse_names:
+        missing.append("bm42")
+    if require_colbert and "colbert" not in dense_names:
+        missing.append("colbert")
+
+    return missing, dense_names, sparse_names
+
+
+async def cmd_schema_check(args: argparse.Namespace) -> int:
+    """Validate Qdrant collection schema for required vector names."""
+    from qdrant_client import QdrantClient
+
+    from src.ingestion.unified.config import UnifiedConfig
+
+    config = UnifiedConfig()
+    collection_name = config.collection_name
+
+    print(f"\n=== Schema Check: {collection_name} ===")
+
+    client = QdrantClient(
+        url=os.getenv("QDRANT_URL", "http://localhost:6333"),
+        api_key=os.getenv("QDRANT_API_KEY"),
+        timeout=60,
+    )
+
+    try:
+        schema = inspect_collection_schema(client, collection_name)
+    except Exception as exc:
+        print(f"  [FAIL] Qdrant error while loading '{collection_name}': {exc}")
+        return 1
+
+    dense_names = schema["dense_names"]
+    sparse_names = schema["sparse_names"]
+    missing = sorted(schema["missing_dense"] | schema["missing_sparse"])
+    if getattr(args, "require_colbert", False):
+        missing.extend(sorted(schema["missing_colbert"]))
+
+    if missing:
+        print(
+            "  [FAIL] Schema drift detected: missing "
+            f"{', '.join(sorted(missing))}. "
+            f"dense={sorted(dense_names)} sparse={sorted(sparse_names)}"
+        )
+        return 1
+
+    print(f"  [OK] Schema valid: dense={sorted(dense_names)} sparse={sorted(sparse_names)}")
+    return 0
+
+
 async def cmd_bootstrap(args: argparse.Namespace) -> int:
     """Create Qdrant collection if it doesn't exist."""
     from qdrant_client import QdrantClient
@@ -192,14 +277,31 @@ async def cmd_bootstrap(args: argparse.Namespace) -> int:
 
     # Check if collection already exists
     exists = False
+    existing_info = None
     try:
-        client.get_collection(collection_name)
+        existing_info = client.get_collection(collection_name)
         exists = True
     except (UnexpectedResponse, Exception):
         pass
 
     if exists:
-        print(f"  Collection '{collection_name}' already exists — nothing to do.")
+        print(f"  Collection '{collection_name}' already exists.")
+        if getattr(args, "require_colbert", False):
+            missing, dense_names, sparse_names = _schema_requirements_status(
+                existing_info,
+                require_colbert=True,
+            )
+            if missing:
+                print(
+                    "  [FAIL] Existing collection schema drift: missing "
+                    f"{', '.join(sorted(missing))}. "
+                    "Recreate collection and run full reingest. "
+                    f"dense={sorted(dense_names)} sparse={sorted(sparse_names)}"
+                )
+                return 1
+            print("  [OK] Existing collection schema includes required vectors.")
+        else:
+            print("  Nothing to do.")
         return 0
 
     # Create collection
@@ -262,6 +364,20 @@ async def cmd_bootstrap(args: argparse.Namespace) -> int:
         except Exception as e:
             print(f"  Warning: Could not create index {field}: {e}")
 
+    if getattr(args, "require_colbert", False):
+        info = client.get_collection(collection_name)
+        missing, dense_names, sparse_names = _schema_requirements_status(
+            info,
+            require_colbert=True,
+        )
+        if missing:
+            print(
+                "  [FAIL] Created collection schema drift: missing "
+                f"{', '.join(sorted(missing))}. "
+                f"dense={sorted(dense_names)} sparse={sorted(sparse_names)}"
+            )
+            return 1
+
     print(f"  Bootstrap completed: {collection_name}")
     return 0
 
@@ -301,6 +417,88 @@ async def cmd_reprocess(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_backfill_colbert(args: argparse.Namespace) -> int:
+    """Backfill missing ColBERT vectors for points in existing collection."""
+    from src.ingestion.unified.config import UnifiedConfig
+
+    config = UnifiedConfig()
+    checkpoint_path = config.effective_manifest_dir() / ".colbert_backfill_checkpoint.json"
+
+    runner = ColbertBackfillRunner(
+        collection_name=config.collection_name,
+        qdrant_url=config.qdrant_url,
+        qdrant_api_key=config.qdrant_api_key,
+        bge_m3_url=config.bge_m3_url,
+        bge_m3_timeout=config.bge_m3_timeout,
+        checkpoint_path=checkpoint_path,
+    )
+    try:
+        stats = runner.run(
+            batch_size=getattr(args, "batch_size", 32),
+            limit=getattr(args, "limit", None),
+            dry_run=getattr(args, "dry_run", False),
+            resume=getattr(args, "resume", False),
+        )
+    except Exception as exc:
+        print(f"  [FAIL] ColBERT backfill failed: {exc}")
+        return 1
+    finally:
+        runner.close()
+
+    print("\n=== ColBERT Backfill ===")
+    if getattr(args, "dry_run", False):
+        print("  Mode: dry-run (vectors are not written)")
+    print(f"  Collection: {config.collection_name}")
+    print(f"  scanned={stats.scanned}")
+    print(f"  processed={stats.processed}")
+    print(f"  skipped={stats.skipped}")
+    print(f"  failed={stats.failed}")
+    print(f"  qps={getattr(stats, 'qps', 0.0):.2f}")
+    print(f"  error_rate={getattr(stats, 'error_rate', 0.0) * 100:.2f}%")
+    print(f"  bge_latency_ms={getattr(stats, 'bge_latency_ms', 0.0):.1f}")
+    print(f"  qdrant_latency_ms={getattr(stats, 'qdrant_latency_ms', 0.0):.1f}")
+    print(f"  checkpoint={checkpoint_path}")
+    errors = getattr(stats, "errors", [])
+    if errors:
+        print("  sample_errors:")
+        for message in errors[:5]:
+            print(f"    - {message}")
+
+    return 0 if stats.failed == 0 else 2
+
+
+async def cmd_coverage_check(args: argparse.Namespace) -> int:
+    """Check ColBERT coverage ratio in collection."""
+    from qdrant_client import QdrantClient
+
+    from src.ingestion.unified.config import UnifiedConfig
+
+    config = UnifiedConfig()
+    client = QdrantClient(
+        url=os.getenv("QDRANT_URL", config.qdrant_url),
+        api_key=os.getenv("QDRANT_API_KEY") or config.qdrant_api_key,
+        timeout=60,
+    )
+
+    try:
+        covered, total, ratio = compute_colbert_coverage(client, config.collection_name)
+    except Exception as exc:
+        print(f"  [FAIL] Coverage check failed: {exc}")
+        return 1
+
+    required_ratio = float(getattr(args, "min_ratio", 0.995))
+    print(f"\n=== ColBERT Coverage: {config.collection_name} ===")
+    print(f"  Coverage: {covered}/{total} ({ratio * 100:.2f}%)")
+    print(f"  Threshold: {required_ratio * 100:.2f}%")
+
+    if ratio < required_ratio:
+        print("  [FAIL] Coverage below threshold")
+        return 1
+
+    print("  [OK] Coverage threshold satisfied")
+    return 0
+
+
 def main() -> int:
     """Main entry point."""
     load_dotenv()
@@ -323,7 +521,45 @@ def main() -> int:
     subparsers.add_parser("preflight", help="Check dependencies are reachable")
 
     # bootstrap
-    subparsers.add_parser("bootstrap", help="Create Qdrant collection if missing")
+    bootstrap_p = subparsers.add_parser("bootstrap", help="Create Qdrant collection if missing")
+    bootstrap_p.add_argument(
+        "--require-colbert",
+        action="store_true",
+        help="Fail if existing/new collection schema misses 'colbert' vector",
+    )
+
+    # schema-check
+    schema_check_p = subparsers.add_parser(
+        "schema-check",
+        help="Validate collection schema (dense/bm42 and optional colbert)",
+    )
+    schema_check_p.add_argument(
+        "--require-colbert",
+        action="store_true",
+        help="Require 'colbert' vector to be present",
+    )
+
+    # coverage-check
+    coverage_check_p = subparsers.add_parser(
+        "coverage-check",
+        help="Check point-level ColBERT vector coverage",
+    )
+    coverage_check_p.add_argument(
+        "--min-ratio",
+        type=float,
+        default=0.995,
+        help="Minimum acceptable ColBERT coverage ratio (default: 0.995)",
+    )
+
+    # backfill-colbert
+    backfill_p = subparsers.add_parser(
+        "backfill-colbert",
+        help="Backfill missing ColBERT vectors for existing points",
+    )
+    backfill_p.add_argument("--batch-size", type=int, default=32, help="Batch size")
+    backfill_p.add_argument("--limit", type=int, help="Process at most N points")
+    backfill_p.add_argument("--dry-run", action="store_true", help="Do not write updates")
+    backfill_p.add_argument("--resume", action="store_true", help="Resume from checkpoint")
 
     # reprocess
     reprocess_p = subparsers.add_parser("reprocess", help="Reprocess files")
@@ -341,6 +577,12 @@ def main() -> int:
         return asyncio.run(cmd_preflight(args))
     if args.command == "bootstrap":
         return asyncio.run(cmd_bootstrap(args))
+    if args.command == "schema-check":
+        return asyncio.run(cmd_schema_check(args))
+    if args.command == "coverage-check":
+        return asyncio.run(cmd_coverage_check(args))
+    if args.command == "backfill-colbert":
+        return cmd_backfill_colbert(args)
     if args.command == "reprocess":
         return asyncio.run(cmd_reprocess(args))
 

--- a/src/ingestion/unified/colbert_backfill.py
+++ b/src/ingestion/unified/colbert_backfill.py
@@ -1,0 +1,381 @@
+"""Backfill ColBERT multivectors for existing Qdrant points."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, TypeVar, cast
+
+from qdrant_client import QdrantClient, models
+
+from telegram_bot.services.bge_m3_client import BGEM3SyncClient
+
+
+logger = logging.getLogger(__name__)
+T = TypeVar("T")
+
+
+@dataclass
+class BackfillStats:
+    """Runtime metrics for ColBERT backfill."""
+
+    scanned: int = 0
+    processed: int = 0
+    skipped: int = 0
+    failed: int = 0
+    batches: int = 0
+    bge_latency_ms: float = 0.0
+    qdrant_latency_ms: float = 0.0
+    started_at: float = field(default_factory=time.perf_counter)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def elapsed_seconds(self) -> float:
+        return max(time.perf_counter() - self.started_at, 1e-9)
+
+    @property
+    def qps(self) -> float:
+        return self.scanned / self.elapsed_seconds
+
+    @property
+    def error_rate(self) -> float:
+        return self.failed / self.scanned if self.scanned else 0.0
+
+
+def inspect_collection_schema(
+    qdrant_client: QdrantClient,
+    collection_name: str,
+) -> dict[str, set[str]]:
+    """Inspect named vector schema for collection."""
+    info = qdrant_client.get_collection(collection_name)
+    dense_vectors = info.config.params.vectors
+    sparse_vectors = info.config.params.sparse_vectors or {}
+    dense_names = set(dense_vectors.keys()) if isinstance(dense_vectors, dict) else set()
+    sparse_names = set(sparse_vectors.keys()) if isinstance(sparse_vectors, dict) else set()
+
+    return {
+        "dense_names": dense_names,
+        "sparse_names": sparse_names,
+        "missing_dense": {"dense"} - dense_names,
+        "missing_sparse": {"bm42"} - sparse_names,
+        "missing_colbert": {"colbert"} - dense_names,
+    }
+
+
+def compute_colbert_coverage(
+    qdrant_client: QdrantClient,
+    collection_name: str,
+) -> tuple[int, int, float]:
+    """Return (colbert_points, total_points, ratio)."""
+    total = qdrant_client.count(collection_name=collection_name).count
+    if total == 0:
+        return 0, 0, 1.0
+
+    colbert_count = qdrant_client.count(
+        collection_name=collection_name,
+        count_filter=models.Filter(must=[models.HasVectorCondition(has_vector="colbert")]),
+        exact=True,
+    ).count
+    return colbert_count, total, colbert_count / total
+
+
+class ColbertBackfillRunner:
+    """Batch backfill of missing ColBERT vectors."""
+
+    def __init__(
+        self,
+        *,
+        collection_name: str,
+        qdrant_url: str | None = None,
+        qdrant_api_key: str | None = None,
+        bge_m3_url: str | None = None,
+        bge_m3_timeout: float = 300.0,
+        checkpoint_path: Path | None = None,
+        retry_attempts: int = 3,
+        retry_backoff_seconds: float = 1.0,
+        qdrant_client: QdrantClient | None = None,
+        bge_client: BGEM3SyncClient | Any | None = None,
+    ) -> None:
+        self.collection_name = collection_name
+        self.retry_attempts = max(1, retry_attempts)
+        self.retry_backoff_seconds = max(0.0, retry_backoff_seconds)
+        self.checkpoint_path = checkpoint_path
+        self._qdrant = qdrant_client or QdrantClient(
+            url=qdrant_url or "http://localhost:6333",
+            api_key=qdrant_api_key,
+            timeout=120,
+        )
+        self._bge = bge_client or BGEM3SyncClient(
+            base_url=bge_m3_url or "http://localhost:8000",
+            timeout=bge_m3_timeout,
+        )
+
+    def run(
+        self,
+        *,
+        batch_size: int = 32,
+        limit: int | None = None,
+        dry_run: bool = False,
+        resume: bool = False,
+    ) -> BackfillStats:
+        """Execute backfill and return runtime stats."""
+        self._ensure_colbert_schema()
+        stats = BackfillStats()
+
+        start_offset = self._load_checkpoint_offset() if resume else None
+        if resume and start_offset is not None:
+            logger.info("Backfill resume from checkpoint offset=%r", start_offset)
+
+        collection_info = self._qdrant.get_collection(self.collection_name)
+        total_points = collection_info.points_count or 0
+        target_total = (
+            min(limit, total_points) if limit is not None and total_points else total_points
+        )
+
+        exhausted_collection = False
+        offset = start_offset
+
+        while True:
+            remaining = None if limit is None else max(limit - stats.scanned, 0)
+            if remaining == 0:
+                break
+            page_size = batch_size if remaining is None else min(batch_size, remaining)
+            if page_size <= 0:
+                break
+
+            def _scroll_page(
+                page_size_value: int = page_size,
+                scroll_offset: Any = offset,
+            ) -> tuple[list[Any], Any]:
+                return self._qdrant.scroll(
+                    collection_name=self.collection_name,
+                    limit=page_size_value,
+                    offset=scroll_offset,
+                    with_payload=["page_content", "text"],
+                    with_vectors=["colbert"],
+                )
+
+            records, next_offset = self._call_with_retry("qdrant.scroll", _scroll_page)
+
+            if not records:
+                if next_offset is None:
+                    exhausted_collection = True
+                break
+
+            stats.batches += 1
+            ids_to_update: list[str | int | uuid.UUID] = []
+            texts: list[str] = []
+
+            for record in records:
+                stats.scanned += 1
+                if self._has_colbert_vector(record):
+                    stats.skipped += 1
+                    continue
+
+                text = self._extract_text(record)
+                if not text:
+                    stats.failed += 1
+                    self._append_error(
+                        stats,
+                        f"point_id={record.id}: missing payload.page_content/payload.text",
+                    )
+                    continue
+
+                ids_to_update.append(record.id)
+                texts.append(text)
+
+            if ids_to_update:
+                if dry_run:
+                    stats.processed += len(ids_to_update)
+                else:
+                    try:
+                        bge_started = time.perf_counter()
+
+                        def _encode_batch(
+                            texts_batch: list[str] = texts,
+                        ) -> list[list[list[float]]]:
+                            return self._encode_colbert(texts_batch)
+
+                        colbert_vecs = self._call_with_retry("bge.encode_colbert", _encode_batch)
+                        stats.bge_latency_ms += (time.perf_counter() - bge_started) * 1000
+
+                        if len(colbert_vecs) != len(ids_to_update):
+                            raise RuntimeError(
+                                "BGE-M3 returned mismatched colbert vectors: "
+                                f"{len(colbert_vecs)} != {len(ids_to_update)}"
+                            )
+
+                        points = [
+                            models.PointVectors(id=point_id, vector={"colbert": colbert_vec})
+                            for point_id, colbert_vec in zip(
+                                ids_to_update, colbert_vecs, strict=True
+                            )
+                        ]
+                        qdrant_started = time.perf_counter()
+
+                        def _update_batch(points_batch: list[Any] = points) -> Any:
+                            return self._qdrant.update_vectors(
+                                collection_name=self.collection_name,
+                                points=points_batch,
+                            )
+
+                        self._call_with_retry("qdrant.update_vectors", _update_batch)
+                        stats.qdrant_latency_ms += (time.perf_counter() - qdrant_started) * 1000
+                        stats.processed += len(points)
+                    except Exception as exc:
+                        stats.failed += len(ids_to_update)
+                        self._append_error(stats, f"batch update failed: {exc}")
+
+            self._save_checkpoint(next_offset=next_offset, last_point_id=records[-1].id)
+            self._log_progress(stats=stats, target_total=target_total)
+
+            if next_offset is None:
+                exhausted_collection = True
+                break
+            offset = next_offset
+
+        if exhausted_collection:
+            self._clear_checkpoint()
+
+        return stats
+
+    def close(self) -> None:
+        """Close resources."""
+        close_fn = getattr(self._bge, "close", None)
+        if callable(close_fn):
+            close_fn()
+
+    def _ensure_colbert_schema(self) -> None:
+        schema = inspect_collection_schema(self._qdrant, self.collection_name)
+        if schema["missing_colbert"]:
+            raise RuntimeError(
+                f"Qdrant collection '{self.collection_name}' missing required vector 'colbert'"
+            )
+
+    @staticmethod
+    def _has_colbert_vector(record: Any) -> bool:
+        vector = getattr(record, "vector", None)
+        if not isinstance(vector, dict):
+            return False
+        colbert = vector.get("colbert")
+        return bool(colbert)
+
+    @staticmethod
+    def _extract_text(record: Any) -> str:
+        payload = getattr(record, "payload", {}) or {}
+        if not isinstance(payload, dict):
+            return ""
+        for key in ("page_content", "text"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+        return ""
+
+    def _encode_colbert(self, texts: list[str]) -> list[list[list[float]]]:
+        if hasattr(self._bge, "encode_colbert"):
+            result = self._bge.encode_colbert(texts)
+            return cast(list[list[list[float]]], result.colbert_vecs)
+
+        if hasattr(self._bge, "encode_hybrid"):
+            result = self._bge.encode_hybrid(texts)
+            colbert_vecs = result.colbert_vecs
+            if colbert_vecs is None:
+                raise RuntimeError("BGE-M3 encode_hybrid response missing colbert_vecs")
+            return cast(list[list[list[float]]], colbert_vecs)
+
+        raise RuntimeError("BGE-M3 client does not provide encode_colbert or encode_hybrid")
+
+    def _call_with_retry(self, name: str, fn: Callable[[], T]) -> T:
+        for attempt in range(1, self.retry_attempts + 1):
+            try:
+                return fn()
+            except Exception:
+                if attempt >= self.retry_attempts:
+                    raise
+                delay = self.retry_backoff_seconds * (2 ** (attempt - 1))
+                logger.warning(
+                    "%s failed (attempt %d/%d), retrying in %.2fs",
+                    name,
+                    attempt,
+                    self.retry_attempts,
+                    delay,
+                )
+                if delay > 0:
+                    time.sleep(delay)
+        raise RuntimeError(f"{name} retry loop ended unexpectedly")
+
+    @staticmethod
+    def _append_error(stats: BackfillStats, message: str) -> None:
+        if len(stats.errors) < 20:
+            stats.errors.append(message)
+        logger.warning("ColBERT backfill: %s", message)
+
+    def _log_progress(self, *, stats: BackfillStats, target_total: int) -> None:
+        eta_seconds: float | None = None
+        if target_total > 0 and stats.qps > 0:
+            remaining = max(target_total - stats.scanned, 0)
+            eta_seconds = remaining / stats.qps
+        eta_str = f"{eta_seconds:.1f}s" if eta_seconds is not None else "n/a"
+
+        logger.info(
+            "ColBERT backfill progress: scanned=%d processed=%d skipped=%d failed=%d "
+            "qps=%.2f error_rate=%.2f%% eta=%s bge_ms=%.1f qdrant_ms=%.1f",
+            stats.scanned,
+            stats.processed,
+            stats.skipped,
+            stats.failed,
+            stats.qps,
+            stats.error_rate * 100,
+            eta_str,
+            stats.bge_latency_ms,
+            stats.qdrant_latency_ms,
+        )
+
+    def _load_checkpoint_offset(self) -> int | str | uuid.UUID | None:
+        if self.checkpoint_path is None or not self.checkpoint_path.exists():
+            return None
+        try:
+            data = json.loads(self.checkpoint_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning("Failed to read checkpoint %s: %s", self.checkpoint_path, exc)
+            return None
+
+        raw_offset = data.get("next_offset")
+        if isinstance(raw_offset, dict) and raw_offset.get("type") == "uuid":
+            value = raw_offset.get("value")
+            try:
+                return uuid.UUID(value)
+            except Exception:
+                logger.warning("Invalid UUID checkpoint offset: %r", value)
+                return None
+        if isinstance(raw_offset, (int, str)):
+            return raw_offset
+        return None
+
+    def _save_checkpoint(self, *, next_offset: Any, last_point_id: Any) -> None:
+        if self.checkpoint_path is None:
+            return
+        self.checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "next_offset": self._serialize_offset(next_offset),
+            "last_point_id": str(last_point_id) if last_point_id is not None else None,
+            "updated_at": int(time.time()),
+        }
+        self.checkpoint_path.write_text(json.dumps(payload, ensure_ascii=True), encoding="utf-8")
+
+    def _clear_checkpoint(self) -> None:
+        if self.checkpoint_path and self.checkpoint_path.exists():
+            self.checkpoint_path.unlink()
+
+    @staticmethod
+    def _serialize_offset(value: Any) -> Any:
+        if value is None or isinstance(value, (int, str)):
+            return value
+        if isinstance(value, uuid.UUID):
+            return {"type": "uuid", "value": str(value)}
+        return str(value)

--- a/telegram_bot/preflight.py
+++ b/telegram_bot/preflight.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 import asyncpg
 import httpx
 import redis.asyncio as aioredis
-from qdrant_client import AsyncQdrantClient
+from qdrant_client import AsyncQdrantClient, models
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from .config import BotConfig
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 # Retry settings for critical deps
 CRITICAL_RETRIES = 3
 CRITICAL_RETRY_DELAY = 5.0  # seconds
+COLBERT_COVERAGE_WARN_THRESHOLD = 0.995
 
 # Cache key prefixes used by CacheService (see telegram_bot/services/cache.py)
 # Used for synthetic write/read/ttl/delete verification at startup.
@@ -254,6 +255,41 @@ async def _check_single_dep(
                     "(server-side ColBERT reranking unavailable, RRF fallback active)",
                     collection,
                 )
+            elif info.points_count:
+                try:
+                    with_colbert = await qdrant.count(
+                        collection_name=collection,
+                        count_filter=models.Filter(
+                            must=[models.HasVectorCondition(has_vector="colbert")]
+                        ),
+                        exact=True,
+                    )
+                    covered = int(with_colbert.count)
+                    total = int(info.points_count)
+                    ratio = covered / total
+
+                    if ratio < COLBERT_COVERAGE_WARN_THRESHOLD:
+                        logger.warning(
+                            "Preflight WARN: Qdrant collection %s colbert coverage is %.2f%% "
+                            "(%d/%d), below %.2f%% threshold",
+                            collection,
+                            ratio * 100,
+                            covered,
+                            total,
+                            COLBERT_COVERAGE_WARN_THRESHOLD * 100,
+                        )
+                    else:
+                        logger.info(
+                            "Preflight Qdrant: colbert coverage %.2f%% (%d/%d)",
+                            ratio * 100,
+                            covered,
+                            total,
+                        )
+                except Exception as exc:
+                    logger.warning(
+                        "Preflight WARN: Qdrant colbert coverage check failed: %s",
+                        exc,
+                    )
 
             return True
         except Exception as exc:

--- a/tests/integration/test_colbert_backfill.py
+++ b/tests/integration/test_colbert_backfill.py
@@ -1,0 +1,179 @@
+"""Integration-style test: partial ColBERT coverage -> backfill -> ColBERT search returns docs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+
+@dataclass
+class _StoredPoint:
+    point_id: int
+    payload: dict
+    vectors: dict
+
+
+class _FakeQdrantStorage:
+    def __init__(self) -> None:
+        self.collection_name = "test_col"
+        self.points: dict[int, _StoredPoint] = {}
+
+    def collection_info(self):
+        return SimpleNamespace(
+            points_count=len(self.points),
+            config=SimpleNamespace(
+                params=SimpleNamespace(
+                    vectors={"dense": object(), "colbert": object()},
+                    sparse_vectors={"bm42": object()},
+                )
+            ),
+        )
+
+
+class _FakeSyncQdrantClient:
+    def __init__(self, storage: _FakeQdrantStorage):
+        self._storage = storage
+
+    def get_collection(self, collection_name: str):
+        return self._storage.collection_info()
+
+    def count(self, collection_name: str, count_filter=None, exact=True):
+        if count_filter is None:
+            return SimpleNamespace(count=len(self._storage.points))
+
+        # Filter contains HasVectorCondition(has_vector="colbert")
+        covered = 0
+        for point in self._storage.points.values():
+            colbert_vec = point.vectors.get("colbert")
+            if colbert_vec:
+                covered += 1
+        return SimpleNamespace(count=covered)
+
+    def scroll(
+        self,
+        *,
+        collection_name: str,
+        limit: int,
+        offset=None,
+        with_payload=True,
+        with_vectors=False,
+    ):
+        ids = sorted(self._storage.points.keys())
+        if offset is None:
+            start_index = 0
+        else:
+            start_index = 0
+            for idx, point_id in enumerate(ids):
+                if point_id > int(offset):
+                    start_index = idx
+                    break
+            else:
+                return [], None
+
+        page_ids = ids[start_index : start_index + limit]
+        records = []
+        for point_id in page_ids:
+            point = self._storage.points[point_id]
+            records.append(
+                SimpleNamespace(
+                    id=point.point_id,
+                    payload=point.payload,
+                    vector={"colbert": point.vectors.get("colbert")} if with_vectors else {},
+                )
+            )
+
+        if not page_ids:
+            return [], None
+        last_id = page_ids[-1]
+        has_next = start_index + limit < len(ids)
+        next_offset = last_id if has_next else None
+        return records, next_offset
+
+    def update_vectors(self, *, collection_name: str, points: list):
+        for point in points:
+            stored = self._storage.points[int(point.id)]
+            for name, value in point.vector.items():
+                stored.vectors[name] = value
+        return SimpleNamespace(status="ok")
+
+
+class _FakeAsyncQdrantClient:
+    def __init__(self, storage: _FakeQdrantStorage):
+        self._storage = storage
+
+    async def get_collections(self):
+        return SimpleNamespace(collections=[SimpleNamespace(name=self._storage.collection_name)])
+
+    async def get_collection(self, collection_name: str):
+        return self._storage.collection_info()
+
+    async def query_points(self, *, collection_name: str, limit: int, using=None, **kwargs):
+        hits = []
+        for point in self._storage.points.values():
+            has_colbert = bool(point.vectors.get("colbert"))
+            if using == "colbert" and not has_colbert:
+                continue
+            hits.append(
+                SimpleNamespace(
+                    id=point.point_id,
+                    score=1.0,
+                    payload=point.payload,
+                )
+            )
+        return SimpleNamespace(points=hits[:limit])
+
+    async def close(self):
+        return None
+
+
+class _FakeBgeClient:
+    def encode_colbert(self, texts: list[str]):
+        return SimpleNamespace(colbert_vecs=[[[0.1, 0.2]]] * len(texts))
+
+
+async def test_backfill_enables_server_side_colbert_search(tmp_path):
+    from src.ingestion.unified.colbert_backfill import ColbertBackfillRunner
+    from telegram_bot.services.qdrant import QdrantService
+
+    storage = _FakeQdrantStorage()
+    storage.points[1] = _StoredPoint(
+        point_id=1,
+        payload={"page_content": "doc without colbert before backfill", "metadata": {}},
+        vectors={"dense": [0.1, 0.2], "bm42": {"indices": [1], "values": [0.4]}},
+    )
+
+    sync_client = _FakeSyncQdrantClient(storage)
+    backfill = ColbertBackfillRunner(
+        collection_name=storage.collection_name,
+        qdrant_client=sync_client,
+        bge_client=_FakeBgeClient(),
+        checkpoint_path=tmp_path / ".checkpoint.json",
+        retry_backoff_seconds=0.0,
+    )
+
+    service = QdrantService(
+        url="http://localhost:6333",
+        collection_name=storage.collection_name,
+    )
+    service._client = _FakeAsyncQdrantClient(storage)
+
+    before = await service.hybrid_search_rrf_colbert(
+        dense_vector=[0.1, 0.2],
+        sparse_vector={"indices": [1], "values": [0.4]},
+        colbert_query=[[0.3, 0.6]],
+        top_k=5,
+    )
+    assert before == []
+
+    stats = backfill.run(batch_size=10)
+    assert stats.processed == 1
+
+    service._collection_validated = False
+    after = await service.hybrid_search_rrf_colbert(
+        dense_vector=[0.1, 0.2],
+        sparse_vector={"indices": [1], "values": [0.4]},
+        colbert_query=[[0.3, 0.6]],
+        top_k=5,
+    )
+    assert len(after) > 0
+    assert after[0]["text"] == "doc without colbert before backfill"

--- a/tests/integration/test_service_chain_agent_tools.py
+++ b/tests/integration/test_service_chain_agent_tools.py
@@ -92,7 +92,7 @@ async def test_manager_service_chain_includes_history_and_crm_tools():
         patch("telegram_bot.agents.manager_tools.create_crm_score_sync_tool", return_value=None),
         patch(
             "telegram_bot.agents.manager_tools.build_tools_for_role",
-            side_effect=lambda _role, base_tools, manager_tools: [*base_tools, *manager_tools],
+            side_effect=lambda **kwargs: [*kwargs["base_tools"], *kwargs["manager_tools"]],
         ),
         patch("telegram_bot.agents.crm_tools.get_crm_tools", return_value=[fake_crm_tool]),
         patch("telegram_bot.agents.utility_tools.get_utility_tools", return_value=[]),

--- a/tests/unit/ingestion/test_colbert_backfill.py
+++ b/tests/unit/ingestion/test_colbert_backfill.py
@@ -1,0 +1,301 @@
+"""Unit tests for ColBERT backfill runner and CLI command wiring."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _record(
+    point_id: int | str,
+    *,
+    page_content: str | None = None,
+    text: str | None = None,
+    colbert: list[list[float]] | None = None,
+):
+    payload = {}
+    if page_content is not None:
+        payload["page_content"] = page_content
+    if text is not None:
+        payload["text"] = text
+
+    vector = {}
+    if colbert is not None:
+        vector["colbert"] = colbert
+
+    return SimpleNamespace(id=point_id, payload=payload, vector=vector)
+
+
+class _StubQdrantClient:
+    def __init__(
+        self, pages: list[tuple[list[SimpleNamespace], int | str | None]], has_colbert=True
+    ):
+        self._pages = list(pages)
+        self.scroll_calls: list[object] = []
+        self.update_vectors_calls: list[list] = []
+        self.upsert_calls = 0
+        vectors: dict[str, object] = {"dense": object()}
+        if has_colbert:
+            vectors["colbert"] = object()
+
+        self._collection = SimpleNamespace(
+            points_count=sum(len(items) for items, _ in pages),
+            config=SimpleNamespace(
+                params=SimpleNamespace(
+                    vectors=vectors,
+                    sparse_vectors={"bm42": object()},
+                )
+            ),
+        )
+
+    def get_collection(self, collection_name: str):
+        return self._collection
+
+    def scroll(
+        self,
+        *,
+        collection_name: str,
+        limit: int,
+        offset=None,
+        with_payload=True,
+        with_vectors=False,
+    ):
+        self.scroll_calls.append(offset)
+        if self._pages:
+            return self._pages.pop(0)
+        return [], None
+
+    def update_vectors(self, *, collection_name: str, points: list):
+        self.update_vectors_calls.append(points)
+        return SimpleNamespace(status="ok")
+
+    def upsert(self, *args, **kwargs):
+        self.upsert_calls += 1
+        return SimpleNamespace(status="ok")
+
+
+class _StubBGEClient:
+    def __init__(self, responses: list[object]):
+        self._responses = list(responses)
+        self.calls: list[list[str]] = []
+
+    def encode_colbert(self, texts: list[str]):
+        self.calls.append(texts)
+        if not self._responses:
+            raise RuntimeError("No stub response available")
+        response = self._responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return SimpleNamespace(colbert_vecs=response)
+
+
+class TestColbertBackfillRunner:
+    def test_backfill_updates_only_missing_colbert_vectors(self, tmp_path: Path):
+        from src.ingestion.unified.colbert_backfill import ColbertBackfillRunner
+
+        qdrant = _StubQdrantClient(
+            pages=[
+                (
+                    [
+                        _record("p1", page_content="already", colbert=[[0.11, 0.22]]),
+                        _record("p2", page_content="need backfill"),
+                    ],
+                    None,
+                )
+            ]
+        )
+        bge = _StubBGEClient(responses=[[[[0.3, 0.4]]]])
+
+        runner = ColbertBackfillRunner(
+            qdrant_client=qdrant,
+            bge_client=bge,
+            collection_name="test_col",
+            checkpoint_path=tmp_path / "checkpoint.json",
+            retry_attempts=2,
+            retry_backoff_seconds=0.0,
+        )
+
+        stats = runner.run(batch_size=2)
+
+        assert stats.scanned == 2
+        assert stats.processed == 1
+        assert stats.skipped == 1
+        assert stats.failed == 0
+        assert len(qdrant.update_vectors_calls) == 1
+        assert len(qdrant.update_vectors_calls[0]) == 1
+        assert qdrant.update_vectors_calls[0][0].id == "p2"
+        assert "colbert" in qdrant.update_vectors_calls[0][0].vector
+        assert qdrant.upsert_calls == 0
+
+    def test_backfill_uses_text_fallback_when_page_content_missing(self, tmp_path: Path):
+        from src.ingestion.unified.colbert_backfill import ColbertBackfillRunner
+
+        qdrant = _StubQdrantClient(pages=[([_record("p1", text="fallback payload text")], None)])
+        bge = _StubBGEClient(responses=[[[[0.1, 0.2]]]])
+        runner = ColbertBackfillRunner(
+            qdrant_client=qdrant,
+            bge_client=bge,
+            collection_name="test_col",
+            checkpoint_path=tmp_path / "checkpoint.json",
+            retry_backoff_seconds=0.0,
+        )
+
+        stats = runner.run(batch_size=1)
+        assert stats.processed == 1
+        assert bge.calls == [["fallback payload text"]]
+
+    def test_backfill_dry_run_does_not_write_vectors(self, tmp_path: Path):
+        from src.ingestion.unified.colbert_backfill import ColbertBackfillRunner
+
+        qdrant = _StubQdrantClient(pages=[([_record("p1", page_content="doc")], None)])
+        bge = _StubBGEClient(responses=[[[[0.8, 0.9]]]])
+        runner = ColbertBackfillRunner(
+            qdrant_client=qdrant,
+            bge_client=bge,
+            collection_name="test_col",
+            checkpoint_path=tmp_path / "checkpoint.json",
+            retry_backoff_seconds=0.0,
+        )
+
+        stats = runner.run(batch_size=1, dry_run=True)
+        assert stats.processed == 1
+        assert bge.calls == []
+        assert qdrant.update_vectors_calls == []
+
+    def test_backfill_resume_reads_checkpoint_offset(self, tmp_path: Path):
+        from src.ingestion.unified.colbert_backfill import ColbertBackfillRunner
+
+        checkpoint = tmp_path / "checkpoint.json"
+        checkpoint.write_text(json.dumps({"next_offset": 777}), encoding="utf-8")
+
+        qdrant = _StubQdrantClient(pages=[([], None)])
+        bge = _StubBGEClient(responses=[])
+        runner = ColbertBackfillRunner(
+            qdrant_client=qdrant,
+            bge_client=bge,
+            collection_name="test_col",
+            checkpoint_path=checkpoint,
+            retry_backoff_seconds=0.0,
+        )
+
+        runner.run(batch_size=10, resume=True)
+        assert qdrant.scroll_calls[0] == 777
+
+    def test_backfill_retries_bge_and_qdrant_transient_errors(self, tmp_path: Path):
+        from src.ingestion.unified.colbert_backfill import ColbertBackfillRunner
+
+        qdrant = _StubQdrantClient(pages=[([_record("p1", page_content="doc")], None)])
+        qdrant_fail_once = {"calls": 0}
+        original_update_vectors = qdrant.update_vectors
+
+        def _flaky_update_vectors(*, collection_name: str, points: list):
+            qdrant_fail_once["calls"] += 1
+            if qdrant_fail_once["calls"] == 1:
+                raise RuntimeError("temporary qdrant error")
+            return original_update_vectors(collection_name=collection_name, points=points)
+
+        qdrant.update_vectors = _flaky_update_vectors
+
+        bge = _StubBGEClient(
+            responses=[
+                RuntimeError("temporary bge timeout"),
+                [[[0.3, 0.4]]],
+            ]
+        )
+        runner = ColbertBackfillRunner(
+            qdrant_client=qdrant,
+            bge_client=bge,
+            collection_name="test_col",
+            checkpoint_path=tmp_path / "checkpoint.json",
+            retry_attempts=3,
+            retry_backoff_seconds=0.0,
+        )
+
+        stats = runner.run(batch_size=1)
+        assert stats.processed == 1
+        assert len(bge.calls) == 2
+        assert qdrant_fail_once["calls"] == 2
+
+    def test_backfill_fails_fast_when_colbert_schema_missing(self, tmp_path: Path):
+        from src.ingestion.unified.colbert_backfill import ColbertBackfillRunner
+
+        qdrant = _StubQdrantClient(pages=[([], None)], has_colbert=False)
+        bge = _StubBGEClient(responses=[])
+        runner = ColbertBackfillRunner(
+            qdrant_client=qdrant,
+            bge_client=bge,
+            collection_name="test_col",
+            checkpoint_path=tmp_path / "checkpoint.json",
+        )
+
+        with pytest.raises(RuntimeError, match="colbert"):
+            runner.run(batch_size=1)
+
+
+class TestColbertCliDispatch:
+    @patch("src.ingestion.unified.cli.cmd_backfill_colbert", return_value=0)
+    @patch("src.ingestion.unified.cli.setup_logging")
+    @patch("src.ingestion.unified.cli.load_dotenv")
+    def test_main_dispatches_backfill_colbert(
+        self, mock_dotenv, mock_logging, mock_cmd, monkeypatch
+    ):
+        monkeypatch.setattr("sys.argv", ["cli", "backfill-colbert", "--dry-run"])
+
+        from src.ingestion.unified.cli import main
+
+        result = main()
+        assert result == 0
+        mock_cmd.assert_called_once()
+        called_args = mock_cmd.call_args.args[0]
+        assert called_args.dry_run is True
+
+    @patch("src.ingestion.unified.cli.cmd_schema_check", new_callable=AsyncMock, return_value=0)
+    @patch("src.ingestion.unified.cli.setup_logging")
+    @patch("src.ingestion.unified.cli.load_dotenv")
+    def test_main_dispatches_schema_check(self, mock_dotenv, mock_logging, mock_cmd, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["cli", "schema-check", "--require-colbert"])
+
+        from src.ingestion.unified.cli import main
+
+        result = main()
+        assert result == 0
+        mock_cmd.assert_awaited_once()
+
+    @patch("src.ingestion.unified.cli.cmd_coverage_check", new_callable=AsyncMock, return_value=0)
+    @patch("src.ingestion.unified.cli.setup_logging")
+    @patch("src.ingestion.unified.cli.load_dotenv")
+    def test_main_dispatches_coverage_check(self, mock_dotenv, mock_logging, mock_cmd, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["cli", "coverage-check"])
+
+        from src.ingestion.unified.cli import main
+
+        result = main()
+        assert result == 0
+        mock_cmd.assert_awaited_once()
+
+    def test_cmd_backfill_colbert_wires_runner(self):
+        from src.ingestion.unified.cli import cmd_backfill_colbert
+
+        args = SimpleNamespace(batch_size=64, limit=100, dry_run=True, resume=True)
+        fake_runner = MagicMock()
+        fake_runner.run.return_value = SimpleNamespace(
+            scanned=100,
+            processed=80,
+            skipped=20,
+            failed=0,
+        )
+
+        with patch("src.ingestion.unified.cli.ColbertBackfillRunner", return_value=fake_runner):
+            result = cmd_backfill_colbert(args)
+
+        assert result == 0
+        fake_runner.run.assert_called_once_with(
+            batch_size=64,
+            limit=100,
+            dry_run=True,
+            resume=True,
+        )

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -573,6 +573,62 @@ class TestQdrantVectorValidation:
             assert result is True
             assert "missing" not in caplog.text.lower()
 
+    async def test_qdrant_warns_when_colbert_coverage_below_threshold(self, caplog):
+        """Low ColBERT point coverage logs warning but does not fail preflight."""
+        import logging
+
+        config = _make_config()
+        mock_qdrant = AsyncMock()
+        mock_collection_info = MagicMock()
+        mock_collection_info.points_count = 200
+        mock_collection_info.config.params.vectors = {
+            "dense": MagicMock(),
+            "colbert": MagicMock(),
+        }
+        mock_collection_info.config.params.sparse_vectors = {"bm42": MagicMock()}
+        mock_qdrant.get_collection = AsyncMock(return_value=mock_collection_info)
+        mock_qdrant.count = AsyncMock(return_value=MagicMock(count=180))
+        mock_qdrant.close = AsyncMock()
+
+        with (
+            patch("telegram_bot.preflight.AsyncQdrantClient", return_value=mock_qdrant),
+            caplog.at_level(logging.WARNING),
+        ):
+            client = AsyncMock()
+            result = await _check_single_dep("qdrant", config, client)
+
+        assert result is True
+        assert "coverage" in caplog.text.lower()
+        assert "90.00%" in caplog.text
+
+    async def test_qdrant_logs_coverage_info_when_threshold_met(self, caplog):
+        """Coverage at/above threshold logs informational line."""
+        import logging
+
+        config = _make_config()
+        mock_qdrant = AsyncMock()
+        mock_collection_info = MagicMock()
+        mock_collection_info.points_count = 100
+        mock_collection_info.config.params.vectors = {
+            "dense": MagicMock(),
+            "colbert": MagicMock(),
+        }
+        mock_collection_info.config.params.sparse_vectors = {"bm42": MagicMock()}
+        mock_qdrant.get_collection = AsyncMock(return_value=mock_collection_info)
+        mock_qdrant.count = AsyncMock(return_value=MagicMock(count=100))
+        mock_qdrant.close = AsyncMock()
+
+        with (
+            patch("telegram_bot.preflight.AsyncQdrantClient", return_value=mock_qdrant),
+            caplog.at_level(logging.INFO),
+        ):
+            client = AsyncMock()
+            result = await _check_single_dep("qdrant", config, client)
+
+        assert result is True
+        assert "coverage" in caplog.text.lower()
+        assert "100.00%" in caplog.text
+
     async def test_qdrant_fails_when_dense_missing(self):
         """Missing dense vector causes check to fail."""
         config = _make_config()


### PR DESCRIPTION
## Summary
Implements full ColBERT backfill workflow for existing Qdrant collections and adds capability/coverage guardrails required by #599.

### What changed
- Added new ingestion backfill runner: `src/ingestion/unified/colbert_backfill.py`
  - batch scroll without loading full collection into memory
  - source text: `payload.page_content` with fallback to `payload.text`
  - idempotent skip for points that already have `colbert`
  - write only named vector `colbert` via `update_vectors` (no payload overwrite)
  - retry/backoff for BGE/Qdrant calls
  - checkpoint/resume support (`.colbert_backfill_checkpoint.json`)
  - observability counters/logs: processed/skipped/failed, qps, error-rate, latency, ETA
- Extended unified ingestion CLI:
  - `backfill-colbert [--batch-size] [--limit] [--dry-run] [--resume]`
  - `schema-check [--require-colbert]`
  - `coverage-check [--min-ratio]`
  - bootstrap fail-fast mode: `bootstrap --require-colbert`
- Extended bot preflight Qdrant check (`telegram_bot/preflight.py`):
  - capability check for `colbert` vector remains
  - new coverage warning when point-level ColBERT coverage is below 99.5%
- Updated docs: `docs/QDRANT_STACK.md`
  - schema-check/coverage-check/backfill commands
  - troubleshooting for low coverage and resume flow

### Tests
- New unit tests: `tests/unit/ingestion/test_colbert_backfill.py`
  - dry-run, resume, retry/backoff, skip-existing, schema fail-fast, CLI dispatch
- New integration test: `tests/integration/test_colbert_backfill.py`
  - partial coverage -> backfill -> server-side ColBERT search returns docs
- Updated preflight tests: `tests/unit/test_preflight.py`
  - coverage warning/info scenarios

### Validation run
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' uv run pytest tests/unit/ingestion/test_colbert_backfill.py tests/integration/test_colbert_backfill.py tests/unit/test_preflight.py::TestQdrantVectorValidation -q`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' uv run pytest tests/unit/ingestion/test_unified_cli.py tests/unit/test_preflight.py -q`

Closes #599
