### PR TITLE
feat(feedback): add 6-category dislike reason keyboard + 2-step flow

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -3293,8 +3293,12 @@ class PropertyBot:
         lf.score_current_trace(name="hitl_action", value=action, data_type="CATEGORICAL")
 
     async def handle_feedback(self, callback: CallbackQuery):
-        """Handle feedback button callback (#229)."""
-        from .feedback import build_feedback_confirmation, parse_feedback_callback
+        """Handle feedback button callback (#229, #755)."""
+        from .feedback import (
+            build_dislike_reason_keyboard,
+            build_feedback_confirmation,
+            parse_feedback_callback,
+        )
 
         data = callback.data or ""
 
@@ -3308,12 +3312,26 @@ class PropertyBot:
             await callback.answer()
             return
 
-        value, trace_id = parsed
+        value, trace_id, reason = parsed
         user_id = callback.from_user.id if callback.from_user else 0
 
+        # Step 1 — dislike without reason: show 6-button reason keyboard
+        if value == 0.0 and reason is None:
+            await callback.answer()
+            try:
+                msg = callback.message
+                if msg is not None and hasattr(msg, "edit_reply_markup"):
+                    await msg.edit_reply_markup(
+                        reply_markup=build_dislike_reason_keyboard(trace_id)
+                    )
+            except Exception:
+                logger.debug("Failed to show dislike reason keyboard", exc_info=True)
+            return
+
+        # Step 2 — reason selected: write user_feedback=0 + user_feedback_reason={category}
+        # Also handles like (value=1.0, reason=None) — single score path
         await callback.answer("Спасибо за отзыв!")
 
-        # Write score to Langfuse (direct client, not context-dependent)
         try:
             lf_client = get_langfuse_client()
             if lf_client is not None:
@@ -3325,6 +3343,15 @@ class PropertyBot:
                     comment=f"user_id:{user_id}",
                     score_id=f"{trace_id}-user_feedback",
                 )
+                if reason is not None:
+                    lf_client.create_score(
+                        trace_id=trace_id,
+                        name="user_feedback_reason",
+                        value=reason,
+                        data_type="CATEGORICAL",
+                        comment=f"user_id:{user_id}",
+                        score_id=f"{trace_id}-user_feedback_reason",
+                    )
         except Exception:
             logger.warning("Failed to write feedback score to Langfuse", exc_info=True)
 

--- a/telegram_bot/feedback.py
+++ b/telegram_bot/feedback.py
@@ -1,4 +1,4 @@
-"""User feedback utilities — inline keyboard builder and callback parser (#229)."""
+"""User feedback utilities — inline keyboard builder and callback parser (#229, #755)."""
 
 from __future__ import annotations
 
@@ -6,6 +6,26 @@ from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
 
 _FB_PREFIX = "fb:"
+
+# 6 dislike reason codes → full category names (#755)
+_REASON_CODES: dict[str, str] = {
+    "wt": "wrong_topic",
+    "mi": "missing_info",
+    "bs": "bad_sources",
+    "ha": "hallucination",
+    "ic": "incomplete",
+    "fm": "formatting",
+}
+
+# Button labels for dislike reasons (displayed to user)
+_REASON_LABELS: dict[str, str] = {
+    "wt": "🎯 Не по теме",
+    "mi": "🔍 Нет информации",
+    "bs": "📚 Плохие источники",
+    "ha": "🤥 Выдумал факты",
+    "ic": "📝 Неполный ответ",
+    "fm": "🎨 Плохой формат",
+}
 
 
 def build_feedback_keyboard(trace_id: str) -> InlineKeyboardMarkup:
@@ -26,6 +46,24 @@ def build_feedback_keyboard(trace_id: str) -> InlineKeyboardMarkup:
     )
 
 
+def build_dislike_reason_keyboard(trace_id: str) -> InlineKeyboardMarkup:
+    """Build inline keyboard with 6 dislike reason buttons (3 rows × 2) (#755)."""
+    # dict insertion order guaranteed in Python 3.7+; layout follows _REASON_CODES order
+    codes = list(_REASON_CODES.keys())
+    rows = []
+    for i in range(0, len(codes), 2):
+        row = []
+        for code in codes[i : i + 2]:
+            row.append(
+                InlineKeyboardButton(
+                    text=_REASON_LABELS[code],
+                    callback_data=f"{_FB_PREFIX}r:{code}:{trace_id}",
+                )
+            )
+        rows.append(row)
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
 def build_feedback_confirmation(*, liked: bool) -> InlineKeyboardMarkup:
     """Build single-button confirmation keyboard after feedback submitted."""
     emoji = "\u2705" if liked else "\U0001f4dd"
