### PR TITLE
feat(mini-app): rewrite frontend to @telegram-apps/sdk-react v3

### DIFF
--- a/mini_app/frontend/index.html
+++ b/mini_app/frontend/index.html
@@ -4,8 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="color-scheme" content="light dark" />
-    <script src="https://telegram.org/js/telegram-web-app.js"></script>
-    <title>FortNoks</title>
+<title>FortNoks</title>
     <style>
       * { margin: 0; padding: 0; box-sizing: border-box; }
       body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }

--- a/mini_app/frontend/package-lock.json
+++ b/mini_app/frontend/package-lock.json
@@ -8,8 +8,7 @@
       "name": "fortnoks-mini-app",
       "version": "0.1.0",
       "dependencies": {
-        "@telegram-apps/sdk": "^2.0.0",
-        "@telegram-apps/telegram-ui": "^2.0.0",
+        "@telegram-apps/sdk-react": "^3.0.0",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "react-router-dom": "^6.26.0",
@@ -22,6 +21,7 @@
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.0",
+        "eruda": "^3.4.0",
         "jsdom": "^28.1.0",
         "typescript": "^5.5.0",
         "vite": "^5.4.0",
@@ -1000,44 +1000,6 @@
         }
       }
     },
-    "node_modules/@floating-ui/core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.7.5",
-        "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.7.6"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-      "license": "MIT"
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1086,337 +1048,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@radix-ui/primitive": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
-      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
-      "license": "MIT"
-    },
-    "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
-      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
-      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
-      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-escape-keydown": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-focus-guards": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
-      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
-      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-id": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
-      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
-      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-presence": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
-      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
-      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
-      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-use-effect-event": "0.0.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-effect-event": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
-      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-escape-keydown": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
-      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-use-callback-ref": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
-      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/@remix-run/router": {
@@ -1792,26 +1423,21 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
-      "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/@telegram-apps/bridge": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/bridge/-/bridge-1.9.2.tgz",
-      "integrity": "sha512-SJLcNWLXhbbZr9MiqFH/g2ceuitSJKMxUIZysK4zUNyTUNuonrQG80Q/yrO+XiNbKUj8WdDNM86NBARhuyyinQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@telegram-apps/bridge/-/bridge-2.11.0.tgz",
+      "integrity": "sha512-kBZjWRRp/lxKeQ8r8cDWUY9EjxUtyeh/9xTQjsjuGRsCR5XTO1cyVbvcvqzHn53csGx3aBs+fOR3Pk3b6w2JHg==",
       "deprecated": "This package is not supported anymore. Use @tma.js/bridge instead",
       "license": "MIT",
       "dependencies": {
-        "@telegram-apps/signals": "^1.1.1",
-        "@telegram-apps/toolkit": "^1.1.1",
-        "@telegram-apps/transformers": "^1.2.2",
-        "@telegram-apps/types": "^1.2.1"
+        "@telegram-apps/signals": "^1.1.2",
+        "@telegram-apps/toolkit": "^2.1.3",
+        "@telegram-apps/transformers": "^2.2.6",
+        "@telegram-apps/types": "^2.0.3",
+        "better-promises": "^0.4.1",
+        "error-kid": "^0.0.7",
+        "mitt": "^3.0.1",
+        "valibot": "1.0.0"
       }
     },
     "node_modules/@telegram-apps/navigation": {
@@ -1821,16 +1447,38 @@
       "license": "MIT"
     },
     "node_modules/@telegram-apps/sdk": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/sdk/-/sdk-2.11.3.tgz",
-      "integrity": "sha512-KdULzgRe1gcR8B3Z/t3hQrEaDmLGrfsL2IePtPP6ehtMn5tT0uPfnjtDLjDNQMyI7D4Tv2ZOzvDx45wOhhreXg==",
+      "version": "3.11.8",
+      "resolved": "https://registry.npmjs.org/@telegram-apps/sdk/-/sdk-3.11.8.tgz",
+      "integrity": "sha512-vlpkYzMJCV9Cadsn9Q+/hbHNR39j5o96N9z4CjZ6AFHkkxOeOqVRrq9zRBw0gmffROkF2bU0WQxhRj8KZ/bPhw==",
       "license": "MIT",
       "dependencies": {
-        "@telegram-apps/bridge": "^1.9.2",
-        "@telegram-apps/navigation": "^1.0.13",
-        "@telegram-apps/signals": "^1.1.1",
-        "@telegram-apps/toolkit": "^1.1.1",
-        "@telegram-apps/transformers": "^1.2.2"
+        "@telegram-apps/bridge": "^2.11.0",
+        "@telegram-apps/navigation": "^1.0.14",
+        "@telegram-apps/signals": "^1.1.2",
+        "@telegram-apps/toolkit": "^2.1.3",
+        "@telegram-apps/transformers": "^2.2.6",
+        "@telegram-apps/types": "^2.0.3",
+        "better-promises": "^0.4.1",
+        "error-kid": "^0.0.7",
+        "valibot": "1.0.0"
+      }
+    },
+    "node_modules/@telegram-apps/sdk-react": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@telegram-apps/sdk-react/-/sdk-react-3.3.9.tgz",
+      "integrity": "sha512-85jF1ICT8sYCNzXu19SqJrfrS8XslsvV14KUcToiyL7H5ZMXHt0JQKM+QJgULjnLjEswweQ4/7Bd7mNULf/BIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@telegram-apps/sdk": "^3.11.8"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@telegram-apps/signals": {
@@ -1839,47 +1487,42 @@
       "integrity": "sha512-1P1kdCLX7MfETGPxH7f3UZKIsdE7Tz5S7QmN4Km1sbYQMakD5Bi1NecSMR7/wnHp50gWMI1JzENcMtCEmouhSg==",
       "license": "MIT"
     },
