### PR TITLE
fix(contextualization): Claude async system prompt caching fix (L6)

### DIFF
--- a/src/contextualization/claude.py
+++ b/src/contextualization/claude.py
@@ -89,32 +89,21 @@ class ClaudeContextualizer(ContextualizeProvider):
         system_prompt = self.get_system_prompt()
         user_prompt = self.get_user_prompt(text, query)
 
-        # Prepare request with optional cache control
-        user_content_item: dict[str, Any] = {
-            "type": "text",
-            "text": user_prompt,
-        }
+        # Build system param with optional prompt caching
+        system_content: str | list[dict[str, Any]]
         if self.use_cache:
-            user_content_item["cache_control"] = {"type": "ephemeral"}
+            system_content = [
+                {"type": "text", "text": system_prompt, "cache_control": {"type": "ephemeral"}}
+            ]
+        else:
+            system_content = system_prompt
 
-        kwargs = {
-            "model": self.settings.model_name,
-            "max_tokens": 256,
-            "messages": [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": system_prompt,
-                        },
-                        user_content_item,
-                    ],
-                }
-            ],
-        }
-
-        response = await self.client.messages.create(**kwargs)
+        response = await self.client.messages.create(
+            model=self.settings.model_name,
+            max_tokens=256,
+            system=system_content,
+            messages=[{"role": "user", "content": user_prompt}],
+        )
 
         # Track tokens and cost
         self.total_tokens += response.usage.input_tokens + response.usage.output_tokens

--- a/tests/unit/contextualization/test_claude.py
+++ b/tests/unit/contextualization/test_claude.py
@@ -249,7 +249,7 @@ class TestClaudeContextualizerContextualizeSingle:
         assert result.context_method == "claude"
 
     async def test_contextualize_single_with_cache_control(self, contextualizer):
-        """Test that cache control is included when use_cache is True."""
+        """Test that cache control is on the system= param when use_cache is True."""
         mock_response = MagicMock()
         mock_response.content = [MagicMock(text="Cached context")]
         mock_response.usage.input_tokens = 100
@@ -259,13 +259,16 @@ class TestClaudeContextualizerContextualizeSingle:
         await contextualizer.contextualize_single(text="Text", article_number="Art1")
 
         call_kwargs = contextualizer.client.messages.create.call_args[1]
-        messages = call_kwargs["messages"]
-        user_content = messages[0]["content"]
-        # Second item should have cache_control
-        assert any("cache_control" in item for item in user_content if isinstance(item, dict))
+        # System param must be a list with cache_control
+        system = call_kwargs["system"]
+        assert isinstance(system, list)
+        assert system[0]["cache_control"] == {"type": "ephemeral"}
+        # User content must be a plain string (no cache_control there)
+        user_content = call_kwargs["messages"][0]["content"]
+        assert isinstance(user_content, str)
 
     async def test_contextualize_single_without_cache_control(self, contextualizer):
-        """Test that cache control is excluded when use_cache is False."""
+        """Test that system= is a plain string when use_cache is False."""
         contextualizer.use_cache = False
         mock_response = MagicMock()
         mock_response.content = [MagicMock(text="Non-cached context")]
@@ -276,12 +279,8 @@ class TestClaudeContextualizerContextualizeSingle:
         await contextualizer.contextualize_single(text="Text", article_number="Art1")
 
         call_kwargs = contextualizer.client.messages.create.call_args[1]
-        messages = call_kwargs["messages"]
-        user_content = messages[0]["content"]
-        # No item should have cache_control
-        for item in user_content:
-            if isinstance(item, dict):
-                assert "cache_control" not in item
+        system = call_kwargs["system"]
+        assert isinstance(system, str)
 
     async def test_contextualize_single_tracks_tokens(self, contextualizer):
         """Test that token usage is tracked."""
@@ -340,12 +339,10 @@ class TestClaudeContextualizerContextualizeSingle:
 
         call_kwargs = contextualizer.client.messages.create.call_args[1]
         messages = call_kwargs["messages"]
-        # User prompt should contain the query
+        # User prompt should be a plain string containing the query
         user_content = messages[0]["content"]
