### PR TITLE
fix(security): add read_only to bge-m3 in compose.vps.yml

### DIFF
--- a/compose.vps.yml
+++ b/compose.vps.yml
@@ -2,6 +2,11 @@
 # Usage: COMPOSE_FILE=compose.yml:compose.vps.yml docker compose up -d
 
 services:
+  bge-m3:
+    read_only: true
+    tmpfs:
+      - /tmp
+
   bot:
     environment:
       RERANK_PROVIDER: "none"


### PR DESCRIPTION
## Summary

- Explicitly set `read_only: true` and `tmpfs: [/tmp]` for `bge-m3` in `compose.vps.yml`
- Provides defense-in-depth: VPS override cannot inadvertently drop the hardening flag that exists in base `compose.yml` via `<<: *security-defaults`
- Matches security baseline parity enforced by `test_vps_service_has_read_only[bge-m3]`

## Test plan

- [x] `uv run pytest tests/unit/test_compose_config.py -v` → 23/23 PASSED
- [x] `make check` (ruff + mypy) → all clean
- [x] Pre-commit hooks → all passed

Closes #828