### PR TITLE
feat(langfuse): externalize flush config + graceful shutdown

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,6 +113,9 @@ LANGFUSE_SECRET_KEY=sk-lf-dev
 LANGFUSE_HOST=http://localhost:3001
 # Isolate traces by environment in Langfuse UI (prod/staging/dev). Optional.
 # LANGFUSE_TRACING_ENVIRONMENT=staging
+# Flush config (defaults match Langfuse SDK: flush_at=512, flush_interval=5.0s). Optional.
+# LANGFUSE_FLUSH_AT=512
+# LANGFUSE_FLUSH_INTERVAL=5.0
 
 # MLflow (optional - for experiment tracking)
 MLFLOW_TRACKING_URI=http://localhost:5000

--- a/telegram_bot/observability.py
+++ b/telegram_bot/observability.py
@@ -8,6 +8,7 @@ Use `initialize_langfuse()` after loading runtime config (e.g. BotConfig) to
 ensure credentials from `.env`/environment are applied before first tracing.
 """
 
+import atexit
 import json
 import logging
 import os
@@ -334,8 +335,6 @@ def initialize_langfuse(
         "public_key": resolved_public_key,
         "secret_key": resolved_secret_key,
         "mask": mask_pii,  # type: ignore[arg-type]  # MaskFunction typing mismatch
-        "flush_at": 50,
-        "flush_interval": 5,
     }
     if resolved_host:
         kwargs["host"] = resolved_host
@@ -344,7 +343,10 @@ def initialize_langfuse(
         kwargs["environment"] = tracing_env
 
     try:
+        kwargs["flush_at"] = int(os.environ.get("LANGFUSE_FLUSH_AT", "512"))
+        kwargs["flush_interval"] = float(os.environ.get("LANGFUSE_FLUSH_INTERVAL", "5.0"))
         _langfuse_client = Langfuse(**kwargs)
+        atexit.register(_langfuse_client.shutdown)
         _langfuse_init_attempted = True
         synced = sync_langfuse_model_definitions(_langfuse_client)
         if synced > 0:

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -184,6 +184,118 @@ class TestLangfuseTracingEnvironment:
         assert "environment" not in kwargs
 
 
+class TestLangfuseFlushConfig:
+    """Tests for LANGFUSE_FLUSH_AT and LANGFUSE_FLUSH_INTERVAL env vars."""
+
+    def test_flush_at_from_env_var(self, monkeypatch):
+        """LANGFUSE_FLUSH_AT env var is passed as flush_at to Langfuse SDK."""
+        import telegram_bot.observability as observability
+
+        monkeypatch.setenv("LANGFUSE_FLUSH_AT", "25")
+        observability._reset_langfuse_client_for_tests()
+        fake_client = MagicMock()
+        with patch("telegram_bot.observability.Langfuse", return_value=fake_client) as mock_cls:
+            observability.initialize_langfuse(
+                public_key="pk-test",
+                secret_key="sk-test",
+                force=True,
+            )
+
+        kwargs = mock_cls.call_args.kwargs
+        assert kwargs["flush_at"] == 25
+
+    def test_flush_interval_from_env_var(self, monkeypatch):
+        """LANGFUSE_FLUSH_INTERVAL env var is passed as flush_interval to Langfuse SDK."""
+        import telegram_bot.observability as observability
+
+        monkeypatch.setenv("LANGFUSE_FLUSH_INTERVAL", "10.5")
+        observability._reset_langfuse_client_for_tests()
+        fake_client = MagicMock()
+        with patch("telegram_bot.observability.Langfuse", return_value=fake_client) as mock_cls:
+            observability.initialize_langfuse(
+                public_key="pk-test",
+                secret_key="sk-test",
+                force=True,
+            )
+
+        kwargs = mock_cls.call_args.kwargs
+        assert kwargs["flush_interval"] == 10.5
+
+    def test_flush_at_default_is_sdk_default(self, monkeypatch):
+        """When LANGFUSE_FLUSH_AT is not set, flush_at defaults to 512."""
+        import telegram_bot.observability as observability
+
+        monkeypatch.delenv("LANGFUSE_FLUSH_AT", raising=False)
+        observability._reset_langfuse_client_for_tests()
+        fake_client = MagicMock()
+        with patch("telegram_bot.observability.Langfuse", return_value=fake_client) as mock_cls:
+            observability.initialize_langfuse(
+                public_key="pk-test",
+                secret_key="sk-test",
+                force=True,
+            )
+
+        kwargs = mock_cls.call_args.kwargs
+        assert kwargs["flush_at"] == 512
+
+    def test_flush_interval_default_is_5_seconds(self, monkeypatch):
+        """When LANGFUSE_FLUSH_INTERVAL is not set, flush_interval defaults to 5.0."""
+        import telegram_bot.observability as observability
+
+        monkeypatch.delenv("LANGFUSE_FLUSH_INTERVAL", raising=False)
+        observability._reset_langfuse_client_for_tests()
+        fake_client = MagicMock()
+        with patch("telegram_bot.observability.Langfuse", return_value=fake_client) as mock_cls:
+            observability.initialize_langfuse(
+                public_key="pk-test",
+                secret_key="sk-test",
+                force=True,
+            )
+
+        kwargs = mock_cls.call_args.kwargs
+        assert kwargs["flush_interval"] == 5.0
+
+    def test_atexit_shutdown_registered_on_init(self, monkeypatch):
+        """atexit.register(langfuse.shutdown) is called when Langfuse initializes."""
+        import telegram_bot.observability as observability
+
+        monkeypatch.delenv("LANGFUSE_FLUSH_AT", raising=False)
+        monkeypatch.delenv("LANGFUSE_FLUSH_INTERVAL", raising=False)
+        observability._reset_langfuse_client_for_tests()
+        fake_client = MagicMock()
+        with (
+            patch("telegram_bot.observability.Langfuse", return_value=fake_client),
+            patch("telegram_bot.observability.atexit") as mock_atexit,
+        ):
+            observability.initialize_langfuse(
+                public_key="pk-test",
+                secret_key="sk-test",
+                force=True,
+            )
+
+        mock_atexit.register.assert_called_once_with(fake_client.shutdown)
+
+    def test_atexit_not_registered_when_init_fails(self, monkeypatch):
+        """atexit.register is NOT called when Langfuse init fails."""
+        import telegram_bot.observability as observability
+
+        monkeypatch.delenv("LANGFUSE_FLUSH_AT", raising=False)
+        monkeypatch.delenv("LANGFUSE_FLUSH_INTERVAL", raising=False)
+        observability._reset_langfuse_client_for_tests()
+        with (
+            patch("telegram_bot.observability.Langfuse", side_effect=RuntimeError("boom")),
+            patch("telegram_bot.observability.atexit") as mock_atexit,
+        ):
+            result = observability.initialize_langfuse(
+                public_key="pk-test",
+                secret_key="sk-test",
+                force=True,
+            )
+
+        assert result is None
+        mock_atexit.register.assert_not_called()
+
+
 class TestLangfuseModelSync:
     def test_load_model_definitions_from_env_parses_valid_payload(self, monkeypatch):
         import telegram_bot.observability as observability


### PR DESCRIPTION
## Summary
- Externalize flush_at/flush_interval to LANGFUSE_FLUSH_AT, LANGFUSE_FLUSH_INTERVAL env vars
- Add atexit.register(langfuse.shutdown) for graceful shutdown
- Defaults: flush_at=512 (SDK default), flush_interval=5.0s

## Test plan
- [x] Unit tests for flush config env vars (set/unset)
- [x] Unit tests for atexit registration (success/failure paths)
- [x] make check passes (ruff + mypy)
- [x] 25/25 test_observability.py tests pass

Closes #752