### PR TITLE
fix: close redis cache coverage gaps in runtime hot paths

### DIFF
--- a/scripts/validate_traces.py
+++ b/scripts/validate_traces.py
@@ -516,7 +516,6 @@ async def _flush_redis_caches(cache: Any) -> str:
     patterns = [
         f"embeddings:{cache_version}:*",
         f"sparse:{cache_version}:*",
-        f"analysis:{cache_version}:*",
         f"search:{cache_version}:*",
         f"rerank:{cache_version}:*",
         "conversation:*",

--- a/telegram_bot/agents/rag_pipeline.py
+++ b/telegram_bot/agents/rag_pipeline.py
@@ -100,22 +100,19 @@ async def _cache_check(
         embedding = await cache.get_embedding(query)
         embeddings_cache_hit = embedding is not None
 
+    _has_hybrid = callable(
+        getattr(embeddings, "aembed_hybrid", None)
+    ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid)
     _has_hybrid_colbert = callable(
         getattr(embeddings, "aembed_hybrid_with_colbert", None)
     ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid_with_colbert)
+    _has_colbert_only = callable(
+        getattr(embeddings, "aembed_colbert_query", None)
+    ) and asyncio.iscoroutinefunction(embeddings.aembed_colbert_query)
 
     if embedding is None:
         try:
-            _has_hybrid = callable(
-                getattr(embeddings, "aembed_hybrid", None)
-            ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid)
-            if _has_hybrid_colbert:
-                embedding, sparse, colbert_query = await embeddings.aembed_hybrid_with_colbert(
-                    query
-                )
-                await cache.store_embedding(query, embedding)
-                await cache.store_sparse_embedding(query, sparse)
-            elif _has_hybrid:
+            if _has_hybrid:
                 embedding, sparse = await embeddings.aembed_hybrid(query)
                 await cache.store_embedding(query, embedding)
                 await cache.store_sparse_embedding(query, sparse)
@@ -149,13 +146,6 @@ async def _cache_check(
                 "latency_stages": {**latency_stages, "cache_check": latency},
             }
 
-    # Compute ColBERT query vectors when embedding was cached but ColBERT not yet computed.
-    if colbert_query is None and _has_hybrid_colbert and embedding is not None:
-        try:
-            _, _, colbert_query = await embeddings.aembed_hybrid_with_colbert(query)
-        except Exception:
-            logger.debug("ColBERT query encode failed (non-critical), skipping")
-
     # Step 2: Check semantic cache (allowlisted types only)
     cached = None
     if query_type in CACHEABLE_QUERY_TYPES:
@@ -187,9 +177,29 @@ async def _cache_check(
             "embeddings_cache_hit": embeddings_cache_hit,
             "embedding_error": False,
             "embedding_error_type": None,
-            "colbert_query": colbert_query,
+            "colbert_query": None,
             "latency_stages": {**latency_stages, "cache_check": latency},
         }
+
+    # ColBERT query vectors are only needed on semantic miss.
+    if colbert_query is None:
+        if pre_computed_colbert is not None:
+            colbert_query = pre_computed_colbert
+        elif _has_colbert_only:
+            try:
+                colbert_query = await embeddings.aembed_colbert_query(query)
+            except Exception:
+                logger.debug("ColBERT query encode failed (non-critical), skipping")
+        elif _has_hybrid_colbert:
+            try:
+                _, sparse_from_hybrid, colbert_query = await embeddings.aembed_hybrid_with_colbert(
+                    query
+                )
+                if sparse is None and sparse_from_hybrid is not None:
+                    sparse = sparse_from_hybrid
+                    await cache.store_sparse_embedding(query, sparse_from_hybrid)
+            except Exception:
+                logger.debug("ColBERT query encode failed (non-critical), skipping")
 
     logger.info("cache_check MISS (%.3fs, type=%s)", latency, query_type)
     lf.update_current_span(
@@ -504,13 +514,14 @@ async def _rerank(
     query: str,
     documents: list[dict[str, Any]],
     *,
+    cache: Any | None = None,
     reranker: Any | None = None,
     top_k: int = _DEFAULT_RERANK_TOP_K,
     latency_stages: dict[str, float],
 ) -> dict[str, Any]:
     """Rerank documents using ColBERT or score-based fallback.
 
-    Returns dict with documents, rerank_applied, and latency.
+    Returns dict with documents, rerank_applied, rerank_cache_hit, and latency.
     """
     t0 = time.perf_counter()
 
@@ -519,11 +530,40 @@ async def _rerank(
         return {
             "documents": [],
             "rerank_applied": False,
+            "rerank_cache_hit": False,
             "latency_stages": {**latency_stages, "rerank": elapsed},
         }
 
     if reranker is not None:
         try:
+            _has_get_rerank = (
+                cache is not None
+                and callable(getattr(cache, "get_rerank_results", None))
+                and asyncio.iscoroutinefunction(cache.get_rerank_results)
+            )
+            _has_store_rerank = (
+                cache is not None
+                and callable(getattr(cache, "store_rerank_results", None))
+                and asyncio.iscoroutinefunction(cache.store_rerank_results)
+            )
+
+            if _has_get_rerank:
+                cached_reranked = await cache.get_rerank_results(query, documents, top_k)
+                if cached_reranked is not None:
+                    elapsed = time.perf_counter() - t0
+                    logger.info(
+                        "rerank: HIT rerank cache %d → %d docs (%.3fs)",
+                        len(documents),
+                        len(cached_reranked),
+                        elapsed,
+                    )
+                    return {
+                        "documents": cached_reranked,
+                        "rerank_applied": True,
+                        "rerank_cache_hit": True,
+                        "latency_stages": {**latency_stages, "rerank": elapsed},
+                    }
+
             doc_texts = [doc.get("text", "") for doc in documents]
             rerank_results = await reranker.rerank(query=query, documents=doc_texts, top_k=top_k)
 
@@ -533,6 +573,9 @@ async def _rerank(
                 if idx < len(documents):
                     doc = {**documents[idx], "score": rr["score"]}
                     reranked.append(doc)
+
+            if _has_store_rerank:
+                await cache.store_rerank_results(query, documents, top_k, reranked)
 
             elapsed = time.perf_counter() - t0
             logger.info(
@@ -544,6 +587,7 @@ async def _rerank(
             return {
                 "documents": reranked,
                 "rerank_applied": True,
+                "rerank_cache_hit": False,
                 "latency_stages": {**latency_stages, "rerank": elapsed},
             }
         except Exception as e:
@@ -566,6 +610,7 @@ async def _rerank(
     return {
         "documents": sorted_docs,
         "rerank_applied": False,
+        "rerank_cache_hit": False,
         "latency_stages": {**latency_stages, "rerank": elapsed},
     }
 
@@ -797,6 +842,7 @@ async def rag_pipeline(
             "documents": [],
             "search_results_count": 0,
             "rerank_applied": False,
+            "rerank_cache_hit": False,
             "grade_confidence": 0.0,
             "embeddings_cache_hit": False,
             "embedding_error": True,
@@ -814,6 +860,7 @@ async def rag_pipeline(
             "documents": [],
             "search_results_count": 0,
             "rerank_applied": False,
+            "rerank_cache_hit": False,
             "grade_confidence": 0.0,
             "embeddings_cache_hit": cache_result["embeddings_cache_hit"],
             "embedding_error": False,
@@ -838,11 +885,11 @@ async def rag_pipeline(
         query_sparse: Any = None  # pre-computed sparse is for cache_key, not reformulated query
         if (
             query_embedding is not None
-            and callable(getattr(embeddings, "aembed_hybrid_with_colbert", None))
-            and asyncio.iscoroutinefunction(embeddings.aembed_hybrid_with_colbert)
+            and callable(getattr(embeddings, "aembed_colbert_query", None))
+            and asyncio.iscoroutinefunction(embeddings.aembed_colbert_query)
         ):
             try:
-                _, _, colbert_query = await embeddings.aembed_hybrid_with_colbert(query)
+                colbert_query = await embeddings.aembed_colbert_query(query)
             except Exception:
                 logger.debug(
                     "ColBERT query encode failed for reformulated query, using RRF fallback"
@@ -888,16 +935,19 @@ async def rag_pipeline(
                     :_DEFAULT_RERANK_TOP_K
                 ]
                 rerank_applied = rerank_from_retrieve  # preserve True from ColBERT path
+                rerank_cache_hit = False
             else:
                 rerank_result = await _rerank(
                     current_query,
                     documents,
+                    cache=cache,
                     reranker=reranker,
                     latency_stages=latency_stages,
                 )
                 latency_stages = rerank_result["latency_stages"]
                 final_docs = rerank_result["documents"]
                 rerank_applied = rerank_result["rerank_applied"]
+                rerank_cache_hit = rerank_result["rerank_cache_hit"]
 
             result = _assemble_context(
                 query=current_query,
@@ -909,6 +959,7 @@ async def rag_pipeline(
                 search_cache_hit=retrieve_result.get("search_cache_hit", False),
                 search_results_count=retrieve_result["search_results_count"],
                 rerank_applied=rerank_applied,
+                rerank_cache_hit=rerank_cache_hit,
                 grade_confidence=grade_confidence,
                 rewrite_count=rewrite_count,
                 query_type=query_type,
@@ -962,16 +1013,19 @@ async def rag_pipeline(
             :_DEFAULT_RERANK_TOP_K
         ]
         rerank_applied = True
+        rerank_cache_hit = False
     else:
         rerank_result = await _rerank(
             current_query,
             documents,
+            cache=cache,
             reranker=reranker,
             latency_stages=latency_stages,
         )
         latency_stages = rerank_result["latency_stages"]
         final_docs = rerank_result["documents"]
         rerank_applied = rerank_result["rerank_applied"]
+        rerank_cache_hit = rerank_result["rerank_cache_hit"]
 
     result = _assemble_context(
         query=current_query,
@@ -983,6 +1037,7 @@ async def rag_pipeline(
         search_cache_hit=retrieve_result.get("search_cache_hit", False),
         search_results_count=retrieve_result["search_results_count"],
         rerank_applied=rerank_applied,
+        rerank_cache_hit=rerank_cache_hit,
         grade_confidence=grade_confidence,
         rewrite_count=rewrite_count,
         query_type=query_type,
@@ -1016,6 +1071,7 @@ def _assemble_context(
     search_cache_hit: bool,
     search_results_count: int,
     rerank_applied: bool,
+    rerank_cache_hit: bool,
     grade_confidence: float,
     rewrite_count: int,
     query_type: str,
@@ -1035,6 +1091,7 @@ def _assemble_context(
         "search_cache_hit": search_cache_hit,
         "search_results_count": search_results_count,
         "rerank_applied": rerank_applied,
+        "rerank_cache_hit": rerank_cache_hit,
         "grade_confidence": grade_confidence,
         "rewrite_count": rewrite_count,
         "query_type": query_type,

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -700,12 +700,9 @@ class PropertyBot:
                 ],
                 [
                     InlineKeyboardButton(text="Sparse", callback_data="cc:sparse"),
-                    InlineKeyboardButton(text="Analysis", callback_data="cc:analysis"),
-                ],
-                [
                     InlineKeyboardButton(text="Search+Rerank", callback_data="cc:search"),
-                    InlineKeyboardButton(text="Все", callback_data="cc:all"),
                 ],
+                [InlineKeyboardButton(text="Все", callback_data="cc:all")],
             ]
         )
         await message.answer("Выберите тип кеша для очистки:", reply_markup=keyboard)
@@ -1075,22 +1072,19 @@ class PropertyBot:
             query_type = classify_query(user_text)
             if query_type in CACHEABLE_QUERY_TYPES:
                 try:
-                    _has_hybrid_colbert = callable(
-                        getattr(self._embeddings, "aembed_hybrid_with_colbert", None)
-                    ) and asyncio.iscoroutinefunction(self._embeddings.aembed_hybrid_with_colbert)
-                    if _has_hybrid_colbert:
-                        # Single call yields dense + sparse + colbert — stash all three (#571)
-                        dense, sparse, colbert = await self._embeddings.aembed_hybrid_with_colbert(
-                            user_text
-                        )
-                        embedding = dense
-                    else:
-                        embedding = await self._embeddings.aembed_query(user_text)
-                        sparse = None
-                        colbert = None
-                    await self._cache.store_embedding(user_text, embedding)
-                    if sparse is not None:
-                        await self._cache.store_sparse_embedding(user_text, sparse)
+                    embedding = await self._cache.get_embedding(user_text)
+                    sparse = await self._cache.get_sparse_embedding(user_text)
+                    if embedding is None:
+                        _has_hybrid = callable(
+                            getattr(self._embeddings, "aembed_hybrid", None)
+                        ) and asyncio.iscoroutinefunction(self._embeddings.aembed_hybrid)
+                        if _has_hybrid:
+                            embedding, sparse = await self._embeddings.aembed_hybrid(user_text)
+                            await self._cache.store_embedding(user_text, embedding)
+                            await self._cache.store_sparse_embedding(user_text, sparse)
+                        else:
+                            embedding = await self._embeddings.aembed_query(user_text)
+                            await self._cache.store_embedding(user_text, embedding)
                     cached = await self._cache.check_semantic(
                         query=user_text,
                         vector=embedding,
@@ -1104,7 +1098,6 @@ class PropertyBot:
                         rag_result_store["query_type"] = query_type
                         rag_result_store["cache_key_embedding"] = embedding
                         rag_result_store["cache_key_sparse"] = sparse
-                        rag_result_store["cache_key_colbert"] = colbert
                         # Write Langfuse scores and trace metadata
                         lf = get_client()
                         lf.update_current_trace(
@@ -1141,7 +1134,6 @@ class PropertyBot:
                     logger.debug("Pre-agent cache MISS (type=%s): %.60s", query_type, user_text)
                     rag_result_store["cache_key_embedding"] = embedding
                     rag_result_store["cache_key_sparse"] = sparse
-                    rag_result_store["cache_key_colbert"] = colbert
                     rag_result_store["query_type"] = query_type
                 except Exception:
                     logger.warning(
@@ -1965,8 +1957,8 @@ class PropertyBot:
             "semantic": "Semantic cache",
             "embeddings": "Embeddings cache",
             "sparse": "Sparse embeddings cache",
-            "analysis": "Analysis cache",
             "search": "Search + Rerank cache",
+            "rerank": "Rerank cache",
             "all": "Все кеши",
         }
         data = (callback_query.data or "").removeprefix("cc:")

--- a/telegram_bot/graph/graph.py
+++ b/telegram_bot/graph/graph.py
@@ -124,7 +124,7 @@ def build_graph(
 
     workflow.add_node(
         "rerank",
-        functools.partial(rerank_node, reranker=reranker),
+        functools.partial(rerank_node, cache=cache, reranker=reranker),
     )
 
     workflow.add_node(

--- a/telegram_bot/graph/nodes/cache.py
+++ b/telegram_bot/graph/nodes/cache.py
@@ -68,24 +68,19 @@ async def cache_check_node(
     embedding_error_type: str | None = None
     colbert_query: list[list[float]] | None = None
 
+    _has_hybrid = callable(
+        getattr(embeddings, "aembed_hybrid", None)
+    ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid)
     _has_hybrid_colbert = callable(
         getattr(embeddings, "aembed_hybrid_with_colbert", None)
     ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid_with_colbert)
+    _has_colbert_only = callable(
+        getattr(embeddings, "aembed_colbert_query", None)
+    ) and asyncio.iscoroutinefunction(embeddings.aembed_colbert_query)
 
     if embedding is None:
         try:
-            _has_hybrid = callable(
-                getattr(embeddings, "aembed_hybrid", None)
-            ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid)
-
-            if _has_hybrid_colbert:
-                # 3-way hybrid: dense + sparse + colbert in one call
-                embedding, sparse, colbert_query = await embeddings.aembed_hybrid_with_colbert(
-                    query
-                )
-                await cache.store_embedding(query, embedding)
-                await cache.store_sparse_embedding(query, sparse)
-            elif _has_hybrid:
+            if _has_hybrid:
                 # Hybrid: get both dense + sparse in one call, cache both
                 embedding, sparse = await embeddings.aembed_hybrid(query)
                 await cache.store_embedding(query, embedding)
@@ -121,14 +116,6 @@ async def cache_check_node(
                 },
             }
 
-    # Compute ColBERT query vectors when embedding was cached but ColBERT not yet computed.
-    # ColBERT vectors are per-query token-level and not cached in Redis.
-    if colbert_query is None and _has_hybrid_colbert and embedding is not None:
-        try:
-            _, _, colbert_query = await embeddings.aembed_hybrid_with_colbert(query)
-        except Exception:
-            logger.debug("ColBERT query encode failed (non-critical), skipping")
-
     # Step 2: Check semantic cache with query-type threshold (allowlisted types only).
     # Voice path has no user role — agent_role is intentionally omitted so that
     # voice responses are shared across roles within the same cache_scope="rag" bucket.
@@ -162,9 +149,23 @@ async def cache_check_node(
             "embeddings_cache_hit": embeddings_cache_hit,
             "embedding_error": False,
             "embedding_error_type": None,
-            "colbert_query": colbert_query,
+            "colbert_query": None,
             "latency_stages": {**state.get("latency_stages", {}), "cache_check": latency},
         }
+
+    # ColBERT vectors are only needed after semantic miss.
+    if colbert_query is None:
+        if _has_colbert_only:
+            try:
+                colbert_query = await embeddings.aembed_colbert_query(query)
+            except Exception:
+                logger.debug("ColBERT query encode failed (non-critical), skipping")
+        elif _has_hybrid_colbert:
+            try:
+                _, sparse, colbert_query = await embeddings.aembed_hybrid_with_colbert(query)
+                await cache.store_sparse_embedding(query, sparse)
+            except Exception:
+                logger.debug("ColBERT query encode failed (non-critical), skipping")
 
     PipelineMetrics.get().inc("cache_miss")
     logger.info("cache_check MISS (%.3fs, type=%s)", latency, query_type)

--- a/telegram_bot/graph/nodes/rerank.py
+++ b/telegram_bot/graph/nodes/rerank.py
@@ -6,6 +6,7 @@ Otherwise, falls back to score-based sort with top-5 selection.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from typing import Any
@@ -23,6 +24,7 @@ _DEFAULT_TOP_K = 5
 async def rerank_node(
     state: dict[str, Any],
     *,
+    cache: Any | None = None,
     reranker: Any | None = None,
     top_k: int = _DEFAULT_TOP_K,
 ) -> dict[str, Any]:
@@ -30,11 +32,12 @@ async def rerank_node(
 
     Args:
         state: RAGState dict (needs documents, messages)
+        cache: Optional CacheLayerManager instance
         reranker: Optional ColbertRerankerService instance
         top_k: Number of top results to keep
 
     Returns:
-        State update with reranked documents, rerank_applied flag, latency.
+        State update with reranked documents, rerank_applied, rerank_cache_hit, latency.
     """
     t0 = time.perf_counter()
 
@@ -47,6 +50,7 @@ async def rerank_node(
         return {
             "documents": [],
             "rerank_applied": False,
+            "rerank_cache_hit": False,
             "llm_call_count": llm_call_count,
             "latency_stages": {**state.get("latency_stages", {}), "rerank": elapsed},
         }
@@ -59,6 +63,32 @@ async def rerank_node(
 
     if reranker is not None:
         try:
+            get_rerank = getattr(cache, "get_rerank_results", None) if cache is not None else None
+            store_rerank = (
+                getattr(cache, "store_rerank_results", None) if cache is not None else None
+            )
+            _has_get_rerank = callable(get_rerank) and asyncio.iscoroutinefunction(get_rerank)
+            _has_store_rerank = callable(store_rerank) and asyncio.iscoroutinefunction(store_rerank)
+
+            if _has_get_rerank and get_rerank is not None:
+                cached_reranked = await get_rerank(query, documents, top_k)
+                if cached_reranked is not None:
+                    elapsed = time.perf_counter() - t0
+                    PipelineMetrics.get().record("rerank", elapsed * 1000)
+                    logger.info(
+                        "rerank: HIT rerank cache %d → %d docs (%.3fs)",
+                        len(documents),
+                        len(cached_reranked),
+                        elapsed,
+                    )
+                    return {
+                        "documents": cached_reranked,
+                        "rerank_applied": True,
+                        "rerank_cache_hit": True,
+                        "llm_call_count": llm_call_count,
+                        "latency_stages": {**state.get("latency_stages", {}), "rerank": elapsed},
+                    }
+
             doc_texts = [doc.get("text", "") for doc in documents]
             rerank_results = await reranker.rerank(query=query, documents=doc_texts, top_k=top_k)
 
@@ -68,6 +98,9 @@ async def rerank_node(
                 if idx < len(documents):
                     doc = {**documents[idx], "score": rr["score"]}
                     reranked.append(doc)
+
+            if _has_store_rerank and store_rerank is not None:
+                await store_rerank(query, documents, top_k, reranked)
 
             elapsed = time.perf_counter() - t0
             PipelineMetrics.get().record("rerank", elapsed * 1000)
@@ -80,6 +113,7 @@ async def rerank_node(
             return {
                 "documents": reranked,
                 "rerank_applied": True,
+                "rerank_cache_hit": False,
                 "llm_call_count": llm_call_count,
                 "latency_stages": {**state.get("latency_stages", {}), "rerank": elapsed},
             }
@@ -104,6 +138,7 @@ async def rerank_node(
     return {
         "documents": sorted_docs,
         "rerank_applied": False,
+        "rerank_cache_hit": False,
         "llm_call_count": llm_call_count,
         "latency_stages": {**state.get("latency_stages", {}), "rerank": elapsed},
     }

--- a/telegram_bot/graph/state.py
+++ b/telegram_bot/graph/state.py
@@ -31,6 +31,7 @@ class RAGState(TypedDict):
     latency_stages: dict[str, float]
     search_results_count: int
     rerank_applied: bool
+    rerank_cache_hit: bool
     grade_confidence: float
     skip_rerank: bool
     response_sent: bool
@@ -110,6 +111,7 @@ def make_initial_state(user_id: int, session_id: str, query: str) -> dict[str, A
         "latency_stages": {},
         "search_results_count": 0,
         "rerank_applied": False,
+        "rerank_cache_hit": False,
         "grade_confidence": 0.0,
         "skip_rerank": False,
         "response_sent": False,

--- a/telegram_bot/integrations/cache.py
+++ b/telegram_bot/integrations/cache.py
@@ -1,4 +1,4 @@
-"""CacheLayerManager — 6-tier Redis cache for RAG pipeline.
+"""CacheLayerManager — 5-tier Redis cache for RAG pipeline.
 
 Replaces CacheService (1000+ LOC) with a focused ~300 LOC implementation.
 
@@ -6,9 +6,8 @@ Tiers:
   1. Semantic cache (RedisVL SemanticCache, threshold per query_type)
   2. Embeddings cache (Redis exact, 7d TTL)
   3. Sparse embeddings cache (Redis exact, 7d TTL)
-  4. Analysis cache (Redis exact, 24h TTL)
-  5. Search results cache (Redis exact, 2h TTL)
-  6. Rerank results cache (Redis exact, 2h TTL)
+  4. Search results cache (Redis exact, 2h TTL)
+  5. Rerank results cache (Redis exact, 2h TTL)
   + Conversation history (Redis LIST, 20 msgs, 2h TTL)
 
 NOTE: redisvl imports are lazy-loaded in initialize() to avoid ~7.5s import
@@ -44,12 +43,11 @@ CACHE_VERSION = "v5"
 DEFAULT_TTLS: dict[str, int] = {
     "embeddings": 7 * 86400,  # 7 days
     "sparse": 7 * 86400,  # 7 days
-    "analysis": 86400,  # 24 hours
     "search": 7200,  # 2 hours
     "rerank": 7200,  # 2 hours
 }
 
-_METRIC_TIERS = ("semantic", "embeddings", "sparse", "analysis", "search", "rerank")
+_METRIC_TIERS = ("semantic", "embeddings", "sparse", "search", "rerank")
 
 
 def _hash(data: str) -> str:
@@ -99,7 +97,7 @@ def _create_semantic_cache(
 
 
 class CacheLayerManager:
-    """6-tier Redis cache manager for RAG pipeline."""
+    """5-tier Redis cache manager for RAG pipeline."""
 
     def __init__(
         self,
@@ -328,7 +326,7 @@ class CacheLayerManager:
         """Get value from exact cache tier.
 
         Args:
-            tier: Cache tier name (embeddings, sparse, analysis, search, rerank)
+            tier: Cache tier name (embeddings, sparse, search, rerank)
             key: Cache key (pre-hashed or raw)
 
         Returns:
@@ -341,13 +339,16 @@ class CacheLayerManager:
         try:
             cached = await self.redis.get(redis_key)
             if cached:
-                self._metrics[tier]["hits"] += 1
+                if tier in self._metrics:
+                    self._metrics[tier]["hits"] += 1
                 return json.loads(cached)
-            self._metrics[tier]["misses"] += 1
+            if tier in self._metrics:
+                self._metrics[tier]["misses"] += 1
             return None
         except Exception as e:
             logger.error("Cache get error (%s): %s: %s", tier, type(e).__name__, e)
-            self._metrics[tier]["misses"] += 1
+            if tier in self._metrics:
+                self._metrics[tier]["misses"] += 1
             return None
 
     @observe(name="cache-exact-store")
@@ -423,6 +424,41 @@ class CacheLayerManager:
         key = _hash(str(embedding_prefix[:10]) + json.dumps(filters, sort_keys=True, default=str))
         await self.store_exact("search", key, results)
 
+    # ========== Convenience: Rerank Results ==========
+
+    def _build_rerank_key(self, query: str, documents: list[dict[str, Any]], top_k: int) -> str:
+        doc_fingerprints = [
+            {
+                "text_hash": _hash(str(doc.get("text", ""))),
+                "score": round(float(doc.get("score", 0.0)), 6),
+            }
+            for doc in documents[:50]
+        ]
+        payload = {
+            "query": _normalize_query_for_cache(query),
+            "top_k": top_k,
+            "docs": doc_fingerprints,
+        }
+        return _hash(json.dumps(payload, sort_keys=True, ensure_ascii=False))
+
+    async def get_rerank_results(
+        self, query: str, documents: list[dict[str, Any]], top_k: int
+    ) -> list[dict[str, Any]] | None:
+        """Get cached rerank results for a query+document set."""
+        key = self._build_rerank_key(query, documents, top_k)
+        return await self.get_exact("rerank", key)
+
+    async def store_rerank_results(
+        self,
+        query: str,
+        documents: list[dict[str, Any]],
+        top_k: int,
+        results: list[dict[str, Any]],
+    ) -> None:
+        """Store rerank results for a query+document set."""
+        key = self._build_rerank_key(query, documents, top_k)
+        await self.store_exact("rerank", key, results)
+
     # ========== Conversation History ==========
     # Legacy store/get methods removed in #157: memory owned by LangGraph checkpointer.
 
@@ -442,7 +478,7 @@ class CacheLayerManager:
         """Clear all Redis keys for the given exact cache tier via SCAN + DELETE.
 
         Args:
-            tier: Cache tier name (embeddings, sparse, analysis, search, rerank).
+            tier: Cache tier name (embeddings, sparse, search, rerank).
                 Passing "search" also clears the "rerank" tier (logically linked).
 
         Returns:
@@ -509,7 +545,7 @@ class CacheLayerManager:
         """
         results: dict[str, int] = {}
         results["semantic"] = await self.clear_semantic_cache()
-        for tier in ("embeddings", "sparse", "analysis", "search", "rerank"):
+        for tier in ("embeddings", "sparse", "search", "rerank"):
             results[tier] = await self.clear_by_tier(tier)
         return results
 

--- a/telegram_bot/integrations/embeddings.py
+++ b/telegram_bot/integrations/embeddings.py
@@ -141,6 +141,12 @@ class BGEM3HybridEmbeddings(Embeddings):
 
         return dense, sparse, colbert
 
+    @observe(name="bge-m3-colbert-query-embed")
+    async def aembed_colbert_query(self, text: str) -> list[list[float]]:
+        """Embed text via /encode/colbert, returning query token vectors only."""
+        result = await self._client.encode_colbert([text])
+        return result.colbert_vecs[0]
+
     @observe(name="bge-m3-hybrid-embed-batch")
     async def aembed_hybrid_batch(
         self, texts: list[str]

--- a/telegram_bot/pipelines/client.py
+++ b/telegram_bot/pipelines/client.py
@@ -25,8 +25,8 @@ logger = logging.getLogger(__name__)
 # Query types that bypass RAG — return canned response immediately.
 _NO_RAG_QUERY_TYPES: frozenset[str] = frozenset({"CHITCHAT", "OFF_TOPIC"})
 
-# Cache store is limited to these types; STRUCTURED excluded (MVP: stale/over-specific risk).
-_PIPELINE_STORE_TYPES: frozenset[str] = frozenset({"FAQ", "GENERAL", "ENTITY"})
+# Cache store allowlist mirrors graph semantic cache policy.
+_PIPELINE_STORE_TYPES: frozenset[str] = frozenset({"FAQ", "GENERAL", "ENTITY", "STRUCTURED"})
 
 _TELEGRAM_MESSAGE_LIMIT = 4096
 

--- a/telegram_bot/preflight.py
+++ b/telegram_bot/preflight.py
@@ -25,7 +25,6 @@ COLBERT_COVERAGE_WARN_THRESHOLD = 0.995
 # Used for synthetic write/read/ttl/delete verification at startup.
 CACHE_KEY_PREFIXES = [
     "sparse:",
-    "analysis:",
     "search:",
     "rerank:",
     "conversation:",

--- a/telegram_bot/scoring.py
+++ b/telegram_bot/scoring.py
@@ -69,7 +69,7 @@ def write_langfuse_scores(lf: Any, result: dict, *, trace_id: str = "") -> None:
         "embeddings_cache_hit": 1.0 if result.get("embeddings_cache_hit") else 0.0,
         "search_cache_hit": 1.0 if result.get("search_cache_hit") else 0.0,
         "rerank_applied": 1.0 if result.get("rerank_applied") else 0.0,
-        "rerank_cache_hit": 0.0,  # Tracked when rerank cache implemented
+        "rerank_cache_hit": 1.0 if result.get("rerank_cache_hit") else 0.0,
         "results_count": float(result.get("search_results_count", 0)),
         "no_results": 1.0 if result.get("search_results_count", 0) == 0 else 0.0,
         "llm_used": 1.0 if "generate" in latency_stages else 0.0,

--- a/tests/smoke/test_zoo_smoke.py
+++ b/tests/smoke/test_zoo_smoke.py
@@ -223,27 +223,27 @@ class TestZooEndToEnd:
         import time
 
         baseline = cache_service.get_metrics()
-        base_hits = baseline["analysis"]["hits"]
-        base_misses = baseline["analysis"]["misses"]
+        base_hits = baseline["search"]["hits"]
+        base_misses = baseline["search"]["misses"]
 
         query = f"zoo_e2e_test_{int(time.time())}"
-        analysis = {"filters": {"test": True}, "semantic_query": query}
+        payload = {"filters": {"test": True}, "semantic_query": query}
 
         # First request - should be MISS
         key = cache_service.make_hash(query)
-        await cache_service.get_exact("analysis", key)
+        await cache_service.get_exact("search", key)
         after_first = cache_service.get_metrics()
-        first_misses = after_first["analysis"]["misses"] - base_misses
-        assert first_misses >= 1, "First request should miss in analysis tier"
+        first_misses = after_first["search"]["misses"] - base_misses
+        assert first_misses >= 1, "First request should miss in search tier"
 
         # Store result
-        await cache_service.store_exact("analysis", key, analysis)
+        await cache_service.store_exact("search", key, payload)
 
         # Second request - should be HIT
-        cached = await cache_service.get_exact("analysis", key)
+        cached = await cache_service.get_exact("search", key)
         after_second = cache_service.get_metrics()
-        second_hits = after_second["analysis"]["hits"] - base_hits
+        second_hits = after_second["search"]["hits"] - base_hits
 
         assert cached is not None, "Second request should return cached result"
-        assert second_hits >= 1, "Second request should be a cache hit in analysis tier"
+        assert second_hits >= 1, "Second request should be a cache hit in search tier"
         assert cached["semantic_query"] == query

--- a/tests/unit/agents/test_rag_pipeline.py
+++ b/tests/unit/agents/test_rag_pipeline.py
@@ -17,6 +17,8 @@ def mock_cache():
     cache.check_semantic = AsyncMock(return_value=None)
     cache.get_search_results = AsyncMock(return_value=None)
     cache.store_search_results = AsyncMock()
+    cache.get_rerank_results = AsyncMock(return_value=None)
+    cache.store_rerank_results = AsyncMock()
     cache.store_semantic = AsyncMock()
     return cache
 
@@ -27,6 +29,7 @@ def mock_embeddings():
     emb.aembed_query = AsyncMock(return_value=[0.1] * 1024)
     emb.aembed_hybrid = AsyncMock(return_value=([0.1] * 1024, {"indices": [1], "values": [0.5]}))
     emb.aembed_hybrid_with_colbert = None  # not available; prevents auto-AsyncMock child
+    emb.aembed_colbert_query = None
     return emb
 
 
@@ -93,6 +96,7 @@ async def test_cache_check_hit(mock_cache, mock_embeddings):
 
     mock_cache.get_embedding = AsyncMock(return_value=[0.1] * 1024)
     mock_cache.check_semantic = AsyncMock(return_value="Cached answer about apartments")
+    mock_embeddings.aembed_colbert_query = AsyncMock(return_value=[[0.2] * 1024])
 
     result = await _cache_check(
         "квартиры",
@@ -105,6 +109,7 @@ async def test_cache_check_hit(mock_cache, mock_embeddings):
 
     assert result["cache_hit"] is True
     assert result["cached_response"] == "Cached answer about apartments"
+    mock_embeddings.aembed_colbert_query.assert_not_awaited()
 
 
 async def test_cache_check_embedding_error(mock_cache, mock_embeddings):
@@ -261,11 +266,13 @@ async def test_rerank_with_colbert(mock_reranker):
     result = await _rerank(
         "query",
         docs,
+        cache=AsyncMock(get_rerank_results=AsyncMock(return_value=None)),
         reranker=mock_reranker,
         latency_stages={},
     )
 
     assert result["rerank_applied"] is True
+    assert result["rerank_cache_hit"] is False
     assert len(result["documents"]) == 2
     assert result["documents"][0]["score"] == 0.95
 
@@ -278,6 +285,7 @@ async def test_rerank_fallback_no_reranker():
     result = await _rerank("query", docs, reranker=None, latency_stages={})
 
     assert result["rerank_applied"] is False
+    assert result["rerank_cache_hit"] is False
     assert result["documents"][0]["score"] == 0.8  # sorted desc
 
 
@@ -288,6 +296,24 @@ async def test_rerank_empty_docs():
 
     assert result["documents"] == []
     assert result["rerank_applied"] is False
+    assert result["rerank_cache_hit"] is False
+
+
+async def test_rerank_uses_cache_hit(mock_reranker):
+    from telegram_bot.agents.rag_pipeline import _rerank
+
+    docs = [{"text": "A", "score": 0.1}, {"text": "B", "score": 0.2}]
+    cached = [{"text": "B", "score": 0.9}]
+    cache = AsyncMock()
+    cache.get_rerank_results = AsyncMock(return_value=cached)
+    cache.store_rerank_results = AsyncMock()
+
+    result = await _rerank("query", docs, cache=cache, reranker=mock_reranker, latency_stages={})
+
+    assert result["rerank_applied"] is True
+    assert result["rerank_cache_hit"] is True
+    assert result["documents"] == cached
+    mock_reranker.rerank.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -812,6 +838,7 @@ async def test_cache_check_returns_colbert_query(mock_cache):
     from telegram_bot.agents.rag_pipeline import _cache_check
 
     mock_embeddings = AsyncMock()
+    mock_embeddings.aembed_hybrid = None
     mock_embeddings.aembed_hybrid_with_colbert = AsyncMock(
         return_value=(
             [0.1] * 1024,
@@ -819,6 +846,7 @@ async def test_cache_check_returns_colbert_query(mock_cache):
             [[0.2] * 1024] * 4,
         )
     )
+    mock_embeddings.aembed_colbert_query = None
 
     result = await _cache_check(
         "test query",
@@ -861,6 +889,7 @@ async def test_cache_check_computes_colbert_when_embedding_cached(mock_cache):
     mock_cache.get_embedding = AsyncMock(return_value=[0.1] * 1024)  # cached!
 
     mock_embeddings = AsyncMock()
+    mock_embeddings.aembed_hybrid = None
     mock_embeddings.aembed_hybrid_with_colbert = AsyncMock(
         return_value=(
             [0.1] * 1024,
@@ -868,6 +897,7 @@ async def test_cache_check_computes_colbert_when_embedding_cached(mock_cache):
             [[0.2] * 1024] * 4,
         )
     )
+    mock_embeddings.aembed_colbert_query = None
 
     result = await _cache_check(
         "test query",
@@ -991,7 +1021,10 @@ async def test_rag_pipeline_uses_colbert_search(mock_cache, mock_sparse):
             [[0.2] * 1024] * 4,
         )
     )
-    mock_embeddings.aembed_hybrid = AsyncMock()
+    mock_embeddings.aembed_hybrid = AsyncMock(
+        return_value=([0.1] * 1024, {"indices": [1], "values": [0.5]})
+    )
+    mock_embeddings.aembed_colbert_query = AsyncMock(return_value=[[0.2] * 1024] * 4)
 
     mock_qdrant = AsyncMock()
     mock_qdrant.hybrid_search_rrf_colbert = AsyncMock(
@@ -1030,6 +1063,10 @@ async def test_rag_pipeline_skips_rerank_when_colbert_used(mock_cache, mock_spar
             [[0.2] * 1024] * 4,
         )
     )
+    mock_embeddings.aembed_hybrid = AsyncMock(
+        return_value=([0.1] * 1024, {"indices": [1], "values": [0.5]})
+    )
+    mock_embeddings.aembed_colbert_query = AsyncMock(return_value=[[0.2] * 1024] * 4)
 
     mock_qdrant = AsyncMock()
     # Score between relevance_threshold (0.005) and skip_rerank_threshold (0.018)
@@ -1073,13 +1110,13 @@ async def test_rag_pipeline_recomputes_colbert_for_reformulated_query(mock_cache
     reformulated_colbert = [[0.7] * 1024] * 3
 
     mock_embeddings = AsyncMock()
-    mock_embeddings.aembed_hybrid_with_colbert = AsyncMock(
-        side_effect=[
-            ([0.1] * 1024, {"indices": [1], "values": [0.5]}, original_colbert),
-            ([0.9] * 1024, {"indices": [2], "values": [0.4]}, reformulated_colbert),
-        ]
+    mock_embeddings.aembed_hybrid = AsyncMock(
+        return_value=([0.1] * 1024, {"indices": [1], "values": [0.5]})
     )
-    mock_embeddings.aembed_hybrid = AsyncMock()
+    mock_embeddings.aembed_hybrid_with_colbert = None
+    mock_embeddings.aembed_colbert_query = AsyncMock(
+        side_effect=[original_colbert, reformulated_colbert]
+    )
 
     # First call is cache_key embedding (miss), second is reformulated query warm embedding (hit).
     mock_cache.get_embedding = AsyncMock(side_effect=[None, [0.9] * 1024])
@@ -1127,6 +1164,7 @@ async def test_cache_check_uses_pre_computed_sparse(mock_cache):
 
     mock_embeddings = AsyncMock()
     mock_embeddings.aembed_hybrid_with_colbert = None  # not available
+    mock_embeddings.aembed_colbert_query = None
 
     result = await _cache_check(
         "test query",
@@ -1155,9 +1193,11 @@ async def test_cache_check_uses_pre_computed_colbert_skips_reencode(mock_cache):
     colbert = [[0.2] * 1024] * 3
 
     mock_embeddings = AsyncMock()
+    mock_embeddings.aembed_hybrid = None
     mock_embeddings.aembed_hybrid_with_colbert = AsyncMock(
         return_value=(dense, {"indices": [1], "values": [0.5]}, colbert)
     )
+    mock_embeddings.aembed_colbert_query = None
 
     result = await _cache_check(
         "test query",
@@ -1186,6 +1226,7 @@ async def test_cache_check_returns_sparse_embedding_in_all_paths(mock_cache):
 
     mock_embeddings = AsyncMock()
     mock_embeddings.aembed_hybrid_with_colbert = None
+    mock_embeddings.aembed_colbert_query = None
 
     # MISS path
     result_miss = await _cache_check(
@@ -1251,6 +1292,7 @@ async def test_rag_pipeline_passes_pre_computed_sparse_to_retrieve(mock_cache, m
     mock_embeddings = AsyncMock()
     mock_embeddings.aembed_hybrid_with_colbert = None  # disable colbert
     mock_embeddings.aembed_hybrid = None  # disable hybrid
+    mock_embeddings.aembed_colbert_query = None
 
     mock_qdrant = AsyncMock()
     mock_qdrant.hybrid_search_rrf_colbert = None  # ensure plain RRF path

--- a/tests/unit/graph/test_agentic_nodes.py
+++ b/tests/unit/graph/test_agentic_nodes.py
@@ -180,6 +180,29 @@ class TestRerankNode:
         assert result["rerank_applied"] is False
         assert result["documents"][0]["text"] == "B"
 
+    async def test_rerank_uses_cache_hit(self):
+        """When rerank cache has a hit, ColBERT service call is skipped."""
+        from telegram_bot.graph.nodes.rerank import rerank_node
+
+        state = make_initial_state(user_id=1, session_id="s", query="test query")
+        state["documents"] = [
+            {"text": "doc A", "score": 0.3},
+            {"text": "doc B", "score": 0.5},
+        ]
+
+        mock_cache = AsyncMock()
+        mock_cache.get_rerank_results = AsyncMock(return_value=[{"text": "doc B", "score": 0.9}])
+        mock_cache.store_rerank_results = AsyncMock()
+
+        mock_reranker = AsyncMock()
+        mock_reranker.rerank = AsyncMock()
+
+        result = await rerank_node(state, cache=mock_cache, reranker=mock_reranker, top_k=1)
+        assert result["rerank_applied"] is True
+        assert result["rerank_cache_hit"] is True
+        assert result["documents"][0]["text"] == "doc B"
+        mock_reranker.rerank.assert_not_awaited()
+
 
 # --- rewrite_node tests ---
 

--- a/tests/unit/graph/test_cache_nodes.py
+++ b/tests/unit/graph/test_cache_nodes.py
@@ -110,6 +110,23 @@ class TestCacheCheckNode:
         # Should use cached embedding, not recompute
         embeddings.aembed_query.assert_not_awaited()
 
+    async def test_hit_path_does_not_compute_colbert(self):
+        """ColBERT vectors must not be computed before semantic cache miss."""
+        state = make_initial_state(user_id=1, session_id="s1", query="test query")
+        state["query_type"] = "GENERAL"
+
+        cache = AsyncMock()
+        cache.get_embedding = AsyncMock(return_value=[0.2] * 1024)
+        cache.check_semantic = AsyncMock(return_value="cached answer")
+
+        embeddings = AsyncMock()
+        embeddings.aembed_colbert_query = AsyncMock(return_value=[[0.2] * 1024] * 2)
+
+        result = await cache_check_node(state, cache=cache, embeddings=embeddings)
+
+        assert result["cache_hit"] is True
+        embeddings.aembed_colbert_query.assert_not_awaited()
+
     async def test_check_does_not_pass_user_id_to_cache(self):
         """cache_check_node does NOT pass user_id to check_semantic (global cache)."""
         state = make_initial_state(user_id=99, session_id="s1", query="test query")
@@ -168,10 +185,11 @@ class TestCacheCheckNode:
         mock_cache.check_semantic = AsyncMock(return_value=None)
 
         mock_embeddings = AsyncMock()
+        mock_embeddings.aembed_hybrid = None
         mock_embeddings.aembed_hybrid_with_colbert = AsyncMock(
             return_value=([0.1] * 1024, {"indices": [1], "values": [0.5]}, [[0.2] * 1024] * 4)
         )
-        mock_embeddings.aembed_hybrid = AsyncMock()
+        mock_embeddings.aembed_colbert_query = None
 
         state = {
             "messages": [{"role": "user", "content": "test query"}],
@@ -190,9 +208,11 @@ class TestCacheCheckNode:
         mock_cache.check_semantic = AsyncMock(return_value=None)
 
         mock_embeddings = AsyncMock()
+        mock_embeddings.aembed_hybrid = None
         mock_embeddings.aembed_hybrid_with_colbert = AsyncMock(
             return_value=([0.1] * 1024, {"indices": [1], "values": [0.5]}, [[0.2] * 1024] * 4)
         )
+        mock_embeddings.aembed_colbert_query = None
 
         state = {
             "messages": [{"role": "user", "content": "test query"}],

--- a/tests/unit/graph/test_state.py
+++ b/tests/unit/graph/test_state.py
@@ -26,6 +26,7 @@ class TestRAGState:
             "latency_stages",
             "search_results_count",
             "rerank_applied",
+            "rerank_cache_hit",
             "grade_confidence",
         ]
         for field in required:
@@ -46,6 +47,7 @@ class TestRAGState:
         assert state["latency_stages"] == {}
         assert state["search_results_count"] == 0
         assert state["rerank_applied"] is False
+        assert state["rerank_cache_hit"] is False
         assert state["query_embedding"] is None
         assert state["sparse_embedding"] is None
         assert state["cached_response"] is None

--- a/tests/unit/integrations/test_cache_layers.py
+++ b/tests/unit/integrations/test_cache_layers.py
@@ -367,7 +367,7 @@ class TestSemanticCacheRedisVLErrors:
 
 
 class TestExactCaches:
-    """Test exact key-value caches (embeddings, sparse, analysis, search, rerank)."""
+    """Test exact key-value caches (embeddings, sparse, search, rerank)."""
 
     async def test_exact_store_and_get(self):
         mgr = CacheLayerManager(redis_url="redis://localhost:6379")
@@ -409,6 +409,21 @@ class TestExactCaches:
         result = await mgr.get_exact("search", "some_hash")
         assert result == cached_docs
         assert mgr._metrics["search"]["hits"] == 1
+
+    async def test_rerank_cache_store_and_get(self):
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        mgr.redis = AsyncMock()
+        docs = [{"text": "Doc A", "score": 0.4}, {"text": "Doc B", "score": 0.5}]
+        reranked = [{"text": "Doc B", "score": 0.9}]
+
+        await mgr.store_rerank_results("test query", docs, 5, reranked)
+        mgr.redis.setex.assert_awaited_once()
+
+        mgr.redis.get = AsyncMock(return_value=json.dumps(reranked))
+        loaded = await mgr.get_rerank_results("test query", docs, 5)
+
+        assert loaded == reranked
+        assert mgr._metrics["rerank"]["hits"] == 1
 
 
 def _make_pipeline_mock():
@@ -765,12 +780,11 @@ class TestCacheClearing:
             "semantic",
             "embeddings",
             "sparse",
-            "analysis",
             "search",
             "rerank",
         }
         assert result["semantic"] == 1
-        assert all(result[t] == 0 for t in ("embeddings", "sparse", "analysis", "search", "rerank"))
+        assert all(result[t] == 0 for t in ("embeddings", "sparse", "search", "rerank"))
         mgr.semantic_cache.aclear.assert_awaited_once()
 
 

--- a/tests/unit/pipelines/test_client_pipeline.py
+++ b/tests/unit/pipelines/test_client_pipeline.py
@@ -799,9 +799,9 @@ class TestCacheStoreGuards:
 
         mock_cache.store_semantic.assert_called_once()
 
-    async def test_structured_query_type_skips_cache_store(self):
-        """STRUCTURED query type is NOT in _PIPELINE_STORE_TYPES so cache store is skipped."""
-        assert "STRUCTURED" not in _PIPELINE_STORE_TYPES
+    async def test_structured_query_type_stores_cache(self):
+        """STRUCTURED query type is in _PIPELINE_STORE_TYPES, so cache store is enabled."""
+        assert "STRUCTURED" in _PIPELINE_STORE_TYPES
         msg = _make_message()
         lf = _make_lf_client()
         mock_cache = AsyncMock()
@@ -836,10 +836,10 @@ class TestCacheStoreGuards:
                 reranker=None,
                 llm=None,
                 config=_make_config(),
-                query_type="STRUCTURED",  # not in _PIPELINE_STORE_TYPES
+                query_type="STRUCTURED",
             )
 
-        mock_cache.store_semantic.assert_not_called()
+        mock_cache.store_semantic.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -2117,6 +2117,8 @@ class TestClientDirectPipeline:
     """Tests for client direct fast-path (feature-flagged)."""
 
     def _setup_pre_agent_cache_miss(self, bot):
+        bot._cache.get_embedding = AsyncMock(return_value=None)
+        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
         bot._embeddings.aembed_query = AsyncMock(return_value=[0.1] * 10)
         bot._cache.store_embedding = AsyncMock()
         bot._cache.check_semantic = AsyncMock(return_value=None)
@@ -2125,6 +2127,8 @@ class TestClientDirectPipeline:
     async def test_client_direct_cache_hit_returns_early(self, mock_config):
         mock_config.client_direct_pipeline_enabled = True
         bot, _ = _create_bot(mock_config)
+        bot._cache.get_embedding = AsyncMock(return_value=None)
+        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
         bot._embeddings.aembed_query = AsyncMock(return_value=[0.2] * 10)
         bot._cache.store_embedding = AsyncMock()
         bot._cache.check_semantic = AsyncMock(return_value="Ответ из кеша")
@@ -2711,6 +2715,8 @@ class TestPreAgentCacheCheck:
         """Configure cache and embeddings mocks on a bot instance."""
         if embedding is None:
             embedding = [0.1] * 10
+        bot._cache.get_embedding = AsyncMock(return_value=None)
+        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
         bot._embeddings.aembed_query = AsyncMock(return_value=embedding)
         bot._cache.store_embedding = AsyncMock()
         bot._cache.store_semantic = AsyncMock()
@@ -2812,6 +2818,8 @@ class TestPreAgentCacheCheck:
     async def test_pre_agent_cache_embedding_error_proceeds_to_agent(self, mock_config):
         """Embedding error in pre-agent check is swallowed; agent.ainvoke still called (#563)."""
         bot, _ = _create_bot(mock_config)
+        bot._cache.get_embedding = AsyncMock(return_value=None)
+        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
         bot._embeddings.aembed_query = AsyncMock(side_effect=RuntimeError("BGE-M3 timeout"))
         bot._cache.store_embedding = AsyncMock()
         bot._cache.store_semantic = AsyncMock()
@@ -2908,18 +2916,17 @@ class TestPreAgentCacheCheck:
         bot._cache.check_semantic.assert_not_called()
         mock_agent.ainvoke.assert_called_once()
 
-    async def test_pre_agent_uses_hybrid_colbert_when_available(self, mock_config):
-        """When aembed_hybrid_with_colbert exists, all three embeddings are stashed (#571)."""
+    async def test_pre_agent_uses_hybrid_when_available(self, mock_config):
+        """When aembed_hybrid exists, pre-agent path stashes dense+sparse only."""
         bot, _ = _create_bot(mock_config)
 
         dense = [0.5] * 10
         sparse = {"indices": [1], "values": [0.7]}
-        colbert = [[0.3] * 10] * 2
 
-        bot._embeddings.aembed_hybrid_with_colbert = AsyncMock(
-            return_value=(dense, sparse, colbert)
-        )
+        bot._embeddings.aembed_hybrid = AsyncMock(return_value=(dense, sparse))
         bot._embeddings.aembed_query = AsyncMock()  # should NOT be called
+        bot._cache.get_embedding = AsyncMock(return_value=None)
+        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
         bot._cache.store_embedding = AsyncMock()
         bot._cache.store_sparse_embedding = AsyncMock()
         bot._cache.check_semantic = AsyncMock(return_value=None)
@@ -2948,23 +2955,25 @@ class TestPreAgentCacheCheck:
                 mock_cas.typing.return_value = _make_typing_cm()
                 await bot.handle_query(message)
 
-        # hybrid_with_colbert must be called; aembed_query must NOT be called
-        bot._embeddings.aembed_hybrid_with_colbert.assert_awaited_once()
+        # aembed_hybrid must be called; aembed_query must NOT be called
+        bot._embeddings.aembed_hybrid.assert_awaited_once()
         bot._embeddings.aembed_query.assert_not_called()
         # sparse must be stored in cache
         bot._cache.store_sparse_embedding.assert_awaited_once()
-        # all three embeddings must be stashed
+        # dense+sparse are stashed; ColBERT is deferred to post-semantic miss paths
         assert stashed_store.get("cache_key_embedding") == dense
         assert stashed_store.get("cache_key_sparse") == sparse
-        assert stashed_store.get("cache_key_colbert") == colbert
+        assert stashed_store.get("cache_key_colbert") is None
 
-    async def test_pre_agent_fallback_to_aembed_query_when_no_hybrid_colbert(self, mock_config):
-        """Fallback to aembed_query when aembed_hybrid_with_colbert is not available (#571)."""
+    async def test_pre_agent_fallback_to_aembed_query_when_no_hybrid(self, mock_config):
+        """Fallback to aembed_query when aembed_hybrid is not available."""
         bot, _ = _create_bot(mock_config)
         test_embedding = [0.5] * 10
 
         bot._embeddings.aembed_query = AsyncMock(return_value=test_embedding)
-        bot._embeddings.aembed_hybrid_with_colbert = None  # not available
+        bot._embeddings.aembed_hybrid = None  # not available
+        bot._cache.get_embedding = AsyncMock(return_value=None)
+        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
         bot._cache.store_embedding = AsyncMock()
         bot._cache.store_sparse_embedding = AsyncMock()
         bot._cache.check_semantic = AsyncMock(return_value=None)
@@ -2998,17 +3007,16 @@ class TestPreAgentCacheCheck:
         assert stashed_store.get("cache_key_sparse") is None
         assert stashed_store.get("cache_key_colbert") is None
 
-    async def test_pre_agent_hybrid_colbert_stash_on_cache_hit(self, mock_config):
-        """On cache HIT with hybrid_with_colbert, sparse is stored in cache (#571)."""
+    async def test_pre_agent_hybrid_stash_on_cache_hit(self, mock_config):
+        """On cache HIT with hybrid embeddings, sparse is stored and agent is skipped."""
         bot, _ = _create_bot(mock_config)
 
         dense = [0.5] * 10
         sparse = {"indices": [2], "values": [0.8]}
-        colbert = [[0.4] * 10] * 3
 
-        bot._embeddings.aembed_hybrid_with_colbert = AsyncMock(
-            return_value=(dense, sparse, colbert)
-        )
+        bot._embeddings.aembed_hybrid = AsyncMock(return_value=(dense, sparse))
+        bot._cache.get_embedding = AsyncMock(return_value=None)
+        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
         bot._cache.store_embedding = AsyncMock()
         bot._cache.store_sparse_embedding = AsyncMock()
         bot._cache.check_semantic = AsyncMock(return_value="Cached answer")
@@ -3087,7 +3095,7 @@ class TestClearCacheCommand:
         assert call_kwargs is not None
         reply_markup = call_kwargs.kwargs.get("reply_markup") or call_kwargs.args[1]
         assert isinstance(reply_markup, InlineKeyboardMarkup)
-        # 3 rows, 2 buttons each
+        # 3 rows total, without analysis tier
         assert len(reply_markup.inline_keyboard) == 3
         all_buttons = [btn for row in reply_markup.inline_keyboard for btn in row]
         callback_data_values = {btn.callback_data for btn in all_buttons}
@@ -3095,7 +3103,6 @@ class TestClearCacheCommand:
             "cc:semantic",
             "cc:embeddings",
             "cc:sparse",
-            "cc:analysis",
             "cc:search",
             "cc:all",
         }
@@ -3137,8 +3144,8 @@ class TestClearCacheCommand:
                 "semantic": 3,
                 "embeddings": 7,
                 "sparse": 2,
-                "analysis": 0,
                 "search": 4,
+                "rerank": 1,
             }
         )
 

--- a/tests/unit/test_bot_scores.py
+++ b/tests/unit/test_bot_scores.py
@@ -925,6 +925,9 @@ class TestTextPathSemanticCacheStore:
 
         bot = _create_bot(mock_config)
         bot._cache = AsyncMock()
+        bot._cache.get_embedding = AsyncMock(return_value=[0.1, 0.2, 0.3])
+        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
+        bot._cache.check_semantic = AsyncMock(return_value=None)
         bot._cache.store_semantic = AsyncMock()
         message = _make_message("какие документы нужны для покупки квартиры")
 
@@ -970,6 +973,9 @@ class TestTextPathSemanticCacheStore:
 
         bot = _create_bot(mock_config)
         bot._cache = AsyncMock()
+        bot._cache.get_embedding = AsyncMock(return_value=[0.1, 0.2, 0.3])
+        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
+        bot._cache.check_semantic = AsyncMock(return_value=None)
         bot._cache.store_semantic = AsyncMock()
         message = _make_message("расскажи в целом про рынок")
 

--- a/tests/unit/test_validate_aggregates.py
+++ b/tests/unit/test_validate_aggregates.py
@@ -605,7 +605,6 @@ class TestRedisFlush:
         assert result == "OK"
         assert any(m == "embeddings:v9:*" for m in seen_matches)
         assert any(m == "sparse:v9:*" for m in seen_matches)
-        assert any(m == "analysis:v9:*" for m in seen_matches)
         assert any(m == "search:v9:*" for m in seen_matches)
         assert any(m == "rerank:v9:*" for m in seen_matches)
 


### PR DESCRIPTION
## Summary
- remove dead `analysis` exact-cache tier from runtime interfaces, cache metrics/clear flows, and related validation paths
- enable real runtime usage of `rerank` exact-cache tier in both graph rerank node and agentic RAG pipeline (`get/store_rerank_results`)
- fix pre-agent hot path to use `cache.get_embedding()` before any encode; only compute embedding on miss
- defer ColBERT query encoding until after semantic cache miss in graph/agent cache-check paths
- unify `STRUCTURED` cache-store policy for client-direct pipeline with graph cache policy
- expose `rerank_cache_hit` in state/scoring and add regression tests

## Validation
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
- `uv run pytest tests/integration/test_graph_paths.py -n auto --dist=worksteal -q`

Closes #607
