### PR TITLE
fix(docker): compose dependency gaps + profile drift + security baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -388,7 +388,7 @@ docker-ml-up: ## Start core + ML platform (langfuse, mlflow, clickhouse, minio)
 
 docker-ai-up: ## Start core + heavy AI services (bge-m3, user-base)
 	@echo "$(BLUE)Starting AI services...$(NC)"
-	$(COMPOSE_CMD) --profile ai up -d
+	$(COMPOSE_CMD) up -d bge-m3 user-base
 	@echo "$(GREEN)✓ AI services started$(NC)"
 
 docker-ingest-up: ## Start core + ingestion service

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -607,6 +607,8 @@ services:
       # Real Estate DB
       REALESTATE_DATABASE_URL: "postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:5432/realestate"
     depends_on:
+      postgres:
+        condition: service_healthy
       redis:
         condition: service_healthy
       qdrant:

--- a/docker-compose.vps.yml
+++ b/docker-compose.vps.yml
@@ -7,6 +7,13 @@ x-logging: &default-logging
     max-size: "10m"
     max-file: "3"
 
+x-security-defaults: &security-defaults
+  security_opt: ["no-new-privileges:true"]
+  cap_drop: ["ALL"]
+  read_only: true
+  tmpfs:
+    - /tmp
+
 services:
   # =============================================================================
   # DATABASES
@@ -86,10 +93,13 @@ services:
   # =============================================================================
 
   docling:
+    <<: *security-defaults
     build:
       context: ./services/docling
       dockerfile: Dockerfile
     container_name: vps-docling
+    # Docling needs write access for temp processing files
+    read_only: false
     restart: unless-stopped
     logging: *default-logging
     environment:
@@ -117,6 +127,7 @@ services:
   # =============================================================================
 
   bge-m3:
+    <<: *security-defaults
     build:
       context: ./services/bge-m3-api
       dockerfile: Dockerfile
@@ -142,6 +153,7 @@ services:
           memory: 4G
 
   user-base:
+    <<: *security-defaults
     build:
       context: ./services/user-base
       dockerfile: Dockerfile
@@ -170,6 +182,9 @@ services:
   # =============================================================================
 
   litellm:
+    <<: *security-defaults
+    # LiteLLM writes migration/UI artifacts under site-packages at startup.
+    read_only: false
     image: ghcr.io/berriai/litellm:main-v1.81.3-stable@sha256:3d80908e35230a0dfb58051ae4e2847371b2a327b44e105e79b8c4f67a65596c
     container_name: vps-litellm
     restart: unless-stopped
@@ -200,6 +215,7 @@ services:
   # =============================================================================
 
   bot:
+    <<: *security-defaults
     build:
       context: .
       dockerfile: telegram_bot/Dockerfile
@@ -253,6 +269,8 @@ services:
       # Real Estate DB
       REALESTATE_DATABASE_URL: "postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/realestate"
     depends_on:
+      postgres:
+        condition: service_healthy
       redis:
         condition: service_healthy
       qdrant:

--- a/tests/unit/test_compose_config.py
+++ b/tests/unit/test_compose_config.py
@@ -1,0 +1,200 @@
+"""Tests for Docker Compose configuration correctness.
+
+Covers three issues (M7, M8, M9):
+  M7 - bot service must declare depends_on postgres in dev and vps compose
+  M8 - Makefile docker-ai-up target must use a profile that exists in dev compose
+  M9 - VPS compose must have the same security baseline as dev compose
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).parents[2]
+DEV_COMPOSE = ROOT / "docker-compose.dev.yml"
+VPS_COMPOSE = ROOT / "docker-compose.vps.yml"
+MAKEFILE = ROOT / "Makefile"
+
+
+def _load_compose(path: Path) -> dict:
+    with path.open() as f:
+        return yaml.full_load(f)
+
+
+@pytest.fixture(scope="module")
+def dev() -> dict:
+    return _load_compose(DEV_COMPOSE)
+
+
+@pytest.fixture(scope="module")
+def vps() -> dict:
+    return _load_compose(VPS_COMPOSE)
+
+
+# =============================================================================
+# M7 — bot depends_on postgres
+# =============================================================================
+
+
+class TestBotDependsOnPostgres:
+    """M7: bot service must wait for postgres before starting."""
+
+    def test_dev_bot_depends_on_postgres(self, dev: dict) -> None:
+        """bot in dev compose must declare depends_on: postgres."""
+        bot = dev["services"]["bot"]
+        assert "depends_on" in bot, "bot service has no depends_on"
+        depends = bot["depends_on"]
+        # depends_on can be a list or a dict (with condition)
+        if isinstance(depends, dict):
+            assert "postgres" in depends, "bot.depends_on in dev compose does not include postgres"
+        else:
+            assert "postgres" in depends, "bot.depends_on in dev compose does not include postgres"
+
+    def test_dev_bot_postgres_dependency_is_healthy(self, dev: dict) -> None:
+        """bot in dev compose must wait for postgres to be healthy."""
+        bot = dev["services"]["bot"]
+        depends = bot["depends_on"]
+        assert isinstance(depends, dict), "bot.depends_on must be a dict with conditions"
+        assert depends["postgres"]["condition"] == "service_healthy", (
+            "bot.depends_on.postgres must use condition: service_healthy"
+        )
+
+    def test_vps_bot_depends_on_postgres(self, vps: dict) -> None:
+        """bot in vps compose must declare depends_on: postgres."""
+        bot = vps["services"]["bot"]
+        assert "depends_on" in bot, "bot service has no depends_on in vps compose"
+        depends = bot["depends_on"]
+        if isinstance(depends, dict):
+            assert "postgres" in depends, "bot.depends_on in vps compose does not include postgres"
+        else:
+            assert "postgres" in depends, "bot.depends_on in vps compose does not include postgres"
+
+    def test_vps_bot_postgres_dependency_is_healthy(self, vps: dict) -> None:
+        """bot in vps compose must wait for postgres to be healthy."""
+        bot = vps["services"]["bot"]
+        depends = bot["depends_on"]
+        assert isinstance(depends, dict), "bot.depends_on must be a dict with conditions in vps"
+        assert depends["postgres"]["condition"] == "service_healthy", (
+            "bot.depends_on.postgres must use condition: service_healthy in vps"
+        )
+
+
+# =============================================================================
+# M8 — Makefile profile drift: docker-ai-up must use an existing profile
+# =============================================================================
+
+
+class TestMakefileAiProfile:
+    """M8: all --profile flags in Makefile docker-* targets must exist in dev compose."""
+
+    def _get_all_profiles(self, compose: dict) -> set[str]:
+        profiles: set[str] = set()
+        for svc in compose.get("services", {}).values():
+            for p in svc.get("profiles", []) or []:
+                profiles.add(str(p))
+        return profiles
+
+    def _get_docker_up_profiles(self) -> set[str]:
+        """Extract --profile values from Makefile docker-*-up target recipes only."""
+        content = MAKEFILE.read_text()
+        # Extract only the docker-*-up section (from .PHONY declaration to docker-up alias)
+        section = re.search(
+            r"(docker-core-up:.*?docker-up:.*?##.*?\n)",
+            content,
+            re.DOTALL,
+        )
+        if not section:
+            return set()
+        return set(re.findall(r"--profile\s+(\S+)", section.group(1)))
+
+    def test_docker_up_profiles_exist_in_dev_compose(self, dev: dict) -> None:
+        """Every --profile in Makefile docker-*-up targets must exist in dev compose."""
+        compose_profiles = self._get_all_profiles(dev)
+        makefile_profiles = self._get_docker_up_profiles()
+        unknown = makefile_profiles - compose_profiles
+        assert not unknown, (
+            f"Makefile docker-*-up targets reference profile(s) not in compose: "
+            f"{sorted(unknown)}. Defined profiles: {sorted(compose_profiles)}"
+        )
+
+    def test_docker_ai_up_does_not_use_undefined_ai_profile(self) -> None:
+        """docker-ai-up must not use '--profile ai' since 'ai' is not a compose profile."""
+        content = MAKEFILE.read_text()
+        match = re.search(r"docker-ai-up:.*?(?=\n[a-zA-Z])", content, re.DOTALL)
+        assert match, "docker-ai-up target not found in Makefile"
+        recipe = match.group(0)
+        assert "--profile ai" not in recipe, (
+            "docker-ai-up still uses '--profile ai' which is not defined in compose"
+        )
+
+
+# =============================================================================
+# M9 — VPS security baseline parity with dev compose
+# =============================================================================
+
+# Services that have security defaults applied in dev compose (via <<: *security-defaults)
+_SECURITY_SERVICES = ["bge-m3", "user-base", "docling", "litellm", "bot"]
+
+# Services that exist in both dev AND vps compose
+_VPS_SECURITY_SERVICES = [s for s in _SECURITY_SERVICES if s != "ingestion"]
+
+
+class TestVpsSecurityBaseline:
+    """M9: VPS compose services must match the security baseline from dev compose."""
+
+    @pytest.mark.parametrize("svc_name", _VPS_SECURITY_SERVICES)
+    def test_vps_service_has_security_opt(self, vps: dict, svc_name: str) -> None:
+        """VPS service must have security_opt: no-new-privileges."""
+        services = vps["services"]
+        if svc_name not in services:
+            pytest.skip(f"Service {svc_name} not present in vps compose")
+        svc = services[svc_name]
+        assert "security_opt" in svc, f"vps:{svc_name} missing security_opt (no-new-privileges)"
+        assert "no-new-privileges:true" in svc["security_opt"], (
+            f"vps:{svc_name}.security_opt must include 'no-new-privileges:true'"
+        )
+
+    @pytest.mark.parametrize("svc_name", _VPS_SECURITY_SERVICES)
+    def test_vps_service_has_cap_drop_all(self, vps: dict, svc_name: str) -> None:
+        """VPS service must drop ALL Linux capabilities."""
+        services = vps["services"]
+        if svc_name not in services:
+            pytest.skip(f"Service {svc_name} not present in vps compose")
+        svc = services[svc_name]
+        assert "cap_drop" in svc, f"vps:{svc_name} missing cap_drop"
+        assert "ALL" in svc["cap_drop"], f"vps:{svc_name}.cap_drop must include 'ALL'"
+
+    def test_vps_has_x_security_defaults_anchor(self) -> None:
+        """VPS compose must define x-security-defaults YAML extension anchor."""
+        content = VPS_COMPOSE.read_text()
+        assert "x-security-defaults" in content, (
+            "docker-compose.vps.yml is missing x-security-defaults extension field"
+        )
+
+    @pytest.mark.parametrize("svc_name", ["bge-m3", "user-base", "bot"])
+    def test_vps_service_has_read_only(self, vps: dict, svc_name: str) -> None:
+        """VPS services that are read-only in dev must also be read-only in vps."""
+        services = vps["services"]
+        if svc_name not in services:
+            pytest.skip(f"Service {svc_name} not present in vps compose")
+        svc = services[svc_name]
+        assert svc.get("read_only") is True, (
+            f"vps:{svc_name} must have read_only: true (matching dev compose)"
+        )
+
+    @pytest.mark.parametrize("svc_name", ["bge-m3", "user-base", "bot"])
+    def test_vps_service_has_tmpfs(self, vps: dict, svc_name: str) -> None:
+        """VPS services must have tmpfs /tmp (required when read_only: true)."""
+        services = vps["services"]
+        if svc_name not in services:
+            pytest.skip(f"Service {svc_name} not present in vps compose")
+        svc = services[svc_name]
+        tmpfs = svc.get("tmpfs", [])
+        assert "/tmp" in tmpfs, (
+            f"vps:{svc_name} missing tmpfs: [/tmp] (needed with read_only: true)"
+        )


### PR DESCRIPTION
## Summary
- **M7**: Add `depends_on: postgres` (condition: service_healthy) to `bot` service in both dev and vps compose — bot uses `REALESTATE_DATABASE_URL` and must wait for postgres
- **M8**: Fix `docker-ai-up` Makefile target — replace non-existent `--profile ai` with explicit `up -d bge-m3 user-base` (these services are profile-free core services)
- **M9**: Add `x-security-defaults` YAML anchor to `docker-compose.vps.yml` and apply `security_opt`/`cap_drop`/`read_only`/`tmpfs` to bge-m3, user-base, bot, docling, litellm — matching dev compose hardening

## Test plan
- [x] New file `tests/unit/test_compose_config.py` with 23 YAML structure tests (TDD red-green verified)
- [x] Existing `test_docker_compose_profiles.py` — all 3 tests still pass (including `test_core_services_are_always_enabled`)
- [x] `make check` (ruff lint + format) — clean
- [x] Full unit suite: 4313 passed, 6 pre-existing failures unrelated to this PR

Closes #778