-    "node_modules/@telegram-apps/telegram-ui": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/telegram-ui/-/telegram-ui-2.1.13.tgz",
-      "integrity": "sha512-W8a3pxyyLWPSp43GSOzo2i4BKcZ4okgaWiL1TU8rkwUXdANT0tR0yYDIqVRY1rOkT9mimJLK8fDQDxeuz8zOoA==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react-dom": "^2.0.8",
-        "@swc/helpers": "^0.5.3",
-        "@twa-dev/types": "^7.0.0",
-        "@xelene/vaul-with-scroll-fix": "0.1.4"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=7.0.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      }
-    },
     "node_modules/@telegram-apps/toolkit": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/toolkit/-/toolkit-1.1.1.tgz",
-      "integrity": "sha512-+vhKx6ngfvjyTE6Xagl3z1TPVbfx5s7xAkcYzCdHYUo6T60jLIqLgyZMcI1UPoIAMuMu1pHoO+p8QNCj/+tFmw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@telegram-apps/toolkit/-/toolkit-2.1.3.tgz",
+      "integrity": "sha512-LPUBL7hxQTOr+Dowyk9a1O82nQS4ja4+OYiYWtvqq5nNUHC6Gbbus0zGWCbFcj9CLnIzaeb5HWOg5iSnhoRcyg==",
       "license": "MIT"
     },
     "node_modules/@telegram-apps/transformers": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/transformers/-/transformers-1.2.2.tgz",
-      "integrity": "sha512-vvMwXckd1D7Ozc0h66PSUwF5QLrRV9HlGJFFeBuUex8QEk5mSPtsJkLiqB8aBbwuFDa91+TUSM/CxqPZO/e9YQ==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@telegram-apps/transformers/-/transformers-2.2.6.tgz",
+      "integrity": "sha512-MMBRs3demeBT9Cd614KKZmak7eEyNdEbfu99a0SwEEJe2oIODjJLrUxrhUcAOc5wvTRfrKka27VXVgruauLhdg==",
       "deprecated": "This package is not supported anymore. Use @tma.js/transfomers instead",
       "license": "MIT",
       "dependencies": {
-        "@telegram-apps/toolkit": "^1.1.1",
-        "@telegram-apps/types": "^1.2.1"
+        "@telegram-apps/toolkit": "^2.1.3",
+        "@telegram-apps/types": "^2.0.3",
+        "valibot": "1.0.0-beta.14"
+      }
+    },
+    "node_modules/@telegram-apps/transformers/node_modules/valibot": {
+      "version": "1.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.0.0-beta.14.tgz",
+      "integrity": "sha512-tLyV2rE5QL6U29MFy3xt4AqMrn+/HErcp2ZThASnQvPMwfSozjV1uBGKIGiegtZIGjinJqn0SlBdannf18wENA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@telegram-apps/types": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/types/-/types-1.2.1.tgz",
-      "integrity": "sha512-so4HLh7clur0YyMthi9KVIgWoGpZdXlFOuQjk3+Q5NAvJZ11nAheBSwPlGw/Ko92+zwvrSBE/lQyN2+p17RP+w==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@telegram-apps/types/-/types-2.0.3.tgz",
+      "integrity": "sha512-pXh9BdnLZF3e2BGc4WL+RTRMAUpqKpaSP3Rs8rB4WyRwIoRSGWFKE4gtT/9m42LGixB8YVwdo/pJ+9XO765XEA==",
       "deprecated": "This package is not supported anymore. Use @tma.js/types instead",
       "license": "MIT"
     },
@@ -1972,12 +1615,6 @@
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
       }
