### PR TITLE
fix(contract): address code review — drift detection, .venv exclusion, error allowlist (#626)

### DIFF
--- a/tests/contract/test_span_coverage_contract.py
+++ b/tests/contract/test_span_coverage_contract.py
@@ -160,7 +160,7 @@ def collect_observe_decorators(
     return results
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def observed_spans() -> dict[str, dict]:
     return collect_observe_decorators(SCAN_DIRS, EXCLUDE_DIRS)
 
@@ -213,4 +213,20 @@ def test_all_observed_spans_accounted_for(observed_spans: dict[str, dict]) -> No
         "The following spans have capture_input=False but are not in SENSITIVE_SPANS.\n"
         "Add them to SENSITIVE_SPANS in tests/contract/test_span_coverage_contract.py:\n"
         + "\n".join(unaccounted)
+    )
+
+
+def test_sensitive_spans_match_yaml_contract(sensitive_spans: list[str]) -> None:
+    """Ensure SENSITIVE_SPANS constant matches trace_contract.yaml sensitive_spans.
+
+    Catches drift between the hardcoded test list and the canonical YAML contract.
+    """
+    python_set = set(SENSITIVE_SPANS)
+    yaml_set = set(sensitive_spans)
+    only_python = python_set - yaml_set
+    only_yaml = yaml_set - python_set
+    assert python_set == yaml_set, (
+        f"SENSITIVE_SPANS drift between test and YAML contract.\n"
+        f"Only in Python constant: {sorted(only_python)}\n"
+        f"Only in YAML contract: {sorted(only_yaml)}"
     )

--- a/tests/contract/test_trace_families_contract.py
+++ b/tests/contract/test_trace_families_contract.py
@@ -50,7 +50,8 @@ def collect_observe_names(
 ) -> set[str]:
     """AST-scan directories and return all @observe(name=...) values."""
     names: set[str] = set()
-    exclude_patterns = exclude_patterns or []
+    always_exclude = [".venv/"]
+    exclude_patterns = (exclude_patterns or []) + always_exclude
     for directory in directories:
         if not directory.exists():
             continue

--- a/tests/observability/trace_contract.yaml
+++ b/tests/observability/trace_contract.yaml
@@ -301,9 +301,15 @@ error_allowlist:
   - span: rag-pipeline
     level: ERROR
     trigger: "Agent pipeline step failed"
-  - span: history-graph-nodes
+  - span: history-retrieve
     level: ERROR
-    trigger: "History graph node failed"
+    trigger: "History retrieval failed"
+  - span: history-rewrite
+    level: ERROR
+    trigger: "History rewrite failed"
+  - span: history-summarize
+    level: ERROR
+    trigger: "History summarization failed"
   # Services — curated error spans for degraded operations
   - span: cache-*
     level: ERROR

--- a/tests/observability/trace_contract.yaml
+++ b/tests/observability/trace_contract.yaml
@@ -303,13 +303,13 @@ error_allowlist:
     trigger: "Agent pipeline step failed"
   - span: history-retrieve
     level: ERROR
-    trigger: "History retrieval failed"
+    trigger: "History search failed"
   - span: history-rewrite
     level: ERROR
     trigger: "History rewrite failed"
   - span: history-summarize
     level: ERROR
-    trigger: "History summarization failed"
+    trigger: "History summarize failed"
   # Services — curated error spans for degraded operations
   - span: cache-*
     level: ERROR


### PR DESCRIPTION
## Summary
- Add `test_sensitive_spans_match_yaml_contract` — catches drift between hardcoded SENSITIVE_SPANS and trace_contract.yaml
- Fix `.venv/` exclusion in all 3 AST scanners (was causing 30s+ timeouts when scanning vendored packages)
- Replace phantom `history-graph-nodes` span with actual span names (`history-retrieve`, `history-rewrite`, `history-summarize`) in YAML error_allowlist
- Expand error_allowlist with curated metadata error/warning spans (cache, qdrant, generate_response, history, rag_pipeline)
- Align `observed_spans` fixture to `session` scope (matches other conftest fixtures)

Follow-up to the trace contract system merged in 2232491. Addresses code review findings.

## Test plan
- [x] `uv run pytest tests/contract/ -q --timeout=30` — 267 passed, 4.05s
- [x] `uv run ruff check tests/contract/ tests/observability/` — all passed
- [x] Existing observability unit tests: 123 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)