### PR TITLE
refactor(pipeline): extract shared RAG core functions — DRY H1-H4

### DIFF
--- a/telegram_bot/agents/rag_pipeline.py
+++ b/telegram_bot/agents/rag_pipeline.py
@@ -22,20 +22,21 @@ import logging
 import time
 from typing import Any
 
-from telegram_bot.graph.nodes.cache import CACHEABLE_QUERY_TYPES
 from telegram_bot.observability import get_client, observe
+from telegram_bot.services.rag_core import (
+    CACHEABLE_QUERY_TYPES,
+    check_semantic_cache,
+    compute_query_embedding,
+    perform_rerank,
+    rewrite_query_via_llm,
+)
+from telegram_bot.services.rag_core import (
+    build_retrieved_context as _build_retrieved_context,
+)
 
 
 logger = logging.getLogger(__name__)
 
-_MAX_CONTEXT_SNIPPET = 500  # chars per doc for judge evaluation
-_REWRITE_PROMPT = (
-    "Ты — помощник по поиску недвижимости. "
-    "Пользователь задал вопрос, но результаты поиска оказались нерелевантными.\n\n"
-    "Переформулируй запрос так, чтобы он лучше подходил для поиска по базе недвижимости.\n"
-    "Верни ТОЛЬКО переформулированный запрос, без пояснений.\n\n"
-    "Оригинальный запрос: {query}"
-)
 # top_k=3 for reranking. Saves ~20ms vs top_k=5 while capturing most relevant docs via ColBERT semantic similarity.
 _DEFAULT_RERANK_TOP_K = 3
 
