### PR TITLE
feat(mini-app): deep link flow for expert consultation

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -337,6 +337,7 @@ services:
       KOMMO_ENABLED: "${KOMMO_ENABLED:-false}"
       KOMMO_SUBDOMAIN: "${KOMMO_SUBDOMAIN:-}"
       KOMMO_ACCESS_TOKEN: "${KOMMO_ACCESS_TOKEN:-}"
+      BOT_USERNAME: "${BOT_USERNAME:-}"
     depends_on:
       redis:
         condition: service_healthy

--- a/mini_app/api.py
+++ b/mini_app/api.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import json
+import os
+import uuid as _uuid_lib
+from typing import Any
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -19,6 +24,21 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+_redis_client: Any = None
+
+_DEEPLINK_TTL = 300  # seconds
+
+
+async def _get_redis() -> Any:
+    """Lazy-init Redis client from REDIS_URL env var."""
+    global _redis_client
+    if _redis_client is None:
+        import redis.asyncio as aioredis
+
+        redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379")
+        _redis_client = aioredis.from_url(redis_url, decode_responses=True)
+    return _redis_client
+
 
 @app.get("/api/config")
 async def get_config() -> dict:
@@ -28,10 +48,8 @@ async def get_config() -> dict:
 
 @app.post("/api/start-expert")
 async def start_expert(request: StartExpertRequest) -> StartExpertResponse:
-    """Create forum topic for expert and optionally send first message."""
+    """Store deep-link payload in Redis and return start_link for openTelegramLink."""
     from fastapi import HTTPException
-
-    from mini_app.bot_bridge import get_bot_bridge
 
     config = load_mini_app_config()
     experts = config.get("experts", [])
@@ -39,26 +57,22 @@ async def start_expert(request: StartExpertRequest) -> StartExpertResponse:
     if expert is None:
         raise HTTPException(status_code=404, detail="Expert not found")
 
