### PR TITLE
feat(handoff): i18n keys for handoff flow

### DIFF
--- a/telegram_bot/locales/en/messages.ftl
+++ b/telegram_bot/locales/en/messages.ftl
@@ -278,3 +278,25 @@ svc-back = Back
 svc-get-offer = Get an Offer
 svc-contact-manager = Contact Manager
 svc-back-to-services = Back to Services
+
+# ── Handoff (Forum Topics) ──────────────────────────────────────
+handoff-qual-prompt = So the manager can help right away — a couple of questions:
+handoff-goal-buy = 🏠 Purchase
+handoff-goal-rent = 🔑 Rental
+handoff-goal-consult = 📋 Consultation
+handoff-budget-prompt = Approximate budget?
+handoff-budget-low = up to 50k€
+handoff-budget-mid = 50-100k€
+handoff-budget-high = 100k€+
+handoff-budget-unknown = Not sure yet
+handoff-contact-prompt = How would you like to connect?
+handoff-contact-chat = 💬 Chat now
+handoff-contact-phone = 📞 Leave phone number
+handoff-connecting = Connecting you with a manager. While you wait — I can answer questions!
+handoff-offline = Manager will respond during business hours (9:00-18:00 EET). I can help in the meantime!
+handoff-manager-joined = Manager connected!
+handoff-timeout = Manager is currently busy. Leave your number for a callback?
+handoff-closed-client = Manager has ended the conversation. I'm back online!
+handoff-closed-topic = ✅ Conversation closed, client returned to bot.
+handoff-wait-more = ⏳ I'll wait
+handoff-leave-phone = 📞 Yes, call me back

--- a/telegram_bot/locales/ru/messages.ftl
+++ b/telegram_bot/locales/ru/messages.ftl
@@ -278,3 +278,25 @@ svc-back = Назад
 svc-get-offer = Получить предложение
 svc-contact-manager = Связаться с менеджером
 svc-back-to-services = Назад к услугам
+
+# ── Handoff (Forum Topics) ──────────────────────────────────────
+handoff-qual-prompt = Чтобы менеджер сразу помог — пару вопросов:
+handoff-goal-buy = 🏠 Покупка
+handoff-goal-rent = 🔑 Аренда
+handoff-goal-consult = 📋 Консультация
+handoff-budget-prompt = Какой бюджет примерно?
+handoff-budget-low = до 50к€
+handoff-budget-mid = 50-100к€
+handoff-budget-high = 100к€+
+handoff-budget-unknown = Пока не знаю
+handoff-contact-prompt = Как удобнее связаться?
+handoff-contact-chat = 💬 Написать сейчас
+handoff-contact-phone = 📞 Оставить номер
+handoff-connecting = Соединяю с менеджером. Пока ждёте — могу ответить на вопросы!
+handoff-offline = Менеджер ответит в рабочее время (9:00-18:00 EET). Пока могу помочь!
+handoff-manager-joined = Менеджер подключился!
+handoff-timeout = Менеджер пока занят. Оставить номер для звонка?
+handoff-closed-client = Менеджер завершил диалог. Я снова на связи!
+handoff-closed-topic = ✅ Диалог закрыт, клиент возвращён боту.
+handoff-wait-more = ⏳ Подожду ещё
+handoff-leave-phone = 📞 Да, перезвоните

--- a/telegram_bot/locales/uk/messages.ftl
+++ b/telegram_bot/locales/uk/messages.ftl
@@ -278,3 +278,25 @@ svc-back = Назад
 svc-get-offer = Отримати пропозицію
 svc-contact-manager = Зв'язатися з менеджером
 svc-back-to-services = Назад до послуг
+
+# ── Handoff (Forum Topics) ──────────────────────────────────────
+handoff-qual-prompt = Щоб менеджер одразу допоміг — кілька питань:
+handoff-goal-buy = 🏠 Купівля
+handoff-goal-rent = 🔑 Оренда
+handoff-goal-consult = 📋 Консультація
+handoff-budget-prompt = Який бюджет приблизно?
+handoff-budget-low = до 50к€
+handoff-budget-mid = 50-100к€
+handoff-budget-high = 100к€+
+handoff-budget-unknown = Поки не знаю
+handoff-contact-prompt = Як зручніше зв'язатися?
+handoff-contact-chat = 💬 Написати зараз
+handoff-contact-phone = 📞 Залишити номер
+handoff-connecting = З'єдную з менеджером. Поки чекаєте — можу відповісти на питання!
+handoff-offline = Менеджер відповість у робочий час (9:00-18:00 EET). Поки можу допомогти!
+handoff-manager-joined = Менеджер підключився!
+handoff-timeout = Менеджер зараз зайнятий. Залишити номер для дзвінка?
+handoff-closed-client = Менеджер завершив діалог. Я знову на зв'язку!
+handoff-closed-topic = ✅ Діалог закрито, клієнт повернений боту.
+handoff-wait-more = ⏳ Почекаю ще
+handoff-leave-phone = 📞 Так, передзвоніть

--- a/tests/unit/test_handoff_i18n.py
+++ b/tests/unit/test_handoff_i18n.py
@@ -1,0 +1,37 @@
+import pytest
+
+from telegram_bot.middlewares.i18n import create_translator_hub
+
+
+HANDOFF_KEYS = [
+    "handoff-qual-prompt",
+    "handoff-goal-buy",
+    "handoff-goal-rent",
+    "handoff-goal-consult",
+    "handoff-budget-prompt",
+    "handoff-budget-low",
+    "handoff-budget-mid",
+    "handoff-budget-high",
+    "handoff-budget-unknown",
+    "handoff-contact-prompt",
+    "handoff-contact-chat",
+    "handoff-contact-phone",
+    "handoff-connecting",
+    "handoff-offline",
+    "handoff-manager-joined",
+    "handoff-timeout",
+    "handoff-closed-client",
+    "handoff-closed-topic",
+    "handoff-wait-more",
+    "handoff-leave-phone",
+]
+
+
+@pytest.mark.parametrize("locale", ["ru", "en", "uk"])
+@pytest.mark.parametrize("key", HANDOFF_KEYS)
+def test_handoff_key_exists(locale, key):
+    hub = create_translator_hub()
+    i18n = hub.get_translator_by_locale(locale)
+    result = i18n.get(key)
+    # Must not return the key itself (means missing translation).
+    assert result != key, f"Missing .ftl key '{key}' for locale '{locale}'"


### PR DESCRIPTION
Task 5 of #730: 20 i18n keys x 3 locales (ru/en/uk) for qualification, context pack, and handoff messages.

## Changes

- `telegram_bot/locales/ru/messages.ftl` — 20 ключей handoff-* (ru)
- `telegram_bot/locales/en/messages.ftl` — 20 ключей handoff-* (en)
- `telegram_bot/locales/uk/messages.ftl` — 20 ключей handoff-* (uk)
- `tests/unit/test_handoff_i18n.py` — параметризованный тест (60 кейсов: 20 ключей × 3 локали)

## Keys added

Qualification flow: `handoff-qual-prompt`, `handoff-goal-{buy,rent,consult}`, `handoff-budget-{prompt,low,mid,high,unknown}`, `handoff-contact-{prompt,chat,phone}`

Bridge messages: `handoff-connecting`, `handoff-offline`, `handoff-manager-joined`, `handoff-timeout`, `handoff-closed-client`, `handoff-closed-topic`, `handoff-wait-more`, `handoff-leave-phone`

## Test results

```
60 passed in 29.67s
```

Closes: part of #730

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>