-        user_text = "".join(
-            item["text"] for item in user_content if isinstance(item, dict) and "text" in item
-        )
-        assert "What are the fines?" in user_text
+        assert isinstance(user_content, str)
+        assert "What are the fines?" in user_content
 
 
 class TestClaudeContextualizerSync:

--- a/tests/unit/test_claude_contextualizer.py
+++ b/tests/unit/test_claude_contextualizer.py
@@ -1,0 +1,98 @@
+"""Tests for ClaudeContextualizer — verifies system prompt placement."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.contextualization.claude import ClaudeContextualizer
+
+
+def _make_response(text: str = "Summary") -> MagicMock:
+    content_block = MagicMock()
+    content_block.text = text
+    usage = MagicMock()
+    usage.input_tokens = 100
+    usage.output_tokens = 20
+    response = MagicMock()
+    response.content = [content_block]
+    response.usage = usage
+    return response
+
+
+@pytest.fixture()
+def contextualizer(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    with (
+        patch("src.contextualization.claude.AsyncAnthropic"),
+        patch("src.contextualization.claude.Anthropic"),
+    ):
+        return ClaudeContextualizer(use_cache=True)
+
+
+@pytest.fixture()
+def contextualizer_no_cache(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    with (
+        patch("src.contextualization.claude.AsyncAnthropic"),
+        patch("src.contextualization.claude.Anthropic"),
+    ):
+        return ClaudeContextualizer(use_cache=False)
+
+
+@pytest.mark.asyncio
+async def test_async_uses_system_param_not_messages(contextualizer):
+    """Async method must pass system prompt via system= param, not inside messages."""
+    response = _make_response("Test context")
+    contextualizer.client.messages.create = AsyncMock(return_value=response)
+
+    await contextualizer.contextualize_single("Some legal text", "art_1")
+
+    call_kwargs = contextualizer.client.messages.create.call_args.kwargs
+    assert "system" in call_kwargs, "system= param must be present"
+    messages = call_kwargs["messages"]
+    assert len(messages) == 1
+    assert messages[0]["role"] == "user"
+    # User content should be a plain string, not a list containing the system prompt
+    user_content = messages[0]["content"]
+    assert isinstance(user_content, str), "user content must be a plain string"
+    assert "legal text" in user_content
+
+
+@pytest.mark.asyncio
+async def test_async_system_param_with_cache(contextualizer):
+    """With use_cache=True, system= must be a list with cache_control."""
+    response = _make_response()
+    contextualizer.client.messages.create = AsyncMock(return_value=response)
+
+    await contextualizer.contextualize_single("text", "art_1")
+
+    system = contextualizer.client.messages.create.call_args.kwargs["system"]
+    assert isinstance(system, list), "system must be list when caching enabled"
+    assert system[0]["type"] == "text"
+    assert system[0]["cache_control"] == {"type": "ephemeral"}
+
+
+@pytest.mark.asyncio
+async def test_async_system_param_without_cache(contextualizer_no_cache):
+    """With use_cache=False, system= must be a plain string."""
+    response = _make_response()
+    contextualizer_no_cache.client.messages.create = AsyncMock(return_value=response)
+
+    await contextualizer_no_cache.contextualize_single("text", "art_1")
+
+    system = contextualizer_no_cache.client.messages.create.call_args.kwargs["system"]
+    assert isinstance(system, str), "system must be string when caching disabled"
+
+
+@pytest.mark.asyncio
+async def test_async_returns_contextualized_chunk(contextualizer):
+    """Async method must return ContextualizedChunk with correct fields."""
+    response = _make_response("Generated summary")
+    contextualizer.client.messages.create = AsyncMock(return_value=response)
+
+    result = await contextualizer.contextualize_single("legal clause text", "art_5")
+
+    assert result.original_text == "legal clause text"
+    assert result.contextual_summary == "Generated summary"
+    assert result.article_number == "art_5"
+    assert result.context_method == "claude"


### PR DESCRIPTION
## Summary
- Move system prompt from messages[] to system= parameter in async contextualize()
- Matches existing sync method pattern
- Enables Anthropic prompt caching optimization

## Test plan
- [x] make check clean
- [x] make test-unit pass

Closes #794