### PR TITLE
refactor(funnel): Multiselect widget for preferences (L11)

### DIFF
--- a/telegram_bot/dialogs/funnel.py
+++ b/telegram_bot/dialogs/funnel.py
@@ -3,13 +3,22 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import operator
 from typing import Any
 
 from aiogram.types import CallbackQuery
 from aiogram_dialog import Dialog, DialogManager, Window
-from aiogram_dialog.widgets.kbd import Back, Button, Cancel, Column, Select
+from aiogram_dialog.widgets.kbd import (
+    Back,
+    Button,
+    Cancel,
+    Column,
+    ManagedMultiselect,
+    Multiselect,
+    Select,
+)
 from aiogram_dialog.widgets.text import Format
 
 from .states import FunnelSG
@@ -120,6 +129,19 @@ _CITY_DISPLAY: dict[str, str] = {
     "Свети Влас": "Свети Влас",
     "Элените": "Элените",
 }
+
+# Preference category items for Multiselect widget
+_PREF_ITEMS: list[tuple[str, str]] = [
+    ("🏢 Этаж", "floor"),
+    ("🌅 Вид", "view"),
+    ("📐 Площадь", "area"),
+    ("🛋 Мебель", "furnished"),
+    ("🏷 Акции", "promotion"),
+    ("🏘 Комплекс", "complex"),
+]
+
+# Widget ID for preferences Multiselect
+_PREF_MS_ID = "pref_ms"
 
 
 def _build_funnel_filters(data: dict[str, Any]) -> dict[str, Any]:
@@ -238,11 +260,29 @@ async def get_budget_options(**kwargs: Any) -> dict[str, Any]:
     return {"title": "Какой бюджет?", "items": items, "btn_back": btn_back}
 
 
+def _compute_active_pref_categories(data: dict[str, Any]) -> list[str]:
+    """Return list of category IDs that have a non-default value set."""
+    checked: list[str] = []
+    if data.get("floor") and data["floor"] != "any":
+        checked.append("floor")
+    if data.get("view") and data["view"] != "any":
+        checked.append("view")
+    if data.get("area") and data["area"] != "any":
+        checked.append("area")
+    if data.get("is_furnished"):
+        checked.append("furnished")
+    if data.get("is_promotion"):
+        checked.append("promotion")
+    if data.get("complex") and data["complex"] != "any":
+        checked.append("complex")
+    return checked
+
+
 async def get_preferences_options(**kwargs: Any) -> dict[str, Any]:
     """Getter for preferences multi-select menu (Step 4).
 
-    Shows 5 category buttons with ✓ checkmark when a value is selected,
-    plus a "Нет, перейти к результатам" button to proceed to summary.
+    Syncs Multiselect widget state from dialog_data so checkmarks reflect
+    actual selections. The "done" button is a separate Button widget.
     """
     i18n = kwargs.get("middleware_data", {}).get("i18n")
     dialog_manager = kwargs.get("dialog_manager")
@@ -252,30 +292,18 @@ async def get_preferences_options(**kwargs: Any) -> dict[str, Any]:
 
     btn_back = i18n.get("back") if i18n else "Назад"
 
-    floor_val = data.get("floor")
-    view_val = data.get("view")
-    area_val = data.get("area")
-    furnished_val = data.get("is_furnished")
-    promotion_val = data.get("is_promotion")
-    complex_val = data.get("complex")
+    # Sync Multiselect widget state from dialog_data
+    if dialog_manager is not None:
+        with contextlib.suppress(AttributeError):
+            dialog_manager.current_context().widget_data[_PREF_MS_ID] = (
+                _compute_active_pref_categories(data)
+            )
 
-    floor_label = f"{'✓ ' if floor_val and floor_val != 'any' else ''}🏢 Этаж"
-    view_label = f"{'✓ ' if view_val and view_val != 'any' else ''}🌅 Вид"
-    area_label = f"{'✓ ' if area_val and area_val != 'any' else ''}📐 Площадь"
-    furnished_label = f"{'✓ ' if furnished_val else ''}🛋 Мебель"
-    promotion_label = f"{'✓ ' if promotion_val else ''}🏷 Акции"
-    complex_label = f"{'✓ ' if complex_val and complex_val != 'any' else ''}🏘 Комплекс"
-
-    items = [
-        (floor_label, "floor"),
-        (view_label, "view"),
-        (area_label, "area"),
-        (furnished_label, "furnished"),
-        (promotion_label, "promotion"),
-        (complex_label, "complex"),
-        ("▶️ Нет, перейти к результатам", "done"),
-    ]
-    return {"title": "✨ Есть ли дополнительные пожелания?", "items": items, "btn_back": btn_back}
+    return {
+        "title": "✨ Есть ли дополнительные пожелания?",
+        "items": _PREF_ITEMS,
+        "btn_back": btn_back,
+    }
 
 
 async def get_pref_floor_options(**kwargs: Any) -> dict[str, Any]:
