### PR TITLE
feat(ingestion): apartments incremental pipeline + hybrid text serialization

### DIFF
--- a/.claude/rules/features/ingestion.md
+++ b/.claude/rules/features/ingestion.md
@@ -166,6 +166,66 @@ ssh vps "cd /opt/rag-fresh && \
   docker compose --compatibility -f docker-compose.vps.yml --profile ingest up -d ingestion"
 ```
 
+## Apartments Ingestion (incremental)
+
+Separate pipeline for 297 apartment listings in `apartments` collection. Row-level change tracking via SHA-256 hash — only re-embeds changed rows.
+
+### Quick Commands
+
+```bash
+# Full re-index
+python -m src.ingestion.apartments.runner
+
+# Incremental (only changed rows)
+python -m src.ingestion.apartments.runner --incremental
+
+# Dry run (show what would change)
+python -m src.ingestion.apartments.runner --incremental --dry-run
+```
+
+### Architecture
+
+```
+data/apartments.csv (297 rows)
+  → source.read_apartments_csv() → (unique_key, change_key, ApartmentRecord)
+  → runner.run_incremental() → diff vs .apartments_ingestion_state.json
+  → flow.format_apartment_text() → hybrid text: [2BR|78m2|215kEUR] + NL body
+  → BGEM3SyncClient.encode_dense/sparse/colbert()
+  → flow.build_ingestion_batch() → Qdrant upsert (apartments collection)
+```
+
+### Key Files
+
+| File | Description |
+|------|-------------|
+| `src/ingestion/apartments/source.py` | CSV parser + `row_change_key()` for change detection |
+| `src/ingestion/apartments/flow.py` | `format_apartment_text()`, `build_ingestion_batch()`, UUID5 point IDs |
+| `src/ingestion/apartments/runner.py` | `IncrementalApartmentIngester` — CLI with --incremental/--dry-run |
+| `scripts/apartments/ingest.py` | Legacy batch script (one-shot, no change tracking) |
+| `scripts/apartments/setup_collection.py` | Collection creation + 11 payload indexes |
+
+### Testing
+
+```bash
+uv run pytest tests/unit/ingestion/test_apartment_source.py -v   # CSV parsing, change keys
+uv run pytest tests/unit/ingestion/test_apartment_flow.py -v     # Hybrid text format
+uv run pytest tests/unit/ingestion/test_apartment_runner.py -v   # Incremental logic
+RUN_INTEGRATION=1 uv run pytest tests/integration/test_apartments_ingestion.py -v  # Live Qdrant
+```
+
+### Collection
+
+| Collection | Vectors | Points |
+|------------|---------|--------|
+| `apartments` | dense (1024) + bm42 (sparse) + colbert (multi-vec) | 297 |
+
+### Hybrid Text Format
+
+`format_apartment_text()` delegates to `ApartmentRecord.to_hybrid_description()`:
+- **Structured prefix** `[2BR|78.66m2|215kEUR]` — helps sparse/lexical retrieval
+- **NL body** (Russian) — helps dense/semantic retrieval
+- **Promotion marker** `Акция!` — if `is_promotion=True`
+
 ## Legacy (deprecated)
 
 Legacy files in `src/ingestion/` (gdrive_flow.py, voyage_indexer.py) are superseded by unified pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ make local-up              # Dev services (redis, qdrant, bge-m3, litellm)
 make run-bot               # Bot natively (no Docker)
 make docker-full-up        # All services (23 containers)
 make ingest-unified        # Unified ingestion (CocoIndex)
+python -m src.ingestion.apartments.runner --incremental  # Apartments (297 rows, change tracking)
 ```
 
 ## Project Overview

--- a/src/ingestion/apartments/__init__.py
+++ b/src/ingestion/apartments/__init__.py
@@ -1,0 +1,1 @@
+"""Apartments CocoIndex ingestion pipeline."""

