### PR TITLE
feat(mini-app): SDK migration @tma.js + bootstrap + TelegramGate

### DIFF
--- a/.claude/rules/mini-app.md
+++ b/.claude/rules/mini-app.md
@@ -6,35 +6,50 @@ paths: "mini_app/**/*.py, mini_app/**/*.tsx, mini_app/**/*.ts, telegram_bot/conf
 
 ## SDK
 
-**@telegram-apps/sdk-react v3** — официальный React SDK для Telegram Mini Apps. Заменяет raw `window.Telegram.WebApp`.
+**@tma.js/sdk-react** — официальный React SDK для Telegram Mini Apps. Заменяет raw `window.Telegram.WebApp`.
+
+Инициализация через `bootstrap.ts` (единый orchestrator):
 
 ```typescript
-// main.tsx — порядок инициализации КРИТИЧЕН:
-setupMockEnv();              // 1. Mock env (только в браузере, до SDK)
-init();                      // 2. SDK init
-mountThemeParamsSync();       // 3. Mount theme params
-bindThemeParamsCssVars();     // 4. Bind --tg-theme-* CSS vars
+// bootstrap.ts — порядок инициализации:
+setupMockEnv();              // 1. Mock env (dev only, до SDK)
+await isTMA("complete");     // 2. Detect TMA environment (@tma.js/bridge)
+init();                      // 3. SDK init (@tma.js/sdk-react)
+initData.restore();          // 4. Restore user/auth_date/hash
+themeParams.mount();         // 5. Mount theme params
+themeParams.bindCssVars();   // 6. Bind --tg-theme-* CSS vars
+await viewport.mount();      // 7. Viewport (async)
+viewport.bindCssVars();      // 8. Viewport CSS vars
+swipeBehavior.mount();       // 9. Swipe protection
+swipeBehavior.disableVertical(); // 10. Disable vertical swipe
 ```
+
+Пакеты:
+- `@tma.js/sdk-react` — init, initData, themeParams, viewport, swipeBehavior, openTelegramLink, closeMiniApp, sendData
+- `@tma.js/bridge` — isTMA, mockTelegramEnv
 
 ### Ключевые API
 
-| Функция | Паттерн | Назначение |
-|---------|---------|------------|
-| `openTelegramLink` | `.isAvailable()` + try/catch + `location.href` fallback | Deep link navigation |
-| `sendData` | `.ifAvailable(text)` | Отправка данных боту (закрывает Mini App) |
-| `closeMiniApp` | `.ifAvailable()` | Закрытие Mini App |
-| `initData.user()` | Прямой вызов | `{ id, firstName, lastName, username }` |
-| `isTMA()` | Sync проверка | `true` в Telegram, `false` в браузере |
-| `mockTelegramEnv` | `({ launchParams: URLSearchParams })` | Фейк env для локальной разработки |
-| `mountThemeParamsSync` | Вызов после `init()` | Загрузка theme params |
-| `bindThemeParamsCssVars` | Вызов после mount | Привязка `--tg-theme-*` CSS переменных |
+| Функция | Пакет | Паттерн | Назначение |
+|---------|-------|---------|------------|
+| `openTelegramLink` | `@tma.js/sdk-react` | `.isAvailable()` + try/catch + `location.href` fallback | Deep link navigation |
+| `sendData` | `@tma.js/sdk-react` | `.ifAvailable(text)` | Отправка данных боту (закрывает Mini App) |
+| `closeMiniApp` | `@tma.js/sdk-react` | `.ifAvailable()` | Закрытие Mini App |
+| `initData.user()` | `@tma.js/sdk-react` | Прямой вызов | `{ id, firstName, lastName, username }` |
+| `viewport.mount` | `@tma.js/sdk-react` | `.isAvailable()` — Computed signal | Async mount viewport |
+| `swipeBehavior.isSupported` | `@tma.js/sdk-react` | Computed signal `()` | true если платформа поддерживает |
+| `swipeBehavior.disableVertical` | `@tma.js/sdk-react` | Вызов после mount | Запрет вертикального свайпа |
+| `isTMA("complete")` | `@tma.js/bridge` | Async проверка | Promise<boolean>, строгая проверка |
+| `mockTelegramEnv` | `@tma.js/bridge` | `({ launchParams: URLSearchParams })` | Фейк env для локальной разработки |
 
 ### Anti-patterns
 
 - **НЕ** `window.Telegram.WebApp.*` — используй SDK хуки
 - **НЕ** `openTelegramLink(url)` без `.isAvailable()` guard — платформенные баги
-- **НЕ** забывай `mountThemeParamsSync()` + `bindThemeParamsCssVars()` — без них CSS переменные пустые
-- **НЕ** `<script src="telegram-web-app.js">` в index.html — SDK v3 сам управляет
+- **НЕ** `@telegram-apps/sdk-react` — мигрировано на `@tma.js/sdk-react`
+- **НЕ** `mountThemeParamsSync` / `bindThemeParamsCssVars` — устаревшие методы, используй `themeParams.mount()` + `themeParams.bindCssVars()`
+- **НЕ** `<script src="telegram-web-app.js">` в index.html — SDK сам управляет
+- **НЕ** инициализировать SDK в main.tsx напрямую — только через `bootstrap.ts`
 
 ## Архитектура
 
@@ -47,11 +62,14 @@ mini_app/
 ├── Dockerfile          # uv sync → uvicorn
 └── frontend/
     ├── src/
-    │   ├── main.tsx        # SDK init, mockEnv, Eruda, theme CSS vars
-    │   ├── mockEnv.ts      # mockTelegramEnv для dev в браузере
+    │   ├── main.tsx        # Entry point: await initApp() → TelegramGate → App
+    │   ├── bootstrap.ts    # TMA lifecycle orchestrator (init, theme, viewport, swipe)
+    │   ├── mockEnv.ts      # mockTelegramEnv для dev в браузере (@tma.js/bridge)
     │   ├── App.tsx         # Routes: /, /question/:id, /expert/:id
     │   ├── api.ts          # fetchConfig(), startExpert(), submitPhone(), remoteLog()
     │   ├── types.ts        # Prompt, Question, Expert, AppConfig
+    │   ├── guards/
+    │   │   └── TelegramGate.tsx  # Guard: fallback если не в Telegram (prod)
     │   └── pages/
     │       ├── HomePage.tsx
     │       ├── QuestionSheet.tsx  # sendData.ifAvailable + closeMiniApp
@@ -161,7 +179,7 @@ ssh -R 8091:127.0.0.1:8091 vps -N
 | Mini app не открывается | `MINI_APP_URL` не обновлён | Обновить .env + перезапустить бота |
 | 502 Bad Gateway | mini-app-frontend не запущен | `docker compose --profile bot up -d` |
 | API ошибки | mini-app-api не healthy | `docker compose logs mini-app-api` |
-| CSS пустые/белый экран | `mountThemeParamsSync` не вызван | Проверить main.tsx порядок инициализации |
+| CSS пустые/белый экран | `themeParams.mount()` не вызван | Проверить bootstrap.ts порядок инициализации |
 | remote port forwarding failed | Порт занят или GatewayPorts off | Остановить mini-app на VPS, проверить sshd_config |
 
 ## Expert Start Flow (Deep Link)
@@ -208,15 +226,20 @@ topic_rev:{chat_id}:{thread_id}       → expert_id (reverse lookup)
 
 ## Тесты
 
-### Frontend (Vitest, 14 файлов, 51 тест)
+### Frontend (Vitest, 16 файлов, 55 тестов)
 
 ```bash
 cd mini_app/frontend && npm test                    # Все тесты
 cd mini_app/frontend && npm run build               # TS build check
 ```
 
-Моки SDK в `test-setup.ts` — глобальный `vi.mock("@telegram-apps/sdk-react")`.
-Для `main.test.tsx` используется `vi.doMock` с `vi.resetModules()`.
+Моки SDK в `test-setup.ts`:
+- Глобальный `vi.mock("@tma.js/sdk-react")` — init, initData, themeParams, viewport, swipeBehavior, openTelegramLink, closeMiniApp, sendData
+- Глобальный `vi.mock("@tma.js/bridge")` — mockTelegramEnv, isTMA
+- `vi.mock("eruda")` — заглушка dev-инструмента
+
+Для `main.test.tsx` используется `vi.doMock` (mock bootstrap, не реальный SDK).
+Для `bootstrap.test.ts` используется `vi.useFakeTimers()` + `vi.clearAllMocks()` в beforeEach.
 
 ### Backend (pytest)
 

--- a/.claude/rules/mini-app.md
+++ b/.claude/rules/mini-app.md
@@ -91,6 +91,37 @@ ssh -R 8091:127.0.0.1:5173 vps -N
 | Telegram | Eruda (автоматически в dev) | Smoke test через tunnel |
 | После закрытия | Remote logging `/api/log` | Отлов ошибок openTelegramLink |
 
+### Telegram Test Environment (HTTP без tunnel)
+
+Для тестирования с реальным initData без VPS/tunnel:
+
+1. **Создать аккаунт в Test DC:**
+   - iOS: Settings → 10 быстрых тапов на версию → "Switch to Test DC"
+   - Android: Settings → 10 тапов на версию → "Enable Test Backend"
+   - Desktop: Settings → Alt + Shift + клик "Add Account" → test server
+
+2. **Создать тестового бота:**
+   - В Test DC написать @BotFather → /newbot
+   - Сохранить токен в `.env.test` как `TELEGRAM_BOT_TOKEN_TEST`
+
+3. **Настроить Mini App URL:**
+   - @BotFather → /newapp (или /setmenubutton)
+   - URL: `http://<WSL-IP>:5173` (HTTP разрешён в test DC)
+   - Узнать IP: `hostname -I | awk '{print $1}'`
+
+4. **Запустить:**
+   ```bash
+   docker compose --profile bot up -d mini-app-api
+   cd mini_app/frontend && npm run dev  # host: true уже в vite.config.ts
+   # Открыть мини-ап в Telegram Test DC
+   ```
+
+| Среда | URL | HTTPS | initData |
+|-------|-----|-------|----------|
+| Браузер (mock) | localhost:5173 | Нет | Фейковый |
+| Test DC | http://WSL-IP:5173 | Нет | Реальный |
+| Production | miniapp.awdawdawd.space | Да | Реальный |
+
 ## Docker-сервисы
 
 - `mini-app-api` — FastAPI, порт **8090** (dev: 127.0.0.1:8090)

--- a/docs/plans/2026-03-10-mini-app-local-dev-design.md
+++ b/docs/plans/2026-03-10-mini-app-local-dev-design.md
@@ -1,0 +1,184 @@
+# Mini App: Local Dev + SDK Migration + Production Hardening
+
+## Scope
+
+Целевой scope — **C** (test environment + SDK миграция + hardening), реализуемый поэтапно: **A → B/C**.
+
+## Фаза 1: Telegram Test Environment + локальный HTTP flow
+
+### Цель
+
+Убрать зависимость от VPS/SSH tunnel/cloudflared для dev-тестирования в Telegram.
+
+### Что делаем
+
+1. Создать аккаунт в **Telegram Test DC** (мобильный клиент → 10 тапов на версию → test server)
+2. Создать тестового бота через **BotFather в test DC**
+3. Указать Mini App URL = `http://<WSL-IP>:5173` (test DC разрешает HTTP и IP)
+4. Vite dev server с `--host` — доступен по IP из Telegram Desktop (test env)
+5. Документировать процесс в `.claude/rules/mini-app.md`
+
+### Dev workflow после настройки
+
+```bash
+# 1. API бэкенд (Docker)
+docker compose --profile bot up -d mini-app-api
+
+# 2. Vite dev server
+cd mini_app/frontend && npm run dev --host
+
+# 3. Открыть мини-ап в Telegram test DC — http://WSL-IP:5173, без tunnel
+```
+
+### Ограничения
+
+- Test DC = отдельный аккаунт, отдельный бот, отдельная сессия
+- На мобильных тоже работает, но нужен отдельный вход
+- Production бот остаётся на production DC с HTTPS
+
+## Фаза 2: SDK миграция + bootstrap refactor + hardening
+
+### SDK миграция
+
+`@telegram-apps/sdk-react` → `@tma.js/sdk-react`
+
+- Ставить **только** `@tma.js/sdk-react` (реэкспортит core SDK, дублировать `@tma.js/sdk` не нужно)
+- Official migration guide: docs.telegram-mini-apps.com/packages/tma-js-sdk/migrate-from-telegram-apps
+- Обновить все импорты + test mocks
+
+### Структура файлов
+
+```
+src/
+├── main.tsx             # await initApp() → render(<TelegramGate>)
+├── bootstrap.ts         # orchestrator: mock → detect → init → viewport → swipe
+├── mockEnv.ts           # dev-only, отдельный файл (независимый concern)
+├── guards/
+│   └── TelegramGate.tsx # isTelegram ? <App/> : <OpenInTelegram/>
+├── App.tsx
+└── pages/
+    └── ...
+```
+
+### Роли файлов
+
+**`main.tsx`** — "тупой" entry point:
+```ts
+const { isTelegram } = await initApp();
+
+createRoot(document.getElementById("root")!).render(
+  <ErrorBoundary>
+    <TelegramGate isTelegram={isTelegram}>
+      <App />
+    </TelegramGate>
+  </ErrorBoundary>
+);
+```
+
+**`bootstrap.ts`** — единый orchestration point для platform init:
+```ts
+import {
+  init,
+  initData,
+  themeParams,
+  viewport,
+  swipeBehavior,
+} from "@tma.js/sdk-react";
+import { isTMA } from "@tma.js/bridge";
+import { setupMockEnv } from "./mockEnv";
+
+export type AppBootstrapResult = {
+  isTelegram: boolean;
+};
+
+export async function initApp(): Promise<AppBootstrapResult> {
+  const isDev = import.meta.env.DEV;
+
+  // 1. Mock env (dev + browser only)
+  if (isDev) {
+    setupMockEnv();
+  }
+
+  // 2. Detect environment ("complete" mode — более надёжный чем sync)
+  const isTelegram = isDev ? true : await isTMA("complete");
+
+  if (!isTelegram) {
+    return { isTelegram: false };
+  }
+
+  // 3. SDK init
+  init();
+
+  // 4. Restore initData (user, auth_date, hash)
+  initData.restore();
+
+  // 5. Theme params (mount → bind CSS vars)
+  themeParams.mount();
+  themeParams.bindCssVars();
+
+  // 6. Viewport (async mount → bind CSS vars)
+  if (viewport.mount.isAvailable()) {
+    await viewport.mount();
+    viewport.bindCssVars();
+  }
+
+  // 7. Swipe protection (mount → disable vertical)
+  if (swipeBehavior.isSupported()) {
+    swipeBehavior.mount();
+    swipeBehavior.disableVerticalSwipe();
+  }
+
+  // 8. Eruda (dev only)
+  if (isDev) {
+    import("eruda").then((e) => e.default.init());
+  }
+
+  return { isTelegram: true };
+}
+```
+
+**`TelegramGate.tsx`** — UX-ветка:
+- `isTelegram === true` → рендерит children
+- `isTelegram === false && !DEV` → страница "Откройте в Telegram" с deep link
+- `isTelegram === false && DEV` → рендерит children (mock env)
+
+**`mockEnv.ts`** — без изменений в контракте, обновить импорты на `@tma.js/bridge`.
+
+### Ключевые отличия `@tma.js` lifecycle от `@telegram-apps/sdk`
+
+| Аспект | `@telegram-apps/sdk` (текущий) | `@tma.js/sdk-react` (целевой) |
+|--------|-------------------------------|-------------------------------|
+| Theme params | `mountThemeParamsSync()` + `bindThemeParamsCssVars()` | `themeParams.mount()` + `themeParams.bindCssVars()` |
+| Swipe | Не было | `swipeBehavior.mount()` + `swipeBehavior.disableVerticalSwipe()` |
+| Viewport | Не было | `await viewport.mount()` + `viewport.bindCssVars()` |
+| Environment detect | `isTMA()` (sync) | `await isTMA("complete")` (async, надёжнее) |
+| `ifAvailable()` return | `result \| undefined` | Tuple: `[false]` или `[true, result]` |
+| `requestContact` fields | camelCase | snake_case |
+
+### Порядок реализации (7 шагов)
+
+| # | Задача | Файлы |
+|---|--------|-------|
+| 1 | Telegram Test Environment setup | docs, .env.test |
+| 2 | Тестовый бот + локальный HTTP flow | BotFather (test DC), vite.config.ts |
+| 3 | `@telegram-apps/sdk-react` → `@tma.js/sdk-react` | package.json, все импорты, test mocks |
+| 4 | Bootstrap refactor: `main.tsx` → `bootstrap.ts` + `main.tsx` | bootstrap.ts, main.tsx |
+| 5 | Viewport mount | bootstrap.ts |
+| 6 | Swipe protection | bootstrap.ts |
+| 7 | TelegramGate fallback page | guards/TelegramGate.tsx |
+
+## Что НЕ делаем
+
+- Back button management (нет навигации назад в текущем UX)
+- Haptics (не нужны)
+- Analytics hooks on launch (Langfuse на бэкенде)
+- `miniApp.ready()` (кандидат на будущее, не блокер)
+- Переход на A-структуру (bootstrap < 100 строк)
+
+## Когда B → A
+
+Переходить с одного `bootstrap.ts` на модульную структуру `bootstrap/` только если:
+- bootstrap > 100–150 строк
+- появились отдельные async ветки инициализации
+- нужна unit-тестируемость отдельных шагов
+- добавляются back button, closing behavior, haptics, navigation, analytics hooks

