### PR TITLE
refactor(bot): cleanup dead code — ColBERT service + unused chunker strategies

### DIFF
--- a/src/ingestion/chunker.py
+++ b/src/ingestion/chunker.py
@@ -2,6 +2,7 @@
 
 import csv
 import re
+import warnings
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
@@ -11,9 +12,13 @@ from typing import Any
 class ChunkingStrategy(StrEnum):
     """Document chunking strategies."""
 
-    FIXED_SIZE = "fixed_size"  # Fixed chunk size with overlap
+    FIXED_SIZE = (
+        "fixed_size"  # Fixed chunk size with overlap (deprecated — use Docling HybridChunker)
+    )
     SEMANTIC = "semantic"  # Based on content structure (paragraphs, sections)
-    SLIDING_WINDOW = "sliding_window"  # Sliding window with overlap
+    SLIDING_WINDOW = (
+        "sliding_window"  # Sliding window with overlap (deprecated — use Docling HybridChunker)
+    )
 
 
 @dataclass
@@ -77,10 +82,22 @@ class DocumentChunker:
             List of chunks
         """
         if self.strategy == ChunkingStrategy.FIXED_SIZE:
+            warnings.warn(
+                "ChunkingStrategy.FIXED_SIZE is deprecated. Use CocoIndex + Docling "
+                "HybridChunker for production chunking.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             return self._chunk_fixed_size(text, document_name, article_number)
         if self.strategy == ChunkingStrategy.SEMANTIC:
             return self._chunk_semantic(text, document_name, article_number)
         if self.strategy == ChunkingStrategy.SLIDING_WINDOW:
+            warnings.warn(
+                "ChunkingStrategy.SLIDING_WINDOW is deprecated. Use CocoIndex + Docling "
+                "HybridChunker for production chunking.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             return self._chunk_sliding_window(text, document_name, article_number)
         raise ValueError(f"Unknown strategy: {self.strategy}")
 

--- a/telegram_bot/services/colbert_reranker.py
+++ b/telegram_bot/services/colbert_reranker.py
@@ -3,10 +3,14 @@
 HTTP client for bge-m3-api /rerank endpoint (ColBERT MaxSim).
 Replaces VoyageService.rerank when RERANK_PROVIDER=colbert.
 Delegates to BGEM3Client (unified SDK layer).
+
+Deprecated: Server-side ColBERT via hybrid_search_rrf_colbert() (#569) is
+the production path. This module will be removed in a future release.
 """
 
 import logging
 import os
+import warnings
 
 from telegram_bot.observability import observe
 from telegram_bot.services.bge_m3_client import BGEM3Client
@@ -20,6 +24,10 @@ class ColbertRerankerService:
 
     Provides drop-in replacement for VoyageService.rerank.
     Uses ColBERT MaxSim scoring for local, fast reranking.
