### PR TITLE
feat(viewing): viewing appointment wizard with CRM integration

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -644,7 +644,6 @@ class PropertyBot:
         self.dp.callback_query(F.data.startswith("cta:"))(self.handle_cta_callback)
         self.dp.callback_query(F.data.startswith("fav:"))(self.handle_favorite_callback)
         self.dp.callback_query(F.data.startswith("results:"))(self.handle_results_callback)
-        self.dp.callback_query(F.data.startswith("viewing:"))(self.handle_viewing_callback)
         self.dp.callback_query(F.data.startswith("card:"))(self.handle_card_callback)
 
     async def _resolve_user_role(self, user_id: int) -> str:
@@ -1021,8 +1020,10 @@ class PropertyBot:
                 await state.update_data(bookmarks_context=False)
             if action_id == "search":
                 await handler(message, dialog_manager)
-            elif action_id == "viewing" or action_id == "bookmarks":
+            elif action_id == "bookmarks":
                 await handler(message, state)
+            elif action_id == "viewing":
+                await handler(message, state, dialog_manager)
             elif action_id == "services":
                 await handler(message, i18n=i18n)
             else:
@@ -1056,25 +1057,18 @@ class PropertyBot:
         kb = build_services_menu(i18n=i18n)
         await message.answer(text, reply_markup=kb)
 
-    async def _handle_viewing(self, message: Message, state: FSMContext) -> None:
-        """Viewing appointment — fork: choose objects or phone (#628)."""
-        from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+    async def _handle_viewing(
+        self, message: Message, state: FSMContext, dialog_manager: Any = None
+    ) -> None:
+        """Start viewing appointment wizard via aiogram-dialog (#719)."""
+        if dialog_manager is not None:
+            from aiogram_dialog import StartMode
 
-        keyboard = InlineKeyboardMarkup(
-            inline_keyboard=[
-                [
-                    InlineKeyboardButton(
-                        text="🏠 Выбрать объекты", callback_data="viewing:choose_objects"
-                    )
-                ],
-                [
-                    InlineKeyboardButton(
-                        text="📞 Обсудим по телефону", callback_data="viewing:phone"
-                    )
-                ],
-            ]
-        )
-        await message.answer("Вас интересуют конкретные объекты?", reply_markup=keyboard)
+            from .dialogs.states import ViewingSG
+
+            await dialog_manager.start(ViewingSG.objects, mode=StartMode.RESET_STACK)
+        else:
+            await message.answer("📅 Для записи на осмотр используйте кнопку меню.")
 
     async def _send_property_card(
         self,
@@ -1513,20 +1507,6 @@ class PropertyBot:
                 service_key="manager_question",
                 viewing_objects=viewing_objects or None,
             )
-        else:
-            await callback.answer()
-
-    async def handle_viewing_callback(self, callback: CallbackQuery, state: FSMContext) -> None:
-        """Handle viewing fork callbacks (choose_objects, phone)."""
-        data = callback.data or ""
-        if data == "viewing:choose_objects":
-            if callback.message:
-                await self.handle_menu_action_text(callback.message, "Подбери апартаменты")
-            await callback.answer()
-        elif data == "viewing:phone":
-            from .handlers.phone_collector import start_phone_collection
-
-            await start_phone_collection(callback, state, service_key="viewing")
         else:
             await callback.answer()
 
@@ -3272,6 +3252,7 @@ class PropertyBot:
         from .dialogs.funnel import funnel_dialog
         from .dialogs.manager_menu import manager_menu_dialog
         from .dialogs.settings import settings_dialog
+        from .dialogs.viewing import viewing_dialog
         from .handlers.crm_callbacks import create_crm_router
 
         # CRM card inline callbacks (crm:* prefix) — before aiogram-dialog setup (#697)
@@ -3293,6 +3274,7 @@ class PropertyBot:
         self.dp.include_router(settings_dialog)
         self.dp.include_router(funnel_dialog)
         self.dp.include_router(faq_dialog)
+        self.dp.include_router(viewing_dialog)
         aiogram_setup_dialogs(self.dp)
         logger.info("aiogram-dialog setup complete")
 

--- a/telegram_bot/dialogs/states.py
+++ b/telegram_bot/dialogs/states.py
@@ -40,6 +40,16 @@ class FunnelSG(StatesGroup):
     results = State()  # Step 6: результаты
 
 
+class ViewingSG(StatesGroup):
+    """Viewing appointment wizard."""
+
+    objects = State()  # Шаг 1: выбор объектов из закладок
+    objects_text = State()  # Шаг 1b: ручной ввод (опционально)
+    date = State()  # Шаг 2: желаемая дата
+    phone = State()  # Шаг 3: номер телефона
+    summary = State()  # Шаг 4: подтверждение + CRM
+
+
 class FaqSG(StatesGroup):
     """FAQ submenu."""
 

