### PR TITLE
feat(feedback): add implicit retry detection via embedding similarity

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -2133,6 +2133,31 @@ class PropertyBot:
         await self._cache.store_embedding(semantic_query, dense)
         await self._cache.store_sparse_embedding(semantic_query, sparse)
 
+        # --- Implicit retry detection (#756) ---
+        if self._cache.redis is not None and message.from_user is not None:
+            try:
+                from .implicit_feedback import is_reformulation
+
+                _uid = message.from_user.id
+                _ikey = f"implicit_retry:{_uid}"
+                _prev_raw = await self._cache.redis.get(_ikey)
+                if _prev_raw:
+                    _prev = json.loads(_prev_raw)
+                    _time_delta = time.time() - float(_prev["ts"])
+                    if is_reformulation(list(dense), _prev["vec"], _time_delta):
+                        lf = get_client()
+                        tid = lf.get_current_trace_id() or ""
+                        if tid:
+                            score(lf, tid, name="implicit_retry", value=1, data_type="BOOLEAN")
+                # Always update state so the next query can compare against this one
+                await self._cache.redis.set(
+                    _ikey,
+                    json.dumps({"vec": list(dense), "ts": time.time()}),
+                    ex=60,
+                )
+            except Exception:
+                logger.debug("Implicit retry check failed", exc_info=True)
+
         filters = parsed.to_filters_dict()
         results, returned_count = await self._apartments_service.search_with_filters(
             dense_vector=dense,

--- a/telegram_bot/implicit_feedback.py
+++ b/telegram_bot/implicit_feedback.py
@@ -1,0 +1,49 @@
+"""Implicit retry detection via embedding similarity (#756).
+
+Detects when a user reformulates a query — an implicit negative feedback signal.
+If cosine_similarity(current, previous) > 0.7 AND time_delta < 60s → implicit_retry=1.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Compute cosine similarity between two vectors.
+
+    Returns a value in [-1, 1] where 1 means identical direction.
+    """
+    dot = sum(x * y for x, y in zip(a, b, strict=True))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(x * x for x in b))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def is_reformulation(
+    current: list[float],
+    previous: list[float],
+    time_delta_seconds: float,
+    *,
+    similarity_threshold: float = 0.7,
+    max_time_seconds: float = 60.0,
+) -> bool:
+    """Detect if current query is a reformulation of previous query.
+
+    Args:
+        current: Dense embedding vector of the current query.
+        previous: Dense embedding vector of the previous query.
+        time_delta_seconds: Seconds elapsed since the previous query.
+        similarity_threshold: Minimum cosine similarity to consider a reformulation.
+        max_time_seconds: Maximum time window (exclusive) for reformulation detection.
+
+    Returns:
+        True if the query appears to be a reformulation (similarity > threshold
+        AND time_delta < max_time_seconds), False otherwise.
+    """
+    if time_delta_seconds >= max_time_seconds:
+        return False
+    sim = cosine_similarity(current, previous)
+    return sim > similarity_threshold