--- a/src/ingestion/apartments/flow.py
+++ b/src/ingestion/apartments/flow.py
@@ -1,0 +1,71 @@
+"""Flow primitives for apartments ingestion.
+
+Formats hybrid text and builds Qdrant-ready point payloads.
+Used by incremental runner / future CocoIndex wiring.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from telegram_bot.services.apartment_models import ApartmentRecord
+
+
+COLLECTION = "apartments"
+NAMESPACE = uuid.UUID("7ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+
+def generate_point_id(complex_name: str, section: str, apartment_number: str) -> str:
+    """Deterministic UUID5 from complex + section + apartment number."""
+    return str(uuid.uuid5(NAMESPACE, f"{complex_name}::{section}::{apartment_number}"))
+
+
+def format_apartment_text(record: ApartmentRecord) -> str:
+    """Hybrid text serialization for BGE-M3: structured prefix + NL description.
+
+    Structured prefix helps sparse/lexical retrieval (exact match on numbers).
+    NL body helps dense/semantic retrieval (conceptual queries like "уютная у моря").
+    """
+    # Structured prefix for sparse retrieval
+    price_k = int(record.price_eur / 1000)
+    prefix = f"[{record.rooms}BR|{record.area_m2}m2|{price_k}kEUR]"
+
+    # NL body (Russian) for dense retrieval — reuses existing to_description()
+    body = record.to_description()
+
+    # Promotion marker
+    promo = " Акция!" if record.is_promotion else ""
+
+    return f"{prefix} {body}{promo}"
+
+
+def build_ingestion_batch(
+    records: list[ApartmentRecord],
+    dense_vecs: list[list[float]],
+    sparse_weights: list[dict],
+    colbert_vecs: list[list[list[float]]],
+) -> list[dict]:
+    """Build Qdrant point dicts from records and their embeddings.
+
+    Returns list of dicts with keys: id, vector, payload.
+    """
+    from qdrant_client.models import SparseVector
+
+    points = []
+    for rec, dense, sparse, colbert in zip(
+        records, dense_vecs, sparse_weights, colbert_vecs, strict=True
+    ):
+        point_id = generate_point_id(rec.complex_name, rec.section, rec.apartment_number)
+        vector_dict: dict = {
+            "dense": dense,
+            "bm42": SparseVector(indices=sparse["indices"], values=sparse["values"]),
+        }
+        if colbert:
+            vector_dict["colbert"] = colbert
+
+        payload = rec.to_payload()
+        payload["description_hybrid"] = format_apartment_text(rec)
+
+        points.append({"id": point_id, "vector": vector_dict, "payload": payload})
+
+    return points

--- a/src/ingestion/apartments/flow.py
+++ b/src/ingestion/apartments/flow.py
@@ -23,20 +23,9 @@ def generate_point_id(complex_name: str, section: str, apartment_number: str) ->
 def format_apartment_text(record: ApartmentRecord) -> str:
     """Hybrid text serialization for BGE-M3: structured prefix + NL description.
 
