### PR TITLE
feat(classify): configurable SemanticRouter classifier (M4)

### DIFF
--- a/telegram_bot/graph/config.py
+++ b/telegram_bot/graph/config.py
@@ -65,6 +65,8 @@ class GraphConfig:
     guard_mode: str = "hard"  # "hard" = block, "soft" = flag + continue, "log" = log only
     # TTFT drift warning threshold in ms (#675); raise for reasoning models behind proxy
     ttft_drift_warn_ms: int = 500
+    # Query classifier mode (#805): "regex" (default) or "semantic" (RedisVL SemanticRouter)
+    classifier_mode: str = "regex"
 
     cache_thresholds: dict[str, float] = field(
         default_factory=lambda: {
@@ -131,6 +133,7 @@ class GraphConfig:
             stt_model=os.getenv("STT_MODEL", "whisper"),
             guard_mode=os.getenv("GUARD_MODE", "hard"),
             ttft_drift_warn_ms=int(os.getenv("TTFT_DRIFT_WARN_MS", "500")),
+            classifier_mode=os.getenv("CLASSIFIER_MODE", "regex"),
             reasoning_effort=os.getenv("REASONING_EFFORT") or None,
             reasoning_format=os.getenv("REASONING_FORMAT") or None,
             disable_reasoning=(

--- a/telegram_bot/graph/graph.py
+++ b/telegram_bot/graph/graph.py
@@ -51,6 +51,7 @@ def build_graph(
     stt_model: str = "whisper",
     content_filter_enabled: bool = True,
     guard_mode: str = "hard",
+    classifier: Any | None = None,
 ) -> Any:
     """Build and compile the RAG StateGraph.
 
@@ -78,7 +79,13 @@ def build_graph(
     workflow = StateGraph(RAGState)
 
     # Add nodes — wrap those that need injected deps via functools.partial
-    workflow.add_node("classify", classify_node)  # type: ignore[type-var]
+    if classifier is not None:
+        workflow.add_node(
+            "classify",
+            functools.partial(classify_node, classifier=classifier),  # type: ignore[type-var]
+        )
+    else:
+        workflow.add_node("classify", classify_node)  # type: ignore[type-var]
 
     workflow.add_node(
         "transcribe",

--- a/telegram_bot/graph/nodes/classify.py
+++ b/telegram_bot/graph/nodes/classify.py
@@ -10,9 +10,13 @@ import logging
 import random
 import re
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from telegram_bot.observability import get_client, observe
+
+
+if TYPE_CHECKING:
+    from telegram_bot.services.semantic_classifier import SemanticClassifier
 
 
 logger = logging.getLogger(__name__)
@@ -269,11 +273,20 @@ def classify_query(query: str) -> str:
 
 
 @observe(name="node-classify")
-async def classify_node(state: dict[str, Any]) -> dict[str, Any]:
+async def classify_node(
+    state: dict[str, Any],
+    *,
+    classifier: SemanticClassifier | None = None,
+) -> dict[str, Any]:
     """LangGraph node: classify the user query.
 
     Reads the last user message, classifies it, and optionally sets
     a canned response for CHITCHAT/OFF_TOPIC queries.
+
+    Args:
+        state: Current graph state.
+        classifier: Optional SemanticClassifier. If provided and available,
+            uses RedisVL SemanticRouter; falls back to regex on any error.
 
     Returns partial state update with query_type, response (if canned),
     and latency_stages["classify"].
@@ -283,8 +296,17 @@ async def classify_node(state: dict[str, Any]) -> dict[str, Any]:
     messages = state["messages"]
     query = messages[-1].content if hasattr(messages[-1], "content") else messages[-1]["content"]
 
-    query_type = classify_query(query)
-    logger.info("Query classified as %s: %.50s", query_type, query)
+    if classifier is not None and classifier.available:
+        try:
+            query_type = classifier.classify(query)
+            logger.info("Semantic query classified as %s: %.50s", query_type, query)
+        except Exception as exc:
+            logger.warning("SemanticClassifier failed, falling back to regex: %s", exc)
+            query_type = classify_query(query)
+            logger.info("Query classified as %s: %.50s", query_type, query)
+    else:
+        query_type = classify_query(query)
+        logger.info("Query classified as %s: %.50s", query_type, query)
 
     result: dict[str, Any] = {
         "query_type": query_type,

--- a/telegram_bot/services/semantic_classifier.py
+++ b/telegram_bot/services/semantic_classifier.py
@@ -1,0 +1,179 @@
+"""SemanticClassifier — RedisVL SemanticRouter-based query classifier.
+
+Optional alternative to regex classification. Enabled via CLASSIFIER_MODE=semantic.
+Falls back to regex if Redis is unavailable or routing fails.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+
+# --- Route references (Russian) ---
+# Mirror the regex categories from classify.py
+
+_FAQ_REFERENCES = [
+    "как оформить покупку",
+    "какие документы нужны для покупки",
+    "сколько стоит оформление сделки",
+    "как арендовать квартиру",
+    "что нужно для покупки недвижимости",
+    "налоги при покупке недвижимости в Болгарии",
+    "процедура оформления сделки",
+    "ВНЖ при покупке недвижимости",
+    "способы оплаты квартиры",
+    "порядок покупки недвижимости",
+    "можно ли купить без агента",
+    "нужно ли нотариальное заверение",
+    "какие расходы при покупке",
+    "как получить ВНЖ",
+]
+
+_CHITCHAT_REFERENCES = [
+    "привет",
+    "здравствуйте",
+    "добрый день",
+    "как дела",
+    "спасибо",
+    "благодарю",
+    "пока",
+    "до свидания",
+    "кто ты",
+    "что ты умеешь",
+    "ты бот",
+    "как тебя зовут",
+    "всего доброго",
+    "привет как дела",
+    "hello",
+    "hi there",
+]
+
+_OFF_TOPIC_REFERENCES = [
+    "как написать код на python",
+    "рецепт борща",
+    "формула воды H2O",
+    "посоветуй фильм на вечер",
+    "лечение простуды таблетками",
+    "биткоин инвестиции криптовалюта",
+    "экзамен в университете",
+    "вакансия разработчика",
+    "история России",
+    "столица Франции",
+    "как приготовить пиццу",
+    "купить авиабилет",
+    "акции на бирже",
+]
+
+_STRUCTURED_REFERENCES = [
+    "двухкомнатная квартира до 80000 евро",
+    "трёхкомнатная квартира с балконом",
+    "студия до 50000 евро",
+    "квартира на третьем этаже",
+    "апартаменты 40 квадратных метров",
+    "дом с тремя спальнями",
+    "2 комнаты до 80000 евро",
+    "однокомнатная квартира 35 кв м",
+    "вилла 200 квадратных метров",
+]
+
+_ENTITY_REFERENCES = [
+    "квартира в Несебре",
+    "апартаменты в Бургасе",
+    "недвижимость в Варне",
+    "Солнечный берег апартаменты",
+    "жилой комплекс в Созополе",
+    "Святой Влас виллы",
+    "Sunny Beach apartments",
+    "комплекс в Поморие",
+    "жк в Равде",
+    "золотые пески квартира",
+]
+
+
+class SemanticClassifier:
+    """Classifier wrapping RedisVL SemanticRouter for query type detection.
+
+    Supported query types: FAQ, CHITCHAT, OFF_TOPIC, STRUCTURED, ENTITY.
+    Unmatched queries return GENERAL.
+    """
+
+    def __init__(
+        self,
+        redis_url: str = "redis://redis:6379",
+        distance_threshold: float = 0.5,
+        vectorizer: Any = None,
+    ) -> None:
+        self._available = False
+        self._router: Any = None
+        try:
+            from redisvl.extensions.router import Route, SemanticRouter
+
+            routes = [
+                Route(
+                    name="CHITCHAT",
+                    references=_CHITCHAT_REFERENCES,
+                    distance_threshold=distance_threshold,
+                ),
+                Route(
+                    name="OFF_TOPIC",
+                    references=_OFF_TOPIC_REFERENCES,
+                    distance_threshold=distance_threshold,
+                ),
+                Route(
+                    name="STRUCTURED",
+                    references=_STRUCTURED_REFERENCES,
+                    distance_threshold=distance_threshold,
+                ),
+                Route(
+                    name="FAQ",
+                    references=_FAQ_REFERENCES,
+                    distance_threshold=distance_threshold,
+                ),
+                Route(
+                    name="ENTITY",
+                    references=_ENTITY_REFERENCES,
+                    distance_threshold=distance_threshold,
+                ),
+            ]
+            kwargs: dict[str, Any] = {
+                "name": "query_classifier",
+                "routes": routes,
+                "redis_url": redis_url,
+            }
+            if vectorizer is not None:
+                kwargs["vectorizer"] = vectorizer
+            self._router = SemanticRouter(**kwargs)
+            self._available = True
+            logger.info("SemanticClassifier initialized (redis_url=%s)", redis_url)
+        except Exception as exc:
+            logger.warning(
+                "SemanticClassifier unavailable, will fallback to regex: %s",
+                exc,
+            )
+
+    @property
+    def available(self) -> bool:
+        """Return True if SemanticRouter is ready."""
+        return self._available
+
+    def classify(self, query: str) -> str:
+        """Classify query using SemanticRouter.
+
+        Args:
+            query: User query text.
+
+        Returns:
+            One of: FAQ, CHITCHAT, OFF_TOPIC, STRUCTURED, ENTITY, GENERAL.
+
+        Raises:
+            RuntimeError: If router is not available.
+        """
+        if not self._available or self._router is None:
+            raise RuntimeError("SemanticClassifier not available")
+        match = self._router(query)
+        if match and match.name:
+            return str(match.name)
+        return "GENERAL"

--- a/tests/unit/graph/test_classify_node.py
+++ b/tests/unit/graph/test_classify_node.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from telegram_bot.graph.nodes.classify import (
@@ -103,3 +105,77 @@ class TestClassifyNode:
         result = await classify_node(state)
         assert result["latency_stages"]["prev"] == 0.5
         assert "classify" in result["latency_stages"]
+
+
+class TestClassifyNodeSemanticMode:
+    """Tests for classify_node with SemanticClassifier injected."""
+
+    def _make_classifier(self, query_type: str, available: bool = True) -> MagicMock:
+        classifier = MagicMock()
+        classifier.available = available
+        classifier.classify.return_value = query_type
+        return classifier
+
+    async def test_semantic_mode_uses_classifier(self):
+        classifier = self._make_classifier(FAQ)
+        state = make_initial_state(user_id=1, session_id="s", query="как оформить покупку")
+        result = await classify_node(state, classifier=classifier)
+        assert result["query_type"] == FAQ
+        classifier.classify.assert_called_once_with("как оформить покупку")
+
+    async def test_semantic_mode_chitchat_returns_canned_response(self):
+        classifier = self._make_classifier(CHITCHAT)
+        state = make_initial_state(user_id=1, session_id="s", query="привет")
+        result = await classify_node(state, classifier=classifier)
+        assert result["query_type"] == CHITCHAT
+        assert result["response"]
+
+    async def test_semantic_mode_off_topic_returns_canned_response(self):
+        classifier = self._make_classifier(OFF_TOPIC)
+        state = make_initial_state(user_id=1, session_id="s", query="рецепт борща")
+        result = await classify_node(state, classifier=classifier)
+        assert result["query_type"] == OFF_TOPIC
+        assert result["response"]
+
+    async def test_semantic_mode_structured_no_canned_response(self):
+        classifier = self._make_classifier(STRUCTURED)
+        state = make_initial_state(user_id=1, session_id="s", query="2 комнаты до 80000 евро")
+        result = await classify_node(state, classifier=classifier)
+        assert result["query_type"] == STRUCTURED
+        assert "response" not in result
+
+    async def test_semantic_mode_general_no_canned_response(self):
+        classifier = self._make_classifier(GENERAL)
+        state = make_initial_state(user_id=1, session_id="s", query="квартира у моря")
+        result = await classify_node(state, classifier=classifier)
+        assert result["query_type"] == GENERAL
+        assert "response" not in result
+
+    async def test_fallback_to_regex_when_classifier_unavailable(self):
+        classifier = self._make_classifier(FAQ, available=False)
+        state = make_initial_state(user_id=1, session_id="s", query="Привет!")
+        result = await classify_node(state, classifier=classifier)
+        # unavailable → regex → CHITCHAT
+        assert result["query_type"] == CHITCHAT
+        classifier.classify.assert_not_called()
+
+    async def test_fallback_to_regex_on_classifier_exception(self):
+        classifier = MagicMock()
+        classifier.available = True
+        classifier.classify.side_effect = RuntimeError("Redis gone")
+        state = make_initial_state(user_id=1, session_id="s", query="Привет!")
+        result = await classify_node(state, classifier=classifier)
+        # fallback → regex → CHITCHAT
+        assert result["query_type"] == CHITCHAT
+
+    async def test_no_classifier_uses_regex(self):
+        state = make_initial_state(user_id=1, session_id="s", query="Привет!")
+        result = await classify_node(state)
+        assert result["query_type"] == CHITCHAT
+
+    async def test_semantic_mode_records_latency(self):
+        classifier = self._make_classifier(FAQ)
+        state = make_initial_state(user_id=1, session_id="s", query="как оформить покупку")
+        result = await classify_node(state, classifier=classifier)
+        assert isinstance(result["latency_stages"]["classify"], float)
+        assert result["latency_stages"]["classify"] >= 0

--- a/tests/unit/services/test_semantic_classifier.py
+++ b/tests/unit/services/test_semantic_classifier.py
@@ -1,0 +1,148 @@
+"""Unit tests for SemanticClassifier."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from telegram_bot.services.semantic_classifier import SemanticClassifier
+
+
+class TestSemanticClassifierInit:
+    """Tests for SemanticClassifier initialization."""
+
+    def test_available_when_router_succeeds(self):
+        mock_router = MagicMock()
+        with patch(
+            "telegram_bot.services.semantic_classifier.SemanticClassifier.__init__",
+            wraps=None,
+        ):
+            classifier = SemanticClassifier.__new__(SemanticClassifier)
+            classifier._available = True
+            classifier._router = mock_router
+            assert classifier.available is True
+
+    def test_unavailable_when_redis_fails(self):
+        with patch(
+            "telegram_bot.services.semantic_classifier.SemanticRouter",
+            side_effect=ConnectionError("Redis unavailable"),
+            create=True,
+        ):
+            with patch.dict(
+                "sys.modules",
+                {
+                    "redisvl.extensions.router": MagicMock(
+                        Route=MagicMock(),
+                        SemanticRouter=MagicMock(side_effect=ConnectionError("Redis unavailable")),
+                    )
+                },
+            ):
+                classifier = SemanticClassifier(redis_url="redis://invalid:9999")
+                assert classifier.available is False
+
+    def test_available_false_by_default_on_import_error(self):
+        with patch.dict("sys.modules", {"redisvl": None, "redisvl.extensions.router": None}):
+            classifier = SemanticClassifier.__new__(SemanticClassifier)
+            classifier._available = False
+            classifier._router = None
+            assert classifier.available is False
+
+
+class TestSemanticClassifierClassify:
+    """Tests for SemanticClassifier.classify() method."""
+
+    def _make_classifier(self, route_name: str | None) -> SemanticClassifier:
+        """Create a classifier with a mocked router that returns given route."""
+        classifier = SemanticClassifier.__new__(SemanticClassifier)
+        mock_router = MagicMock()
+        mock_match = MagicMock()
+        mock_match.name = route_name
+        mock_router.return_value = mock_match
+        classifier._router = mock_router
+        classifier._available = True
+        return classifier
+
+    def test_classify_returns_faq(self):
+        classifier = self._make_classifier("FAQ")
+        assert classifier.classify("как оформить покупку") == "FAQ"
+
+    def test_classify_returns_chitchat(self):
+        classifier = self._make_classifier("CHITCHAT")
+        assert classifier.classify("привет") == "CHITCHAT"
+
+    def test_classify_returns_off_topic(self):
+        classifier = self._make_classifier("OFF_TOPIC")
+        assert classifier.classify("рецепт борща") == "OFF_TOPIC"
+
+    def test_classify_returns_structured(self):
+        classifier = self._make_classifier("STRUCTURED")
+        assert classifier.classify("2 комнаты до 80000 евро") == "STRUCTURED"
+
+    def test_classify_returns_entity(self):
+        classifier = self._make_classifier("ENTITY")
+        assert classifier.classify("квартира в Несебре") == "ENTITY"
+
+    def test_classify_returns_general_when_no_match(self):
+        classifier = self._make_classifier(None)
+        assert classifier.classify("уютная квартира с видом на море") == "GENERAL"
+
+    def test_classify_returns_general_when_match_name_is_none(self):
+        classifier = SemanticClassifier.__new__(SemanticClassifier)
+        mock_router = MagicMock()
+        mock_match = MagicMock()
+        mock_match.name = None
+        mock_router.return_value = mock_match
+        classifier._router = mock_router
+        classifier._available = True
+        assert classifier.classify("неопределённый запрос") == "GENERAL"
+
+    def test_classify_raises_when_unavailable(self):
+        classifier = SemanticClassifier.__new__(SemanticClassifier)
+        classifier._available = False
+        classifier._router = None
+        with pytest.raises(RuntimeError, match="SemanticClassifier not available"):
+            classifier.classify("любой запрос")
+
+    def test_classify_passes_query_to_router(self):
+        classifier = self._make_classifier("FAQ")
+        query = "как оформить покупку"
+        classifier.classify(query)
+        classifier._router.assert_called_once_with(query)
+
+
+class TestSemanticClassifierRouteConfig:
+    """Tests for route configuration (references count)."""
+
+    def test_has_reference_lists_populated(self):
+        from telegram_bot.services.semantic_classifier import (
+            _CHITCHAT_REFERENCES,
+            _ENTITY_REFERENCES,
+            _FAQ_REFERENCES,
+            _OFF_TOPIC_REFERENCES,
+            _STRUCTURED_REFERENCES,
+        )
+
+        assert len(_FAQ_REFERENCES) >= 5
+        assert len(_CHITCHAT_REFERENCES) >= 5
+        assert len(_OFF_TOPIC_REFERENCES) >= 5
+        assert len(_STRUCTURED_REFERENCES) >= 5
+        assert len(_ENTITY_REFERENCES) >= 5
+
+    def test_all_references_are_strings(self):
+        from telegram_bot.services.semantic_classifier import (
+            _CHITCHAT_REFERENCES,
+            _ENTITY_REFERENCES,
+            _FAQ_REFERENCES,
+            _OFF_TOPIC_REFERENCES,
+            _STRUCTURED_REFERENCES,
+        )
+
+        for ref_list in [
+            _FAQ_REFERENCES,
+            _CHITCHAT_REFERENCES,
+            _OFF_TOPIC_REFERENCES,
+            _STRUCTURED_REFERENCES,
+            _ENTITY_REFERENCES,
+        ]:
+            assert all(isinstance(r, str) for r in ref_list)


### PR DESCRIPTION
## Summary
- Add RedisVL SemanticRouter as opt-in classifier mode (`telegram_bot/services/semantic_classifier.py`)
- Config: `CLASSIFIER_MODE=regex` (default) | `semantic` env var + `GraphConfig.classifier_mode`
- Fallback to regex if Redis unavailable or classifier raises exception
- Same 6 query types (CHITCHAT, OFF_TOPIC, STRUCTURED, FAQ, ENTITY, GENERAL), Russian references
- `build_graph()` accepts optional `classifier` param for injection

## Test plan
- [x] make check clean
- [x] make test-unit pass (4466 passed)
- [x] Regex mode unchanged (existing tests unmodified)
- [x] Semantic mode tests with mock (`TestClassifyNodeSemanticMode`)
- [x] Fallback tests: unavailable classifier → regex, exception → regex
- [x] `TestSemanticClassifier*` unit tests

Closes #805