### PR TITLE
fix(compose): repair tests and ops checks after compose unification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
             echo "=== Pull latest code ==="
             git pull origin main
 
+            export COMPOSE_FILE="${COMPOSE_FILE:-compose.yml:compose.vps.yml}"
+            export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-vps}"
+
             echo "=== Rebuild bot image ==="
             docker compose build bot
 
@@ -72,6 +75,6 @@ jobs:
             sleep 15
 
             echo "=== Health check ==="
-            docker ps --format '{{.Names}} {{.Status}}' | grep vps-bot
+            docker compose ps --format '{{.Service}} {{.Status}}' | grep '^bot '
 
             echo "=== Deploy complete $(date -Iseconds) ==="

--- a/Makefile
+++ b/Makefile
@@ -293,32 +293,32 @@ smoke-zoo: ## Run zoo smoke tests (pytest)
 
 test-redis: ## Verify Redis Query Engine is available
 	@echo "$(BLUE)Testing Redis Query Engine...$(NC)"
-	@redis_policy=$$(docker exec $(REDIS_CONTAINER) redis-cli CONFIG GET maxmemory-policy | tail -n 1); \
+	@redis_policy=$$($(COMPOSE_CMD) exec -T redis redis-cli CONFIG GET maxmemory-policy | tail -n 1); \
 		if [ "$$redis_policy" != "volatile-lfu" ]; then \
 			echo "$(RED)FAIL: maxmemory-policy is $$redis_policy (expected volatile-lfu)$(NC)"; \
 			exit 1; \
 		fi; \
 		echo "  maxmemory-policy: $$redis_policy"
-	@redis_samples=$$(docker exec $(REDIS_CONTAINER) redis-cli CONFIG GET maxmemory-samples | tail -n 1); \
+	@redis_samples=$$($(COMPOSE_CMD) exec -T redis redis-cli CONFIG GET maxmemory-samples | tail -n 1); \
 		if [ "$$redis_samples" != "$(EXPECTED_MAXMEMORY_SAMPLES)" ]; then \
 			echo "$(RED)FAIL: maxmemory-samples is $$redis_samples (expected $(EXPECTED_MAXMEMORY_SAMPLES))$(NC)"; \
 			exit 1; \
 		fi; \
 		echo "  maxmemory-samples: $$redis_samples"
-	@docker exec $(REDIS_CONTAINER) redis-cli FT._LIST > /dev/null 2>&1 || \
+	@$(COMPOSE_CMD) exec -T redis redis-cli FT._LIST > /dev/null 2>&1 || \
 		(echo "$(RED)FAIL: FT._LIST not available - Query Engine missing$(NC)" && exit 1)
 	@echo "  FT._LIST: OK"
-	@docker exec $(REDIS_CONTAINER) redis-cli FT.CREATE __test_vec_idx ON HASH PREFIX 1 __test_vec: SCHEMA name TEXT vec VECTOR FLAT 6 TYPE FLOAT32 DIM 4 DISTANCE_METRIC COSINE > /dev/null 2>&1 || \
+	@$(COMPOSE_CMD) exec -T redis redis-cli FT.CREATE __test_vec_idx ON HASH PREFIX 1 __test_vec: SCHEMA name TEXT vec VECTOR FLAT 6 TYPE FLOAT32 DIM 4 DISTANCE_METRIC COSINE > /dev/null 2>&1 || \
 		(echo "$(RED)FAIL: Cannot create VECTOR index$(NC)" && exit 1)
 	@echo "  FT.CREATE VECTOR: OK"
-	@docker exec $(REDIS_CONTAINER) redis-cli FT.DROPINDEX __test_vec_idx > /dev/null 2>&1 || true
+	@$(COMPOSE_CMD) exec -T redis redis-cli FT.DROPINDEX __test_vec_idx > /dev/null 2>&1 || true
 	@echo "$(GREEN)Query Engine + Vector Search: OK$(NC)"
 	@if [ "$${REQUIRE_REDIS_JSON:-0}" = "1" ]; then \