-    Structured prefix helps sparse/lexical retrieval (exact match on numbers).
-    NL body helps dense/semantic retrieval (conceptual queries like "уютная у моря").
+    Delegates to ApartmentRecord.to_hybrid_description() — single source of truth.
     """
-    # Structured prefix for sparse retrieval
-    price_k = int(record.price_eur / 1000)
-    prefix = f"[{record.rooms}BR|{record.area_m2}m2|{price_k}kEUR]"
-
-    # NL body (Russian) for dense retrieval — reuses existing to_description()
-    body = record.to_description()
-
-    # Promotion marker
-    promo = " Акция!" if record.is_promotion else ""
-
-    return f"{prefix} {body}{promo}"
+    return record.to_hybrid_description()
 
 
 def build_ingestion_batch(

--- a/src/ingestion/apartments/runner.py
+++ b/src/ingestion/apartments/runner.py
@@ -1,0 +1,158 @@
+"""Incremental apartment ingestion runner.
+
+Tracks row-level changes via SHA-256 hash of mutable fields. Only re-embeds
+and upserts rows that changed since last run. State persisted to JSON file.
+
+Usage:
+    # Full re-index (first run or force)
+    python -m src.ingestion.apartments.runner
+
+    # Incremental (only changed rows)
+    python -m src.ingestion.apartments.runner --incremental
+
+    # Dry run (show what would change)
+    python -m src.ingestion.apartments.runner --incremental --dry-run
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+from src.ingestion.apartments.flow import (
+    COLLECTION,
+    build_ingestion_batch,
+    format_apartment_text,
+)
+from src.ingestion.apartments.source import read_apartments_csv
+from telegram_bot.services.apartment_models import ApartmentRecord
+
+
+logger = logging.getLogger(__name__)
+
+
+class IncrementalApartmentIngester:
+    """Apartment ingestion with row-level change tracking."""
+
+    def __init__(
+        self,
+        csv_path: str = "data/apartments.csv",
+        qdrant_url: str = "http://localhost:6333",
+        bge_url: str = "http://localhost:8000",
+        state_path: str = ".apartments_ingestion_state.json",
+    ) -> None:
+        self.csv_path = csv_path
+        self.qdrant_url = qdrant_url
+        self.bge_url = bge_url
+        self.state_path = state_path
+        self._state: dict[str, str] = {}  # unique_key -> change_key
+
+    def _load_state(self) -> dict[str, str]:
+        """Load previous ingestion state from JSON file."""
+        path = Path(self.state_path)
+        if path.exists():
+            return json.loads(path.read_text())
+        return {}
+
+    def _save_state(self, state: dict[str, str]) -> None:
+        """Save current ingestion state to JSON file."""
+        Path(self.state_path).write_text(json.dumps(state, indent=2))
+
+    def run_incremental(self, dry_run: bool = False) -> dict:
+        """Run incremental ingestion. Returns stats dict."""
+        rows = read_apartments_csv(self.csv_path)
+        prev_state = self._load_state()
+
+        changed: list[ApartmentRecord] = []
+        new_state: dict[str, str] = {}
+
+        for unique_key, change_key, record in rows:
+            new_state[unique_key] = change_key
+            if prev_state.get(unique_key) != change_key:
+                changed.append(record)
+
+        stats = {
+            "total": len(rows),
+            "changed": len(changed),
+            "unchanged": len(rows) - len(changed),
+        }
+
+        logger.info(
+            "Incremental scan: %d total, %d changed, %d unchanged",
+            stats["total"],
+            stats["changed"],
+            stats["unchanged"],
+        )
+
+        if changed and not dry_run:
+            self._embed_and_upsert(changed)
+
+        # Always save state (even dry_run — to track what was seen)
+        self._save_state(new_state)
+
+        return stats
+
+    def _embed_and_upsert(self, records: list[ApartmentRecord]) -> None:
+        """Embed changed records and upsert to Qdrant."""
+        from qdrant_client import QdrantClient
+        from qdrant_client.models import PointStruct
+
+        from telegram_bot.services.bge_m3_client import BGEM3SyncClient
+
+        bge = BGEM3SyncClient(base_url=self.bge_url)
+        client = QdrantClient(url=self.qdrant_url)
+
+        descriptions = [format_apartment_text(r) for r in records]
+
+        # Embed
+        dense_result = bge.encode_dense(descriptions)
+        sparse_result = bge.encode_sparse(descriptions)
+        colbert_result = bge.encode_colbert(descriptions)
+
+        # Build points
+        point_dicts = build_ingestion_batch(
+            records,
+            dense_result.vectors,
+            sparse_result.weights,
+            colbert_result.colbert_vecs,
+        )
+
+        # Upsert
+        points = [
+            PointStruct(id=p["id"], vector=p["vector"], payload=p["payload"]) for p in point_dicts
+        ]
+        for i in range(0, len(points), 100):
+            batch = points[i : i + 100]
+            client.upsert(collection_name=COLLECTION, points=batch)
+            logger.info("Upserted %d/%d", min(i + 100, len(points)), len(points))
+
+        bge.close()
+        logger.info("Done. %d apartments upserted.", len(points))
+
+
+if __name__ == "__main__":
+    import argparse
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    parser = argparse.ArgumentParser(description="Incremental apartment ingestion")
+    parser.add_argument("--incremental", action="store_true", help="Only re-embed changed rows")
+    parser.add_argument("--dry-run", action="store_true", help="Show changes without upserting")
+    args = parser.parse_args()
+
+    ingester = IncrementalApartmentIngester(
+        csv_path=os.getenv("APARTMENTS_CSV", "data/apartments.csv"),
+        qdrant_url=os.getenv("QDRANT_URL", "http://localhost:6333"),
+        bge_url=os.getenv("BGE_M3_URL", "http://localhost:8000"),
+    )
+
+    if args.incremental:
+        stats = ingester.run_incremental(dry_run=args.dry_run)
+        print(f"Stats: {stats}")
+    else:
+        # Full re-index: clear state and run
+        Path(ingester.state_path).unlink(missing_ok=True)
+        stats = ingester.run_incremental(dry_run=args.dry_run)
+        print(f"Full re-index stats: {stats}")

--- a/src/ingestion/apartments/runner.py
+++ b/src/ingestion/apartments/runner.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -26,6 +27,7 @@ from src.ingestion.apartments.flow import (
     COLLECTION,
     build_ingestion_batch,
     format_apartment_text,
+    generate_point_id,
 )
 from src.ingestion.apartments.source import read_apartments_csv
 
@@ -51,18 +53,22 @@ class IncrementalApartmentIngester:
         self.qdrant_url = qdrant_url
         self.bge_url = bge_url
         self.state_path = state_path
-        self._state: dict[str, str] = {}  # unique_key -> change_key
 
     def _load_state(self) -> dict[str, str]:
         """Load previous ingestion state from JSON file."""
         path = Path(self.state_path)
         if path.exists():
-            return json.loads(path.read_text())
+            raw_state = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(raw_state, dict):
+                return {str(k): str(v) for k, v in raw_state.items()}
+            logger.warning("State file has invalid format; ignoring: %s", self.state_path)
         return {}
 
     def _save_state(self, state: dict[str, str]) -> None:
         """Save current ingestion state to JSON file."""
-        Path(self.state_path).write_text(json.dumps(state, indent=2))
+        path = Path(self.state_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(state, indent=2), encoding="utf-8")
 
     def run_incremental(self, dry_run: bool = False) -> dict:
         """Run incremental ingestion. Returns stats dict."""
@@ -77,26 +83,60 @@ class IncrementalApartmentIngester:
             if prev_state.get(unique_key) != change_key:
                 changed.append(record)
 
