### PR TITLE
feat(handoff): summary + business hours services

### DIFF
--- a/telegram_bot/services/business_hours.py
+++ b/telegram_bot/services/business_hours.py
@@ -1,0 +1,24 @@
+"""Business hours checker for handoff flow."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+
+def is_business_hours(
+    dt: datetime | None = None,
+    *,
+    start: int = 9,
+    end: int = 18,
+    tz: str = "Europe/Sofia",
+) -> bool:
+    if dt is None:
+        dt = datetime.now(ZoneInfo(tz))
+    elif dt.tzinfo is None:
+        dt = dt.replace(tzinfo=ZoneInfo(tz))
+    local = dt.astimezone(ZoneInfo(tz))
+    # Weekdays only (Mon=0, Sun=6).
+    if local.weekday() >= 5:
+        return False
+    return start <= local.hour < end

--- a/telegram_bot/services/handoff_summary.py
+++ b/telegram_bot/services/handoff_summary.py
@@ -1,0 +1,58 @@
+"""Generate AI summary of chat history for manager handoff."""
+
+from __future__ import annotations
+
+import logging
+
+from langfuse.openai import AsyncOpenAI
+
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM_PROMPT = """\
+Ты — ассистент агентства недвижимости. Сгенерируй краткое саммари разговора \
+для менеджера, который подключается к клиенту.
+
+Формат (строго):
+- Что искал клиент (тип, район, бюджет)
+- Просмотренные объекты (если были)
+- Неотвеченные вопросы
+- Уровень готовности (холодный/тёплый/горячий)
+
+Максимум 5 строк. Без приветствий. Только факты."""
+
+
+async def _call_llm(messages: list[dict[str, str]]) -> str:
+    import os
+
+    client = AsyncOpenAI(
+        api_key=os.getenv("LLM_API_KEY", "sk-dev"),
+        base_url=os.getenv("LLM_BASE_URL", "http://litellm:4000/v1"),
+    )
+    resp = await client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=messages,  # type: ignore[arg-type]
+        max_tokens=300,
+        temperature=0.3,
+    )
+    return resp.choices[0].message.content.strip()
+
+
+async def generate_handoff_summary(
+    history: list[dict[str, str]],
+    min_messages: int = 3,
+) -> str | None:
+    if len(history) < min_messages:
+        return None
+
+    # Trim to last 20 messages to avoid token overflow.
+    trimmed = history[-20:]
+    messages = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        *trimmed,
+    ]
+    try:
+        return await _call_llm(messages)
+    except Exception:
+        logger.exception("Failed to generate handoff summary")
+        return None

--- a/tests/unit/services/test_business_hours.py
+++ b/tests/unit/services/test_business_hours.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from telegram_bot.services.business_hours import is_business_hours
+
+
+def test_during_business_hours():
+    # Wednesday 10:30 Sofia time
+    dt = datetime(2026, 3, 4, 10, 30, tzinfo=ZoneInfo("Europe/Sofia"))
+    assert is_business_hours(dt, start=9, end=18, tz="Europe/Sofia") is True
+
+
+def test_before_business_hours():
+    dt = datetime(2026, 3, 4, 7, 0, tzinfo=ZoneInfo("Europe/Sofia"))
+    assert is_business_hours(dt, start=9, end=18, tz="Europe/Sofia") is False
+
+
+def test_after_business_hours():
+    dt = datetime(2026, 3, 4, 20, 0, tzinfo=ZoneInfo("Europe/Sofia"))
+    assert is_business_hours(dt, start=9, end=18, tz="Europe/Sofia") is False
+
+
+def test_weekend():
+    # Saturday 12:00 — still outside business hours (weekday only)
+    dt = datetime(2026, 3, 7, 12, 0, tzinfo=ZoneInfo("Europe/Sofia"))
+    assert is_business_hours(dt, start=9, end=18, tz="Europe/Sofia") is False
+
+
+def test_boundary_start():
+    dt = datetime(2026, 3, 4, 9, 0, tzinfo=ZoneInfo("Europe/Sofia"))
+    assert is_business_hours(dt, start=9, end=18, tz="Europe/Sofia") is True
+
+
+def test_boundary_end():
+    dt = datetime(2026, 3, 4, 18, 0, tzinfo=ZoneInfo("Europe/Sofia"))
+    assert is_business_hours(dt, start=9, end=18, tz="Europe/Sofia") is False

--- a/tests/unit/services/test_handoff_summary.py
+++ b/tests/unit/services/test_handoff_summary.py
@@ -1,0 +1,38 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from telegram_bot.services.handoff_summary import generate_handoff_summary
+
+
+@pytest.mark.asyncio
+async def test_summary_returns_none_for_short_history():
+    history = [{"role": "user", "content": "привет"}]
+    result = await generate_handoff_summary(history, min_messages=3)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_summary_returns_none_for_empty_history():
+    result = await generate_handoff_summary([], min_messages=3)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_summary_calls_llm_for_sufficient_history():
+    history = [
+        {"role": "user", "content": "Ищу квартиру в Варне"},
+        {"role": "assistant", "content": "Какой бюджет?"},
+        {"role": "user", "content": "Около 70 тысяч евро"},
+        {"role": "assistant", "content": "Вот несколько вариантов..."},
+        {"role": "user", "content": "А что с ипотекой?"},
+    ]
+    with patch(
+        "telegram_bot.services.handoff_summary._call_llm",
+        new_callable=AsyncMock,
+        return_value="Клиент ищет квартиру в Варне, бюджет ~70к EUR. Интересуется ипотекой.",
+    ):
+        result = await generate_handoff_summary(history, min_messages=3)
+    assert result is not None
+    assert "Варне" in result
+    assert "ипотек" in result.lower()


### PR DESCRIPTION
Tasks 4, 7 of #730: AI handoff summary service, business hours helper.

## Changes

- **Task 4** (`telegram_bot/services/handoff_summary.py`): AI context generation for manager handoff — generates structured 5-line summary of chat history via LLM. Returns `None` if history too short. Uses `langfuse.openai.AsyncOpenAI` per project pattern.
- **Task 7** (`telegram_bot/services/business_hours.py`): Pure-function business hours checker — weekdays only (Mon–Fri), configurable start/end/tz, boundary-correct (`start <= hour < end`).

## Tests

- 3 tests for handoff summary (short/empty history → None, sufficient history → LLM called)
- 6 tests for business hours (during/before/after hours, weekend, boundaries)
- 9/9 passing

Closes: part of #730

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>