@@ -76,88 +77,54 @@ async def _cache_check(
 
     start = time.perf_counter()
 
-    # Step 1: Get or compute dense embedding (prefer hybrid for efficiency)
-    # If caller pre-computed the embedding (pre-agent cache check), reuse it directly.
-    embedding_error: bool = False
-    embedding_error_type: str | None = None
-    colbert_query: list[list[float]] | None = None
-    sparse: Any = None  # tracked for return so _hybrid_retrieve can skip re-fetch
-
+    # Step 1: Get or compute dense embedding via shared core
     if pre_computed_embedding:
         logger.debug(
             "_cache_check: reusing pre-computed embedding (%d dims)", len(pre_computed_embedding)
         )
-        embedding = pre_computed_embedding
-        embeddings_cache_hit = False  # embedding came from caller, not Redis
-        # Pre-agent already stored embeddings in cache — no need to re-store (#633)
-        if pre_computed_sparse is not None:
-            sparse = pre_computed_sparse
-        if pre_computed_colbert is not None:
-            colbert_query = pre_computed_colbert
-    else:
-        embedding = await cache.get_embedding(query)
-        embeddings_cache_hit = embedding is not None
-
-    _has_hybrid = callable(
-        getattr(embeddings, "aembed_hybrid", None)
-    ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid)
-    _has_hybrid_colbert = callable(
-        getattr(embeddings, "aembed_hybrid_with_colbert", None)
-    ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid_with_colbert)
-    _has_colbert_only = callable(
-        getattr(embeddings, "aembed_colbert_query", None)
-    ) and asyncio.iscoroutinefunction(embeddings.aembed_colbert_query)
-
-    if embedding is None:
-        try:
-            if _has_hybrid:
-                embedding, sparse = await embeddings.aembed_hybrid(query)
-                await cache.store_embedding(query, embedding)
-                await cache.store_sparse_embedding(query, sparse)
-            else:
-                embedding = await embeddings.aembed_query(query)
-                await cache.store_embedding(query, embedding)
-        except Exception as exc:
-            embedding_error = True
-            embedding_error_type = type(exc).__name__
-            logger.error("Embedding failed: %s: %s", embedding_error_type, exc)
-            latency = time.perf_counter() - start
-            lf.update_current_span(
-                level="ERROR",
-                output={
-                    "embedding_error": True,
-                    "embedding_error_type": embedding_error_type,
-                    "error_message": str(exc)[:200],
-                    "duration_ms": round(latency * 1000, 1),
-                },
-            )
-            return {
-                "cache_hit": False,
-                "cached_response": None,
-                "query_embedding": None,
-                "sparse_embedding": None,
-                "embeddings_cache_hit": False,
+    try:
+        embedding, sparse, colbert_query, embeddings_cache_hit = await compute_query_embedding(
+            query,
+            cache=cache,
+            embeddings=embeddings,
+            pre_computed=pre_computed_embedding,
+            pre_computed_sparse=pre_computed_sparse,
+            pre_computed_colbert=pre_computed_colbert,
+        )
+    except Exception as exc:
+        embedding_error_type = type(exc).__name__
+        logger.error("Embedding failed: %s: %s", embedding_error_type, exc)
+        latency = time.perf_counter() - start
+        lf.update_current_span(
+            level="ERROR",
+            output={
                 "embedding_error": True,
                 "embedding_error_type": embedding_error_type,
-                "error_response": "Сервис временно недоступен. Пожалуйста, повторите через минуту.",
-                "colbert_query": None,
-                "latency_stages": {**latency_stages, "cache_check": latency},
-            }
-
-    # Step 2: Check semantic cache (allowlisted types only)
-    cached = None
-    if query_type in CACHEABLE_QUERY_TYPES:
-        cached = await cache.check_semantic(
-            query=query,
-            vector=embedding,
-            query_type=query_type,
-            cache_scope="rag",
-            agent_role=agent_role,
+                "error_message": str(exc)[:200],
+                "duration_ms": round(latency * 1000, 1),
+            },
         )
+        return {
+            "cache_hit": False,
+            "cached_response": None,
+            "query_embedding": None,
+            "sparse_embedding": None,
+            "embeddings_cache_hit": False,
+            "embedding_error": True,
+            "embedding_error_type": embedding_error_type,
+            "error_response": "Сервис временно недоступен. Пожалуйста, повторите через минуту.",
+            "colbert_query": None,
+            "latency_stages": {**latency_stages, "cache_check": latency},
+        }
+
+    # Step 2: Check semantic cache via shared core
+    hit, cached = await check_semantic_cache(
+        query, embedding, query_type, cache=cache, agent_role=agent_role
+    )
 
     latency = time.perf_counter() - start
 
-    if cached:
+    if hit:
         logger.info("cache_check HIT (%.3fs, type=%s)", latency, query_type)
         lf.update_current_span(
             output={
@@ -181,9 +148,14 @@ async def _cache_check(
 
     # ColBERT query vectors are only needed on semantic miss.
     if colbert_query is None:
-        if pre_computed_colbert is not None:
-            colbert_query = pre_computed_colbert
-        elif _has_colbert_only:
+        _has_colbert_only = callable(
+            getattr(embeddings, "aembed_colbert_query", None)
+        ) and asyncio.iscoroutinefunction(embeddings.aembed_colbert_query)
+        _has_hybrid_colbert = callable(
+            getattr(embeddings, "aembed_hybrid_with_colbert", None)
+        ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid_with_colbert)
+
+        if _has_colbert_only:
             try:
                 colbert_query = await embeddings.aembed_colbert_query(query)
             except Exception:
@@ -215,8 +187,8 @@ async def _cache_check(
         "query_embedding": embedding,
         "sparse_embedding": sparse,
         "embeddings_cache_hit": embeddings_cache_hit,
-        "embedding_error": embedding_error,
-        "embedding_error_type": embedding_error_type,
+        "embedding_error": False,
+        "embedding_error_type": None,
         "colbert_query": colbert_query,
         "latency_stages": {**latency_stages, "cache_check": latency},
     }
@@ -225,27 +197,6 @@ async def _cache_check(
 # ---------------------------------------------------------------------------
 # Step 2: Hybrid retrieve
 # ---------------------------------------------------------------------------
-
-
-def _build_retrieved_context(
-    results: list[dict[str, Any]],
-    limit: int = 5,
-) -> list[dict[str, str | float]]:
-    """Build curated context snippets for LLM-as-a-Judge evaluation."""
-    ctx: list[dict[str, str | float]] = []
-    for doc in results[:limit]:
-        if not isinstance(doc, dict):
-            continue
-        text = doc.get("text", "")
-        meta = doc.get("metadata", {})
-        ctx.append(
-            {
-                "content": text[:_MAX_CONTEXT_SNIPPET],
-                "score": doc.get("score", 0),
-                "chunk_location": meta.get("chunk_location", ""),
-            }
-        )
-    return ctx
 
 
 @observe(name="hybrid-retrieve", capture_input=False, capture_output=False)
@@ -537,83 +488,36 @@ async def _rerank(
             "latency_stages": {**latency_stages, "rerank": elapsed},
         }
 
-    if reranker is not None:
-        try:
-            _has_get_rerank = (
-                cache is not None
-                and callable(getattr(cache, "get_rerank_results", None))
-                and asyncio.iscoroutinefunction(cache.get_rerank_results)
-            )
-            _has_store_rerank = (
-                cache is not None
-                and callable(getattr(cache, "store_rerank_results", None))
-                and asyncio.iscoroutinefunction(cache.store_rerank_results)
-            )
-
-            if _has_get_rerank:
-                cached_reranked = await cache.get_rerank_results(query, documents, top_k)
-                if cached_reranked is not None:
-                    elapsed = time.perf_counter() - t0
-                    logger.info(
-                        "rerank: HIT rerank cache %d → %d docs (%.3fs)",
-                        len(documents),
-                        len(cached_reranked),
-                        elapsed,
-                    )
-                    return {
-                        "documents": cached_reranked,
-                        "rerank_applied": True,
-                        "rerank_cache_hit": True,
-                        "latency_stages": {**latency_stages, "rerank": elapsed},
-                    }
-
-            doc_texts = [doc.get("text", "") for doc in documents]
-            rerank_results = await reranker.rerank(query=query, documents=doc_texts, top_k=top_k)
-
-            reranked: list[dict[str, Any]] = []
-            for rr in rerank_results:
-                idx = rr["index"]
-                if idx < len(documents):
-                    doc = {**documents[idx], "score": rr["score"]}
-                    reranked.append(doc)
-
-            if _has_store_rerank:
-                await cache.store_rerank_results(query, documents, top_k, reranked)
-
-            elapsed = time.perf_counter() - t0
-            logger.info(
-                "rerank: ColBERT reranked %d → %d docs (%.3fs)",
-                len(documents),
-                len(reranked),
-                elapsed,
-            )
-            return {
-                "documents": reranked,
-                "rerank_applied": True,
-                "rerank_cache_hit": False,
-                "latency_stages": {**latency_stages, "rerank": elapsed},
-            }
-        except Exception as e:
-            logger.exception("rerank: ColBERT failed, falling back to score sort")
-            get_client().update_current_span(
-                level="ERROR",
-                status_message=f"ColBERT rerank failed: {str(e)[:200]}",
-            )
-
-    # Fallback: sort by existing score, take top-k
-    sorted_docs = sorted(documents, key=lambda d: d.get("score", 0), reverse=True)[:top_k]
+    try:
+        reranked_docs, rerank_applied, rerank_cache_hit = await perform_rerank(
+            query, documents, cache=cache, reranker=reranker, top_k=top_k
+        )
+        if not rerank_applied:
+            # No reranker path: sort and trim here
+            reranked_docs = sorted(documents, key=lambda d: d.get("score", 0), reverse=True)[:top_k]
+    except Exception as e:
+        logger.exception("rerank: ColBERT failed, falling back to score sort")
+        get_client().update_current_span(
+            level="ERROR",
+            status_message=f"ColBERT rerank failed: {str(e)[:200]}",
+        )
+        reranked_docs = sorted(documents, key=lambda d: d.get("score", 0), reverse=True)[:top_k]
+        rerank_applied = False
+        rerank_cache_hit = False
 
     elapsed = time.perf_counter() - t0
     logger.info(
-        "rerank: score-based sort %d → %d docs (%.3fs)",
+        "rerank: %d → %d docs, applied=%s cache_hit=%s (%.3fs)",
         len(documents),
-        len(sorted_docs),
+        len(reranked_docs),
+        rerank_applied,
+        rerank_cache_hit,
         elapsed,
     )
     return {
-        "documents": sorted_docs,
-        "rerank_applied": False,
-        "rerank_cache_hit": False,
+        "documents": reranked_docs,
+        "rerank_applied": rerank_applied,
+        "rerank_cache_hit": rerank_cache_hit,
         "latency_stages": {**latency_stages, "rerank": elapsed},
     }
 
@@ -643,25 +547,7 @@ async def _rewrite_query(
         config = GraphConfig.from_env()
         if llm is None:
             llm = config.create_llm()
-
-        prompt = _REWRITE_PROMPT.format(query=query)
-        response = await llm.chat.completions.create(
-            model=config.rewrite_model,
-            messages=[{"role": "user", "content": prompt}],
-            temperature=0.3,
-            max_tokens=config.rewrite_max_tokens,
-            name="rewrite-query",  # type: ignore[call-overload]
-        )
-        rewritten = (response.choices[0].message.content or "").strip()
-        rewrite_actual_model = (
-            getattr(response, "model", config.rewrite_model) or config.rewrite_model
-        )
-
-        if not rewritten or rewritten == query:
-            rewritten = query
-            effective = False
-        else:
-            effective = True
+        rewritten, effective, rewrite_actual_model = await rewrite_query_via_llm(query, llm=llm)
     except Exception as e:
         logger.exception("rewrite: LLM rewrite failed, keeping original query")
         get_client().update_current_span(

--- a/telegram_bot/graph/nodes/cache.py
+++ b/telegram_bot/graph/nodes/cache.py
@@ -14,13 +14,14 @@ from typing import Any
 
 from telegram_bot.observability import get_client, observe
 from telegram_bot.services.metrics import PipelineMetrics
+from telegram_bot.services.rag_core import (
+    CACHEABLE_QUERY_TYPES,
+    check_semantic_cache,
+    compute_query_embedding,
+)
 
 
 logger = logging.getLogger(__name__)
-
-# Only these query types use semantic cache (check + store).
-# GENERAL uses a stricter threshold (0.08) to avoid false positives.
-CACHEABLE_QUERY_TYPES: frozenset[str] = frozenset({"FAQ", "ENTITY", "STRUCTURED", "GENERAL"})
 
 
 @observe(name="node-cache-check", capture_input=False, capture_output=False)
@@ -61,76 +62,47 @@ async def cache_check_node(
 
     start = time.perf_counter()
 
-    # Step 1: Get or compute dense embedding (prefer hybrid for efficiency)
-    embedding = await cache.get_embedding(query)
-    embeddings_cache_hit = embedding is not None
-    embedding_error = False
-    embedding_error_type: str | None = None
-    colbert_query: list[list[float]] | None = None
-
-    _has_hybrid = callable(
-        getattr(embeddings, "aembed_hybrid", None)
-    ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid)
-    _has_hybrid_colbert = callable(
-        getattr(embeddings, "aembed_hybrid_with_colbert", None)
-    ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid_with_colbert)
-    _has_colbert_only = callable(
-        getattr(embeddings, "aembed_colbert_query", None)
-    ) and asyncio.iscoroutinefunction(embeddings.aembed_colbert_query)
-
-    if embedding is None:
-        try:
-            if _has_hybrid:
-                # Hybrid: get both dense + sparse in one call, cache both
-                embedding, sparse = await embeddings.aembed_hybrid(query)
-                await cache.store_embedding(query, embedding)
-                await cache.store_sparse_embedding(query, sparse)
-            else:
-                embedding = await embeddings.aembed_query(query)
-                await cache.store_embedding(query, embedding)
-        except Exception as exc:
-            embedding_error = True
-            embedding_error_type = type(exc).__name__
-            logger.error("Embedding failed after retries: %s: %s", embedding_error_type, exc)
-            latency = time.perf_counter() - start
-            lf.update_current_span(
-                level="ERROR",
-                output={
-                    "embedding_error": True,
-                    "embedding_error_type": embedding_error_type,
-                    "error_message": str(exc)[:200],
-                    "duration_ms": round(latency * 1000, 1),
-                },
-            )
-            return {
-                "cache_hit": False,
-                "cached_response": None,
-                "query_embedding": None,
-                "embeddings_cache_hit": False,
+    # Step 1: Get or compute dense embedding via shared core.
+    # Voice path has no pre-computed vectors — no pre_computed args passed.
+    try:
+        embedding, _sparse, colbert_query, embeddings_cache_hit = await compute_query_embedding(
+            query, cache=cache, embeddings=embeddings
+        )
+    except Exception as exc:
+        embedding_error_type = type(exc).__name__
+        logger.error("Embedding failed after retries: %s: %s", embedding_error_type, exc)
+        latency = time.perf_counter() - start
+        lf.update_current_span(
+            level="ERROR",
+            output={
                 "embedding_error": True,
                 "embedding_error_type": embedding_error_type,
-                "response": "Сервис временно недоступен. Пожалуйста, повторите через минуту.",
-                "latency_stages": {
-                    **state.get("latency_stages", {}),
-                    "cache_check": latency,
-                },
-            }
-
-    # Step 2: Check semantic cache with query-type threshold (allowlisted types only).
-    # Voice path has no user role — agent_role is intentionally omitted so that
-    # voice responses are shared across roles within the same cache_scope="rag" bucket.
-    cached = None
-    if query_type in CACHEABLE_QUERY_TYPES:
-        cached = await cache.check_semantic(
-            query=query,
-            vector=embedding,
-            query_type=query_type,
-            cache_scope="rag",
+                "error_message": str(exc)[:200],
+                "duration_ms": round(latency * 1000, 1),
+            },
         )
+        return {
+            "cache_hit": False,
+            "cached_response": None,
+            "query_embedding": None,
+            "embeddings_cache_hit": False,
+            "embedding_error": True,
+            "embedding_error_type": embedding_error_type,
+            "response": "Сервис временно недоступен. Пожалуйста, повторите через минуту.",
+            "latency_stages": {
+                **state.get("latency_stages", {}),
+                "cache_check": latency,
+            },
+        }
+
+    # Step 2: Check semantic cache via shared core.
+    # Voice path has no user role — agent_role omitted so voice responses are
+    # shared across roles within the same cache_scope="rag" bucket.
+    hit, cached = await check_semantic_cache(query, embedding, query_type, cache=cache)
 
     latency = time.perf_counter() - start
 
-    if cached:
+    if hit:
         PipelineMetrics.get().inc("cache_hit")
         logger.info("cache_check HIT (%.3fs, type=%s)", latency, query_type)
         lf.update_current_span(
@@ -155,6 +127,13 @@ async def cache_check_node(
 
     # ColBERT vectors are only needed after semantic miss.
     if colbert_query is None:
+        _has_colbert_only = callable(
+            getattr(embeddings, "aembed_colbert_query", None)
+        ) and asyncio.iscoroutinefunction(embeddings.aembed_colbert_query)
+        _has_hybrid_colbert = callable(
+            getattr(embeddings, "aembed_hybrid_with_colbert", None)
+        ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid_with_colbert)
+
         if _has_colbert_only:
             try:
                 colbert_query = await embeddings.aembed_colbert_query(query)
@@ -182,8 +161,8 @@ async def cache_check_node(
         "cached_response": None,
         "query_embedding": embedding,
         "embeddings_cache_hit": embeddings_cache_hit,
-        "embedding_error": embedding_error,
-        "embedding_error_type": embedding_error_type,
+        "embedding_error": False,
+        "embedding_error_type": None,
         "colbert_query": colbert_query,
         "latency_stages": {**state.get("latency_stages", {}), "cache_check": latency},
     }

--- a/telegram_bot/graph/nodes/rerank.py
+++ b/telegram_bot/graph/nodes/rerank.py
@@ -6,13 +6,13 @@ Otherwise, falls back to score-based sort with top-5 selection.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import time
 from typing import Any
 
 from telegram_bot.observability import get_client, observe
 from telegram_bot.services.metrics import PipelineMetrics
+from telegram_bot.services.rag_core import perform_rerank
 
 
 logger = logging.getLogger(__name__)
@@ -61,84 +61,37 @@ async def rerank_node(
         else state["messages"][-1]["content"]
     )
 
-    if reranker is not None:
-        try:
-            get_rerank = getattr(cache, "get_rerank_results", None) if cache is not None else None
-            store_rerank = (
-                getattr(cache, "store_rerank_results", None) if cache is not None else None
-            )
-            _has_get_rerank = callable(get_rerank) and asyncio.iscoroutinefunction(get_rerank)
-            _has_store_rerank = callable(store_rerank) and asyncio.iscoroutinefunction(store_rerank)
-
-            if _has_get_rerank and get_rerank is not None:
-                cached_reranked = await get_rerank(query, documents, top_k)
-                if cached_reranked is not None:
-                    elapsed = time.perf_counter() - t0
-                    PipelineMetrics.get().record("rerank", elapsed * 1000)
-                    logger.info(
-                        "rerank: HIT rerank cache %d → %d docs (%.3fs)",
-                        len(documents),
-                        len(cached_reranked),
-                        elapsed,
-                    )
-                    return {
-                        "documents": cached_reranked,
-                        "rerank_applied": True,
-                        "rerank_cache_hit": True,
-                        "llm_call_count": llm_call_count,
-                        "latency_stages": {**state.get("latency_stages", {}), "rerank": elapsed},
-                    }
-
-            doc_texts = [doc.get("text", "") for doc in documents]
-            rerank_results = await reranker.rerank(query=query, documents=doc_texts, top_k=top_k)
-
-            reranked: list[dict[str, Any]] = []
-            for rr in rerank_results:
-                idx = rr["index"]
-                if idx < len(documents):
-                    doc = {**documents[idx], "score": rr["score"]}
-                    reranked.append(doc)
-
-            if _has_store_rerank and store_rerank is not None:
-                await store_rerank(query, documents, top_k, reranked)
-
-            elapsed = time.perf_counter() - t0
-            PipelineMetrics.get().record("rerank", elapsed * 1000)
-            logger.info(
-                "rerank: ColBERT reranked %d → %d docs (%.3fs)",
-                len(documents),
-                len(reranked),
-                elapsed,
-            )
-            return {
-                "documents": reranked,
-                "rerank_applied": True,
-                "rerank_cache_hit": False,
-                "llm_call_count": llm_call_count,
-                "latency_stages": {**state.get("latency_stages", {}), "rerank": elapsed},
-            }
-        except Exception as e:
-            logger.exception("rerank: ColBERT failed, falling back to score sort")
-            get_client().update_current_span(
-                level="ERROR",
-                status_message=f"ColBERT rerank failed: {str(e)[:200]}",
-            )
-
-    # Fallback: sort by existing score, take top-k
-    sorted_docs = sorted(documents, key=lambda d: d.get("score", 0), reverse=True)[:top_k]
+    try:
+        reranked_docs, rerank_applied, rerank_cache_hit = await perform_rerank(
+            query, documents, cache=cache, reranker=reranker, top_k=top_k
+        )
+        if not rerank_applied:
+            # No reranker path: sort and trim here
+            reranked_docs = sorted(documents, key=lambda d: d.get("score", 0), reverse=True)[:top_k]
+    except Exception as e:
+        logger.exception("rerank: ColBERT failed, falling back to score sort")
+        get_client().update_current_span(
+            level="ERROR",
+            status_message=f"ColBERT rerank failed: {str(e)[:200]}",
+        )
+        reranked_docs = sorted(documents, key=lambda d: d.get("score", 0), reverse=True)[:top_k]
+        rerank_applied = False
+        rerank_cache_hit = False
 
     elapsed = time.perf_counter() - t0
     PipelineMetrics.get().record("rerank", elapsed * 1000)
     logger.info(
-        "rerank: score-based sort %d → %d docs (%.3fs)",
+        "rerank: %d → %d docs, applied=%s cache_hit=%s (%.3fs)",
         len(documents),
-        len(sorted_docs),
+        len(reranked_docs),
+        rerank_applied,
+        rerank_cache_hit,
         elapsed,
     )
     return {
-        "documents": sorted_docs,
-        "rerank_applied": False,
-        "rerank_cache_hit": False,
+        "documents": reranked_docs,
+        "rerank_applied": rerank_applied,
+        "rerank_cache_hit": rerank_cache_hit,
         "llm_call_count": llm_call_count,
         "latency_stages": {**state.get("latency_stages", {}), "rerank": elapsed},
     }

--- a/telegram_bot/graph/nodes/retrieve.py
+++ b/telegram_bot/graph/nodes/retrieve.py
@@ -15,32 +15,10 @@ from typing import Any
 
 from telegram_bot.observability import get_client, observe
 from telegram_bot.services.metrics import PipelineMetrics
+from telegram_bot.services.rag_core import build_retrieved_context as _build_retrieved_context
 
 
 logger = logging.getLogger(__name__)
-
-_MAX_CONTEXT_SNIPPET = 500  # chars per doc for judge evaluation
-
-
-def _build_retrieved_context(
-    results: list[dict[str, Any]],
-    limit: int = 5,
-) -> list[dict[str, str | float]]:
-    """Build curated context snippets for LLM-as-a-Judge evaluation."""
-    ctx: list[dict[str, str | float]] = []
-    for doc in results[:limit]:
-        if not isinstance(doc, dict):
-            continue
-        text = doc.get("text", "")
-        meta = doc.get("metadata", {})
-        ctx.append(
-            {
-                "content": text[:_MAX_CONTEXT_SNIPPET],
-                "score": doc.get("score", 0),
-                "chunk_location": meta.get("chunk_location", ""),
-            }
-        )
-    return ctx
 
 
 @observe(name="node-retrieve", capture_input=False, capture_output=False)

--- a/telegram_bot/graph/nodes/rewrite.py
+++ b/telegram_bot/graph/nodes/rewrite.py
@@ -13,18 +13,10 @@ from typing import Any
 from langchain_core.messages import HumanMessage
 
 from telegram_bot.observability import get_client, observe
+from telegram_bot.services.rag_core import rewrite_query_via_llm
 
 
 logger = logging.getLogger(__name__)
-
-
-_REWRITE_PROMPT = (
-    "Ты — помощник по поиску недвижимости. "
-    "Пользователь задал вопрос, но результаты поиска оказались нерелевантными.\n\n"
-    "Переформулируй запрос так, чтобы он лучше подходил для поиска по базе недвижимости.\n"
-    "Верни ТОЛЬКО переформулированный запрос, без пояснений.\n\n"
-    "Оригинальный запрос: {query}"
-)
 
 
 @observe(name="node-rewrite")
@@ -60,25 +52,9 @@ async def rewrite_node(
         config = GraphConfig.from_env()
         if llm is None:
             llm = config.create_llm()
-
-        prompt = _REWRITE_PROMPT.format(query=original_query)
-        response = await llm.chat.completions.create(
-            model=config.rewrite_model,
-            messages=[{"role": "user", "content": prompt}],
-            temperature=0.3,
-            max_tokens=config.rewrite_max_tokens,
-            name="rewrite-query",  # type: ignore[call-overload]  # langfuse kwarg
+        rewritten, effective, rewrite_actual_model = await rewrite_query_via_llm(
+            original_query, llm=llm
         )
-        rewritten = (response.choices[0].message.content or "").strip()
-        rewrite_actual_model = (
-            getattr(response, "model", config.rewrite_model) or config.rewrite_model
-        )
-
-        if not rewritten or rewritten == original_query:
-            rewritten = original_query
-            effective = False
-        else:
-            effective = True
     except Exception as e:
         logger.exception("rewrite_node: LLM rewrite failed, keeping original query")
         get_client().update_current_span(

--- a/telegram_bot/services/rag_core.py
+++ b/telegram_bot/services/rag_core.py
@@ -1,0 +1,281 @@
+"""Shared RAG core functions used by both agent SDK pipeline and LangGraph nodes.
+
+Extracted to avoid ~300 LOC duplication between:
+  telegram_bot/agents/rag_pipeline.py
+  telegram_bot/graph/nodes/*.py
+
+Core functions are pure computation (no Langfuse spans, no PipelineMetrics).
+Adapters (pipeline / nodes) handle span tracking, metrics, and state wrapping.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+
+_MAX_CONTEXT_SNIPPET = 500  # chars per doc for judge evaluation
+
+# Query types eligible for semantic cache. Shared between agent SDK and LangGraph paths.
+CACHEABLE_QUERY_TYPES: frozenset[str] = frozenset({"FAQ", "ENTITY", "STRUCTURED", "GENERAL"})
+
+_REWRITE_PROMPT = (
+    "Ты — помощник по поиску недвижимости. "
+    "Пользователь задал вопрос, но результаты поиска оказались нерелевантными.\n\n"
+    "Переформулируй запрос так, чтобы он лучше подходил для поиска по базе недвижимости.\n"
+    "Верни ТОЛЬКО переформулированный запрос, без пояснений.\n\n"
+    "Оригинальный запрос: {query}"
+)
+
+
+# ---------------------------------------------------------------------------
+# H2: Context builder
+# ---------------------------------------------------------------------------
+
+
+def build_retrieved_context(
+    results: list[dict[str, Any]],
+    limit: int = 5,
+) -> list[dict[str, str | float]]:
+    """Build curated context snippets for LLM-as-a-Judge evaluation.
+
+    Shared between rag_pipeline._build_retrieved_context and
+    graph/nodes/retrieve._build_retrieved_context (identical logic).
+    """
+    ctx: list[dict[str, str | float]] = []
+    for doc in results[:limit]:
+        if not isinstance(doc, dict):
+            continue
+        text = doc.get("text", "")
+        meta = doc.get("metadata", {})
+        ctx.append(
+            {
+                "content": text[:_MAX_CONTEXT_SNIPPET],
+                "score": doc.get("score", 0),
+                "chunk_location": meta.get("chunk_location", ""),
+            }
+        )
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# H4: Query rewrite
+# ---------------------------------------------------------------------------
+
+
+async def rewrite_query_via_llm(
+    query: str,
+    *,
+    llm: Any,
+) -> tuple[str, bool, str]:
+    """Call LLM to rewrite query for better retrieval.
+
+    Args:
+        query: The original query string.
+        llm: LLM client (OpenAI-compatible: llm.chat.completions.create).
+
+    Returns:
+        Tuple of (rewritten_query, effective, model_name).
+        - rewritten_query: reformulated query, or original if rewrite same
+        - effective: True if the rewrite produced a different query
+        - model_name: the model used for rewriting
+
+    Raises:
+        Exception: propagates LLM errors to caller (adapter handles fallback).
+    """
+    from telegram_bot.graph.config import GraphConfig
+
+    config = GraphConfig.from_env()
+    prompt = _REWRITE_PROMPT.format(query=query)
+    response = await llm.chat.completions.create(
+        model=config.rewrite_model,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.3,
+        max_tokens=config.rewrite_max_tokens,
+        name="rewrite-query",  # type: ignore[call-overload]  # langfuse kwarg
+    )
+    rewritten = (response.choices[0].message.content or "").strip()
+    actual_model = getattr(response, "model", config.rewrite_model) or config.rewrite_model
+
+    if not rewritten or rewritten == query:
+        return (query, False, actual_model)
+    return (rewritten, True, actual_model)
+
+
+# ---------------------------------------------------------------------------
+# H3: Rerank
+# ---------------------------------------------------------------------------
+
+
+async def perform_rerank(
+    query: str,
+    documents: list[dict[str, Any]],
+    *,
+    cache: Any | None = None,
+    reranker: Any | None = None,
+    top_k: int,
+) -> tuple[list[dict[str, Any]], bool, bool]:
+    """Rerank documents using ColBERT reranker or return cache hit.
+
+    Args:
+        query: The query string for reranking.
+        documents: Retrieved document dicts with "text" and "score" keys.
+        cache: Optional cache instance with get_rerank_results / store_rerank_results.
+        reranker: Optional ColBERT reranker instance with .rerank() method.
+        top_k: Number of documents to return.
+
+    Returns:
+        Tuple of (reranked_docs, rerank_applied, rerank_cache_hit).
+        - reranked_docs: the final list of documents
+        - rerank_applied: True if ColBERT reranking was used
+        - rerank_cache_hit: True if result came from cache
+
+    Notes:
+        Callers are responsible for Langfuse span tracking, PipelineMetrics,
+        and fallback logic when reranker raises an exception.
+        When no reranker is provided, returns all documents unmodified (no sort).
+        Callers should sort/trim on the no-reranker path if needed.
+    """
+    if not documents:
+        return ([], False, False)
+
+    if reranker is not None:
+        _cache_get = getattr(cache, "get_rerank_results", None) if cache is not None else None
+        _cache_store = getattr(cache, "store_rerank_results", None) if cache is not None else None
+        _has_get_rerank = callable(_cache_get) and asyncio.iscoroutinefunction(_cache_get)
+        _has_store_rerank = callable(_cache_store) and asyncio.iscoroutinefunction(_cache_store)
+
+        if _has_get_rerank and _cache_get is not None:
+            cached_reranked = await _cache_get(query, documents, top_k)
+            if cached_reranked is not None:
+                return (cached_reranked, True, True)
+
+        # May raise — callers handle error + fallback sort
+        doc_texts = [doc.get("text", "") for doc in documents]
+        rerank_results = await reranker.rerank(query=query, documents=doc_texts, top_k=top_k)
+
+        reranked: list[dict[str, Any]] = []
+        for rr in rerank_results:
+            idx = rr["index"]
+            if idx < len(documents):
+                doc = {**documents[idx], "score": rr["score"]}
+                reranked.append(doc)
+
+        if _has_store_rerank and _cache_store is not None:
+            await _cache_store(query, documents, top_k, reranked)
+
+        return (reranked, True, False)
+
+    # No reranker — return documents as-is; callers sort/trim as needed
+    return (documents, False, False)
+
+
+# ---------------------------------------------------------------------------
+# H1: Embedding computation + semantic cache check
+# ---------------------------------------------------------------------------
+
+
+async def compute_query_embedding(
+    query: str,
+    *,
+    cache: Any,
+    embeddings: Any,
+    pre_computed: list[float] | None = None,
+    pre_computed_sparse: Any = None,
+    pre_computed_colbert: list[list[float]] | None = None,
+) -> tuple[list[float], Any, list[list[float]] | None, bool]:
+    """Get or compute dense query embedding with optional sparse side-product.
+
+    Handles three paths:
+    1. Pre-computed: caller already has the embedding (e.g. agent pre-fetch) → return immediately.
+    2. Redis cache hit: embedding stored from previous request → return with from_cache=True.
+    3. Model compute: call embeddings.aembed_hybrid (preferred) or aembed_query, cache result.
+
+    Args:
+        query: The query string.
+        cache: Cache instance with get_embedding / store_embedding / store_sparse_embedding.
+        embeddings: Embedding model with aembed_hybrid or aembed_query.
+        pre_computed: Pre-computed dense vector (bypasses all computation).
+        pre_computed_sparse: Pre-computed sparse vector; returned alongside pre_computed.
+        pre_computed_colbert: Pre-computed ColBERT vectors; returned alongside pre_computed.
+
+    Returns:
+        Tuple of (dense, sparse, colbert, from_cache).
+        - dense: dense embedding vector (always present)
+        - sparse: sparse vector if computed via hybrid or pre_computed_sparse; else None
+        - colbert: pre_computed_colbert if provided; else None
+          (ColBERT-after-miss fetching is the caller's responsibility)
+        - from_cache: True if dense vector came from Redis cache
+
+    Raises:
+        Exception: propagates embedding model errors to caller (adapter handles fallback).
+    """
+    # Path 1: caller already has pre-computed vectors
+    if pre_computed is not None:
+        return (pre_computed, pre_computed_sparse, pre_computed_colbert, False)
+
+    # Path 2: check Redis embedding cache
+    dense = await cache.get_embedding(query)
+    from_cache = dense is not None
+
+    if dense is not None:
+        return (dense, None, None, from_cache)
+
+    # Path 3: compute via model
+    _has_hybrid = callable(
+        getattr(embeddings, "aembed_hybrid", None)
+    ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid)
+
+    if _has_hybrid:
+        dense, sparse = await embeddings.aembed_hybrid(query)
+        await cache.store_embedding(query, dense)
+        await cache.store_sparse_embedding(query, sparse)
+    else:
+        dense = await embeddings.aembed_query(query)
+        await cache.store_embedding(query, dense)
+        sparse = None
+
+    return (dense, sparse, None, False)
+
+
+async def check_semantic_cache(
+    query: str,
+    vector: list[float],
+    query_type: str,
+    *,
+    cache: Any,
+    agent_role: str | None = None,
+) -> tuple[bool, str | None]:
+    """Check semantic cache for a given query vector.
+
+    Only checks for query types in CACHEABLE_QUERY_TYPES.
+
+    Args:
+        query: The query string.
+        vector: Dense embedding vector for semantic similarity lookup.
+        query_type: Query type (e.g. "FAQ", "GENERAL"). Non-cacheable types skip check.
+        cache: Cache instance with check_semantic method.
+        agent_role: Optional role for role-gated cache scoping (agent SDK only).
+
+    Returns:
+        Tuple of (hit, response).
+        - hit: True if a cached response was found
+        - response: The cached response string, or None on miss
+    """
+    if query_type not in CACHEABLE_QUERY_TYPES:
+        return (False, None)
+
+    cached = await cache.check_semantic(
+        query=query,
+        vector=vector,
+        query_type=query_type,
+        cache_scope="rag",
+        agent_role=agent_role,
+    )
+
+    if cached:
+        return (True, cached)
+    return (False, None)

--- a/tests/unit/services/test_rag_core.py
+++ b/tests/unit/services/test_rag_core.py
@@ -1,0 +1,426 @@
+"""Tests for telegram_bot.services.rag_core — shared RAG core functions.
+
+TDD: tests written BEFORE implementation.  All tests will initially fail with
+ImportError (module doesn't exist yet) — that's the expected RED state.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from telegram_bot.services.rag_core import (
+    CACHEABLE_QUERY_TYPES,
+    build_retrieved_context,
+    check_semantic_cache,
+    compute_query_embedding,
+    perform_rerank,
+    rewrite_query_via_llm,
+)
+
+
+# ---------------------------------------------------------------------------
+# H2: build_retrieved_context
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRetrievedContext:
+    """Tests for build_retrieved_context — identical in both pipeline files."""
+
+    def test_empty_list_returns_empty(self):
+        assert build_retrieved_context([]) == []
+
+    def test_extracts_text_score_and_chunk_location(self):
+        docs = [
+            {"text": "hello world", "score": 0.85, "metadata": {"chunk_location": "doc/p1"}},
+        ]
+        result = build_retrieved_context(docs)
+        assert len(result) == 1
+        assert result[0]["content"] == "hello world"
+        assert result[0]["score"] == 0.85
+        assert result[0]["chunk_location"] == "doc/p1"
+
+    def test_respects_limit(self):
+        docs = [{"text": f"doc {i}", "score": 0.1 * i, "metadata": {}} for i in range(10)]
+        result = build_retrieved_context(docs, limit=3)
+        assert len(result) == 3
+
+    def test_default_limit_is_five(self):
+        docs = [{"text": f"doc {i}", "score": 0.1, "metadata": {}} for i in range(10)]
+        result = build_retrieved_context(docs)
+        assert len(result) == 5
+
+    def test_skips_non_dict_entries(self):
+        docs = [
+            "not a dict",
+            {"text": "valid", "score": 0.5, "metadata": {}},
+        ]
+        result = build_retrieved_context(docs)
+        assert len(result) == 1
+        assert result[0]["content"] == "valid"
+
+    def test_truncates_text_to_500_chars(self):
+        long_text = "x" * 600
+        docs = [{"text": long_text, "score": 0.5, "metadata": {}}]
+        result = build_retrieved_context(docs)
+        assert len(result[0]["content"]) == 500
+
+    def test_missing_metadata_uses_empty_string_for_chunk_location(self):
+        docs = [{"text": "content", "score": 0.7}]
+        result = build_retrieved_context(docs)
+        assert result[0]["chunk_location"] == ""
+
+
+# ---------------------------------------------------------------------------
+# H4: rewrite_query_via_llm
+# ---------------------------------------------------------------------------
+
+
+def _make_llm_response(content: str, model: str = "gpt-4o") -> MagicMock:
+    """Create a mock LLM response object matching OpenAI-compatible API."""
+    response = MagicMock()
+    response.choices[0].message.content = content
+    response.model = model
+    return response
+
+
+class TestRewriteQueryViaLlm:
+    """Tests for rewrite_query_via_llm core function."""
+
+    async def test_successful_rewrite_returns_new_query(self, monkeypatch):
+        llm = MagicMock()
+        llm.chat.completions.create = AsyncMock(
+            return_value=_make_llm_response("квартира с балконом", model="gpt-4o")
+        )
+
+        monkeypatch.setenv("REWRITE_MODEL", "gpt-4o")
+        monkeypatch.setenv("REWRITE_MAX_TOKENS", "200")
+
+        rewritten, effective, model = await rewrite_query_via_llm("балкон квартира", llm=llm)
+
+        assert rewritten == "квартира с балконом"
+        assert effective is True
+        assert model == "gpt-4o"
+
+    async def test_same_as_original_marks_not_effective(self, monkeypatch):
+        original = "двухкомнатная квартира"
+        llm = MagicMock()
+        llm.chat.completions.create = AsyncMock(
+            return_value=_make_llm_response(original, model="gpt-4o")
+        )
+
+        monkeypatch.setenv("REWRITE_MODEL", "gpt-4o")
+        monkeypatch.setenv("REWRITE_MAX_TOKENS", "200")
+
+        rewritten, effective, _ = await rewrite_query_via_llm(original, llm=llm)
+
+        assert rewritten == original
+        assert effective is False
+
+    async def test_empty_llm_response_keeps_original(self, monkeypatch):
+        original = "студия у моря"
+        llm = MagicMock()
+        llm.chat.completions.create = AsyncMock(return_value=_make_llm_response("", model="gpt-4o"))
+
+        monkeypatch.setenv("REWRITE_MODEL", "gpt-4o")
+        monkeypatch.setenv("REWRITE_MAX_TOKENS", "200")
+
+        rewritten, effective, _ = await rewrite_query_via_llm(original, llm=llm)
+
+        assert rewritten == original
+        assert effective is False
+
+    async def test_llm_error_raises_exception(self, monkeypatch):
+        llm = MagicMock()
+        llm.chat.completions.create = AsyncMock(side_effect=ConnectionError("LLM unavailable"))
+
+        monkeypatch.setenv("REWRITE_MODEL", "gpt-4o")
+        monkeypatch.setenv("REWRITE_MAX_TOKENS", "200")
+
+        with pytest.raises(ConnectionError, match="LLM unavailable"):
+            await rewrite_query_via_llm("test query", llm=llm)
+
+
+# ---------------------------------------------------------------------------
+# H3: perform_rerank
+# ---------------------------------------------------------------------------
+
+
+class TestPerformRerank:
+    """Tests for perform_rerank core function."""
+
+    async def test_empty_documents_returns_empty(self):
+        docs, applied, cache_hit = await perform_rerank(
+            "query", [], cache=None, reranker=None, top_k=3
+        )
+        assert docs == []
+        assert applied is False
+        assert cache_hit is False
+
+    async def test_no_reranker_returns_documents_unchanged(self):
+        """Without reranker, returns all docs unmodified; callers sort/trim."""
+        documents = [
+            {"text": "doc1", "score": 0.5},
+            {"text": "doc2", "score": 0.9},
+            {"text": "doc3", "score": 0.7},
+        ]
+        docs, applied, cache_hit = await perform_rerank(
+            "query", documents, cache=None, reranker=None, top_k=2
+        )
+        assert docs == documents  # unchanged, caller's responsibility to sort
+        assert applied is False
+        assert cache_hit is False
+
+    async def test_reranker_cache_hit_skips_rerank_call(self):
+        documents = [{"text": "doc1", "score": 0.5}]
+        cached = [{"text": "doc1", "score": 0.95}]
+
+        cache = AsyncMock()
+        cache.get_rerank_results = AsyncMock(return_value=cached)
+        reranker = AsyncMock()
+
+        docs, applied, cache_hit = await perform_rerank(
+            "query", documents, cache=cache, reranker=reranker, top_k=3
+        )
+
+        assert docs == cached
+        assert applied is True
+        assert cache_hit is True
+        reranker.rerank.assert_not_awaited()
+
+    async def test_reranker_success_returns_reranked_docs(self):
+        documents = [
+            {"text": "doc0", "score": 0.5},
+            {"text": "doc1", "score": 0.6},
+            {"text": "doc2", "score": 0.7},
+        ]
+        rerank_results = [
+            {"index": 2, "score": 0.98},
+            {"index": 0, "score": 0.85},
+        ]
+
+        cache = AsyncMock()
+        cache.get_rerank_results = AsyncMock(return_value=None)
+        cache.store_rerank_results = AsyncMock()
+        reranker = AsyncMock()
+        reranker.rerank = AsyncMock(return_value=rerank_results)
+
+        docs, applied, cache_hit = await perform_rerank(
+            "query", documents, cache=cache, reranker=reranker, top_k=2
+        )
+
+        assert len(docs) == 2
+        assert docs[0]["text"] == "doc2"  # index=2
+        assert docs[0]["score"] == 0.98
+        assert docs[1]["text"] == "doc0"  # index=0
+        assert docs[1]["score"] == 0.85
+        assert applied is True
+        assert cache_hit is False
+        cache.store_rerank_results.assert_awaited_once()
+
+    async def test_reranker_error_propagates_to_caller(self):
+        """Reranker errors propagate so callers can log spans and do fallback."""
+        documents = [
+            {"text": "doc1", "score": 0.5},
+            {"text": "doc2", "score": 0.9},
+        ]
+
+        cache = AsyncMock()
+        cache.get_rerank_results = AsyncMock(return_value=None)
+        reranker = AsyncMock()
+        reranker.rerank = AsyncMock(side_effect=RuntimeError("reranker unavailable"))
+
+        with pytest.raises(RuntimeError, match="reranker unavailable"):
+            await perform_rerank("query", documents, cache=cache, reranker=reranker, top_k=2)
+
+    async def test_no_cache_skips_rerank_cache_operations(self):
+        """When cache=None, reranker works without caching."""
+        documents = [{"text": "doc0", "score": 0.5}]
+        rerank_results = [{"index": 0, "score": 0.9}]
+
+        reranker = AsyncMock()
+        reranker.rerank = AsyncMock(return_value=rerank_results)
+
+        docs, applied, cache_hit = await perform_rerank(
+            "query", documents, cache=None, reranker=reranker, top_k=1
+        )
+
+        assert len(docs) == 1
+        assert applied is True
+        assert cache_hit is False
+
+
+# ---------------------------------------------------------------------------
+# H1: compute_query_embedding + check_semantic_cache
+# ---------------------------------------------------------------------------
+
+
+class TestComputeQueryEmbedding:
+    """Tests for compute_query_embedding core function."""
+
+    async def test_pre_computed_returns_immediately(self):
+        """Pre-computed embedding bypasses cache and model calls."""
+        cache = AsyncMock()
+        embeddings = AsyncMock()
+        pre_dense = [0.1] * 10
+        pre_sparse = {"indices": [1], "values": [0.5]}
+        pre_colbert = [[0.1] * 10]
+
+        dense, sparse, colbert, from_cache = await compute_query_embedding(
+            "query",
+            cache=cache,
+            embeddings=embeddings,
+            pre_computed=pre_dense,
+            pre_computed_sparse=pre_sparse,
+            pre_computed_colbert=pre_colbert,
+        )
+
+        assert dense == pre_dense
+        assert sparse == pre_sparse
+        assert colbert == pre_colbert
+        assert from_cache is False
+        cache.get_embedding.assert_not_awaited()
+        embeddings.aembed_query.assert_not_awaited()
+
+    async def test_pre_computed_no_sparse_colbert_returns_none(self):
+        """Pre-computed dense only: sparse and colbert are None."""
+        cache = AsyncMock()
+        embeddings = AsyncMock()
+        pre_dense = [0.2] * 10
+
+        dense, sparse, colbert, from_cache = await compute_query_embedding(
+            "query",
+            cache=cache,
+            embeddings=embeddings,
+            pre_computed=pre_dense,
+        )
+
+        assert dense == pre_dense
+        assert sparse is None
+        assert colbert is None
+        assert from_cache is False
+
+    async def test_from_redis_cache_returns_with_flag(self):
+        """Embedding found in Redis: from_cache=True, no model call."""
+        cached_dense = [0.2] * 10
+        cache = AsyncMock()
+        cache.get_embedding = AsyncMock(return_value=cached_dense)
+        embeddings = AsyncMock()
+
+        dense, sparse, colbert, from_cache = await compute_query_embedding(
+            "query", cache=cache, embeddings=embeddings
+        )
+
+        assert dense == cached_dense
+        assert sparse is None
+        assert colbert is None
+        assert from_cache is True
+        embeddings.aembed_query.assert_not_awaited()
+
+    async def test_hybrid_embedding_stores_both(self):
+        """When aembed_hybrid is available, use it and store both vectors."""
+        cache = AsyncMock()
+        cache.get_embedding = AsyncMock(return_value=None)
+        cache.store_embedding = AsyncMock()
+        cache.store_sparse_embedding = AsyncMock()
+
+        dense_vec = [0.3] * 10
+        sparse_vec = {"indices": [2], "values": [0.8]}
+
+        embeddings = AsyncMock()
+        embeddings.aembed_hybrid = AsyncMock(return_value=(dense_vec, sparse_vec))
+
+        dense, sparse, colbert, from_cache = await compute_query_embedding(
+            "query", cache=cache, embeddings=embeddings
+        )
+
+        assert dense == dense_vec
+        assert sparse == sparse_vec
+        assert colbert is None
+        assert from_cache is False
+        cache.store_embedding.assert_awaited_once_with("query", dense_vec)
+        cache.store_sparse_embedding.assert_awaited_once_with("query", sparse_vec)
+
+    async def test_dense_only_embedding_stored(self):
+        """When aembed_hybrid not available, use aembed_query."""
+        cache = AsyncMock()
+        cache.get_embedding = AsyncMock(return_value=None)
+        cache.store_embedding = AsyncMock()
+
+        dense_vec = [0.4] * 10
+
+        # Use spec= so aembed_hybrid is absent → _has_hybrid = False
+        embeddings = AsyncMock(spec=["aembed_query"])
+        embeddings.aembed_query = AsyncMock(return_value=dense_vec)
+
+        dense, sparse, colbert, from_cache = await compute_query_embedding(
+            "query", cache=cache, embeddings=embeddings
+        )
+
+        assert dense == dense_vec
+        assert sparse is None
+        assert colbert is None
+        assert from_cache is False
+        cache.store_embedding.assert_awaited_once_with("query", dense_vec)
+
+    async def test_embedding_error_raises_exception(self):
+        """On embedding failure, raises the original exception."""
+        cache = AsyncMock()
+        cache.get_embedding = AsyncMock(return_value=None)
+
+        embeddings = AsyncMock()
+        embeddings.aembed_hybrid = AsyncMock(side_effect=RuntimeError("BGE-M3 connection failed"))
+
+        with pytest.raises(RuntimeError, match="BGE-M3 connection failed"):
+            await compute_query_embedding("query", cache=cache, embeddings=embeddings)
+
+
+class TestCheckSemanticCache:
+    """Tests for check_semantic_cache core function."""
+
+    async def test_non_cacheable_type_returns_miss(self):
+        """Non-cacheable query type skips cache.check_semantic entirely."""
+        cache = AsyncMock()
+        hit, response = await check_semantic_cache("query", [0.1] * 10, "APARTMENT", cache=cache)
+        assert hit is False
+        assert response is None
+        cache.check_semantic.assert_not_awaited()
+
+    async def test_cacheable_type_hit_returns_response(self):
+        cache = AsyncMock()
+        cache.check_semantic = AsyncMock(return_value="Cached FAQ answer")
+
+        hit, response = await check_semantic_cache("query", [0.1] * 10, "FAQ", cache=cache)
+
+        assert hit is True
+        assert response == "Cached FAQ answer"
+
+    async def test_cacheable_type_miss_returns_false(self):
+        cache = AsyncMock()
+        cache.check_semantic = AsyncMock(return_value=None)
+
+        hit, response = await check_semantic_cache("query", [0.1] * 10, "GENERAL", cache=cache)
+
+        assert hit is False
+        assert response is None
+
+    async def test_agent_role_passed_to_cache(self):
+        """agent_role kwarg is forwarded to cache.check_semantic."""
+        cache = AsyncMock()
+        cache.check_semantic = AsyncMock(return_value="Role-gated response")
+
+        hit, _response = await check_semantic_cache(
+            "query", [0.1] * 10, "ENTITY", cache=cache, agent_role="sales"
+        )
+
+        assert hit is True
+        call_kwargs = cache.check_semantic.call_args.kwargs
+        assert call_kwargs.get("agent_role") == "sales"
+
+    async def test_all_cacheable_types_are_checked(self):
+        """CACHEABLE_QUERY_TYPES includes expected types."""
+        assert "FAQ" in CACHEABLE_QUERY_TYPES
+        assert "ENTITY" in CACHEABLE_QUERY_TYPES
+        assert "STRUCTURED" in CACHEABLE_QUERY_TYPES
+        assert "GENERAL" in CACHEABLE_QUERY_TYPES
+        # Non-cacheable types not included
+        assert "APARTMENT" not in CACHEABLE_QUERY_TYPES


### PR DESCRIPTION
## Summary

Resolves #779. Eliminates ~300 LOC of duplication between the agent SDK pipeline (`rag_pipeline.py`) and LangGraph nodes (`cache.py` / `retrieve.py` / `rerank.py` / `rewrite.py`).

### New module: `telegram_bot/services/rag_core.py`

| Function | Duplication type | Callers |
|---|---|---|
| `build_retrieved_context()` | H2 — 100% identical | `retrieve.py`, `rag_pipeline.py` |
| `rewrite_query_via_llm()` | H4 — 75% overlap | `rewrite.py`, `rag_pipeline.py` |
| `perform_rerank()` | H3 — 70% overlap | `rerank.py`, `rag_pipeline.py` |
| `compute_query_embedding()` | H1a — 60% overlap | `cache.py`, `rag_pipeline.py` |
| `check_semantic_cache()` | H1b — 60% overlap | `cache.py`, `rag_pipeline.py` |
| `CACHEABLE_QUERY_TYPES` | moved from `cache.py` | all of the above |

### Design

- **Core functions**: pure computation, no Langfuse spans, no PipelineMetrics, raise on error
- **Adapters** (pipeline / nodes): keep `@observe()`, `PipelineMetrics.get().record()`, `get_client().update_current_span(level="ERROR")`, fallback sort logic
- `perform_rerank()` propagates reranker exceptions so callers can set Langfuse error spans and fall back to score sort

### TDD

28 unit tests written **before** implementation (`tests/unit/services/test_rag_core.py`). All RED first, then GREEN after minimal code.

## Test plan

- [x] `uv run pytest tests/unit/services/test_rag_core.py` — 28/28 pass
- [x] `uv run pytest tests/unit/ -n auto` — 4418 pass, 6 pre-existing failures unchanged
- [x] `make check` — ruff + mypy clean (73 source files)
- [x] Pre-commit hooks pass (ruff-check, ruff-format, trailing-whitespace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)