### PR TITLE
refactor(bot): migrate I18nMiddleware DI to dp.workflow_data (H5)

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -3848,20 +3848,22 @@ class PropertyBot:
         # Initialize i18n (fluentogram)
         from .middlewares.i18n import create_translator_hub, setup_i18n_middleware
 
+        # Register services in dp.workflow_data so all handlers receive them via data dict
+        self.dp["user_service"] = self._user_service
+        self.dp["lead_scoring_store"] = self._lead_scoring_store
+        self.dp["hot_lead_notifier"] = self._hot_lead_notifier
+        self.dp["kommo_client"] = self._kommo_client
+        self.dp["pg_pool"] = self._pg_pool
+        self.dp["bot_config"] = self.config
+        self.dp["property_bot"] = self
+        self.dp["ai_advisor_service"] = self._ai_advisor_service
+        self.dp["apartments_service"] = self._apartments_service
+        self.dp["favorites_service"] = self._favorites_service
+        self.dp["search_event_store"] = self._search_event_store
+
         if self._i18n_hub is None:
             self._i18n_hub = create_translator_hub()
-        setup_i18n_middleware(
-            self.dp,
-            self._i18n_hub,
-            self._user_service,
-            lead_scoring_store=self._lead_scoring_store,
-            hot_lead_notifier=self._hot_lead_notifier,
-            kommo_client=self._kommo_client,
-            pg_pool=self._pg_pool,
-            bot_config=self.config,
-            property_bot=self,
-            ai_advisor_service=self._ai_advisor_service,
-        )
+        setup_i18n_middleware(self.dp, self._i18n_hub, self._user_service)
         logger.info("i18n middleware ready")
 
         # Setup aiogram-dialog (#658: removed dead client_menu_dialog)

--- a/telegram_bot/middlewares/i18n.py
+++ b/telegram_bot/middlewares/i18n.py
@@ -71,25 +71,11 @@ class I18nMiddleware(BaseMiddleware):
         self,
         hub: TranslatorHub,
         user_service: UserService | None = None,
-        lead_scoring_store: Any | None = None,
-        hot_lead_notifier: Any | None = None,
-        kommo_client: Any | None = None,
-        pg_pool: Any | None = None,
-        bot_config: Any | None = None,
-        property_bot: Any | None = None,
-        ai_advisor_service: Any | None = None,
         default_locale: str = "ru",
     ) -> None:
         super().__init__()
         self._hub = hub
         self._user_service = user_service
