### PR TITLE
feat(funnel): improve preferences screen UX

### DIFF
--- a/telegram_bot/dialogs/funnel.py
+++ b/telegram_bot/dialogs/funnel.py
@@ -238,11 +238,11 @@ async def get_preferences_options(**kwargs: Any) -> dict[str, Any]:
     promotion_val = data.get("is_promotion")
     complex_val = data.get("complex")
 
-    floor_label = f"{'✓ ' if floor_val and floor_val != 'any' else ''}Этаж"
-    view_label = f"{'✓ ' if view_val and view_val != 'any' else ''}Вид"
-    furnished_label = f"{'✓ ' if furnished_val else ''}Мебель"
-    promotion_label = f"{'✓ ' if promotion_val else ''}Акции"
-    complex_label = f"{'✓ ' if complex_val and complex_val != 'any' else ''}Комплекс"
+    floor_label = f"{'✓ ' if floor_val and floor_val != 'any' else ''}🏢 Этаж"
+    view_label = f"{'✓ ' if view_val and view_val != 'any' else ''}🌅 Вид"
+    furnished_label = f"{'✓ ' if furnished_val else ''}🛋 Мебель"
+    promotion_label = f"{'✓ ' if promotion_val else ''}🏷 Акции"
+    complex_label = f"{'✓ ' if complex_val and complex_val != 'any' else ''}🏘 Комплекс"
 
     items = [
         (floor_label, "floor"),
@@ -250,9 +250,9 @@ async def get_preferences_options(**kwargs: Any) -> dict[str, Any]:
         (furnished_label, "furnished"),
         (promotion_label, "promotion"),
         (complex_label, "complex"),
-        ("🔍 Показать результаты ➜", "done"),
+        ("▶️ Нет, перейти к результатам", "done"),
     ]
-    return {"title": "Дополнительные фильтры:", "items": items, "btn_back": btn_back}
+    return {"title": "✨ Есть ли дополнительные пожелания?", "items": items, "btn_back": btn_back}
 
 
 async def get_pref_floor_options(**kwargs: Any) -> dict[str, Any]:

--- a/telegram_bot/dialogs/funnel.py
+++ b/telegram_bot/dialogs/funnel.py
@@ -222,7 +222,7 @@ async def get_preferences_options(**kwargs: Any) -> dict[str, Any]:
     """Getter for preferences multi-select menu (Step 4).
 
     Shows 5 category buttons with ✓ checkmark when a value is selected,
-    plus a "Показать результаты" button to proceed to results via summary.
+    plus a "Нет, перейти к результатам" button to proceed to summary.
     """
     i18n = kwargs.get("middleware_data", {}).get("i18n")
     dialog_manager = kwargs.get("dialog_manager")

--- a/tests/unit/dialogs/test_funnel.py
+++ b/tests/unit/dialogs/test_funnel.py
@@ -131,6 +131,7 @@ async def test_preferences_options_has_5_categories_plus_done():
         dialog_manager=SimpleNamespace(dialog_data={}),
     )
     items = result["items"]
+    assert result["title"] == "✨ Есть ли дополнительные пожелания?"
     ids = [item_id for _, item_id in items]
     assert "floor" in ids
     assert "view" in ids
@@ -138,6 +139,24 @@ async def test_preferences_options_has_5_categories_plus_done():
     assert "promotion" in ids
     assert "complex" in ids
     assert "done" in ids
+    assert any(
+        label == "▶️ Нет, перейти к результатам" for label, item_id in items if item_id == "done"
+    )
+
+
+@pytest.mark.asyncio
+async def test_preferences_options_uses_emoji_labels_for_all_categories():
+    result = await funnel_module.get_preferences_options(
+        middleware_data={},
+        dialog_manager=SimpleNamespace(dialog_data={}),
+    )
+    labels_by_id = {item_id: label for label, item_id in result["items"]}
+
+    assert labels_by_id["floor"] == "🏢 Этаж"
+    assert labels_by_id["view"] == "🌅 Вид"
+    assert labels_by_id["furnished"] == "🛋 Мебель"
+    assert labels_by_id["promotion"] == "🏷 Акции"
+    assert labels_by_id["complex"] == "🏘 Комплекс"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Заголовок `Дополнительные фильтры:` → `✨ Есть ли дополнительные пожелания?`
- Добавлены эмодзи к кнопкам категорий (🏢 Этаж, 🌅 Вид, 🛋 Мебель, 🏷 Акции, 🏘 Комплекс)
- Кнопка `🔍 Показать результаты ➜` → `▶️ Нет, перейти к результатам` — устраняет дублирование с Summary (Step 5)

Fixes #735

## Test plan
- [ ] Запустить воронку подбора апартаментов, дойти до Step 4 (preferences)
- [ ] Проверить заголовок и эмодзи на кнопках
- [ ] Выбрать фильтр — убедиться что ✓ корректно отображается рядом с эмодзи
- [ ] Нажать «▶️ Нет, перейти к результатам» — попасть на Summary
- [ ] На Summary кнопка «🔍 Показать результаты» без изменений

🤖 Generated with [Claude Code](https://claude.com/claude-code)