### PR TITLE
feat(langfuse): add LANGFUSE_TRACING_ENVIRONMENT support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,6 +111,8 @@ MAX_CONTEXT_TOKENS=8000
 LANGFUSE_PUBLIC_KEY=pk-lf-dev
 LANGFUSE_SECRET_KEY=sk-lf-dev
 LANGFUSE_HOST=http://localhost:3001
+# Isolate traces by environment in Langfuse UI (prod/staging/dev). Optional.
+# LANGFUSE_TRACING_ENVIRONMENT=staging
 
 # MLflow (optional - for experiment tracking)
 MLFLOW_TRACKING_URI=http://localhost:5000

--- a/telegram_bot/observability.py
+++ b/telegram_bot/observability.py
@@ -339,6 +339,9 @@ def initialize_langfuse(
     }
     if resolved_host:
         kwargs["host"] = resolved_host
+    tracing_env = os.environ.get("LANGFUSE_TRACING_ENVIRONMENT")
+    if tracing_env:
+        kwargs["environment"] = tracing_env
 
     try:
         _langfuse_client = Langfuse(**kwargs)

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -144,6 +144,46 @@ class TestLangfuseInitialization:
         sync.assert_called_once_with(fake_client)
 
 
+class TestLangfuseTracingEnvironment:
+    """Tests for LANGFUSE_TRACING_ENVIRONMENT support."""
+
+    def test_environment_passed_when_env_var_set(self, monkeypatch):
+        """When LANGFUSE_TRACING_ENVIRONMENT is set, it is forwarded to Langfuse(**kwargs)."""
+        import telegram_bot.observability as observability
+
+        monkeypatch.setenv("LANGFUSE_TRACING_ENVIRONMENT", "staging")
+        observability._reset_langfuse_client_for_tests()
+        fake_client = MagicMock()
+        with patch("telegram_bot.observability.Langfuse", return_value=fake_client) as mock_cls:
+            result = observability.initialize_langfuse(
+                public_key="pk-test",
+                secret_key="sk-test",
+                force=True,
+            )
+
+        assert result is fake_client
+        kwargs = mock_cls.call_args.kwargs
+        assert kwargs.get("environment") == "staging"
+
+    def test_environment_not_passed_when_env_var_absent(self, monkeypatch):
+        """When LANGFUSE_TRACING_ENVIRONMENT is unset, environment key is not in kwargs."""
+        import telegram_bot.observability as observability
+
+        monkeypatch.delenv("LANGFUSE_TRACING_ENVIRONMENT", raising=False)
+        observability._reset_langfuse_client_for_tests()
+        fake_client = MagicMock()
+        with patch("telegram_bot.observability.Langfuse", return_value=fake_client) as mock_cls:
+            result = observability.initialize_langfuse(
+                public_key="pk-test",
+                secret_key="sk-test",
+                force=True,
+            )
+
+        assert result is fake_client
+        kwargs = mock_cls.call_args.kwargs
+        assert "environment" not in kwargs
+
+
 class TestLangfuseModelSync:
     def test_load_model_definitions_from_env_parses_valid_payload(self, monkeypatch):
         import telegram_bot.observability as observability


### PR DESCRIPTION
## Summary
- Add LANGFUSE_TRACING_ENVIRONMENT env var for trace isolation (prod/staging/dev)
- Backward compatible: no env var = no change in behavior

## Test plan
- [x] Unit tests for both cases (with/without env var)
- [x] make check passes

Closes #751