### PR TITLE
feat(viewing): simplify viewing dialog — remove objects, auto-confirm contact

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -1278,7 +1278,7 @@ class PropertyBot:
 
             from .dialogs.states import ViewingSG
 
-            await dialog_manager.start(ViewingSG.objects, mode=StartMode.RESET_STACK)
+            await dialog_manager.start(ViewingSG.date, mode=StartMode.RESET_STACK)
         else:
             await message.answer("📅 Для записи на осмотр используйте кнопку меню.")
 

--- a/telegram_bot/dialogs/handoff.py
+++ b/telegram_bot/dialogs/handoff.py
@@ -143,10 +143,10 @@ async def _on_contact_phone(
     manager.show_mode = ShowMode.NO_UPDATE
     await manager.done()
 
-    # Replace dialog message with status text (removes inline buttons).
-    if msg and hasattr(msg, "edit_text"):
+    # Remove inline keyboard message — phone_collector sends its own prompt.
+    if msg and hasattr(msg, "delete"):
         with contextlib.suppress(Exception):
-            await msg.edit_text("📞 Сейчас попрошу номер телефона...")
+            await msg.delete()
 
     if state is None:
         logger.warning("FSMContext not in middleware_data for phone handoff")

--- a/telegram_bot/dialogs/states.py
+++ b/telegram_bot/dialogs/states.py
@@ -44,11 +44,9 @@ class FunnelSG(StatesGroup):
 class ViewingSG(StatesGroup):
     """Viewing appointment wizard."""
 
-    objects = State()  # Шаг 1: выбор объектов из закладок
-    objects_text = State()  # Шаг 1b: ручной ввод (опционально)
-    date = State()  # Шаг 2: желаемая дата
-    phone = State()  # Шаг 3: номер телефона
-    summary = State()  # Шаг 4: подтверждение + CRM
+    date = State()  # Шаг 1: желаемая дата
+    phone = State()  # Шаг 2: номер телефона
+    summary = State()  # Шаг 3: подтверждение + CRM
 
 
 class FaqSG(StatesGroup):

--- a/telegram_bot/dialogs/viewing.py
+++ b/telegram_bot/dialogs/viewing.py
@@ -13,23 +13,17 @@ from aiogram.types import (
     Message,
     ReplyKeyboardRemove,
 )
-from aiogram_dialog import Dialog, DialogManager, ShowMode, Window
+from aiogram_dialog import Dialog, DialogManager, ShowMode, StartMode, Window
 from aiogram_dialog.widgets.input import MessageInput
-from aiogram_dialog.widgets.kbd import Back, Button, Cancel, Column, Select
+from aiogram_dialog.widgets.kbd import Button, Column, Select
 from aiogram_dialog.widgets.text import Const, Format  # noqa: F401
 
 from telegram_bot.observability import observe
 
-from .states import ViewingSG
+from .states import HandoffSG, ViewingSG
 
 
 logger = logging.getLogger(__name__)
-
-
-async def on_dialog_start(start_data: dict[str, Any], manager: DialogManager) -> None:
-    """Transfer start_data into dialog_data on dialog start."""
-    if start_data and "selected_objects" in start_data:
-        manager.dialog_data["selected_objects"] = start_data["selected_objects"]
 
 
 # --- Date range → label mapping ---
@@ -61,180 +55,164 @@ def compute_due_date(date_range: str) -> int:
 # ── Getters ──────────────────────────────────────────────────────────
 
 
-async def get_objects_options(
-    event_from_user: Any = None,
-    favorites_service: Any = None,
-    middleware_data: dict[str, Any] | None = None,
-    dialog_manager: DialogManager | None = None,
-    **kwargs: Any,
-) -> dict[str, Any]:
-    """Load user favorites for object selection (Step 1)."""
-    items: list[tuple[str, str]] = []
-    has_favorites = False
-    favorites_by_id: dict[str, dict[str, Any]] = {}
-
-    resolved_favorites_service = favorites_service
-    if resolved_favorites_service is None:
-        resolved_favorites_service = (middleware_data or {}).get("favorites_service")
-    if resolved_favorites_service is None:
-        property_bot = (middleware_data or {}).get("property_bot")
-        if property_bot is not None:
-            resolved_favorites_service = getattr(property_bot, "_favorites_service", None)
-
-    if resolved_favorites_service is not None and event_from_user is not None:
-        try:
-            favs = await resolved_favorites_service.list(event_from_user.id, limit=10)
-            for fav in favs:
-                data = fav.property_data
-                property_id = str(fav.property_id)
-                complex_name = data.get("complex_name", "?")
-                property_type = data.get("property_type", "")
-                area = data.get("area_m2", "")
-                area_suffix = f"{area}м²" if area not in ("", None) else ""
-                label = (f"{complex_name} {property_type} {area_suffix}").strip()
-                items.append((label, property_id))
-                favorites_by_id[property_id] = {
-                    "id": property_id,
-                    "complex_name": complex_name,
-                    "property_type": property_type,
-                    "area_m2": data.get("area_m2", 0),
-                    "price_eur": data.get("price_eur", 0),
-                }
-            has_favorites = len(items) > 0
-        except Exception:
-            logger.exception("Failed to load favorites for viewing wizard")
-
-    if dialog_manager is not None:
-        dialog_manager.dialog_data["favorites_by_id"] = favorites_by_id
-
-    return {
-        "title": "🏠 Выберите объекты для осмотра:",
-        "items": items,
-        "has_favorites": has_favorites,
-        "btn_manual": "📝 Ввести вручную",
-        "btn_skip": "⏭ Пропустить",
-        "btn_next": "▶ Далее",
-        "btn_back": "◀ Назад",
-    }
-
-
-async def get_objects_text_prompt(**kwargs: Any) -> dict[str, str]:
-    """Getter for free-text object input (Step 1b)."""
-    return {
-        "title": "📝 Опишите, какие объекты хотите посмотреть:",
-        "btn_back": "◀ Назад",
-    }
-
-
 async def get_date_options(
     dialog_manager: DialogManager | None = None, **kwargs: Any
 ) -> dict[str, Any]:
-    """Getter for date range selection (Step 2)."""
+    """Getter for date range selection (Step 1)."""
     items = list(DATE_LABELS.items())  # [(key, label), ...]
     # Flip to (label, key) for Select widget
     return {
         "title": "📅 Когда удобно осмотреть?",
         "items": [(label, key) for key, label in items],
-        "btn_back": "◀ Назад",
+        "btn_cancel": "✉ Написать менеджеру",
     }
 
 
 async def get_phone_prompt(**kwargs: Any) -> dict[str, str]:
-    """Getter for phone input (Step 3)."""
+    """Getter for phone input (Step 2)."""
     return {
         "title": "📞 Введите ваш номер телефона\n\nНапример: +359 88 123 4567 или +380 50 123 4567",
-        "btn_back": "◀ Назад",
+        "btn_cancel": "✉ Написать менеджеру",
     }
 
 
 async def get_summary_data(
     dialog_manager: DialogManager | Any = None, **kwargs: Any
 ) -> dict[str, Any]:
-    """Build summary text from collected data (Step 4)."""
+    """Build summary text from collected data (Step 3)."""
     data = dialog_manager.dialog_data if dialog_manager else {}
 
-    objects = data.get("selected_objects", [])
-    manual_text = data.get("manual_text", "")
     date_range = data.get("date_range", "unknown")
     phone = data.get("phone", "—")
 
-    # Format objects
-    if objects:
-        obj_lines = []
-        for obj in objects:
-            name = obj.get("complex_name", "?")
-            ptype = obj.get("property_type", "")
-            obj_lines.append(f"  • {name} {ptype}".strip())
-        objects_text = "\n".join(obj_lines)
-    elif manual_text:
-        objects_text = f"  {manual_text}"
-    else:
-        objects_text = "  Не указаны (менеджер подберёт)"
-
     date_label = DATE_LABELS.get(date_range, date_range)
 
-    summary = (
-        f"📋 Ваша заявка на осмотр:\n\n"
-        f"🏠 Объекты:\n{objects_text}\n\n"
-        f"📅 Дата: {date_label}\n\n"
-        f"📞 Телефон: {phone}"
-    )
+    summary = f"📋 Ваша заявка на осмотр:\n\n📅 Дата: {date_label}\n\n📞 Телефон: {phone}"
 
     return {
         "summary_text": summary,
         "btn_confirm": "✅ Подтвердить",
-        "btn_edit": "✏ Изменить",
-        "btn_cancel": "❌ Отмена",
+        "btn_cancel": "✉ Написать менеджеру",
     }
 
 
-# ── Handlers ─────────────────────────────────────────────────────────
+# ── Shared CRM logic ────────────────────────────────────────────────
 
 
-async def on_object_selected(
-    callback: CallbackQuery,
-    widget: Select,
+async def _restore_menu_keyboard(bot: Any, chat_id: int) -> None:
+    """Restore client menu ReplyKeyboard after dialog completes."""
+    from telegram_bot.keyboards.client_keyboard import build_client_keyboard
+
+    await bot.send_message(
+        chat_id=chat_id,
+        text="✅ Ваша заявка на осмотр получена!\n\n"
+        "Наш менеджер свяжется с вами в ближайшее время "
+        "для согласования деталей. Спасибо за обращение! 🙏",
+        reply_markup=build_client_keyboard(),
+    )
+
+
+@observe(name="dialog-viewing-submit", capture_input=False, capture_output=False)
+async def _submit_viewing_request(
     manager: DialogManager,
-    item_id: str,
+    phone: str,
+    user: Any,
+    bot: Any,
 ) -> None:
-    """Toggle object selection (multi-select via dialog_data list)."""
-    item_key = str(item_id)
-    selected: list[dict[str, Any]] = manager.dialog_data.get("selected_objects", [])
-    # Check if already selected → remove (toggle)
-    existing_ids = [str(obj.get("id", obj.get("property_id", ""))) for obj in selected]
-    if item_key in existing_ids:
-        selected = [
-            obj for obj in selected if str(obj.get("id", obj.get("property_id", ""))) != item_key
-        ]
-    else:
-        favorites_by_id = manager.dialog_data.get("favorites_by_id", {})
-        selected_obj = favorites_by_id.get(item_key, {"id": item_key})
-        selected.append(dict(selected_obj))
-    manager.dialog_data["selected_objects"] = selected
+    """Submit viewing request to Kommo CRM (shared by on_confirm and contact share)."""
+    from telegram_bot.handlers.phone_collector import (
+        _build_custom_fields,
+        build_display_name,
+    )
+    from telegram_bot.services.kommo_models import ContactCreate, LeadCreate, TaskCreate
+
+    data = manager.dialog_data
+    date_range = data.get("date_range", "unknown")
+
+    display_name = build_display_name(user, phone)
+    username = getattr(user, "username", None)
+    user_id = user.id if user else 0
+
+    logger.info(
+        "submit_viewing: phone=%s date=%s user=%s",
+        phone,
+        date_range,
+        user_id,
+    )
+
+    date_label = DATE_LABELS.get(date_range, date_range)
+
+    kommo_client = manager.middleware_data.get("kommo_client")
+    bot_config = manager.middleware_data.get("bot_config")
+
+    if kommo_client is not None:
+        try:
+            contact_data = ContactCreate(
+                first_name=user.first_name if user else "",
+                last_name=getattr(user, "last_name", None) if user else None,
+                phone=phone,
+            )
+            contact = await kommo_client.upsert_contact(phone, contact_data)
+
+            pipeline_id = (bot_config.kommo_default_pipeline_id if bot_config else 0) or None
+            status_id = (bot_config.kommo_new_status_id if bot_config else 0) or None
+            responsible = (bot_config.kommo_responsible_user_id if bot_config else None) or None
+
+            custom_fields = _build_custom_fields(
+                "Запись на осмотр",
+                user_id,
+                username,
+                service_field_id=(bot_config.kommo_service_field_id if bot_config else 0),
+                source_field_id=(bot_config.kommo_source_field_id if bot_config else 0),
+                telegram_field_id=(bot_config.kommo_telegram_field_id if bot_config else 0),
+                telegram_username_field_id=(
+                    bot_config.kommo_telegram_username_field_id if bot_config else 0
+                ),
+            )
+
+            lead_name = f"Осмотр — {display_name}"
+            lead = await kommo_client.create_lead(
+                LeadCreate(  # type: ignore[call-arg]
+                    name=lead_name,
+                    pipeline_id=pipeline_id,
+                    status_id=status_id,
+                    responsible_user_id=responsible,
+                    custom_fields_values=custom_fields or None,
+                )
+            )
+            await kommo_client.link_contact_to_lead(lead.id, contact.id)
+
+            note_text = f"Запись на осмотр\nТелефон: {phone}\nЖелаемая дата осмотра: {date_label}"
+            if username:
+                note_text += f"\nTelegram: @{username}"
+            note_text += f"\nTelegram ID: {user_id}"
+            await kommo_client.add_note("leads", lead.id, note_text)
+
+            due_date = compute_due_date(date_range)
+            task_text = f"Осмотр: {display_name} ({date_label})"
+            await kommo_client.create_task(
+                TaskCreate(
+                    text=task_text,
+                    entity_id=lead.id,
+                    complete_till=due_date,
+                )
+            )
+
+            logger.info(
+                "Viewing lead created: lead_id=%s phone=%s date=%s",
+                lead.id,
+                phone,
+                date_range,
+            )
+        except Exception:
+            logger.exception("CRM viewing lead creation failed for phone=%s", phone)
+
+    # Send confirmation + restore client menu keyboard
+    await _restore_menu_keyboard(bot, user_id)
+    logger.info("Viewing confirmation sent to user=%s", user_id)
 
 
-async def on_objects_next(callback: CallbackQuery, button: Button, manager: DialogManager) -> None:
-    """Proceed to date selection with selected objects."""
-    await manager.switch_to(ViewingSG.date)
-
-
-async def on_objects_skip(callback: CallbackQuery, button: Button, manager: DialogManager) -> None:
-    """Skip object selection, proceed to date."""
-    manager.dialog_data["selected_objects"] = []
-    await manager.switch_to(ViewingSG.date)
-
-
-async def on_objects_manual(
-    callback: CallbackQuery, button: Button, manager: DialogManager
-) -> None:
-    """Switch to free-text object input."""
-    await manager.switch_to(ViewingSG.objects_text)
-
-
-async def on_manual_text_received(message: Message, widget: Any, manager: DialogManager) -> None:
-    """Save manual text and proceed to date."""
-    manager.dialog_data["manual_text"] = message.text or ""
-    await manager.switch_to(ViewingSG.date)
+# ── Handlers ─────────────────────────────────────────────────────────
 
 
 async def _send_phone_reply_keyboard(callback: CallbackQuery) -> None:
@@ -249,17 +227,11 @@ async def _send_phone_reply_keyboard(callback: CallbackQuery) -> None:
     )
 
 
-async def _restore_menu_keyboard(bot: Any, chat_id: int) -> None:
-    """Restore client menu ReplyKeyboard after dialog completes."""
-    from telegram_bot.keyboards.client_keyboard import build_client_keyboard
-
-    await bot.send_message(
-        chat_id=chat_id,
-        text="✅ Ваша заявка на осмотр получена!\n\n"
-        "Наш менеджер свяжется с вами в ближайшее время "
-        "для согласования деталей. Спасибо за обращение! 🙏",
-        reply_markup=build_client_keyboard(),
-    )
+async def on_cancel_to_manager(
+    callback: CallbackQuery, button: Button, manager: DialogManager
+) -> None:
+    """Cancel viewing and redirect to manager handoff."""
+    await manager.start(HandoffSG.goal, mode=StartMode.RESET_STACK)
 
 
 async def on_date_selected(
@@ -306,7 +278,7 @@ async def on_phone_text_received(message: Message, widget: Any, manager: DialogM
 
 
 async def on_phone_contact_received(message: Message, widget: Any, manager: DialogManager) -> None:
-    """Handle shared contact (request_contact button)."""
+    """Handle shared contact (request_contact button) — auto-confirm."""
     if message.contact and message.contact.phone_number:
         from telegram_bot.keyboards.phone_keyboard import normalize_phone
 
@@ -314,8 +286,20 @@ async def on_phone_contact_received(message: Message, widget: Any, manager: Dial
         phone = normalize_phone(raw) or raw
         manager.dialog_data["phone"] = phone
         await message.answer("📞 Номер принят!", reply_markup=ReplyKeyboardRemove())
-        manager.show_mode = ShowMode.DELETE_AND_SEND
-        await manager.switch_to(ViewingSG.summary)
+
+        # Auto-confirm: submit CRM and close dialog without summary step
+        try:
+            await _submit_viewing_request(
+                manager=manager,
+                phone=phone,
+                user=message.from_user,
+                bot=message.bot,
+            )
+        except Exception:
+            logger.exception("Auto-confirm CRM failed for phone=%s", phone)
+
+        manager.show_mode = ShowMode.EDIT
+        await manager.done()
     else:
         await message.answer("❌ Не удалось получить номер. Введите вручную:")
 
@@ -324,129 +308,13 @@ async def on_phone_contact_received(message: Message, widget: Any, manager: Dial
 async def on_confirm(callback: CallbackQuery, button: Button, manager: DialogManager) -> None:
     """Submit viewing request to Kommo CRM and close dialog."""
     try:
-        from telegram_bot.handlers.phone_collector import (
-            _build_custom_fields,
-            _build_note_text,
-            build_display_name,
+        phone = manager.dialog_data.get("phone", "")
+        await _submit_viewing_request(
+            manager=manager,
+            phone=phone,
+            user=callback.from_user,
+            bot=callback.bot,
         )
-        from telegram_bot.services.kommo_models import ContactCreate, LeadCreate, TaskCreate
-
-        data = manager.dialog_data
-        phone = data.get("phone", "")
-        date_range = data.get("date_range", "unknown")
-        selected_objects = data.get("selected_objects", [])
-        manual_text = data.get("manual_text", "")
-
-        user = callback.from_user
-        display_name = build_display_name(user, phone)
-        username = getattr(user, "username", None)
-        user_id = user.id if user else 0
-
-        # Build viewing_objects for note (reuse phone_collector format)
-        viewing_objects = selected_objects or []
-
-        logger.info(
-            "on_confirm: phone=%s date=%s objects=%d manual=%r",
-            phone,
-            date_range,
-            len(viewing_objects),
-            bool(manual_text),
-        )
-
-        # Build object summary for lead title and task
-        obj_summary = ""
-        if viewing_objects:
-            names = [
-                o.get("complex_name", "?") + " " + o.get("property_type", "")
-                for o in viewing_objects
-            ]
-            obj_summary = ", ".join(n.strip() for n in names)
-        elif manual_text:
-            obj_summary = manual_text[:60]
-
-        # Build note with date info
-        date_label = DATE_LABELS.get(date_range, date_range)
-        extra_note = f"\nЖелаемая дата осмотра: {date_label}"
-        if manual_text:
-            extra_note += f"\nОписание объектов: {manual_text}"
-
-        kommo_client = manager.middleware_data.get("kommo_client")
-        bot_config = manager.middleware_data.get("bot_config")
-
-        if kommo_client is not None:
-            try:
-                contact_data = ContactCreate(
-                    first_name=user.first_name if user else "",
-                    last_name=getattr(user, "last_name", None) if user else None,
-                    phone=phone,
-                )
-                contact = await kommo_client.upsert_contact(phone, contact_data)
-
-                pipeline_id = (bot_config.kommo_default_pipeline_id if bot_config else 0) or None
-                status_id = (bot_config.kommo_new_status_id if bot_config else 0) or None
-                responsible = (bot_config.kommo_responsible_user_id if bot_config else None) or None
-
-                custom_fields = _build_custom_fields(
-                    "Запись на осмотр",
-                    user_id,
-                    username,
-                    service_field_id=(bot_config.kommo_service_field_id if bot_config else 0),
-                    source_field_id=(bot_config.kommo_source_field_id if bot_config else 0),
-                    telegram_field_id=(bot_config.kommo_telegram_field_id if bot_config else 0),
-                    telegram_username_field_id=(
-                        bot_config.kommo_telegram_username_field_id if bot_config else 0
-                    ),
-                )
-
-                lead_name = f"Осмотр — {display_name}"
-                if obj_summary:
-                    lead_name = f"Осмотр {obj_summary} — {display_name}"
-                lead = await kommo_client.create_lead(
-                    LeadCreate(  # type: ignore[call-arg]
-                        name=lead_name,
-                        pipeline_id=pipeline_id,
-                        status_id=status_id,
-                        responsible_user_id=responsible,
-                        custom_fields_values=custom_fields or None,
-                    )
-                )
-                await kommo_client.link_contact_to_lead(lead.id, contact.id)
-
-                note_text = _build_note_text(
-                    "Запись на осмотр",
-                    phone,
-                    username,
-                    user_id,
-                    display_name,
-                    viewing_objects,
-                )
-                note_text += extra_note
-                await kommo_client.add_note("leads", lead.id, note_text)
-
-                due_date = compute_due_date(date_range)
-                task_text = f"Осмотр: {display_name} ({date_label})"
-                if obj_summary:
-                    task_text = f"Осмотр {obj_summary}: {display_name} ({date_label})"
-                await kommo_client.create_task(
-                    TaskCreate(
-                        text=task_text,
-                        entity_id=lead.id,
-                        complete_till=due_date,
-                    )
-                )
-
-                logger.info(
-                    "Viewing lead created: lead_id=%s phone=%s date=%s",
-                    lead.id,
-                    phone,
-                    date_range,
-                )
-            except Exception:
-                logger.exception("CRM viewing lead creation failed for phone=%s", phone)
-
-        # Send confirmation + restore client menu keyboard
-        await _restore_menu_keyboard(callback.bot, callback.from_user.id)
-        logger.info("Viewing confirmation sent to user=%s", callback.from_user.id)
     except Exception:
         logger.exception("on_confirm failed for user=%s", getattr(callback.from_user, "id", "?"))
 
@@ -454,43 +322,10 @@ async def on_confirm(callback: CallbackQuery, button: Button, manager: DialogMan
     await manager.done()
 
 
-async def on_edit(callback: CallbackQuery, button: Button, manager: DialogManager) -> None:
-    """Go back to objects selection to edit."""
-    await manager.switch_to(ViewingSG.objects)
-
-
 # ── Dialog Assembly ──────────────────────────────────────────────────
 
 viewing_dialog = Dialog(
-    # Step 1: Objects from favorites
-    Window(
-        Format("{title}"),
-        Column(
-            Select(
-                Format("{item[0]}"),
-                id="viewing_objects",
-                item_id_getter=operator.itemgetter(1),
-                items="items",
-                on_click=on_object_selected,
-            ),
-            when="has_favorites",
-        ),
-        Button(Format("{btn_manual}"), id="manual", on_click=on_objects_manual),
-        Button(Format("{btn_next}"), id="next", on_click=on_objects_next),
-        Button(Format("{btn_skip}"), id="skip", on_click=on_objects_skip),
-        Cancel(Format("{btn_back}")),
-        getter=get_objects_options,
-        state=ViewingSG.objects,
-    ),
-    # Step 1b: Free-text object input
-    Window(
-        Format("{title}"),
-        MessageInput(on_manual_text_received, content_types=[ContentType.TEXT]),
-        Back(Format("{btn_back}")),
-        getter=get_objects_text_prompt,
-        state=ViewingSG.objects_text,
-    ),
-    # Step 2: Date range
+    # Step 1: Date range
     Window(
         Format("{title}"),
         Column(
@@ -502,11 +337,11 @@ viewing_dialog = Dialog(
                 on_click=on_date_selected,
             ),
         ),
-        Back(Format("{btn_back}")),
+        Button(Format("{btn_cancel}"), id="cancel", on_click=on_cancel_to_manager),
         getter=get_date_options,
         state=ViewingSG.date,
     ),
-    # Step 3: Phone input
+    # Step 2: Phone input
     Window(
         Format("{title}"),
         MessageInput(
@@ -517,18 +352,16 @@ viewing_dialog = Dialog(
             on_phone_contact_received,
             content_types=[ContentType.CONTACT],
         ),
-        Back(Format("{btn_back}")),
+        Button(Format("{btn_cancel}"), id="cancel", on_click=on_cancel_to_manager),
         getter=get_phone_prompt,
         state=ViewingSG.phone,
     ),
-    # Step 4: Summary + confirm
+    # Step 3: Summary + confirm
     Window(
         Format("{summary_text}"),
         Button(Format("{btn_confirm}"), id="confirm", on_click=on_confirm),
-        Button(Format("{btn_edit}"), id="edit", on_click=on_edit),
-        Cancel(Format("{btn_cancel}")),
+        Button(Format("{btn_cancel}"), id="cancel", on_click=on_cancel_to_manager),
         getter=get_summary_data,
         state=ViewingSG.summary,
     ),
-    on_start=on_dialog_start,
 )

--- a/tests/unit/dialogs/test_viewing.py
+++ b/tests/unit/dialogs/test_viewing.py
@@ -9,11 +9,12 @@ from telegram_bot.dialogs.states import ViewingSG
 
 
 def test_viewing_sg_has_all_states():
-    assert hasattr(ViewingSG, "objects")
-    assert hasattr(ViewingSG, "objects_text")
     assert hasattr(ViewingSG, "date")
     assert hasattr(ViewingSG, "phone")
     assert hasattr(ViewingSG, "summary")
+    # objects states removed
+    assert not hasattr(ViewingSG, "objects")
+    assert not hasattr(ViewingSG, "objects_text")
 
 
 # --- Date options ---
@@ -54,95 +55,6 @@ async def test_on_date_selected_saves_and_switches_to_phone():
     callback.bot.send_message.assert_awaited_once()
 
 
-# --- Objects getter (empty favorites) ---
-
-
-@pytest.mark.asyncio
-async def test_get_objects_options_empty_favorites():
-    from telegram_bot.dialogs.viewing import get_objects_options
-
-    result = await get_objects_options(
-        event_from_user=SimpleNamespace(id=12345),
-        favorites_service=None,
-    )
-    items = result["items"]
-    assert len(items) == 0
-    assert result["has_favorites"] is False
-
-
-@pytest.mark.asyncio
-async def test_get_objects_options_reads_favorites_from_middleware_data():
-    from telegram_bot.dialogs.viewing import get_objects_options
-
-    favorites_service = SimpleNamespace(
-        list=AsyncMock(
-            return_value=[
-                SimpleNamespace(
-                    property_id="prop-1",
-                    property_data={
-                        "complex_name": "Sunset",
-                        "property_type": "1+1",
-                        "area_m2": 61,
-                        "price_eur": 95000,
-                    },
-                )
-            ]
-        )
-    )
-    manager = SimpleNamespace(dialog_data={})
-
-    result = await get_objects_options(
-        event_from_user=SimpleNamespace(id=12345),
-        middleware_data={"favorites_service": favorites_service},
-        dialog_manager=manager,
-    )
-
-    assert result["has_favorites"] is True
-    assert len(result["items"]) == 1
-    assert result["items"][0][1] == "prop-1"
-    assert "Sunset" in result["items"][0][0]
-    assert manager.dialog_data["favorites_by_id"]["prop-1"]["complex_name"] == "Sunset"
-
-
-# --- Objects skip handler ---
-
-
-@pytest.mark.asyncio
-async def test_on_objects_skip_switches_to_date():
-    from telegram_bot.dialogs.viewing import on_objects_skip
-
-    manager = SimpleNamespace(dialog_data={}, switch_to=AsyncMock())
-    await on_objects_skip(MagicMock(), MagicMock(), manager)
-    manager.switch_to.assert_awaited_once_with(ViewingSG.date)
-
-
-@pytest.mark.asyncio
-async def test_on_object_selected_keeps_object_metadata_for_summary_and_crm():
-    from telegram_bot.dialogs.viewing import on_object_selected
-
-    manager = SimpleNamespace(
-        dialog_data={
-            "favorites_by_id": {
-                "prop-1": {
-                    "id": "prop-1",
-                    "complex_name": "Sunset",
-                    "property_type": "1+1",
-                    "area_m2": 61,
-                    "price_eur": 95000,
-                }
-            }
-        }
-    )
-
-    await on_object_selected(MagicMock(), MagicMock(), manager, "prop-1")
-
-    selected = manager.dialog_data["selected_objects"]
-    assert len(selected) == 1
-    assert selected[0]["id"] == "prop-1"
-    assert selected[0]["complex_name"] == "Sunset"
-    assert selected[0]["price_eur"] == 95000
-
-
 # --- Summary getter ---
 
 
@@ -152,15 +64,15 @@ async def test_get_summary_data_formats_all_fields():
 
     manager = SimpleNamespace(
         dialog_data={
-            "selected_objects": [{"complex_name": "Sunset", "property_type": "1+1"}],
             "date_range": "nearest",
             "phone": "+380990091392",
         }
     )
     result = await get_summary_data(dialog_manager=manager)
     assert "+380990091392" in result["summary_text"]
-    assert "Sunset" in result["summary_text"]
     assert "Ближайшие дни" in result["summary_text"]
+    # Objects section removed from summary
+    assert "Объекты" not in result["summary_text"]
 
 
 # --- Due date calculation ---
@@ -203,8 +115,6 @@ def test_viewing_dialog_has_all_windows():
 
     windows = viewing_dialog.windows
     states = [w.get_state() for w in windows.values()]
-    assert ViewingSG.objects in states
-    assert ViewingSG.objects_text in states
     assert ViewingSG.date in states
     assert ViewingSG.phone in states
     assert ViewingSG.summary in states
@@ -215,7 +125,7 @@ def test_viewing_dialog_importable_from_module():
     from telegram_bot.dialogs.viewing import viewing_dialog
 
     assert viewing_dialog is not None
-    assert len(viewing_dialog.windows) == 5
+    assert len(viewing_dialog.windows) == 3
 
 
 @pytest.mark.asyncio
@@ -269,21 +179,33 @@ async def test_phone_text_handler_sets_delete_and_send_mode():
 
 
 @pytest.mark.asyncio
-async def test_phone_contact_handler_sets_delete_and_send_mode():
-    """After contact share, dialog should DELETE_AND_SEND to avoid stale messages."""
+async def test_phone_contact_auto_confirm():
+    """Contact share should auto-confirm: submit CRM and call manager.done()."""
     from aiogram_dialog import ShowMode
 
     from telegram_bot.dialogs.viewing import on_phone_contact_received
 
     manager = AsyncMock()
-    manager.dialog_data = {}
+    manager.dialog_data = {"date_range": "nearest"}
+    manager.middleware_data = {"kommo_client": None, "bot_config": None}
     message = AsyncMock()
     message.contact = MagicMock()
     message.contact.phone_number = "+380501234567"
+    message.from_user = SimpleNamespace(
+        id=12345, first_name="Test", last_name=None, username="testuser"
+    )
+    message.bot = AsyncMock()
 
     await on_phone_contact_received(message, None, manager)
 
-    assert manager.show_mode == ShowMode.DELETE_AND_SEND
+    assert manager.show_mode == ShowMode.EDIT
+    assert manager.dialog_data["phone"] == "+380501234567"
+    # Should call done() directly (no switch to summary)
+    manager.done.assert_awaited_once()
+    # Should NOT switch to summary
+    manager.switch_to.assert_not_awaited()
+    # Should send confirmation message
+    message.bot.send_message.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -313,15 +235,6 @@ async def test_on_confirm_creates_crm_entities():
 
     manager = MagicMock()
     manager.dialog_data = {
-        "selected_objects": [
-            {
-                "id": "prop-1",
-                "complex_name": "Sunset",
-                "property_type": "1+1",
-                "area_m2": 61,
-                "price_eur": 95000,
-            }
-        ],
         "date_range": "nearest",
         "phone": "+380990091392",
     }
@@ -335,19 +248,15 @@ async def test_on_confirm_creates_crm_entities():
 
     kommo.upsert_contact.assert_awaited_once()
     kommo.create_lead.assert_awaited_once()
-    # Lead name should contain the object name
+    # Lead name should NOT contain objects (simplified)
     lead_arg = kommo.create_lead.await_args.args[0]
-    assert "Sunset" in lead_arg.name
-    assert "1+1" in lead_arg.name
+    assert "Осмотр —" in lead_arg.name
     kommo.link_contact_to_lead.assert_awaited_once_with(200, 100)
     kommo.add_note.assert_awaited_once()
     note_text = kommo.add_note.await_args.args[2]
-    assert "Sunset" in note_text
-    assert "ID: prop-1" in note_text
+    assert "Запись на осмотр" in note_text
+    assert "+380990091392" in note_text
     kommo.create_task.assert_awaited_once()
-    # Task text should contain the object name
-    task_arg = kommo.create_task.await_args.args[0]
-    assert "Sunset" in task_arg.text
     callback.bot.send_message.assert_awaited_once()
     manager.done.assert_awaited_once()
 
@@ -406,15 +315,6 @@ async def test_on_confirm_sends_confirmation_with_correct_text():
 
     manager = MagicMock()
     manager.dialog_data = {
-        "selected_objects": [
-            {
-                "id": "prop-42",
-                "complex_name": "Panorama",
-                "property_type": "2+1",
-                "area_m2": 85,
-                "price_eur": 120000,
-            }
-        ],
         "date_range": "next_week",
         "phone": "+359881234567",
     }
@@ -430,9 +330,28 @@ async def test_on_confirm_sends_confirmation_with_correct_text():
     assert "заявка на осмотр получена" in call_kwargs["text"].lower()
     assert "менеджер свяжется" in call_kwargs["text"].lower()
 
-    # 2. Lead title contains object name
+    # 2. Lead title simplified (no objects)
     lead_arg = kommo.create_lead.await_args.args[0]
-    assert "Panorama" in lead_arg.name
+    assert "Осмотр —" in lead_arg.name
 
     # 3. Dialog closed
     manager.done.assert_awaited_once()
+
+
+# --- Cancel → HandoffSG ---
+
+
+@pytest.mark.asyncio
+async def test_cancel_starts_handoff_dialog():
+    """Cancel button should start HandoffSG.goal dialog."""
+    from aiogram_dialog import StartMode
+
+    from telegram_bot.dialogs.states import HandoffSG
+    from telegram_bot.dialogs.viewing import on_cancel_to_manager
+
+    manager = AsyncMock()
+    callback = MagicMock()
+
+    await on_cancel_to_manager(callback, MagicMock(), manager)
+
+    manager.start.assert_awaited_once_with(HandoffSG.goal, mode=StartMode.RESET_STACK)

--- a/tests/unit/test_bot_entry_points_crm.py
+++ b/tests/unit/test_bot_entry_points_crm.py
@@ -104,7 +104,7 @@ def _fav_bot(favorites: list | None = None) -> PropertyBot:
 
 
 async def test_handle_viewing_starts_dialog_when_manager_available() -> None:
-    """_handle_viewing starts ViewingSG.objects via dialog_manager (#719)."""
+    """_handle_viewing starts ViewingSG.date via dialog_manager (#719)."""
     from unittest.mock import AsyncMock
 
     from aiogram_dialog import StartMode
@@ -119,7 +119,7 @@ async def test_handle_viewing_starts_dialog_when_manager_available() -> None:
 
     await bot._handle_viewing(msg, state, dialog_manager=dialog_manager)
 
-    dialog_manager.start.assert_awaited_once_with(ViewingSG.objects, mode=StartMode.RESET_STACK)
+    dialog_manager.start.assert_awaited_once_with(ViewingSG.date, mode=StartMode.RESET_STACK)
 
 
 async def test_handle_viewing_fallback_without_dialog_manager() -> None:


### PR DESCRIPTION
## Summary
- Remove objects/objects_text steps from ViewingSG — dialog now starts at date selection
- Extract shared CRM logic into `_submit_viewing_request()` for reuse
- Auto-confirm on contact share (skip summary step, call `done()` directly with `ShowMode.EDIT`)
- Replace all Cancel buttons with "Написать менеджеру" button that starts `HandoffSG.goal`
- Simplify CRM lead name to `"Осмотр — {display_name}"` (no objects)
- Remove handoff "Сейчас попрошу номер телефона..." intermediate message, use `msg.delete()`
- Update tests: remove objects-related tests, add auto-confirm and cancel→HandoffSG tests

## Test plan
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `mypy` passes (0 issues)
- [x] `pytest tests/unit/dialogs/test_viewing.py` — 17 tests pass
- [x] `pytest tests/unit/test_bot_entry_points_crm.py` — 6 tests pass
- [x] `pytest tests/unit/dialogs/ tests/unit/test_card_callbacks.py tests/unit/test_results_callbacks.py tests/unit/test_callback_fsm_regression.py` — 387 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)