### PR TITLE
feat(streaming): native sendMessageDraft in voice path

### DIFF
--- a/telegram_bot/graph/nodes/generate.py
+++ b/telegram_bot/graph/nodes/generate.py
@@ -4,13 +4,13 @@ Formats top-3 retrieved documents as context, builds system prompt with
 domain from GraphConfig, includes conversation history, and calls LLM.
 Falls back to a summary of retrieved docs if LLM is unavailable.
 
-Supports streaming delivery to Telegram: sends placeholder message,
-edits with accumulated chunks (throttled 500ms), finalizes with Markdown.
+Supports streaming delivery to Telegram via native sendMessageDraft
+(Bot API 9.5): sends draft updates during generation, finalizes with
+message.answer() for chat history persistence.
 """
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
 import logging
 import time
@@ -42,11 +42,8 @@ class StreamingPartialDeliveryError(Exception):
 
 # 3 context docs: saves ~50ms TTFT vs 5 docs while top-3 capture 90%+ relevant context.
 _MAX_CONTEXT_DOCS = 3
-# 0.5s edit interval: reduces Telegram API load and 429 risk.
-# Trade-off: slightly chunkier streaming UX vs 0.3s, but safer margin.
-# Telegram editMessageText counts 1 unit toward rate limit; 0.5s = max 120/min burst.
-_STREAM_EDIT_INTERVAL = 0.5
-_STREAM_PLACEHOLDER = "⏳ Генерирую ответ..."
+# 200ms draft interval — sendMessageDraft has no rate limit.
+_DRAFT_INTERVAL = 0.2
 _MAX_HISTORY_MESSAGES = 12
 _detector = ResponseStyleDetector()
 _HISTORY_INSTRUCTION = (
@@ -203,67 +200,35 @@ async def _generate_streaming(
     max_tokens: int = 0,
     lf_client: Any | None = None,
 ) -> tuple[str, str, float, int | None, float | None, Any]:
-    """Stream LLM response directly to Telegram via message editing.
+    """Stream LLM response to Telegram via native sendMessageDraft (Bot API 9.5).
 
-    Sends a placeholder message, then edits it with accumulated text as chunks
-    arrive from the OpenAI streaming API. Throttles edits to _STREAM_EDIT_INTERVAL.
-    Finalizes with Markdown parse_mode (falls back to plain text).
-
-    Args:
-        llm: AsyncOpenAI client instance.
-        config: GraphConfig with model parameters.
-        llm_messages: OpenAI-format message list.
-        message: aiogram Message object for Telegram delivery.
-
-    Returns:
-        Tuple of (response_text, actual_model, ttft_ms, completion_tokens, sent_msg).
-
-    Raises:
-        Exception: On any streaming failure (caller handles fallback).
+    Sends draft updates as chunks arrive, then finalizes with message.answer().
     """
     accumulated = ""
-    last_edit = 0.0
+    last_draft = 0.0
     ttft_ms = 0.0
     actual_model = config.llm_model
     completion_tokens: int | None = None
 
     effective_max_tokens = max_tokens if max_tokens > 0 else int(config.generate_max_tokens)
-    # t_request_start must be before gather for correct TTFT measurement.
-    t_request_start = time.monotonic()
-    # Parallelize LLM stream creation and Telegram placeholder send to reduce TTFT (#685).
-    results = await asyncio.gather(
-        _chat_create_with_optional_name(
-            llm,
-            observation_name="generate-answer",
-            model=config.llm_model,
-            messages=llm_messages,
-            temperature=config.llm_temperature,
-            max_tokens=effective_max_tokens,
-            stream=True,
-            stream_options={"include_usage": True},
-        ),
-        message.answer(_STREAM_PLACEHOLDER),
-        return_exceptions=True,
-    )
-    stream_result: Any = results[0]
-    sent_result: Any = results[1]
-    if isinstance(stream_result, BaseException):
-        # LLM unavailable — clean up placeholder and propagate.
-        if not isinstance(sent_result, BaseException):
-            with contextlib.suppress(Exception):
-                await sent_result.delete()
-        raise stream_result
-    if isinstance(sent_result, BaseException):
-        # Telegram rate-limited or unavailable — degrade gracefully, stream without indicator.
-        logger.warning(
-            "Placeholder send failed, streaming without progress indicator: %s", sent_result
-        )
-        sent_msg = None
-    else:
-        sent_msg = sent_result
-    stream = stream_result
 
