### PR TITLE
feat(langfuse): add hourly alert script + morning digest

### DIFF
--- a/scripts/langfuse_alert.py
+++ b/scripts/langfuse_alert.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python3
+"""Langfuse alert script: hourly Tier-1 alerts + morning digest (#758).
+
+Modes:
+  --mode hourly   Check last hour: dislike rate > 15%, faithfulness < 0.5 → Telegram alert
+  --mode digest   Morning summary: dislike rate, latency p95, cache hit rate, top reasons
+
+Alerting Tiers:
+  Tier 1 — Immediate: dislike rate > 15%/hour (min 20 samples)
+  Tier 1 — Immediate: judge_faithfulness < 0.5/hour
+  Tier 2 — Daily trends: morning digest
+
+Usage:
+    uv run python -m scripts.langfuse_alert --mode hourly
+    uv run python -m scripts.langfuse_alert --mode digest
+    uv run python -m scripts.langfuse_alert --mode hourly --hours 1
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import logging
+import os
+import sys
+from collections import Counter
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import httpx
+from dotenv import load_dotenv
+from langfuse import Langfuse
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Alert thresholds
+# ---------------------------------------------------------------------------
+
+DISLIKE_RATE_THRESHOLD = 0.15  # Tier 1: > 15% dislike
+FAITHFULNESS_THRESHOLD = 0.5  # Tier 1: < 0.5 faithfulness
+MIN_SAMPLES = 20  # Minimum samples required before triggering
+
+# ---------------------------------------------------------------------------
+# Metrics query helpers
+# ---------------------------------------------------------------------------
+
+
+def build_metrics_query(
+    score_name: str,
+    from_ts: str,
+    to_ts: str,
+    aggregations: list[str] | None = None,
+) -> str:
+    """Build Langfuse Metrics API JSON query for a single score.
+
+    Args:
+        score_name: Langfuse score name (e.g. "user_feedback").
+        from_ts: ISO8601 start timestamp.
+        to_ts: ISO8601 end timestamp.
+        aggregations: List of aggregations (default: ["avg", "p95", "count"]).
+
+    Returns:
+        JSON string suitable for lf.api.metrics.metrics(query=...).
+    """
+    if aggregations is None:
+        aggregations = ["avg", "p95", "count"]
+
+    metrics: list[dict[str, str]] = []
+    for agg in aggregations:
+        if agg == "count":
+            metrics.append({"measure": "count", "aggregation": "count"})
+        else:
+            metrics.append({"measure": "value", "aggregation": agg})
+
+    query = {
+        "view": "scores-numeric",
+        "metrics": metrics,
+        "dimensions": [],
+        "filters": [
+            {"column": "name", "operator": "=", "value": score_name, "type": "string"},
+        ],
+        "fromTimestamp": from_ts,
+        "toTimestamp": to_ts,
+    }
+    return json.dumps(query)
+
+
+def query_score_metrics(
+    lf: Langfuse,
+    score_name: str,
+    from_ts: str,
+    to_ts: str,
+    aggregations: list[str] | None = None,
+) -> dict[str, Any]:
+    """Query Langfuse Metrics API for a single score's aggregates.
+
+    Returns:
+        Dict with keys like "value_avg", "value_p95", "count_count".
+        Empty dict on error or no data.
+    """
+    query_str = build_metrics_query(score_name, from_ts, to_ts, aggregations)
+    try:
+        result = lf.api.metrics.metrics(query=query_str)
+        data = getattr(result, "data", [])
+        if data:
+            row = data[0]
+            parsed: dict[str, Any] = {}
+            if hasattr(row, "__dict__"):
+                for key, val in row.__dict__.items():
+                    if val is not None:
+                        try:
+                            parsed[key] = float(val)
+                        except (TypeError, ValueError):
+                            parsed[key] = val
+            elif isinstance(row, dict):
+                for k, v in row.items():
+                    if v is not None:
+                        try:
+                            parsed[k] = float(v)
+                        except (TypeError, ValueError):
+                            parsed[k] = v
+            return parsed
+        return {}
+    except Exception as e:
+        logger.warning("Metrics API query failed for %s: %s", score_name, e)
+        return {}
+
+
+def get_top_dislike_reasons(
+    api: Any,
+    from_ts: str,
+    to_ts: str,
+    top_n: int = 5,
+) -> list[tuple[str, int]]:
+    """Fetch top dislike reasons from user_feedback_reason categorical scores.
+
+    Args:
+        api: Langfuse low-level API client (langfuse.api).
+        from_ts: ISO8601 start timestamp.
+        to_ts: ISO8601 end timestamp.
+        top_n: Number of top reasons to return.
+
+    Returns:
+        List of (reason_label, count) sorted by count descending.
+    """
+    try:
+        response = api.scores.get(
+            name="user_feedback_reason",
+            from_timestamp=from_ts,
+            to_timestamp=to_ts,
+        )
+        scores = getattr(response, "data", [])
+        counter: Counter[str] = Counter()
+        for score in scores:
+            label = getattr(score, "string_value", None)
+            if label:
+                counter[label] += 1
+        return counter.most_common(top_n)
+    except Exception as e:
+        logger.warning("Failed to fetch dislike reasons: %s", e)
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Dislike rate computation
+# ---------------------------------------------------------------------------
+
+
+def compute_dislike_rate(metrics: dict[str, Any]) -> tuple[float, int]:
+    """Compute dislike rate from user_feedback score metrics.
+
+    user_feedback: 0.0 = dislike, 1.0 = like.
+    dislike_rate = 1.0 - avg_like.
+
+    Args:
+        metrics: Dict from query_score_metrics with keys like "value_avg", "count_count".
+
+    Returns:
+        (dislike_rate, total_count). Returns (0.0, 0) if no data.
+    """
+    avg_like = metrics.get("value_avg")
+    raw_count = metrics.get("count_count", 0)
+    count = int(raw_count) if raw_count else 0
+
+    if avg_like is None or count == 0:
+        return 0.0, 0
+
+    return 1.0 - float(avg_like), count
+
+
+# ---------------------------------------------------------------------------
+# Alert checking
+# ---------------------------------------------------------------------------
+
+
+def check_hourly_alerts(
+    user_feedback_metrics: dict[str, Any],
+    faithfulness_metrics: dict[str, Any],
+    *,
+    dislike_threshold: float = DISLIKE_RATE_THRESHOLD,
+    min_samples: int = MIN_SAMPLES,
+    faithfulness_threshold: float = FAITHFULNESS_THRESHOLD,
+) -> list[dict[str, Any]]:
+    """Check hourly metrics against Tier-1 alert thresholds.
+
+    Args:
+        user_feedback_metrics: Metrics dict for "user_feedback" score.
+        faithfulness_metrics: Metrics dict for "judge_faithfulness" score.
+        dislike_threshold: Dislike rate threshold (default 0.15 = 15%).
+        min_samples: Minimum feedback samples required (default 20).
+        faithfulness_threshold: Faithfulness score threshold (default 0.5).
+
+    Returns:
+        List of fired alert dicts. Empty list if all metrics are healthy.
+    """
+    alerts: list[dict[str, Any]] = []
+
+    # Tier 1: Dislike rate
+    dislike_rate, count = compute_dislike_rate(user_feedback_metrics)
+    if count >= min_samples and dislike_rate > dislike_threshold:
+        alerts.append(
+            {
+                "tier": 1,
+                "type": "dislike_rate",
+                "value": dislike_rate,
+                "threshold": dislike_threshold,
+                "count": count,
+            }
+        )
+
+    # Tier 1: Faithfulness
+    faith_avg = faithfulness_metrics.get("value_avg")
+    faith_raw = faithfulness_metrics.get("count_count", 0)
+    faith_count = int(faith_raw) if faith_raw else 0
+    if (
+        faith_avg is not None
+        and faith_count >= min_samples
+        and float(faith_avg) < faithfulness_threshold
+    ):
+        alerts.append(
+            {
+                "tier": 1,
+                "type": "judge_faithfulness",
+                "value": float(faith_avg),
+                "threshold": faithfulness_threshold,
+                "count": faith_count,
+            }
+        )
+
+    return alerts
+
+
+# ---------------------------------------------------------------------------
+# Message formatting
+# ---------------------------------------------------------------------------
+
+
+def format_alert_message(alert: dict[str, Any]) -> str:
+    """Format a Tier-1 Telegram alert message.
+
+    Args:
+        alert: Alert dict from check_hourly_alerts().
+
+    Returns:
+        Formatted alert message string.
+    """
+    alert_type = alert.get("type", "unknown")
+    value = alert.get("value", 0.0)
+    threshold = alert.get("threshold", 0.0)
+    count = alert.get("count", 0)
+
+    if alert_type == "dislike_rate":
+        return (
+            f"🚨 ALERT Tier 1: High dislike rate\n"
+            f"Dislike rate: {value:.0%} (threshold: {threshold:.0%})\n"
+            f"Samples: {count}\n"
+            f"Action: Review recent responses for quality issues."
+        )
+    if alert_type == "judge_faithfulness":
+        return (
+            f"🚨 ALERT Tier 1: Low faithfulness score\n"
+            f"judge_faithfulness avg: {value:.2f} (threshold: {threshold})\n"
+            f"Samples: {count}\n"
+            f"Action: Check for hallucinations in recent answers."
+        )
+    return (
+        f"🚨 ALERT Tier 1: {alert_type}\n"
+        f"Value: {value:.3f} (threshold: {threshold})\n"
+        f"Samples: {count}"
+    )
+
+
+def format_digest_message(
+    user_feedback_metrics: dict[str, Any],
+    faithfulness_metrics: dict[str, Any],
+    latency_metrics: dict[str, Any],
+    cache_metrics: dict[str, Any],
+    top_reasons: list[tuple[str, int]],
+) -> str:
+    """Format daily digest Telegram message.
+
+    Args:
+        user_feedback_metrics: Metrics dict for "user_feedback" score.
+        faithfulness_metrics: Metrics dict for "judge_faithfulness" score.
+        latency_metrics: Metrics dict for "latency_total_ms" score.
+        cache_metrics: Metrics dict for "semantic_cache_hit" score.
+        top_reasons: List of (reason_label, count) from get_top_dislike_reasons().
+
+    Returns:
+        Formatted digest message string.
+    """
+    dislike_rate, feedback_count = compute_dislike_rate(user_feedback_metrics)
+    faith_avg = faithfulness_metrics.get("value_avg")
+    latency_p95 = latency_metrics.get("value_p95")
+    cache_hit_rate = cache_metrics.get("value_avg")
+
+    lines = [
+        "📊 Daily RAG Digest",
+        f"Date: {datetime.now(UTC).strftime('%Y-%m-%d')}",
+        "",
+        "── Feedback ──",
+    ]
+
+    if feedback_count > 0:
+        like_rate = 1.0 - dislike_rate
+        lines.append(f"  Like rate:    {like_rate:.0%}  |  Dislike rate: {dislike_rate:.0%}")
+        lines.append(f"  Total feedback: {feedback_count}")
+    else:
+        lines.append("  No feedback data")
+
+    lines.append("")
+    lines.append("── Quality ──")
+    if faith_avg is not None:
+        lines.append(f"  Faithfulness avg: {float(faith_avg):.2f}")
+    else:
+        lines.append("  Faithfulness: no data")
+
+    lines.append("")
+    lines.append("── Latency ──")
+    if latency_p95 is not None:
+        lines.append(f"  p95 latency: {latency_p95:.0f} ms")
+    else:
+        lines.append("  Latency p95: no data")
+
+    lines.append("")
+    lines.append("── Cache ──")
+    if cache_hit_rate is not None:
+        lines.append(f"  Semantic cache hit rate: {float(cache_hit_rate):.0%}")
+    else:
+        lines.append("  Cache hit rate: no data")
+
+    if top_reasons:
+        lines.append("")
+        lines.append("── Top dislike reasons ──")
+        for label, cnt in top_reasons:
+            lines.append(f"  {label}: {cnt}")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Telegram delivery
+# ---------------------------------------------------------------------------
+
+
+def send_telegram_message(token: str, chat_id: str, text: str) -> bool:
+    """Send message to Telegram admin chat via Bot API.
+
+    Args:
+        token: Telegram bot token.
+        chat_id: Target chat ID (e.g. "-100123456789").
+        text: Message text (will be HTML-escaped and sent as plain text).
+
+    Returns:
+        True on success, False on failure.
+    """
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    safe_text = html.escape(text)
+    try:
+        response = httpx.post(
+            url,
+            json={"chat_id": chat_id, "text": safe_text, "parse_mode": "HTML"},
+            timeout=10.0,
+        )
+        data = response.json()
+        if response.status_code == 200 and data.get("ok"):
+            return True
+        logger.warning("Telegram API error: %s", data.get("description", "unknown"))
+        return False
+    except Exception as e:
+        logger.error("Failed to send Telegram message: %s", e)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Main entry points
+# ---------------------------------------------------------------------------
+
+
+def run_hourly(lf: Langfuse, token: str, chat_id: str, hours: int = 1) -> int:
+    """Run hourly alert check. Returns number of alerts fired."""
+    to_dt = datetime.now(UTC)
+    from_dt = to_dt - timedelta(hours=hours)
+    from_ts = from_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    to_ts = to_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    logger.info("Hourly check: %s — %s", from_ts, to_ts)
+
+    feedback_metrics = query_score_metrics(lf, "user_feedback", from_ts, to_ts, ["avg", "count"])
+    faith_metrics = query_score_metrics(lf, "judge_faithfulness", from_ts, to_ts, ["avg", "count"])
+
+    alerts = check_hourly_alerts(feedback_metrics, faith_metrics)
+
+    if not alerts:
+        logger.info("No Tier-1 alerts fired.")
+        return 0
+
+    for alert in alerts:
+        msg = format_alert_message(alert)
+        ok = send_telegram_message(token, chat_id, msg)
+        if ok:
+            logger.info("Alert sent: %s", alert["type"])
+        else:
+            logger.error("Failed to send alert: %s", alert["type"])
+
+    return len(alerts)
+
+
+def run_digest(lf: Langfuse, token: str, chat_id: str, hours: int = 24) -> bool:
+    """Run daily digest. Queries last N hours and sends summary.
+
+    Returns:
+        True if digest was sent successfully, False on delivery failure.
+    """
+    to_dt = datetime.now(UTC)
+    from_dt = to_dt - timedelta(hours=hours)
+    from_ts = from_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    to_ts = to_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    logger.info("Daily digest: %s — %s", from_ts, to_ts)
+
+    feedback_metrics = query_score_metrics(lf, "user_feedback", from_ts, to_ts, ["avg", "count"])
+    faith_metrics = query_score_metrics(lf, "judge_faithfulness", from_ts, to_ts, ["avg", "count"])
+    latency_metrics = query_score_metrics(
+        lf, "latency_total_ms", from_ts, to_ts, ["p95", "avg", "count"]
+    )
+    cache_metrics = query_score_metrics(lf, "semantic_cache_hit", from_ts, to_ts, ["avg", "count"])
+    top_reasons = get_top_dislike_reasons(lf.api, from_ts, to_ts, top_n=5)
+
+    msg = format_digest_message(
+        feedback_metrics, faith_metrics, latency_metrics, cache_metrics, top_reasons
+    )
+
+    ok = send_telegram_message(token, chat_id, msg)
+    if ok:
+        logger.info("Daily digest sent.")
+    else:
+        logger.error("Failed to send daily digest.")
+    return ok
+
+
+def main() -> None:
+    load_dotenv()
+
+    parser = argparse.ArgumentParser(description="Langfuse alert script (#758)")
+    parser.add_argument(
+        "--mode",
+        choices=["hourly", "digest"],
+        default="hourly",
+        help="Alert mode: 'hourly' (Tier-1 checks) or 'digest' (daily summary)",
+    )
+    parser.add_argument(
+        "--hours",
+        type=int,
+        default=None,
+        help="Lookback window in hours (default: 1 for hourly, 24 for digest)",
+    )
+    args = parser.parse_args()
+
+    # Resolve lookback window
+    hours = args.hours
+    if hours is None:
+        hours = 1 if args.mode == "hourly" else 24
+
+    # Required env vars (see .env.example: ALERTING section)
+    token = os.environ.get("TELEGRAM_ALERTING_BOT_TOKEN", "")
+    chat_id = os.environ.get("TELEGRAM_ALERTING_CHAT_ID", "")
+
+    if not token or not chat_id:
+        logger.error(
+            "Missing required env vars: TELEGRAM_ALERTING_BOT_TOKEN and TELEGRAM_ALERTING_CHAT_ID"
+        )
+        sys.exit(1)
+
+    try:
+        lf = Langfuse()
+    except Exception as e:
+        logger.error("Failed to initialize Langfuse client: %s", e)
+        sys.exit(1)
+
+    try:
+        if args.mode == "hourly":
+            alert_count = run_hourly(lf, token, chat_id, hours=hours)
+            if alert_count > 0:
+                sys.exit(2)  # Non-zero exit for monitoring systems
+        else:
+            sent = run_digest(lf, token, chat_id, hours=hours)
+            if not sent:
+                sys.exit(1)
+    finally:
+        lf.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_langfuse_alert.py
+++ b/tests/unit/test_langfuse_alert.py
@@ -1,0 +1,578 @@
+"""Tests for scripts/langfuse_alert.py (TDD — RED first).
+
+Tests: dislike rate computation, alert thresholds, Telegram sending, digest formatting.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def _load_module():
+    """Load langfuse_alert as a module without executing main()."""
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / "langfuse_alert.py"
+    spec = importlib.util.spec_from_file_location("langfuse_alert", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# compute_dislike_rate
+# ---------------------------------------------------------------------------
+
+
+def test_compute_dislike_rate_from_avg_like():
+    """avg_like=0.8 means 20% dislike rate, count=50."""
+    module = _load_module()
+    rate, count = module.compute_dislike_rate({"value_avg": 0.8, "count_count": 50.0})
+    assert abs(rate - 0.2) < 1e-9
+    assert count == 50
+
+
+def test_compute_dislike_rate_all_dislikes():
+    """avg_like=0.0 means 100% dislike rate."""
+    module = _load_module()
+    rate, count = module.compute_dislike_rate({"value_avg": 0.0, "count_count": 25.0})
+    assert abs(rate - 1.0) < 1e-9
+    assert count == 25
+
+
+def test_compute_dislike_rate_no_data():
+    """Empty metrics return zero rate and zero count."""
+    module = _load_module()
+    rate, count = module.compute_dislike_rate({})
+    assert rate == 0.0
+    assert count == 0
+
+
+def test_compute_dislike_rate_zero_count():
+    """Zero count returns (0.0, 0) even if avg is present."""
+    module = _load_module()
+    rate, count = module.compute_dislike_rate({"value_avg": 0.5, "count_count": 0.0})
+    assert rate == 0.0
+    assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# check_hourly_alerts — Tier 1
+# ---------------------------------------------------------------------------
+
+
+def test_check_hourly_alerts_fires_on_high_dislike_rate():
+    """Dislike rate > 15% with >= 20 samples triggers Tier 1 alert."""
+    module = _load_module()
+    # avg_like=0.8 → 20% dislike, 25 samples
+    feedback_metrics = {"value_avg": 0.8, "count_count": 25.0}
+    faith_metrics = {"value_avg": 0.7, "count_count": 25.0}
+
+    alerts = module.check_hourly_alerts(feedback_metrics, faith_metrics)
+
+    assert len(alerts) == 1
+    assert alerts[0]["type"] == "dislike_rate"
+    assert alerts[0]["tier"] == 1
+    assert abs(alerts[0]["value"] - 0.2) < 1e-9
+
+
+def test_check_hourly_alerts_not_fired_below_dislike_threshold():
+    """Dislike rate <= 15% does not trigger alert."""
+    module = _load_module()
+    # avg_like=0.9 → 10% dislike, 30 samples
+    feedback_metrics = {"value_avg": 0.9, "count_count": 30.0}
+    faith_metrics = {"value_avg": 0.7, "count_count": 30.0}
+
+    alerts = module.check_hourly_alerts(feedback_metrics, faith_metrics)
+    dislike_alerts = [a for a in alerts if a["type"] == "dislike_rate"]
+    assert dislike_alerts == []
+
+
+def test_check_hourly_alerts_not_fired_insufficient_samples():
+    """Dislike rate > 15% but < 20 samples does NOT trigger alert."""
+    module = _load_module()
+    # avg_like=0.7 → 30% dislike but only 5 samples
+    feedback_metrics = {"value_avg": 0.7, "count_count": 5.0}
+    faith_metrics = {"value_avg": 0.7, "count_count": 5.0}
+
+    alerts = module.check_hourly_alerts(feedback_metrics, faith_metrics)
+    dislike_alerts = [a for a in alerts if a["type"] == "dislike_rate"]
+    assert dislike_alerts == []
+
+
+def test_check_hourly_alerts_fires_on_low_faithfulness():
+    """judge_faithfulness avg < 0.5 with sufficient samples triggers Tier 1 alert."""
+    module = _load_module()
+    feedback_metrics = {"value_avg": 0.95, "count_count": 30.0}
+    faith_metrics = {"value_avg": 0.4, "count_count": 25.0}
+
+    alerts = module.check_hourly_alerts(feedback_metrics, faith_metrics)
+
+    faith_alerts = [a for a in alerts if a["type"] == "judge_faithfulness"]
+    assert len(faith_alerts) == 1
+    assert faith_alerts[0]["tier"] == 1
+    assert abs(faith_alerts[0]["value"] - 0.4) < 1e-9
+
+
+def test_check_hourly_alerts_not_fired_on_good_metrics():
+    """No alert when all metrics within thresholds."""
+    module = _load_module()
+    feedback_metrics = {"value_avg": 0.92, "count_count": 50.0}
+    faith_metrics = {"value_avg": 0.75, "count_count": 50.0}
+
+    alerts = module.check_hourly_alerts(feedback_metrics, faith_metrics)
+    assert alerts == []
+
+
+def test_check_hourly_alerts_both_tiers_fire():
+    """Both dislike rate and faithfulness can fire simultaneously."""
+    module = _load_module()
+    feedback_metrics = {"value_avg": 0.7, "count_count": 30.0}  # 30% dislike
+    faith_metrics = {"value_avg": 0.3, "count_count": 30.0}  # 0.3 faithfulness
+
+    alerts = module.check_hourly_alerts(feedback_metrics, faith_metrics)
+    assert len(alerts) == 2
+    types = {a["type"] for a in alerts}
+    assert types == {"dislike_rate", "judge_faithfulness"}
+
+
+def test_check_hourly_alerts_no_data_no_alert():
+    """Empty metrics produce no alerts."""
+    module = _load_module()
+    alerts = module.check_hourly_alerts({}, {})
+    assert alerts == []
+
+
+# ---------------------------------------------------------------------------
+# format_alert_message
+# ---------------------------------------------------------------------------
+
+
+def test_format_alert_message_dislike_contains_key_info():
+    """Alert message for dislike_rate includes rate, count, threshold."""
+    module = _load_module()
+    alert = {
+        "tier": 1,
+        "type": "dislike_rate",
+        "value": 0.22,
+        "threshold": 0.15,
+        "count": 25,
+    }
+    msg = module.format_alert_message(alert)
+    assert "22%" in msg or "0.22" in msg
+    assert "15%" in msg or "0.15" in msg
+    assert "25" in msg
+
+
+def test_format_alert_message_faithfulness_contains_key_info():
+    """Alert message for judge_faithfulness includes score and threshold."""
+    module = _load_module()
+    alert = {
+        "tier": 1,
+        "type": "judge_faithfulness",
+        "value": 0.38,
+        "threshold": 0.5,
+        "count": 20,
+    }
+    msg = module.format_alert_message(alert)
+    assert "faithfulness" in msg.lower() or "0.38" in msg
+    assert "0.5" in msg or "50%" in msg
+
+
+def test_format_alert_message_is_non_empty_string():
+    """format_alert_message always returns a non-empty string."""
+    module = _load_module()
+    alert = {"tier": 1, "type": "dislike_rate", "value": 0.2, "threshold": 0.15, "count": 20}
+    msg = module.format_alert_message(alert)
+    assert isinstance(msg, str)
+    assert len(msg) > 10
+
+
+# ---------------------------------------------------------------------------
+# format_digest_message
+# ---------------------------------------------------------------------------
+
+
+def test_format_digest_message_includes_dislike_rate():
+    """Daily digest message includes dislike rate percentage."""
+    module = _load_module()
+    feedback_metrics = {"value_avg": 0.85, "count_count": 120.0}
+    faith_metrics = {"value_avg": 0.78, "count_count": 120.0}
+    latency_metrics = {"value_p95": 3200.0, "count_count": 120.0}
+    cache_metrics = {"value_avg": 0.65, "count_count": 120.0}
+    top_reasons: list[tuple[str, int]] = [("irrelevant", 15), ("incomplete", 8)]
+
+    msg = module.format_digest_message(
+        feedback_metrics, faith_metrics, latency_metrics, cache_metrics, top_reasons
+    )
+    # 15% dislike (1 - 0.85)
+    assert "15%" in msg or "0.15" in msg
+
+
+def test_format_digest_message_includes_latency_p95():
+    """Daily digest message includes latency p95 in ms."""
+    module = _load_module()
+    feedback_metrics = {"value_avg": 0.9, "count_count": 50.0}
+    faith_metrics = {"value_avg": 0.8, "count_count": 50.0}
+    latency_metrics = {"value_p95": 4500.0, "count_count": 50.0}
+    cache_metrics = {"value_avg": 0.7, "count_count": 50.0}
+
+    msg = module.format_digest_message(
+        feedback_metrics, faith_metrics, latency_metrics, cache_metrics, []
+    )
+    assert "4500" in msg or "4.5" in msg
+
+
+def test_format_digest_message_includes_cache_hit_rate():
+    """Daily digest message includes cache hit rate."""
+    module = _load_module()
+    feedback_metrics = {"value_avg": 0.9, "count_count": 50.0}
+    faith_metrics = {"value_avg": 0.8, "count_count": 50.0}
+    latency_metrics = {"value_p95": 2000.0, "count_count": 50.0}
+    cache_metrics = {"value_avg": 0.42, "count_count": 50.0}
+
+    msg = module.format_digest_message(
+        feedback_metrics, faith_metrics, latency_metrics, cache_metrics, []
+    )
+    assert "42%" in msg or "0.42" in msg
+
+
+def test_format_digest_message_includes_top_reasons():
+    """Daily digest message includes top dislike reason labels."""
+    module = _load_module()
+    feedback_metrics = {"value_avg": 0.8, "count_count": 80.0}
+    faith_metrics = {"value_avg": 0.75, "count_count": 80.0}
+    latency_metrics = {"value_p95": 2000.0, "count_count": 80.0}
+    cache_metrics = {"value_avg": 0.6, "count_count": 80.0}
+    top_reasons: list[tuple[str, int]] = [("irrelevant", 10), ("incomplete", 5)]
+
+    msg = module.format_digest_message(
+        feedback_metrics, faith_metrics, latency_metrics, cache_metrics, top_reasons
+    )
+    assert "irrelevant" in msg
+
+
+def test_format_digest_message_handles_empty_data():
+    """format_digest_message handles empty metrics without crashing."""
+    module = _load_module()
+    msg = module.format_digest_message({}, {}, {}, {}, [])
+    assert isinstance(msg, str)
+    assert len(msg) > 0
+
+
+# ---------------------------------------------------------------------------
+# send_telegram_message
+# ---------------------------------------------------------------------------
+
+
+def test_send_telegram_message_success():
+    """Returns True when Telegram API responds 200 with ok=true."""
+    module = _load_module()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"ok": True, "result": {"message_id": 42}}
+
+    with patch("httpx.post", return_value=mock_response) as mock_post:
+        result = module.send_telegram_message(
+            token="test_token", chat_id="-100123456", text="Test alert"
+        )
+
+    assert result is True
+    mock_post.assert_called_once()
+    call_args = mock_post.call_args
+    assert "sendMessage" in call_args[0][0]
+
+
+def test_send_telegram_message_api_error():
+    """Returns False when Telegram API responds with ok=false."""
+    module = _load_module()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 400
+    mock_response.json.return_value = {"ok": False, "description": "Bad Request"}
+
+    with patch("httpx.post", return_value=mock_response):
+        result = module.send_telegram_message(
+            token="test_token", chat_id="-100123456", text="Test alert"
+        )
+
+    assert result is False
+
+
+def test_send_telegram_message_network_error():
+    """Returns False on network exception."""
+    module = _load_module()
+
+    with patch("httpx.post", side_effect=Exception("Connection refused")):
+        result = module.send_telegram_message(
+            token="test_token", chat_id="-100123456", text="Test alert"
+        )
+
+    assert result is False
+
+
+def test_send_telegram_message_posts_correct_url():
+    """Uses correct Telegram Bot API URL with token."""
+    module = _load_module()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"ok": True}
+
+    with patch("httpx.post", return_value=mock_response) as mock_post:
+        module.send_telegram_message(token="abc:123", chat_id="-999", text="hello")
+
+    url = mock_post.call_args[0][0]
+    assert "abc:123" in url
+    assert "sendMessage" in url
+
+
+# ---------------------------------------------------------------------------
+# build_metrics_query
+# ---------------------------------------------------------------------------
+
+
+def test_build_metrics_query_returns_valid_json():
+    """build_metrics_query returns a JSON-serializable string."""
+    module = _load_module()
+    query_str = module.build_metrics_query(
+        score_name="user_feedback",
+        from_ts="2026-03-03T08:00:00Z",
+        to_ts="2026-03-03T09:00:00Z",
+    )
+    query = json.loads(query_str)
+    assert isinstance(query, dict)
+
+
+def test_build_metrics_query_includes_score_filter():
+    """build_metrics_query filters by score name."""
+    module = _load_module()
+    query_str = module.build_metrics_query(
+        score_name="user_feedback",
+        from_ts="2026-03-03T08:00:00Z",
+        to_ts="2026-03-03T09:00:00Z",
+    )
+    query = json.loads(query_str)
+    filters = query.get("filters", [])
+    name_filters = [f for f in filters if f.get("column") == "name"]
+    assert len(name_filters) == 1
+    assert name_filters[0]["value"] == "user_feedback"
+
+
+def test_build_metrics_query_includes_time_range():
+    """build_metrics_query includes from/to timestamps."""
+    module = _load_module()
+    from_ts = "2026-03-03T08:00:00Z"
+    to_ts = "2026-03-03T09:00:00Z"
+    query_str = module.build_metrics_query("latency_total_ms", from_ts, to_ts)
+    query = json.loads(query_str)
+    assert query["fromTimestamp"] == from_ts
+    assert query["toTimestamp"] == to_ts
+
+
+def test_build_metrics_query_default_aggregations_include_avg_and_count():
+    """Default aggregations include avg and count."""
+    module = _load_module()
+    query_str = module.build_metrics_query(
+        "user_feedback",
+        "2026-03-03T08:00:00Z",
+        "2026-03-03T09:00:00Z",
+    )
+    query = json.loads(query_str)
+    aggregations = {m["aggregation"] for m in query.get("metrics", [])}
+    assert "avg" in aggregations
+    assert "count" in aggregations
+
+
+def test_build_metrics_query_p95_aggregation():
+    """Latency query can include p95 aggregation."""
+    module = _load_module()
+    query_str = module.build_metrics_query(
+        "latency_total_ms",
+        "2026-03-03T08:00:00Z",
+        "2026-03-03T09:00:00Z",
+        aggregations=["p95", "avg", "count"],
+    )
+    query = json.loads(query_str)
+    aggregations = {m["aggregation"] for m in query.get("metrics", [])}
+    assert "p95" in aggregations
+
+
+# ---------------------------------------------------------------------------
+# get_top_dislike_reasons
+# ---------------------------------------------------------------------------
+
+
+def test_get_top_dislike_reasons_returns_sorted_list():
+    """Returns list of (reason, count) sorted by count descending."""
+    module = _load_module()
+
+    score1 = MagicMock()
+    score1.string_value = "irrelevant"
+    score1.value = None
+
+    score2 = MagicMock()
+    score2.string_value = "incomplete"
+    score2.value = None
+
+    score3 = MagicMock()
+    score3.string_value = "irrelevant"
+    score3.value = None
+
+    mock_api = MagicMock()
+    mock_api.scores.get.return_value.data = [score1, score2, score3]
+    mock_api.scores.get.return_value.meta.total_items = 3
+
+    result = module.get_top_dislike_reasons(
+        api=mock_api,
+        from_ts="2026-03-03T00:00:00Z",
+        to_ts="2026-03-03T23:59:59Z",
+        top_n=3,
+    )
+
+    assert result[0] == ("irrelevant", 2)
+    assert result[1] == ("incomplete", 1)
+
+
+def test_get_top_dislike_reasons_returns_empty_on_no_data():
+    """Returns empty list when no dislike reason scores found."""
+    module = _load_module()
+    mock_api = MagicMock()
+    mock_api.scores.get.return_value.data = []
+
+    result = module.get_top_dislike_reasons(
+        api=mock_api,
+        from_ts="2026-03-03T00:00:00Z",
+        to_ts="2026-03-03T23:59:59Z",
+    )
+    assert result == []
+
+
+def test_get_top_dislike_reasons_limits_to_top_n():
+    """Returns at most top_n reasons."""
+    module = _load_module()
+
+    scores = []
+    for reason in ["a", "b", "c", "d", "e"]:
+        s = MagicMock()
+        s.string_value = reason
+        s.value = None
+        scores.append(s)
+
+    mock_api = MagicMock()
+    mock_api.scores.get.return_value.data = scores
+
+    result = module.get_top_dislike_reasons(
+        api=mock_api,
+        from_ts="2026-03-03T00:00:00Z",
+        to_ts="2026-03-03T23:59:59Z",
+        top_n=3,
+    )
+    assert len(result) <= 3
+
+
+# ---------------------------------------------------------------------------
+# check_hourly_alerts — min_samples guard on faithfulness
+# ---------------------------------------------------------------------------
+
+
+def test_check_hourly_alerts_faithfulness_not_fired_insufficient_samples():
+    """Low faithfulness but < 20 samples does NOT trigger alert."""
+    module = _load_module()
+    feedback_metrics = {"value_avg": 0.95, "count_count": 5.0}
+    faith_metrics = {"value_avg": 0.3, "count_count": 5.0}  # below 0.5 but only 5 samples
+
+    alerts = module.check_hourly_alerts(feedback_metrics, faith_metrics)
+    faith_alerts = [a for a in alerts if a["type"] == "judge_faithfulness"]
+    assert faith_alerts == []
+
+
+# ---------------------------------------------------------------------------
+# run_hourly / run_digest integration (mocked Langfuse + Telegram)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_lf(feedback_avg: float = 0.95, faith_avg: float = 0.8, count: float = 30.0):
+    """Build a mock Langfuse object whose metrics API returns predictable data."""
+    mock_lf = MagicMock()
+
+    def fake_metrics(query: str):
+        q = json.loads(query)
+        name_filter = next(
+            (f["value"] for f in q.get("filters", []) if f["column"] == "name"), None
+        )
+        # Use dicts so query_score_metrics takes the isinstance(row, dict) branch
+        if name_filter == "user_feedback":
+            row: dict = {"value_avg": feedback_avg, "count_count": count}
+        elif name_filter == "judge_faithfulness":
+            row = {"value_avg": faith_avg, "count_count": count}
+        else:
+            row = {"value_avg": 0.6, "value_p95": 2000.0, "count_count": count}
+        result = MagicMock()
+        result.data = [row]
+        return result
+
+    mock_lf.api.metrics.metrics.side_effect = fake_metrics
+    mock_lf.api.scores.get.return_value.data = []
+    return mock_lf
+
+
+def test_run_hourly_returns_zero_when_no_alerts():
+    """run_hourly returns 0 when metrics are healthy and sends no messages."""
+    module = _load_module()
+    mock_lf = _make_mock_lf(feedback_avg=0.92, faith_avg=0.8, count=30.0)
+
+    with patch("httpx.post") as mock_post:
+        result = module.run_hourly(mock_lf, token="tok", chat_id="-100", hours=1)
+
+    assert result == 0
+    mock_post.assert_not_called()
+
+
+def test_run_hourly_returns_alert_count_and_sends_message():
+    """run_hourly returns alert count and sends Telegram message when dislike > 15%."""
+    module = _load_module()
+    # avg_like=0.7 → 30% dislike, 30 samples
+    mock_lf = _make_mock_lf(feedback_avg=0.7, faith_avg=0.8, count=30.0)
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"ok": True}
+
+    with patch("httpx.post", return_value=mock_response):
+        result = module.run_hourly(mock_lf, token="tok", chat_id="-100", hours=1)
+
+    assert result == 1
+
+
+def test_run_digest_returns_true_on_success():
+    """run_digest returns True when digest is sent successfully."""
+    module = _load_module()
+    mock_lf = _make_mock_lf()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"ok": True}
+
+    with patch("httpx.post", return_value=mock_response):
+        result = module.run_digest(mock_lf, token="tok", chat_id="-100", hours=24)
+
+    assert result is True
+
+
+def test_run_digest_returns_false_on_send_failure():
+    """run_digest returns False when Telegram delivery fails."""
+    module = _load_module()
+    mock_lf = _make_mock_lf()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 400
+    mock_response.json.return_value = {"ok": False, "description": "Bad Request"}
+
+    with patch("httpx.post", return_value=mock_response):
+        result = module.run_digest(mock_lf, token="tok", chat_id="-100", hours=24)
+
+    assert result is False


### PR DESCRIPTION
## Summary
- Add `scripts/langfuse_alert.py` with hourly Tier-1 alerts and daily digest
- Tier 1: dislike rate > 15% (min 20 samples) → immediate Telegram alert
- Tier 1: judge_faithfulness < 0.5 (min 20 samples) → immediate Telegram alert
- Tier 2: daily trends summary (dislike rate, latency p95, cache hit rate, top dislike reasons)

## Alerting modes
- `--mode hourly` (default): checks last 1h, exits with code 2 if alerts fired
- `--mode digest`: queries last 24h, sends morning summary
- Env vars: `TELEGRAM_ALERTING_BOT_TOKEN` + `TELEGRAM_ALERTING_CHAT_ID` (per `.env.example`)

## Test plan
- [x] 36 unit tests with mocked Langfuse Metrics API + mocked httpx (Telegram)
- [x] TDD: tests written first, watched RED → GREEN cycle
- [x] `make check` passes (ruff + mypy clean)
- [x] Code review issues addressed: env var naming, html.escape, run_digest returns bool, faithfulness min_samples test, run_hourly/run_digest integration tests

Closes #758