### PR TITLE
feat(crm): seed Kommo tokens from KOMMO_ACCESS_TOKEN fallback (#678)

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -245,6 +245,36 @@ def _is_checkpointer_runtime_error(exc: Exception) -> bool:
     return False
 
 
+async def _seed_kommo_access_token(
+    *,
+    redis: Any,
+    access_token: str,
+    subdomain: str,
+) -> bool:
+    """Seed Redis with access_token from env when no auth_code and Redis empty.
+
+    Returns True if seeded, False if skipped.
+    """
+    from .services.kommo_tokens import REDIS_KEY
+
+    if not access_token:
+        return False
+    existing = await redis.hgetall(REDIS_KEY)
+    if existing:
+        return False
+    await redis.hset(
+        REDIS_KEY,
+        mapping={
+            "access_token": access_token,
+            "refresh_token": "",
+            "expires_at": "0",
+            "subdomain": subdomain,
+        },
+    )
+    logger.info("Kommo: seeded Redis from KOMMO_ACCESS_TOKEN (no refresh_token)")
+    return True
+
+
 class PropertyBot:
     """Telegram bot for domain-specific search (configurable via BOT_DOMAIN)."""
 
@@ -2947,14 +2977,21 @@ class PropertyBot:
                     auth_code = self.config.kommo_auth_code or None
                     should_init_kommo = True
                     if auth_code is None:
-                        existing = await self._cache.redis.hgetall(REDIS_KEY)
-                        if not existing:
-                            logger.info(
-                                "Kommo CRM disabled: no stored tokens and no KOMMO_AUTH_CODE "
-                                "(set env var for first-time setup)"
-                            )
-                            self._kommo_client = None
-                            should_init_kommo = False
+                        # Fallback: seed Redis from KOMMO_ACCESS_TOKEN (#678)
+                        seeded = await _seed_kommo_access_token(
+                            redis=self._cache.redis,
+                            access_token=self.config.kommo_access_token.get_secret_value(),
+                            subdomain=self.config.kommo_subdomain,
+                        )
+                        if not seeded:
+                            existing = await self._cache.redis.hgetall(REDIS_KEY)
+                            if not existing:
+                                logger.info(
+                                    "Kommo CRM disabled: no stored tokens, "
+                                    "no KOMMO_AUTH_CODE, no KOMMO_ACCESS_TOKEN"
+                                )
+                                self._kommo_client = None
+                                should_init_kommo = False
 
                     if should_init_kommo:
                         await token_store.initialize(authorization_code=auth_code)

--- a/telegram_bot/services/kommo_tokens.py
+++ b/telegram_bot/services/kommo_tokens.py
@@ -58,6 +58,14 @@ class KommoTokenStore:
         access_token = data.get("access_token", "")
         refresh_token = data.get("refresh_token", "")
         expires_at = int(data.get("expires_at", 0))
+        if not access_token:
+            msg = "Kommo token store has no access_token."
+            raise RuntimeError(msg)
+
+        # Fallback seed mode (#678): access token was pre-provisioned via env and
+        # may not have refresh metadata. Try it as-is instead of forcing refresh.
+        if not refresh_token:
+            return access_token
 
         if time.time() + REFRESH_BUFFER_SEC >= expires_at:
             logger.info("Kommo token near expiry, refreshing")

--- a/tests/unit/services/test_kommo_tokens.py
+++ b/tests/unit/services/test_kommo_tokens.py
@@ -57,6 +57,18 @@ class TestKommoTokenStore:
             assert token == "new_token"
             mock_refresh.assert_called_once_with("refresh_123")
 
+    async def test_get_valid_token_seeded_without_refresh_token(self, token_store, mock_redis):
+        """Seeded access_token without refresh token should be returned as-is."""
+        mock_redis.hgetall.return_value = {
+            b"access_token": b"seeded_access",
+            b"refresh_token": b"",
+            b"expires_at": b"0",
+        }
+        with patch.object(token_store, "_refresh_tokens", new_callable=AsyncMock) as mock_refresh:
+            token = await token_store.get_valid_token()
+            assert token == "seeded_access"
+            mock_refresh.assert_not_called()
+
     async def test_get_valid_token_raises_when_no_tokens(self, token_store, mock_redis):
         """Raise when no tokens stored and no auth code."""
         mock_redis.hgetall.return_value = {}

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -1827,9 +1827,12 @@ class TestKommoGracefulInit:
 
     async def test_kommo_missing_tokens_logs_info_not_warning(self, mock_config, caplog):
         """INFO log (no traceback) when no Redis tokens and no KOMMO_AUTH_CODE."""
+        from pydantic import SecretStr
+
         mock_config.kommo_enabled = True
         mock_config.kommo_subdomain = "test"
         mock_config.kommo_auth_code = ""
+        mock_config.kommo_access_token = SecretStr("")
 
         bot, _ = _create_bot(mock_config)
         bot._cache = MagicMock()

--- a/tests/unit/test_kommo_token_seed.py
+++ b/tests/unit/test_kommo_token_seed.py
@@ -1,0 +1,63 @@
+"""Tests for Kommo access_token fallback seeding (#678)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from telegram_bot.services.kommo_tokens import REDIS_KEY
+
+
+@pytest.fixture
+def mock_redis():
+    redis = AsyncMock()
+    redis.hgetall = AsyncMock(return_value={})
+    redis.hset = AsyncMock()
+    return redis
+
+
+class TestKommoAccessTokenSeed:
+    async def test_seed_access_token_when_redis_empty(self, mock_redis):
+        from telegram_bot.bot import _seed_kommo_access_token
+
+        seeded = await _seed_kommo_access_token(
+            redis=mock_redis,
+            access_token="eyJ0eXA...",
+            subdomain="testdomain",
+        )
+        assert seeded is True
+        mock_redis.hset.assert_called_once_with(
+            REDIS_KEY,
+            mapping={
+                "access_token": "eyJ0eXA...",
+                "refresh_token": "",
+                "expires_at": "0",
+                "subdomain": "testdomain",
+            },
+        )
+
+    async def test_skip_seed_when_redis_has_tokens(self, mock_redis):
+        mock_redis.hgetall = AsyncMock(
+            return_value={b"access_token": b"existing", b"refresh_token": b"rf"}
+        )
+        from telegram_bot.bot import _seed_kommo_access_token
+
+        seeded = await _seed_kommo_access_token(
+            redis=mock_redis,
+            access_token="new-token",
+            subdomain="testdomain",
+        )
+        assert seeded is False
+        mock_redis.hset.assert_not_called()
+
+    async def test_skip_seed_when_no_access_token(self, mock_redis):
+        from telegram_bot.bot import _seed_kommo_access_token
+
+        seeded = await _seed_kommo_access_token(
+            redis=mock_redis,
+            access_token="",
+            subdomain="testdomain",
+        )
+        assert seeded is False
+        mock_redis.hset.assert_not_called()


### PR DESCRIPTION
## Summary
- Add `_seed_kommo_access_token()` helper to seed Redis with access_token from env when no `KOMMO_AUTH_CODE` and Redis empty
- Wire into `PropertyBot.__init__` Kommo initialization — fallback chain: auth_code → seed from access_token → check existing Redis → disable

## Issues
Partially closes #678 (Task 3 of 5)

## Test plan
- [x] 3/3 unit tests pass (`test_kommo_token_seed.py`)
- [x] ruff check clean
- [x] .env vars renamed: `KOMMO_INTEGRATION_ID` → `KOMMO_CLIENT_ID`, `KOMMO_SECRET_KEY` → `KOMMO_CLIENT_SECRET`, added `KOMMO_REDIRECT_URI`

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)