### PR TITLE
fix(ci): sync k8s LiteLLM config with Docker config

### DIFF
--- a/k8s/base/configmaps/litellm-config.yaml
+++ b/k8s/base/configmaps/litellm-config.yaml
@@ -5,32 +5,45 @@ metadata:
 data:
   config.yaml: |
     model_list:
+      # Primary: Cerebras GLM 4.7 (reasoning disabled for low TTFT)
+      # ALIAS: "gpt-4o-mini" is an internal alias — it does NOT call OpenAI.
+      # The bot sends requests to "gpt-4o-mini" which LiteLLM routes to Cerebras.
+      # See fallbacks below for the actual OpenAI fallback (gpt-4o-mini-openai).
       - model_name: gpt-4o-mini
         litellm_params:
-          model: cerebras/gpt-oss-120b
+          model: cerebras/zai-glm-4.7
           api_key: os.environ/CEREBRAS_API_KEY
           max_completion_tokens: 1024
-          merge_reasoning_content_in_choices: true
+          disable_reasoning: true
+
+      # Standalone alias for benchmarking (reasoning model)
       - model_name: gpt-oss-120b
         litellm_params:
           model: cerebras/gpt-oss-120b
           api_key: os.environ/CEREBRAS_API_KEY
           max_completion_tokens: 1024
           merge_reasoning_content_in_choices: true
-      - model_name: gpt-4o-mini-cerebras-glm
+
+      # Fallback 1: Cerebras gpt-oss-120b (reasoning, slower TTFT)
+      - model_name: gpt-4o-mini-cerebras-oss
         litellm_params:
-          model: openai/zai-glm-4.7
-          api_base: https://api.cerebras.ai/v1
+          model: cerebras/gpt-oss-120b
           api_key: os.environ/CEREBRAS_API_KEY
           max_completion_tokens: 1024
+          merge_reasoning_content_in_choices: true
+
+      # Fallback 2: Groq (fast, free tier)
       - model_name: gpt-4o-mini-fallback
         litellm_params:
           model: groq/llama-3.1-70b-versatile
           api_key: os.environ/GROQ_API_KEY
+
+      # Fallback 3: OpenAI (reliable)
       - model_name: gpt-4o-mini-openai
         litellm_params:
           model: openai/gpt-4o-mini
           api_key: os.environ/OPENAI_API_KEY
+
       # Speech-to-text: Whisper via OpenAI
       - model_name: whisper
         litellm_params:
@@ -38,19 +51,28 @@ data:
           api_key: os.environ/OPENAI_API_KEY
         model_info:
           mode: audio_transcription
+
     general_settings:
       master_key: os.environ/LITELLM_MASTER_KEY
       proxy_batch_write_at: 60
       disable_error_logs: true
       allow_requests_on_db_unavailable: true
+
     router_settings:
       retry_policy:
         retry_count: 2
+
     litellm_settings:
       request_timeout: 600
       set_verbose: false
       json_logs: true
       drop_params: true
       fallbacks:
-        - gpt-4o-mini: [gpt-4o-mini-cerebras-glm, gpt-4o-mini-fallback, gpt-4o-mini-openai]
-        - gpt-oss-120b: [gpt-4o-mini-cerebras-glm, gpt-4o-mini-fallback, gpt-4o-mini-openai]
+        - gpt-4o-mini: [gpt-4o-mini-cerebras-oss, gpt-4o-mini-fallback, gpt-4o-mini-openai]
+        - gpt-oss-120b: [gpt-4o-mini-cerebras-oss, gpt-4o-mini-fallback, gpt-4o-mini-openai]
+
+    environment_variables:
+      LANGFUSE_PUBLIC_KEY: os.environ/LANGFUSE_PUBLIC_KEY
+      LANGFUSE_SECRET_KEY: os.environ/LANGFUSE_SECRET_KEY
+      LANGFUSE_HOST: os.environ/LANGFUSE_HOST
+      LANGFUSE_OTEL_HOST: os.environ/LANGFUSE_OTEL_HOST


### PR DESCRIPTION
## Summary
- Synced k8s LiteLLM config with Docker config to fix model name and fallback drift
- `gpt-4o-mini` entry corrected: `cerebras/gpt-oss-120b` → `cerebras/zai-glm-4.7` with `disable_reasoning: true`
- `gpt-4o-mini-cerebras-glm` renamed to `gpt-4o-mini-cerebras-oss` (correct model: `cerebras/gpt-oss-120b`)
- Fallback groups updated to reference `gpt-4o-mini-cerebras-oss`
- `test_model_list_matches` and `test_litellm_settings_match` now pass

Closes #816

## Test plan
- [x] `uv run pytest tests/unit/test_litellm_config_sync.py -v` passes (10/10)
- [x] pre-commit hooks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)