### PR TITLE
feat(throttling): per-handler rate limiting via flags.rate_limit

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -475,7 +475,7 @@ class PropertyBot:
         # Langfuse context must be outermost to wrap all handlers
         self.dp.message.outer_middleware(LangfuseContextMiddleware())
         self.dp.callback_query.outer_middleware(LangfuseContextMiddleware())
-        setup_throttling_middleware(self.dp, rate_limit=1.5, admin_ids=self.config.admin_ids)
+        setup_throttling_middleware(self.dp, default_rate=1.0, admin_ids=self.config.admin_ids)
         setup_error_handler(self.dp)
         self.dp.message.outer_middleware(FSMCancelMiddleware())
         logger.info("Middlewares configured")
@@ -709,7 +709,11 @@ class PropertyBot:
         self.dp.message(Command("call"))(self.cmd_call)
         self.dp.message(Command("history"))(self.cmd_history)
         self.dp.message(Command("clearcache"))(self.cmd_clearcache)
-        self.dp.message(StateFilter(None), F.voice)(self.handle_voice)
+        self.dp.message(
+            StateFilter(None),
+            F.voice,
+            flags={"rate_limit": {"rate": 3.5, "key": "voice"}},
+        )(self.handle_voice)
         # ReplyKeyboard buttons — registered before catch-all F.text (#628)
         from telegram_bot.dialogs.states import CatalogBrowsingSG
 
@@ -719,7 +723,7 @@ class PropertyBot:
         self.dp.message(
             ~StateFilter(CatalogBrowsingSG.browsing),
             F.text.in_(menu_button_texts),
-            flags={"menu_nav": True},
+            flags={"rate_limit": {"rate": 0.6, "key": "menu"}},
         )(self.handle_menu_button)
         # NOTE: catch-all handle_query is registered on self._catch_all_router
         # which is included AFTER dialog routers in _setup_dialogs().
@@ -4331,7 +4335,11 @@ class PropertyBot:
         self.dp.include_router(catalog_router)
 
         self._catch_all_router = _Router(name="catch_all_query")
-        self._catch_all_router.message(StateFilter(None), F.text)(self.handle_query)
+        self._catch_all_router.message(
+            StateFilter(None),
+            F.text,
+            flags={"rate_limit": {"rate": 2.0, "key": "query"}},
+        )(self.handle_query)
         self.dp.include_router(self._catch_all_router)
 
         aiogram_setup_dialogs(self.dp)

