### PR TITLE
refactor(cache): RedisVL EmbeddingsCache SDK integration (L9)

### DIFF
--- a/telegram_bot/integrations/cache.py
+++ b/telegram_bot/integrations/cache.py
@@ -33,6 +33,7 @@ from telegram_bot.observability import get_client, observe
 
 
 if TYPE_CHECKING:
+    from redisvl.extensions.cache.embeddings import EmbeddingsCache
     from redisvl.extensions.cache.llm import SemanticCache
 
 logger = logging.getLogger(__name__)
@@ -96,6 +97,26 @@ def _create_semantic_cache(
         return None
 
 
+def _create_embed_cache(
+    async_redis_client: Any,
+    ttl: int,
+) -> EmbeddingsCache | None:
+    """Create RedisVL EmbeddingsCache instance. Returns None on failure."""
+    try:
+        from redisvl.extensions.cache.embeddings import EmbeddingsCache
+
+        cache = EmbeddingsCache(
+            name=f"embeddings:{CACHE_VERSION}",
+            ttl=ttl,
+            async_redis_client=async_redis_client,
+        )
+        logger.info("EmbeddingsCache initialized (ttl=%ds)", ttl)
+        return cache
+    except Exception as e:
+        logger.warning("EmbeddingsCache init failed: %s: %s", type(e).__name__, e)
+        return None
+
+
 class CacheLayerManager:
     """5-tier Redis cache manager for RAG pipeline."""
 
@@ -111,6 +132,7 @@ class CacheLayerManager:
         self.redis_url = redis_url
         self.redis: redis.Redis | None = None
         self.semantic_cache: SemanticCache | None = None
+        self.embed_cache: EmbeddingsCache | None = None
 
         # Semantic cache thresholds per query type (cosine distance, lower = stricter)
         self.cache_thresholds = cache_thresholds or {
@@ -181,6 +203,17 @@ class CacheLayerManager:
         except Exception as e:
             logger.warning("Semantic cache setup skipped: %s: %s", type(e).__name__, e)
             self.semantic_cache = None
+
+        # Init EmbeddingsCache (RedisVL SDK) for dense embedding storage
+        try:
+            embed_ttl = self.exact_ttls.get("embeddings", DEFAULT_TTLS["embeddings"])
+            self.embed_cache = _create_embed_cache(
+                async_redis_client=self.redis,
+                ttl=embed_ttl,
+            )
+        except Exception as e:
+            logger.warning("EmbeddingsCache setup skipped: %s: %s", type(e).__name__, e)
+            self.embed_cache = None
 
     async def close(self) -> None:
         """Close all connections."""
@@ -456,28 +489,61 @@ class CacheLayerManager:
 
     @observe(name="cache-embedding-get", capture_input=False, capture_output=False)
     async def get_embedding(self, text: str, model: str = "bge-m3") -> list[float] | None:
-        """Get cached dense embedding."""
+        """Get cached dense embedding via RedisVL EmbeddingsCache."""
         lf = get_client()
         lf.update_current_span(input={"model": model, "text_length": len(text)})
-        result = await self.get_exact(
-            "embeddings", _hash(f"{model}:{_normalize_query_for_cache(text)}")
-        )
-        lf.update_current_span(output={"hit": result is not None})
-        return result
+        if self.embed_cache is None:
+            lf.update_current_span(output={"hit": False, "embed_cache_enabled": False})
+            return None
+        try:
+            normalized = _normalize_query_for_cache(text)
+            result = await self.embed_cache.aget(content=normalized, model_name=model)
+            if result is not None:
+                self._metrics["embeddings"]["hits"] += 1
+                lf.update_current_span(output={"hit": True})
+                return list(result["embedding"])
+            self._metrics["embeddings"]["misses"] += 1
+            lf.update_current_span(output={"hit": False})
+            return None
+        except Exception as e:
+            logger.error("EmbeddingsCache get error: %s: %s", type(e).__name__, e)
+            self._metrics["embeddings"]["misses"] += 1
+            lf.update_current_span(
+                level="ERROR",
+                status_message=f"EmbeddingsCache get error: {type(e).__name__}",
+                output={"hit": False, "error": type(e).__name__},
+            )
+            return None
 
     @observe(name="cache-embedding-store", capture_input=False, capture_output=False)
     async def store_embedding(
         self, text: str, embedding: list[float], model: str = "bge-m3"
     ) -> None:
-        """Store dense embedding."""
+        """Store dense embedding via RedisVL EmbeddingsCache."""
         lf = get_client()
         lf.update_current_span(
             input={"model": model, "text_length": len(text), "embedding_dim": len(embedding)}
         )
-        await self.store_exact(
-            "embeddings", _hash(f"{model}:{_normalize_query_for_cache(text)}"), embedding
-        )
-        lf.update_current_span(output={"stored": True})
+        if self.embed_cache is None:
+            lf.update_current_span(output={"stored": False, "embed_cache_enabled": False})
+            return
+        try:
+            normalized = _normalize_query_for_cache(text)
+            ttl = self.exact_ttls.get("embeddings")
+            await self.embed_cache.aset(
+                content=normalized,
+                model_name=model,
+                embedding=embedding,
+                ttl=ttl,
+            )
+            lf.update_current_span(output={"stored": True})
+        except Exception as e:
+            logger.error("EmbeddingsCache store error: %s: %s", type(e).__name__, e)
+            lf.update_current_span(
+                level="ERROR",
+                status_message=f"EmbeddingsCache store error: {type(e).__name__}",
+                output={"stored": False, "error": type(e).__name__},
+            )
 
     # ========== Convenience: Sparse Embeddings ==========
 

--- a/tests/unit/integrations/test_cache_layers.py
+++ b/tests/unit/integrations/test_cache_layers.py
@@ -52,6 +52,7 @@ class TestCacheLayerManagerInit:
         assert mgr.redis_url == "redis://localhost:6379"
         assert mgr.redis is None
         assert mgr.semantic_cache is None
+        assert mgr.embed_cache is None
 
     def test_metrics_initialized(self):
         mgr = CacheLayerManager(redis_url="redis://localhost:6379")
@@ -426,6 +427,114 @@ class TestExactCaches:
         assert mgr._metrics["rerank"]["hits"] == 1
 
 
+class TestEmbeddingsCacheSDK:
+    """Test get_embedding / store_embedding via RedisVL EmbeddingsCache SDK."""
+
+    async def test_get_embedding_hit(self):
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        mock_ec = AsyncMock()
+        mock_ec.aget = AsyncMock(return_value={"embedding": [0.1] * 1024})
+        mgr.embed_cache = mock_ec
+
+        result = await mgr.get_embedding("тест", model="bge-m3")
+
+        assert result == [0.1] * 1024
+        assert mgr._metrics["embeddings"]["hits"] == 1
+        mock_ec.aget.assert_awaited_once_with(content="тест", model_name="bge-m3")
+
+    async def test_get_embedding_miss(self):
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        mock_ec = AsyncMock()
+        mock_ec.aget = AsyncMock(return_value=None)
+        mgr.embed_cache = mock_ec
+
+        result = await mgr.get_embedding("тест")
+
+        assert result is None
+        assert mgr._metrics["embeddings"]["misses"] == 1
+
+    async def test_get_embedding_no_cache_returns_none(self):
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        mgr.embed_cache = None
+
+        result = await mgr.get_embedding("тест")
+
+        assert result is None
+
+    async def test_get_embedding_error_returns_none(self):
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        mock_ec = AsyncMock()
+        mock_ec.aget = AsyncMock(side_effect=Exception("Redis error"))
+        mgr.embed_cache = mock_ec
+
+        result = await mgr.get_embedding("тест")
+
+        assert result is None
+        assert mgr._metrics["embeddings"]["misses"] == 1
+
+    async def test_store_embedding_calls_sdk(self):
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        mock_ec = AsyncMock()
+        mock_ec.aset = AsyncMock(return_value="key:тест")
+        mgr.embed_cache = mock_ec
+
+        await mgr.store_embedding("тест", [0.2] * 1024, model="bge-m3")
+
+        mock_ec.aset.assert_awaited_once_with(
+            content="тест",
+            model_name="bge-m3",
+            embedding=[0.2] * 1024,
+            ttl=7 * 86400,
+        )
+
+    async def test_store_embedding_no_cache_is_noop(self):
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        mgr.embed_cache = None
+
+        # Should not raise
+        await mgr.store_embedding("тест", [0.2] * 1024)
+
+    async def test_store_embedding_normalizes_text(self):
+        """store_embedding normalizes text for consistent cache keys."""
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        stored_contents: list[str] = []
+
+        async def mock_aset(content, model_name, embedding, ttl=None):
+            stored_contents.append(content)
+            return "key"
+
+        mock_ec = AsyncMock()
+        mock_ec.aset = mock_aset
+        mgr.embed_cache = mock_ec
+
+        await mgr.store_embedding("ВНЖ?", [0.5] * 1024)
+
+        assert stored_contents == ["внж"], "Text should be normalized before storage"
+
+    async def test_initialize_creates_embed_cache(self):
+        """initialize() creates EmbeddingsCache after Redis connects."""
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        mock_redis = AsyncMock()
+        mock_redis.ping = AsyncMock(return_value=True)
+        mock_embed_cache = MagicMock()
+
+        with (
+            patch("telegram_bot.integrations.cache.redis.from_url", return_value=mock_redis),
+            patch("telegram_bot.integrations.cache._create_semantic_cache", return_value=None),
+            patch(
+                "telegram_bot.integrations.cache._create_embed_cache",
+                return_value=mock_embed_cache,
+            ) as mock_create,
+        ):
+            await mgr.initialize()
+
+        mock_create.assert_called_once_with(
+            async_redis_client=mock_redis,
+            ttl=7 * 86400,
+        )
+        assert mgr.embed_cache is mock_embed_cache
+
+
 def _make_pipeline_mock():
     """Create a mock Redis pipeline with async context manager support."""
     pipe = AsyncMock()
@@ -497,24 +606,28 @@ class TestQueryNormalization:
     async def test_embedding_cache_shares_key_after_normalization(self):
         """Storing 'ВНЖ?' and getting 'внж' should hit the same cache key."""
         mgr = CacheLayerManager(redis_url="redis://localhost:6379")
-        stored_keys: list[str] = []
 
-        async def mock_setex(key, ttl, value):
-            stored_keys.append(key)
+        stored: dict[str, list[float]] = {}
 
-        async def mock_get(key):
-            if key in stored_keys:
-                return json.dumps([0.5] * 1024)
+        async def mock_aset(content, model_name, embedding, ttl=None):
+            stored[f"{content}:{model_name}"] = embedding
+            return f"key:{content}"
+
+        async def mock_aget(content, model_name):
+            key = f"{content}:{model_name}"
+            if key in stored:
+                return {"embedding": stored[key]}
             return None
 
-        mgr.redis = AsyncMock()
-        mgr.redis.setex = mock_setex
-        mgr.redis.get = mock_get
+        mock_embed_cache = AsyncMock()
+        mock_embed_cache.aset = mock_aset
+        mock_embed_cache.aget = mock_aget
+        mgr.embed_cache = mock_embed_cache
 
-        # Store with uppercase + trailing punctuation
+        # Store with uppercase + trailing punctuation — normalized to 'внж'
         await mgr.store_embedding("ВНЖ?", [0.5] * 1024)
 
-        # Get with lowercase, no punctuation
+        # Get with lowercase, no punctuation — same normalized form
         result = await mgr.get_embedding("внж")
 
         assert result == [0.5] * 1024, "Normalized queries should share embedding cache key"


### PR DESCRIPTION
## Summary
- Replace manual embedding cache with RedisVL EmbeddingsCache
- Reduce custom code, leverage SDK TTL/storage management

## Test plan
- [x] make check clean
- [x] make test-unit pass (4469 passed)
- [x] Cache layer tests passing

Closes #803