### PR TITLE
feat(apartments): switch funnel to SDK scroll with pagination

### DIFF
--- a/telegram_bot/dialogs/funnel.py
+++ b/telegram_bot/dialogs/funnel.py
@@ -231,6 +231,11 @@ async def get_results_data(
         if i18n
         else "К сожалению, по вашим критериям ничего не найдено."
     )
+    results_title = i18n.get("funnel-results-title") if i18n else "Результаты"
+    btn_more = i18n.get("results-show-more") if i18n else "🔄 Показать ещё"
+    service_unavailable_text = (
+        i18n.get("results-service-unavailable") if i18n else "Сервис поиска недоступен."
+    )
     btn_back = i18n.get("back") if i18n else "Назад"
 
     # Resolve apartments_service with property_bot fallback
@@ -281,14 +286,22 @@ async def get_results_data(
             logger.exception("Failed to fetch funnel results from Qdrant")
             results_text = no_results_text
     else:
-        results_text = "Сервис поиска недоступен."
+        results_text = service_unavailable_text
 
-    title = f"Найдено {total_count} апартаментов" if total_count else "Результаты"
+    if total_count:
+        title = (
+            i18n.get("results-found", total=total_count)
+            if i18n
+            else f"Найдено {total_count} апартаментов"
+        )
+    else:
+        title = results_title
 
     return {
         "title": title,
         "results_text": results_text,
         "has_more": has_more,
+        "btn_more": btn_more,
         "btn_back": btn_back,
     }
 
@@ -537,7 +550,7 @@ funnel_dialog = Dialog(
     Window(
         Format("{title}\n\n{results_text}"),
         Button(
-            Format("🔄 Показать ещё"),
+            Format("{btn_more}"),
             id="more",
             on_click=on_results_more,
             when="has_more",

--- a/telegram_bot/dialogs/funnel.py
+++ b/telegram_bot/dialogs/funnel.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from aiogram.types import CallbackQuery
 from aiogram_dialog import Dialog, DialogManager, Window
-from aiogram_dialog.widgets.kbd import Back, Cancel, Column, Select
+from aiogram_dialog.widgets.kbd import Back, Button, Cancel, Column, Select
 from aiogram_dialog.widgets.text import Format
 
 from .states import FunnelSG
@@ -213,11 +213,14 @@ async def get_view_options(**kwargs: Any) -> dict[str, Any]:
     return {"title": "Какой вид предпочитаете?", "items": items, "btn_back": btn_back}
 
 
+_SCROLL_PAGE_SIZE = 5
+
+
 async def get_results_data(
     dialog_manager: DialogManager,
     **kwargs: Any,
 ) -> dict[str, Any]:
-    """Getter for results window — fetches real apartments via hybrid search (#628)."""
+    """Getter for results window — SDK scroll with pagination (no embeddings needed)."""
     from telegram_bot.keyboards.property_card import format_property_card
 
     i18n = dialog_manager.middleware_data.get("i18n")
@@ -228,35 +231,31 @@ async def get_results_data(
         if i18n
         else "К сожалению, по вашим критериям ничего не найдено."
     )
-    results_title = i18n.get("funnel-results-title") if i18n else "Подобрали для вас:"
     btn_back = i18n.get("back") if i18n else "Назад"
 
-    # Resolve apartments_service and hybrid_embeddings with property_bot fallback
+    # Resolve apartments_service with property_bot fallback
     svc = dialog_manager.middleware_data.get("apartments_service")
-    embeddings = dialog_manager.middleware_data.get("hybrid_embeddings")
-    if svc is None or embeddings is None:
+    if svc is None:
         property_bot = dialog_manager.middleware_data.get("property_bot")
         if property_bot is not None:
-            if svc is None:
-                svc = getattr(property_bot, "_apartments_service", None)
-            if embeddings is None:
-                embeddings = getattr(property_bot, "_embeddings", None)
+            svc = getattr(property_bot, "_apartments_service", None)
 
     results_text: str
-    if svc is not None and embeddings is not None:
+    has_more = False
+    total_count = 0
+    if svc is not None:
         try:
-            location = data.get("location", "")
-            city = _LOCATION_TO_CITY.get(location, location)
-            query_text = _build_query_text(data)
-
-            dense, sparse = await embeddings.aembed_hybrid(query_text)
             filters = _build_funnel_filters(data)
-            results = await svc.search(
-                dense_vector=dense,
-                sparse_vector=sparse,
+            scroll_offset = data.get("scroll_offset")
+
+            results, total_count, next_offset = await svc.scroll_with_filters(
                 filters=filters,
-                top_k=5,
+                limit=_SCROLL_PAGE_SIZE,
+                offset=scroll_offset,
             )
+            data["scroll_next_offset"] = str(next_offset) if next_offset else None
+            has_more = next_offset is not None
+
             if results:
                 cards = []
                 for apt in results:
@@ -267,7 +266,7 @@ async def get_results_data(
                         format_property_card(
                             property_id=apt["id"],
                             complex_name=p.get("complex_name", ""),
-                            location=p.get("city") or (city if city != "any" else "Болгария"),
+                            location=p.get("city", "Болгария"),
                             property_type=rooms_display,
                             floor=p.get("floor", 0),
                             area_m2=p.get("area_m2", 0),
@@ -282,11 +281,14 @@ async def get_results_data(
             logger.exception("Failed to fetch funnel results from Qdrant")
             results_text = no_results_text
     else:
-        results_text = "Не нашли подходящих вариантов."
+        results_text = "Сервис поиска недоступен."
+
+    title = f"Найдено {total_count} апартаментов" if total_count else "Результаты"
 
     return {
-        "title": results_title,
+        "title": title,
         "results_text": results_text,
+        "has_more": has_more,
         "btn_back": btn_back,
     }
 
@@ -336,6 +338,9 @@ async def on_refine_or_show_selected(
     """Branch: show results immediately or go to optional refinement steps."""
     manager.dialog_data["refine_or_show"] = item_id
     if item_id == "show":
+        manager.dialog_data.pop("scroll_offset", None)
+        manager.dialog_data.pop("scroll_next_offset", None)
+        manager.dialog_data["scroll_page"] = 1
         try:
             from telegram_bot.bot import make_session_id
 
@@ -375,6 +380,21 @@ async def on_floor_selected(
     await manager.switch_to(FunnelSG.view)
 
 
+async def on_results_more(
+    callback: CallbackQuery,
+    button: Button,
+    manager: DialogManager,
+) -> None:
+    """Load next page of scroll results."""
+    data = manager.dialog_data
+    next_offset = data.get("scroll_next_offset")
+    if not next_offset:
+        await callback.answer("Все результаты показаны")
+        return
+    data["scroll_offset"] = next_offset
+    data["scroll_page"] = data.get("scroll_page", 1) + 1
+
+
 async def on_view_selected(
     callback: CallbackQuery,
     widget: Select,
@@ -383,6 +403,9 @@ async def on_view_selected(
 ) -> None:
     """Save view preference, persist lead score and show results."""
     manager.dialog_data["view"] = item_id
+    manager.dialog_data.pop("scroll_offset", None)
+    manager.dialog_data.pop("scroll_next_offset", None)
+    manager.dialog_data["scroll_page"] = 1
 
     try:
         from telegram_bot.bot import make_session_id
@@ -510,9 +533,15 @@ funnel_dialog = Dialog(
         getter=get_view_options,
         state=FunnelSG.view,
     ),
-    # Step 5: Results
+    # Step 5: Results (SDK scroll with pagination)
     Window(
         Format("{title}\n\n{results_text}"),
+        Button(
+            Format("🔄 Показать ещё"),
+            id="more",
+            on_click=on_results_more,
+            when="has_more",
+        ),
         Cancel(Format("{btn_back}")),
         getter=get_results_data,
         state=FunnelSG.results,

--- a/telegram_bot/locales/en/messages.ftl
+++ b/telegram_bot/locales/en/messages.ftl
@@ -121,6 +121,8 @@ funnel-refine-more = ⚙️ Refine more
 # Results (#660)
 results-shown = Showing { $shown } of { $total } options
 results-show-more = 🔄 Show more
+results-found = Found { $total } apartments
+results-service-unavailable = Search service is unavailable.
 results-refine = ⚙️ Change filters
 results-book-viewing = 📅 Book a viewing
 results-no-results =

--- a/telegram_bot/locales/ru/messages.ftl
+++ b/telegram_bot/locales/ru/messages.ftl
@@ -121,6 +121,8 @@ funnel-refine-more = ⚙️ Уточнить ещё
 # Результаты (#660)
 results-shown = Показано { $shown } из { $total } вариантов
 results-show-more = 🔄 Показать ещё
+results-found = Найдено { $total } апартаментов
+results-service-unavailable = Сервис поиска недоступен.
 results-refine = ⚙️ Изменить параметры
 results-book-viewing = 📅 Запись на осмотр
 results-no-results =

--- a/telegram_bot/locales/uk/messages.ftl
+++ b/telegram_bot/locales/uk/messages.ftl
@@ -121,6 +121,8 @@ funnel-refine-more = ⚙️ Уточнити ще
 # Результати (#660)
 results-shown = Показано { $shown } з { $total } варіантів
 results-show-more = 🔄 Показати ще
+results-found = Знайдено { $total } апартаментів
+results-service-unavailable = Сервіс пошуку недоступний.
 results-refine = ⚙️ Змінити параметри
 results-book-viewing = 📅 Запис на огляд
 results-no-results =

--- a/tests/unit/dialogs/test_funnel.py
+++ b/tests/unit/dialogs/test_funnel.py
@@ -139,71 +139,54 @@ async def test_refine_path_switches_to_floor(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_get_results_data_calls_apartments_service():
-    mock_search = AsyncMock(
-        return_value=[
-            {
-                "id": "p1",
-                "score": 0.95,
-                "payload": {
-                    "complex_name": "Sunrise",
-                    "city": "Sunny Beach",
-                    "property_type": "studio",
-                    "floor": 2,
-                    "area_m2": 42,
-                    "view_primary": "sea",
-                    "view_tags": ["sea"],
-                    "price_eur": 48500,
-                    "rooms": 1,
-                },
-            }
-        ]
-    )
-    mock_aembed = AsyncMock(return_value=([0.1] * 1024, {"indices": [1], "values": [0.5]}))
-
+    results = [
+        {
+            "id": "p1",
+            "payload": {
+                "complex_name": "Sunrise",
+                "city": "Sunny Beach",
+                "property_type": "studio",
+                "floor": 2,
+                "area_m2": 42,
+                "view_primary": "sea",
+                "view_tags": ["sea"],
+                "price_eur": 48500,
+                "rooms": 1,
+            },
+        }
+    ]
     mock_svc = MagicMock()
-    mock_svc.search = mock_search
-    mock_embeddings = MagicMock()
-    mock_embeddings.aembed_hybrid = mock_aembed
+    mock_svc.scroll_with_filters = AsyncMock(return_value=(results, 1, None))
 
     manager = SimpleNamespace(
         dialog_data={"location": "sunny_beach", "property_type": "studio", "budget": "low"},
-        middleware_data={
-            "apartments_service": mock_svc,
-            "hybrid_embeddings": mock_embeddings,
-        },
+        middleware_data={"apartments_service": mock_svc},
     )
 
     result = await funnel_module.get_results_data(manager)
 
-    mock_embeddings.aembed_hybrid.assert_awaited_once_with("Sunny Beach студия")
-    mock_svc.search.assert_awaited_once()
+    mock_svc.scroll_with_filters.assert_awaited_once()
     assert "Sunrise" in result["results_text"]
     assert "Sunny Beach" in result["results_text"]
     assert "sunny_beach" not in result["results_text"]
 
 
 @pytest.mark.asyncio
-async def test_get_results_data_any_any_uses_fallback_query():
-    mock_search = AsyncMock(return_value=[])
-    mock_aembed = AsyncMock(return_value=([0.1] * 1024, {"indices": [], "values": []}))
-
+async def test_get_results_data_any_any_returns_all():
     mock_svc = MagicMock()
-    mock_svc.search = mock_search
-    mock_embeddings = MagicMock()
-    mock_embeddings.aembed_hybrid = mock_aembed
+    mock_svc.scroll_with_filters = AsyncMock(return_value=([], 0, None))
 
     manager = SimpleNamespace(
         dialog_data={"location": "any", "property_type": "any", "budget": "any"},
-        middleware_data={
-            "apartments_service": mock_svc,
-            "hybrid_embeddings": mock_embeddings,
-        },
+        middleware_data={"apartments_service": mock_svc},
     )
 
     await funnel_module.get_results_data(manager)
 
-    mock_embeddings.aembed_hybrid.assert_awaited_once_with("апартаменты в Болгарии")
-    mock_svc.search.assert_awaited_once()
+    mock_svc.scroll_with_filters.assert_awaited_once()
+    # No filters when all "any"
+    call_kwargs = mock_svc.scroll_with_filters.call_args
+    assert call_kwargs.kwargs.get("filters") == {} or call_kwargs[1].get("filters") == {}
 
 
 @pytest.mark.asyncio
@@ -215,22 +198,16 @@ async def test_get_results_data_fallback_without_service():
 
     result = await funnel_module.get_results_data(manager)
 
-    assert "не нашли" in result["results_text"].lower()
+    assert "недоступен" in result["results_text"].lower()
 
 
 @pytest.mark.asyncio
 async def test_get_results_data_uses_property_bot_fallback():
-    mock_search = AsyncMock(return_value=[])
-    mock_aembed = AsyncMock(return_value=([0.1] * 1024, {"indices": [1], "values": [0.5]}))
-
     mock_svc = MagicMock()
-    mock_svc.search = mock_search
-    mock_embeddings = MagicMock()
-    mock_embeddings.aembed_hybrid = mock_aembed
+    mock_svc.scroll_with_filters = AsyncMock(return_value=([], 0, None))
 
     mock_property_bot = MagicMock()
     mock_property_bot._apartments_service = mock_svc
-    mock_property_bot._embeddings = mock_embeddings
 
     manager = SimpleNamespace(
         dialog_data={"location": "sunny_beach", "property_type": "studio", "budget": "low"},
@@ -238,9 +215,7 @@ async def test_get_results_data_uses_property_bot_fallback():
     )
 
     await funnel_module.get_results_data(manager)
-
-    mock_embeddings.aembed_hybrid.assert_awaited_once()
-    mock_svc.search.assert_awaited_once()
+    mock_svc.scroll_with_filters.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/dialogs/test_funnel_results.py
+++ b/tests/unit/dialogs/test_funnel_results.py
@@ -86,40 +86,35 @@ def test_city_any_not_included():
 
 @pytest.mark.asyncio
 async def test_get_results_data_returns_cards():
-    """get_results_data calls search with embeddings and formats cards."""
+    """get_results_data calls scroll_with_filters and formats cards."""
     from telegram_bot.dialogs.funnel import get_results_data
 
+    results = [
+        {
+            "id": "apt-1",
+            "payload": {
+                "complex_name": "Sunrise Complex",
+                "rooms": 1,
+                "floor": 2,
+                "area_m2": 42.0,
+                "view_primary": "Море",
+                "price_eur": 48500,
+            },
+        }
+    ]
     mock_svc = MagicMock()
-    mock_svc.search = AsyncMock(
-        return_value=[
-            {
-                "id": "apt-1",
-                "payload": {
-                    "complex_name": "Sunrise Complex",
-                    "rooms": 1,
-                    "floor": 2,
-                    "area_m2": 42.0,
-                    "view_primary": "Море",
-                    "price_eur": 48500,
-                },
-            }
-        ],
-    )
-
-    mock_embeddings = AsyncMock()
-    mock_embeddings.aembed_hybrid = AsyncMock(
-        return_value=([0.1] * 1024, {"indices": [1], "values": [0.5]})
-    )
+    mock_svc.scroll_with_filters = AsyncMock(return_value=(results, 297, "next-uuid"))
 
     manager = SimpleNamespace(
         dialog_data={"property_type": "studio", "budget": "low", "location": "sunny_beach"},
-        middleware_data={"apartments_service": mock_svc, "hybrid_embeddings": mock_embeddings},
+        middleware_data={"apartments_service": mock_svc},
     )
 
     result = await get_results_data(dialog_manager=manager)
-    assert result["title"] == "Подобрали для вас:"
+    assert "297" in result["title"]
     assert "Sunrise Complex" in result["results_text"]
-    mock_svc.search.assert_awaited_once()
+    assert result["has_more"] is True
+    mock_svc.scroll_with_filters.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -128,20 +123,16 @@ async def test_get_results_data_no_results():
     from telegram_bot.dialogs.funnel import get_results_data
 
     mock_svc = MagicMock()
-    mock_svc.search = AsyncMock(return_value=[])
-
-    mock_embeddings = AsyncMock()
-    mock_embeddings.aembed_hybrid = AsyncMock(
-        return_value=([0.1] * 1024, {"indices": [], "values": []})
-    )
+    mock_svc.scroll_with_filters = AsyncMock(return_value=([], 0, None))
 
     manager = SimpleNamespace(
         dialog_data={"property_type": "3bed", "budget": "luxury"},
-        middleware_data={"apartments_service": mock_svc, "hybrid_embeddings": mock_embeddings},
+        middleware_data={"apartments_service": mock_svc},
     )
 
     result = await get_results_data(dialog_manager=manager)
     assert "ничего не найдено" in result["results_text"]
+    assert result["has_more"] is False
 
 
 @pytest.mark.asyncio
@@ -155,30 +146,23 @@ async def test_get_results_data_no_service():
     )
 
     result = await get_results_data(dialog_manager=manager)
-    assert result["results_text"]  # non-empty fallback
+    assert "недоступен" in result["results_text"].lower()
     assert result["btn_back"] == "Назад"
 
 
 @pytest.mark.asyncio
 async def test_get_results_data_malformed_payload():
-    """get_results_data must not crash when search returns items without payload key."""
+    """get_results_data must not crash when scroll returns items without payload key."""
     from telegram_bot.dialogs.funnel import get_results_data
 
     mock_svc = MagicMock()
-    mock_svc.search = AsyncMock(
-        return_value=[
-            {"id": "apt-bad"},  # missing "payload" key
-        ],
-    )
-
-    mock_embeddings = AsyncMock()
-    mock_embeddings.aembed_hybrid = AsyncMock(
-        return_value=([0.1] * 16, {"indices": [], "values": []})
+    mock_svc.scroll_with_filters = AsyncMock(
+        return_value=([{"id": "apt-bad"}], 1, None),  # missing "payload" key
     )
 
     manager = SimpleNamespace(
         dialog_data={"property_type": "any", "budget": "any"},
-        middleware_data={"apartments_service": mock_svc, "hybrid_embeddings": mock_embeddings},
+        middleware_data={"apartments_service": mock_svc},
     )
 
     result = await get_results_data(dialog_manager=manager)

--- a/tests/unit/dialogs/test_funnel_results.py
+++ b/tests/unit/dialogs/test_funnel_results.py
@@ -8,6 +8,19 @@ import pytest
 from telegram_bot.dialogs.funnel import build_funnel_filters
 
 
+class _FakeI18n:
+    def get(self, key: str, **kwargs):
+        messages = {
+            "funnel-results-title": "We found for you:",
+            "results-show-more": "🔄 Show more",
+            "results-service-unavailable": "Search service unavailable.",
+            "results-no-results": "No matches.",
+            "results-found": f"Found {kwargs.get('total', 0)} apartments",
+            "back": "Back",
+        }
+        return messages[key]
+
+
 # --- build_funnel_filters ---
 
 
@@ -114,6 +127,7 @@ async def test_get_results_data_returns_cards():
     assert "297" in result["title"]
     assert "Sunrise Complex" in result["results_text"]
     assert result["has_more"] is True
+    assert result["btn_more"] == "🔄 Показать ещё"
     mock_svc.scroll_with_filters.assert_awaited_once()
 
 
@@ -148,6 +162,25 @@ async def test_get_results_data_no_service():
     result = await get_results_data(dialog_manager=manager)
     assert "недоступен" in result["results_text"].lower()
     assert result["btn_back"] == "Назад"
+
+
+@pytest.mark.asyncio
+async def test_get_results_data_uses_i18n_strings():
+    from telegram_bot.dialogs.funnel import get_results_data
+
+    mock_svc = MagicMock()
+    mock_svc.scroll_with_filters = AsyncMock(return_value=([], 12, "next"))
+
+    manager = SimpleNamespace(
+        dialog_data={"property_type": "any", "budget": "any"},
+        middleware_data={"apartments_service": mock_svc, "i18n": _FakeI18n()},
+    )
+
+    result = await get_results_data(dialog_manager=manager)
+
+    assert result["title"] == "Found 12 apartments"
+    assert result["btn_more"] == "🔄 Show more"
+    assert result["btn_back"] == "Back"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Funnel подбора апартаментов показывал только 4-5 результатов из-за vector similarity search (`svc.search(top_k=5)`)
- Переключено на `scroll_with_filters()` — Qdrant SDK scroll с cursor-based пагинацией
- Убраны embeddings из funnel (не нужны для payload-only scroll)
- Добавлена кнопка "Показать ещё" в results window (aiogram-dialog)
- Заголовок теперь показывает "Найдено N апартаментов"

## Test plan

- [x] `uv run pytest tests/unit/dialogs/test_funnel.py -v` — 19 passed
- [x] `uv run pytest tests/unit/dialogs/test_funnel_results.py -v` — 13 passed
- [x] Ruff lint clean
- [ ] Manual: проверить funnel в боте без фильтров → должно показать 297 апартаментов
- [ ] Manual: проверить "Показать ещё" → следующие 5 апартаментов
- [ ] Manual: проверить с фильтрами (rooms, budget) → отфильтрованные результаты

🤖 Generated with [Claude Code](https://claude.com/claude-code)