### PR TITLE
feat(demo): LLM-first apartment search with demo flow

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -368,14 +368,6 @@ class PropertyBot:
         )
         self._apartments_service = ApartmentsService(qdrant=self._qdrant_apartments)
 
-        # Apartment extraction pipeline: regex → confidence gate → LLM fallback
-        from .services.apartment_extraction_pipeline import ApartmentExtractionPipeline
-        from .services.apartment_filter_extractor import ApartmentFilterExtractor
-
-        self._apartment_pipeline = ApartmentExtractionPipeline(
-            regex_extractor=ApartmentFilterExtractor(),
-        )
-
         # Rerank provider (feature flag)
         self._reranker = None
         if config.rerank_provider == "colbert":
@@ -388,6 +380,18 @@ class PropertyBot:
 
         # LLM (optional, defaults via GraphConfig.create_llm)
         self._llm = self._graph_config.create_llm()
+
+        # Apartment extraction pipeline: LLM first → regex fallback
+        from .services.apartment_extraction_pipeline import ApartmentExtractionPipeline
+        from .services.apartment_filter_extractor import ApartmentFilterExtractor
+        from .services.apartment_llm_extractor import ApartmentLlmExtractor
+
+        _apt_llm = ApartmentLlmExtractor(llm=self._llm, model="gpt-4o-mini")
+        self._apartment_pipeline = ApartmentExtractionPipeline(
+            regex_extractor=ApartmentFilterExtractor(),
+            llm_extractor=_apt_llm,
+            redis=self._cache.redis,
+        )
         # Redis health monitor (periodic background task)
         self._redis_monitor = RedisHealthMonitor(redis_url=config.redis_url)
 
@@ -705,6 +709,11 @@ class PropertyBot:
         # which is included AFTER dialog routers in _setup_dialogs().
         # This ensures dialog MessageInput (e.g. viewing phone input)
         # is resolved before the catch-all (aiogram SDK: first-match wins).
+        # Demo flow router
+        from .handlers.demo_handler import demo_router
+
+        self.dp.include_router(demo_router)
+
         self.dp.callback_query(FeedbackCB.filter())(self.handle_feedback)
         # Legacy buttons in old chat history may contain "fb:done" (without trailing ':').
         self.dp.callback_query(F.data == "fb:done")(self.handle_feedback)
@@ -1094,6 +1103,7 @@ class PropertyBot:
             "bookmarks": self._handle_bookmarks,
             "ask": self._handle_ask,
             "manager": self._handle_manager,
+            "demo": self._handle_demo,
         }
         handler = handlers.get(action_id)
         if handler:
@@ -1109,8 +1119,15 @@ class PropertyBot:
                 await handler(message, i18n=i18n)
             elif action_id == "manager":
                 await handler(message, i18n=i18n, state=state)
+            elif action_id == "demo":
+                await handler(message)
             else:
                 await handler(message)
+
+    async def _handle_demo(self, message: Message) -> None:
+        from .handlers.demo_handler import handle_demo_button
+
+        await handle_demo_button(message)
 
     async def handle_menu_action_text(self, message: Message, query_text: str) -> None:
         """Dispatch text query to agent pipeline (from ReplyKeyboard context) (#628)."""
@@ -1412,6 +1429,9 @@ class PropertyBot:
         elif value == "phone":
             if msg and hasattr(msg, "edit_text"):
                 await msg.edit_text("Сейчас попросим номер телефона...")
+            from .handlers.phone_collector import start_phone_collection
+
+            await start_phone_collection(callback, state, service_key="manager")
         else:
             # Fallback — delegate to agent pipeline.
             if msg and hasattr(msg, "edit_text"):