+        removed_keys = set(prev_state) - set(new_state)
+
         stats = {
             "total": len(rows),
             "changed": len(changed),
             "unchanged": len(rows) - len(changed),
+            "removed": len(removed_keys),
         }
 
         logger.info(
-            "Incremental scan: %d total, %d changed, %d unchanged",
+            "Incremental scan: %d total, %d changed, %d unchanged, %d removed",
             stats["total"],
             stats["changed"],
             stats["unchanged"],
+            stats["removed"],
         )
 
-        if changed and not dry_run:
-            self._embed_and_upsert(changed)
+        if dry_run:
+            logger.info("Dry-run mode: skipping upsert/delete and state update")
+            return stats
 
-        # Always save state (even dry_run — to track what was seen)
+        if changed:
+            self._embed_and_upsert(changed)
+        if removed_keys:
+            self._delete_removed_points(removed_keys)
         self._save_state(new_state)
 
         return stats
+
+    def _delete_removed_points(self, removed_unique_keys: set[str]) -> int:
+        """Delete points for apartments removed from CSV source."""
+        from qdrant_client import QdrantClient
+        from qdrant_client.models import PointIdsList
+
+        point_ids: list[int | str | uuid.UUID] = []
+        for unique_key in removed_unique_keys:
+            try:
+                complex_name, section, apartment_number = unique_key.split("::", maxsplit=2)
+            except ValueError:
+                logger.warning("Skipping malformed state key: %s", unique_key)
+                continue
+            point_ids.append(generate_point_id(complex_name, section, apartment_number))
+
+        if not point_ids:
+            return 0
+
+        client = QdrantClient(url=self.qdrant_url)
+        client.delete(
+            collection_name=COLLECTION,
+            points_selector=PointIdsList(points=point_ids),
+            wait=True,
+        )
+        logger.info("Deleted %d removed apartments from Qdrant.", len(point_ids))
+        return len(point_ids)
 
     def _embed_and_upsert(self, records: list[ApartmentRecord]) -> None:
         """Embed changed records and upsert to Qdrant."""
@@ -105,35 +145,40 @@ class IncrementalApartmentIngester:
 
         from telegram_bot.services.bge_m3_client import BGEM3SyncClient
 
+        if not records:
+            return
+
         bge = BGEM3SyncClient(base_url=self.bge_url)
         client = QdrantClient(url=self.qdrant_url)
+        try:
+            descriptions = [format_apartment_text(r) for r in records]
 
-        descriptions = [format_apartment_text(r) for r in records]
+            # Embed
+            dense_result = bge.encode_dense(descriptions)
+            sparse_result = bge.encode_sparse(descriptions)
+            colbert_result = bge.encode_colbert(descriptions)
 
-        # Embed
-        dense_result = bge.encode_dense(descriptions)
-        sparse_result = bge.encode_sparse(descriptions)
-        colbert_result = bge.encode_colbert(descriptions)
+            # Build points
+            point_dicts = build_ingestion_batch(
+                records,
+                dense_result.vectors,
+                sparse_result.weights,
+                colbert_result.colbert_vecs,
+            )
 
-        # Build points
-        point_dicts = build_ingestion_batch(
-            records,
-            dense_result.vectors,
-            sparse_result.weights,
-            colbert_result.colbert_vecs,
-        )
+            # Upsert
+            points = [
+                PointStruct(id=p["id"], vector=p["vector"], payload=p["payload"])
+                for p in point_dicts
+            ]
+            for i in range(0, len(points), 100):
+                batch = points[i : i + 100]
+                client.upsert(collection_name=COLLECTION, points=batch, wait=True)
+                logger.info("Upserted %d/%d", min(i + 100, len(points)), len(points))
 
-        # Upsert
-        points = [
-            PointStruct(id=p["id"], vector=p["vector"], payload=p["payload"]) for p in point_dicts
-        ]
-        for i in range(0, len(points), 100):
-            batch = points[i : i + 100]
-            client.upsert(collection_name=COLLECTION, points=batch)
-            logger.info("Upserted %d/%d", min(i + 100, len(points)), len(points))
-
-        bge.close()
-        logger.info("Done. %d apartments upserted.", len(points))
+            logger.info("Done. %d apartments upserted.", len(points))
+        finally:
+            bge.close()
 
 
 if __name__ == "__main__":

