### PR TITLE
feat: SDK canonical remediation (phases 0-8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,11 @@ CLAUDE.md
 .claude/prompts/
 docs/plans/
 docs/archive/
+!docs/plans/
+!docs/plans/2026-03-02-sdk-migration-audit.md
+!docs/plans/2026-03-13-issue-728-sdk-realignment-plan.md
+!docs/plans/2026-03-13-sdk-first-remediation-plan.md
+!docs/plans/2026-03-15-sdk-canonical-remediation-plan.md
 
 # Build artifacts & test outputs
 test_output*.txt

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **AI-powered Telegram bot for real estate — RAG search, apartment finder, voice calls, CRM automation**
 
 [![CI](https://github.com/yastman/rag/actions/workflows/ci.yml/badge.svg)](https://github.com/yastman/rag/actions/workflows/ci.yml)
-[![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Code style: ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
@@ -129,7 +129,7 @@ CocoIndex pipeline: Docling parses PDFs/DOCX → semantic chunking → BGE-M3 de
 
 ### Prerequisites
 
-- Python 3.12+, [uv](https://docs.astral.sh/uv/), Docker
+- Python 3.11+ (3.12 recommended), [uv](https://docs.astral.sh/uv/), Docker
 
 ### 1. Install & Configure
 
@@ -209,7 +209,7 @@ src/
 
 mini_app/                  # Telegram Mini App (React + TypeScript)
 k8s/                       # Kubernetes manifests (k3s deployment)
-evaluation/                # RAG evaluation (RAGAS, A/B testing)
+src/evaluation/            # RAG evaluation (RAGAS, A/B testing)
 ```
 
 ## Entry Points

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -47,6 +47,9 @@ services:
     profiles: ["bot", "voice", "full"]
     ports:
       - "127.0.0.1:4000:4000"
+    environment:
+      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
+      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-sk-lf-dev}
 
   bot:
     profiles: ["bot", "full"]
@@ -54,6 +57,8 @@ services:
       RERANK_PROVIDER: colbert
       RERANK_CANDIDATES_MAX: "${RERANK_CANDIDATES_MAX:-10}"
       COLBERT_TIMEOUT: "${COLBERT_TIMEOUT:-120}"
+      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
+      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-sk-lf-dev}
 
   # ML services — profile-gated on dev (VPS: always-on via compose.yml base)
   clickhouse:
@@ -61,6 +66,8 @@ services:
     ports:
       - "127.0.0.1:8123:8123"
       - "127.0.0.1:9009:9000"
+    environment:
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-clickhouse}
 
   minio:
     profiles: ["ml", "full"]
@@ -68,19 +75,43 @@ services:
       - "127.0.0.1:9090:9000"
       - "127.0.0.1:9091:9001"
     command: -c 'mkdir -p /data/langfuse && minio server --address ":9000" --console-address ":9001" /data'
+    environment:
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-miniosecret}
 
   redis-langfuse:
     profiles: ["ml", "full"]
     ports:
       - "127.0.0.1:6380:6379"
+    command: redis-server --requirepass ${LANGFUSE_REDIS_PASSWORD:-langfuseredis}
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${LANGFUSE_REDIS_PASSWORD:-langfuseredis}", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
 
   langfuse-worker:
     profiles: ["ml", "full"]
+    environment:
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-clickhouse}
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-miniosecret}
+      LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-miniosecret}
+      REDIS_AUTH: ${LANGFUSE_REDIS_PASSWORD:-langfuseredis}
 
   langfuse:
     profiles: ["ml", "full"]
     ports:
       - "127.0.0.1:3001:3000"
+    environment:
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-clickhouse}
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-miniosecret}
+      LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-miniosecret}
+      REDIS_AUTH: ${LANGFUSE_REDIS_PASSWORD:-langfuseredis}
+
+  ingestion:
+    profiles: ["ingest", "full"]
+    environment:
+      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
+      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-sk-lf-dev}
 
   mlflow:
     ports:
@@ -93,6 +124,9 @@ services:
   rag-api:
     ports:
       - "127.0.0.1:8080:8080"
+    environment:
+      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
+      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-sk-lf-dev}
 
   livekit-server:
     ports:
@@ -105,10 +139,23 @@ services:
       - "5060:5060/udp"
       - "5061:5061/tcp"
       - "10000-10100:10000-10100/udp"
+    environment:
+      LIVEKIT_API_KEY: ${LIVEKIT_API_KEY:-devkey}
+      LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET:-secret}
+
+  voice-agent:
+    environment:
+      LIVEKIT_API_KEY: ${LIVEKIT_API_KEY:-devkey}
+      LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET:-secret}
+      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
+      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-sk-lf-dev}
 
   mini-app-api:
     ports:
       - "127.0.0.1:8090:8090"
+    environment:
+      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
+      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-sk-lf-dev}
 
   mini-app-frontend:
     ports:

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 # Base configuration — all services, no ports exposed.
 # Use with override: COMPOSE_FILE=compose.yml:compose.dev.yml
-# See docs/plans/2026-03-05-docker-compose-unification-design.md
+# See DOCKER.md and docs/LOCAL-DEVELOPMENT.md
 
 x-logging: &default-logging
   driver: json-file
@@ -192,8 +192,8 @@ services:
       GROQ_API_KEY: ${GROQ_API_KEY:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       # Langfuse v3 OTEL (Docker internal network)
-      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
-      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-sk-lf-dev}
+      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}
+      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
       LANGFUSE_HOST: ${LANGFUSE_HOST:-http://langfuse:3000}
       LANGFUSE_OTEL_HOST: ${LANGFUSE_HOST:-http://langfuse:3000}
       # Database disabled — config.yaml is source of truth for local dev
@@ -253,8 +253,8 @@ services:
       BOT_DOMAIN: ${BOT_DOMAIN:-недвижимость}
       BOT_LANGUAGE: ${BOT_LANGUAGE:-ru}
       # Langfuse observability (optional — bot degrades gracefully)
-      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
-      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-sk-lf-dev}
+      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}
+      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
       LANGFUSE_HOST: ${LANGFUSE_HOST:-http://langfuse:3000}
       LANGFUSE_TRACING_ENVIRONMENT: "${LANGFUSE_TRACING_ENVIRONMENT:-}"
       LANGFUSE_FLUSH_AT: "${LANGFUSE_FLUSH_AT:-512}"
@@ -328,8 +328,8 @@ services:
       LLM_API_KEY: ${LITELLM_MASTER_KEY:?LITELLM_MASTER_KEY is required}
       LLM_BASE_URL: http://litellm:4000
       LLM_MODEL: gpt-4o-mini
-      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
-      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-sk-lf-dev}
+      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}
+      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
       LANGFUSE_HOST: ${LANGFUSE_HOST:-http://langfuse:3000}
       REALESTATE_DATABASE_URL: "postgresql://postgres:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/realestate"
       KOMMO_ENABLED: "${KOMMO_ENABLED:-false}"
@@ -390,8 +390,8 @@ services:
     stop_grace_period: 30s
     logging: *default-logging
     environment:
-      - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
-      - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY:-sk-lf-dev}
+      - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-}
+      - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY:-}
       - LANGFUSE_HOST=${LANGFUSE_HOST:-http://langfuse:3000}
       - GDRIVE_SYNC_DIR=/data/drive-sync
       - INGESTION_DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/cocoindex
@@ -434,7 +434,7 @@ services:
     environment:
       CLICKHOUSE_DB: default
       CLICKHOUSE_USER: clickhouse
-      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-clickhouse}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-}
     volumes:
       - clickhouse_data:/var/lib/clickhouse
       - clickhouse_logs:/var/log/clickhouse-server
@@ -458,7 +458,7 @@ services:
     command: -c 'mkdir -p /data/langfuse && minio server --address ":9000" /data'
     environment:
       MINIO_ROOT_USER: minio
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-miniosecret}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-}
     volumes:
       - minio_data:/data
     healthcheck:
@@ -477,9 +477,9 @@ services:
     image: redis:8.6.1@sha256:1c054d54ecd1597bba52f4304bca5afbc5565ebe614c5b3d7dc5b7f8a0cd768d
     restart: unless-stopped
     logging: *default-logging
-    command: redis-server --requirepass ${LANGFUSE_REDIS_PASSWORD:-langfuseredis}
+    command: redis-server --requirepass ${LANGFUSE_REDIS_PASSWORD:-}
     healthcheck:
-      test: ["CMD", "redis-cli", "-a", "${LANGFUSE_REDIS_PASSWORD:-langfuseredis}", "ping"]
+      test: ["CMD", "redis-cli", "-a", "${LANGFUSE_REDIS_PASSWORD:-}", "ping"]
       interval: 5s
       timeout: 5s
       retries: 3
@@ -513,27 +513,27 @@ services:
       CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse:9000
       CLICKHOUSE_URL: http://clickhouse:8123
       CLICKHOUSE_USER: clickhouse
-      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-clickhouse}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-}
       CLICKHOUSE_CLUSTER_ENABLED: "false"
       # S3/MinIO
       LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse
       LANGFUSE_S3_EVENT_UPLOAD_REGION: auto
       LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: minio
-      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-miniosecret}
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-}
       LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://minio:9000
       LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
       LANGFUSE_S3_EVENT_UPLOAD_PREFIX: events/
       LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: langfuse
       LANGFUSE_S3_MEDIA_UPLOAD_REGION: auto
       LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID: minio
-      LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-miniosecret}
+      LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-}
       LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: http://minio:9000
       LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: "true"
       LANGFUSE_S3_MEDIA_UPLOAD_PREFIX: media/
       # Redis
       REDIS_HOST: redis-langfuse
       REDIS_PORT: 6379
-      REDIS_AUTH: ${LANGFUSE_REDIS_PASSWORD:-langfuseredis}
+      REDIS_AUTH: ${LANGFUSE_REDIS_PASSWORD:-}
       # Telemetry
       TELEMETRY_ENABLED: "false"
       LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES: "true"
@@ -720,8 +720,8 @@ services:
       LLM_BASE_URL: http://litellm:4000
       LLM_MODEL: gpt-4o-mini
       RERANK_PROVIDER: colbert
-      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
-      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-sk-lf-dev}
+      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}
+      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
       LANGFUSE_HOST: ${LANGFUSE_HOST:-http://langfuse:3000}
     depends_on:
       redis:
@@ -768,12 +768,12 @@ services:
     restart: unless-stopped
     logging: *default-logging
     environment:
-      LIVEKIT_API_KEY: ${LIVEKIT_API_KEY:-devkey}
-      LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET:-secret}
+      LIVEKIT_API_KEY: ${LIVEKIT_API_KEY:-}
+      LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET:-}
       LIVEKIT_WS_URL: ws://livekit-server:7880
       SIP_CONFIG_BODY: |
-        api_key: ${LIVEKIT_API_KEY:-devkey}
-        api_secret: ${LIVEKIT_API_SECRET:-secret}
+        api_key: ${LIVEKIT_API_KEY:-}
+        api_secret: ${LIVEKIT_API_SECRET:-}
         ws_url: ws://livekit-server:7880
         redis:
           address: redis:6379
@@ -810,13 +810,13 @@ services:
     logging: *default-logging
     environment:
       LIVEKIT_URL: ws://livekit-server:7880
-      LIVEKIT_API_KEY: ${LIVEKIT_API_KEY:-devkey}
-      LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET:-secret}
+      LIVEKIT_API_KEY: ${LIVEKIT_API_KEY:-}
+      LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET:-}
       ELEVEN_API_KEY: ${ELEVENLABS_API_KEY:-}
       RAG_API_URL: http://rag-api:8080
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/postgres
-      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
-      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-sk-lf-dev}
+      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}
+      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
       LANGFUSE_HOST: ${LANGFUSE_HOST:-http://langfuse:3000}
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8081')\" || exit 1"]

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -20,6 +20,11 @@ Minimum env for bot profile:
 - `LITELLM_MASTER_KEY`
 - at least one provider key: `CEREBRAS_API_KEY` or `GROQ_API_KEY` or `OPENAI_API_KEY`
 
+Secret model by compose file:
+- `compose.yml` is the secure baseline: no predictable built-in secret defaults.
+- `compose.dev.yml` may provide local-only defaults for development convenience (`pk-lf-dev`, `sk-lf-dev`, `clickhouse`, `miniosecret`, `langfuseredis`, `devkey`).
+- Production/VPS stacks must set real secret values via environment management or file-backed secret patterns (`*_FILE` / `secrets:`) when available.
+
 ## 2. Start Services
 
 ```bash

--- a/docs/SDK_CANONICAL_REMEDIATION_REPORT_2026-03-15.md
+++ b/docs/SDK_CANONICAL_REMEDIATION_REPORT_2026-03-15.md
@@ -1,0 +1,116 @@
+# SDK Canonical Remediation Report
+
+Date: 2026-03-15
+Branch: `feat/sdk-canonical-remediation`
+Plan: `docs/plans/2026-03-15-sdk-canonical-remediation-plan.md`
+
+## Scope
+
+This report summarizes execution of phases 0-8 from the canonical SDK remediation plan, including autofixes, SDK-aligned refactors, and validation results.
+
+## Context7 SDK Inputs Used
+
+- Langfuse (`/langfuse/langfuse-docs`): use `get_prompt(...)` + `compile(...)`, fallback-safe prompt retrieval, and `update_current_span(...)`.
+- Qdrant (`/qdrant/qdrant-client`): standard sync/async client initialization and query API usage.
+- LiveKit Agents (`/livekit/agents`): `@function_tool` boundaries with explicit tool-layer error handling and testability.
+- Docling (`/docling-project/docling`): native `DocumentConverter` adapter pattern with format/pipeline options.
+
+## Implemented Changes By Phase
+
+### Phase 0: Source Of Truth Recovery
+
+- Restored and tracked historical SDK docs + canonical plan in `docs/plans/`.
+- Fixed stale broken references in compose/docs/agents override files.
+- Aligned Python version and structure drift in README/docs.
+- Updated `.gitignore` to allow tracking canonical plan/audit docs.
+
+### Phase 1: Compose Secret Posture
+
+- Removed predictable secret defaults from `compose.yml` baseline.
+- Moved dev-only secret defaults into `compose.dev.yml`.
+- Updated compose secret policy documentation in `docs/LOCAL-DEVELOPMENT.md`.
+- Updated unit tests to enforce secure baseline + dev override model.
+
+### Phase 2: Langfuse Prompt Manager Simplification
+
+- Removed manual prompt probe path (`client.api.prompts.get(...)`).
+- Kept SDK-native prompt flow (`client.get_prompt(...)`) with deterministic fallback.
+- Preserved prompt version span output updates.
+- Updated prompt manager tests accordingly.
+
+### Phase 3: LLMService Runtime Surface Retirement
+
+- Removed `LLMService` from `telegram_bot.services.__all__` recommended surface.
+- Kept compatibility lazy import path (`services.LLMService`) for legacy consumers.
+- Updated bot-facing README to present `generate_response()` as canonical runtime path.
+- Added a public API unit test for this contract.
+
+### Phase 4: Kommo Token Store Consolidation
+
+- Made `telegram_bot/services/kommo_tokens.py` canonical implementation.
+- Replaced `kommo_token_store.py` with compatibility shim inheriting canonical store.
+- Kept serialized refresh behavior via shim-level lock.
+- Updated `kommo_client` to depend on token-store protocol, not duplicate implementation type.
+- Updated unit tests to target canonical HTTP path.
+
+### Phase 5: Typed Voice RAG API Client
+
+- Added `src/voice/rag_api_client.py` with:
+  - `RagQueryRequest` typed payload
+  - `RagApiClient` HTTP boundary
+  - centralized error mapping (`RagApiClientError`)
+- Refactored `src/voice/agent.py` tool call path to use typed client.
+- Kept compatibility wrappers for shared HTTP lifecycle behavior.
+- Added unit tests for typed client behavior.
+
+### Phase 6: Feature-Flagged Docling Native Spike
+
+- Added optional native adapter `src/ingestion/docling_native.py` using `DocumentConverter`.
+- Added `docling_backend` + `docling_native_enabled` config flags.
+- Updated unified ingestion target connector to choose HTTP vs native path by flag.
+- Added unit tests for native adapter chunking/error path.
+
+### Phase 7: Qdrant Configuration Policy Consolidation
+
+- Added shared helper `src/config/qdrant_policy.py` for canonical collection naming.
+- Wired helper into:
+  - `src/config/settings.py`
+  - `telegram_bot/config.py`
+  - `telegram_bot/services/qdrant.py`
+- Added unit tests for collection policy helper.
+
+### Phase 8: Langfuse Runtime Surface Reduction
+
+- Extracted bootstrap-only infrastructure helpers into `telegram_bot/observability_bootstrap.py`.
+- Preserved backward-compatible private wrappers in `telegram_bot/observability.py` (`_is_endpoint_reachable`, `_disable_otel_exporter`) for existing tests and call sites.
+- Kept existing tracing/score contracts unchanged.
+
+## Additional Autofixes
+
+- Fixed test regressions in bot stop lifecycle, graph doc limit assertion, apartment extractor invalid-city fixture, and env-sensitive config tests.
+- Kept full unit suite green after SDK refactors.
+
+## Validation Results
+
+Passed:
+
+- `make check`
+- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
+- `uv run pytest tests/integration/test_graph_paths.py -n auto --dist=worksteal -q`
+- `make ingest-unified-status`
+
+Known environment-limited check:
+
+- `uv run python -m src.ingestion.unified.cli preflight`
+  Result: `3/5 checks passed — NOT READY` because Docling service (`http://localhost:5001`) was unreachable in local runtime at verification time.
+
+## Outcome
+
+The branch now follows SDK-first canonical direction with:
+
+- reduced custom surface,
+- compatibility-safe shims where removal would be risky,
+- typed boundaries for voice external calls,
+- feature-flagged native Docling path,
+- shared Qdrant policy logic,
+- and green core validation gates.

--- a/docs/plans/2026-03-02-sdk-migration-audit.md
+++ b/docs/plans/2026-03-02-sdk-migration-audit.md
@@ -1,0 +1,93 @@
+# SDK Migration Audit
+
+> Reviewed and refreshed on **2026-03-13** against the current repository state, installed dependencies, and official SDK documentation.
+
+**Original scope:** audit custom code that may be replaced by SDK/native framework solutions.
+
+**Current verdict:** the audit summary in issue `#728` is directionally useful, but it is no longer a reliable execution plan as-is. Several "migration" items are already implemented, one recommended RedisVL SDK feature could not be verified, and the historical "big bang" rewrite direction is too risky for the current codebase.
+
+---
+
+## What Is Already Done
+
+These items should be removed from the active migration backlog:
+
+- `telegram_bot/services/rag_core.py` already exists and has extracted shared RAG logic for cache/retrieve/rerank/rewrite.
+- `aiogram` service injection via dispatcher workflow data is already used in `PropertyBot`.
+- Typed `CallbackData` factories already exist in `telegram_bot/callback_data.py`.
+- `handle_favorite_callback()` is already downgraded to a compatibility dispatcher while production routing uses per-action handlers.
+- `RedisVL SemanticRouter` is already integrated as an optional classifier path behind `CLASSIFIER_MODE=semantic`.
+- `RedisVL EmbeddingsCache` is already integrated in the cache layer.
+- `dp.errors` registration is already present; the legacy middleware wrapper remains only for backward compatibility.
+
+## Keep As Active Work
+
+These items remain valid and worth planning:
+
+- Continue shrinking `PropertyBot` into router/domain modules. The file is still large enough to justify decomposition.
+- Finish removing legacy `LLMService` call sites and treat `generate_response.py` as the single supported path.
+- Evaluate `Langfuse` experiment APIs for dataset-backed evaluation instead of growing more custom experiment scaffolding.
+- Keep direct Qdrant SDK usage for the main retrieval path where nested `prefetch`, fusion, and ColBERT reranking are required.
+
+## Re-Scope Before Doing
+
+These items are plausible, but only as narrow spikes with explicit success criteria:
+
+### `langchain-qdrant` `SelfQueryRetriever`
+
+Use only for a contained apartment-filter prototype. Do **not** treat it as a replacement for the current main retrieval stack, because the repository intentionally uses direct Qdrant APIs for features that exceed the thin vector-store wrapper.
+
+### Docling Python API
+
+Do not frame this as a blanket "HTTP client -> Python API" migration. The repository already uses direct `DocumentConverter` in `src/ingestion/document_parser.py`, while unified ingestion still uses `src/ingestion/docling_client.py`. Any further migration must account for packaging, runtime isolation, and whether ingestion runs with the `docling` extra installed.
+
+### Guardrails / PII SDKs
+
+`NeMo Guardrails` and `Presidio` are still optional exploratory candidates. They are not installed in the current environment and should not be elevated above the existing regex/content-filter path without a measured eval plan.
+
+## Drop Or Replace
+
+These points should not stay in the plan unchanged:
+
+### RedisVL `CacheThresholdOptimizer`
+
+This recommendation is not verified in the current environment and was not confirmed in the official RedisVL docs review. Replace it with an internal threshold-calibration task based on existing trace/eval data.
+
+### Big-Bang Stack Rewrite
+
+Do not replace LangChain/LangGraph with `pydantic-ai` / `pydantic-graph` in one migration branch. That is a separate architecture proposal, not a safe follow-up to issue `#728`. The current repository is already on `langchain>=1.2` and uses SDK-native agent features; a wholesale rewrite would mix platform migration with cleanup work and destroy incremental validation.
+
+---
+
+## Reviewed Roadmap
+
+### Phase 1: Remove Stale Audit Items
+
+- Update issue `#728` summary so already-shipped items are marked done.
+- Link this file instead of the previously missing local artifact.
+- Split "implemented", "active", and "exploratory" recommendations.
+
+### Phase 2: Finish High-ROI SDK Adoption
+
+- Remove remaining `LLMService` call sites and compatibility exports.
+- Continue `PropertyBot` decomposition into routers/handlers without changing the transport stack.
+- Keep using aiogram native patterns (`CallbackData`, `dp.errors`, workflow data / DI) instead of introducing a second DI system.
+
+### Phase 3: Evaluate Bounded SDK Spikes
+
+- `Langfuse` experiment runner for offline/managed evals.
+- `langchain-qdrant` only for apartment metadata filtering prototype.
+- Direct Docling Python API only for the unified ingestion path, if packaging/runtime constraints are acceptable.
+
+### Phase 4: Optional Research Track
+
+- `Presidio` for PII detection if the product needs higher recall than regex.
+- `NeMo Guardrails` only if there is a concrete policy layer requirement that current prompt + regex guards cannot satisfy.
+
+---
+
+## Review Notes
+
+- Issue `#728` references this path, but the file was missing in the working tree as of **2026-03-13**.
+- A historical successor design in git history (`docs/plans/2026-03-03-sdk-migration-design.md`) proposed a big-bang move to `dishka` + `pydantic-ai`; that direction is intentionally **not** adopted here as the default recommendation.
+- This document is a corrected local source of truth for the audit until the GitHub issue text is updated.

--- a/docs/plans/2026-03-13-issue-728-sdk-realignment-plan.md
+++ b/docs/plans/2026-03-13-issue-728-sdk-realignment-plan.md
@@ -1,0 +1,181 @@
+# Issue #728: SDK Realignment Plan
+
+> **For Codex:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Realign the stale SDK migration backlog around what the repo already ships well (`aiogram`, `aiogram-dialog`, `qdrant-client`, `redisvl`) and execute only the remaining high-ROI SDK work.
+
+**Architecture:** Treat this as three tracks: (1) close stale audit scope and lock in guardrails, (2) simplify runtime code where official SDKs already cover the behavior (`Langfuse` prompts, deprecated `LLMService` surface), (3) run bounded spikes where native SDKs are promising but not yet proven (`Docling`, optional Langfuse eval expansion).
+
+**Tech Stack:** aiogram 3, aiogram-dialog, Langfuse Python SDK, qdrant-client, RedisVL, Docling, pytest
+
+---
+
+## Research Report
+
+- `aiogram` already provides the transport-layer primitives we need: `Router`, dispatcher workflow data, typed `CallbackData`, and `dp.errors`. No extra Telegram abstraction layer is justified right now.
+- `aiogram-dialog` already provides the menu/navigation primitives we need: `Start`, `SwitchTo`, `StartMode`, and `ShowMode`. Dialog work should stay there instead of expanding custom FSM code.
+- `qdrant-client` should remain the primary retrieval SDK because the official Query API already matches our dense+sparse+fusion+rerank path.
+- `redisvl` is already correctly scoped to cache/router duties. The right next step is threshold calibration, not a framework migration.
+- `langfuse` is the best remaining SDK candidate for incremental value: prompt management should become more SDK-native, and evaluation APIs are worth a bounded spike.
+- `docling` native Python API is real and viable, but only a feature-flagged contract-parity spike is justified while unified ingestion still depends on `docling-serve`.
+
+## Execution Order
+
+1. Cleanup stale audit scope and make the repo guidance canonical.
+2. Remove prompt-manager complexity that duplicates the Langfuse SDK.
+3. Retire deprecated `LLMService` surface from active runtime/documentation paths.
+4. Run the Docling native spike behind a flag with parity tests.
+5. Revisit broader SDK migrations only after the above lands and is measured.
+
+## Task 1: Canonicalize The Audit And Roadmap
+
+**Files:**
+- Modify: `docs/SDK_MIGRATION_AUDIT_2026-03-13.md`
+- Modify: `docs/SDK_MIGRATION_ROADMAP_2026-03-13.md`
+- Modify: `README.md`
+
+**Step 1: Lock the refreshed verdict into repo docs**
+
+- Add the validated keeper stack explicitly: `aiogram`, `aiogram-dialog`, `qdrant-client`, `redisvl`.
+- Mark `Langfuse` and `Docling` as bounded follow-up work, not broad migrations.
+- Link the audit from the docs index if the team wants it discoverable from `README.md`.
+
+**Step 2: Verify docs remain coherent**
+
+Run: `git diff -- docs/SDK_MIGRATION_AUDIT_2026-03-13.md docs/SDK_MIGRATION_ROADMAP_2026-03-13.md README.md`
+Expected: wording is specific about what stays, what is a spike, and what is dropped.
+
+**Step 3: Commit**
+
+```bash
+git add docs/SDK_MIGRATION_AUDIT_2026-03-13.md docs/SDK_MIGRATION_ROADMAP_2026-03-13.md README.md
+git commit -m "docs: realign sdk migration audit around shipped stack"
+```
+
+## Task 2: Simplify Prompt Management To SDK-Native Langfuse
+
+**Files:**
+- Modify: `telegram_bot/integrations/prompt_manager.py`
+- Modify: `tests/unit/integrations/test_prompt_manager.py`
+- Reference: `telegram_bot/services/generate_response.py`
+
+**Step 1: Write the failing tests**
+
+- Add/adjust tests to assert `get_prompt()` relies on `client.get_prompt(..., cache_ttl_seconds=..., fallback=...)`.
+- Add a regression test that missing prompts no longer depend on `client.api.prompts.get(...)`.
+- Keep variable compilation and span-output behavior covered.
+
+**Step 2: Run the focused test**
+
+Run: `uv run pytest tests/unit/integrations/test_prompt_manager.py -q`
+Expected: FAIL once tests require SDK-native behavior instead of the current probe/cache helpers.
+
+**Step 3: Write the minimal implementation**
+
+- Remove `_probe_prompt_available()`, `_missing_prompts_until`, and `_known_prompts_until`.
+- Keep one fallback path for SDK exceptions and no-client mode.
+- Preserve the current public API and span metadata so downstream callers do not change.
+
+**Step 4: Run the focused test again**
+
+Run: `uv run pytest tests/unit/integrations/test_prompt_manager.py -q`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add telegram_bot/integrations/prompt_manager.py tests/unit/integrations/test_prompt_manager.py
+git commit -m "refactor: use langfuse sdk prompt fallback directly"
+```
+
+## Task 3: Retire The Deprecated `LLMService` Surface
+
+**Files:**
+- Modify: `telegram_bot/services/__init__.py`
+- Modify: `telegram_bot/services/llm.py`
+- Modify: `telegram_bot/README.md`
+- Modify: `tests/unit/test_llm_service.py`
+- Modify: `tests/unit/services/test_llm.py`
+- Reference: `telegram_bot/services/generate_response.py`
+- Reference: `telegram_bot/pipelines/client.py`
+
+**Step 1: Write the failing tests**
+
+- Add one test that the package-level public surface no longer encourages `LLMService` usage.
+- Keep one compatibility test if the module stays as a shim, but require deprecation to be explicit and non-runtime-critical.
+- Add a grep-based assertion or targeted import test that production code paths use `generate_response()` instead.
+
+**Step 2: Run the focused tests**
+
+Run: `uv run pytest tests/unit/test_llm_service.py tests/unit/services/test_llm.py tests/unit/services/test_generate_response.py -q`
+Expected: FAIL once the public-surface expectations are tightened.
+
+**Step 3: Write the minimal implementation**
+
+- Remove `LLMService` from `telegram_bot.services.__all__` and lazy exports.
+- Update `telegram_bot/README.md` to point to `generate_response()` as the canonical path.
+- Keep `telegram_bot/services/llm.py` only as an explicit compatibility shim or remove it if no supported imports remain.
+
+**Step 4: Re-run the focused tests**
+
+Run: `uv run pytest tests/unit/test_llm_service.py tests/unit/services/test_llm.py tests/unit/services/test_generate_response.py -q`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add telegram_bot/services/__init__.py telegram_bot/services/llm.py telegram_bot/README.md tests/unit/test_llm_service.py tests/unit/services/test_llm.py tests/unit/services/test_generate_response.py
+git commit -m "refactor: retire deprecated llmservice surface"
+```
+
+## Task 4: Run A Feature-Flagged Docling Native Spike
+
+**Files:**
+- Create: `src/ingestion/docling_native.py`
+- Modify: `src/ingestion/unified/config.py`
+- Modify: `src/ingestion/unified/targets/qdrant_hybrid_target.py`
+- Modify: `tests/unit/ingestion/test_docling_client.py`
+- Create: `tests/unit/ingestion/test_docling_native.py`
+- Reference: `src/ingestion/docling_client.py`
+
+**Step 1: Write the failing tests**
+
+- Add a contract test that native chunks expose the same normalized fields used today by the unified ingestion target.
+- Add a config test for selecting `docling_native` vs `docling_http`.
+- Keep the current `DoclingClient` tests unchanged for the HTTP path.
+
+**Step 2: Run the focused tests**
+
+Run: `uv run pytest tests/unit/ingestion/test_docling_client.py tests/unit/ingestion/test_docling_native.py -q`
+Expected: FAIL because the native adapter and selector do not exist yet.
+
+**Step 3: Write the minimal implementation**
+
+- Introduce a narrow adapter around Docling `DocumentConverter`.
+- Gate it behind explicit config so rollback is immediate.
+- Preserve deterministic metadata mapping and chunk identity.
+- Do not remove `docling-serve` until native parity is demonstrated on representative documents.
+
+**Step 4: Re-run the focused tests**
+
+Run: `uv run pytest tests/unit/ingestion/test_docling_client.py tests/unit/ingestion/test_docling_native.py -q`
+Expected: PASS
+
+**Step 5: Run one integration confirmation if fixtures are available**
+
+Run: `uv run pytest tests/integration/test_gdrive_ingestion.py -q`
+Expected: PASS when local services/fixtures are available; otherwise document the blocker.
+
+**Step 6: Commit**
+
+```bash
+git add src/ingestion/docling_native.py src/ingestion/unified/config.py src/ingestion/unified/targets/qdrant_hybrid_target.py tests/unit/ingestion/test_docling_client.py tests/unit/ingestion/test_docling_native.py
+git commit -m "feat(ingestion): add feature-flagged native docling path"
+```
+
+## Guardrails
+
+- No big-bang replacement of `aiogram`, `aiogram-dialog`, `qdrant-client`, or `redisvl`.
+- No new Telegram orchestration layer unless a concrete gap is proven against native aiogram features.
+- No replacement of direct `qdrant-client` in the main retrieval path unless advanced feature parity is demonstrated.
+- Every spike must ship with a rollback path, focused tests, and explicit measurement criteria.

--- a/docs/plans/2026-03-13-sdk-first-remediation-plan.md
+++ b/docs/plans/2026-03-13-sdk-first-remediation-plan.md
@@ -1,0 +1,330 @@
+# SDK-First Remediation Plan
+
+> **For Codex:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Reduce unnecessary custom integration code by adopting official SDK/native APIs where they already cover the use case, while preserving the custom adapters that are still justified.
+
+**Architecture:** Keep SDK boundaries explicit per subsystem. Replace repo-local logic only where the vendor SDK already exposes the same behavior (`Langfuse` prompt fetching, `Docling` conversion/chunking). Do not force third-party or low-trust community wrappers into production paths when the repo's first-party adapter is safer (`Kommo`, local BGE-M3 service). Build on the audit in `docs/plans/2026-03-02-sdk-migration-audit.md`, but turn it into an execution-ready sequence.
+
+**Tech Stack:** Python 3.12, Langfuse Python SDK, Docling Python API, Qdrant Python SDK, LiveKit Agents, aiogram, Redis, asyncpg, httpx
+
+---
+
+## Scope
+
+**In scope**
+- Remove SDK duplication in `Langfuse` prompt access.
+- Consolidate duplicate Kommo token-store implementations into one canonical adapter.
+- Run a bounded Docling native-SDK migration spike for unified ingestion.
+- Add a typed internal client for voice-to-RAG calls instead of ad-hoc `httpx` usage in the tool body.
+- Update SDK guidance/docs after code changes land.
+
+**Out of scope**
+- Replacing direct `qdrant-client` usage with `langchain-qdrant`.
+- Replacing the self-hosted BGE-M3 REST boundary with a third-party wrapper.
+- Replacing `LiveKit Agents` or `aiogram` architecture.
+- Introducing unofficial Kommo SDKs into production without a separate approval decision.
+
+## Research Verdicts To Preserve
+
+- `Langfuse` official SDK already supports `get_prompt(..., cache_ttl_seconds=..., fallback=...)` and prompt lookup via `client.prompts.get(...)`.
+- `Docling` official Python package already exposes `DocumentConverter` and `HybridChunker`; the repo also already depends on `docling` and uses it outside unified ingestion.
+- `Qdrant` direct SDK usage is already the correct path for named vectors, hybrid search, and server-side rerank flows.
+- `LiveKit Agents` explicitly supports external backend calls from `@function_tool`; the problem in voice is not missing SDK support, but the lack of a shared typed client boundary.
+- Kommo official docs document REST + OAuth2, but no official Python SDK was verified. Community packages exist, but they are third-party and lower-trust than the current in-repo adapter.
+
+### Task 1: Simplify Langfuse Prompt Management To SDK-Native Behavior
+
+**Files:**
+- Modify: `telegram_bot/integrations/prompt_manager.py`
+- Test: `tests/unit/test_prompt_manager.py`
+- Reference: `.claude/rules/sdk-registry.md`
+
+**Step 1: Write the failing tests**
+
+Add/extend tests to assert:
+- `get_prompt()` passes `cache_ttl_seconds` through to the SDK.
+- fallback text is returned when the SDK raises a not-found error.
+- prompt compilation still applies `variables`.
+- no direct use of `client.api.prompts.get(...)` is required for the happy path.
+
+Example test shape:
+
+```python
+def test_get_prompt_uses_sdk_fallback(mock_langfuse_client):
+    mock_langfuse_client.get_prompt.side_effect = Exception("Prompt not found")
+    result = prompt_manager.get_prompt("missing", fallback="hello {{name}}", variables={"name": "A"})
+    assert result == "hello A"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_prompt_manager.py -q`
+Expected: FAIL because current implementation still depends on manual probe/cache helpers.
+
+**Step 3: Write minimal implementation**
+
+Refactor `prompt_manager.py` to:
+- remove `_missing_prompts_until`, `_known_prompts_until`, and `_probe_prompt_available()`;
+- call `client.get_prompt(name, label=..., cache_ttl_seconds=..., fallback=...)`;
+- keep local fallback-variable substitution only for the no-client case or for SDK exceptions that still need graceful degradation;
+- keep public API unchanged.
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/test_prompt_manager.py -q`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add telegram_bot/integrations/prompt_manager.py tests/unit/test_prompt_manager.py .claude/rules/sdk-registry.md
+git commit -m "refactor: use langfuse sdk prompt cache and fallback"
+```
+
+### Task 2: Consolidate Kommo OAuth State Into One Canonical Token Store
+
+**Files:**
+- Modify: `telegram_bot/services/kommo_client.py`
+- Modify: `telegram_bot/services/kommo_tokens.py`
+- Modify: `telegram_bot/services/kommo_token_store.py`
+- Modify: `telegram_bot/bot.py`
+- Test: `tests/unit/services/test_kommo_tokens.py`
+- Test: `tests/unit/services/test_kommo_token_store.py`
+- Test: `tests/unit/services/test_kommo_client.py`
+
+**Step 1: Write the failing tests**
+
+Add/extend tests to assert:
+- bot initialization and `KommoClient` use the same token-store implementation;
+- only one Redis key format is used;
+- refresh flow still works for stored refresh tokens;
+- seed-from-env mode still works when only an access token is present.
+
+Example test shape:
+
+```python
+async def test_bot_and_client_share_same_kommo_token_store(redis_client):
+    store = KommoTokenStore(...)
+    await store.seed_env_token("token")
+    assert await store.get_valid_token() == "token"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/services/test_kommo_tokens.py tests/unit/services/test_kommo_token_store.py tests/unit/services/test_kommo_client.py -q`
+Expected: FAIL once assertions require a single canonical implementation.
+
+**Step 3: Write minimal implementation**
+
+Choose one canonical module:
+- keep one `KommoTokenStore` implementation;
+- make the other module a compatibility shim or delete it after import-site cleanup;
+- align Redis keying strategy;
+- update `telegram_bot/bot.py` and `telegram_bot/services/kommo_client.py` to import the same class/protocol;
+- preserve current OAuth2 behavior and fail-safe startup.
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/services/test_kommo_tokens.py tests/unit/services/test_kommo_token_store.py tests/unit/services/test_kommo_client.py -q`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add telegram_bot/services/kommo_client.py telegram_bot/services/kommo_tokens.py telegram_bot/services/kommo_token_store.py telegram_bot/bot.py tests/unit/services/test_kommo_tokens.py tests/unit/services/test_kommo_token_store.py tests/unit/services/test_kommo_client.py
+git commit -m "refactor: unify kommo oauth token store"
+```
+
+### Task 3: Run A Feature-Flagged Docling Native-SDK Migration Spike For Unified Ingestion
+
+**Files:**
+- Modify: `src/ingestion/unified/config.py`
+- Modify: `src/ingestion/unified/targets/qdrant_hybrid_target.py`
+- Modify: `src/ingestion/docling_client.py`
+- Create: `src/ingestion/docling_native.py`
+- Test: `tests/unit/ingestion/test_docling_client.py`
+- Test: `tests/unit/ingestion/test_docling_native.py`
+- Test: `tests/integration/test_gdrive_ingestion.py`
+
+**Step 1: Write the failing tests**
+
+Add a contract-focused test suite that asserts the native path returns the same normalized chunk shape as the current HTTP client:
+- `text`
+- `seq_no`
+- `headings`
+- `page_range`
+- `metadata`
+
+Example test shape:
+
+```python
+def test_native_docling_chunk_contract(sample_docx):
+    chunks = chunk_with_native_docling(sample_docx)
+    assert chunks
+    assert {"text", "seq_no", "headings", "page_range", "metadata"} <= chunks[0].model_dump().keys()
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/ingestion/test_docling_native.py -q`
+Expected: FAIL because the native adapter does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Implement a bounded migration:
+- add a native adapter using `DocumentConverter` + `HybridChunker`;
+- keep the current HTTP `DoclingClient` as fallback behind config/feature flag;
+- wire unified ingestion to choose native vs HTTP path explicitly;
+- preserve deterministic metadata mapping and chunk identity;
+- do not remove the HTTP path until integration results are acceptable.
+
+**Step 4: Run tests to verify behavior**
+
+Run: `uv run pytest tests/unit/ingestion/test_docling_client.py tests/unit/ingestion/test_docling_native.py -q`
+Expected: PASS
+
+Run: `uv run pytest tests/integration/test_gdrive_ingestion.py -q`
+Expected: PASS when the required local services/test fixtures are available
+
+**Step 5: Commit**
+
+```bash
+git add src/ingestion/unified/config.py src/ingestion/unified/targets/qdrant_hybrid_target.py src/ingestion/docling_client.py src/ingestion/docling_native.py tests/unit/ingestion/test_docling_client.py tests/unit/ingestion/test_docling_native.py tests/integration/test_gdrive_ingestion.py
+git commit -m "feat: add native docling path for unified ingestion"
+```
+
+### Task 4: Add A Typed Voice RAG API Client
+
+**Files:**
+- Create: `src/voice/rag_api_client.py`
+- Modify: `src/voice/agent.py`
+- Test: `tests/unit/voice/test_rag_api_client.py`
+- Test: `tests/unit/voice/test_agent.py`
+
+**Step 1: Write the failing tests**
+
+Add tests to assert:
+- `search_knowledge_base()` delegates to a typed client instead of inline `httpx`;
+- HTTP errors return the current user-facing fallback;
+- the request payload still includes `query`, `user_id`, `session_id`, `channel`, and optional `langfuse_trace_id`.
+
+Example test shape:
+
+```python
+async def test_voice_agent_uses_rag_api_client(mock_rag_client):
+    result = await agent.search_knowledge_base(context, "price in Sofia")
+    assert result == "ok"
+    mock_rag_client.query.assert_awaited_once()
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/voice/test_rag_api_client.py tests/unit/voice/test_agent.py -q`
+Expected: FAIL because the typed client boundary does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create `src/voice/rag_api_client.py` that:
+- owns the shared `httpx.AsyncClient`;
+- exposes one typed `query()` method returning parsed response data;
+- centralizes timeout/error handling and request schema.
+
+Update `src/voice/agent.py` so the tool calls that client instead of issuing inline HTTP requests.
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/voice/test_rag_api_client.py tests/unit/voice/test_agent.py -q`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/voice/rag_api_client.py src/voice/agent.py tests/unit/voice/test_rag_api_client.py tests/unit/voice/test_agent.py
+git commit -m "refactor: add typed rag api client for voice agent"
+```
+
+### Task 5: Refresh SDK Guidance And Audit Docs
+
+**Files:**
+- Modify: `.claude/rules/sdk-registry.md`
+- Modify: `docs/plans/2026-03-02-sdk-migration-audit.md`
+- Modify: `README.md`
+
+**Step 1: Write the failing test/check**
+
+There is no unit test here. Use a docs consistency check instead:
+- ensure the SDK registry reflects the canonical Kommo, Langfuse, and Docling decisions;
+- ensure README/plan text does not describe removed legacy paths as primary.
+
+**Step 2: Run the check**
+
+Run: `rg -n "kommo_token_store|docling-serve|client.api.prompts.get|Prompt availability probe" .claude/rules/sdk-registry.md README.md docs/plans/2026-03-02-sdk-migration-audit.md telegram_bot src`
+Expected: reveals stale references before docs updates.
+
+**Step 3: Write minimal implementation**
+
+Update docs to reflect:
+- Kommo stays first-party/internal, but only one adapter is supported;
+- Langfuse prompt access is SDK-native;
+- Docling has a feature-flagged native ingestion path and the old HTTP path is compatibility only if still present.
+
+**Step 4: Run the check again**
+
+Run: `rg -n "kommo_token_store|client.api.prompts.get|Prompt availability probe" .claude/rules/sdk-registry.md README.md docs/plans/2026-03-02-sdk-migration-audit.md telegram_bot src`
+Expected: no stale references, or only intentional compatibility mentions
+
+**Step 5: Commit**
+
+```bash
+git add .claude/rules/sdk-registry.md docs/plans/2026-03-02-sdk-migration-audit.md README.md
+git commit -m "docs: refresh sdk-first guidance after integration cleanup"
+```
+
+### Task 6: Full Validation
+
+**Files:**
+- N/A
+
+**Step 1: Run repo checks**
+
+Run: `make check`
+Expected: PASS
+
+**Step 2: Run unit suite**
+
+Run: `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
+Expected: PASS
+
+**Step 3: Run ingestion-specific checks if Task 3 changed code**
+
+Run: `uv run pytest tests/unit/ingestion/test_docling_client.py tests/unit/ingestion/test_docling_native.py -n auto --dist=worksteal -q`
+Expected: PASS
+
+**Step 4: Run voice-specific checks if Task 4 changed code**
+
+Run: `uv run pytest tests/unit/voice/test_rag_api_client.py tests/unit/voice/test_agent.py -n auto --dist=worksteal -q`
+Expected: PASS
+
+**Step 5: Commit validation state**
+
+```bash
+git status --short
+```
+
+## References
+
+- Kommo OAuth docs: `https://developers.kommo.com/docs/oauth-20`
+- Third-party Kommo package found during audit: `https://pypi.org/project/kommo-python/`
+- Langfuse Python SDK prompt docs: `https://context7.com/langfuse/langfuse-python/llms.txt`
+- Qdrant Python SDK docs: `https://context7.com/qdrant/qdrant-client/llms.txt`
+- Docling repository/docs: `https://github.com/docling-project/docling`
+- Docling chunking docs: `https://docling-project.github.io/docling/concepts/chunking/`
+- LiveKit Agents docs: `https://context7.com/livekit/agents/llms.txt`
+
+## Implementation Notes
+
+- Preserve Telegram transport/domain boundaries from `telegram_bot/AGENTS.override.md`.
+- Preserve ingestion determinism/resumability from `src/ingestion/unified/AGENTS.override.md`.
+- If Task 3 cannot match native Docling output closely enough, keep the HTTP path and document the measured reason instead of forcing the migration.
+- Do not adopt `kommo-python`, `amochka`, or other third-party Kommo clients without a separate approval step and live-account verification.

--- a/docs/plans/2026-03-15-sdk-canonical-remediation-plan.md
+++ b/docs/plans/2026-03-15-sdk-canonical-remediation-plan.md
@@ -1,0 +1,422 @@
+# SDK Canonical Remediation Plan
+
+Date: 2026-03-15
+Branch: `review/project-dev`
+Status: canonical execution plan derived from repository review plus historical local SDK plan artifacts
+
+## Precedence
+
+This file is the canonical execution plan for SDK-first cleanup and bounded SDK adoption on this branch.
+
+It consolidates and supersedes the execution direction spread across:
+
+- `docs/plans/2026-03-15-sdk-review-remediation-plan.md`
+- local historical artifacts found outside this worktree:
+  - `docs/plans/2026-03-02-sdk-migration-audit.md`
+  - `docs/plans/2026-03-13-issue-728-sdk-realignment-plan.md`
+  - `docs/plans/2026-03-13-sdk-first-remediation-plan.md`
+  - `docs/SDK_MIGRATION_AUDIT_2026-03-13.md`
+  - `docs/SDK_MIGRATION_ROADMAP_2026-03-13.md`
+
+## Executive Verdict
+
+The correct direction is not a big-bang replacement of the current stack.
+
+The repo should:
+
+1. Keep the SDKs that already match the product well.
+2. Remove custom layers that duplicate vendor SDK behavior without adding product value.
+3. Collapse duplicate in-repo adapters where one canonical internal abstraction is enough.
+4. Treat promising SDK migrations as bounded spikes behind flags or compatibility shims.
+
+## Keeper Stack
+
+These are the stacks the plan assumes will remain primary:
+
+- `aiogram` for Telegram transport, routing, middleware data, and typed callback handling
+- `aiogram-dialog` for menu/dialog state transitions
+- direct `qdrant-client` for main retrieval paths with hybrid search, fusion, and rerank features
+- `redisvl` for cache/router-classifier responsibilities
+- `Langfuse` for tracing, prompts, and possible bounded eval expansion
+- current first-party/in-repo Kommo integration rather than third-party Kommo SDKs
+
+## Non-Goals
+
+- No replacement of `aiogram`, `aiogram-dialog`, `qdrant-client`, or `redisvl`.
+- No big-bang rewrite to another orchestration or agent framework.
+- No migration to third-party Kommo packages without a separate approval decision.
+- No forced replacement of direct Qdrant APIs with higher-level wrappers unless advanced feature parity is proven.
+- No full ingestion architecture rewrite as part of the Docling work.
+
+## Guardrails
+
+- Preserve Telegram transport/domain boundaries from `telegram_bot/AGENTS.override.md`.
+- Preserve ingestion determinism/resumability and file identity semantics from `src/ingestion/unified/AGENTS.override.md`.
+- Preserve LangGraph state and node contract shapes while refactoring bot/runtime code.
+- Preserve trace/score instrumentation unless an explicit replacement is defined and validated.
+- Before introducing or keeping custom integration code, check Context7 for official/native SDK patterns for the target library.
+- Every bounded spike must have:
+  - explicit acceptance criteria
+  - rollback path
+  - targeted tests
+  - documented measured result
+
+## Required SDK Discovery Workflow
+
+For each workstream, use this decision order:
+
+1. Check Context7 for official/native SDK support.
+2. Prefer first-party SDK or native framework capability when it covers the requirement.
+3. Keep custom code only if:
+   - the SDK does not support the needed behavior,
+   - the SDK path would regress product/runtime constraints,
+   - or the custom adapter is the minimal glue layer between subsystems.
+
+Context7 should be queried first for these libraries/frameworks when relevant:
+
+- `Langfuse`
+- `qdrant-client`
+- `aiogram`
+- `aiogram-dialog`
+- `RedisVL`
+- `Docling`
+- `LiveKit Agents`
+
+Expected output from each Context7 check:
+
+- what the official SDK already supports
+- what custom code can be removed
+- what custom code must remain
+- any SDK constraints or version-sensitive caveats
+
+## Current Audit Findings (2026-03-15)
+
+These findings came from repository audit against the current worktree and should be treated as active backlog input.
+
+### High
+
+- Broken documentation references in tracked files:
+  - `compose.yml` references missing `docs/plans/2026-03-05-docker-compose-unification-design.md`
+  - `telegram_bot/AGENTS.override.md` and `src/ingestion/unified/AGENTS.override.md` reference missing `docs/agent-rules/*`
+- `LLMService` remains widely embedded in tests/docs even though runtime direction has moved to `generate_response()`
+- Prompt management still contains manual Langfuse prompt probing via `_probe_prompt_available()` and `client.api.prompts.get(...)`
+- Kommo OAuth/token state is duplicated across `telegram_bot/services/kommo_tokens.py` and `telegram_bot/services/kommo_token_store.py`
+- Voice agent still uses inline shared `httpx.AsyncClient` plumbing inside `src/voice/agent.py` instead of a typed internal client boundary
+
+### Medium
+
+- Qdrant client/config/query policy is duplicated across bot, retrieval, ingestion, and evaluation code
+- README/runtime support drift:
+  - README advertises Python 3.12+
+  - `pyproject.toml` requires `>=3.11`
+  - Ruff target is `py311`
+- README project structure still points to top-level `evaluation/`, while the repo uses `src/evaluation/`
+- Multiple deprecated/legacy compatibility surfaces remain active in runtime/docs/tests, increasing cleanup cost and masking dead code
+
+### Low
+
+- Several evaluation modules still carry TODO placeholders and legacy references that should be either promoted into explicit backlog or removed
+- Deprecated ingestion/chunking helpers remain documented/tested beyond their current product importance
+
+## Workstreams
+
+### Phase 0: Recover Source Of Truth
+
+Goal: restore one tracked documentation baseline before code cleanup continues.
+
+Actions:
+
+- Restore the historically relevant SDK audit/roadmap docs into git, or archive them explicitly if they are intentionally obsolete.
+- Keep this file as the canonical execution plan.
+- Fix stale doc references in code/comments, especially broken `docs/plans/...` links.
+- Align README/runtime version statements where they currently disagree.
+
+Acceptance criteria:
+
+- At least one historical SDK migration/audit document beyond this file is restored as tracked documentation.
+- Broken plan references in tracked files are either repaired or removed.
+- Team can point to one canonical plan and one canonical audit snapshot.
+
+Suggested checks:
+
+- `rg -n "docs/plans/" README.md compose.yml telegram_bot src docs`
+
+### Phase 1: Harden Docker Secret Posture
+
+Goal: separate development convenience from base security posture.
+
+Actions:
+
+- Remove predictable secret fallbacks from `compose.yml`.
+- Keep local/dev-only defaults in `compose.dev.yml`.
+- Document which services may continue to use environment variables for secrets and which should move to `secrets:` or `*_FILE` patterns.
+- Re-check service exceptions to `x-security-defaults`.
+
+Primary files:
+
+- `compose.yml`
+- `compose.dev.yml`
+- `compose.vps.yml`
+- `docs/LOCAL-DEVELOPMENT.md`
+
+Acceptance criteria:
+
+- Base Compose fails fast on missing sensitive credentials.
+- Dev overrides still provide a low-friction local startup path.
+- Secret handling target model is documented.
+
+### Phase 2: Simplify Langfuse Prompt Management
+
+Goal: stop duplicating SDK prompt lookup behavior in local code.
+
+Actions:
+
+- Check Context7 Langfuse docs for the current prompt-management API before changing code.
+- Refactor `telegram_bot/integrations/prompt_manager.py` toward SDK-native `client.get_prompt(...)` behavior.
+- Remove or shrink `_probe_prompt_available()`, `_missing_prompts_until`, and `_known_prompts_until` if they are no longer justified.
+- Keep fallback behavior only where the SDK/client is absent or still raises recoverable exceptions.
+- Preserve public API and prompt variable compilation behavior for callers.
+
+Primary files:
+
+- `telegram_bot/integrations/prompt_manager.py`
+- `tests/unit/integrations/test_prompt_manager.py`
+
+Acceptance criteria:
+
+- Happy path does not require manual `client.api.prompts.get(...)` probing.
+- Fallback behavior remains deterministic.
+- Existing callers do not need to change.
+
+Suggested checks:
+
+- `uv run pytest tests/unit/integrations/test_prompt_manager.py -q`
+- `rg -n "client\\.api\\.prompts\\.get|_probe_prompt_available|Prompt availability probe" telegram_bot tests`
+
+### Phase 3: Retire Deprecated `LLMService` From Active Runtime Surface
+
+Goal: make `generate_response()` the canonical runtime path.
+
+Actions:
+
+- Check Context7 for the current supported OpenAI-compatible and Langfuse instrumentation patterns used by the repo.
+- Audit all imports and references to `LLMService`.
+- Separate runtime-critical dependencies from compatibility tests and legacy documentation.
+- Remove `LLMService` from package-level “recommended” surface in `telegram_bot/services/__init__.py`.
+- Update bot-facing docs to point to `generate_response()` as the supported path.
+- Keep `telegram_bot/services/llm.py` only as a bounded compatibility shim until test migration is complete, or remove it once no supported imports remain.
+
+Primary files:
+
+- `telegram_bot/services/__init__.py`
+- `telegram_bot/services/llm.py`
+- `telegram_bot/services/generate_response.py`
+- `telegram_bot/README.md`
+- tests under `tests/unit/` and `tests/integration/` that still target `LLMService`
+
+Acceptance criteria:
+
+- No production/runtime path depends on `LLMService`.
+- Any remaining references are explicit compatibility debt with an owner.
+- Canonical documentation no longer presents `LLMService` as the primary API.
+
+Suggested checks:
+
+- `rg -n "LLMService" telegram_bot src tests`
+- `uv run pytest tests/unit/services/test_generate_response.py -q`
+
+### Phase 4: Consolidate Kommo Token Store Duplication
+
+Goal: stop maintaining two competing token-store implementations.
+
+Current duplication:
+
+- `telegram_bot/services/kommo_tokens.py`
+- `telegram_bot/services/kommo_token_store.py`
+
+Actions:
+
+- Choose one canonical token-store implementation and one Redis keying model.
+- Convert the other module into a compatibility shim or delete it after import cleanup.
+- Ensure `telegram_bot/services/kommo_client.py` and bot startup use the same abstraction.
+- Preserve refresh-token flow and env-seeding behavior.
+
+Primary files:
+
+- `telegram_bot/services/kommo_client.py`
+- `telegram_bot/services/kommo_tokens.py`
+- `telegram_bot/services/kommo_token_store.py`
+- `telegram_bot/bot.py`
+- related unit tests
+
+Acceptance criteria:
+
+- One canonical token-store implementation is used in runtime code.
+- Redis key format is consistent.
+- OAuth refresh behavior remains intact.
+
+Suggested checks:
+
+- `uv run pytest tests/unit/services/test_kommo_tokens.py tests/unit/services/test_kommo_token_store.py tests/unit/services/test_kommo_client.py -q`
+
+### Phase 5: Add A Typed Voice RAG API Client
+
+Goal: replace inline voice-to-RAG HTTP calls with one typed internal boundary.
+
+Actions:
+
+- Check Context7 for current LiveKit Agents patterns around external backend/tool calls before refactoring the client boundary.
+- Create a dedicated client module for voice-to-RAG API interaction.
+- Move request schema, timeout handling, and error mapping out of `src/voice/agent.py`.
+- Keep the user-facing fallback behavior unchanged.
+
+Primary files:
+
+- `src/voice/agent.py`
+- `src/voice/rag_api_client.py` or equivalent shared internal client module
+- `tests/unit/voice/test_voice_agent.py`
+- new tests for the typed client
+
+Acceptance criteria:
+
+- `search_knowledge_base()` no longer owns ad-hoc inline HTTP request assembly.
+- Request payload shape remains explicit and tested.
+- Error handling is centralized.
+
+Suggested checks:
+
+- `uv run pytest tests/unit/voice/test_voice_agent.py -q`
+
+### Phase 6: Run A Feature-Flagged Docling Native Spike
+
+Goal: evaluate native Docling usage in unified ingestion without forcing a full migration.
+
+Actions:
+
+- Check Context7 for current Docling native conversion/chunking patterns before implementing the adapter.
+- Add a narrow native adapter using `DocumentConverter` and the current normalized chunk contract.
+- Gate native vs HTTP behavior behind explicit config.
+- Keep current HTTP behavior as rollback path until parity is demonstrated.
+- Measure contract parity, runtime behavior, and packaging/deployment implications.
+
+Primary files:
+
+- `src/ingestion/docling_client.py`
+- `src/ingestion/docling_native.py`
+- `src/ingestion/unified/config.py`
+- `src/ingestion/unified/targets/qdrant_hybrid_target.py`
+- `tests/unit/ingestion/test_docling_client.py`
+- `tests/unit/ingestion/test_docling_native.py`
+
+Acceptance criteria:
+
+- Native path is optional and reversible.
+- Normalized chunk contract remains stable.
+- Ingestion identity and resumability semantics are preserved.
+- Measured result is documented: keep native path, keep HTTP path, or keep both.
+
+Suggested checks:
+
+- `uv run pytest tests/unit/ingestion/test_docling_client.py tests/unit/ingestion/test_docling_native.py -q`
+- `uv run pytest tests/integration/test_gdrive_ingestion.py -q`
+
+### Phase 7: Consolidate Qdrant Configuration Policy
+
+Goal: reduce duplicated client/config/query policy logic without weakening runtime-specific needs.
+
+Actions:
+
+- Check Context7 Qdrant client docs for current sync/async initialization and query API patterns before extracting shared abstractions.
+- Introduce one shared source of truth for Qdrant connection and collection policy.
+- Centralize collection naming and quantization policy.
+- Extract reusable query/search parameter builders where overlap is real.
+- Preserve thin runtime-specific adapters when async vs sync or ingestion vs retrieval concerns differ.
+
+Primary files:
+
+- `telegram_bot/services/qdrant.py`
+- `src/retrieval/search_engines.py`
+- `src/ingestion/unified/qdrant_writer.py`
+- `src/ingestion/service.py`
+- `src/ingestion/indexer.py`
+- `src/evaluation/search_engines.py`
+
+Acceptance criteria:
+
+- Qdrant connection/config policy has one shared source of truth.
+- Collection and quantization policy do not drift across runtimes.
+- Search feature changes no longer require copy-paste edits in multiple modules.
+
+Suggested checks:
+
+- `rg -n "QdrantClient\\(|AsyncQdrantClient\\(" telegram_bot src`
+
+### Phase 8: Reduce Langfuse Runtime Custom Surface
+
+Goal: keep only project-specific observability behavior that the SDK does not already cover.
+
+Actions:
+
+- Re-check Context7 Langfuse SDK docs before removing or retaining custom observability helpers.
+- Split or simplify `telegram_bot/observability.py` into a smaller bootstrap-oriented module.
+- Retain PII redaction and explicitly justified custom behavior.
+- Move optional startup synchronization logic behind a clear boundary if it remains necessary.
+- Preserve current trace/score behavior until equivalent replacement is verified.
+
+Primary files:
+
+- `telegram_bot/observability.py`
+- `telegram_bot/middlewares/langfuse_middleware.py`
+- `telegram_bot/scoring.py`
+- related observability tests
+
+Acceptance criteria:
+
+- Module responsibility is narrower and clearer.
+- SDK upgrade risk is reduced.
+- Trace/score contracts remain validated.
+
+## Explicitly Dropped Or Deferred Ideas
+
+- `langchain-qdrant` as a replacement for the main retrieval path
+- big-bang migration to another agent/orchestration framework
+- speculative RedisVL optimizer work not verified against current docs/runtime
+- third-party Kommo SDK adoption
+- broad Guardrails/PII SDK adoption without a separate eval-driven proposal
+
+## Validation Gates
+
+Required before closing any implementation batch derived from this plan:
+
+- `make check`
+- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
+
+Additional targeted gates when relevant:
+
+- Graph/bot flow changes:
+  - `uv run pytest tests/integration/test_graph_paths.py -n auto --dist=worksteal -q`
+- Ingestion unified changes:
+  - `make ingest-unified-status`
+  - `python -m src.ingestion.unified.cli preflight`
+- Docling spike:
+  - `uv run pytest tests/unit/ingestion/test_docling_client.py tests/unit/ingestion/test_docling_native.py -n auto --dist=worksteal -q`
+- Voice client work:
+  - `uv run pytest tests/unit/voice/test_voice_agent.py -n auto --dist=worksteal -q`
+
+## Recommended Order
+
+1. Phase 0: recover tracked documentation and fix source-of-truth drift.
+2. Phase 1: Docker secret hardening.
+3. Phase 2: Langfuse prompt-manager simplification.
+4. Phase 3: `LLMService` retirement from active runtime surface.
+5. Phase 4: Kommo token-store consolidation.
+6. Phase 5: typed voice RAG client.
+7. Phase 6: Docling native spike.
+8. Phase 7: Qdrant configuration consolidation.
+9. Phase 8: Langfuse runtime surface reduction.
+
+## Notes
+
+- Historical local plans contained useful task ideas, but some assumptions were stale.
+- This plan intentionally keeps the valid detailed tasks and drops the stale migration framing.
+- If a phase proves too large, split it into a dedicated sub-plan rather than broadening scope inside implementation.

--- a/src/config/qdrant_policy.py
+++ b/src/config/qdrant_policy.py
@@ -1,0 +1,17 @@
+"""Shared Qdrant collection policy helpers."""
+
+from __future__ import annotations
+
+
+def resolve_collection_name(base_name: str, mode: str) -> str:
+    """Return collection name with quantization suffix based on mode."""
+    base = base_name
+    for suffix in ("_binary", "_scalar"):
+        base = base.removesuffix(suffix)
+
+    normalized = (mode or "off").lower()
+    if normalized == "scalar":
+        return f"{base}_scalar"
+    if normalized == "binary":
+        return f"{base}_binary"
+    return base

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -17,6 +17,7 @@ from .constants import (
     RetrievalStages,
     SearchEngine,
 )
+from .qdrant_policy import resolve_collection_name
 
 
 class Settings:
@@ -236,17 +237,7 @@ class Settings:
             - QuantizationMode.SCALAR: base_scalar
             - QuantizationMode.BINARY: base_binary
         """
-        base = self.collection_name
-        # Strip existing suffixes
-        for suffix in ["_binary", "_scalar"]:
-            base = base.removesuffix(suffix)
-
-        if self.quantization_mode == QuantizationMode.SCALAR:
-            return f"{base}_scalar"
-        if self.quantization_mode == QuantizationMode.BINARY:
-            return f"{base}_binary"
-        # OFF
-        return base
+        return resolve_collection_name(self.collection_name, self.quantization_mode.value)
 
     def to_dict(self) -> dict[str, Any]:
         """Export settings as dictionary (excluding sensitive data)."""

--- a/src/evaluation/ragas_evaluation.py
+++ b/src/evaluation/ragas_evaluation.py
@@ -33,6 +33,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from datasets import Dataset
 from openai import OpenAI
 from ragas import evaluate
 from ragas.llms import llm_factory
@@ -45,7 +46,6 @@ from ragas.metrics.collections import (
     Faithfulness,
 )
 
-from datasets import Dataset
 from src.evaluation.mlflow_integration import MLflowRAGLogger
 
 

--- a/src/ingestion/docling_native.py
+++ b/src/ingestion/docling_native.py
@@ -1,0 +1,77 @@
+"""Optional native Docling adapter (feature-flagged)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from src.ingestion.docling_client import DoclingChunk
+
+
+def _chunk_text(text: str, *, max_tokens: int) -> list[str]:
+    """Split markdown text into bounded chunks by word count."""
+    words = text.split()
+    if not words:
+        return []
+
+    chunks: list[str] = []
+    cursor = 0
+    while cursor < len(words):
+        window = words[cursor : cursor + max_tokens]
+        chunks.append(" ".join(window))
+        cursor += max_tokens
+    return chunks
+
+
+@dataclass
+class DoclingNativeConfig:
+    """Runtime config for native Docling adapter."""
+
+    max_tokens: int = 512
+
+
+class DoclingNativeConverter:
+    """Narrow wrapper around Docling `DocumentConverter` for spike usage."""
+
+    def __init__(self, config: DoclingNativeConfig | None = None) -> None:
+        self.config = config or DoclingNativeConfig()
+
+    @staticmethod
+    def is_available() -> bool:
+        """Return True when native docling package is installed."""
+        try:
+            from docling.document_converter import DocumentConverter  # noqa: F401
+        except Exception:
+            return False
+        return True
+
+    @staticmethod
+    def _create_document_converter():
+        from docling.document_converter import DocumentConverter
+
+        return DocumentConverter()
+
+    def chunk_file_sync(self, file_path: Path) -> list[DoclingChunk]:
+        """Convert file with native Docling and return normalized chunks."""
+        try:
+            converter = self._create_document_converter()
+        except Exception as exc:  # pragma: no cover - environment dependent
+            raise RuntimeError("Native docling is not installed") from exc
+
+        result = converter.convert(str(file_path))
+        document = result.document
+        markdown = document.export_to_markdown()
+        raw_chunks = _chunk_text(markdown, max_tokens=self.config.max_tokens)
+
+        chunks: list[DoclingChunk] = []
+        for idx, text in enumerate(raw_chunks):
+            chunks.append(
+                DoclingChunk(
+                    text=text,
+                    seq_no=idx,
+                    headings=[],
+                    page_range=None,
+                    metadata={"backend": "docling-native", "offset": idx},
+                )
+            )
+        return chunks

--- a/src/ingestion/unified/AGENTS.override.md
+++ b/src/ingestion/unified/AGENTS.override.md
@@ -29,6 +29,6 @@
 
 ## References
 - `docs/INGESTION.md`
-- `docs/agent-rules/workflow.md`
-- `docs/agent-rules/testing-and-validation.md`
+- `docs/LOCAL-DEVELOPMENT.md`
+- `docs/PIPELINE_OVERVIEW.md`
 - `src/ingestion/unified/cli.py`

--- a/src/ingestion/unified/config.py
+++ b/src/ingestion/unified/config.py
@@ -41,6 +41,10 @@ class UnifiedConfig:
         default_factory=lambda: os.getenv("DOCLING_URL", "http://localhost:5001")
     )
     docling_timeout: float = 300.0
+    docling_backend: str = field(default_factory=lambda: os.getenv("DOCLING_BACKEND", "http"))
+    docling_native_enabled: bool = field(
+        default_factory=lambda: os.getenv("DOCLING_NATIVE_ENABLED", "false").lower() == "true"
+    )
     max_tokens_per_chunk: int = 512
 
     # Voyage

--- a/src/ingestion/unified/targets/qdrant_hybrid_target.py
+++ b/src/ingestion/unified/targets/qdrant_hybrid_target.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from cocoindex.op import TargetSpec, target_connector
 
 from src.ingestion.docling_client import DoclingClient, DoclingConfig
+from src.ingestion.docling_native import DoclingNativeConfig, DoclingNativeConverter
 from src.ingestion.unified.config import UnifiedConfig
 from src.ingestion.unified.qdrant_writer import QdrantHybridWriter
 from src.ingestion.unified.state_manager import FileState, UnifiedStateManager
@@ -47,6 +48,8 @@ class QdrantHybridTargetSpec(TargetSpec):
     # Docling
     docling_url: str = "http://localhost:5001"
     docling_timeout: float = 300.0
+    docling_backend: str = "http"
+    docling_native_enabled: bool = False
     max_tokens_per_chunk: int = 512
 
     # Voyage
@@ -75,6 +78,8 @@ class QdrantHybridTargetSpec(TargetSpec):
             collection_name=config.collection_name,
             docling_url=config.docling_url,
             docling_timeout=config.docling_timeout,
+            docling_backend=config.docling_backend,
+            docling_native_enabled=config.docling_native_enabled,
             max_tokens_per_chunk=config.max_tokens_per_chunk,
             voyage_api_key=config.voyage_api_key,
             voyage_model=config.voyage_model,
@@ -117,8 +122,10 @@ class QdrantHybridTargetConnector:
     # Note: StateManager is created fresh per mutate() call to avoid asyncpg pool issues
     _writer: QdrantHybridWriter | None = None
     _docling: DoclingClient | None = None
+    _docling_native: DoclingNativeConverter | None = None
     _writer_lock = threading.Lock()
     _docling_lock = threading.Lock()
+    _docling_native_lock = threading.Lock()
 
     # Sequential processing: Semaphore(1) ensures only one file is processed at a time.
     # Critical for CPU-only VPS where BGE-M3 is slow (~10-50s per batch).
@@ -185,6 +192,17 @@ class QdrantHybridTargetConnector:
                     )
                     cls._docling = DoclingClient(config)
         return cls._docling
+
+    @classmethod
+    def _get_docling_native(cls, spec: QdrantHybridTargetSpec) -> DoclingNativeConverter:
+        """Get or create native Docling converter."""
+        if cls._docling_native is None:
+            with cls._docling_native_lock:
+                if cls._docling_native is None:
+                    cls._docling_native = DoclingNativeConverter(
+                        DoclingNativeConfig(max_tokens=spec.max_tokens_per_chunk)
+                    )
+        return cls._docling_native
 
     @classmethod
     def mutate(
@@ -256,7 +274,9 @@ class QdrantHybridTargetConnector:
         logger.debug(f"Upsert: file_id={file_id}, path={mutation.abs_path}")
 
         writer = cls._get_writer(spec)
-        docling = cls._get_docling(spec)
+        use_native_docling = spec.docling_native_enabled or spec.docling_backend.lower() == "native"
+        docling_http = cls._get_docling(spec)
+        docling_native = cls._get_docling_native(spec) if use_native_docling else None
 
         abs_path = Path(mutation.abs_path)
         source_path = mutation.source_path
@@ -288,14 +308,17 @@ class QdrantHybridTargetConnector:
 
         try:
             # Parse and chunk (sync)
-            docling_chunks = docling.chunk_file_sync(abs_path)
+            if docling_native is not None:
+                docling_chunks = docling_native.chunk_file_sync(abs_path)
+            else:
+                docling_chunks = docling_http.chunk_file_sync(abs_path)
             if not docling_chunks:
                 state_manager.mark_indexed_sync(file_id, 0, content_hash)
                 logger.warning(f"No chunks from: {source_path}")
                 return
 
             # Convert to ingestion chunks
-            chunks = docling.to_ingestion_chunks(
+            chunks = docling_http.to_ingestion_chunks(
                 docling_chunks,
                 source=source_path,
                 source_type=abs_path.suffix.lstrip("."),

--- a/src/voice/agent.py
+++ b/src/voice/agent.py
@@ -9,7 +9,6 @@ import json
 import logging
 import os
 import time
-from typing import Any
 
 import httpx
 from dotenv import load_dotenv
@@ -26,6 +25,7 @@ from livekit.agents import (
 from livekit.plugins import elevenlabs, openai, silero
 
 from src.voice.observability import trace_voice_session, update_voice_trace, voice_session_id
+from src.voice.rag_api_client import RagApiClient, RagApiClientError, RagQueryRequest
 from src.voice.schemas import CallStatus
 from src.voice.transcript_store import TranscriptStore
 
@@ -36,28 +36,30 @@ logger = logging.getLogger(__name__)
 RAG_API_URL = os.getenv("RAG_API_URL", "http://rag-api:8080")
 DATABASE_URL = os.getenv("DATABASE_URL") or os.getenv("VOICE_DATABASE_URL", "")
 _transcript_store: TranscriptStore | None = None
-_http_client: httpx.AsyncClient | None = None
+_rag_api_client: RagApiClient | None = None
 _active_jobs = 0
 _jobs_lock: asyncio.Lock | None = None
 
 
+def _get_rag_api_client() -> RagApiClient:
+    """Return shared typed RAG API client."""
+    global _rag_api_client
+    if _rag_api_client is None:
+        _rag_api_client = RagApiClient(base_url=RAG_API_URL)
+    return _rag_api_client
+
+
 def _get_http_client() -> httpx.AsyncClient:
-    """Return a shared httpx client with connection pooling."""
-    global _http_client
-    if _http_client is None:
-        _http_client = httpx.AsyncClient(
-            timeout=30.0,
-            limits=httpx.Limits(max_connections=10, max_keepalive_connections=5),
-        )
-    return _http_client
+    """Compatibility wrapper for tests that assert shared HTTP client behavior."""
+    return _get_rag_api_client().client
 
 
 async def _close_http_client() -> None:
-    """Close the shared httpx client (called on server shutdown)."""
-    global _http_client
-    if _http_client is not None:
-        await _http_client.aclose()
-        _http_client = None
+    """Close the shared typed RAG API client (called on server shutdown)."""
+    global _rag_api_client
+    if _rag_api_client is not None:
+        await _rag_api_client.close()
+        _rag_api_client = None
 
 
 def _get_jobs_lock() -> asyncio.Lock:
@@ -192,15 +194,11 @@ class VoiceBot(Agent):
         """
         await self._append_transcript("user", query)
         try:
-            client = _get_http_client()
-            payload: dict[str, Any] = {
-                "query": query,
-                "user_id": 0,
-                "session_id": self._session_id,
-                "channel": "voice",
-            }
-            if self._langfuse_trace_id:
-                payload["langfuse_trace_id"] = self._langfuse_trace_id
+            request = RagQueryRequest(
+                query=query,
+                session_id=self._session_id,
+                langfuse_trace_id=self._langfuse_trace_id,
+            )
             with contextlib.suppress(Exception):
                 update_voice_trace(
                     call_id=self._call_id,
@@ -208,15 +206,14 @@ class VoiceBot(Agent):
                     session_id=self._session_id,
                     langfuse_trace_id=self._langfuse_trace_id,
                 )
-            resp = await client.post(
-                f"{RAG_API_URL}/query",
-                json=payload,
-            )
-            resp.raise_for_status()
-            data = resp.json()
-            answer = str(data.get("response", "Информация не найдена."))
+            answer = await _get_rag_api_client().search_knowledge_base(request)
             await self._append_transcript("bot", answer)
             return answer
+        except RagApiClientError:
+            logger.exception("RAG API call failed")
+            fallback = "Извините, не могу найти информацию сейчас."
+            await self._append_transcript("bot", fallback)
+            return fallback
         except Exception:
             logger.exception("RAG API call failed")
             fallback = "Извините, не могу найти информацию сейчас."

--- a/src/voice/rag_api_client.py
+++ b/src/voice/rag_api_client.py
@@ -1,0 +1,88 @@
+"""Typed client boundary for voice -> RAG API calls."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+
+@dataclass(frozen=True)
+class RagQueryRequest:
+    """Typed payload for `/query` requests."""
+
+    query: str
+    session_id: str
+    user_id: int = 0
+    channel: str = "voice"
+    langfuse_trace_id: str | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "query": self.query,
+            "user_id": self.user_id,
+            "session_id": self.session_id,
+            "channel": self.channel,
+        }
+        if self.langfuse_trace_id:
+            payload["langfuse_trace_id"] = self.langfuse_trace_id
+        return payload
+
+
+class RagApiClientError(RuntimeError):
+    """Raised when voice RAG API request failed in a recoverable way."""
+
+
+class RagApiClient:
+    """Small typed API client around `/query` endpoint."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        timeout: float = 30.0,
+        max_connections: int = 10,
+        max_keepalive_connections: int = 5,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._max_connections = max_connections
+        self._max_keepalive_connections = max_keepalive_connections
+        self._client: httpx.AsyncClient | None = None
+
+    @property
+    def client(self) -> httpx.AsyncClient:
+        """Expose underlying client for compatibility/test assertions."""
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                timeout=self._timeout,
+                limits=httpx.Limits(
+                    max_connections=self._max_connections,
+                    max_keepalive_connections=self._max_keepalive_connections,
+                ),
+            )
+        return self._client
+
+    async def close(self) -> None:
+        """Close internal HTTP client."""
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def search_knowledge_base(self, request: RagQueryRequest) -> str:
+        """Call RAG API and return response text."""
+        try:
+            response = await self.client.post(
+                f"{self._base_url}/query",
+                json=request.to_payload(),
+            )
+            response.raise_for_status()
+            data = response.json()
+            if not isinstance(data, dict):
+                raise RagApiClientError("Unexpected RAG API response shape")
+            return str(data.get("response", "Информация не найдена."))
+        except httpx.HTTPError as exc:
+            raise RagApiClientError("RAG API request failed") from exc
+        except ValueError as exc:
+            raise RagApiClientError("Invalid RAG API response payload") from exc

--- a/telegram_bot/AGENTS.override.md
+++ b/telegram_bot/AGENTS.override.md
@@ -27,6 +27,5 @@
 ## References
 - `telegram_bot/README.md`
 - `docs/PIPELINE_OVERVIEW.md`
-- `docs/agent-rules/workflow.md`
-- `docs/agent-rules/testing-and-validation.md`
-- `docs/agent-rules/architecture-map.md`
+- `docs/LOCAL-DEVELOPMENT.md`
+- `docs/PROJECT_STACK.md`

--- a/telegram_bot/README.md
+++ b/telegram_bot/README.md
@@ -81,7 +81,7 @@ python -m telegram_bot.main
 
 - **EmbeddingService** - генерация embeddings через BGE-M3 API
 - **RetrieverService** - поиск в Qdrant с фильтрами
-- **LLMService** - генерация ответов через OpenAI API
+- **generate_response()** - каноничный runtime-путь генерации ответов
 - **CacheService** - 4-уровневое кеширование (semantic, embeddings, analyzer, search)
 - **QueryAnalyzer** - анализ запросов и извлечение фильтров через LLM
 - **UserContextService** - управление контекстом пользователя (CESC)

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -460,6 +460,7 @@ class PropertyBot:
         # Expert topic service (user+expert → thread_id mapping)
         self._topic_service: TopicService | None = None
         self._topics_enabled: bool = False
+        self._miniapp_subscriber_task: asyncio.Task[None] | None = None
 
         # Track initialization state
         self._cache_initialized = False

--- a/telegram_bot/config.py
+++ b/telegram_bot/config.py
@@ -5,6 +5,8 @@ from typing import Annotated
 from pydantic import AliasChoices, BeforeValidator, Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
+from src.config.qdrant_policy import resolve_collection_name
+
 
 def _empty_str_to_false(v: object) -> object:
     """Convert empty string to False (env vars with no value)."""
@@ -613,13 +615,4 @@ class BotConfig(BaseSettings):
             - 'scalar': base_scalar
             - 'binary': base_binary
         """
-        base = self.qdrant_collection
-        for suffix in ["_binary", "_scalar"]:
-            base = base.removesuffix(suffix)
-
-        mode = self.qdrant_quantization_mode.lower()
-        if mode == "scalar":
-            return f"{base}_scalar"
-        if mode == "binary":
-            return f"{base}_binary"
-        return base
+        return resolve_collection_name(self.qdrant_collection, self.qdrant_quantization_mode)

--- a/telegram_bot/integrations/prompt_manager.py
+++ b/telegram_bot/integrations/prompt_manager.py
@@ -7,6 +7,7 @@ Falls back to hardcoded prompts when Langfuse is unavailable.
 from __future__ import annotations
 
 import logging
+import os
 import time
 from typing import Any
 
@@ -105,7 +106,11 @@ def _fetch_prompt_core(
         return _fallback_result()
 
     try:
-        prompt = client.get_prompt(name, cache_ttl_seconds=cache_ttl)
+        prompt_kwargs: dict[str, Any] = {"cache_ttl_seconds": cache_ttl}
+        label = os.getenv("LANGFUSE_PROMPT_LABEL", "").strip()
+        if label:
+            prompt_kwargs["label"] = label
+        prompt = client.get_prompt(name, **prompt_kwargs)
         _missing_prompts_until.pop(name, None)
         config: dict[str, Any] = getattr(prompt, "config", None) or {}
         _update_prompt_span_output(

--- a/telegram_bot/integrations/prompt_manager.py
+++ b/telegram_bot/integrations/prompt_manager.py
@@ -7,7 +7,6 @@ Falls back to hardcoded prompts when Langfuse is unavailable.
 from __future__ import annotations
 
 import logging
-import os
 import time
 from typing import Any
 
@@ -21,7 +20,26 @@ DEFAULT_CACHE_TTL = 3600
 
 # Module-level TTL caches for prompt existence
 _missing_prompts_until: dict[str, float] = {}
-_known_prompts_until: dict[str, float] = {}
+
+
+def _update_prompt_span_output(
+    client: Any,
+    *,
+    name: str,
+    source: str,
+    prompt_version: Any | None = None,
+) -> None:
+    """Attach safe prompt fetch metadata to the current Langfuse span."""
+    output: dict[str, Any] = {
+        "prompt_name": name,
+        "prompt_source": source,
+    }
+    if prompt_version is not None:
+        output["prompt_version"] = prompt_version
+    try:
+        client.update_current_span(output=output)
+    except Exception:
+        logger.debug("Failed to update prompt span output", exc_info=True)
 
 
 def get_prompt_with_config(
@@ -76,32 +94,26 @@ def _fetch_prompt_core(
     vars_ = variables or {}
 
     def _fallback_result() -> tuple[str, dict[str, Any]]:
+        _update_prompt_span_output(client, name=name, source="fallback")
         return _apply_fallback_vars(fallback, vars_), {}
 
     client = get_client()
     if client is None:
-        return _fallback_result()
+        return _apply_fallback_vars(fallback, vars_), {}
 
     if _is_temporarily_missing(name):
         return _fallback_result()
-
-    if not _is_temporarily_known(name):
-        available = _probe_prompt_available(client, name)
-        if available is False:
-            _missing_prompts_until[name] = time.monotonic() + cache_ttl
-            logger.debug(
-                "Prompt '%s' not found in Langfuse API, using fallback for %ds",
-                name,
-                cache_ttl,
-            )
-            return _fallback_result()
-        if available is True:
-            _known_prompts_until[name] = time.monotonic() + cache_ttl
 
     try:
         prompt = client.get_prompt(name, cache_ttl_seconds=cache_ttl)
         _missing_prompts_until.pop(name, None)
         config: dict[str, Any] = getattr(prompt, "config", None) or {}
+        _update_prompt_span_output(
+            client,
+            name=name,
+            source="langfuse",
+            prompt_version=getattr(prompt, "version", None),
+        )
         if vars_:
             return str(prompt.compile(**vars_)), config
         return str(prompt.compile()), config
@@ -148,37 +160,6 @@ def _is_temporarily_missing(name: str) -> bool:
     return False
 
 
-def _is_temporarily_known(name: str) -> bool:
-    """True when prompt is in local known-available TTL window."""
-    until = _known_prompts_until.get(name)
-    if until is None:
-        return False
-    if until > time.monotonic():
-        return True
-    _known_prompts_until.pop(name, None)
-    return False
-
-
-def _probe_prompt_available(client: Any, name: str) -> bool | None:
-    """Probe prompt existence via Langfuse API without triggering SDK warning logs."""
-    api = getattr(client, "api", None)
-    if api is None or not hasattr(api, "prompts"):
-        return None
-
-    label = os.getenv("LANGFUSE_PROMPT_LABEL", "production")
-
-    try:
-        api.prompts.get(prompt_name=name, label=label)
-        return True
-    except Exception as e:
-        status = getattr(e, "status_code", None)
-        if status == 404 or _is_prompt_not_found(e):
-            return False
-        logger.debug("Prompt availability probe failed for '%s': %s", name, e)
-        return None
-
-
 def _reset_client() -> None:
     """Reset the prompt TTL caches (for testing)."""
     _missing_prompts_until.clear()
-    _known_prompts_until.clear()

--- a/telegram_bot/observability.py
+++ b/telegram_bot/observability.py
@@ -12,10 +12,8 @@ import atexit
 import json
 import logging
 import os
-import socket
 from datetime import UTC, datetime
 from typing import Any
-from urllib.parse import urlparse
 
 from langfuse import (
     Langfuse,
@@ -31,6 +29,12 @@ from langfuse import (
 )
 
 from src.security.pii_redaction import PIIRedactor
+from telegram_bot.observability_bootstrap import (
+    disable_otel_exporter as _bootstrap_disable_otel_exporter,
+)
+from telegram_bot.observability_bootstrap import (
+    is_endpoint_reachable as _bootstrap_is_endpoint_reachable,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -48,21 +52,14 @@ _pii_redactor = PIIRedactor()
 _langfuse_endpoint_warned = False
 
 
-# ---------------------------------------------------------------------------
-# Endpoint reachability check
-# ---------------------------------------------------------------------------
-
-
 def _is_endpoint_reachable(url: str, *, timeout: float = 2.0) -> bool:
-    """Return True if host:port from *url* accepts a TCP connection within *timeout* seconds."""
-    parsed = urlparse(url)
-    host = parsed.hostname or "localhost"
-    port = parsed.port or (443 if parsed.scheme == "https" else 80)
-    try:
-        with socket.create_connection((host, port), timeout=timeout):
-            return True
-    except OSError:
-        return False
+    """Compatibility wrapper used by unit tests and init flow."""
+    return _bootstrap_is_endpoint_reachable(url, timeout=timeout)
+
+
+def _disable_otel_exporter() -> None:
+    """Compatibility wrapper used by unit tests and init flow."""
+    _bootstrap_disable_otel_exporter()
 
 
 # ---------------------------------------------------------------------------
@@ -324,30 +321,6 @@ def sync_langfuse_model_definitions(
             )
 
     return created_or_updated
-
-
-def _disable_otel_exporter() -> None:
-    """Shutdown any active OTel TracerProvider to stop span exports.
-
-    Shuts down the SDK TracerProvider (if present) but keeps it in place so that
-    Langfuse SDK lazy-init can still call ``add_span_processor`` without crashing.
-    Replacing with ``NoOpTracerProvider`` would break Langfuse v3 which assumes the
-    provider always has ``add_span_processor``.
-
-    Also sets ``LANGFUSE_TRACING_ENABLED=false`` so that Langfuse SDK's own
-    lazy-init path skips OTEL setup entirely.
-    """
-    os.environ.setdefault("LANGFUSE_TRACING_ENABLED", "false")
-    try:
-        from opentelemetry import trace as otel_trace_api
-        from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
-
-        current = otel_trace_api.get_tracer_provider()
-        actual = getattr(current, "_real_provider", current)
-        if isinstance(actual, SdkTracerProvider):
-            actual.shutdown()
-    except ImportError:
-        pass
 
 
 def initialize_langfuse(

--- a/telegram_bot/observability_bootstrap.py
+++ b/telegram_bot/observability_bootstrap.py
@@ -1,0 +1,34 @@
+"""Bootstrap helpers for Langfuse runtime initialization."""
+
+from __future__ import annotations
+
+import os
+import socket
+from urllib.parse import urlparse
+
+
+def is_endpoint_reachable(url: str, *, timeout: float = 2.0) -> bool:
+    """Return True if host:port from *url* accepts TCP connection."""
+    parsed = urlparse(url)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def disable_otel_exporter() -> None:
+    """Shutdown active OTel tracer provider and disable Langfuse tracing export."""
+    os.environ.setdefault("LANGFUSE_TRACING_ENABLED", "false")
+    try:
+        from opentelemetry import trace as otel_trace_api
+        from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
+
+        current = otel_trace_api.get_tracer_provider()
+        actual = getattr(current, "_real_provider", current)
+        if isinstance(actual, SdkTracerProvider):
+            actual.shutdown()
+    except ImportError:
+        pass

--- a/telegram_bot/services/__init__.py
+++ b/telegram_bot/services/__init__.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from .colbert_reranker import ColbertRerankerService
     from .history_service import HistoryService
     from .lead_scoring_store import LeadScoringStore
-    from .llm import LOW_CONFIDENCE_THRESHOLD, ConfidenceResult, LLMService
+    from .llm import LOW_CONFIDENCE_THRESHOLD, ConfidenceResult
     from .metrics import PipelineMetrics
     from .qdrant import QdrantService
     from .query_analyzer import QueryAnalyzer
@@ -38,8 +38,6 @@ __all__ = [
     "ExpandedChunk",
     "HistoryService",
     "HyDEGenerator",
-    # LLMService is deprecated — use generate_response() instead
-    "LLMService",
     "LeadScoringStore",
     "PipelineMetrics",
     "QdrantService",
@@ -66,7 +64,7 @@ _IMPORT_MAP = {
     "LeadScoringStore": ".lead_scoring_store",
     "SessionSummary": ".session_summary",
     "check_responses_parse_compat": ".session_summary",
-    # LLMService is deprecated — kept for backward compatibility only
+    # Compatibility-only export: deprecated, intentionally not in __all__.
     "LLMService": ".llm",
     "LOW_CONFIDENCE_THRESHOLD": ".llm",
     "PipelineMetrics": ".metrics",

--- a/telegram_bot/services/kommo_client.py
+++ b/telegram_bot/services/kommo_client.py
@@ -36,7 +36,7 @@ from telegram_bot.services.kommo_models import (
 
 
 if TYPE_CHECKING:
-    from telegram_bot.services.kommo_token_store import KommoTokenStore
+    from telegram_bot.services.kommo_tokens import KommoTokenStoreProtocol
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +61,7 @@ _kommo_retry = retry(
 class KommoClient:
     """Async Kommo CRM API adapter with auto-refresh OAuth2."""
 
-    def __init__(self, *, subdomain: str, token_store: KommoTokenStore):
+    def __init__(self, *, subdomain: str, token_store: KommoTokenStoreProtocol):
         subdomain = subdomain.removesuffix(".kommo.com")
         self._base_url = f"https://{subdomain}.kommo.com/api/v4"
         self._token_store = token_store

--- a/telegram_bot/services/kommo_token_store.py
+++ b/telegram_bot/services/kommo_token_store.py
@@ -1,29 +1,24 @@
-"""Redis-backed OAuth2 token store for Kommo CRM (#413).
+"""Compatibility shim for the canonical Kommo token store.
 
-Stores access_token + refresh_token in Redis hash.
-Auto-refreshes via Kommo OAuth2 endpoint when expired.
+Canonical implementation lives in :mod:`telegram_bot.services.kommo_tokens`.
+This module keeps backward-compatible import path and serialized refresh behavior.
 """
 
 from __future__ import annotations
 
 import asyncio
-import logging
-import time
 from typing import Any
 
-import httpx
-
-from telegram_bot.observability import get_client, observe
-
-
-logger = logging.getLogger(__name__)
-
-REDIS_KEY_PREFIX = "kommo:tokens:"
-TOKEN_REFRESH_BUFFER_S = 300  # Refresh 5 min before expiry
+from telegram_bot.observability import observe
+from telegram_bot.services.kommo_tokens import KommoTokenStore as _CanonicalKommoTokenStore
 
 
-class KommoTokenStore:
-    """Redis-backed Kommo OAuth2 token manager."""
+class KommoTokenStore(_CanonicalKommoTokenStore):
+    """Backward-compatible adapter over canonical Kommo token store.
+
+    Keeps legacy constructor defaults used by older tests/imports while delegating
+    token lifecycle/storage logic to the canonical implementation.
+    """
 
     def __init__(
         self,
@@ -34,107 +29,17 @@ class KommoTokenStore:
         client_secret: str = "",
         redirect_uri: str = "",
     ):
-        self._redis = redis
-        self._subdomain = subdomain
-        self._client_id = client_id
-        self._client_secret = client_secret
-        self._redirect_uri = redirect_uri
-        self._key = f"{REDIS_KEY_PREFIX}{subdomain}"
+        super().__init__(
+            redis=redis,
+            client_id=client_id,
+            client_secret=client_secret,
+            subdomain=subdomain,
+            redirect_uri=redirect_uri,
+        )
         self._refresh_lock = asyncio.Lock()
-
-    @observe(name="kommo-token-get", capture_input=False, capture_output=False)
-    async def get_valid_token(self) -> str:
-        """Get valid access token, refreshing if needed."""
-        lf = get_client()
-        data = await self._redis.hgetall(self._key)
-        if not data:
-            raise ValueError(f"No token stored for {self._subdomain}")
-
-        expires_at = self._to_int(data.get(b"expires_at", b"0"), default=0)
-        if time.time() < expires_at - TOKEN_REFRESH_BUFFER_S:
-            lf.update_current_span(output={"refresh_needed": False})
-            return self._to_str_token(data.get(b"access_token"), field="access_token")
-
-        lf.update_current_span(output={"refresh_needed": True})
-        return await self.force_refresh()
 
     @observe(name="kommo-token-refresh", capture_input=False, capture_output=False)
     async def force_refresh(self) -> str:
-        """Force token refresh via Kommo OAuth2.
-
-        Serialized via asyncio.Lock to prevent concurrent refreshes from sending
-        duplicate requests with the same (soon-to-be-invalidated) refresh_token.
-        """
+        """Serialize refresh calls to avoid concurrent refresh-token races."""
         async with self._refresh_lock:
-            lf = get_client()
-            data = await self._redis.hgetall(self._key)
-            refresh_token = self._to_str_token(
-                data.get(b"refresh_token", b""), field="refresh_token"
-            )
-
-            async with httpx.AsyncClient() as client:
-                response = await client.post(
-                    f"https://{self._subdomain}.kommo.com/oauth2/access_token",
-                    json={
-                        "client_id": self._client_id,
-                        "client_secret": self._client_secret,
-                        "grant_type": "refresh_token",
-                        "refresh_token": refresh_token,
-                        "redirect_uri": self._redirect_uri,
-                    },
-                )
-                response.raise_for_status()
-                tokens_raw = response.json()
-
-            if not isinstance(tokens_raw, dict):
-                raise ValueError("Invalid token response from Kommo")
-            access_token = self._to_str_token(tokens_raw.get("access_token"), field="access_token")
-            refreshed_token = self._to_str_token(
-                tokens_raw.get("refresh_token"), field="refresh_token"
-            )
-            expires_in = self._to_int(tokens_raw.get("expires_in", 86400), default=86400)
-
-            await self._store_tokens(
-                access_token,
-                refreshed_token,
-                expires_in,
-            )
-            lf.update_current_span(output={"refreshed": True, "expires_in_s": expires_in})
-            return access_token
-
-    async def _store_tokens(
-        self,
-        access_token: str,
-        refresh_token: str,
-        expires_in: int,
-    ) -> None:
-        """Save tokens to Redis hash with expiry timestamp."""
-        expires_at = int(time.time()) + expires_in
-        await self._redis.hset(
-            self._key,
-            mapping={
-                "access_token": access_token,
-                "refresh_token": refresh_token,
-                "expires_at": str(expires_at),
-            },
-        )
-        logger.info("Stored Kommo tokens for %s (expires_in=%ds)", self._subdomain, expires_in)
-
-    @staticmethod
-    def _to_int(value: Any, *, default: int) -> int:
-        """Convert token fields to int with safe fallback."""
-        if isinstance(value, bytes):
-            value = value.decode()
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            return default
-
-    @staticmethod
-    def _to_str_token(value: Any, *, field: str) -> str:
-        """Normalize token values to string or fail fast on invalid payload."""
-        if isinstance(value, bytes):
-            return value.decode()
-        if isinstance(value, str):
-            return value
-        raise ValueError(f"Invalid {field} value in token payload")
+            return await super().force_refresh()

--- a/telegram_bot/services/kommo_token_store.py
+++ b/telegram_bot/services/kommo_token_store.py
@@ -43,3 +43,16 @@ class KommoTokenStore(_CanonicalKommoTokenStore):
         """Serialize refresh calls to avoid concurrent refresh-token races."""
         async with self._refresh_lock:
             return await super().force_refresh()
+
+    async def _store_tokens(
+        self,
+        access_token: str,
+        refresh_token: str,
+        expires_in: int,
+    ) -> None:
+        """Legacy helper kept for script compatibility."""
+        await self._save_tokens(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_in=expires_in,
+        )

--- a/telegram_bot/services/qdrant.py
+++ b/telegram_bot/services/qdrant.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 import numpy as np
 from qdrant_client import AsyncQdrantClient, models
 
+from src.config.qdrant_policy import resolve_collection_name
 from telegram_bot.observability import get_client, observe
 
 
@@ -82,17 +83,7 @@ class QdrantService:
         Returns:
             Collection name with suffix
         """
-        # Strip existing suffixes
-        for suffix in ["_binary", "_scalar"]:
-            base_name = base_name.removesuffix(suffix)
-
-        mode = mode.lower()
-        if mode == "scalar":
-            return f"{base_name}_scalar"
-        if mode == "binary":
-            return f"{base_name}_binary"
-        # off or any other value
-        return base_name
+        return resolve_collection_name(base_name, mode)
 
     @property
     def collection_name(self) -> str:

--- a/tests/unit/config/test_bot_config_kommo_scoring.py
+++ b/tests/unit/config/test_bot_config_kommo_scoring.py
@@ -13,7 +13,9 @@ def test_config_reads_kommo_scoring_field_ids(monkeypatch):
     assert cfg.kommo_lead_band_field_id == 702
 
 
-def test_config_kommo_scoring_fields_default_to_zero():
+def test_config_kommo_scoring_fields_default_to_zero(monkeypatch):
+    monkeypatch.delenv("KOMMO_LEAD_SCORE_FIELD_ID", raising=False)
+    monkeypatch.delenv("KOMMO_LEAD_BAND_FIELD_ID", raising=False)
     cfg = BotConfig()
 
     assert cfg.kommo_lead_score_field_id == 0

--- a/tests/unit/config/test_qdrant_policy.py
+++ b/tests/unit/config/test_qdrant_policy.py
@@ -1,0 +1,19 @@
+"""Tests for shared Qdrant collection policy helpers."""
+
+from src.config.qdrant_policy import resolve_collection_name
+
+
+def test_resolve_collection_name_off_mode():
+    assert resolve_collection_name("docs", "off") == "docs"
+
+
+def test_resolve_collection_name_scalar_mode():
+    assert resolve_collection_name("docs", "scalar") == "docs_scalar"
+
+
+def test_resolve_collection_name_binary_mode():
+    assert resolve_collection_name("docs", "binary") == "docs_binary"
+
+
+def test_resolve_collection_name_strips_existing_suffix():
+    assert resolve_collection_name("docs_scalar", "binary") == "docs_binary"

--- a/tests/unit/graph/test_generate_node.py
+++ b/tests/unit/graph/test_generate_node.py
@@ -413,8 +413,8 @@ class TestGenerateNode:
         system_msg = messages[0]
         assert "недвижимость" in system_msg["content"]
 
-    async def test_limits_to_top_3_docs(self) -> None:
-        """generate_node formats only top-3 documents for context."""
+    async def test_limits_to_top_5_docs(self) -> None:
+        """generate_node formats only top-5 documents for context."""
         from telegram_bot.graph.nodes.generate import generate_node
 
         mock_config, mock_client = _make_mock_config()
@@ -431,13 +431,13 @@ class TestGenerateNode:
         ):
             await generate_node(state)
 
-        # Check that context has at most 3 documents
+        # Check that context has at most 5 documents
         call_kwargs = mock_client.chat.completions.create.call_args
         messages = call_kwargs.kwargs.get("messages") or call_kwargs[1].get("messages")
         messages_text = " ".join(m["content"] for m in messages)
         assert "Doc 0" in messages_text
-        assert "Doc 2" in messages_text
-        assert "Doc 3" not in messages_text
+        assert "Doc 4" in messages_text
+        assert "Doc 5" not in messages_text
 
     async def test_respects_generate_max_tokens(self) -> None:
         """generate_node passes generate_max_tokens from config to LLM call."""

--- a/tests/unit/ingestion/test_docling_native.py
+++ b/tests/unit/ingestion/test_docling_native.py
@@ -1,0 +1,45 @@
+"""Tests for optional native Docling adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from src.ingestion.docling_native import DoclingNativeConfig, DoclingNativeConverter
+
+
+def test_chunk_text_splits_by_token_window(tmp_path: Path):
+    converter = DoclingNativeConverter(DoclingNativeConfig(max_tokens=3))
+
+    class _Doc:
+        def export_to_markdown(self) -> str:
+            return "one two three four five six"
+
+    class _Converter:
+        def convert(self, _path: str):
+            return SimpleNamespace(document=_Doc())
+
+    with patch.object(
+        DoclingNativeConverter,
+        "_create_document_converter",
+        return_value=_Converter(),
+    ):
+        chunks = converter.chunk_file_sync(tmp_path / "test.md")
+
+    assert len(chunks) == 2
+    assert chunks[0].text == "one two three"
+    assert chunks[1].text == "four five six"
+
+
+def test_chunk_file_sync_raises_when_docling_missing(tmp_path: Path):
+    converter = DoclingNativeConverter()
+    with patch.object(
+        DoclingNativeConverter,
+        "_create_document_converter",
+        side_effect=ImportError("missing"),
+    ):
+        with pytest.raises(RuntimeError, match="not installed"):
+            converter.chunk_file_sync(tmp_path / "test.md")

--- a/tests/unit/integrations/test_prompt_manager.py
+++ b/tests/unit/integrations/test_prompt_manager.py
@@ -120,20 +120,19 @@ class TestGetPrompt:
         # 2nd call should use local missing-cache and skip Langfuse call.
         assert mock_client.get_prompt.call_count == 1
 
-    def test_api_probe_skips_sdk_get_prompt_for_missing_prompt(self):
-        from langfuse.api.core.api_error import ApiError
-
+    def test_no_manual_api_probe_for_missing_prompt(self):
         mock_client = MagicMock()
-        mock_client.api.prompts.get.side_effect = ApiError(
-            status_code=404, body={"message": "missing"}
+        mock_client.api.prompts.get.side_effect = RuntimeError("must not be called")
+        mock_client.get_prompt.side_effect = Exception(
+            "status_code: 404, body: {'message': \"Prompt not found: 'generate'\"}"
         )
 
         with patch("telegram_bot.integrations.prompt_manager.get_client", return_value=mock_client):
             result = get_prompt("generate", fallback="fallback", cache_ttl=60)
 
         assert result == "fallback"
-        mock_client.api.prompts.get.assert_called_once()
-        mock_client.get_prompt.assert_not_called()
+        mock_client.get_prompt.assert_called_once()
+        mock_client.api.prompts.get.assert_not_called()
 
 
 class TestApplyFallbackVars:
@@ -216,10 +215,3 @@ class TestResetClient:
         _missing_prompts_until["some-prompt"] = 9999999999.0
         _reset_client()
         assert "some-prompt" not in _missing_prompts_until
-
-    def test_reset_clears_known_prompt_cache(self):
-        from telegram_bot.integrations.prompt_manager import _known_prompts_until
-
-        _known_prompts_until["some-prompt"] = 9999999999.0
-        _reset_client()
-        assert "some-prompt" not in _known_prompts_until

--- a/tests/unit/integrations/test_prompt_manager.py
+++ b/tests/unit/integrations/test_prompt_manager.py
@@ -134,6 +134,23 @@ class TestGetPrompt:
         mock_client.get_prompt.assert_called_once()
         mock_client.api.prompts.get.assert_not_called()
 
+    def test_forwards_langfuse_prompt_label_from_env(self, monkeypatch: pytest.MonkeyPatch):
+        mock_prompt = MagicMock()
+        mock_prompt.compile.return_value = "staging prompt"
+        mock_client = MagicMock()
+        mock_client.get_prompt.return_value = mock_prompt
+        monkeypatch.setenv("LANGFUSE_PROMPT_LABEL", "staging")
+
+        with patch("telegram_bot.integrations.prompt_manager.get_client", return_value=mock_client):
+            result = get_prompt("my-prompt", fallback="fallback text")
+
+        assert result == "staging prompt"
+        mock_client.get_prompt.assert_called_once_with(
+            "my-prompt",
+            cache_ttl_seconds=DEFAULT_CACHE_TTL,
+            label="staging",
+        )
+
 
 class TestApplyFallbackVars:
     def test_no_vars(self):

--- a/tests/unit/services/test_apartment_llm_extractor.py
+++ b/tests/unit/services/test_apartment_llm_extractor.py
@@ -63,8 +63,9 @@ class TestApartmentLlmExtractor:
         assert result.meta.source == "hybrid"
 
     async def test_invalid_city_cleared(self) -> None:
-        bad_result = ApartmentSearchFilters(
-            hard=HardFilters(city="Бургас", rooms=2),
+        # Bypass Literal validation to emulate malformed LLM output.
+        bad_result = ApartmentSearchFilters.model_construct(
+            hard=HardFilters.model_construct(city="Бургас", rooms=2),
             meta=ExtractionMeta(source="llm"),
         )
         extractor = ApartmentLlmExtractor.__new__(ApartmentLlmExtractor)

--- a/tests/unit/services/test_kommo_token_store.py
+++ b/tests/unit/services/test_kommo_token_store.py
@@ -134,3 +134,29 @@ async def test_force_refresh_concurrent_calls_serialized(mock_redis):
 
     # Both calls completed, second one also made HTTP request after first finished
     assert "http_end" in call_log
+
+
+async def test_legacy_store_tokens_method_still_available(mock_redis):
+    """Compatibility shim must preserve _store_tokens for legacy callers/scripts."""
+    from unittest.mock import AsyncMock
+
+    from telegram_bot.services.kommo_token_store import KommoTokenStore
+
+    storage: dict[str, str] = {}
+
+    async def hset(_key, *, mapping):
+        storage.update({str(k): str(v) for k, v in mapping.items()})
+
+    async def hgetall(_key):
+        return {k.encode(): v.encode() for k, v in storage.items()}
+
+    redis = AsyncMock()
+    redis.hset.side_effect = hset
+    redis.hgetall.side_effect = hgetall
+
+    store = KommoTokenStore(redis=redis, subdomain="test")
+
+    await store._store_tokens("seed-token", "", 3600)
+
+    token = await store.get_valid_token()
+    assert token == "seed-token"

--- a/tests/unit/services/test_kommo_token_store.py
+++ b/tests/unit/services/test_kommo_token_store.py
@@ -53,7 +53,7 @@ async def test_get_valid_token_refreshes_when_expired(mock_redis):
         redirect_uri="https://example.com/callback",
     )
 
-    with patch("telegram_bot.services.kommo_token_store.httpx.AsyncClient") as mock_httpx:
+    with patch("telegram_bot.services.kommo_tokens.httpx.AsyncClient") as mock_httpx:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
@@ -113,7 +113,7 @@ async def test_force_refresh_concurrent_calls_serialized(mock_redis):
         call_log.append("http_end")
         return resp
 
-    with patch("telegram_bot.services.kommo_token_store.httpx.AsyncClient") as mock_httpx:
+    with patch("telegram_bot.services.kommo_tokens.httpx.AsyncClient") as mock_httpx:
         mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_httpx.return_value)
         mock_httpx.return_value.__aexit__ = AsyncMock()
         mock_httpx.return_value.post = controlled_post

--- a/tests/unit/services/test_services_public_api.py
+++ b/tests/unit/services/test_services_public_api.py
@@ -1,0 +1,10 @@
+"""Public API surface checks for telegram_bot.services."""
+
+
+def test_llmservice_not_in_recommended_public_api():
+    """LLMService remains compatibility-only and is excluded from __all__."""
+    import telegram_bot.services as services
+
+    assert "LLMService" not in services.__all__
+    # Compatibility import path still available for legacy consumers.
+    assert services.LLMService is not None

--- a/tests/unit/test_compose_langfuse.py
+++ b/tests/unit/test_compose_langfuse.py
@@ -10,10 +10,11 @@ import yaml
 
 ROOT = Path(__file__).parents[2]
 BASE_COMPOSE = ROOT / "compose.yml"
+DEV_COMPOSE = ROOT / "compose.dev.yml"
 
 
-def _load_compose() -> dict:
-    return yaml.safe_load(BASE_COMPOSE.read_text())
+def _load_compose(path: Path) -> dict:
+    return yaml.safe_load(path.read_text())
 
 
 def _get_service_env(compose: dict, service: str) -> dict[str, str]:
@@ -39,8 +40,13 @@ REQUIRED_LANGFUSE_VARS = [
 
 
 @pytest.fixture(scope="module")
-def compose() -> dict:
-    return _load_compose()
+def compose_base() -> dict:
+    return _load_compose(BASE_COMPOSE)
+
+
+@pytest.fixture(scope="module")
+def compose_dev() -> dict:
+    return _load_compose(DEV_COMPOSE)
 
 
 class TestLangfuseEnvVarsPresent:
@@ -48,41 +54,52 @@ class TestLangfuseEnvVarsPresent:
 
     @pytest.mark.parametrize("service", TRACED_SERVICES)
     @pytest.mark.parametrize("var", REQUIRED_LANGFUSE_VARS)
-    def test_service_has_langfuse_var(self, compose: dict, service: str, var: str):
-        env = _get_service_env(compose, service)
+    def test_service_has_langfuse_var(self, compose_base: dict, service: str, var: str):
+        env = _get_service_env(compose_base, service)
         assert var in env, f"compose.yml: {service} missing {var} in environment block"
 
 
-# Сервисы где дефолт ДОЛЖЕН быть непустым (dev-ready)
 SERVICES_WITH_DEV_DEFAULTS = ["bot", "litellm", "rag-api", "voice-agent", "ingestion"]
 
-# Паттерн для пустого дефолта: ${VAR:-} или ${VAR:-""} или просто ""
-_EMPTY_PATTERNS = ("${", "")
 
-
-class TestLangfuseDevDefaults:
-    """Services must have non-empty dev defaults for LANGFUSE keys (pk-lf-dev/sk-lf-dev)."""
+class TestLangfuseSecretPosture:
+    """Base compose avoids predictable secrets; dev compose restores convenience defaults."""
 
     @pytest.mark.parametrize("service", SERVICES_WITH_DEV_DEFAULTS)
-    def test_public_key_has_dev_default(self, compose: dict, service: str):
-        env = _get_service_env(compose, service)
+    def test_base_compose_has_no_dev_public_key_default(self, compose_base: dict, service: str):
+        env = _get_service_env(compose_base, service)
         val = str(env.get("LANGFUSE_PUBLIC_KEY", ""))
-        # Проверяем что дефолт содержит pk-lf-dev
-        assert "pk-lf-dev" in val, (
-            f"compose.yml: {service}.LANGFUSE_PUBLIC_KEY must default to pk-lf-dev, got: {val!r}"
+        assert "pk-lf-dev" not in val, (
+            f"compose.yml: {service}.LANGFUSE_PUBLIC_KEY must not hardcode dev defaults, got: {val!r}"
         )
 
     @pytest.mark.parametrize("service", SERVICES_WITH_DEV_DEFAULTS)
-    def test_secret_key_has_dev_default(self, compose: dict, service: str):
-        env = _get_service_env(compose, service)
+    def test_base_compose_has_no_dev_secret_key_default(self, compose_base: dict, service: str):
+        env = _get_service_env(compose_base, service)
+        val = str(env.get("LANGFUSE_SECRET_KEY", ""))
+        assert "sk-lf-dev" not in val, (
+            f"compose.yml: {service}.LANGFUSE_SECRET_KEY must not hardcode dev defaults, got: {val!r}"
+        )
+
+    @pytest.mark.parametrize("service", SERVICES_WITH_DEV_DEFAULTS)
+    def test_dev_compose_restores_public_key_default(self, compose_dev: dict, service: str):
+        env = _get_service_env(compose_dev, service)
+        val = str(env.get("LANGFUSE_PUBLIC_KEY", ""))
+        assert "pk-lf-dev" in val, (
+            f"compose.dev.yml: {service}.LANGFUSE_PUBLIC_KEY must provide dev default, got: {val!r}"
+        )
+
+    @pytest.mark.parametrize("service", SERVICES_WITH_DEV_DEFAULTS)
+    def test_dev_compose_restores_secret_key_default(self, compose_dev: dict, service: str):
+        env = _get_service_env(compose_dev, service)
         val = str(env.get("LANGFUSE_SECRET_KEY", ""))
         assert "sk-lf-dev" in val, (
-            f"compose.yml: {service}.LANGFUSE_SECRET_KEY must default to sk-lf-dev, got: {val!r}"
+            f"compose.dev.yml: {service}.LANGFUSE_SECRET_KEY must provide dev default, got: {val!r}"
         )
 
     @pytest.mark.parametrize("service", SERVICES_WITH_DEV_DEFAULTS)
-    def test_host_has_docker_default(self, compose: dict, service: str):
-        env = _get_service_env(compose, service)
+    def test_host_has_docker_default(self, compose_base: dict, service: str):
+        env = _get_service_env(compose_base, service)
         val = str(env.get("LANGFUSE_HOST", ""))
         assert "langfuse:3000" in val, (
             f"compose.yml: {service}.LANGFUSE_HOST must default to http://langfuse:3000, "

--- a/tests/unit/voice/test_rag_api_client.py
+++ b/tests/unit/voice/test_rag_api_client.py
@@ -1,0 +1,70 @@
+"""Tests for typed voice RAG API client."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.voice.rag_api_client import RagApiClient, RagApiClientError, RagQueryRequest
+
+
+def test_query_request_payload_includes_optional_trace_id():
+    req = RagQueryRequest(
+        query="test",
+        session_id="voice-1",
+        langfuse_trace_id="trace-1",
+    )
+    payload = req.to_payload()
+    assert payload["query"] == "test"
+    assert payload["session_id"] == "voice-1"
+    assert payload["channel"] == "voice"
+    assert payload["langfuse_trace_id"] == "trace-1"
+
+
+def test_query_request_payload_omits_empty_trace_id():
+    req = RagQueryRequest(query="test", session_id="voice-1")
+    payload = req.to_payload()
+    assert "langfuse_trace_id" not in payload
+
+
+async def test_search_knowledge_base_success(httpx_mock):
+    client = RagApiClient(base_url="http://rag-api:8080")
+    httpx_mock.add_response(
+        url="http://rag-api:8080/query",
+        method="POST",
+        json={"response": "answer"},
+    )
+
+    answer = await client.search_knowledge_base(RagQueryRequest(query="q", session_id="s1"))
+    assert answer == "answer"
+    await client.close()
+
+
+async def test_search_knowledge_base_http_error_raises_domain_error(httpx_mock):
+    client = RagApiClient(base_url="http://rag-api:8080")
+    httpx_mock.add_response(
+        url="http://rag-api:8080/query",
+        method="POST",
+        status_code=500,
+        json={"detail": "error"},
+    )
+
+    with pytest.raises(RagApiClientError):
+        await client.search_knowledge_base(RagQueryRequest(query="q", session_id="s1"))
+    await client.close()
+
+
+async def test_client_property_reuses_shared_async_client():
+    client = RagApiClient(base_url="http://rag-api:8080")
+    first = client.client
+    second = client.client
+    assert first is second
+    await client.close()
+
+
+async def test_close_resets_client_instance():
+    client = RagApiClient(base_url="http://rag-api:8080")
+    old = client.client
+    await client.close()
+    new = client.client
+    assert new is not old
+    await client.close()

--- a/tests/unit/voice/test_voice_agent.py
+++ b/tests/unit/voice/test_voice_agent.py
@@ -100,17 +100,14 @@ async def test_voice_tool_propagates_langfuse_trace_id_to_api_payload():
         langfuse_trace_id="trace-123",
     )
 
-    mock_response = MagicMock()
-    mock_response.raise_for_status = MagicMock()
-    mock_response.json.return_value = {"response": "OK"}
+    mock_rag_client = MagicMock()
+    mock_rag_client.search_knowledge_base = AsyncMock(return_value="OK")
 
-    mock_client = MagicMock()
-    mock_client.post = AsyncMock(return_value=mock_response)
-
-    with patch("src.voice.agent._get_http_client", return_value=mock_client):
+    with patch("src.voice.agent._get_rag_api_client", return_value=mock_rag_client):
         await VoiceBot.search_knowledge_base.__wrapped__(agent, None, "test query")
 
-    payload = mock_client.post.await_args.kwargs["json"]
+    request = mock_rag_client.search_knowledge_base.await_args.args[0]
+    payload = request.to_payload()
     assert payload["langfuse_trace_id"] == "trace-123"
     assert payload["channel"] == "voice"
 
@@ -121,17 +118,14 @@ async def test_search_tool_omits_langfuse_trace_id_when_none():
 
     agent = VoiceBot(call_id="22222222-2222-2222-2222-222222222222")
 
-    mock_response = MagicMock()
-    mock_response.raise_for_status = MagicMock()
-    mock_response.json.return_value = {"response": "OK"}
+    mock_rag_client = MagicMock()
+    mock_rag_client.search_knowledge_base = AsyncMock(return_value="OK")
 
-    mock_client = MagicMock()
-    mock_client.post = AsyncMock(return_value=mock_response)
-
-    with patch("src.voice.agent._get_http_client", return_value=mock_client):
+    with patch("src.voice.agent._get_rag_api_client", return_value=mock_rag_client):
         await VoiceBot.search_knowledge_base.__wrapped__(agent, None, "test query")
 
-    payload = mock_client.post.await_args.kwargs["json"]
+    request = mock_rag_client.search_knowledge_base.await_args.args[0]
+    payload = request.to_payload()
     assert "langfuse_trace_id" not in payload
 
 
@@ -143,14 +137,10 @@ async def test_search_tool_appends_transcript_entries_with_store():
 
     agent = VoiceBot(call_id="22222222-2222-2222-2222-222222222222", transcript_store=store)
 
-    mock_response = MagicMock()
-    mock_response.raise_for_status = MagicMock()
-    mock_response.json.return_value = {"response": "Найдено 3 варианта."}
+    mock_rag_client = MagicMock()
+    mock_rag_client.search_knowledge_base = AsyncMock(return_value="Найдено 3 варианта.")
 
-    mock_client = MagicMock()
-    mock_client.post = AsyncMock(return_value=mock_response)
-
-    with patch("src.voice.agent._get_http_client", return_value=mock_client):
+    with patch("src.voice.agent._get_rag_api_client", return_value=mock_rag_client):
         result = await VoiceBot.search_knowledge_base.__wrapped__(agent, None, "что есть в Несебре")
 
     assert result == "Найдено 3 варианта."
@@ -166,56 +156,56 @@ def test_get_http_client_returns_shared_instance():
     """_get_http_client returns the same AsyncClient on repeated calls (#369)."""
     import src.voice.agent as mod
 
-    original = mod._http_client
+    original = mod._rag_api_client
     try:
-        mod._http_client = None
+        mod._rag_api_client = None
         first = mod._get_http_client()
         second = mod._get_http_client()
         assert first is second
         assert isinstance(first, httpx.AsyncClient)
     finally:
-        mod._http_client = original
+        mod._rag_api_client = original
 
 
 def test_get_http_client_has_pool_limits():
     """Shared httpx client uses connection pool limits (#369)."""
     import src.voice.agent as mod
 
-    original = mod._http_client
+    original = mod._rag_api_client
     try:
-        mod._http_client = None
+        mod._rag_api_client = None
         client = mod._get_http_client()
         pool = client._transport._pool
         assert pool._max_connections == 10
         assert pool._max_keepalive_connections == 5
     finally:
-        mod._http_client = original
+        mod._rag_api_client = original
 
 
 async def test_close_http_client():
     """_close_http_client closes the client and resets the global (#369)."""
     import src.voice.agent as mod
 
-    original = mod._http_client
+    original = mod._rag_api_client
     try:
-        mod._http_client = None
+        mod._rag_api_client = None
         mod._get_http_client()
-        assert mod._http_client is not None
+        assert mod._rag_api_client is not None
         await mod._close_http_client()
-        assert mod._http_client is None
+        assert mod._rag_api_client is None
     finally:
-        mod._http_client = original
+        mod._rag_api_client = original
 
 
 async def test_mark_job_finished_closes_http_client_when_last_job():
     """Last finished job should close shared HTTP client."""
     import src.voice.agent as mod
 
-    original_client = mod._http_client
+    original_client = mod._rag_api_client
     original_jobs = mod._active_jobs
     original_lock = mod._jobs_lock
     try:
-        mod._http_client = None
+        mod._rag_api_client = None
         mod._active_jobs = 0
         mod._jobs_lock = None
         mod._get_http_client()
@@ -225,11 +215,11 @@ async def test_mark_job_finished_closes_http_client_when_last_job():
         await mod._mark_job_finished()
 
         assert mod._active_jobs == 0
-        assert mod._http_client is None
+        assert mod._rag_api_client is None
     finally:
-        if mod._http_client is not None:
+        if mod._rag_api_client is not None:
             await mod._close_http_client()
-        mod._http_client = original_client
+        mod._rag_api_client = original_client
         mod._active_jobs = original_jobs
         mod._jobs_lock = original_lock
 
@@ -238,11 +228,11 @@ async def test_mark_job_finished_keeps_client_while_other_jobs_active():
     """Shared HTTP client stays open until the last active job finishes."""
     import src.voice.agent as mod
 
-    original_client = mod._http_client
+    original_client = mod._rag_api_client
     original_jobs = mod._active_jobs
     original_lock = mod._jobs_lock
     try:
-        mod._http_client = None
+        mod._rag_api_client = None
         mod._active_jobs = 0
         mod._jobs_lock = None
         mod._get_http_client()
@@ -253,14 +243,14 @@ async def test_mark_job_finished_keeps_client_while_other_jobs_active():
         await mod._mark_job_finished()
 
         assert mod._active_jobs == 1
-        assert mod._http_client is not None
+        assert mod._rag_api_client is not None
 
         await mod._mark_job_finished()
         assert mod._active_jobs == 0
-        assert mod._http_client is None
+        assert mod._rag_api_client is None
     finally:
-        if mod._http_client is not None:
+        if mod._rag_api_client is not None:
             await mod._close_http_client()
-        mod._http_client = original_client
+        mod._rag_api_client = original_client
         mod._active_jobs = original_jobs
         mod._jobs_lock = original_lock


### PR DESCRIPTION
## Summary
- execute canonical SDK remediation plan phases 0-8
- align compose secret posture and simplify Langfuse prompt manager to SDK-native flow
- consolidate Qdrant policy, add typed voice RAG client, add feature-flagged Docling native adapter
- reduce observability runtime surface with compatibility wrappers
- add/update tests covering all introduced behavior and autofixes

## Validation
- make check
- PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit
- uv run pytest tests/integration/test_graph_paths.py -n auto --dist=worksteal -q
- make ingest-unified-status
- uv run python -m src.ingestion.unified.cli preflight (known local blocker: Docling HTTP at http://localhost:5001 unreachable)