-    # Legacy stream-only TTFT baseline kept for drift diagnostics.
+    chat_id = message.chat.id
+    bot = message.bot
+    draft_id = abs(hash(f"{chat_id}:{time.monotonic_ns()}")) % (2**31) or 1
+
+    t_request_start = time.monotonic()
+
+    stream = await _chat_create_with_optional_name(
+        llm,
+        observation_name="generate-answer",
+        model=config.llm_model,
+        messages=llm_messages,
+        temperature=config.llm_temperature,
+        max_tokens=effective_max_tokens,
+        stream=True,
+        stream_options={"include_usage": True},
+    )
+
     t_stream_start = time.monotonic()
     stream_only_ttft_ms: float | None = None
     try:
@@ -296,37 +261,36 @@ async def _generate_streaming(
                             )
                 accumulated += text
                 now = time.monotonic()
-                if sent_msg is not None and now - last_edit >= _STREAM_EDIT_INTERVAL:
+                if now - last_draft >= _DRAFT_INTERVAL:
                     with contextlib.suppress(Exception):
-                        await sent_msg.edit_text(accumulated)
-                    last_edit = now
+                        await bot.send_message_draft(
+                            chat_id=chat_id,
+                            draft_id=draft_id,
+                            text=accumulated,
+                        )
+                    last_draft = now
             if hasattr(chunk, "model") and chunk.model:
                 actual_model = chunk.model
     except Exception:
         if accumulated:
-            raise StreamingPartialDeliveryError(sent_msg, accumulated) from None
-        # No real content delivered — clean up placeholder
-        if sent_msg is not None:
+            sent_msg = None
             with contextlib.suppress(Exception):
-                await sent_msg.delete()
+                sent_msg = await message.answer(accumulated)
+            raise StreamingPartialDeliveryError(sent_msg, accumulated) from None
         raise
 
     if not accumulated:
-        # Stream produced no content — clean up placeholder
-        if sent_msg is not None:
-            with contextlib.suppress(Exception):
-                await sent_msg.delete()
         raise ValueError("Streaming produced empty response")
 
-    # Final edit with Markdown formatting
-    if sent_msg is not None:
+    # Final message — persisted in chat history
+    try:
+        sent_msg = await message.answer(accumulated, parse_mode="Markdown")
+    except Exception:
         try:
-            await sent_msg.edit_text(accumulated, parse_mode="Markdown")
+            sent_msg = await message.answer(accumulated)
         except Exception:
-            try:
-                await sent_msg.edit_text(accumulated)
-            except Exception:
-                logger.warning("Failed to finalize streaming message")
+            logger.warning("Failed to send final streaming message")
+            sent_msg = None
 
     return accumulated, actual_model, ttft_ms, completion_tokens, stream_only_ttft_ms, sent_msg
 

--- a/tests/unit/graph/nodes/test_generate.py
+++ b/tests/unit/graph/nodes/test_generate.py
@@ -1,12 +1,8 @@
-"""Tests for _generate_streaming parallelization in voice path (#685).
-
-Issue #685: parallelize placeholder send + LLM stream creation via asyncio.gather.
-"""
+"""Tests for _generate_streaming in voice path — native sendMessageDraft (Bot API 9.5)."""
 
 from __future__ import annotations
 
-import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -49,7 +45,6 @@ class _MockAsyncStream:
 
 def _make_mocks(
     chunks: list[str] | None = None,
-    placeholder_error: Exception | None = None,
     stream_error: Exception | None = None,
 ) -> tuple[MagicMock, MagicMock, AsyncMock, AsyncMock]:
     """Return (llm, config, message, sent_msg) mocks for _generate_streaming tests."""
