### PR TITLE
fix(langfuse): fix dataset export bugs — field mapping, dedup, idempotency

### DIFF
--- a/scripts/eval/goldset_sync.py
+++ b/scripts/eval/goldset_sync.py
@@ -49,7 +49,7 @@ def sync_to_langfuse(
         langfuse.create_dataset_item(
             dataset_name=dataset_name,
             id=item_id,
-            input={"question": sample["question"]},
+            input={"query": sample["question"]},
             expected_output={"answer": sample["ground_truth"]},
             metadata={
                 "id": sample.get("id"),

--- a/scripts/eval/run_experiment.py
+++ b/scripts/eval/run_experiment.py
@@ -92,9 +92,7 @@ def build_rag_task(graph: Any) -> Any:
     """
 
     def task(*, item: Any, **kwargs: Any) -> dict[str, str]:
-        question = (
-            item.input.get("question", "") if isinstance(item.input, dict) else str(item.input)
-        )
+        question = item.input.get("query", "") if isinstance(item.input, dict) else str(item.input)
         result = asyncio.run(graph.ainvoke(_build_eval_state(question)))
         return {
             "answer": result.get("response", ""),

--- a/scripts/export_traces_to_dataset.py
+++ b/scripts/export_traces_to_dataset.py
@@ -89,7 +89,9 @@ def extract_item_data(
     if not answer:
         return None
 
-    # Extract retrieved context from node-retrieve observation
+    # Extract retrieved context from node-retrieve observation.
+    # node-retrieve writes eval_docs as a concatenated string
+    # (format: "[score] content\n\n[score] content"), not retrieved_context.
     context_parts: list[str] = []
     for obs in observations:
         if getattr(obs, "name", "") != "node-retrieve":
@@ -97,9 +99,9 @@ def extract_item_data(
         output = getattr(obs, "output", None)
         if not isinstance(output, dict):
             continue
-        for doc in output.get("retrieved_context", []):
-            if isinstance(doc, dict) and doc.get("content"):
-                context_parts.append(str(doc["content"]))
+        eval_docs = output.get("eval_docs", "")
+        if isinstance(eval_docs, str) and eval_docs:
+            context_parts.extend(part.strip() for part in eval_docs.split("\n\n") if part.strip())
 
     return {
         "query": query,
@@ -203,12 +205,16 @@ def export_to_langfuse(
 
     Returns count of items created.
     """
-    langfuse.create_dataset(name=dataset_name)
+    try:
+        langfuse.create_dataset(name=dataset_name)
+    except Exception:
+        logger.debug("Dataset '%s' already exists, reusing it", dataset_name)
     created = 0
 
     for item in items:
         langfuse.create_dataset_item(
             dataset_name=dataset_name,
+            id=item["trace_id"],
             input={"query": item["query"]},
             expected_output={"response": item["answer"]},
             source_trace_id=item["trace_id"],

--- a/tests/unit/test_dataset_export.py
+++ b/tests/unit/test_dataset_export.py
@@ -1,0 +1,257 @@
+"""Tests for dataset export bug fixes (#759).
+
+Covers:
+1. Field mapping: eval_docs (not retrieved_context) — line 100
+2. Deduplication: trace_id as item ID — lines 209-223
+3. Idempotent create: dataset creation error handling — line 206
+4. Key mismatch: query (not question) in goldset_sync — line 52
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from scripts.eval.goldset_sync import sync_to_langfuse
+from scripts.export_traces_to_dataset import (
+    export_to_langfuse,
+    extract_item_data,
+)
+
+
+def _make_trace(
+    trace_id: str = "trace-1",
+    query: str = "test query",
+    answer: str = "test answer",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=trace_id,
+        input={"query": query} if query else {},
+        output={"response": answer} if answer else {},
+        scores=[],
+    )
+
+
+def _make_observation(name: str = "node-retrieve", output: dict | None = None) -> SimpleNamespace:
+    return SimpleNamespace(name=name, output=output)
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: Field mapping mismatch — eval_docs vs retrieved_context
+# ---------------------------------------------------------------------------
+
+
+class TestExtractItemDataEvalDocs:
+    def test_uses_eval_docs_field(self):
+        """Bug #759-1: node-retrieve writes eval_docs string, not retrieved_context list."""
+        trace = _make_trace()
+        obs = _make_observation(
+            name="node-retrieve",
+            output={"eval_docs": "[0.90] first document\n\n[0.80] second document"},
+        )
+        data = extract_item_data(trace, [obs])
+        assert data is not None
+        assert len(data["context"]) == 2
+
+    def test_retrieved_context_no_longer_used(self):
+        """Bug #759-1: old retrieved_context field must not populate context."""
+        trace = _make_trace()
+        obs = _make_observation(
+            name="node-retrieve",
+            output={"retrieved_context": [{"content": "legacy doc"}]},
+        )
+        data = extract_item_data(trace, [obs])
+        assert data is not None
+        assert data["context"] == []
+
+    def test_empty_eval_docs_yields_empty_context(self):
+        """Empty eval_docs string gives empty context list."""
+        trace = _make_trace()
+        obs = _make_observation(name="node-retrieve", output={"eval_docs": ""})
+        data = extract_item_data(trace, [obs])
+        assert data is not None
+        assert data["context"] == []
+
+    def test_eval_docs_content_is_preserved(self):
+        """Context parts must contain the document text from eval_docs."""
+        trace = _make_trace()
+        obs = _make_observation(
+            name="node-retrieve",
+            output={"eval_docs": "[0.95] article about property\n\n[0.85] tax rules"},
+        )
+        data = extract_item_data(trace, [obs])
+        assert data is not None
+        assert any("property" in part for part in data["context"])
+        assert any("tax" in part for part in data["context"])
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: No deduplication — trace_id as item ID
+# ---------------------------------------------------------------------------
+
+
+class TestExportToLangfuseDeduplication:
+    def test_trace_id_used_as_item_id(self):
+        """Bug #759-2: trace_id must be passed as dataset item id for idempotency."""
+        langfuse = MagicMock()
+        items = [
+            {
+                "trace_id": "trace-abc",
+                "query": "q",
+                "answer": "a",
+                "context": [],
+                "scores": {},
+                "reasons": [],
+            }
+        ]
+        export_to_langfuse(langfuse, "ds", items)
+        call_kwargs = langfuse.create_dataset_item.call_args.kwargs
+        assert call_kwargs.get("id") == "trace-abc"
+
+    def test_each_item_uses_its_own_trace_id(self):
+        """Each exported item gets its trace_id as the dataset item id."""
+        langfuse = MagicMock()
+        items = [
+            {
+                "trace_id": "t1",
+                "query": "q1",
+                "answer": "a1",
+                "context": [],
+                "scores": {},
+                "reasons": [],
+            },
+            {
+                "trace_id": "t2",
+                "query": "q2",
+                "answer": "a2",
+                "context": [],
+                "scores": {},
+                "reasons": [],
+            },
+        ]
+        export_to_langfuse(langfuse, "ds", items)
+        calls = langfuse.create_dataset_item.call_args_list
+        ids = [c.kwargs.get("id") for c in calls]
+        assert "t1" in ids
+        assert "t2" in ids
+
+
+# ---------------------------------------------------------------------------
+# Bug 3: No idempotent create — handles existing dataset
+# ---------------------------------------------------------------------------
+
+
+class TestExportToLangfuseIdempotentCreate:
+    def test_does_not_raise_if_dataset_exists(self):
+        """Bug #759-3: create_dataset must not raise when dataset already exists."""
+        langfuse = MagicMock()
+        langfuse.create_dataset.side_effect = Exception("Dataset already exists")
+        items = [
+            {
+                "trace_id": "t1",
+                "query": "q",
+                "answer": "a",
+                "context": [],
+                "scores": {},
+                "reasons": [],
+            }
+        ]
+        # Must not raise
+        count = export_to_langfuse(langfuse, "existing-dataset", items)
+        assert count == 1
+
+    def test_still_creates_items_when_dataset_exists(self):
+        """Items are created even when dataset already existed."""
+        langfuse = MagicMock()
+        langfuse.create_dataset.side_effect = Exception("already exists")
+        items = [
+            {
+                "trace_id": "t1",
+                "query": "q",
+                "answer": "a",
+                "context": [],
+                "scores": {},
+                "reasons": [],
+            }
+        ]
+        export_to_langfuse(langfuse, "existing-dataset", items)
+        langfuse.create_dataset_item.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Bug 4: Key mismatch — query vs question in goldset_sync + run_experiment
+# ---------------------------------------------------------------------------
+
+
+class TestGoldsetSyncQueryKey:
+    def test_uses_query_key_not_question(self):
+        """Bug #759-4: goldset_sync must use 'query' key in input, not 'question'."""
+        langfuse = MagicMock()
+        langfuse.get_dataset.side_effect = Exception("not found")
+        samples = [
+            {"question": "What is X?", "ground_truth": "X is Y", "id": 1},
+        ]
+        sync_to_langfuse(langfuse, "test-dataset", samples)
+        call_kwargs = langfuse.create_dataset_item.call_args.kwargs
+        assert call_kwargs["input"] == {"query": "What is X?"}
+        assert "question" not in call_kwargs["input"]
+
+    def test_question_value_is_preserved_under_query_key(self):
+        """The question text is still accessible via the query key."""
+        langfuse = MagicMock()
+        langfuse.get_dataset.side_effect = Exception("not found")
+        samples = [
+            {"question": "How much tax?", "ground_truth": "10%", "id": 2},
+        ]
+        sync_to_langfuse(langfuse, "test-dataset", samples)
+        call_kwargs = langfuse.create_dataset_item.call_args.kwargs
+        assert call_kwargs["input"]["query"] == "How much tax?"
+
+
+# ---------------------------------------------------------------------------
+# Bug 4 (consumer): run_experiment reads 'query' key, not 'question'
+# ---------------------------------------------------------------------------
+
+
+class TestRunExperimentQueryKey:
+    def test_build_rag_task_reads_query_key(self):
+        """Bug #759-4: build_rag_task must read 'query' from item.input, not 'question'."""
+        from unittest.mock import patch
+
+        from scripts.eval.run_experiment import build_rag_task
+
+        with (
+            patch("scripts.eval.run_experiment._build_eval_state") as mock_state,
+            patch("scripts.eval.run_experiment.asyncio") as mock_asyncio,
+        ):
+            mock_state.return_value = {}
+            mock_asyncio.run.return_value = {"response": "ok", "retrieved_context": []}
+
+            task = build_rag_task(MagicMock())
+            item = MagicMock()
+            item.input = {"query": "tax question"}
+            task(item=item)
+
+            mock_state.assert_called_once_with("tax question")
+
+    def test_build_rag_task_does_not_read_question_key(self):
+        """When input has only 'question' (no 'query'), task passes empty string."""
+        from unittest.mock import patch
+
+        from scripts.eval.run_experiment import build_rag_task
+
+        with (
+            patch("scripts.eval.run_experiment._build_eval_state") as mock_state,
+            patch("scripts.eval.run_experiment.asyncio") as mock_asyncio,
+        ):
+            mock_state.return_value = {}
+            mock_asyncio.run.return_value = {"response": "ok", "retrieved_context": []}
+
+            task = build_rag_task(MagicMock())
+            item = MagicMock()
+            # Only old 'question' key, no 'query'
+            item.input = {"question": "legacy question key"}
+            task(item=item)
+
+            # 'question' key is not read; empty string is passed instead
+            mock_state.assert_called_once_with("")

--- a/tests/unit/test_export_traces_to_dataset.py
+++ b/tests/unit/test_export_traces_to_dataset.py
@@ -135,16 +135,14 @@ class TestExtractItemData:
         obs = _make_observation(
             name="node-retrieve",
             output={
-                "retrieved_context": [
-                    {"content": "doc1", "score": 0.9},
-                    {"content": "doc2", "score": 0.8},
-                ]
+                # node-retrieve writes eval_docs as a joined string, not retrieved_context
+                "eval_docs": "[0.90] doc1\n\n[0.80] doc2",
             },
         )
         data = extract_item_data(trace, [obs])
         assert data is not None
         assert len(data["context"]) == 2
-        assert "doc1" in data["context"]
+        assert any("doc1" in part for part in data["context"])
 
     def test_skips_non_retrieve_observations(self):
         trace = _make_trace()


### PR DESCRIPTION
## Summary
- Fix field mapping: `retrieved_context` → `eval_docs` (node-retrieve writes a joined string, not a list of dicts)
- Add deduplication: pass `id=trace_id` to `create_dataset_item` so re-runs upsert rather than duplicate
- Add idempotent dataset creation: wrap `create_dataset()` in try/except to handle existing datasets
- Fix key mismatch: `question` → `query` in both `goldset_sync.py` and consumer `run_experiment.py`

## Test plan
- [x] 12 new unit tests in `tests/unit/test_dataset_export.py` (TDD Red-Green verified)
- [x] Updated `test_export_traces_to_dataset.py` — old test used buggy `retrieved_context` field
- [x] 40/40 tests pass
- [x] `make check` passes (ruff + mypy)

Closes #759