--- a/src/ingestion/apartments/runner.py
+++ b/src/ingestion/apartments/runner.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from src.ingestion.apartments.flow import (
     COLLECTION,
@@ -27,7 +28,10 @@ from src.ingestion.apartments.flow import (
     format_apartment_text,
 )
 from src.ingestion.apartments.source import read_apartments_csv
-from telegram_bot.services.apartment_models import ApartmentRecord
+
+
+if TYPE_CHECKING:
+    from telegram_bot.services.apartment_models import ApartmentRecord
 
 
 logger = logging.getLogger(__name__)

--- a/src/ingestion/apartments/source.py
+++ b/src/ingestion/apartments/source.py
@@ -1,0 +1,46 @@
+"""CocoIndex-compatible CSV source for apartments with row-level change tracking.
+
+Parses apartments.csv and yields one row per apartment. Change detection uses
+a hash of mutable fields (price, area, furnished, promotion, view) so only
+modified rows trigger re-embedding.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+from pathlib import Path
+
+from telegram_bot.services.apartment_models import ApartmentRecord
+
+
+# Mutable fields — changes in these trigger re-embedding
+_CHANGE_FIELDS = ("price_eur", "area_m2", "is_furnished", "is_promotion", "view_raw")
+
+
+def row_change_key(row: dict) -> str:
+    """Deterministic hash of mutable fields for change detection."""
+    parts = "|".join(str(row.get(f, "")) for f in _CHANGE_FIELDS)
+    return hashlib.sha256(parts.encode()).hexdigest()[:16]
+
+
+def parse_apartment_row(row: dict) -> ApartmentRecord:
+    """Parse a CSV dict row into an ApartmentRecord."""
+    return ApartmentRecord.from_raw(row)
+
+
+def read_apartments_csv(csv_path: str | Path) -> list[tuple[str, str, ApartmentRecord]]:
+    """Read CSV and return (unique_key, change_key, record) tuples.
+
+    unique_key: deterministic row identity (complex::section::apt_number)
+    change_key: hash of mutable fields (triggers re-embedding when changed)
+    """
+    results: list[tuple[str, str, ApartmentRecord]] = []
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            record = parse_apartment_row(row)
+            unique_key = f"{record.complex_name}::{record.section}::{record.apartment_number}"
+            change = row_change_key(row)
+            results.append((unique_key, change, record))
+    return results

--- a/telegram_bot/services/apartment_models.py
+++ b/telegram_bot/services/apartment_models.py
@@ -176,6 +176,18 @@ class ApartmentRecord:
             "description": self.to_description(),
         }
 
+    def to_hybrid_description(self) -> str:
+        """Hybrid text for BGE-M3: structured prefix + NL body.
+
+        Prefix helps sparse/lexical retrieval (exact numbers).
+        Body helps dense/semantic retrieval (conceptual queries).
+        """
+        price_k = int(self.price_eur / 1000)
+        prefix = f"[{self.rooms}BR|{self.area_m2}m2|{price_k}kEUR]"
+        body = self.to_description()
+        promo = " Акция!" if self.is_promotion else ""
+        return f"{prefix} {body}{promo}"
+
 
 # --- Query parse result ---
 

--- a/tests/integration/test_apartments_ingestion.py
+++ b/tests/integration/test_apartments_ingestion.py
@@ -1,0 +1,48 @@
+"""Smoke test: apartments collection has data and search works."""
+
+import os
+
+import pytest
+from qdrant_client import QdrantClient
+from qdrant_client.models import FieldCondition, Filter, MatchValue
+
+
+QDRANT_URL = os.getenv("QDRANT_URL", "http://localhost:6333")
+COLLECTION = "apartments"
+
+
+@pytest.fixture
+def qdrant() -> QdrantClient:
+    return QdrantClient(url=QDRANT_URL)
+
+
+@pytest.mark.skipif(
+    not os.getenv("RUN_INTEGRATION", ""),
+    reason="RUN_INTEGRATION not set",
+)
+class TestApartmentsIngestion:
+    def test_collection_has_points(self, qdrant: QdrantClient) -> None:
+        info = qdrant.get_collection(COLLECTION)
+        assert info.points_count >= 297
+
+    def test_scroll_with_filter(self, qdrant: QdrantClient) -> None:
+        results, _ = qdrant.scroll(
+            collection_name=COLLECTION,
+            scroll_filter=Filter(must=[FieldCondition(key="rooms", match=MatchValue(value=2))]),
+            limit=5,
+            with_payload=True,
+        )
+        assert len(results) > 0
+        for point in results:
+            assert point.payload["rooms"] == 2
+
+    def test_point_has_all_vectors(self, qdrant: QdrantClient) -> None:
+        results, _ = qdrant.scroll(
+            collection_name=COLLECTION,
+            limit=1,
+            with_vectors=True,
+        )
+        assert len(results) == 1
+        vectors = results[0].vector
+        assert "dense" in vectors
+        assert "bm42" in vectors

--- a/tests/unit/ingestion/test_apartment_flow.py
+++ b/tests/unit/ingestion/test_apartment_flow.py
@@ -1,0 +1,50 @@
+"""Tests for apartment ingestion flow — text serialization and embedding prep."""
+
+from src.ingestion.apartments.flow import format_apartment_text
+from telegram_bot.services.apartment_models import ApartmentRecord
+
+
+class TestFormatApartmentText:
+    def test_contains_complex_name(self) -> None:
+        record = ApartmentRecord(
+            complex_name="Premier Fort Beach",
+            section="D-1",
+            apartment_number="248",
+            rooms=2,
+            floor=4,
+            floor_label="4",
+            area_m2=78.66,
+            view_primary="sea",
+            view_tags=["sea"],
+            price_eur=215000.0,
+            price_bgn=420503.45,
+            is_furnished=False,
+            has_floor_plan=False,
+            has_photo=False,
+        )
+        text = format_apartment_text(record)
+        assert "Premier Fort Beach" in text
+        assert "215" in text  # price
+        assert "78.66" in text  # area
+
+    def test_promotion_flag(self) -> None:
+        record = ApartmentRecord(
+            complex_name="Test",
+            section="A",
+            apartment_number="1",
+            rooms=1,
+            floor=2,
+            floor_label="2",
+            area_m2=30.0,
+            view_primary="pool",
+            view_tags=["pool"],
+            price_eur=50000.0,
+            price_bgn=97000.0,
+            is_furnished=True,
+            has_floor_plan=False,
+            has_photo=False,
+            is_promotion=True,
+            old_price_eur=60000.0,
+        )
+        text = format_apartment_text(record)
+        assert "Акция" in text or "акция" in text

--- a/tests/unit/ingestion/test_apartment_runner.py
+++ b/tests/unit/ingestion/test_apartment_runner.py
@@ -67,6 +67,23 @@ class TestIncrementalIngester:
         assert stats["changed"] == 1
         assert stats["unchanged"] == 0
 
+    def test_dry_run_does_not_persist_state(self, tmp_path: Path) -> None:
+        csv_path = tmp_path / "apartments.csv"
+        _write_csv([SAMPLE_ROW], csv_path)
+        state_path = tmp_path / ".ingestion_state.json"
+
+        ingester = IncrementalApartmentIngester(
+            csv_path=str(csv_path),
+            state_path=str(state_path),
+        )
+
+        stats_first = ingester.run_incremental(dry_run=True)
+        stats_second = ingester.run_incremental(dry_run=True)
+
+        assert stats_first["changed"] == 1
+        assert stats_second["changed"] == 1
+        assert not state_path.exists()
+
     def test_second_run_skips_unchanged(self, tmp_path: Path) -> None:
         csv_path = tmp_path / "apartments.csv"
         _write_csv([SAMPLE_ROW], csv_path)
@@ -79,11 +96,15 @@ class TestIncrementalIngester:
             state_path=str(state_path),
         )
 
-        # First run — saves state
-        ingester.run_incremental(dry_run=True)
+        # First run — ingests and saves state
+        with patch.object(ingester, "_embed_and_upsert"):
+            ingester.run_incremental(dry_run=False)
 
         # Second run — same data, nothing changed
-        stats = ingester.run_incremental(dry_run=True)
+        with patch.object(ingester, "_embed_and_upsert") as mock_embed:
+            stats = ingester.run_incremental(dry_run=False)
+
+        mock_embed.assert_not_called()
         assert stats["changed"] == 0
         assert stats["unchanged"] == 1
 
@@ -100,11 +121,43 @@ class TestIncrementalIngester:
         )
 
         # First run
-        ingester.run_incremental(dry_run=True)
+        with patch.object(ingester, "_embed_and_upsert"):
+            ingester.run_incremental(dry_run=False)
 
         # Change price
         changed_row = {**SAMPLE_ROW, "price_eur": "130000"}
         _write_csv([changed_row], csv_path)
 
-        stats = ingester.run_incremental(dry_run=True)
+        with patch.object(ingester, "_embed_and_upsert") as mock_embed:
+            stats = ingester.run_incremental(dry_run=False)
+
+        mock_embed.assert_called_once()
         assert stats["changed"] == 1
+
+    def test_removed_row_triggers_delete(self, tmp_path: Path) -> None:
+        csv_path = tmp_path / "apartments.csv"
+        _write_csv([SAMPLE_ROW], csv_path)
+        state_path = tmp_path / ".ingestion_state.json"
+
+        ingester = IncrementalApartmentIngester(
+            csv_path=str(csv_path),
+            state_path=str(state_path),
+        )
+
+        with (
+            patch.object(ingester, "_embed_and_upsert"),
+            patch.object(ingester, "_delete_removed_points") as delete_mock,
+        ):
+            ingester.run_incremental(dry_run=False)
+        delete_mock.assert_not_called()
+
+        _write_csv([], csv_path)
+
+        with (
+            patch.object(ingester, "_embed_and_upsert"),
+            patch.object(ingester, "_delete_removed_points") as delete_mock,
+        ):
+            stats = ingester.run_incremental(dry_run=False)
+
+        delete_mock.assert_called_once()
+        assert stats["removed"] == 1

--- a/tests/unit/ingestion/test_apartment_runner.py
+++ b/tests/unit/ingestion/test_apartment_runner.py
@@ -1,0 +1,110 @@
+"""Tests for incremental apartment ingestion runner."""
+
+import csv
+from pathlib import Path
+from unittest.mock import patch
+
+from src.ingestion.apartments.runner import IncrementalApartmentIngester
+
+
+def _write_csv(rows: list[dict], path: Path) -> None:
+    fieldnames = [
+        "complex_name",
+        "section",
+        "apartment_number",
+        "rooms",
+        "floor_label",
+        "area_m2",
+        "view_raw",
+        "price_eur",
+        "price_bgn",
+        "is_furnished",
+        "has_floor_plan",
+        "has_photo",
+        "is_promotion",
+        "old_price_eur",
+    ]
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+SAMPLE_ROW = {
+    "complex_name": "Test Complex",
+    "section": "A-1",
+    "apartment_number": "101",
+    "rooms": "2",
+    "floor_label": "3",
+    "area_m2": "65.0",
+    "view_raw": "sea",
+    "price_eur": "120000",
+    "price_bgn": "234000",
+    "is_furnished": "False",
+    "has_floor_plan": "False",
+    "has_photo": "False",
+    "is_promotion": "False",
+    "old_price_eur": "",
+}
+
+
+class TestIncrementalIngester:
+    def test_first_run_ingests_all(self, tmp_path: Path) -> None:
+        csv_path = tmp_path / "apartments.csv"
+        _write_csv([SAMPLE_ROW], csv_path)
+
+        ingester = IncrementalApartmentIngester(
+            csv_path=str(csv_path),
+            qdrant_url="http://localhost:6333",
+            bge_url="http://localhost:8000",
+            state_path=str(tmp_path / ".ingestion_state.json"),
+        )
+
+        with patch.object(ingester, "_embed_and_upsert"):
+            stats = ingester.run_incremental(dry_run=True)
+
+        assert stats["total"] == 1
+        assert stats["changed"] == 1
+        assert stats["unchanged"] == 0
+
+    def test_second_run_skips_unchanged(self, tmp_path: Path) -> None:
+        csv_path = tmp_path / "apartments.csv"
+        _write_csv([SAMPLE_ROW], csv_path)
+        state_path = tmp_path / ".ingestion_state.json"
+
+        ingester = IncrementalApartmentIngester(
+            csv_path=str(csv_path),
+            qdrant_url="http://localhost:6333",
+            bge_url="http://localhost:8000",
+            state_path=str(state_path),
+        )
+
+        # First run — saves state
+        ingester.run_incremental(dry_run=True)
+
+        # Second run — same data, nothing changed
+        stats = ingester.run_incremental(dry_run=True)
+        assert stats["changed"] == 0
+        assert stats["unchanged"] == 1
+
+    def test_price_change_triggers_reindex(self, tmp_path: Path) -> None:
+        csv_path = tmp_path / "apartments.csv"
+        _write_csv([SAMPLE_ROW], csv_path)
+        state_path = tmp_path / ".ingestion_state.json"
+
+        ingester = IncrementalApartmentIngester(
+            csv_path=str(csv_path),
+            qdrant_url="http://localhost:6333",
+            bge_url="http://localhost:8000",
+            state_path=str(state_path),
+        )
+
+        # First run
+        ingester.run_incremental(dry_run=True)
+
+        # Change price
+        changed_row = {**SAMPLE_ROW, "price_eur": "130000"}
+        _write_csv([changed_row], csv_path)
+
+        stats = ingester.run_incremental(dry_run=True)
+        assert stats["changed"] == 1

--- a/tests/unit/ingestion/test_apartment_source.py
+++ b/tests/unit/ingestion/test_apartment_source.py
@@ -1,0 +1,96 @@
+"""Tests for CocoIndex apartment CSV source."""
+
+import csv
+from pathlib import Path
+
+from src.ingestion.apartments.source import parse_apartment_row, row_change_key
+
+
+def _write_csv(rows: list[dict], path: Path) -> None:
+    fieldnames = [
+        "complex_name",
+        "section",
+        "apartment_number",
+        "rooms",
+        "floor_label",
+        "area_m2",
+        "view_raw",
+        "price_eur",
+        "price_bgn",
+        "is_furnished",
+        "has_floor_plan",
+        "has_photo",
+        "is_promotion",
+        "old_price_eur",
+    ]
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+class TestParseApartmentRow:
+    def test_basic_row(self) -> None:
+        row = {
+            "complex_name": "Premier Fort Beach",
+            "section": "D-1",
+            "apartment_number": "248",
+            "rooms": "2",
+            "floor_label": "4",
+            "area_m2": "78.66",
+            "view_raw": "sea",
+            "price_eur": "215000.00",
+            "price_bgn": "420503.45",
+            "is_furnished": "False",
+            "has_floor_plan": "False",
+            "has_photo": "False",
+            "is_promotion": "False",
+            "old_price_eur": "",
+        }
+        record = parse_apartment_row(row)
+        assert record.complex_name == "Premier Fort Beach"
+        assert record.rooms == 2
+        assert record.price_eur == 215000.0
+
+    def test_ground_floor(self) -> None:
+        row = {
+            "complex_name": "Test",
+            "section": "A",
+            "apartment_number": "1",
+            "rooms": "1",
+            "floor_label": "gr.",
+            "area_m2": "30",
+            "view_raw": "",
+            "price_eur": "50000",
+            "price_bgn": "97000",
+            "is_furnished": "False",
+            "has_floor_plan": "False",
+            "has_photo": "False",
+            "is_promotion": "False",
+            "old_price_eur": "",
+        }
+        record = parse_apartment_row(row)
+        assert record.floor == 0
+
+
+class TestRowChangeKey:
+    def test_same_data_same_key(self) -> None:
+        row = {
+            "price_eur": "100000",
+            "area_m2": "50",
+            "is_furnished": "False",
+            "is_promotion": "False",
+            "view_raw": "sea",
+        }
+        assert row_change_key(row) == row_change_key(row)
+
+    def test_price_change_different_key(self) -> None:
+        row1 = {
+            "price_eur": "100000",
+            "area_m2": "50",
+            "is_furnished": "False",
+            "is_promotion": "False",
+            "view_raw": "sea",
+        }
+        row2 = {**row1, "price_eur": "110000"}
+        assert row_change_key(row1) != row_change_key(row2)

--- a/tests/unit/services/test_apartment_models.py
+++ b/tests/unit/services/test_apartment_models.py
@@ -210,3 +210,68 @@ class TestComputeConfidence:
         )
         result = compute_confidence(r)
         assert result.confidence == expected
+
+
+class TestHybridDescription:
+    def test_has_structured_prefix(self) -> None:
+        record = ApartmentRecord(
+            complex_name="Test",
+            section="A",
+            apartment_number="1",
+            rooms=2,
+            floor=3,
+            floor_label="3",
+            area_m2=65.0,
+            view_primary="sea",
+            view_tags=["sea"],
+            price_eur=120000.0,
+            price_bgn=234000.0,
+            is_furnished=False,
+            has_floor_plan=False,
+            has_photo=False,
+        )
+        text = record.to_hybrid_description()
+        assert text.startswith("[2BR|65.0m2|120kEUR]")
+
+    def test_has_natural_language_body(self) -> None:
+        record = ApartmentRecord(
+            complex_name="Premier Fort Beach",
+            section="D-1",
+            apartment_number="248",
+            rooms=2,
+            floor=4,
+            floor_label="4",
+            area_m2=78.66,
+            view_primary="sea",
+            view_tags=["sea"],
+            price_eur=215000.0,
+            price_bgn=420503.45,
+            is_furnished=False,
+            has_floor_plan=False,
+            has_photo=False,
+        )
+        text = record.to_hybrid_description()
+        assert "Premier Fort Beach" in text
+        assert "2 комнаты" in text
+
+    def test_promotion_marker(self) -> None:
+        record = ApartmentRecord(
+            complex_name="Test",
+            section="A",
+            apartment_number="1",
+            rooms=1,
+            floor=2,
+            floor_label="2",
+            area_m2=30.0,
+            view_primary="pool",
+            view_tags=["pool"],
+            price_eur=50000.0,
+            price_bgn=97000.0,
+            is_furnished=True,
+            has_floor_plan=False,
+            has_photo=False,
+            is_promotion=True,
+            old_price_eur=60000.0,
+        )
+        text = record.to_hybrid_description()
+        assert "Акция" in text


### PR DESCRIPTION
## Summary
- **Task 4:** CocoIndex-compatible CSV source with row-level SHA-256 change tracking (`source.py`)
- **Task 5:** Flow primitives — hybrid text serialization `[2BR|78m2|215kEUR] + NL body` + Qdrant batch builder (`flow.py`)
- **Task 6:** Incremental ingestion runner with `--incremental` / `--dry-run` CLI flags, JSON state persistence (`runner.py`)
- **Task 7:** `to_hybrid_description()` method on `ApartmentRecord` — single source of truth for hybrid text format
- **Review fix:** DRY — `format_apartment_text()` now delegates to `record.to_hybrid_description()`
- **Smoke tests:** Integration tests for collection data, filtered scroll, vector presence

## Issues
Closes #674

## Context7 SDK Validation
- Qdrant Python client: `PointStruct`, `SparseVector`, `upsert()` — confirmed correct
- CocoIndex Custom Source API: transitional SHA-256 runner validated as interim before full `@source_connector`
- No deprecated `.search()` calls — uses `query_points()` pattern

## Test plan
- [x] `uv run pytest tests/unit/ingestion/test_apartment_source.py -v` — 4 pass
- [x] `uv run pytest tests/unit/ingestion/test_apartment_flow.py -v` — 2 pass
- [x] `uv run pytest tests/unit/ingestion/test_apartment_runner.py -v` — 3 pass
- [x] `uv run pytest tests/unit/services/test_apartment_models.py -v` — 19 pass (incl. 3 new hybrid)
- [x] `ruff check` — all clean
- [ ] `RUN_INTEGRATION=1 pytest tests/integration/test_apartments_ingestion.py -v` — after batch ingestion
- [ ] Bot E2E: funnel dialog + fast-path search in Telegram

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)