### PR TITLE
feat(apartments): add apartments catalog with hybrid search in Qdrant

### DIFF
--- a/data/apartments.csv
+++ b/data/apartments.csv
@@ -1,0 +1,17 @@
+complex_name,section,apartment_number,rooms,floor_label,area_m2,view_raw,price_eur,price_bgn,is_furnished,has_floor_plan,has_photo
+Premier Fort Beach,D-1,248,2,4,78.66,sea,215000.0,420503.45,True,True,True
+Premier Fort Beach,A-2,101,1,1,42.5,garden,89000.0,174025.55,False,True,True
+Premier Fort Beach,B-3,315,3,5,105.3,ultra sea panorama,380000.0,743062.0,True,True,True
+Prestige Fort Beach,C-1,122,2,3,74.8,sea,195000.0,381274.5,True,True,False
+Prestige Fort Beach,A-4,205,1,gr.,38.9,garden,78000.0,152517.9,False,True,True
+Panorama Fort Beach,E-2,430,3,6,112.0,sea panorama,420000.0,821022.0,True,True,True
+Panorama Fort Beach,D-3,318,2,4,80.5,sea,210000.0,410623.5,False,True,True
+Marina View Fort Beach,B-1,150,1,2,45.2,sea,95000.0,185778.5,True,True,True
+Marina View Fort Beach,C-2,267,4,7,140.0,ultra sea panorama,580000.0,1133978.0,True,True,True
+Messambria Fort Beach,A-1,88,2,3,76.4,pool/sea,185000.0,361675.5,True,True,False
+Messambria Fort Beach,B-2,174,1,1,40.0,garden,82000.0,160299.1,False,True,True
+Imperial Fort Club,F-3,502,3,5,108.0,sea,355000.0,694142.5,True,True,True
+Crown Fort Club,F-2,547,1,gr.,37.92,garden,81500.0,159400.15,True,True,False
+Green Fort Suites,G-1,601,2,4,72.0,pool,170000.0,332343.0,True,True,True
+Premier Fort Suites,H-2,712,1,2,39.5,garden,76000.0,148643.0,False,True,True
+Nessebar Fort Residence,I-1,801,3,6,118.5,sea panorama,450000.0,879682.5,True,True,True

--- a/scripts/apartments/ingest.py
+++ b/scripts/apartments/ingest.py
@@ -1,0 +1,87 @@
+"""Ingest apartments CSV into Qdrant with BGE-M3 embeddings."""
+
+import csv
+import os
+import uuid
+
+from qdrant_client import QdrantClient
+from qdrant_client.models import PointStruct, SparseVector
+
+from telegram_bot.services.apartment_models import ApartmentRecord
+from telegram_bot.services.bge_m3_client import BGEM3SyncClient
+
+
+COLLECTION = "apartments"
+NAMESPACE = uuid.UUID("7ba7b810-9dad-11d1-80b4-00c04fd430c8")
+BATCH_SIZE = 32
+
+
+def generate_point_id(complex_name: str, section: str, apartment_number: str) -> str:
+    """Deterministic UUID from complex + section + apartment number."""
+    return str(uuid.uuid5(NAMESPACE, f"{complex_name}::{section}::{apartment_number}"))
+
+
+def ingest(csv_path: str, qdrant_url: str, bge_url: str) -> None:
+    client = QdrantClient(url=qdrant_url)
+    bge = BGEM3SyncClient(base_url=bge_url)
+
+    # Read CSV
+    with open(csv_path) as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    print(f"Loaded {len(rows)} apartments from {csv_path}")
+
+    # Convert to records
+    records = [ApartmentRecord.from_raw(row) for row in rows]
+    descriptions = [r.to_description() for r in records]
+
+    # Embed in batches
+    all_dense, all_sparse, all_colbert = [], [], []
+    for i in range(0, len(descriptions), BATCH_SIZE):
+        batch = descriptions[i : i + BATCH_SIZE]
+        # BGEM3SyncClient has no encode_hybrid(); call sync endpoints explicitly.
+        dense_result = bge.encode_dense(batch)
+        sparse_result = bge.encode_sparse(batch)
+        colbert_result = bge.encode_colbert(batch)
+        all_dense.extend(dense_result.vectors)
+        all_sparse.extend(sparse_result.weights)
+        all_colbert.extend(colbert_result.colbert_vecs)
+        print(f"  Embedded {min(i + BATCH_SIZE, len(descriptions))}/{len(descriptions)}")
+
+    # Build points
+    points = []
+    for rec, dense, sparse, colbert in zip(
+        records, all_dense, all_sparse, all_colbert, strict=True
+    ):
+        point_id = generate_point_id(rec.complex_name, rec.section, rec.apartment_number)
+        vector_dict: dict = {
+            "dense": dense,
+            "bm42": SparseVector(indices=sparse["indices"], values=sparse["values"]),
+        }
+        if colbert:
+            vector_dict["colbert"] = colbert
+
+        points.append(
+            PointStruct(
+                id=point_id,
+                vector=vector_dict,
+                payload=rec.to_payload(),
+            )
+        )
+
+    # Upsert in batches
+    for i in range(0, len(points), 100):
+        batch = points[i : i + 100]
+        client.upsert(collection_name=COLLECTION, points=batch)
+        print(f"  Upserted {min(i + 100, len(points))}/{len(points)}")
+
+    print(f"Done. {len(points)} apartments in collection '{COLLECTION}'.")
+
+
+if __name__ == "__main__":
+    ingest(
+        csv_path=os.getenv("APARTMENTS_CSV", "data/apartments.csv"),
+        qdrant_url=os.getenv("QDRANT_URL", "http://localhost:6333"),
+        bge_url=os.getenv("BGE_M3_URL", "http://localhost:8000"),
+    )

--- a/scripts/apartments/setup_collection.py
+++ b/scripts/apartments/setup_collection.py
@@ -1,0 +1,92 @@
+"""Create apartments Qdrant collection with vectors and payload indexes."""
+
+from qdrant_client import QdrantClient, models
+from qdrant_client.models import (
+    BinaryQuantization,
+    BinaryQuantizationConfig,
+    Distance,
+    HnswConfigDiff,
+    Modifier,
+    MultiVectorComparator,
+    MultiVectorConfig,
+    SparseVectorParams,
+    VectorParams,
+)
+
+
+COLLECTION_NAME = "apartments"
+DENSE_DIM = 1024
+
+
+def create_apartments_collection(client: QdrantClient) -> None:
+    """Create collection mirroring gdrive_documents_bge vector schema."""
+    if client.collection_exists(COLLECTION_NAME):
+        print(f"Collection '{COLLECTION_NAME}' already exists, skipping creation")
+        return
+
+    client.create_collection(
+        collection_name=COLLECTION_NAME,
+        vectors_config={
+            "dense": VectorParams(
+                size=DENSE_DIM,
+                distance=Distance.COSINE,
+                hnsw_config=HnswConfigDiff(m=16, ef_construct=200, on_disk=False),
+                quantization_config=BinaryQuantization(
+                    binary=BinaryQuantizationConfig(always_ram=True)
+                ),
+                on_disk=True,
+            ),
+            "colbert": VectorParams(
+                size=DENSE_DIM,
+                distance=Distance.COSINE,
+                multivector_config=MultiVectorConfig(comparator=MultiVectorComparator.MAX_SIM),
+                hnsw_config=HnswConfigDiff(m=0),
+                on_disk=True,
+            ),
+        },
+        sparse_vectors_config={
+            "bm42": SparseVectorParams(modifier=Modifier.IDF),
+        },
+    )
+    print(f"Created collection: {COLLECTION_NAME}")
+
+
+def create_payload_indexes(client: QdrantClient) -> None:
+    """Create indexes for apartment payload fields (top-level, no metadata. prefix)."""
+    indexes = {
+        # Keyword (facets + exact match)
+        "complex_name": "keyword",
+        "section": "keyword",
+        "apartment_number": "keyword",
+        "view_primary": "keyword",
+        "view_tags": "keyword",
+        # Integer (lookup + range)
+        "rooms": models.PayloadSchemaType.INTEGER,
+        "floor": models.PayloadSchemaType.INTEGER,
+        # Float (range + order_by)
+        "price_eur": models.PayloadSchemaType.FLOAT,
+        "area_m2": models.PayloadSchemaType.FLOAT,
+        # Bool
+        "is_furnished": "bool",
+    }
+
+    for field_name, schema in indexes.items():
+        try:
+            client.create_payload_index(
+                collection_name=COLLECTION_NAME,
+                field_name=field_name,
+                field_schema=schema,
+            )
+            print(f"  Index: {field_name} ({schema})")
+        except Exception as e:
+            print(f"  Warning: {field_name}: {e}")
+
+
+if __name__ == "__main__":
+    import os
+
+    url = os.getenv("QDRANT_URL", "http://localhost:6333")
+    client = QdrantClient(url=url)
+    create_apartments_collection(client)
+    create_payload_indexes(client)
+    print("Done.")

