### PR TITLE
feat(ingestion): index services.yaml into Qdrant for RAG search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -847,7 +847,10 @@ ingest-gdrive-status: ## Show GDrive collection stats
 # UNIFIED INGESTION PIPELINE (v3.2.1)
 # =============================================================================
 
-.PHONY: ingest-unified ingest-unified-watch ingest-unified-status ingest-unified-reprocess ingest-unified-logs
+.PHONY: ingest-services ingest-unified ingest-unified-watch ingest-unified-status ingest-unified-reprocess ingest-unified-logs
+
+ingest-services: ## Index services.yaml into Qdrant
+	uv run python scripts/index_services.py
 
 ingest-unified: ## Run unified ingestion once
 	@echo "$(BLUE)Running unified ingestion (CocoIndex)...$(NC)"

--- a/scripts/index_services.py
+++ b/scripts/index_services.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Index services.yaml card_text into Qdrant for RAG search.
+
+Usage:
+    uv run python scripts/index_services.py
+
+Environment variables:
+    QDRANT_URL      Qdrant base URL (default: http://localhost:6333)
+    BGE_M3_URL      BGE-M3 API base URL (default: http://localhost:8000)
+    COLLECTION      Qdrant collection name (default: gdrive_documents_bge)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+
+import httpx
+from qdrant_client import QdrantClient
+from qdrant_client.models import PointStruct, SparseVector
+
+from telegram_bot.services.content_loader import load_services_config
+
+
+logger = logging.getLogger(__name__)
+
+COLLECTION = os.getenv("COLLECTION", "gdrive_documents_bge")
+
+
+def extract_service_documents(config: dict) -> list[dict]:
+    """Extract indexable documents from services config.
+
+    Args:
+        config: Parsed services.yaml dict.
+
+    Returns:
+        List of dicts with keys: point_id, text, metadata, service_key.
+        Services without card_text (or with empty card_text) are skipped.
+    """
+    services = config.get("services", {})
+    docs: list[dict] = []
+    for key, svc in services.items():
+        card_text = svc.get("card_text", "")
+        if not card_text:
+            continue
+        title = svc.get("title", key)
+        docs.append(
+            {
+                "point_id": str(uuid.uuid5(uuid.NAMESPACE_URL, f"services.yaml:{key}")),
+                "text": f"{title}\n\n{card_text}",
+                "service_key": key,
+                "metadata": {
+                    "source": "services.yaml",
+                    "service_key": key,
+                    "title": title,
+                },
+            }
+        )
+    return docs
+
+
+def _embed_texts(texts: list[str], bge_url: str) -> tuple[list[list[float]], list[dict]]:
+    """Call BGE-M3 /encode/hybrid and return (dense_vecs, lexical_weights)."""
+    resp = httpx.post(
+        f"{bge_url}/encode/hybrid",
+        json={"texts": texts, "max_length": 512},
+        timeout=60.0,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return data["dense_vecs"], data["lexical_weights"]
+
+
+def index_services(
+    qdrant_url: str = "http://localhost:6333",
+    bge_url: str = "http://localhost:8000",
+    collection: str = COLLECTION,
+) -> None:
+    """Load services.yaml, embed card_text, upsert to Qdrant."""
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    config = load_services_config()
+    docs = extract_service_documents(config)
+
+    if not docs:
+        logger.info("No service documents found — nothing to index.")
+        return
+
+    logger.info("Indexing %d services into '%s'", len(docs), collection)
+
+    texts = [d["text"] for d in docs]
+    dense_vecs, lexical_weights = _embed_texts(texts, bge_url)
+
+    points: list[PointStruct] = []
+    for doc, dense, sparse in zip(docs, dense_vecs, lexical_weights, strict=True):
+        points.append(
+            PointStruct(
+                id=doc["point_id"],
+                vector={
+                    "dense": dense,
+                    "bm42": SparseVector(
+                        indices=sparse["indices"],
+                        values=sparse["values"],
+                    ),
+                },
+                payload={
+                    "text": doc["text"],
+                    **doc["metadata"],
+                },
+            )
+        )
+
+    client = QdrantClient(url=qdrant_url)
+    client.upsert(collection_name=collection, points=points)
+    logger.info("Done. Upserted %d points.", len(points))
+
+
+if __name__ == "__main__":
+    index_services(
+        qdrant_url=os.getenv("QDRANT_URL", "http://localhost:6333"),
+        bge_url=os.getenv("BGE_M3_URL", "http://localhost:8000"),
+        collection=os.getenv("COLLECTION", "gdrive_documents_bge"),
+    )

--- a/tests/unit/test_index_services.py
+++ b/tests/unit/test_index_services.py
@@ -1,0 +1,159 @@
+"""Tests for services.yaml indexing script."""
+
+import uuid
+
+
+# ---------------------------------------------------------------------------
+# Test: parsing services config
+# ---------------------------------------------------------------------------
+
+
+def test_extract_service_documents_returns_docs_with_card_text() -> None:
+    """extract_service_documents returns docs for services that have card_text."""
+    from scripts.index_services import extract_service_documents
+
+    config = {
+        "services": {
+            "vnzh": {"title": "ВНЖ", "card_text": "ВНЖ в Болгарии..."},
+            "installment": {"title": "Рассрочка", "card_text": "Рассрочка от застройщика..."},
+            "no_card": {"title": "Empty"},
+        }
+    }
+
+    docs = extract_service_documents(config)
+
+    assert len(docs) == 2
+    keys = {d["service_key"] for d in docs}
+    assert keys == {"vnzh", "installment"}
+
+
+def test_extract_service_documents_text_combines_title_and_card_text() -> None:
+    """Document text is title + newlines + card_text."""
+    from scripts.index_services import extract_service_documents
+
+    config = {
+        "services": {
+            "vnzh": {"title": "ВНЖ", "card_text": "ВНЖ в Болгарии..."},
+        }
+    }
+
+    docs = extract_service_documents(config)
+
+    assert docs[0]["text"] == "ВНЖ\n\nВНЖ в Болгарии..."
+
+
+def test_extract_service_documents_metadata() -> None:
+    """Each document has source, service_key, title metadata."""
+    from scripts.index_services import extract_service_documents
+
+    config = {
+        "services": {
+            "infotour": {"title": "Инфотур", "card_text": "Тур по Болгарии"},
+        }
+    }
+
+    docs = extract_service_documents(config)
+    doc = docs[0]
+
+    assert doc["metadata"]["source"] == "services.yaml"
+    assert doc["metadata"]["service_key"] == "infotour"
+    assert doc["metadata"]["title"] == "Инфотур"
+
+
+def test_extract_service_documents_skips_missing_card_text() -> None:
+    """Services without card_text are not included."""
+    from scripts.index_services import extract_service_documents
+
+    config = {
+        "services": {
+            "only_title": {"title": "No card"},
+            "empty_card": {"title": "Empty", "card_text": ""},
+        }
+    }
+
+    docs = extract_service_documents(config)
+
+    assert docs == []
+
+
+def test_extract_service_documents_empty_services() -> None:
+    """Empty or missing services section returns empty list."""
+    from scripts.index_services import extract_service_documents
+
+    assert extract_service_documents({}) == []
+    assert extract_service_documents({"services": {}}) == []
+
+
+# ---------------------------------------------------------------------------
+# Test: deterministic UUID
+# ---------------------------------------------------------------------------
+
+
+def test_deterministic_uuid_stable_for_same_key() -> None:
+    """point_id is the same across multiple calls for the same service_key."""
+    from scripts.index_services import extract_service_documents
+
+    config = {
+        "services": {
+            "vnzh": {"title": "ВНЖ", "card_text": "ВНЖ в Болгарии..."},
+        }
+    }
+
+    docs1 = extract_service_documents(config)
+    docs2 = extract_service_documents(config)
+
+    assert docs1[0]["point_id"] == docs2[0]["point_id"]
+
+
+def test_deterministic_uuid_matches_expected_value() -> None:
+    """point_id equals uuid5(NAMESPACE_URL, 'services.yaml:vnzh')."""
+    from scripts.index_services import extract_service_documents
+
+    config = {
+        "services": {
+            "vnzh": {"title": "ВНЖ", "card_text": "ВНЖ в Болгарии..."},
+        }
+    }
+
+    docs = extract_service_documents(config)
+    expected = str(uuid.uuid5(uuid.NAMESPACE_URL, "services.yaml:vnzh"))
+
+    assert docs[0]["point_id"] == expected
+
+
+def test_deterministic_uuid_different_for_different_keys() -> None:
+    """Different service_key produces different point_id."""
+    from scripts.index_services import extract_service_documents
+
+    config = {
+        "services": {
+            "vnzh": {"title": "ВНЖ", "card_text": "text1"},
+            "installment": {"title": "Рассрочка", "card_text": "text2"},
+        }
+    }
+
+    docs = extract_service_documents(config)
+    ids = [d["point_id"] for d in docs]
+
+    assert len(set(ids)) == 2
+
+
+# ---------------------------------------------------------------------------
+# Test: idempotent upsert (same point_id = no duplicates)
+# ---------------------------------------------------------------------------
+
+
+def test_idempotent_upsert_same_point_id() -> None:
+    """Two calls with same service produce the same point_id — upsert is idempotent."""
+    from scripts.index_services import extract_service_documents
+
+    config = {
+        "services": {
+            "vnzh": {"title": "ВНЖ", "card_text": "ВНЖ в Болгарии..."},
+        }
+    }
+
+    docs_first = extract_service_documents(config)
+    docs_second = extract_service_documents(config)
+
+    assert docs_first[0]["point_id"] == docs_second[0]["point_id"]


### PR DESCRIPTION
Closes #901

## Summary
- New script `scripts/index_services.py` indexes services.yaml card_text into Qdrant collection `gdrive_documents_bge`
- Deterministic UUIDs (`uuid5(NAMESPACE_URL, "services.yaml:{key}")`) ensure idempotent upserts
- New `make ingest-services` Makefile target

## Test plan
- [x] 9 unit tests pass (`tests/unit/test_index_services.py`)
- [x] Ruff lint + format clean
- [x] TDD: tests written before implementation