@@ -632,13 +660,22 @@ async def on_pref_back_to_menu(
     await manager.switch_to(FunnelSG.preferences)
 
 
+async def on_pref_done(
+    callback: CallbackQuery,
+    button: Button,
+    manager: DialogManager,
+) -> None:
+    """Proceed to summary from preferences menu."""
+    await manager.switch_to(FunnelSG.summary)
+
+
 async def on_pref_category_selected(
     callback: CallbackQuery,
-    widget: Select,
+    widget: ManagedMultiselect,
     manager: DialogManager,
     item_id: str,
 ) -> None:
-    """Route to the appropriate sub-option window or summary."""
+    """Route to the appropriate sub-option window."""
     _PREF_STATE_MAP = {
         "floor": FunnelSG.pref_floor,
         "view": FunnelSG.pref_view,
@@ -646,10 +683,10 @@ async def on_pref_category_selected(
         "furnished": FunnelSG.pref_furnished,
         "promotion": FunnelSG.pref_promotion,
         "complex": FunnelSG.pref_complex,
-        "done": FunnelSG.summary,
     }
-    target = _PREF_STATE_MAP.get(item_id, FunnelSG.summary)
-    await manager.switch_to(target)
+    target = _PREF_STATE_MAP.get(item_id)
+    if target:
+        await manager.switch_to(target)
 
 
 async def on_pref_floor_selected(
@@ -974,13 +1011,19 @@ funnel_dialog = Dialog(
     Window(
         Format("{title}"),
         Column(
-            Select(
-                Format("{item[0]}"),
-                id="preferences",
+            Multiselect(
+                checked_text=Format("✓ {item[0]}"),
+                unchecked_text=Format("{item[0]}"),
+                id=_PREF_MS_ID,
                 item_id_getter=operator.itemgetter(1),
                 items="items",
                 on_click=on_pref_category_selected,
             ),
+        ),
+        Button(
+            Format("▶️ Нет, перейти к результатам"),
+            id="pref_done",
+            on_click=on_pref_done,
         ),
         Back(Format("{btn_back}")),
         getter=get_preferences_options,

--- a/tests/unit/dialogs/test_funnel.py
+++ b/tests/unit/dialogs/test_funnel.py
@@ -1,6 +1,7 @@
 """Tests for property search funnel dialog (#697 refactor, #712 city filter)."""
 
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -147,7 +148,8 @@ async def test_pref_complex_any_clears_value():
 
 
 @pytest.mark.asyncio
-async def test_preferences_options_has_5_categories_plus_done():
+async def test_preferences_options_has_6_categories():
+    """Preferences getter returns 6 category items; 'done' is now a separate Button."""
     result = await funnel_module.get_preferences_options(
         middleware_data={},
         dialog_manager=SimpleNamespace(dialog_data={}),
@@ -161,10 +163,8 @@ async def test_preferences_options_has_5_categories_plus_done():
     assert "furnished" in ids
     assert "promotion" in ids
     assert "complex" in ids
-    assert "done" in ids
-    assert any(
-        label == "▶️ Нет, перейти к результатам" for label, item_id in items if item_id == "done"
-    )
+    assert "done" not in ids  # "done" is now a separate Button widget
+    assert len(items) == 6
 
 
 @pytest.mark.asyncio
@@ -184,26 +184,33 @@ async def test_preferences_options_uses_emoji_labels_for_all_categories():
 
 
 @pytest.mark.asyncio
-async def test_preferences_options_shows_checkmark_when_selected():
-    result = await funnel_module.get_preferences_options(
-        middleware_data={},
-        dialog_manager=SimpleNamespace(dialog_data={"floor": "mid", "view": "sea"}),
+async def test_preferences_options_syncs_widget_state_when_selected():
+    """get_preferences_options syncs Multiselect widget_data from dialog_data."""
+    widget_data: dict[str, Any] = {}
+    ctx = SimpleNamespace(widget_data=widget_data)
+    manager = SimpleNamespace(
+        dialog_data={"floor": "mid", "view": "sea"},
+        current_context=lambda: ctx,
     )
-    items = result["items"]
-    labels = [label for label, _ in items]
-    floor_labels = [label for label in labels if "таж" in label.lower()]
-    assert any("✓" in label for label in floor_labels)
+    await funnel_module.get_preferences_options(middleware_data={}, dialog_manager=manager)
+    checked = widget_data.get(funnel_module._PREF_MS_ID, [])
+    assert "floor" in checked
+    assert "view" in checked
+    assert "area" not in checked
 
 
 @pytest.mark.asyncio
-async def test_preferences_complex_shows_checkmark_when_selected():
-    result = await funnel_module.get_preferences_options(
-        middleware_data={},
-        dialog_manager=SimpleNamespace(dialog_data={"complex": "Premier Fort Beach"}),
+async def test_preferences_complex_syncs_widget_state_when_selected():
+    """get_preferences_options marks 'complex' as checked in widget_data when complex is set."""
+    widget_data: dict[str, Any] = {}
+    ctx = SimpleNamespace(widget_data=widget_data)
+    manager = SimpleNamespace(
+        dialog_data={"complex": "Premier Fort Beach"},
+        current_context=lambda: ctx,
     )
-    items = result["items"]
-    complex_labels = [label for label, item_id in items if item_id == "complex"]
-    assert any("✓" in label for label in complex_labels)
+    await funnel_module.get_preferences_options(middleware_data={}, dialog_manager=manager)
+    checked = widget_data.get(funnel_module._PREF_MS_ID, [])
+    assert "complex" in checked
 
 
 @pytest.mark.asyncio
@@ -286,9 +293,10 @@ async def test_pref_category_floor_switches_to_pref_floor():
 
 
 @pytest.mark.asyncio
-async def test_pref_category_done_switches_to_summary():
+async def test_pref_done_switches_to_summary():
+    """The dedicated 'done' button handler navigates to summary."""
     manager = SimpleNamespace(dialog_data={}, switch_to=AsyncMock())
-    await funnel_module.on_pref_category_selected(MagicMock(), SimpleNamespace(), manager, "done")
+    await funnel_module.on_pref_done(MagicMock(), SimpleNamespace(), manager)
     manager.switch_to.assert_awaited_once_with(FunnelSG.summary)
 
 


### PR DESCRIPTION
## Summary
- Replace manual ✅/☐ checkmark toggling with aiogram-dialog Multiselect widget
- Preserves existing UX and dialog_data compatibility

## Test plan
- [x] make check clean
- [x] make test-unit pass (4470 passed)
- [x] Funnel dialog tests updated

Closes #799