--- a/telegram_bot/dialogs/viewing.py
+++ b/telegram_bot/dialogs/viewing.py
@@ -1,0 +1,444 @@
+"""Viewing appointment wizard dialog (aiogram-dialog)."""
+
+from __future__ import annotations
+
+import logging
+import operator
+import time
+from typing import Any
+
+from aiogram.types import (
+    CallbackQuery,
+    ContentType,
+    KeyboardButton,
+    Message,
+    ReplyKeyboardMarkup,
+)
+from aiogram_dialog import Dialog, DialogManager, Window
+from aiogram_dialog.widgets.input import MessageInput
+from aiogram_dialog.widgets.kbd import Back, Button, Cancel, Column, Select
+from aiogram_dialog.widgets.text import Const, Format  # noqa: F401
+
+from .states import ViewingSG
+
+
+logger = logging.getLogger(__name__)
+
+# --- Date range → label mapping ---
+
+DATE_LABELS: dict[str, str] = {
+    "nearest": "📅 Ближайшие дни",
+    "next_week": "📅 Через неделю",
+    "next_month": "📅 Через месяц",
+    "unknown": "🤷 Не знаю когда",
+    "phone": "📞 Согласуем по телефону",
+}
+
+# --- Due date offsets (seconds) ---
+
+_DUE_OFFSETS: dict[str, int] = {
+    "nearest": 3 * 86400,
+    "next_week": 7 * 86400,
+    "next_month": 30 * 86400,
+    "unknown": 7 * 86400,
+    "phone": 1 * 86400,
+}
+
+
+def compute_due_date(date_range: str) -> int:
+    """Compute unix timestamp for CRM task due date."""
+    return int(time.time()) + _DUE_OFFSETS.get(date_range, 7 * 86400)
+
+
+def build_phone_keyboard() -> ReplyKeyboardMarkup:
+    """Build temporary ReplyKeyboard with request_contact button."""
+    return ReplyKeyboardMarkup(
+        keyboard=[
+            [KeyboardButton(text="📱 Отправить мой номер", request_contact=True)],
+        ],
+        resize_keyboard=True,
+        one_time_keyboard=True,
+    )
+
+
+# ── Getters ──────────────────────────────────────────────────────────
+
+
+async def get_objects_options(
+    event_from_user: Any = None, favorites_service: Any = None, **kwargs: Any
+) -> dict[str, Any]:
+    """Load user favorites for object selection (Step 1)."""
+    items: list[tuple[str, str]] = []
+    has_favorites = False
+
+    if favorites_service is not None and event_from_user is not None:
+        try:
+            favs = await favorites_service.list(event_from_user.id, limit=10)
+            for fav in favs:
+                data = fav.property_data
+                label = (
+                    f"{data.get('complex_name', '?')} "
+                    f"{data.get('property_type', '')} "
+                    f"{data.get('area_m2', '')}м²"
+                ).strip()
+                items.append((label, fav.property_id))
+            has_favorites = len(items) > 0
+        except Exception:
+            logger.exception("Failed to load favorites for viewing wizard")
+
+    return {
+        "title": "🏠 Выберите объекты для осмотра:",
+        "items": items,
+        "has_favorites": has_favorites,
+        "btn_manual": "📝 Ввести вручную",
+        "btn_skip": "⏭ Пропустить",
+        "btn_next": "▶ Далее",
+        "btn_back": "◀ Назад",
+    }
+
+
+async def get_objects_text_prompt(**kwargs: Any) -> dict[str, str]:
+    """Getter for free-text object input (Step 1b)."""
+    return {
+        "title": "📝 Опишите, какие объекты хотите посмотреть:",
+        "btn_back": "◀ Назад",
+    }
+
+
+async def get_date_options(**kwargs: Any) -> dict[str, Any]:
+    """Getter for date range selection (Step 2)."""
+    items = list(DATE_LABELS.items())  # [(key, label), ...]
+    # Flip to (label, key) for Select widget
+    return {
+        "title": "📅 Когда удобно осмотреть?",
+        "items": [(label, key) for key, label in items],
+        "btn_back": "◀ Назад",
+    }
+
+
+async def get_phone_prompt(**kwargs: Any) -> dict[str, str]:
+    """Getter for phone input (Step 3)."""
+    return {
+        "title": (
+            "📞 Введите номер телефона в формате +380990091392\n"
+            "или нажмите кнопку «📱 Отправить мой номер» ниже."
+        ),
+        "btn_back": "◀ Назад",
+    }
+
+
+async def get_summary_data(
+    dialog_manager: DialogManager | Any = None, **kwargs: Any
+) -> dict[str, Any]:
+    """Build summary text from collected data (Step 4)."""
+    data = dialog_manager.dialog_data if dialog_manager else {}
+
+    objects = data.get("selected_objects", [])
+    manual_text = data.get("manual_text", "")
+    date_range = data.get("date_range", "unknown")
+    phone = data.get("phone", "—")
+
+    # Format objects
+    if objects:
+        obj_lines = []
+        for obj in objects:
+            name = obj.get("complex_name", "?")
+            ptype = obj.get("property_type", "")
+            obj_lines.append(f"  • {name} {ptype}".strip())
+        objects_text = "\n".join(obj_lines)
+    elif manual_text:
+        objects_text = f"  {manual_text}"
+    else:
+        objects_text = "  Не указаны (менеджер подберёт)"
+
+    date_label = DATE_LABELS.get(date_range, date_range)
+
+    summary = (
+        f"📋 Ваша заявка на осмотр:\n\n"
+        f"🏠 Объекты:\n{objects_text}\n\n"
+        f"📅 Дата: {date_label}\n\n"
+        f"📞 Телефон: {phone}"
+    )
+
+    return {
+        "summary_text": summary,
+        "btn_confirm": "✅ Подтвердить",
+        "btn_edit": "✏ Изменить",
+        "btn_cancel": "❌ Отмена",
+    }
+
+
+# ── Handlers ─────────────────────────────────────────────────────────
+
+
+async def on_object_selected(
+    callback: CallbackQuery,
+    widget: Select,
+    manager: DialogManager,
+    item_id: str,
+) -> None:
+    """Toggle object selection (multi-select via dialog_data list)."""
+    selected: list[dict[str, Any]] = manager.dialog_data.get("selected_objects", [])
+    # Check if already selected → remove (toggle)
+    existing_ids = [obj.get("id", obj.get("property_id", "")) for obj in selected]
+    if item_id in existing_ids:
+        selected = [obj for obj in selected if obj.get("id", obj.get("property_id", "")) != item_id]
+    else:
+        selected.append({"property_id": item_id})
+    manager.dialog_data["selected_objects"] = selected
+
+
+async def on_objects_next(callback: CallbackQuery, button: Button, manager: DialogManager) -> None:
+    """Proceed to date selection with selected objects."""
+    await manager.switch_to(ViewingSG.date)
+
+
+async def on_objects_skip(callback: CallbackQuery, button: Button, manager: DialogManager) -> None:
+    """Skip object selection, proceed to date."""
+    manager.dialog_data["selected_objects"] = []
+    await manager.switch_to(ViewingSG.date)
+
+
+async def on_objects_manual(
+    callback: CallbackQuery, button: Button, manager: DialogManager
+) -> None:
+    """Switch to free-text object input."""
+    await manager.switch_to(ViewingSG.objects_text)
+
+
+async def on_manual_text_received(message: Message, widget: Any, manager: DialogManager) -> None:
+    """Save manual text and proceed to date."""
+    manager.dialog_data["manual_text"] = message.text or ""
+    await manager.switch_to(ViewingSG.date)
+
+
+async def on_date_selected(
+    callback: CallbackQuery,
+    widget: Select,
+    manager: DialogManager,
+    item_id: str,
+) -> None:
+    """Save date range, send request_contact keyboard and proceed to phone."""
+    manager.dialog_data["date_range"] = item_id
+    # Send request_contact keyboard
+    if callback.message:
+        kb = build_phone_keyboard()
+        await callback.message.answer(
+            "📞 Введите номер в формате +380990091392\nили воспользуйтесь кнопкой:",
+            reply_markup=kb,
+        )
+    await manager.switch_to(ViewingSG.phone)
+
+
+async def on_phone_text_received(message: Message, widget: Any, manager: DialogManager) -> None:
+    """Handle phone number text input."""
+    from telegram_bot.handlers.phone_collector import normalize_phone, validate_phone
+
+    text = message.text or ""
+    if not validate_phone(text):
+        await message.answer("❌ Некорректный номер. Введите в формате +380990091392:")
+        return
+    phone = normalize_phone(text)
+    if phone is None:
+        await message.answer("❌ Некорректный номер. Введите в формате +380990091392:")
+        return
+    manager.dialog_data["phone"] = phone
+    await manager.switch_to(ViewingSG.summary)
+
+
+async def on_phone_contact_received(message: Message, widget: Any, manager: DialogManager) -> None:
+    """Handle shared contact (request_contact button)."""
+    if message.contact and message.contact.phone_number:
+        from telegram_bot.handlers.phone_collector import normalize_phone
+
+        raw = message.contact.phone_number
+        phone = normalize_phone(raw) or raw
+        manager.dialog_data["phone"] = phone
+        await manager.switch_to(ViewingSG.summary)
+    else:
+        await message.answer("❌ Не удалось получить номер. Введите вручную:")
+
+
+async def on_confirm(callback: CallbackQuery, button: Button, manager: DialogManager) -> None:
+    """Submit viewing request to Kommo CRM and close dialog."""
+    from telegram_bot.handlers.phone_collector import (
+        _build_custom_fields,
+        _build_note_text,
+        build_display_name,
+    )
+    from telegram_bot.services.kommo_models import ContactCreate, LeadCreate, TaskCreate
+
+    data = manager.dialog_data
+    phone = data.get("phone", "")
+    date_range = data.get("date_range", "unknown")
+    selected_objects = data.get("selected_objects", [])
+    manual_text = data.get("manual_text", "")
+
+    user = callback.from_user
+    display_name = build_display_name(user, phone)
+    username = getattr(user, "username", None)
+    user_id = user.id if user else 0
+
+    # Build viewing_objects for note (reuse phone_collector format)
+    viewing_objects = selected_objects or []
+
+    # Build note with date info
+    date_label = DATE_LABELS.get(date_range, date_range)
+    extra_note = f"\nЖелаемая дата осмотра: {date_label}"
+    if manual_text:
+        extra_note += f"\nОписание объектов: {manual_text}"
+
+    kommo_client = manager.middleware_data.get("kommo_client")
+    bot_config = manager.middleware_data.get("bot_config")
+
+    if kommo_client is not None:
+        try:
+            contact_data = ContactCreate(
+                first_name=user.first_name if user else "",
+                last_name=getattr(user, "last_name", None) if user else None,
+                phone=phone,
+            )
+            contact = await kommo_client.upsert_contact(phone, contact_data)
+
+            pipeline_id = (bot_config.kommo_default_pipeline_id if bot_config else 0) or None
+            status_id = (bot_config.kommo_new_status_id if bot_config else 0) or None
+            responsible = (bot_config.kommo_responsible_user_id if bot_config else None) or None
+
+            custom_fields = _build_custom_fields(
+                "Запись на осмотр",
+                user_id,
+                username,
+                service_field_id=(bot_config.kommo_service_field_id if bot_config else 0),
+                source_field_id=(bot_config.kommo_source_field_id if bot_config else 0),
+                telegram_field_id=(bot_config.kommo_telegram_field_id if bot_config else 0),
+                telegram_username_field_id=(
+                    bot_config.kommo_telegram_username_field_id if bot_config else 0
+                ),
+            )
+
+            lead = await kommo_client.create_lead(
+                LeadCreate(
+                    name=f"Осмотр — {display_name}",
+                    pipeline_id=pipeline_id,
+                    status_id=status_id,
+                    responsible_user_id=responsible,
+                    custom_fields_values=custom_fields or None,
+                )
+            )
+            await kommo_client.link_contact_to_lead(lead.id, contact.id)
+
+            note_text = _build_note_text(
+                "Запись на осмотр",
+                phone,
+                username,
+                user_id,
+                display_name,
+                viewing_objects,
+            )
+            note_text += extra_note
+            await kommo_client.add_note("leads", lead.id, note_text)
+
+            due_date = compute_due_date(date_range)
+            task_text = f"Осмотр: {display_name} ({date_label})"
+            await kommo_client.create_task(
+                TaskCreate(
+                    text=task_text,
+                    entity_id=lead.id,
+                    complete_till=due_date,
+                )
+            )
+
+            logger.info(
+                "Viewing lead created: lead_id=%s phone=%s date=%s",
+                lead.id,
+                phone,
+                date_range,
+            )
+        except Exception:
+            logger.exception("CRM viewing lead creation failed for phone=%s", phone)
+
+    if callback.message:
+        await callback.message.answer(
+            "✅ Заявка принята! Менеджер свяжется с вами в ближайшее время."
+        )
+    await callback.answer()
+    await manager.done()
+
+
+async def on_edit(callback: CallbackQuery, button: Button, manager: DialogManager) -> None:
+    """Go back to objects selection to edit."""
+    await manager.switch_to(ViewingSG.objects)
+
+
+# ── Dialog Assembly ──────────────────────────────────────────────────
+
+viewing_dialog = Dialog(
+    # Step 1: Objects from favorites
+    Window(
+        Format("{title}"),
+        Column(
+            Select(
+                Format("{item[0]}"),
+                id="viewing_objects",
+                item_id_getter=operator.itemgetter(1),
+                items="items",
+                on_click=on_object_selected,
+            ),
+            when="has_favorites",
+        ),
+        Button(Format("{btn_manual}"), id="manual", on_click=on_objects_manual),
+        Button(Format("{btn_next}"), id="next", on_click=on_objects_next),
+        Button(Format("{btn_skip}"), id="skip", on_click=on_objects_skip),
+        Cancel(Format("{btn_back}")),
+        getter=get_objects_options,
+        state=ViewingSG.objects,
+    ),
+    # Step 1b: Free-text object input
+    Window(
+        Format("{title}"),
+        MessageInput(on_manual_text_received, content_types=[ContentType.TEXT]),
+        Back(Format("{btn_back}")),
+        getter=get_objects_text_prompt,
+        state=ViewingSG.objects_text,
+    ),
+    # Step 2: Date range
+    Window(
+        Format("{title}"),
+        Column(
+            Select(
+                Format("{item[0]}"),
+                id="viewing_date",
+                item_id_getter=operator.itemgetter(1),
+                items="items",
+                on_click=on_date_selected,
+            ),
+        ),
+        Back(Format("{btn_back}")),
+        getter=get_date_options,
+        state=ViewingSG.date,
+    ),
+    # Step 3: Phone input
+    Window(
+        Format("{title}"),
+        MessageInput(
+            on_phone_text_received,
+            content_types=[ContentType.TEXT],
+        ),
+        MessageInput(
+            on_phone_contact_received,
+            content_types=[ContentType.CONTACT],
+        ),
+        Back(Format("{btn_back}")),
+        getter=get_phone_prompt,
+        state=ViewingSG.phone,
+    ),
+    # Step 4: Summary + confirm
+    Window(
+        Format("{summary_text}"),
+        Button(Format("{btn_confirm}"), id="confirm", on_click=on_confirm),
+        Button(Format("{btn_edit}"), id="edit", on_click=on_edit),
+        Cancel(Format("{btn_cancel}")),
+        getter=get_summary_data,
+        state=ViewingSG.summary,
+    ),
+)

