### PR TITLE
feat(phone): add cancel/escape mechanism to phone collector (#887)

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -1328,6 +1328,10 @@ class PropertyBot:
         """Handoff to manager (#628, #730)."""
         if self._forum_bridge is not None:
             await start_qualification(message, i18n=i18n, state=state)
+        elif state is not None:
+            from .handlers.phone_collector import start_phone_collection
+
+            await start_phone_collection(message, state, service_key="manager")
         else:
             await self.handle_menu_action_text(message, "Соедини с менеджером")
 

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -48,6 +48,7 @@ from .handlers.handoff import (
 )
 from .keyboards.client_keyboard import build_client_keyboard, parse_menu_button
 from .middlewares import setup_error_handler, setup_throttling_middleware
+from .middlewares.fsm_cancel import FSMCancelMiddleware
 from .observability import (
     create_callback_handler,
     get_client,
@@ -451,6 +452,7 @@ class PropertyBot:
         """Setup bot middlewares."""
         setup_throttling_middleware(self.dp, rate_limit=1.5, admin_ids=self.config.admin_ids)
         setup_error_handler(self.dp)
+        self.dp.message.outer_middleware(FSMCancelMiddleware())
         logger.info("Middlewares configured")
 
     @staticmethod

--- a/telegram_bot/dialogs/viewing.py
+++ b/telegram_bot/dialogs/viewing.py
@@ -10,9 +10,7 @@ from typing import Any
 from aiogram.types import (
     CallbackQuery,
     ContentType,
-    KeyboardButton,
     Message,
-    ReplyKeyboardMarkup,
     ReplyKeyboardRemove,
 )
 from aiogram_dialog import Dialog, DialogManager, ShowMode, Window
@@ -239,14 +237,9 @@ async def on_manual_text_received(message: Message, widget: Any, manager: Dialog
 
 async def _send_phone_reply_keyboard(callback: CallbackQuery) -> None:
     """Send ReplyKeyboard with 'Share Contact' button for phone step."""
-    kb = ReplyKeyboardMarkup(
-        keyboard=[
-            [KeyboardButton(text="📱 Поделиться контактом", request_contact=True)],
-            [KeyboardButton(text="❌ Отмена")],
-        ],
-        resize_keyboard=True,
-        one_time_keyboard=True,
-    )
+    from telegram_bot.keyboards.phone_keyboard import build_phone_keyboard
+
+    kb = build_phone_keyboard()
     await callback.bot.send_message(  # type: ignore[union-attr]
         chat_id=callback.from_user.id,
         text="👇 Нажмите кнопку ниже или введите номер вручную:",
@@ -281,13 +274,17 @@ async def on_date_selected(
 
 async def on_phone_text_received(message: Message, widget: Any, manager: DialogManager) -> None:
     """Handle phone number text input."""
-    from telegram_bot.handlers.phone_collector import normalize_phone, validate_phone
+    from telegram_bot.keyboards.phone_keyboard import (
+        is_phone_cancel,
+        normalize_phone,
+        validate_phone,
+    )
 
     text = message.text or ""
     logger.info("on_phone_text_received: raw=%r", text)
 
     # Handle cancel from ReplyKeyboard
-    if text in ("❌ Отмена", "Отмена"):
+    if is_phone_cancel(text):
         await message.answer("Запись отменена.", reply_markup=ReplyKeyboardRemove())
         await manager.done()
         return
@@ -309,7 +306,7 @@ async def on_phone_text_received(message: Message, widget: Any, manager: DialogM
 async def on_phone_contact_received(message: Message, widget: Any, manager: DialogManager) -> None:
     """Handle shared contact (request_contact button)."""
     if message.contact and message.contact.phone_number:
-        from telegram_bot.handlers.phone_collector import normalize_phone
+        from telegram_bot.keyboards.phone_keyboard import normalize_phone
 
         raw = message.contact.phone_number
         phone = normalize_phone(raw) or raw

--- a/telegram_bot/handlers/phone_collector.py
+++ b/telegram_bot/handlers/phone_collector.py
@@ -5,52 +5,32 @@ from __future__ import annotations
 
 import datetime
 import logging
-import re
 import time
 from typing import Any
 
-import phonenumbers
 from aiogram import F, Router
+from aiogram.enums import ContentType
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 from aiogram.types import CallbackQuery, Message
 
+from telegram_bot.keyboards.phone_keyboard import (
+    build_phone_keyboard,
+    is_phone_attempt,
+    normalize_phone,
+    validate_phone,
+)
 from telegram_bot.services.content_loader import get_phone_config
 from telegram_bot.services.kommo_models import ContactCreate, LeadCreate, TaskCreate
 
 
 logger = logging.getLogger(__name__)
 
-_PHONE_PATTERN = re.compile(r"^\+?\d{7,15}$")
-
 
 class PhoneCollectorStates(StatesGroup):
     """FSM states for phone collection."""
 
     waiting_phone = State()
-
-
-def normalize_phone(raw: str, default_region: str = "BG") -> str | None:
-    """Parse and validate phone via phonenumbers; return E164 or None if invalid.
-
-    Tries with default_region first (for local numbers like 088...),
-    then without region (for international +380, +7, etc.).
-    """
-    cleaned = re.sub(r"[\s\-\(\)]", "", raw)
-    for region in (default_region, None):
-        try:
-            parsed = phonenumbers.parse(cleaned, region)
-            if phonenumbers.is_valid_number(parsed):
-                return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164)
-        except phonenumbers.NumberParseException:
-            continue
-    return None
-
-
-def validate_phone(text: str) -> bool:
-    """Validate phone number format."""
-    cleaned = re.sub(r"[\s\-\(\)]", "", text)
-    return bool(_PHONE_PATTERN.match(cleaned))
 
 
 def build_display_name(user: Any | None, phone: str) -> str:
@@ -138,7 +118,7 @@ async def start_phone_collection(
     service_key: str,
     viewing_objects: list[dict[str, Any]] | None = None,
 ) -> None:
-    """Start phone collection flow. Called from various handlers."""
+    """Start phone collection flow with reply keyboard."""
     config = get_phone_config(service_key)
     phone_prompt = (
         config["phone_prompt"]
@@ -149,40 +129,27 @@ async def start_phone_collection(
     await state.set_state(PhoneCollectorStates.waiting_phone)
     await state.update_data(service_key=service_key, viewing_objects=viewing_objects or [])
 
+    kb = build_phone_keyboard()
+    text = f"{phone_prompt}\n\n👇 Нажмите кнопку или введите номер вручную:"
+
     if isinstance(message_or_callback, CallbackQuery) and message_or_callback.message:
-        await message_or_callback.message.answer(phone_prompt)
+        await message_or_callback.message.answer(text, reply_markup=kb)
         await message_or_callback.answer()
     else:
-        await message_or_callback.answer(phone_prompt)  # type: ignore[union-attr]
+        await message_or_callback.answer(text, reply_markup=kb)  # type: ignore[union-attr]
 
 
-async def on_phone_received(
+async def _process_valid_phone(
+    phone: str,
     message: Message,
     state: FSMContext,
     kommo_client: Any | None = None,
-    i18n: Any | None = None,
     bot_config: Any | None = None,
     search_event_store: Any | None = None,
 ) -> None:
-    """Handle phone number input."""
-    if not message.text or not validate_phone(message.text):
-        phone_invalid = (
-            i18n.get("phone-invalid")
-            if i18n
-            else "Пожалуйста, введите корректный номер телефона.\nНапример: +359 88 123 4567"
-        )
-        await message.answer(phone_invalid)
-        return
+    """Process validated phone: CRM lead + success message."""
+    from telegram_bot.keyboards.client_keyboard import build_client_keyboard
 
-    phone = normalize_phone(message.text)
-    if phone is None:
-        phone_invalid = (
-            i18n.get("phone-invalid")
-            if i18n
-            else "Пожалуйста, введите корректный номер телефона.\nНапример: +359 88 123 4567"
-        )
-        await message.answer(phone_invalid)
-        return
     data = await state.get_data()
     service_key = data.get("service_key", "unknown")
     viewing_objects: list[dict[str, Any]] = data.get("viewing_objects", [])
@@ -210,7 +177,7 @@ async def on_phone_received(
         user_id,
     )
 
-    await message.answer(phone_success)
+    await message.answer(phone_success, reply_markup=build_client_keyboard())
 
     if kommo_client is not None:
         try:
@@ -281,8 +248,72 @@ async def on_phone_received(
             logger.exception("CRM lead creation failed for phone=%s", phone)
 
 
+async def on_phone_received(
+    message: Message,
+    state: FSMContext,
+    kommo_client: Any | None = None,
+    i18n: Any | None = None,
+    bot_config: Any | None = None,
+    search_event_store: Any | None = None,
+) -> None:
+    """Handle phone number text input."""
+    from telegram_bot.keyboards.client_keyboard import build_client_keyboard
+
+    text = message.text or ""
+
+    # Not a phone attempt (no 5+ digits) — silently exit FSM
+    if not is_phone_attempt(text):
+        await state.clear()
+        await message.answer(
+            "Ввод телефона отменён. Вы можете задать вопрос.",
+            reply_markup=build_client_keyboard(),
+        )
+        return
+
+    if not validate_phone(text):
+        phone_invalid = (
+            i18n.get("phone-invalid")
+            if i18n
+            else "Пожалуйста, введите корректный номер телефона.\nНапример: +359 88 123 4567"
+        )
+        await message.answer(phone_invalid)
+        return
+
+    phone = normalize_phone(text)
+    if phone is None:
+        phone_invalid = (
+            i18n.get("phone-invalid")
+            if i18n
+            else "Пожалуйста, введите корректный номер телефона.\nНапример: +359 88 123 4567"
+        )
+        await message.answer(phone_invalid)
+        return
+
+    await _process_valid_phone(phone, message, state, kommo_client, bot_config, search_event_store)
+
+
+async def on_phone_contact(
+    message: Message,
+    state: FSMContext,
+    kommo_client: Any | None = None,
+    bot_config: Any | None = None,
+    search_event_store: Any | None = None,
+) -> None:
+    """Handle shared contact via request_contact button."""
+    if message.contact and message.contact.phone_number:
+        phone = normalize_phone(message.contact.phone_number) or message.contact.phone_number
+        await _process_valid_phone(
+            phone, message, state, kommo_client, bot_config, search_event_store
+        )
+    else:
+        await message.answer("Не удалось получить номер. Введите вручную:")
+
+
 def create_phone_router() -> Router:
     """Create a fresh router instance for phone FSM handlers."""
     router = Router(name="phone_collector")
     router.message(PhoneCollectorStates.waiting_phone, F.text)(on_phone_received)
+    router.message(PhoneCollectorStates.waiting_phone, F.content_type == ContentType.CONTACT)(
+        on_phone_contact
+    )
     return router

--- a/telegram_bot/keyboards/phone_keyboard.py
+++ b/telegram_bot/keyboards/phone_keyboard.py
@@ -1,0 +1,58 @@
+"""Shared phone keyboard and validation utilities.
+
+Used by phone_collector FSM and viewing dialog to avoid duplication.
+"""
+
+from __future__ import annotations
+
+import re
+
+import phonenumbers
+from aiogram.types import KeyboardButton, ReplyKeyboardMarkup
+
+
+_PHONE_PATTERN = re.compile(r"^\+?\d{7,15}$")
+_DIGITS_RE = re.compile(r"\D")
+_CANCEL_TEXTS = frozenset({"❌ отмена", "отмена"})
+
+
+def build_phone_keyboard() -> ReplyKeyboardMarkup:
+    """Reply keyboard with 'Share contact' + 'Cancel' buttons."""
+    return ReplyKeyboardMarkup(
+        keyboard=[
+            [KeyboardButton(text="\U0001f4f1 Поделиться контактом", request_contact=True)],
+            [KeyboardButton(text="❌ Отмена")],
+        ],
+        resize_keyboard=True,
+        one_time_keyboard=True,
+    )
+
+
+def is_phone_cancel(text: str) -> bool:
+    """Check if text is a cancel command from reply keyboard."""
+    return text.strip().lower() in _CANCEL_TEXTS
+
+
+def is_phone_attempt(text: str) -> bool:
+    """Check if text looks like a phone number attempt (5+ digits)."""
+    digits = _DIGITS_RE.sub("", text)
+    return len(digits) >= 5
+
+
+def validate_phone(text: str) -> bool:
+    """Validate phone number format (7-15 digits, optional +)."""
+    cleaned = re.sub(r"[\s\-\(\)]", "", text)
+    return bool(_PHONE_PATTERN.match(cleaned))
+
+
+def normalize_phone(raw: str, default_region: str = "BG") -> str | None:
+    """Parse and normalize phone to E164 format. Returns None if invalid."""
+    cleaned = re.sub(r"[\s\-\(\)]", "", raw)
+    for region in (default_region, None):
+        try:
+            parsed = phonenumbers.parse(cleaned, region)
+            if phonenumbers.is_valid_number(parsed):
+                return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164)
+        except phonenumbers.NumberParseException:
+            continue
+    return None

--- a/telegram_bot/middlewares/__init__.py
+++ b/telegram_bot/middlewares/__init__.py
@@ -6,12 +6,14 @@ from .error_handler import (
     setup_error_handler,
     setup_error_middleware,
 )
+from .fsm_cancel import FSMCancelMiddleware
 from .i18n import I18nMiddleware, create_translator_hub, setup_i18n_middleware
 from .throttling import ThrottlingMiddleware, setup_throttling_middleware
 
 
 __all__ = [
     "ErrorHandlerMiddleware",
+    "FSMCancelMiddleware",
     "I18nMiddleware",
     "ThrottlingMiddleware",
     "create_translator_hub",

--- a/telegram_bot/middlewares/fsm_cancel.py
+++ b/telegram_bot/middlewares/fsm_cancel.py
@@ -1,0 +1,41 @@
+"""Global FSM cancel middleware."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from aiogram import BaseMiddleware
+from aiogram.fsm.context import FSMContext
+from aiogram.types import Message
+
+from telegram_bot.keyboards.client_keyboard import build_client_keyboard
+
+
+_CANCEL_TRIGGERS = frozenset({"/cancel", "отмена", "cancel", "❌ отмена"})
+
+
+class FSMCancelMiddleware(BaseMiddleware):
+    """Intercept cancel commands in any FSM state and clear it."""
+
+    async def __call__(
+        self,
+        handler: Callable[[Message, dict[str, Any]], Awaitable[Any]],
+        event: Message,
+        data: dict[str, Any],
+    ) -> Any:
+        state: FSMContext | None = data.get("state")
+        if not state:
+            return await handler(event, data)
+
+        text = (event.text or "").strip().lower()
+        if text not in _CANCEL_TRIGGERS:
+            return await handler(event, data)
+
+        current = await state.get_state()
+        if current is None:
+            return await handler(event, data)
+
+        await state.clear()
+        await event.answer("Действие отменено.", reply_markup=build_client_keyboard())
+        return None

--- a/tests/unit/handlers/test_phone_collector.py
+++ b/tests/unit/handlers/test_phone_collector.py
@@ -10,9 +10,8 @@ from telegram_bot.handlers.phone_collector import (
     _build_note_text,
     build_display_name,
     create_phone_router,
-    normalize_phone,
-    validate_phone,
 )
+from telegram_bot.keyboards.phone_keyboard import normalize_phone, validate_phone
 
 
 def test_validate_phone_valid():
@@ -516,7 +515,8 @@ async def test_phone_error_message_shows_format_mask():
     """Fallback error message should show format examples, not raw phone numbers."""
     state = AsyncMock()
     message = AsyncMock()
-    message.text = "invalid"
+    # Use a phone-like string (5+ digits) that fails validate_phone
+    message.text = "+11111111111"
     message.from_user = SimpleNamespace(id=1, first_name="Test", last_name=None, username=None)
 
     await mod.on_phone_received(message, state)
@@ -524,3 +524,56 @@ async def test_phone_error_message_shows_format_mask():
     call_text = message.answer.call_args[0][0]
     assert "+359" in call_text
     assert "+380501234567" not in call_text
+
+
+# --- Reply keyboard and contact handler tests ---
+
+
+async def test_start_phone_collection_sends_reply_keyboard():
+    """start_phone_collection must send ReplyKeyboardMarkup with contact + cancel."""
+    from unittest.mock import MagicMock
+
+    from aiogram.fsm.context import FSMContext
+    from aiogram.types import ReplyKeyboardMarkup
+
+    from telegram_bot.handlers.phone_collector import start_phone_collection
+
+    message = MagicMock()
+    message.answer = AsyncMock()
+    state = MagicMock(spec=FSMContext)
+    state.set_state = AsyncMock()
+    state.update_data = AsyncMock()
+
+    with patch("telegram_bot.handlers.phone_collector.get_phone_config", return_value=None):
+        await start_phone_collection(message, state, service_key="test")
+
+    message.answer.assert_awaited_once()
+    call_kwargs = message.answer.call_args
+    reply_markup = call_kwargs.kwargs.get("reply_markup") or call_kwargs[1].get("reply_markup")
+    assert isinstance(reply_markup, ReplyKeyboardMarkup)
+
+
+async def test_on_phone_received_non_phone_text_exits_fsm():
+    """Text without 5+ digits should silently exit FSM."""
+    from unittest.mock import MagicMock
+
+    message = MagicMock()
+    message.text = "Какие есть апартаменты?"
+    message.answer = AsyncMock()
+    state = MagicMock()
+    state.clear = AsyncMock()
+
+    await mod.on_phone_received(message, state)
+
+    state.clear.assert_awaited_once()
+    assert (
+        "отменён" in message.answer.call_args[0][0].lower()
+        or "отменен" in message.answer.call_args[0][0].lower()
+    )
+
+
+def test_create_phone_router_has_contact_handler():
+    """Router must handle ContentType.CONTACT in waiting_phone state."""
+    router = create_phone_router()
+    # Router should have at least 2 message handlers (text + contact)
+    assert len(router.message.handlers) >= 2

--- a/tests/unit/keyboards/test_phone_keyboard.py
+++ b/tests/unit/keyboards/test_phone_keyboard.py
@@ -1,0 +1,85 @@
+"""Tests for shared phone keyboard utilities."""
+
+import pytest
+
+
+pytest.importorskip("aiogram", reason="aiogram not installed")
+
+from telegram_bot.keyboards.phone_keyboard import (
+    build_phone_keyboard,
+    is_phone_attempt,
+    is_phone_cancel,
+    normalize_phone,
+    validate_phone,
+)
+
+
+class TestBuildPhoneKeyboard:
+    def test_returns_reply_keyboard(self):
+        from aiogram.types import ReplyKeyboardMarkup
+
+        kb = build_phone_keyboard()
+        assert isinstance(kb, ReplyKeyboardMarkup)
+
+    def test_has_contact_button(self):
+        kb = build_phone_keyboard()
+        buttons = [btn for row in kb.keyboard for btn in row]
+        contact_btns = [b for b in buttons if b.request_contact]
+        assert len(contact_btns) == 1
+
+    def test_has_cancel_button(self):
+        kb = build_phone_keyboard()
+        texts = [btn.text for row in kb.keyboard for btn in row]
+        assert any("Отмена" in t for t in texts)
+
+    def test_resize_and_one_time(self):
+        kb = build_phone_keyboard()
+        assert kb.resize_keyboard is True
+        assert kb.one_time_keyboard is True
+
+
+class TestIsPhoneCancel:
+    @pytest.mark.parametrize("text", ["❌ Отмена", "Отмена", "отмена", "  Отмена  "])
+    def test_cancel_texts(self, text):
+        assert is_phone_cancel(text) is True
+
+    @pytest.mark.parametrize("text", ["Привет", "+380501234567", "", "Отменить"])
+    def test_non_cancel_texts(self, text):
+        assert is_phone_cancel(text) is False
+
+
+class TestIsPhoneAttempt:
+    @pytest.mark.parametrize("text", ["+380501234567", "088 123 4567", "12345"])
+    def test_phone_like_texts(self, text):
+        assert is_phone_attempt(text) is True
+
+    @pytest.mark.parametrize("text", ["Привет", "Какие апартаменты?", "2 комнаты", "цена 100", ""])
+    def test_non_phone_texts(self, text):
+        assert is_phone_attempt(text) is False
+
+
+class TestValidatePhone:
+    def test_valid(self):
+        assert validate_phone("+380501234567") is True
+        assert validate_phone("+359896759292") is True
+
+    def test_invalid(self):
+        assert validate_phone("hello") is False
+        assert validate_phone("123") is False
+
+
+class TestNormalizePhone:
+    def test_valid_international(self):
+        assert normalize_phone("+380501234567") == "+380501234567"
+
+    def test_valid_local_bg(self):
+        result = normalize_phone("0896759292")
+        assert result is not None
+        assert result.startswith("+359")
+
+    def test_invalid(self):
+        assert normalize_phone("hello") is None
+        assert normalize_phone("") is None
+
+    def test_strips_formatting(self):
+        assert normalize_phone("+38 050 123-45-67") == "+380501234567"

--- a/tests/unit/middlewares/test_fsm_cancel.py
+++ b/tests/unit/middlewares/test_fsm_cancel.py
@@ -1,0 +1,86 @@
+"""Tests for FSMCancelMiddleware."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+pytest.importorskip("aiogram", reason="aiogram not installed")
+
+from telegram_bot.middlewares.fsm_cancel import FSMCancelMiddleware
+
+
+def _make_message(text: str) -> MagicMock:
+    msg = MagicMock()
+    msg.text = text
+    msg.answer = AsyncMock()
+    return msg
+
+
+def _make_state(current: str | None) -> MagicMock:
+    state = MagicMock()
+    state.get_state = AsyncMock(return_value=current)
+    state.clear = AsyncMock()
+    return state
+
+
+class TestFSMCancelMiddleware:
+    @pytest.fixture()
+    def middleware(self):
+        return FSMCancelMiddleware()
+
+    @pytest.mark.asyncio()
+    @pytest.mark.parametrize("text", ["/cancel", "Отмена", "отмена", "cancel", "❌ Отмена"])
+    async def test_cancel_clears_fsm_state(self, middleware, text):
+        msg = _make_message(text)
+        state = _make_state("PhoneCollectorStates:waiting_phone")
+        handler = AsyncMock()
+
+        with patch("telegram_bot.middlewares.fsm_cancel.build_client_keyboard") as mock_kb:
+            mock_kb.return_value = MagicMock()
+            await middleware(handler, msg, {"state": state})
+
+        state.clear.assert_awaited_once()
+        msg.answer.assert_awaited_once()
+        handler.assert_not_awaited()
+
+    @pytest.mark.asyncio()
+    async def test_no_fsm_state_passes_through(self, middleware):
+        msg = _make_message("/cancel")
+        state = _make_state(None)
+        handler = AsyncMock()
+
+        await middleware(handler, msg, {"state": state})
+
+        state.clear.assert_not_awaited()
+        handler.assert_awaited_once()
+
+    @pytest.mark.asyncio()
+    async def test_non_cancel_text_passes_through(self, middleware):
+        msg = _make_message("Привет")
+        state = _make_state("PhoneCollectorStates:waiting_phone")
+        handler = AsyncMock()
+
+        await middleware(handler, msg, {"state": state})
+
+        state.clear.assert_not_awaited()
+        handler.assert_awaited_once()
+
+    @pytest.mark.asyncio()
+    async def test_no_state_in_data_passes_through(self, middleware):
+        msg = _make_message("/cancel")
+        handler = AsyncMock()
+
+        await middleware(handler, msg, {})
+
+        handler.assert_awaited_once()
+
+    @pytest.mark.asyncio()
+    async def test_no_text_passes_through(self, middleware):
+        msg = _make_message(None)
+        state = _make_state("PhoneCollectorStates:waiting_phone")
+        handler = AsyncMock()
+
+        await middleware(handler, msg, {"state": state})
+
+        handler.assert_awaited_once()

--- a/tests/unit/test_bot_menu_handlers.py
+++ b/tests/unit/test_bot_menu_handlers.py
@@ -1,0 +1,32 @@
+"""Tests for bot menu handler edge cases."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+pytest.importorskip("aiogram", reason="aiogram not installed")
+
+
+@pytest.mark.asyncio()
+async def test_handle_manager_no_forum_bridge_starts_phone_collection():
+    """Without forum_bridge, manager button should start phone collection."""
+    with patch("telegram_bot.bot.PropertyBot.__init__", return_value=None):
+        from telegram_bot.bot import PropertyBot
+
+        bot = PropertyBot.__new__(PropertyBot)
+        bot._forum_bridge = None
+
+    message = MagicMock()
+    message.answer = AsyncMock()
+    state = MagicMock()
+    state.set_state = AsyncMock()
+    state.update_data = AsyncMock()
+
+    with patch("telegram_bot.handlers.phone_collector.start_phone_collection") as mock_phone:
+        mock_phone.return_value = None
+        await bot._handle_manager(message, state=state)
+
+    mock_phone.assert_awaited_once()
+    call_kwargs = mock_phone.call_args
+    assert call_kwargs.kwargs.get("service_key") == "manager"


### PR DESCRIPTION
## Summary

- Add shared `phone_keyboard.py` module with `build_phone_keyboard`, `is_phone_cancel`, `is_phone_attempt`, `validate_phone`, `normalize_phone` utilities
- Add `FSMCancelMiddleware` (outer middleware on `dp.message`) for global FSM cancel via `/cancel`, `Отмена`, `cancel`, `❌ Отмена`
- Refactor `phone_collector.py`: reply keyboard with contact share + cancel buttons, silent FSM exit for non-phone text, contact handler via `ContentType.CONTACT`
- Refactor `viewing.py`: use shared `phone_keyboard` module instead of duplicated phone logic
- Manager button without `forum_bridge` now starts phone collection instead of useless RAG query

## Test plan

- [x] 26 tests for shared phone keyboard module (keyboard builder, cancel detection, phone attempt, validation, normalization)
- [x] 9 tests for FSMCancelMiddleware (cancel clears state, passthrough for no state/no text/non-cancel)
- [x] 35 tests for phone_collector (existing + 3 new: reply keyboard, non-phone exit, contact handler)
- [x] 20 tests for viewing dialog (no regression)
- [x] 1 test for manager button without forum_bridge
- [x] `make check` passes (ruff + mypy)
- [x] 4659 unit tests pass (`uv run pytest tests/unit/ -n auto --timeout=30`)

Closes #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)