### PR TITLE
fix(preflight): auto-create Qdrant collection when missing

### DIFF
--- a/telegram_bot/preflight.py
+++ b/telegram_bot/preflight.py
@@ -22,6 +22,9 @@ CRITICAL_RETRIES = 3
 CRITICAL_RETRY_DELAY = 5.0  # seconds
 _DEFAULT_COLBERT_COVERAGE_WARN_THRESHOLD = 0.995
 
+# BGE-M3 dense vector dimensionality (used when auto-creating missing collections)
+_BGEM3_DENSE_DIM = 1024
+
 
 def _read_colbert_coverage_warn_threshold() -> float:
     """Read configurable ColBERT coverage warning threshold safely."""
@@ -214,6 +217,43 @@ async def _verify_cache_synthetic(redis_url: str) -> tuple[bool, list[str]]:
         await r.aclose()
 
 
+def _is_collection_not_found(exc: Exception) -> bool:
+    """Return True when the exception indicates a missing Qdrant collection (HTTP 404)."""
+    msg = str(exc).lower()
+    return "not found" in msg or "doesn't exist" in msg or "404" in msg
+
+
+async def _ensure_qdrant_collection(qdrant: AsyncQdrantClient, collection_name: str) -> None:
+    """Create Qdrant collection with the standard BGE-M3 vector schema.
+
+    Schema mirrors gdrive_documents_bge: dense (1024-dim COSINE), colbert
+    (multi-vector MAX_SIM), and bm42 (sparse IDF).  The collection will be
+    empty — ingestion should populate it afterwards.
+    """
+    await qdrant.create_collection(
+        collection_name=collection_name,
+        vectors_config={
+            "dense": models.VectorParams(
+                size=_BGEM3_DENSE_DIM,
+                distance=models.Distance.COSINE,
+            ),
+            "colbert": models.VectorParams(
+                size=_BGEM3_DENSE_DIM,
+                distance=models.Distance.COSINE,
+                multivector_config=models.MultiVectorConfig(
+                    comparator=models.MultiVectorComparator.MAX_SIM
+                ),
+                hnsw_config=models.HnswConfigDiff(m=0),
+            ),
+        },
+        sparse_vectors_config={
+            "bm42": models.SparseVectorParams(
+                modifier=models.Modifier.IDF,
+            ),
+        },
+    )
+
+
 async def _check_single_dep(
     name: str,
     config: BotConfig,
@@ -313,6 +353,25 @@ async def _check_single_dep(
 
             return True
         except Exception as exc:
+            if _is_collection_not_found(exc):
+                logger.warning(
+                    "Preflight WARN: Qdrant collection %s not found — creating with default schema",
+                    collection,
+                )
+                try:
+                    await _ensure_qdrant_collection(qdrant, collection)
+                    logger.info(
+                        "Preflight Qdrant: collection %s created (empty, ready for ingestion)",
+                        collection,
+                    )
+                    return True
+                except Exception as create_exc:
+                    logger.error(
+                        "Preflight FAIL: Qdrant — could not create collection %s: %s",
+                        collection,
+                        create_exc,
+                    )
+                    return False
             logger.error("Preflight FAIL: Qdrant — %s", exc)
             return False
         finally:

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -305,12 +305,13 @@ class TestCheckSingleDep:
         mock_qdrant_client.get_collection.assert_awaited_once_with(config.qdrant_collection)
         mock_qdrant_client.close.assert_awaited_once()
 
-    async def test_qdrant_exception_fails(self):
+    async def test_qdrant_connection_error_fails(self):
+        """Non-404 exceptions (e.g. connection refused) still fail the check."""
         config = _make_config()
         client = AsyncMock(spec=httpx.AsyncClient)
 
         mock_qdrant_client = AsyncMock()
-        mock_qdrant_client.get_collection = AsyncMock(side_effect=Exception("not found"))
+        mock_qdrant_client.get_collection = AsyncMock(side_effect=Exception("Connection refused"))
         mock_qdrant_client.close = AsyncMock()
 
         with patch("telegram_bot.preflight.AsyncQdrantClient", return_value=mock_qdrant_client):
@@ -773,3 +774,92 @@ class TestPostgresOptionalBehavior:
             results = await check_dependencies(config)
 
         assert results["postgres"] is False
+
+
+# ===========================================================================
+# Qdrant preflight: auto-create missing collection
+# ===========================================================================
+
+
+class TestQdrantPreflightEnsureCollection:
+    """Preflight auto-creates Qdrant collection when it is missing."""
+
+    async def test_creates_collection_when_not_found(self):
+        """When collection missing (not-found error), preflight creates it and returns True."""
+        config = _make_config()
+        mock_qdrant = AsyncMock()
+        mock_qdrant.get_collection = AsyncMock(
+            side_effect=Exception("Not found: Collection `test_col` doesn't exist!")
+        )
+        mock_qdrant.create_collection = AsyncMock()
+        mock_qdrant.close = AsyncMock()
+
+        with patch("telegram_bot.preflight.AsyncQdrantClient", return_value=mock_qdrant):
+            client = AsyncMock()
+            result = await _check_single_dep("qdrant", config, client)
+
+        assert result is True
+        mock_qdrant.create_collection.assert_awaited_once()
+
+    async def test_returns_true_after_auto_create(self):
+        """Returns True after successfully creating missing collection (404 variant)."""
+        config = _make_config()
+        mock_qdrant = AsyncMock()
+        mock_qdrant.get_collection = AsyncMock(side_effect=Exception("status_code=404"))
+        mock_qdrant.create_collection = AsyncMock()
+        mock_qdrant.close = AsyncMock()
+
+        with patch("telegram_bot.preflight.AsyncQdrantClient", return_value=mock_qdrant):
+            client = AsyncMock()
+            result = await _check_single_dep("qdrant", config, client)
+
+        assert result is True
+
+    async def test_fails_when_create_also_raises(self):
+        """Returns False when collection missing AND create_collection also fails."""
+        config = _make_config()
+        mock_qdrant = AsyncMock()
+        mock_qdrant.get_collection = AsyncMock(side_effect=Exception("Not found"))
+        mock_qdrant.create_collection = AsyncMock(side_effect=Exception("Permission denied"))
+        mock_qdrant.close = AsyncMock()
+
+        with patch("telegram_bot.preflight.AsyncQdrantClient", return_value=mock_qdrant):
+            client = AsyncMock()
+            result = await _check_single_dep("qdrant", config, client)
+
+        assert result is False
+
+    async def test_non_404_exception_still_fails_without_create(self):
+        """Connection-refused and other non-404 errors fail without attempting create."""
+        config = _make_config()
+        mock_qdrant = AsyncMock()
+        mock_qdrant.get_collection = AsyncMock(side_effect=Exception("Connection refused"))
+        mock_qdrant.create_collection = AsyncMock()
+        mock_qdrant.close = AsyncMock()
+
+        with patch("telegram_bot.preflight.AsyncQdrantClient", return_value=mock_qdrant):
+            client = AsyncMock()
+            result = await _check_single_dep("qdrant", config, client)
+
+        assert result is False
+        mock_qdrant.create_collection.assert_not_awaited()
+
+    async def test_created_collection_has_required_vector_schema(self):
+        """Auto-created collection has dense, colbert (multivector), and bm42 vectors."""
+        config = _make_config(qdrant_collection="gdrive_documents_bge")
+        mock_qdrant = AsyncMock()
+        mock_qdrant.get_collection = AsyncMock(side_effect=Exception("Not found"))
+        mock_qdrant.create_collection = AsyncMock()
+        mock_qdrant.close = AsyncMock()
+
+        with patch("telegram_bot.preflight.AsyncQdrantClient", return_value=mock_qdrant):
+            client = AsyncMock()
+            await _check_single_dep("qdrant", config, client)
+
+        call_kwargs = mock_qdrant.create_collection.call_args[1]
+        assert call_kwargs["collection_name"] == "gdrive_documents_bge"
+        vectors_config = call_kwargs["vectors_config"]
+        assert "dense" in vectors_config
+        assert "colbert" in vectors_config
+        sparse_config = call_kwargs["sparse_vectors_config"]
+        assert "bm42" in sparse_config


### PR DESCRIPTION
## Summary

- When Qdrant collection is missing at bot startup, preflight now auto-creates it with the standard BGE-M3 schema (`dense` 1024-dim COSINE, `colbert` multivector MAX_SIM, `bm42` sparse IDF) instead of triggering a CRITICAL failure → restart loop
- Non-404 errors (connection refused, auth failures) still fail and retry as before
- 5 new unit tests cover: create on not-found, 404 variant, create-fails case, non-404 still fails, schema validation

## Root cause

`get_collection()` on a missing collection raises an exception → CRITICAL preflight fails after 3 retries → Docker restarts bot → restart loop

## Test plan

- [x] `make check` — ruff + mypy clean
- [x] `make test-unit` — 4519 passed, 15 skipped
- [x] `TestQdrantPreflightEnsureCollection` — 5 new tests covering all paths
- [x] Existing preflight tests — all still pass

Closes #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)