--- a/tests/unit/test_implicit_feedback.py
+++ b/tests/unit/test_implicit_feedback.py
@@ -1,0 +1,133 @@
+"""Tests for implicit retry detection via embedding similarity (#756)."""
+
+import math
+
+
+def _make_vec(dim: int = 4, value: float = 1.0) -> list[float]:
+    """Create a unit vector in the given dimension."""
+    raw = [value] * dim
+    norm = math.sqrt(sum(x * x for x in raw))
+    return [x / norm for x in raw]
+
+
+def _similar_vec(base: list[float], noise: float = 0.05) -> list[float]:
+    """Create a slightly perturbed version of base (still similar)."""
+    noised = [x + noise * (i % 2 - 0.5) for i, x in enumerate(base)]
+    norm = math.sqrt(sum(x * x for x in noised))
+    return [x / norm for x in noised]
+
+
+class TestIsReformulation:
+    """Test the is_reformulation() function from implicit_feedback module."""
+
+    def test_similar_query_within_60s_returns_true(self):
+        """Similar query within 60s → implicit_retry=1 (reformulation detected)."""
+        from telegram_bot.implicit_feedback import is_reformulation
+
+        current = _make_vec()
+        previous = _similar_vec(_make_vec())
+        result = is_reformulation(current, previous, time_delta_seconds=30.0)
+        assert result is True
+
+    def test_different_query_returns_false(self):
+        """Different query (low cosine similarity) → no implicit retry signal."""
+        from telegram_bot.implicit_feedback import is_reformulation
+
+        current = _make_vec(4, 1.0)
+        # A nearly orthogonal vector will have similarity ~0
+        previous = [1.0, 0.0, 0.0, 0.0]
+        # current is [0.5, 0.5, 0.5, 0.5], previous is [1, 0, 0, 0]
+        # cosine = 0.5, which is < 0.7 threshold
+        result = is_reformulation(current, previous, time_delta_seconds=30.0)
+        assert result is False
+
+    def test_similar_query_after_60s_returns_false(self):
+        """> 60s elapsed → no score even if queries are similar."""
+        from telegram_bot.implicit_feedback import is_reformulation
+
+        current = _make_vec()
+        previous = _similar_vec(_make_vec())
+        result = is_reformulation(current, previous, time_delta_seconds=61.0)
+        assert result is False
+
+    def test_exactly_60s_returns_false(self):
+        """Exactly 60s is NOT within the window (strict less-than)."""
+        from telegram_bot.implicit_feedback import is_reformulation
+
+        current = _make_vec()
+        previous = _similar_vec(_make_vec())
+        result = is_reformulation(current, previous, time_delta_seconds=60.0)
+        assert result is False
+
+    def test_near_identical_query_returns_true(self):
+        """Near-identical vectors (same query) should be detected as reformulation."""
+        from telegram_bot.implicit_feedback import is_reformulation
+
+        vec = _make_vec()
+        result = is_reformulation(vec, vec, time_delta_seconds=5.0)
+        assert result is True
+
+    def test_similarity_threshold_boundary_below_returns_false(self):
+        """Similarity just below 0.7 → not a reformulation."""
+        import math
+
+        from telegram_bot.implicit_feedback import is_reformulation
+
+        # Create two vectors with cosine similarity ~0.65 (below threshold)
+        # vec_a = [1, 0], vec_b = [cos(49.5°), sin(49.5°)]
+        angle = math.radians(49.5)  # cosine ~0.648
+        current = [1.0, 0.0]
+        previous = [math.cos(angle), math.sin(angle)]
+        result = is_reformulation(current, previous, time_delta_seconds=30.0)
+        assert result is False
+
+    def test_similarity_threshold_boundary_above_returns_true(self):
+        """Similarity just above 0.7 → is a reformulation."""
+        import math
+
+        from telegram_bot.implicit_feedback import is_reformulation
+
+        angle = math.radians(44.0)  # cosine ~0.719 (above 0.7)
+        current = [1.0, 0.0]
+        previous = [math.cos(angle), math.sin(angle)]
+        result = is_reformulation(current, previous, time_delta_seconds=30.0)
+        assert result is True
+
+    def test_zero_time_delta_returns_true_for_similar(self):
+        """Zero time delta (instant follow-up) with similar query → reformulation."""
+        from telegram_bot.implicit_feedback import is_reformulation
+
+        current = _make_vec()
+        previous = _make_vec()
+        result = is_reformulation(current, previous, time_delta_seconds=0.0)
+        assert result is True
+
+
+class TestCosineSimilarity:
+    """Test the cosine_similarity helper."""
+
+    def test_identical_vectors_have_similarity_one(self):
+        """Identical vectors → cosine similarity = 1.0."""
+        from telegram_bot.implicit_feedback import cosine_similarity
+
+        v = [0.5, 0.5, 0.5, 0.5]
+        sim = cosine_similarity(v, v)
+        assert abs(sim - 1.0) < 1e-6
+
+    def test_orthogonal_vectors_have_similarity_zero(self):
+        """Orthogonal vectors → cosine similarity = 0.0."""
+        from telegram_bot.implicit_feedback import cosine_similarity
+
+        a = [1.0, 0.0]
+        b = [0.0, 1.0]
+        sim = cosine_similarity(a, b)
+        assert abs(sim - 0.0) < 1e-6
+
+    def test_opposite_vectors_have_similarity_negative_one(self):
+        """Opposite vectors → cosine similarity = -1.0."""
+        from telegram_bot.implicit_feedback import cosine_similarity
+
+        a = [1.0, 0.0]
+        b = [-1.0, 0.0]
+        sim = cosine_similarity(a, b)
+        assert abs(sim - (-1.0)) < 1e-6


### PR DESCRIPTION
## Summary
- Add `telegram_bot/implicit_feedback.py` with `is_reformulation()` using cosine similarity
- Detect reformulated queries: `cosine_similarity(current, previous) > 0.7` within 60s window → score `implicit_retry=1` to Langfuse
- Integrate into `_handle_apartment_fast_path()` after dense embedding is computed; previous embedding stored in Redis with 60s TTL

## Test plan
- [x] `test_similar_query_within_60s_returns_true` — AC1: similar query < 60s → True
- [x] `test_different_query_returns_false` — AC2: low similarity → False
- [x] `test_similar_query_after_60s_returns_false` — AC3: >60s → False
- [x] `test_exactly_60s_returns_false` — boundary condition: exactly 60s is exclusive
- [x] AC4: No previous query → `if _prev_raw:` guard in bot.py, no score written
- [x] All 11 tests pass, `ruff check` clean, `mypy` clean

Closes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)