+
+    Deprecated:
+        Use server-side ColBERT via hybrid_search_rrf_colbert() (see #569).
+        This class will be removed in a future release.
     """
 
     def __init__(
@@ -29,6 +37,13 @@ class ColbertRerankerService:
         *,
         client: BGEM3Client | None = None,
     ):
+        warnings.warn(
+            "ColbertRerankerService is deprecated. Server-side ColBERT reranking via "
+            "hybrid_search_rrf_colbert() (introduced in #569) is the production path. "
+            "This client-side service will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if timeout is None:
             timeout = float(os.getenv("COLBERT_TIMEOUT", "120.0"))
         self._client = client or BGEM3Client(base_url=base_url, timeout=timeout)

--- a/tests/unit/test_chunker.py
+++ b/tests/unit/test_chunker.py
@@ -3,6 +3,8 @@
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from src.ingestion.chunker import (
     Chunk,
     ChunkingStrategy,
@@ -62,8 +64,9 @@ class TestChunkingStrategy:
         assert ChunkingStrategy.SLIDING_WINDOW.value == "sliding_window"
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 class TestDocumentChunkerFixedSize:
-    """Test fixed-size chunking strategy."""
+    """Test fixed-size chunking strategy (deprecated — see #780)."""
 
     def test_fixed_size_basic(self):
         """Test basic fixed-size chunking."""
@@ -185,8 +188,9 @@ class TestDocumentChunkerSemantic:
         assert "115" in chunks[0].text
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 class TestDocumentChunkerSlidingWindow:
-    """Test sliding window chunking strategy."""
+    """Test sliding window chunking strategy (deprecated — see #780)."""
 
     def test_sliding_window_basic(self):
         """Test basic sliding window chunking."""

--- a/tests/unit/test_colbert_reranker.py
+++ b/tests/unit/test_colbert_reranker.py
@@ -5,8 +5,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 class TestColbertRerankerService:
-    """Tests for ColbertRerankerService."""
+    """Tests for ColbertRerankerService (deprecated — see #780)."""
 
     @pytest.fixture
     def service(self):

--- a/tests/unit/test_dead_code_cleanup.py
+++ b/tests/unit/test_dead_code_cleanup.py
@@ -1,0 +1,127 @@
+"""Tests for dead code cleanup — issue #780.
+
+Verifies:
+1. ColbertRerankerService emits DeprecationWarning (client-side reranking replaced
+   by server-side ColBERT via hybrid_search_rrf_colbert() in #569).
+2. DocumentChunker FIXED_SIZE and SLIDING_WINDOW strategies emit DeprecationWarning
+   (replaced by CocoIndex + Docling HybridChunker in production).
+3. DocumentChunker SEMANTIC strategy does NOT emit DeprecationWarning
+   (still the production path via src/core/pipeline.py).
+"""
+
+import warnings
+from unittest.mock import MagicMock
+
+
+class TestColbertRerankerDeprecation:
+    """ColbertRerankerService should emit DeprecationWarning on instantiation."""
+
+    def test_colbert_reranker_emits_deprecation_warning(self):
+        """Instantiating ColbertRerankerService must warn that it is deprecated."""
+        from telegram_bot.services.colbert_reranker import ColbertRerankerService
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            ColbertRerankerService(client=MagicMock())
+
+        deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(deprecation_warnings) >= 1, (
+            "ColbertRerankerService.__init__ must emit DeprecationWarning "
+            "(replaced by server-side ColBERT via hybrid_search_rrf_colbert)"
+        )
+
+    def test_colbert_reranker_deprecation_message_mentions_replacement(self):
+        """Deprecation message should mention the replacement (hybrid_search or #569)."""
+        from telegram_bot.services.colbert_reranker import ColbertRerankerService
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            ColbertRerankerService(client=MagicMock())
+
+        deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert deprecation_warnings, "Expected at least one DeprecationWarning"
+        msg = str(deprecation_warnings[0].message).lower()
+        assert "deprecated" in msg or "569" in msg or "hybrid_search" in msg, (
+            f"Deprecation message should mention replacement, got: {msg!r}"
+        )
+
+
+class TestChunkerDeprecatedStrategies:
+    """FIXED_SIZE and SLIDING_WINDOW strategies must emit DeprecationWarning."""
+
+    def test_fixed_size_strategy_emits_deprecation(self):
+        """FIXED_SIZE strategy is not used in prod — must emit DeprecationWarning."""
+        from src.ingestion.chunker import ChunkingStrategy, DocumentChunker
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            chunker = DocumentChunker(strategy=ChunkingStrategy.FIXED_SIZE)
+            chunker.chunk_text("some text content here", "doc.pdf", "1")
+
+        deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(deprecation_warnings) >= 1, (
+            "ChunkingStrategy.FIXED_SIZE must emit DeprecationWarning "
+            "(production path uses CocoIndex + Docling HybridChunker)"
+        )
+
+    def test_sliding_window_strategy_emits_deprecation(self):
+        """SLIDING_WINDOW strategy is not used in prod — must emit DeprecationWarning."""
+        from src.ingestion.chunker import ChunkingStrategy, DocumentChunker
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            chunker = DocumentChunker(strategy=ChunkingStrategy.SLIDING_WINDOW)
+            chunker.chunk_text("some text content here", "doc.pdf", "1")
+
+        deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(deprecation_warnings) >= 1, (
+            "ChunkingStrategy.SLIDING_WINDOW must emit DeprecationWarning "
+            "(production path uses CocoIndex + Docling HybridChunker)"
+        )
+
+    def test_semantic_strategy_no_deprecation(self):
+        """SEMANTIC is the production path in src/core/pipeline.py — no warning."""
+        from src.ingestion.chunker import ChunkingStrategy, DocumentChunker
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            chunker = DocumentChunker(strategy=ChunkingStrategy.SEMANTIC)
+            chunker.chunk_text("Стаття 1. Загальні положення законодавства", "doc.pdf", "1")
+
+        deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(deprecation_warnings) == 0, (
+            f"ChunkingStrategy.SEMANTIC must NOT emit DeprecationWarning, "
+            f"got: {[str(x.message) for x in deprecation_warnings]}"
+        )
+
+    def test_fixed_size_deprecation_message_mentions_replacement(self):
+        """FIXED_SIZE deprecation message should mention the replacement."""
+        from src.ingestion.chunker import ChunkingStrategy, DocumentChunker
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            chunker = DocumentChunker(strategy=ChunkingStrategy.FIXED_SIZE)
+            chunker.chunk_text("text", "doc.pdf", "1")
+
+        deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert deprecation_warnings, "Expected DeprecationWarning"
+        msg = str(deprecation_warnings[0].message).lower()
+        assert (
+            "deprecated" in msg or "hybridchunker" in msg or "docling" in msg or "cocoindex" in msg
+        ), f"Message should mention replacement, got: {msg!r}"
+
+    def test_sliding_window_deprecation_message_mentions_replacement(self):
+        """SLIDING_WINDOW deprecation message should mention the replacement."""
+        from src.ingestion.chunker import ChunkingStrategy, DocumentChunker
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            chunker = DocumentChunker(strategy=ChunkingStrategy.SLIDING_WINDOW)
+            chunker.chunk_text("text", "doc.pdf", "1")
+
+        deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert deprecation_warnings, "Expected DeprecationWarning"
+        msg = str(deprecation_warnings[0].message).lower()
+        assert (
+            "deprecated" in msg or "hybridchunker" in msg or "docling" in msg or "cocoindex" in msg
+        ), f"Message should mention replacement, got: {msg!r}"


### PR DESCRIPTION
## Summary

- Add `DeprecationWarning` to `ColbertRerankerService.__init__`: client-side reranking superseded by server-side ColBERT via `hybrid_search_rrf_colbert()` (#569). Has runtime callers in `bot.py`, `api/main.py`, and scripts → deprecation-before-deletion.
- Add `DeprecationWarning` to `DocumentChunker.chunk_text()` for `FIXED_SIZE` and `SLIDING_WINDOW` strategies: not on the production path (CocoIndex → Docling HybridChunker is prod). `SEMANTIC` strategy unchanged.
- Update module/class docstrings with `Deprecated:` notes for IDE hover discoverability.
- Suppress `DeprecationWarning` in existing tests (`test_chunker.py`, `test_colbert_reranker.py`) to keep output clean.

## Test plan

- [x] Verified runtime callers via grep — ColBERT: `bot.py`, `api/main.py`, `scripts/` (deprecation warning added); FIXED_SIZE/SLIDING_WINDOW: tests only (deprecation warning added)
- [x] 7 new TDD tests in `tests/unit/test_dead_code_cleanup.py` — assert deprecation behaviour and that SEMANTIC is warning-free
- [x] All 37 affected unit tests pass (`test_dead_code_cleanup`, `test_colbert_reranker`, `test_chunker`)
- [x] Full unit suite: 4296 pass, 6 pre-existing failures (unrelated to this PR)
- [x] `make check` passes (ruff + mypy, 0 issues)
- [x] Pre-commit hooks pass (ruff-check, ruff-format, trailing-whitespace, etc.)

> Note: `scripts/validate_traces.py` and `scripts/eval/run_experiment.py` also instantiate `ColbertRerankerService` — they will now emit the deprecation warning when run, which is the intended behaviour.

Closes #780