-        self._lead_scoring_store = lead_scoring_store
-        self._hot_lead_notifier = hot_lead_notifier
-        self._kommo_client = kommo_client
-        self._pg_pool = pg_pool
-        self._bot_config = bot_config
-        self._property_bot = property_bot
-        self._ai_advisor_service = ai_advisor_service
         self._default_locale = default_locale
 
     async def __call__(
@@ -117,18 +103,6 @@ class I18nMiddleware(BaseMiddleware):
 
         data["i18n"] = self._hub.get_translator_by_locale(locale)
         data["locale"] = locale
-        data["user_service"] = self._user_service
-        data["lead_scoring_store"] = self._lead_scoring_store
-        data["hot_lead_notifier"] = self._hot_lead_notifier
-        data["kommo_client"] = self._kommo_client
-        data["pg_pool"] = self._pg_pool
-        data["bot_config"] = self._bot_config
-        data["property_bot"] = self._property_bot
-        data["ai_advisor_service"] = self._ai_advisor_service
-        if self._property_bot is not None:
-            data["apartments_service"] = getattr(self._property_bot, "_apartments_service", None)
-            data["favorites_service"] = getattr(self._property_bot, "_favorites_service", None)
-            data["search_event_store"] = getattr(self._property_bot, "_search_event_store", None)
         return await handler(event, data)
 
 
@@ -136,25 +110,11 @@ def setup_i18n_middleware(
     dp: Dispatcher,
     hub: TranslatorHub,
     user_service: UserService | None = None,
-    lead_scoring_store: Any | None = None,
-    hot_lead_notifier: Any | None = None,
-    kommo_client: Any | None = None,
-    pg_pool: Any | None = None,
-    bot_config: Any | None = None,
-    property_bot: Any | None = None,
-    ai_advisor_service: Any | None = None,
 ) -> None:
     """Register i18n middleware on all routers."""
     middleware = I18nMiddleware(
         hub=hub,
         user_service=user_service,
-        lead_scoring_store=lead_scoring_store,
-        hot_lead_notifier=hot_lead_notifier,
-        kommo_client=kommo_client,
-        pg_pool=pg_pool,
-        bot_config=bot_config,
-        property_bot=property_bot,
-        ai_advisor_service=ai_advisor_service,
     )
     dp.message.outer_middleware(middleware)
     dp.callback_query.outer_middleware(middleware)

--- a/tests/unit/middlewares/test_i18n.py
+++ b/tests/unit/middlewares/test_i18n.py
@@ -64,22 +64,19 @@ def test_translator_menu_keys(hub):
 
 
 @pytest.mark.asyncio
-async def test_i18n_middleware_injects_favorites_service(hub):
-    """Middleware injects favorites service for dialog getters via middleware_data."""
-    apartments_service = object()
-    favorites_service = object()
-    property_bot = SimpleNamespace(
-        _apartments_service=apartments_service,
-        _favorites_service=favorites_service,
-    )
-    middleware = I18nMiddleware(hub=hub, property_bot=property_bot)
+async def test_i18n_middleware_injects_only_i18n(hub):
+    """After H5 refactor: middleware injects only i18n + locale, not services."""
+    middleware = I18nMiddleware(hub=hub)
 
     event = SimpleNamespace()
-    data = {"event_from_user": SimpleNamespace(id=123, language_code="ru")}
+    data: dict = {"event_from_user": SimpleNamespace(id=123, language_code="ru")}
 
     async def handler(_event, _data):
         return _data
 
     result = await middleware(handler, event, data)
-    assert result["apartments_service"] is apartments_service
-    assert result["favorites_service"] is favorites_service
+    assert "i18n" in result
+    assert "locale" in result
+    # Services are NOT injected by middleware; they come from dp.workflow_data
+    assert "apartments_service" not in result
+    assert "favorites_service" not in result

--- a/tests/unit/test_i18n_middleware.py
+++ b/tests/unit/test_i18n_middleware.py
@@ -1,0 +1,194 @@
+"""Unit tests for simplified I18nMiddleware (H5 refactor)."""
+
+import pytest
+
+
+pytest.importorskip("aiogram", reason="aiogram not installed")
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aiogram import Dispatcher
+from aiogram.types import Message, User
+
+from telegram_bot.middlewares.i18n import I18nMiddleware, setup_i18n_middleware
+
+
+class TestI18nMiddlewareInit:
+    """Test I18nMiddleware.__init__ signature is simplified."""
+
+    def test_only_hub_required(self):
+        hub = MagicMock()
+        mw = I18nMiddleware(hub=hub)
+        assert mw._hub is hub
+        assert mw._user_service is None
+        assert mw._default_locale == "ru"
+
+    def test_with_user_service(self):
+        hub = MagicMock()
+        user_service = MagicMock()
+        mw = I18nMiddleware(hub=hub, user_service=user_service)
+        assert mw._user_service is user_service
+
+    def test_no_service_params(self):
+        """Middleware must NOT accept old service params (lead_scoring_store etc.)."""
+        import inspect
+
+        sig = inspect.signature(I18nMiddleware.__init__)
+        params = set(sig.parameters.keys())
+        forbidden = {
+            "lead_scoring_store",
+            "hot_lead_notifier",
+            "kommo_client",
+            "pg_pool",
+            "bot_config",
+            "property_bot",
+            "ai_advisor_service",
+        }
+        assert not (forbidden & params), f"Unexpected params still present: {forbidden & params}"
+
+
+class TestI18nMiddlewareCall:
+    """Test I18nMiddleware.__call__ injects only i18n + locale."""
+
+    def _make_hub(self, locale: str = "ru") -> MagicMock:
+        hub = MagicMock()
+        translator = MagicMock()
+        hub.get_translator_by_locale.return_value = translator
+        return hub
+
+    async def test_injects_i18n_and_locale(self):
+        hub = self._make_hub()
+        mw = I18nMiddleware(hub=hub, default_locale="ru")
+        handler = AsyncMock(return_value="ok")
+        event = MagicMock(spec=Message)
+        data: dict = {}
+
+        result = await mw(handler, event, data)
+
+        assert result == "ok"
+        assert "i18n" in data
+        assert data["locale"] == "ru"
+        hub.get_translator_by_locale.assert_called_once_with("ru")
+
+    async def test_does_not_inject_services(self):
+        """After refactor, services must NOT be injected by middleware."""
+        hub = self._make_hub()
+        mw = I18nMiddleware(hub=hub)
+        handler = AsyncMock(return_value=None)
+        event = MagicMock(spec=Message)
+        data: dict = {}
+
+        await mw(handler, event, data)
+
+        service_keys = {
+            "user_service",
+            "lead_scoring_store",
+            "hot_lead_notifier",
+            "kommo_client",
+            "pg_pool",
+            "bot_config",
+            "property_bot",
+            "ai_advisor_service",
+            "apartments_service",
+            "favorites_service",
+            "search_event_store",
+        }
+        injected = service_keys & data.keys()
+        assert not injected, f"Middleware should not inject services, got: {injected}"
+
+    async def test_uses_user_service_for_locale(self):
+        hub = self._make_hub()
+        user_service = MagicMock()
+        user_service.get_locale = AsyncMock(return_value="uk")
+        mw = I18nMiddleware(hub=hub, user_service=user_service)
+
+        user = MagicMock(spec=User)
+        user.id = 42
+        user.language_code = "uk"
+
+        handler = AsyncMock(return_value=None)
+        event = MagicMock(spec=Message)
+        data: dict = {"event_from_user": user}
+
+        await mw(handler, event, data)
+
+        assert data["locale"] == "uk"
+        user_service.get_locale.assert_called_once_with(telegram_id=42)
+
+    async def test_fallback_to_language_code(self):
+        hub = self._make_hub()
+        user_service = MagicMock()
+        user_service.get_locale = AsyncMock(return_value="ru")  # returns default
+        mw = I18nMiddleware(hub=hub, user_service=user_service, default_locale="ru")
+
+        user = MagicMock(spec=User)
+        user.id = 99
+        user.language_code = "en"
+
+        handler = AsyncMock(return_value=None)
+        event = MagicMock(spec=Message)
+        data: dict = {"event_from_user": user}
+
+        with patch(
+            "telegram_bot.services.user_service.detect_locale",
+            return_value="en",
+        ) as mock_detect:
+            await mw(handler, event, data)
+            mock_detect.assert_called_once_with("en")
+
+        assert data["locale"] == "en"
+
+    async def test_user_service_exception_fallback(self):
+        hub = self._make_hub()
+        user_service = MagicMock()
+        user_service.get_locale = AsyncMock(side_effect=RuntimeError("db down"))
+        mw = I18nMiddleware(hub=hub, user_service=user_service, default_locale="ru")
+
+        user = MagicMock(spec=User)
+        user.id = 7
+        user.language_code = None
+
+        handler = AsyncMock(return_value=None)
+        event = MagicMock(spec=Message)
+        data: dict = {"event_from_user": user}
+
+        # Should not raise; fall back to default locale
+        await mw(handler, event, data)
+        assert data["locale"] == "ru"
+
+    async def test_no_user_uses_default_locale(self):
+        hub = self._make_hub()
+        mw = I18nMiddleware(hub=hub, default_locale="en")
+        handler = AsyncMock(return_value=None)
+        event = MagicMock(spec=Message)
+        data: dict = {}
+
+        await mw(handler, event, data)
+
+        assert data["locale"] == "en"
+
+
+class TestSetupI18nMiddleware:
+    """Test that setup_i18n_middleware accepts only 3 params."""
+
+    def test_setup_signature(self):
+        import inspect
+
+        sig = inspect.signature(setup_i18n_middleware)
+        params = list(sig.parameters.keys())
+        assert params == ["dp", "hub", "user_service"], (
+            f"Expected [dp, hub, user_service], got {params}"
+        )
+
+    def test_registers_on_message_and_callback(self):
+        dp = MagicMock(spec=Dispatcher)
+        dp.message = MagicMock()
+        dp.message.outer_middleware = MagicMock()
+        dp.callback_query = MagicMock()
+        dp.callback_query.outer_middleware = MagicMock()
+
+        hub = MagicMock()
+        setup_i18n_middleware(dp, hub)
+
+        dp.message.outer_middleware.assert_called_once()
+        dp.callback_query.outer_middleware.assert_called_once()


### PR DESCRIPTION
## Summary
- Move 8 service injections from I18nMiddleware → dp.workflow_data
- I18nMiddleware now only handles i18n (locale detection + translator)
- Handlers continue receiving same data dict keys — no handler changes needed

## Test plan
- [x] make check (ruff + mypy) clean
- [x] make test-unit — all tests pass (parallel -n auto)
- [x] Unit tests for simplified I18nMiddleware

Closes #784