### PR TITLE
feat(docker): compose cleanup + VPS ColBERT rerank + Qdrant indexes

### DIFF
--- a/compose.vps.yml
+++ b/compose.vps.yml
@@ -1,4 +1,4 @@
-# compose.vps.yml — VPS production overrides: memory limits, no colbert reranking.
+# compose.vps.yml — VPS production overrides: ColBERT rerank with reduced candidates, security.
 # Usage: COMPOSE_FILE=compose.yml:compose.vps.yml docker compose up -d
 
 services:
@@ -9,8 +9,8 @@ services:
 
   bot:
     environment:
-      RERANK_PROVIDER: "none"
-      RERANK_CANDIDATES_MAX: "5"
+      RERANK_PROVIDER: "colbert"
+      RERANK_CANDIDATES_MAX: "3"
 
   langfuse:
     ports:

--- a/scripts/qdrant_ensure_indexes.py
+++ b/scripts/qdrant_ensure_indexes.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Ensure Qdrant payload indexes exist for all collections.
+
+Creates missing keyword and integer payload indexes needed for efficient
+filtering and order_by queries. Safe to run multiple times (idempotent).
+
+Issue: #810 — VPS/local parity: Qdrant indexes
+
+Usage:
+    python scripts/qdrant_ensure_indexes.py
+    python scripts/qdrant_ensure_indexes.py --collection gdrive_documents_bge
+    QDRANT_URL=http://qdrant:6333 python scripts/qdrant_ensure_indexes.py
+"""
+
+import argparse
+import os
+import sys
+
+from qdrant_client import QdrantClient
+from qdrant_client.http.exceptions import UnexpectedResponse
+from qdrant_client.models import PayloadSchemaType
+
+
+KEYWORD_FIELDS = [
+    "file_id",
+    "metadata.file_id",
+    "metadata.doc_id",
+    "metadata.source",
+    "metadata.file_name",
+    "metadata.mime_type",
+]
+
+INTEGER_FIELDS = [
+    "metadata.order",
+    "metadata.chunk_id",
+]
+
+
+def get_qdrant_client() -> QdrantClient:
+    url = os.getenv("QDRANT_URL", "http://localhost:6333")
+    api_key = os.getenv("QDRANT_API_KEY")
+    return QdrantClient(url=url, api_key=api_key, timeout=30)
+
+
+def ensure_indexes(client: QdrantClient, collection: str) -> None:
+    """Create payload indexes for *collection* if they don't exist.
+
+    Args:
+        client: Connected Qdrant client.
+        collection: Collection name to index.
+    """
+    for field in KEYWORD_FIELDS:
+        try:
+            client.create_payload_index(
+                collection_name=collection,
+                field_name=field,
+                field_schema=PayloadSchemaType.KEYWORD,
+            )
+            print(f"  OK: {field} (keyword)")
+        except UnexpectedResponse as e:
+            if "already exists" in str(e).lower() or e.status_code in (400, 409):
+                print(f"  SKIP: {field} already indexed")
+            else:
+                print(f"  ERROR: {field}: {e}", file=sys.stderr)
+
+    for field in INTEGER_FIELDS:
+        try:
+            client.create_payload_index(
+                collection_name=collection,
+                field_name=field,
+                field_schema=PayloadSchemaType.INTEGER,
+            )
+            print(f"  OK: {field} (integer)")
+        except UnexpectedResponse as e:
+            if "already exists" in str(e).lower() or e.status_code in (400, 409):
+                print(f"  SKIP: {field} already indexed")
+            else:
+                print(f"  ERROR: {field}: {e}", file=sys.stderr)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--collection",
+        default="gdrive_documents_bge",
+        help="Qdrant collection name (default: gdrive_documents_bge)",
+    )
+    args = parser.parse_args()
+
+    client = get_qdrant_client()
+    print(f"Ensuring indexes for collection: {args.collection}")
+    ensure_indexes(client, args.collection)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_compose.py
+++ b/tests/unit/test_compose.py
@@ -1,0 +1,186 @@
+"""Tests for Docker Compose file structure and correctness.
+
+Covers:
+- #818: compose.yml/compose.dev.yml/compose.vps.yml structure
+- #812: VPS ColBERT rerank enabled with reduced candidates
+- #810: qdrant_ensure_indexes.py exists and creates correct indexes
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def load_yaml(filename: str) -> dict:
+    path = REPO_ROOT / filename
+    assert path.exists(), f"Missing compose file: {filename}"
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+# ---------------------------------------------------------------------------
+# #818 — compose unification structure
+# ---------------------------------------------------------------------------
+
+
+def test_compose_yml_is_valid_yaml():
+    """compose.yml must be parseable and have a services key."""
+    data = load_yaml("compose.yml")
+    assert "services" in data
+    assert len(data["services"]) > 0
+
+
+def test_compose_dev_yml_is_valid_yaml():
+    """compose.dev.yml must be parseable and have a services key."""
+    data = load_yaml("compose.dev.yml")
+    assert "services" in data
+
+
+def test_compose_vps_yml_is_valid_yaml():
+    """compose.vps.yml must be parseable and have a services key."""
+    data = load_yaml("compose.vps.yml")
+    assert "services" in data
+
+
+def test_compose_yml_has_no_container_name():
+    """Base compose.yml must not hardcode container names (uses project prefix)."""
+    data = load_yaml("compose.yml")
+    for name, svc in data["services"].items():
+        assert "container_name" not in svc, (
+            f"Service '{name}' in compose.yml has container_name — "
+            "remove it; COMPOSE_PROJECT_NAME provides the prefix"
+        )
+
+
+def test_compose_yml_has_no_ports():
+    """Base compose.yml must not expose ports (only overrides do)."""
+    data = load_yaml("compose.yml")
+    for name, svc in data["services"].items():
+        assert "ports" not in svc, (
+            f"Service '{name}' in compose.yml has ports — "
+            "move to compose.dev.yml or compose.vps.yml override"
+        )
+
+
+def test_compose_dev_has_colbert_rerank():
+    """Dev override must enable ColBERT reranking."""
+    data = load_yaml("compose.dev.yml")
+    bot_env = data["services"]["bot"]["environment"]
+    assert bot_env.get("RERANK_PROVIDER") == "colbert"
+
+
+def test_compose_dev_has_ports_for_core_services():
+    """Dev override must expose localhost ports for core services."""
+    data = load_yaml("compose.dev.yml")
+    services = data["services"]
+    for svc_name in ("postgres", "redis", "qdrant", "bge-m3"):
+        assert "ports" in services.get(svc_name, {}), (
+            f"compose.dev.yml missing ports for '{svc_name}'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# #812 — VPS ColBERT rerank enabled
+# ---------------------------------------------------------------------------
+
+
+def test_vps_rerank_provider_is_colbert():
+    """compose.vps.yml must enable ColBERT rerank (not 'none')."""
+    data = load_yaml("compose.vps.yml")
+    bot_env = data["services"]["bot"]["environment"]
+    assert bot_env.get("RERANK_PROVIDER") == "colbert", (
+        "VPS must use ColBERT rerank — set RERANK_PROVIDER=colbert in compose.vps.yml. "
+        "See issue #812."
+    )
+
+
+def test_vps_rerank_candidates_reduced():
+    """VPS must use reduced candidates to keep latency acceptable (<= 5)."""
+    data = load_yaml("compose.vps.yml")
+    bot_env = data["services"]["bot"]["environment"]
+    candidates = int(bot_env.get("RERANK_CANDIDATES_MAX", 10))
+    assert candidates <= 5, (
+        f"VPS RERANK_CANDIDATES_MAX={candidates} — must be <= 5 to keep latency <2s on CPU"
+    )
+
+
+def test_vps_bge_m3_read_only():
+    """VPS bge-m3 must run read-only for security hardening."""
+    data = load_yaml("compose.vps.yml")
+    bge = data["services"].get("bge-m3", {})
+    assert bge.get("read_only") is True, "compose.vps.yml bge-m3 must have read_only: true"
+
+
+# ---------------------------------------------------------------------------
+# #810 — qdrant_ensure_indexes.py exists
+# ---------------------------------------------------------------------------
+
+
+def test_qdrant_ensure_indexes_script_exists():
+    """scripts/qdrant_ensure_indexes.py must exist."""
+    script = REPO_ROOT / "scripts" / "qdrant_ensure_indexes.py"
+    assert script.exists(), "Missing scripts/qdrant_ensure_indexes.py — create it to fix issue #810"
+
+
+def test_qdrant_ensure_indexes_creates_keyword_indexes():
+    """ensure_indexes() must create keyword payload indexes for filter fields."""
+    script_dir = str(REPO_ROOT / "scripts")
+    if script_dir not in sys.path:
+        sys.path.insert(0, script_dir)
+
+    import qdrant_ensure_indexes as m
+
+    mock_client = MagicMock()
+    mock_client.create_payload_index = MagicMock()
+
+    m.ensure_indexes(mock_client, "gdrive_documents_bge")
+
+    created_fields = {
+        c.kwargs.get("field_name") or c.args[1]
+        for c in mock_client.create_payload_index.call_args_list
+    }
+    expected_keyword_fields = {
+        "file_id",
+        "metadata.file_id",
+        "metadata.doc_id",
+        "metadata.source",
+        "metadata.file_name",
+        "metadata.mime_type",
+    }
+    for field in expected_keyword_fields:
+        assert field in created_fields, f"ensure_indexes() must create keyword index for '{field}'"
+
+
+def test_qdrant_ensure_indexes_creates_integer_indexes():
+    """ensure_indexes() must create integer payload indexes for order/chunk_id."""
+    script_dir = str(REPO_ROOT / "scripts")
+    if script_dir not in sys.path:
+        sys.path.insert(0, script_dir)
+
+    import qdrant_ensure_indexes as m
+
+    mock_client = MagicMock()
+
+    m.ensure_indexes(mock_client, "gdrive_documents_bge")
+
+    created_calls = {
+        (
+            c.kwargs.get("field_name") or c.args[1],
+            str(c.kwargs.get("field_schema") or c.args[2]),
+        )
+        for c in mock_client.create_payload_index.call_args_list
+    }
+
+    for field in ("metadata.order", "metadata.chunk_id"):
+        matched = any(f == field for f, _ in created_calls)
+        assert matched, f"ensure_indexes() must create integer index for '{field}'"


### PR DESCRIPTION
## Summary

- **#818** — compose unification verified: `compose.yml` (base) + `compose.dev.yml` + `compose.vps.yml` are already in place; 7 structural tests added
- **#812** — VPS ColBERT rerank enabled: `RERANK_PROVIDER=colbert`, `RERANK_CANDIDATES_MAX=3`; VPS uses server-side ColBERT via Qdrant Query API (~100-200ms vs 16s CPU-side)
- **#810** — `scripts/qdrant_ensure_indexes.py` created: idempotent script to create keyword/integer payload indexes for `gdrive_documents_bge` collection

## Changes

| File | Change |
|------|--------|
| `compose.vps.yml` | `RERANK_PROVIDER: none → colbert`, `RERANK_CANDIDATES_MAX: 5 → 3` |
| `scripts/qdrant_ensure_indexes.py` | New script: ensures Qdrant payload indexes exist |
| `tests/unit/test_compose.py` | 13 new tests covering all 3 issues |

## Test Plan

- [x] `uv run pytest tests/unit/test_compose.py -v` → 13/13 passed
- [x] `make test-unit` → 4527 passed, 0 failed
- [x] `make check` (ruff + mypy) → clean
- [x] Pre-commit hooks → all passed

Closes #818, #810, #812