### PR TITLE
fix(bot,crm): viewing funnel routing + BotConfig injection (#672, #673)

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -1377,11 +1377,8 @@ class PropertyBot:
         """Handle viewing fork callbacks (choose_objects, phone)."""
         data = callback.data or ""
         if data == "viewing:choose_objects":
-            # Перенаправить в воронку подбора апартаментов
             if callback.message:
-                await callback.message.answer(
-                    "Опишите, какие апартаменты вас интересуют, и я подберу варианты."
-                )
+                await self.handle_menu_action_text(callback.message, "Подбери апартаменты")
             await callback.answer()
         elif data == "viewing:phone":
             from .handlers.phone_collector import start_phone_collection

--- a/telegram_bot/handlers/phone_collector.py
+++ b/telegram_bot/handlers/phone_collector.py
@@ -193,7 +193,7 @@ async def on_phone_received(
 
             pipeline_id = (bot_config.kommo_default_pipeline_id if bot_config else 0) or None
             status_id = (bot_config.kommo_new_status_id if bot_config else 0) or None
-            responsible = bot_config.kommo_responsible_user_id if bot_config else None
+            responsible = (bot_config.kommo_responsible_user_id if bot_config else None) or None
 
             custom_fields = _build_custom_fields(
                 crm_title,

--- a/telegram_bot/handlers/phone_collector.py
+++ b/telegram_bot/handlers/phone_collector.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import datetime
 import logging
-import os
 import re
 import time
 from typing import Any
@@ -36,21 +35,6 @@ def validate_phone(text: str) -> bool:
     return bool(_PHONE_PATTERN.match(cleaned))
 
 
-def _get_int_env(name: str, default: int = 0) -> int:
-    """Safely parse integer env var; empty/invalid values fall back to default."""
-    raw = os.getenv(name)
-    if raw is None:
-        return default
-    raw = raw.strip()
-    if raw == "":
-        return default
-    try:
-        return int(raw)
-    except ValueError:
-        logger.warning("Invalid integer env value for %s=%r; using default=%s", name, raw, default)
-        return default
-
-
 def build_display_name(user: Any | None, phone: str) -> str:
     """Build human-readable display name with fallback chain."""
     if user and getattr(user, "first_name", None):
@@ -65,22 +49,25 @@ def _build_custom_fields(
     crm_title: str,
     telegram_id: int | str,
     username: str | None,
+    *,
+    service_field_id: int = 0,
+    source_field_id: int = 0,
+    telegram_field_id: int = 0,
+    telegram_username_field_id: int = 0,
 ) -> list[dict]:
     """Build Kommo custom_fields_values for lead."""
     fields: list[dict] = []
-    svc_field = _get_int_env("KOMMO_SERVICE_FIELD_ID")
-    src_field = _get_int_env("KOMMO_SOURCE_FIELD_ID")
-    tg_id_field = _get_int_env("KOMMO_TELEGRAM_FIELD_ID")
-    tg_user_field = _get_int_env("KOMMO_TELEGRAM_USERNAME_FIELD_ID")
 
-    if svc_field:
-        fields.append({"field_id": svc_field, "values": [{"value": crm_title}]})
-    if src_field:
-        fields.append({"field_id": src_field, "values": [{"value": "Telegram-бот"}]})
-    if tg_id_field and telegram_id:
-        fields.append({"field_id": tg_id_field, "values": [{"value": str(telegram_id)}]})
-    if tg_user_field and username:
-        fields.append({"field_id": tg_user_field, "values": [{"value": f"@{username}"}]})
+    if service_field_id:
+        fields.append({"field_id": service_field_id, "values": [{"value": crm_title}]})
+    if source_field_id:
+        fields.append({"field_id": source_field_id, "values": [{"value": "Telegram-бот"}]})
+    if telegram_field_id and telegram_id:
+        fields.append({"field_id": telegram_field_id, "values": [{"value": str(telegram_id)}]})
+    if telegram_username_field_id and username:
+        fields.append(
+            {"field_id": telegram_username_field_id, "values": [{"value": f"@{username}"}]}
+        )
     return fields
 
 
@@ -156,6 +143,7 @@ async def on_phone_received(
     state: FSMContext,
     kommo_client: Any | None = None,
     i18n: Any | None = None,
+    bot_config: Any | None = None,
 ) -> None:
     """Handle phone number input."""
     if not message.text or not validate_phone(message.text):
@@ -203,11 +191,21 @@ async def on_phone_received(
             )
             contact = await kommo_client.upsert_contact(phone, contact_data)
 
-            pipeline_id = _get_int_env("KOMMO_DEFAULT_PIPELINE_ID") or None
-            status_id = _get_int_env("KOMMO_NEW_STATUS_ID") or None
-            responsible = _get_int_env("KOMMO_RESPONSIBLE_USER_ID") or None
+            pipeline_id = (bot_config.kommo_default_pipeline_id if bot_config else 0) or None
+            status_id = (bot_config.kommo_new_status_id if bot_config else 0) or None
+            responsible = bot_config.kommo_responsible_user_id if bot_config else None
 
-            custom_fields = _build_custom_fields(crm_title, user_id, username)
+            custom_fields = _build_custom_fields(
+                crm_title,
+                user_id,
+                username,
+                service_field_id=bot_config.kommo_service_field_id if bot_config else 0,
+                source_field_id=bot_config.kommo_source_field_id if bot_config else 0,
+                telegram_field_id=bot_config.kommo_telegram_field_id if bot_config else 0,
+                telegram_username_field_id=bot_config.kommo_telegram_username_field_id
+                if bot_config
+                else 0,
+            )
 
             lead = await kommo_client.create_lead(
                 LeadCreate(

--- a/tests/unit/handlers/test_phone_collector.py
+++ b/tests/unit/handlers/test_phone_collector.py
@@ -65,13 +65,16 @@ def test_build_display_name_phone():
 # --- _build_custom_fields tests ---
 
 
-def test_build_custom_fields_with_env_vars(monkeypatch):
-    monkeypatch.setenv("KOMMO_SERVICE_FIELD_ID", "100")
-    monkeypatch.setenv("KOMMO_SOURCE_FIELD_ID", "200")
-    monkeypatch.setenv("KOMMO_TELEGRAM_FIELD_ID", "300")
-    monkeypatch.setenv("KOMMO_TELEGRAM_USERNAME_FIELD_ID", "400")
-
-    fields = _build_custom_fields("Осмотр объектов", 12345, "ivan")
+def test_build_custom_fields_with_explicit_field_ids():
+    fields = _build_custom_fields(
+        "Осмотр объектов",
+        12345,
+        "ivan",
+        service_field_id=100,
+        source_field_id=200,
+        telegram_field_id=300,
+        telegram_username_field_id=400,
+    )
 
     assert {"field_id": 100, "values": [{"value": "Осмотр объектов"}]} in fields
     assert {"field_id": 200, "values": [{"value": "Telegram-бот"}]} in fields
@@ -79,33 +82,34 @@ def test_build_custom_fields_with_env_vars(monkeypatch):
     assert {"field_id": 400, "values": [{"value": "@ivan"}]} in fields
 
 
-def test_build_custom_fields_no_env_vars(monkeypatch):
-    monkeypatch.delenv("KOMMO_SERVICE_FIELD_ID", raising=False)
-    monkeypatch.delenv("KOMMO_SOURCE_FIELD_ID", raising=False)
-    monkeypatch.delenv("KOMMO_TELEGRAM_FIELD_ID", raising=False)
-    monkeypatch.delenv("KOMMO_TELEGRAM_USERNAME_FIELD_ID", raising=False)
-
+def test_build_custom_fields_no_field_ids_returns_empty():
     fields = _build_custom_fields("Осмотр объектов", 12345, "ivan")
     assert fields == []
 
 
-def test_build_custom_fields_no_username(monkeypatch):
-    monkeypatch.setenv("KOMMO_SERVICE_FIELD_ID", "100")
-    monkeypatch.setenv("KOMMO_TELEGRAM_USERNAME_FIELD_ID", "400")
-
-    fields = _build_custom_fields("Осмотр объектов", 12345, None)
+def test_build_custom_fields_no_username():
+    fields = _build_custom_fields(
+        "Осмотр объектов",
+        12345,
+        None,
+        service_field_id=100,
+        telegram_username_field_id=400,
+    )
     field_ids = [f["field_id"] for f in fields]
     assert 100 in field_ids
     assert 400 not in field_ids
 
 
-def test_build_custom_fields_blank_env_vars(monkeypatch):
-    monkeypatch.setenv("KOMMO_SERVICE_FIELD_ID", "")
-    monkeypatch.setenv("KOMMO_SOURCE_FIELD_ID", "")
-    monkeypatch.setenv("KOMMO_TELEGRAM_FIELD_ID", "")
-    monkeypatch.setenv("KOMMO_TELEGRAM_USERNAME_FIELD_ID", "")
-
-    fields = _build_custom_fields("Осмотр объектов", 12345, "ivan")
+def test_build_custom_fields_zero_field_ids_returns_empty():
+    fields = _build_custom_fields(
+        "Осмотр объектов",
+        12345,
+        "ivan",
+        service_field_id=0,
+        source_field_id=0,
+        telegram_field_id=0,
+        telegram_username_field_id=0,
+    )
     assert fields == []
 
 
@@ -267,11 +271,17 @@ async def test_on_phone_received_sends_personalized_success():
     assert "бронирования инфотура" in answer_text
 
 
-async def test_on_phone_received_blank_responsible_id_does_not_break_crm(monkeypatch):
-    """Empty KOMMO_RESPONSIBLE_USER_ID should not abort lead creation."""
-    monkeypatch.setenv("KOMMO_RESPONSIBLE_USER_ID", "")
-    monkeypatch.setenv("KOMMO_DEFAULT_PIPELINE_ID", "0")
-    monkeypatch.setenv("KOMMO_NEW_STATUS_ID", "0")
+async def test_on_phone_received_none_responsible_id_does_not_break_crm():
+    """bot_config.kommo_responsible_user_id=None should not abort lead creation."""
+    bot_config = SimpleNamespace(
+        kommo_default_pipeline_id=0,
+        kommo_new_status_id=0,
+        kommo_responsible_user_id=None,
+        kommo_service_field_id=0,
+        kommo_source_field_id=0,
+        kommo_telegram_field_id=0,
+        kommo_telegram_username_field_id=0,
+    )
 
     mock_kommo = AsyncMock()
     mock_kommo.upsert_contact.return_value = SimpleNamespace(id=7)
@@ -293,6 +303,74 @@ async def test_on_phone_received_blank_responsible_id_does_not_break_crm(monkeyp
                 }
             }
         }
-        await mod.on_phone_received(message, state, kommo_client=mock_kommo)
+        await mod.on_phone_received(message, state, kommo_client=mock_kommo, bot_config=bot_config)
 
     mock_kommo.create_lead.assert_awaited_once()
+
+
+# --- BotConfig injection tests (new API, RED first) ---
+
+
+def test_build_custom_fields_with_explicit_ids():
+    """_build_custom_fields must accept explicit field IDs without reading env vars."""
+    fields = _build_custom_fields(
+        "Осмотр",
+        12345,
+        "ivan",
+        service_field_id=100,
+        source_field_id=200,
+        telegram_field_id=300,
+        telegram_username_field_id=400,
+    )
+    assert len(fields) == 4
+    assert {"field_id": 100, "values": [{"value": "Осмотр"}]} in fields
+    assert {"field_id": 200, "values": [{"value": "Telegram-бот"}]} in fields
+    assert {"field_id": 300, "values": [{"value": "12345"}]} in fields
+    assert {"field_id": 400, "values": [{"value": "@ivan"}]} in fields
+
+
+def test_build_custom_fields_explicit_zero_ids_returns_empty():
+    """When all explicit field IDs are 0 (default), no fields are added."""
+    fields = _build_custom_fields("Осмотр", 12345, "ivan")
+    assert fields == []
+
+
+async def test_on_phone_received_uses_bot_config_for_pipeline_ids():
+    """on_phone_received must read pipeline/status/responsible IDs from bot_config, not env vars."""
+    bot_config = SimpleNamespace(
+        kommo_default_pipeline_id=55,
+        kommo_new_status_id=77,
+        kommo_responsible_user_id=88,
+        kommo_service_field_id=100,
+        kommo_source_field_id=200,
+        kommo_telegram_field_id=300,
+        kommo_telegram_username_field_id=400,
+    )
+
+    mock_kommo = AsyncMock()
+    mock_kommo.upsert_contact.return_value = SimpleNamespace(id=10)
+    mock_kommo.create_lead.return_value = SimpleNamespace(id=20)
+
+    state = AsyncMock()
+    state.get_data.return_value = {"service_key": "viewing", "viewing_objects": []}
+
+    message = AsyncMock()
+    message.text = "+380501234567"
+    message.from_user = SimpleNamespace(id=99, first_name="Анна", last_name=None, username="anna")
+
+    with patch("telegram_bot.services.content_loader.load_services_config") as mock_cfg:
+        mock_cfg.return_value = {
+            "entry_points": {
+                "viewing": {
+                    "crm_title": "Осмотр объектов",
+                    "phone_success": "Спасибо!",
+                }
+            }
+        }
+        await mod.on_phone_received(message, state, kommo_client=mock_kommo, bot_config=bot_config)
+
+    mock_kommo.create_lead.assert_awaited_once()
+    lead_arg = mock_kommo.create_lead.call_args[0][0]
+    assert lead_arg.pipeline_id == 55
+    assert lead_arg.status_id == 77
+    assert lead_arg.responsible_user_id == 88

--- a/tests/unit/handlers/test_phone_collector.py
+++ b/tests/unit/handlers/test_phone_collector.py
@@ -308,6 +308,45 @@ async def test_on_phone_received_none_responsible_id_does_not_break_crm():
     mock_kommo.create_lead.assert_awaited_once()
 
 
+async def test_on_phone_received_zero_responsible_id_normalized_to_none():
+    """bot_config.kommo_responsible_user_id=0 should be normalized to None."""
+    bot_config = SimpleNamespace(
+        kommo_default_pipeline_id=0,
+        kommo_new_status_id=0,
+        kommo_responsible_user_id=0,
+        kommo_service_field_id=0,
+        kommo_source_field_id=0,
+        kommo_telegram_field_id=0,
+        kommo_telegram_username_field_id=0,
+    )
+
+    mock_kommo = AsyncMock()
+    mock_kommo.upsert_contact.return_value = SimpleNamespace(id=17)
+    mock_kommo.create_lead.return_value = SimpleNamespace(id=18)
+
+    state = AsyncMock()
+    state.get_data.return_value = {"service_key": "manager", "viewing_objects": []}
+
+    message = AsyncMock()
+    message.text = "+380501234567"
+    message.from_user = SimpleNamespace(id=654, first_name="Иван", last_name=None, username=None)
+
+    with patch("telegram_bot.services.content_loader.load_services_config") as mock_cfg:
+        mock_cfg.return_value = {
+            "entry_points": {
+                "manager": {
+                    "crm_title": "Консультация",
+                    "phone_success": "Спасибо! Менеджер свяжется с вами в ближайшее время",
+                }
+            }
+        }
+        await mod.on_phone_received(message, state, kommo_client=mock_kommo, bot_config=bot_config)
+
+    mock_kommo.create_lead.assert_awaited_once()
+    lead_arg = mock_kommo.create_lead.call_args[0][0]
+    assert lead_arg.responsible_user_id is None
+
+
 # --- BotConfig injection tests (new API, RED first) ---
 
 

--- a/tests/unit/test_bot_entry_points_crm.py
+++ b/tests/unit/test_bot_entry_points_crm.py
@@ -149,17 +149,30 @@ async def test_viewing_phone_callback_starts_phone_collection() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_viewing_choose_objects_redirects() -> None:
-    """viewing:choose_objects -> sends redirect message and answers callback."""
+async def test_viewing_choose_objects_starts_search() -> None:
+    """viewing:choose_objects -> routes to apartment search pipeline."""
     bot = _create_bot()
     state = _make_state()
     cb = _make_callback("viewing:choose_objects")
 
-    await bot.handle_viewing_callback(cb, state)
+    with patch.object(bot, "handle_menu_action_text", new=AsyncMock()) as mock_action:
+        await bot.handle_viewing_callback(cb, state)
 
-    cb.message.answer.assert_awaited_once()
-    text = cb.message.answer.call_args[0][0]
-    assert "апартамент" in text.lower() or "опиш" in text.lower()
+    mock_action.assert_awaited_once_with(cb.message, "Подбери апартаменты")
+    cb.answer.assert_awaited_once()
+
+
+async def test_viewing_choose_objects_no_message() -> None:
+    """viewing:choose_objects with message=None -> handle_menu_action_text not called, answer still called."""
+    bot = _create_bot()
+    state = _make_state()
+    cb = _make_callback("viewing:choose_objects")
+    cb.message = None
+
+    with patch.object(bot, "handle_menu_action_text", new=AsyncMock()) as mock_action:
+        await bot.handle_viewing_callback(cb, state)
+
+    mock_action.assert_not_awaited()
     cb.answer.assert_awaited_once()
 
 


### PR DESCRIPTION
## Summary
- **#672**: `viewing:choose_objects` callback now routes to apartment search pipeline via `handle_menu_action_text` instead of sending a dead-end text prompt
- **#673**: `phone_collector` reads Kommo IDs (`pipeline_id`, `status_id`, `responsible_user_id`, custom field IDs) from injected `BotConfig` instead of `os.getenv()` — single source of truth, deterministic testability

## Changes
| File | Change |
|------|--------|
| `telegram_bot/bot.py` | `viewing:choose_objects` → `handle_menu_action_text(msg, "Подбери апартаменты")` |
| `telegram_bot/handlers/phone_collector.py` | `_build_custom_fields` accepts explicit field IDs; `on_phone_received` accepts `bot_config`; `import os` removed |
| `tests/unit/test_bot_entry_points_crm.py` | Updated test + added edge case (message=None) |
| `tests/unit/handlers/test_phone_collector.py` | Migrated env-based tests to explicit args + new BotConfig injection tests |

## Issues
Closes #672, Closes #673

## Test plan
- [x] `ruff check` + `ruff format` — clean
- [x] 35/35 tests pass (`test_bot_entry_points_crm`, `test_phone_collector`, `test_phone_crm_integration`)
- [ ] `make check` (CI)
- [ ] `make test-unit` (CI)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>