### PR TITLE
feat(funnel): refactor apartment search — complex, preferences, summary

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -1037,7 +1037,7 @@ class PropertyBot:
 
             from .dialogs.states import FunnelSG
 
-            await dialog_manager.start(FunnelSG.location, mode=StartMode.RESET_STACK)
+            await dialog_manager.start(FunnelSG.complex, mode=StartMode.RESET_STACK)
         else:
             # Fallback when dialog_manager not available (e.g., tests)
             await self.handle_menu_action_text(message, "Подбери апартаменты")

--- a/telegram_bot/dialogs/client_menu.py
+++ b/telegram_bot/dialogs/client_menu.py
@@ -90,7 +90,7 @@ client_menu_dialog = Dialog(
             Start(
                 Format("{btn_search}"),
                 id="funnel",
-                state=FunnelSG.location,
+                state=FunnelSG.complex,
             ),
             Button(
                 Format("{btn_catalog}"),

--- a/telegram_bot/dialogs/funnel.py
+++ b/telegram_bot/dialogs/funnel.py
@@ -667,6 +667,50 @@ async def on_results_more(
     data["scroll_page"] = data.get("scroll_page", 1) + 1
 
 
+async def on_zero_suggestion_selected(
+    callback: CallbackQuery,
+    widget: Select,
+    manager: DialogManager,
+    item_id: str,
+) -> None:
+    """Apply zero-results recovery suggestion and refresh results/new search."""
+    data = manager.dialog_data
+
+    if item_id == "rm_floor":
+        data.pop("floor", None)
+    elif item_id == "rm_view":
+        data.pop("view", None)
+    elif item_id == "rm_furnished":
+        data.pop("is_furnished", None)
+    elif item_id == "rm_promotion":
+        data.pop("is_promotion", None)
+    elif item_id == "rm_budget":
+        data["budget"] = "any"
+    elif item_id == "new_search":
+        for key in (
+            "complex",
+            "property_type",
+            "budget",
+            "floor",
+            "view",
+            "is_furnished",
+            "is_promotion",
+            "scroll_offset",
+            "scroll_next_offset",
+            "scroll_page",
+        ):
+            data.pop(key, None)
+        await manager.switch_to(FunnelSG.complex)
+        return
+    else:
+        return
+
+    data.pop("scroll_offset", None)
+    data.pop("scroll_next_offset", None)
+    data["scroll_page"] = 1
+    await manager.switch_to(FunnelSG.results)
+
+
 # --- Dialog ---
 
 
@@ -841,6 +885,16 @@ funnel_dialog = Dialog(
     # Step 6: Results (SDK scroll with pagination)
     Window(
         Format("{title}\n\n{results_text}"),
+        Column(
+            Select(
+                Format("{item[0]}"),
+                id="zero_suggestions",
+                item_id_getter=operator.itemgetter(1),
+                items="zero_suggestions",
+                on_click=on_zero_suggestion_selected,
+            ),
+            when="zero_suggestions",
+        ),
         Button(
             Format("{btn_more}"),
             id="more",

--- a/telegram_bot/dialogs/funnel.py
+++ b/telegram_bot/dialogs/funnel.py
@@ -1,4 +1,4 @@
-"""Property search funnel dialog (aiogram-dialog) — #628."""
+"""Property search funnel dialog (aiogram-dialog) — #628, refactored #697."""
 
 from __future__ import annotations
 
@@ -15,7 +15,21 @@ from aiogram_dialog.widgets.text import Format
 from .states import FunnelSG
 
 
-# --- Filter building helpers ---
+# --- Constants ---
+
+_COMPLEX_OPTIONS: list[tuple[str, str]] = [
+    ("Crown Fort Club", "Crown Fort Club"),
+    ("Green Fort Suites", "Green Fort Suites"),
+    ("Imperial Fort Club", "Imperial Fort Club"),
+    ("Marina View Fort Beach", "Marina View Fort Beach"),
+    ("Messambria Fort Beach", "Messambria Fort Beach"),
+    ("Nessebar Fort Residence", "Nessebar Fort Residence"),
+    ("Panorama Fort Beach", "Panorama Fort Beach"),
+    ("Premier Fort Beach", "Premier Fort Beach"),
+    ("Premier Fort Suites", "Premier Fort Suites"),
+    ("Prestige Fort Beach", "Prestige Fort Beach"),
+    ("Любой комплекс", "any"),
+]
 
 _ROOMS_MAP: dict[str, int | list[int]] = {"studio": [0, 1], "1bed": 2, "2bed": 3, "3bed": 4}
 _PROPERTY_TYPE_QUERY_TEXT: dict[str, str] = {
@@ -48,10 +62,34 @@ _ROOMS_DISPLAY: dict[int, str] = {
     4: "3-спальни",
 }
 
-_LOCATION_TO_CITY: dict[str, str] = {
-    "sunny_beach": "Sunny Beach",
-    "elenite": "Elenite",
-    "nessebar": "Nesebar",
+# Display labels for summary
+_BUDGET_DISPLAY: dict[str, str] = {
+    "low": "До 50 000 €",
+    "mid": "50 000 – 100 000 €",
+    "high": "100 000 – 150 000 €",
+    "premium": "150 000 – 200 000 €",
+    "luxury": "Более 200 000 €",
+}
+
+_FLOOR_DISPLAY: dict[str, str] = {
+    "low": "0-1 этаж",
+    "mid": "2-3 этаж",
+    "high": "4-5 этаж",
+    "top": "6+ этаж",
+}
+
+_VIEW_DISPLAY: dict[str, str] = {
+    "sea": "Море",
+    "pool": "Бассейн",
+    "garden": "Газон/сад",
+    "forest": "Лес/горы",
+}
+
+_PROPERTY_TYPE_DISPLAY: dict[str, str] = {
+    "studio": "Студия",
+    "1bed": "1-спальня",
+    "2bed": "2-спальни",
+    "3bed": "3-спальни",
 }
 
 
@@ -60,26 +98,12 @@ def _build_funnel_filters(data: dict[str, Any]) -> dict[str, Any]:
     return build_funnel_filters(
         rooms=data.get("property_type", "any"),
         budget=data.get("budget", "any"),
-        city=data.get("location"),
+        complex_name=data.get("complex"),
         floor=data.get("floor"),
         view=data.get("view"),
+        is_furnished=data.get("is_furnished"),
+        is_promotion=data.get("is_promotion"),
     )
-
-
-def _build_query_text(data: dict[str, Any]) -> str:
-    """Build semantic query text without internal placeholder tokens like 'any'."""
-    location_key = data.get("location")
-    city = _LOCATION_TO_CITY.get(location_key, location_key) if location_key != "any" else ""
-
-    property_type = data.get("property_type")
-    prop_text = (
-        _PROPERTY_TYPE_QUERY_TEXT.get(property_type, property_type)
-        if property_type and property_type != "any"
-        else ""
-    )
-
-    query_parts = [part.strip() for part in (city or "", prop_text or "") if str(part).strip()]
-    return " ".join(query_parts) or "апартаменты в Болгарии"
 
 
 def build_funnel_filters(
@@ -87,9 +111,10 @@ def build_funnel_filters(
     rooms: str = "any",
     budget: str = "any",
     complex_name: str | None = None,
-    city: str | None = None,
     floor: str | None = None,
     view: str | None = None,
+    is_furnished: str | None = None,
+    is_promotion: str | None = None,
 ) -> dict[str, Any]:
     """Build Qdrant payload filter dict from funnel dialog selections."""
     filters: dict[str, Any] = {}
@@ -97,14 +122,18 @@ def build_funnel_filters(
         filters["rooms"] = _ROOMS_MAP[rooms]
     if budget in _BUDGET_MAP:
         filters["price_eur"] = _BUDGET_MAP[budget]
-    if complex_name:
+    if complex_name and complex_name != "any":
         filters["complex_name"] = complex_name
-    if city and city != "any":
-        filters["city"] = _LOCATION_TO_CITY.get(city, city)
     if floor and floor != "any" and floor in _FLOOR_MAP:
         filters["floor"] = _FLOOR_MAP[floor]
     if view and view != "any":
         filters["view_tags"] = [view]
+    if is_furnished == "yes":
+        filters["is_furnished"] = True
+    elif is_furnished == "no":
+        filters["is_furnished"] = False
+    if is_promotion == "yes":
+        filters["is_promotion"] = True
     return filters
 
 
@@ -132,17 +161,15 @@ def _spawn_persist_funnel_lead_score(**kwargs: Any) -> None:
 # --- Getters (provide data to windows) ---
 
 
-async def get_location_options(**kwargs: Any) -> dict[str, Any]:
-    """Getter for location (district) selection."""
+async def get_complex_options(**kwargs: Any) -> dict[str, Any]:
+    """Getter for complex (residential compound) selection."""
     i18n = kwargs.get("middleware_data", {}).get("i18n")
-    items = [
-        ("Солнечный Берег", "sunny_beach"),
-        ("Елените", "elenite"),
-        ("Несебр", "nessebar"),
-        ("Любой район", "any"),
-    ]
     btn_back = i18n.get("back") if i18n else "Назад"
-    return {"title": "В каком районе ищете?", "items": items, "btn_back": btn_back}
+    return {
+        "title": "В каком комплексе ищете?",
+        "items": _COMPLEX_OPTIONS,
+        "btn_back": btn_back,
+    }
 
 
 async def get_property_types(**kwargs: Any) -> dict[str, Any]:
@@ -174,19 +201,42 @@ async def get_budget_options(**kwargs: Any) -> dict[str, Any]:
     return {"title": "Какой бюджет?", "items": items, "btn_back": btn_back}
 
 
-async def get_refine_or_show_options(**kwargs: Any) -> dict[str, Any]:
-    """Getter for refine-or-show decision step."""
+async def get_preferences_options(**kwargs: Any) -> dict[str, Any]:
+    """Getter for preferences multi-select menu (Step 4).
+
+    Shows 4 category buttons with ✓ checkmark when a value is selected,
+    plus a "Готово" button to proceed to summary.
+    """
     i18n = kwargs.get("middleware_data", {}).get("i18n")
-    items = [
-        ("Показать результаты", "show"),
-        ("Уточнить параметры", "refine"),
-    ]
+    dialog_manager = kwargs.get("dialog_manager")
+    data: dict[str, Any] = {}
+    if dialog_manager is not None:
+        data = getattr(dialog_manager, "dialog_data", {})
+
     btn_back = i18n.get("back") if i18n else "Назад"
-    return {"title": "Что делаем дальше?", "items": items, "btn_back": btn_back}
+
+    floor_val = data.get("floor")
+    view_val = data.get("view")
+    furnished_val = data.get("is_furnished")
+    promotion_val = data.get("is_promotion")
+
+    floor_label = f"{'✓ ' if floor_val and floor_val != 'any' else ''}Этаж"
+    view_label = f"{'✓ ' if view_val and view_val != 'any' else ''}Вид"
+    furnished_label = f"{'✓ ' if furnished_val else ''}Мебель"
+    promotion_label = f"{'✓ ' if promotion_val else ''}Акции"
+
+    items = [
+        (floor_label, "floor"),
+        (view_label, "view"),
+        (furnished_label, "furnished"),
+        (promotion_label, "promotion"),
+        ("Готово ➜", "done"),
+    ]
+    return {"title": "Дополнительные пожелания:", "items": items, "btn_back": btn_back}
 
 
-async def get_floor_options(**kwargs: Any) -> dict[str, Any]:
-    """Getter for floor selection (optional refinement)."""
+async def get_pref_floor_options(**kwargs: Any) -> dict[str, Any]:
+    """Getter for floor sub-options."""
     i18n = kwargs.get("middleware_data", {}).get("i18n")
     items = [
         ("0-1 этаж", "low"),
@@ -195,12 +245,12 @@ async def get_floor_options(**kwargs: Any) -> dict[str, Any]:
         ("6+ этаж", "top"),
         ("Любой этаж", "any"),
     ]
-    btn_back = i18n.get("back") if i18n else "Назад"
+    btn_back = i18n.get("back") if i18n else "← Назад"
     return {"title": "Какой этаж предпочитаете?", "items": items, "btn_back": btn_back}
 
 
-async def get_view_options(**kwargs: Any) -> dict[str, Any]:
-    """Getter for view selection (optional refinement)."""
+async def get_pref_view_options(**kwargs: Any) -> dict[str, Any]:
+    """Getter for view sub-options."""
     i18n = kwargs.get("middleware_data", {}).get("i18n")
     items = [
         ("Море", "sea"),
@@ -209,8 +259,100 @@ async def get_view_options(**kwargs: Any) -> dict[str, Any]:
         ("Лес/горы", "forest"),
         ("Любой вид", "any"),
     ]
-    btn_back = i18n.get("back") if i18n else "Назад"
+    btn_back = i18n.get("back") if i18n else "← Назад"
     return {"title": "Какой вид предпочитаете?", "items": items, "btn_back": btn_back}
+
+
+async def get_pref_furnished_options(**kwargs: Any) -> dict[str, Any]:
+    """Getter for furnished sub-options."""
+    i18n = kwargs.get("middleware_data", {}).get("i18n")
+    items = [
+        ("С мебелью", "yes"),
+        ("Без мебели", "no"),
+        ("Не важно", "any"),
+    ]
+    btn_back = i18n.get("back") if i18n else "← Назад"
+    return {"title": "Меблировка:", "items": items, "btn_back": btn_back}
+
+
+async def get_pref_promotion_options(**kwargs: Any) -> dict[str, Any]:
+    """Getter for promotion sub-options."""
+    i18n = kwargs.get("middleware_data", {}).get("i18n")
+    items = [
+        ("Только акции", "yes"),
+        ("Неважно", "any"),
+    ]
+    btn_back = i18n.get("back") if i18n else "← Назад"
+    return {"title": "Специальные акции:", "items": items, "btn_back": btn_back}
+
+
+async def get_summary_data(**kwargs: Any) -> dict[str, Any]:
+    """Getter for summary window — shows selected filters and can_search flag."""
+    dialog_manager = kwargs.get("dialog_manager")
+    data: dict[str, Any] = {}
+    if dialog_manager is not None:
+        data = getattr(dialog_manager, "dialog_data", {})
+
+    lines: list[str] = ["Ваши параметры поиска:\n"]
+
+    complex_val = data.get("complex", "any")
+    if complex_val and complex_val != "any":
+        lines.append(f"🏢 Комплекс: {complex_val}")
+
+    property_type_val = data.get("property_type", "any")
+    if property_type_val and property_type_val != "any":
+        lines.append(f"🏠 Тип: {_PROPERTY_TYPE_DISPLAY.get(property_type_val, property_type_val)}")
+
+    budget_val = data.get("budget", "any")
+    if budget_val and budget_val != "any":
+        lines.append(f"💰 Бюджет: {_BUDGET_DISPLAY.get(budget_val, budget_val)}")
+
+    floor_val = data.get("floor")
+    if floor_val and floor_val != "any":
+        lines.append(f"🏗 Этаж: {_FLOOR_DISPLAY.get(floor_val, floor_val)}")
+
+    view_val = data.get("view")
+    if view_val and view_val != "any":
+        lines.append(f"🌅 Вид: {_VIEW_DISPLAY.get(view_val, view_val)}")
+
+    furnished_val = data.get("is_furnished")
+    if furnished_val == "yes":
+        lines.append("🛋 Меблировка: С мебелью")
+    elif furnished_val == "no":
+        lines.append("🛋 Меблировка: Без мебели")
+
+    promotion_val = data.get("is_promotion")
+    if promotion_val == "yes":
+        lines.append("🎁 Акции: Только акции")
+
+    has_filter = (
+        complex_val not in (None, "any")
+        or property_type_val not in (None, "any")
+        or budget_val not in (None, "any")
+        or (floor_val not in (None, "any"))
+        or (view_val not in (None, "any"))
+        or furnished_val is not None
+        or promotion_val is not None
+    )
+
+    if not has_filter:
+        lines.append("(все параметры — любые)")
+
+    summary_text = "\n".join(lines)
+    return {
+        "summary_text": summary_text,
+        "can_search": has_filter,
+    }
+
+
+async def get_change_filter_options(**kwargs: Any) -> dict[str, Any]:
+    """Getter for change-filter selection window."""
+    items = [
+        ("Комплекс", "complex"),
+        ("Тип жилья", "property_type"),
+        ("Бюджет", "budget"),
+    ]
+    return {"title": "Что хотите изменить?", "items": items, "btn_back": "← Назад"}
 
 
 _SCROLL_PAGE_SIZE = 5
@@ -248,6 +390,8 @@ async def get_results_data(
     results_text: str
     has_more = False
     total_count = 0
+    zero_suggestions: list[tuple[str, str]] = []
+
     if svc is not None:
         try:
             filters = _build_funnel_filters(data)
@@ -282,6 +426,29 @@ async def get_results_data(
                 results_text = "\n\n".join(cards)
             else:
                 results_text = no_results_text
+                # Build zero-results recovery suggestions
+                if total_count == 0:
+                    floor_v = data.get("floor")
+                    view_v = data.get("view")
+                    furnished_v = data.get("is_furnished")
+                    promotion_v = data.get("is_promotion")
+                    budget_v = data.get("budget", "any")
+
+                    if floor_v and floor_v != "any":
+                        zero_suggestions.append(
+                            ("Убрать: " + _FLOOR_DISPLAY.get(floor_v, "этаж"), "rm_floor")
+                        )
+                    if view_v and view_v != "any":
+                        zero_suggestions.append(
+                            ("Убрать: " + _VIEW_DISPLAY.get(view_v, "вид"), "rm_view")
+                        )
+                    if furnished_v:
+                        zero_suggestions.append(("Убрать: мебель", "rm_furnished"))
+                    if promotion_v:
+                        zero_suggestions.append(("Убрать: акции", "rm_promotion"))
+                    if budget_v != "any":
+                        zero_suggestions.append(("Расширить бюджет", "rm_budget"))
+                    zero_suggestions.append(("Новый поиск", "new_search"))
         except Exception:
             logger.exception("Failed to fetch funnel results from Qdrant")
             results_text = no_results_text
@@ -303,21 +470,25 @@ async def get_results_data(
         "has_more": has_more,
         "btn_more": btn_more,
         "btn_back": btn_back,
+        "zero_suggestions": zero_suggestions,
     }
 
 
 # --- Handlers (on_click) ---
 
 
-async def on_location_selected(
+async def on_complex_selected(
     callback: CallbackQuery,
     widget: Select,
     manager: DialogManager,
     item_id: str,
 ) -> None:
-    """Save location and advance to property type."""
-    manager.dialog_data["location"] = item_id
-    await manager.switch_to(FunnelSG.property_type)
+    """Save complex selection and advance to property type."""
+    manager.dialog_data["complex"] = item_id
+    if manager.dialog_data.pop("_return_to_summary", False):
+        await manager.switch_to(FunnelSG.summary)
+    else:
+        await manager.switch_to(FunnelSG.property_type)
 
 
 async def on_property_type_selected(
@@ -328,7 +499,10 @@ async def on_property_type_selected(
 ) -> None:
     """Save property type and advance to budget."""
     manager.dialog_data["property_type"] = item_id
-    await manager.switch_to(FunnelSG.budget)
+    if manager.dialog_data.pop("_return_to_summary", False):
+        await manager.switch_to(FunnelSG.summary)
+    else:
+        await manager.switch_to(FunnelSG.budget)
 
 
 async def on_budget_selected(
@@ -337,60 +511,145 @@ async def on_budget_selected(
     manager: DialogManager,
     item_id: str,
 ) -> None:
-    """Save budget and advance to refine-or-show."""
+    """Save budget and advance to preferences."""
     manager.dialog_data["budget"] = item_id
-    await manager.switch_to(FunnelSG.refine_or_show)
-
-
-async def on_refine_or_show_selected(
-    callback: CallbackQuery,
-    widget: Select,
-    manager: DialogManager,
-    item_id: str,
-) -> None:
-    """Branch: show results immediately or go to optional refinement steps."""
-    manager.dialog_data["refine_or_show"] = item_id
-    if item_id == "show":
-        manager.dialog_data.pop("scroll_offset", None)
-        manager.dialog_data.pop("scroll_next_offset", None)
-        manager.dialog_data["scroll_page"] = 1
-        try:
-            from telegram_bot.bot import make_session_id
-
-            if callback.from_user is not None:
-                data = manager.dialog_data
-                _spawn_persist_funnel_lead_score(
-                    telegram_user_id=callback.from_user.id,
-                    session_id=make_session_id("chat", callback.message.chat.id)
-                    if callback.message is not None
-                    else make_session_id("chat", callback.from_user.id),
-                    property_type=data.get("property_type"),
-                    budget=data.get("budget"),
-                    timeline=data.get("refine_or_show"),
-                    user_service=manager.middleware_data.get("user_service"),
-                    pg_pool=manager.middleware_data.get("pg_pool"),
-                    lead_scoring_store=manager.middleware_data.get("lead_scoring_store"),
-                    kommo_client=manager.middleware_data.get("kommo_client"),
-                    hot_lead_notifier=manager.middleware_data.get("hot_lead_notifier"),
-                    config=manager.middleware_data.get("bot_config"),
-                )
-        except Exception:
-            logger.exception("Failed to schedule funnel lead score persistence")
-
-        await manager.switch_to(FunnelSG.results)
+    if manager.dialog_data.pop("_return_to_summary", False):
+        await manager.switch_to(FunnelSG.summary)
     else:
-        await manager.switch_to(FunnelSG.floor)
+        await manager.switch_to(FunnelSG.preferences)
 
 
-async def on_floor_selected(
+async def on_pref_category_selected(
     callback: CallbackQuery,
     widget: Select,
     manager: DialogManager,
     item_id: str,
 ) -> None:
-    """Save floor preference and advance to view selection."""
+    """Route to the appropriate sub-option window or summary."""
+    _PREF_STATE_MAP = {
+        "floor": FunnelSG.pref_floor,
+        "view": FunnelSG.pref_view,
+        "furnished": FunnelSG.pref_furnished,
+        "promotion": FunnelSG.pref_promotion,
+        "done": FunnelSG.summary,
+    }
+    target = _PREF_STATE_MAP.get(item_id, FunnelSG.summary)
+    await manager.switch_to(target)
+
+
+async def on_pref_floor_selected(
+    callback: CallbackQuery,
+    widget: Select,
+    manager: DialogManager,
+    item_id: str,
+) -> None:
+    """Save floor preference and return to preferences menu."""
     manager.dialog_data["floor"] = item_id
-    await manager.switch_to(FunnelSG.view)
+    await manager.switch_to(FunnelSG.preferences)
+
+
+async def on_pref_view_selected(
+    callback: CallbackQuery,
+    widget: Select,
+    manager: DialogManager,
+    item_id: str,
+) -> None:
+    """Save view preference and return to preferences menu."""
+    manager.dialog_data["view"] = item_id
+    await manager.switch_to(FunnelSG.preferences)
+
+
+async def on_pref_furnished_selected(
+    callback: CallbackQuery,
+    widget: Select,
+    manager: DialogManager,
+    item_id: str,
+) -> None:
+    """Save furnished preference and return to preferences menu."""
+    manager.dialog_data["is_furnished"] = item_id if item_id != "any" else None
+    await manager.switch_to(FunnelSG.preferences)
+
+
+async def on_pref_promotion_selected(
+    callback: CallbackQuery,
+    widget: Select,
+    manager: DialogManager,
+    item_id: str,
+) -> None:
+    """Save promotion preference and return to preferences menu."""
+    manager.dialog_data["is_promotion"] = item_id if item_id != "any" else None
+    await manager.switch_to(FunnelSG.preferences)
+
+
+async def on_summary_search(
+    callback: CallbackQuery,
+    button: Button,
+    manager: DialogManager,
+) -> None:
+    """Confirm search: reset pagination, persist lead score, go to results."""
+    manager.dialog_data.pop("scroll_offset", None)
+    manager.dialog_data.pop("scroll_next_offset", None)
+    manager.dialog_data["scroll_page"] = 1
+
+    try:
+        from telegram_bot.bot import make_session_id
+
+        if callback.from_user is not None:
+            data = manager.dialog_data
+            _spawn_persist_funnel_lead_score(
+                telegram_user_id=callback.from_user.id,
+                session_id=make_session_id("chat", callback.message.chat.id)
+                if callback.message is not None
+                else make_session_id("chat", callback.from_user.id),
+                property_type=data.get("property_type"),
+                budget=data.get("budget"),
+                timeline=None,
+                user_service=manager.middleware_data.get("user_service"),
+                pg_pool=manager.middleware_data.get("pg_pool"),
+                lead_scoring_store=manager.middleware_data.get("lead_scoring_store"),
+                kommo_client=manager.middleware_data.get("kommo_client"),
+                hot_lead_notifier=manager.middleware_data.get("hot_lead_notifier"),
+                config=manager.middleware_data.get("bot_config"),
+            )
+    except Exception:
+        logger.exception("Failed to schedule funnel lead score persistence")
+
+    await manager.switch_to(FunnelSG.results)
+
+
+async def on_summary_refine(
+    callback: CallbackQuery,
+    button: Button,
+    manager: DialogManager,
+) -> None:
+    """Go back to preferences to refine filters."""
+    await manager.switch_to(FunnelSG.preferences)
+
+
+async def on_summary_change(
+    callback: CallbackQuery,
+    button: Button,
+    manager: DialogManager,
+) -> None:
+    """Go to change-filter selection window."""
+    await manager.switch_to(FunnelSG.change_filter)
+
+
+async def on_change_filter_selected(
+    callback: CallbackQuery,
+    widget: Select,
+    manager: DialogManager,
+    item_id: str,
+) -> None:
+    """Set return-to-summary flag and jump to selected step for editing."""
+    manager.dialog_data["_return_to_summary"] = True
+    _CHANGE_STATE_MAP = {
+        "complex": FunnelSG.complex,
+        "property_type": FunnelSG.property_type,
+        "budget": FunnelSG.budget,
+    }
+    target = _CHANGE_STATE_MAP.get(item_id, FunnelSG.summary)
+    await manager.switch_to(target)
 
 
 async def on_results_more(
@@ -408,63 +667,25 @@ async def on_results_more(
     data["scroll_page"] = data.get("scroll_page", 1) + 1
 
 
-async def on_view_selected(
-    callback: CallbackQuery,
-    widget: Select,
-    manager: DialogManager,
-    item_id: str,
-) -> None:
-    """Save view preference, persist lead score and show results."""
-    manager.dialog_data["view"] = item_id
-    manager.dialog_data.pop("scroll_offset", None)
-    manager.dialog_data.pop("scroll_next_offset", None)
-    manager.dialog_data["scroll_page"] = 1
-
-    try:
-        from telegram_bot.bot import make_session_id
-
-        if callback.from_user is not None:
-            data = manager.dialog_data
-            _spawn_persist_funnel_lead_score(
-                telegram_user_id=callback.from_user.id,
-                session_id=make_session_id("chat", callback.message.chat.id)
-                if callback.message is not None
-                else make_session_id("chat", callback.from_user.id),
-                property_type=data.get("property_type"),
-                budget=data.get("budget"),
-                timeline=data.get("refine_or_show"),
-                user_service=manager.middleware_data.get("user_service"),
-                pg_pool=manager.middleware_data.get("pg_pool"),
-                lead_scoring_store=manager.middleware_data.get("lead_scoring_store"),
-                kommo_client=manager.middleware_data.get("kommo_client"),
-                hot_lead_notifier=manager.middleware_data.get("hot_lead_notifier"),
-                config=manager.middleware_data.get("bot_config"),
-            )
-    except Exception:
-        logger.exception("Failed to schedule funnel lead score persistence")
-
-    await manager.switch_to(FunnelSG.results)
-
-
 # --- Dialog ---
 
 
 funnel_dialog = Dialog(
-    # Step 1: Location (район)
+    # Step 1: Complex selection
     Window(
         Format("{title}"),
         Column(
             Select(
                 Format("{item[0]}"),
-                id="location",
+                id="complex",
                 item_id_getter=operator.itemgetter(1),
                 items="items",
-                on_click=on_location_selected,
+                on_click=on_complex_selected,
             ),
         ),
         Cancel(Format("{btn_back}")),
-        getter=get_location_options,
-        state=FunnelSG.location,
+        getter=get_complex_options,
+        state=FunnelSG.complex,
     ),
     # Step 2: Property type
     Window(
@@ -498,55 +719,126 @@ funnel_dialog = Dialog(
         getter=get_budget_options,
         state=FunnelSG.budget,
     ),
-    # Step 4: Refine or show
+    # Step 4: Preferences multi-select menu
     Window(
         Format("{title}"),
         Column(
             Select(
                 Format("{item[0]}"),
-                id="refine_or_show",
+                id="preferences",
                 item_id_getter=operator.itemgetter(1),
                 items="items",
-                on_click=on_refine_or_show_selected,
+                on_click=on_pref_category_selected,
             ),
         ),
         Back(Format("{btn_back}")),
-        getter=get_refine_or_show_options,
-        state=FunnelSG.refine_or_show,
+        getter=get_preferences_options,
+        state=FunnelSG.preferences,
     ),
-    # Step 4a: Floor (optional)
+    # Step 4a: Floor sub-options
     Window(
         Format("{title}"),
         Column(
             Select(
                 Format("{item[0]}"),
-                id="floor",
+                id="pref_floor",
                 item_id_getter=operator.itemgetter(1),
                 items="items",
-                on_click=on_floor_selected,
+                on_click=on_pref_floor_selected,
             ),
         ),
         Back(Format("{btn_back}")),
-        getter=get_floor_options,
-        state=FunnelSG.floor,
+        getter=get_pref_floor_options,
+        state=FunnelSG.pref_floor,
     ),
-    # Step 4b: View (optional)
+    # Step 4b: View sub-options
     Window(
         Format("{title}"),
         Column(
             Select(
                 Format("{item[0]}"),
-                id="view",
+                id="pref_view",
                 item_id_getter=operator.itemgetter(1),
                 items="items",
-                on_click=on_view_selected,
+                on_click=on_pref_view_selected,
             ),
         ),
         Back(Format("{btn_back}")),
-        getter=get_view_options,
-        state=FunnelSG.view,
+        getter=get_pref_view_options,
+        state=FunnelSG.pref_view,
     ),
-    # Step 5: Results (SDK scroll with pagination)
+    # Step 4c: Furnished sub-options
+    Window(
+        Format("{title}"),
+        Column(
+            Select(
+                Format("{item[0]}"),
+                id="pref_furnished",
+                item_id_getter=operator.itemgetter(1),
+                items="items",
+                on_click=on_pref_furnished_selected,
+            ),
+        ),
+        Back(Format("{btn_back}")),
+        getter=get_pref_furnished_options,
+        state=FunnelSG.pref_furnished,
+    ),
+    # Step 4d: Promotion sub-options
+    Window(
+        Format("{title}"),
+        Column(
+            Select(
+                Format("{item[0]}"),
+                id="pref_promotion",
+                item_id_getter=operator.itemgetter(1),
+                items="items",
+                on_click=on_pref_promotion_selected,
+            ),
+        ),
+        Back(Format("{btn_back}")),
+        getter=get_pref_promotion_options,
+        state=FunnelSG.pref_promotion,
+    ),
+    # Step 5: Summary + confirmation
+    Window(
+        Format("{summary_text}"),
+        Button(
+            Format("🔍 Показать результаты"),
+            id="search",
+            on_click=on_summary_search,
+            when="can_search",
+        ),
+        Button(
+            Format("✏️ Изменить параметры"),
+            id="change",
+            on_click=on_summary_change,
+        ),
+        Button(
+            Format("⚙️ Доп. пожелания"),
+            id="refine",
+            on_click=on_summary_refine,
+        ),
+        Cancel(Format("Отмена")),
+        getter=get_summary_data,
+        state=FunnelSG.summary,
+    ),
+    # Step 5a: Change filter selection
+    Window(
+        Format("{title}"),
+        Column(
+            Select(
+                Format("{item[0]}"),
+                id="change_filter",
+                item_id_getter=operator.itemgetter(1),
+                items="items",
+                on_click=on_change_filter_selected,
+            ),
+        ),
+        Back(Format("{btn_back}")),
+        getter=get_change_filter_options,
+        state=FunnelSG.change_filter,
+    ),
+    # Step 6: Results (SDK scroll with pagination)
     Window(
         Format("{title}\n\n{results_text}"),
         Button(

--- a/telegram_bot/dialogs/states.py
+++ b/telegram_bot/dialogs/states.py
@@ -23,15 +23,19 @@ class SettingsSG(StatesGroup):
 
 
 class FunnelSG(StatesGroup):
-    """Property search funnel (#628)."""
+    """Property search funnel (#628, refactored #697)."""
 
-    location = State()  # Step 1: район
+    complex = State()  # Step 1: комплекс
     property_type = State()  # Step 2: тип квартиры
     budget = State()  # Step 3: бюджет
-    refine_or_show = State()  # Step 4: показать / уточнить
-    floor = State()  # Step 4a: этаж (optional)
-    view = State()  # Step 4b: вид (optional)
-    results = State()  # Step 5: результаты
+    preferences = State()  # Step 4: доп. пожелания (multi-select menu)
+    pref_floor = State()  # Step 4a: этаж sub-options
+    pref_view = State()  # Step 4b: вид sub-options
+    pref_furnished = State()  # Step 4c: мебель sub-options
+    pref_promotion = State()  # Step 4d: акции sub-options
+    summary = State()  # Step 5: саммари + confirmation
+    change_filter = State()  # Step 5a: выбор фильтра для изменения
+    results = State()  # Step 6: результаты
 
 
 class FaqSG(StatesGroup):

--- a/telegram_bot/services/apartments_service.py
+++ b/telegram_bot/services/apartments_service.py
@@ -38,6 +38,9 @@ def _build_apartment_filter(filters: dict | None) -> models.Filter | None:
                     match=models.MatchAny(any=value),
                 )
             )
+        elif isinstance(value, bool):
+            # Explicit bool check BEFORE dict/int — isinstance(True, int) is True in Python
+            conditions.append(models.FieldCondition(key=key, match=models.MatchValue(value=value)))
         elif isinstance(value, dict):
             range_params = {op: value[op] for op in ("lt", "lte", "gt", "gte") if op in value}
             if range_params:

--- a/tests/unit/dialogs/test_client_menu.py
+++ b/tests/unit/dialogs/test_client_menu.py
@@ -75,10 +75,10 @@ def test_client_menu_launch_mode_root():
     assert client_menu_dialog.launch_mode == LaunchMode.ROOT
 
 
-def test_client_menu_search_starts_funnel_from_location():
-    """Search button must start funnel from the first location step."""
+def test_client_menu_search_starts_funnel_from_complex():
+    """Search button must start funnel from the complex selection step (#697)."""
     window = client_menu_dialog.windows[ClientMenuSG.main]
     buttons = getattr(window.keyboard, "buttons", ())
     funnel_start = next((btn for btn in buttons if getattr(btn, "widget_id", "") == "funnel"), None)
     assert funnel_start is not None
-    assert getattr(funnel_start, "state", None) == FunnelSG.location
+    assert getattr(funnel_start, "state", None) == FunnelSG.complex

--- a/tests/unit/dialogs/test_funnel.py
+++ b/tests/unit/dialogs/test_funnel.py
@@ -297,3 +297,48 @@ async def test_pref_promotion_any_clears_value():
     await funnel_module.on_pref_promotion_selected(MagicMock(), SimpleNamespace(), manager, "any")
     assert manager.dialog_data["is_promotion"] is None
     manager.switch_to.assert_awaited_once_with(FunnelSG.preferences)
+
+
+@pytest.mark.asyncio
+async def test_zero_suggestion_removes_floor_and_refreshes_results():
+    manager = SimpleNamespace(
+        dialog_data={"floor": "mid", "scroll_offset": "off1", "scroll_next_offset": "off2"},
+        switch_to=AsyncMock(),
+    )
+    await funnel_module.on_zero_suggestion_selected(
+        MagicMock(),
+        SimpleNamespace(),
+        manager,
+        "rm_floor",
+    )
+    assert "floor" not in manager.dialog_data
+    assert manager.dialog_data.get("scroll_offset") is None
+    assert manager.dialog_data.get("scroll_next_offset") is None
+    manager.switch_to.assert_awaited_once_with(FunnelSG.results)
+
+
+@pytest.mark.asyncio
+async def test_zero_suggestion_new_search_clears_filters_and_goes_to_complex():
+    manager = SimpleNamespace(
+        dialog_data={
+            "complex": "Premier Fort Beach",
+            "property_type": "2bed",
+            "budget": "high",
+            "floor": "mid",
+            "view": "sea",
+            "is_furnished": "yes",
+            "is_promotion": "yes",
+            "scroll_offset": "off1",
+            "scroll_next_offset": "off2",
+            "scroll_page": 2,
+        },
+        switch_to=AsyncMock(),
+    )
+    await funnel_module.on_zero_suggestion_selected(
+        MagicMock(),
+        SimpleNamespace(),
+        manager,
+        "new_search",
+    )
+    assert manager.dialog_data == {}
+    manager.switch_to.assert_awaited_once_with(FunnelSG.complex)

--- a/tests/unit/dialogs/test_funnel.py
+++ b/tests/unit/dialogs/test_funnel.py
@@ -1,4 +1,4 @@
-"""Tests for property search funnel dialog (#628)."""
+"""Tests for property search funnel dialog (#697 refactor)."""
 
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -16,53 +16,166 @@ def test_funnel_dialog_exists():
     assert isinstance(funnel_dialog, Dialog)
 
 
-@pytest.mark.asyncio
-async def test_location_options_has_exactly_3_cities_plus_any():
-    """Funnel must only offer cities that exist in data: Sunny Beach, Elenite, Nesebar + Any."""
-    result = await funnel_module.get_location_options()
-    items = result["items"]
-    keys = [key for _, key in items]
-    # Only real cities + any
-    assert "sunny_beach" in keys
-    assert "elenite" in keys
-    assert "nessebar" in keys
-    assert "any" in keys
-    # Removed phantom cities
-    assert "sveti_vlas" not in keys
-    assert "ravda" not in keys
-    assert "burgas" not in keys
-    assert "pomorie" not in keys
-    assert "sozopol" not in keys
-    assert "primorsko" not in keys
-    assert "bansko" not in keys
-    assert "sofia" not in keys
-    # Total: 3 real + 1 any = 4
-    assert len(items) == 4
-
-
 def test_funnel_has_all_windows():
     windows = funnel_dialog.windows
     states = [w.get_state() for w in windows.values()]
-    assert FunnelSG.location in states
+    assert FunnelSG.complex in states
     assert FunnelSG.property_type in states
     assert FunnelSG.budget in states
-    assert FunnelSG.refine_or_show in states
-    assert FunnelSG.floor in states
-    assert FunnelSG.view in states
+    assert FunnelSG.preferences in states
+    assert FunnelSG.pref_floor in states
+    assert FunnelSG.pref_view in states
+    assert FunnelSG.pref_furnished in states
+    assert FunnelSG.pref_promotion in states
+    assert FunnelSG.summary in states
+    assert FunnelSG.change_filter in states
     assert FunnelSG.results in states
 
 
 @pytest.mark.asyncio
-async def test_show_results_schedules_background_persist(monkeypatch):
+async def test_complex_options_has_10_complexes_plus_any():
+    result = await funnel_module.get_complex_options()
+    items = result["items"]
+    keys = [key for _, key in items]
+    assert "Premier Fort Beach" in keys
+    assert "any" in keys
+    assert len(items) == 11  # 10 complexes + "Любой комплекс"
+
+
+@pytest.mark.asyncio
+async def test_preferences_options_has_4_categories_plus_done():
+    result = await funnel_module.get_preferences_options(
+        middleware_data={},
+        dialog_manager=SimpleNamespace(dialog_data={}),
+    )
+    items = result["items"]
+    labels = [label for label, _ in items]
+    assert any("Этаж" in label for label in labels)
+    assert any("Вид" in label for label in labels)
+    assert any("Мебель" in label or "мебель" in label for label in labels)
+    assert any("Акции" in label or "акции" in label for label in labels)
+
+
+@pytest.mark.asyncio
+async def test_preferences_options_shows_checkmark_when_selected():
+    result = await funnel_module.get_preferences_options(
+        middleware_data={},
+        dialog_manager=SimpleNamespace(dialog_data={"floor": "mid", "view": "sea"}),
+    )
+    items = result["items"]
+    labels = [label for label, _ in items]
+    floor_labels = [label for label in labels if "таж" in label.lower()]
+    assert any("✓" in label for label in floor_labels)
+
+
+@pytest.mark.asyncio
+async def test_complex_selected_saves_and_switches():
+    manager = SimpleNamespace(dialog_data={}, switch_to=AsyncMock())
+    await funnel_module.on_complex_selected(
+        MagicMock(), SimpleNamespace(), manager, "Premier Fort Beach"
+    )
+    assert manager.dialog_data["complex"] == "Premier Fort Beach"
+    manager.switch_to.assert_awaited_once_with(FunnelSG.property_type)
+
+
+@pytest.mark.asyncio
+async def test_property_type_selected_saves_and_switches():
+    manager = SimpleNamespace(dialog_data={}, switch_to=AsyncMock())
+    await funnel_module.on_property_type_selected(MagicMock(), SimpleNamespace(), manager, "studio")
+    assert manager.dialog_data["property_type"] == "studio"
+    manager.switch_to.assert_awaited_once_with(FunnelSG.budget)
+
+
+@pytest.mark.asyncio
+async def test_budget_selected_switches_to_preferences():
+    manager = SimpleNamespace(dialog_data={}, switch_to=AsyncMock())
+    await funnel_module.on_budget_selected(MagicMock(), SimpleNamespace(), manager, "mid")
+    assert manager.dialog_data["budget"] == "mid"
+    manager.switch_to.assert_awaited_once_with(FunnelSG.preferences)
+
+
+@pytest.mark.asyncio
+async def test_pref_category_floor_switches_to_pref_floor():
+    manager = SimpleNamespace(dialog_data={}, switch_to=AsyncMock())
+    await funnel_module.on_pref_category_selected(MagicMock(), SimpleNamespace(), manager, "floor")
+    manager.switch_to.assert_awaited_once_with(FunnelSG.pref_floor)
+
+
+@pytest.mark.asyncio
+async def test_pref_category_done_switches_to_summary():
+    manager = SimpleNamespace(dialog_data={}, switch_to=AsyncMock())
+    await funnel_module.on_pref_category_selected(MagicMock(), SimpleNamespace(), manager, "done")
+    manager.switch_to.assert_awaited_once_with(FunnelSG.summary)
+
+
+@pytest.mark.asyncio
+async def test_pref_floor_selected_saves_and_returns_to_preferences():
+    manager = SimpleNamespace(dialog_data={}, switch_to=AsyncMock())
+    await funnel_module.on_pref_floor_selected(MagicMock(), SimpleNamespace(), manager, "mid")
+    assert manager.dialog_data["floor"] == "mid"
+    manager.switch_to.assert_awaited_once_with(FunnelSG.preferences)
+
+
+@pytest.mark.asyncio
+async def test_pref_furnished_selected_saves_and_returns():
+    manager = SimpleNamespace(dialog_data={}, switch_to=AsyncMock())
+    await funnel_module.on_pref_furnished_selected(MagicMock(), SimpleNamespace(), manager, "yes")
+    assert manager.dialog_data["is_furnished"] == "yes"
+    manager.switch_to.assert_awaited_once_with(FunnelSG.preferences)
+
+
+@pytest.mark.asyncio
+async def test_pref_promotion_selected_saves_and_returns():
+    manager = SimpleNamespace(dialog_data={}, switch_to=AsyncMock())
+    await funnel_module.on_pref_promotion_selected(MagicMock(), SimpleNamespace(), manager, "yes")
+    assert manager.dialog_data["is_promotion"] == "yes"
+    manager.switch_to.assert_awaited_once_with(FunnelSG.preferences)
+
+
+@pytest.mark.asyncio
+async def test_summary_data_shows_selected_filters():
+    result = await funnel_module.get_summary_data(
+        dialog_manager=SimpleNamespace(
+            dialog_data={
+                "complex": "Premier Fort Beach",
+                "property_type": "2bed",
+                "budget": "high",
+                "floor": "mid",
+                "view": "sea",
+            },
+            middleware_data={},
+        ),
+    )
+    assert "Premier Fort Beach" in result["summary_text"]
+    assert "2-спальни" in result["summary_text"]
+    assert "100 000" in result["summary_text"]
+    assert "2-3 этаж" in result["summary_text"]
+    assert "Море" in result["summary_text"]
+    assert result["can_search"] is True
+
+
+@pytest.mark.asyncio
+async def test_summary_all_any_disables_search():
+    """When all filters are 'any'/empty, search should be disabled."""
+    result = await funnel_module.get_summary_data(
+        dialog_manager=SimpleNamespace(
+            dialog_data={"complex": "any", "property_type": "any", "budget": "any"},
+            middleware_data={},
+        ),
+    )
+    assert result["can_search"] is False
+
+
+@pytest.mark.asyncio
+async def test_on_summary_search_resets_scroll_and_goes_to_results(monkeypatch):
     spawn_mock = MagicMock()
     monkeypatch.setattr(funnel_module, "_spawn_persist_funnel_lead_score", spawn_mock)
-
     callback = SimpleNamespace(
-        from_user=SimpleNamespace(id=12345),
-        message=SimpleNamespace(chat=SimpleNamespace(id=777)),
+        from_user=SimpleNamespace(id=99),
+        message=SimpleNamespace(chat=SimpleNamespace(id=111)),
     )
     manager = SimpleNamespace(
-        dialog_data={"location": "sunny_beach", "property_type": "2bed", "budget": "mid"},
+        dialog_data={"complex": "Premier Fort Beach", "property_type": "2bed", "budget": "high"},
         middleware_data={
             "user_service": object(),
             "pg_pool": object(),
@@ -73,72 +186,59 @@ async def test_show_results_schedules_background_persist(monkeypatch):
         },
         switch_to=AsyncMock(),
     )
-
-    await funnel_module.on_refine_or_show_selected(
-        callback=callback,
-        widget=SimpleNamespace(),
-        manager=manager,
-        item_id="show",
-    )
-
-    spawn_mock.assert_called_once()
-    assert spawn_mock.call_args.kwargs["telegram_user_id"] == 12345
-    assert spawn_mock.call_args.kwargs["property_type"] == "2bed"
-    assert spawn_mock.call_args.kwargs["budget"] == "mid"
-    assert spawn_mock.call_args.kwargs["timeline"] == "show"
-    assert manager.dialog_data["refine_or_show"] == "show"
+    await funnel_module.on_summary_search(callback, SimpleNamespace(), manager)
     manager.switch_to.assert_awaited_once_with(FunnelSG.results)
+    assert manager.dialog_data.get("scroll_offset") is None
 
 
 @pytest.mark.asyncio
-async def test_show_results_fail_soft(monkeypatch):
-    def _raise_on_schedule(**kwargs):
-        raise RuntimeError("boom")
-
-    monkeypatch.setattr(funnel_module, "_spawn_persist_funnel_lead_score", _raise_on_schedule)
-
-    callback = SimpleNamespace(
-        from_user=SimpleNamespace(id=1),
-        message=SimpleNamespace(chat=SimpleNamespace(id=2)),
-    )
-    manager = SimpleNamespace(
-        dialog_data={},
-        middleware_data={},
-        switch_to=AsyncMock(),
-    )
-
-    await funnel_module.on_refine_or_show_selected(
-        callback=callback,
-        widget=SimpleNamespace(),
-        manager=manager,
-        item_id="show",
-    )
-
-    manager.switch_to.assert_awaited_once_with(FunnelSG.results)
+async def test_on_summary_refine_goes_to_preferences():
+    manager = SimpleNamespace(dialog_data={}, switch_to=AsyncMock())
+    await funnel_module.on_summary_refine(MagicMock(), SimpleNamespace(), manager)
+    manager.switch_to.assert_awaited_once_with(FunnelSG.preferences)
 
 
 @pytest.mark.asyncio
-async def test_refine_path_switches_to_floor(monkeypatch):
-    callback = SimpleNamespace(from_user=SimpleNamespace(id=1), message=None)
-    manager = SimpleNamespace(
-        dialog_data={},
-        middleware_data={},
-        switch_to=AsyncMock(),
-    )
+async def test_on_summary_change_goes_to_change_filter():
+    manager = SimpleNamespace(dialog_data={}, switch_to=AsyncMock())
+    await funnel_module.on_summary_change(MagicMock(), SimpleNamespace(), manager)
+    manager.switch_to.assert_awaited_once_with(FunnelSG.change_filter)
 
-    await funnel_module.on_refine_or_show_selected(
-        callback=callback,
-        widget=SimpleNamespace(),
-        manager=manager,
-        item_id="refine",
-    )
 
-    assert manager.dialog_data["refine_or_show"] == "refine"
-    manager.switch_to.assert_awaited_once_with(FunnelSG.floor)
+@pytest.mark.asyncio
+async def test_change_filter_complex_jumps_to_complex():
+    manager = SimpleNamespace(dialog_data={"_return_to_summary": True}, switch_to=AsyncMock())
+    await funnel_module.on_change_filter_selected(
+        MagicMock(), SimpleNamespace(), manager, "complex"
+    )
+    manager.switch_to.assert_awaited_once_with(FunnelSG.complex)
+
+
+@pytest.mark.asyncio
+async def test_change_filter_sets_return_flag():
+    """After selecting a filter to change, _return_to_summary flag should be set."""
+    manager = SimpleNamespace(dialog_data={}, switch_to=AsyncMock())
+    await funnel_module.on_change_filter_selected(MagicMock(), SimpleNamespace(), manager, "budget")
+    assert manager.dialog_data.get("_return_to_summary") is True
+    manager.switch_to.assert_awaited_once_with(FunnelSG.budget)
+
+
+@pytest.mark.asyncio
+async def test_complex_return_to_summary_when_flag_set():
+    """When _return_to_summary is True, complex selection should return to summary."""
+    manager = SimpleNamespace(dialog_data={"_return_to_summary": True}, switch_to=AsyncMock())
+    await funnel_module.on_complex_selected(
+        MagicMock(), SimpleNamespace(), manager, "Green Fort Suites"
+    )
+    assert manager.dialog_data["complex"] == "Green Fort Suites"
+    assert "_return_to_summary" not in manager.dialog_data
+    manager.switch_to.assert_awaited_once_with(FunnelSG.summary)
 
 
 @pytest.mark.asyncio
 async def test_get_results_data_calls_apartments_service():
+    from telegram_bot.dialogs.funnel import get_results_data
+
     results = [
         {
             "id": "p1",
@@ -159,141 +259,41 @@ async def test_get_results_data_calls_apartments_service():
     mock_svc.scroll_with_filters = AsyncMock(return_value=(results, 1, None))
 
     manager = SimpleNamespace(
-        dialog_data={"location": "sunny_beach", "property_type": "studio", "budget": "low"},
+        dialog_data={"property_type": "studio", "budget": "low"},
         middleware_data={"apartments_service": mock_svc},
     )
 
-    result = await funnel_module.get_results_data(manager)
-
+    result = await get_results_data(manager)
     mock_svc.scroll_with_filters.assert_awaited_once()
     assert "Sunrise" in result["results_text"]
-    assert "Sunny Beach" in result["results_text"]
-    assert "sunny_beach" not in result["results_text"]
-
-
-@pytest.mark.asyncio
-async def test_get_results_data_any_any_returns_all():
-    mock_svc = MagicMock()
-    mock_svc.scroll_with_filters = AsyncMock(return_value=([], 0, None))
-
-    manager = SimpleNamespace(
-        dialog_data={"location": "any", "property_type": "any", "budget": "any"},
-        middleware_data={"apartments_service": mock_svc},
-    )
-
-    await funnel_module.get_results_data(manager)
-
-    mock_svc.scroll_with_filters.assert_awaited_once()
-    # No filters when all "any"
-    call_kwargs = mock_svc.scroll_with_filters.call_args
-    assert call_kwargs.kwargs.get("filters") == {} or call_kwargs[1].get("filters") == {}
 
 
 @pytest.mark.asyncio
 async def test_get_results_data_fallback_without_service():
+    from telegram_bot.dialogs.funnel import get_results_data
+
     manager = SimpleNamespace(
         dialog_data={},
         middleware_data={},
     )
 
-    result = await funnel_module.get_results_data(manager)
-
+    result = await get_results_data(manager)
     assert "недоступен" in result["results_text"].lower()
 
 
 @pytest.mark.asyncio
-async def test_get_results_data_uses_property_bot_fallback():
-    mock_svc = MagicMock()
-    mock_svc.scroll_with_filters = AsyncMock(return_value=([], 0, None))
-
-    mock_property_bot = MagicMock()
-    mock_property_bot._apartments_service = mock_svc
-
-    manager = SimpleNamespace(
-        dialog_data={"location": "sunny_beach", "property_type": "studio", "budget": "low"},
-        middleware_data={"property_bot": mock_property_bot},
-    )
-
-    await funnel_module.get_results_data(manager)
-    mock_svc.scroll_with_filters.assert_awaited_once()
+async def test_pref_furnished_any_clears_value():
+    """Selecting 'any' for furnished should set is_furnished to None."""
+    manager = SimpleNamespace(dialog_data={"is_furnished": "yes"}, switch_to=AsyncMock())
+    await funnel_module.on_pref_furnished_selected(MagicMock(), SimpleNamespace(), manager, "any")
+    assert manager.dialog_data["is_furnished"] is None
+    manager.switch_to.assert_awaited_once_with(FunnelSG.preferences)
 
 
 @pytest.mark.asyncio
-async def test_location_selected_saves_and_switches():
-    manager = SimpleNamespace(dialog_data={}, switch_to=AsyncMock())
-
-    await funnel_module.on_location_selected(MagicMock(), SimpleNamespace(), manager, "sunny_beach")
-
-    assert manager.dialog_data["location"] == "sunny_beach"
-    manager.switch_to.assert_awaited_once_with(FunnelSG.property_type)
-
-
-@pytest.mark.asyncio
-async def test_property_type_selected_saves_and_switches():
-    manager = SimpleNamespace(dialog_data={}, switch_to=AsyncMock())
-
-    await funnel_module.on_property_type_selected(MagicMock(), SimpleNamespace(), manager, "studio")
-
-    assert manager.dialog_data["property_type"] == "studio"
-    manager.switch_to.assert_awaited_once_with(FunnelSG.budget)
-
-
-@pytest.mark.asyncio
-async def test_budget_selected_saves_and_switches():
-    manager = SimpleNamespace(dialog_data={}, switch_to=AsyncMock())
-
-    await funnel_module.on_budget_selected(MagicMock(), SimpleNamespace(), manager, "mid")
-
-    assert manager.dialog_data["budget"] == "mid"
-    manager.switch_to.assert_awaited_once_with(FunnelSG.refine_or_show)
-
-
-@pytest.mark.asyncio
-async def test_floor_selected_saves_and_switches():
-    manager = SimpleNamespace(dialog_data={}, switch_to=AsyncMock())
-
-    await funnel_module.on_floor_selected(MagicMock(), SimpleNamespace(), manager, "mid")
-
-    assert manager.dialog_data["floor"] == "mid"
-    manager.switch_to.assert_awaited_once_with(FunnelSG.view)
-
-
-@pytest.mark.asyncio
-async def test_view_selected_schedules_persist_and_switches(monkeypatch):
-    spawn_mock = MagicMock()
-    monkeypatch.setattr(funnel_module, "_spawn_persist_funnel_lead_score", spawn_mock)
-
-    callback = SimpleNamespace(
-        from_user=SimpleNamespace(id=99),
-        message=SimpleNamespace(chat=SimpleNamespace(id=111)),
-    )
-    manager = SimpleNamespace(
-        dialog_data={
-            "property_type": "studio",
-            "budget": "low",
-            "floor": "mid",
-            "refine_or_show": "refine",
-        },
-        middleware_data={
-            "user_service": object(),
-            "pg_pool": object(),
-            "lead_scoring_store": object(),
-            "kommo_client": object(),
-            "hot_lead_notifier": object(),
-            "bot_config": object(),
-        },
-        switch_to=AsyncMock(),
-    )
-
-    await funnel_module.on_view_selected(
-        callback=callback,
-        widget=SimpleNamespace(),
-        manager=manager,
-        item_id="sea",
-    )
-
-    assert manager.dialog_data["view"] == "sea"
-    spawn_mock.assert_called_once()
-    assert spawn_mock.call_args.kwargs["telegram_user_id"] == 99
-    assert spawn_mock.call_args.kwargs["timeline"] == "refine"
-    manager.switch_to.assert_awaited_once_with(FunnelSG.results)
+async def test_pref_promotion_any_clears_value():
+    """Selecting 'any' for promotion should set is_promotion to None."""
+    manager = SimpleNamespace(dialog_data={"is_promotion": "yes"}, switch_to=AsyncMock())
+    await funnel_module.on_pref_promotion_selected(MagicMock(), SimpleNamespace(), manager, "any")
+    assert manager.dialog_data["is_promotion"] is None
+    manager.switch_to.assert_awaited_once_with(FunnelSG.preferences)

--- a/tests/unit/dialogs/test_funnel_results.py
+++ b/tests/unit/dialogs/test_funnel_results.py
@@ -1,4 +1,4 @@
-"""Tests for funnel filter building and results getter (#660)."""
+"""Tests for funnel filter building and results getter (#697)."""
 
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -80,18 +80,58 @@ def test_budget_luxury():
 
 
 def test_complex_name_filter():
-    filters = build_funnel_filters(rooms="any", budget="any", complex_name="Sunrise")
-    assert filters["complex_name"] == "Sunrise"
+    filters = build_funnel_filters(rooms="any", budget="any", complex_name="Premier Fort Beach")
+    assert filters["complex_name"] == "Premier Fort Beach"
 
 
-def test_city_filter_maps_location_to_city():
-    filters = build_funnel_filters(rooms="any", budget="any", city="sunny_beach")
-    assert filters["city"] == "Sunny Beach"
+def test_complex_name_any_not_included():
+    filters = build_funnel_filters(rooms="any", budget="any", complex_name="any")
+    assert "complex_name" not in filters
 
 
-def test_city_any_not_included():
-    filters = build_funnel_filters(rooms="any", budget="any", city="any")
-    assert "city" not in filters
+def test_is_furnished_true():
+    filters = build_funnel_filters(rooms="any", budget="any", is_furnished="yes")
+    assert filters["is_furnished"] is True
+
+
+def test_is_furnished_false():
+    filters = build_funnel_filters(rooms="any", budget="any", is_furnished="no")
+    assert filters["is_furnished"] is False
+
+
+def test_is_furnished_none_not_included():
+    filters = build_funnel_filters(rooms="any", budget="any", is_furnished=None)
+    assert "is_furnished" not in filters
+
+
+def test_is_promotion_true():
+    filters = build_funnel_filters(rooms="any", budget="any", is_promotion="yes")
+    assert filters["is_promotion"] is True
+
+
+def test_is_promotion_none_not_included():
+    filters = build_funnel_filters(rooms="any", budget="any", is_promotion=None)
+    assert "is_promotion" not in filters
+
+
+def test_combined_filters():
+    """All filter types combined."""
+    filters = build_funnel_filters(
+        rooms="2bed",
+        budget="high",
+        complex_name="Premier Fort Beach",
+        floor="mid",
+        view="sea",
+        is_furnished="yes",
+        is_promotion="yes",
+    )
+    assert filters["rooms"] == 3
+    assert filters["price_eur"] == {"gte": 100000, "lte": 150000}
+    assert filters["complex_name"] == "Premier Fort Beach"
+    assert filters["floor"] == {"gte": 2, "lte": 3}
+    assert filters["view_tags"] == ["sea"]
+    assert filters["is_furnished"] is True
+    assert filters["is_promotion"] is True
 
 
 # --- get_results_data integration (mocked svc) ---
@@ -119,7 +159,7 @@ async def test_get_results_data_returns_cards():
     mock_svc.scroll_with_filters = AsyncMock(return_value=(results, 297, "next-uuid"))
 
     manager = SimpleNamespace(
-        dialog_data={"property_type": "studio", "budget": "low", "location": "sunny_beach"},
+        dialog_data={"property_type": "studio", "budget": "low"},
         middleware_data={"apartments_service": mock_svc},
     )
 
@@ -127,13 +167,11 @@ async def test_get_results_data_returns_cards():
     assert "297" in result["title"]
     assert "Sunrise Complex" in result["results_text"]
     assert result["has_more"] is True
-    assert result["btn_more"] == "🔄 Показать ещё"
     mock_svc.scroll_with_filters.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_get_results_data_no_results():
-    """get_results_data returns empty message when no apartments match."""
     from telegram_bot.dialogs.funnel import get_results_data
 
     mock_svc = MagicMock()
@@ -151,7 +189,6 @@ async def test_get_results_data_no_results():
 
 @pytest.mark.asyncio
 async def test_get_results_data_no_service():
-    """get_results_data returns placeholder when service unavailable."""
     from telegram_bot.dialogs.funnel import get_results_data
 
     manager = SimpleNamespace(
@@ -177,27 +214,6 @@ async def test_get_results_data_uses_i18n_strings():
     )
 
     result = await get_results_data(dialog_manager=manager)
-
     assert result["title"] == "Found 12 apartments"
     assert result["btn_more"] == "🔄 Show more"
     assert result["btn_back"] == "Back"
-
-
-@pytest.mark.asyncio
-async def test_get_results_data_malformed_payload():
-    """get_results_data must not crash when scroll returns items without payload key."""
-    from telegram_bot.dialogs.funnel import get_results_data
-
-    mock_svc = MagicMock()
-    mock_svc.scroll_with_filters = AsyncMock(
-        return_value=([{"id": "apt-bad"}], 1, None),  # missing "payload" key
-    )
-
-    manager = SimpleNamespace(
-        dialog_data={"property_type": "any", "budget": "any"},
-        middleware_data={"apartments_service": mock_svc},
-    )
-
-    result = await get_results_data(dialog_manager=manager)
-    # Must not crash — falls through to no_results_text via exception handler
-    assert result["results_text"]

--- a/tests/unit/dialogs/test_menu_wiring.py
+++ b/tests/unit/dialogs/test_menu_wiring.py
@@ -98,7 +98,7 @@ async def test_handle_menu_button_no_clear_for_unrelated_state():
 
 
 async def test_handle_search_starts_funnel_dialog():
-    """_handle_search starts FunnelSG.location dialog when dialog_manager available (#658)."""
+    """_handle_search starts FunnelSG.complex dialog when dialog_manager available (#658, #697)."""
     with patch("telegram_bot.bot.PropertyBot.__init__", return_value=None):
         from telegram_bot.bot import PropertyBot
         from telegram_bot.dialogs.states import FunnelSG
@@ -113,7 +113,7 @@ async def test_handle_search_starts_funnel_dialog():
 
         dialog_manager.start.assert_called_once()
         call_args = dialog_manager.start.call_args
-        assert call_args[0][0] == FunnelSG.location
+        assert call_args[0][0] == FunnelSG.complex
 
 
 async def test_handle_search_fallback_without_dialog_manager():

--- a/tests/unit/services/test_apartments_service.py
+++ b/tests/unit/services/test_apartments_service.py
@@ -42,6 +42,39 @@ class TestBuildApartmentFilter:
         # Key should be "rooms" not "metadata.rooms"
         assert f.must[0].key == "rooms"
 
+    def test_build_filter_is_furnished_true(self) -> None:
+        f = _build_apartment_filter({"is_furnished": True})
+        assert f is not None
+        assert len(f.must) == 1
+        assert f.must[0].key == "is_furnished"
+        assert f.must[0].match.value is True
+
+    def test_build_filter_is_furnished_false(self) -> None:
+        f = _build_apartment_filter({"is_furnished": False})
+        assert f is not None
+        assert len(f.must) == 1
+        assert f.must[0].key == "is_furnished"
+        assert f.must[0].match.value is False
+
+    def test_build_filter_is_promotion_true(self) -> None:
+        f = _build_apartment_filter({"is_promotion": True})
+        assert f is not None
+        assert len(f.must) == 1
+        assert f.must[0].key == "is_promotion"
+        assert f.must[0].match.value is True
+
+    def test_build_filter_combined_bool_and_range(self) -> None:
+        """Bool must use MatchValue, not Range — isinstance(True, int) == True in Python."""
+        f = _build_apartment_filter({"is_furnished": True, "price_eur": {"gte": 50000}})
+        assert f is not None
+        assert len(f.must) == 2
+        # Bool condition should use MatchValue, not Range
+        for cond in f.must:
+            if cond.key == "is_furnished":
+                assert cond.match is not None
+                assert cond.match.value is True
+                assert cond.range is None
+
 
 class TestCheckEscalation:
     def test_no_escalation(self) -> None:


### PR DESCRIPTION
## Summary

Closes #696

- **Step 1** replaced district (3 cities) with complex selection (10 complexes + "any")
- **Step 4** added preferences multi-select with sub-options: floor, view, furnished, promotions — with ✓ checkmarks for selected values
- **Step 5** added summary confirmation window with "search / change / refine" buttons and validation (all-any → search disabled)
- **Bool filters** added explicit `isinstance(value, bool)` check before `isinstance(value, int)` in `_build_apartment_filter` (Python's `isinstance(True, int)` is True)
- **Zero-results recovery** — suggestions computed in getter (partially wired, needs widget in results Window — see Known Issues)

## Known Issues (from review)

- `zero_suggestions` returned by getter but no `Select` widget renders them in results Window — recovery buttons invisible
- `_COMPLEX_OPTIONS` hardcoded (10 complexes); consider loading from config/Qdrant
- `timeline=None` in lead scoring — lost refine/show analytics path

## Files Changed (10, +720/-372)

| File | Change |
|------|--------|
| `telegram_bot/dialogs/funnel.py` | Full rewrite: getters, handlers, Dialog windows |
| `telegram_bot/dialogs/states.py` | 11 states (was 7) |
| `telegram_bot/services/apartments_service.py` | Explicit bool filter support |
| `telegram_bot/bot.py` | `FunnelSG.location` → `FunnelSG.complex` |
| `telegram_bot/dialogs/client_menu.py` | Same ref update |
| `tests/unit/dialogs/test_funnel.py` | 25 new/rewritten tests |
| `tests/unit/dialogs/test_funnel_results.py` | Filter + results tests |
| `tests/unit/services/test_apartments_service.py` | Bool filter tests |

## Test plan

- [x] `make check` — ruff clean, mypy clean
- [x] `uv run pytest tests/unit/dialogs/ tests/unit/services/test_apartments_service.py` — 115 passed
- [ ] Manual: start funnel → complex → type → budget → preferences → summary → results
- [ ] Manual: zero results → verify recovery buttons missing (known issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)