@@ -41,15 +79,31 @@ def build_feedback_confirmation(*, liked: bool) -> InlineKeyboardMarkup:
     )
 
 
-def parse_feedback_callback(data: str) -> tuple[float, str] | None:
+def parse_feedback_callback(data: str) -> tuple[float, str, str | None] | None:
     """Parse callback_data from feedback button.
 
-    Returns (value, trace_id) or None if not a feedback callback.
-    Format: fb:{0|1}:{trace_id}
+    Returns (value, trace_id, reason) or None if not a feedback callback.
+
+    Formats:
+      fb:{0|1}:{trace_id}          — initial like/dislike (reason=None)
+      fb:r:{code}:{trace_id}       — dislike reason selection (value=0.0)
     """
     if not data.startswith(_FB_PREFIX):
         return None
 
+    # Reason callback: fb:r:{code}:{trace_id}
+    if data.startswith(f"{_FB_PREFIX}r:"):
+        parts = data.split(":", 3)  # ["fb", "r", "code", "trace_id"]
+        if len(parts) != 4:
+            return None
+        code, trace_id = parts[2], parts[3]
+        if code not in _REASON_CODES:
+            return None
+        if not trace_id:
+            return None
+        return 0.0, trace_id, _REASON_CODES[code]
+
+    # Initial like/dislike callback: fb:{0|1}:{trace_id}
     parts = data.split(":", 2)  # ["fb", "0|1", "trace_id"]
     if len(parts) != 3:
         return None
@@ -60,4 +114,4 @@ def parse_feedback_callback(data: str) -> tuple[float, str] | None:
     if not trace_id:
         return None
 
-    return float(value_str), trace_id
+    return float(value_str), trace_id, None

--- a/tests/unit/test_feedback.py
+++ b/tests/unit/test_feedback.py
@@ -38,12 +38,12 @@ class TestParseFeedbackCallback:
     def test_parses_like(self):
         from telegram_bot.feedback import parse_feedback_callback
 
-        assert parse_feedback_callback("fb:1:abc123def456") == (1.0, "abc123def456")
+        assert parse_feedback_callback("fb:1:abc123def456") == (1.0, "abc123def456", None)
 
     def test_parses_dislike(self):
         from telegram_bot.feedback import parse_feedback_callback
 
-        assert parse_feedback_callback("fb:0:abc123def456") == (0.0, "abc123def456")
+        assert parse_feedback_callback("fb:0:abc123def456") == (0.0, "abc123def456", None)
 
     def test_invalid_prefix_returns_none(self):
         from telegram_bot.feedback import parse_feedback_callback

--- a/tests/unit/test_feedback_handler.py
+++ b/tests/unit/test_feedback_handler.py
@@ -1,4 +1,4 @@
-"""Tests for feedback callback_query handler (#229, #277)."""
+"""Tests for feedback callback_query handler (#229, #277, #755)."""
 
 from __future__ import annotations
 
@@ -11,15 +11,144 @@ class TestParseFeedbackIntegration:
     async def test_parses_like_callback(self):
         parsed = parse_feedback_callback("fb:1:abc123def456789012345678901234")
         assert parsed is not None
-        value, trace_id = parsed
+        value, trace_id, reason = parsed
         assert value == 1.0
         assert trace_id == "abc123def456789012345678901234"
+        assert reason is None
 
     async def test_invalid_callback_ignored(self):
         assert parse_feedback_callback("not_feedback") is None
 
     async def test_done_callback_returns_none(self):
         assert parse_feedback_callback("fb:done") is None