--- a/telegram_bot/agents/apartment_tools.py
+++ b/telegram_bot/agents/apartment_tools.py
@@ -1,0 +1,130 @@
+"""Apartment search tool for agent SDK."""
+
+from __future__ import annotations
+
+import logging
+
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import tool
+
+from telegram_bot.observability import get_client, observe
+
+
+logger = logging.getLogger(__name__)
+
+
+def _format_apartment_results(results: list[dict]) -> str:
+    """Format apartment search results for LLM context."""
+    if not results:
+        return "Апартаменты по вашим критериям не найдены. Попробуйте изменить параметры поиска."
+
+    lines = []
+    for i, apt in enumerate(results, 1):
+        p = apt.get("payload", {})
+        price_fmt = f"{p.get('price_eur', 0):,.0f}".replace(",", " ")
+        view = ", ".join(p.get("view_tags", [])) or p.get("view_primary", "")
+        furnished = "с мебелью" if p.get("is_furnished") else "без мебели"
+        floor_str = "цоколь" if p.get("floor", 0) == 0 else f"{p.get('floor')} эт."
+
+        lines.append(
+            f"{i}. {p.get('complex_name', '?')}, секция {p.get('section', '?')}, "
+            f"апп. {p.get('apartment_number', '?')} — "
+            f"{p.get('rooms', '?')}к, {p.get('area_m2', '?')} м², {floor_str}, "
+            f"вид: {view}, {price_fmt} €, {furnished}"
+        )
+
+    return f"Найдено {len(results)} апартаментов:\n" + "\n".join(lines)
+
+
+@tool
+@observe(name="tool-apartment-search", capture_input=False, capture_output=False)
+async def apartment_search(
+    query: str,
+    config: RunnableConfig,
+    rooms: int | None = None,
+    min_price_eur: float | None = None,
+    max_price_eur: float | None = None,
+    min_area_m2: float | None = None,
+    max_area_m2: float | None = None,
+    min_floor: int | None = None,
+    max_floor: int | None = None,
+    complex_name: str | None = None,
+    view: str | None = None,
+    is_furnished: bool | None = None,
+) -> str:
+    """Search available apartments in Fort Beach complexes.
+
+    Use for ALL apartment/property listing queries. Supports structured filters
+    and free-text semantic search.
+
+    Args:
+        query: Free-text search query (e.g. "уютная двушка у моря").
+        rooms: Number of rooms (1=studio, 2=1-bedroom, 3=2-bedroom, 4=3-bedroom).
+        min_price_eur: Minimum price in EUR.
+        max_price_eur: Maximum price in EUR.
+        min_area_m2: Minimum area in m².
+        max_area_m2: Maximum area in m².
+        min_floor: Minimum floor (0=ground).
+        max_floor: Maximum floor.
+        complex_name: Complex name (e.g. "Premier Fort Beach").
+        view: View type (sea, pool, garden, forest, panorama).
+        is_furnished: Whether apartment is furnished.
+    """
+    ctx = (config.get("configurable") or {}).get("bot_context")
+    if not ctx or not ctx.apartments_service:
+        return "Сервис поиска апартаментов недоступен."
+
+    lf = get_client()
+    lf.update_current_span(input={"query": query[:100], "rooms": rooms, "max_price": max_price_eur})
+
+    # Build filters dict
+    filters: dict = {}
+    if rooms is not None:
+        filters["rooms"] = rooms
+    if min_price_eur is not None or max_price_eur is not None:
+        price_f: dict = {}
+        if min_price_eur is not None:
+            price_f["gte"] = min_price_eur
+        if max_price_eur is not None:
+            price_f["lte"] = max_price_eur
+        filters["price_eur"] = price_f
+    if min_area_m2 is not None or max_area_m2 is not None:
+        area_f: dict = {}
+        if min_area_m2 is not None:
+            area_f["gte"] = min_area_m2
+        if max_area_m2 is not None:
+            area_f["lte"] = max_area_m2
+        filters["area_m2"] = area_f
+    if min_floor is not None or max_floor is not None:
+        floor_f: dict = {}
+        if min_floor is not None:
+            floor_f["gte"] = min_floor
+        if max_floor is not None:
+            floor_f["lte"] = max_floor
+        filters["floor"] = floor_f
+    if complex_name is not None:
+        filters["complex_name"] = complex_name
+    if view is not None:
+        filters["view_tags"] = [view]
+    if is_furnished is not None:
+        filters["is_furnished"] = is_furnished
+
+    try:
+        # Embed query
+        dense, sparse, colbert = await ctx.embeddings.aembed_hybrid_with_colbert(query)
+
+        results, total = await ctx.apartments_service.search_with_filters(
+            dense_vector=dense,
+            colbert_query=colbert or None,
+            sparse_vector=sparse,
+            filters=filters or None,
+            top_k=10,
+        )
+
+        response = _format_apartment_results(results)
+        lf.update_current_span(output={"results_count": total})
+        return response
+
+    except Exception:
+        logger.exception("Apartment search failed")
+        return "Ошибка при поиске апартаментов. Попробуйте позже."

--- a/telegram_bot/agents/context.py
+++ b/telegram_bot/agents/context.py
@@ -43,3 +43,4 @@ class BotContext:
     history_reply_markup: Any | None = None  # side-channel for #434
     bot: Any | None = None  # aiogram Bot instance (for handoff tool, #445)
     manager_ids: list[int] | None = None  # Telegram IDs of managers (for handoff, #445)
+    apartments_service: Any | None = None  # ApartmentsService (#629)

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -290,6 +290,16 @@ class PropertyBot:
             timeout=config.qdrant_timeout,
         )
 
+        # Apartments collection (#629)
+        from .services.apartments_service import ApartmentsService
+
+        self._qdrant_apartments = QdrantService(
+            url=config.qdrant_url,
+            api_key=config.qdrant_api_key,
+            collection_name="apartments",
+        )
+        self._apartments_service = ApartmentsService(qdrant=self._qdrant_apartments)
+
         # Rerank provider (feature flag)
         self._reranker = None
         if config.rerank_provider == "colbert":
@@ -951,6 +961,64 @@ class PropertyBot:
                     logger.exception("Failed to send text response chunk")
                     await message.answer(chunk)
 
+    async def _handle_apartment_fast_path(
+        self,
+        *,
+        user_text: str,
+        message: Message,
+    ) -> str | None:
+        """C+ fast path: regex filters -> hybrid search -> generate. No agent loop (#629)."""
+        from .services.apartment_filter_extractor import ApartmentFilterExtractor
+        from .services.apartments_service import check_escalation
+
+        extractor = ApartmentFilterExtractor()
+        parsed = extractor.parse(user_text)
+
+        if parsed.confidence == "LOW":
+            return None  # escalate to agent
+
+        dense, sparse, colbert = await self._embeddings.aembed_hybrid_with_colbert(
+            parsed.semantic_query or user_text
+        )
+
+        filters = parsed.to_filters_dict()
+        results, returned_count = await self._apartments_service.search_with_filters(
+            dense_vector=dense,
+            colbert_query=colbert or None,
+            sparse_vector=sparse,
+            filters=filters or None,
+            top_k=10,
+        )
+
+        score_spread = (results[0]["score"] - results[-1]["score"]) if len(results) > 1 else 0
+        escalation = check_escalation(
+            returned_count=returned_count,
+            top_k=10,
+            score_spread=score_spread,
+            confidence=parsed.confidence,
+        )
+        if escalation:
+            return None  # escalate to agent
+
+        from .agents.apartment_tools import _format_apartment_results
+        from .services.generate_response import generate_response
+
+        context = _format_apartment_results(results)
+
+        generated = await generate_response(
+            query=user_text,
+            documents=[],
+            retrieved_context=[{"content": context, "source": "apartments_catalog"}],
+            raw_messages=[{"role": "user", "content": user_text}],
+            config=self._graph_config,
+            message=message,
+        )
+
+        response_text = str(generated.get("response", "") or context)
+        if not generated.get("response_sent"):
+            await self._send_markdown_chunks(message, response_text)
+        return response_text
+
     async def _handle_client_direct_pipeline(
         self,
         *,
@@ -968,6 +1036,18 @@ class PropertyBot:
             Response text if the pipeline handled the request.
             None if the pipeline signals needs_agent=True (caller falls through to sdk_agent).
         """
+        # Apartment fast path: intent check → regex filters → hybrid search → generate (#629)
+        from .pipelines.client import detect_agent_intent
+
+        if detect_agent_intent(user_text) == "apartment":
+            apt_answer = await self._handle_apartment_fast_path(
+                user_text=user_text,
+                message=message,
+            )
+            if apt_answer is not None:
+                return apt_answer
+            return None  # escalate to agent path
+
         result = await run_client_pipeline(
             user_text=user_text,
             user_id=user_id,
@@ -999,6 +1079,7 @@ class PropertyBot:
     ) -> str:
         """Handle query via create_agent SDK (#413 — replaces build_supervisor_graph)."""
         from .agents.agent import LOCALE_TO_LANGUAGE
+        from .agents.apartment_tools import apartment_search
         from .agents.history_tool import history_search
         from .agents.rag_tool import rag_search
 
@@ -1233,7 +1314,7 @@ class PropertyBot:
                     )
 
             # Build base tools list (client-only: rag_search)
-            base_tools: list[Any] = [rag_search]
+            base_tools: list[Any] = [rag_search, apartment_search]
 
             manager_tools: list[Any] = []
             if role == "manager":
@@ -1319,6 +1400,7 @@ class PropertyBot:
                 original_user_query=message.text or "",
                 bot=bot,
                 manager_ids=list(self.config.manager_ids),
+                apartments_service=self._apartments_service,
             )
 
             # Initialize handler inside propagation context so it inherits session/user/tags.
@@ -1858,13 +1940,14 @@ class PropertyBot:
             await callback.message.edit_reply_markup(reply_markup=None)
 
         # Rebuild agent with same tools and checkpointer (mirrors _handle_query_supervisor)
+        from .agents.apartment_tools import apartment_search
         from .agents.rag_tool import rag_search
         from .agents.utility_tools import get_utility_tools
 
         role = await self._resolve_user_role(user_id)
         session_id = make_session_id("chat", chat_id)
 