--- a/telegram_bot/handlers/demo_handler.py
+++ b/telegram_bot/handlers/demo_handler.py
@@ -1,0 +1,222 @@
+"""Demo flow handler — FSM-based apartment search with LLM extraction."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from aiogram import F, Router
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.types import CallbackQuery, Message
+
+from telegram_bot.keyboards.demo_keyboard import (
+    DEFAULT_EXAMPLES,
+    build_demo_examples,
+    build_demo_menu,
+)
+
+
+logger = logging.getLogger(__name__)
+
+demo_router = Router(name="demo")
+
+
+class DemoStates(StatesGroup):
+    waiting_query = State()
+
+
+async def handle_demo_button(message: Message) -> None:
+    """Handle '🎯 Демонстрация' button press."""
+    await message.answer(
+        "🎯 Демонстрация возможностей\n\nПосмотрите, как работает умный подбор недвижимости:",
+        reply_markup=build_demo_menu(),
+    )
+
+
+@demo_router.callback_query(lambda c: c.data == "demo:apartments")
+async def handle_demo_apartments(
+    callback: CallbackQuery,
+    state: FSMContext,
+    **kwargs: Any,
+) -> None:
+    """Show instruction + example buttons, set FSM state."""
+    await callback.answer()
+    await state.set_state(DemoStates.waiting_query)
+
+    apartments_service = kwargs.get("apartments_service")
+    examples = DEFAULT_EXAMPLES
+    if apartments_service is not None:
+        try:
+            from telegram_bot.services.apartments_service import generate_search_examples
+
+            stats = await apartments_service.get_collection_stats()
+            examples = generate_search_examples(stats)
+        except Exception:
+            logger.warning("Failed to get dynamic examples, using defaults", exc_info=True)
+
+    await state.update_data(examples=examples)
+
+    await callback.message.answer(
+        "🏖 Подбор апартаментов\n\n"
+        "Напишите текстом или отправьте голосовое сообщение.\n"
+        "Или выберите пример:",
+        reply_markup=build_demo_examples(examples),
+    )
+
+
+@demo_router.callback_query(lambda c: c.data is not None and c.data.startswith("demo:example:"))
+async def handle_demo_example(
+    callback: CallbackQuery,
+    state: FSMContext,
+    **kwargs: Any,
+) -> None:
+    """Handle example button click — treat as text query."""
+    await callback.answer()
+    idx = int(callback.data.split(":")[-1])  # type: ignore[union-attr]
+    data = await state.get_data()
+    examples = data.get("examples", DEFAULT_EXAMPLES)
+    if idx >= len(examples):
+        return
+    query = examples[idx]
+
+    # Delegate search using callback.message as the reply target
+    await _run_demo_search(query, callback.message, state, **kwargs)  # type: ignore[arg-type]
+
+
+@demo_router.message(DemoStates.waiting_query)
+async def handle_demo_search_text(
+    message: Message,
+    state: FSMContext,
+    pipeline: Any = None,
+    apartments_service: Any = None,
+    embeddings: Any = None,
+    **kwargs: Any,
+) -> None:
+    """Handle text input in demo mode — LLM extraction → search → results."""
+    if not message.text:
+        await message.answer("Отправьте текстовое или голосовое сообщение.")
+        return
+    await _run_demo_search(
+        message.text,
+        message,
+        state,
+        pipeline=pipeline,
+        apartments_service=apartments_service,
+        embeddings=embeddings,
+        **kwargs,
+    )
+
+
+async def _run_demo_search(
+    query: str,
+    message: Message,
+    state: FSMContext,
+    pipeline: Any = None,
+    apartments_service: Any = None,
+    embeddings: Any = None,
+    **kwargs: Any,
+) -> None:
+    """Core search logic: LLM extraction → Qdrant → format results."""
+    if not pipeline:
+        await message.answer("Сервис поиска временно недоступен.")
+        return
+
+    await message.answer("🔍 Ищу подходящие варианты...")
+
+    # 1. LLM extraction
+    extraction = await pipeline.extract(query)
+
+    if not apartments_service or not embeddings:
+        await message.answer(
+            f"📋 Распознано: {extraction.hard.model_dump(exclude_none=True)}\n"
+            "(поиск недоступен в тестовом режиме)"
+        )
+        return
+
+    # 2. Embeddings
+    semantic_query = extraction.meta.semantic_remainder or query
+    dense, sparse, colbert = await embeddings.aembed_hybrid_with_colbert(semantic_query)
+
+    # 3. Search
+    filters = extraction.hard.to_filters_dict()
+    results, count = await apartments_service.search_with_filters(
+        dense_vector=dense,
+        colbert_query=colbert or None,
+        sparse_vector=sparse,
+        filters=filters or None,
+        top_k=5,
+    )
+
+    # 4. Format results
+    if not results:
+        await message.answer(
+            "К сожалению, ничего не найдено по вашему запросу.\n"
+            "Попробуйте изменить параметры или напишите другой запрос."
+        )
+        return
+
+    text_parts = [f"Найдено {count} вариантов:\n"]
+    for i, r in enumerate(results[:5], 1):
+        name = r.get("complex_name", "—")
+        rooms = r.get("rooms", "?")
+        price = r.get("price_eur", 0)
+        area = r.get("area_m2", 0)
+        city = r.get("city", "")
+        text_parts.append(f"{i}. **{name}** — {rooms} комн., {area:.0f} м², {price:,.0f}€, {city}")
+
+    await message.answer("\n".join(text_parts), parse_mode="Markdown")
+
+
+@demo_router.message(DemoStates.waiting_query, F.voice)
+async def handle_demo_search_voice(
+    message: Message,
+    state: FSMContext,
+    pipeline: Any = None,
+    apartments_service: Any = None,
+    embeddings: Any = None,
+    **kwargs: Any,
+) -> None:
+    """Handle voice input — STT → LLM extraction → search."""
+    await message.answer("🎤 Распознаю голос...")
+
+    text = await transcribe_voice(message)
+    if not text:
+        await message.answer("Не удалось распознать речь. Попробуйте ещё раз.")
+        return
+
+    await message.answer(f"📝 Распознано: {text}")
+
+    await _run_demo_search(
+        text,
+        message,
+        state,
+        pipeline=pipeline,
+        apartments_service=apartments_service,
+        embeddings=embeddings,
+        **kwargs,
+    )
+
+
+async def transcribe_voice(message: Message) -> str | None:
+    """Download voice and transcribe via Whisper."""
+    import io
+
+    from langfuse.openai import AsyncOpenAI
+
+    bot = message.bot
+    if bot is None or message.voice is None:
+        return None
+    file = await bot.get_file(message.voice.file_id)
+    data = io.BytesIO()
+    await bot.download_file(file.file_path, data)  # type: ignore[arg-type]
+    data.seek(0)
+    data.name = "voice.ogg"  # type: ignore[attr-defined]
+
+    client = AsyncOpenAI()
+    transcript = await client.audio.transcriptions.create(
+        model="whisper",
+        file=data,
+        language="ru",
+    )
+    return transcript.text or None

--- a/telegram_bot/handlers/demo_handler.py
+++ b/telegram_bot/handlers/demo_handler.py
@@ -34,7 +34,7 @@ async def handle_demo_button(message: Message) -> None:
     )
 
 
-@demo_router.callback_query(lambda c: c.data == "demo:apartments")
+@demo_router.callback_query(F.data == "demo:apartments")
 async def handle_demo_apartments(
     callback: CallbackQuery,
     state: FSMContext,
@@ -65,7 +65,7 @@ async def handle_demo_apartments(
     )
 
 
-@demo_router.callback_query(lambda c: c.data is not None and c.data.startswith("demo:example:"))
+@demo_router.callback_query(F.data.startswith("demo:example:"))
 async def handle_demo_example(
     callback: CallbackQuery,
     state: FSMContext,

--- a/telegram_bot/keyboards/client_keyboard.py
+++ b/telegram_bot/keyboards/client_keyboard.py
@@ -16,6 +16,7 @@ MENU_BUTTONS: dict[str, str] = {
     "👤 Менеджер": "manager",
     "💬 Задать вопрос": "ask",
     "📌 Мои закладки": "bookmarks",
+    "🎯 Демонстрация": "demo",
 }
 
 # Reverse lookup: action_id -> button text (ru fallback)
@@ -29,6 +30,7 @@ _ACTION_IDS: dict[str, str] = {
     "kb-manager": "manager",
     "kb-ask": "ask",
     "kb-bookmarks": "bookmarks",
+    "kb-demo": "demo",
 }
 
 
@@ -62,16 +64,17 @@ def build_client_keyboard(i18n: Any = None) -> ReplyKeyboardMarkup:
     else:
         texts = list(MENU_BUTTONS.keys())  # fallback to hardcoded Russian
 
-    # Ensure exactly 6 buttons (pad or trim if needed)
-    while len(texts) < 6:
+    # Ensure exactly 7 buttons (pad or trim if needed)
+    while len(texts) < 7:
         texts.append("")
-    texts = texts[:6]
+    texts = texts[:7]
 
     return ReplyKeyboardMarkup(
         keyboard=[
             [KeyboardButton(text=texts[0]), KeyboardButton(text=texts[1])],
             [KeyboardButton(text=texts[2]), KeyboardButton(text=texts[3])],
             [KeyboardButton(text=texts[4]), KeyboardButton(text=texts[5])],
+            [KeyboardButton(text=texts[6])],  # Демонстрация — отдельный ряд
         ],
         resize_keyboard=True,
         is_persistent=True,

--- a/telegram_bot/keyboards/demo_keyboard.py
+++ b/telegram_bot/keyboards/demo_keyboard.py
@@ -1,0 +1,31 @@
+"""Inline keyboards for demo flow."""
+
+from __future__ import annotations
+
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+
+def build_demo_menu() -> InlineKeyboardMarkup:
+    """Main demo menu with feature buttons."""
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="🏖 Подбор апартаментов", callback_data="demo:apartments")],
+        ]
+    )
+
+
+def build_demo_examples(examples: list[str]) -> InlineKeyboardMarkup:
+    """Example query buttons for apartment search."""
+    buttons = [
+        [InlineKeyboardButton(text=ex, callback_data=f"demo:example:{i}")]
+        for i, ex in enumerate(examples)
+    ]
+    return InlineKeyboardMarkup(inline_keyboard=buttons)
+
+
+DEFAULT_EXAMPLES = [
+    "Студия в Солнечном берегу до 100 000€",
+    "Двушка в Premier Fort Beach",
+    "Трёшка в Элените до 200 000€",
+    "Апартамент в Свети Влас от 150 000€",
+]

--- a/telegram_bot/keyboards/demo_keyboard.py
+++ b/telegram_bot/keyboards/demo_keyboard.py
@@ -2,25 +2,25 @@
 
 from __future__ import annotations
 
-from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from aiogram.types import InlineKeyboardMarkup
+from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 
 def build_demo_menu() -> InlineKeyboardMarkup:
     """Main demo menu with feature buttons."""
-    return InlineKeyboardMarkup(
-        inline_keyboard=[
-            [InlineKeyboardButton(text="🏖 Подбор апартаментов", callback_data="demo:apartments")],
-        ]
-    )
+    builder = InlineKeyboardBuilder()
+    builder.button(text="🏖 Подбор апартаментов", callback_data="demo:apartments")
+    builder.adjust(1)
+    return builder.as_markup()
 
 
 def build_demo_examples(examples: list[str]) -> InlineKeyboardMarkup:
     """Example query buttons for apartment search."""
-    buttons = [
-        [InlineKeyboardButton(text=ex, callback_data=f"demo:example:{i}")]
-        for i, ex in enumerate(examples)
-    ]
-    return InlineKeyboardMarkup(inline_keyboard=buttons)
+    builder = InlineKeyboardBuilder()
+    for i, ex in enumerate(examples):
+        builder.button(text=ex, callback_data=f"demo:example:{i}")
+    builder.adjust(1)
+    return builder.as_markup()
 
 
 DEFAULT_EXAMPLES = [

--- a/telegram_bot/locales/ru/messages.ftl
+++ b/telegram_bot/locales/ru/messages.ftl
@@ -158,6 +158,7 @@ kb-viewing = 📅 Запись на осмотр
 kb-manager = 👤 Менеджер
 kb-ask = 💬 Задать вопрос
 kb-bookmarks = 📌 Мои закладки
+kb-demo = 🎯 Демонстрация
 
 # Welcome (#660)
 welcome-text =

--- a/telegram_bot/services/apartment_extraction_pipeline.py
+++ b/telegram_bot/services/apartment_extraction_pipeline.py
@@ -1,4 +1,4 @@
-"""Apartment extraction pipeline: regex → confidence gate → LLM fallback."""
+"""Apartment extraction pipeline: LLM first, regex fallback."""
 
 from __future__ import annotations
 
@@ -27,7 +27,7 @@ _CACHE_TTL = 86400  # 24h
 
 
 class ApartmentExtractionPipeline:
-    """Orchestrates regex → confidence gate → LLM fallback."""
+    """Orchestrates LLM first, regex fallback."""
 
     def __init__(
         self,
@@ -40,35 +40,24 @@ class ApartmentExtractionPipeline:
         self._redis = redis
 
     async def extract(self, query: str) -> ApartmentSearchFilters:
-        """Main entry point: regex → confidence gate → LLM fallback."""
+        """Main entry point: cache → LLM (primary) → regex (fallback)."""
         # 1. Check cache
         cached = await self._cache_get(query)
         if cached:
             return cached
 
-        # 2. Regex extraction
+        # 2. LLM primary
+        if self._llm is not None:
+            try:
+                result = await self._llm.extract(query=query)
+                await self._cache_set(query, result)
+                return result
+            except Exception:
+                logger.warning("LLM extraction failed, falling back to regex", exc_info=True)
+
+        # 3. Regex fallback
         parsed = self._regex.parse(query)
-        regex_result = self._parsed_to_search_filters(parsed)
-
-        # 3. Confidence gate
-        if regex_result.meta.confidence == "HIGH":
-            return regex_result
-
-        if self._llm is None:
-            return regex_result  # no LLM available, return regex result as-is
-
-        if regex_result.meta.confidence == "MEDIUM":
-            llm_result = await self._llm.extract(query=query, partial_filters=regex_result.hard)
-            from telegram_bot.services.apartment_llm_extractor import merge_extraction_results
-
-            merged = merge_extraction_results(regex_result, llm_result)
-            await self._cache_set(query, merged)
-            return merged
-
-        # LOW confidence — full LLM extraction
-        llm_result = await self._llm.extract(query=query)
-        await self._cache_set(query, llm_result)
-        return llm_result
+        return self._parsed_to_search_filters(parsed)
 
     def _parsed_to_search_filters(self, parsed: object) -> ApartmentSearchFilters:
         """Convert legacy ApartmentQueryParseResult to ApartmentSearchFilters."""

--- a/telegram_bot/services/apartments_service.py
+++ b/telegram_bot/services/apartments_service.py
@@ -254,3 +254,82 @@ class ApartmentsService:
                 break
             offset = next_offset
         return sorted(values)
+
+    async def get_collection_stats(self) -> dict:
+        """Get unique cities, complexes, rooms, price range for example generation."""
+        records, _ = await self._qdrant.client.scroll(
+            collection_name=self._qdrant.collection_name,
+            limit=100,
+            with_payload=True,
+            with_vectors=False,
+        )
+        cities: set[str] = set()
+        complexes: set[str] = set()
+        rooms_set: set[int] = set()
+        prices: list[float] = []
+        for p in records:
+            d = p.payload or {}
+            if d.get("city"):
+                cities.add(d["city"])
+            if d.get("complex_name"):
+                complexes.add(d["complex_name"])
+            if d.get("rooms"):
+                rooms_set.add(int(d["rooms"]))
+            if d.get("price_eur"):
+                prices.append(float(d["price_eur"]))
+        return {
+            "cities": sorted(cities),
+            "complexes": sorted(complexes),
+            "rooms": sorted(rooms_set),
+            "min_price": min(prices) if prices else 0,
+            "max_price": max(prices) if prices else 0,
+        }
+
+
+def generate_search_examples(stats: dict) -> list[str]:
+    """Generate 4 diverse search example strings from DB stats."""
+    cities = stats.get("cities", [])
+    complexes = stats.get("complexes", [])
+    rooms_list = stats.get("rooms", [1, 2, 3])
+    max_price = stats.get("max_price", 200000)
+
+    room_names = {1: "Студия", 2: "Двушка", 3: "Трёшка"}
+    examples: list[str] = []
+
+    # Example 1: room type + city + price
+    if cities:
+        r = rooms_list[0] if rooms_list else 1
+        price = round(max_price * 0.4 / 5000) * 5000
+        examples.append(
+            f"{room_names.get(r, 'Апартамент')} в {cities[0]} до {price:,.0f}€".replace(",", " ")
+        )
+
+    # Example 2: room type + complex
+    if complexes:
+        r = rooms_list[1] if len(rooms_list) > 1 else 2
+        examples.append(f"{room_names.get(r, 'Двушка')} в {complexes[0]}")
+
+    # Example 3: room type + city + price
+    if len(cities) > 1:
+        r = rooms_list[-1] if rooms_list else 3
+        price = round(max_price * 0.65 / 5000) * 5000
+        examples.append(
+            f"{room_names.get(r, 'Трёшка')} в {cities[-1]} до {price:,.0f}€".replace(",", " ")
+        )
+
+    # Example 4: generic + city + price range
+    if len(cities) > 1:
+        price = round(max_price * 0.5 / 5000) * 5000
+        examples.append(f"Апартамент в {cities[1]} от {price:,.0f}€".replace(",", " "))
+
+    # Pad with defaults if needed
+    defaults = [
+        "Студия у моря до 100 000€",
+        "Двушка с видом на море",
+        "Трёшка с бассейном",
+        "Апартамент с мебелью",
+    ]
+    while len(examples) < 4:
+        examples.append(defaults[len(examples)])
+
+    return examples[:4]

--- a/tests/unit/handlers/test_demo_e2e.py
+++ b/tests/unit/handlers/test_demo_e2e.py
@@ -1,0 +1,41 @@
+"""E2E test for full demo flow: button → examples → search."""
+
+import pytest
+
+from telegram_bot.handlers.demo_handler import DemoStates
+from telegram_bot.keyboards.client_keyboard import MENU_BUTTONS
+from telegram_bot.keyboards.demo_keyboard import (
+    DEFAULT_EXAMPLES,
+    build_demo_examples,
+    build_demo_menu,
+)
+from telegram_bot.services.apartment_extraction_pipeline import ApartmentExtractionPipeline
+from telegram_bot.services.apartment_filter_extractor import ApartmentFilterExtractor
+
+
+def test_demo_button_exists_in_menu():
+    assert "demo" in MENU_BUTTONS.values()
+
+
+def test_demo_menu_has_apartments_button():
+    kb = build_demo_menu()
+    texts = [btn.text for row in kb.inline_keyboard for btn in row]
+    assert "🏖 Подбор апартаментов" in texts
+
+
+def test_demo_examples_keyboard():
+    kb = build_demo_examples(DEFAULT_EXAMPLES)
+    assert len(kb.inline_keyboard) == 4
+
+
+def test_demo_states_defined():
+    assert DemoStates.waiting_query is not None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_regex_fallback_works():
+    """Without LLM, pipeline falls back to regex."""
+    pipe = ApartmentExtractionPipeline(regex_extractor=ApartmentFilterExtractor())
+    result = await pipe.extract("двушка до 100000")
+    assert result.hard.rooms == 2
+    assert result.meta.source == "regex"

--- a/tests/unit/handlers/test_demo_handler.py
+++ b/tests/unit/handlers/test_demo_handler.py
@@ -1,0 +1,114 @@
+"""Tests for demo handler FSM flow."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from aiogram.fsm.context import FSMContext
+from aiogram.types import CallbackQuery
+
+from telegram_bot.handlers.demo_handler import (
+    DemoStates,
+    handle_demo_apartments,
+    handle_demo_button,
+    handle_demo_search_text,
+)
+
+
+class TestDemoFlow:
+    @pytest.mark.asyncio
+    async def test_demo_button_sends_inline_menu(self) -> None:
+        message = AsyncMock()
+        await handle_demo_button(message)
+        message.answer.assert_awaited_once()
+        call_kwargs = message.answer.await_args
+        assert "Демонстрация" in call_kwargs.args[0]
+        assert call_kwargs.kwargs.get("reply_markup") is not None
+
+    @pytest.mark.asyncio
+    async def test_demo_apartments_sets_fsm_state(self) -> None:
+        callback = AsyncMock(spec=CallbackQuery)
+        callback.answer = AsyncMock()
+        callback.message = AsyncMock()
+        state = AsyncMock(spec=FSMContext)
+        await handle_demo_apartments(callback, state)
+        state.set_state.assert_awaited_once_with(DemoStates.waiting_query)
+
+    @pytest.mark.asyncio
+    async def test_demo_apartments_shows_examples(self) -> None:
+        callback = AsyncMock(spec=CallbackQuery)
+        callback.answer = AsyncMock()
+        callback.message = AsyncMock()
+        state = AsyncMock(spec=FSMContext)
+        await handle_demo_apartments(callback, state)
+        sent = callback.message.answer.await_args
+        assert "Напишите текстом" in sent.args[0]
+        assert sent.kwargs.get("reply_markup") is not None
+
+    @pytest.mark.asyncio
+    async def test_demo_search_calls_pipeline(self) -> None:
+        message = AsyncMock()
+        message.text = "двушка до 100к"
+        state = AsyncMock(spec=FSMContext)
+        pipeline = AsyncMock()
+        from telegram_bot.services.apartment_models import (
+            ApartmentSearchFilters,
+            ExtractionMeta,
+            HardFilters,
+        )
+
+        pipeline.extract.return_value = ApartmentSearchFilters(
+            hard=HardFilters(rooms=2, max_price_eur=100000),
+            meta=ExtractionMeta(source="llm", confidence="HIGH"),
+        )
+        await handle_demo_search_text(message, state, pipeline=pipeline)
+        pipeline.extract.assert_awaited_once_with("двушка до 100к")
+
+
+class TestDemoExampleClick:
+    @pytest.mark.asyncio
+    async def test_example_click_triggers_search(self) -> None:
+        from telegram_bot.handlers.demo_handler import handle_demo_example
+        from telegram_bot.services.apartment_models import (
+            ApartmentSearchFilters,
+            ExtractionMeta,
+            HardFilters,
+        )
+
+        callback = AsyncMock(spec=CallbackQuery)
+        callback.data = "demo:example:0"
+        callback.answer = AsyncMock()
+        callback.message = AsyncMock()
+        state = AsyncMock(spec=FSMContext)
+        state.get_data.return_value = {"examples": ["Студия в Солнечном берегу до 100 000€"]}
+
+        pipeline = AsyncMock()
+        pipeline.extract.return_value = ApartmentSearchFilters(
+            hard=HardFilters(rooms=1, city="Солнечный берег", max_price_eur=100000),
+            meta=ExtractionMeta(source="llm", confidence="HIGH"),
+        )
+        apartments_service = AsyncMock()
+        apartments_service.search_with_filters.return_value = (
+            [
+                {
+                    "complex_name": "Test",
+                    "rooms": 1,
+                    "price_eur": 90000,
+                    "area_m2": 40,
+                    "city": "Солнечный берег",
+                }
+            ],
+            1,
+        )
+        embeddings = AsyncMock()
+        embeddings.aembed_hybrid_with_colbert.return_value = ([0.1] * 1024, {}, [])
+
+        await handle_demo_example(
+            callback,
+            state,
+            pipeline=pipeline,
+            apartments_service=apartments_service,
+            embeddings=embeddings,
+        )
+        pipeline.extract.assert_awaited_once()

