### PR TITLE
refactor(llm): deprecate LLMService in favor of generate_response (M1)

### DIFF
--- a/telegram_bot/services/__init__.py
+++ b/telegram_bot/services/__init__.py
@@ -38,6 +38,7 @@ __all__ = [
     "ExpandedChunk",
     "HistoryService",
     "HyDEGenerator",
+    # LLMService is deprecated — use generate_response() instead
     "LLMService",
     "LeadScoringStore",
     "PipelineMetrics",
@@ -65,6 +66,7 @@ _IMPORT_MAP = {
     "LeadScoringStore": ".lead_scoring_store",
     "SessionSummary": ".session_summary",
     "check_responses_parse_compat": ".session_summary",
+    # LLMService is deprecated — kept for backward compatibility only
     "LLMService": ".llm",
     "LOW_CONFIDENCE_THRESHOLD": ".llm",
     "PipelineMetrics": ".metrics",

--- a/telegram_bot/services/llm.py
+++ b/telegram_bot/services/llm.py
@@ -6,6 +6,7 @@ Uses OpenAI SDK via Langfuse drop-in replacement for auto-tracing.
 import json
 import logging
 import re
+import warnings
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from typing import Any
@@ -47,6 +48,12 @@ class LLMService:
         model: str = "gpt-4o-mini",
         low_confidence_threshold: float = LOW_CONFIDENCE_THRESHOLD,
     ):
+        warnings.warn(
+            "LLMService is deprecated and will be removed in a future release. "
+            "Use generate_response() from telegram_bot.services.generate_response instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.api_key = api_key
         self.base_url = base_url.rstrip("/")
         self.model = model

--- a/tests/chaos/test_llm_fallback.py
+++ b/tests/chaos/test_llm_fallback.py
@@ -12,7 +12,10 @@ from pytest_httpx import HTTPXMock
 from telegram_bot.services.llm import LOW_CONFIDENCE_THRESHOLD, ConfidenceResult, LLMService
 
 
-pytestmark = pytest.mark.httpx_mock(can_send_already_matched_responses=True)
+pytestmark = [
+    pytest.mark.httpx_mock(can_send_already_matched_responses=True),
+    pytest.mark.filterwarnings("ignore::DeprecationWarning"),
+]
 
 
 class TestLLMTimeout:

--- a/tests/integration/test_llm_generate.py
+++ b/tests/integration/test_llm_generate.py
@@ -2,6 +2,11 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
 
 async def test_llm_service_has_generate_method():
     """LLMService should have generate() method."""

--- a/tests/unit/services/test_llm.py
+++ b/tests/unit/services/test_llm.py
@@ -11,6 +11,9 @@ import pytest
 from telegram_bot.services.llm import LLMService
 
 
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
+
 def _mock_completion(content: str) -> MagicMock:
     """Helper: create a mock ChatCompletion response."""
     mock_response = MagicMock()

--- a/tests/unit/services/test_llm_observability.py
+++ b/tests/unit/services/test_llm_observability.py
@@ -11,6 +11,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
+
 class TestLLMServiceObservability:
     """Tests for LLMService observability via Langfuse drop-in replacement."""
 

--- a/tests/unit/test_guardrails.py
+++ b/tests/unit/test_guardrails.py
@@ -12,6 +12,9 @@ import pytest
 from telegram_bot.services.llm import LOW_CONFIDENCE_THRESHOLD, ConfidenceResult, LLMService
 
 
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
+
 def _mock_completion(content: str) -> MagicMock:
     """Helper: create a mock ChatCompletion response."""
     mock_response = MagicMock()

--- a/tests/unit/test_llm_service.py
+++ b/tests/unit/test_llm_service.py
@@ -8,6 +8,9 @@ import pytest
 from telegram_bot.services.llm import LLMService
 
 
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
+
 def _mock_completion(content: str) -> MagicMock:
     """Helper: create a mock ChatCompletion response."""
     mock_response = MagicMock()


### PR DESCRIPTION
## Summary
- Analyzed LLMService callers: zero production callers found in `telegram_bot/` — only tests directly reference it
- Added `DeprecationWarning` in `LLMService.__init__` pointing to `generate_response()` as the unified path
- Added deprecation comment in `telegram_bot/services/__init__.py` for LLMService export
- Updated 6 test files with `pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")` to keep tests clean

## Test plan
- [x] `make check` — ruff + mypy clean
- [x] `make test-unit` — 4456 passed, 15 skipped

Closes #791