### PR TITLE
fix(docker): align Python version in multi-stage builds

### DIFF
--- a/Dockerfile.ingestion
+++ b/Dockerfile.ingestion
@@ -43,7 +43,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # =============================================================================
 # Runtime stage
 # =============================================================================
-FROM python:3.14-slim-bookworm@sha256:5404df00cf00e6e7273375f415651837b4d192ac6859c44d3b740888ac798c99 AS runtime
+FROM python:3.12-slim-bookworm AS runtime
 
 WORKDIR /app
 

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --extra voice
 
 # ====== RUNTIME STAGE ======
-FROM python:3.14-slim-bookworm@sha256:5404df00cf00e6e7273375f415651837b4d192ac6859c44d3b740888ac798c99 AS runtime
+FROM python:3.12-slim-bookworm AS runtime
 
 WORKDIR /app
 

--- a/tests/unit/test_dockerfile_python_abi.py
+++ b/tests/unit/test_dockerfile_python_abi.py
@@ -1,0 +1,52 @@
+"""Tests for Python ABI consistency in multi-stage Dockerfiles.
+
+Builder and runtime must use the same Python major.minor version,
+otherwise binary wheels (asyncpg, uvloop, etc.) will fail at import time.
+"""
+
+import re
+from pathlib import Path
+
+
+def _get_builder_python_version(dockerfile_text: str) -> str:
+    """Extract Python version from uv builder image tag (e.g. uv:0.9-python3.12-...)."""
+    match = re.search(r"astral-sh/uv:[^-]+-python(\d+\.\d+)-", dockerfile_text)
+    assert match, "Could not find uv builder image with python version"
+    return match.group(1)
+
+
+def _get_runtime_python_version(dockerfile_text: str) -> str:
+    """Extract Python version from runtime FROM line (e.g. FROM python:3.12-slim-bookworm)."""
+    match = re.search(r"FROM python:(\d+\.\d+)-slim", dockerfile_text)
+    assert match, "Could not find runtime python image with version"
+    return match.group(1)
+
+
+def test_api_dockerfile_python_version_consistency() -> None:
+    text = Path("src/api/Dockerfile").read_text(encoding="utf-8")
+    builder_ver = _get_builder_python_version(text)
+    runtime_ver = _get_runtime_python_version(text)
+    assert builder_ver == runtime_ver, (
+        f"src/api/Dockerfile: builder Python {builder_ver} != runtime Python {runtime_ver}. "
+        "Binary wheels compiled for one version break on another."
+    )
+
+
+def test_ingestion_dockerfile_python_version_consistency() -> None:
+    text = Path("Dockerfile.ingestion").read_text(encoding="utf-8")
+    builder_ver = _get_builder_python_version(text)
+    runtime_ver = _get_runtime_python_version(text)
+    assert builder_ver == runtime_ver, (
+        f"Dockerfile.ingestion: builder Python {builder_ver} != runtime Python {runtime_ver}. "
+        "Binary wheels compiled for one version break on another."
+    )
+
+
+def test_telegram_bot_dockerfile_python_version_consistency() -> None:
+    text = Path("telegram_bot/Dockerfile").read_text(encoding="utf-8")
+    builder_ver = _get_builder_python_version(text)
+    runtime_ver = _get_runtime_python_version(text)
+    assert builder_ver == runtime_ver, (
+        f"telegram_bot/Dockerfile: builder Python {builder_ver} != runtime Python {runtime_ver}. "
+        "Binary wheels compiled for one version break on another."
+    )


### PR DESCRIPTION
## Summary
- Fix Python ABI mismatch: runtime was 3.14 while builder was 3.12
- Align src/api/Dockerfile and Dockerfile.ingestion runtime to python:3.12-slim-bookworm
- Binary wheels (asyncpg, uvloop) now match builder ABI

## Test plan
- [x] Dockerfile syntax verified
- [x] make check passes

Closes #777