-		docker exec $(REDIS_CONTAINER) redis-cli JSON.SET __test_json '$$' '{"test":1}' > /dev/null 2>&1 || \
+		$(COMPOSE_CMD) exec -T redis redis-cli JSON.SET __test_json '$$' '{"test":1}' > /dev/null 2>&1 || \
 			(echo "$(RED)FAIL: JSON.SET not available$(NC)" && exit 1); \
-		docker exec $(REDIS_CONTAINER) redis-cli JSON.GET __test_json > /dev/null 2>&1 || \
+		$(COMPOSE_CMD) exec -T redis redis-cli JSON.GET __test_json > /dev/null 2>&1 || \
 			(echo "$(RED)FAIL: JSON.GET not available$(NC)" && exit 1); \
-		docker exec $(REDIS_CONTAINER) redis-cli DEL __test_json > /dev/null 2>&1 || true; \
+		$(COMPOSE_CMD) exec -T redis redis-cli DEL __test_json > /dev/null 2>&1 || true; \
 		echo "  JSON: OK"; \
 	fi
 	@echo "$(GREEN)✓ Redis capabilities verified$(NC)"
@@ -332,7 +332,7 @@ test-bot-health: ## Preflight: verify Qdrant collection + LLM (local dev, ports 
 
 test-bot-health-vps: ## Preflight: verify Qdrant + LLM from inside Docker network (VPS)
 	@echo "$(BLUE)Running VPS bot health preflight...$(NC)"
-	@docker exec vps-bot python -c "\
+	@$(COMPOSE_CMD) exec -T bot python -c "\
 	import urllib.request, json, sys; \
 	r = json.loads(urllib.request.urlopen('http://qdrant:6333/collections', timeout=10).read()); \
 	names = [c['name'] for c in r['result']['collections']]; \
@@ -516,12 +516,15 @@ deploy-bot:  ## Deploy bot to VPS (git push + SSH rebuild)
 	@echo "$(CYAN)Pushing to origin...$(NC)"
 	git push origin main
 	@echo "$(CYAN)Deploying bot on VPS...$(NC)"
-	ssh vps "cd /opt/rag-fresh && git pull origin main && \
+	ssh vps 'cd /opt/rag-fresh && git pull origin main && \
+		export COMPOSE_FILE="$${COMPOSE_FILE:-compose.yml:compose.vps.yml}" COMPOSE_PROJECT_NAME="$${COMPOSE_PROJECT_NAME:-vps}" && \
 		docker compose build bot && \
-		docker compose --compatibility up -d --force-recreate bot"
+		docker compose --compatibility up -d --force-recreate bot'
 	@echo "$(GREEN)Bot deployed. Waiting for startup...$(NC)"
 	@sleep 15
-	ssh vps "docker ps --format '{{.Names}} {{.Status}}' | grep vps-bot"
+	ssh vps 'cd /opt/rag-fresh && \
+		export COMPOSE_FILE="$${COMPOSE_FILE:-compose.yml:compose.vps.yml}" COMPOSE_PROJECT_NAME="$${COMPOSE_PROJECT_NAME:-vps}" && \
+		docker compose ps --format "{{.Service}} {{.Status}}" | grep "^bot "'
 	@echo "$(GREEN)✓ Deploy complete$(NC)"
 
 # =============================================================================

--- a/tests/unit/security/test_secret_hygiene.py
+++ b/tests/unit/security/test_secret_hygiene.py
@@ -46,8 +46,9 @@ def test_compose_redis_uses_requirepass():
 
     project_root = Path(__file__).parent.parent.parent.parent
     compose_files = [
-        project_root / "docker-compose.dev.yml",
-        project_root / "docker-compose.vps.yml",
+        project_root / "compose.yml",
+        project_root / "compose.dev.yml",
+        project_root / "compose.vps.yml",
     ]
 
     errors = []

--- a/tests/unit/test_compose_config.py
+++ b/tests/unit/test_compose_config.py
@@ -1,9 +1,9 @@
 """Tests for Docker Compose configuration correctness.
 
 Covers three issues (M7, M8, M9):
-  M7 - bot service must declare depends_on postgres in dev and vps compose
-  M8 - Makefile docker-ai-up target must use a profile that exists in dev compose
-  M9 - VPS compose must have the same security baseline as dev compose
+  M7 - bot service must declare depends_on postgres in unified base compose
+  M8 - Makefile docker-* profile flags must exist in effective dev compose
+  M9 - security defaults must remain intact after dev/vps overrides
 """
 
 from __future__ import annotations
