### PR TITLE
fix(telemetry): graceful fallback when Langfuse endpoint unreachable

### DIFF
--- a/telegram_bot/observability.py
+++ b/telegram_bot/observability.py
@@ -12,8 +12,10 @@ import atexit
 import json
 import logging
 import os
+import socket
 from datetime import UTC, datetime
 from typing import Any
+from urllib.parse import urlparse
 
 from langfuse import (
     Langfuse,
@@ -42,6 +44,25 @@ _MODEL_SYNC_ENABLED_ENV = "LANGFUSE_MODEL_SYNC_ENABLED"
 _MODEL_LIST_PAGE_SIZE = 100
 
 _pii_redactor = PIIRedactor()
+
+_langfuse_endpoint_warned = False
+
+
+# ---------------------------------------------------------------------------
+# Endpoint reachability check
+# ---------------------------------------------------------------------------
+
+
+def _is_endpoint_reachable(url: str, *, timeout: float = 2.0) -> bool:
+    """Return True if host:port from *url* accepts a TCP connection within *timeout* seconds."""
+    parsed = urlparse(url)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -312,13 +333,19 @@ def initialize_langfuse(
 ) -> Langfuse | None:
     """Initialize a Langfuse client after runtime config is loaded.
 
-    Returns None when credentials are missing or client creation fails.
+    Returns None when credentials are missing, endpoint unreachable, or client creation fails.
+    When the endpoint is unreachable, logs a WARNING once and skips OTEL exporter registration.
     """
     global _langfuse_client
     global _langfuse_init_attempted
+    global _langfuse_endpoint_warned
 
     if _langfuse_client is not None and not force:
         return _langfuse_client
+
+    # Return cached None without re-logging when already attempted
+    if _langfuse_init_attempted and _langfuse_client is None and not force:
+        return None
 
     resolved_public_key = _resolve_config_value(public_key, "LANGFUSE_PUBLIC_KEY")
     resolved_secret_key = _resolve_config_value(secret_key, "LANGFUSE_SECRET_KEY")
@@ -329,6 +356,20 @@ def initialize_langfuse(
         if force or not _langfuse_init_attempted:
             logger.info("Langfuse disabled (missing LANGFUSE_PUBLIC_KEY/LANGFUSE_SECRET_KEY)")
         _langfuse_init_attempted = True
+        return None
+
+    # Probe endpoint reachability only when an explicit host is configured.
+    # Cloud default (no host) is assumed reachable to avoid blocking startup.
+    if resolved_host and not _is_endpoint_reachable(resolved_host):
+        _langfuse_client = None
+        _langfuse_init_attempted = True
+        if not _langfuse_endpoint_warned:
+            _langfuse_endpoint_warned = True
+            logger.warning(
+                "Langfuse endpoint unreachable (%s) — tracing disabled. "
+                "Start Langfuse locally or unset LANGFUSE_HOST to suppress this warning.",
+                resolved_host,
+            )
         return None
 
     kwargs: dict[str, Any] = {
@@ -413,5 +454,7 @@ def _reset_langfuse_client_for_tests() -> None:
     """Reset module-level client cache (test-only helper)."""
     global _langfuse_client
     global _langfuse_init_attempted
+    global _langfuse_endpoint_warned
     _langfuse_client = None
     _langfuse_init_attempted = False
+    _langfuse_endpoint_warned = False

--- a/telegram_bot/observability.py
+++ b/telegram_bot/observability.py
@@ -101,6 +101,8 @@ def _resolve_config_value(explicit: str | None, env_name: str) -> str | None:
     value = explicit if explicit is not None else os.getenv(env_name)
     if value is None:
         return None
+    if not isinstance(value, str):
+        return None
     normalized = value.strip()
     return normalized or None
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -69,13 +69,16 @@ class TestMainFunction:
         mock_config_instance.llm_api_key = "test-api-key"
         mock_bot_config.return_value = mock_config_instance
 
-        with patch.dict(
-            sys.modules,
-            {
-                "telegram_bot.bot": mock_bot_mod,
-                "telegram_bot.config": mock_config_mod,
-                "telegram_bot.logging_config": mock_logging_config_mod,
-            },
+        with (
+            patch.dict(
+                sys.modules,
+                {
+                    "telegram_bot.bot": mock_bot_mod,
+                    "telegram_bot.config": mock_config_mod,
+                    "telegram_bot.logging_config": mock_logging_config_mod,
+                },
+            ),
+            patch("telegram_bot.observability._is_endpoint_reachable", return_value=True),
         ):
             from telegram_bot import main as main_module
 
@@ -106,13 +109,16 @@ class TestMainFunction:
         mock_config_instance.llm_api_key = "test-api-key"
         mock_bot_config.return_value = mock_config_instance
 
-        with patch.dict(
-            sys.modules,
-            {
-                "telegram_bot.bot": mock_bot_mod,
-                "telegram_bot.config": mock_config_mod,
-                "telegram_bot.logging_config": mock_logging_config_mod,
-            },
+        with (
+            patch.dict(
+                sys.modules,
+                {
+                    "telegram_bot.bot": mock_bot_mod,
+                    "telegram_bot.config": mock_config_mod,
+                    "telegram_bot.logging_config": mock_logging_config_mod,
+                },
+            ),
+            patch("telegram_bot.observability._is_endpoint_reachable", return_value=True),
         ):
             from telegram_bot import main as main_module
 
@@ -143,13 +149,16 @@ class TestMainFunction:
         mock_config_instance.llm_api_key = "test-api-key"
         mock_bot_config.return_value = mock_config_instance
 
-        with patch.dict(
-            sys.modules,
-            {
-                "telegram_bot.bot": mock_bot_mod,
-                "telegram_bot.config": mock_config_mod,
-                "telegram_bot.logging_config": mock_logging_config_mod,
-            },
+        with (
+            patch.dict(
+                sys.modules,
+                {
+                    "telegram_bot.bot": mock_bot_mod,
+                    "telegram_bot.config": mock_config_mod,
+                    "telegram_bot.logging_config": mock_logging_config_mod,
+                },
+            ),
+            patch("telegram_bot.observability._is_endpoint_reachable", return_value=True),
         ):
             from telegram_bot import main as main_module
 
@@ -182,13 +191,16 @@ class TestMainFunction:
         mock_config_instance.llm_api_key = "test-api-key"
         mock_bot_config.return_value = mock_config_instance
 
-        with patch.dict(
-            sys.modules,
-            {
-                "telegram_bot.bot": mock_bot_mod,
-                "telegram_bot.config": mock_config_mod,
-                "telegram_bot.logging_config": mock_logging_config_mod,
-            },
+        with (
+            patch.dict(
+                sys.modules,
+                {
+                    "telegram_bot.bot": mock_bot_mod,
+                    "telegram_bot.config": mock_config_mod,
+                    "telegram_bot.logging_config": mock_logging_config_mod,
+                },
+            ),
+            patch("telegram_bot.observability._is_endpoint_reachable", return_value=True),
         ):
             from telegram_bot import main as main_module
 

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -99,7 +99,10 @@ class TestLangfuseInitialization:
 
         observability._reset_langfuse_client_for_tests()
         fake_client = MagicMock()
-        with patch("telegram_bot.observability.Langfuse", return_value=fake_client) as mock_cls:
+        with (
+            patch("telegram_bot.observability._is_endpoint_reachable", return_value=True),
+            patch("telegram_bot.observability.Langfuse", return_value=fake_client) as mock_cls,
+        ):
             result = observability.initialize_langfuse(
                 public_key="pk-test",
                 secret_key="sk-test",
@@ -128,6 +131,7 @@ class TestLangfuseInitialization:
         observability._reset_langfuse_client_for_tests()
         fake_client = MagicMock()
         with (
+            patch("telegram_bot.observability._is_endpoint_reachable", return_value=True),
             patch("telegram_bot.observability.Langfuse", return_value=fake_client),
             patch(
                 "telegram_bot.observability.sync_langfuse_model_definitions", return_value=2
@@ -294,6 +298,133 @@ class TestLangfuseFlushConfig:
 
         assert result is None
         mock_atexit.register.assert_not_called()
+
+
+class TestEndpointReachability:
+    """Tests for graceful fallback when Langfuse endpoint is unreachable (#824)."""
+
+    def test_is_endpoint_reachable_returns_false_for_refused_connection(self):
+        """_is_endpoint_reachable returns False when connection is refused."""
+        from telegram_bot.observability import _is_endpoint_reachable
+
+        # Port 1 is almost never open
+        result = _is_endpoint_reachable("http://localhost:1", timeout=0.1)
+        assert result is False
+
+    def test_is_endpoint_reachable_returns_true_when_port_is_open(self):
+        """_is_endpoint_reachable returns True when host:port accepts connections."""
+        import socket
+
+        from telegram_bot.observability import _is_endpoint_reachable
+
+        with socket.socket() as srv:
+            srv.bind(("127.0.0.1", 0))
+            srv.listen(1)
+            port = srv.getsockname()[1]
+            result = _is_endpoint_reachable(f"http://127.0.0.1:{port}", timeout=1.0)
+
+        assert result is True
+
+    def test_initialize_langfuse_skips_when_endpoint_unreachable(self):
+        """When Langfuse endpoint is unreachable, initialize_langfuse returns None."""
+        from unittest.mock import patch
+
+        import telegram_bot.observability as observability
+
+        observability._reset_langfuse_client_for_tests()
+        with (
+            patch(
+                "telegram_bot.observability._is_endpoint_reachable", return_value=False
+            ) as mock_check,
+            patch("telegram_bot.observability.Langfuse") as mock_langfuse,
+        ):
+            result = observability.initialize_langfuse(
+                public_key="pk-test",
+                secret_key="sk-test",
+                host="http://localhost:3001",
+                force=True,
+            )
+
+        assert result is None
+        mock_langfuse.assert_not_called()
+        mock_check.assert_called_once()
+
+    def test_initialize_langfuse_proceeds_when_endpoint_reachable(self):
+        """When Langfuse endpoint is reachable, initialize_langfuse creates the client."""
+        from unittest.mock import MagicMock, patch
+
+        import telegram_bot.observability as observability
+
+        observability._reset_langfuse_client_for_tests()
+        fake_client = MagicMock()
+        with (
+            patch("telegram_bot.observability._is_endpoint_reachable", return_value=True),
+            patch("telegram_bot.observability.Langfuse", return_value=fake_client),
+        ):
+            result = observability.initialize_langfuse(
+                public_key="pk-test",
+                secret_key="sk-test",
+                host="http://localhost:3001",
+                force=True,
+            )
+
+        assert result is fake_client
+
+    def test_initialize_langfuse_logs_warning_once_when_unreachable(self, caplog):
+        """When endpoint unreachable, WARNING is logged exactly once (no spam)."""
+        import logging
+        from unittest.mock import patch
+
+        import telegram_bot.observability as observability
+
+        observability._reset_langfuse_client_for_tests()
+        with (
+            patch("telegram_bot.observability._is_endpoint_reachable", return_value=False),
+            patch("telegram_bot.observability.Langfuse"),
+            caplog.at_level(logging.WARNING, logger="telegram_bot.observability"),
+        ):
+            # First call — should log warning
+            observability.initialize_langfuse(
+                public_key="pk-test",
+                secret_key="sk-test",
+                host="http://localhost:3001",
+                force=True,
+            )
+            # Second call without force — should NOT log again (cached None)
+            observability.initialize_langfuse(
+                public_key="pk-test",
+                secret_key="sk-test",
+                host="http://localhost:3001",
+            )
+
+        unreachable_warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "unreachable" in r.message.lower()
+        ]
+        assert len(unreachable_warnings) == 1
+
+    def test_initialize_langfuse_no_endpoint_check_without_host(self):
+        """Without explicit host, endpoint check is skipped (cloud default assumed reachable)."""
+        from unittest.mock import MagicMock, patch
+
+        import telegram_bot.observability as observability
+
+        observability._reset_langfuse_client_for_tests()
+        fake_client = MagicMock()
+        with (
+            patch("telegram_bot.observability._is_endpoint_reachable") as mock_check,
+            patch("telegram_bot.observability.Langfuse", return_value=fake_client),
+        ):
+            result = observability.initialize_langfuse(
+                public_key="pk-test",
+                secret_key="sk-test",
+                force=True,
+            )
+
+        # No host → no reachability check, client created normally
+        mock_check.assert_not_called()
+        assert result is fake_client
 
 
 class TestLangfuseModelSync:

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -147,6 +147,26 @@ class TestLangfuseInitialization:
         assert result is fake_client
         sync.assert_called_once_with(fake_client)
 
+    def test_initialize_langfuse_ignores_non_string_host_values(self):
+        """Non-string host values should be treated as absent and not crash."""
+        import telegram_bot.observability as observability
+
+        observability._reset_langfuse_client_for_tests()
+        fake_client = MagicMock()
+        with (
+            patch("telegram_bot.observability._is_endpoint_reachable") as mock_check,
+            patch("telegram_bot.observability.Langfuse", return_value=fake_client),
+        ):
+            result = observability.initialize_langfuse(
+                public_key="pk-test",
+                secret_key="sk-test",
+                host=MagicMock(),
+                force=True,
+            )
+
+        assert result is fake_client
+        mock_check.assert_not_called()
+
 
 class TestLangfuseTracingEnvironment:
     """Tests for LANGFUSE_TRACING_ENVIRONMENT support."""


### PR DESCRIPTION
## Summary

- Adds `_is_endpoint_reachable(url, timeout=2.0)` — TCP socket probe before OTEL exporter registration
- If `LANGFUSE_HOST` is set but unreachable, `initialize_langfuse()` returns `None` (noop), logs one `WARNING`, suppresses all further OTEL `ERROR` spam
- No host configured → no probe, cloud default assumed reachable (no startup delay)

## Root Cause

OpenTelemetry SDK periodically flushes spans to the configured host. When Langfuse isn't running locally (not started under `ml` profile), the SDK logs `ConnectionRefusedError` at `ERROR` level on every flush cycle.

## Fix Approach

Probe before registering — never register the exporter if the endpoint is down.

## Test Plan

- [x] `test_is_endpoint_reachable_returns_false_for_refused_connection` — socket closed → False
- [x] `test_is_endpoint_reachable_returns_true_when_port_is_open` — listening socket → True
- [x] `test_initialize_langfuse_skips_when_endpoint_unreachable` — Langfuse() never called
- [x] `test_initialize_langfuse_proceeds_when_endpoint_reachable` — normal init preserved
- [x] `test_initialize_langfuse_logs_warning_once_when_unreachable` — WARNING logged exactly once
- [x] `test_initialize_langfuse_no_endpoint_check_without_host` — cloud default skips probe
- [x] All 31 existing observability tests pass
- [x] Full unit suite: 4527 passed (5 pre-existing failures unrelated to this change)
- [x] `make check` clean (ruff + mypy)

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)