-        base_tools: list[Any] = [rag_search]
+        base_tools: list[Any] = [rag_search, apartment_search]
         manager_tools: list[Any] = []
         if role == "manager":
             from .agents.manager_tools import (
@@ -1937,6 +2020,7 @@ class PropertyBot:
             guard_mode=self.config.guard_mode,
             role=role,
             manager_id=(self.config.kommo_responsible_user_id if role == "manager" else None),
+            apartments_service=self._apartments_service,
         )
 
         with propagate_attributes(
@@ -2075,6 +2159,7 @@ class PropertyBot:
         Reuses _ainvoke_supervisor_with_recovery for consistency with handle_query.
         """
         from .agents.agent import LOCALE_TO_LANGUAGE
+        from .agents.apartment_tools import apartment_search
         from .agents.rag_tool import rag_search
 
         if callback.from_user is None or callback.message is None:
@@ -2089,7 +2174,7 @@ class PropertyBot:
         session_id = make_session_id("chat", chat_id)
 
         # Build tools list (mirrors _handle_query_supervisor tool assembly)
-        base_tools: list[Any] = [rag_search]
+        base_tools: list[Any] = [rag_search, apartment_search]
         manager_tools: list[Any] = []
         if role == "manager":
             from .agents.manager_tools import (
@@ -2171,6 +2256,7 @@ class PropertyBot:
             original_user_query=query_text,
             bot=bot,
             manager_ids=list(self.config.manager_ids),
+            apartments_service=self._apartments_service,
         )
 
         rag_result_store: dict[str, Any] = {}

--- a/telegram_bot/pipelines/client.py
+++ b/telegram_bot/pipelines/client.py
@@ -55,7 +55,7 @@ def detect_agent_intent(user_text: str) -> str:
         user_text: Raw user message.
 
     Returns:
-        Intent string: "mortgage" | "handoff" | "daily_summary" | "".
+        Intent string: "mortgage" | "handoff" | "daily_summary" | "apartment" | "".
     """
     text = user_text.lower()
     lf = get_client()
@@ -66,6 +66,21 @@ def detect_agent_intent(user_text: str) -> str:
         intent = "handoff"
     elif any(kw in text for kw in ("сводк", "отчёт", "итог дня", "итоги дня")):
         intent = "daily_summary"
+    elif any(
+        kw in text
+        for kw in (
+            "апартамент",
+            "двушк",
+            "трёшк",
+            "трешк",
+            "трёхкомнат",
+            "трехкомнат",
+            "студи",
+            "подобрать",
+            "подбор",
+        )
+    ):
+        intent = "apartment"
     else:
         intent = ""
     lf.update_current_span(output={"intent": intent or "none"})

--- a/telegram_bot/services/apartment_filter_extractor.py
+++ b/telegram_bot/services/apartment_filter_extractor.py
@@ -1,0 +1,269 @@
+# telegram_bot/services/apartment_filter_extractor.py
+"""Apartment-specific filter extraction from natural language queries (0 LLM calls)."""
+
+from __future__ import annotations
+
+import re
+
+from telegram_bot.services.apartment_models import ApartmentQueryParseResult, compute_confidence
+
+
+# All canonical complex names plus RU/EN short aliases — sorted longest-first for greedy match
+_COMPLEX_ALIASES: dict[str, str] = {
+    # EN canonical
+    "premier fort beach": "Premier Fort Beach",
+    "prestige fort beach": "Prestige Fort Beach",
+    "panorama fort beach": "Panorama Fort Beach",
+    "marina view fort beach": "Marina View Fort Beach",
+    "messambria fort beach": "Messambria Fort Beach",
+    "imperial fort club": "Imperial Fort Club",
+    "crown fort club": "Crown Fort Club",
+    "green fort suites": "Green Fort Suites",
+    "premier fort suites": "Premier Fort Suites",
+    "nessebar fort residence": "Nessebar Fort Residence",
+    # RU short aliases
+    "премьер форт бич": "Premier Fort Beach",
+    "премьер форт": "Premier Fort Beach",
+    "в премьере": "Premier Fort Beach",
+    "престиж форт": "Prestige Fort Beach",
+    "в престиже": "Prestige Fort Beach",
+    "панорама форт": "Panorama Fort Beach",
+    "марина вью": "Marina View Fort Beach",
+    "мессамбрия": "Messambria Fort Beach",
+    "империал форт": "Imperial Fort Club",
+    "кроун форт": "Crown Fort Club",
+    "грин форт": "Green Fort Suites",
+    "гринфорт": "Green Fort Suites",
+    "премьер форт сьютс": "Premier Fort Suites",
+    "несебр форт": "Nessebar Fort Residence",
+}
+
+_COMPLEX_ALIASES_SORTED = sorted(_COMPLEX_ALIASES, key=len, reverse=True)
+
+
+class ApartmentFilterExtractor:
+    """Extract apartment filters from natural language (regex-only, 0 LLM calls)."""
+
+    def parse(self, query: str) -> ApartmentQueryParseResult:
+        """Parse query into ApartmentQueryParseResult with confidence score."""
+        q = query.lower()
+        consumed: list[tuple[int, int]] = []
+
+        rooms = self._extract_rooms(q, consumed)
+        min_price, max_price = self._extract_price(q, consumed)
+        min_area, max_area = self._extract_area(q, consumed)
+        min_floor, max_floor = self._extract_floor(q, consumed)
+        complex_name = self._extract_complex(q, consumed)
+        view_tags = self._extract_view(q, consumed)
+
+        conflicts: list[str] = []
+        if min_price is not None and max_price is not None and min_price > max_price:
+            conflicts.append("price_conflict:min>max")
+
+        result = ApartmentQueryParseResult(
+            rooms=rooms,
+            min_price_eur=min_price,
+            max_price_eur=max_price,
+            min_area_m2=min_area,
+            max_area_m2=max_area,
+            min_floor=min_floor,
+            max_floor=max_floor,
+            complex_name=complex_name,
+            view_tags=view_tags,
+            semantic_query=self._build_semantic_query(query, consumed),
+            conflicts=conflicts,
+            raw_query=query,
+        )
+        return compute_confidence(result)
+
+    # --- Rooms ---
+
+    def _extract_rooms(self, text: str, consumed: list[tuple[int, int]]) -> int | None:
+        _num_map = {"одно": 1, "дву": 2, "трех": 3, "трёх": 3, "четырех": 4, "пяти": 5}
+        patterns: list[tuple[str, int | None]] = [
+            (r"двушка", 2),
+            (r"трёхкомнатная|трехкомнатная", 3),
+            (r"однокомнатная", 1),
+            (r"студия", 1),
+            (r"(\d+)\s*комнат", None),
+            (r"(\d+)\s*спальн", None),
+            (r"(одно|дву|трех|трёх|четырех|пяти)комнатн", None),
+        ]
+        for pat, val in patterns:
+            m = re.search(pat, text)
+            if m:
+                consumed.append(m.span())
+                if val is not None:
+                    return val
+                g = m.group(1)
+                if g.isdigit():
+                    return int(g)
+                for word, num in _num_map.items():
+                    if g.startswith(word):
+                        return num
+        return None
+
+    # --- Price ---
+
+    def _parse_number(self, text: str) -> int | None:
+        """Parse integer from text, handling spaces and 'к' = 1000 suffix."""
+        text = text.strip().replace(" ", "").replace("\xa0", "")
+        if text.endswith("к"):
+            text = text[:-1] + "000"
+        try:
+            return int(text)
+        except ValueError:
+            return None
+
+    def _extract_price(
+        self, text: str, consumed: list[tuple[int, int]]
+    ) -> tuple[float | None, float | None]:
+        # Range first: "от 100к до 300к"
+        m = re.search(r"от\s+(\d[\d\s]*к?)\s+до\s+(\d[\d\s]*к?)", text)
+        if m:
+            consumed.append(m.span())
+            mn = self._parse_number(m.group(1))
+            mx = self._parse_number(m.group(2))
+            return (float(mn) if mn else None, float(mx) if mx else None)
+
+        min_p: float | None = None
+        max_p: float | None = None
+
+        # Max price
+        for pat in [
+            r"до\s+(\d[\d\s]*к?)\s*(?:евро|€|eur)?",
+            r"дешевле\s+(\d[\d\s]*к?)",
+            r"меньше\s+(\d[\d\s]*к?)",
+            r"не\s+дороже\s+(\d[\d\s]*к?)",
+        ]:
+            m2 = re.search(pat, text)
+            if m2:
+                val = self._parse_number(m2.group(1))
+                # Prices are always >= 1000 EUR; guard against area "до 80 м²" false-matches
+                if val and val >= 1000:
+                    consumed.append(m2.span())
+                    max_p = float(val)
+                    break
+
+        # Min price
+        for pat in [
+            r"от\s+(\d[\d\s]*к?)\s*(?:евро|€|eur)?",
+            r"дороже\s+(\d[\d\s]*к?)",
+            r"больше\s+(\d[\d\s]*к?)",
+        ]:
+            m3 = re.search(pat, text)
+            if m3:
+                val = self._parse_number(m3.group(1))
+                if val and val >= 1000:
+                    consumed.append(m3.span())
+                    min_p = float(val)
+                    break
+
+        return (min_p, max_p)
+
+    # --- Area ---
+
+    def _extract_area(
+        self, text: str, consumed: list[tuple[int, int]]
+    ) -> tuple[float | None, float | None]:
+        # Range: "от 60 до 120 м²"
+        m = re.search(r"от\s+(\d+)\s+до\s+(\d+)\s*(?:м²|м2|кв\.?м?)", text)
+        if m:
+            consumed.append(m.span())
+            return (float(m.group(1)), float(m.group(2)))
+
+        min_a: float | None = None
+        max_a: float | None = None
+
+        m2 = re.search(r"от\s+(\d+)\s*(?:м²|м2|кв\.?м?)", text)
+        if m2:
+            consumed.append(m2.span())
+            min_a = float(m2.group(1))
+
+        m3 = re.search(r"до\s+(\d+)\s*(?:м²|м2|кв\.?м?)", text)
+        if m3:
+            consumed.append(m3.span())
+            max_a = float(m3.group(1))
+
+        return (min_a, max_a)
+
+    # --- Floor ---
+
+    def _extract_floor(
+        self, text: str, consumed: list[tuple[int, int]]
+    ) -> tuple[int | None, int | None]:
+        m = re.search(r"не\s+выше\s+(\d+)\s*этаж", text)
+        if m:
+            consumed.append(m.span())
+            return (None, int(m.group(1)))
+
+        m2 = re.search(r"от\s+(\d+)\s*этаж", text)
+        if m2:
+            consumed.append(m2.span())
+            return (int(m2.group(1)), None)
+
+        m3 = re.search(r"высокий\s+этаж", text)
+        if m3:
+            consumed.append(m3.span())
+            return (4, None)
+
+        # Exact floor: "3 этаж"
+        m4 = re.search(r"(\d+)\s*этаж", text)
+        if m4:
+            consumed.append(m4.span())
+            n = int(m4.group(1))
+            return (n, n)
+
+        return (None, None)
+
+    # --- Complex name ---
+
+    def _extract_complex(self, text: str, consumed: list[tuple[int, int]]) -> str | None:
+        for alias in _COMPLEX_ALIASES_SORTED:
+            if alias in text:
+                start = text.index(alias)
+                consumed.append((start, start + len(alias)))
+                return _COMPLEX_ALIASES[alias]
+        return None
+
+    # --- View ---
+
+    def _extract_view(self, text: str, consumed: list[tuple[int, int]]) -> list[str]:
+        view_patterns: list[tuple[str, list[str]]] = [
+            (r"панорама\s+моря|sea\s+panorama", ["sea", "panorama"]),
+            (r"с\s+видом\s+на\s+море|вид\s+на\s+море|sea\s+view|морской\s+вид", ["sea"]),
+            (r"у\s+бассейна|вид\s+на\s+бассейн|pool\s+view", ["pool"]),
+            (r"вид\s+на\s+сад|garden\s+view", ["garden"]),
+            (r"вид\s+на\s+лес|forest\s+view", ["forest"]),
+        ]
+        for pat, tags in view_patterns:
+            m = re.search(pat, text)
+            if m:
+                consumed.append(m.span())
+                return tags
+        return []
+
+    # --- Semantic query ---
+
+    def _build_semantic_query(self, query: str, consumed: list[tuple[int, int]]) -> str:
+        """Remove filter token spans from original query; return descriptive remainder."""
+        if not consumed:
+            return query.strip()
+        spans = sorted(set(consumed))
+        merged: list[tuple[int, int]] = []
+        for start, end in spans:
+            if merged and start <= merged[-1][1]:
+                merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+            else:
+                merged.append((start, end))
+        parts: list[str] = []
+        prev = 0
+        for start, end in merged:
+            chunk = query[prev:start].strip()
+            if chunk:
+                parts.append(chunk)
+            prev = end
+        tail = query[prev:].strip()
+        if tail:
+            parts.append(tail)
+        return " ".join(parts).strip()

--- a/telegram_bot/services/apartment_filter_extractor.py
+++ b/telegram_bot/services/apartment_filter_extractor.py
@@ -118,13 +118,19 @@ class ApartmentFilterExtractor:
     def _extract_price(
         self, text: str, consumed: list[tuple[int, int]]
     ) -> tuple[float | None, float | None]:
-        # Range first: "от 100к до 300к"
-        m = re.search(r"от\s+(\d[\d\s]*к?)\s+до\s+(\d[\d\s]*к?)", text)
+        # Range first: "от 100к до 300к" / "от 100000 до 300000 евро"
+        # Guard against area/floor phrases like "от 60 до 120 м²".
+        m = re.search(r"от\s+(\d[\d\s]*к?)\s+до\s+(\d[\d\s]*к?)\s*(евро|€|eur)?", text)
         if m:
-            consumed.append(m.span())
-            mn = self._parse_number(m.group(1))
-            mx = self._parse_number(m.group(2))
-            return (float(mn) if mn else None, float(mx) if mx else None)
+            mn_raw = m.group(1)
+            mx_raw = m.group(2)
+            mn = self._parse_number(mn_raw)
+            mx = self._parse_number(mx_raw)
+            has_currency = bool(m.group(3))
+            has_k_suffix = "к" in mn_raw.lower() or "к" in mx_raw.lower()
+            if mn and mx and (has_currency or has_k_suffix or mn >= 1000 or mx >= 1000):
+                consumed.append(m.span())
+                return (float(mn), float(mx))
 
         min_p: float | None = None
         max_p: float | None = None

--- a/telegram_bot/services/apartment_models.py
+++ b/telegram_bot/services/apartment_models.py
@@ -1,0 +1,262 @@
+"""Data models for apartment catalog in Qdrant."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+
+
+# --- View normalization ---
+
+_VIEW_SYNONYMS: dict[str, str] = {
+    "ultra sea panorama": "ultra_sea_panorama",
+    "ultra sea view": "ultra_sea_panorama",
+    "ultra sea": "ultra_sea",
+    "sea panorama": "sea_panorama",
+    "sea panorama/forest": "sea_panorama",
+    "garden/forest": "garden",
+    "garden/pool": "garden",
+    "pool/garden": "pool",
+    "pool/sea": "pool",
+    "backyard": "garden",
+}
+
+_VIEW_TAG_MAP: dict[str, list[str]] = {
+    "ultra_sea_panorama": ["sea", "panorama"],
+    "ultra_sea": ["sea"],
+    "sea_panorama": ["sea", "panorama"],
+    "sea": ["sea"],
+    "pool": ["pool"],
+    "garden": ["garden"],
+    "forest": ["forest"],
+}
+
+
+def normalize_view(raw: str) -> tuple[str, list[str]]:
+    """Normalize view string to (primary, tags).
+
+    Handles: "ultra sea panorama", "sea/garden", "garden/pool", etc.
+    Returns: ("sea", ["sea", "garden"]) for "sea/garden"
+    """
+    raw = raw.strip().lower()
+    if not raw:
+        return ("", [])
+
+    # Check exact synonym first
+    if raw in _VIEW_SYNONYMS:
+        primary = _VIEW_SYNONYMS[raw]
+        tags = list(_VIEW_TAG_MAP.get(primary, [primary]))
+        return (primary, tags)
+
+    # Handle slash-separated: "sea/garden" → primary="sea", tags=["sea","garden"]
+    if "/" in raw:
+        parts = [p.strip() for p in raw.split("/")]
+        all_tags: list[str] = []
+        for p in parts:
+            normalized = _VIEW_SYNONYMS.get(p, p.replace(" ", "_"))
+            all_tags.extend(_VIEW_TAG_MAP.get(normalized, [normalized]))
+        primary_normalized = _VIEW_SYNONYMS.get(parts[0], parts[0].replace(" ", "_"))
+        return (primary_normalized, list(dict.fromkeys(all_tags)))
+
+    # Single word or phrase
+    normalized = raw.replace(" ", "_")
+    tags = list(_VIEW_TAG_MAP.get(normalized, [normalized]))
+    return (normalized, tags)
+
+
+# --- Records ---
+
+
+@dataclass(frozen=True, slots=True)
+class ApartmentRecord:
+    """Single apartment listing for Qdrant ingestion."""
+
+    complex_name: str
+    section: str
+    apartment_number: str
+    rooms: int
+    floor: int
+    floor_label: str
+    area_m2: float
+    view_primary: str
+    view_tags: list[str]
+    price_eur: float
+    price_bgn: float
+    is_furnished: bool
+    has_floor_plan: bool
+    has_photo: bool
+
+    @classmethod
+    def from_raw(cls, row: dict) -> ApartmentRecord:
+        """Create from raw data dict (CSV row or parsed HTML)."""
+        floor_label = str(row.get("floor_label", "0"))
+        floor = 0 if floor_label.lower().startswith("gr") else int(floor_label)
+
+        view_primary, view_tags = normalize_view(str(row.get("view_raw", "")))
+
+        return cls(
+            complex_name=str(row["complex_name"]),
+            section=str(row["section"]),
+            apartment_number=str(row["apartment_number"]),
+            rooms=int(row["rooms"]),
+            floor=floor,
+            floor_label=floor_label,
+            area_m2=float(row["area_m2"]),
+            view_primary=view_primary,
+            view_tags=view_tags,
+            price_eur=float(row["price_eur"]),
+            price_bgn=float(row.get("price_bgn", 0)),
+            is_furnished=bool(row.get("is_furnished", False)),
+            has_floor_plan=bool(row.get("has_floor_plan", False)),
+            has_photo=bool(row.get("has_photo", False)),
+        )
+
+    def to_description(self) -> str:
+        """Generate natural language description for embedding."""
+        furnished = "С мебелью" if self.is_furnished else "Без мебели"
+        floor_str = "цокольный этаж" if self.floor == 0 else f"{self.floor} этаж"
+        price_fmt = f"{self.price_eur:,.0f}".replace(",", " ")
+        view_str = ", ".join(self.view_tags) if self.view_tags else "не указан"
+        rooms_word = {
+            1: "Студио",
+            2: "2 комнаты (1 спальня)",
+            3: "3 комнаты (2 спальни)",
+            4: "4 комнаты (3 спальни)",
+        }.get(self.rooms, f"{self.rooms} комнат")
+
+        return (
+            f"{self.complex_name}, секция {self.section}, "
+            f"апартамент {self.apartment_number}. "
+            f"{rooms_word}, {floor_str}, {self.area_m2} м². "
+            f"Вид: {view_str}. Цена: {price_fmt} €. {furnished}."
+        )
+
+    def to_payload(self) -> dict:
+        """Build Qdrant point payload (top-level fields, no metadata. prefix)."""
+        return {
+            "complex_name": self.complex_name,
+            "section": self.section,
+            "apartment_number": self.apartment_number,
+            "rooms": self.rooms,
+            "floor": self.floor,
+            "floor_label": self.floor_label,
+            "area_m2": self.area_m2,
+            "view_primary": self.view_primary,
+            "view_tags": self.view_tags,
+            "price_eur": self.price_eur,
+            "price_bgn": self.price_bgn,
+            "is_furnished": self.is_furnished,
+            "has_floor_plan": self.has_floor_plan,
+            "has_photo": self.has_photo,
+            "description": self.to_description(),
+        }
+
+
+# --- Query parse result ---
+
+
+@dataclass
+class ApartmentQueryParseResult:
+    """Parsed apartment search query with confidence scoring."""
+
+    # Hard filters (numeric)
+    rooms: int | None = None
+    min_price_eur: float | None = None
+    max_price_eur: float | None = None
+    min_area_m2: float | None = None
+    max_area_m2: float | None = None
+    min_floor: int | None = None
+    max_floor: int | None = None
+    is_furnished: bool | None = None
+
+    # Entity filters
+    complex_name: str | None = None
+    view_tags: list[str] = field(default_factory=list)
+    section: str | None = None
+
+    # Meta
+    semantic_query: str = ""
+    confidence: str = "LOW"
+    score: int = 0
+    conflicts: list[str] = field(default_factory=list)
+    raw_query: str = ""
+
+    def to_filters_dict(self) -> dict:
+        """Convert to Qdrant-compatible filters dict for _build_apartment_filter()."""
+        f: dict = {}
+        if self.rooms is not None:
+            f["rooms"] = self.rooms
+        if self.min_price_eur is not None or self.max_price_eur is not None:
+            price_range: dict = {}
+            if self.min_price_eur is not None:
+                price_range["gte"] = self.min_price_eur
+            if self.max_price_eur is not None:
+                price_range["lte"] = self.max_price_eur
+            f["price_eur"] = price_range
+        if self.min_area_m2 is not None or self.max_area_m2 is not None:
+            area_range: dict = {}
+            if self.min_area_m2 is not None:
+                area_range["gte"] = self.min_area_m2
+            if self.max_area_m2 is not None:
+                area_range["lte"] = self.max_area_m2
+            f["area_m2"] = area_range
+        if self.min_floor is not None or self.max_floor is not None:
+            floor_range: dict = {}
+            if self.min_floor is not None:
+                floor_range["gte"] = self.min_floor
+            if self.max_floor is not None:
+                floor_range["lte"] = self.max_floor
+            f["floor"] = floor_range
+        if self.complex_name is not None:
+            f["complex_name"] = self.complex_name
+        if self.view_tags:
+            f["view_tags"] = self.view_tags  # handled by MatchAny
+        if self.section is not None:
+            f["section"] = self.section
+        if self.is_furnished is not None:
+            f["is_furnished"] = self.is_furnished
+        return f
+
+
+def compute_confidence(parse_result: ApartmentQueryParseResult) -> ApartmentQueryParseResult:
+    """Score and assign confidence level. Returns new instance."""
+    if parse_result.conflicts:
+        return replace(parse_result, confidence="LOW", score=-1)
+
+    score = 0
+    has_hard = False
+    has_entity = False
+
+    # Hard filters
+    if parse_result.rooms is not None:
+        score += 2
+        has_hard = True
+    if parse_result.min_price_eur is not None or parse_result.max_price_eur is not None:
+        score += 2
+        has_hard = True
+    if parse_result.min_area_m2 is not None or parse_result.max_area_m2 is not None:
+        score += 1
+        has_hard = True
+    if parse_result.min_floor is not None or parse_result.max_floor is not None:
+        score += 1
+        has_hard = True
+
+    # Entity filters
+    if parse_result.complex_name is not None:
+        score += 2
+        has_entity = True
+    if parse_result.view_tags:
+        score += 1
+        has_entity = True
+    if parse_result.section is not None:
+        score += 1
+        has_entity = True
+
+    # Confidence mapping
+    if score >= 4 and has_hard and has_entity:
+        confidence = "HIGH"
+    elif score >= 2:
+        confidence = "MEDIUM"
+    else:
+        confidence = "LOW"
+
+    return replace(parse_result, confidence=confidence, score=score)

--- a/telegram_bot/services/apartment_models.py
+++ b/telegram_bot/services/apartment_models.py
@@ -1,0 +1,267 @@
+# telegram_bot/services/apartment_models.py
+"""Data models for apartment catalog in Qdrant."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+
+
+# --- View normalization ---
+
+_VIEW_SYNONYMS: dict[str, str] = {
+    "ultra sea panorama": "ultra_sea_panorama",
+    "ultra sea view": "ultra_sea_panorama",
+    "ultra sea": "ultra_sea",
+    "sea panorama": "sea_panorama",
+    "sea panorama/forest": "sea_panorama",
+    "garden/forest": "garden",
+    "garden/pool": "garden",
+    "pool/garden": "pool",
+    "pool/sea": "pool",
+    "backyard": "garden",
+}
+
+_VIEW_TAG_MAP: dict[str, list[str]] = {
+    "ultra_sea_panorama": ["sea", "panorama"],
+    "ultra_sea": ["sea"],
+    "sea_panorama": ["sea", "panorama"],
+    "sea": ["sea"],
+    "pool": ["pool"],
+    "garden": ["garden"],
+    "forest": ["forest"],
+}
+
+
+def normalize_view(raw: str) -> tuple[str, list[str]]:
+    """Normalize view string to (primary, tags).
+
+    Handles: "ultra sea panorama", "sea/garden", "pool/sea", etc.
+    Returns: ("sea", ["sea", "garden"]) for "sea/garden"
+    """
+    raw = raw.strip().lower()
+    if not raw:
+        return ("", [])
+
+    # Slash-separated FIRST: expand tags from all parts, use synonym for primary
+    if "/" in raw:
+        parts = [p.strip() for p in raw.split("/")]
+        all_tags: list[str] = []
+        for p in parts:
+            normalized = _VIEW_SYNONYMS.get(p, p.replace(" ", "_"))
+            all_tags.extend(_VIEW_TAG_MAP.get(normalized, [normalized]))
+        # Use synonym for primary if the combined string is recognized
+        if raw in _VIEW_SYNONYMS:
+            primary_normalized = _VIEW_SYNONYMS[raw]
+        else:
+            primary_normalized = _VIEW_SYNONYMS.get(parts[0], parts[0].replace(" ", "_"))
+        return (primary_normalized, list(dict.fromkeys(all_tags)))
+
+    # Check exact synonym (non-slash inputs only)
+    if raw in _VIEW_SYNONYMS:
+        primary = _VIEW_SYNONYMS[raw]
+        tags = list(_VIEW_TAG_MAP.get(primary, [primary]))
+        return (primary, tags)
+
+    # Single word or phrase
+    normalized = raw.replace(" ", "_")
+    tags = list(_VIEW_TAG_MAP.get(normalized, [normalized]))
+    return (normalized, tags)
+
+
+# --- Records ---
+
+
+@dataclass(frozen=True, slots=True)
+class ApartmentRecord:
+    """Single apartment listing for Qdrant ingestion."""
+
+    complex_name: str
+    section: str
+    apartment_number: str
+    rooms: int
+    floor: int
+    floor_label: str
+    area_m2: float
+    view_primary: str
+    view_tags: list[str]
+    price_eur: float
+    price_bgn: float
+    is_furnished: bool
+    has_floor_plan: bool
+    has_photo: bool
+
+    @classmethod
+    def from_raw(cls, row: dict) -> ApartmentRecord:
+        """Create from raw data dict (CSV row or parsed HTML)."""
+        floor_label = str(row.get("floor_label", "0"))
+        floor = 0 if floor_label.lower().startswith("gr") else int(floor_label)
+
+        view_primary, view_tags = normalize_view(str(row.get("view_raw", "")))
+
+        return cls(
+            complex_name=str(row["complex_name"]),
+            section=str(row["section"]),
+            apartment_number=str(row["apartment_number"]),
+            rooms=int(row["rooms"]),
+            floor=floor,
+            floor_label=floor_label,
+            area_m2=float(row["area_m2"]),
+            view_primary=view_primary,
+            view_tags=view_tags,
+            price_eur=float(row["price_eur"]),
+            price_bgn=float(row.get("price_bgn", 0)),
+            is_furnished=bool(row.get("is_furnished", False)),
+            has_floor_plan=bool(row.get("has_floor_plan", False)),
+            has_photo=bool(row.get("has_photo", False)),
+        )
+
+    def to_description(self) -> str:
+        """Generate natural language description for embedding."""
+        furnished = "С мебелью" if self.is_furnished else "Без мебели"
+        floor_str = "цокольный этаж" if self.floor == 0 else f"{self.floor} этаж"
+        price_fmt = f"{self.price_eur:,.0f}".replace(",", " ")
+        view_str = ", ".join(self.view_tags) if self.view_tags else "не указан"
+        rooms_word = {
+            1: "Студио",
+            2: "2 комнаты (1 спальня)",
+            3: "3 комнаты (2 спальни)",
+            4: "4 комнаты (3 спальни)",
+        }.get(self.rooms, f"{self.rooms} комнат")
+
+        return (
+            f"{self.complex_name}, секция {self.section}, "
+            f"апартамент {self.apartment_number}. "
+            f"{rooms_word}, {floor_str}, {self.area_m2} м². "
+            f"Вид: {view_str}. Цена: {price_fmt} €. {furnished}."
+        )
+
+    def to_payload(self) -> dict:
+        """Build Qdrant point payload (top-level fields, no metadata. prefix)."""
+        return {
+            "complex_name": self.complex_name,
+            "section": self.section,
+            "apartment_number": self.apartment_number,
+            "rooms": self.rooms,
+            "floor": self.floor,
+            "floor_label": self.floor_label,
+            "area_m2": self.area_m2,
+            "view_primary": self.view_primary,
+            "view_tags": self.view_tags,
+            "price_eur": self.price_eur,
+            "price_bgn": self.price_bgn,
+            "is_furnished": self.is_furnished,
+            "has_floor_plan": self.has_floor_plan,
+            "has_photo": self.has_photo,
+            "description": self.to_description(),
+        }
+
+
+# --- Query parse result ---
+
+
+@dataclass
+class ApartmentQueryParseResult:
+    """Parsed apartment search query with confidence scoring."""
+
+    # Hard filters (numeric)
+    rooms: int | None = None
+    min_price_eur: float | None = None
+    max_price_eur: float | None = None
+    min_area_m2: float | None = None
+    max_area_m2: float | None = None
+    min_floor: int | None = None
+    max_floor: int | None = None
+    is_furnished: bool | None = None
+
+    # Entity filters
+    complex_name: str | None = None
+    view_tags: list[str] = field(default_factory=list)
+    section: str | None = None
+
+    # Meta
+    semantic_query: str = ""
+    confidence: str = "LOW"
+    score: int = 0
+    conflicts: list[str] = field(default_factory=list)
+    raw_query: str = ""
+
+    def to_filters_dict(self) -> dict:
+        """Convert to Qdrant-compatible filters dict for _build_apartment_filter()."""
+        f: dict = {}
+        if self.rooms is not None:
+            f["rooms"] = self.rooms
+        if self.min_price_eur is not None or self.max_price_eur is not None:
+            price_range: dict = {}
+            if self.min_price_eur is not None:
+                price_range["gte"] = self.min_price_eur
+            if self.max_price_eur is not None:
+                price_range["lte"] = self.max_price_eur
+            f["price_eur"] = price_range
+        if self.min_area_m2 is not None or self.max_area_m2 is not None:
+            area_range: dict = {}
+            if self.min_area_m2 is not None:
+                area_range["gte"] = self.min_area_m2
+            if self.max_area_m2 is not None:
+                area_range["lte"] = self.max_area_m2
+            f["area_m2"] = area_range
+        if self.min_floor is not None or self.max_floor is not None:
+            floor_range: dict = {}
+            if self.min_floor is not None:
+                floor_range["gte"] = self.min_floor
+            if self.max_floor is not None:
+                floor_range["lte"] = self.max_floor
+            f["floor"] = floor_range
+        if self.complex_name is not None:
+            f["complex_name"] = self.complex_name
+        if self.view_tags:
+            f["view_tags"] = self.view_tags  # handled by MatchAny
+        if self.section is not None:
+            f["section"] = self.section
+        if self.is_furnished is not None:
+            f["is_furnished"] = self.is_furnished
+        return f
+
+
+def compute_confidence(parse_result: ApartmentQueryParseResult) -> ApartmentQueryParseResult:
+    """Score and assign confidence level. Returns new instance."""
+    if parse_result.conflicts:
+        return replace(parse_result, confidence="LOW", score=-1)
+
+    score = 0
+    has_hard = False
+    has_entity = False
+
+    # Hard filters
+    if parse_result.rooms is not None:
+        score += 2
+        has_hard = True
+    if parse_result.min_price_eur is not None or parse_result.max_price_eur is not None:
+        score += 2
+        has_hard = True
+    if parse_result.min_area_m2 is not None or parse_result.max_area_m2 is not None:
+        score += 1
+        has_hard = True
+    if parse_result.min_floor is not None or parse_result.max_floor is not None:
+        score += 1
+        has_hard = True
+
+    # Entity filters
+    if parse_result.complex_name is not None:
+        score += 2
+        has_entity = True
+    if parse_result.view_tags:
+        score += 1
+        has_entity = True
+    if parse_result.section is not None:
+        score += 1
+        has_entity = True
+
+    # Confidence mapping
+    if score >= 4 and has_hard and has_entity:
+        confidence = "HIGH"
+    elif score >= 1:
+        confidence = "MEDIUM"
+    else:
+        confidence = "LOW"
+
+    return replace(parse_result, confidence=confidence, score=score)

--- a/telegram_bot/services/apartment_models.py
+++ b/telegram_bot/services/apartment_models.py
@@ -68,6 +68,21 @@ def normalize_view(raw: str) -> tuple[str, list[str]]:
     return (normalized, tags)
 
 
+def _parse_bool(raw: object) -> bool:
+    """Parse bool-like values from CSV/JSON sources."""
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, (int, float)):
+        return raw != 0
+    if isinstance(raw, str):
+        normalized = raw.strip().lower()
+        if normalized in {"1", "true", "yes", "y", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "n", "off", ""}:
+            return False
+    return bool(raw)
+
+
 # --- Records ---
 
 