--- a/docs/plans/2026-03-10-mini-app-local-dev-plan.md
+++ b/docs/plans/2026-03-10-mini-app-local-dev-plan.md
@@ -1,0 +1,767 @@
+# Mini App Local Dev + SDK Migration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Убрать зависимость от VPS/tunnel для dev-тестирования, мигрировать на @tma.js/sdk-react, добавить viewport/swipe/TelegramGate.
+
+**Architecture:** Один bootstrap.ts orchestrator, mockEnv.ts отдельно, TelegramGate.tsx как guard-компонент. main.tsx — тупой entry point.
+
+**Tech Stack:** @tma.js/sdk-react, Vite, React 18, Vitest, cloudflared (test env)
+
+**Design doc:** `docs/plans/2026-03-10-mini-app-local-dev-design.md`
+
+---
+
+## Phase 1: Telegram Test Environment
+
+### Task 1: Документация Test Environment setup
+
+**Files:**
+- Modify: `.claude/rules/mini-app.md` (секция Dev Workflow)
+
+**Step 1: Добавить секцию Test Environment в правила**
+
+В `.claude/rules/mini-app.md` после секции "Dev Workflow" добавить:
+
+```markdown
+### Telegram Test Environment (HTTP без tunnel)
+
+Для тестирования с реальным initData без VPS/tunnel:
+
+1. **Создать аккаунт в Test DC:**
+   - iOS: Settings → 10 быстрых тапов на версию → "Switch to Test DC"
+   - Android: Settings → 10 тапов на версию → "Enable Test Backend"
+   - Desktop: Settings → Alt + Shift + клик "Add Account" → test server
+
+2. **Создать тестового бота:**
+   - В Test DC написать @BotFather → /newbot
+   - Сохранить токен в `.env.test` как `TELEGRAM_BOT_TOKEN_TEST`
+
+3. **Настроить Mini App URL:**
+   - @BotFather → /newapp (или /setmenubutton)
+   - URL: `http://<WSL-IP>:5173` (HTTP разрешён в test DC)
+   - Узнать IP: `hostname -I | awk '{print $1}'`
+
+4. **Запустить:**
+   ```bash
+   docker compose --profile bot up -d mini-app-api
+   cd mini_app/frontend && npm run dev  # host: true уже в vite.config.ts
+   # Открыть мини-ап в Telegram Test DC
+   ```
+
+| Среда | URL | HTTPS | initData |
+|-------|-----|-------|----------|
+| Браузер (mock) | localhost:5173 | Нет | Фейковый |
+| Test DC | http://WSL-IP:5173 | Нет | Реальный |
+| Production | miniapp.awdawdawd.space | Да | Реальный |
+```
+
+**Step 2: Commit**
+
+```bash
+git add .claude/rules/mini-app.md
+git commit -m "docs(mini-app): add Telegram Test Environment setup guide"
+```
+
+---
+
+## Phase 2: SDK Migration + Bootstrap Refactor
+
+### Task 2: Заменить @telegram-apps/sdk-react на @tma.js/sdk-react
+
+**Files:**
+- Modify: `mini_app/frontend/package.json`
+
+**Step 1: Удалить старый SDK, установить новый**
+
+```bash
+cd mini_app/frontend
+npm remove @telegram-apps/sdk-react
+npm install @tma.js/sdk-react
+```
+
+**Step 2: Проверить что установилось**
+
+```bash
+cd mini_app/frontend && cat node_modules/@tma.js/sdk-react/package.json | head -5
+```
+
+Expected: name = "@tma.js/sdk-react"
+
+**Step 3: Commit**
+
+```bash
+git add mini_app/frontend/package.json mini_app/frontend/package-lock.json
+git commit -m "feat(mini-app): replace @telegram-apps/sdk-react with @tma.js/sdk-react"
+```
+
+---
+
+### Task 3: Создать bootstrap.ts с тестами
+
+**Files:**
+- Create: `mini_app/frontend/src/bootstrap.ts`
+- Create: `mini_app/frontend/src/__tests__/bootstrap.test.ts`
+
+**Step 1: Написать тест на bootstrap**
+
+```typescript
+// mini_app/frontend/src/__tests__/bootstrap.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Мокаем модули до импорта
+const mockSetupMockEnv = vi.fn();
+const mockInit = vi.fn();
+const mockRestore = vi.fn();
+const mockThemeMount = vi.fn();
+const mockThemeBindCss = vi.fn();
+const mockViewportMount = vi.fn(() => Promise.resolve());
+const mockViewportBindCss = vi.fn();
+const mockSwipeMount = vi.fn();
+const mockSwipeDisable = vi.fn();
+
+vi.mock("@tma.js/sdk-react", () => ({
+  init: mockInit,
+  initData: { restore: mockRestore },
+  themeParams: {
+    mount: mockThemeMount,
+    bindCssVars: mockThemeBindCss,
+  },
+  viewport: {
+    mount: Object.assign(mockViewportMount, {
+      isAvailable: vi.fn(() => true),
+    }),
+    bindCssVars: mockViewportBindCss,
+  },
+  swipeBehavior: {
+    isSupported: vi.fn(() => true),
+    mount: mockSwipeMount,
+    disableVerticalSwipe: mockSwipeDisable,
+  },
+}));
+
+vi.mock("@tma.js/bridge", () => ({
+  isTMA: vi.fn(() => Promise.resolve(true)),
+}));
+
+vi.mock("../mockEnv", () => ({
+  setupMockEnv: mockSetupMockEnv,
+}));
+
+vi.mock("eruda", () => ({ default: { init: vi.fn() } }));
+
+describe("bootstrap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls init sequence in correct order", async () => {
+    const { initApp } = await import("../bootstrap");
+    const result = await initApp();
+
+    expect(mockInit).toHaveBeenCalled();
+    expect(mockRestore).toHaveBeenCalled();
+    expect(mockThemeMount).toHaveBeenCalled();
+    expect(mockThemeBindCss).toHaveBeenCalled();
+    expect(result.isTelegram).toBe(true);
+  });
+
+  it("mounts viewport when available", async () => {
+    const { initApp } = await import("../bootstrap");
+    await initApp();
+
+    expect(mockViewportMount).toHaveBeenCalled();
+    expect(mockViewportBindCss).toHaveBeenCalled();
+  });
+
+  it("enables swipe protection when supported", async () => {
+    const { initApp } = await import("../bootstrap");
+    await initApp();
+
+    expect(mockSwipeMount).toHaveBeenCalled();
+    expect(mockSwipeDisable).toHaveBeenCalled();
+  });
+
+  it("returns isTelegram=false when not in TMA", async () => {
+    const bridge = await import("@tma.js/bridge");
+    vi.mocked(bridge.isTMA).mockResolvedValueOnce(false);
+
+    // Нужен resetModules чтобы bootstrap переимпортировался
+    vi.resetModules();
+
+    // Переопределяем моки после resetModules
+    vi.doMock("@tma.js/bridge", () => ({
+      isTMA: vi.fn(() => Promise.resolve(false)),
+    }));
+    vi.doMock("@tma.js/sdk-react", () => ({
+      init: mockInit,
+      initData: { restore: mockRestore },
+      themeParams: { mount: mockThemeMount, bindCssVars: mockThemeBindCss },
+      viewport: {
+        mount: Object.assign(mockViewportMount, { isAvailable: vi.fn(() => true) }),
+        bindCssVars: mockViewportBindCss,
+      },
+      swipeBehavior: {
+        isSupported: vi.fn(() => true),
+        mount: mockSwipeMount,
+        disableVerticalSwipe: mockSwipeDisable,
+      },
+    }));
+    vi.doMock("../mockEnv", () => ({ setupMockEnv: mockSetupMockEnv }));
+    vi.doMock("eruda", () => ({ default: { init: vi.fn() } }));
+
+    const { initApp } = await import("../bootstrap");
+    const result = await initApp();
+
+    expect(result.isTelegram).toBe(false);
+    expect(mockInit).not.toHaveBeenCalled();
+  });
+});
+```
+
+**Step 2: Запустить тест — должен упасть (bootstrap.ts не существует)**
+
+```bash
+cd mini_app/frontend && npx vitest run src/__tests__/bootstrap.test.ts
+```
+
+Expected: FAIL — module not found
+
+**Step 3: Написать bootstrap.ts**
+
+```typescript
+// mini_app/frontend/src/bootstrap.ts
+import {
+  init,
+  initData,
+  themeParams,
+  viewport,
+  swipeBehavior,
+} from "@tma.js/sdk-react";
+import { isTMA } from "@tma.js/bridge";
+import { setupMockEnv } from "./mockEnv";
+
+export type AppBootstrapResult = {
+  isTelegram: boolean;
+};
+
+export async function initApp(): Promise<AppBootstrapResult> {
+  const isDev = import.meta.env.DEV;
+
+  // 1. Mock env (dev + browser only)
+  if (isDev) {
+    setupMockEnv();
+  }
+
+  // 2. Detect environment
+  const isTelegram = isDev ? true : await isTMA("complete");
+
+  if (!isTelegram) {
+    return { isTelegram: false };
+  }
+
+  // 3. SDK init
+  init();
+
+  // 4. Restore initData (user, auth_date, hash)
+  initData.restore();
+
+  // 5. Theme params (mount → bind CSS vars)
+  themeParams.mount();
+  themeParams.bindCssVars();
+
+  // 6. Viewport (async mount → bind CSS vars)
+  if (viewport.mount.isAvailable()) {
+    await viewport.mount();
+    viewport.bindCssVars();
+  }
+
+  // 7. Swipe protection (mount → disable vertical)
+  if (swipeBehavior.isSupported()) {
+    swipeBehavior.mount();
+    swipeBehavior.disableVerticalSwipe();
+  }
+
+  // 8. Eruda (dev only)
+  if (isDev) {
+    import("eruda").then((e) => e.default.init());
+  }
+
+  return { isTelegram: true };
+}
+```
+
+**Step 4: Запустить тест — должен пройти**
+
+```bash
+cd mini_app/frontend && npx vitest run src/__tests__/bootstrap.test.ts
+```
+
+Expected: 4 tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add mini_app/frontend/src/bootstrap.ts mini_app/frontend/src/__tests__/bootstrap.test.ts
+git commit -m "feat(mini-app): add bootstrap.ts with TMA lifecycle init"
+```
+
+---
+
+### Task 4: Создать TelegramGate с тестами
+
+**Files:**
+- Create: `mini_app/frontend/src/guards/TelegramGate.tsx`
+- Create: `mini_app/frontend/src/guards/__tests__/TelegramGate.test.tsx`
+
+**Step 1: Написать тест**
+
+```typescript
+// mini_app/frontend/src/guards/__tests__/TelegramGate.test.tsx
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TelegramGate } from "../TelegramGate";
+
+describe("TelegramGate", () => {
+  it("renders children when isTelegram=true", () => {
+    render(
+      <TelegramGate isTelegram={true}>
+        <div>App Content</div>
+      </TelegramGate>,
+    );
+    expect(screen.getByText("App Content")).toBeInTheDocument();
+  });
+
+  it("renders children in dev mode even when isTelegram=false", () => {
+    const originalDev = import.meta.env.DEV;
+    // В тестах DEV = true по умолчанию
+    render(
+      <TelegramGate isTelegram={false}>
+        <div>App Content</div>
+      </TelegramGate>,
+    );
+    expect(screen.getByText("App Content")).toBeInTheDocument();
+  });
+
+  it("renders fallback when isTelegram=false and not dev", () => {
+    // Мокаем production mode
+    const original = import.meta.env.DEV;
+    import.meta.env.DEV = false;
+
+    render(
+      <TelegramGate isTelegram={false}>
+        <div>App Content</div>
+      </TelegramGate>,
+    );
+
+    expect(screen.queryByText("App Content")).not.toBeInTheDocument();
+    expect(screen.getByText(/Telegram/i)).toBeInTheDocument();
+
+    import.meta.env.DEV = original;
+  });
+});
+```
+
+**Step 2: Запустить тест — должен упасть**
+
+```bash
+cd mini_app/frontend && npx vitest run src/guards/__tests__/TelegramGate.test.tsx
+```
+
+Expected: FAIL — module not found
+
+**Step 3: Написать TelegramGate**
+
+```typescript
+// mini_app/frontend/src/guards/TelegramGate.tsx
+import type { ReactNode } from "react";
+
+interface Props {
+  isTelegram: boolean;
+  children: ReactNode;
+}
+
+export function TelegramGate({ isTelegram, children }: Props) {
+  // В dev mode всегда показываем app (mockEnv работает)
+  if (isTelegram || import.meta.env.DEV) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: "100vh",
+        padding: 32,
+        fontFamily: "system-ui, sans-serif",
+        textAlign: "center",
+        background: "#17212b",
+        color: "#f5f5f5",
+      }}
+    >
+      <h1 style={{ fontSize: 24, marginBottom: 16 }}>
+        Откройте в Telegram
+      </h1>
+      <p style={{ fontSize: 16, color: "#708499", marginBottom: 24 }}>
+        Это приложение работает только внутри Telegram.
+      </p>
+      <a
+        href="https://t.me/FortnoksBot"
+        style={{
+          display: "inline-block",
+          padding: "12px 24px",
+          background: "#5288c1",
+          color: "#fff",
+          borderRadius: 8,
+          textDecoration: "none",
+          fontSize: 16,
+        }}
+      >
+        Открыть в Telegram
+      </a>
+    </div>
+  );
+}
+```
+
+**Step 4: Запустить тест — должен пройти**
+
+```bash
+cd mini_app/frontend && npx vitest run src/guards/__tests__/TelegramGate.test.tsx
+```
+
+Expected: 3 tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add mini_app/frontend/src/guards/TelegramGate.tsx mini_app/frontend/src/guards/__tests__/TelegramGate.test.tsx
+git commit -m "feat(mini-app): add TelegramGate fallback component"
+```
+
+---
+
+### Task 5: Обновить mockEnv.ts — миграция импортов
+
+**Files:**
+- Modify: `mini_app/frontend/src/mockEnv.ts`
+
+**Step 1: Обновить импорты**
+
+Заменить:
+```typescript
+import { mockTelegramEnv, isTMA } from "@telegram-apps/sdk-react";
+```
+
+На:
+```typescript
+import { mockTelegramEnv, isTMA } from "@tma.js/bridge";
+```
+
+Логика и API `mockTelegramEnv` идентичны — меняется только пакет.
+
+**Step 2: Запустить тесты mockEnv**
+
+```bash
+cd mini_app/frontend && npx vitest run src/__tests__/mockEnv.test.ts
+```
+
+Expected: PASS (мок в test-setup перехватит)
+
+**Step 3: Commit**
+
+```bash
+git add mini_app/frontend/src/mockEnv.ts
+git commit -m "refactor(mini-app): migrate mockEnv imports to @tma.js/bridge"
+```
+
+---
+
+### Task 6: Обновить страницы — миграция импортов
+
+**Files:**
+- Modify: `mini_app/frontend/src/pages/ExpertSheet.tsx`
+- Modify: `mini_app/frontend/src/pages/QuestionSheet.tsx`
+
+**Step 1: ExpertSheet.tsx — обновить импорт**
+
+Заменить:
+```typescript
+import { openTelegramLink, initData } from "@telegram-apps/sdk-react";
+```
+
+На:
+```typescript
+import { openTelegramLink, initData } from "@tma.js/sdk-react";
+```
+
+**Step 2: QuestionSheet.tsx — обновить импорт**
+
+Заменить:
+```typescript
+import { closeMiniApp, sendData } from "@telegram-apps/sdk-react";
+```
+
+На:
+```typescript
+import { closeMiniApp, sendData } from "@tma.js/sdk-react";
+```
+
+**Step 3: Commit**
+
+```bash
+git add mini_app/frontend/src/pages/ExpertSheet.tsx mini_app/frontend/src/pages/QuestionSheet.tsx
+git commit -m "refactor(mini-app): migrate page imports to @tma.js/sdk-react"
+```
+
+---
+
+### Task 7: Обновить test-setup и тесты — миграция моков
+
+**Files:**
+- Modify: `mini_app/frontend/src/test-setup.ts`
+- Modify: `mini_app/frontend/src/__tests__/main.test.tsx`
+- Modify: `mini_app/frontend/src/pages/__tests__/ExpertSheet.test.tsx`
+- Modify: `mini_app/frontend/src/pages/__tests__/QuestionSheet.test.tsx`
+- Modify: `mini_app/frontend/src/__tests__/mockEnv.test.ts`
+
+**Step 1: test-setup.ts — обновить глобальный мок**
+
+Заменить весь блок `vi.mock("@telegram-apps/sdk-react", ...)`:
+
+```typescript
+// Mock @tma.js/sdk-react для тестов
+vi.mock("@tma.js/sdk-react", () => ({
+  init: vi.fn(),
+  openTelegramLink: Object.assign(vi.fn(), {
+    isAvailable: vi.fn(() => true),
+    ifAvailable: vi.fn(),
+  }),
+  closeMiniApp: Object.assign(vi.fn(), { ifAvailable: vi.fn() }),
+  sendData: Object.assign(vi.fn(), { ifAvailable: vi.fn() }),
+  initData: {
+    user: () => ({ id: 99999, firstName: "Test" }),
+    restore: vi.fn(),
+  },
+  themeParams: {
+    mount: vi.fn(),
+    bindCssVars: vi.fn(),
+  },
+  viewport: {
+    mount: Object.assign(vi.fn(() => Promise.resolve()), {
+      isAvailable: vi.fn(() => true),
+    }),
+    bindCssVars: vi.fn(),
+  },
+  swipeBehavior: {
+    isSupported: vi.fn(() => true),
+    mount: vi.fn(),
+    disableVerticalSwipe: vi.fn(),
+  },
+  parseInitData: vi.fn(),
+}));
+
+// Mock @tma.js/bridge
+vi.mock("@tma.js/bridge", () => ({
+  mockTelegramEnv: vi.fn(),
+  isTMA: vi.fn(() => false),
+}));
+```
+
+**Step 2: main.test.tsx — обновить доки на новые пакеты**
+
+Все `'@telegram-apps/sdk-react'` → `'@tma.js/sdk-react'`.
+Добавить мок `@tma.js/bridge`.
+Обновить мок SDK: убрать `mountThemeParamsSync`/`bindThemeParamsCssVars`, добавить `themeParams`/`viewport`/`swipeBehavior`.
+
+Тест полностью переписывается под новый `main.tsx` (который будет вызывать `initApp()`).
+
+**Step 3: ExpertSheet.test.tsx и QuestionSheet.test.tsx**
+
+Заменить `import * as sdkReact from '@telegram-apps/sdk-react'` на `import * as sdkReact from '@tma.js/sdk-react'`.
+
+**Step 4: mockEnv.test.ts**
+
+Заменить `import * as sdkReact from '@telegram-apps/sdk-react'` на `import * as bridge from '@tma.js/bridge'`.
+Обновить мок вызовы соответственно.
+
+**Step 5: Запустить все тесты**
+
+```bash
+cd mini_app/frontend && npm test
+```
+
+Expected: Все тесты PASS
+
+**Step 6: Commit**
+
+```bash
+git add mini_app/frontend/src/test-setup.ts mini_app/frontend/src/__tests__/ mini_app/frontend/src/pages/__tests__/
+git commit -m "refactor(mini-app): migrate all test mocks to @tma.js packages"
+```
+
+---
+
+### Task 8: Переписать main.tsx на bootstrap + TelegramGate
+
+**Files:**
+- Modify: `mini_app/frontend/src/main.tsx`
+- Modify: `mini_app/frontend/src/__tests__/main.test.tsx`
+
+**Step 1: Обновить main.test.tsx**
+
+```typescript
+// mini_app/frontend/src/__tests__/main.test.tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("main.tsx", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    document.body.innerHTML = '<div id="root"></div>';
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("calls initApp and renders", async () => {
+    const mockRender = vi.fn();
+    const mockCreateRoot = vi.fn(() => ({ render: mockRender }));
+
+    vi.doMock("react-dom/client", () => ({ createRoot: mockCreateRoot }));
+    vi.doMock("../bootstrap", () => ({
+      initApp: vi.fn(() => Promise.resolve({ isTelegram: true })),
+    }));
+    vi.doMock("../App", () => ({ App: () => null }));
+    vi.doMock("../guards/TelegramGate", () => ({
+      TelegramGate: ({ children }: { children: React.ReactNode }) => children,
+    }));
+    vi.doMock("../ErrorBoundary", () => ({
+      ErrorBoundary: ({ children }: { children: React.ReactNode }) => children,
+    }));
+
+    await import("../main");
+
+    // Ждём async initApp
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockCreateRoot).toHaveBeenCalled();
+    expect(mockRender).toHaveBeenCalled();
+  });
+});
+```
+
+**Step 2: Переписать main.tsx**
+
+```typescript
+// mini_app/frontend/src/main.tsx
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import { ErrorBoundary } from "./ErrorBoundary";
+import { TelegramGate } from "./guards/TelegramGate";
+import { initApp } from "./bootstrap";
+
+const { isTelegram } = await initApp();
+
+createRoot(document.getElementById("root")!).render(
+  <ErrorBoundary>
+    <TelegramGate isTelegram={isTelegram}>
+      <App />
+    </TelegramGate>
+  </ErrorBoundary>,
+);
+```
+
+**Step 3: Запустить все тесты**
+
+```bash
+cd mini_app/frontend && npm test
+```
+
+Expected: Все тесты PASS
+
+**Step 4: Проверить build**
+
+```bash
+cd mini_app/frontend && npm run build
+```
+
+Expected: tsc + vite build OK
+
+**Step 5: Commit**
+
+```bash
+git add mini_app/frontend/src/main.tsx mini_app/frontend/src/__tests__/main.test.tsx
+git commit -m "refactor(mini-app): rewrite main.tsx to use bootstrap + TelegramGate"
+```
+
+---
+
+### Task 9: Обновить правила .claude/rules/mini-app.md
+
+**Files:**
+- Modify: `.claude/rules/mini-app.md`
+
+**Step 1: Обновить секцию SDK**
+
+Заменить `@telegram-apps/sdk-react` на `@tma.js/sdk-react` во всех упоминаниях.
+Обновить порядок инициализации на новый (bootstrap.ts).
+Добавить viewport и swipeBehavior в таблицу API.
+
+**Step 2: Обновить секцию Архитектура**
+
+Добавить `bootstrap.ts` и `guards/TelegramGate.tsx` в дерево файлов.
+
+**Step 3: Commit**
+
+```bash
+git add .claude/rules/mini-app.md
+git commit -m "docs(mini-app): update rules for @tma.js/sdk-react migration"
+```
+
+---
+
+### Task 10: Финальная верификация
+
+**Step 1: Все тесты**
+
+```bash
+cd mini_app/frontend && npm test
+```
+
+Expected: Все тесты PASS (должно быть ~55+ тестов)
+
+**Step 2: Build check**
+
+```bash
+cd mini_app/frontend && npm run build
+```
+
+Expected: OK
+
+**Step 3: Backend checks (не сломали ли что-то)**
+
+```bash
+make check
+```
+
+Expected: OK (mini_app frontend не влияет на Python lint/mypy)
+
+**Step 4: Dev server smoke test**
+
+```bash
+cd mini_app/frontend && npx vite --host &
+sleep 3
+# Открыть http://localhost:5173 — должен работать с mock env
+kill %1
+```
+
+**Step 5: Commit финального состояния (если есть незакоммиченное)**
+
+```bash
+git status
+# Если чисто — ничего не делать
+```

--- a/mini_app/frontend/package-lock.json
+++ b/mini_app/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "fortnoks-mini-app",
       "version": "0.1.0",
       "dependencies": {
-        "@telegram-apps/sdk-react": "^3.0.0",
+        "@tma.js/sdk-react": "^3.0.16",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "react-router-dom": "^6.26.0",
@@ -1423,109 +1423,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@telegram-apps/bridge": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/bridge/-/bridge-2.11.0.tgz",
-      "integrity": "sha512-kBZjWRRp/lxKeQ8r8cDWUY9EjxUtyeh/9xTQjsjuGRsCR5XTO1cyVbvcvqzHn53csGx3aBs+fOR3Pk3b6w2JHg==",
-      "deprecated": "This package is not supported anymore. Use @tma.js/bridge instead",
-      "license": "MIT",
-      "dependencies": {
-        "@telegram-apps/signals": "^1.1.2",
-        "@telegram-apps/toolkit": "^2.1.3",
-        "@telegram-apps/transformers": "^2.2.6",
-        "@telegram-apps/types": "^2.0.3",
-        "better-promises": "^0.4.1",
-        "error-kid": "^0.0.7",
-        "mitt": "^3.0.1",
-        "valibot": "1.0.0"
-      }
-    },
-    "node_modules/@telegram-apps/navigation": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/navigation/-/navigation-1.0.14.tgz",
-      "integrity": "sha512-bqNgF/J8Po7ZtsELm3E1a6aPr7awwxO3sIqD8J6u12urOlGoW5+1KxKKbkPa58mgXuQdsltd8apI+OVy0IYiUA==",
-      "license": "MIT"
-    },
-    "node_modules/@telegram-apps/sdk": {
-      "version": "3.11.8",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/sdk/-/sdk-3.11.8.tgz",
-      "integrity": "sha512-vlpkYzMJCV9Cadsn9Q+/hbHNR39j5o96N9z4CjZ6AFHkkxOeOqVRrq9zRBw0gmffROkF2bU0WQxhRj8KZ/bPhw==",
-      "license": "MIT",
-      "dependencies": {
-        "@telegram-apps/bridge": "^2.11.0",
-        "@telegram-apps/navigation": "^1.0.14",
-        "@telegram-apps/signals": "^1.1.2",
-        "@telegram-apps/toolkit": "^2.1.3",
-        "@telegram-apps/transformers": "^2.2.6",
-        "@telegram-apps/types": "^2.0.3",
-        "better-promises": "^0.4.1",
-        "error-kid": "^0.0.7",
-        "valibot": "1.0.0"
-      }
-    },
-    "node_modules/@telegram-apps/sdk-react": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/sdk-react/-/sdk-react-3.3.9.tgz",
-      "integrity": "sha512-85jF1ICT8sYCNzXu19SqJrfrS8XslsvV14KUcToiyL7H5ZMXHt0JQKM+QJgULjnLjEswweQ4/7Bd7mNULf/BIg==",
-      "license": "MIT",
-      "dependencies": {
-        "@telegram-apps/sdk": "^3.11.8"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@telegram-apps/signals": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/signals/-/signals-1.1.2.tgz",
-      "integrity": "sha512-1P1kdCLX7MfETGPxH7f3UZKIsdE7Tz5S7QmN4Km1sbYQMakD5Bi1NecSMR7/wnHp50gWMI1JzENcMtCEmouhSg==",
-      "license": "MIT"
-    },
-    "node_modules/@telegram-apps/toolkit": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/toolkit/-/toolkit-2.1.3.tgz",
-      "integrity": "sha512-LPUBL7hxQTOr+Dowyk9a1O82nQS4ja4+OYiYWtvqq5nNUHC6Gbbus0zGWCbFcj9CLnIzaeb5HWOg5iSnhoRcyg==",
-      "license": "MIT"
-    },
-    "node_modules/@telegram-apps/transformers": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/transformers/-/transformers-2.2.6.tgz",
-      "integrity": "sha512-MMBRs3demeBT9Cd614KKZmak7eEyNdEbfu99a0SwEEJe2oIODjJLrUxrhUcAOc5wvTRfrKka27VXVgruauLhdg==",
-      "deprecated": "This package is not supported anymore. Use @tma.js/transfomers instead",
-      "license": "MIT",
-      "dependencies": {
-        "@telegram-apps/toolkit": "^2.1.3",
-        "@telegram-apps/types": "^2.0.3",
-        "valibot": "1.0.0-beta.14"
-      }
-    },
-    "node_modules/@telegram-apps/transformers/node_modules/valibot": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.0.0-beta.14.tgz",
-      "integrity": "sha512-tLyV2rE5QL6U29MFy3xt4AqMrn+/HErcp2ZThASnQvPMwfSozjV1uBGKIGiegtZIGjinJqn0SlBdannf18wENA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "typescript": ">=5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@telegram-apps/types": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/types/-/types-2.0.3.tgz",
-      "integrity": "sha512-pXh9BdnLZF3e2BGc4WL+RTRMAUpqKpaSP3Rs8rB4WyRwIoRSGWFKE4gtT/9m42LGixB8YVwdo/pJ+9XO765XEA==",
-      "deprecated": "This package is not supported anymore. Use @tma.js/types instead",
-      "license": "MIT"
-    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -1615,6 +1512,92 @@
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
       }
+    },
+    "node_modules/@tma.js/bridge": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@tma.js/bridge/-/bridge-2.2.3.tgz",
+      "integrity": "sha512-R+FQTxaFbQVBgtegfCvOU4SH1TcXhgGvFotNzrtsaRmiuPlvsMNSbtslfsysg0Yv3d6svAPAWJ1PJjimAopfag==",
+      "license": "MIT",
+      "dependencies": {
+        "@tma.js/signals": "^1.0.1",
+        "@tma.js/toolkit": "^1.0.4",
+        "@tma.js/transformers": "^1.1.3",
+        "@tma.js/types": "^1.0.2",
+        "better-promises": "^1.0.0",
+        "error-kid": "^1.0.2",
+        "fp-ts": "^2.16.11",
+        "mitt": "^3.0.1",
+        "valibot": "^1.1.0"
+      }
+    },
+    "node_modules/@tma.js/sdk": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@tma.js/sdk/-/sdk-3.1.7.tgz",
+      "integrity": "sha512-yHYqr+Gwj2wptmkceYAZ+ZPOV1Tv3f/UpJTkpngUt7shZg2vJQnZINnHC93iqznLo/Vqr15TO8UGzOdBQ7rhNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tma.js/bridge": "^2.2.3",
+        "@tma.js/signals": "^1.0.1",
+        "@tma.js/toolkit": "^1.0.4",
+        "@tma.js/transformers": "^1.1.3",
+        "@tma.js/types": "^1.0.2",
+        "better-promises": "^1.0.0",
+        "error-kid": "^1.0.2",
+        "fp-ts": "^2.16.11",
+        "valibot": "^1.1.0"
+      }
+    },
+    "node_modules/@tma.js/sdk-react": {
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@tma.js/sdk-react/-/sdk-react-3.0.16.tgz",
+      "integrity": "sha512-/DhMV6jwLh2Yja/gGrZu4CTWt0enC1tbG6Bp0lfUUHK0x+9q90z+zCN0XuytNKk1gedZfmzpeTyR/4sroW2CLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tma.js/sdk": "^3.1.7"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tma.js/signals": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tma.js/signals/-/signals-1.0.1.tgz",
+      "integrity": "sha512-i2HUuwGqL4BmM5KAklAUhMhlEgUOF+F4nMHHS/zxrmD0upHE/0CiXCEdQxVeeOGN6e2RrKlonA40sDtR6OUDCw==",
+      "license": "MIT"
+    },
+    "node_modules/@tma.js/toolkit": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tma.js/toolkit/-/toolkit-1.0.4.tgz",
+      "integrity": "sha512-6CDlkgc+43WD2jy6jog3B50yt9t+/wRwrN25zOa4iSw4IzfqoFjaQcJzTupBYaRxz19C3Rrir7p0/qStS/Z8vw==",
+      "license": "MIT",
+      "dependencies": {
+        "better-promises": "^1.0.0",
+        "fp-ts": "^2.16.11"
+      }
+    },
+    "node_modules/@tma.js/transformers": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@tma.js/transformers/-/transformers-1.1.3.tgz",
+      "integrity": "sha512-zRL+fdo/NBpGqCJfl8ItAvcJIFT5Zy6UOYJwQPmUV5/gTHgmSvmGlrP43PeVi9XZ7Ggf4xbO6LUa4ehxozhMTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tma.js/toolkit": "^1.0.4",
+        "@tma.js/types": "^1.0.2",
+        "fp-ts": "^2.16.11",
+        "valibot": "^1.1.0"
+      }
+    },
+    "node_modules/@tma.js/types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tma.js/types/-/types-1.0.2.tgz",
+      "integrity": "sha512-qs4mi+U1xZmMQBdMhWAo1X4YqUJ/ae0y28s+GNCpQq58bsJo0h8rvyVOB1RwPvXogIY9+yribbZe6z3AIJmsAQ==",
+      "license": "MIT"
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
@@ -1895,12 +1878,12 @@
       }
     },
     "node_modules/better-promises": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/better-promises/-/better-promises-0.4.1.tgz",
-      "integrity": "sha512-cDW7eMvhvCoWzSih5o/OxsAgTUfP05yGMq77xNZUTmcZoNU9vEeFZJ+yJJi4lnocvxFrVFKsG0Yxt7ZnuYJEig==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/better-promises/-/better-promises-1.0.0.tgz",
+      "integrity": "sha512-gPgL2nRgeSbMIe3QpsYdKR3K0S9OZuphVuos60Eqsw8d/6GivOkyJ5D/zmnolJ6hzh7upnnflBUWUlQh4qpU2A==",
       "license": "MIT",
       "dependencies": {
-        "error-kid": "^0.0.7"
+        "error-kid": "^1.0.1"
       }
     },
     "node_modules/bidi-js": {
@@ -2117,9 +2100,9 @@
       }
     },
     "node_modules/error-kid": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/error-kid/-/error-kid-0.0.7.tgz",
-      "integrity": "sha512-8mFs7ZaDWlBFgjOy4lHLMCe2+KZfZXGx5GOgh2VQ/M1CCIvSWzbl2OMl+5fdZgrgoUfhTeF+NPhmqfEvUhN8yw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/error-kid/-/error-kid-1.0.2.tgz",
+      "integrity": "sha512-Xvq0ZrY/azCbREWKt9E/3mXDF0MkuEVVvHnOKutUhtq2O8pyneEixQ4nSFkA19Xfn+/OVSg//iVG0dxIDj7DIA==",
       "license": "MIT"
     },
     "node_modules/eruda": {
@@ -2222,6 +2205,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fp-ts": {
+      "version": "2.16.11",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.11.tgz",
+      "integrity": "sha512-LaI+KaX2NFkfn1ZGHoKCmcfv7yrZsC3b8NtWsTVQeHkq4F27vI5igUuO53sxqDEa2gNQMHFPmpojDw/1zmUK7w==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2968,9 +2957,9 @@
       }
     },
     "node_modules/valibot": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.0.0.tgz",
-      "integrity": "sha512-1Hc0ihzWxBar6NGeZv7fPLY0QuxFMyxwYR2sF1Blu7Wq7EnremwY2W02tit2ij2VJT8HcSkHAQqmFfl77f73Yw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
+      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">=5"

--- a/mini_app/frontend/package.json
+++ b/mini_app/frontend/package.json
@@ -11,7 +11,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@telegram-apps/sdk-react": "^3.0.0",
+    "@tma.js/sdk-react": "^3.0.16",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "react-router-dom": "^6.26.0",

--- a/mini_app/frontend/src/__tests__/bootstrap.test.ts
+++ b/mini_app/frontend/src/__tests__/bootstrap.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterAll, beforeAll } from "vitest";
+
+// Мокаем модули до импорта
+const mockSetupMockEnv = vi.fn();
+const mockInit = vi.fn();
+const mockRestore = vi.fn();
+const mockThemeMount = vi.fn();
+const mockThemeBindCss = vi.fn();
+const mockViewportMount = vi.fn(() => Promise.resolve());
+const mockViewportBindCss = vi.fn();
+const mockSwipeMount = vi.fn();
+const mockSwipeDisable = vi.fn();
+
+vi.mock("@tma.js/sdk-react", () => ({
+  init: mockInit,
+  initData: { restore: mockRestore },
+  themeParams: {
+    mount: mockThemeMount,
+    bindCssVars: mockThemeBindCss,
+  },
+  viewport: {
+    mount: Object.assign(mockViewportMount, {
+      isAvailable: vi.fn(() => true),
+    }),
+    bindCssVars: mockViewportBindCss,
+  },
+  swipeBehavior: {
+    isSupported: vi.fn(() => true),
+    mount: mockSwipeMount,
+    disableVertical: mockSwipeDisable,
+  },
+}));
+
+vi.mock("@tma.js/bridge", () => ({
+  isTMA: vi.fn(() => Promise.resolve(true)),
+}));
+
+vi.mock("../mockEnv", () => ({
+  setupMockEnv: mockSetupMockEnv,
+}));
+
+vi.mock("eruda", () => ({ default: { init: vi.fn() } }));
+
+describe("bootstrap", () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls init sequence in correct order", async () => {
+    const { initApp } = await import("../bootstrap");
+    const result = await initApp();
+
+    expect(mockInit).toHaveBeenCalled();
+    expect(mockRestore).toHaveBeenCalled();
+    expect(mockThemeMount).toHaveBeenCalled();
+    expect(mockThemeBindCss).toHaveBeenCalled();
+    expect(result.isTelegram).toBe(true);
+  });
+
+  it("mounts viewport when available", async () => {
+    const { initApp } = await import("../bootstrap");
+    await initApp();
+
+    expect(mockViewportMount).toHaveBeenCalled();
+    expect(mockViewportBindCss).toHaveBeenCalled();
+  });
+
+  it("enables swipe protection when supported", async () => {
+    const { initApp } = await import("../bootstrap");
+    await initApp();
+
+    expect(mockSwipeMount).toHaveBeenCalled();
+    expect(mockSwipeDisable).toHaveBeenCalled();
+  });
+
+  it("returns isTelegram=false when not in TMA", async () => {
+    const bridge = await import("@tma.js/bridge");
+    vi.mocked(bridge.isTMA).mockResolvedValueOnce(false);
+
+    const { initApp } = await import("../bootstrap");
+    const result = await initApp();
+
+    expect(result.isTelegram).toBe(false);
+    expect(mockInit).not.toHaveBeenCalled();
+  });
+});

--- a/mini_app/frontend/src/__tests__/main.test.tsx
+++ b/mini_app/frontend/src/__tests__/main.test.tsx
@@ -4,73 +4,34 @@ describe('main.tsx', () => {
   beforeEach(() => {
     vi.resetModules();
     document.body.innerHTML = '<div id="root"></div>';
-    vi.doMock('react-dom/client', () => ({
-      createRoot: vi.fn(() => ({ render: vi.fn() })),
-    }));
-    vi.doMock('../App', () => ({ App: () => null }));
-    vi.doMock('../mockEnv', () => ({ setupMockEnv: vi.fn() }));
-    vi.doMock('@telegram-apps/sdk-react', () => ({
-      init: vi.fn(),
-      initData: { restore: vi.fn() },
-      mountThemeParamsSync: vi.fn(),
-      bindThemeParamsCssVars: vi.fn(),
-    }));
   });
 
   afterEach(() => {
     vi.resetModules();
   });
 
-  it('imports without throwing', async () => {
-    await expect(import('../main')).resolves.not.toThrow();
-  });
+  it('calls initApp and renders', async () => {
+    const mockRender = vi.fn();
+    const mockCreateRoot = vi.fn(() => ({ render: mockRender }));
 
-  it('calls SDK init on load', async () => {
-    const { init } = await import('@telegram-apps/sdk-react');
-    await import('../main');
-    expect(init).toHaveBeenCalled();
-  });
-
-  it('restores initData after init', async () => {
-    const { initData } = await import('@telegram-apps/sdk-react');
-    await import('../main');
-    expect(initData.restore).toHaveBeenCalled();
-  });
-
-  it('calls setupMockEnv before init', async () => {
-    const callOrder: string[] = [];
-
-    vi.doMock('../mockEnv', () => ({
-      setupMockEnv: vi.fn(() => {
-        callOrder.push('setupMockEnv');
-      }),
+    vi.doMock('react-dom/client', () => ({ createRoot: mockCreateRoot }));
+    vi.doMock('../bootstrap', () => ({
+      initApp: vi.fn(() => Promise.resolve({ isTelegram: true })),
     }));
-    vi.doMock('@telegram-apps/sdk-react', () => ({
-      init: vi.fn(() => {
-        callOrder.push('init');
-      }),
-      initData: { restore: vi.fn() },
-      mountThemeParamsSync: vi.fn(),
-      bindThemeParamsCssVars: vi.fn(),
+    vi.doMock('../App', () => ({ App: () => null }));
+    vi.doMock('../guards/TelegramGate', () => ({
+      TelegramGate: ({ children }: { children: React.ReactNode }) => children,
+    }));
+    vi.doMock('../ErrorBoundary', () => ({
+      ErrorBoundary: ({ children }: { children: React.ReactNode }) => children,
     }));
 
     await import('../main');
 
-    const setupIdx = callOrder.indexOf('setupMockEnv');
-    const initIdx = callOrder.indexOf('init');
+    // Ждём async initApp
+    await new Promise((r) => setTimeout(r, 0));
 
-    expect(setupIdx).toBeGreaterThanOrEqual(0);
-    expect(initIdx).toBeGreaterThanOrEqual(0);
-    expect(setupIdx).toBeLessThan(initIdx);
-  });
-
-  it('calls init after mockEnv', async () => {
-    const { init } = await import('@telegram-apps/sdk-react');
-    const { setupMockEnv } = await import('../mockEnv');
-
-    await import('../main');
-
-    expect(setupMockEnv).toHaveBeenCalled();
-    expect(init).toHaveBeenCalled();
+    expect(mockCreateRoot).toHaveBeenCalled();
+    expect(mockRender).toHaveBeenCalled();
   });
 });

--- a/mini_app/frontend/src/__tests__/mockEnv.test.ts
+++ b/mini_app/frontend/src/__tests__/mockEnv.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import * as sdkReact from '@telegram-apps/sdk-react';
+import * as bridge from '@tma.js/bridge';
 
 describe('setupMockEnv', () => {
   beforeEach(() => {
@@ -11,8 +11,8 @@ describe('setupMockEnv', () => {
   });
 
   it('does nothing when isTMA returns true', async () => {
-    vi.spyOn(sdkReact, 'isTMA').mockReturnValue(true as unknown as ReturnType<typeof sdkReact.isTMA>);
-    const mockTelegramEnvSpy = vi.spyOn(sdkReact, 'mockTelegramEnv');
+    vi.spyOn(bridge, 'isTMA').mockReturnValue(true as unknown as ReturnType<typeof bridge.isTMA>);
+    const mockTelegramEnvSpy = vi.spyOn(bridge, 'mockTelegramEnv');
 
     const { setupMockEnv } = await import('../mockEnv');
     setupMockEnv();
@@ -21,8 +21,8 @@ describe('setupMockEnv', () => {
   });
 
   it('calls mockTelegramEnv when not in TMA', async () => {
-    vi.spyOn(sdkReact, 'isTMA').mockReturnValue(false as unknown as ReturnType<typeof sdkReact.isTMA>);
-    const mockTelegramEnvSpy = vi.spyOn(sdkReact, 'mockTelegramEnv');
+    vi.spyOn(bridge, 'isTMA').mockReturnValue(false as unknown as ReturnType<typeof bridge.isTMA>);
+    const mockTelegramEnvSpy = vi.spyOn(bridge, 'mockTelegramEnv');
 
     const { setupMockEnv } = await import('../mockEnv');
     setupMockEnv();
@@ -31,8 +31,8 @@ describe('setupMockEnv', () => {
   });
 
   it('passes correct launchParams structure', async () => {
-    vi.spyOn(sdkReact, 'isTMA').mockReturnValue(false as unknown as ReturnType<typeof sdkReact.isTMA>);
-    const mockTelegramEnvSpy = vi.spyOn(sdkReact, 'mockTelegramEnv');
+    vi.spyOn(bridge, 'isTMA').mockReturnValue(false as unknown as ReturnType<typeof bridge.isTMA>);
+    const mockTelegramEnvSpy = vi.spyOn(bridge, 'mockTelegramEnv');
 
     const { setupMockEnv } = await import('../mockEnv');
     setupMockEnv();

--- a/mini_app/frontend/src/bootstrap.ts
+++ b/mini_app/frontend/src/bootstrap.ts
@@ -1,0 +1,58 @@
+import {
+  init,
+  initData,
+  themeParams,
+  viewport,
+  swipeBehavior,
+} from "@tma.js/sdk-react";
+import { isTMA } from "@tma.js/bridge";
+import { setupMockEnv } from "./mockEnv";
+
+export type AppBootstrapResult = {
+  isTelegram: boolean;
+};
+
+export async function initApp(): Promise<AppBootstrapResult> {
+  const isDev = import.meta.env.DEV;
+
+  // 1. Mock env (dev + browser only)
+  if (isDev) {
+    setupMockEnv();
+  }
+
+  // 2. Detect environment (setupMockEnv ensures isTMA returns true in browser dev)
+  const isTelegram = await isTMA("complete");
+
+  if (!isTelegram) {
+    return { isTelegram: false };
+  }
+
+  // 3. SDK init
+  init();
+
+  // 4. Restore initData (user, auth_date, hash)
+  initData.restore();
+
+  // 5. Theme params (mount → bind CSS vars)
+  themeParams.mount();
+  themeParams.bindCssVars();
+
+  // 6. Viewport (async mount → bind CSS vars)
+  if (viewport.mount.isAvailable()) {
+    await viewport.mount();
+    viewport.bindCssVars();
+  }
+
+  // 7. Swipe protection (mount → disable vertical)
+  if (swipeBehavior.isSupported()) {
+    swipeBehavior.mount();
+    swipeBehavior.disableVertical();
+  }
+
+  // 8. Eruda (dev only)
+  if (isDev) {
+    import("eruda").then((e) => e.default.init());
+  }
+
+  return { isTelegram: true };
+}

--- a/mini_app/frontend/src/guards/TelegramGate.tsx
+++ b/mini_app/frontend/src/guards/TelegramGate.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from "react";
+
+interface Props {
+  isTelegram: boolean;
+  children: ReactNode;
+}
+
+export function TelegramGate({ isTelegram, children }: Props) {
+  // В dev mode всегда показываем app (mockEnv работает)
+  if (isTelegram || import.meta.env.DEV) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: "100vh",
+        padding: 32,
+        fontFamily: "system-ui, sans-serif",
+        textAlign: "center",
+        background: "#17212b",
+        color: "#f5f5f5",
+      }}
+    >
+      <h1 style={{ fontSize: 24, marginBottom: 16 }}>Откройте в Telegram</h1>
+      <p style={{ fontSize: 16, color: "#708499", marginBottom: 24 }}>
+        Это приложение работает только внутри Telegram.
+      </p>
+      <a
+        href="https://t.me/FortnoksBot"
+        style={{
+          display: "inline-block",
+          padding: "12px 24px",
+          background: "#5288c1",
+          color: "#fff",
+          borderRadius: 8,
+          textDecoration: "none",
+          fontSize: 16,
+        }}
+      >
+        Открыть в Telegram
+      </a>
+    </div>
+  );
+}

--- a/mini_app/frontend/src/guards/__tests__/TelegramGate.test.tsx
+++ b/mini_app/frontend/src/guards/__tests__/TelegramGate.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TelegramGate } from "../TelegramGate";
+
+describe("TelegramGate", () => {
+  it("renders children when isTelegram=true", () => {
+    render(
+      <TelegramGate isTelegram={true}>
+        <div>App Content</div>
+      </TelegramGate>,
+    );
+    expect(screen.getByText("App Content")).toBeInTheDocument();
+  });
+
+  it("renders children in dev mode even when isTelegram=false", () => {
+    // В тестах DEV = true по умолчанию
+    render(
+      <TelegramGate isTelegram={false}>
+        <div>App Content</div>
+      </TelegramGate>,
+    );
+    expect(screen.getByText("App Content")).toBeInTheDocument();
+  });
+
+  it("renders fallback when isTelegram=false and not dev", () => {
+    // Мокаем production mode
+    const original = import.meta.env.DEV;
+    import.meta.env.DEV = false;
+
+    render(
+      <TelegramGate isTelegram={false}>
+        <div>App Content</div>
+      </TelegramGate>,
+    );
+
+    expect(screen.queryByText("App Content")).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Telegram/i })).toBeInTheDocument();
+
+    import.meta.env.DEV = original;
+  });
+});

--- a/mini_app/frontend/src/main.tsx
+++ b/mini_app/frontend/src/main.tsx
@@ -4,12 +4,12 @@ import { ErrorBoundary } from "./ErrorBoundary";
 import { TelegramGate } from "./guards/TelegramGate";
 import { initApp } from "./bootstrap";
 
-const { isTelegram } = await initApp();
-
-createRoot(document.getElementById("root")!).render(
-  <ErrorBoundary>
-    <TelegramGate isTelegram={isTelegram}>
-      <App />
-    </TelegramGate>
-  </ErrorBoundary>,
-);
+initApp().then(({ isTelegram }) => {
+  createRoot(document.getElementById("root")!).render(
+    <ErrorBoundary>
+      <TelegramGate isTelegram={isTelegram}>
+        <App />
+      </TelegramGate>
+    </ErrorBoundary>,
+  );
+});

--- a/mini_app/frontend/src/main.tsx
+++ b/mini_app/frontend/src/main.tsx
@@ -1,35 +1,15 @@
 import { createRoot } from "react-dom/client";
-import {
-  init,
-  initData,
-  mountThemeParamsSync,
-  bindThemeParamsCssVars,
-} from "@telegram-apps/sdk-react";
 import { App } from "./App";
 import { ErrorBoundary } from "./ErrorBoundary";
-import { setupMockEnv } from "./mockEnv";
+import { TelegramGate } from "./guards/TelegramGate";
+import { initApp } from "./bootstrap";
 
-// Mock env BEFORE any SDK calls — only activates in browser
-setupMockEnv();
+const { isTelegram } = await initApp();
 
-// Init Eruda in development
-if (import.meta.env.DEV) {
-  import("eruda").then(({ default: eruda }) => eruda.init());
-}
-
-// SDK init
-init();
-
-// Restore init data (user, auth_date, hash, etc.)
-initData.restore();
-
-// Mount theme params and bind --tg-theme-* CSS variables
-mountThemeParamsSync();
-bindThemeParamsCssVars();
-
-// Render
 createRoot(document.getElementById("root")!).render(
   <ErrorBoundary>
-    <App />
+    <TelegramGate isTelegram={isTelegram}>
+      <App />
+    </TelegramGate>
   </ErrorBoundary>,
 );

--- a/mini_app/frontend/src/mockEnv.ts
+++ b/mini_app/frontend/src/mockEnv.ts
@@ -1,4 +1,4 @@
-import { mockTelegramEnv, isTMA } from "@telegram-apps/sdk-react";
+import { mockTelegramEnv, isTMA } from "@tma.js/bridge";
 
 /**
  * Мок Telegram окружения для разработки в браузере.

--- a/mini_app/frontend/src/pages/ExpertSheet.tsx
+++ b/mini_app/frontend/src/pages/ExpertSheet.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { openTelegramLink, initData } from "@telegram-apps/sdk-react";
+import { openTelegramLink, initData } from "@tma.js/sdk-react";
 import { fetchConfig, remoteLog, startExpert } from "../api";
 import { BottomSheet } from "../components/BottomSheet";
 import { ChatInput } from "../components/ChatInput";

--- a/mini_app/frontend/src/pages/QuestionSheet.tsx
+++ b/mini_app/frontend/src/pages/QuestionSheet.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { closeMiniApp, sendData } from "@tma.js/sdk-react";
+import { miniApp, sendData } from "@tma.js/sdk-react";
 import { fetchConfig } from "../api";
 import { BottomSheet } from "../components/BottomSheet";
 import { PromptRow } from "../components/PromptRow";
@@ -22,7 +22,7 @@ export function QuestionSheet() {
 
   const handlePrompt = (text: string) => {
     sendData.ifAvailable(text);
-    closeMiniApp.ifAvailable();
+    miniApp.close.ifAvailable();
   };
 
   return (

--- a/mini_app/frontend/src/pages/QuestionSheet.tsx
+++ b/mini_app/frontend/src/pages/QuestionSheet.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { closeMiniApp, sendData } from "@telegram-apps/sdk-react";
+import { closeMiniApp, sendData } from "@tma.js/sdk-react";
 import { fetchConfig } from "../api";
 import { BottomSheet } from "../components/BottomSheet";
 import { PromptRow } from "../components/PromptRow";

--- a/mini_app/frontend/src/pages/__tests__/ExpertSheet.test.tsx
+++ b/mini_app/frontend/src/pages/__tests__/ExpertSheet.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { ExpertSheet } from '../ExpertSheet';
 import * as api from '../../api';
-import * as sdkReact from '@telegram-apps/sdk-react';
+import * as sdkReact from '@tma.js/sdk-react';
 import type { AppConfig } from '../../types';
 
 const mockConfig: AppConfig = {

--- a/mini_app/frontend/src/pages/__tests__/QuestionSheet.test.tsx
+++ b/mini_app/frontend/src/pages/__tests__/QuestionSheet.test.tsx
@@ -68,15 +68,13 @@ describe('QuestionSheet', () => {
     expect(sendDataMock.ifAvailable).toHaveBeenCalledWith('С чего начать поиск квартиры?');
   });
 
-  it('calls closeMiniApp.ifAvailable on prompt click', async () => {
-    const closeMiniAppMock = sdkReact.closeMiniApp as ReturnType<typeof vi.fn> & {
-      ifAvailable: ReturnType<typeof vi.fn>;
-    };
+  it('calls miniApp.close.ifAvailable on prompt click', async () => {
+    const miniAppMock = sdkReact.miniApp as { close: ReturnType<typeof vi.fn> & { ifAvailable: ReturnType<typeof vi.fn> } };
 
     renderQuestionSheet();
     await waitFor(() => screen.getByText('С чего начать поиск квартиры?'));
     fireEvent.click(screen.getByText('С чего начать поиск квартиры?'));
 
-    expect(closeMiniAppMock.ifAvailable).toHaveBeenCalled();
+    expect(miniAppMock.close.ifAvailable).toHaveBeenCalled();
   });
 });

--- a/mini_app/frontend/src/pages/__tests__/QuestionSheet.test.tsx
+++ b/mini_app/frontend/src/pages/__tests__/QuestionSheet.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QuestionSheet } from '../QuestionSheet';
 import * as api from '../../api';
-import * as sdkReact from '@telegram-apps/sdk-react';
+import * as sdkReact from '@tma.js/sdk-react';
 import type { AppConfig } from '../../types';
 
 const mockConfig: AppConfig = {

--- a/mini_app/frontend/src/test-setup.ts
+++ b/mini_app/frontend/src/test-setup.ts
@@ -3,6 +3,13 @@ import "@testing-library/jest-dom";
 
 // jsdom stubs
 window.HTMLElement.prototype.scrollIntoView = () => {};
+// CSS.supports not available in jsdom — stub it to prevent eruda errors
+if (!globalThis.CSS) {
+  (globalThis as unknown as Record<string, unknown>).CSS = {};
+}
+if (!(globalThis.CSS as Record<string, unknown>).supports) {
+  (globalThis.CSS as unknown as Record<string, unknown>).supports = () => false;
+}
 window.matchMedia = window.matchMedia ?? (() => ({
   matches: false,
   addListener: () => {},
@@ -15,8 +22,8 @@ window.matchMedia = window.matchMedia ?? (() => ({
 // Mock eruda (dev tool, not needed in tests)
 vi.mock("eruda", () => ({ default: { init: vi.fn() } }));
 
-// Mock @telegram-apps/sdk-react для тестов
-vi.mock("@telegram-apps/sdk-react", () => ({
+// Mock @tma.js/sdk-react для тестов
+vi.mock("@tma.js/sdk-react", () => ({
   init: vi.fn(),
   openTelegramLink: Object.assign(vi.fn(), {
     isAvailable: vi.fn(() => true),
@@ -28,9 +35,26 @@ vi.mock("@telegram-apps/sdk-react", () => ({
     user: () => ({ id: 99999, firstName: "Test" }),
     restore: vi.fn(),
   },
-  mockTelegramEnv: vi.fn(),
-  isTMA: () => false,
+  themeParams: {
+    mount: vi.fn(),
+    bindCssVars: vi.fn(),
+  },
+  viewport: {
+    mount: Object.assign(vi.fn(() => Promise.resolve()), {
+      isAvailable: vi.fn(() => true),
+    }),
+    bindCssVars: vi.fn(),
+  },
+  swipeBehavior: {
+    isSupported: vi.fn(() => true),
+    mount: vi.fn(),
+    disableVertical: vi.fn(),
+  },
   parseInitData: vi.fn(),
-  mountThemeParamsSync: vi.fn(),
-  bindThemeParamsCssVars: vi.fn(),
+}));
+
+// Mock @tma.js/bridge
+vi.mock("@tma.js/bridge", () => ({
+  mockTelegramEnv: vi.fn(),
+  isTMA: vi.fn(() => false),
 }));

--- a/mini_app/frontend/src/test-setup.ts
+++ b/mini_app/frontend/src/test-setup.ts
@@ -29,7 +29,9 @@ vi.mock("@tma.js/sdk-react", () => ({
     isAvailable: vi.fn(() => true),
     ifAvailable: vi.fn(),
   }),
-  closeMiniApp: Object.assign(vi.fn(), { ifAvailable: vi.fn() }),
+  miniApp: {
+    close: Object.assign(vi.fn(), { ifAvailable: vi.fn() }),
+  },
   sendData: Object.assign(vi.fn(), { ifAvailable: vi.fn() }),
   initData: {
     user: () => ({ id: 99999, firstName: "Test" }),

--- a/telegram_bot/handlers/catalog_router.py
+++ b/telegram_bot/handlers/catalog_router.py
@@ -70,7 +70,7 @@ async def handle_catalog_more(
         telegram_id = message.from_user.id if message.from_user else 0
         for result in results:
             await property_bot._send_property_card(message, result, telegram_id)
-        await message.answer("📋 Каталог", reply_markup=catalog_kb)
+        await message.answer("\u200b", reply_markup=catalog_kb)
 
     await state.update_data(
         apartment_offset=new_offset,

--- a/telegram_bot/handlers/catalog_router.py
+++ b/telegram_bot/handlers/catalog_router.py
@@ -128,6 +128,42 @@ async def handle_catalog_bookmarks(
         await property_bot._handle_bookmarks(message, state)
 
 
+# --- Запись на осмотр ---
+
+
+@catalog_router.message(
+    StateFilter(CatalogBrowsingSG.browsing),
+    F.text == "📅 Запись на осмотр",
+)
+async def handle_catalog_viewing(
+    message: Message,
+    state: FSMContext,
+    property_bot: Any = None,
+    dialog_manager: Any = None,
+) -> None:
+    """Route to viewing appointment from catalog mode."""
+    if property_bot is not None:
+        await property_bot._handle_viewing(message, state, dialog_manager)
+
+
+# --- Написать менеджеру ---
+
+
+@catalog_router.message(
+    StateFilter(CatalogBrowsingSG.browsing),
+    F.text == "👤 Написать менеджеру",
+)
+async def handle_catalog_manager(
+    message: Message,
+    state: FSMContext,
+    property_bot: Any = None,
+    dialog_manager: Any = None,
+) -> None:
+    """Route to manager contact from catalog mode."""
+    if property_bot is not None:
+        await property_bot._handle_manager(message, state=state, dialog_manager=dialog_manager)
+
+
 # --- Главное меню ---
 
 

--- a/telegram_bot/handlers/catalog_router.py
+++ b/telegram_bot/handlers/catalog_router.py
@@ -70,10 +70,7 @@ async def handle_catalog_more(
         telegram_id = message.from_user.id if message.from_user else 0
         for result in results:
             await property_bot._send_property_card(message, result, telegram_id)
-        await message.answer(
-            f"Показано {new_offset} из {total_count}",
-            reply_markup=catalog_kb,
-        )
+        await message.answer("📋 Каталог", reply_markup=catalog_kb)
 
     await state.update_data(
         apartment_offset=new_offset,
@@ -160,9 +157,10 @@ async def handle_filter_panel_callback(
     state: FSMContext,
     callback_data: FilterPanelCB,
     apartments_service: Any = None,
+    property_bot: Any = None,
 ) -> None:
     """Dispatch filter panel inline button callbacks."""
-    await handle_filter_panel(callback, state, callback_data, apartments_service)
+    await handle_filter_panel(callback, state, callback_data, apartments_service, property_bot)
 
 
 # --- Catch-all: any other text in catalog mode ---

--- a/telegram_bot/handlers/filter_panel.py
+++ b/telegram_bot/handlers/filter_panel.py
@@ -53,7 +53,7 @@ async def handle_filter_panel(
 
     try:
         if action == "select":
-            await _handle_select(callback, state, field)
+            await _handle_select(callback, state, field, apartments_service)
         elif action == "set":
             await _handle_set(callback, state, field, value, apartments_service)
         elif action == "apply":
@@ -76,6 +76,7 @@ async def _handle_select(
     callback: CallbackQuery,
     state: FSMContext,
     field: str,
+    apartments_service: Any = None,
 ) -> None:
     """Show sub-menu for a specific filter field."""
     data = await state.get_data()
@@ -86,7 +87,16 @@ async def _handle_select(
     if field == "budget" and isinstance(current_value, dict):
         current_value = _price_to_budget(current_value)
 
-    kb = build_filter_options_keyboard(field, current_value=current_value)
+    # Load dynamic options for complex field
+    dynamic_options: list[str] | None = None
+    if field == "complex" and apartments_service is not None:
+        with contextlib.suppress(Exception):
+            stats = await apartments_service.get_collection_stats()
+            dynamic_options = stats.get("complexes") or []
+
+    kb = build_filter_options_keyboard(
+        field, current_value=current_value, dynamic_options=dynamic_options
+    )
 
     # Build sub-menu header text
     _FIELD_LABELS = {

--- a/telegram_bot/handlers/filter_panel.py
+++ b/telegram_bot/handlers/filter_panel.py
@@ -217,15 +217,20 @@ def _field_to_filter_key(field: str) -> str:
 
 def _coerce_value(field: str, value: str) -> Any:
     """Coerce string value to appropriate Python type for filter."""
-    if field == "rooms":
+    if field in ("rooms", "floor"):
         try:
             return int(value)
         except (ValueError, TypeError):
             return None
+    if field == "area":
+        try:
+            return {"gte": int(value)}
+        except (ValueError, TypeError):
+            return None
     if field == "budget":
         return _BUDGET_TO_PRICE.get(value)
-    if field == "furnished":
+    if field in ("furnished", "promotion"):
         return value == "true"
-    if field == "promotion":
-        return value == "true"
+    if field == "view":
+        return [value] if value else None
     return value or None

--- a/telegram_bot/handlers/filter_panel.py
+++ b/telegram_bot/handlers/filter_panel.py
@@ -192,7 +192,7 @@ async def _handle_apply(
         telegram_id = callback.from_user.id if callback.from_user else 0
         for result in results:
             await property_bot._send_property_card(msg, result, telegram_id)
-        await msg.answer("📋 Каталог", reply_markup=catalog_kb)
+        await msg.answer("\u200b", reply_markup=catalog_kb)
 
     await state.update_data(
         apartment_offset=shown,

--- a/telegram_bot/handlers/filter_panel.py
+++ b/telegram_bot/handlers/filter_panel.py
@@ -44,6 +44,7 @@ async def handle_filter_panel(
     state: FSMContext,
     callback_data: FilterPanelCB,
     apartments_service: Any = None,
+    property_bot: Any = None,
 ) -> None:
     """Dispatch filter panel callback by action."""
     action = callback_data.action
@@ -56,7 +57,7 @@ async def handle_filter_panel(
         elif action == "set":
             await _handle_set(callback, state, field, value, apartments_service)
         elif action == "apply":
-            await _handle_apply(callback, state)
+            await _handle_apply(callback, state, apartments_service, property_bot)
         elif action == "reset":
             await _handle_reset(callback, state, apartments_service)
         elif action == "back":
@@ -142,11 +143,53 @@ async def _handle_set(
 async def _handle_apply(
     callback: CallbackQuery,
     state: FSMContext,
+    apartments_service: Any = None,
+    property_bot: Any = None,
 ) -> None:
-    """Apply current filters — reset offset to start fresh search."""
-    await state.update_data(apartment_offset=0)
+    """Apply current filters — reload results with updated filters."""
+    from telegram_bot.keyboards.client_keyboard import build_catalog_keyboard
+
+    data = await state.get_data()
+    filters: dict[str, Any] = data.get("apartment_filters") or {}
+
     await callback.message.delete()  # type: ignore[union-attr]
     await callback.answer("Фильтры применены")
+
+    svc = apartments_service or (
+        getattr(property_bot, "_apartments_service", None) if property_bot else None
+    )
+    if svc is None:
+        return
+
+    results, total_count, next_start, page_ids = await svc.scroll_with_filters(
+        filters=filters,
+        limit=10,
+        start_from=None,
+        exclude_ids=None,
+    )
+
+    shown = len(results)
+    catalog_kb = build_catalog_keyboard(shown=shown, total=total_count)
+    msg = callback.message  # type: ignore[union-attr]
+
+    view_mode = data.get("catalog_view_mode", "cards")
+    if view_mode == "list":
+        from telegram_bot.dialogs.funnel import format_apartment_list
+
+        text = format_apartment_list(results, shown_start=1, total=total_count)
+        await msg.answer(text, parse_mode="HTML", reply_markup=catalog_kb)
+    else:
+        telegram_id = callback.from_user.id if callback.from_user else 0
+        for result in results:
+            await property_bot._send_property_card(msg, result, telegram_id)
+        await msg.answer("📋 Каталог", reply_markup=catalog_kb)
+
+    await state.update_data(
+        apartment_offset=shown,
+        apartment_total=total_count,
+        apartment_next_offset=next_start,
+        apartment_scroll_seen_ids=page_ids,
+    )
 
 
 async def _handle_reset(

--- a/telegram_bot/handlers/filter_panel.py
+++ b/telegram_bot/handlers/filter_panel.py
@@ -23,6 +23,21 @@ from telegram_bot.keyboards.filter_panel import (
 
 logger = logging.getLogger(__name__)
 
+_BUDGET_TO_PRICE: dict[str, dict[str, int]] = {
+    "low": {"lte": 50_000},
+    "mid": {"gte": 50_000, "lte": 100_000},
+    "high": {"gte": 100_000, "lte": 150_000},
+    "premium": {"gte": 150_000, "lte": 200_000},
+    "luxury": {"gte": 200_000},
+}
+
+_PRICE_TO_BUDGET: dict[str, str] = {str(v): k for k, v in _BUDGET_TO_PRICE.items()}
+
+
+def _price_to_budget(price_filter: dict) -> str | None:
+    """Reverse-map price_eur filter dict to budget label."""
+    return _PRICE_TO_BUDGET.get(str(price_filter))
+
 
 async def handle_filter_panel(
     callback: CallbackQuery,
@@ -64,7 +79,11 @@ async def _handle_select(
     """Show sub-menu for a specific filter field."""
     data = await state.get_data()
     filters: dict[str, Any] = data.get("apartment_filters") or {}
-    current_value = filters.get(field)
+    filter_key = _field_to_filter_key(field)
+    current_value = filters.get(filter_key)
+    # For budget, reverse-map price_eur dict back to budget label
+    if field == "budget" and isinstance(current_value, dict):
+        current_value = _price_to_budget(current_value)
 
     kb = build_filter_options_keyboard(field, current_value=current_value)
 
@@ -185,7 +204,7 @@ def _field_to_filter_key(field: str) -> str:
     _MAP = {
         "city": "city",
         "rooms": "rooms",
-        "budget": "budget",
+        "budget": "price_eur",
         "view": "view_tags",
         "area": "area_m2",
         "floor": "floor",
@@ -203,6 +222,8 @@ def _coerce_value(field: str, value: str) -> Any:
             return int(value)
         except (ValueError, TypeError):
             return None
+    if field == "budget":
+        return _BUDGET_TO_PRICE.get(value)
     if field == "furnished":
         return value == "true"
     if field == "promotion":

--- a/telegram_bot/keyboards/client_keyboard.py
+++ b/telegram_bot/keyboards/client_keyboard.py
@@ -107,6 +107,12 @@ def build_catalog_keyboard(*, shown: int, total: int) -> ReplyKeyboardMarkup:
             ]
         )
     rows.append([KeyboardButton(text="🔍 Фильтры"), KeyboardButton(text="📌 Избранное")])
+    rows.append(
+        [
+            KeyboardButton(text="📅 Запись на осмотр"),
+            KeyboardButton(text="👤 Написать менеджеру"),
+        ]
+    )
     rows.append([KeyboardButton(text="🏠 Главное меню")])
     return ReplyKeyboardMarkup(keyboard=rows, resize_keyboard=True)
 

--- a/telegram_bot/keyboards/filter_panel.py
+++ b/telegram_bot/keyboards/filter_panel.py
@@ -123,6 +123,7 @@ def build_filter_options_keyboard(
     field: str,
     *,
     current_value: str | int | None = None,
+    dynamic_options: list[str] | None = None,
 ) -> InlineKeyboardMarkup:
     """Build sub-menu keyboard for selecting a filter value."""
     rows: list[list[InlineKeyboardButton]] = []
@@ -247,8 +248,26 @@ def build_filter_options_keyboard(
             ]
         )
 
+    elif dynamic_options:
+        # Dynamic options loaded from service (e.g. complex names)
+        any_btn = InlineKeyboardButton(
+            text="✅ Любое" if current_value is None else "Любое",
+            callback_data=FilterPanelCB(action="set", field=field, value="").pack(),
+        )
+        rows.append([any_btn])
+        for option in dynamic_options:
+            label = f"✅ {option}" if option == current_value else option
+            rows.append(
+                [
+                    InlineKeyboardButton(
+                        text=label,
+                        callback_data=FilterPanelCB(action="set", field=field, value=option).pack(),
+                    )
+                ]
+            )
+
     else:
-        # Generic text-based filter (view, area, floor, complex) — placeholder
+        # Generic fallback (view, area, floor without dynamic data)
         rows.append(
             [
                 InlineKeyboardButton(

--- a/tests/unit/handlers/test_filter_panel.py
+++ b/tests/unit/handlers/test_filter_panel.py
@@ -17,6 +17,22 @@ from telegram_bot.handlers.filter_panel import (
 )
 
 
+# Helper to build callback + state mocks for handler tests
+def _make_handler_mocks(filters=None, svc_count=10):
+    svc = AsyncMock()
+    svc.count_with_filters = AsyncMock(return_value=svc_count)
+    state = AsyncMock()
+    state.get_data = AsyncMock(
+        return_value={"apartment_filters": filters or {}, "apartment_total": 50}
+    )
+    state.update_data = AsyncMock()
+    callback = AsyncMock()
+    callback.message = AsyncMock()
+    callback.message.edit_text = AsyncMock()
+    callback.answer = AsyncMock()
+    return callback, state, svc
+
+
 @pytest.mark.asyncio
 async def test_get_count_uses_service_when_available():
     """_get_count calls count_with_filters when service is provided."""
@@ -228,3 +244,110 @@ async def test_handle_set_budget_clear():
     update_kwargs = state.update_data.call_args[1]
     filters = update_kwargs["apartment_filters"]
     assert "price_eur" not in filters
+
+
+# ============================================================
+# All filter coercion tests
+# ============================================================
+
+
+@pytest.mark.parametrize(
+    "field,filter_key",
+    [
+        ("city", "city"),
+        ("rooms", "rooms"),
+        ("budget", "price_eur"),
+        ("view", "view_tags"),
+        ("area", "area_m2"),
+        ("floor", "floor"),
+        ("complex", "complex_name"),
+        ("furnished", "is_furnished"),
+        ("promotion", "is_promotion"),
+    ],
+)
+def test_all_field_to_filter_key_mappings(field, filter_key):
+    """Every panel field maps to the correct apartment_filters key."""
+    assert _field_to_filter_key(field) == filter_key
+
+
+@pytest.mark.parametrize(
+    "field,value,expected",
+    [
+        ("city", "Бургас", "Бургас"),
+        ("rooms", "3", 3),
+        ("floor", "5", 5),
+        ("floor", "abc", None),
+        ("area", "60", {"gte": 60}),
+        ("area", "bad", None),
+        ("view", "sea", ["sea"]),
+        ("view", "", None),
+        ("complex", "Harmony Suites", "Harmony Suites"),
+        ("complex", "", None),
+        ("furnished", "true", True),
+        ("furnished", "false", False),
+        ("promotion", "true", True),
+        ("promotion", "false", False),
+    ],
+)
+def test_coerce_value_all_fields(field, value, expected):
+    """_coerce_value returns correct type for each field."""
+    assert _coerce_value(field, value) == expected
+
+
+# ============================================================
+# Handler set/clear tests for all filter types
+# ============================================================
+
+
+@pytest.mark.parametrize(
+    "field,value,expected_key,expected_value",
+    [
+        ("city", "Варна", "city", "Варна"),
+        ("rooms", "2", "rooms", 2),
+        ("floor", "3", "floor", 3),
+        ("area", "50", "area_m2", {"gte": 50}),
+        ("view", "sea", "view_tags", ["sea"]),
+        ("complex", "Resort", "complex_name", "Resort"),
+        ("furnished", "true", "is_furnished", True),
+        ("promotion", "true", "is_promotion", True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_handle_set_all_filters(field, value, expected_key, expected_value):
+    """Setting any filter stores correct key and coerced value."""
+    from telegram_bot.callback_data import FilterPanelCB
+
+    callback, state, svc = _make_handler_mocks()
+    cb_data = FilterPanelCB(action="set", field=field, value=value)
+    await handle_filter_panel(callback, state, cb_data, apartments_service=svc)
+
+    filters = state.update_data.call_args[1]["apartment_filters"]
+    assert expected_key in filters
+    assert filters[expected_key] == expected_value
+
+
+@pytest.mark.parametrize(
+    "field,initial_key,initial_value",
+    [
+        ("city", "city", "Варна"),
+        ("rooms", "rooms", 2),
+        ("floor", "floor", 3),
+        ("area", "area_m2", {"gte": 50}),
+        ("view", "view_tags", ["sea"]),
+        ("complex", "complex_name", "Resort"),
+        ("furnished", "is_furnished", True),
+        ("promotion", "is_promotion", True),
+        ("budget", "price_eur", {"lte": 50_000}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_handle_clear_all_filters(field, initial_key, initial_value):
+    """Clearing any filter removes the key from apartment_filters."""
+    from telegram_bot.callback_data import FilterPanelCB
+
+    callback, state, svc = _make_handler_mocks(filters={initial_key: initial_value})
+    cb_data = FilterPanelCB(action="set", field=field, value="")
+    await handle_filter_panel(callback, state, cb_data, apartments_service=svc)
+
+    filters = state.update_data.call_args[1]["apartment_filters"]
+    assert initial_key not in filters

--- a/tests/unit/handlers/test_filter_panel.py
+++ b/tests/unit/handlers/test_filter_panel.py
@@ -499,3 +499,80 @@ async def test_handle_unknown_action_answers_callback():
     await handle_filter_panel(callback, state, cb_data, apartments_service=svc)
 
     callback.answer.assert_awaited_once()
+
+
+# ============================================================
+# complex filter — dynamic options from service
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_handle_select_complex_loads_from_service():
+    """Select complex loads dynamic options via get_collection_stats."""
+    from telegram_bot.callback_data import FilterPanelCB
+
+    svc = AsyncMock()
+    svc.get_collection_stats = AsyncMock(
+        return_value={"complexes": ["Premier Fort", "Harmony Suites", "Grand Resort"]}
+    )
+
+    callback, state, _ = _make_handler_mocks()
+    cb_data = FilterPanelCB(action="select", field="complex", value="")
+    await handle_filter_panel(callback, state, cb_data, apartments_service=svc)
+
+    svc.get_collection_stats.assert_awaited_once()
+    call_text = callback.message.edit_text.call_args[0][0]
+    assert "комплекс" in call_text.lower()
+    # Keyboard should contain dynamic options
+    kb = callback.message.edit_text.call_args[1]["reply_markup"]
+    button_texts = [btn.text for row in kb.inline_keyboard for btn in row]
+    assert "Premier Fort" in button_texts
+    assert "Harmony Suites" in button_texts
+    assert "Grand Resort" in button_texts
+
+
+@pytest.mark.asyncio
+async def test_handle_select_complex_current_value_checked():
+    """Selected complex shows checkmark on current value."""
+    from telegram_bot.callback_data import FilterPanelCB
+
+    svc = AsyncMock()
+    svc.get_collection_stats = AsyncMock(
+        return_value={"complexes": ["Premier Fort", "Harmony Suites"]}
+    )
+
+    callback, state, _ = _make_handler_mocks(filters={"complex_name": "Premier Fort"})
+    cb_data = FilterPanelCB(action="select", field="complex", value="")
+    await handle_filter_panel(callback, state, cb_data, apartments_service=svc)
+
+    kb = callback.message.edit_text.call_args[1]["reply_markup"]
+    button_texts = [btn.text for row in kb.inline_keyboard for btn in row]
+    assert "✅ Premier Fort" in button_texts
+    assert "Harmony Suites" in button_texts  # no checkmark
+
+
+@pytest.mark.asyncio
+async def test_handle_select_complex_no_service_shows_fallback():
+    """Without service, complex shows generic fallback."""
+    from telegram_bot.callback_data import FilterPanelCB
+
+    callback, state, _ = _make_handler_mocks()
+    cb_data = FilterPanelCB(action="select", field="complex", value="")
+    await handle_filter_panel(callback, state, cb_data, apartments_service=None)
+
+    kb = callback.message.edit_text.call_args[1]["reply_markup"]
+    button_texts = [btn.text for row in kb.inline_keyboard for btn in row]
+    assert "Любое" in button_texts
+
+
+@pytest.mark.asyncio
+async def test_handle_set_complex_stores_complex_name():
+    """Setting complex stores complex_name in filters."""
+    from telegram_bot.callback_data import FilterPanelCB
+
+    callback, state, svc = _make_handler_mocks()
+    cb_data = FilterPanelCB(action="set", field="complex", value="Premier Fort")
+    await handle_filter_panel(callback, state, cb_data, apartments_service=svc)
+
+    filters = state.update_data.call_args[1]["apartment_filters"]
+    assert filters["complex_name"] == "Premier Fort"

--- a/tests/unit/handlers/test_filter_panel.py
+++ b/tests/unit/handlers/test_filter_panel.py
@@ -407,19 +407,63 @@ async def test_handle_select_budget_shows_current():
 
 
 @pytest.mark.asyncio
-async def test_handle_apply_resets_offset_and_deletes_message():
-    """Apply action resets offset to 0 and deletes filter panel message."""
+async def test_handle_apply_reloads_results():
+    """Apply action deletes panel, reloads results with current filters."""
+    from unittest.mock import MagicMock
+
     from telegram_bot.callback_data import FilterPanelCB
 
-    callback, state, svc = _make_handler_mocks()
-    cb_data = FilterPanelCB(action="apply", field="", value="")
-    await handle_filter_panel(callback, state, cb_data, apartments_service=svc)
+    apt = {
+        "id": "a1",
+        "payload": {
+            "complex_name": "X",
+            "city": "Y",
+            "rooms": 1,
+            "floor": 1,
+            "area_m2": 40,
+            "view_primary": "sea",
+            "price_eur": 50000,
+        },
+    }
+    svc = AsyncMock()
+    svc.count_with_filters = AsyncMock(return_value=5)
+    svc.scroll_with_filters = AsyncMock(return_value=([apt] * 3, 5, 60000.0, ["a1"]))
 
-    state.update_data.assert_awaited_once_with(apartment_offset=0)
+    property_bot = MagicMock()
+    property_bot._apartments_service = svc
+    property_bot._send_property_card = AsyncMock()
+
+    state = AsyncMock()
+    state.get_data = AsyncMock(
+        return_value={
+            "apartment_filters": {"city": "Бургас"},
+            "apartment_total": 50,
+        }
+    )
+    state.update_data = AsyncMock()
+
+    callback = AsyncMock()
+    callback.from_user = MagicMock(id=123)
+    callback.message = AsyncMock()
+    callback.message.delete = AsyncMock()
+    callback.message.answer = AsyncMock()
+    callback.answer = AsyncMock()
+
+    cb_data = FilterPanelCB(action="apply", field="", value="")
+    await handle_filter_panel(
+        callback, state, cb_data, apartments_service=svc, property_bot=property_bot
+    )
+
     callback.message.delete.assert_awaited_once()
     callback.answer.assert_awaited_once()
-    answer_text = callback.answer.call_args[0][0]
-    assert "применен" in answer_text.lower()
+    svc.scroll_with_filters.assert_awaited_once()
+    # Cards sent
+    assert property_bot._send_property_card.await_count == 3
+    # State updated with new offset
+    update_calls = state.update_data.call_args_list
+    last_update = update_calls[-1][1]
+    assert last_update["apartment_offset"] == 3
+    assert last_update["apartment_total"] == 5
 
 
 # ============================================================

--- a/tests/unit/handlers/test_filter_panel.py
+++ b/tests/unit/handlers/test_filter_panel.py
@@ -8,7 +8,11 @@ from unittest.mock import AsyncMock
 import pytest
 
 from telegram_bot.handlers.filter_panel import (
+    _BUDGET_TO_PRICE,
+    _coerce_value,
+    _field_to_filter_key,
     _get_count,
+    _price_to_budget,
     handle_filter_panel,
 )
 
@@ -130,3 +134,97 @@ async def test_handle_main_recalculates_count():
     svc.count_with_filters.assert_awaited_once()
     call_text = callback.message.edit_text.call_args[0][0]
     assert "77" in call_text
+
+
+# ============================================================
+# Budget filter coercion
+# ============================================================
+
+
+def test_budget_field_maps_to_price_eur():
+    """Budget field maps to price_eur filter key."""
+    assert _field_to_filter_key("budget") == "price_eur"
+
+
+@pytest.mark.parametrize(
+    "budget_key,expected_range",
+    [
+        ("low", {"lte": 50_000}),
+        ("mid", {"gte": 50_000, "lte": 100_000}),
+        ("high", {"gte": 100_000, "lte": 150_000}),
+        ("premium", {"gte": 150_000, "lte": 200_000}),
+        ("luxury", {"gte": 200_000}),
+    ],
+)
+def test_budget_coerce_produces_price_range(budget_key, expected_range):
+    """Budget value coerces to price_eur range dict."""
+    assert _coerce_value("budget", budget_key) == expected_range
+
+
+def test_budget_coerce_unknown_returns_none():
+    """Unknown budget value returns None."""
+    assert _coerce_value("budget", "unknown") is None
+
+
+def test_price_to_budget_roundtrip():
+    """price_eur dict roundtrips back to budget label."""
+    for label, price_range in _BUDGET_TO_PRICE.items():
+        assert _price_to_budget(price_range) == label
+
+
+@pytest.mark.asyncio
+async def test_handle_set_budget_stores_price_eur():
+    """Setting budget stores price_eur dict in apartment_filters."""
+    from telegram_bot.callback_data import FilterPanelCB
+
+    svc = AsyncMock()
+    svc.count_with_filters = AsyncMock(return_value=10)
+
+    state = AsyncMock()
+    state.get_data = AsyncMock(return_value={"apartment_filters": {}, "apartment_total": 50})
+    state.update_data = AsyncMock()
+
+    callback = AsyncMock()
+    callback.message = AsyncMock()
+    callback.message.edit_text = AsyncMock()
+    callback.answer = AsyncMock()
+
+    cb_data = FilterPanelCB(action="set", field="budget", value="mid")
+    await handle_filter_panel(callback, state, cb_data, apartments_service=svc)
+
+    # Should store price_eur, not budget
+    update_kwargs = state.update_data.call_args[1]
+    filters = update_kwargs["apartment_filters"]
+    assert "price_eur" in filters
+    assert filters["price_eur"] == {"gte": 50_000, "lte": 100_000}
+    assert "budget" not in filters
+
+
+@pytest.mark.asyncio
+async def test_handle_set_budget_clear():
+    """Setting budget to empty clears price_eur from filters."""
+    from telegram_bot.callback_data import FilterPanelCB
+
+    svc = AsyncMock()
+    svc.count_with_filters = AsyncMock(return_value=99)
+
+    state = AsyncMock()
+    state.get_data = AsyncMock(
+        return_value={
+            "apartment_filters": {"price_eur": {"lte": 50_000}},
+            "apartment_total": 50,
+        }
+    )
+    state.update_data = AsyncMock()
+
+    callback = AsyncMock()
+    callback.message = AsyncMock()
+    callback.message.edit_text = AsyncMock()
+    callback.answer = AsyncMock()
+
+    cb_data = FilterPanelCB(action="set", field="budget", value="")
+    await handle_filter_panel(callback, state, cb_data, apartments_service=svc)
+
+    update_kwargs = state.update_data.call_args[1]
+    filters = update_kwargs["apartment_filters"]
+    assert "price_eur" not in filters

--- a/tests/unit/handlers/test_filter_panel.py
+++ b/tests/unit/handlers/test_filter_panel.py
@@ -351,3 +351,107 @@ async def test_handle_clear_all_filters(field, initial_key, initial_value):
 
     filters = state.update_data.call_args[1]["apartment_filters"]
     assert initial_key not in filters
+
+
+# ============================================================
+# select action — opens sub-menu
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_handle_select_shows_submenu():
+    """Select action edits message with sub-menu keyboard."""
+    from telegram_bot.callback_data import FilterPanelCB
+
+    callback, state, svc = _make_handler_mocks(filters={"city": "Бургас"})
+    cb_data = FilterPanelCB(action="select", field="city", value="")
+    await handle_filter_panel(callback, state, cb_data, apartments_service=svc)
+
+    callback.message.edit_text.assert_awaited_once()
+    call_text = callback.message.edit_text.call_args[0][0]
+    assert "город" in call_text.lower()
+    callback.answer.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_select_shows_current_value():
+    """Select action displays current filter value in sub-menu."""
+    from telegram_bot.callback_data import FilterPanelCB
+
+    callback, state, svc = _make_handler_mocks(filters={"rooms": 3})
+    cb_data = FilterPanelCB(action="select", field="rooms", value="")
+    await handle_filter_panel(callback, state, cb_data, apartments_service=svc)
+
+    call_text = callback.message.edit_text.call_args[0][0]
+    assert "3" in call_text
+
+
+@pytest.mark.asyncio
+async def test_handle_select_budget_shows_current():
+    """Select budget shows current value via reverse lookup."""
+    from telegram_bot.callback_data import FilterPanelCB
+
+    callback, state, svc = _make_handler_mocks(
+        filters={"price_eur": {"gte": 50_000, "lte": 100_000}}
+    )
+    cb_data = FilterPanelCB(action="select", field="budget", value="")
+    await handle_filter_panel(callback, state, cb_data, apartments_service=svc)
+
+    call_text = callback.message.edit_text.call_args[0][0]
+    assert "mid" in call_text
+
+
+# ============================================================
+# apply action — applies filters
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_handle_apply_resets_offset_and_deletes_message():
+    """Apply action resets offset to 0 and deletes filter panel message."""
+    from telegram_bot.callback_data import FilterPanelCB
+
+    callback, state, svc = _make_handler_mocks()
+    cb_data = FilterPanelCB(action="apply", field="", value="")
+    await handle_filter_panel(callback, state, cb_data, apartments_service=svc)
+
+    state.update_data.assert_awaited_once_with(apartment_offset=0)
+    callback.message.delete.assert_awaited_once()
+    callback.answer.assert_awaited_once()
+    answer_text = callback.answer.call_args[0][0]
+    assert "применен" in answer_text.lower()
+
+
+# ============================================================
+# back action — returns to catalog results
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_handle_back_deletes_panel():
+    """Back action deletes filter panel message."""
+    from telegram_bot.callback_data import FilterPanelCB
+
+    callback, state, svc = _make_handler_mocks()
+    cb_data = FilterPanelCB(action="back", field="", value="")
+    await handle_filter_panel(callback, state, cb_data, apartments_service=svc)
+
+    callback.message.delete.assert_awaited_once()
+    callback.answer.assert_awaited_once()
+
+
+# ============================================================
+# unknown action — logs warning
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_handle_unknown_action_answers_callback():
+    """Unknown action answers callback without error."""
+    from telegram_bot.callback_data import FilterPanelCB
+
+    callback, state, svc = _make_handler_mocks()
+    cb_data = FilterPanelCB(action="unknown_action", field="", value="")
+    await handle_filter_panel(callback, state, cb_data, apartments_service=svc)
+
+    callback.answer.assert_awaited_once()

--- a/tests/unit/test_catalog_handler.py
+++ b/tests/unit/test_catalog_handler.py
@@ -109,6 +109,36 @@ class TestCatalogMoreHandler:
         button_texts = [btn.text for row in kb.keyboard for btn in row]
         assert any("20 из 30" in t for t in button_texts)
 
+    async def test_cards_mode_no_counter_text(self):
+        """In cards mode, status message should NOT contain 'Показано N из M'."""
+        from telegram_bot.handlers.catalog_router import handle_catalog_more
+
+        new_page = [_APT] * 5
+        mock_svc = MagicMock()
+        mock_svc.scroll_with_filters = AsyncMock(
+            return_value=(new_page, 30, 65000.0, ["apt-1"]),
+        )
+        property_bot = MagicMock()
+        property_bot._apartments_service = mock_svc
+        property_bot._send_property_card = AsyncMock()
+
+        state = _make_state(
+            {
+                "apartment_offset": 10,
+                "apartment_total": 30,
+                "apartment_next_offset": 55000.0,
+                "apartment_filters": {},
+                "apartment_scroll_seen_ids": [],
+            }
+        )
+        message = _make_message()
+
+        await handle_catalog_more(message, state, property_bot=property_bot)
+
+        last_call = message.answer.call_args_list[-1]
+        text = last_call.args[0] if last_call.args else last_call.kwargs.get("text", "")
+        assert "Показано" not in text
+
     async def test_all_shown_hides_more_button(self):
         """When all shown, 'Показать ещё' row is removed from keyboard."""
         from telegram_bot.handlers.catalog_router import handle_catalog_more

--- a/tests/unit/test_catalog_handler.py
+++ b/tests/unit/test_catalog_handler.py
@@ -167,7 +167,7 @@ class TestCatalogMoreHandler:
 
         last_call = message.answer.call_args_list[-1]
         kb = last_call.kwargs.get("reply_markup")
-        assert len(kb.keyboard) == 2  # filters+bookmarks and menu only
+        assert len(kb.keyboard) == 3  # filters+bookmarks, viewing+manager, menu
         button_texts = [btn.text for row in kb.keyboard for btn in row]
         assert not any("Показать" in t for t in button_texts)
 
@@ -295,6 +295,78 @@ class TestCatalogBookmarksHandler:
 
 
 # ============================================================
+# handle_catalog_viewing
+# ============================================================
+
+
+class TestCatalogViewingHandler:
+    async def test_routes_to_handle_viewing(self):
+        """'📅 Запись на осмотр' routes to property_bot._handle_viewing."""
+        from telegram_bot.handlers.catalog_router import handle_catalog_viewing
+
+        property_bot = MagicMock()
+        property_bot._handle_viewing = AsyncMock()
+
+        state = _make_state({})
+        message = _make_message()
+        dialog_manager = MagicMock()
+
+        await handle_catalog_viewing(
+            message, state, property_bot=property_bot, dialog_manager=dialog_manager
+        )
+
+        property_bot._handle_viewing.assert_awaited_once_with(message, state, dialog_manager)
+
+    async def test_no_property_bot_does_nothing(self):
+        """Without property_bot, handler does nothing."""
+        from telegram_bot.handlers.catalog_router import handle_catalog_viewing
+
+        state = _make_state({})
+        message = _make_message()
+
+        await handle_catalog_viewing(message, state, property_bot=None)
+
+        message.answer.assert_not_awaited()
+
+
+# ============================================================
+# handle_catalog_manager
+# ============================================================
+
+
+class TestCatalogManagerHandler:
+    async def test_routes_to_handle_manager(self):
+        """'👤 Написать менеджеру' routes to property_bot._handle_manager."""
+        from telegram_bot.handlers.catalog_router import handle_catalog_manager
+
+        property_bot = MagicMock()
+        property_bot._handle_manager = AsyncMock()
+
+        state = _make_state({})
+        message = _make_message()
+        dialog_manager = MagicMock()
+
+        await handle_catalog_manager(
+            message, state, property_bot=property_bot, dialog_manager=dialog_manager
+        )
+
+        property_bot._handle_manager.assert_awaited_once_with(
+            message, state=state, dialog_manager=dialog_manager
+        )
+
+    async def test_no_property_bot_does_nothing(self):
+        """Without property_bot, handler does nothing."""
+        from telegram_bot.handlers.catalog_router import handle_catalog_manager
+
+        state = _make_state({})
+        message = _make_message()
+
+        await handle_catalog_manager(message, state, property_bot=None)
+
+        message.answer.assert_not_awaited()
+
+
+# ============================================================
 # handle_catalog_more — list view mode
 # ============================================================
 
@@ -333,3 +405,29 @@ class TestCatalogListViewMode:
         assert message.answer.await_count == 1
         call = message.answer.call_args
         assert call.kwargs.get("parse_mode") == "HTML"
+
+
+# ============================================================
+# build_catalog_keyboard — viewing + manager buttons
+# ============================================================
+
+
+class TestCatalogKeyboardButtons:
+    def test_keyboard_has_viewing_and_manager_buttons(self):
+        """Catalog keyboard includes viewing and manager buttons."""
+        from telegram_bot.keyboards.client_keyboard import build_catalog_keyboard
+
+        kb = build_catalog_keyboard(shown=5, total=20)
+        button_texts = [btn.text for row in kb.keyboard for btn in row]
+        assert "📅 Запись на осмотр" in button_texts
+        assert "👤 Написать менеджеру" in button_texts
+
+    def test_keyboard_viewing_manager_row_present_when_no_more(self):
+        """Even when all shown, viewing/manager row is present."""
+        from telegram_bot.keyboards.client_keyboard import build_catalog_keyboard
+
+        kb = build_catalog_keyboard(shown=20, total=20)
+        button_texts = [btn.text for row in kb.keyboard for btn in row]
+        assert "📅 Запись на осмотр" in button_texts
+        assert "👤 Написать менеджеру" in button_texts
+        assert not any("Показать" in t for t in button_texts)


### PR DESCRIPTION
## Summary
- Migrate from `@telegram-apps/sdk-react` to `@tma.js/sdk-react` (v3.0.16)
- Add `bootstrap.ts` — single TMA lifecycle orchestrator (init, theme, viewport, swipe)
- Add `TelegramGate` — guard component that shows fallback outside Telegram (prod only)
- Migrate `mockEnv.ts` + `test-setup.ts` to `@tma.js/bridge` for mockTelegramEnv/isTMA
- Rewrite `main.tsx` to use bootstrap + TelegramGate pattern
- Fix `closeMiniApp` → `miniApp.close()` (API change in new SDK)
- Fix top-level await → `.then()` for es2020 build target compatibility
- Add Telegram Test Environment docs (HTTP without tunnel)
- Update `.claude/rules/mini-app.md` with new SDK patterns

## Test plan
- [x] All vitest tests pass: 55/55 (`npm test`)
- [x] Build succeeds (`npm run build`, 221kB bundle)
- [x] TDD: bootstrap.test.ts (4 tests), TelegramGate.test.tsx (3 tests) written first

Closes #942

🤖 Generated with [Claude Code](https://claude.com/claude-code)