### PR TITLE
fix(bot,test): hotfix PR661 favorites crash + stricter LiteLLM drift checks

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -1159,10 +1159,15 @@ class PropertyBot:
         if action == "add" and property_id:
             # Build property_data from saved apartment results (#655)
             state_data = await state.get_data()
-            apt_results = state_data.get("apartment_results", [])
-            matched = next((r for r in apt_results if r.get("id") == property_id), None)
+            raw_results = state_data.get("apartment_results")
+            apt_results = raw_results if isinstance(raw_results, list) else []
+            matched = next(
+                (r for r in apt_results if isinstance(r, dict) and r.get("id") == property_id),
+                None,
+            )
             if matched:
-                p = matched["payload"]
+                payload = matched.get("payload")
+                p = payload if isinstance(payload, dict) else {}
                 property_data: dict[str, Any] = {
                     "complex_name": p.get("complex_name", ""),
                     "location": p.get("city", ""),

--- a/tests/unit/test_favorites_callbacks.py
+++ b/tests/unit/test_favorites_callbacks.py
@@ -128,6 +128,21 @@ async def test_fav_add_no_state_fallback() -> None:
     assert call_kwargs["property_data"] == {}
 
 
+async def test_fav_add_none_state_fallback() -> None:
+    """apartment_results=None in state → property_data={} (no crash)."""
+    bot = _create_bot()
+    bot._favorites_service = MagicMock()
+    bot._favorites_service.add = AsyncMock(return_value={"id": 1, "property_id": "prop-42"})
+
+    state = _make_state({"apartment_results": None})
+    callback = _make_callback("fav:add:prop-42")
+
+    await bot.handle_favorite_callback(callback, state)
+
+    call_kwargs = bot._favorites_service.add.call_args.kwargs
+    assert call_kwargs["property_data"] == {}
+
+
 async def test_fav_add_property_not_found() -> None:
     """Results in state but no matching id → property_data={}."""
     bot = _create_bot()

--- a/tests/unit/test_litellm_config_sync.py
+++ b/tests/unit/test_litellm_config_sync.py
@@ -34,13 +34,24 @@ def _fallback_model_groups(cfg: dict) -> set[str]:
     return {next(iter(item.keys())) for item in fallbacks if isinstance(item, dict) and item}
 
 
-_TOKEN_LIMIT_KEYS = {"max_tokens", "max_completion_tokens"}
+_TOKEN_LIMIT_KEYS = ("max_completion_tokens", "max_tokens")
+
+
+def _token_limit_key(params: dict) -> str | None:
+    keys = [key for key in _TOKEN_LIMIT_KEYS if key in params]
+    if not keys:
+        return None
+    if len(keys) > 1:
+        raise AssertionError(
+            f"Model params must use a single token limit key, got {keys} in {params!r}"
+        )
+    return keys[0]
 
 
 def _normalize_token_limit(params: dict) -> int | None:
-    for key in _TOKEN_LIMIT_KEYS:
-        if key in params:
-            return int(params[key])
+    key = _token_limit_key(params)
+    if key is not None:
+        return int(params[key])
     return None
 
 
@@ -180,8 +191,8 @@ class TestLiteLLMConfigSync:
 
         mismatches = []
         for name in set(docker_models) & set(k8s_models):
-            docker_key = next((k for k in _TOKEN_LIMIT_KEYS if k in docker_models[name]), None)
-            k8s_key = next((k for k in _TOKEN_LIMIT_KEYS if k in k8s_models[name]), None)
+            docker_key = _token_limit_key(docker_models[name])
+            k8s_key = _token_limit_key(k8s_models[name])
 
             if docker_key is None and k8s_key is None:
                 continue  # both absent — OK


### PR DESCRIPTION
## Summary
- hotfix for PR #661 callback crash in favorites flow
- strengthen LiteLLM config sync tests to fail fast on ambiguous token-limit keys
- add regression test coverage for `apartment_results=None`

## What changed
1. `telegram_bot/bot.py`
- `fav:add` now treats non-list/None `apartment_results` as empty list
- payload extraction is guarded (`payload` must be dict)

2. `tests/unit/test_favorites_callbacks.py`
- added `test_fav_add_none_state_fallback` to lock the `None`-state regression

3. `tests/unit/test_litellm_config_sync.py`
- introduced deterministic token-key resolution helper
- fail if both `max_tokens` and `max_completion_tokens` are present simultaneously
- reused helper in key-name consistency checks

## SDK docs check (Context7)
- `aiogram` (`/aiogram/aiogram`): `FSMContext.update_data(...)` performs partial updates and keeps provided values as-is, so handlers should defensively normalize data read via `get_data()`.
- `LiteLLM` (`/berriai/litellm`): proxy `model_list.litellm_params` passes completion params; docs consistently show `max_tokens` input semantics. We enforce single-key policy in tests to prevent ambiguous config drift.

## Validation
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' uv run pytest tests/unit/test_favorites_callbacks.py tests/unit/test_litellm_config_sync.py -q`
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`

Closes #662