@@ -110,9 +125,9 @@ class ApartmentRecord:
             view_tags=view_tags,
             price_eur=float(row["price_eur"]),
             price_bgn=float(row.get("price_bgn", 0)),
-            is_furnished=bool(row.get("is_furnished", False)),
-            has_floor_plan=bool(row.get("has_floor_plan", False)),
-            has_photo=bool(row.get("has_photo", False)),
+            is_furnished=_parse_bool(row.get("is_furnished", False)),
+            has_floor_plan=_parse_bool(row.get("has_floor_plan", False)),
+            has_photo=_parse_bool(row.get("has_photo", False)),
         )
 
     def to_description(self) -> str:

--- a/telegram_bot/services/apartments_service.py
+++ b/telegram_bot/services/apartments_service.py
@@ -1,0 +1,181 @@
+"""Apartments search service wrapping QdrantService for apartments collection."""
+
+from __future__ import annotations
+
+import logging
+
+from qdrant_client import models
+
+from telegram_bot.observability import get_client, observe
+from telegram_bot.services.qdrant import QdrantService
+
+
+logger = logging.getLogger(__name__)
+
+_ESCALATION_MIN_SPREAD = 0.002
+
+
+def _build_apartment_filter(filters: dict | None) -> models.Filter | None:
+    """Build Qdrant filter for apartments (top-level fields, no metadata. prefix).
+
+    Supports:
+    - Exact match: {"rooms": 2, "complex_name": "Premier Fort Beach"}
+    - Range: {"price_eur": {"gte": 100000, "lte": 200000}}
+    - MatchAny: {"view_tags": ["sea", "pool"]}
+    """
+    if not filters:
+        return None
+
+    conditions: list[models.Condition] = []
+
+    for key, value in filters.items():
+        if isinstance(value, list):
+            # MatchAny for tags
+            conditions.append(
+                models.FieldCondition(
+                    key=key,
+                    match=models.MatchAny(any=value),
+                )
+            )
+        elif isinstance(value, dict):
+            range_params = {op: value[op] for op in ("lt", "lte", "gt", "gte") if op in value}
+            if range_params:
+                conditions.append(
+                    models.FieldCondition(key=key, range=models.Range(**range_params))
+                )
+        else:
+            conditions.append(models.FieldCondition(key=key, match=models.MatchValue(value=value)))
+
+    return models.Filter(must=conditions) if conditions else None
+
+
+def check_escalation(
+    *,
+    returned_count: int,
+    top_k: int,
+    score_spread: float,
+    confidence: str,
+) -> str | None:
+    """Check if fast path result needs agent escalation.
+
+    Returns: escalation reason string, or None if no escalation needed.
+    """
+    reasons = []
+    if returned_count == 0:
+        reasons.append("no_results")
+    if returned_count >= top_k and score_spread < _ESCALATION_MIN_SPREAD and confidence != "HIGH":
+        reasons.append("ambiguous_topk")
+    if confidence == "LOW":
+        reasons.append("low_confidence")
+    return "; ".join(reasons) if reasons else None
+
+
+class ApartmentsService:
+    """Apartment search via existing QdrantService."""
+
+    def __init__(self, qdrant: QdrantService) -> None:
+        self._qdrant = qdrant
+
+    @observe(name="apartments-hybrid-search", capture_input=False, capture_output=False)
+    async def search(
+        self,
+        dense_vector: list[float],
+        sparse_vector: dict | None = None,
+        colbert_query: list[list[float]] | None = None,
+        filters: dict | None = None,
+        top_k: int = 10,
+    ) -> list[dict]:
+        """Hybrid search on apartments collection with apartment-specific filters."""
+        lf = get_client()
+        lf.update_current_span(input={"filters": filters, "top_k": top_k})
+        results, _ = await self.search_with_filters(
+            dense_vector=dense_vector,
+            colbert_query=colbert_query,
+            sparse_vector=sparse_vector,
+            filters=filters,
+            top_k=top_k,
+        )
+        return results
+
+    @observe(name="apartments-filtered-search")
+    async def search_with_filters(
+        self,
+        dense_vector: list[float],
+        colbert_query: list[list[float]] | None,
+        sparse_vector: dict | None,
+        filters: dict | None,
+        top_k: int = 10,
+    ) -> tuple[list[dict], int]:
+        """Search with apartment-specific filter (no metadata. prefix).
+
+        Returns: (results, returned_count)
+        """
+        qdrant_filter = _build_apartment_filter(filters)
+
+        # Build sparse vector
+        sparse_v = None
+        if sparse_vector and sparse_vector.get("indices"):
+            sparse_v = models.SparseVector(
+                indices=sparse_vector["indices"],
+                values=sparse_vector["values"],
+            )
+
+        # Build prefetch (dense + sparse → RRF)
+        prefetch = []
+        prefetch.append(
+            models.Prefetch(
+                query=dense_vector,
+                using="dense",
+                limit=100,
+            )
+        )
+        if sparse_v:
+            prefetch.append(
+                models.Prefetch(
+                    query=sparse_v,
+                    using="bm42",
+                    limit=100,
+                )
+            )
+
+        rrf_query = models.FusionQuery(fusion=models.Fusion.RRF)
+
+        if colbert_query:
+            # 3-stage: dense+sparse → RRF → ColBERT rescore
+            rrf_prefetch = models.Prefetch(
+                prefetch=prefetch,
+                query=rrf_query,
+                limit=top_k * 3,
+            )
+            result = await self._qdrant.client.query_points(
+                collection_name=self._qdrant.collection_name,
+                prefetch=[rrf_prefetch],
+                query=colbert_query,
+                using="colbert",
+                query_filter=qdrant_filter,
+                limit=top_k,
+                with_payload=True,
+            )
+        else:
+            result = await self._qdrant.client.query_points(
+                collection_name=self._qdrant.collection_name,
+                prefetch=prefetch,
+                query=rrf_query,
+                query_filter=qdrant_filter,
+                limit=top_k,
+                with_payload=True,
+            )
+
+        # Format results
+        formatted = []
+        for pt in result.points:
+            payload = pt.payload or {}
+            formatted.append(
+                {
+                    "score": pt.score,
+                    "payload": payload,
+                    "id": str(pt.id),
+                }
+            )
+
+        return formatted, len(result.points)