@@ -16,8 +16,9 @@ import yaml
 
 
 ROOT = Path(__file__).parents[2]
-DEV_COMPOSE = ROOT / "docker-compose.dev.yml"
-VPS_COMPOSE = ROOT / "docker-compose.vps.yml"
+BASE_COMPOSE = ROOT / "compose.yml"
+DEV_OVERRIDE = ROOT / "compose.dev.yml"
+VPS_OVERRIDE = ROOT / "compose.vps.yml"
 MAKEFILE = ROOT / "Makefile"
 
 
@@ -27,13 +28,18 @@ def _load_compose(path: Path) -> dict:
 
 
 @pytest.fixture(scope="module")
-def dev() -> dict:
-    return _load_compose(DEV_COMPOSE)
+def base() -> dict:
+    return _load_compose(BASE_COMPOSE)
 
 
 @pytest.fixture(scope="module")
-def vps() -> dict:
-    return _load_compose(VPS_COMPOSE)
+def dev_override() -> dict:
+    return _load_compose(DEV_OVERRIDE)
+
+
+@pytest.fixture(scope="module")
+def vps_override() -> dict:
+    return _load_compose(VPS_OVERRIDE)
 
 
 # =============================================================================
@@ -44,44 +50,35 @@ def vps() -> dict:
 class TestBotDependsOnPostgres:
     """M7: bot service must wait for postgres before starting."""
 
-    def test_dev_bot_depends_on_postgres(self, dev: dict) -> None:
-        """bot in dev compose must declare depends_on: postgres."""
-        bot = dev["services"]["bot"]
+    def test_base_bot_depends_on_postgres(self, base: dict) -> None:
+        """bot in base compose must declare depends_on: postgres."""
+        bot = base["services"]["bot"]
         assert "depends_on" in bot, "bot service has no depends_on"
         depends = bot["depends_on"]
         # depends_on can be a list or a dict (with condition)
         if isinstance(depends, dict):
-            assert "postgres" in depends, "bot.depends_on in dev compose does not include postgres"
+            assert "postgres" in depends, "bot.depends_on does not include postgres"
         else:
-            assert "postgres" in depends, "bot.depends_on in dev compose does not include postgres"
+            assert "postgres" in depends, "bot.depends_on does not include postgres"
 
-    def test_dev_bot_postgres_dependency_is_healthy(self, dev: dict) -> None:
-        """bot in dev compose must wait for postgres to be healthy."""
-        bot = dev["services"]["bot"]
+    def test_base_bot_postgres_dependency_is_healthy(self, base: dict) -> None:
+        """bot in base compose must wait for postgres to be healthy."""
+        bot = base["services"]["bot"]
         depends = bot["depends_on"]
         assert isinstance(depends, dict), "bot.depends_on must be a dict with conditions"
         assert depends["postgres"]["condition"] == "service_healthy", (
             "bot.depends_on.postgres must use condition: service_healthy"
         )
 
-    def test_vps_bot_depends_on_postgres(self, vps: dict) -> None:
-        """bot in vps compose must declare depends_on: postgres."""
-        bot = vps["services"]["bot"]
-        assert "depends_on" in bot, "bot service has no depends_on in vps compose"
-        depends = bot["depends_on"]
-        if isinstance(depends, dict):
-            assert "postgres" in depends, "bot.depends_on in vps compose does not include postgres"
-        else:
-            assert "postgres" in depends, "bot.depends_on in vps compose does not include postgres"
+    def test_dev_override_does_not_replace_bot_depends_on(self, dev_override: dict) -> None:
+        """dev override should not drop/replace bot depends_on from base compose."""
+        bot = dev_override.get("services", {}).get("bot", {})
+        assert "depends_on" not in bot, "compose.dev.yml must not override bot.depends_on"
 
