### PR TITLE
fix(bot): implement results callbacks, favorites metadata, LiteLLM config sync (#654, #655, #656)

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -61,6 +61,7 @@ logger = logging.getLogger(__name__)
 # --- Checkpoint namespace constants (versioned for safe migration) ---
 _CHECKPOINT_NS_VOICE = "tg:voice:v1"
 _FEEDBACK_CONFIRMATION_TTL_S = 5.0
+_APARTMENT_PAGE_SIZE = 5
 
 
 def make_session_id(session_type: str, identifier: int | str) -> str:
@@ -1156,10 +1157,27 @@ class PropertyBot:
             return
 
         if action == "add" and property_id:
+            # Build property_data from saved apartment results (#655)
+            state_data = await state.get_data()
+            apt_results = state_data.get("apartment_results", [])
+            matched = next((r for r in apt_results if r.get("id") == property_id), None)
+            if matched:
+                p = matched["payload"]
+                property_data: dict[str, Any] = {
+                    "complex_name": p.get("complex_name", ""),
+                    "location": p.get("city", ""),
+                    "property_type": p.get("property_type", ""),
+                    "floor": p.get("floor", 0),
+                    "area_m2": p.get("area_m2", 0),
+                    "view": ", ".join(p.get("view_tags", [])) or p.get("view_primary", ""),
+                    "price_eur": p.get("price_eur", 0),
+                }
+            else:
+                property_data = {}
             result = await favorites_service.add(
                 telegram_id=callback.from_user.id,
                 property_id=property_id,
-                property_data={},
+                property_data=property_data,
             )
             if result:
                 await callback.answer("Добавлено в закладки")
@@ -1192,14 +1210,59 @@ class PropertyBot:
             await callback.answer()
 
     async def handle_results_callback(self, callback: CallbackQuery, state: FSMContext) -> None:
-        """Handle property results callbacks (more/refine/viewing) (#628)."""
+        """Handle property results callbacks (more/refine/viewing) (#654)."""
+        from .keyboards.property_card import (
+            build_card_buttons,
+            build_results_footer,
+            format_property_card,
+        )
+
         data = callback.data or ""
         if data == "results:more":
-            # Placeholder — будет показывать следующую порцию
-            await callback.answer("Загрузка...")
+            state_data = await state.get_data()
+            results = state_data.get("apartment_results")
+            offset = state_data.get("apartment_offset", 0)
+            if not results:
+                await callback.answer("Нет сохранённых результатов")
+                return
+            new_offset = offset + _APARTMENT_PAGE_SIZE
+            if new_offset >= len(results):
+                await callback.answer("Все результаты уже показаны")
+                return
+            page = results[new_offset : new_offset + _APARTMENT_PAGE_SIZE]
+            for result in page:
+                p = result.get("payload", {})
+                card = format_property_card(
+                    property_id=result["id"],
+                    complex_name=p.get("complex_name", ""),
+                    location=p.get("city", ""),
+                    property_type=p.get("property_type", ""),
+                    floor=p.get("floor", 0),
+                    area_m2=p.get("area_m2", 0),
+                    view=", ".join(p.get("view_tags", [])) or p.get("view_primary", ""),
+                    price_eur=p.get("price_eur", 0),
+                )
+                if callback.message:
+                    await callback.message.answer(
+                        card, reply_markup=build_card_buttons(result["id"])
+                    )
+            shown = len(page)
+            total = len(results)
+            has_more = new_offset + _APARTMENT_PAGE_SIZE < total
+            if callback.message:
+                await callback.message.answer(
+                    f"Показано {new_offset + 1}–{new_offset + shown} из {total}",
+                    reply_markup=build_results_footer(shown=shown, total=total, has_more=has_more),
+                )
+            await state.update_data(apartment_offset=new_offset)
+            await callback.answer()
         elif data == "results:refine":
-            # Placeholder — возвращает в воронку
-            await callback.answer("Изменение параметров...")
+            await state.update_data(apartment_results=None, apartment_offset=0)
+            if callback.message:
+                await callback.message.answer(
+                    "Опишите, какие апартаменты вы ищете, и я подберу варианты."
+                )
+            await callback.answer()
         elif data == "results:viewing":
             from .handlers.phone_collector import start_phone_collection
 
@@ -1208,7 +1271,9 @@ class PropertyBot:
             await callback.answer()
 
     @observe(name="telegram-rag-query")
-    async def handle_query(self, message: Message, locale: str = "ru"):
+    async def handle_query(
+        self, message: Message, locale: str = "ru", state: FSMContext | None = None
+    ):
         """Handle user query via supervisor graph (#310: supervisor-only)."""
         pipeline_start = time.perf_counter()
         assert message.bot is not None
@@ -1222,6 +1287,7 @@ class PropertyBot:
             pipeline_start,
             locale=locale,
             root_trace_metadata=root_trace_metadata,
+            state=state,
         )
         update_kwargs: dict[str, Any] = {"output": {"response": response_text or ""}}
         if root_trace_metadata:
@@ -1266,6 +1332,7 @@ class PropertyBot:
         *,
         user_text: str,
         message: Message,
+        state: FSMContext | None = None,
     ) -> str | None:
         """C+ fast path: regex filters -> hybrid search -> generate. No agent loop (#629)."""
         from .services.apartment_filter_extractor import ApartmentFilterExtractor
@@ -1318,6 +1385,41 @@ class PropertyBot:
         response_text = str(generated.get("response", "") or context)
         if not generated.get("response_sent"):
             await self._send_markdown_chunks(message, response_text)
+
+        # Store results in FSMContext and send property cards (#654)
+        if state is not None and results:
+            from .keyboards.property_card import (
+                build_card_buttons,
+                build_results_footer,
+                format_property_card,
+            )
+
+            await state.update_data(
+                apartment_results=results, apartment_query=user_text, apartment_offset=0
+            )
+            page = results[:_APARTMENT_PAGE_SIZE]
+            for result in page:
+                p = result.get("payload", {})
+                card = format_property_card(
+                    property_id=result["id"],
+                    complex_name=p.get("complex_name", ""),
+                    location=p.get("city", ""),
+                    property_type=p.get("property_type", ""),
+                    floor=p.get("floor", 0),
+                    area_m2=p.get("area_m2", 0),
+                    view=", ".join(p.get("view_tags", [])) or p.get("view_primary", ""),
+                    price_eur=p.get("price_eur", 0),
+                )
+                await message.answer(card, reply_markup=build_card_buttons(result["id"]))
+            shown = len(page)
+            total = len(results)
+            await message.answer(
+                f"Показано {shown} из {total}",
+                reply_markup=build_results_footer(
+                    shown=shown, total=total, has_more=total > _APARTMENT_PAGE_SIZE
+                ),
+            )
+
         return response_text
 
     async def _handle_client_direct_pipeline(
@@ -1330,6 +1432,7 @@ class PropertyBot:
         role: str,
         query_type: str,
         rag_result_store: dict[str, Any],
+        state: FSMContext | None = None,
     ) -> str | None:
         """Thin wrapper: delegates to run_client_pipeline (see pipelines/client.py).
 
@@ -1344,6 +1447,7 @@ class PropertyBot:
             apt_answer = await self._handle_apartment_fast_path(
                 user_text=user_text,
                 message=message,
+                state=state,
             )
             if apt_answer is not None:
                 return apt_answer
@@ -1377,6 +1481,7 @@ class PropertyBot:
         pipeline_start: float,
         locale: str = "ru",
         root_trace_metadata: dict[str, Any] | None = None,
+        state: FSMContext | None = None,
     ) -> str:
         """Handle query via create_agent SDK (#413 — replaces build_supervisor_graph)."""
         from .agents.agent import LOCALE_TO_LANGUAGE
@@ -1643,6 +1748,7 @@ class PropertyBot:
                             role=role,
                             query_type=query_type,
                             rag_result_store=rag_result_store,
+                            state=state,
                         )
                         if pipeline_answer is not None:
                             if root_trace_metadata is not None:

--- a/tests/unit/test_favorites_callbacks.py
+++ b/tests/unit/test_favorites_callbacks.py
@@ -1,0 +1,178 @@
+"""Unit tests for handle_favorite_callback metadata fix (#655)."""
+
+from __future__ import annotations
+
+import pytest
+
+
+pytest.importorskip("aiogram", reason="aiogram not installed")
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from telegram_bot.bot import PropertyBot
+from telegram_bot.config import BotConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers (same pattern as test_results_callbacks.py)
+# ---------------------------------------------------------------------------
+
+
+def _make_config() -> BotConfig:
+    return BotConfig(
+        _env_file=None,
+        telegram_token="test-token",
+        voyage_api_key="voyage-key",
+        llm_api_key="llm-key",
+        llm_base_url="https://api.example.com/v1",
+        llm_model="gpt-4o-mini",
+        qdrant_url="http://localhost:6333",
+        qdrant_api_key="qdrant-key",
+        qdrant_collection="test_collection",
+        redis_url="redis://localhost:6379",
+        realestate_database_url="postgresql://postgres:postgres@127.0.0.1:1/realestate",
+        rerank_provider="none",
+    )
+
+
+def _create_bot() -> PropertyBot:
+    config = _make_config()
+    with (
+        patch("telegram_bot.bot.Bot"),
+        patch("telegram_bot.integrations.cache.CacheLayerManager"),
+        patch("telegram_bot.integrations.embeddings.BGEM3HybridEmbeddings"),
+        patch("telegram_bot.integrations.embeddings.BGEM3SparseEmbeddings"),
+        patch("telegram_bot.services.qdrant.QdrantService"),
+        patch("telegram_bot.graph.config.GraphConfig.create_llm"),
+        patch("telegram_bot.graph.config.GraphConfig.create_supervisor_llm"),
+    ):
+        return PropertyBot(config)
+
+
+def _make_callback(data: str = "fav:add:prop-42", user_id: int = 12345) -> MagicMock:
+    cb = MagicMock()
+    cb.data = data
+    cb.from_user = MagicMock(id=user_id)
+    cb.answer = AsyncMock()
+    cb.message = MagicMock()
+    cb.message.answer = AsyncMock()
+    cb.message.delete = AsyncMock()
+    return cb
+
+
+def _make_state(data: dict | None = None) -> MagicMock:
+    state = MagicMock()
+    state.get_data = AsyncMock(return_value=data or {})
+    state.update_data = AsyncMock()
+    state.clear = AsyncMock()
+    return state
+
+
+def _sample_result(property_id: str = "prop-42") -> dict:
+    return {
+        "id": property_id,
+        "score": 0.95,
+        "payload": {
+            "complex_name": "Ocean Vista",
+            "city": "Dubai",
+            "property_type": "Studio",
+            "floor": 5,
+            "area_m2": 55,
+            "view_tags": ["Sea", "Pool"],
+            "view_primary": "Sea",
+            "price_eur": 250000,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: fav:add with metadata
+# ---------------------------------------------------------------------------
+
+
+async def test_fav_add_saves_metadata() -> None:
+    """State has matching result → property_data is built from payload."""
+    bot = _create_bot()
+    bot._favorites_service = MagicMock()
+    bot._favorites_service.add = AsyncMock(return_value={"id": 1, "property_id": "prop-42"})
+
+    result = _sample_result("prop-42")
+    state = _make_state({"apartment_results": [result]})
+    callback = _make_callback("fav:add:prop-42")
+
+    await bot.handle_favorite_callback(callback, state)
+
+    bot._favorites_service.add.assert_awaited_once()
+    call_kwargs = bot._favorites_service.add.call_args.kwargs
+    pd = call_kwargs["property_data"]
+    assert pd["complex_name"] == "Ocean Vista"
+    assert pd["price_eur"] == 250000
+    assert pd["location"] == "Dubai"
+    assert pd["area_m2"] == 55
+    assert pd["floor"] == 5
+    callback.answer.assert_awaited_once_with("Добавлено в закладки")
+
+
+async def test_fav_add_no_state_fallback() -> None:
+    """No apartment_results in state → property_data={}."""
+    bot = _create_bot()
+    bot._favorites_service = MagicMock()
+    bot._favorites_service.add = AsyncMock(return_value={"id": 1, "property_id": "prop-42"})
+
+    state = _make_state({})
+    callback = _make_callback("fav:add:prop-42")
+
+    await bot.handle_favorite_callback(callback, state)
+
+    call_kwargs = bot._favorites_service.add.call_args.kwargs
+    assert call_kwargs["property_data"] == {}
+
+
+async def test_fav_add_property_not_found() -> None:
+    """Results in state but no matching id → property_data={}."""
+    bot = _create_bot()
+    bot._favorites_service = MagicMock()
+    bot._favorites_service.add = AsyncMock(return_value={"id": 1, "property_id": "prop-99"})
+
+    state = _make_state({"apartment_results": [_sample_result("prop-10")]})
+    callback = _make_callback("fav:add:prop-99")
+
+    await bot.handle_favorite_callback(callback, state)
+
+    call_kwargs = bot._favorites_service.add.call_args.kwargs
+    assert call_kwargs["property_data"] == {}
+
+
+async def test_fav_add_duplicate() -> None:
+    """favorites_service.add returns None → 'Уже в закладках'."""
+    bot = _create_bot()
+    bot._favorites_service = MagicMock()
+    bot._favorites_service.add = AsyncMock(return_value=None)
+
+    state = _make_state({"apartment_results": [_sample_result("prop-42")]})
+    callback = _make_callback("fav:add:prop-42")
+
+    await bot.handle_favorite_callback(callback, state)
+
+    callback.answer.assert_awaited_once_with("Уже в закладках")
+
+
+# ---------------------------------------------------------------------------
+# Tests: fav:remove
+# ---------------------------------------------------------------------------
+
+
+async def test_fav_remove_deletes_and_removes_message() -> None:
+    """fav:remove → calls remove service, deletes message, answers callback."""
+    bot = _create_bot()
+    bot._favorites_service = MagicMock()
+    bot._favorites_service.remove = AsyncMock()
+
+    state = _make_state()
+    callback = _make_callback("fav:remove:prop-42")
+
+    await bot.handle_favorite_callback(callback, state)
+
+    bot._favorites_service.remove.assert_awaited_once_with(telegram_id=12345, property_id="prop-42")
+    callback.message.delete.assert_awaited_once()
+    callback.answer.assert_awaited_once_with("Удалено из закладок")

--- a/tests/unit/test_litellm_config_sync.py
+++ b/tests/unit/test_litellm_config_sync.py
@@ -34,6 +34,16 @@ def _fallback_model_groups(cfg: dict) -> set[str]:
     return {next(iter(item.keys())) for item in fallbacks if isinstance(item, dict) and item}
 
 
+_TOKEN_LIMIT_KEYS = {"max_tokens", "max_completion_tokens"}
+
+
+def _normalize_token_limit(params: dict) -> int | None:
+    for key in _TOKEN_LIMIT_KEYS:
+        if key in params:
+            return int(params[key])
+    return None
+
+
 class TestLiteLLMConfigSync:
     def test_model_list_matches(self):
         """Docker and k8s model_list have same models with same params."""
@@ -48,18 +58,30 @@ class TestLiteLLMConfigSync:
         )
 
         for name in docker_models:
-            for key in (
-                "model",
-                "max_tokens",
-                "max_completion_tokens",
-                "merge_reasoning_content_in_choices",
-            ):
-                docker_val = docker_models[name].get(key)
-                k8s_val = k8s_models[name].get(key)
-                if key in docker_models[name] or key in k8s_models[name]:
-                    assert docker_val == k8s_val, (
-                        f"Model '{name}' param '{key}': docker={docker_val}, k8s={k8s_val}"
-                    )
+            docker_params = docker_models[name]
+            k8s_params = k8s_models[name]
+
+            # provider model must match exactly
+            assert docker_params.get("model") == k8s_params.get("model"), (
+                f"Model '{name}' provider model: docker={docker_params.get('model')!r}, "
+                f"k8s={k8s_params.get('model')!r}"
+            )
+
+            # token limits must match (normalized across key names)
+            docker_limit = _normalize_token_limit(docker_params)
+            k8s_limit = _normalize_token_limit(k8s_params)
+            assert docker_limit == k8s_limit, (
+                f"Model '{name}' token limit: docker={docker_limit} (from {docker_params!r}), "
+                f"k8s={k8s_limit} (from {k8s_params!r})"
+            )
+
+            # merge_reasoning_content_in_choices must match if present in either
+            docker_merge = docker_params.get("merge_reasoning_content_in_choices")
+            k8s_merge = k8s_params.get("merge_reasoning_content_in_choices")
+            assert docker_merge == k8s_merge, (
+                f"Model '{name}' merge_reasoning_content_in_choices: "
+                f"docker={docker_merge}, k8s={k8s_merge}"
+            )
 
     def test_router_settings_match(self):
         """Docker and k8s router_settings are identical."""
@@ -114,3 +136,57 @@ class TestLiteLLMConfigSync:
 
         assert {"gpt-4o-mini", "gpt-oss-120b"}.issubset(docker_groups)
         assert {"gpt-4o-mini", "gpt-oss-120b"}.issubset(k8s_groups)
+
+    def test_token_limit_keys_consistent(self):
+        """Both configs must have the same normalized token limit for each model."""
+        docker = _load_docker_config()
+        k8s = _load_k8s_config()
+
+        docker_models = {m["model_name"]: m["litellm_params"] for m in docker["model_list"]}
+        k8s_models = {m["model_name"]: m["litellm_params"] for m in k8s["model_list"]}
+
+        mismatches = []
+        for name in set(docker_models) & set(k8s_models):
+            docker_limit = _normalize_token_limit(docker_models[name])
+            k8s_limit = _normalize_token_limit(k8s_models[name])
+
+            if docker_limit is None and k8s_limit is None:
+                continue  # both have no token limit — OK
+
+            if docker_limit != k8s_limit:
+                mismatches.append(f"  '{name}': docker={docker_limit}, k8s={k8s_limit}")
+
+        assert not mismatches, "Token limit drift detected:\n" + "\n".join(mismatches)
+
+    def test_drift_detected_on_value_mismatch(self):
+        """Normalization check catches value drift when patched in memory."""
+        docker_params = {"max_completion_tokens": 1024}
+        k8s_params_drifted = {"max_completion_tokens": 2048}
+
+        docker_limit = _normalize_token_limit(docker_params)
+        k8s_limit = _normalize_token_limit(k8s_params_drifted)
+
+        assert docker_limit != k8s_limit, (
+            "Drift detection failed: normalization should catch 1024 vs 2048 mismatch"
+        )
+
+    def test_token_limit_key_names_match(self):
+        """Both configs should use the same token-limit key name for each model."""
+        docker = _load_docker_config()
+        k8s = _load_k8s_config()
+
+        docker_models = {m["model_name"]: m["litellm_params"] for m in docker["model_list"]}
+        k8s_models = {m["model_name"]: m["litellm_params"] for m in k8s["model_list"]}
+
+        mismatches = []
+        for name in set(docker_models) & set(k8s_models):
+            docker_key = next((k for k in _TOKEN_LIMIT_KEYS if k in docker_models[name]), None)
+            k8s_key = next((k for k in _TOKEN_LIMIT_KEYS if k in k8s_models[name]), None)
+
+            if docker_key is None and k8s_key is None:
+                continue  # both absent — OK
+
+            if docker_key != k8s_key:
+                mismatches.append(f"  '{name}': docker uses {docker_key!r}, k8s uses {k8s_key!r}")
+
+        assert not mismatches, "Token limit key name drift detected:\n" + "\n".join(mismatches)

--- a/tests/unit/test_results_callbacks.py
+++ b/tests/unit/test_results_callbacks.py
@@ -1,0 +1,190 @@
+"""Unit tests for handle_results_callback (#654)."""
+
+from __future__ import annotations
+
+import pytest
+
+
+pytest.importorskip("aiogram", reason="aiogram not installed")
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from telegram_bot.bot import PropertyBot
+from telegram_bot.config import BotConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PAGE_SIZE = 5  # must match _APARTMENT_PAGE_SIZE in bot.py
+
+
+def _make_config() -> BotConfig:
+    return BotConfig(
+        _env_file=None,
+        telegram_token="test-token",
+        voyage_api_key="voyage-key",
+        llm_api_key="llm-key",
+        llm_base_url="https://api.example.com/v1",
+        llm_model="gpt-4o-mini",
+        qdrant_url="http://localhost:6333",
+        qdrant_api_key="qdrant-key",
+        qdrant_collection="test_collection",
+        redis_url="redis://localhost:6379",
+        realestate_database_url="postgresql://postgres:postgres@127.0.0.1:1/realestate",
+        rerank_provider="none",
+    )
+
+
+def _create_bot() -> PropertyBot:
+    config = _make_config()
+    with (
+        patch("telegram_bot.bot.Bot"),
+        patch("telegram_bot.integrations.cache.CacheLayerManager"),
+        patch("telegram_bot.integrations.embeddings.BGEM3HybridEmbeddings"),
+        patch("telegram_bot.integrations.embeddings.BGEM3SparseEmbeddings"),
+        patch("telegram_bot.services.qdrant.QdrantService"),
+        patch("telegram_bot.graph.config.GraphConfig.create_llm"),
+        patch("telegram_bot.graph.config.GraphConfig.create_supervisor_llm"),
+    ):
+        return PropertyBot(config)
+
+
+def _make_callback(data: str = "results:more", user_id: int = 12345) -> MagicMock:
+    cb = MagicMock()
+    cb.data = data
+    cb.from_user = MagicMock(id=user_id)
+    cb.answer = AsyncMock()
+    cb.message = MagicMock()
+    cb.message.answer = AsyncMock()
+    cb.message.delete = AsyncMock()
+    return cb
+
+
+def _make_state(data: dict | None = None) -> MagicMock:
+    state = MagicMock()
+    state.get_data = AsyncMock(return_value=data or {})
+    state.update_data = AsyncMock()
+    state.clear = AsyncMock()
+    return state
+
+
+def _make_results(n: int = 8) -> list[dict]:
+    return [
+        {
+            "id": f"prop-{i}",
+            "score": 0.9 - i * 0.01,
+            "payload": {
+                "complex_name": f"Complex {i}",
+                "city": "Dubai",
+                "property_type": "Apartment",
+                "floor": i + 1,
+                "area_m2": 60 + i * 5,
+                "view_tags": ["Sea"],
+                "view_primary": "Sea",
+                "price_eur": 200000 + i * 10000,
+            },
+        }
+        for i in range(n)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Tests: results:more
+# ---------------------------------------------------------------------------
+
+
+async def test_results_more_shows_next_page() -> None:
+    """8 results, offset=0 → sends 3 cards + 1 footer, updates offset to PAGE_SIZE."""
+    bot = _create_bot()
+    results = _make_results(8)
+    state = _make_state({"apartment_results": results, "apartment_offset": 0})
+    callback = _make_callback("results:more")
+
+    await bot.handle_results_callback(callback, state)
+
+    # 3 remaining cards (results[5:8]) + 1 footer message
+    assert callback.message.answer.await_count == 4
+    state.update_data.assert_awaited_once_with(apartment_offset=_PAGE_SIZE)
+    callback.answer.assert_awaited_once_with()
+
+
+async def test_results_more_no_results_in_state() -> None:
+    """No apartment_results in state → answer with error message."""
+    bot = _create_bot()
+    state = _make_state({})
+    callback = _make_callback("results:more")
+
+    await bot.handle_results_callback(callback, state)
+
+    callback.answer.assert_awaited_once_with("Нет сохранённых результатов")
+    callback.message.answer.assert_not_called()
+
+
+async def test_results_more_exhausted() -> None:
+    """offset == len(results) → answer 'all shown'."""
+    bot = _create_bot()
+    results = _make_results(5)
+    state = _make_state({"apartment_results": results, "apartment_offset": 5})
+    callback = _make_callback("results:more")
+
+    await bot.handle_results_callback(callback, state)
+
+    callback.answer.assert_awaited_once_with("Все результаты уже показаны")
+    callback.message.answer.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: results:refine
+# ---------------------------------------------------------------------------
+
+
+async def test_results_refine_clears_state() -> None:
+    """results:refine → clears results from state, sends prompt, answers callback."""
+    bot = _create_bot()
+    state = _make_state({"apartment_results": _make_results(3)})
+    callback = _make_callback("results:refine")
+
+    await bot.handle_results_callback(callback, state)
+
+    state.update_data.assert_awaited_once_with(apartment_results=None, apartment_offset=0)
+    callback.message.answer.assert_awaited_once()
+    callback.answer.assert_awaited_once_with()
+
+
+# ---------------------------------------------------------------------------
+# Tests: results:viewing
+# ---------------------------------------------------------------------------
+
+
+async def test_results_viewing_delegates() -> None:
+    """results:viewing → delegates to start_phone_collection."""
+    bot = _create_bot()
+    state = _make_state()
+    callback = _make_callback("results:viewing")
+
+    with patch(
+        "telegram_bot.handlers.phone_collector.start_phone_collection",
+        new=AsyncMock(),
+    ) as mock_collect:
+        await bot.handle_results_callback(callback, state)
+
+    mock_collect.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests: unknown action
+# ---------------------------------------------------------------------------
+
+
+async def test_results_unknown_action() -> None:
+    """Unknown results: action → just answer callback."""
+    bot = _create_bot()
+    state = _make_state()
+    callback = _make_callback("results:unknown_xyz")
+
+    await bot.handle_results_callback(callback, state)
+
+    callback.answer.assert_awaited_once()
+    callback.message.answer.assert_not_called()


### PR DESCRIPTION
## Summary
- **#654** Results callbacks: replaced placeholder responses with real pagination (`results:more` loads next 5 cards from FSMContext, `results:refine` clears state and prompts re-search), property cards sent after apartment fast-path search
- **#655** Favorites metadata: `fav:add` now extracts property data (complex_name, location, price, floor, area, view) from FSMContext stored results instead of passing empty `{}`
- **#656** LiteLLM config sync: fixed k8s config drift (`max_tokens:4096` → `max_completion_tokens:1024`), removed spurious `merge_reasoning_content_in_choices` from cerebras-glm, added 3 new drift-detection tests with token-limit key normalization

## Issues
Closes #654, Closes #655, Closes #656

## Test plan
- [x] 6 unit tests for results callbacks (more/refine/viewing/unknown/exhausted/no-state)
- [x] 5 unit tests for favorites callbacks (metadata/fallback/not-found/duplicate/remove)
- [x] 8 LiteLLM config sync tests (existing + 3 new drift detection)
- [x] `make check` (ruff + mypy) clean
- [x] 19/19 tests pass

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>