-    },
-    "node_modules/@twa-dev/types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/@twa-dev/types/-/types-7.10.0.tgz",
-      "integrity": "sha512-BXHyNLXy+cPbOZ2qQq5ArPKcP4kUfuX3YBSFT0XUxtMNWAzvyMuYAiq59UTfQ8OnELXlfChrAoIT3c2pujBtcQ==",
-      "license": "MIT"
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
@@ -2079,7 +1716,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
@@ -2191,19 +1828,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@xelene/vaul-with-scroll-fix": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@xelene/vaul-with-scroll-fix/-/vaul-with-scroll-fix-0.1.4.tgz",
-      "integrity": "sha512-R9J7y92rzZKIQLtFHKtzRsb4x8G26cvwGIDSf7OQZCdROFt7xic4Yz1BlFYjm8oiQsYV4SFSQfOzatZjvxz5XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-dialog": "^1.0.4"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2237,18 +1861,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/aria-hidden": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
-      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -2280,6 +1892,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/better-promises": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/better-promises/-/better-promises-0.4.1.tgz",
+      "integrity": "sha512-cDW7eMvhvCoWzSih5o/OxsAgTUfP05yGMq77xNZUTmcZoNU9vEeFZJ+yJJi4lnocvxFrVFKsG0Yxt7ZnuYJEig==",
+      "license": "MIT",
+      "dependencies": {
+        "error-kid": "^0.0.7"
       }
     },
     "node_modules/bidi-js": {
@@ -2468,12 +2089,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/detect-node-es": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
-      "license": "MIT"
-    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -2500,6 +2115,19 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/error-kid": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/error-kid/-/error-kid-0.0.7.tgz",
+      "integrity": "sha512-8mFs7ZaDWlBFgjOy4lHLMCe2+KZfZXGx5GOgh2VQ/M1CCIvSWzbl2OMl+5fdZgrgoUfhTeF+NPhmqfEvUhN8yw==",
+      "license": "MIT"
+    },
+    "node_modules/eruda": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eruda/-/eruda-3.4.3.tgz",
+      "integrity": "sha512-J2TsF4dXSspOXev5bJ6mljv0dRrxj21wklrDzbvPmYaEmVoC+2psylyRi70nUPFh1mTQfIBsSusUtAMZtUN+/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -2618,15 +2246,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/get-nonce": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
-      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -2820,6 +2439,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3003,53 +2628,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-remove-scroll": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
-      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "react-remove-scroll-bar": "^2.3.7",
-        "react-style-singleton": "^2.2.3",
-        "tslib": "^2.1.0",
-        "use-callback-ref": "^1.3.3",
-        "use-sidecar": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-remove-scroll-bar": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
-      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
-      "license": "MIT",
-      "dependencies": {
-        "react-style-singleton": "^2.2.2",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-router": {
       "version": "6.30.3",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
@@ -3080,28 +2658,6 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/react-style-singleton": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
-      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "get-nonce": "^1.0.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/redent": {
@@ -3346,18 +2902,13 @@
         "node": ">=20"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3407,49 +2958,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/use-callback-ref": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
-      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-sidecar": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
-      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "detect-node-es": "^1.1.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -3457,6 +2965,20 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.0.0.tgz",
+      "integrity": "sha512-1Hc0ihzWxBar6NGeZv7fPLY0QuxFMyxwYR2sF1Blu7Wq7EnremwY2W02tit2ij2VJT8HcSkHAQqmFfl77f73Yw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite": {

--- a/mini_app/frontend/package.json
+++ b/mini_app/frontend/package.json
@@ -11,8 +11,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@telegram-apps/sdk": "^2.0.0",
-    "@telegram-apps/telegram-ui": "^2.0.0",
+    "@telegram-apps/sdk-react": "^3.0.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "react-router-dom": "^6.26.0",
@@ -25,6 +24,7 @@
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "eruda": "^3.4.0",
     "jsdom": "^28.1.0",
     "typescript": "^5.5.0",
     "vite": "^5.4.0",

--- a/mini_app/frontend/src/__tests__/main.test.tsx
+++ b/mini_app/frontend/src/__tests__/main.test.tsx
@@ -27,4 +27,38 @@ describe('main.tsx', () => {
     await import('../main');
     expect(init).toHaveBeenCalled();
   });
+
+  it('calls setupMockEnv before init', async () => {
+    const callOrder: string[] = [];
+
+    vi.doMock('../mockEnv', () => ({
+      setupMockEnv: vi.fn(() => {
+        callOrder.push('setupMockEnv');
+      }),
+    }));
+    vi.doMock('@telegram-apps/sdk-react', () => ({
+      init: vi.fn(() => {
+        callOrder.push('init');
+      }),
+    }));
+
+    await import('../main');
+
+    const setupIdx = callOrder.indexOf('setupMockEnv');
+    const initIdx = callOrder.indexOf('init');
+
+    expect(setupIdx).toBeGreaterThanOrEqual(0);
+    expect(initIdx).toBeGreaterThanOrEqual(0);
+    expect(setupIdx).toBeLessThan(initIdx);
+  });
+
+  it('calls init after mockEnv', async () => {
+    const { init } = await import('@telegram-apps/sdk-react');
+    const { setupMockEnv } = await import('../mockEnv');
+
+    await import('../main');
+
+    expect(setupMockEnv).toHaveBeenCalled();
+    expect(init).toHaveBeenCalled();
+  });
 });

--- a/mini_app/frontend/src/__tests__/main.test.tsx
+++ b/mini_app/frontend/src/__tests__/main.test.tsx
@@ -4,41 +4,27 @@ describe('main.tsx', () => {
   beforeEach(() => {
     vi.resetModules();
     document.body.innerHTML = '<div id="root"></div>';
-    // Mock react-dom/client and App to avoid actual DOM rendering
     vi.doMock('react-dom/client', () => ({
       createRoot: vi.fn(() => ({ render: vi.fn() })),
     }));
     vi.doMock('../App', () => ({ App: () => null }));
+    vi.doMock('../mockEnv', () => ({ setupMockEnv: vi.fn() }));
+    vi.doMock('@telegram-apps/sdk-react', () => ({
+      init: vi.fn(),
+    }));
   });
 
   afterEach(() => {
-    delete window.Telegram;
     vi.resetModules();
   });
 
-  it('calls Telegram.WebApp.ready() if available', async () => {
-    const ready = vi.fn();
-    const expand = vi.fn();
-    window.Telegram = { WebApp: { ready, expand } as Window['Telegram']['WebApp'] };
-
-    await import('../main');
-
-    expect(ready).toHaveBeenCalled();
-  });
-
-  it('calls Telegram.WebApp.expand() if available', async () => {
-    const ready = vi.fn();
-    const expand = vi.fn();
-    window.Telegram = { WebApp: { ready, expand } as Window['Telegram']['WebApp'] };
-
-    await import('../main');
-
-    expect(expand).toHaveBeenCalled();
-  });
-
-  it('does not throw if Telegram is undefined', async () => {
-    delete window.Telegram;
-
+  it('imports without throwing', async () => {
     await expect(import('../main')).resolves.not.toThrow();
+  });
+
+  it('calls SDK init on load', async () => {
+    const { init } = await import('@telegram-apps/sdk-react');
+    await import('../main');
+    expect(init).toHaveBeenCalled();
   });
 });

--- a/mini_app/frontend/src/__tests__/mockEnv.test.ts
+++ b/mini_app/frontend/src/__tests__/mockEnv.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as sdkReact from '@telegram-apps/sdk-react';
+
+describe('setupMockEnv', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does nothing when isTMA returns true', async () => {
+    vi.spyOn(sdkReact, 'isTMA').mockReturnValue(true as unknown as ReturnType<typeof sdkReact.isTMA>);
+    const mockTelegramEnvSpy = vi.spyOn(sdkReact, 'mockTelegramEnv');
+
+    const { setupMockEnv } = await import('../mockEnv');
+    setupMockEnv();
+
+    expect(mockTelegramEnvSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls mockTelegramEnv when not in TMA', async () => {
+    vi.spyOn(sdkReact, 'isTMA').mockReturnValue(false as unknown as ReturnType<typeof sdkReact.isTMA>);
+    const mockTelegramEnvSpy = vi.spyOn(sdkReact, 'mockTelegramEnv');
+
+    const { setupMockEnv } = await import('../mockEnv');
+    setupMockEnv();
+
+    expect(mockTelegramEnvSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes correct launchParams structure', async () => {
+    vi.spyOn(sdkReact, 'isTMA').mockReturnValue(false as unknown as ReturnType<typeof sdkReact.isTMA>);
+    const mockTelegramEnvSpy = vi.spyOn(sdkReact, 'mockTelegramEnv');
+
+    const { setupMockEnv } = await import('../mockEnv');
+    setupMockEnv();
+
+    expect(mockTelegramEnvSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        launchParams: expect.any(URLSearchParams),
+      }),
+    );
+
+    const callArg = mockTelegramEnvSpy.mock.calls[0][0] as { launchParams: URLSearchParams };
+    const launchParams = callArg.launchParams;
+    expect(launchParams.get('tgWebAppVersion')).toBe('8');
+    expect(launchParams.get('tgWebAppPlatform')).toBe('tdesktop');
+    expect(launchParams.get('tgWebAppData')).toBeTruthy();
+    expect(launchParams.get('tgWebAppThemeParams')).toBeTruthy();
+  });
+});

