### PR TITLE
fix(apartments): align _ROOMS_MAP with real Qdrant data

### DIFF
--- a/telegram_bot/dialogs/funnel.py
+++ b/telegram_bot/dialogs/funnel.py
@@ -17,7 +17,7 @@ from .states import FunnelSG
 
 # --- Filter building helpers ---
 
-_ROOMS_MAP: dict[str, int] = {"studio": 1, "1bed": 2, "2bed": 3, "3bed": 4}
+_ROOMS_MAP: dict[str, int | list[int]] = {"studio": [0, 1], "1bed": 2, "2bed": 3, "3bed": 4}
 _PROPERTY_TYPE_QUERY_TEXT: dict[str, str] = {
     "studio": "студия",
     "1bed": "1 спальня",
@@ -40,7 +40,13 @@ _FLOOR_MAP: dict[str, dict[str, int]] = {
     "top": {"gte": 6},
 }
 
-_ROOMS_DISPLAY: dict[int, str] = {1: "Студия", 2: "1-спальня", 3: "2-спальни", 4: "3-спальни"}
+_ROOMS_DISPLAY: dict[int, str] = {
+    0: "Студия",
+    1: "Студия",
+    2: "1-спальня",
+    3: "2-спальни",
+    4: "3-спальни",
+}
 
 _LOCATION_TO_CITY: dict[str, str] = {
     "sunny_beach": "Sunny Beach",

--- a/tests/unit/dialogs/test_funnel_results.py
+++ b/tests/unit/dialogs/test_funnel_results.py
@@ -13,7 +13,7 @@ from telegram_bot.dialogs.funnel import build_funnel_filters
 
 def test_rooms_studio():
     filters = build_funnel_filters(rooms="studio", budget="any")
-    assert filters.get("rooms") == 1
+    assert filters.get("rooms") == [0, 1]
     assert "price_eur" not in filters
 
 


### PR DESCRIPTION
## Summary

- `_ROOMS_MAP` was off-by-one vs actual Qdrant data (Bulgarian standard: rooms = total rooms incl. living room)
- `studio` now maps to `[0, 1]` (MatchAny) covering both студии (0) and едностаен (1) — 60 units total
- `1bed`→2, `2bed`→3, `3bed`→4 unchanged (already correct values)
- `_ROOMS_DISPLAY` updated to label both rooms=0 and rooms=1 as "Студия"

## Data

| Filter | Old rooms= | New rooms= | Qdrant count |
|--------|-----------|-----------|--------------|
| studio | 1 | [0, 1] | 17 + 43 = 60 |
| 1bed | 2 | 2 | 112 |
| 2bed | 3 | 3 | 118 |
| 3bed | 4 | 4 | 7 |

## Test plan

- [x] `test_rooms_studio` updated to expect `[0, 1]`
- [x] 17/17 funnel tests passing
- [x] mypy — no new errors
- [ ] Manual: funnel studio filter returns results (was returning wrong set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)