@@ -57,14 +52,16 @@ def _make_mocks(
         chunks = ["Hello ", "world!"]
 
     mock_sent_msg = AsyncMock()
-    mock_sent_msg.edit_text = AsyncMock()
-    mock_sent_msg.delete = AsyncMock()
+    mock_sent_msg.chat = MagicMock(id=123)
+    mock_sent_msg.message_id = 456
+
+    mock_bot = AsyncMock()
+    mock_bot.send_message_draft = AsyncMock(return_value=True)
 
     mock_message = AsyncMock()
-    if placeholder_error is not None:
-        mock_message.answer = AsyncMock(side_effect=placeholder_error)
-    else:
-        mock_message.answer = AsyncMock(return_value=mock_sent_msg)
+    mock_message.chat = MagicMock(id=123)
+    mock_message.bot = mock_bot
+    mock_message.answer = AsyncMock(return_value=mock_sent_msg)
 
     mock_stream = _MockAsyncStream(chunks)
     mock_llm = MagicMock()
@@ -86,34 +83,9 @@ def _make_mocks(
 # ---------------------------------------------------------------------------
 
 
-async def test_placeholder_and_stream_parallel() -> None:
-    """asyncio.gather is called to run placeholder send and LLM stream concurrently."""
+async def test_streaming_uses_send_message_draft() -> None:
+    """Voice path streaming uses bot.send_message_draft instead of edit_text."""
     mock_llm, mock_config, mock_message, _ = _make_mocks()
-
-    with patch(
-        "telegram_bot.graph.nodes.generate.asyncio.gather", wraps=asyncio.gather
-    ) as mock_gather:
-        from telegram_bot.graph.nodes.generate import _generate_streaming
-
-        await _generate_streaming(
-            llm=mock_llm,
-            config=mock_config,
-            llm_messages=[{"role": "user", "content": "test"}],
-            message=mock_message,
-        )
-
-    assert mock_gather.called, "asyncio.gather must be used for parallel execution (#685)"
-    # gather should receive exactly 2 coroutines: LLM stream create + placeholder answer
-    args = mock_gather.call_args[0]
-    assert len(args) == 2, f"Expected 2 coroutines in gather, got {len(args)}"
-
-
-async def test_placeholder_failure_graceful_degradation() -> None:
-    """Placeholder send failure degrades gracefully: stream continues, sent_msg is None."""
-    mock_llm, mock_config, mock_message, _ = _make_mocks(
-        chunks=["Response text"],
-        placeholder_error=Exception("Telegram rate limit"),
-    )
 
     from telegram_bot.graph.nodes.generate import _generate_streaming
 
@@ -124,16 +96,14 @@ async def test_placeholder_failure_graceful_degradation() -> None:
         message=mock_message,
     )
 
-    response_text = result[0]
-    sent_msg = result[-1]
-
-    assert response_text == "Response text", "Stream response must still be returned"
-    assert sent_msg is None, "sent_msg must be None when placeholder fails (graceful degradation)"
+    assert result[0] == "Hello world!"
+    mock_message.bot.send_message_draft.assert_called()
+    mock_message.answer.assert_called_once()
 
 
 async def test_stream_failure_raises() -> None:
-    """LLM stream creation failure raises the exception and cleans up placeholder."""
-    mock_llm, mock_config, mock_message, mock_sent_msg = _make_mocks(
+    """LLM stream creation failure raises the exception."""
+    mock_llm, mock_config, mock_message, _ = _make_mocks(
         stream_error=ConnectionError("LLM unavailable"),
     )
 
@@ -146,9 +116,6 @@ async def test_stream_failure_raises() -> None:
             llm_messages=[{"role": "user", "content": "test"}],
             message=mock_message,
         )
-
-    # Placeholder must be cleaned up when stream creation fails (#685 safety)
-    mock_sent_msg.delete.assert_called_once()
 
 
 async def test_streaming_retries_without_name_kwarg_for_plain_openai() -> None:


### PR DESCRIPTION
## Summary

Tasks 3-4 of #744: replace edit-based streaming with native `sendMessageDraft` in `generate.py` (voice LangGraph path).

- **Task 3:** Replace `asyncio.gather(LLM, placeholder) + edit_text` with `bot.send_message_draft(draft_id, chunk)` every 200ms + `message.answer(final)` — voice path (`generate.py`)
- **Task 4:** Update `test_generate.py`: new `_make_mocks` with `bot.send_message_draft`, remove deleted `test_placeholder_*` tests, add `test_streaming_uses_send_message_draft`

## Changes

- `telegram_bot/graph/nodes/generate.py`: remove `asyncio`, `_STREAM_PLACEHOLDER`, `_STREAM_EDIT_INTERVAL`; add `_DRAFT_INTERVAL = 0.2`; rewrite `_generate_streaming`
- `tests/unit/graph/nodes/test_generate.py`: 3 tests (was 4), all pass

Closes #744

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>