### PR TITLE
test: unit tests for 6 modules (search_engines, manager_tools, crm_cards, ingestion)

### DIFF
--- a/tests/unit/agents/test_manager_tools.py
+++ b/tests/unit/agents/test_manager_tools.py
@@ -1,0 +1,262 @@
+"""Unit tests for telegram_bot/agents/manager_tools.py."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from langchain_core.runnables import RunnableConfig
+
+from telegram_bot.agents.manager_tools import (
+    _get_user_context,
+    _resolve_role,
+    build_tools_for_role,
+    create_crm_score_sync_tool,
+    create_manager_nurturing_tools,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _cfg(**kwargs: Any) -> RunnableConfig:
+    """Build a RunnableConfig with configurable dict."""
+    return RunnableConfig(configurable=kwargs)
+
+
+def _passthrough_observe(name: str | None = None, **kw: Any):  # type: ignore[return]
+    """Passthrough decorator replacing telegram_bot.observability.observe."""
+
+    def dec(fn: Any) -> Any:
+        return fn
+
+    return dec
+
+
+def _make_nurturing_tools(
+    analytics: Any = None,
+    nurturing: Any = None,
+) -> list[Any]:
+    """Create nurturing tools with observe mocked out."""
+    import unittest.mock as mock
+
+    with mock.patch("telegram_bot.agents.manager_tools.observe", _passthrough_observe):
+        return create_manager_nurturing_tools(
+            analytics_service=analytics,
+            nurturing_service=nurturing,
+        )
+
+
+def _make_score_sync_tool(
+    scoring_store: Any = None,
+    kommo_client: Any = None,
+    score_field_id: int = 1,
+    band_field_id: int = 2,
+) -> Any:
+    """Create crm_score_sync tool with observe mocked out."""
+    import unittest.mock as mock
+
+    with mock.patch("telegram_bot.agents.manager_tools.observe", _passthrough_observe):
+        return create_crm_score_sync_tool(
+            scoring_store=scoring_store,
+            kommo_client=kommo_client,
+            score_field_id=score_field_id,
+            band_field_id=band_field_id,
+        )
+
+
+# ---------------------------------------------------------------------------
+# _resolve_role
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRole:
+    def test_role_from_configurable_dict(self) -> None:
+        assert _resolve_role(_cfg(role="manager")) == "manager"
+
+    def test_role_lowercased(self) -> None:
+        assert _resolve_role(_cfg(role="ADMIN")) == "admin"
+
+    def test_role_stripped(self) -> None:
+        assert _resolve_role(_cfg(role="  manager  ")) == "manager"
+
+    def test_role_from_bot_context(self) -> None:
+        ctx = MagicMock()
+        ctx.role = "manager"
+        assert _resolve_role(_cfg(bot_context=ctx)) == "manager"
+
+    def test_defaults_to_client_when_no_role(self) -> None:
+        assert _resolve_role(_cfg()) == "client"
+
+    def test_defaults_to_client_for_none_config(self) -> None:
+        # RunnableConfig can be empty
+        assert _resolve_role(RunnableConfig()) == "client"
+
+
+# ---------------------------------------------------------------------------
+# _get_user_context
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserContext:
+    def test_returns_user_id_and_session_id(self) -> None:
+        uid, sid = _get_user_context(_cfg(user_id=42, session_id="abc"))
+        assert uid == 42
+        assert sid == "abc"
+
+    def test_returns_none_when_missing(self) -> None:
+        uid, sid = _get_user_context(_cfg())
+        assert uid is None
+        assert sid is None
+
+    def test_returns_only_user_id(self) -> None:
+        uid, sid = _get_user_context(_cfg(user_id=99))
+        assert uid == 99
+        assert sid is None
+
+
+# ---------------------------------------------------------------------------
+# build_tools_for_role
+# ---------------------------------------------------------------------------
+
+
+class TestBuildToolsForRole:
+    def test_manager_gets_extra_tools(self) -> None:
+        base = ["tool_a"]
+        extra = ["tool_b", "tool_c"]
+        result = build_tools_for_role(role="manager", base_tools=base, manager_tools=extra)
+        assert "tool_a" in result
+        assert "tool_b" in result
+        assert "tool_c" in result
+
+    def test_client_does_not_get_extra_tools(self) -> None:
+        base = ["tool_a"]
+        extra = ["tool_b"]
+        result = build_tools_for_role(role="client", base_tools=base, manager_tools=extra)
+        assert "tool_a" in result
+        assert "tool_b" not in result
+
+    def test_admin_does_not_get_extra_tools(self) -> None:
+        # build_tools_for_role only checks for "manager"
+        result = build_tools_for_role(role="admin", base_tools=[], manager_tools=["x"])
+        assert "x" not in result
+
+    def test_returns_new_list_not_same_object(self) -> None:
+        base = ["tool_a"]
+        result = build_tools_for_role(role="client", base_tools=base, manager_tools=[])
+        assert result is not base
+
+
+# ---------------------------------------------------------------------------
+# create_manager_nurturing_tools
+# ---------------------------------------------------------------------------
+
+
+class TestCreateManagerNurturingTools:
+    def test_returns_two_tools(self) -> None:
+        tools = _make_nurturing_tools()
+        assert len(tools) == 2
+
+    async def test_analytics_access_denied_for_client(self) -> None:
+        tools = _make_nurturing_tools()
+        result = await tools[0].ainvoke({"query": "stats"}, config=_cfg(role="client"))
+        assert result == "Access denied"
+
+    async def test_analytics_unavailable_when_service_none(self) -> None:
+        tools = _make_nurturing_tools(analytics=None)
+        result = await tools[0].ainvoke({"query": "stats"}, config=_cfg(role="manager"))
+        assert result == "Analytics service unavailable"
+
+    async def test_analytics_calls_get_latest_summary(self) -> None:
+        svc = AsyncMock()
+        svc.get_latest_summary.return_value = "report data"
+        tools = _make_nurturing_tools(analytics=svc)
+        result = await tools[0].ainvoke({"query": "stats"}, config=_cfg(role="manager"))
+        assert "report data" in result
+        svc.get_latest_summary.assert_awaited_once()
+
+    async def test_nurturing_access_denied_for_client(self) -> None:
+        tools = _make_nurturing_tools()
+        result = await tools[1].ainvoke({"query": "run"}, config=_cfg(role="client"))
+        assert result == "Access denied"
+
+    async def test_nurturing_unavailable_when_service_none(self) -> None:
+        tools = _make_nurturing_tools(nurturing=None)
+        result = await tools[1].ainvoke({"query": "run"}, config=_cfg(role="manager"))
+        assert result == "Nurturing service unavailable"
+
+    async def test_nurturing_returns_count(self) -> None:
+        svc = AsyncMock()
+        svc.run_once.return_value = 7
+        tools = _make_nurturing_tools(nurturing=svc)
+        result = await tools[1].ainvoke({"query": "run"}, config=_cfg(role="manager"))
+        assert "7" in result
+
+
+# ---------------------------------------------------------------------------
+# create_crm_score_sync_tool
+# ---------------------------------------------------------------------------
+
+
+class TestCreateCrmScoreSyncTool:
+    async def test_access_denied_for_client(self) -> None:
+        import unittest.mock as mock
+
+        with (
+            mock.patch(
+                "telegram_bot.agents.manager_tools.sync_pending_lead_scores",
+                new_callable=AsyncMock,
+            ),
+            mock.patch("telegram_bot.agents.manager_tools.observe", _passthrough_observe),
+        ):
+            tool = _make_score_sync_tool()
+            result = await tool.ainvoke({"query": "sync"}, config=_cfg(role="client"))
+        assert result == "Access denied"
+
+    async def test_manager_can_sync(self) -> None:
+        import unittest.mock as mock
+
+        mock_sync = AsyncMock(return_value={"synced": 3, "failed": 0, "skipped": 1})
+        with (
+            mock.patch(
+                "telegram_bot.agents.manager_tools.sync_pending_lead_scores",
+                mock_sync,
+            ),
+            mock.patch("telegram_bot.agents.manager_tools.observe", _passthrough_observe),
+        ):
+            tool = create_crm_score_sync_tool(
+                scoring_store=None,
+                kommo_client=None,
+                score_field_id=1,
+                band_field_id=2,
+            )
+            result = await tool.ainvoke(
+                {"query": "sync"}, config=_cfg(role="manager", user_id=5, session_id="s1")
+            )
+        assert "synced 3" in result
+        assert "failed 0" in result
+
+    async def test_result_contains_user_context(self) -> None:
+        import unittest.mock as mock
+
+        mock_sync = AsyncMock(return_value={"synced": 1, "failed": 0, "skipped": 0})
+        with (
+            mock.patch(
+                "telegram_bot.agents.manager_tools.sync_pending_lead_scores",
+                mock_sync,
+            ),
+            mock.patch("telegram_bot.agents.manager_tools.observe", _passthrough_observe),
+        ):
+            tool = create_crm_score_sync_tool(
+                scoring_store=None,
+                kommo_client=None,
+                score_field_id=1,
+                band_field_id=2,
+            )
+            result = await tool.ainvoke(
+                {"query": "sync"}, config=_cfg(role="admin", user_id=99, session_id="xyz")
+            )
+        assert "99" in result
+        assert "xyz" in result

--- a/tests/unit/dialogs/test_crm_cards.py
+++ b/tests/unit/dialogs/test_crm_cards.py
@@ -1,0 +1,179 @@
+"""Unit tests for telegram_bot/dialogs/crm_cards.py."""
+
+from __future__ import annotations
+
+from telegram_bot.dialogs.crm_cards import (
+    build_pagination_buttons,
+    format_contact_card,
+    format_lead_card,
+    format_task_card,
+)
+from telegram_bot.services.kommo_models import Contact, Lead, Task
+
+
+# ---------------------------------------------------------------------------
+# format_lead_card
+# ---------------------------------------------------------------------------
+
+
+class TestFormatLeadCard:
+    def _make_lead(self, **kwargs) -> Lead:
+        defaults = {"id": 1, "name": "Test Lead"}
+        return Lead(**(defaults | kwargs))
+
+    def test_contains_lead_id(self) -> None:
+        text, _ = format_lead_card(self._make_lead(id=42))
+        assert "#42" in text
+
+    def test_contains_lead_name(self) -> None:
+        text, _ = format_lead_card(self._make_lead(name="My Deal"))
+        assert "My Deal" in text
+
+    def test_budget_formatted(self) -> None:
+        text, _ = format_lead_card(self._make_lead(budget=100000))
+        assert "€" in text
+
+    def test_budget_none_shows_not_specified(self) -> None:
+        text, _ = format_lead_card(self._make_lead(budget=None))
+        assert "не указан" in text
+
+    def test_task_count_shown(self) -> None:
+        text, _ = format_lead_card(self._make_lead(), task_count=5)
+        assert "5" in text
+
+    def test_contact_name_shown(self) -> None:
+        lead = self._make_lead(contacts=[{"name": "John Smith"}])
+        text, _ = format_lead_card(lead)
+        assert "John Smith" in text
+
+    def test_keyboard_has_four_buttons(self) -> None:
+        _, keyboard = format_lead_card(self._make_lead())
+        all_buttons = [btn for row in keyboard.inline_keyboard for btn in row]
+        assert len(all_buttons) == 4
+
+    def test_keyboard_callback_contains_lead_id(self) -> None:
+        _, keyboard = format_lead_card(self._make_lead(id=7))
+        all_callbacks = [btn.callback_data for row in keyboard.inline_keyboard for btn in row]
+        assert any("7" in (cb or "") for cb in all_callbacks)
+
+
+# ---------------------------------------------------------------------------
+# format_contact_card
+# ---------------------------------------------------------------------------
+
+
+class TestFormatContactCard:
+    def _make_contact(self, **kwargs) -> Contact:
+        defaults = {"id": 10}
+        return Contact(**(defaults | kwargs))
+
+    def test_contains_contact_id(self) -> None:
+        text, _ = format_contact_card(self._make_contact(id=10))
+        assert "#10" in text
+
+    def test_full_name_shown(self) -> None:
+        text, _ = format_contact_card(self._make_contact(first_name="Jane", last_name="Doe"))
+        assert "Jane Doe" in text
+
+    def test_only_first_name(self) -> None:
+        text, _ = format_contact_card(self._make_contact(first_name="Alice"))
+        assert "Alice" in text
+
+    def test_no_name_shows_dash(self) -> None:
+        text, _ = format_contact_card(self._make_contact())
+        assert "—" in text
+
+    def test_keyboard_has_two_buttons(self) -> None:
+        _, keyboard = format_contact_card(self._make_contact())
+        all_buttons = [btn for row in keyboard.inline_keyboard for btn in row]
+        assert len(all_buttons) == 2
+
+    def test_created_at_shown(self) -> None:
+        text, _ = format_contact_card(self._make_contact(created_at=1700000000))
+        assert "Создан:" in text
+
+
+# ---------------------------------------------------------------------------
+# format_task_card
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTaskCard:
+    def _make_task(self, **kwargs) -> Task:
+        defaults = {"id": 100, "is_completed": False}
+        return Task(**(defaults | kwargs))
+
+    def test_contains_task_id(self) -> None:
+        text, _ = format_task_card(self._make_task(id=100))
+        assert "#100" in text
+
+    def test_incomplete_task_shows_checkbox(self) -> None:
+        text, _ = format_task_card(self._make_task(is_completed=False))
+        assert "🔲" in text
+
+    def test_completed_task_shows_checkmark(self) -> None:
+        text, _ = format_task_card(self._make_task(is_completed=True))
+        assert "✅" in text
+
+    def test_task_text_shown(self) -> None:
+        text, _ = format_task_card(self._make_task(text="Call client"))
+        assert "Call client" in text
+
+    def test_no_text_shows_dash(self) -> None:
+        text, _ = format_task_card(self._make_task(text=None))
+        assert "—" in text
+
+    def test_due_date_shown(self) -> None:
+        text, _ = format_task_card(self._make_task(complete_till=1700000000))
+        assert "Срок:" in text
+
+    def test_entity_shown_when_present(self) -> None:
+        text, _ = format_task_card(self._make_task(entity_id=5, entity_type="leads"))
+        assert "leads" in text
+        assert "5" in text
+
+    def test_incomplete_task_has_three_buttons(self) -> None:
+        _, keyboard = format_task_card(self._make_task(is_completed=False))
+        all_buttons = [btn for row in keyboard.inline_keyboard for btn in row]
+        assert len(all_buttons) == 3
+
+    def test_completed_task_has_one_button(self) -> None:
+        _, keyboard = format_task_card(self._make_task(is_completed=True))
+        all_buttons = [btn for row in keyboard.inline_keyboard for btn in row]
+        assert len(all_buttons) == 1
+
+
+# ---------------------------------------------------------------------------
+# build_pagination_buttons
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPaginationButtons:
+    def test_first_page_no_prev_button(self) -> None:
+        buttons = build_pagination_buttons(prefix="p", page=0, total=20)
+        texts = [b.text for b in buttons]
+        assert not any("Назад" in t for t in texts)
+
+    def test_first_page_has_next_when_more_items(self) -> None:
+        buttons = build_pagination_buttons(prefix="p", page=0, total=20, page_size=5)
+        texts = [b.text for b in buttons]
+        assert any("Вперёд" in t for t in texts)
+
+    def test_last_page_no_next_button(self) -> None:
+        buttons = build_pagination_buttons(prefix="p", page=3, total=20, page_size=5)
+        texts = [b.text for b in buttons]
+        assert not any("Вперёд" in t for t in texts)
+
+    def test_middle_page_has_both_buttons(self) -> None:
+        buttons = build_pagination_buttons(prefix="p", page=1, total=20, page_size=5)
+        assert len(buttons) == 2
+
+    def test_callback_data_contains_prefix_and_page(self) -> None:
+        buttons = build_pagination_buttons(prefix="crm:lead:page", page=2, total=30, page_size=5)
+        callbacks = [b.callback_data for b in buttons]
+        assert any("crm:lead:page:1" in (c or "") for c in callbacks)
+        assert any("crm:lead:page:3" in (c or "") for c in callbacks)
+
+    def test_single_page_no_buttons(self) -> None:
+        buttons = build_pagination_buttons(prefix="p", page=0, total=3, page_size=5)
+        assert buttons == []

--- a/tests/unit/ingestion/conftest.py
+++ b/tests/unit/ingestion/conftest.py
@@ -1,0 +1,27 @@
+"""Conftest for ingestion unit tests.
+
+Mocks heavy ML dependencies (fastembed) before test collection
+so that gdrive_indexer.py can be imported without the actual package.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+
+_MOCKED_MODULES: list[str] = []
+
+
+def pytest_configure(config: object) -> None:
+    """Mock unavailable heavy ML deps before test collection."""
+    if "fastembed" not in sys.modules:
+        mock_fastembed = MagicMock()
+        mock_fastembed.SparseTextEmbedding = MagicMock()
+        sys.modules["fastembed"] = mock_fastembed
+        _MOCKED_MODULES.append("fastembed")
+
+
+def pytest_unconfigure(config: object) -> None:
+    """Clean up mocked modules after tests."""
+    for mod in _MOCKED_MODULES:
+        sys.modules.pop(mod, None)
+    _MOCKED_MODULES.clear()