-    def test_vps_bot_postgres_dependency_is_healthy(self, vps: dict) -> None:
-        """bot in vps compose must wait for postgres to be healthy."""
-        bot = vps["services"]["bot"]
-        depends = bot["depends_on"]
-        assert isinstance(depends, dict), "bot.depends_on must be a dict with conditions in vps"
-        assert depends["postgres"]["condition"] == "service_healthy", (
-            "bot.depends_on.postgres must use condition: service_healthy in vps"
-        )
+    def test_vps_override_does_not_replace_bot_depends_on(self, vps_override: dict) -> None:
+        """vps override should not drop/replace bot depends_on from base compose."""
+        bot = vps_override.get("services", {}).get("bot", {})
+        assert "depends_on" not in bot, "compose.vps.yml must not override bot.depends_on"
 
 
 # =============================================================================
@@ -92,11 +89,21 @@ class TestBotDependsOnPostgres:
 class TestMakefileAiProfile:
     """M8: all --profile flags in Makefile docker-* targets must exist in dev compose."""
 
-    def _get_all_profiles(self, compose: dict) -> set[str]:
+    def _get_effective_profiles(self, base_compose: dict, dev_compose: dict) -> set[str]:
+        """Compute effective dev profiles from base + dev override."""
+        effective: dict[str, set[str]] = {}
+
+        for svc_name, svc in base_compose.get("services", {}).items():
+            if "profiles" in svc:
+                effective[svc_name] = {str(p) for p in (svc.get("profiles") or [])}
+
+        for svc_name, svc in dev_compose.get("services", {}).items():
+            if "profiles" in svc:
+                effective[svc_name] = {str(p) for p in (svc.get("profiles") or [])}
+
         profiles: set[str] = set()
-        for svc in compose.get("services", {}).values():
-            for p in svc.get("profiles", []) or []:
-                profiles.add(str(p))
+        for vals in effective.values():
+            profiles.update(vals)
         return profiles
 
     def _get_docker_up_profiles(self) -> set[str]:
@@ -112,9 +119,9 @@ class TestMakefileAiProfile:
             return set()
         return set(re.findall(r"--profile\s+(\S+)", section.group(1)))
 
-    def test_docker_up_profiles_exist_in_dev_compose(self, dev: dict) -> None:
+    def test_docker_up_profiles_exist_in_dev_compose(self, base: dict, dev_override: dict) -> None:
         """Every --profile in Makefile docker-*-up targets must exist in dev compose."""
