### PR TITLE
feat(crm): task edit/close handlers (#731)

### DIFF
--- a/telegram_bot/dialogs/crm_tasks.py
+++ b/telegram_bot/dialogs/crm_tasks.py
@@ -18,6 +18,7 @@ from aiogram_dialog.widgets.input import ManagedTextInput, TextInput
 from aiogram_dialog.widgets.kbd import Back, Button, Cancel, Column, Select, Start
 from aiogram_dialog.widgets.text import Const, Format
 
+from telegram_bot.handlers.crm_callbacks import _EDIT_FIELD_PROMPT
 from telegram_bot.services.kommo_models import Task
 
 from .states import CreateTaskSG, CrmQuickActionSG, MyTasksSG, TasksMenuSG
@@ -301,7 +302,7 @@ async def get_task_list(dialog_manager: DialogManager, **kwargs: Any) -> dict[st
 
     # Edit tasks for edit select widget
     edit_tasks = [
-        (f"✏️ #{t.id}: {(t.text or '')[:25]}", str(t.id)) for t in page_tasks if not t.is_completed
+        (f"#{t.id}: {(t.text or '')[:25]}", str(t.id)) for t in page_tasks if not t.is_completed
     ]
 
     return {
@@ -477,9 +478,7 @@ async def on_task_edit_from_list(
         await fsm.update_data(edit_task_id=task_id)
     await manager.done()
     if callback.message and not isinstance(callback.message, InaccessibleMessage):
-        await callback.message.answer(
-            "✏️ Что изменить?\n\n1️⃣ Текст задачи\n2️⃣ Срок выполнения\n\nОтправьте 1 или 2:"
-        )
+        await callback.message.answer(_EDIT_FIELD_PROMPT)
     await callback.answer()
 
 

--- a/telegram_bot/dialogs/crm_tasks.py
+++ b/telegram_bot/dialogs/crm_tasks.py
@@ -12,7 +12,7 @@ import logging
 import operator
 from typing import Any
 
-from aiogram.types import CallbackQuery, Message
+from aiogram.types import CallbackQuery, InaccessibleMessage, Message
 from aiogram_dialog import Dialog, DialogManager, Window
 from aiogram_dialog.widgets.input import ManagedTextInput, TextInput
 from aiogram_dialog.widgets.kbd import Back, Button, Cancel, Column, Select, Start
@@ -20,7 +20,7 @@ from aiogram_dialog.widgets.text import Const, Format
 
 from telegram_bot.services.kommo_models import Task
 
-from .states import CreateTaskSG, MyTasksSG, TasksMenuSG
+from .states import CreateTaskSG, CrmQuickActionSG, MyTasksSG, TasksMenuSG
 
 
 logger = logging.getLogger(__name__)
@@ -299,6 +299,11 @@ async def get_task_list(dialog_manager: DialogManager, **kwargs: Any) -> dict[st
         (f"#{t.id}: {(t.text or '')[:30]}", str(t.id)) for t in page_tasks if not t.is_completed
     ]
 
+    # Edit tasks for edit select widget
+    edit_tasks = [
+        (f"✏️ #{t.id}: {(t.text or '')[:25]}", str(t.id)) for t in page_tasks if not t.is_completed
+    ]
+
     return {
         "title": f"📋 Мои задачи — {filter_label} ({total})",
         "tasks_text": tasks_text,
@@ -307,6 +312,7 @@ async def get_task_list(dialog_manager: DialogManager, **kwargs: Any) -> dict[st
         "page": page,
         "total": total,
         "active_tasks": active_tasks,
+        "edit_tasks": edit_tasks,
         "has_active": len(active_tasks) > 0,
     }
 
@@ -457,6 +463,26 @@ async def on_next_page(
     manager.dialog_data["page"] = page + 1
 
 
+async def on_task_edit_from_list(
+    callback: CallbackQuery,
+    widget: Any,
+    manager: DialogManager,
+    item_id: str,
+) -> None:
+    """Start task edit from dialog select — close dialog and trigger FSM."""
+    task_id = int(item_id)
+    fsm = manager.middleware_data.get("state")
+    if fsm:
+        await fsm.set_state(CrmQuickActionSG.edit_task_choose_field)
+        await fsm.update_data(edit_task_id=task_id)
+    await manager.done()
+    if callback.message and not isinstance(callback.message, InaccessibleMessage):
+        await callback.message.answer(
+            "✏️ Что изменить?\n\n1️⃣ Текст задачи\n2️⃣ Срок выполнения\n\nОтправьте 1 или 2:"
+        )
+    await callback.answer()
+
+
 async def on_task_complete(
     callback: CallbackQuery,
     widget: Select,
@@ -566,7 +592,7 @@ my_tasks_dialog = Dialog(
         getter=get_filter_options,
         state=MyTasksSG.filter,
     ),
-    # Step 2: Task list with pagination and complete action
+    # Step 2: Task list with pagination and complete/edit actions
     Window(
         Format("{title}\n\n{tasks_text}"),
         # Complete task select (shown only when there are active tasks)
@@ -577,6 +603,17 @@ my_tasks_dialog = Dialog(
                 item_id_getter=operator.itemgetter(1),
                 items="active_tasks",
                 on_click=on_task_complete,
+                when="has_active",
+            ),
+        ),
+        # Edit task select (shown only when there are active tasks)
+        Column(
+            Select(
+                Format("✏️ Редактировать: {item[0]}"),
+                id="edit_task_select",
+                item_id_getter=operator.itemgetter(1),
+                items="edit_tasks",
+                on_click=on_task_edit_from_list,
                 when="has_active",
             ),
         ),

--- a/telegram_bot/dialogs/states.py
+++ b/telegram_bot/dialogs/states.py
@@ -170,3 +170,6 @@ class CrmQuickActionSG(StatesGroup):
 
     waiting_note = State()  # waiting for note text (lead or contact)
     waiting_task = State()  # waiting for task text (lead)
+    edit_task_choose_field = State()  # choose what to edit (text or due date)
+    edit_task_text = State()  # waiting for new task text
+    edit_task_date = State()  # waiting for new due date

--- a/telegram_bot/handlers/crm_callbacks.py
+++ b/telegram_bot/handlers/crm_callbacks.py
@@ -250,20 +250,22 @@ async def on_edit_task_text_received(
     data = await state.get_data()
     task_id = data.get("edit_task_id", 0)
     text = (message.text or "").strip()
-    await state.clear()
 
     if not text:
         await message.answer("⚠️ Текст не может быть пустым.")
         return
     if kommo_client is None:
+        await state.clear()
         await message.answer(_NO_CRM)
         return
 
     try:
         await kommo_client.update_task(task_id, TaskUpdate(text=text))
+        await state.clear()
         await message.answer(_EDIT_SUCCESS)
     except Exception:
         logger.exception("Failed to update task %d text", task_id)
+        await state.clear()
         await message.answer("⚠️ Ошибка при обновлении задачи.")
 
 
@@ -276,9 +278,9 @@ async def on_edit_task_date_received(
     data = await state.get_data()
     task_id = data.get("edit_task_id", 0)
     raw = (message.text or "").strip()
-    await state.clear()
 
     if kommo_client is None:
+        await state.clear()
         await message.answer(_NO_CRM)
         return
 
@@ -292,9 +294,11 @@ async def on_edit_task_date_received(
 
     try:
         await kommo_client.update_task(task_id, TaskUpdate(complete_till=due_ts))
+        await state.clear()
         await message.answer(_EDIT_SUCCESS)
     except Exception:
         logger.exception("Failed to update task %d due date", task_id)
+        await state.clear()
         await message.answer("⚠️ Ошибка при обновлении задачи.")
 
 

--- a/telegram_bot/handlers/crm_callbacks.py
+++ b/telegram_bot/handlers/crm_callbacks.py
@@ -200,6 +200,104 @@ async def on_task_text_received(
         await message.answer("⚠️ Ошибка при создании задачи.")
 
 
+_EDIT_FIELD_PROMPT = "✏️ Что изменить?\n\n1️⃣ Текст задачи\n2️⃣ Срок выполнения\n\nОтправьте 1 или 2:"
+_EDIT_TEXT_PROMPT = "📝 Введите новый текст задачи:"
+_EDIT_DATE_PROMPT = "📅 Введите новый срок (ДД.ММ.ГГГГ ЧЧ:ММ):"
+_EDIT_SUCCESS = "✅ Задача обновлена."
+
+
+async def on_task_edit(
+    callback: CallbackQuery,
+    state: FSMContext,
+    kommo_client: Any | None = None,
+) -> None:
+    """Handle crm:task:edit:{id} — start edit field choice FSM."""
+    if kommo_client is None:
+        await callback.answer(_NO_CRM, show_alert=True)
+        return
+    assert callback.data is not None
+    task_id = int(callback.data.split(":")[3])
+    await state.set_state(CrmQuickActionSG.edit_task_choose_field)
+    await state.update_data(edit_task_id=task_id)
+    if callback.message and not isinstance(callback.message, InaccessibleMessage):
+        await callback.message.answer(_EDIT_FIELD_PROMPT)
+    await callback.answer()
+
+
+async def on_edit_field_chosen(
+    message: Message,
+    state: FSMContext,
+    kommo_client: Any | None = None,
+) -> None:
+    """Handle field choice: 1=text, 2=date."""
+    choice = (message.text or "").strip()
+    if choice == "1":
+        await state.set_state(CrmQuickActionSG.edit_task_text)
+        await message.answer(_EDIT_TEXT_PROMPT)
+    elif choice == "2":
+        await state.set_state(CrmQuickActionSG.edit_task_date)
+        await message.answer(_EDIT_DATE_PROMPT)
+    else:
+        await message.answer("⚠️ Отправьте 1 или 2.")
+
+
+async def on_edit_task_text_received(
+    message: Message,
+    state: FSMContext,
+    kommo_client: Any | None = None,
+) -> None:
+    """Handle new task text input."""
+    data = await state.get_data()
+    task_id = data.get("edit_task_id", 0)
+    text = (message.text or "").strip()
+    await state.clear()
+
+    if not text:
+        await message.answer("⚠️ Текст не может быть пустым.")
+        return
+    if kommo_client is None:
+        await message.answer(_NO_CRM)
+        return
+
+    try:
+        await kommo_client.update_task(task_id, TaskUpdate(text=text))
+        await message.answer(_EDIT_SUCCESS)
+    except Exception:
+        logger.exception("Failed to update task %d text", task_id)
+        await message.answer("⚠️ Ошибка при обновлении задачи.")
+
+
+async def on_edit_task_date_received(
+    message: Message,
+    state: FSMContext,
+    kommo_client: Any | None = None,
+) -> None:
+    """Handle new task due date input (DD.MM.YYYY HH:MM)."""
+    data = await state.get_data()
+    task_id = data.get("edit_task_id", 0)
+    raw = (message.text or "").strip()
+    await state.clear()
+
+    if kommo_client is None:
+        await message.answer(_NO_CRM)
+        return
+
+    try:
+        dt = datetime.datetime.strptime(raw, "%d.%m.%Y %H:%M")
+        dt = dt.replace(tzinfo=datetime.UTC)
+        due_ts = int(dt.timestamp())
+    except ValueError:
+        await message.answer("⚠️ Неверный формат. Используйте: ДД.ММ.ГГГГ ЧЧ:ММ")
+        return
+
+    try:
+        await kommo_client.update_task(task_id, TaskUpdate(complete_till=due_ts))
+        await message.answer(_EDIT_SUCCESS)
+    except Exception:
+        logger.exception("Failed to update task %d due date", task_id)
+        await message.answer("⚠️ Ошибка при обновлении задачи.")
+
+
 def create_crm_router() -> Router:
     """Create router with CRM card action handlers."""
     router = Router(name="crm_callbacks")
@@ -216,5 +314,13 @@ def create_crm_router() -> Router:
     # FSM text input handlers
     router.message(StateFilter(CrmQuickActionSG.waiting_note), F.text)(on_note_text_received)
     router.message(StateFilter(CrmQuickActionSG.waiting_task), F.text)(on_task_text_received)
+
+    # Task edit FSM
+    router.callback_query(F.data.regexp(r"^crm:task:edit:\d+$"))(on_task_edit)
+    router.message(StateFilter(CrmQuickActionSG.edit_task_choose_field), F.text)(
+        on_edit_field_chosen
+    )
+    router.message(StateFilter(CrmQuickActionSG.edit_task_text), F.text)(on_edit_task_text_received)
+    router.message(StateFilter(CrmQuickActionSG.edit_task_date), F.text)(on_edit_task_date_received)
 
     return router

--- a/tests/unit/dialogs/test_crm_tasks.py
+++ b/tests/unit/dialogs/test_crm_tasks.py
@@ -239,3 +239,85 @@ def test_render_tasks_text_multiple_tasks():
 
     assert "First task" in result
     assert "Second task" in result
+
+
+# --- get_task_list: edit_tasks data ---
+
+
+async def test_get_task_list_includes_edit_tasks():
+    """get_task_list getter returns edit_tasks for active tasks on page."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from telegram_bot.dialogs.crm_tasks import get_task_list
+    from telegram_bot.services.kommo_models import Task
+
+    kommo = AsyncMock()
+    kommo.get_tasks = AsyncMock(
+        return_value=[
+            Task(id=10, text="Edit me", is_completed=False),
+            Task(id=11, text="Also active", is_completed=False),
+        ]
+    )
+
+    manager = MagicMock()
+    manager.middleware_data = {"kommo_client": kommo}
+    manager.dialog_data = {"task_filter": "all", "page": 0}
+
+    result = await get_task_list(dialog_manager=manager)
+
+    assert "edit_tasks" in result
+    ids = [item_id for _, item_id in result["edit_tasks"]]
+    assert "10" in ids
+    assert "11" in ids
+
+
+async def test_get_task_list_edit_tasks_excludes_completed():
+    """get_task_list edit_tasks does not include completed tasks."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from telegram_bot.dialogs.crm_tasks import get_task_list
+    from telegram_bot.services.kommo_models import Task
+
+    kommo = AsyncMock()
+    kommo.get_tasks = AsyncMock(
+        return_value=[
+            Task(id=10, text="Active", is_completed=False),
+            Task(id=20, text="Done", is_completed=True),
+        ]
+    )
+
+    manager = MagicMock()
+    manager.middleware_data = {"kommo_client": kommo}
+    manager.dialog_data = {"task_filter": "all", "page": 0}
+
+    result = await get_task_list(dialog_manager=manager)
+
+    ids = [item_id for _, item_id in result["edit_tasks"]]
+    assert "10" in ids
+    assert "20" not in ids
+
+
+# --- on_task_edit_from_list ---
+
+
+async def test_on_task_edit_from_list_sets_fsm_and_closes_dialog():
+    """on_task_edit_from_list sets FSM edit state and closes dialog."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from telegram_bot.dialogs.crm_tasks import on_task_edit_from_list
+    from telegram_bot.dialogs.states import CrmQuickActionSG
+
+    fsm_state = AsyncMock()
+    callback = AsyncMock()
+    callback.message = AsyncMock()
+    widget = MagicMock()
+    manager = MagicMock()
+    manager.done = AsyncMock()
+    manager.middleware_data = {"state": fsm_state}
+
+    await on_task_edit_from_list(callback, widget, manager, item_id="42")
+
+    fsm_state.set_state.assert_called_once_with(CrmQuickActionSG.edit_task_choose_field)
+    fsm_state.update_data.assert_called_once_with(edit_task_id=42)
+    manager.done.assert_called_once()
+    callback.answer.assert_called()

--- a/tests/unit/handlers/test_crm_callbacks.py
+++ b/tests/unit/handlers/test_crm_callbacks.py
@@ -273,6 +273,167 @@ async def test_task_no_kommo_sends_error_message():
     message.answer.assert_called()
 
 
+# --- Task edit FSM states ---
+
+
+def test_crm_quick_action_states_have_edit_states():
+    """CrmQuickActionSG has edit_task_choose_field, edit_task_text, edit_task_date states."""
+    from telegram_bot.dialogs.states import CrmQuickActionSG
+
+    assert hasattr(CrmQuickActionSG, "edit_task_choose_field")
+    assert hasattr(CrmQuickActionSG, "edit_task_text")
+    assert hasattr(CrmQuickActionSG, "edit_task_date")
+
+
+async def test_on_task_edit_starts_field_choice():
+    """crm:task:edit:{id} sets edit_task_choose_field state and stores task id."""
+    from telegram_bot.dialogs.states import CrmQuickActionSG
+    from telegram_bot.handlers.crm_callbacks import on_task_edit
+
+    kommo = AsyncMock()
+    state = AsyncMock()
+    callback = AsyncMock()
+    callback.data = "crm:task:edit:42"
+    callback.message = AsyncMock()
+
+    await on_task_edit(callback, state, kommo_client=kommo)
+
+    state.set_state.assert_called_once_with(CrmQuickActionSG.edit_task_choose_field)
+    state.update_data.assert_called_once_with(edit_task_id=42)
+    callback.answer.assert_called()
+
+
+async def test_on_task_edit_no_kommo_answers_alert():
+    """on_task_edit without kommo_client answers with show_alert=True."""
+    from telegram_bot.handlers.crm_callbacks import on_task_edit
+
+    state = AsyncMock()
+    callback = AsyncMock()
+    callback.data = "crm:task:edit:5"
+
+    await on_task_edit(callback, state, kommo_client=None)
+
+    callback.answer.assert_called_once()
+    call_kwargs = callback.answer.call_args.kwargs
+    assert call_kwargs.get("show_alert") is True
+    state.set_state.assert_not_called()
+
+
+async def test_on_edit_field_chosen_1_goes_to_text():
+    """on_edit_field_chosen with '1' sets edit_task_text state."""
+    from telegram_bot.dialogs.states import CrmQuickActionSG
+    from telegram_bot.handlers.crm_callbacks import on_edit_field_chosen
+
+    state = AsyncMock()
+    message = AsyncMock()
+    message.text = "1"
+
+    await on_edit_field_chosen(message, state)
+
+    state.set_state.assert_called_once_with(CrmQuickActionSG.edit_task_text)
+    message.answer.assert_called()
+
+
+async def test_on_edit_field_chosen_2_goes_to_date():
+    """on_edit_field_chosen with '2' sets edit_task_date state."""
+    from telegram_bot.dialogs.states import CrmQuickActionSG
+    from telegram_bot.handlers.crm_callbacks import on_edit_field_chosen
+
+    state = AsyncMock()
+    message = AsyncMock()
+    message.text = "2"
+
+    await on_edit_field_chosen(message, state)
+
+    state.set_state.assert_called_once_with(CrmQuickActionSG.edit_task_date)
+    message.answer.assert_called()
+
+
+async def test_on_edit_field_chosen_invalid_sends_warning():
+    """on_edit_field_chosen with invalid input sends warning, no state change."""
+    from telegram_bot.handlers.crm_callbacks import on_edit_field_chosen
+
+    state = AsyncMock()
+    message = AsyncMock()
+    message.text = "5"
+
+    await on_edit_field_chosen(message, state)
+
+    state.set_state.assert_not_called()
+    message.answer.assert_called()
+
+
+async def test_on_edit_task_text_received_calls_update():
+    """on_edit_task_text_received calls kommo_client.update_task with new text."""
+    from telegram_bot.handlers.crm_callbacks import on_edit_task_text_received
+    from telegram_bot.services.kommo_models import TaskUpdate
+
+    kommo = AsyncMock()
+    state = AsyncMock()
+    state.get_data = AsyncMock(return_value={"edit_task_id": 77})
+    message = AsyncMock()
+    message.text = "New task text"
+
+    await on_edit_task_text_received(message, state, kommo_client=kommo)
+
+    kommo.update_task.assert_called_once()
+    call_args = kommo.update_task.call_args
+    assert call_args.args[0] == 77
+    update_obj = call_args.args[1]
+    assert isinstance(update_obj, TaskUpdate)
+    assert update_obj.text == "New task text"
+    state.clear.assert_called_once()
+
+
+async def test_on_edit_task_date_received_calls_update():
+    """on_edit_task_date_received parses date and calls kommo_client.update_task."""
+    from telegram_bot.handlers.crm_callbacks import on_edit_task_date_received
+    from telegram_bot.services.kommo_models import TaskUpdate
+
+    kommo = AsyncMock()
+    state = AsyncMock()
+    state.get_data = AsyncMock(return_value={"edit_task_id": 55})
+    message = AsyncMock()
+    message.text = "31.12.2027 10:00"
+
+    await on_edit_task_date_received(message, state, kommo_client=kommo)
+
+    kommo.update_task.assert_called_once()
+    call_args = kommo.update_task.call_args
+    assert call_args.args[0] == 55
+    update_obj = call_args.args[1]
+    assert isinstance(update_obj, TaskUpdate)
+    assert update_obj.complete_till is not None
+    assert update_obj.complete_till > 0
+    state.clear.assert_called_once()
+
+
+async def test_on_edit_task_date_received_invalid_format():
+    """on_edit_task_date_received with bad date sends warning, no update."""
+    from telegram_bot.handlers.crm_callbacks import on_edit_task_date_received
+
+    kommo = AsyncMock()
+    state = AsyncMock()
+    state.get_data = AsyncMock(return_value={"edit_task_id": 55})
+    message = AsyncMock()
+    message.text = "not-a-date"
+
+    await on_edit_task_date_received(message, state, kommo_client=kommo)
+
+    kommo.update_task.assert_not_called()
+    message.answer.assert_called()
+
+
+def test_crm_router_registers_edit_callback():
+    """create_crm_router registers crm:task:edit handler."""
+    from telegram_bot.handlers.crm_callbacks import create_crm_router
+
+    router = create_crm_router()
+    # Verify router was created without errors (handlers registered)
+    assert router is not None
+    assert router.name == "crm_callbacks"
+
+
 # --- crm_cards.py: postpone button ---
 
 


### PR DESCRIPTION
Tasks 1+2 from #731: FSM for task editing (text + due date), edit/close buttons in my_tasks dialog.

Part of #731