### PR TITLE
feat(langfuse): add score configs setup script

### DIFF
--- a/scripts/setup_score_configs.py
+++ b/scripts/setup_score_configs.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Setup Langfuse Score Configs for typed scoring (#753).
+
+Creates Score Configs in Langfuse for structured, typed scoring of RAG pipeline traces.
+Idempotent: checks existing configs before creating new ones.
+
+Usage:
+    uv run python -m scripts.setup_score_configs
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Any
+
+from dotenv import load_dotenv
+from langfuse import Langfuse
+from langfuse.api.resources.commons.types.config_category import ConfigCategory
+from langfuse.api.resources.commons.types.score_config_data_type import ScoreConfigDataType
+from langfuse.api.resources.score_configs.types.create_score_config_request import (
+    CreateScoreConfigRequest,
+)
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Score Config definitions
+# ---------------------------------------------------------------------------
+
+SCORE_CONFIGS: list[dict[str, Any]] = [
+    {
+        "name": "user_feedback",
+        "data_type": "NUMERIC",
+        "min_value": 0.0,
+        "max_value": 1.0,
+    },
+    {
+        "name": "user_feedback_reason",
+        "data_type": "CATEGORICAL",
+        "categories": [
+            {"label": "irrelevant", "value": 0},
+            {"label": "incomplete", "value": 1},
+            {"label": "incorrect", "value": 2},
+            {"label": "too_long", "value": 3},
+            {"label": "too_short", "value": 4},
+            {"label": "other", "value": 5},
+        ],
+    },
+    {
+        "name": "implicit_retry",
+        "data_type": "BOOLEAN",
+    },
+    {
+        "name": "judge_faithfulness",
+        "data_type": "NUMERIC",
+        "min_value": 0.0,
+        "max_value": 1.0,
+    },
+    {
+        "name": "judge_answer_relevance",
+        "data_type": "NUMERIC",
+        "min_value": 0.0,
+        "max_value": 1.0,
+    },
+    {
+        "name": "judge_context_relevance",
+        "data_type": "NUMERIC",
+        "min_value": 0.0,
+        "max_value": 1.0,
+    },
+    {
+        "name": "latency_total_ms",
+        "data_type": "NUMERIC",
+        "min_value": None,
+        "max_value": None,
+    },
+    {
+        "name": "confidence_score",
+        "data_type": "NUMERIC",
+        "min_value": 0.0,
+        "max_value": 1.0,
+    },
+]
+
+_DATA_TYPE_MAP = {
+    "NUMERIC": ScoreConfigDataType.NUMERIC,
+    "CATEGORICAL": ScoreConfigDataType.CATEGORICAL,
+    "BOOLEAN": ScoreConfigDataType.BOOLEAN,
+}
+
+
+def get_existing_configs(api: Any) -> dict[str, str]:
+    """Return {name: id} mapping for non-archived score configs."""
+    response = api.score_configs.list()
+    return {item.name: item.id for item in response.data if not item.is_archived}
+
+
+def setup_score_configs(api: Any) -> dict[str, str]:
+    """Create all required score configs. Skip configs that already exist.
+
+    Args:
+        api: Langfuse low-level API client (langfuse.api).
+
+    Returns:
+        Mapping of {config_name: config_id} for all required configs.
+    """
+    existing = get_existing_configs(api)
+    result: dict[str, str] = dict(existing)
+
+    for cfg in SCORE_CONFIGS:
+        name = cfg["name"]
+        if name in existing:
+            logger.info("Skipping existing config: %s (%s)", name, existing[name])
+            continue
+
+        data_type = _DATA_TYPE_MAP[cfg["data_type"]]
+
+        kwargs: dict[str, Any] = {"name": name, "data_type": data_type}
+
+        if cfg.get("min_value") is not None:
+            kwargs["min_value"] = cfg["min_value"]
+        if cfg.get("max_value") is not None:
+            kwargs["max_value"] = cfg["max_value"]
+
+        if cfg.get("categories"):
+            kwargs["categories"] = [
+                ConfigCategory(label=cat["label"], value=cat["value"]) for cat in cfg["categories"]
+            ]
+
+        created = api.score_configs.create(request=CreateScoreConfigRequest(**kwargs))
+        result[name] = created.id
+        logger.info("Created score config: %s (%s)", name, created.id)
+
+    return result
+
+
+def main() -> None:
+    load_dotenv()
+
+    try:
+        lf = Langfuse()
+    except Exception as e:
+        logger.error("Failed to initialize Langfuse client: %s", e)
+        sys.exit(1)
+
+    logger.info("Setting up Langfuse Score Configs...")
+    result = setup_score_configs(lf.api)
+
+    logger.info("Done. %d score config(s) ready:", len(result))
+    for name, config_id in sorted(result.items()):
+        logger.info("  %s → %s", name, config_id)
+
+    lf.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup_score_configs.py
+++ b/scripts/setup_score_configs.py
@@ -94,7 +94,7 @@ _DATA_TYPE_MAP = {
 
 def get_existing_configs(api: Any) -> dict[str, str]:
     """Return {name: id} mapping for non-archived score configs."""
-    response = api.score_configs.list()
+    response = api.score_configs.get()
     return {item.name: item.id for item in response.data if not item.is_archived}
 
 

--- a/tests/unit/test_setup_score_configs.py
+++ b/tests/unit/test_setup_score_configs.py
@@ -98,7 +98,7 @@ def test_get_existing_configs_returns_name_id_mapping():
     mock_item.is_archived = False
 
     mock_api = MagicMock()
-    mock_api.score_configs.list.return_value.data = [mock_item]
+    mock_api.score_configs.get.return_value.data = [mock_item]
 
     result = module.get_existing_configs(mock_api)
     assert result == {"user_feedback": "uuid-123"}
@@ -112,7 +112,7 @@ def test_get_existing_configs_excludes_archived():
     mock_item.is_archived = True
 
     mock_api = MagicMock()
-    mock_api.score_configs.list.return_value.data = [mock_item]
+    mock_api.score_configs.get.return_value.data = [mock_item]
 
     result = module.get_existing_configs(mock_api)
     assert result == {}
@@ -121,7 +121,7 @@ def test_get_existing_configs_excludes_archived():
 def test_get_existing_configs_empty_when_no_configs():
     module = _load_module()
     mock_api = MagicMock()
-    mock_api.score_configs.list.return_value.data = []
+    mock_api.score_configs.get.return_value.data = []
 
     result = module.get_existing_configs(mock_api)
     assert result == {}
@@ -133,7 +133,7 @@ def test_get_existing_configs_empty_when_no_configs():
 def test_setup_score_configs_creates_all_when_none_exist():
     module = _load_module()
     mock_api = MagicMock()
-    mock_api.score_configs.list.return_value.data = []
+    mock_api.score_configs.get.return_value.data = []
 
     created = MagicMock()
     created.id = "new-id"
@@ -156,7 +156,7 @@ def test_setup_score_configs_skips_existing():
         existing_data.append(item)
 
     mock_api = MagicMock()
-    mock_api.score_configs.list.return_value.data = existing_data
+    mock_api.score_configs.get.return_value.data = existing_data
 
     result = module.setup_score_configs(mock_api)
 
@@ -172,7 +172,7 @@ def test_setup_score_configs_creates_only_missing():
     existing.is_archived = False
 
     mock_api = MagicMock()
-    mock_api.score_configs.list.return_value.data = [existing]
+    mock_api.score_configs.get.return_value.data = [existing]
 
     created = MagicMock()
     created.id = "new-id"

--- a/tests/unit/test_setup_score_configs.py
+++ b/tests/unit/test_setup_score_configs.py
@@ -1,0 +1,184 @@
+"""Tests for scripts/setup_score_configs.py (TDD red-green-refactor)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+def _load_module():
+    """Load setup_score_configs as a module without executing main()."""
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / "setup_score_configs.py"
+    spec = importlib.util.spec_from_file_location("setup_score_configs", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---- SCORE_CONFIGS structure tests ----
+
+EXPECTED_CONFIG_NAMES = {
+    "user_feedback",
+    "user_feedback_reason",
+    "implicit_retry",
+    "judge_faithfulness",
+    "judge_answer_relevance",
+    "judge_context_relevance",
+    "latency_total_ms",
+    "confidence_score",
+}
+
+
+def test_score_configs_has_all_required_names():
+    module = _load_module()
+    names = {cfg["name"] for cfg in module.SCORE_CONFIGS}
+    assert names == EXPECTED_CONFIG_NAMES
+
+
+def test_user_feedback_is_numeric_0_to_1():
+    module = _load_module()
+    cfg = next(c for c in module.SCORE_CONFIGS if c["name"] == "user_feedback")
+    assert cfg["data_type"] == "NUMERIC"
+    assert cfg["min_value"] == 0.0
+    assert cfg["max_value"] == 1.0
+
+
+def test_user_feedback_reason_is_categorical_with_6_categories():
+    module = _load_module()
+    cfg = next(c for c in module.SCORE_CONFIGS if c["name"] == "user_feedback_reason")
+    assert cfg["data_type"] == "CATEGORICAL"
+    assert len(cfg["categories"]) == 6
+    for cat in cfg["categories"]:
+        assert "label" in cat
+        assert "value" in cat
+
+
+def test_implicit_retry_is_boolean():
+    module = _load_module()
+    cfg = next(c for c in module.SCORE_CONFIGS if c["name"] == "implicit_retry")
+    assert cfg["data_type"] == "BOOLEAN"
+
+
+def test_judge_scores_are_numeric_0_to_1():
+    module = _load_module()
+    judge_names = {"judge_faithfulness", "judge_answer_relevance", "judge_context_relevance"}
+    for cfg in module.SCORE_CONFIGS:
+        if cfg["name"] in judge_names:
+            assert cfg["data_type"] == "NUMERIC"
+            assert cfg["min_value"] == 0.0
+            assert cfg["max_value"] == 1.0
+
+
+def test_latency_total_ms_is_numeric_no_range():
+    module = _load_module()
+    cfg = next(c for c in module.SCORE_CONFIGS if c["name"] == "latency_total_ms")
+    assert cfg["data_type"] == "NUMERIC"
+    assert cfg.get("min_value") is None
+    assert cfg.get("max_value") is None
+
+
+def test_confidence_score_is_numeric_0_to_1():
+    module = _load_module()
+    cfg = next(c for c in module.SCORE_CONFIGS if c["name"] == "confidence_score")
+    assert cfg["data_type"] == "NUMERIC"
+    assert cfg["min_value"] == 0.0
+    assert cfg["max_value"] == 1.0
+
+
+# ---- get_existing_configs() tests ----
+
+
+def test_get_existing_configs_returns_name_id_mapping():
+    module = _load_module()
+    mock_item = MagicMock(spec=["name", "id", "is_archived"])
+    mock_item.name = "user_feedback"
+    mock_item.id = "uuid-123"
+    mock_item.is_archived = False
+
+    mock_api = MagicMock()
+    mock_api.score_configs.list.return_value.data = [mock_item]
+
+    result = module.get_existing_configs(mock_api)
+    assert result == {"user_feedback": "uuid-123"}
+
+
+def test_get_existing_configs_excludes_archived():
+    module = _load_module()
+    mock_item = MagicMock(spec=["name", "id", "is_archived"])
+    mock_item.name = "old_config"
+    mock_item.id = "uuid-old"
+    mock_item.is_archived = True
+
+    mock_api = MagicMock()
+    mock_api.score_configs.list.return_value.data = [mock_item]
+
+    result = module.get_existing_configs(mock_api)
+    assert result == {}
+
+
+def test_get_existing_configs_empty_when_no_configs():
+    module = _load_module()
+    mock_api = MagicMock()
+    mock_api.score_configs.list.return_value.data = []
+
+    result = module.get_existing_configs(mock_api)
+    assert result == {}
+
+
+# ---- setup_score_configs() tests ----
+
+
+def test_setup_score_configs_creates_all_when_none_exist():
+    module = _load_module()
+    mock_api = MagicMock()
+    mock_api.score_configs.list.return_value.data = []
+
+    created = MagicMock()
+    created.id = "new-id"
+    mock_api.score_configs.create.return_value = created
+
+    result = module.setup_score_configs(mock_api)
+
+    assert mock_api.score_configs.create.call_count == len(module.SCORE_CONFIGS)
+    assert len(result) == len(module.SCORE_CONFIGS)
+
+
+def test_setup_score_configs_skips_existing():
+    module = _load_module()
+    existing_data = []
+    for cfg in module.SCORE_CONFIGS:
+        item = MagicMock(spec=["name", "id", "is_archived"])
+        item.name = cfg["name"]
+        item.id = f"id-{cfg['name']}"
+        item.is_archived = False
+        existing_data.append(item)
+
+    mock_api = MagicMock()
+    mock_api.score_configs.list.return_value.data = existing_data
+
+    result = module.setup_score_configs(mock_api)
+
+    mock_api.score_configs.create.assert_not_called()
+    assert len(result) == len(module.SCORE_CONFIGS)
+
+
+def test_setup_score_configs_creates_only_missing():
+    module = _load_module()
+    existing = MagicMock(spec=["name", "id", "is_archived"])
+    existing.name = "user_feedback"
+    existing.id = "existing-id"
+    existing.is_archived = False
+
+    mock_api = MagicMock()
+    mock_api.score_configs.list.return_value.data = [existing]
+
+    created = MagicMock()
+    created.id = "new-id"
+    mock_api.score_configs.create.return_value = created
+
+    result = module.setup_score_configs(mock_api)
+
+    assert mock_api.score_configs.create.call_count == len(module.SCORE_CONFIGS) - 1
+    assert result["user_feedback"] == "existing-id"


### PR DESCRIPTION
## Summary
- Add scripts/setup_score_configs.py for creating typed Score Configs in Langfuse
- Covers: user_feedback, judge scores, latency, confidence, implicit_retry
- Idempotent: checks existing configs before creating

## Test plan
- [x] Unit tests mock Langfuse API calls
- [x] make check passes

Closes #753