--- a/mini_app/frontend/src/api.ts
+++ b/mini_app/frontend/src/api.ts
@@ -1,5 +1,14 @@
 const API_BASE = import.meta.env.VITE_API_URL || "/api";
 
+export function remoteLog(level: "info" | "error" | "warn", message: string, data?: unknown) {
+  console.log(`[remote:${level}]`, message, data);
+  fetch(`${API_BASE}/log`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ level, message, data: data ? JSON.stringify(data) : undefined }),
+  }).catch(() => {});
+}
+
 export async function fetchConfig() {
   try {
     const resp = await fetch(`${API_BASE}/config`);

--- a/mini_app/frontend/src/main.tsx
+++ b/mini_app/frontend/src/main.tsx
@@ -1,19 +1,23 @@
 import { createRoot } from "react-dom/client";
+import { init } from "@telegram-apps/sdk-react";
 import { App } from "./App";
 import { ErrorBoundary } from "./ErrorBoundary";
+import { setupMockEnv } from "./mockEnv";
 
+// Mock env BEFORE any SDK calls — only activates in browser
+setupMockEnv();
+
+// Init Eruda in development
+if (import.meta.env.DEV) {
+  import("eruda").then(({ default: eruda }) => eruda.init());
+}
+
+// SDK init
+init();
+
+// Render
 createRoot(document.getElementById("root")!).render(
   <ErrorBoundary>
     <App />
-  </ErrorBoundary>
+  </ErrorBoundary>,
 );
-
-// Telegram WebApp initialization
-try {
-  if (window.Telegram?.WebApp) {
-    window.Telegram.WebApp.ready();
-    window.Telegram.WebApp.expand();
-  }
-} catch (e) {
-  console.warn("Telegram WebApp init error:", e);
-}

--- a/mini_app/frontend/src/mockEnv.ts
+++ b/mini_app/frontend/src/mockEnv.ts
@@ -1,0 +1,53 @@
+import { mockTelegramEnv, isTMA } from "@telegram-apps/sdk-react";
+
+/**
+ * Мок Telegram окружения для разработки в браузере.
+ * В Telegram (isTMA=true) — ничего не делает.
+ * В браузере — подставляет фейковые launchParams.
+ */
+export function setupMockEnv(): void {
+  if (isTMA()) return;
+
+  const initDataRaw = new URLSearchParams([
+    [
+      "user",
+      JSON.stringify({
+        id: 99999999,
+        first_name: "Dev",
+        last_name: "User",
+        username: "dev_user",
+        language_code: "ru",
+        is_premium: false,
+      }),
+    ],
+    ["hash", "mock_hash_for_dev"],
+    ["auth_date", String(Math.floor(Date.now() / 1000))],
+    ["signature", "mock_signature_for_dev"],
+  ]).toString();
+
+  const launchParams = new URLSearchParams([
+    ["tgWebAppVersion", "8"],
+    ["tgWebAppPlatform", "tdesktop"],
+    ["tgWebAppData", initDataRaw],
+    [
+      "tgWebAppThemeParams",
+      JSON.stringify({
+        accent_text_color: "#6ab2f2",
+        bg_color: "#17212b",
+        button_color: "#5288c1",
+        button_text_color: "#ffffff",
+        destructive_text_color: "#ec3942",
+        header_bg_color: "#17212b",
+        hint_color: "#708499",
+        link_color: "#6ab3f3",
+        secondary_bg_color: "#232e3c",
+        subtitle_text_color: "#708499",
+        text_color: "#f5f5f5",
+      }),
+    ],
+  ]);
+
+  mockTelegramEnv({ launchParams });
+
+  console.log("[mockEnv] Telegram environment mocked for browser dev");
+}

--- a/mini_app/frontend/src/pages/ExpertSheet.tsx
+++ b/mini_app/frontend/src/pages/ExpertSheet.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { openTelegramLink, initData } from "@telegram-apps/sdk-react";
-import { fetchConfig, startExpert } from "../api";
+import { fetchConfig, remoteLog, startExpert } from "../api";
 import { BottomSheet } from "../components/BottomSheet";
 import { ChatInput } from "../components/ChatInput";
 import { PromptRow } from "../components/PromptRow";
@@ -25,8 +25,10 @@ export function ExpertSheet() {
   const userId = user?.id;
 
   const handleStart = async (text: string) => {
+    remoteLog("info", "handleStart", { userId, id, text });
+
     if (!userId) {
-      console.error("[ExpertSheet] userId undefined — initData.user() is null");
+      remoteLog("error", "userId undefined — initData.user() is null");
       alert("Ошибка: не удалось определить пользователя.");
       return;
     }
@@ -35,15 +37,21 @@ export function ExpertSheet() {
 
     try {
       const data = await startExpert(userId, id, text);
+      remoteLog("info", "startExpert OK", { start_link: data.start_link });
 
-      if (openTelegramLink.isAvailable()) {
-        openTelegramLink(data.start_link);
-      } else {
-        console.warn("[ExpertSheet] openTelegramLink not available, fallback to location.href");
+      try {
+        if (openTelegramLink.isAvailable()) {
+          openTelegramLink(data.start_link);
+        } else {
+          remoteLog("warn", "openTelegramLink not available, fallback");
+          window.location.href = data.start_link;
+        }
+      } catch (e) {
+        remoteLog("warn", "openTelegramLink threw, fallback", { error: String(e) });
         window.location.href = data.start_link;
       }
     } catch (err) {
-      console.error("[ExpertSheet] startExpert failed:", err);
+      remoteLog("error", "startExpert failed", { error: String(err) });
       setLoading(false);
     }
   };

--- a/mini_app/frontend/src/pages/ExpertSheet.tsx
+++ b/mini_app/frontend/src/pages/ExpertSheet.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { openTelegramLink, initData } from "@telegram-apps/sdk-react";
 import { fetchConfig, startExpert } from "../api";
 import { BottomSheet } from "../components/BottomSheet";
 import { ChatInput } from "../components/ChatInput";
@@ -20,17 +21,29 @@ export function ExpertSheet() {
 
   if (!expert) return null;
 
-  const userId = window.Telegram?.WebApp?.initDataUnsafe?.user?.id;
+  const user = initData.user();
+  const userId = user?.id;
 
   const handleStart = async (text: string) => {
-    if (!userId || !id || loading) return;
+    if (!userId) {
+      console.error("[ExpertSheet] userId undefined — initData.user() is null");
+      alert("Ошибка: не удалось определить пользователя.");
+      return;
+    }
+    if (!id || loading) return;
     setLoading(true);
+
     try {
       const data = await startExpert(userId, id, text);
-      // Deep link: open bot chat with /start q_{uuid} — creates forum topic
-      window.Telegram?.WebApp?.openTelegramLink(data.start_link);
+
+      if (openTelegramLink.isAvailable()) {
+        openTelegramLink(data.start_link);
+      } else {
+        console.warn("[ExpertSheet] openTelegramLink not available, fallback to location.href");
+        window.location.href = data.start_link;
+      }
     } catch (err) {
-      console.error("Failed to start expert:", err);
+      console.error("[ExpertSheet] startExpert failed:", err);
       setLoading(false);
     }
   };

--- a/mini_app/frontend/src/pages/QuestionSheet.tsx
+++ b/mini_app/frontend/src/pages/QuestionSheet.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
+import { closeMiniApp, sendData } from "@telegram-apps/sdk-react";
 import { fetchConfig } from "../api";
 import { BottomSheet } from "../components/BottomSheet";
 import { PromptRow } from "../components/PromptRow";
@@ -20,8 +21,8 @@ export function QuestionSheet() {
   if (!question) return null;
 
   const handlePrompt = (text: string) => {
-    window.Telegram?.WebApp?.sendData(text);
-    window.Telegram?.WebApp?.close();
+    sendData.ifAvailable(text);
+    closeMiniApp.ifAvailable();
   };
 
   return (

--- a/mini_app/frontend/src/pages/__tests__/ExpertSheet.test.tsx
+++ b/mini_app/frontend/src/pages/__tests__/ExpertSheet.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { ExpertSheet } from '../ExpertSheet';
 import * as api from '../../api';
+import * as sdkReact from '@telegram-apps/sdk-react';
 import type { AppConfig } from '../../types';
 
 const mockConfig: AppConfig = {
@@ -27,6 +28,7 @@ const mockConfig: AppConfig = {
 describe('ExpertSheet', () => {
   beforeEach(() => {
     vi.spyOn(api, 'fetchConfig').mockResolvedValue(mockConfig);
+    vi.spyOn(api, 'remoteLog').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -56,5 +58,158 @@ describe('ExpertSheet', () => {
       expect(screen.getByText('Как выбрать квартиру?')).toBeInTheDocument();
     });
     expect(screen.getByText('Что проверить перед покупкой?')).toBeInTheDocument();
+  });
+
+  it('handleStart calls startExpert with correct params', async () => {
+    const startExpertMock = vi.spyOn(api, 'startExpert').mockResolvedValue({
+      start_link: 'https://t.me/testbot?start=abc',
+      expert_name: 'Консультант',
+      status: 'ok',
+    });
+
+    renderExpertSheet();
+    await waitFor(() => screen.getByText('Как выбрать квартиру?'));
+
+    fireEvent.click(screen.getByText('Как выбрать квартиру?'));
+
+    await waitFor(() => {
+      expect(startExpertMock).toHaveBeenCalledWith(99999, 'consultant', 'Как выбрать квартиру?');
+    });
+  });
+
+  it('handleStart calls openTelegramLink on success', async () => {
+    const openTelegramLinkMock = sdkReact.openTelegramLink as ReturnType<typeof vi.fn>;
+    vi.spyOn(api, 'startExpert').mockResolvedValue({
+      start_link: 'https://t.me/testbot?start=abc',
+      expert_name: 'Консультант',
+      status: 'ok',
+    });
+
+    renderExpertSheet();
+    await waitFor(() => screen.getByText('Как выбрать квартиру?'));
+    fireEvent.click(screen.getByText('Как выбрать квартиру?'));
+
+    await waitFor(() => {
+      expect(openTelegramLinkMock).toHaveBeenCalledWith('https://t.me/testbot?start=abc');
+    });
+  });
+
+  it('falls back to location.href when openTelegramLink unavailable', async () => {
+    const openTelegramLink = sdkReact.openTelegramLink as ReturnType<typeof vi.fn> & {
+      isAvailable: ReturnType<typeof vi.fn>;
+    };
+    openTelegramLink.isAvailable.mockReturnValue(false);
+
+    const originalLocation = window.location;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).location;
+    window.location = { ...originalLocation, href: '' };
+
+    vi.spyOn(api, 'startExpert').mockResolvedValue({
+      start_link: 'https://t.me/testbot?start=abc',
+      expert_name: 'Консультант',
+      status: 'ok',
+    });
+
+    renderExpertSheet();
+    await waitFor(() => screen.getByText('Как выбрать квартиру?'));
+    fireEvent.click(screen.getByText('Как выбрать квартиру?'));
+
+    await waitFor(() => {
+      expect(window.location.href).toBe('https://t.me/testbot?start=abc');
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).location = originalLocation;
+    openTelegramLink.isAvailable.mockReturnValue(true);
+  });
+
+  it('falls back to location.href when openTelegramLink throws', async () => {
+    const openTelegramLink = sdkReact.openTelegramLink as ReturnType<typeof vi.fn> & {
+      isAvailable: ReturnType<typeof vi.fn>;
+    };
+    openTelegramLink.isAvailable.mockReturnValue(true);
+    openTelegramLink.mockImplementationOnce(() => {
+      throw new Error('TG link failed');
+    });
+
+    const originalLocation = window.location;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).location;
+    window.location = { ...originalLocation, href: '' };
+
+    vi.spyOn(api, 'startExpert').mockResolvedValue({
+      start_link: 'https://t.me/testbot?start=abc',
+      expert_name: 'Консультант',
+      status: 'ok',
+    });
+
+    renderExpertSheet();
+    await waitFor(() => screen.getByText('Как выбрать квартиру?'));
+    fireEvent.click(screen.getByText('Как выбрать квартиру?'));
+
+    await waitFor(() => {
+      expect(window.location.href).toBe('https://t.me/testbot?start=abc');
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).location = originalLocation;
+  });
+
+  it('shows error alert when userId is null', async () => {
+    vi.spyOn(sdkReact.initData, 'user').mockReturnValue(null);
+    const alertMock = vi.spyOn(window, 'alert').mockImplementation(() => {});
+
+    renderExpertSheet();
+    await waitFor(() => screen.getByText('Как выбрать квартиру?'));
+    fireEvent.click(screen.getByText('Как выбрать квартиру?'));
+
+    await waitFor(() => {
+      expect(alertMock).toHaveBeenCalledWith('Ошибка: не удалось определить пользователя.');
+    });
+
+    alertMock.mockRestore();
+  });
+
+  it('shows loading state during API call', async () => {
+    let resolveStart!: (v: api.StartExpertResponse) => void;
+    vi.spyOn(api, 'startExpert').mockReturnValue(
+      new Promise<api.StartExpertResponse>((resolve) => {
+        resolveStart = resolve;
+      }),
+    );
+
+    renderExpertSheet();
+    await waitFor(() => screen.getByText('Как выбрать квартиру?'));
+    fireEvent.click(screen.getByText('Как выбрать квартиру?'));
+
+    // Button should be disabled/loading — clicking again should not call startExpert twice
+    fireEvent.click(screen.getByText('Как выбрать квартиру?'));
+
+    resolveStart({
+      start_link: 'https://t.me/testbot?start=abc',
+      expert_name: 'Консультант',
+      status: 'ok',
+    });
+
+    await waitFor(() => {
+      expect(api.startExpert).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('handles API error gracefully', async () => {
+    vi.spyOn(api, 'startExpert').mockRejectedValue(new Error('Network error'));
+
+    renderExpertSheet();
+    await waitFor(() => screen.getByText('Как выбрать квартиру?'));
+    fireEvent.click(screen.getByText('Как выбрать квартиру?'));
+
+    await waitFor(() => {
+      expect(api.remoteLog).toHaveBeenCalledWith(
+        'error',
+        'startExpert failed',
+        expect.objectContaining({ error: expect.stringContaining('Network error') }),
+      );
+    });
   });
 });

--- a/mini_app/frontend/src/pages/__tests__/QuestionSheet.test.tsx
+++ b/mini_app/frontend/src/pages/__tests__/QuestionSheet.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QuestionSheet } from '../QuestionSheet';
 import * as api from '../../api';
+import * as sdkReact from '@telegram-apps/sdk-react';
 import type { AppConfig } from '../../types';
 
 const mockConfig: AppConfig = {
@@ -53,5 +54,29 @@ describe('QuestionSheet', () => {
       expect(screen.getByText('С чего начать поиск квартиры?')).toBeInTheDocument();
     });
     expect(screen.getByText('Как рассчитать бюджет?')).toBeInTheDocument();
+  });
+
+  it('calls sendData.ifAvailable on prompt click', async () => {
+    const sendDataMock = sdkReact.sendData as ReturnType<typeof vi.fn> & {
+      ifAvailable: ReturnType<typeof vi.fn>;
+    };
+
+    renderQuestionSheet();
+    await waitFor(() => screen.getByText('С чего начать поиск квартиры?'));
+    fireEvent.click(screen.getByText('С чего начать поиск квартиры?'));
+
+    expect(sendDataMock.ifAvailable).toHaveBeenCalledWith('С чего начать поиск квартиры?');
+  });
+
+  it('calls closeMiniApp.ifAvailable on prompt click', async () => {
+    const closeMiniAppMock = sdkReact.closeMiniApp as ReturnType<typeof vi.fn> & {
+      ifAvailable: ReturnType<typeof vi.fn>;
+    };
+
+    renderQuestionSheet();
+    await waitFor(() => screen.getByText('С чего начать поиск квартиры?'));
+    fireEvent.click(screen.getByText('С чего начать поиск квартиры?'));
+
+    expect(closeMiniAppMock.ifAvailable).toHaveBeenCalled();
   });
 });

--- a/mini_app/frontend/src/test-setup.ts
+++ b/mini_app/frontend/src/test-setup.ts
@@ -1,4 +1,34 @@
-import '@testing-library/jest-dom';
+/// <reference types="vitest/globals" />
+import "@testing-library/jest-dom";
 
-// jsdom does not implement scrollIntoView
+// jsdom stubs
 window.HTMLElement.prototype.scrollIntoView = () => {};
+window.matchMedia = window.matchMedia ?? (() => ({
+  matches: false,
+  addListener: () => {},
+  removeListener: () => {},
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  dispatchEvent: () => false,
+}));
+
+// Mock eruda (dev tool, not needed in tests)
+vi.mock("eruda", () => ({ default: { init: vi.fn() } }));
+
+// Mock @telegram-apps/sdk-react для тестов
+vi.mock("@telegram-apps/sdk-react", () => ({
+  init: vi.fn(),
+  openTelegramLink: Object.assign(vi.fn(), {
+    isAvailable: vi.fn(() => true),
+    ifAvailable: vi.fn(),
+  }),
+  closeMiniApp: Object.assign(vi.fn(), { ifAvailable: vi.fn() }),
+  sendData: Object.assign(vi.fn(), { ifAvailable: vi.fn() }),
+  initData: {
+    user: () => ({ id: 99999, firstName: "Test" }),
+    restore: vi.fn(),
+  },
+  mockTelegramEnv: vi.fn(),
+  isTMA: () => false,
+  parseInitData: vi.fn(),
+}));

--- a/mini_app/frontend/src/types.ts
+++ b/mini_app/frontend/src/types.ts
@@ -26,22 +26,3 @@ export interface AppConfig {
   questions: Question[];
   experts: Expert[];
 }
-
-declare global {
-  interface Window {
-    Telegram?: {
-      WebApp: {
-        BackButton: { show(): void; hide(): void; onClick(cb: () => void): void; offClick(cb: () => void): void };
-        MainButton: { show(): void; hide(): void; setText(t: string): void; onClick(cb: () => void): void };
-        ready(): void;
-        expand(): void;
-        close(): void;
-        sendData(data: string): void;
-        openTelegramLink(url: string): void;
-        initData: string;
-        initDataUnsafe: { user?: { id: number; first_name: string } };
-        themeParams: Record<string, string>;
-      };
-    };
-  }
-}

--- a/mini_app/frontend/vite.config.ts
+++ b/mini_app/frontend/vite.config.ts
@@ -5,8 +5,9 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   server: {
+    host: true,
     proxy: {
-      "/api": "http://localhost:8080",
+      "/api": "http://localhost:8090",
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- Full frontend rewrite from raw window.Telegram.WebApp to @telegram-apps/sdk-react v3
- mockTelegramEnv for browser dev (correct v3 API: launchParams URLSearchParams), Eruda for in-app debugging
- openTelegramLink.isAvailable() guard with location.href fallback; sendData.ifAvailable + closeMiniApp.ifAvailable
- Fix vite proxy port 8080→8090, add host:true for tunnel
- Remove custom Window.Telegram declare global (SDK v3 provides types)
- Update all 13 test files: global vi.mock for sdk-react + eruda, 37 tests pass

## Test plan
- [x] `npm test` — 13 files, 37 tests pass, 0 errors
- [x] `npm run build` — TS build clean, dist/ generated
- [ ] Browser: localhost:5173 → mock env works, cards visible, Eruda button
- [ ] Telegram: deep link flow works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)