### PR TITLE
refactor(bot): ErrorHandlerMiddleware → dp.errors router (M5)

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -46,7 +46,7 @@ from .handlers.handoff import (
     start_qualification,
 )
 from .keyboards.client_keyboard import build_client_keyboard, parse_menu_button
-from .middlewares import setup_error_middleware, setup_throttling_middleware
+from .middlewares import setup_error_handler, setup_throttling_middleware
 from .observability import (
     create_callback_handler,
     get_client,
@@ -461,7 +461,7 @@ class PropertyBot:
     def _setup_middlewares(self):
         """Setup bot middlewares."""
         setup_throttling_middleware(self.dp, rate_limit=1.5, admin_ids=self.config.admin_ids)
-        setup_error_middleware(self.dp)
+        setup_error_handler(self.dp)
         logger.info("Middlewares configured")
 
     @staticmethod

--- a/telegram_bot/middlewares/__init__.py
+++ b/telegram_bot/middlewares/__init__.py
@@ -1,16 +1,16 @@
 """Middlewares for bot."""
 
-from .error_handler import ErrorHandlerMiddleware, setup_error_middleware
+from .error_handler import handle_error, setup_error_handler
 from .i18n import I18nMiddleware, create_translator_hub, setup_i18n_middleware
 from .throttling import ThrottlingMiddleware, setup_throttling_middleware
 
 
 __all__ = [
-    "ErrorHandlerMiddleware",
     "I18nMiddleware",
     "ThrottlingMiddleware",
     "create_translator_hub",
-    "setup_error_middleware",
+    "handle_error",
+    "setup_error_handler",
     "setup_i18n_middleware",
     "setup_throttling_middleware",
 ]

--- a/telegram_bot/middlewares/error_handler.py
+++ b/telegram_bot/middlewares/error_handler.py
@@ -1,58 +1,53 @@
-"""Error handling middleware for bot."""
+"""Error handler registered on dp.errors router for all event types."""
 
 from __future__ import annotations
 
 import logging
-from collections.abc import Awaitable, Callable
-from typing import Any
 
-from aiogram import BaseMiddleware, Dispatcher
-from aiogram.types import Message, TelegramObject
+from aiogram import Dispatcher
+from aiogram.filters import ExceptionTypeFilter
+from aiogram.types import ErrorEvent
 
 
 logger = logging.getLogger(__name__)
 
+_ERROR_TEXT = (
+    "❌ Произошла ошибка при обработке запроса. Попробуйте позже или обратитесь к администратору."
+)
 
-class ErrorHandlerMiddleware(BaseMiddleware):
+
+async def handle_error(event: ErrorEvent) -> None:
+    """Handle any exception raised in an aiogram handler.
+
+    Covers all event types: Message, CallbackQuery, InlineQuery, etc.
+    Logs the error and sends a user-friendly reply when possible.
     """
-    Middleware for centralized error handling.
+    exception = event.exception
+    update = event.update
 
-    Catches exceptions in handlers and provides user-friendly error messages.
-    """
+    logger.error(
+        "Error in handler for update %s: %s",
+        type(update).__name__,
+        exception,
+        exc_info=exception,
+    )
 
-    async def __call__(
-        self,
-        handler: Callable[[TelegramObject, dict[str, Any]], Awaitable[Any]],
-        event: TelegramObject,
-        data: dict[str, Any],
-    ) -> Any:
-        """Process event with error handling."""
-        try:
-            return await handler(event, data)
-        except Exception as e:
-            logger.error(
-                f"Error in handler for event {type(event).__name__}: {e}",
-                exc_info=True,
-            )
+    # Resolve a message to reply to, if the update carries one.
+    message = None
+    if update.message is not None:
+        message = update.message
+    elif update.callback_query is not None and update.callback_query.message is not None:
+        message = update.callback_query.message
 
-            # Send user-friendly error message
-            if isinstance(event, Message):
-                await event.answer(
-                    "❌ Произошла ошибка при обработке запроса. "
-                    "Попробуйте позже или обратитесь к администратору."
-                )
-
-            # Re-raise to allow error router to handle if needed
-            raise
+    if message is not None:
+        await message.answer(_ERROR_TEXT)
 
 
-def setup_error_middleware(dp: Dispatcher) -> None:
-    """
-    Setup error handling middleware.
+def setup_error_handler(dp: Dispatcher) -> None:
+    """Register handle_error on dp.errors, covering all aiogram event types.
 
     Args:
         dp: Dispatcher instance
     """
-    middleware = ErrorHandlerMiddleware()
-    dp.message.outer_middleware.register(middleware)
-    logger.info("Error handling middleware registered")
+    dp.errors.register(handle_error, ExceptionTypeFilter(Exception))
+    logger.info("Error handler registered via dp.errors")

--- a/tests/unit/test_error_handler.py
+++ b/tests/unit/test_error_handler.py
@@ -1,0 +1,143 @@
+"""Tests for dp.errors router error handler (M5 refactor).
+
+Verifies that handle_error covers all event types (Message, CallbackQuery,
+InlineQuery) and that setup_error_handler registers via dp.errors.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestHandleError:
+    """Tests for the handle_error function."""
+
+    async def test_logs_error_with_exc_info(self) -> None:
+        """Handler logs the exception with exc_info for traceback capture."""
+        from telegram_bot.middlewares.error_handler import handle_error
+
+        exception = ValueError("something went wrong")
+        mock_update = MagicMock()
+        mock_update.message = None
+        mock_update.callback_query = None
+
+        mock_event = MagicMock()
+        mock_event.exception = exception
+        mock_event.update = mock_update
+
+        with patch("telegram_bot.middlewares.error_handler.logger") as mock_logger:
+            await handle_error(mock_event)
+
+        mock_logger.error.assert_called_once()
+        call_kwargs = mock_logger.error.call_args.kwargs
+        assert call_kwargs.get("exc_info") is exception
+
+    async def test_sends_message_when_update_has_message(self) -> None:
+        """Handler sends user-friendly reply when update.message is present."""
+        from telegram_bot.middlewares.error_handler import handle_error
+
+        mock_message = AsyncMock()
+        mock_update = MagicMock()
+        mock_update.message = mock_message
+        mock_update.callback_query = None
+
+        mock_event = MagicMock()
+        mock_event.exception = RuntimeError("handler crashed")
+        mock_event.update = mock_update
+
+        with patch("telegram_bot.middlewares.error_handler.logger"):
+            await handle_error(mock_event)
+
+        mock_message.answer.assert_called_once()
+        text = mock_message.answer.call_args.args[0]
+        assert "❌" in text
+
+    async def test_sends_message_via_callback_query(self) -> None:
+        """Handler replies via callback_query.message for CallbackQuery events."""
+        from telegram_bot.middlewares.error_handler import handle_error
+
+        mock_message = AsyncMock()
+        mock_callback = MagicMock()
+        mock_callback.message = mock_message
+
+        mock_update = MagicMock()
+        mock_update.message = None
+        mock_update.callback_query = mock_callback
+
+        mock_event = MagicMock()
+        mock_event.exception = RuntimeError("callback handler crashed")
+        mock_event.update = mock_update
+
+        with patch("telegram_bot.middlewares.error_handler.logger"):
+            await handle_error(mock_event)
+
+        mock_message.answer.assert_called_once()
+        text = mock_message.answer.call_args.args[0]
+        assert "❌" in text
+
+    async def test_no_crash_for_inline_or_other_event_types(self) -> None:
+        """Handler does not crash when update has no message or callback_query."""
+        from telegram_bot.middlewares.error_handler import handle_error
+
+        mock_update = MagicMock()
+        mock_update.message = None
+        mock_update.callback_query = None
+
+        mock_event = MagicMock()
+        mock_event.exception = RuntimeError("inline query error")
+        mock_event.update = mock_update
+
+        with patch("telegram_bot.middlewares.error_handler.logger"):
+            await handle_error(mock_event)  # must not raise
+
+    async def test_no_message_sent_when_no_message_in_update(self) -> None:
+        """Handler does not attempt answer() when there is no message to reply to."""
+        from telegram_bot.middlewares.error_handler import handle_error
+
+        mock_answer = AsyncMock()
+        mock_update = MagicMock()
+        mock_update.message = None
+        # callback_query exists but has no .message
+        mock_update.callback_query = MagicMock()
+        mock_update.callback_query.message = None
+
+        mock_event = MagicMock()
+        mock_event.exception = RuntimeError("poll error")
+        mock_event.update = mock_update
+
+        with patch("telegram_bot.middlewares.error_handler.logger"):
+            await handle_error(mock_event)
+
+        # Neither path should have triggered answer()
+        mock_answer.assert_not_called()
+
+
+class TestSetupErrorHandler:
+    """Tests for setup_error_handler registration."""
+
+    def test_registers_handle_error_on_dp_errors(self) -> None:
+        """setup_error_handler calls dp.errors.register with handle_error."""
+        from telegram_bot.middlewares.error_handler import handle_error, setup_error_handler
+
+        mock_dp = MagicMock()
+        setup_error_handler(mock_dp)
+
+        mock_dp.errors.register.assert_called_once()
+        registered_fn = mock_dp.errors.register.call_args.args[0]
+        assert registered_fn is handle_error
+
+    def test_registers_with_exception_type_filter(self) -> None:
+        """setup_error_handler passes ExceptionTypeFilter(Exception) as filter."""
+        from aiogram.filters import ExceptionTypeFilter
+
+        from telegram_bot.middlewares.error_handler import setup_error_handler
+
+        mock_dp = MagicMock()
+        setup_error_handler(mock_dp)
+
+        call_args = mock_dp.errors.register.call_args
+        # Second positional arg should be ExceptionTypeFilter instance
+        filters = call_args.args[1:]
+        assert any(isinstance(f, ExceptionTypeFilter) for f in filters), (
+            "setup_error_handler must pass ExceptionTypeFilter to dp.errors.register"
+        )


### PR DESCRIPTION
## Summary
- Replace ErrorHandlerMiddleware (Message-only) with dp.errors handler
- Covers ALL aiogram event types via ExceptionTypeFilter(Exception)
- Preserves: logging, user-friendly reply via message.answer()
- Resolves via callback_query.message for callback events

## Test plan
- [x] 7 unit tests for handle_error + setup_error_handler
- [x] All tests pass
- [x] Pre-commit (ruff + format) clean

Closes #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)