### PR TITLE
feat(streaming): native sendMessageDraft in service layer

### DIFF
--- a/telegram_bot/services/generate_response.py
+++ b/telegram_bot/services/generate_response.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
 import hashlib
 import inspect
@@ -35,8 +34,7 @@ class StreamingPartialDeliveryError(Exception):
 
 
 _MAX_CONTEXT_DOCS = 3
-_STREAM_EDIT_INTERVAL = 0.5  # 500ms throttle for Telegram edit_text
-_STREAM_PLACEHOLDER = "⏳ Генерирую ответ..."
+_DRAFT_INTERVAL = 0.2  # 200ms — sendMessageDraft has no rate limit
 _MAX_HISTORY_MESSAGES = 12
 _detector = ResponseStyleDetector()
 _HISTORY_INSTRUCTION = (
@@ -229,9 +227,12 @@ async def _generate_streaming(
     max_tokens: int = 0,
     lf_client: Any | None = None,
 ) -> tuple[str, str, float, float | None, float | None, dict[str, int] | None, Any]:
-    """Stream LLM response directly to Telegram via message editing."""
+    """Stream LLM response to Telegram via native sendMessageDraft (Bot API 9.5).
+
+    Sends draft updates as chunks arrive, then finalizes with message.answer().
+    """
     accumulated = ""
-    last_edit = 0.0
+    last_draft = 0.0
     ttft_ms = 0.0
     actual_model = config.llm_model
     completion_tokens: float | None = None
@@ -239,48 +240,24 @@ async def _generate_streaming(
 
     effective_max_tokens = max_tokens if max_tokens > 0 else int(config.generate_max_tokens)
 
-    # Measure TTFT from before parallel dispatch (includes pre-stream provider wait).
+    chat_id = message.chat.id
+    bot = message.bot
+    draft_id = abs(hash(f"{chat_id}:{time.monotonic_ns()}")) % (2**31) or 1
+
     t_request_start = time.monotonic()
 
-    # Parallelize placeholder send + LLM stream creation to reduce TTFT drift (#675).
-    # return_exceptions=True ensures both tasks complete before results are inspected,
-    # preventing background LLM tasks from leaking on placeholder failure (#683).
-    # NOTE: message.answer() returns a SendMessage object (awaitable but not hashable),
-    # so we wrap it in a coroutine for asyncio.gather() compatibility (Python 3.12+).
-    async def _send_placeholder() -> Any:
-        return await message.answer(_STREAM_PLACEHOLDER)
-
-    gather_results = await asyncio.gather(
-        _send_placeholder(),
-        _chat_create_with_optional_name(
-            llm,
-            observation_name="generate-answer",
-            model=config.llm_model,
-            messages=llm_messages,
-            temperature=config.llm_temperature,
-            max_tokens=effective_max_tokens,
-            stream=True,
-            stream_options={"include_usage": True},
-            **config.get_reasoning_kwargs(),
-        ),
-        return_exceptions=True,
+    stream = await _chat_create_with_optional_name(
+        llm,
+        observation_name="generate-answer",
+        model=config.llm_model,
+        messages=llm_messages,
+        temperature=config.llm_temperature,
+        max_tokens=effective_max_tokens,
+        stream=True,
+        stream_options={"include_usage": True},
+        **config.get_reasoning_kwargs(),
     )
-    sent_msg, stream = gather_results[0], gather_results[1]
 
-    # Placeholder failure is non-critical: degrade gracefully (skip message edits).
-    if isinstance(sent_msg, BaseException):
-        logger.warning("Placeholder send failed, continuing without edit: %s", sent_msg)
-        sent_msg = None
-
-    # LLM stream failure is critical: clean up and propagate.
-    if isinstance(stream, BaseException):
-        if sent_msg is not None:
-            with contextlib.suppress(Exception):
-                await sent_msg.delete()
-        raise stream
-
-    # t_stream_start: when stream object is available (after parallel gather).
-    # Used for "stream-only TTFT" drift diagnostics.
     t_stream_start = time.monotonic()
     stream_only_ttft_ms: float | None = None
 
@@ -319,37 +296,37 @@ async def _generate_streaming(
                             )
                 accumulated += text
                 now = time.monotonic()
-                if sent_msg is not None and now - last_edit >= _STREAM_EDIT_INTERVAL:
+                if now - last_draft >= _DRAFT_INTERVAL:
                     with contextlib.suppress(Exception):
-                        await sent_msg.edit_text(accumulated)
-                    last_edit = now
+                        await bot.send_message_draft(
+                            chat_id=chat_id,
+                            draft_id=draft_id,
+                            text=accumulated,
+                        )
+                    last_draft = now
             if hasattr(chunk, "model") and chunk.model:
                 actual_model = chunk.model
     except Exception:
         if accumulated:
-            raise StreamingPartialDeliveryError(sent_msg, accumulated) from None
-        # No real content delivered — clean up placeholder
-        if sent_msg is not None:
+            # Draft showed partial text — try to finalize as real message
+            sent_msg = None
             with contextlib.suppress(Exception):
-                await sent_msg.delete()
+                sent_msg = await message.answer(accumulated)
+            raise StreamingPartialDeliveryError(sent_msg, accumulated) from None
         raise
 
     if not accumulated:
-        # Stream produced no content — clean up placeholder
-        if sent_msg is not None:
-            with contextlib.suppress(Exception):
-                await sent_msg.delete()
         raise ValueError("Streaming produced empty response")
 
-    # Final edit with Markdown formatting (only if placeholder was sent successfully)
-    if sent_msg is not None:
+    # Final message — persisted in chat history
+    try:
+        sent_msg = await message.answer(accumulated, parse_mode="Markdown")
+    except Exception:
         try:
-            await sent_msg.edit_text(accumulated, parse_mode="Markdown")
+            sent_msg = await message.answer(accumulated)
         except Exception:
-            try:
-                await sent_msg.edit_text(accumulated)
-            except Exception:
-                logger.warning("Failed to finalize streaming message")
+            logger.warning("Failed to send final streaming message")
+            sent_msg = None
 
     return (
         accumulated,
@@ -566,20 +543,19 @@ async def generate_response(
                         )
                     stream_recovery = True
                     delivered = False
-                    if sent_msg is not None:
+                    try:
+                        sent_msg = await message.answer(answer, parse_mode="Markdown")
+                        delivered = True
+                    except Exception:
                         try:
-                            await sent_msg.edit_text(answer, parse_mode="Markdown")
+                            sent_msg = await message.answer(answer)
                             delivered = True
                         except Exception:
-                            try:
-                                await sent_msg.edit_text(answer)
-                                delivered = True
-                            except Exception:
-                                logger.warning(
-                                    "Failed to deliver fallback edit after partial stream; "
-                                    "respond_node will send final answer",
-                                    exc_info=True,
-                                )
+                            logger.warning(
+                                "Failed to deliver fallback answer after partial stream; "
+                                "respond_node will send final answer",
+                                exc_info=True,
+                            )
                     response_sent = delivered
                 else:
                     logger.warning("Streaming failed, falling back to non-streaming", exc_info=True)

--- a/tests/unit/services/test_generate_response.py
+++ b/tests/unit/services/test_generate_response.py
@@ -166,11 +166,14 @@ async def test_generate_response_streaming_sets_response_sent_and_message_ref() 
     config.create_llm.return_value = client
 
     lf = MagicMock()
+    bot = AsyncMock()
+    bot.send_message_draft = AsyncMock(return_value=True)
     sent_msg = AsyncMock()
     sent_msg.chat = MagicMock(id=555)
     sent_msg.message_id = 777
-    sent_msg.edit_text = AsyncMock()
     message = AsyncMock()
+    message.chat = MagicMock(id=555)
+    message.bot = bot
     message.answer = AsyncMock(return_value=sent_msg)
 
     result = await generate_response(
@@ -202,11 +205,14 @@ async def test_generate_response_retries_without_name_kwarg_streaming() -> None:
     config.create_llm.return_value = client
 
     lf = MagicMock()
+    bot = AsyncMock()
+    bot.send_message_draft = AsyncMock(return_value=True)
     sent_msg = AsyncMock()
     sent_msg.chat = MagicMock(id=111)
     sent_msg.message_id = 222
-    sent_msg.edit_text = AsyncMock()
     message = AsyncMock()
+    message.chat = MagicMock(id=111)
+    message.bot = bot
     message.answer = AsyncMock(return_value=sent_msg)
 
     result = await generate_response(
@@ -242,11 +248,14 @@ async def test_generate_response_streaming_ttft_includes_pre_stream_wait() -> No
     config.create_llm.return_value = client
 
     lf = MagicMock()
+    bot = AsyncMock()
+    bot.send_message_draft = AsyncMock(return_value=True)
     sent_msg = AsyncMock()
     sent_msg.chat = MagicMock(id=555)
     sent_msg.message_id = 777
-    sent_msg.edit_text = AsyncMock()
     message = AsyncMock()
+    message.chat = MagicMock(id=555)
+    message.bot = bot
     message.answer = AsyncMock(return_value=sent_msg)
 
     result = await generate_response(
@@ -351,11 +360,14 @@ async def test_generate_response_streaming_updates_generation_usage_details() ->
     config.create_llm.return_value = client
 
     lf = MagicMock()
+    bot = AsyncMock()
+    bot.send_message_draft = AsyncMock(return_value=True)
     sent_msg = AsyncMock()
     sent_msg.chat = MagicMock(id=555)
     sent_msg.message_id = 777
-    sent_msg.edit_text = AsyncMock()
     message = AsyncMock()
+    message.chat = MagicMock(id=555)
+    message.bot = bot
     message.answer = AsyncMock(return_value=sent_msg)
 
     await generate_response(
@@ -468,11 +480,14 @@ async def test_streaming_reasoning_content_merged_into_response() -> None:
     config.create_llm.return_value = client
 
     lf = MagicMock()
+    bot = AsyncMock()
+    bot.send_message_draft = AsyncMock(return_value=True)
     sent_msg = AsyncMock()
     sent_msg.chat = MagicMock(id=100)
     sent_msg.message_id = 200
-    sent_msg.edit_text = AsyncMock()
     message = AsyncMock()
+    message.chat = MagicMock(id=100)
+    message.bot = bot
     message.answer = AsyncMock(return_value=sent_msg)
 
     result = await generate_response(
@@ -507,11 +522,14 @@ async def test_streaming_raw_reasoning_merged_into_response() -> None:
     config.create_llm.return_value = client
 
     lf = MagicMock()
+    bot = AsyncMock()
+    bot.send_message_draft = AsyncMock(return_value=True)
     sent_msg = AsyncMock()
     sent_msg.chat = MagicMock(id=100)
     sent_msg.message_id = 200
-    sent_msg.edit_text = AsyncMock()
     message = AsyncMock()
+    message.chat = MagicMock(id=100)
+    message.bot = bot
     message.answer = AsyncMock(return_value=sent_msg)
 
     result = await generate_response(
@@ -547,11 +565,14 @@ async def test_streaming_mixed_content_and_reasoning() -> None:
     config.create_llm.return_value = client
 
     lf = MagicMock()
+    bot = AsyncMock()
+    bot.send_message_draft = AsyncMock(return_value=True)
     sent_msg = AsyncMock()
     sent_msg.chat = MagicMock(id=100)
     sent_msg.message_id = 200
-    sent_msg.edit_text = AsyncMock()
     message = AsyncMock()
+    message.chat = MagicMock(id=100)
+    message.bot = bot
     message.answer = AsyncMock(return_value=sent_msg)
 
     result = await generate_response(
@@ -568,89 +589,43 @@ async def test_streaming_mixed_content_and_reasoning() -> None:
 
 
 @pytest.mark.asyncio
-async def test_streaming_placeholder_failure_degrades_gracefully() -> None:
-    """Placeholder failure → sent_msg=None, LLM stream still runs (#675, #683).
+async def test_streaming_answer_failure_degrades_gracefully() -> None:
+    """When final message.answer fails, stream still completes but response_sent=False.
 
-    With asyncio.gather(return_exceptions=True) both tasks complete before results
-    are inspected. Placeholder exception is non-critical: stream continues and
-    returns the response without Telegram message editing.
+    LLM stream runs, draft updates are sent via send_message_draft, but if the
+    final message.answer() to persist the message fails, the response is still
+    generated — downstream sender must deliver it.
     """
     config, client = _make_non_streaming_config()
     config.streaming_enabled = True
-    stream = _AsyncStream([_StreamChunk("Ответ несмотря на ошибку плейсхолдера")])
+    stream = _AsyncStream([_StreamChunk("Ответ несмотря на ошибку доставки")])
     client.chat.completions.create = AsyncMock(return_value=stream)
     config.create_llm.return_value = client
 
     lf = MagicMock()
+    bot = AsyncMock()
+    bot.send_message_draft = AsyncMock(return_value=True)
     message = AsyncMock()
+    message.chat = MagicMock(id=999)
+    message.bot = bot
     message.answer = AsyncMock(side_effect=RuntimeError("telegram send failed"))
 
     result = await generate_response(
-        query="Тест placeholder fail",
+        query="Тест ошибки доставки",
         documents=[{"text": "Контекст", "score": 0.8, "metadata": {}}],
         config=config,
         lf_client=lf,
         message=message,
-        raw_messages=[{"role": "user", "content": "Тест placeholder fail"}],
+        raw_messages=[{"role": "user", "content": "Тест ошибки доставки"}],
     )
 
     # Stream ran successfully — no non-streaming recovery needed
-    assert result["response"] == "Ответ несмотря на ошибку плейсхолдера"
+    assert result["response"] == "Ответ несмотря на ошибку доставки"
     assert result["llm_stream_recovery"] is False
-    # Placeholder was never delivered, so downstream sender must deliver final response.
+    # Final message was never delivered, downstream sender must deliver it
     assert result["response_sent"] is False
     # LLM was called exactly once (streaming path, no separate fallback call)
     assert client.chat.completions.create.await_count == 1
-
-
-@pytest.mark.asyncio
-async def test_placeholder_and_stream_run_in_parallel() -> None:
-    """asyncio.gather used so message.answer and llm.create start simultaneously (#675).
-
-    Uses cross-waiting asyncio.Events: each task waits until the other has started.
-    Sequential execution would deadlock; parallel execution completes normally.
-    """
-    config, client = _make_non_streaming_config()
-    config.streaming_enabled = True
-
-    answer_started = asyncio.Event()
-    create_started = asyncio.Event()
-
-    sent_msg = AsyncMock()
-    sent_msg.chat = MagicMock(id=1)
-    sent_msg.message_id = 2
-    sent_msg.edit_text = AsyncMock()
-    stream = _AsyncStream([_StreamChunk("Параллельный ответ")])
-
-    async def parallel_answer(*_args: object, **_kwargs: object) -> AsyncMock:
-        answer_started.set()
-        await create_started.wait()
-        return sent_msg
-
-    async def parallel_create(*_args: object, **_kwargs: object) -> _AsyncStream:
-        create_started.set()
-        await answer_started.wait()
-        return stream
-
-    client.chat.completions.create = parallel_create
-    config.create_llm.return_value = client
-
-    lf = MagicMock()
-    message = AsyncMock()
-    message.answer = parallel_answer
-
-    result = await generate_response(
-        query="Тест параллелизма",
-        documents=[{"text": "Контекст", "score": 0.7, "metadata": {}}],
-        config=config,
-        lf_client=lf,
-        message=message,
-        raw_messages=[{"role": "user", "content": "Тест параллелизма"}],
-    )
-
-    assert result["response"] == "Параллельный ответ"
-    assert answer_started.is_set()
-    assert create_started.is_set()
 
 
 @pytest.mark.asyncio
@@ -669,9 +644,15 @@ async def test_stream_failure_raises_and_triggers_fallback() -> None:
     )
     config.create_llm.return_value = client
 
-    sent_msg = AsyncMock()
     lf = MagicMock()
+    bot = AsyncMock()
+    bot.send_message_draft = AsyncMock(return_value=True)
+    sent_msg = AsyncMock()
+    sent_msg.chat = MagicMock(id=1)
+    sent_msg.message_id = 2
     message = AsyncMock()
+    message.chat = MagicMock(id=1)
+    message.bot = bot
     message.answer = AsyncMock(return_value=sent_msg)
 
     result = await generate_response(
@@ -715,11 +696,14 @@ async def test_ttft_drift_warn_ms_config() -> None:
     config.create_llm.return_value = client
 
     lf = MagicMock()
+    bot = AsyncMock()
+    bot.send_message_draft = AsyncMock(return_value=True)
     sent_msg = AsyncMock()
     sent_msg.chat = MagicMock(id=1)
     sent_msg.message_id = 2
-    sent_msg.edit_text = AsyncMock()
     message = AsyncMock()
+    message.chat = MagicMock(id=1)
+    message.bot = bot
     message.answer = AsyncMock(return_value=sent_msg)
 
     await generate_response(
@@ -738,3 +722,45 @@ async def test_ttft_drift_warn_ms_config() -> None:
         and "TTFT drift" in (c.kwargs.get("status_message") or "")
     ]
     assert len(warning_calls) >= 1
+
+
+@pytest.mark.asyncio
+async def test_streaming_uses_send_message_draft() -> None:
+    """Streaming path uses bot.send_message_draft instead of edit_text."""
+    config, client = _make_non_streaming_config()
+    config.streaming_enabled = True
+    stream = _AsyncStream([_StreamChunk("Часть 1 "), _StreamChunk("Часть 2")])
+    client.chat.completions.create = AsyncMock(return_value=stream)
+    config.create_llm.return_value = client
+
+    lf = MagicMock()
+    bot = AsyncMock()
+    bot.send_message_draft = AsyncMock(return_value=True)
+
+    sent_msg = AsyncMock()
+    sent_msg.chat = MagicMock(id=555)
+    sent_msg.message_id = 777
+
+    message = AsyncMock()
+    message.chat = MagicMock(id=555)
+    message.bot = bot
+    message.answer = AsyncMock(return_value=sent_msg)
+
+    result = await generate_response(
+        query="Стриминг draft?",
+        documents=[{"text": "Контекст", "score": 0.7, "metadata": {}}],
+        config=config,
+        lf_client=lf,
+        message=message,
+        raw_messages=[{"role": "user", "content": "Стриминг draft?"}],
+    )
+
+    assert result["response"] == "Часть 1 Часть 2"
+    assert result["response_sent"] is True
+    assert result["sent_message"] == {"chat_id": 555, "message_id": 777}
+    # Должен вызвать send_message_draft, а НЕ edit_text
+    bot.send_message_draft.assert_called()
+    # Финальный ответ через message.answer (не edit_text)
+    message.answer.assert_called_once()
+    call_kwargs = message.answer.call_args
+    assert "Часть 1 Часть 2" in str(call_kwargs)


### PR DESCRIPTION
## Summary

Tasks 1-2 of #744: replace edit-based streaming with native `sendMessageDraft` (Bot API 9.5) in `generate_response.py`.

- **Task 1:** Rewrote `_generate_streaming` in `telegram_bot/services/generate_response.py`
  - Removed `asyncio.gather(placeholder, stream)` + `edit_text` pattern
  - Draft updates sent every 200ms via `bot.send_message_draft(chat_id, draft_id, text)`
  - Final message persisted via `message.answer()` (not `edit_text`)
  - Stream recovery updated: `message.answer()` instead of `sent_msg.edit_text()`
  - Removed unused `import asyncio`, `_STREAM_EDIT_INTERVAL`, `_STREAM_PLACEHOLDER`

- **Task 2:** Updated `tests/unit/services/test_generate_response.py`
  - Added `test_streaming_uses_send_message_draft` (TDD anchor test)
  - Updated all streaming mocks: `message.chat`, `message.bot.send_message_draft`
  - Removed `test_placeholder_and_stream_run_in_parallel` (parallel pattern removed)
  - Renamed `test_streaming_placeholder_failure_degrades_gracefully` → `test_streaming_answer_failure_degrades_gracefully`

## Test plan

- [x] `uv run pytest tests/unit/services/test_generate_response.py -v` — 20/20 passed
- [x] `ruff check` — clean
- [x] `ruff format` — no changes
- [x] pre-commit hooks passed on both commits

Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>