--- a/tests/unit/ingestion/test_gdrive_flow.py
+++ b/tests/unit/ingestion/test_gdrive_flow.py
@@ -1,0 +1,250 @@
+"""Unit tests for src/ingestion/gdrive_flow.py."""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    from src.ingestion.gdrive_flow import GDriveFileProcessor, GDriveFlowConfig, ProcessedFile
+
+
+# ---------------------------------------------------------------------------
+# GDriveFlowConfig
+# ---------------------------------------------------------------------------
+
+
+class TestGDriveFlowConfig:
+    def test_default_collection_name(self) -> None:
+        config = GDriveFlowConfig()
+        assert config.collection_name == "gdrive_documents_bge"
+
+    def test_custom_sync_dir(self) -> None:
+        config = GDriveFlowConfig(sync_dir="/tmp/test-sync")
+        assert config.sync_dir == "/tmp/test-sync"
+
+    def test_default_chunk_max_tokens(self) -> None:
+        config = GDriveFlowConfig()
+        assert config.chunk_max_tokens == 512
+
+    def test_default_watch_interval(self) -> None:
+        config = GDriveFlowConfig()
+        assert config.watch_interval_seconds == 60
+
+    def test_custom_qdrant_url(self) -> None:
+        config = GDriveFlowConfig(qdrant_url="http://custom:6333")
+        assert config.qdrant_url == "http://custom:6333"
+
+
+# ---------------------------------------------------------------------------
+# GDriveFileProcessor._is_supported_file
+# ---------------------------------------------------------------------------
+
+
+class TestIsSupportedFile:
+    @pytest.fixture
+    def processor(self, tmp_path: Path) -> GDriveFileProcessor:
+        with (
+            patch("src.ingestion.gdrive_flow.DoclingClient"),
+            patch("src.ingestion.gdrive_flow.GDriveIndexer"),
+        ):
+            return GDriveFileProcessor(GDriveFlowConfig(sync_dir=str(tmp_path)))
+
+    def test_pdf_supported(self, processor: GDriveFileProcessor, tmp_path: Path) -> None:
+        assert processor._is_supported_file(tmp_path / "doc.pdf") is True
+
+    def test_docx_supported(self, processor: GDriveFileProcessor, tmp_path: Path) -> None:
+        assert processor._is_supported_file(tmp_path / "doc.docx") is True
+
+    def test_txt_supported(self, processor: GDriveFileProcessor, tmp_path: Path) -> None:
+        assert processor._is_supported_file(tmp_path / "readme.txt") is True
+
+    def test_md_supported(self, processor: GDriveFileProcessor, tmp_path: Path) -> None:
+        assert processor._is_supported_file(tmp_path / "notes.md") is True
+
+    def test_html_supported(self, processor: GDriveFileProcessor, tmp_path: Path) -> None:
+        assert processor._is_supported_file(tmp_path / "page.html") is True
+
+    def test_py_not_supported(self, processor: GDriveFileProcessor, tmp_path: Path) -> None:
+        assert processor._is_supported_file(tmp_path / "script.py") is False
+
+    def test_hidden_file_not_supported(
+        self, processor: GDriveFileProcessor, tmp_path: Path
+    ) -> None:
+        assert processor._is_supported_file(tmp_path / ".hidden.pdf") is False
+
+    def test_temp_office_file_not_supported(
+        self, processor: GDriveFileProcessor, tmp_path: Path
+    ) -> None:
+        assert processor._is_supported_file(tmp_path / "~$doc.docx") is False
+
+    def test_uppercase_extension_supported(
+        self, processor: GDriveFileProcessor, tmp_path: Path
+    ) -> None:
+        assert processor._is_supported_file(tmp_path / "DOC.PDF") is True
+
+
+# ---------------------------------------------------------------------------
+# GDriveFileProcessor._compute_file_id
+# ---------------------------------------------------------------------------
+
+
+class TestComputeFileId:
+    @pytest.fixture
+    def processor(self, tmp_path: Path) -> GDriveFileProcessor:
+        with (
+            patch("src.ingestion.gdrive_flow.DoclingClient"),
+            patch("src.ingestion.gdrive_flow.GDriveIndexer"),
+        ):
+            return GDriveFileProcessor(GDriveFlowConfig(sync_dir=str(tmp_path)))
+
+    def test_returns_16_char_hex(self, processor: GDriveFileProcessor, tmp_path: Path) -> None:
+        file_id = processor._compute_file_id(tmp_path / "test.pdf")
+        assert len(file_id) == 16
+        assert all(c in "0123456789abcdef" for c in file_id)
+
+    def test_deterministic(self, processor: GDriveFileProcessor, tmp_path: Path) -> None:
+        path = tmp_path / "test.pdf"
+        assert processor._compute_file_id(path) == processor._compute_file_id(path)
+
+    def test_different_paths_different_ids(
+        self, processor: GDriveFileProcessor, tmp_path: Path
+    ) -> None:
+        id1 = processor._compute_file_id(tmp_path / "a.pdf")
+        id2 = processor._compute_file_id(tmp_path / "b.pdf")
+        assert id1 != id2
+
+    def test_nested_path(self, processor: GDriveFileProcessor, tmp_path: Path) -> None:
+        path = tmp_path / "subdir" / "deep" / "file.pdf"
+        file_id = processor._compute_file_id(path)
+        assert len(file_id) == 16
+
+
+# ---------------------------------------------------------------------------
+# GDriveFileProcessor._get_mime_type
+# ---------------------------------------------------------------------------
+
+
+class TestGetMimeType:
+    def test_pdf(self) -> None:
+        assert GDriveFileProcessor._get_mime_type(Path("doc.pdf")) == "application/pdf"
+
+    def test_docx(self) -> None:
+        result = GDriveFileProcessor._get_mime_type(Path("doc.docx"))
+        assert "wordprocessingml" in result
+
+    def test_txt(self) -> None:
+        assert GDriveFileProcessor._get_mime_type(Path("file.txt")) == "text/plain"
+
+    def test_md(self) -> None:
+        assert GDriveFileProcessor._get_mime_type(Path("notes.md")) == "text/markdown"
+
+    def test_html(self) -> None:
+        assert GDriveFileProcessor._get_mime_type(Path("page.html")) == "text/html"
+
+    def test_htm_same_as_html(self) -> None:
+        assert GDriveFileProcessor._get_mime_type(Path("page.htm")) == "text/html"
+
+    def test_unknown_extension(self) -> None:
+        assert GDriveFileProcessor._get_mime_type(Path("file.xyz")) == "application/octet-stream"
+
+
+# ---------------------------------------------------------------------------
+# GDriveFileProcessor._needs_processing
+# ---------------------------------------------------------------------------
+
+
+class TestNeedsProcessing:
+    @pytest.fixture
+    def processor(self, tmp_path: Path) -> GDriveFileProcessor:
+        with (
+            patch("src.ingestion.gdrive_flow.DoclingClient"),
+            patch("src.ingestion.gdrive_flow.GDriveIndexer"),
+        ):
+            return GDriveFileProcessor(GDriveFlowConfig(sync_dir=str(tmp_path)))
+
+    def test_new_file_needs_processing(
+        self, processor: GDriveFileProcessor, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "new.pdf"
+        path.write_bytes(b"content")
+        assert processor._needs_processing(path, "unknown_id") is True
+
+    def test_unchanged_file_does_not_need_processing(
+        self, processor: GDriveFileProcessor, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "existing.pdf"
+        path.write_bytes(b"content")
+        file_id = processor._compute_file_id(path)
+        content_hash = processor._compute_content_hash(path)
+        from datetime import UTC, datetime
+
+        from src.ingestion.gdrive_flow import ProcessedFile
+
+        processor._processed[file_id] = ProcessedFile(
+            file_path="existing.pdf",
+            file_id=file_id,
+            content_hash=content_hash,
+            chunks_count=1,
+            processed_at=datetime.now(UTC),
+        )
+        assert processor._needs_processing(path, file_id) is False
+
+    def test_changed_file_needs_processing(
+        self, processor: GDriveFileProcessor, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "changed.pdf"
+        path.write_bytes(b"old content")
+        file_id = processor._compute_file_id(path)
+        from datetime import UTC, datetime
+
+        from src.ingestion.gdrive_flow import ProcessedFile
+
+        processor._processed[file_id] = ProcessedFile(
+            file_path="changed.pdf",
+            file_id=file_id,
+            content_hash="old_hash_value_xx",
+            chunks_count=1,
+            processed_at=datetime.now(UTC),
+        )
+        path.write_bytes(b"new content that is different")
+        assert processor._needs_processing(path, file_id) is True
+
+
+# ---------------------------------------------------------------------------
+# ProcessedFile
+# ---------------------------------------------------------------------------
+
+
+class TestProcessedFile:
+    def test_creates_with_error(self) -> None:
+        from datetime import UTC, datetime
+
+        pf = ProcessedFile(
+            file_path="test.pdf",
+            file_id="abc123",
+            content_hash="hash",
+            chunks_count=0,
+            processed_at=datetime.now(UTC),
+            error="Some error",
+        )
+        assert pf.error == "Some error"
+
+    def test_creates_without_error(self) -> None:
+        from datetime import UTC, datetime
+
+        pf = ProcessedFile(
+            file_path="test.pdf",
+            file_id="abc123",
+            content_hash="hash",
+            chunks_count=5,
+            processed_at=datetime.now(UTC),
+        )
+        assert pf.error is None

--- a/tests/unit/ingestion/test_gdrive_indexer.py
+++ b/tests/unit/ingestion/test_gdrive_indexer.py
@@ -1,0 +1,184 @@
+"""Unit tests for src/ingestion/gdrive_indexer.py."""
+
+from __future__ import annotations
+
+import uuid
+import warnings
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    from src.ingestion.gdrive_indexer import (
+        NAMESPACE_GDRIVE,
+        GDriveIndexer,
+        IndexStats,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def indexer() -> GDriveIndexer:
+    with (
+        patch("src.ingestion.gdrive_indexer.QdrantClient"),
+        patch("src.ingestion.gdrive_indexer.VoyageService"),
+        patch("src.ingestion.gdrive_indexer.SparseTextEmbedding"),
+    ):
+        idx = GDriveIndexer(qdrant_url="http://localhost:6333", voyage_api_key="test-key")
+        # Replace lazily-created mocks with explicit ones
+        idx.client = MagicMock()
+        idx.voyage_service = AsyncMock()
+        idx.sparse_model = MagicMock()
+    return idx
+
+
+# ---------------------------------------------------------------------------
+# IndexStats
+# ---------------------------------------------------------------------------
+
+
+class TestIndexStats:
+    def test_default_values(self) -> None:
+        stats = IndexStats()
+        assert stats.total_chunks == 0
+        assert stats.indexed_chunks == 0
+        assert stats.deleted_points == 0
+        assert stats.failed_chunks == 0
+        assert stats.errors == []
+
+    def test_errors_list_independent(self) -> None:
+        s1 = IndexStats()
+        s2 = IndexStats()
+        s1.errors.append("err")
+        assert s2.errors == []
+
+
+# ---------------------------------------------------------------------------
+# _generate_point_id
+# ---------------------------------------------------------------------------
+
+
+class TestGeneratePointId:
+    def test_returns_uuid_string(self, indexer: GDriveIndexer) -> None:
+        point_id = indexer._generate_point_id("file123", "chunk_0")
+        uuid.UUID(point_id)  # raises if invalid
+
+    def test_deterministic(self, indexer: GDriveIndexer) -> None:
+        id1 = indexer._generate_point_id("file123", "chunk_0")
+        id2 = indexer._generate_point_id("file123", "chunk_0")
+        assert id1 == id2
+
+    def test_different_chunk_different_id(self, indexer: GDriveIndexer) -> None:
+        id1 = indexer._generate_point_id("file123", "chunk_0")
+        id2 = indexer._generate_point_id("file123", "chunk_1")
+        assert id1 != id2
+
+    def test_different_file_different_id(self, indexer: GDriveIndexer) -> None:
+        id1 = indexer._generate_point_id("fileA", "chunk_0")
+        id2 = indexer._generate_point_id("fileB", "chunk_0")
+        assert id1 != id2
+
+    def test_uses_namespace_gdrive(self, indexer: GDriveIndexer) -> None:
+        point_id = indexer._generate_point_id("file", "chunk")
+        expected = str(uuid.uuid5(NAMESPACE_GDRIVE, "file::chunk"))
+        assert point_id == expected
+
+
+# ---------------------------------------------------------------------------
+# delete_file_points
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteFilePoints:
+    async def test_returns_zero_when_no_points(self, indexer: GDriveIndexer) -> None:
+        count_result = MagicMock()
+        count_result.count = 0
+        indexer.client.count.return_value = count_result
+
+        result = await indexer.delete_file_points("file123")
+        assert result == 0
+        indexer.client.delete.assert_not_called()
+
+    async def test_deletes_when_points_exist(self, indexer: GDriveIndexer) -> None:
+        count_result = MagicMock()
+        count_result.count = 5
+        indexer.client.count.return_value = count_result
+
+        result = await indexer.delete_file_points("file123", "my_collection")
+        assert result == 5
+        indexer.client.delete.assert_called_once()
+
+    async def test_uses_default_collection(self, indexer: GDriveIndexer) -> None:
+        count_result = MagicMock()
+        count_result.count = 0
+        indexer.client.count.return_value = count_result
+
+        await indexer.delete_file_points("file123")
+        call_kwargs = indexer.client.count.call_args[1]
+        assert call_kwargs["collection_name"] == GDriveIndexer.DEFAULT_COLLECTION
+
+
+# ---------------------------------------------------------------------------
+# index_file_chunks
+# ---------------------------------------------------------------------------
+
+
+class TestIndexFileChunks:
+    def _make_chunk(self, text: str = "test text") -> MagicMock:
+        chunk = MagicMock()
+        chunk.text = text
+        chunk.document_name = "test.pdf"
+        chunk.chunk_id = "c1"
+        chunk.section = None
+        chunk.page_range = None
+        chunk.extra_metadata = {}
+        return chunk
+
+    async def test_empty_chunks_returns_zero_indexed(self, indexer: GDriveIndexer) -> None:
+        stats = await indexer.index_file_chunks(chunks=[], file_id="f1")
+        assert stats.indexed_chunks == 0
+        assert stats.total_chunks == 0
+
+    async def test_indexes_chunks_successfully(self, indexer: GDriveIndexer) -> None:
+        # Mock delete
+        count_result = MagicMock()
+        count_result.count = 0
+        indexer.client.count.return_value = count_result
+
+        # Mock embeddings
+        indexer.voyage_service.embed_documents = AsyncMock(return_value=[[0.1] * 1024])
+        sparse_emb = MagicMock()
+        sparse_emb.indices = MagicMock()
+        sparse_emb.indices.tolist.return_value = [1, 2, 3]
+        sparse_emb.values = MagicMock()
+        sparse_emb.values.tolist.return_value = [0.1, 0.2, 0.3]
+        indexer.sparse_model.embed.return_value = iter([sparse_emb])
+
+        chunks = [self._make_chunk("hello world")]
+        stats = await indexer.index_file_chunks(chunks=chunks, file_id="f1")
+
+        assert stats.indexed_chunks == 1
+        assert stats.total_chunks == 1
+        indexer.client.upsert.assert_called_once()
+
+    async def test_handles_exception_and_records_error(self, indexer: GDriveIndexer) -> None:
+        count_result = MagicMock()
+        count_result.count = 0
+        indexer.client.count.return_value = count_result
+
+        indexer.voyage_service.embed_documents = AsyncMock(side_effect=RuntimeError("API down"))
+
+        chunks = [self._make_chunk()]
+        stats = await indexer.index_file_chunks(chunks=chunks, file_id="f1")
+
+        assert stats.failed_chunks == 1
+        assert len(stats.errors) == 1
+        assert "API down" in stats.errors[0]

--- a/tests/unit/ingestion/test_qdrant_hybrid_target.py
+++ b/tests/unit/ingestion/test_qdrant_hybrid_target.py
@@ -1,0 +1,148 @@
+"""Unit tests for src/ingestion/unified/targets/qdrant_hybrid_target.py.
+
+Skipped entirely if cocoindex is not installed (ingest extra).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+
+cocoindex = pytest.importorskip("cocoindex", reason="cocoindex not installed (ingest extra)")
+
+from src.ingestion.unified.targets.qdrant_hybrid_target import (
+    QdrantHybridTargetConnector,
+    QdrantHybridTargetSpec,
+    QdrantHybridTargetValues,
+    compute_content_hash,
+)
+
+
+# ---------------------------------------------------------------------------
+# compute_content_hash
+# ---------------------------------------------------------------------------
+
+
+class TestComputeContentHash:
+    def test_returns_16_char_hex(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.txt"
+        f.write_bytes(b"hello")
+        result = compute_content_hash(f)
+        assert len(result) == 16
+        assert all(c in "0123456789abcdef" for c in result)
+
+    def test_deterministic(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.txt"
+        f.write_bytes(b"hello")
+        assert compute_content_hash(f) == compute_content_hash(f)
+
+    def test_different_content_different_hash(self, tmp_path: Path) -> None:
+        f1 = tmp_path / "a.txt"
+        f2 = tmp_path / "b.txt"
+        f1.write_bytes(b"content A")
+        f2.write_bytes(b"content B")
+        assert compute_content_hash(f1) != compute_content_hash(f2)
+
+    def test_matches_sha256_first_16_chars(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.txt"
+        f.write_bytes(b"test data")
+        hasher = hashlib.sha256()
+        hasher.update(b"test data")
+        expected = hasher.hexdigest()[:16]
+        assert compute_content_hash(f) == expected
+
+    def test_large_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "large.bin"
+        f.write_bytes(b"x" * 100_000)
+        result = compute_content_hash(f)
+        assert len(result) == 16
+
+
+# ---------------------------------------------------------------------------
+# QdrantHybridTargetSpec
+# ---------------------------------------------------------------------------
+
+
+class TestQdrantHybridTargetSpec:
+    def test_default_qdrant_url(self) -> None:
+        spec = QdrantHybridTargetSpec()
+        assert spec.qdrant_url == "http://localhost:6333"
+
+    def test_default_collection_name(self) -> None:
+        spec = QdrantHybridTargetSpec()
+        assert spec.collection_name == "gdrive_documents_bge"
+
+    def test_default_max_tokens(self) -> None:
+        spec = QdrantHybridTargetSpec()
+        assert spec.max_tokens_per_chunk == 512
+
+    def test_default_pipeline_version(self) -> None:
+        spec = QdrantHybridTargetSpec()
+        assert spec.pipeline_version == "v3.2.1"
+
+    def test_from_config(self) -> None:
+        from src.ingestion.unified.config import UnifiedConfig
+
+        config = UnifiedConfig()
+        spec = QdrantHybridTargetSpec.from_config(config)
+        assert spec.qdrant_url == config.qdrant_url
+        assert spec.collection_name == config.collection_name
+
+    def test_custom_values(self) -> None:
+        spec = QdrantHybridTargetSpec(
+            qdrant_url="http://custom:6333",
+            collection_name="my_col",
+        )
+        assert spec.qdrant_url == "http://custom:6333"
+        assert spec.collection_name == "my_col"
+
+
+# ---------------------------------------------------------------------------
+# QdrantHybridTargetValues
+# ---------------------------------------------------------------------------
+
+
+class TestQdrantHybridTargetValues:
+    def test_creates_correctly(self) -> None:
+        val = QdrantHybridTargetValues(
+            abs_path="/tmp/file.pdf",
+            source_path="docs/file.pdf",
+            file_name="file.pdf",
+            mime_type="application/pdf",
+            file_size=12345,
+        )
+        assert val.abs_path == "/tmp/file.pdf"
+        assert val.file_size == 12345
+
+
+# ---------------------------------------------------------------------------
+# Connector static methods
+# ---------------------------------------------------------------------------
+
+
+class TestConnectorStatics:
+    def test_get_persistent_key_format(self) -> None:
+        spec = QdrantHybridTargetSpec(
+            qdrant_url="http://localhost:6333",
+            collection_name="my_col",
+        )
+        key = QdrantHybridTargetConnector.get_persistent_key(spec, "target")
+        assert key == "my_col@http://localhost:6333"
+
+    def test_describe_returns_string(self) -> None:
+        desc = QdrantHybridTargetConnector.describe("my_col@http://localhost:6333")
+        assert isinstance(desc, str)
+        assert "my_col" in desc
+
+    def test_apply_setup_change_create(self) -> None:
+        spec = QdrantHybridTargetSpec()
+        # Should not raise
+        QdrantHybridTargetConnector.apply_setup_change("key", None, spec)
+
+    def test_prepare_returns_spec(self) -> None:
+        spec = QdrantHybridTargetSpec()
+        result = QdrantHybridTargetConnector.prepare(spec)
+        assert result is spec

--- a/tests/unit/retrieval/test_search_engines.py
+++ b/tests/unit/retrieval/test_search_engines.py
@@ -1,0 +1,380 @@
+"""Unit tests for src/retrieval/search_engines.py."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from qdrant_client import models
+
+from src.config import AcornMode, QuantizationMode, SearchEngine, Settings
+from src.retrieval.search_engines import (
+    BaselineSearchEngine,
+    HybridRRFSearchEngine,
+    SearchResult,
+    create_search_engine,
+    lexical_weights_to_sparse,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_settings() -> Settings:
+    s = MagicMock(spec=Settings)
+    s.qdrant_url = "http://localhost:6333"
+    s.acorn_mode = AcornMode.OFF
+    s.quantization_mode = QuantizationMode.OFF
+    s.quantization_rescore = True
+    s.quantization_oversampling = 2.0
+    s.acorn_enabled_selectivity_threshold = 0.5
+    s.acorn_max_selectivity = 1.0
+    s.search_engine = SearchEngine.BASELINE
+    s.get_collection_name.return_value = "test_collection"
+    return s
+
+
+@pytest.fixture
+def baseline_engine(mock_settings: Settings) -> BaselineSearchEngine:
+    with patch("src.retrieval.search_engines.QdrantClient"):
+        engine = BaselineSearchEngine(mock_settings)
+        engine.client = MagicMock()
+    return engine
+
+
+# ---------------------------------------------------------------------------
+# lexical_weights_to_sparse
+# ---------------------------------------------------------------------------
+
+
+class TestLexicalWeightsToSparse:
+    def test_empty_dict_returns_empty_sparse(self) -> None:
+        result = lexical_weights_to_sparse({})
+        assert result.indices == []
+        assert result.values == []
+
+    def test_converts_string_keys_to_int_indices(self) -> None:
+        result = lexical_weights_to_sparse({"10": 0.5, "20": 0.3})
+        assert 10 in result.indices
+        assert 20 in result.indices
+
+    def test_preserves_values(self) -> None:
+        weights = {"5": 0.9}
+        result = lexical_weights_to_sparse(weights)
+        assert 0.9 in result.values
+
+
+# ---------------------------------------------------------------------------
+# _should_use_acorn
+# ---------------------------------------------------------------------------
+
+
+class TestShouldUseAcorn:
+    def test_acorn_off_returns_false_with_filters(
+        self, baseline_engine: BaselineSearchEngine
+    ) -> None:
+        baseline_engine.settings.acorn_mode = AcornMode.OFF
+        assert (
+            baseline_engine._should_use_acorn(has_filters=True, estimated_selectivity=0.1) is False
+        )
+
+    def test_acorn_off_returns_false_without_filters(
+        self, baseline_engine: BaselineSearchEngine
+    ) -> None:
+        baseline_engine.settings.acorn_mode = AcornMode.OFF
+        assert (
+            baseline_engine._should_use_acorn(has_filters=False, estimated_selectivity=None)
+            is False
+        )
+
+    def test_acorn_on_with_filters_returns_true(
+        self, baseline_engine: BaselineSearchEngine
+    ) -> None:
+        baseline_engine.settings.acorn_mode = AcornMode.ON
+        assert (
+            baseline_engine._should_use_acorn(has_filters=True, estimated_selectivity=0.8) is True
+        )
+
+    def test_acorn_on_without_filters_returns_false(
+        self, baseline_engine: BaselineSearchEngine
+    ) -> None:
+        baseline_engine.settings.acorn_mode = AcornMode.ON
+        assert (
+            baseline_engine._should_use_acorn(has_filters=False, estimated_selectivity=None)
+            is False
+        )
+
+    def test_acorn_auto_no_filters_returns_false(
+        self, baseline_engine: BaselineSearchEngine
+    ) -> None:
+        baseline_engine.settings.acorn_mode = AcornMode.AUTO
+        assert (
+            baseline_engine._should_use_acorn(has_filters=False, estimated_selectivity=0.1) is False
+        )
+
+    def test_acorn_auto_unknown_selectivity_returns_true(
+        self, baseline_engine: BaselineSearchEngine
+    ) -> None:
+        baseline_engine.settings.acorn_mode = AcornMode.AUTO
+        assert (
+            baseline_engine._should_use_acorn(has_filters=True, estimated_selectivity=None) is True
+        )
+
+    def test_acorn_auto_low_selectivity_returns_true(
+        self, baseline_engine: BaselineSearchEngine
+    ) -> None:
+        baseline_engine.settings.acorn_mode = AcornMode.AUTO
+        baseline_engine.settings.acorn_enabled_selectivity_threshold = 0.5
+        assert (
+            baseline_engine._should_use_acorn(has_filters=True, estimated_selectivity=0.1) is True
+        )
+
+    def test_acorn_auto_high_selectivity_returns_false(
+        self, baseline_engine: BaselineSearchEngine
+    ) -> None:
+        baseline_engine.settings.acorn_mode = AcornMode.AUTO
+        baseline_engine.settings.acorn_enabled_selectivity_threshold = 0.5
+        assert (
+            baseline_engine._should_use_acorn(has_filters=True, estimated_selectivity=0.9) is False
+        )
+
+
+# ---------------------------------------------------------------------------
+# _build_search_params
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSearchParams:
+    def test_returns_search_params_instance(self, baseline_engine: BaselineSearchEngine) -> None:
+        params = baseline_engine._build_search_params()
+        assert isinstance(params, models.SearchParams)
+
+    def test_quantization_ignore_true_when_off(self, baseline_engine: BaselineSearchEngine) -> None:
+        baseline_engine.settings.quantization_mode = QuantizationMode.OFF
+        params = baseline_engine._build_search_params()
+        assert params.quantization is not None
+        assert params.quantization.ignore is True
+
+    def test_quantization_ignore_false_when_not_off(
+        self, baseline_engine: BaselineSearchEngine
+    ) -> None:
+        baseline_engine.settings.quantization_mode = QuantizationMode.SCALAR
+        params = baseline_engine._build_search_params()
+        assert params.quantization is not None
+        assert params.quantization.ignore is False
+
+    def test_no_acorn_when_acorn_mode_off(self, baseline_engine: BaselineSearchEngine) -> None:
+        baseline_engine.settings.acorn_mode = AcornMode.OFF
+        params = baseline_engine._build_search_params(has_filters=True)
+        # acorn attribute should not be set or should be None
+        assert not hasattr(params, "acorn") or params.acorn is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_group_results
+# ---------------------------------------------------------------------------
+
+
+class TestParseGroupResults:
+    def _make_group_response(self, groups_data: list[list[dict]]) -> MagicMock:
+        """Build a mock grouped response."""
+        response = MagicMock()
+        response.groups = []
+        for hits_data in groups_data:
+            group = MagicMock()
+            hits = []
+            for d in hits_data:
+                point = MagicMock()
+                point.score = d["score"]
+                point.payload = {
+                    "page_content": d.get("text", ""),
+                    "metadata": {"article_number": d.get("article_number", "")},
+                }
+                hits.append(point)
+            group.hits = hits
+            response.groups.append(group)
+        return response
+
+    def test_empty_groups(self, baseline_engine: BaselineSearchEngine) -> None:
+        response = self._make_group_response([])
+        results = baseline_engine._parse_group_results(response)
+        assert results == []
+
+    def test_single_group_single_hit(self, baseline_engine: BaselineSearchEngine) -> None:
+        response = self._make_group_response(
+            [[{"score": 0.9, "text": "hello", "article_number": "A1"}]]
+        )
+        results = baseline_engine._parse_group_results(response)
+        assert len(results) == 1
+        assert results[0].score == 0.9
+        assert results[0].text == "hello"
+        assert results[0].article_number == "A1"
+
+    def test_multiple_groups(self, baseline_engine: BaselineSearchEngine) -> None:
+        response = self._make_group_response(
+            [
+                [{"score": 0.9, "text": "doc1", "article_number": "A1"}],
+                [{"score": 0.7, "text": "doc2", "article_number": "A2"}],
+            ]
+        )
+        results = baseline_engine._parse_group_results(response)
+        assert len(results) == 2
+
+    def test_preserves_order(self, baseline_engine: BaselineSearchEngine) -> None:
+        response = self._make_group_response(
+            [
+                [{"score": 0.9, "article_number": "FIRST"}],
+                [{"score": 0.5, "article_number": "SECOND"}],
+            ]
+        )
+        results = baseline_engine._parse_group_results(response)
+        assert results[0].article_number == "FIRST"
+        assert results[1].article_number == "SECOND"
+
+
+# ---------------------------------------------------------------------------
+# BaselineSearchEngine.search
+# ---------------------------------------------------------------------------
+
+
+class TestBaselineEngineSearch:
+    def _make_response(self, points_data: list[dict]) -> MagicMock:
+        response = MagicMock()
+        points = []
+        for d in points_data:
+            p = MagicMock()
+            p.score = d["score"]
+            p.payload = {
+                "page_content": d.get("text", ""),
+                "metadata": {"article_number": d.get("article_number", "")},
+            }
+            points.append(p)
+        response.points = points
+        return response
+
+    def test_raises_type_error_for_string_input(
+        self, baseline_engine: BaselineSearchEngine
+    ) -> None:
+        with pytest.raises(TypeError, match="requires pre-computed embeddings"):
+            baseline_engine.search("some query string")
+
+    def test_returns_search_results(self, baseline_engine: BaselineSearchEngine) -> None:
+        baseline_engine.client.query_points.return_value = self._make_response(
+            [
+                {"score": 0.8, "text": "result text", "article_number": "X1"},
+            ]
+        )
+        results = baseline_engine.search([0.1, 0.2, 0.3])
+        assert len(results) == 1
+        assert isinstance(results[0], SearchResult)
+        assert results[0].score == 0.8
+
+    def test_default_score_threshold_05(self, baseline_engine: BaselineSearchEngine) -> None:
+        baseline_engine.client.query_points.return_value = self._make_response([])
+        baseline_engine.search([0.1, 0.2])
+        call_kwargs = baseline_engine.client.query_points.call_args[1]
+        assert call_kwargs["score_threshold"] == 0.5
+
+    def test_custom_score_threshold_used(self, baseline_engine: BaselineSearchEngine) -> None:
+        baseline_engine.client.query_points.return_value = self._make_response([])
+        baseline_engine.search([0.1, 0.2], score_threshold=0.7)
+        call_kwargs = baseline_engine.client.query_points.call_args[1]
+        assert call_kwargs["score_threshold"] == 0.7
+
+    def test_empty_results(self, baseline_engine: BaselineSearchEngine) -> None:
+        baseline_engine.client.query_points.return_value = self._make_response([])
+        results = baseline_engine.search([0.1, 0.2])
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# HybridRRFSearchEngine
+# ---------------------------------------------------------------------------
+
+
+class TestHybridRRFEngineSearch:
+    @pytest.fixture
+    def hybrid_engine(self, mock_settings: Settings) -> HybridRRFSearchEngine:
+        with (
+            patch("src.retrieval.search_engines.QdrantClient"),
+            patch("src.retrieval.search_engines.get_bge_m3_model"),
+        ):
+            engine = HybridRRFSearchEngine(mock_settings)
+            engine.client = MagicMock()
+        return engine
+
+    def test_default_score_threshold_03(self, hybrid_engine: HybridRRFSearchEngine) -> None:
+        response = MagicMock()
+        response.points = []
+        hybrid_engine.client.query_points.return_value = response
+
+        hybrid_engine.search([0.1, 0.2], score_threshold=None)
+        call_kwargs = hybrid_engine.client.query_points.call_args[1]
+        assert call_kwargs["score_threshold"] == 0.3
+
+    def test_dense_vector_search_when_list_provided(
+        self, hybrid_engine: HybridRRFSearchEngine
+    ) -> None:
+        response = MagicMock()
+        response.points = []
+        hybrid_engine.client.query_points.return_value = response
+
+        hybrid_engine.search([0.1, 0.2, 0.3])
+        call_kwargs = hybrid_engine.client.query_points.call_args[1]
+        assert call_kwargs["using"] == "dense"
+
+
+# ---------------------------------------------------------------------------
+# Engine names
+# ---------------------------------------------------------------------------
+
+
+class TestEngineNames:
+    def test_baseline_engine_name(self, mock_settings: Settings) -> None:
+        with patch("src.retrieval.search_engines.QdrantClient"):
+            engine = BaselineSearchEngine(mock_settings)
+        assert engine.get_name() == "baseline"
+
+    def test_hybrid_rrf_engine_name(self, mock_settings: Settings) -> None:
+        with (
+            patch("src.retrieval.search_engines.QdrantClient"),
+            patch("src.retrieval.search_engines.get_bge_m3_model"),
+        ):
+            engine = HybridRRFSearchEngine(mock_settings)
+        assert engine.get_name() == "hybrid_rrf"
+
+
+# ---------------------------------------------------------------------------
+# create_search_engine factory
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSearchEngine:
+    def test_creates_baseline_for_baseline_engine_type(self, mock_settings: Settings) -> None:
+        with patch("src.retrieval.search_engines.QdrantClient"):
+            engine = create_search_engine(SearchEngine.BASELINE, settings=mock_settings)
+        assert isinstance(engine, BaselineSearchEngine)
+
+    def test_creates_hybrid_rrf_for_hybrid_engine_type(self, mock_settings: Settings) -> None:
+        with (
+            patch("src.retrieval.search_engines.QdrantClient"),
+            patch("src.retrieval.search_engines.get_bge_m3_model"),
+        ):
+            engine = create_search_engine(SearchEngine.HYBRID_RRF, settings=mock_settings)
+        assert isinstance(engine, HybridRRFSearchEngine)
+
+    def test_uses_settings_engine_type_when_none(self, mock_settings: Settings) -> None:
+        mock_settings.search_engine = SearchEngine.BASELINE
+        with patch("src.retrieval.search_engines.QdrantClient"):
+            engine = create_search_engine(None, settings=mock_settings)
+        assert isinstance(engine, BaselineSearchEngine)
+
+    def test_returns_search_engine_instance(self, mock_settings: Settings) -> None:
+        with patch("src.retrieval.search_engines.QdrantClient"):
+            engine = create_search_engine(SearchEngine.BASELINE, settings=mock_settings)
+        assert engine is not None
+        assert hasattr(engine, "search")
+        assert hasattr(engine, "get_name")


### PR DESCRIPTION
## Summary

- Adds 127 unit tests + 1 skip (cocoindex) for 6 previously uncovered modules
- `src/retrieval/search_engines.py` — ACORN logic, build_search_params, parse_group_results, BaselineSearchEngine, HybridRRF
- `telegram_bot/agents/manager_tools.py` — role resolution, user context, nurturing tools, CRM score sync
- `telegram_bot/dialogs/crm_cards.py` — Lead/Contact/Task card formatting, pagination buttons
- `src/ingestion/gdrive_flow.py` — GDriveFlowConfig, file filtering, hashing, MIME types
- `src/ingestion/gdrive_indexer.py` — IndexStats, UUID5 point IDs, delete/index operations
- `src/ingestion/unified/targets/qdrant_hybrid_target.py` — content hash, spec/values, connector statics (skipped when cocoindex not installed)

## Test plan

- [x] 127 tests pass, 1 skipped (cocoindex not installed)
- [x] fastembed mocked via `tests/unit/ingestion/conftest.py` (pytest_configure hook)
- [x] DeprecationWarning from deprecated gdrive modules suppressed
- [x] LangChain RunnableConfig passed as second arg to `ainvoke`
- [x] All pre-commit hooks pass (ruff lint + format)

Closes #857

🤖 Generated with [Claude Code](https://claude.com/claude-code)