### PR TITLE
feat(langfuse): tracing coverage for all services

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -255,8 +255,8 @@ services:
       BOT_DOMAIN: ${BOT_DOMAIN:-недвижимость}
       BOT_LANGUAGE: ${BOT_LANGUAGE:-ru}
       # Langfuse observability (optional — bot degrades gracefully)
-      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}
-      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
+      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
+      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-sk-lf-dev}
       LANGFUSE_HOST: ${LANGFUSE_HOST:-http://langfuse:3000}
       LANGFUSE_TRACING_ENVIRONMENT: "${LANGFUSE_TRACING_ENVIRONMENT:-}"
       LANGFUSE_FLUSH_AT: "${LANGFUSE_FLUSH_AT:-512}"
@@ -323,6 +323,9 @@ services:
     stop_grace_period: 30s
     logging: *default-logging
     environment:
+      - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
+      - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY:-sk-lf-dev}
+      - LANGFUSE_HOST=${LANGFUSE_HOST:-http://langfuse:3000}
       - GDRIVE_SYNC_DIR=/data/drive-sync
       - INGESTION_DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/cocoindex
       - QDRANT_URL=http://qdrant:6333
@@ -650,8 +653,8 @@ services:
       LLM_BASE_URL: http://litellm:4000
       LLM_MODEL: gpt-4o-mini
       RERANK_PROVIDER: colbert
-      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}
-      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
+      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
+      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-sk-lf-dev}
       LANGFUSE_HOST: ${LANGFUSE_HOST:-http://langfuse:3000}
     depends_on:
       redis:
@@ -745,8 +748,8 @@ services:
       ELEVEN_API_KEY: ${ELEVENLABS_API_KEY:-}
       RAG_API_URL: http://rag-api:8080
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/postgres
-      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}
-      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
+      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
+      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-sk-lf-dev}
       LANGFUSE_HOST: ${LANGFUSE_HOST:-http://langfuse:3000}
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8081')\" || exit 1"]

--- a/docker/litellm/config.yaml
+++ b/docker/litellm/config.yaml
@@ -69,6 +69,9 @@ litellm_settings:
   json_logs: true
   # Drop provider-unsupported request params instead of failing hard
   drop_params: true
+  # Langfuse observability callbacks
+  success_callback: ["langfuse"]
+  failure_callback: ["langfuse"]
   # Model-group fallbacks on upstream/provider errors
   fallbacks:
     - gpt-4o-mini: [gpt-4o-mini-cerebras-oss, gpt-4o-mini-fallback, gpt-4o-mini-openai]

--- a/k8s/base/configmaps/litellm-config.yaml
+++ b/k8s/base/configmaps/litellm-config.yaml
@@ -67,6 +67,8 @@ data:
       set_verbose: false
       json_logs: true
       drop_params: true
+      success_callback: ["langfuse"]
+      failure_callback: ["langfuse"]
       fallbacks:
         - gpt-4o-mini: [gpt-4o-mini-cerebras-oss, gpt-4o-mini-fallback, gpt-4o-mini-openai]
         - gpt-oss-120b: [gpt-4o-mini-cerebras-oss, gpt-4o-mini-fallback, gpt-4o-mini-openai]

--- a/tests/unit/test_compose_langfuse.py
+++ b/tests/unit/test_compose_langfuse.py
@@ -1,0 +1,112 @@
+"""Verify all traced services have LANGFUSE env vars with dev defaults (#langfuse-coverage)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).parents[2]
+BASE_COMPOSE = ROOT / "compose.yml"
+
+
+def _load_compose() -> dict:
+    return yaml.safe_load(BASE_COMPOSE.read_text())
+
+
+def _get_service_env(compose: dict, service: str) -> dict[str, str]:
+    """Extract environment dict from a compose service."""
+    svc = compose["services"][service]
+    env = svc.get("environment", {})
+    if isinstance(env, list):
+        return {
+            item.split("=", 1)[0]: (item.split("=", 1)[1] if "=" in item else "") for item in env
+        }
+    return env
+
+
+# Сервисы которые ДОЛЖНЫ иметь LANGFUSE vars
+TRACED_SERVICES = ["bot", "litellm", "rag-api", "voice-agent", "ingestion"]
+
+# Минимальный набор vars для трейсинга
+REQUIRED_LANGFUSE_VARS = [
+    "LANGFUSE_PUBLIC_KEY",
+    "LANGFUSE_SECRET_KEY",
+    "LANGFUSE_HOST",
+]
+
+
+@pytest.fixture(scope="module")
+def compose() -> dict:
+    return _load_compose()
+
+
+class TestLangfuseEnvVarsPresent:
+    """All traced services must declare LANGFUSE_PUBLIC_KEY, SECRET_KEY, HOST."""
+
+    @pytest.mark.parametrize("service", TRACED_SERVICES)
+    @pytest.mark.parametrize("var", REQUIRED_LANGFUSE_VARS)
+    def test_service_has_langfuse_var(self, compose: dict, service: str, var: str):
+        env = _get_service_env(compose, service)
+        assert var in env, f"compose.yml: {service} missing {var} in environment block"
+
+
+# Сервисы где дефолт ДОЛЖЕН быть непустым (dev-ready)
+SERVICES_WITH_DEV_DEFAULTS = ["bot", "litellm", "rag-api", "voice-agent", "ingestion"]
+
+# Паттерн для пустого дефолта: ${VAR:-} или ${VAR:-""} или просто ""
+_EMPTY_PATTERNS = ("${", "")
+
+
+class TestLangfuseDevDefaults:
+    """Services must have non-empty dev defaults for LANGFUSE keys (pk-lf-dev/sk-lf-dev)."""
+
+    @pytest.mark.parametrize("service", SERVICES_WITH_DEV_DEFAULTS)
+    def test_public_key_has_dev_default(self, compose: dict, service: str):
+        env = _get_service_env(compose, service)
+        val = str(env.get("LANGFUSE_PUBLIC_KEY", ""))
+        # Проверяем что дефолт содержит pk-lf-dev
+        assert "pk-lf-dev" in val, (
+            f"compose.yml: {service}.LANGFUSE_PUBLIC_KEY must default to pk-lf-dev, got: {val!r}"
+        )
+
+    @pytest.mark.parametrize("service", SERVICES_WITH_DEV_DEFAULTS)
+    def test_secret_key_has_dev_default(self, compose: dict, service: str):
+        env = _get_service_env(compose, service)
+        val = str(env.get("LANGFUSE_SECRET_KEY", ""))
+        assert "sk-lf-dev" in val, (
+            f"compose.yml: {service}.LANGFUSE_SECRET_KEY must default to sk-lf-dev, got: {val!r}"
+        )
+
+    @pytest.mark.parametrize("service", SERVICES_WITH_DEV_DEFAULTS)
+    def test_host_has_docker_default(self, compose: dict, service: str):
+        env = _get_service_env(compose, service)
+        val = str(env.get("LANGFUSE_HOST", ""))
+        assert "langfuse:3000" in val, (
+            f"compose.yml: {service}.LANGFUSE_HOST must default to http://langfuse:3000, "
+            f"got: {val!r}"
+        )
+
+
+class TestLitellmCallbacks:
+    """LiteLLM config must have langfuse callbacks configured."""
+
+    def test_success_callback_configured(self):
+        config_path = ROOT / "docker" / "litellm" / "config.yaml"
+        config = yaml.safe_load(config_path.read_text())
+        settings = config.get("litellm_settings", {})
+        callbacks = settings.get("success_callback", [])
+        assert "langfuse" in callbacks, (
+            "docker/litellm/config.yaml: litellm_settings.success_callback must include 'langfuse'"
+        )
+
+    def test_failure_callback_configured(self):
+        config_path = ROOT / "docker" / "litellm" / "config.yaml"
+        config = yaml.safe_load(config_path.read_text())
+        settings = config.get("litellm_settings", {})
+        callbacks = settings.get("failure_callback", [])
+        assert "langfuse" in callbacks, (
+            "docker/litellm/config.yaml: litellm_settings.failure_callback must include 'langfuse'"
+        )


### PR DESCRIPTION
## Summary

- Set `pk-lf-dev`/`sk-lf-dev` defaults for bot, rag-api, voice-agent in `compose.yml` (were empty `:-`)
- Add `LANGFUSE_PUBLIC_KEY`/`SECRET_KEY`/`HOST` env vars to ingestion service
- Add `success_callback`/`failure_callback: [langfuse]` to litellm docker + k8s configs
- Add 32 parametrized unit tests validating LANGFUSE env presence and defaults for all 5 services

Closes #880

## Test plan

- [x] `make check` passes (ruff + mypy)
- [x] `uv run pytest tests/unit/ -n auto` passes (4618 passed, 0 failed)
- [x] New tests cover all 5 services: bot, rag-api, voice-agent, ingestion, litellm
- [x] `TestLangfuseEnvVarsPresent` — 15 cases (5 services × 3 vars)
- [x] `TestLangfuseDevDefaults` — 15 cases (5 services × 3 defaults)
- [x] `TestLitellmCallbacks` — 2 cases (success/failure callbacks)

Generated with [Claude Code](https://claude.com/claude-code)