--- a/tests/unit/agents/test_apartment_tools.py
+++ b/tests/unit/agents/test_apartment_tools.py
@@ -1,0 +1,69 @@
+"""Tests for apartment_search @tool."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from telegram_bot.agents.apartment_tools import apartment_search
+
+
+class TestApartmentSearchTool:
+    @pytest.mark.asyncio
+    async def test_returns_formatted_results(self) -> None:
+        mock_service = AsyncMock()
+        mock_service.search_with_filters.return_value = (
+            [
+                {
+                    "score": 0.85,
+                    "payload": {
+                        "complex_name": "Premier Fort Beach",
+                        "apartment_number": "248",
+                        "rooms": 2,
+                        "floor": 4,
+                        "area_m2": 78.66,
+                        "view_primary": "sea",
+                        "price_eur": 215000.0,
+                    },
+                },
+            ],
+            1,
+        )
+
+        ctx = MagicMock()
+        ctx.apartments_service = mock_service
+        ctx.embeddings = AsyncMock()
+        ctx.embeddings.aembed_hybrid_with_colbert = AsyncMock(
+            return_value=([0.1] * 1024, {"indices": [1], "values": [0.5]}, [[0.1] * 1024])
+        )
+
+        config = {"configurable": {"bot_context": ctx}}
+        result = await apartment_search.ainvoke(
+            {"query": "двушка до 200к", "rooms": 2, "max_price_eur": 200000},
+            config=config,
+        )
+
+        assert "Premier Fort Beach" in result
+        assert "215" in result
+        assert "248" in result
+
+    @pytest.mark.asyncio
+    async def test_no_results(self) -> None:
+        mock_service = AsyncMock()
+        mock_service.search_with_filters.return_value = ([], 0)
+
+        ctx = MagicMock()
+        ctx.apartments_service = mock_service
+        ctx.embeddings = AsyncMock()
+        ctx.embeddings.aembed_hybrid_with_colbert = AsyncMock(
+            return_value=([0.1] * 1024, {"indices": [], "values": []}, [])
+        )
+
+        config = {"configurable": {"bot_context": ctx}}
+        result = await apartment_search.ainvoke(
+            {"query": "пентхаус на крыше"},
+            config=config,
+        )
+
+        assert "нет" in result.lower() or "не найден" in result.lower()

--- a/tests/unit/pipelines/test_client_pipeline.py
+++ b/tests/unit/pipelines/test_client_pipeline.py
@@ -97,9 +97,16 @@ class TestDetectAgentIntent:
         assert detect_agent_intent("Итог дня") == "daily_summary"
         assert detect_agent_intent("Отчёт за день") == "daily_summary"
 
+    def test_detect_agent_intent_apartment(self):
+        assert detect_agent_intent("хочу двушку с видом на море") == "apartment"
+        assert detect_agent_intent("подобрать квартиру") == "apartment"
+        assert detect_agent_intent("студия до 80000") == "apartment"
+        assert detect_agent_intent("трёхкомнатная квартира") == "apartment"
+        assert detect_agent_intent("апартаменты в Несебре") == "apartment"
+
     def test_detect_agent_intent_empty(self):
-        assert detect_agent_intent("Какие квартиры есть в центре?") == ""
-        assert detect_agent_intent("Цена на однушку") == ""
+        assert detect_agent_intent("как оформить ВНЖ") == ""
+        assert detect_agent_intent("какие документы нужны") == ""
         assert detect_agent_intent("") == ""
 
 
@@ -882,7 +889,7 @@ class TestCacheStoreGuards:
             patch("telegram_bot.pipelines.client.score"),
         ):
             await run_client_pipeline(
-                user_text="Найди двушку до 10 млн в Москве",
+                user_text="Найди объект до 10 млн в Москве",
                 user_id=1,
                 session_id="s1",
                 message=msg,

--- a/tests/unit/services/test_apartment_filter_extractor.py
+++ b/tests/unit/services/test_apartment_filter_extractor.py
@@ -1,0 +1,141 @@
+# tests/unit/services/test_apartment_filter_extractor.py
+"""Tests for apartment-specific filter extraction."""
+
+from __future__ import annotations
+
+import pytest
+
+from telegram_bot.services.apartment_filter_extractor import ApartmentFilterExtractor
+
+
+_ext = ApartmentFilterExtractor()
+
+
+class TestRooms:
+    @pytest.mark.parametrize(
+        ("query", "expected_rooms"),
+        [
+            ("двушка с видом на море", 2),
+            ("2 комнаты до 200к", 2),
+            ("трёхкомнатная квартира", 3),
+            ("студия в Несебре", 1),
+            ("однокомнатная", 1),
+            ("4 спальни", 4),
+        ],
+    )
+    def test_rooms_extraction(self, query: str, expected_rooms: int) -> None:
+        result = _ext.parse(query)
+        assert result.rooms == expected_rooms
+
+
+class TestPrice:
+    @pytest.mark.parametrize(
+        ("query", "min_p", "max_p"),
+        [
+            ("до 200000 евро", None, 200000.0),
+            ("до 200к", None, 200000.0),
+            ("от 100к до 300к", 100000.0, 300000.0),
+            ("дешевле 150000", None, 150000.0),
+            ("от 80000 евро", 80000.0, None),
+        ],
+    )
+    def test_price_extraction(self, query: str, min_p, max_p) -> None:
+        result = _ext.parse(query)
+        assert result.min_price_eur == min_p
+        assert result.max_price_eur == max_p
+
+    def test_price_conflict_min_gt_max(self) -> None:
+        result = _ext.parse("от 300к до 100к")
+        assert "price_conflict" in result.conflicts[0]
+
+
+class TestComplex:
+    @pytest.mark.parametrize(
+        ("query", "expected"),
+        [
+            ("квартира в Премьер Форт Бич", "Premier Fort Beach"),
+            ("Premier Fort Beach двушка", "Premier Fort Beach"),
+            ("апартамент в Кроун Форт", "Crown Fort Club"),
+            ("Green Fort Suites студия", "Green Fort Suites"),
+            ("Nessebar Fort Residence", "Nessebar Fort Residence"),
+            ("в Престиже", "Prestige Fort Beach"),
+        ],
+    )
+    def test_complex_extraction(self, query: str, expected: str) -> None:
+        result = _ext.parse(query)
+        assert result.complex_name == expected
+
+
+class TestView:
+    @pytest.mark.parametrize(
+        ("query", "expected_tags"),
+        [
+            ("с видом на море", ["sea"]),
+            ("sea view", ["sea"]),
+            ("у бассейна", ["pool"]),
+            ("вид на сад", ["garden"]),
+            ("панорама моря", ["sea", "panorama"]),
+        ],
+    )
+    def test_view_extraction(self, query: str, expected_tags: list[str]) -> None:
+        result = _ext.parse(query)
+        assert set(result.view_tags) == set(expected_tags)
+
+
+class TestFloor:
+    @pytest.mark.parametrize(
+        ("query", "min_floor", "max_floor"),
+        [
+            ("высокий этаж", 4, None),
+            ("3 этаж", 3, 3),
+            ("не выше 2 этажа", None, 2),
+            ("от 5 этажа", 5, None),
+        ],
+    )
+    def test_floor_extraction(self, query: str, min_floor, max_floor) -> None:
+        result = _ext.parse(query)
+        assert result.min_floor == min_floor
+        assert result.max_floor == max_floor
+
+
+class TestArea:
+    @pytest.mark.parametrize(
+        ("query", "min_area", "max_area"),
+        [
+            ("от 80 м2", 80.0, None),
+            ("до 100 кв.м", None, 100.0),
+            ("площадь от 60 до 120 м²", 60.0, 120.0),
+        ],
+    )
+    def test_area_extraction(self, query: str, min_area, max_area) -> None:
+        result = _ext.parse(query)
+        assert result.min_area_m2 == min_area
+        assert result.max_area_m2 == max_area
+
+
+class TestCombined:
+    def test_full_query(self) -> None:
+        result = _ext.parse("двушка до 200к с видом на море в Премьере")
+        assert result.rooms == 2
+        assert result.max_price_eur == 200000.0
+        assert "sea" in result.view_tags
+        assert result.complex_name == "Premier Fort Beach"
+
+    def test_semantic_query_extracted(self) -> None:
+        result = _ext.parse("уютная двушка до 200к в Премьере")
+        # semantic_query should retain descriptive words, strip numbers/filters
+        assert "уютн" in result.semantic_query.lower() or result.semantic_query != ""
+
+
+class TestConfidenceIntegration:
+    def test_high_confidence(self) -> None:
+        result = _ext.parse("двушка до 200к в Премьере")
+        assert result.confidence == "HIGH"
+
+    def test_medium_confidence(self) -> None:
+        result = _ext.parse("квартира до 200к")
+        assert result.confidence == "MEDIUM"
+
+    def test_low_confidence(self) -> None:
+        result = _ext.parse("что-нибудь хорошее")
+        assert result.confidence == "LOW"

--- a/tests/unit/services/test_apartment_filter_extractor.py
+++ b/tests/unit/services/test_apartment_filter_extractor.py
@@ -112,6 +112,13 @@ class TestArea:
         assert result.min_area_m2 == min_area
         assert result.max_area_m2 == max_area
 
+    def test_area_range_not_interpreted_as_price(self) -> None:
+        result = _ext.parse("площадь от 60 до 120 м²")
+        assert result.min_area_m2 == 60.0
+        assert result.max_area_m2 == 120.0
+        assert result.min_price_eur is None
+        assert result.max_price_eur is None
+
 
 class TestCombined:
     def test_full_query(self) -> None:

--- a/tests/unit/services/test_apartment_models.py
+++ b/tests/unit/services/test_apartment_models.py
@@ -1,0 +1,192 @@
+# tests/unit/services/test_apartment_models.py
+"""Tests for apartment data models."""
+
+from __future__ import annotations
+
+import pytest
+
+from telegram_bot.services.apartment_models import (
+    ApartmentQueryParseResult,
+    ApartmentRecord,
+    compute_confidence,
+)
+
+
+class TestApartmentRecord:
+    def test_from_raw_row_basic(self) -> None:
+        row = {
+            "complex_name": "Premier Fort Beach",
+            "section": "D-1",
+            "apartment_number": "248",
+            "rooms": 2,
+            "floor_label": "4",
+            "area_m2": 78.66,
+            "view_raw": "sea",
+            "price_eur": 215000.0,
+            "price_bgn": 420503.45,
+            "is_furnished": True,
+            "has_floor_plan": True,
+            "has_photo": True,
+        }
+        rec = ApartmentRecord.from_raw(row)
+        assert rec.complex_name == "Premier Fort Beach"
+        assert rec.rooms == 2
+        assert rec.floor == 4
+        assert rec.view_primary == "sea"
+        assert rec.view_tags == ["sea"]
+        assert rec.price_eur == 215000.0
+
+    def test_from_raw_ground_floor(self) -> None:
+        row = {
+            "floor_label": "gr.",
+            "rooms": 1,
+            "price_eur": 80000.0,
+            "complex_name": "Test",
+            "section": "A",
+            "apartment_number": "1",
+            "area_m2": 40.0,
+            "view_raw": "garden",
+            "price_bgn": 156466.0,
+            "is_furnished": False,
+            "has_floor_plan": True,
+            "has_photo": False,
+        }
+        rec = ApartmentRecord.from_raw(row)
+        assert rec.floor == 0
+        assert rec.floor_label == "gr."
+
+    def test_view_normalization_compound(self) -> None:
+        row = {
+            "view_raw": "ultra sea panorama",
+            "complex_name": "T",
+            "section": "A",
+            "apartment_number": "1",
+            "rooms": 3,
+            "floor_label": "2",
+            "area_m2": 100.0,
+            "price_eur": 300000.0,
+            "price_bgn": 0,
+            "is_furnished": True,
+            "has_floor_plan": True,
+            "has_photo": True,
+        }
+        rec = ApartmentRecord.from_raw(row)
+        assert rec.view_primary == "ultra_sea_panorama"
+        assert "sea" in rec.view_tags
+
+    def test_view_normalization_slash(self) -> None:
+        row = {
+            "view_raw": "sea/garden",
+            "complex_name": "T",
+            "section": "A",
+            "apartment_number": "1",
+            "rooms": 2,
+            "floor_label": "1",
+            "area_m2": 80.0,
+            "price_eur": 200000.0,
+            "price_bgn": 0,
+            "is_furnished": False,
+            "has_floor_plan": True,
+            "has_photo": True,
+        }
+        rec = ApartmentRecord.from_raw(row)
+        assert rec.view_primary == "sea"
+        assert set(rec.view_tags) == {"sea", "garden"}
+
+    def test_to_description(self) -> None:
+        row = {
+            "complex_name": "Crown Fort Club",
+            "section": "F-2",
+            "apartment_number": "547",
+            "rooms": 1,
+            "floor_label": "gr.",
+            "area_m2": 37.92,
+            "view_raw": "garden",
+            "price_eur": 81500.0,
+            "price_bgn": 159400.15,
+            "is_furnished": True,
+            "has_floor_plan": True,
+            "has_photo": False,
+        }
+        rec = ApartmentRecord.from_raw(row)
+        desc = rec.to_description()
+        assert "Crown Fort Club" in desc
+        assert "37.92" in desc
+        assert "81 500" in desc or "81500" in desc
+
+    def test_to_payload(self) -> None:
+        row = {
+            "complex_name": "Test",
+            "section": "A-1",
+            "apartment_number": "10",
+            "rooms": 2,
+            "floor_label": "3",
+            "area_m2": 70.0,
+            "view_raw": "pool/sea",
+            "price_eur": 150000.0,
+            "price_bgn": 293000.0,
+            "is_furnished": True,
+            "has_floor_plan": True,
+            "has_photo": True,
+        }
+        rec = ApartmentRecord.from_raw(row)
+        payload = rec.to_payload()
+        assert payload["complex_name"] == "Test"
+        assert payload["rooms"] == 2
+        assert payload["floor"] == 3
+        assert payload["price_eur"] == 150000.0
+        assert "sea" in payload["view_tags"]
+        assert payload["view_primary"] == "pool"
+
+
+class TestApartmentQueryParseResult:
+    def test_defaults(self) -> None:
+        r = ApartmentQueryParseResult(raw_query="test")
+        assert r.confidence == "LOW"
+        assert r.score == 0
+        assert r.conflicts == []
+
+    def test_to_filters_dict(self) -> None:
+        r = ApartmentQueryParseResult(
+            rooms=2,
+            max_price_eur=200000.0,
+            raw_query="двушка до 200к",
+        )
+        filters = r.to_filters_dict()
+        assert filters["rooms"] == 2
+        assert filters["price_eur"]["lte"] == 200000.0
+        assert "area_m2" not in filters
+
+
+class TestComputeConfidence:
+    @pytest.mark.parametrize(
+        ("rooms", "max_price", "complex_name", "view_tags", "conflicts", "expected"),
+        [
+            (2, 200000.0, "Premier Fort Beach", [], [], "HIGH"),
+            (2, None, None, ["sea"], [], "MEDIUM"),
+            (None, 200000.0, None, [], [], "MEDIUM"),
+            (2, None, None, [], [], "MEDIUM"),
+            (None, None, None, ["sea"], [], "MEDIUM"),
+            (None, None, None, [], [], "LOW"),
+            (2, 200000.0, "Premier", [], ["min>max"], "LOW"),
+        ],
+    )
+    def test_confidence_levels(
+        self,
+        rooms,
+        max_price,
+        complex_name,
+        view_tags,
+        conflicts,
+        expected,
+    ) -> None:
+        r = ApartmentQueryParseResult(
+            rooms=rooms,
+            max_price_eur=max_price,
+            complex_name=complex_name,
+            view_tags=view_tags or [],
+            conflicts=conflicts,
+            raw_query="test",
+        )
+        result = compute_confidence(r)
+        assert result.confidence == expected

--- a/tests/unit/services/test_apartment_models.py
+++ b/tests/unit/services/test_apartment_models.py
@@ -138,6 +138,26 @@ class TestApartmentRecord:
         assert "sea" in payload["view_tags"]
         assert payload["view_primary"] == "pool"
 
+    def test_from_raw_parses_string_booleans(self) -> None:
+        row = {
+            "complex_name": "Test",
+            "section": "A-1",
+            "apartment_number": "10",
+            "rooms": 2,
+            "floor_label": "3",
+            "area_m2": 70.0,
+            "view_raw": "pool/sea",
+            "price_eur": 150000.0,
+            "price_bgn": 293000.0,
+            "is_furnished": "False",
+            "has_floor_plan": "True",
+            "has_photo": "0",
+        }
+        rec = ApartmentRecord.from_raw(row)
+        assert rec.is_furnished is False
+        assert rec.has_floor_plan is True
+        assert rec.has_photo is False
+
 
 class TestApartmentQueryParseResult:
     def test_defaults(self) -> None:

--- a/tests/unit/services/test_apartments_service.py
+++ b/tests/unit/services/test_apartments_service.py
@@ -1,0 +1,68 @@
+"""Tests for ApartmentsService."""
+
+from __future__ import annotations
+
+from telegram_bot.services.apartments_service import (
+    _build_apartment_filter,
+    check_escalation,
+)
+
+
+class TestBuildApartmentFilter:
+    """Test filter construction without metadata. prefix."""
+
+    def test_exact_match(self) -> None:
+        f = _build_apartment_filter({"rooms": 2, "complex_name": "Premier Fort Beach"})
+        assert f is not None
+        assert len(f.must) == 2
+
+    def test_range_filter(self) -> None:
+        f = _build_apartment_filter({"price_eur": {"gte": 100000, "lte": 200000}})
+        assert f is not None
+        assert len(f.must) == 1
+
+    def test_view_tags_match_any(self) -> None:
+        f = _build_apartment_filter({"view_tags": ["sea", "pool"]})
+        assert f is not None
+        # Should use MatchAny, not MatchValue
+        condition = f.must[0]
+        assert hasattr(condition, "match")
+
+    def test_empty_returns_none(self) -> None:
+        assert _build_apartment_filter({}) is None
+        assert _build_apartment_filter(None) is None
+
+    def test_no_metadata_prefix(self) -> None:
+        f = _build_apartment_filter({"rooms": 2})
+        # Key should be "rooms" not "metadata.rooms"
+        assert f.must[0].key == "rooms"
+
+
+class TestCheckEscalation:
+    def test_no_escalation(self) -> None:
+        assert not check_escalation(
+            returned_count=5,
+            top_k=10,
+            score_spread=0.3,
+            confidence="HIGH",
+        )
+
+    def test_escalate_zero_results(self) -> None:
+        result = check_escalation(returned_count=0, top_k=10, score_spread=0, confidence="HIGH")
+        assert result is not None
+        assert "no_results" in result
+
+    def test_escalate_wide_ambiguous_topk(self) -> None:
+        result = check_escalation(
+            returned_count=10,
+            top_k=10,
+            score_spread=0.001,
+            confidence="MEDIUM",
+        )
+        assert result is not None
+        assert "ambiguous_topk" in result
+
+    def test_escalate_low_confidence(self) -> None:
+        result = check_escalation(returned_count=5, top_k=10, score_spread=0.3, confidence="LOW")
+        assert result is not None
+        assert "low_confidence" in result

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -104,7 +104,7 @@ class TestPropertyBotInit:
             mock_cache.assert_called_once()
             mock_emb.assert_called_once()
             mock_sparse.assert_called_once()
-            mock_qdrant.assert_called_once()
+            assert mock_qdrant.call_count == 2  # main + apartments collection
 
     def test_init_passes_qdrant_timeout(self, mock_config):
         """PropertyBot should pass configured timeout to QdrantService."""
@@ -120,7 +120,8 @@ class TestPropertyBotInit:
         ):
             PropertyBot(mock_config)
 
-        assert mock_qdrant.call_args.kwargs["timeout"] == 7
+        # First call is main collection (with timeout), second is apartments
+        assert mock_qdrant.call_args_list[0].kwargs["timeout"] == 7
 
     def test_init_creates_llm_guard_client_when_enabled(self, mock_config):
         """PropertyBot initializes LLMGuardClient when ML guard is enabled."""


### PR DESCRIPTION
## Summary
- Add structured apartments catalog to Qdrant with hybrid search (dense + sparse + ColBERT) and payload filtering
- Two-stage routing: fast path (regex filters, 0 LLM calls) → agent escalation
- 7 new files, 5 modified files, 3307 unit tests passing

## Changes
- **ApartmentRecord** data model with view normalization and confidence scoring
- **ApartmentFilterExtractor** — regex-based query parser (rooms, price, complex, view, floor, area)
- **ApartmentsService** — hybrid search with top-level payload filters (no `metadata.` prefix)
- **apartment_search** @tool for agent SDK escalation path
- **Qdrant setup + ingestion scripts** — collection creation, CSV → BGE-M3 → Qdrant
- **Bot integration** — `detect_agent_intent("apartment")`, fast path in `_handle_client_direct_pipeline`, `apartments_service` wired into BotContext

## Architecture
```
User query → detect_agent_intent("apartment")
  → ApartmentFilterExtractor.parse() → confidence scoring
    → HIGH/MEDIUM: hybrid search → generate_response → respond
    → LOW or escalation signals: fall through to agent with apartment_search @tool
```

## Test plan
- [x] 61 apartment-specific unit tests (models, filter extractor, service, tool)
- [x] 29 client pipeline tests (including apartment intent)
- [x] 3307 total unit tests passing (0 failures)
- [x] Ruff lint + format clean
- [ ] E2E: `make local-up` → `setup_collection.py` → `ingest.py` → bot queries

Closes #629

🤖 Generated with [Claude Code](https://claude.com/claude-code)