--- a/telegram_bot/dialogs/viewing.py
+++ b/telegram_bot/dialogs/viewing.py
@@ -65,26 +65,50 @@ def build_phone_keyboard() -> ReplyKeyboardMarkup:
 
 
 async def get_objects_options(
-    event_from_user: Any = None, favorites_service: Any = None, **kwargs: Any
+    event_from_user: Any = None,
+    favorites_service: Any = None,
+    middleware_data: dict[str, Any] | None = None,
+    dialog_manager: DialogManager | None = None,
+    **kwargs: Any,
 ) -> dict[str, Any]:
     """Load user favorites for object selection (Step 1)."""
     items: list[tuple[str, str]] = []
     has_favorites = False
+    favorites_by_id: dict[str, dict[str, Any]] = {}
 
-    if favorites_service is not None and event_from_user is not None:
+    resolved_favorites_service = favorites_service
+    if resolved_favorites_service is None:
+        resolved_favorites_service = (middleware_data or {}).get("favorites_service")
+    if resolved_favorites_service is None:
+        property_bot = (middleware_data or {}).get("property_bot")
+        if property_bot is not None:
+            resolved_favorites_service = getattr(property_bot, "_favorites_service", None)
+
+    if resolved_favorites_service is not None and event_from_user is not None:
         try:
-            favs = await favorites_service.list(event_from_user.id, limit=10)
+            favs = await resolved_favorites_service.list(event_from_user.id, limit=10)
             for fav in favs:
                 data = fav.property_data
-                label = (
-                    f"{data.get('complex_name', '?')} "
-                    f"{data.get('property_type', '')} "
-                    f"{data.get('area_m2', '')}м²"
-                ).strip()
-                items.append((label, fav.property_id))
+                property_id = str(fav.property_id)
+                complex_name = data.get("complex_name", "?")
+                property_type = data.get("property_type", "")
+                area = data.get("area_m2", "")
+                area_suffix = f"{area}м²" if area not in ("", None) else ""
+                label = (f"{complex_name} {property_type} {area_suffix}").strip()
+                items.append((label, property_id))
+                favorites_by_id[property_id] = {
+                    "id": property_id,
+                    "complex_name": complex_name,
+                    "property_type": property_type,
+                    "area_m2": data.get("area_m2", 0),
+                    "price_eur": data.get("price_eur", 0),
+                }
             has_favorites = len(items) > 0
         except Exception:
             logger.exception("Failed to load favorites for viewing wizard")
+
+    if dialog_manager is not None:
+        dialog_manager.dialog_data["favorites_by_id"] = favorites_by_id
 
     return {
         "title": "🏠 Выберите объекты для осмотра:",
@@ -178,13 +202,18 @@ async def on_object_selected(
     item_id: str,
 ) -> None:
     """Toggle object selection (multi-select via dialog_data list)."""
+    item_key = str(item_id)
     selected: list[dict[str, Any]] = manager.dialog_data.get("selected_objects", [])
     # Check if already selected → remove (toggle)
-    existing_ids = [obj.get("id", obj.get("property_id", "")) for obj in selected]
-    if item_id in existing_ids:
-        selected = [obj for obj in selected if obj.get("id", obj.get("property_id", "")) != item_id]
+    existing_ids = [str(obj.get("id", obj.get("property_id", ""))) for obj in selected]
+    if item_key in existing_ids:
+        selected = [
+            obj for obj in selected if str(obj.get("id", obj.get("property_id", ""))) != item_key
+        ]
     else:
-        selected.append({"property_id": item_id})
+        favorites_by_id = manager.dialog_data.get("favorites_by_id", {})
+        selected_obj = favorites_by_id.get(item_key, {"id": item_key})
+        selected.append(dict(selected_obj))
     manager.dialog_data["selected_objects"] = selected
 
 

--- a/telegram_bot/middlewares/i18n.py
+++ b/telegram_bot/middlewares/i18n.py
@@ -127,6 +127,7 @@ class I18nMiddleware(BaseMiddleware):
         data["ai_advisor_service"] = self._ai_advisor_service
         if self._property_bot is not None:
             data["apartments_service"] = getattr(self._property_bot, "_apartments_service", None)
+            data["favorites_service"] = getattr(self._property_bot, "_favorites_service", None)
         return await handler(event, data)
 
 

--- a/tests/unit/dialogs/test_viewing.py
+++ b/tests/unit/dialogs/test_viewing.py
@@ -1,5 +1,10 @@
 """Tests for viewing appointment wizard dialog."""
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
 from telegram_bot.dialogs.states import ViewingSG
 
 
@@ -9,3 +14,109 @@ def test_viewing_sg_has_all_states():
     assert hasattr(ViewingSG, "date")
     assert hasattr(ViewingSG, "phone")
     assert hasattr(ViewingSG, "summary")
+
+
+# --- Date options ---
+
+
+@pytest.mark.asyncio
+async def test_get_date_options_returns_5_items():
+    from telegram_bot.dialogs.viewing import get_date_options
+
+    result = await get_date_options()
+    items = result["items"]
+    assert len(items) == 5
+    keys = [key for _, key in items]
+    assert "nearest" in keys
+    assert "next_week" in keys
+    assert "next_month" in keys
+    assert "unknown" in keys
+    assert "phone" in keys
+
+
+# --- Date handler ---
+
+
+@pytest.mark.asyncio
+async def test_on_date_selected_saves_and_switches_to_phone():
+    from telegram_bot.dialogs.viewing import on_date_selected
+
+    callback = MagicMock()
+    callback.message = AsyncMock()
+    callback.message.answer = AsyncMock()
+    manager = SimpleNamespace(dialog_data={}, switch_to=AsyncMock())
+    await on_date_selected(callback, SimpleNamespace(), manager, "next_week")
+    assert manager.dialog_data["date_range"] == "next_week"
+    manager.switch_to.assert_awaited_once_with(ViewingSG.phone)
+
+
+# --- Objects getter (empty favorites) ---
+
+
+@pytest.mark.asyncio
+async def test_get_objects_options_empty_favorites():
+    from telegram_bot.dialogs.viewing import get_objects_options
+
+    result = await get_objects_options(
+        event_from_user=SimpleNamespace(id=12345),
+        favorites_service=None,
+    )
+    items = result["items"]
+    assert len(items) == 0
+    assert result["has_favorites"] is False
+
+
+# --- Objects skip handler ---
+
+
+@pytest.mark.asyncio
+async def test_on_objects_skip_switches_to_date():
+    from telegram_bot.dialogs.viewing import on_objects_skip
+
+    manager = SimpleNamespace(dialog_data={}, switch_to=AsyncMock())
+    await on_objects_skip(MagicMock(), MagicMock(), manager)
+    manager.switch_to.assert_awaited_once_with(ViewingSG.date)
+
+
+# --- Summary getter ---
+
+
+@pytest.mark.asyncio
+async def test_get_summary_data_formats_all_fields():
+    from telegram_bot.dialogs.viewing import get_summary_data
+
+    manager = SimpleNamespace(
+        dialog_data={
+            "selected_objects": [{"complex_name": "Sunset", "property_type": "1+1"}],
+            "date_range": "nearest",
+            "phone": "+380990091392",
+        }
+    )
+    result = await get_summary_data(dialog_manager=manager)
+    assert "+380990091392" in result["summary_text"]
+    assert "Sunset" in result["summary_text"]
+    assert "Ближайшие дни" in result["summary_text"]
+
+
+# --- Due date calculation ---
+
+
+def test_compute_due_date_nearest():
+    import time
+
+    from telegram_bot.dialogs.viewing import compute_due_date
+
+    now = int(time.time())
+    due = compute_due_date("nearest")
+    # nearest = +3 days
+    assert abs(due - now - 3 * 86400) < 5
+
+
+def test_compute_due_date_unknown_defaults_7_days():
+    import time
+
+    from telegram_bot.dialogs.viewing import compute_due_date
+
+    now = int(time.time())
+    due = compute_due_date("unknown")
+    assert abs(due - now - 7 * 86400) < 5

--- a/tests/unit/dialogs/test_viewing.py
+++ b/tests/unit/dialogs/test_viewing.py
@@ -120,3 +120,42 @@ def test_compute_due_date_unknown_defaults_7_days():
     now = int(time.time())
     due = compute_due_date("unknown")
     assert abs(due - now - 7 * 86400) < 5
+
+
+# --- Dialog structure ---
+
+
+def test_viewing_dialog_exists():
+    from aiogram_dialog import Dialog
+
+    from telegram_bot.dialogs.viewing import viewing_dialog
+
+    assert isinstance(viewing_dialog, Dialog)
+
+
+def test_viewing_dialog_has_all_windows():
+    from telegram_bot.dialogs.viewing import viewing_dialog
+
+    windows = viewing_dialog.windows
+    states = [w.get_state() for w in windows.values()]
+    assert ViewingSG.objects in states
+    assert ViewingSG.objects_text in states
+    assert ViewingSG.date in states
+    assert ViewingSG.phone in states
+    assert ViewingSG.summary in states
+
+
+def test_viewing_dialog_importable_from_module():
+    """Verify viewing_dialog can be imported (registration sanity check)."""
+    from telegram_bot.dialogs.viewing import viewing_dialog
+
+    assert viewing_dialog is not None
+    assert len(viewing_dialog.windows) == 5
+
+
+def test_build_phone_keyboard_has_contact_button():
+    from telegram_bot.dialogs.viewing import build_phone_keyboard
+
+    kb = build_phone_keyboard()
+    # ReplyKeyboardMarkup with request_contact button
+    assert kb.keyboard[0][0].request_contact is True

--- a/tests/unit/dialogs/test_viewing.py
+++ b/tests/unit/dialogs/test_viewing.py
@@ -159,3 +159,76 @@ def test_build_phone_keyboard_has_contact_button():
     kb = build_phone_keyboard()
     # ReplyKeyboardMarkup with request_contact button
     assert kb.keyboard[0][0].request_contact is True
+
+
+# --- CRM integration ---
+
+
+@pytest.mark.asyncio
+async def test_on_confirm_creates_crm_entities():
+    from telegram_bot.dialogs.viewing import on_confirm
+
+    kommo = AsyncMock()
+    kommo.upsert_contact.return_value = SimpleNamespace(id=100)
+    kommo.create_lead.return_value = SimpleNamespace(id=200)
+
+    bot_config = SimpleNamespace(
+        kommo_default_pipeline_id=0,
+        kommo_new_status_id=0,
+        kommo_responsible_user_id=None,
+        kommo_service_field_id=0,
+        kommo_source_field_id=0,
+        kommo_telegram_field_id=0,
+        kommo_telegram_username_field_id=0,
+    )
+
+    callback = MagicMock()
+    callback.from_user = SimpleNamespace(
+        id=12345, first_name="Test", last_name=None, username="testuser"
+    )
+    callback.message = AsyncMock()
+    callback.answer = AsyncMock()
+
+    manager = MagicMock()
+    manager.dialog_data = {
+        "selected_objects": [],
+        "date_range": "nearest",
+        "phone": "+380990091392",
+    }
+    manager.middleware_data = {
+        "kommo_client": kommo,
+        "bot_config": bot_config,
+    }
+    manager.done = AsyncMock()
+
+    await on_confirm(callback, MagicMock(), manager)
+
+    kommo.upsert_contact.assert_awaited_once()
+    kommo.create_lead.assert_awaited_once()
+    kommo.link_contact_to_lead.assert_awaited_once_with(200, 100)
+    kommo.add_note.assert_awaited_once()
+    kommo.create_task.assert_awaited_once()
+    manager.done.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_on_confirm_graceful_when_no_kommo():
+    from telegram_bot.dialogs.viewing import on_confirm
+
+    callback = MagicMock()
+    callback.from_user = SimpleNamespace(id=12345, first_name="Test", last_name=None, username=None)
+    callback.message = AsyncMock()
+    callback.answer = AsyncMock()
+
+    manager = MagicMock()
+    manager.dialog_data = {
+        "date_range": "unknown",
+        "phone": "+380990091392",
+    }
+    manager.middleware_data = {"kommo_client": None, "bot_config": None}
+    manager.done = AsyncMock()
+
+    # Should not raise
+    await on_confirm(callback, MagicMock(), manager)
+    callback.message.answer.assert_awaited_once()
+    manager.done.assert_awaited_once()

--- a/tests/unit/dialogs/test_viewing.py
+++ b/tests/unit/dialogs/test_viewing.py
@@ -1,0 +1,11 @@
+"""Tests for viewing appointment wizard dialog."""
+
+from telegram_bot.dialogs.states import ViewingSG
+
+
+def test_viewing_sg_has_all_states():
+    assert hasattr(ViewingSG, "objects")
+    assert hasattr(ViewingSG, "objects_text")
+    assert hasattr(ViewingSG, "date")
+    assert hasattr(ViewingSG, "phone")
+    assert hasattr(ViewingSG, "summary")

--- a/tests/unit/dialogs/test_viewing.py
+++ b/tests/unit/dialogs/test_viewing.py
@@ -66,6 +66,40 @@ async def test_get_objects_options_empty_favorites():
     assert result["has_favorites"] is False
 
 
+@pytest.mark.asyncio
+async def test_get_objects_options_reads_favorites_from_middleware_data():
+    from telegram_bot.dialogs.viewing import get_objects_options
+
+    favorites_service = SimpleNamespace(
+        list=AsyncMock(
+            return_value=[
+                SimpleNamespace(
+                    property_id="prop-1",
+                    property_data={
+                        "complex_name": "Sunset",
+                        "property_type": "1+1",
+                        "area_m2": 61,
+                        "price_eur": 95000,
+                    },
+                )
+            ]
+        )
+    )
+    manager = SimpleNamespace(dialog_data={})
+
+    result = await get_objects_options(
+        event_from_user=SimpleNamespace(id=12345),
+        middleware_data={"favorites_service": favorites_service},
+        dialog_manager=manager,
+    )
+
+    assert result["has_favorites"] is True
+    assert len(result["items"]) == 1
+    assert result["items"][0][1] == "prop-1"
+    assert "Sunset" in result["items"][0][0]
+    assert manager.dialog_data["favorites_by_id"]["prop-1"]["complex_name"] == "Sunset"
+
+
 # --- Objects skip handler ---
 
 
@@ -76,6 +110,33 @@ async def test_on_objects_skip_switches_to_date():
     manager = SimpleNamespace(dialog_data={}, switch_to=AsyncMock())
     await on_objects_skip(MagicMock(), MagicMock(), manager)
     manager.switch_to.assert_awaited_once_with(ViewingSG.date)
+
+
+@pytest.mark.asyncio
+async def test_on_object_selected_keeps_object_metadata_for_summary_and_crm():
+    from telegram_bot.dialogs.viewing import on_object_selected
+
+    manager = SimpleNamespace(
+        dialog_data={
+            "favorites_by_id": {
+                "prop-1": {
+                    "id": "prop-1",
+                    "complex_name": "Sunset",
+                    "property_type": "1+1",
+                    "area_m2": 61,
+                    "price_eur": 95000,
+                }
+            }
+        }
+    )
+
+    await on_object_selected(MagicMock(), MagicMock(), manager, "prop-1")
+
+    selected = manager.dialog_data["selected_objects"]
+    assert len(selected) == 1
+    assert selected[0]["id"] == "prop-1"
+    assert selected[0]["complex_name"] == "Sunset"
+    assert selected[0]["price_eur"] == 95000
 
 
 # --- Summary getter ---
@@ -191,7 +252,15 @@ async def test_on_confirm_creates_crm_entities():
 
     manager = MagicMock()
     manager.dialog_data = {
-        "selected_objects": [],
+        "selected_objects": [
+            {
+                "id": "prop-1",
+                "complex_name": "Sunset",
+                "property_type": "1+1",
+                "area_m2": 61,
+                "price_eur": 95000,
+            }
+        ],
         "date_range": "nearest",
         "phone": "+380990091392",
     }
@@ -207,6 +276,9 @@ async def test_on_confirm_creates_crm_entities():
     kommo.create_lead.assert_awaited_once()
     kommo.link_contact_to_lead.assert_awaited_once_with(200, 100)
     kommo.add_note.assert_awaited_once()
+    note_text = kommo.add_note.await_args.args[2]
+    assert "Sunset" in note_text
+    assert "ID: prop-1" in note_text
     kommo.create_task.assert_awaited_once()
     manager.done.assert_awaited_once()
 

--- a/tests/unit/middlewares/test_i18n.py
+++ b/tests/unit/middlewares/test_i18n.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from telegram_bot.middlewares.i18n import (
+    I18nMiddleware,
     create_translator_hub,
 )
 
@@ -59,3 +61,25 @@ def test_translator_menu_keys(hub):
         for key in keys:
             result = t.get(key)
             assert result, f"Missing key '{key}' in locale '{locale}'"
+
+
+@pytest.mark.asyncio
+async def test_i18n_middleware_injects_favorites_service(hub):
+    """Middleware injects favorites service for dialog getters via middleware_data."""
+    apartments_service = object()
+    favorites_service = object()
+    property_bot = SimpleNamespace(
+        _apartments_service=apartments_service,
+        _favorites_service=favorites_service,
+    )
+    middleware = I18nMiddleware(hub=hub, property_bot=property_bot)
+
+    event = SimpleNamespace()
+    data = {"event_from_user": SimpleNamespace(id=123, language_code="ru")}
+
+    async def handler(_event, _data):
+        return _data
+
+    result = await middleware(handler, event, data)
+    assert result["apartments_service"] is apartments_service
+    assert result["favorites_service"] is favorites_service

--- a/tests/unit/test_bot_entry_points_crm.py
+++ b/tests/unit/test_bot_entry_points_crm.py
@@ -99,81 +99,40 @@ def _fav_bot(favorites: list | None = None) -> PropertyBot:
 
 
 # ---------------------------------------------------------------------------
-# Test: _handle_viewing — fork keyboard
+# Test: _handle_viewing — starts aiogram-dialog wizard (#719)
 # ---------------------------------------------------------------------------
 
 
-async def test_handle_viewing_shows_fork_keyboard() -> None:
-    """_handle_viewing sends InlineKeyboard with 2 buttons (choose_objects, phone)."""
+async def test_handle_viewing_starts_dialog_when_manager_available() -> None:
+    """_handle_viewing starts ViewingSG.objects via dialog_manager (#719)."""
+    from unittest.mock import AsyncMock
+
+    from aiogram_dialog import StartMode
+
+    from telegram_bot.dialogs.states import ViewingSG
+
+    bot = _create_bot()
+    state = _make_state()
+    msg = _make_message()
+    dialog_manager = AsyncMock()
+    dialog_manager.start = AsyncMock()
+
+    await bot._handle_viewing(msg, state, dialog_manager=dialog_manager)
+
+    dialog_manager.start.assert_awaited_once_with(ViewingSG.objects, mode=StartMode.RESET_STACK)
+
+
+async def test_handle_viewing_fallback_without_dialog_manager() -> None:
+    """_handle_viewing sends fallback message when dialog_manager is None (#719)."""
     bot = _create_bot()
     state = _make_state()
     msg = _make_message()
 
-    await bot._handle_viewing(msg, state)
+    await bot._handle_viewing(msg, state, dialog_manager=None)
 
     msg.answer.assert_awaited_once()
-    call_kwargs = msg.answer.call_args
-    # Check text
-    assert "объект" in call_kwargs[0][0].lower() or "конкретн" in call_kwargs[0][0].lower()
-    # Check keyboard has 2 rows
-    keyboard = call_kwargs[1]["reply_markup"]
-    assert len(keyboard.inline_keyboard) == 2
-    # Check callback_data values
-    button_datas = [row[0].callback_data for row in keyboard.inline_keyboard]
-    assert "viewing:choose_objects" in button_datas
-    assert "viewing:phone" in button_datas
-
-
-# ---------------------------------------------------------------------------
-# Test: viewing:phone -> start_phone_collection(service_key="viewing")
-# ---------------------------------------------------------------------------
-
-
-async def test_viewing_phone_callback_starts_phone_collection() -> None:
-    """viewing:phone -> start_phone_collection called with service_key='viewing'."""
-    bot = _create_bot()
-    state = _make_state()
-    cb = _make_callback("viewing:phone")
-
-    with patch(
-        "telegram_bot.handlers.phone_collector.start_phone_collection",
-        new=AsyncMock(),
-    ) as mock_collect:
-        await bot.handle_viewing_callback(cb, state)
-
-    mock_collect.assert_awaited_once_with(cb, state, service_key="viewing")
-
-
-# ---------------------------------------------------------------------------
-# Test: viewing:choose_objects -> redirect to apartment search
-# ---------------------------------------------------------------------------
-
-
-async def test_viewing_choose_objects_starts_search() -> None:
-    """viewing:choose_objects -> routes to apartment search pipeline."""
-    bot = _create_bot()
-    state = _make_state()
-    cb = _make_callback("viewing:choose_objects")
-
-    with patch.object(bot, "handle_menu_action_text", new=AsyncMock()) as mock_action:
-        await bot.handle_viewing_callback(cb, state)
-
-    mock_action.assert_awaited_once_with(cb.message, "Подбери апартаменты")
-    cb.answer.assert_awaited_once()
-
-
-async def test_viewing_choose_objects_no_message() -> None:
-    """viewing:choose_objects with message=None -> handle_menu_action_text not called, answer still called."""
-    bot = _create_bot()
-    state = _make_state()
-    cb = _make_callback("viewing:choose_objects")
-    cb.message = None
-
-    with patch.object(bot, "handle_menu_action_text", new=AsyncMock()) as mock_action:
-        await bot.handle_viewing_callback(cb, state)
-
-    mock_action.assert_not_awaited()
-    cb.answer.assert_awaited_once()
+    text = msg.answer.call_args[0][0]
+    assert "осмотр" in text.lower() or "меню" in text.lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace 2-button _handle_viewing with full aiogram-dialog wizard (#719)
- Flow: objects (favorites multiselect) → date (range buttons) → phone (request_contact + manual) → summary → Kommo CRM
- Graceful degradation when Kommo unavailable
- 14 unit tests covering getters, handlers, CRM integration + 2 updated bot entry point tests

## Test plan
- [x] make check (ruff + mypy)
- [x] pytest tests/unit/dialogs/test_viewing.py (14/14 pass)
- [x] pytest tests/unit/ -n auto (3981 passed, 0 failures)
- [ ] Manual: start wizard via menu button, complete flow

Closes #719

Generated with [Claude Code](https://claude.com/claude-code)