+
+
+class TestBuildDislikeReasonKeyboard:
+    """Tests for the 6-button dislike reason keyboard (#755)."""
+
+    def test_returns_3_rows_of_2_buttons(self):
+        from telegram_bot.feedback import build_dislike_reason_keyboard
+
+        kb = build_dislike_reason_keyboard("trace123abc")
+        assert len(kb.inline_keyboard) == 3
+        for row in kb.inline_keyboard:
+            assert len(row) == 2
+
+    def test_callback_data_starts_with_fb_r(self):
+        from telegram_bot.feedback import build_dislike_reason_keyboard
+
+        kb = build_dislike_reason_keyboard("trace123abc")
+        for row in kb.inline_keyboard:
+            for btn in row:
+                assert btn.callback_data is not None
+                assert btn.callback_data.startswith("fb:r:")
+
+    def test_all_6_reason_codes_present(self):
+        from telegram_bot.feedback import build_dislike_reason_keyboard
+
+        kb = build_dislike_reason_keyboard("trace123abc")
+        codes = set()
+        for row in kb.inline_keyboard:
+            for btn in row:
+                # format: fb:r:{code}:{trace_id}
+                parts = (btn.callback_data or "").split(":")
+                codes.add(parts[2])
+        assert codes == {"wt", "mi", "bs", "ha", "ic", "fm"}
+
+    def test_trace_id_encoded_in_callback(self):
+        from telegram_bot.feedback import build_dislike_reason_keyboard
+
+        trace_id = "my_trace_xyz"
+        kb = build_dislike_reason_keyboard(trace_id)
+        for row in kb.inline_keyboard:
+            for btn in row:
+                assert trace_id in (btn.callback_data or "")
+
+    def test_callback_within_64_bytes(self):
+        from telegram_bot.feedback import build_dislike_reason_keyboard
+
+        trace_id = "a" * 32  # max W3C Trace Context
+        kb = build_dislike_reason_keyboard(trace_id)
+        for row in kb.inline_keyboard:
+            for btn in row:
+                assert len((btn.callback_data or "").encode()) <= 64
+
+
+class TestParseFeedbackCallbackReasonPath:
+    """Tests for 3-tuple return and reason path parsing (#755)."""
+
+    def test_like_returns_3_tuple_with_none_reason(self):
+        from telegram_bot.feedback import parse_feedback_callback
+
+        result = parse_feedback_callback("fb:1:abc123")
+        assert result == (1.0, "abc123", None)
+
+    def test_dislike_returns_3_tuple_with_none_reason(self):
+        from telegram_bot.feedback import parse_feedback_callback
+
+        result = parse_feedback_callback("fb:0:abc123")
+        assert result == (0.0, "abc123", None)
+
+    def test_parses_reason_wrong_topic(self):
+        from telegram_bot.feedback import parse_feedback_callback
+
+        result = parse_feedback_callback("fb:r:wt:abc123")
+        assert result == (0.0, "abc123", "wrong_topic")
+
+    def test_parses_reason_missing_info(self):
+        from telegram_bot.feedback import parse_feedback_callback
+
+        result = parse_feedback_callback("fb:r:mi:abc123")
+        assert result == (0.0, "abc123", "missing_info")
+
+    def test_parses_reason_bad_sources(self):
+        from telegram_bot.feedback import parse_feedback_callback
+
+        result = parse_feedback_callback("fb:r:bs:abc123")
+        assert result == (0.0, "abc123", "bad_sources")
+
+    def test_parses_reason_hallucination(self):
+        from telegram_bot.feedback import parse_feedback_callback
+
+        result = parse_feedback_callback("fb:r:ha:abc123")
+        assert result == (0.0, "abc123", "hallucination")
+
+    def test_parses_reason_incomplete(self):
+        from telegram_bot.feedback import parse_feedback_callback
+
+        result = parse_feedback_callback("fb:r:ic:abc123")
+        assert result == (0.0, "abc123", "incomplete")
+
+    def test_parses_reason_formatting(self):
+        from telegram_bot.feedback import parse_feedback_callback
+
+        result = parse_feedback_callback("fb:r:fm:abc123")
+        assert result == (0.0, "abc123", "formatting")
+
+    def test_invalid_reason_code_returns_none(self):
+        from telegram_bot.feedback import parse_feedback_callback
+
+        assert parse_feedback_callback("fb:r:xx:abc123") is None
+
+    def test_missing_trace_in_reason_returns_none(self):
+        from telegram_bot.feedback import parse_feedback_callback
+
+        assert parse_feedback_callback("fb:r:wt:") is None
+
+    def test_invalid_prefix_returns_none(self):
+        from telegram_bot.feedback import parse_feedback_callback
+
+        assert parse_feedback_callback("other:data") is None
+
+    def test_invalid_value_returns_none(self):
+        from telegram_bot.feedback import parse_feedback_callback
+
+        assert parse_feedback_callback("fb:x:abc123") is None
+
+    def test_missing_trace_id_returns_none(self):
+        from telegram_bot.feedback import parse_feedback_callback
+
+        assert parse_feedback_callback("fb:1:") is None
 
 
 class TestHandleFeedbackLangfuse:
@@ -74,6 +203,173 @@ class TestHandleFeedbackLangfuse:
             await bot_instance.handle_feedback(callback)
 
         # Should complete without error — no create_score call
+        callback.answer.assert_awaited_once_with("Спасибо за отзыв!")
+
+
+class TestHandleFeedback2Step:
+    """Tests for the 2-step dislike flow (#755)."""
+
+    async def test_dislike_shows_reason_keyboard_not_score(self):
+        """fb:0:trace → show reason keyboard, NO score written."""
+        mock_lf = MagicMock()
+        callback = AsyncMock()
+        callback.data = "fb:0:trace123abc"
+        callback.from_user = MagicMock()
+        callback.from_user.id = 42
+        callback.message = AsyncMock()
+
+        from telegram_bot import bot as bot_module
+        from telegram_bot.bot import PropertyBot
+
+        with patch.object(bot_module, "get_langfuse_client", return_value=mock_lf):
+            bot_instance = MagicMock(spec=PropertyBot)
+            bot_instance.handle_feedback = PropertyBot.handle_feedback.__get__(
+                bot_instance, PropertyBot
+            )
+            await bot_instance.handle_feedback(callback)
+
+        mock_lf.create_score.assert_not_called()
+        callback.message.edit_reply_markup.assert_awaited_once()
+        called_markup = callback.message.edit_reply_markup.call_args.kwargs["reply_markup"]
+        # Reason keyboard: 3 rows × 2 buttons
+        assert len(called_markup.inline_keyboard) == 3
+
+    async def test_dislike_answers_callback(self):
+        """fb:0:trace → callback.answer() is called."""
+        callback = AsyncMock()
+        callback.data = "fb:0:trace123abc"
+        callback.from_user = MagicMock()
+        callback.from_user.id = 42
+        callback.message = AsyncMock()
+
+        from telegram_bot import bot as bot_module
+        from telegram_bot.bot import PropertyBot
+
+        with patch.object(bot_module, "get_langfuse_client", return_value=None):
+            bot_instance = MagicMock(spec=PropertyBot)
+            bot_instance.handle_feedback = PropertyBot.handle_feedback.__get__(
+                bot_instance, PropertyBot
+            )
+            await bot_instance.handle_feedback(callback)
+
+        callback.answer.assert_awaited_once()
+
+    async def test_reason_selected_writes_two_scores(self):
+        """fb:r:wt:trace → create_score called twice: user_feedback + user_feedback_reason."""
+        mock_lf = MagicMock()
+        callback = AsyncMock()
+        callback.data = "fb:r:wt:trace123abc"
+        callback.from_user = MagicMock()
+        callback.from_user.id = 42
+        callback.message = AsyncMock()
+
+        from telegram_bot import bot as bot_module
+        from telegram_bot.bot import PropertyBot
+
+        with patch.object(bot_module, "get_langfuse_client", return_value=mock_lf):
+            bot_instance = MagicMock(spec=PropertyBot)
+            bot_instance.handle_feedback = PropertyBot.handle_feedback.__get__(
+                bot_instance, PropertyBot
+            )
+            await bot_instance.handle_feedback(callback)
+
+        assert mock_lf.create_score.call_count == 2
+        score_names = {c.kwargs["name"] for c in mock_lf.create_score.call_args_list}
+        assert "user_feedback" in score_names
+        assert "user_feedback_reason" in score_names
+
+    async def test_reason_score_values_correct(self):
+        """fb:r:ha:trace → user_feedback=0 NUMERIC + user_feedback_reason='hallucination' CATEGORICAL."""
+        mock_lf = MagicMock()
+        callback = AsyncMock()
+        callback.data = "fb:r:ha:trace123abc"
+        callback.from_user = MagicMock()
+        callback.from_user.id = 42
+        callback.message = AsyncMock()
+
+        from telegram_bot import bot as bot_module
+        from telegram_bot.bot import PropertyBot
+
+        with patch.object(bot_module, "get_langfuse_client", return_value=mock_lf):
+            bot_instance = MagicMock(spec=PropertyBot)
+            bot_instance.handle_feedback = PropertyBot.handle_feedback.__get__(
+                bot_instance, PropertyBot
+            )
+            await bot_instance.handle_feedback(callback)
+
+        calls_by_name = {c.kwargs["name"]: c for c in mock_lf.create_score.call_args_list}
+        assert calls_by_name["user_feedback"].kwargs["value"] == 0.0
+        assert calls_by_name["user_feedback"].kwargs["data_type"] == "NUMERIC"
+        assert calls_by_name["user_feedback_reason"].kwargs["value"] == "hallucination"
+        assert calls_by_name["user_feedback_reason"].kwargs["data_type"] == "CATEGORICAL"
+
+    async def test_reason_score_idempotency_ids(self):
+        """fb:r:fm:trace → both scores have stable score_id."""
+        mock_lf = MagicMock()
+        callback = AsyncMock()
+        callback.data = "fb:r:fm:trace123abc"
+        callback.from_user = MagicMock()
+        callback.from_user.id = 42
+        callback.message = AsyncMock()
+
+        from telegram_bot import bot as bot_module
+        from telegram_bot.bot import PropertyBot
+
+        with patch.object(bot_module, "get_langfuse_client", return_value=mock_lf):
+            bot_instance = MagicMock(spec=PropertyBot)
+            bot_instance.handle_feedback = PropertyBot.handle_feedback.__get__(
+                bot_instance, PropertyBot
+            )
+            await bot_instance.handle_feedback(callback)
+
+        calls_by_name = {c.kwargs["name"]: c for c in mock_lf.create_score.call_args_list}
+        assert calls_by_name["user_feedback"].kwargs["score_id"] == "trace123abc-user_feedback"
+        assert (
+            calls_by_name["user_feedback_reason"].kwargs["score_id"]
+            == "trace123abc-user_feedback_reason"
+        )
+
+    async def test_reason_selected_shows_confirmation_keyboard(self):
+        """fb:r:fm:trace → edit_reply_markup with 1-button confirmation."""
+        callback = AsyncMock()
+        callback.data = "fb:r:fm:trace123abc"
+        callback.from_user = MagicMock()
+        callback.from_user.id = 42
+        callback.message = AsyncMock()
+
+        from telegram_bot import bot as bot_module
+        from telegram_bot.bot import PropertyBot
+
+        with patch.object(bot_module, "get_langfuse_client", return_value=None):
+            bot_instance = MagicMock(spec=PropertyBot)
+            bot_instance.handle_feedback = PropertyBot.handle_feedback.__get__(
+                bot_instance, PropertyBot
+            )
+            await bot_instance.handle_feedback(callback)
+
+        callback.message.edit_reply_markup.assert_awaited_once()
+        called_markup = callback.message.edit_reply_markup.call_args.kwargs["reply_markup"]
+        # Confirmation: 1 row × 1 button
+        assert len(called_markup.inline_keyboard) == 1
+
+    async def test_reason_selected_answers_thanks(self):
+        """fb:r:*:trace → callback.answer called with thanks message."""
+        callback = AsyncMock()
+        callback.data = "fb:r:ic:trace123abc"
+        callback.from_user = MagicMock()
+        callback.from_user.id = 42
+        callback.message = AsyncMock()
+
+        from telegram_bot import bot as bot_module
+        from telegram_bot.bot import PropertyBot
+
+        with patch.object(bot_module, "get_langfuse_client", return_value=None):
+            bot_instance = MagicMock(spec=PropertyBot)
+            bot_instance.handle_feedback = PropertyBot.handle_feedback.__get__(
+                bot_instance, PropertyBot
+            )
+            await bot_instance.handle_feedback(callback)
+
         callback.answer.assert_awaited_once_with("Спасибо за отзыв!")
 
 


### PR DESCRIPTION
## Summary
- Extend feedback from simple thumbs up/down to 2-step flow with 6 dislike reasons
- Categories: wrong_topic, missing_info, bad_sources, hallucination, incomplete, formatting
- Backward compatible with legacy fb:0:trace_id callbacks

## Test plan
- [x] Unit tests for all feedback paths (43 tests)
- [x] make check passes

Closes #755