--- a/telegram_bot/handlers/catalog_router.py
+++ b/telegram_bot/handlers/catalog_router.py
@@ -32,6 +32,7 @@ catalog_router = Router(name="catalog_browsing")
 @catalog_router.message(
     StateFilter(CatalogBrowsingSG.browsing),
     F.text.startswith("📥 Показать"),
+    flags={"rate_limit": {"rate": 0.3, "key": "catalog_more"}},
 )
 async def handle_catalog_more(
     message: Message,
@@ -89,6 +90,7 @@ async def handle_catalog_more(
 @catalog_router.message(
     StateFilter(CatalogBrowsingSG.browsing),
     F.text == "🔍 Фильтры",
+    flags={"rate_limit": {"rate": 0.3, "key": "catalog_filters"}},
 )
 async def handle_catalog_filters(
     message: Message,
@@ -120,6 +122,7 @@ async def handle_catalog_filters(
 @catalog_router.message(
     StateFilter(CatalogBrowsingSG.browsing),
     F.text == "📌 Избранное",
+    flags={"rate_limit": {"rate": 0.3, "key": "catalog_bookmarks"}},
 )
 async def handle_catalog_bookmarks(
     message: Message,
@@ -137,6 +140,7 @@ async def handle_catalog_bookmarks(
 @catalog_router.message(
     StateFilter(CatalogBrowsingSG.browsing),
     F.text == "🏠 Главное меню",
+    flags={"rate_limit": {"rate": 0.6, "key": "catalog_exit"}},
 )
 async def handle_catalog_exit(message: Message, state: FSMContext) -> None:
     """Exit catalog mode and restore main keyboard."""
@@ -154,7 +158,10 @@ async def handle_catalog_exit(message: Message, state: FSMContext) -> None:
 # --- Filter panel inline callbacks ---
 
 
-@catalog_router.callback_query(FilterPanelCB.filter())
+@catalog_router.callback_query(
+    FilterPanelCB.filter(),
+    flags={"rate_limit": {"rate": 0.3, "key": "filter_panel"}},
+)
 async def handle_filter_panel_callback(
     callback: CallbackQuery,
     state: FSMContext,

--- a/telegram_bot/middlewares/throttling.py
+++ b/telegram_bot/middlewares/throttling.py
@@ -15,44 +15,54 @@ from cachetools import TTLCache  # type: ignore[import-untyped]
 
 logger = logging.getLogger(__name__)
 
+# Defaults when no rate_limit flag is set on the handler
+_DEFAULT_MESSAGE_RATE = 1.0
+_DEFAULT_CALLBACK_RATE = 0.3
+_DEFAULT_KEY = "default"
+
 
 class ThrottlingMiddleware(BaseMiddleware):
     """
-    Middleware for rate limiting user requests.
+    Middleware for per-handler rate limiting via aiogram flags.
 
-    Uses in-memory TTL cache to track user requests.
+    Handlers declare ``flags={"rate_limit": {"rate": 0.3, "key": "catalog_more"}}``
+    to get isolated throttle buckets.  Handlers without the flag fall back to
+    sensible defaults (1.0 s for messages, 0.3 s for callback queries).
+
+    Uses lazy-created ``TTLCache`` instances keyed by rate value.
     Admins are exempt from rate limiting.
-    Callback queries (button clicks) and menu buttons use shorter rate limits
-    for snappy navigation.  Per-handler rates via aiogram flags (``menu_nav``).
     """
 
     def __init__(
         self,
-        rate_limit: float = 1.5,
-        callback_rate_limit: float = 0.3,
-        menu_rate_limit: float = 0.3,
+        default_rate: float = _DEFAULT_MESSAGE_RATE,
         admin_ids: list[int] | None = None,
     ) -> None:
         """
         Initialize throttling middleware.
 
         Args:
-            rate_limit: Time window in seconds for message rate limiting
-            callback_rate_limit: Time window in seconds for callback query rate limiting
-            menu_rate_limit: Time window in seconds for menu button rate limiting
-            admin_ids: List of admin user IDs exempt from throttling
+            default_rate: Default rate limit for messages (seconds).
+            admin_ids: List of admin user IDs exempt from throttling.
         """
-        self.cache: TTLCache[Any, None] = TTLCache(maxsize=10_000, ttl=rate_limit)
-        self.callback_cache: TTLCache[Any, None] = TTLCache(maxsize=10_000, ttl=callback_rate_limit)
-        self.menu_cache: TTLCache[Any, None] = TTLCache(maxsize=10_000, ttl=menu_rate_limit)
+        self._caches: dict[float, TTLCache[Any, None]] = {}
         self.admin_ids = set(admin_ids or [])
-        self.rate_limit = rate_limit
-        self.callback_rate_limit = callback_rate_limit
-        self.menu_rate_limit = menu_rate_limit
-        logger.info(
-            f"ThrottlingMiddleware initialized: "
-            f"msg={rate_limit}s, callback={callback_rate_limit}s, menu={menu_rate_limit}s"
-        )
+        self.default_rate = default_rate
+        logger.info(f"ThrottlingMiddleware initialized: default_rate={default_rate}s")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _get_cache(self, rate: float) -> TTLCache[Any, None]:
+        """Return (or lazily create) a TTLCache for the given *rate*."""
+        cache = self._caches.get(rate)
+        if cache is None:
+            cache = TTLCache(maxsize=10_000, ttl=rate)
+            self._caches[rate] = cache
+        return cache
+
+    # ------------------------------------------------------------------
 
     async def __call__(
         self,
@@ -71,24 +81,25 @@ class ThrottlingMiddleware(BaseMiddleware):
         if user_id in self.admin_ids:
             return await handler(event, data)
 
-        # Route to the right cache based on event type / handler flags
-        if isinstance(event, CallbackQuery):
-            cache = self.callback_cache
-            cache_key = (user_id, event.message.message_id if event.message else 0)
-            throttle_type = "callback"
-        elif get_flag(data, "menu_nav"):
-            # Menu buttons (ReplyKeyboard) — navigation, use short rate limit
-            cache = self.menu_cache
-            cache_key = user_id
-            throttle_type = "menu"
+        # Resolve rate & key from handler flag or defaults
+        rate_config: dict[str, Any] | None = get_flag(data, "rate_limit")
+
+        if rate_config is not None:
+            rate: float = float(rate_config.get("rate", self.default_rate))
+            key: str = str(rate_config.get("key", _DEFAULT_KEY))
+        elif isinstance(event, CallbackQuery):
+            rate = _DEFAULT_CALLBACK_RATE
+            key = _DEFAULT_KEY
         else:
-            cache = self.cache
-            cache_key = user_id
-            throttle_type = "message"
+            rate = self.default_rate
+            key = _DEFAULT_KEY
+
+        cache = self._get_cache(rate)
+        cache_key = (user_id, key)
 
         # Check if user is throttled
         if cache_key in cache:
-            logger.warning(f"User {user_id} throttled ({throttle_type})")
+            logger.warning(f"User {user_id} throttled (key={key}, rate={rate}s)")
 
             if isinstance(event, CallbackQuery):
                 await event.answer("Слишком часто, подожди немного", show_alert=True)
@@ -104,9 +115,7 @@ class ThrottlingMiddleware(BaseMiddleware):
 
 def setup_throttling_middleware(
     dp: Dispatcher,
-    rate_limit: float = 1.5,
-    callback_rate_limit: float = 0.3,
-    menu_rate_limit: float = 0.3,
+    default_rate: float = _DEFAULT_MESSAGE_RATE,
     admin_ids: list[int] | None = None,
 ) -> None:
     """
@@ -114,12 +123,10 @@ def setup_throttling_middleware(
 
     Args:
         dp: Dispatcher instance
-        rate_limit: Time window in seconds for messages
-        callback_rate_limit: Time window in seconds for callback queries
-        menu_rate_limit: Time window in seconds for menu buttons
+        default_rate: Default rate limit for messages (seconds).
         admin_ids: List of admin user IDs
     """
-    middleware = ThrottlingMiddleware(rate_limit, callback_rate_limit, menu_rate_limit, admin_ids)
+    middleware = ThrottlingMiddleware(default_rate=default_rate, admin_ids=admin_ids)
     dp.message.middleware.register(middleware)
     dp.callback_query.middleware.register(middleware)
     # Auto-answer callbacks (pre=True) to dismiss Telegram "loading" spinner immediately

--- a/tests/unit/test_middlewares.py
+++ b/tests/unit/test_middlewares.py
@@ -9,7 +9,7 @@ pytest.importorskip("aiogram", reason="aiogram not installed")
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiogram import Dispatcher
-from aiogram.types import Message, User
+from aiogram.types import CallbackQuery, Message, User
 
 from telegram_bot.middlewares.error_handler import (
     ErrorHandlerMiddleware,
@@ -96,19 +96,19 @@ class TestThrottlingMiddleware:
         """Test middleware creation with defaults."""
         middleware = ThrottlingMiddleware()
 
-        assert middleware.rate_limit == 1.5
+        assert middleware.default_rate == 1.0
         assert middleware.admin_ids == set()
 
     def test_middleware_creation_custom(self):
         """Test middleware creation with custom values."""
-        middleware = ThrottlingMiddleware(rate_limit=2.0, admin_ids=[123, 456])
+        middleware = ThrottlingMiddleware(default_rate=2.0, admin_ids=[123, 456])
 
-        assert middleware.rate_limit == 2.0
+        assert middleware.default_rate == 2.0
         assert middleware.admin_ids == {123, 456}
 
     async def test_middleware_allows_first_request(self):
         """Test that first request is allowed."""
-        middleware = ThrottlingMiddleware(rate_limit=1.5)
+        middleware = ThrottlingMiddleware(default_rate=1.0)
 
         handler = AsyncMock(return_value="success")
 
@@ -125,7 +125,7 @@ class TestThrottlingMiddleware:
 
     async def test_middleware_throttles_rapid_requests(self):
         """Test that rapid requests are throttled."""
-        middleware = ThrottlingMiddleware(rate_limit=1.5)
+        middleware = ThrottlingMiddleware(default_rate=1.0)
 
         handler = AsyncMock(return_value="success")
 
@@ -149,7 +149,7 @@ class TestThrottlingMiddleware:
 
     async def test_middleware_exempts_admins(self):
         """Test that admins are exempt from throttling."""
-        middleware = ThrottlingMiddleware(rate_limit=1.5, admin_ids=[12345])
+        middleware = ThrottlingMiddleware(default_rate=1.0, admin_ids=[12345])
 
         handler = AsyncMock(return_value="success")
 
@@ -181,9 +181,9 @@ class TestThrottlingMiddleware:
         assert result == "success"
         handler.assert_called_once()
 
-    async def test_menu_buttons_use_shorter_rate_limit(self):
-        """Test that handlers with menu_nav flag use menu_rate_limit (shorter)."""
-        middleware = ThrottlingMiddleware(rate_limit=1.5, menu_rate_limit=0.3)
+    async def test_handler_with_rate_limit_flag_uses_custom_rate(self):
+        """Handler with rate_limit flag throttles at its declared rate, not default."""
+        middleware = ThrottlingMiddleware(default_rate=1.0)
 
         handler = AsyncMock(return_value="success")
 
@@ -192,26 +192,22 @@ class TestThrottlingMiddleware:
 
         event = MagicMock(spec=Message)
         event.answer = AsyncMock()
-        # Simulate aiogram flags: get_flag(data, "menu_nav") returns True
-        data = {"event_from_user": user, "handler": MagicMock(flags={"menu_nav": True})}
+        data = {"event_from_user": user}
 
-        # First menu button press
         with patch(
             "telegram_bot.middlewares.throttling.get_flag",
-            side_effect=lambda data, name, **_kw: data.get(
-                "handler", MagicMock(flags={})
-            ).flags.get(name),
+            return_value={"rate": 0.3, "key": "catalog_more"},
         ):
             result1 = await middleware(handler, event, data)
             assert result1 == "success"
 
-            # Second rapid press — should be throttled (within 0.3s)
+            # Second rapid request — should be throttled
             result2 = await middleware(handler, event, data)
             assert result2 is None
 
-    async def test_menu_buttons_not_throttled_by_message_cache(self):
-        """Menu button presses use separate cache from regular messages."""
-        middleware = ThrottlingMiddleware(rate_limit=1.5, menu_rate_limit=0.3)
+    async def test_handler_without_flag_uses_default_message_rate(self):
+        """Handler without flag falls back to default_rate (1.0) for Message."""
+        middleware = ThrottlingMiddleware(default_rate=1.0)
 
         handler = AsyncMock(return_value="success")
 
@@ -220,33 +216,147 @@ class TestThrottlingMiddleware:
 
         event = MagicMock(spec=Message)
         event.answer = AsyncMock()
+        data = {"event_from_user": user}
 
-        # First: regular message (fills message cache)
-        data_regular = {"event_from_user": user}
         with patch(
             "telegram_bot.middlewares.throttling.get_flag",
             return_value=None,
         ):
-            await middleware(handler, event, data_regular)
+            result1 = await middleware(handler, event, data)
+            assert result1 == "success"
 
-        # Second: menu button press — should NOT be throttled by message cache
-        data_menu = {"event_from_user": user, "handler": MagicMock(flags={"menu_nav": True})}
+            result2 = await middleware(handler, event, data)
+            assert result2 is None
+
+    async def test_handler_without_flag_uses_callback_default(self):
+        """Handler without flag falls back to 0.3 for CallbackQuery."""
+        middleware = ThrottlingMiddleware(default_rate=1.0)
+
+        handler = AsyncMock(return_value="success")
+
+        user = MagicMock(spec=User)
+        user.id = 12345
+
+        event = MagicMock(spec=CallbackQuery)
+        event.answer = AsyncMock()
+        data = {"event_from_user": user}
+
         with patch(
             "telegram_bot.middlewares.throttling.get_flag",
-            side_effect=lambda data, name, **_kw: data.get(
-                "handler", MagicMock(flags={})
-            ).flags.get(name),
+            return_value=None,
         ):
-            result = await middleware(handler, event, data_menu)
-            assert result == "success", (
-                "Menu button should use separate cache from regular messages"
-            )
+            result1 = await middleware(handler, event, data)
+            assert result1 == "success"
 
-    async def test_middleware_creation_with_menu_rate(self):
-        """Test middleware creation with custom menu_rate_limit."""
-        middleware = ThrottlingMiddleware(rate_limit=2.0, menu_rate_limit=0.5, admin_ids=[123])
-        assert middleware.rate_limit == 2.0
-        assert middleware.menu_rate_limit == 0.5
+            result2 = await middleware(handler, event, data)
+            assert result2 is None
+            event.answer.assert_called_once()
+
+    async def test_different_keys_do_not_block_each_other(self):
+        """Requests with different keys are independently throttled."""
+        middleware = ThrottlingMiddleware(default_rate=1.0)
+
+        handler = AsyncMock(return_value="success")
+
+        user = MagicMock(spec=User)
+        user.id = 12345
+
+        event = MagicMock(spec=Message)
+        event.answer = AsyncMock()
+        data = {"event_from_user": user}
+
+        # First request with key "catalog_more"
+        with patch(
+            "telegram_bot.middlewares.throttling.get_flag",
+            return_value={"rate": 0.3, "key": "catalog_more"},
+        ):
+            result1 = await middleware(handler, event, data)
+            assert result1 == "success"
+
+        # Second request with key "catalog_filters" — should NOT be blocked
+        with patch(
+            "telegram_bot.middlewares.throttling.get_flag",
+            return_value={"rate": 0.3, "key": "catalog_filters"},
+        ):
+            result2 = await middleware(handler, event, data)
+            assert result2 == "success", "Different keys should not block each other"
+
+    async def test_same_key_twice_faster_than_rate_is_throttled(self):
+        """Same key hit twice within rate window is throttled."""
+        middleware = ThrottlingMiddleware(default_rate=1.0)
+
+        handler = AsyncMock(return_value="success")
+
+        user = MagicMock(spec=User)
+        user.id = 12345
+
+        event = MagicMock(spec=Message)
+        event.answer = AsyncMock()
+        data = {"event_from_user": user}
+
+        with patch(
+            "telegram_bot.middlewares.throttling.get_flag",
+            return_value={"rate": 0.3, "key": "voice"},
+        ):
+            result1 = await middleware(handler, event, data)
+            assert result1 == "success"
+
+            result2 = await middleware(handler, event, data)
+            assert result2 is None
+
+    async def test_admin_bypass_with_rate_limit_flag(self):
+        """Admin bypasses throttling even when handler has rate_limit flag."""
+        middleware = ThrottlingMiddleware(default_rate=1.0, admin_ids=[12345])
+
+        handler = AsyncMock(return_value="success")
+
+        user = MagicMock(spec=User)
+        user.id = 12345
+
+        event = MagicMock(spec=Message)
+        data = {"event_from_user": user}
+
+        with patch(
+            "telegram_bot.middlewares.throttling.get_flag",
+            return_value={"rate": 0.3, "key": "catalog_more"},
+        ):
+            result1 = await middleware(handler, event, data)
+            assert result1 == "success"
+
+            result2 = await middleware(handler, event, data)
+            assert result2 == "success"
+
+    async def test_lazy_cache_creation(self):
+        """Caches are created lazily per unique rate value."""
+        middleware = ThrottlingMiddleware(default_rate=1.0)
+        assert len(middleware._caches) == 0
+
+        handler = AsyncMock(return_value="success")
+        user = MagicMock(spec=User)
+        user.id = 12345
+        event = MagicMock(spec=Message)
+        data = {"event_from_user": user}
+
+        # Use rate=0.3
+        with patch(
+            "telegram_bot.middlewares.throttling.get_flag",
+            return_value={"rate": 0.3, "key": "a"},
+        ):
+            await middleware(handler, event, data)
+        assert 0.3 in middleware._caches
+        assert len(middleware._caches) == 1
+
+        # Use rate=0.6
+        user2 = MagicMock(spec=User)
+        user2.id = 99999
+        data2 = {"event_from_user": user2}
+        with patch(
+            "telegram_bot.middlewares.throttling.get_flag",
+            return_value={"rate": 0.6, "key": "b"},
+        ):
+            await middleware(handler, event, data2)
+        assert 0.6 in middleware._caches
+        assert len(middleware._caches) == 2
 
 
 class TestSetupThrottlingMiddleware:
@@ -260,7 +370,7 @@ class TestSetupThrottlingMiddleware:
         dp.callback_query = MagicMock()
         dp.callback_query.middleware = MagicMock()
 
-        setup_throttling_middleware(dp, rate_limit=2.0, admin_ids=[123])
+        setup_throttling_middleware(dp, default_rate=2.0, admin_ids=[123])
 
         dp.message.middleware.register.assert_called_once()
         # 2 registrations: ThrottlingMiddleware + CallbackAnswerMiddleware

--- a/tests/unit/test_middlewares_impl.py
+++ b/tests/unit/test_middlewares_impl.py
@@ -105,7 +105,7 @@ class TestThrottlingMiddleware:
         """Create ThrottlingMiddleware instance."""
         from telegram_bot.middlewares.throttling import ThrottlingMiddleware
 
-        return ThrottlingMiddleware(rate_limit=1.5, admin_ids=[123, 456])
+        return ThrottlingMiddleware(default_rate=1.0, admin_ids=[123, 456])
 
     async def test_first_request_passes_through(self, middleware):
         """Test that first request from a user passes through."""
@@ -182,9 +182,6 @@ class TestThrottlingMiddleware:
         handler = AsyncMock(return_value="result")
         event = MagicMock(spec=CallbackQuery)
         event.answer = AsyncMock()
-        # Callback key uses user_id + message_id
-        event.message = MagicMock()
-        event.message.message_id = 100
         user = MagicMock()
         user.id = 789
         data = {"event_from_user": user}
@@ -208,7 +205,7 @@ class TestThrottlingMiddleware:
         with patch("telegram_bot.middlewares.throttling.logger"):
             middleware = ThrottlingMiddleware()
 
-        assert middleware.rate_limit == 1.5
+        assert middleware.default_rate == 1.0
         assert middleware.admin_ids == set()
 
     def test_initialization_with_custom_values(self):
@@ -216,10 +213,57 @@ class TestThrottlingMiddleware:
         from telegram_bot.middlewares.throttling import ThrottlingMiddleware
 
         with patch("telegram_bot.middlewares.throttling.logger"):
-            middleware = ThrottlingMiddleware(rate_limit=3.0, admin_ids=[100, 200])
+            middleware = ThrottlingMiddleware(default_rate=3.0, admin_ids=[100, 200])
 
-        assert middleware.rate_limit == 3.0
+        assert middleware.default_rate == 3.0
         assert middleware.admin_ids == {100, 200}
+
+    async def test_handler_with_rate_limit_flag(self):
+        """Handler with rate_limit flag uses its rate, not default."""
+        from telegram_bot.middlewares.throttling import ThrottlingMiddleware
+
+        middleware = ThrottlingMiddleware(default_rate=1.0)
+        handler = AsyncMock(return_value="result")
+        event = MagicMock()
+        event.answer = AsyncMock()
+        user = MagicMock()
+        user.id = 789
+        data = {"event_from_user": user}
+
+        with patch(
+            "telegram_bot.middlewares.throttling.get_flag",
+            return_value={"rate": 0.3, "key": "catalog_more"},
+        ):
+            result1 = await middleware(handler, event, data)
+            assert result1 == "result"
+
+            with patch("telegram_bot.middlewares.throttling.logger"):
+                result2 = await middleware(handler, event, data)
+            assert result2 is None
+
+    async def test_different_keys_independent(self):
+        """Different keys do not block each other for the same user."""
+        from telegram_bot.middlewares.throttling import ThrottlingMiddleware
+
+        middleware = ThrottlingMiddleware(default_rate=1.0)
+        handler = AsyncMock(return_value="result")
+        event = MagicMock()
+        user = MagicMock()
+        user.id = 789
+        data = {"event_from_user": user}
+
+        with patch(
+            "telegram_bot.middlewares.throttling.get_flag",
+            return_value={"rate": 0.3, "key": "catalog_more"},
+        ):
+            await middleware(handler, event, data)
+
+        with patch(
+            "telegram_bot.middlewares.throttling.get_flag",
+            return_value={"rate": 0.3, "key": "catalog_filters"},
+        ):
+            result = await middleware(handler, event, data)
+            assert result == "result", "Different keys must not block each other"
 
 
 class TestSetupThrottlingMiddleware:
@@ -232,7 +276,7 @@ class TestSetupThrottlingMiddleware:
         mock_dp = MagicMock()
 
         with patch("telegram_bot.middlewares.throttling.logger"):
-            setup_throttling_middleware(mock_dp, rate_limit=2.0, admin_ids=[111])
+            setup_throttling_middleware(mock_dp, default_rate=2.0, admin_ids=[111])
 
         mock_dp.message.middleware.register.assert_called_once()
         # 2 registrations: ThrottlingMiddleware + CallbackAnswerMiddleware


### PR DESCRIPTION
## Summary
- Replaced 3 fixed TTLCache instances (message/callback/menu) with lazy-created `_caches: dict[float, TTLCache]` keyed by rate value
- Handlers now declare per-action rate limits via `flags={"rate_limit": {"rate": 0.3, "key": "catalog_more"}}` — isolated throttle buckets
- Updated catalog_router (5 handlers), bot.py (voice 3.5s, menu 0.6s, query 2.0s), and all throttling tests

## Test plan
- [x] `make check` passes (ruff + mypy)
- [x] All 36 middleware tests pass (test_middlewares.py + test_middlewares_impl.py)
- [x] Full unit suite: 4996 passed (5 pre-existing keyboard failures unrelated)
- [x] Tests cover: flag-based throttling, default fallbacks, key isolation, admin bypass, lazy cache creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)