-        compose_profiles = self._get_all_profiles(dev)
+        compose_profiles = self._get_effective_profiles(base, dev_override)
         makefile_profiles = self._get_docker_up_profiles()
         unknown = makefile_profiles - compose_profiles
         assert not unknown, (
@@ -137,64 +144,136 @@ class TestMakefileAiProfile:
 # M9 — VPS security baseline parity with dev compose
 # =============================================================================
 
-# Services that have security defaults applied in dev compose (via <<: *security-defaults)
+# Services that have security defaults applied in base compose (via <<: *security-defaults)
 _SECURITY_SERVICES = ["bge-m3", "user-base", "docling", "litellm", "bot"]
-
-# Services that exist in both dev AND vps compose
-_VPS_SECURITY_SERVICES = [s for s in _SECURITY_SERVICES if s != "ingestion"]
 
 
 class TestVpsSecurityBaseline:
-    """M9: VPS compose services must match the security baseline from dev compose."""
+    """M9: Security baseline must be present in base and preserved by overrides."""
 
-    @pytest.mark.parametrize("svc_name", _VPS_SECURITY_SERVICES)
-    def test_vps_service_has_security_opt(self, vps: dict, svc_name: str) -> None:
-        """VPS service must have security_opt: no-new-privileges."""
-        services = vps["services"]
-        if svc_name not in services:
-            pytest.skip(f"Service {svc_name} not present in vps compose")
+    @pytest.mark.parametrize("svc_name", _SECURITY_SERVICES)
+    def test_base_service_has_security_opt(self, base: dict, svc_name: str) -> None:
+        """Base service must have security_opt: no-new-privileges."""
+        services = base["services"]
         svc = services[svc_name]
-        assert "security_opt" in svc, f"vps:{svc_name} missing security_opt (no-new-privileges)"
+        assert "security_opt" in svc, f"base:{svc_name} missing security_opt (no-new-privileges)"
         assert "no-new-privileges:true" in svc["security_opt"], (
-            f"vps:{svc_name}.security_opt must include 'no-new-privileges:true'"
+            f"base:{svc_name}.security_opt must include 'no-new-privileges:true'"
         )
 
-    @pytest.mark.parametrize("svc_name", _VPS_SECURITY_SERVICES)
-    def test_vps_service_has_cap_drop_all(self, vps: dict, svc_name: str) -> None:
-        """VPS service must drop ALL Linux capabilities."""
-        services = vps["services"]
-        if svc_name not in services:
-            pytest.skip(f"Service {svc_name} not present in vps compose")
+    @pytest.mark.parametrize("svc_name", _SECURITY_SERVICES)
+    def test_base_service_has_cap_drop_all(self, base: dict, svc_name: str) -> None:
+        """Base service must drop ALL Linux capabilities."""
+        services = base["services"]
         svc = services[svc_name]
-        assert "cap_drop" in svc, f"vps:{svc_name} missing cap_drop"
-        assert "ALL" in svc["cap_drop"], f"vps:{svc_name}.cap_drop must include 'ALL'"
+        assert "cap_drop" in svc, f"base:{svc_name} missing cap_drop"
+        assert "ALL" in svc["cap_drop"], f"base:{svc_name}.cap_drop must include 'ALL'"
 
-    def test_vps_has_x_security_defaults_anchor(self) -> None:
-        """VPS compose must define x-security-defaults YAML extension anchor."""
-        content = VPS_COMPOSE.read_text()
+    def test_base_has_x_security_defaults_anchor(self) -> None:
+        """Base compose must define x-security-defaults YAML extension anchor."""
+        content = BASE_COMPOSE.read_text()
         assert "x-security-defaults" in content, (
-            "docker-compose.vps.yml is missing x-security-defaults extension field"
+            "compose.yml is missing x-security-defaults extension field"
         )
 
     @pytest.mark.parametrize("svc_name", ["bge-m3", "user-base", "bot"])
-    def test_vps_service_has_read_only(self, vps: dict, svc_name: str) -> None:
-        """VPS services that are read-only in dev must also be read-only in vps."""
-        services = vps["services"]
-        if svc_name not in services:
-            pytest.skip(f"Service {svc_name} not present in vps compose")
+    def test_base_service_has_read_only(self, base: dict, svc_name: str) -> None:
+        """Security-hardened services in base must be read_only."""
+        services = base["services"]
         svc = services[svc_name]
-        assert svc.get("read_only") is True, (
-            f"vps:{svc_name} must have read_only: true (matching dev compose)"
-        )
+        assert svc.get("read_only") is True, f"base:{svc_name} must have read_only: true"
 
     @pytest.mark.parametrize("svc_name", ["bge-m3", "user-base", "bot"])
-    def test_vps_service_has_tmpfs(self, vps: dict, svc_name: str) -> None:
-        """VPS services must have tmpfs /tmp (required when read_only: true)."""
-        services = vps["services"]
-        if svc_name not in services:
-            pytest.skip(f"Service {svc_name} not present in vps compose")
+    def test_base_service_has_tmpfs(self, base: dict, svc_name: str) -> None:
+        """Security-hardened services must have tmpfs /tmp with read_only."""
+        services = base["services"]
         svc = services[svc_name]
         tmpfs = svc.get("tmpfs", [])
         assert "/tmp" in tmpfs, (
-            f"vps:{svc_name} missing tmpfs: [/tmp] (needed with read_only: true)"
+            f"base:{svc_name} missing tmpfs: [/tmp] (needed with read_only: true)"
+        )
+
+    @pytest.mark.parametrize("svc_name", _SECURITY_SERVICES)
+    def test_vps_override_does_not_relax_security_opt(
+        self, vps_override: dict, svc_name: str
+    ) -> None:
+        """compose.vps.yml must not remove/relax security_opt if overridden."""
+        svc = vps_override.get("services", {}).get(svc_name, {})
+        if "security_opt" not in svc:
+            return
+        assert "no-new-privileges:true" in svc["security_opt"]
+
+    @pytest.mark.parametrize("svc_name", _SECURITY_SERVICES)
+    def test_vps_override_does_not_relax_cap_drop(self, vps_override: dict, svc_name: str) -> None:
+        """compose.vps.yml must not remove cap_drop if overridden."""
+        svc = vps_override.get("services", {}).get(svc_name, {})
+        if "cap_drop" not in svc:
+            return
+        assert "ALL" in svc["cap_drop"]
+
+    @pytest.mark.parametrize("svc_name", ["bge-m3", "user-base", "bot"])
+    def test_vps_override_does_not_disable_read_only(
+        self, vps_override: dict, svc_name: str
+    ) -> None:
+        """compose.vps.yml must not disable read_only for hardened services."""
+        svc = vps_override.get("services", {}).get(svc_name, {})
+        if "read_only" not in svc:
+            return
+        assert svc["read_only"] is True
+
+    @pytest.mark.parametrize("svc_name", ["bge-m3", "user-base", "bot"])
+    def test_vps_override_does_not_remove_tmpfs(self, vps_override: dict, svc_name: str) -> None:
+        """compose.vps.yml must not remove /tmp tmpfs for hardened services."""
+        svc = vps_override.get("services", {}).get(svc_name, {})
+        if "tmpfs" not in svc:
+            return
+        assert "/tmp" in (svc.get("tmpfs") or [])
+
+    @pytest.mark.parametrize("svc_name", _SECURITY_SERVICES)
+    def test_dev_override_does_not_relax_security_opt(
+        self, dev_override: dict, svc_name: str
+    ) -> None:
+        """compose.dev.yml must not remove/relax security_opt if overridden."""
+        svc = dev_override.get("services", {}).get(svc_name, {})
+        if "security_opt" not in svc:
+            return
+        assert "no-new-privileges:true" in svc["security_opt"]
+
+    @pytest.mark.parametrize("svc_name", _SECURITY_SERVICES)
+    def test_dev_override_does_not_relax_cap_drop(self, dev_override: dict, svc_name: str) -> None:
+        """compose.dev.yml must not remove cap_drop if overridden."""
+        svc = dev_override.get("services", {}).get(svc_name, {})
+        if "cap_drop" not in svc:
+            return
+        assert "ALL" in svc["cap_drop"]
+
+    @pytest.mark.parametrize("svc_name", ["bge-m3", "user-base", "bot"])
+    def test_dev_override_does_not_disable_read_only(
+        self, dev_override: dict, svc_name: str
+    ) -> None:
+        """compose.dev.yml must not disable read_only for hardened services."""
+        svc = dev_override.get("services", {}).get(svc_name, {})
+        if "read_only" not in svc:
+            return
+        assert svc["read_only"] is True
+
+    @pytest.mark.parametrize("svc_name", ["bge-m3", "user-base", "bot"])
+    def test_dev_override_does_not_remove_tmpfs(self, dev_override: dict, svc_name: str) -> None:
+        """compose.dev.yml must not remove /tmp tmpfs for hardened services."""
+        svc = dev_override.get("services", {}).get(svc_name, {})
+        if "tmpfs" not in svc:
+            return
+        assert "/tmp" in (svc.get("tmpfs") or [])
+
+    def test_vps_override_exists(self, vps_override: dict) -> None:
+        assert "services" in vps_override
+
+    def test_dev_override_exists(self, dev_override: dict) -> None:
+        assert "services" in dev_override
+
+    def test_security_services_exist_in_base(self, base: dict) -> None:
+        base_services = base.get("services", {})
+        missing = [svc for svc in _SECURITY_SERVICES if svc not in base_services]
+        assert not missing, (
+            f"Expected security-hardened services are missing in compose.yml: {missing}"
         )

--- a/tests/unit/test_docker_compose_env.py
+++ b/tests/unit/test_docker_compose_env.py
@@ -1,4 +1,4 @@
-"""Verify docker-compose bot service has CRM env vars (#402)."""
+"""Verify bot service environment across unified compose files (#402)."""
 
 from functools import cache
 from pathlib import Path
@@ -39,14 +39,28 @@ REQUIRED_VARS = [
 
 
 class TestDevComposeEnv:
+    """CRM vars must be present in base compose bot environment."""
+
     @pytest.mark.parametrize("var", REQUIRED_VARS)
     def test_dev_compose_has_var(self, var: str):
-        env = _load_bot_env("docker-compose.dev.yml")
-        assert var in env, f"{var} missing from docker-compose.dev.yml bot environment"
+        env = _load_bot_env("compose.yml")
+        assert var in env, f"{var} missing from compose.yml bot environment"
 
 
 class TestVpsComposeEnv:
+    """Overrides must keep required bot behavior knobs explicit."""
+
     @pytest.mark.parametrize("var", REQUIRED_VARS)
     def test_vps_compose_has_var(self, var: str):
-        env = _load_bot_env("docker-compose.vps.yml")
-        assert var in env, f"{var} missing from docker-compose.vps.yml bot environment"
+        env = _load_bot_env("compose.yml")
+        assert var in env, f"{var} missing from compose.yml bot environment"
+
+    def test_dev_override_sets_colbert_rerank(self):
+        env = _load_bot_env("compose.dev.yml")
+        assert env.get("RERANK_PROVIDER") == "colbert"
+        assert "RERANK_CANDIDATES_MAX" in env
+
+    def test_vps_override_sets_none_rerank(self):
+        env = _load_bot_env("compose.vps.yml")
+        assert env.get("RERANK_PROVIDER") == "none"
+        assert env.get("RERANK_CANDIDATES_MAX") == "5"

--- a/tests/unit/test_docker_compose_profiles.py
+++ b/tests/unit/test_docker_compose_profiles.py
@@ -7,11 +7,25 @@ from pathlib import Path
 import yaml
 
 
-_COMPOSE_PATH = Path("docker-compose.dev.yml")
+_BASE_COMPOSE_PATH = Path("compose.yml")
+_DEV_OVERRIDE_PATH = Path("compose.dev.yml")
 
 
-def _load_compose() -> dict:
-    return yaml.safe_load(_COMPOSE_PATH.read_text())
+def _load_compose(path: Path) -> dict:
+    return yaml.safe_load(path.read_text())
+
+
+def _effective_services() -> dict[str, dict]:
+    """Build lightweight effective service view for dev (base + dev override)."""
+    base = _load_compose(_BASE_COMPOSE_PATH)
+    override = _load_compose(_DEV_OVERRIDE_PATH)
+
+    services = {name: dict(cfg) for name, cfg in base.get("services", {}).items()}
+    for service_name, override_cfg in override.get("services", {}).items():
+        merged = dict(services.get(service_name, {}))
+        merged.update(override_cfg)
+        services[service_name] = merged
+    return services
 
 
 def _extract_host_port(port_mapping: str) -> str | None:
@@ -35,8 +49,7 @@ def _extract_host_port(port_mapping: str) -> str | None:
 
 def test_compose_includes_expected_profile_groups():
     """All required optional profile groups should be present."""
-    data = _load_compose()
-    services = data.get("services", {})
+    services = _effective_services()
 
     explicit_profiles: set[str] = set()
     for service in services.values():
@@ -49,8 +62,7 @@ def test_compose_includes_expected_profile_groups():
 
 def test_core_services_are_always_enabled():
     """Core services should have no profile restriction (default compose up)."""
-    data = _load_compose()
-    services = data.get("services", {})
+    services = _effective_services()
 
     core_services = {"redis", "qdrant", "bge-m3", "docling"}
     missing = [name for name in core_services if name not in services]
@@ -62,8 +74,7 @@ def test_core_services_are_always_enabled():
 
 def test_compose_has_no_duplicate_host_ports():
     """No two services should bind the same host port in short syntax."""
-    data = _load_compose()
-    services = data.get("services", {})
+    services = _effective_services()
 
     seen: dict[str, str] = {}
     collisions: list[str] = []


### PR DESCRIPTION
## Summary
- update compose-related unit tests to new `compose.yml` + overrides layout
- remove hardcoded container-name assumptions in Makefile health/redis checks by using `docker compose exec`
- harden deploy commands with VPS defaults for `COMPOSE_FILE` / `COMPOSE_PROJECT_NAME`
- make CI health check service-based (`docker compose ps`) instead of name grep

## Verification
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
- targeted: `uv run pytest tests/unit/test_compose_config.py tests/unit/test_docker_compose_env.py tests/unit/test_docker_compose_profiles.py tests/unit/security/test_secret_hygiene.py -n auto --dist=worksteal -q`
