### PR TITLE
feat: close Langfuse trace coverage gaps for API/voice/ingestion (#609)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -826,20 +826,20 @@ ingest-gdrive-status: ## Show GDrive collection stats
 
 ingest-unified: ## Run unified ingestion once
 	@echo "$(BLUE)Running unified ingestion (CocoIndex)...$(NC)"
-	set -a && source .env && set +a && uv run python -m src.ingestion.unified.cli run
+	@if [ -f .env ]; then set -a; . ./.env; set +a; fi; uv run python -m src.ingestion.unified.cli run
 	@echo "$(GREEN)✓ Ingestion complete$(NC)"
 
 ingest-unified-watch: ## Run unified ingestion continuously (watch mode)
 	@echo "$(BLUE)Starting unified ingestion watch mode...$(NC)"
-	set -a && source .env && set +a && uv run python -m src.ingestion.unified.cli run --watch
+	@if [ -f .env ]; then set -a; . ./.env; set +a; fi; uv run python -m src.ingestion.unified.cli run --watch
 
 ingest-unified-status: ## Show unified ingestion status
 	@echo "$(BLUE)Unified ingestion status:$(NC)"
-	set -a && source .env && set +a && uv run python -m src.ingestion.unified.cli status
+	@if [ -f .env ]; then set -a; . ./.env; set +a; fi; uv run python -m src.ingestion.unified.cli status
 
 ingest-unified-reprocess: ## Reprocess all error files
 	@echo "$(BLUE)Reprocessing error files...$(NC)"
-	set -a && source .env && set +a && uv run python -m src.ingestion.unified.cli reprocess --errors
+	@if [ -f .env ]; then set -a; . ./.env; set +a; fi; uv run python -m src.ingestion.unified.cli reprocess --errors
 	@echo "$(GREEN)✓ Reprocess queued$(NC)"
 
 ingest-unified-logs: ## Show ingestion service logs

--- a/Makefile
+++ b/Makefile
@@ -869,7 +869,7 @@ validate-traces: ## Full rebuild + trace validation + report
 	uv run python scripts/validate_traces.py --report
 	@echo "$(GREEN)Validation complete — see docs/reports/$(NC)"
 
-validate-traces-fast: ## No rebuild, just start stack + trace validation + report
+validate-traces-fast: ## No rebuild; trace validation fails if required trace families are missing
 	@echo "$(BLUE)Fast validation (no rebuild)...$(NC)"
 	$(COMPOSE_CMD) --profile core --profile bot --profile ml up -d --wait
 	uv run python scripts/validate_traces.py --report

--- a/docs/INGESTION.md
+++ b/docs/INGESTION.md
@@ -45,6 +45,23 @@ uv run python -m src.ingestion.unified.cli status
 uv run python -m src.ingestion.unified.cli reprocess --errors
 ```
 
+## Langfuse Trace Contract
+
+- CLI root spans:
+  - `ingestion-cli-run`
+  - `ingestion-cli-preflight`
+- Runtime stage spans:
+  - `ingestion-flow-run-once`
+  - `ingestion-flow-watch`
+  - `ingestion-qdrant-upsert-chunks`
+  - `ingestion-qdrant-delete-file`
+
+Validate coverage together with API/voice traces:
+
+```bash
+make validate-traces-fast
+```
+
 ## Required Environment Variables
 
 - `INGESTION_DATABASE_URL`

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -65,6 +65,18 @@ make test
 make test-full
 ```
 
+Trace coverage gate:
+
+```bash
+make validate-traces-fast
+```
+
+If Langfuse CLI returns `401` or points to wrong host, run with explicit host:
+
+```bash
+lf --host "$LANGFUSE_HOST" traces list --name rag-api-query --limit 1
+```
+
 ## 5. Running Components Without Docker Wrapper
 
 ```bash

--- a/docs/PIPELINE_OVERVIEW.md
+++ b/docs/PIPELINE_OVERVIEW.md
@@ -67,13 +67,18 @@ Source code: `src/voice/agent.py` + `src/api/main.py`.
 
 Runtime path:
 1. LiveKit session starts voice agent.
-2. Voice agent calls RAG API (`POST /query`).
-3. RAG API runs the same graph pipeline used by Telegram bot.
-4. Transcript persistence goes to PostgreSQL when configured.
+2. `/call` dispatch metadata carries `langfuse_trace_id` for continuity.
+3. Voice agent calls RAG API (`POST /query`) with the same `langfuse_trace_id`.
+4. RAG API runs the same graph pipeline used by Telegram bot.
+5. Transcript persistence goes to PostgreSQL when configured.
 
 ## 5) Observability
 
 - App traces/scores: Langfuse (`telegram_bot/observability.py`, scoring hooks)
+- Required trace families validated by `make validate-traces-fast`:
+  - `rag-api-query`
+  - `voice-session`
+  - `ingestion-cli-run`
 - Log monitoring: Loki + Promtail + Alertmanager
 - Alert rules: `docker/monitoring/rules/*.yaml`
 

--- a/docs/agent-rules/testing-and-validation.md
+++ b/docs/agent-rules/testing-and-validation.md
@@ -40,7 +40,12 @@ Run full test suite when touching cross-cutting logic:
 ## Observability Validation
 - For tracing changes, run:
   - `make validate-traces-fast`
-- Verify that critical spans/scores remain present in Langfuse-driven outputs.
+- Verify that critical trace families remain present in Langfuse-driven outputs:
+  - `rag-api-query`
+  - `voice-session`
+  - `ingestion-cli-run`
+- If CLI auth/host issues occur, validate host explicitly:
+  - `lf --host "$LANGFUSE_HOST" traces list --name rag-api-query --limit 1`
 
 ## Documentation Validation
 - Ensure commands in docs match `Makefile` or real CLI modules.

--- a/scripts/validate_traces.py
+++ b/scripts/validate_traces.py
@@ -21,7 +21,7 @@ import sys
 import time
 import uuid
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -83,6 +83,7 @@ TRACKED_NODE_NAMES = [
     "summarize",
 ]
 _TRACKED_NODE_SET = frozenset(TRACKED_NODE_NAMES)
+REQUIRED_TRACE_NAMES = ["rag-api-query", "voice-session", "ingestion-cli-run"]
 
 GO_NO_GO_THRESHOLDS_PATH = (
     Path(__file__).resolve().parent.parent / "tests" / "baseline" / "thresholds.yaml"
@@ -754,10 +755,44 @@ def check_orphan_traces(results: list[TraceResult]) -> float:
     return rate
 
 
+def check_required_trace_coverage(
+    *,
+    required_trace_names: list[str] | None = None,
+    lookback_hours: int = 24,
+) -> dict[str, list[str]]:
+    """Check that required trace families exist in Langfuse within lookback window."""
+    required = required_trace_names or REQUIRED_TRACE_NAMES
+    from_timestamp = datetime.now(UTC) - timedelta(hours=lookback_hours)
+    lf = Langfuse()
+    present: list[str] = []
+    missing: list[str] = []
+
+    for trace_name in required:
+        try:
+            traces_page = lf.api.trace.list(
+                name=trace_name,
+                from_timestamp=from_timestamp,
+                order_by="timestamp.desc",
+                limit=1,
+            )
+            if getattr(traces_page, "data", None):
+                present.append(trace_name)
+            else:
+                missing.append(trace_name)
+        except Exception as exc:
+            logger.warning("Failed to check required trace '%s': %s", trace_name, exc)
+            missing.append(trace_name)
+
+    lf.flush()
+    logger.info("Required trace coverage: present=%s missing=%s", present, missing)
+    return {"required": required, "present": present, "missing": missing}
+
+
 def evaluate_go_no_go(
     aggregates: dict[str, Any],
     results: list[TraceResult],
     orphan_rate: float = 0.0,
+    required_trace_coverage: dict[str, list[str]] | None = None,
     thresholds: dict[str, Any] | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Evaluate Go/No-Go criteria for Gate 1.
@@ -886,7 +921,30 @@ def evaluate_go_no_go(
         "stddev": "\u2014",
     }
 
-    # 10. Streaming TTFT p50 (skipped if sample < min)
+    # 10. Required trace families are present in Langfuse.
+    if required_trace_coverage is None:
+        criteria["required_trace_families_present"] = {
+            "target": ", ".join(REQUIRED_TRACE_NAMES),
+            "actual": "N/A (coverage not checked)",
+            "passed": True,
+            "skipped": True,
+            "stddev": "\u2014",
+        }
+    else:
+        missing_families = required_trace_coverage.get("missing", [])
+        criteria["required_trace_families_present"] = {
+            "target": ", ".join(required_trace_coverage.get("required", REQUIRED_TRACE_NAMES)),
+            "actual": (
+                "all present"
+                if not missing_families
+                else f"missing: {', '.join(sorted(missing_families))}"
+            ),
+            "passed": not missing_families,
+            "skipped": False,
+            "stddev": "\u2014",
+        }
+
+    # 11. Streaming TTFT p50 (skipped if sample < min)
     ttft_min_sample = t.get("ttft_min_sample", 3)
     ttft_p50_limit = t.get("ttft_p50_ms", 1000)
     streaming = aggregates.get("streaming", {})
@@ -910,7 +968,7 @@ def evaluate_go_no_go(
             "stddev": "\u2014",
         }
 
-    # 11. Judge quality scores (#386) — from Langfuse managed evaluators
+    # 12. Judge quality scores (#386) — from Langfuse managed evaluators
     judge_thresholds = t.get("judge", {})
     for metric, key, label in [
         ("judge_faithfulness_mean", "faithfulness_mean_gte", "faithfulness"),
@@ -1372,8 +1430,16 @@ async def run_validation(args: argparse.Namespace) -> None:
     logger.info("Checking orphan traces...")
     orphan_rate = check_orphan_traces(all_results)
 
+    logger.info("Checking required trace family coverage...")
+    required_trace_coverage = check_required_trace_coverage()
+
     # Evaluate Go/No-Go criteria
-    go_no_go = evaluate_go_no_go(aggregates, all_results, orphan_rate=orphan_rate)
+    go_no_go = evaluate_go_no_go(
+        aggregates,
+        all_results,
+        orphan_rate=orphan_rate,
+        required_trace_coverage=required_trace_coverage,
+    )
     all_passed = all(c["passed"] for c in go_no_go.values())
     passed_count = sum(1 for c in go_no_go.values() if c["passed"])
     logger.info(
@@ -1392,6 +1458,14 @@ async def run_validation(args: argparse.Namespace) -> None:
         else:
             status = "FAIL"
         logger.info("  [%s] %s: %s (target: %s)", status, name, c["actual"], c["target"])
+
+    required_coverage_gate = go_no_go.get("required_trace_families_present", {})
+    if not required_coverage_gate.get("passed", False):
+        logger.error(
+            "Missing required trace families: %s",
+            required_coverage_gate.get("actual", "unknown"),
+        )
+        sys.exit(1)
 
     # Print summary to console
     for phase, agg in aggregates.items():
@@ -1442,6 +1516,7 @@ async def run_validation(args: argparse.Namespace) -> None:
         "go_no_go": go_no_go,
         "payload_summary": payload_summary,
         "orphan_rate": orphan_rate,
+        "required_trace_coverage": required_trace_coverage,
         "traces": [
             {
                 "trace_id": r.trace_id,

--- a/src/ingestion/unified/cli.py
+++ b/src/ingestion/unified/cli.py
@@ -15,6 +15,7 @@ from src.ingestion.unified.colbert_backfill import (
     compute_colbert_coverage,
     inspect_collection_schema,
 )
+from src.ingestion.unified.observability import observe, try_update_ingestion_trace
 
 
 def setup_logging(verbose: bool = False) -> None:
@@ -29,18 +30,31 @@ def setup_logging(verbose: bool = False) -> None:
     logging.getLogger("cocoindex").setLevel(logging.INFO)
 
 
+@observe(name="ingestion-cli-run", capture_input=False, capture_output=False)
 def cmd_run(args: argparse.Namespace) -> int:
     """Run ingestion."""
     from src.ingestion.unified.config import UnifiedConfig
     from src.ingestion.unified.flow import run_once, run_watch
 
     config = UnifiedConfig()
+    watch_mode = bool(args.watch)
+    try_update_ingestion_trace(command="run", status="started", metadata={"watch": watch_mode})
 
-    if args.watch:
-        logging.info("Starting CocoIndex watch mode (FlowLiveUpdater)")
-        run_watch(config)
-    else:
-        run_once(config)
+    try:
+        if watch_mode:
+            logging.info("Starting CocoIndex watch mode (FlowLiveUpdater)")
+            run_watch(config)
+        else:
+            run_once(config)
+    except Exception as exc:
+        try_update_ingestion_trace(
+            command="run",
+            status="error",
+            metadata={"watch": watch_mode, "error_type": type(exc).__name__},
+        )
+        raise
+
+    try_update_ingestion_trace(command="run", status="completed", metadata={"watch": watch_mode})
 
     return 0
 
@@ -72,6 +86,7 @@ async def cmd_status(args: argparse.Namespace) -> int:
     return 0
 
 
+@observe(name="ingestion-cli-preflight", capture_input=False, capture_output=False)
 async def cmd_preflight(args: argparse.Namespace) -> int:
     """Check that all ingestion dependencies are reachable."""
     import httpx
@@ -79,6 +94,7 @@ async def cmd_preflight(args: argparse.Namespace) -> int:
     from src.ingestion.unified.config import UnifiedConfig
 
     config = UnifiedConfig()
+    try_update_ingestion_trace(command="preflight", status="started")
     timeout = httpx.Timeout(float(os.getenv("BGE_M3_TIMEOUT", "60")))
     results: dict[str, bool] = {}
 
@@ -156,6 +172,11 @@ async def cmd_preflight(args: argparse.Namespace) -> int:
     total = len(results)
     all_ok = ok == total
     print(f"\nPreflight: {ok}/{total} checks passed {'— READY' if all_ok else '— NOT READY'}")
+    try_update_ingestion_trace(
+        command="preflight",
+        status="completed" if all_ok else "failed",
+        metadata={"checks_passed": ok, "checks_total": total},
+    )
     return 0 if all_ok else 1
 
 

--- a/src/ingestion/unified/flow.py
+++ b/src/ingestion/unified/flow.py
@@ -228,6 +228,9 @@ def run_watch(config: UnifiedConfig | None = None) -> None:
     if config is None:
         config = UnifiedConfig()
 
+    final_status = "completed"
+    final_metadata: dict[str, str] | None = None
+
     try_update_ingestion_trace(command="flow-watch", status="started")
     flow = build_flow(config)
     flow.setup()
@@ -242,14 +245,15 @@ def run_watch(config: UnifiedConfig | None = None) -> None:
             updater.wait()
     except KeyboardInterrupt:
         logger.info("Watch mode interrupted")
-        try_update_ingestion_trace(command="flow-watch", status="interrupted")
+        final_status = "interrupted"
     except Exception as exc:
-        try_update_ingestion_trace(
-            command="flow-watch",
-            status="error",
-            metadata={"error_type": type(exc).__name__},
-        )
+        final_status = "error"
+        final_metadata = {"error_type": type(exc).__name__}
         raise
     finally:
         flow.close()
-        try_update_ingestion_trace(command="flow-watch", status="completed")
+        try_update_ingestion_trace(
+            command="flow-watch",
+            status=final_status,
+            metadata=final_metadata,
+        )

--- a/src/ingestion/unified/flow.py
+++ b/src/ingestion/unified/flow.py
@@ -19,6 +19,7 @@ from cocoindex.op import function as cocoindex_function
 
 from src.ingestion.unified.config import UnifiedConfig
 from src.ingestion.unified.manifest import GDriveManifest, compute_content_hash_from_bytes
+from src.ingestion.unified.observability import observe, try_update_ingestion_trace
 from src.ingestion.unified.targets.qdrant_hybrid_target import (
     QdrantHybridTargetConnector,  # noqa: F401 - registers the connector
     QdrantHybridTargetSpec,
@@ -202,19 +203,32 @@ def build_flow(config: UnifiedConfig | None = None) -> cocoindex.Flow:
     return cocoindex.open_flow(flow_name, flow_def)
 
 
+@observe(name="ingestion-flow-run-once", capture_input=False, capture_output=False)
 def run_once(config: UnifiedConfig | None = None) -> None:
     """Run ingestion once (single pass)."""
-    flow = build_flow(config)
-    flow.setup()
-    flow.update(print_stats=True)
-    flow.close()
+    try_update_ingestion_trace(command="flow-run-once", status="started")
+    try:
+        flow = build_flow(config)
+        flow.setup()
+        flow.update(print_stats=True)
+        flow.close()
+    except Exception as exc:
+        try_update_ingestion_trace(
+            command="flow-run-once",
+            status="error",
+            metadata={"error_type": type(exc).__name__},
+        )
+        raise
+    try_update_ingestion_trace(command="flow-run-once", status="completed")
 
 
+@observe(name="ingestion-flow-watch", capture_input=False, capture_output=False)
 def run_watch(config: UnifiedConfig | None = None) -> None:
     """Run ingestion continuously using FlowLiveUpdater."""
     if config is None:
         config = UnifiedConfig()
 
+    try_update_ingestion_trace(command="flow-watch", status="started")
     flow = build_flow(config)
     flow.setup()
 
@@ -228,5 +242,14 @@ def run_watch(config: UnifiedConfig | None = None) -> None:
             updater.wait()
     except KeyboardInterrupt:
         logger.info("Watch mode interrupted")
+        try_update_ingestion_trace(command="flow-watch", status="interrupted")
+    except Exception as exc:
+        try_update_ingestion_trace(
+            command="flow-watch",
+            status="error",
+            metadata={"error_type": type(exc).__name__},
+        )
+        raise
     finally:
         flow.close()
+        try_update_ingestion_trace(command="flow-watch", status="completed")

--- a/src/ingestion/unified/observability.py
+++ b/src/ingestion/unified/observability.py
@@ -1,0 +1,74 @@
+"""Unified ingestion tracing helpers."""
+
+from __future__ import annotations
+
+from contextlib import suppress
+from typing import Any
+
+from telegram_bot.observability import get_client, observe, propagate_attributes
+
+
+INGESTION_TAGS = ["ingestion", "unified"]
+__all__ = [
+    "ingestion_session_id",
+    "observe",
+    "try_update_ingestion_trace",
+    "update_ingestion_trace",
+]
+
+
+def ingestion_session_id(command: str) -> str:
+    """Build stable trace session id for ingestion command family."""
+    normalized = (command or "unknown").strip().replace(" ", "-")
+    return f"ingestion-{normalized or 'unknown'}"
+
+
+def update_ingestion_trace(
+    *,
+    command: str,
+    status: str,
+    metadata: dict[str, Any] | None = None,
+    trace_id: str | None = None,
+) -> None:
+    """Update trace metadata for ingestion lifecycle events."""
+    session_id = ingestion_session_id(command)
+    trace_kwargs: dict[str, Any] = {
+        "session_id": session_id,
+        "user_id": "ingestion-cli",
+        "tags": INGESTION_TAGS,
+    }
+    if trace_id:
+        trace_kwargs["trace_id"] = trace_id
+
+    payload: dict[str, Any] = {
+        "command": command,
+        "status": status,
+    }
+    if metadata:
+        payload.update(metadata)
+
+    with propagate_attributes(**trace_kwargs):
+        lf = get_client()
+        lf.update_current_trace(
+            session_id=session_id,
+            user_id="ingestion-cli",
+            tags=INGESTION_TAGS,
+            metadata=payload,
+        )
+
+
+def try_update_ingestion_trace(
+    *,
+    command: str,
+    status: str,
+    metadata: dict[str, Any] | None = None,
+    trace_id: str | None = None,
+) -> None:
+    """Best-effort wrapper for ingestion trace updates."""
+    with suppress(Exception):
+        update_ingestion_trace(
+            command=command,
+            status=status,
+            metadata=metadata,
+            trace_id=trace_id,
+        )

--- a/src/ingestion/unified/qdrant_writer.py
+++ b/src/ingestion/unified/qdrant_writer.py
@@ -16,6 +16,7 @@ from qdrant_client.models import (
     SparseVector,
 )
 
+from src.ingestion.unified.observability import observe, try_update_ingestion_trace
 from telegram_bot.services import VoyageService
 
 
@@ -233,11 +234,17 @@ class QdrantHybridWriter:
             "file_id": file_id,  # Flat for fast delete
         }
 
+    @observe(name="ingestion-qdrant-delete-file", capture_input=False, capture_output=False)
     async def delete_file(self, file_id: str, collection_name: str) -> int:
         """Delete all points for a file.
 
         Uses metadata.file_id filter (more reliable than flat file_id).
         """
+        try_update_ingestion_trace(
+            command="qdrant-delete-file",
+            status="started",
+            metadata={"collection": collection_name},
+        )
         # Count before delete
         count_result = self.client.count(
             collection_name=collection_name,
@@ -257,8 +264,14 @@ class QdrantHybridWriter:
             )
             logger.info(f"Deleted {count} points for file_id={file_id}")
 
+        try_update_ingestion_trace(
+            command="qdrant-delete-file",
+            status="completed",
+            metadata={"collection": collection_name, "points_deleted": count},
+        )
         return count
 
+    @observe(name="ingestion-qdrant-upsert-chunks", capture_input=False, capture_output=False)
     async def upsert_chunks(
         self,
         chunks: list[Any],
@@ -275,8 +288,18 @@ class QdrantHybridWriter:
         4. Upsert to Qdrant
         """
         stats = WriteStats()
+        try_update_ingestion_trace(
+            command="qdrant-upsert-chunks",
+            status="started",
+            metadata={"collection": collection_name, "chunks": len(chunks)},
+        )
 
         if not chunks:
+            try_update_ingestion_trace(
+                command="qdrant-upsert-chunks",
+                status="completed",
+                metadata={"collection": collection_name, "chunks": 0},
+            )
             return stats
 
         try:
@@ -333,7 +356,22 @@ class QdrantHybridWriter:
         except Exception as e:
             stats.errors = [str(e)]
             logger.error(f"Error upserting chunks: {e}", exc_info=True)
+            try_update_ingestion_trace(
+                command="qdrant-upsert-chunks",
+                status="error",
+                metadata={"collection": collection_name, "error_type": type(e).__name__},
+            )
+            return stats
 
+        try_update_ingestion_trace(
+            command="qdrant-upsert-chunks",
+            status="completed",
+            metadata={
+                "collection": collection_name,
+                "points_deleted": stats.points_deleted,
+                "points_upserted": stats.points_upserted,
+            },
+        )
         return stats
 
     def delete_file_sync(self, file_id: str, collection_name: str) -> int:

--- a/src/voice/agent.py
+++ b/src/voice/agent.py
@@ -25,6 +25,7 @@ from livekit.agents import (
 )
 from livekit.plugins import elevenlabs, openai, silero
 
+from src.voice.observability import trace_voice_session, update_voice_trace, voice_session_id
 from src.voice.schemas import CallStatus
 from src.voice.transcript_store import TranscriptStore
 
@@ -164,6 +165,7 @@ class VoiceBot(Agent):
             ),
         )
         self._call_id = call_id
+        self._session_id = voice_session_id(call_id)
         self._transcript_store = transcript_store
         self._langfuse_trace_id = langfuse_trace_id
 
@@ -194,11 +196,18 @@ class VoiceBot(Agent):
             payload: dict[str, Any] = {
                 "query": query,
                 "user_id": 0,
-                "session_id": f"voice-{self._call_id}",
+                "session_id": self._session_id,
                 "channel": "voice",
             }
             if self._langfuse_trace_id:
                 payload["langfuse_trace_id"] = self._langfuse_trace_id
+            with contextlib.suppress(Exception):
+                update_voice_trace(
+                    call_id=self._call_id,
+                    status="tool_call",
+                    session_id=self._session_id,
+                    langfuse_trace_id=self._langfuse_trace_id,
+                )
             resp = await client.post(
                 f"{RAG_API_URL}/query",
                 json=payload,
@@ -249,6 +258,7 @@ async def entrypoint(ctx: agents.JobContext):
     phone = str(metadata.get("phone", "")).strip()
     callback_chat_id = metadata.get("callback_chat_id")
     langfuse_trace_id = metadata.get("langfuse_trace_id")
+    session_id = voice_session_id(call_id)
 
     store = await _get_transcript_store()
     if store is not None and phone:
@@ -260,8 +270,23 @@ async def entrypoint(ctx: agents.JobContext):
                 call_id=call_id or None,
             )
             await store.update_status(call_id, CallStatus.ANSWERED)
+            session_id = voice_session_id(call_id)
         except Exception:
             logger.exception("Failed to initialize transcript row for call_id=%s", call_id)
+            await trace_voice_session(
+                call_id=call_id,
+                status="error",
+                session_id=session_id,
+                error="transcript_init_failed",
+                langfuse_trace_id=langfuse_trace_id,
+            )
+
+    await trace_voice_session(
+        call_id=call_id,
+        status="answered",
+        session_id=session_id,
+        langfuse_trace_id=langfuse_trace_id,
+    )
 
     # Create agent session with ElevenLabs STT/TTS
     session: AgentSession = AgentSession(
@@ -297,9 +322,23 @@ async def entrypoint(ctx: agents.JobContext):
                     duration_sec=duration_sec,
                     langfuse_trace_id=langfuse_trace_id,
                 )
+                await trace_voice_session(
+                    call_id=call_id,
+                    status="finalized",
+                    duration_sec=duration_sec,
+                    session_id=session_id,
+                    langfuse_trace_id=langfuse_trace_id,
+                )
                 logger.info("Call %s finalized: duration=%ds", call_id, duration_sec)
         except Exception:
             logger.exception("Failed to finalize call %s", call_id)
+            await trace_voice_session(
+                call_id=call_id,
+                status="error",
+                session_id=session_id,
+                error="finalize_failed",
+                langfuse_trace_id=langfuse_trace_id,
+            )
         finally:
             await _mark_job_finished()
 

--- a/src/voice/observability.py
+++ b/src/voice/observability.py
@@ -1,0 +1,98 @@
+"""Voice tracing helpers for Langfuse lifecycle updates."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import suppress
+from typing import Any
+
+from telegram_bot.observability import get_client, observe, propagate_attributes
+
+
+logger = logging.getLogger(__name__)
+
+VOICE_TRACE_TAGS = ["voice", "call-lifecycle"]
+
+
+def voice_session_id(call_id: str | None) -> str:
+    """Build stable voice session id from call id."""
+    raw = (call_id or "").strip()
+    if not raw:
+        return "voice-unknown"
+    return f"voice-{raw}"
+
+
+def build_voice_trace_metadata(
+    *,
+    call_id: str,
+    status: str,
+    duration_sec: int | None = None,
+    error: str | None = None,
+) -> dict[str, Any]:
+    """Build lifecycle metadata payload for trace updates."""
+    metadata: dict[str, Any] = {
+        "call_id": call_id,
+        "status": status,
+    }
+    if duration_sec is not None:
+        metadata["duration_sec"] = duration_sec
+    if error:
+        metadata["error"] = error
+    return metadata
+
+
+def update_voice_trace(
+    *,
+    call_id: str,
+    status: str,
+    duration_sec: int | None = None,
+    error: str | None = None,
+    session_id: str | None = None,
+    langfuse_trace_id: str | None = None,
+) -> None:
+    """Write lifecycle status onto active trace context."""
+    resolved_session_id = session_id or voice_session_id(call_id)
+    metadata = build_voice_trace_metadata(
+        call_id=call_id,
+        status=status,
+        duration_sec=duration_sec,
+        error=error,
+    )
+    trace_kwargs: dict[str, Any] = {
+        "session_id": resolved_session_id,
+        "user_id": "voice-agent",
+        "tags": VOICE_TRACE_TAGS,
+    }
+    if langfuse_trace_id:
+        trace_kwargs["trace_id"] = langfuse_trace_id
+
+    with propagate_attributes(**trace_kwargs):
+        lf = get_client()
+        lf.update_current_trace(
+            session_id=resolved_session_id,
+            user_id="voice-agent",
+            tags=VOICE_TRACE_TAGS,
+            metadata=metadata,
+        )
+
+
+@observe(name="voice-session", capture_input=False, capture_output=False)
+async def trace_voice_session(
+    *,
+    call_id: str,
+    status: str,
+    duration_sec: int | None = None,
+    error: str | None = None,
+    session_id: str | None = None,
+    langfuse_trace_id: str | None = None,
+) -> None:
+    """Async wrapper used by voice runtime for lifecycle traces."""
+    with suppress(Exception):
+        update_voice_trace(
+            call_id=call_id,
+            status=status,
+            duration_sec=duration_sec,
+            error=error,
+            session_id=session_id,
+            langfuse_trace_id=langfuse_trace_id,
+        )

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -737,6 +737,13 @@ class PropertyBot:
             return
 
         lead_desc = parts[2] if len(parts) > 2 else ""
+        trace_id = ""
+        try:
+            trace_id = get_client().get_current_trace_id() or ""
+        except Exception:
+            logger.debug("Failed to resolve current Langfuse trace id for /call", exc_info=True)
+        if not trace_id:
+            trace_id = f"call-{uuid.uuid4().hex}"
 
         try:
             from livekit import api
@@ -765,6 +772,7 @@ class PropertyBot:
                                     "triggered_by": message.from_user.id,
                                 },
                                 "callback_chat_id": message.chat.id,
+                                "langfuse_trace_id": trace_id,
                             }
                         ),
                     )

--- a/tests/unit/api/test_rag_api_runtime.py
+++ b/tests/unit/api/test_rag_api_runtime.py
@@ -98,6 +98,34 @@ async def test_query_observe_trace_sets_api_tags_and_ids() -> None:
     assert call_kwargs["user_id"] == "42"
 
 
+async def test_query_propagates_explicit_langfuse_trace_id() -> None:
+    """POST /query should forward explicit trace id into propagate_attributes."""
+    graph = _DummyGraph()
+    app.state.graph = graph
+    app.state.max_rewrite_attempts = 1
+
+    lf = MagicMock()
+    lf.update_current_trace = MagicMock()
+
+    with (
+        patch(
+            "telegram_bot.observability.propagate_attributes", return_value=nullcontext()
+        ) as mock_propagate,
+        patch("telegram_bot.observability.get_client", return_value=lf),
+    ):
+        await query(
+            QueryRequest(
+                query="test",
+                user_id=42,
+                session_id="sess-1",
+                channel="voice",
+                langfuse_trace_id="trace-123",
+            )
+        )
+
+    assert mock_propagate.call_args.kwargs["trace_id"] == "trace-123"
+
+
 async def test_lifespan_respects_rerank_provider_none() -> None:
     fake_cfg = SimpleNamespace(
         redis_url="redis://localhost:6379",

--- a/tests/unit/ingestion/test_unified_flow.py
+++ b/tests/unit/ingestion/test_unified_flow.py
@@ -432,9 +432,10 @@ class TestRunWatch:
         mock_updater.wait.assert_called_once()
         mock_flow.close.assert_called_once()
 
+    @patch("src.ingestion.unified.flow.try_update_ingestion_trace")
     @patch("src.ingestion.unified.flow.build_flow")
     @patch("cocoindex.FlowLiveUpdater")
-    def test_handles_keyboard_interrupt(self, mock_updater_cls, mock_build):
+    def test_handles_keyboard_interrupt(self, mock_updater_cls, mock_build, mock_update_trace):
         from src.ingestion.unified.flow import run_watch
 
         mock_flow = MagicMock()
@@ -449,10 +450,14 @@ class TestRunWatch:
         run_watch()
 
         mock_flow.close.assert_called_once()
+        assert mock_update_trace.call_count == 2
+        assert mock_update_trace.call_args_list[0].kwargs["status"] == "started"
+        assert mock_update_trace.call_args_list[1].kwargs["status"] == "interrupted"
 
+    @patch("src.ingestion.unified.flow.try_update_ingestion_trace")
     @patch("src.ingestion.unified.flow.build_flow")
     @patch("cocoindex.FlowLiveUpdater")
-    def test_uses_default_config_when_none(self, mock_updater_cls, mock_build):
+    def test_uses_default_config_when_none(self, mock_updater_cls, mock_build, mock_update_trace):
         from src.ingestion.unified.flow import run_watch
 
         mock_flow = MagicMock()
@@ -465,3 +470,33 @@ class TestRunWatch:
         run_watch(None)
 
         mock_build.assert_called_once()
+        assert mock_update_trace.call_count == 2
+        assert mock_update_trace.call_args_list[0].kwargs["status"] == "started"
+        assert mock_update_trace.call_args_list[1].kwargs["status"] == "completed"
+
+    @patch("src.ingestion.unified.flow.try_update_ingestion_trace")
+    @patch("src.ingestion.unified.flow.build_flow")
+    @patch("cocoindex.FlowLiveUpdater")
+    def test_records_error_status_without_completed(
+        self, mock_updater_cls, mock_build, mock_update_trace
+    ):
+        from src.ingestion.unified.flow import run_watch
+
+        mock_flow = MagicMock()
+        mock_build.return_value = mock_flow
+        mock_updater = MagicMock()
+        mock_updater.__enter__ = MagicMock(return_value=mock_updater)
+        mock_updater.__exit__ = MagicMock(return_value=False)
+        mock_updater.wait.side_effect = RuntimeError("boom")
+        mock_updater_cls.return_value = mock_updater
+
+        with pytest.raises(RuntimeError, match="boom"):
+            run_watch()
+
+        mock_flow.close.assert_called_once()
+        assert mock_update_trace.call_count == 2
+        assert mock_update_trace.call_args_list[0].kwargs["status"] == "started"
+        assert mock_update_trace.call_args_list[1].kwargs["status"] == "error"
+        assert mock_update_trace.call_args_list[1].kwargs["metadata"] == {
+            "error_type": "RuntimeError"
+        }

--- a/tests/unit/observability/test_trace_contracts.py
+++ b/tests/unit/observability/test_trace_contracts.py
@@ -10,6 +10,7 @@ Contracts tested:
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from unittest.mock import MagicMock
 
 import pytest
@@ -380,6 +381,46 @@ class TestBuildTraceMetadataContract:
         assert "documents" not in metadata
         assert "query_embedding" not in metadata
         assert "voice_audio" not in metadata
+
+
+class TestVoiceLifecycleTraceContract:
+    """Voice lifecycle traces should preserve call/session/status contract (#609)."""
+
+    def test_voice_session_id_has_voice_prefix(self):
+        from src.voice.observability import voice_session_id
+
+        assert voice_session_id("call-123") == "voice-call-123"
+        assert voice_session_id("") == "voice-unknown"
+
+    def test_build_voice_trace_metadata_includes_finalize_duration(self):
+        from src.voice.observability import build_voice_trace_metadata
+
+        payload = build_voice_trace_metadata(
+            call_id="call-123",
+            status="finalized",
+            duration_sec=31,
+        )
+        assert payload["call_id"] == "call-123"
+        assert payload["status"] == "finalized"
+        assert payload["duration_sec"] == 31
+
+    def test_update_voice_trace_writes_answered_status(self):
+        from src.voice.observability import update_voice_trace
+
+        lf = MagicMock()
+        lf.update_current_trace = MagicMock()
+        with (
+            pytest.MonkeyPatch().context() as mp,
+        ):
+            mp.setattr("src.voice.observability.get_client", lambda: lf)
+            mp.setattr("src.voice.observability.propagate_attributes", lambda **_: nullcontext())
+            update_voice_trace(call_id="call-123", status="answered")
+
+        lf.update_current_trace.assert_called_once()
+        kwargs = lf.update_current_trace.call_args.kwargs
+        assert kwargs["session_id"] == "voice-call-123"
+        assert kwargs["metadata"]["status"] == "answered"
+        assert kwargs["metadata"]["call_id"] == "call-123"
 
 
 class TestSessionIdFormatContract:

--- a/tests/unit/observability/test_trace_coverage_609.py
+++ b/tests/unit/observability/test_trace_coverage_609.py
@@ -1,0 +1,11 @@
+"""Trace coverage contract tests for issue #609."""
+
+from pathlib import Path
+
+
+def test_ingestion_cli_has_observe_on_run_and_preflight() -> None:
+    """Ingestion CLI entrypoints must be wrapped with observe spans."""
+    source = Path("src/ingestion/unified/cli.py").read_text(encoding="utf-8")
+
+    assert '@observe(name="ingestion-cli-run"' in source
+    assert '@observe(name="ingestion-cli-preflight"' in source

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -1,7 +1,10 @@
 """Unit tests for telegram_bot/bot.py handlers (LangGraph pipeline)."""
 
 import asyncio
+import json
 import logging
+import sys
+import types
 
 import pytest
 
@@ -404,6 +407,41 @@ class TestCommandHandlers:
         message.answer.assert_called_once()
         call_args = message.answer.call_args[0][0]
         assert "p50" in call_args
+
+    async def test_cmd_call_dispatch_includes_langfuse_trace_id(self, mock_config):
+        """`/call` dispatch metadata should include langfuse_trace_id for continuity (#609)."""
+        mock_config.admin_ids = [12345]
+        mock_config.livekit_url = "ws://livekit.local"
+        mock_config.livekit_api_key = "lk-key"
+        mock_config.livekit_api_secret = "lk-secret"
+        mock_config.sip_trunk_id = "trunk-123"
+
+        bot, _ = _create_bot(mock_config)
+        message = _make_text_message("/call +380501234567 тестовая заявка")
+
+        fake_lk = MagicMock()
+        fake_lk.agent_dispatch.create_dispatch = AsyncMock()
+        fake_lk.sip.create_sip_participant = AsyncMock()
+        fake_lk.aclose = AsyncMock()
+
+        fake_api = types.SimpleNamespace(
+            LiveKitAPI=MagicMock(return_value=fake_lk),
+            CreateAgentDispatchRequest=lambda **kwargs: types.SimpleNamespace(**kwargs),
+            CreateSIPParticipantRequest=lambda **kwargs: types.SimpleNamespace(**kwargs),
+        )
+        fake_livekit = types.SimpleNamespace(api=fake_api)
+        mock_lf = MagicMock()
+        mock_lf.get_current_trace_id.return_value = "trace-123"
+
+        with (
+            patch.dict(sys.modules, {"livekit": fake_livekit}),
+            patch("telegram_bot.bot.get_client", return_value=mock_lf),
+        ):
+            await bot.cmd_call(message)
+
+        dispatch_request = fake_lk.agent_dispatch.create_dispatch.await_args.args[0]
+        metadata = json.loads(dispatch_request.metadata)
+        assert metadata["langfuse_trace_id"] == "trace-123"
 
 
 def _mock_agent_result(**overrides):

--- a/tests/unit/test_lazy_imports.py
+++ b/tests/unit/test_lazy_imports.py
@@ -37,3 +37,15 @@ def test_unified_config_import_is_lazy(monkeypatch: pytest.MonkeyPatch) -> None:
     assert cfg is not None
     assert "src.ingestion.unified.qdrant_writer" not in sys.modules
     assert "src.ingestion.unified.targets.qdrant_hybrid_target" not in sys.modules
+    assert "src.ingestion.unified.observability" not in sys.modules
+
+
+def test_unified_cli_import_keeps_flow_lazy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CLI import should not eagerly import flow/writer modules."""
+    _clear_modules_safe(monkeypatch, ("src",))
+
+    module = importlib.import_module("src.ingestion.unified.cli")
+
+    assert module is not None
+    assert "src.ingestion.unified.flow" not in sys.modules
+    assert "src.ingestion.unified.qdrant_writer" not in sys.modules

--- a/tests/unit/test_validate_aggregates.py
+++ b/tests/unit/test_validate_aggregates.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from scripts.validate_traces import (
+    REQUIRED_TRACE_NAMES,
     TRACKED_NODE_NAMES,
     TraceResult,
     ValidationRun,
@@ -187,6 +188,12 @@ class TestComputeAggregates:
             "respond",
         ]:
             assert node in TRACKED_NODE_NAMES
+
+    def test_required_trace_names_include_api_voice_and_ingestion(self):
+        """Coverage gate should require API, voice, and ingestion trace families (#609)."""
+        assert "rag-api-query" in REQUIRED_TRACE_NAMES
+        assert "voice-session" in REQUIRED_TRACE_NAMES
+        assert "ingestion-cli-run" in REQUIRED_TRACE_NAMES
 
     def test_node_latencies_includes_transcribe(self):
         """Transcribe node spans are tracked in aggregates (#241)."""

--- a/tests/unit/test_validate_traces_coverage_gate.py
+++ b/tests/unit/test_validate_traces_coverage_gate.py
@@ -1,0 +1,62 @@
+"""Unit tests for required trace-family coverage gate in validate_traces."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from scripts.validate_traces import (
+    REQUIRED_TRACE_NAMES,
+    check_required_trace_coverage,
+    evaluate_go_no_go,
+)
+
+
+def test_check_required_trace_coverage_marks_missing_trace_families() -> None:
+    mock_lf = MagicMock()
+    mock_lf.api.trace.list.side_effect = [
+        SimpleNamespace(data=[SimpleNamespace(id="trace-api")]),
+        SimpleNamespace(data=[]),
+        SimpleNamespace(data=[]),
+    ]
+
+    with patch("scripts.validate_traces.Langfuse", return_value=mock_lf):
+        coverage = check_required_trace_coverage()
+
+    assert coverage["present"] == ["rag-api-query"]
+    assert set(coverage["missing"]) == {"voice-session", "ingestion-cli-run"}
+
+
+def test_evaluate_go_no_go_fails_when_required_trace_family_missing() -> None:
+    criteria = evaluate_go_no_go(
+        {"cold": {}, "cache_hit": {}},
+        [],
+        orphan_rate=0.0,
+        required_trace_coverage={
+            "required": REQUIRED_TRACE_NAMES,
+            "present": ["rag-api-query"],
+            "missing": ["voice-session", "ingestion-cli-run"],
+        },
+    )
+
+    gate = criteria["required_trace_families_present"]
+    assert gate["passed"] is False
+    assert "voice-session" in gate["actual"]
+    assert "ingestion-cli-run" in gate["actual"]
+
+
+def test_evaluate_go_no_go_passes_when_required_trace_families_present() -> None:
+    criteria = evaluate_go_no_go(
+        {"cold": {}, "cache_hit": {}},
+        [],
+        orphan_rate=0.0,
+        required_trace_coverage={
+            "required": REQUIRED_TRACE_NAMES,
+            "present": REQUIRED_TRACE_NAMES,
+            "missing": [],
+        },
+    )
+
+    gate = criteria["required_trace_families_present"]
+    assert gate["passed"] is True
+    assert gate["actual"] == "all present"

--- a/tests/unit/voice/test_voice_agent.py
+++ b/tests/unit/voice/test_voice_agent.py
@@ -79,8 +79,16 @@ def test_voice_bot_langfuse_trace_id_defaults_none():
     assert agent._langfuse_trace_id is None
 
 
-async def test_search_tool_forwards_langfuse_trace_id():
-    """langfuse_trace_id is included in the RAG API payload (#241)."""
+def test_voice_bot_stores_trace_session_id():
+    """Voice agent keeps `voice-<call_id>` session id for lifecycle traces."""
+    from src.voice.agent import VoiceBot
+
+    agent = VoiceBot(call_id="call-xyz")
+    assert agent._session_id == "voice-call-xyz"
+
+
+async def test_voice_tool_propagates_langfuse_trace_id_to_api_payload():
+    """Voice tool should pass langfuse_trace_id to RAG API payload (#609)."""
     from src.voice.agent import VoiceBot
 
     store = MagicMock()
@@ -89,7 +97,7 @@ async def test_search_tool_forwards_langfuse_trace_id():
     agent = VoiceBot(
         call_id="22222222-2222-2222-2222-222222222222",
         transcript_store=store,
-        langfuse_trace_id="trace-link-test",
+        langfuse_trace_id="trace-123",
     )
 
     mock_response = MagicMock()
@@ -103,7 +111,7 @@ async def test_search_tool_forwards_langfuse_trace_id():
         await VoiceBot.search_knowledge_base.__wrapped__(agent, None, "test query")
 
     payload = mock_client.post.await_args.kwargs["json"]
-    assert payload["langfuse_trace_id"] == "trace-link-test"
+    assert payload["langfuse_trace_id"] == "trace-123"
     assert payload["channel"] == "voice"
 
 


### PR DESCRIPTION
## Summary
- add `/call` trace continuity: inject `langfuse_trace_id` into LiveKit dispatch metadata and keep voice->API propagation contract
- add voice lifecycle tracing contract (`voice-session`) with answered/tool_call/finalized/error metadata updates
- add unified ingestion tracing layer (`ingestion-cli-run`, `ingestion-cli-preflight`, flow/qdrant stage spans)
- extend trace validation gate with required trace families (`rag-api-query`, `voice-session`, `ingestion-cli-run`) and fail-fast behavior when missing
- update docs/runbooks with the new trace contract and `lf --host` troubleshooting
- add/extend unit tests for continuity, lifecycle contracts, coverage gate, and lazy-import safety

## Verification
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' uv run pytest tests/unit/test_bot_handlers.py tests/unit/voice/test_voice_agent.py tests/unit/api/test_rag_api_runtime.py -q -k 'cmd_call_dispatch_includes_langfuse_trace_id or voice_tool_propagates_langfuse_trace_id_to_api_payload or query_propagates_explicit_langfuse_trace_id or voice_bot_stores_trace_session_id' -rs`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' uv run pytest tests/unit/observability/test_trace_coverage_609.py tests/unit/test_lazy_imports.py tests/unit/observability/test_trace_contracts.py -q -k 'ingestion_cli_has_observe_on_run_and_preflight or unified_cli_import_keeps_flow_lazy or VoiceLifecycleTraceContract' -rs`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' uv run pytest tests/unit/test_validate_aggregates.py tests/unit/test_validate_traces_coverage_gate.py -q -k 'required_trace_names_include_api_voice_and_ingestion or required_trace_coverage or required_trace_families_present' -rs`
- `uv run pytest tests/integration/test_graph_paths.py -n auto --dist=worksteal -q`

## Notes
- `make validate-traces-fast` currently fails in this environment because compose requires `SALT` env var.
- `uv run python -m src.ingestion.unified.cli preflight` returns NOT READY because `INGESTION_DATABASE_URL` is missing.
- `make ingest-unified-status` fails under `/bin/sh` because target uses `source`; direct CLI status command works.

Closes #609