--- a/tests/unit/handlers/test_demo_search.py
+++ b/tests/unit/handlers/test_demo_search.py
@@ -1,0 +1,133 @@
+"""Tests for demo search — text and voice input → results."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from telegram_bot.handlers.demo_handler import handle_demo_search_text
+from telegram_bot.services.apartment_models import (
+    ApartmentSearchFilters,
+    ExtractionMeta,
+    HardFilters,
+)
+
+
+class TestDemoSearchText:
+    @pytest.mark.asyncio
+    async def test_extracts_and_searches(self) -> None:
+        message = AsyncMock()
+        message.text = "двушка до 100к"
+        state = AsyncMock()
+
+        pipeline = AsyncMock()
+        pipeline.extract.return_value = ApartmentSearchFilters(
+            hard=HardFilters(rooms=2, max_price_eur=100000),
+            meta=ExtractionMeta(source="llm", confidence="HIGH"),
+        )
+
+        apartments_service = AsyncMock()
+        apartments_service.search_with_filters.return_value = (
+            [
+                {
+                    "complex_name": "Test",
+                    "rooms": 2,
+                    "price_eur": 95000,
+                    "area_m2": 60,
+                    "city": "Солнечный берег",
+                }
+            ],
+            1,
+        )
+
+        embeddings = AsyncMock()
+        embeddings.aembed_hybrid_with_colbert.return_value = (
+            [0.1] * 1024,
+            {"idx": [1]},
+            [[0.1] * 128],
+        )
+
+        await handle_demo_search_text(
+            message,
+            state,
+            pipeline=pipeline,
+            apartments_service=apartments_service,
+            embeddings=embeddings,
+        )
+        pipeline.extract.assert_awaited_once_with("двушка до 100к")
+        message.answer.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_low_confidence_still_searches(self) -> None:
+        message = AsyncMock()
+        message.text = "что-нибудь красивое"
+        state = AsyncMock()
+
+        pipeline = AsyncMock()
+        pipeline.extract.return_value = ApartmentSearchFilters(
+            meta=ExtractionMeta(source="llm", confidence="LOW"),
+        )
+
+        apartments_service = AsyncMock()
+        apartments_service.search_with_filters.return_value = ([], 0)
+
+        embeddings = AsyncMock()
+        embeddings.aembed_hybrid_with_colbert.return_value = (
+            [0.1] * 1024,
+            {"idx": [1]},
+            [[0.1] * 128],
+        )
+
+        await handle_demo_search_text(
+            message,
+            state,
+            pipeline=pipeline,
+            apartments_service=apartments_service,
+            embeddings=embeddings,
+        )
+        apartments_service.search_with_filters.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_pipeline_returns_error(self) -> None:
+        message = AsyncMock()
+        message.text = "двушка"
+        state = AsyncMock()
+
+        await handle_demo_search_text(message, state, pipeline=None)
+        message.answer.assert_awaited_once()
+        args = message.answer.await_args.args[0]
+        assert "недоступен" in args
+
+
+class TestDemoVoice:
+    @pytest.mark.asyncio
+    async def test_voice_transcribed_and_searched(self) -> None:
+        from telegram_bot.handlers.demo_handler import handle_demo_search_voice
+
+        message = AsyncMock()
+        message.voice = AsyncMock()
+        message.text = None
+        state = AsyncMock()
+
+        with patch("telegram_bot.handlers.demo_handler.transcribe_voice") as mock_stt:
+            mock_stt.return_value = "двушка до 100к"
+            pipeline = AsyncMock()
+            pipeline.extract.return_value = ApartmentSearchFilters(
+                hard=HardFilters(rooms=2, max_price_eur=100000),
+                meta=ExtractionMeta(source="llm", confidence="HIGH"),
+            )
+            apartments_service = AsyncMock()
+            apartments_service.search_with_filters.return_value = ([], 0)
+            embeddings = AsyncMock()
+            embeddings.aembed_hybrid_with_colbert.return_value = ([0.1] * 1024, {}, [])
+
+            await handle_demo_search_voice(
+                message,
+                state,
+                pipeline=pipeline,
+                apartments_service=apartments_service,
+                embeddings=embeddings,
+            )
+            mock_stt.assert_awaited_once()
+            pipeline.extract.assert_awaited_once_with("двушка до 100к")

--- a/tests/unit/keyboards/test_client_keyboard.py
+++ b/tests/unit/keyboards/test_client_keyboard.py
@@ -22,15 +22,15 @@ def test_build_client_keyboard_returns_markup():
     assert isinstance(kb, ReplyKeyboardMarkup)
 
 
-def test_keyboard_has_3_rows():
+def test_keyboard_has_4_rows():
     kb = build_client_keyboard()
-    assert len(kb.keyboard) == 3
+    assert len(kb.keyboard) == 4
 
 
-def test_keyboard_has_6_buttons():
+def test_keyboard_has_7_buttons():
     kb = build_client_keyboard()
     buttons = [btn for row in kb.keyboard for btn in row]
-    assert len(buttons) == 6
+    assert len(buttons) == 7
 
 
 def test_keyboard_is_persistent():
@@ -48,12 +48,12 @@ def test_build_no_i18n_uses_ru_fallback():
     assert any("Подобрать" in b for b in buttons)
 
 
-def test_menu_buttons_has_6_entries():
-    assert len(MENU_BUTTONS) == 6
+def test_menu_buttons_has_7_entries():
+    assert len(MENU_BUTTONS) == 7
 
 
-def test_action_ids_has_6_entries():
-    assert len(_ACTION_IDS) == 6
+def test_action_ids_has_7_entries():
+    assert len(_ACTION_IDS) == 7
 
 
 # --- i18n-aware tests ---
@@ -77,12 +77,13 @@ def test_build_with_i18n():
             "kb-manager": "👤 Manager",
             "kb-ask": "💬 Ask",
             "kb-bookmarks": "📌 Bookmarks",
+            "kb-demo": "🎯 Demo",
         }
     )
     kb = build_client_keyboard(i18n=i18n)
     assert isinstance(kb, ReplyKeyboardMarkup)
     buttons = [btn.text for row in kb.keyboard for btn in row]
-    assert len(buttons) == 6
+    assert len(buttons) == 7
     assert "🏠 Search" in buttons
     assert "🔑 Services" in buttons
 

--- a/tests/unit/keyboards/test_demo_button.py
+++ b/tests/unit/keyboards/test_demo_button.py
@@ -1,0 +1,25 @@
+"""Tests for demo button in client keyboard."""
+
+from telegram_bot.keyboards.client_keyboard import (
+    MENU_BUTTONS,
+    build_client_keyboard,
+)
+
+
+def test_menu_buttons_has_demo():
+    assert "🎯 Демонстрация" in MENU_BUTTONS
+    assert MENU_BUTTONS["🎯 Демонстрация"] == "demo"
+
+
+def test_keyboard_has_7_buttons():
+    kb = build_client_keyboard()
+    all_buttons = [btn.text for row in kb.keyboard for btn in row]
+    assert len(all_buttons) == 7
+    assert "🎯 Демонстрация" in all_buttons
+
+
+def test_demo_is_last_row_alone():
+    kb = build_client_keyboard()
+    last_row = kb.keyboard[-1]
+    assert len(last_row) == 1
+    assert last_row[0].text == "🎯 Демонстрация"

--- a/tests/unit/services/test_apartment_examples.py
+++ b/tests/unit/services/test_apartment_examples.py
@@ -1,0 +1,39 @@
+"""Tests for dynamic example generation from Qdrant."""
+
+from telegram_bot.services.apartments_service import generate_search_examples
+
+
+class TestGenerateExamples:
+    def test_returns_4_examples(self) -> None:
+        stats = {
+            "cities": ["Солнечный берег", "Свети Влас", "Элените"],
+            "complexes": ["Premier Fort Beach", "Nessebar Fort Residence"],
+            "rooms": [1, 2, 3],
+            "min_price": 69500,
+            "max_price": 314000,
+        }
+        examples = generate_search_examples(stats)
+        assert len(examples) == 4
+        assert all(isinstance(e, str) for e in examples)
+
+    def test_examples_contain_real_data(self) -> None:
+        stats = {
+            "cities": ["Солнечный берег"],
+            "complexes": ["Premier Fort Beach"],
+            "rooms": [2],
+            "min_price": 80000,
+            "max_price": 200000,
+        }
+        examples = generate_search_examples(stats)
+        assert any("Солнечный берег" in e or "Premier Fort" in e for e in examples)
+
+    def test_examples_diverse(self) -> None:
+        stats = {
+            "cities": ["Солнечный берег", "Свети Влас", "Элените"],
+            "complexes": ["Premier Fort Beach"],
+            "rooms": [1, 2, 3],
+            "min_price": 69500,
+            "max_price": 314000,
+        }
+        examples = generate_search_examples(stats)
+        assert len(set(examples)) == 4

--- a/tests/unit/services/test_apartment_extraction_pipeline.py
+++ b/tests/unit/services/test_apartment_extraction_pipeline.py
@@ -1,8 +1,8 @@
-"""Tests for ApartmentExtractionPipeline (regex → confidence gate → LLM fallback)."""
+"""Tests for ApartmentExtractionPipeline (LLM first, regex fallback)."""
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 from telegram_bot.services.apartment_extraction_pipeline import ApartmentExtractionPipeline
 from telegram_bot.services.apartment_models import (
@@ -56,38 +56,33 @@ class TestPipelineHighConfidence:
         assert result.meta.source == "regex"
         assert result.hard.rooms == 2
 
-    async def test_high_confidence_no_llm_call(self) -> None:
+    async def test_llm_called_first_regardless_of_regex_confidence(self) -> None:
         regex = _make_regex_extractor("HIGH")
         llm = AsyncMock()
+        llm.extract = AsyncMock(return_value=_make_filters("HIGH", "llm"))
         pipeline = ApartmentExtractionPipeline(regex_extractor=regex, llm_extractor=llm)
 
         await pipeline.extract("двушка солнечный берег")
 
-        llm.extract.assert_not_called()
+        llm.extract.assert_called_once()
 
 
 class TestPipelineMediumConfidence:
-    async def test_medium_calls_llm_with_partial_filters(self) -> None:
+    async def test_llm_called_without_partial_filters(self) -> None:
+        """LLM-first: no partial_filters — LLM extracts from scratch."""
         regex = _make_regex_extractor("MEDIUM")
-        llm_result = _make_filters("HIGH", "hybrid")
+        llm_result = _make_filters("HIGH", "llm")
         llm = AsyncMock()
         llm.extract = AsyncMock(return_value=llm_result)
 
         pipeline = ApartmentExtractionPipeline(regex_extractor=regex, llm_extractor=llm)
-
-        with patch(
-            "telegram_bot.services.apartment_llm_extractor.merge_extraction_results",
-            return_value=_make_filters("HIGH", "hybrid"),
-        ):
-            await pipeline.extract("двушка")
+        result = await pipeline.extract("двушка")
 
         llm.extract.assert_called_once()
-        # partial_filters passed to llm.extract
         call_kwargs = llm.extract.call_args
-        partial = call_kwargs.kwargs.get("partial_filters") or (
-            call_kwargs.args[1] if len(call_kwargs.args) > 1 else None
-        )
-        assert partial is not None
+        partial = call_kwargs.kwargs.get("partial_filters")
+        assert partial is None
+        assert result.meta.source == "llm"
 
     async def test_medium_without_llm_returns_regex(self) -> None:
         regex = _make_regex_extractor("MEDIUM")

--- a/tests/unit/services/test_apartment_pipeline_llm_first.py
+++ b/tests/unit/services/test_apartment_pipeline_llm_first.py
@@ -1,0 +1,90 @@
+"""Tests for LLM-first extraction pipeline."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from telegram_bot.services.apartment_extraction_pipeline import ApartmentExtractionPipeline
+from telegram_bot.services.apartment_filter_extractor import ApartmentFilterExtractor
+from telegram_bot.services.apartment_models import (
+    ApartmentSearchFilters,
+    ExtractionMeta,
+    HardFilters,
+)
+
+
+@pytest.fixture
+def mock_llm():
+    llm = AsyncMock()
+    result = ApartmentSearchFilters(
+        hard=HardFilters(rooms=2, city="Солнечный берег", max_price_eur=100000),
+        meta=ExtractionMeta(source="llm", confidence="HIGH"),
+    )
+    llm.extract.return_value = result
+    return llm
+
+
+@pytest.fixture
+def pipeline(mock_llm):
+    return ApartmentExtractionPipeline(
+        regex_extractor=ApartmentFilterExtractor(),
+        llm_extractor=mock_llm,
+    )
+
+
+class TestLlmFirstPipeline:
+    """LLM is called first, regex is fallback."""
+
+    @pytest.mark.asyncio
+    async def test_llm_called_first(self, pipeline, mock_llm) -> None:
+        result = await pipeline.extract("двушка в солнечном береге до 100к")
+        mock_llm.extract.assert_awaited_once()
+        assert result.meta.source == "llm"
+        assert result.hard.rooms == 2
+
+    @pytest.mark.asyncio
+    async def test_regex_fallback_on_llm_error(self, pipeline, mock_llm) -> None:
+        mock_llm.extract.side_effect = RuntimeError("LLM unavailable")
+        result = await pipeline.extract("двушка до 100000")
+        assert result.meta.source == "regex"
+        assert result.hard.rooms == 2
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_llm(self, mock_llm) -> None:
+        redis = AsyncMock()
+        cached = ApartmentSearchFilters(
+            hard=HardFilters(rooms=3),
+            meta=ExtractionMeta(source="llm", confidence="HIGH"),
+        )
+        redis.get.return_value = cached.model_dump_json()
+        pipe = ApartmentExtractionPipeline(
+            regex_extractor=ApartmentFilterExtractor(),
+            llm_extractor=mock_llm,
+            redis=redis,
+        )
+        result = await pipe.extract("трешка")
+        mock_llm.extract.assert_not_awaited()
+        assert result.hard.rooms == 3
+
+    @pytest.mark.asyncio
+    async def test_no_llm_uses_regex(self) -> None:
+        pipe = ApartmentExtractionPipeline(
+            regex_extractor=ApartmentFilterExtractor(),
+        )
+        result = await pipe.extract("двушка до 100000")
+        assert result.meta.source == "regex"
+        assert result.hard.rooms == 2
+
+    @pytest.mark.asyncio
+    async def test_llm_result_cached(self, mock_llm) -> None:
+        redis = AsyncMock()
+        redis.get.return_value = None
+        pipe = ApartmentExtractionPipeline(
+            regex_extractor=ApartmentFilterExtractor(),
+            llm_extractor=mock_llm,
+            redis=redis,
+        )
+        await pipe.extract("двушка")
+        redis.set.assert_awaited_once()

