### PR TITLE
feat(docker): add Langfuse v3 stack to VPS compose

### DIFF
--- a/.claude/rules/docker.md
+++ b/.claude/rules/docker.md
@@ -78,6 +78,11 @@ ssh vps "cd /opt/rag-fresh && docker compose --compatibility -f docker-compose.v
 | vps-litellm | 512MB | |
 | vps-bot | 512MB | **RERANK_PROVIDER=none** (ColBERT too slow on CPU) |
 | vps-ingestion | 512MB | profile: ingest only |
+| vps-clickhouse | 1.5GB | Langfuse analytics |
+| vps-minio | 256MB | S3 storage (Langfuse events/media) |
+| vps-redis-langfuse | 128MB | Langfuse queues |
+| vps-langfuse-worker | 512MB | Langfuse background processing |
+| vps-langfuse | 512MB | Langfuse UI + API (port 3001) |
 
 **Collection:** `gdrive_documents_bge` (1024-dim BGE-M3 dense + BGE-M3 sparse, field "bm42")
 

--- a/docker-compose.vps.yml
+++ b/docker-compose.vps.yml
@@ -350,6 +350,162 @@ services:
         limits:
           memory: 1G
 
+  # =============================================================================
+  # ML PLATFORM (Langfuse)
+  # =============================================================================
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:26.1@sha256:7f6546e5e293cfcdb812675fde424dc9bce3d32ac86f18051fedc23bff75a724
+    container_name: vps-clickhouse
+    restart: unless-stopped
+    logging: *default-logging
+    user: "101:101"
+    environment:
+      CLICKHOUSE_DB: default
+      CLICKHOUSE_USER: clickhouse
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-clickhouse}
+    volumes:
+      - clickhouse_data:/var/lib/clickhouse
+      - clickhouse_logs:/var/log/clickhouse-server
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+    deploy:
+      resources:
+        limits:
+          memory: 1536M
+
+  minio:
+    image: minio/minio:RELEASE.2024-12-18T13-15-44Z@sha256:1dce27c494a16bae114774f1cec295493f3613142713130c2d22dd5696be6ad3
+    container_name: vps-minio
+    restart: unless-stopped
+    logging: *default-logging
+    entrypoint: sh
+    command: -c 'mkdir -p /data/langfuse && minio server --address ":9000" /data'
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-miniosecret}
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:9000/minio/health/live || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+
+  redis-langfuse:
+    image: redis:8.6.0@sha256:7b6fb55d8b0adcd77269dc52b3cfffe5f59ca5d43dec3c90dbe18aacce7942e1
+    container_name: vps-redis-langfuse
+    restart: unless-stopped
+    logging: *default-logging
+    command: redis-server --requirepass ${LANGFUSE_REDIS_PASSWORD:-langfuseredis}
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${LANGFUSE_REDIS_PASSWORD:-langfuseredis}", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+
+  langfuse-worker:
+    image: langfuse/langfuse-worker:3.150.0@sha256:e4c98263d86593e2ba76e104c7e62e1c0c306785b84d83e21f74ef9f2d9bd0c9
+    container_name: vps-langfuse-worker
+    restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      redis-langfuse:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+    environment: &langfuse-worker-env
+      DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/langfuse
+      NEXTAUTH_URL: ${NEXTAUTH_URL:-https://langfuse.awdawdawd.space}
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?NEXTAUTH_SECRET is required}
+      SALT: ${SALT:?SALT is required}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?ENCRYPTION_KEY is required}
+      CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse:9000
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_USER: clickhouse
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-clickhouse}
+      CLICKHOUSE_CLUSTER_ENABLED: "false"
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: auto
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: minio
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-miniosecret}
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://minio:9000
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_EVENT_UPLOAD_PREFIX: events/
+      LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_MEDIA_UPLOAD_REGION: auto
+      LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID: minio
+      LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-miniosecret}
+      LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: http://minio:9000
+      LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_MEDIA_UPLOAD_PREFIX: media/
+      REDIS_HOST: redis-langfuse
+      REDIS_PORT: 6379
+      REDIS_AUTH: ${LANGFUSE_REDIS_PASSWORD:-langfuseredis}
+      TELEMETRY_ENABLED: "false"
+      LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES: "true"
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+
+  langfuse:
+    image: langfuse/langfuse:3.150.0@sha256:7f47fd823a5d6f8b1195e0ca6830f8f99e78a659b150ccdb077d188674efb1b6
+    container_name: vps-langfuse
+    restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      redis-langfuse:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+      langfuse-worker:
+        condition: service_started
+    ports:
+      - "127.0.0.1:3001:3000"
+    environment:
+      <<: *langfuse-worker-env
+      HOSTNAME: 0.0.0.0
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:3000/api/public/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+
 volumes:
   postgres_data:
   redis_data:
@@ -357,3 +513,6 @@ volumes:
   hf_cache:
   docling_cache:
   ingestion-manifest:
+  clickhouse_data:
+  clickhouse_logs:
+  minio_data:


### PR DESCRIPTION
## Summary
- Add 5 Langfuse v3 services (clickhouse, minio, redis-langfuse, langfuse-worker, langfuse) to docker-compose.vps.yml
- Memory budget: ~2.9GB (clickhouse 1.5GB, langfuse+worker 1GB, minio 256MB, redis 128MB)
- Update docker.md with new VPS services table

## Test plan
- [x] `docker compose config --quiet` validates
- [x] docker.md table format correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)