-    topic_name = f"{expert['emoji']} {expert['name']}"
-
-    bridge = get_bot_bridge()
-    thread_id = await bridge.ensure_topic(
-        chat_id=request.user_id,
-        user_id=request.user_id,
-        expert_id=request.expert_id,
-        topic_name=topic_name,
+    uid = str(_uuid_lib.uuid4())
+    payload = json.dumps(
+        {
+            "expert_id": request.expert_id,
+            "message": request.message,
+            "user_id": request.user_id,
+        }
     )
+    redis = await _get_redis()
+    await redis.set(f"miniapp:q:{uid}", payload, ex=_DEEPLINK_TTL)
 
-    if request.message:
-        await bridge.send_to_topic(
-            chat_id=request.user_id,
-            thread_id=thread_id,
-            message=request.message,
-            expert_id=request.expert_id,
-        )
+    bot_username = os.environ.get("BOT_USERNAME", "")
+    start_link = f"https://t.me/{bot_username}?start=q_{uid}"
 
     return StartExpertResponse(
-        thread_id=thread_id,
+        start_link=start_link,
         expert_name=expert["name"],
     )
 

--- a/mini_app/api.py
+++ b/mini_app/api.py
@@ -69,6 +69,8 @@ async def start_expert(request: StartExpertRequest) -> StartExpertResponse:
     await redis.set(f"miniapp:q:{uid}", payload, ex=_DEEPLINK_TTL)
 
     bot_username = os.environ.get("BOT_USERNAME", "")
+    if not bot_username:
+        raise HTTPException(status_code=500, detail="BOT_USERNAME not configured")
     start_link = f"https://t.me/{bot_username}?start=q_{uid}"
 
     return StartExpertResponse(

--- a/mini_app/expert_start.py
+++ b/mini_app/expert_start.py
@@ -12,6 +12,6 @@ class StartExpertRequest(BaseModel):
 
 
 class StartExpertResponse(BaseModel):
-    thread_id: int
+    start_link: str
     expert_name: str
     status: str = "ok"

--- a/mini_app/frontend/src/api.ts
+++ b/mini_app/frontend/src/api.ts
@@ -12,7 +12,7 @@ export async function fetchConfig() {
 }
 
 export interface StartExpertResponse {
-  thread_id: number;
+  start_link: string;
   expert_name: string;
   status: string;
 }

--- a/mini_app/frontend/src/pages/ExpertSheet.tsx
+++ b/mini_app/frontend/src/pages/ExpertSheet.tsx
@@ -26,9 +26,9 @@ export function ExpertSheet() {
     if (!userId || !id || loading) return;
     setLoading(true);
     try {
-      await startExpert(userId, id, text);
-      // Close Mini App — user lands in bot chat with the topic
-      window.Telegram?.WebApp?.close();
+      const data = await startExpert(userId, id, text);
+      // Deep link: open bot chat with /start q_{uuid} — creates forum topic
+      window.Telegram?.WebApp?.openTelegramLink(data.start_link);
     } catch (err) {
       console.error("Failed to start expert:", err);
       setLoading(false);

--- a/mini_app/frontend/src/types.ts
+++ b/mini_app/frontend/src/types.ts
@@ -37,6 +37,7 @@ declare global {
         expand(): void;
         close(): void;
         sendData(data: string): void;
+        openTelegramLink(url: string): void;
         initData: string;
         initDataUnsafe: { user?: { id: number; first_name: string } };
         themeParams: Record<string, string>;

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -14,7 +14,7 @@ from urllib.parse import unquote, urlparse
 
 from aiogram import Bot, Dispatcher, F
 from aiogram.exceptions import TelegramBadRequest
-from aiogram.filters import Command, CommandObject, StateFilter
+from aiogram.filters import Command, CommandObject, CommandStart, StateFilter
 from aiogram.fsm.context import FSMContext
 from aiogram.types import (
     BotCommand,
@@ -687,6 +687,10 @@ class PropertyBot:
                 F.message_thread_id,
             )(self._handle_group_message)
 
+        # Deep link: /start q_<uuid> — must be registered BEFORE generic /start
+        self.dp.message(CommandStart(deep_link=True, magic=F.args.startswith("q_")))(
+            self.cmd_start_deeplink
+        )
         self.dp.message(Command("start"))(self.cmd_start)
         self.dp.message(Command("help"))(self.cmd_help)
         self.dp.message(Command("clear"))(self.cmd_clear)
@@ -753,6 +757,17 @@ class PropertyBot:
         return db_role or "client"
 
     @observe(name="cmd-start", capture_input=False, capture_output=False)
+    async def cmd_start_deeplink(
+        self,
+        message: Message,
+        command: CommandObject,
+    ):
+        """Handle /start q_<uuid> — Mini App deep link flow."""
+        assert message.from_user is not None
+        assert command.args is not None
+        uuid_str = command.args[2:]  # strip "q_" prefix
+        await self._handle_deeplink_start(message, uuid_str)
+
     async def cmd_start(
         self,
         message: Message,
@@ -760,17 +775,8 @@ class PropertyBot:
         dialog_manager: Any = None,
         i18n: Any = None,
     ):
-        """Handle /start command — ReplyKeyboard for clients, dialog for managers.
-
-        If command args start with 'q_', handle as Mini App deep link payload.
-        """
+        """Handle /start command — ReplyKeyboard for clients, dialog for managers."""
         assert message.from_user is not None
-
-        # Deep link: /start q_<uuid>
-        args = command.args if command else None
-        if args and args.startswith("q_") and self._topic_manager is not None:
-            await self._handle_deeplink_start(message, args[2:])
-            return
 
         role = await self._resolve_user_role(message.from_user.id)
 

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -14,7 +14,7 @@ from urllib.parse import unquote, urlparse
 
 from aiogram import Bot, Dispatcher, F
 from aiogram.exceptions import TelegramBadRequest
-from aiogram.filters import Command, StateFilter
+from aiogram.filters import Command, CommandObject, StateFilter
 from aiogram.fsm.context import FSMContext
 from aiogram.types import (
     BotCommand,
@@ -753,9 +753,25 @@ class PropertyBot:
         return db_role or "client"
 
     @observe(name="cmd-start", capture_input=False, capture_output=False)
-    async def cmd_start(self, message: Message, dialog_manager: Any = None, i18n: Any = None):
-        """Handle /start command — ReplyKeyboard for clients, dialog for managers."""
+    async def cmd_start(
+        self,
+        message: Message,
+        command: CommandObject | None = None,
+        dialog_manager: Any = None,
+        i18n: Any = None,
+    ):
+        """Handle /start command — ReplyKeyboard for clients, dialog for managers.
+
+        If command args start with 'q_', handle as Mini App deep link payload.
+        """
         assert message.from_user is not None
+
+        # Deep link: /start q_<uuid>
+        args = command.args if command else None
+        if args and args.startswith("q_") and self._topic_manager is not None:
+            await self._handle_deeplink_start(message, args[2:])
+            return
+
         role = await self._resolve_user_role(message.from_user.id)
 
         kommo_enabled = getattr(self.config, "kommo_enabled", False)
@@ -776,6 +792,64 @@ class PropertyBot:
                 cfg = load_services_config()
                 welcome = cfg.get("welcome", {}).get("text", "Добро пожаловать!")
             await message.answer(welcome, reply_markup=build_client_keyboard(i18n=i18n))
+
+    async def _handle_deeplink_start(self, message: Message, uuid_str: str) -> None:
+        """Handle Mini App deep link: /start q_<uuid>.
+
+        Reads one-time payload from Redis, creates forum topic via TopicManager,
+        echoes user message to topic, then triggers RAG pipeline.
+        """
+        import json as _json
+
+        assert self._deeplink_redis is not None
+        key = f"miniapp:q:{uuid_str}"
+        raw = await self._deeplink_redis.get(key)
+        if raw is None:
+            await message.answer("Ссылка устарела. Пожалуйста, вернитесь в приложение.")
+            return
+
+        # One-time: delete immediately after reading
+        await self._deeplink_redis.delete(key)
+
+        try:
+            payload = _json.loads(raw)
+        except (ValueError, TypeError):
+            await message.answer("Ошибка обработки ссылки.")
+            return
+
+        expert_id = payload.get("expert_id", "")
+        user_message = payload.get("message") or ""
+
+        # Look up expert config
+        from .services.content_loader import load_mini_app_config
+
+        config_data = load_mini_app_config()
+        expert = next((e for e in config_data.get("experts", []) if e["id"] == expert_id), None)
+        if not expert:
+            await message.answer("Эксперт не найден.")
+            return
+
+        # Create / get forum topic for this expert
+        assert self._topic_manager is not None
+        topic_id = await self._topic_manager.get_or_create_topic(
+            chat_id=message.chat.id,
+            expert_id=expert_id,
+            expert_name=expert["name"],
+            expert_emoji=expert.get("emoji", "💬"),
+        )
+
+        if user_message:
+            # Echo user question in the topic
+            await self.bot.send_message(
+                chat_id=message.chat.id,
+                message_thread_id=topic_id,
+                text=f"❝ {user_message} ❞",
+            )
+            # Trigger RAG pipeline: synthetic message in the topic
+            topic_msg = message.model_copy(
+                update={"text": user_message, "message_thread_id": topic_id}
+            )
+            await self.handle_query(topic_msg)
 
     async def cmd_help(self, message: Message):
         """Handle /help command."""
@@ -3876,6 +3950,19 @@ class PropertyBot:
         topic_redis = aioredis.from_url(self.config.redis_url, decode_responses=False)
         self._topic_service = TopicService(redis=topic_redis)
         logger.info("TopicService ready (Redis)")
+
+        # Initialize TopicManager + deeplink Redis for Mini App deep link flow
+        if self.config.expert_topics_enabled:
+            from telegram_bot.services.topic_manager import TopicManager
+
+            self._deeplink_redis = aioredis.from_url(self.config.redis_url, decode_responses=True)
+            self._topic_manager: TopicManager | None = TopicManager(
+                bot=self.bot, redis=self._deeplink_redis
+            )
+            logger.info("TopicManager ready (expert deep link flow)")
+        else:
+            self._deeplink_redis = None
+            self._topic_manager = None
 
         # Initialize bot bridge for Mini App API
         from mini_app.bot_bridge import BotBridge, set_bot_bridge

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -799,20 +799,19 @@ class PropertyBot:
         Reads one-time payload from Redis, creates forum topic via TopicManager,
         echoes user message to topic, then triggers RAG pipeline.
         """
-        import json as _json
+        if self._deeplink_redis is None or self._topic_manager is None:
+            logger.warning("Deep link received but TopicManager not initialized")
+            return
 
-        assert self._deeplink_redis is not None
         key = f"miniapp:q:{uuid_str}"
-        raw = await self._deeplink_redis.get(key)
+        # Atomic GET+DEL — prevents race condition with duplicate requests
+        raw = await self._deeplink_redis.getdel(key)
         if raw is None:
             await message.answer("Ссылка устарела. Пожалуйста, вернитесь в приложение.")
             return
 
-        # One-time: delete immediately after reading
-        await self._deeplink_redis.delete(key)
-
         try:
-            payload = _json.loads(raw)
+            payload = json.loads(raw)
         except (ValueError, TypeError):
             await message.answer("Ошибка обработки ссылки.")
             return
@@ -830,13 +829,17 @@ class PropertyBot:
             return
 
         # Create / get forum topic for this expert
-        assert self._topic_manager is not None
-        topic_id = await self._topic_manager.get_or_create_topic(
-            chat_id=message.chat.id,
-            expert_id=expert_id,
-            expert_name=expert["name"],
-            expert_emoji=expert.get("emoji", "💬"),
-        )
+        try:
+            topic_id = await self._topic_manager.get_or_create_topic(
+                chat_id=message.chat.id,
+                expert_id=expert_id,
+                expert_name=expert["name"],
+                expert_emoji=expert.get("emoji", "💬"),
+            )
+        except TelegramBadRequest as exc:
+            logger.error("Failed to create forum topic: %s", exc)
+            await message.answer("Не удалось создать тему. Попробуйте позже.")
+            return
 
         if user_message:
             # Echo user question in the topic

--- a/telegram_bot/config.py
+++ b/telegram_bot/config.py
@@ -262,6 +262,10 @@ class BotConfig(BaseSettings):
         default="",
         validation_alias=AliasChoices("mini_app_url", "MINI_APP_URL"),
     )
+    expert_topics_enabled: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("expert_topics_enabled", "EXPERT_TOPICS_ENABLED"),
+    )
 
     # LiveKit (voice calls)
     livekit_url: str = Field(

--- a/telegram_bot/services/topic_manager.py
+++ b/telegram_bot/services/topic_manager.py
@@ -1,0 +1,83 @@
+"""Forum topic manager for expert chats in private conversations."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from aiogram import Bot
+    from redis.asyncio import Redis
+
+logger = logging.getLogger(__name__)
+
+_MAX_TOPIC_NAME_LEN = 128
+_TOPIC_TTL = 30 * 86400  # 30 дней
+
+
+def _truncate(name: str) -> str:
+    if len(name) <= _MAX_TOPIC_NAME_LEN:
+        return name
+    return name[: _MAX_TOPIC_NAME_LEN - 1].rstrip() + "\u2026"
+
+
+class TopicManager:
+    """Manage forum topics per expert in private chats.
+
+    Redis keys:
+        topic:{chat_id}:{expert_id}          → message_thread_id
+        topic_rev:{chat_id}:{message_thread_id} → expert_id
+    """
+
+    def __init__(self, *, bot: Bot, redis: Redis) -> None:
+        self._bot = bot
+        self._redis = redis
+
+    def _fwd_key(self, chat_id: int, expert_id: str) -> str:
+        return f"topic:{chat_id}:{expert_id}"
+
+    def _rev_key(self, chat_id: int, topic_id: int) -> str:
+        return f"topic_rev:{chat_id}:{topic_id}"
+
+    async def get_or_create_topic(
+        self,
+        chat_id: int,
+        expert_id: str,
+        expert_name: str,
+        expert_emoji: str,
+    ) -> int:
+        """Return existing topic_id or create a new one."""
+        fwd = self._fwd_key(chat_id, expert_id)
+        cached = await self._redis.get(fwd)
+        if cached is not None:
+            return int(cached)
+
+        name = _truncate(f"{expert_emoji} {expert_name}")
+        topic = await self._bot.create_forum_topic(chat_id=chat_id, name=name)
+        tid = topic.message_thread_id
+
+        await self._redis.set(fwd, tid, ex=_TOPIC_TTL)
+        await self._redis.set(self._rev_key(chat_id, tid), expert_id, ex=_TOPIC_TTL)
+        logger.info("Created topic %d for expert=%s chat=%d", tid, expert_id, chat_id)
+        return tid
+
+    async def get_expert_for_topic(self, chat_id: int, topic_id: int) -> str | None:
+        """Reverse lookup: topic_id → expert_id."""
+        val = await self._redis.get(self._rev_key(chat_id, topic_id))
+        return val if val is None else str(val)
+
+    async def rename_topic(self, chat_id: int, topic_id: int, new_name: str) -> None:
+        """Rename topic with truncation."""
+        await self._bot.edit_forum_topic(
+            chat_id=chat_id,
+            message_thread_id=topic_id,
+            name=_truncate(new_name),
+        )
+
+    async def invalidate_topic(self, chat_id: int, expert_id: str) -> None:
+        """Remove topic mapping (e.g. when topic deleted by user)."""
+        fwd = self._fwd_key(chat_id, expert_id)
+        cached = await self._redis.get(fwd)
+        if cached is not None:
+            await self._redis.delete(fwd, self._rev_key(chat_id, int(cached)))

--- a/tests/unit/mini_app/test_chat.py
+++ b/tests/unit/mini_app/test_chat.py
@@ -92,3 +92,21 @@ async def test_start_expert_stores_payload_in_redis():
     assert call_args.kwargs.get("ex") == 300 or (
         len(call_args.args) > 2 and call_args.args[2] == 300
     )
+
+
+@pytest.mark.asyncio
+async def test_start_expert_fails_without_bot_username():
+    """Missing BOT_USERNAME should return 500."""
+    mock_redis = AsyncMock()
+    experts = [{"id": "consultant", "name": "Консультант", "emoji": "👷"}]
+    with patch("mini_app.api.load_mini_app_config", return_value={"experts": experts}):
+        with patch("mini_app.api._get_redis", new=AsyncMock(return_value=mock_redis)):
+            with patch.dict(os.environ, {"BOT_USERNAME": ""}, clear=False):
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.post(
+                        "/api/start-expert",
+                        json={"user_id": 123, "expert_id": "consultant"},
+                    )
+    assert resp.status_code == 500

--- a/tests/unit/mini_app/test_chat.py
+++ b/tests/unit/mini_app/test_chat.py
@@ -1,11 +1,12 @@
-"""Tests for Mini App API — /api/start-expert endpoint."""
+"""Tests for Mini App API — /api/start-expert deep link endpoint."""
+
+import os
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 
 pytest.importorskip("fastapi")
-
-from unittest.mock import AsyncMock, patch
 
 from httpx import ASGITransport, AsyncClient
 
@@ -24,50 +25,70 @@ async def test_health_endpoint():
 @pytest.mark.asyncio
 async def test_start_expert_not_found():
     """Unknown expert_id should return 404."""
-    from mini_app.bot_bridge import BotBridge, set_bot_bridge
-
-    bridge = BotBridge(
-        bot=AsyncMock(),
-        topic_service=AsyncMock(),
-        rag_fn=AsyncMock(return_value={}),
-    )
-    set_bot_bridge(bridge)
-
-    with patch(
-        "mini_app.api.load_mini_app_config",
-        return_value={"experts": []},
-    ):
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            resp = await client.post(
-                "/api/start-expert",
-                json={"user_id": 123, "expert_id": "nonexistent"},
-            )
+    mock_redis = AsyncMock()
+    with patch("mini_app.api.load_mini_app_config", return_value={"experts": []}):
+        with patch("mini_app.api._get_redis", new=AsyncMock(return_value=mock_redis)):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.post(
+                    "/api/start-expert",
+                    json={"user_id": 123, "expert_id": "nonexistent"},
+                )
     assert resp.status_code == 404
 
 
 @pytest.mark.asyncio
-async def test_start_expert_success():
-    """Valid expert should return thread_id and expert_name."""
-    from mini_app.bot_bridge import BotBridge, set_bot_bridge
-
-    topic_svc = AsyncMock()
-    topic_svc.get_or_create_thread.return_value = 42
-    bridge = BotBridge(
-        bot=AsyncMock(),
-        topic_service=topic_svc,
-        rag_fn=AsyncMock(return_value={}),
-    )
-    set_bot_bridge(bridge)
-
+async def test_start_expert_returns_start_link():
+    """Valid expert should return start_link for deep linking."""
+    mock_redis = AsyncMock()
     experts = [{"id": "consultant", "name": "Консультант", "emoji": "👷"}]
     with patch("mini_app.api.load_mini_app_config", return_value={"experts": experts}):
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            resp = await client.post(
-                "/api/start-expert",
-                json={"user_id": 123, "expert_id": "consultant"},
-            )
+        with patch("mini_app.api._get_redis", new=AsyncMock(return_value=mock_redis)):
+            with patch.dict(os.environ, {"BOT_USERNAME": "testbot"}):
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.post(
+                        "/api/start-expert",
+                        json={
+                            "user_id": 123,
+                            "expert_id": "consultant",
+                            "message": "Подбери квартиру",
+                        },
+                    )
     assert resp.status_code == 200
     data = resp.json()
-    assert data["thread_id"] == 42
+    assert "start_link" in data
+    assert "testbot" in data["start_link"]
+    assert "q_" in data["start_link"]
     assert data["expert_name"] == "Консультант"
     assert data["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_start_expert_stores_payload_in_redis():
+    """API should store payload in Redis with TTL 300s."""
+    mock_redis = AsyncMock()
+    experts = [{"id": "consultant", "name": "Консультант", "emoji": "👷"}]
+    with patch("mini_app.api.load_mini_app_config", return_value={"experts": experts}):
+        with patch("mini_app.api._get_redis", new=AsyncMock(return_value=mock_redis)):
+            with patch.dict(os.environ, {"BOT_USERNAME": "testbot"}):
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.post(
+                        "/api/start-expert",
+                        json={"user_id": 123, "expert_id": "consultant", "message": "Тест"},
+                    )
+    assert resp.status_code == 200
+    # Redis.set should have been called with TTL=300
+    mock_redis.set.assert_called_once()
+    call_args = mock_redis.set.call_args
+    # key starts with "miniapp:q:"
+    key = call_args.args[0] if call_args.args else call_args.kwargs.get("name", "")
+    assert key.startswith("miniapp:q:")
+    # TTL is 300
+    assert call_args.kwargs.get("ex") == 300 or (
+        len(call_args.args) > 2 and call_args.args[2] == 300
+    )

--- a/tests/unit/mini_app/test_start_expert.py
+++ b/tests/unit/mini_app/test_start_expert.py
@@ -1,3 +1,6 @@
+"""Tests for mini_app.expert_start models."""
+
+
 def test_start_expert_request_model():
     """StartExpertRequest should have required fields."""
     from mini_app.expert_start import StartExpertRequest
@@ -14,3 +17,27 @@ def test_start_expert_request_optional_message():
 
     req = StartExpertRequest(user_id=123, expert_id="consultant")
     assert req.message is None
+
+
+def test_start_expert_response_has_start_link():
+    """StartExpertResponse should return start_link for deep linking."""
+    from mini_app.expert_start import StartExpertResponse
+
+    resp = StartExpertResponse(
+        start_link="https://t.me/testbot?start=q_abc123",
+        expert_name="Консультант",
+    )
+    assert resp.start_link == "https://t.me/testbot?start=q_abc123"
+    assert resp.expert_name == "Консультант"
+    assert resp.status == "ok"
+
+
+def test_start_expert_response_no_thread_id():
+    """StartExpertResponse should NOT have thread_id (old approach removed)."""
+    from mini_app.expert_start import StartExpertResponse
+
+    resp = StartExpertResponse(
+        start_link="https://t.me/testbot?start=q_abc",
+        expert_name="Консультант",
+    )
+    assert not hasattr(resp, "thread_id")

--- a/tests/unit/services/test_topic_manager.py
+++ b/tests/unit/services/test_topic_manager.py
@@ -1,0 +1,129 @@
+"""Tests for TopicManager — expert topic lifecycle in private chats."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from telegram_bot.services.topic_manager import TopicManager
+
+
+@pytest.fixture
+def mock_bot():
+    bot = AsyncMock()
+    bot.create_forum_topic = AsyncMock(return_value=MagicMock(message_thread_id=42))
+    bot.edit_forum_topic = AsyncMock()
+    return bot
+
+
+@pytest.fixture
+def mock_redis():
+    store: dict[str, str] = {}
+
+    async def _get(key: str) -> str | None:
+        return store.get(key)
+
+    async def _set(key: str, value: int | str, ex: int | None = None) -> None:
+        store[key] = str(value)
+
+    async def _delete(*keys: str) -> None:
+        for k in keys:
+            store.pop(k, None)
+
+    redis = AsyncMock()
+    redis.get = AsyncMock(side_effect=_get)
+    redis.set = AsyncMock(side_effect=_set)
+    redis.delete = AsyncMock(side_effect=_delete)
+    return redis
+
+
+@pytest.fixture
+def manager(mock_bot, mock_redis):
+    return TopicManager(bot=mock_bot, redis=mock_redis)
+
+
+@pytest.mark.asyncio
+async def test_create_new_topic(manager, mock_bot):
+    topic_id = await manager.get_or_create_topic(
+        chat_id=111,
+        expert_id="consultant",
+        expert_name="Консультант",
+        expert_emoji="👷",
+    )
+    assert topic_id == 42
+    mock_bot.create_forum_topic.assert_called_once_with(
+        chat_id=111,
+        name="👷 Консультант",
+    )
+
+
+@pytest.mark.asyncio
+async def test_reuse_existing_topic(manager, mock_bot, mock_redis):
+    # Первый вызов — создаёт
+    await manager.get_or_create_topic(
+        chat_id=111,
+        expert_id="consultant",
+        expert_name="Консультант",
+        expert_emoji="👷",
+    )
+    mock_bot.create_forum_topic.reset_mock()
+
+    # Второй вызов — переиспользует
+    topic_id = await manager.get_or_create_topic(
+        chat_id=111,
+        expert_id="consultant",
+        expert_name="Консультант",
+        expert_emoji="👷",
+    )
+    assert topic_id == 42
+    mock_bot.create_forum_topic.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reverse_lookup(manager):
+    await manager.get_or_create_topic(
+        chat_id=111,
+        expert_id="consultant",
+        expert_name="Консультант",
+        expert_emoji="👷",
+    )
+    expert_id = await manager.get_expert_for_topic(chat_id=111, topic_id=42)
+    assert expert_id == "consultant"
+
+
+@pytest.mark.asyncio
+async def test_reverse_lookup_unknown(manager):
+    result = await manager.get_expert_for_topic(chat_id=111, topic_id=999)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_rename_topic(manager, mock_bot):
+    await manager.rename_topic(chat_id=111, topic_id=42, new_name="🏠 Двушка в Бургасе")
+    mock_bot.edit_forum_topic.assert_called_once_with(
+        chat_id=111,
+        message_thread_id=42,
+        name="🏠 Двушка в Бургасе",
+    )
+
+
+@pytest.mark.asyncio
+async def test_rename_truncates_long_name(manager, mock_bot):
+    long_name = "A" * 200
+    await manager.rename_topic(chat_id=111, topic_id=42, new_name=long_name)
+    call_name = mock_bot.edit_forum_topic.call_args.kwargs["name"]
+    assert len(call_name) <= 128
+
+
+@pytest.mark.asyncio
+async def test_invalidate_topic(manager):
+    await manager.get_or_create_topic(
+        chat_id=111,
+        expert_id="consultant",
+        expert_name="Консультант",
+        expert_emoji="👷",
+    )
+    await manager.invalidate_topic(chat_id=111, expert_id="consultant")
+    result = await manager.get_expert_for_topic(chat_id=111, topic_id=42)
+    assert result is None

--- a/tests/unit/test_bot_deeplink.py
+++ b/tests/unit/test_bot_deeplink.py
@@ -1,0 +1,234 @@
+"""Tests for bot deep link handler — /start q_<uuid> flow."""
+
+import json
+
+import pytest
+
+
+pytest.importorskip("aiogram", reason="aiogram not installed")
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from telegram_bot.bot import PropertyBot
+from telegram_bot.config import BotConfig
+
+
+@pytest.fixture
+def mock_config(monkeypatch):
+    monkeypatch.delenv("CLIENT_DIRECT_PIPELINE_ENABLED", raising=False)
+    monkeypatch.delenv("KOMMO_ACCESS_TOKEN", raising=False)
+    return BotConfig(
+        _env_file=None,
+        telegram_token="test-token",
+        voyage_api_key="voyage-key",
+        llm_api_key="llm-key",
+        llm_base_url="https://api.example.com/v1",
+        llm_model="gpt-4o-mini",
+        qdrant_url="http://localhost:6333",
+        qdrant_api_key="qdrant-key",
+        qdrant_collection="test_collection",
+        redis_url="redis://localhost:6379",
+        realestate_database_url="postgresql://postgres:postgres@127.0.0.1:1/realestate",
+        rerank_provider="none",
+    )
+
+
+def _create_bot(mock_config):
+    result: PropertyBot | None = None
+    with (
+        patch("telegram_bot.bot.Bot"),
+        patch("telegram_bot.integrations.cache.CacheLayerManager"),
+        patch("telegram_bot.integrations.embeddings.BGEM3HybridEmbeddings"),
+        patch("telegram_bot.integrations.embeddings.BGEM3SparseEmbeddings"),
+        patch("telegram_bot.services.qdrant.QdrantService"),
+        patch("telegram_bot.graph.config.GraphConfig.create_llm"),
+        patch("telegram_bot.graph.config.GraphConfig.create_supervisor_llm"),
+    ):
+        result = PropertyBot(mock_config)
+    assert result is not None
+    return result
+
+
+def _make_message(user_id=123, chat_id=123):
+    msg = MagicMock()
+    msg.from_user = MagicMock(id=user_id, first_name="Test")
+    msg.chat = MagicMock(id=chat_id)
+    msg.answer = AsyncMock()
+    msg.model_copy = MagicMock(return_value=msg)
+    msg.text = "/start q_test-uuid"
+    return msg
+
+
+@pytest.mark.asyncio
+async def test_deeplink_expired_uuid(mock_config):
+    """Expired/missing UUID should reply with 'link expired' message."""
+    bot = _create_bot(mock_config)
+    bot._deeplink_redis = AsyncMock()
+    bot._deeplink_redis.getdel = AsyncMock(return_value=None)
+    bot._topic_manager = MagicMock()
+
+    msg = _make_message()
+    await bot._handle_deeplink_start(msg, "nonexistent-uuid")
+
+    msg.answer.assert_called_once()
+    assert "устарела" in msg.answer.call_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_deeplink_invalid_json(mock_config):
+    """Invalid JSON payload should reply with error."""
+    bot = _create_bot(mock_config)
+    bot._deeplink_redis = AsyncMock()
+    bot._deeplink_redis.getdel = AsyncMock(return_value="not-json{{{")
+    bot._topic_manager = MagicMock()
+
+    msg = _make_message()
+    await bot._handle_deeplink_start(msg, "test-uuid")
+
+    msg.answer.assert_called_once()
+    assert "ошибка" in msg.answer.call_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_deeplink_unknown_expert(mock_config):
+    """Unknown expert_id should reply with 'expert not found'."""
+    bot = _create_bot(mock_config)
+    payload = json.dumps({"expert_id": "nonexistent", "message": "hello"})
+    bot._deeplink_redis = AsyncMock()
+    bot._deeplink_redis.getdel = AsyncMock(return_value=payload)
+    bot._topic_manager = MagicMock()
+
+    msg = _make_message()
+    with patch(
+        "telegram_bot.services.content_loader.load_mini_app_config",
+        return_value={"experts": []},
+    ):
+        await bot._handle_deeplink_start(msg, "test-uuid")
+
+    msg.answer.assert_called_once()
+    assert "не найден" in msg.answer.call_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_deeplink_success_creates_topic_and_triggers_rag(mock_config):
+    """Valid deep link should create topic, echo message, and trigger RAG."""
+    bot = _create_bot(mock_config)
+    payload = json.dumps({"expert_id": "consultant", "message": "Подбери квартиру"})
+    bot._deeplink_redis = AsyncMock()
+    bot._deeplink_redis.getdel = AsyncMock(return_value=payload)
+    bot._topic_manager = AsyncMock()
+    bot._topic_manager.get_or_create_topic = AsyncMock(return_value=42)
+    bot.bot = AsyncMock()
+    bot.handle_query = AsyncMock()
+
+    msg = _make_message()
+    experts = [{"id": "consultant", "name": "Консультант", "emoji": "👷"}]
+    with patch(
+        "telegram_bot.services.content_loader.load_mini_app_config",
+        return_value={"experts": experts},
+    ):
+        await bot._handle_deeplink_start(msg, "test-uuid")
+
+    # Topic created for the right expert
+    bot._topic_manager.get_or_create_topic.assert_called_once_with(
+        chat_id=msg.chat.id,
+        expert_id="consultant",
+        expert_name="Консультант",
+        expert_emoji="👷",
+    )
+    # User message echoed in topic
+    bot.bot.send_message.assert_called_once()
+    send_kwargs = bot.bot.send_message.call_args.kwargs
+    assert send_kwargs["message_thread_id"] == 42
+    assert "Подбери квартиру" in send_kwargs["text"]
+    # RAG pipeline triggered
+    bot.handle_query.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_deeplink_no_message_skips_rag(mock_config):
+    """Deep link without message should create topic but not trigger RAG."""
+    bot = _create_bot(mock_config)
+    payload = json.dumps({"expert_id": "consultant", "message": ""})
+    bot._deeplink_redis = AsyncMock()
+    bot._deeplink_redis.getdel = AsyncMock(return_value=payload)
+    bot._topic_manager = AsyncMock()
+    bot._topic_manager.get_or_create_topic = AsyncMock(return_value=42)
+    bot.bot = AsyncMock()
+    bot.handle_query = AsyncMock()
+
+    msg = _make_message()
+    experts = [{"id": "consultant", "name": "Консультант", "emoji": "👷"}]
+    with patch(
+        "telegram_bot.services.content_loader.load_mini_app_config",
+        return_value={"experts": experts},
+    ):
+        await bot._handle_deeplink_start(msg, "test-uuid")
+
+    # Topic created
+    bot._topic_manager.get_or_create_topic.assert_called_once()
+    # No message echo, no RAG
+    bot.bot.send_message.assert_not_called()
+    bot.handle_query.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_deeplink_redis_deletes_key(mock_config):
+    """Deep link should use atomic getdel (key consumed after read)."""
+    bot = _create_bot(mock_config)
+    payload = json.dumps({"expert_id": "consultant", "message": "test"})
+    bot._deeplink_redis = AsyncMock()
+    bot._deeplink_redis.getdel = AsyncMock(return_value=payload)
+    bot._topic_manager = AsyncMock()
+    bot._topic_manager.get_or_create_topic = AsyncMock(return_value=42)
+    bot.bot = AsyncMock()
+    bot.handle_query = AsyncMock()
+
+    msg = _make_message()
+    experts = [{"id": "consultant", "name": "Консультант", "emoji": "👷"}]
+    with patch(
+        "telegram_bot.services.content_loader.load_mini_app_config",
+        return_value={"experts": experts},
+    ):
+        await bot._handle_deeplink_start(msg, "test-uuid")
+
+    bot._deeplink_redis.getdel.assert_called_once_with("miniapp:q:test-uuid")
+
+
+@pytest.mark.asyncio
+async def test_deeplink_topic_manager_none_skips(mock_config):
+    """If TopicManager not initialized, deep link should silently return."""
+    bot = _create_bot(mock_config)
+    bot._deeplink_redis = None
+    bot._topic_manager = None
+
+    msg = _make_message()
+    await bot._handle_deeplink_start(msg, "test-uuid")
+
+    msg.answer.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_deeplink_create_topic_error(mock_config):
+    """TelegramBadRequest from create_forum_topic should be handled gracefully."""
+    from aiogram.exceptions import TelegramBadRequest
+
+    bot = _create_bot(mock_config)
+    payload = json.dumps({"expert_id": "consultant", "message": "test"})
+    bot._deeplink_redis = AsyncMock()
+    bot._deeplink_redis.getdel = AsyncMock(return_value=payload)
+    bot._topic_manager = AsyncMock()
+    bot._topic_manager.get_or_create_topic = AsyncMock(
+        side_effect=TelegramBadRequest(method=MagicMock(), message="Bad Request: not enough rights")
+    )
+
+    msg = _make_message()
+    experts = [{"id": "consultant", "name": "Консультант", "emoji": "👷"}]
+    with patch(
+        "telegram_bot.services.content_loader.load_mini_app_config",
+        return_value={"experts": experts},
+    ):
+        await bot._handle_deeplink_start(msg, "test-uuid")
+
+    msg.answer.assert_called_once()
+    assert "не удалось" in msg.answer.call_args.args[0].lower()


### PR DESCRIPTION
## Summary
- API returns `start_link` instead of sending messages directly via bot
- Frontend uses `openTelegramLink` for seamless transition to bot chat
- Bot `/start` handler processes deep link UUID, creates forum topic, triggers RAG pipeline
- Redis-based one-time payload passing (`miniapp:q:{uuid}`, TTL 300s)
- New `TopicManager` service for forum topic lifecycle management

## Changes
- `mini_app/api.py` — Redis SET + start_link generation
- `mini_app/expert_start.py` — `StartExpertResponse(start_link=...)`
- `ExpertSheet.tsx` — `openTelegramLink(data.start_link)`
- `telegram_bot/bot.py` — `_handle_deeplink_start()`, TopicManager init
- `compose.yml` — `BOT_USERNAME` env
- Tests: 11 new/updated tests

## Test plan
- [x] Unit tests for API start_link generation
- [x] Unit tests for StartExpertResponse model
- [x] Unit tests for TopicManager (create, reuse, reverse lookup, rename, invalidate)
- [ ] E2E: click prompt in Mini App → deep link → forum topic → RAG response

🤖 Generated with [Claude Code](https://claude.com/claude-code)