--- a/uv.lock
+++ b/uv.lock
@@ -747,6 +747,7 @@ dependencies = [
     { name = "cachetools" },
     { name = "fluentogram" },
     { name = "groq" },
+    { name = "instructor" },
     { name = "langchain-core" },
     { name = "langfuse" },
     { name = "langgraph" },
@@ -817,6 +818,11 @@ ingest = [
     { name = "fastembed" },
     { name = "pymupdf" },
 ]
+mini-app = [
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "uvicorn" },
+]
 ml-local = [
     { name = "flagembedding" },
     { name = "scipy" },
@@ -874,12 +880,15 @@ requires-dist = [
     { name = "datasets", marker = "extra == 'eval'", specifier = ">=3.0.0" },
     { name = "docling", marker = "extra == 'ingest'", specifier = ">=2.70.0" },
     { name = "docling-core", marker = "extra == 'ingest'", specifier = ">=2.61.0" },
+    { name = "fastapi", marker = "extra == 'mini-app'", specifier = ">=0.115.0" },
     { name = "fastapi", marker = "extra == 'voice'", specifier = ">=0.115.0" },
     { name = "fastembed", marker = "extra == 'ingest'", specifier = ">=0.7.4" },
     { name = "flagembedding", marker = "extra == 'ml-local'" },
     { name = "fluentogram", specifier = ">=1.2.0" },
     { name = "groq" },
+    { name = "httpx", marker = "extra == 'mini-app'", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'voice'", specifier = ">=0.27.0" },
+    { name = "instructor", specifier = ">=1.7.0" },
     { name = "langchain-core", specifier = ">=1.2" },
     { name = "langfuse", specifier = ">=3.14.0" },
     { name = "langgraph", specifier = ">=1.0.3,<2.0" },
@@ -914,11 +923,12 @@ requires-dist = [
     { name = "torch", marker = "extra == 'ml-local'", specifier = ">=2.0.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torchvision", marker = "extra == 'ml-local'", specifier = ">=0.15.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "transformers", marker = "extra == 'ml-local'", specifier = ">=4.30.0" },
+    { name = "uvicorn", marker = "extra == 'mini-app'", specifier = ">=0.30.0" },
     { name = "uvicorn", marker = "extra == 'voice'", specifier = ">=0.30.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
     { name = "voyageai", specifier = ">=0.3.0" },
 ]
-provides-extras = ["ml-local", "docs", "voice", "ingest", "eval", "all"]
+provides-extras = ["ml-local", "docs", "mini-app", "voice", "ingest", "eval", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Invert apartment extraction pipeline: LLM first (Instructor + gpt-4o-mini), regex fallback
- Add "Демонстрация" button to ReplyKeyboard with FSM-based demo flow
- Dynamic example queries generated from Qdrant collection stats
- Full search flow: text/voice input -> LLM extraction -> hybrid search -> results
- Comprehensive unit tests for all components

## Test plan
- [ ] `make check` passes (ruff + mypy)
- [ ] `make test-unit` passes
- [ ] Demo button visible in menu
- [ ] Inline menu -> apartment search works
- [ ] Text input -> LLM extraction -> results
- [ ] Voice input -> STT -> extraction -> results

Generated with [Claude Code](https://claude.com/claude-code)