### PR TITLE
fix: auto-resolve typing blockers and harden state manager sql

### DIFF
--- a/docs/plans/2026-03-16-pre-pr-pre-main-audit-report.md
+++ b/docs/plans/2026-03-16-pre-pr-pre-main-audit-report.md
@@ -28,6 +28,18 @@
   Reason: file self-identifies as deprecated and may still preserve a runtime compatibility surface that overlaps with `generate_response.py`.
   Keep / remove / refactor: confirm active call sites; remove or fence off if deprecated path is no longer needed.
 
+- [ ] Static-analysis blocker:
+  Tool: `mypy`
+  File: multiple (`telegram_bot/middlewares/fsm_cancel.py`, `telegram_bot/middlewares/error_handler.py`, `telegram_bot/services/apartments_service.py`, `telegram_bot/services/apartment_llm_extractor.py`, `telegram_bot/dialogs/handoff.py`, `telegram_bot/services/apartment_extraction_pipeline.py`, `src/ingestion/cocoindex_flow.py`, `telegram_bot/bot.py`, others)
+  Root cause: repo-wide typing drift across aiogram middleware signatures, Langfuse API usage, Qdrant filter typing, OpenAI/Instructor message types, dialog payload narrowing, and apartment extraction models.
+  Fix strategy: split by subsystem; start with narrow middleware/typing fixes instead of mixing unrelated services in one patch.
+
+- [ ] Static-analysis blocker:
+  Tool: `bandit`
+  File: `src/ingestion/unified/state_manager.py`
+  Root cause: repeated `B608` SQL-construction findings around dynamic table-name interpolation need review for safe composition or explicit justification.
+  Fix strategy: review table-name provenance and replace ad-hoc f-strings with validated composition or targeted suppressions only if proven safe.
+
 ## Cleanup If Time Permits
 - [ ] Candidate path: top-level `uv.lock`
   Reason: matched `*.lock` inventory command but is the repository dependency lockfile, not disposable garbage.
@@ -38,6 +50,11 @@
 - [ ] Candidate path: `src/ingestion/chunker.py`, `src/ingestion/gdrive_indexer.py`, `src/ingestion/gdrive_flow.py`
   Reason: deprecated entry points are documented inline; verify whether they are still intentionally preserved.
 
+- [ ] Static-analysis cleanup:
+  Tool: `vulture`
+  File: multiple `telegram_bot/dialogs/*`, `telegram_bot/agents/rag_tool.py`
+  Reason deferred: current output is dominated by unused callback/widget parameters common in dialog handlers; these need manual triage to avoid false-positive deletions.
+
 ## Research-Needed Via Context7 / Official Docs
 
 ## Command Log
@@ -45,6 +62,11 @@
 - `find ... -name '*.lock'`: matched `uv.lock` only; kept as intentional tracked lockfile.
 - `rg -n "deprecated|legacy|TODO|FIXME|temporary|workaround|compat shim" ...`: surfaced compatibility wrappers, deprecated service surfaces, and evaluation/ingestion cleanup candidates.
 - `rg -n "make docker-|make local-|docker compose|uv run" README.md docs/LOCAL-DEVELOPMENT.md`: surfaced multiple operator-facing command paths for later validation.
+- `uv run ruff check src/ telegram_bot/`: passed cleanly.
+- `uv run ruff format --check src/ telegram_bot/`: passed cleanly.
+- `uv run mypy src/ telegram_bot/ --ignore-missing-imports --no-error-summary`: failed with multiple blocker classes across middleware, apartment services, dialogs, ingestion, and bot runtime typing.
+- `uv run bandit -r src/ telegram_bot/ -c pyproject.toml`: failed with one high-severity cache-hash issue plus multiple `state_manager.py` SQL-construction findings.
+- `uv run vulture src/ telegram_bot/ --min-confidence 80`: surfaced many likely-false-positive unused dialog callback parameters; triaged as cleanup until validated.
 
 ## Files Changed During Audit
 - `docs/plans/2026-03-16-pre-pr-pre-main-audit-report.md`

--- a/docs/plans/2026-03-16-pre-pr-pre-main-audit-report.md
+++ b/docs/plans/2026-03-16-pre-pr-pre-main-audit-report.md
@@ -1,0 +1,30 @@
+# Pre-PR / Pre-Main Audit Report
+
+- Branch: `audit/pre-pr-pre-main-2026-03-16`
+- Base: `origin/dev`
+- Date: `2026-03-16`
+- Worktree: `/home/user/projects/rag-fresh-pre-pr-audit`
+
+## Baseline
+- `git status`:
+  clean
+- `git log --oneline -5`:
+  - `f2f0eb49 Merge pull request #973 from yastman/feat/sdk-canonical-remediation`
+  - `30649266 Merge remote-tracking branch 'origin/dev' into feat/sdk-canonical-remediation`
+  - `dd26418b fix: restore prompt label and kommo shim compatibility`
+  - `73255d63 feat: complete sdk canonical remediation plan phases 0-8`
+  - `0c00a618 Merge pull request #971 from yastman/feat/952-858-855-857-901-956`
+
+## Blockers Before PR
+
+## Cleanup If Time Permits
+
+## Research-Needed Via Context7 / Official Docs
+
+## Command Log
+
+## Files Changed During Audit
+
+## Final PR Decision
+- Ready:
+- Not ready because:

--- a/docs/plans/2026-03-16-pre-pr-pre-main-audit-report.md
+++ b/docs/plans/2026-03-16-pre-pr-pre-main-audit-report.md
@@ -16,14 +16,38 @@
   - `0c00a618 Merge pull request #971 from yastman/feat/952-858-855-857-901-956`
 
 ## Blockers Before PR
+- [ ] Candidate path: `README.md`, `docs/LOCAL-DEVELOPMENT.md`
+  Reason: operator-facing commands mix `make docker-*`, `make local-*`, and `uv run` paths; these need validation against actual runtime/deploy flow before PR.
+  Keep / remove / refactor: validate; refactor docs if commands are stale or misleading.
+
+- [ ] Candidate path: `telegram_bot/middlewares/error_handler.py`
+  Reason: compatibility-only middleware wrapper and legacy registration helper remain in runtime surface.
+  Keep / remove / refactor: verify active imports/tests; remove if compatibility surface is dead.
+
+- [ ] Candidate path: `telegram_bot/services/llm.py`
+  Reason: file self-identifies as deprecated and may still preserve a runtime compatibility surface that overlaps with `generate_response.py`.
+  Keep / remove / refactor: confirm active call sites; remove or fence off if deprecated path is no longer needed.
 
 ## Cleanup If Time Permits
+- [ ] Candidate path: top-level `uv.lock`
+  Reason: matched `*.lock` inventory command but is the repository dependency lockfile, not disposable garbage.
+
+- [ ] Candidate path: `src/evaluation/`
+  Reason: multiple TODO/temporary/legacy references suggest cleanup debt, but not obviously PR-blocking without import/runtime evidence.
+
+- [ ] Candidate path: `src/ingestion/chunker.py`, `src/ingestion/gdrive_indexer.py`, `src/ingestion/gdrive_flow.py`
+  Reason: deprecated entry points are documented inline; verify whether they are still intentionally preserved.
 
 ## Research-Needed Via Context7 / Official Docs
 
 ## Command Log
+- `git status --short`: clean baseline in dedicated worktree.
+- `find ... -name '*.lock'`: matched `uv.lock` only; kept as intentional tracked lockfile.
+- `rg -n "deprecated|legacy|TODO|FIXME|temporary|workaround|compat shim" ...`: surfaced compatibility wrappers, deprecated service surfaces, and evaluation/ingestion cleanup candidates.
+- `rg -n "make docker-|make local-|docker compose|uv run" README.md docs/LOCAL-DEVELOPMENT.md`: surfaced multiple operator-facing command paths for later validation.
 
 ## Files Changed During Audit
+- `docs/plans/2026-03-16-pre-pr-pre-main-audit-report.md`
 
 ## Final PR Decision
 - Ready:

--- a/src/ingestion/cocoindex_flow.py
+++ b/src/ingestion/cocoindex_flow.py
@@ -79,7 +79,8 @@ class VoyageEmbedFunction:
             api_key: Voyage API key (defaults to VOYAGE_API_KEY env var)
             model: Voyage model name
         """
-        self.api_key = api_key or os.getenv("VOYAGE_API_KEY", "")
+        resolved_api_key = api_key if api_key is not None else os.getenv("VOYAGE_API_KEY")
+        self.api_key: str = resolved_api_key or ""
         self.model = model
         self._service: Any | None = None
 

--- a/src/ingestion/document_parser.py
+++ b/src/ingestion/document_parser.py
@@ -51,8 +51,8 @@ class ParserCache:
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
     def _get_file_hash(self, filepath: Path) -> str:
-        """Calculate MD5 hash of file."""
-        md5 = hashlib.md5()
+        """Calculate a non-cryptographic MD5 hash for parser cache keys."""
+        md5 = hashlib.md5(usedforsecurity=False)
         with open(filepath, "rb") as f:
             for chunk in iter(lambda: f.read(8192), b""):
                 md5.update(chunk)

--- a/src/ingestion/unified/state_manager.py
+++ b/src/ingestion/unified/state_manager.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import re
 from collections.abc import Coroutine
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -18,6 +19,7 @@ if TYPE_CHECKING:
     from typing import Self
 
 T = TypeVar("T")
+_PG_IDENTIFIER_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
 
 
 class _SyncContext:
@@ -90,8 +92,15 @@ class UnifiedStateManager:
         self._database_url = database_url
         self._owns_pool = pool is None
         # Tables are in public schema of cocoindex database
-        self._table = "ingestion_state"
-        self._dlq_table = "ingestion_dead_letter"
+        self._table = self._safe_identifier("ingestion_state")
+        self._dlq_table = self._safe_identifier("ingestion_dead_letter")
+
+    @staticmethod
+    def _safe_identifier(value: str) -> str:
+        """Validate SQL identifier used in interpolated table names."""
+        if not _PG_IDENTIFIER_RE.fullmatch(value):
+            raise ValueError(f"Unsafe SQL identifier: {value}")
+        return value
 
     async def _get_pool(self) -> asyncpg.Pool:
         if self._pool is None:
@@ -107,14 +116,14 @@ class UnifiedStateManager:
 
     async def get_state(self, file_id: str) -> FileState | None:
         pool = await self._get_pool()
-        row = await pool.fetchrow(f"SELECT * FROM {self._table} WHERE file_id = $1", file_id)
+        row = await pool.fetchrow("SELECT * FROM ingestion_state WHERE file_id = $1", file_id)
         return FileState.from_row(row) if row else None
 
     async def upsert_state(self, state: FileState) -> None:
         pool = await self._get_pool()
         await pool.execute(
-            f"""
-            INSERT INTO {self._table} (
+            """
+            INSERT INTO ingestion_state (
                 file_id, source_path, file_name, mime_type, file_size,
                 modified_time, content_hash, parser_version, chunker_version,
                 embedding_model, chunk_count, collection_name, pipeline_version,
@@ -163,8 +172,8 @@ class UnifiedStateManager:
     async def mark_processing(self, file_id: str) -> None:
         pool = await self._get_pool()
         await pool.execute(
-            f"""
-            INSERT INTO {self._table} (file_id, status, updated_at)
+            """
+            INSERT INTO ingestion_state (file_id, status, updated_at)
             VALUES ($1, 'processing', NOW())
             ON CONFLICT (file_id) DO UPDATE SET status = 'processing', updated_at = NOW()
             """,
@@ -174,8 +183,8 @@ class UnifiedStateManager:
     async def mark_indexed(self, file_id: str, chunk_count: int, content_hash: str) -> None:
         pool = await self._get_pool()
         await pool.execute(
-            f"""
-            INSERT INTO {self._table} (file_id, status, chunk_count, content_hash, indexed_at, updated_at)
+            """
+            INSERT INTO ingestion_state (file_id, status, chunk_count, content_hash, indexed_at, updated_at)
             VALUES ($1, 'indexed', $2, $3, NOW(), NOW())
             ON CONFLICT (file_id) DO UPDATE SET
                 status = 'indexed', chunk_count = $2, content_hash = $3,
@@ -191,8 +200,8 @@ class UnifiedStateManager:
         pool = await self._get_pool()
         # Exponential backoff: 1min, 5min, 30min
         await pool.execute(
-            f"""
-            UPDATE {self._table}
+            """
+            UPDATE ingestion_state
             SET status = 'error',
                 error_message = $2,
                 retry_count = retry_count + 1,
@@ -207,7 +216,7 @@ class UnifiedStateManager:
     async def mark_deleted(self, file_id: str) -> None:
         pool = await self._get_pool()
         await pool.execute(
-            f"UPDATE {self._table} SET status = 'deleted', updated_at = NOW() WHERE file_id = $1",
+            "UPDATE ingestion_state SET status = 'deleted', updated_at = NOW() WHERE file_id = $1",
             file_id,
         )
 
@@ -225,7 +234,7 @@ class UnifiedStateManager:
 
     async def get_all_indexed_file_ids(self) -> set[str]:
         pool = await self._get_pool()
-        rows = await pool.fetch(f"SELECT file_id FROM {self._table} WHERE status = 'indexed'")
+        rows = await pool.fetch("SELECT file_id FROM ingestion_state WHERE status = 'indexed'")
         return {row["file_id"] for row in rows}
 
     async def add_to_dlq(
@@ -237,8 +246,8 @@ class UnifiedStateManager:
     ) -> int:
         pool = await self._get_pool()
         row = await pool.fetchrow(
-            f"""
-            INSERT INTO {self._dlq_table} (file_id, error_type, error_message, payload)
+            """
+            INSERT INTO ingestion_dead_letter (file_id, error_type, error_message, payload)
             VALUES ($1, $2, $3, $4::jsonb) RETURNING id
             """,
             file_id,
@@ -253,13 +262,13 @@ class UnifiedStateManager:
     async def get_stats(self) -> dict[str, int]:
         pool = await self._get_pool()
         rows = await pool.fetch(
-            f"SELECT status, COUNT(*) as count FROM {self._table} GROUP BY status"
+            "SELECT status, COUNT(*) as count FROM ingestion_state GROUP BY status"
         )
         return {str(row["status"]): int(row["count"]) for row in rows}
 
     async def get_dlq_count(self) -> int:
         pool = await self._get_pool()
-        row = await pool.fetchrow(f"SELECT COUNT(*) as count FROM {self._dlq_table}")
+        row = await pool.fetchrow("SELECT COUNT(*) as count FROM ingestion_dead_letter")
         if row is None:
             return 0
         return int(row["count"])

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -73,7 +73,7 @@ if TYPE_CHECKING:
     from .services.history_service import HistoryService
 
 # Keep a patchable module-level symbol for tests without importing qdrant-heavy code.
-HistoryService: Any = None
+HistoryService: Any = None  # type: ignore[no-redef]
 
 
 logger = logging.getLogger(__name__)
@@ -2616,8 +2616,12 @@ class PropertyBot:
                 apartment_filters=None,
             )
             page = results[:_APARTMENT_PAGE_SIZE]
-            for result in page:
-                await self._send_property_card(message, result, message.from_user.id)  # type: ignore[union-attr]
+            for card_result in page:
+                await self._send_property_card(
+                    message,
+                    card_result,
+                    message.from_user.id,  # type: ignore[union-attr]
+                )
             shown = len(page)
             total = len(results)
             _has_more = total > _APARTMENT_PAGE_SIZE
@@ -3342,11 +3346,12 @@ class PropertyBot:
                     score(lf, tid, name="sources_count", value=float(sources_count_actual))
 
             # Persist Q&A to history (fire-and-forget — response already sent)
-            if self._history_service and response_text:
+            history_service = self._history_service
+            if history_service and response_text:
 
                 async def _bg_save_history() -> None:
                     try:
-                        saved = await self._history_service.save_turn(
+                        saved = await history_service.save_turn(
                             user_id=user_id,
                             session_id=session_id,
                             query=message.text or "",

--- a/telegram_bot/dialogs/filter_dialog.py
+++ b/telegram_bot/dialogs/filter_dialog.py
@@ -288,7 +288,8 @@ async def on_filter_dialog_start(
         if value is not None:
             with contextlib.suppress(Exception):
                 radio_widget = manager.find(radio_id)
-                await radio_widget.set_checked(str(value))
+                if radio_widget is not None:
+                    await radio_widget.set_checked(str(value))
 
 
 # ============================================================
@@ -399,7 +400,8 @@ async def on_reset(
     for radio_id in _FIELD_TO_RADIO_ID.values():
         with contextlib.suppress(Exception):
             radio_widget = manager.find(radio_id)
-            await radio_widget.set_checked(None)
+            if radio_widget is not None:
+                await radio_widget.set_checked(None)
 
 
 # ============================================================

--- a/telegram_bot/dialogs/handoff.py
+++ b/telegram_bot/dialogs/handoff.py
@@ -93,7 +93,8 @@ async def _on_contact_chat(
     manager: DialogManager,
 ) -> None:
     """Complete qualification with chat — trigger handoff via PropertyBot."""
-    goal = manager.dialog_data.get("goal") or (manager.start_data or {}).get("goal", "")
+    start_data = manager.start_data if isinstance(manager.start_data, dict) else {}
+    goal = manager.dialog_data.get("goal") or start_data.get("goal", "")
     qualification = {"goal": goal, "contact": "chat"}
 
     # Grab refs BEFORE done() destroys dialog context.

--- a/telegram_bot/handlers/demo_handler.py
+++ b/telegram_bot/handlers/demo_handler.py
@@ -55,7 +55,11 @@ async def handle_demo_apartments(
 
     await state.update_data(examples=examples)
 
-    await callback.message.answer(
+    msg = callback.message
+    if msg is None or not hasattr(msg, "answer"):
+        return
+
+    await msg.answer(
         "🏖 Подбор апартаментов\n\n"
         "Напишите текстом или отправьте голосовое сообщение.\n"
         "Или выберите пример:",

--- a/telegram_bot/middlewares/error_handler.py
+++ b/telegram_bot/middlewares/error_handler.py
@@ -63,10 +63,14 @@ async def handle_error(event: ErrorEvent) -> None:
 
         lf = get_client()
         if lf is not None and lf.get_current_trace_id():
-            lf.update_current_observation(
-                level="ERROR",
-                status_message=f"{type(exception).__name__}: {str(exception)[:200]}",
-            )
+            status_message = f"{type(exception).__name__}: {str(exception)[:200]}"
+            update_observation = getattr(lf, "update_current_observation", None)
+            if callable(update_observation):
+                update_observation(level="ERROR", status_message=status_message)
+            else:
+                update_generation = getattr(lf, "update_current_generation", None)
+                if callable(update_generation):
+                    update_generation(level="ERROR", status_message=status_message)
     except Exception:
         logger.debug("Failed to report error to Langfuse", exc_info=True)
 

--- a/telegram_bot/middlewares/error_handler.py
+++ b/telegram_bot/middlewares/error_handler.py
@@ -68,9 +68,13 @@ async def handle_error(event: ErrorEvent) -> None:
             if callable(update_observation):
                 update_observation(level="ERROR", status_message=status_message)
             else:
-                update_generation = getattr(lf, "update_current_generation", None)
-                if callable(update_generation):
-                    update_generation(level="ERROR", status_message=status_message)
+                update_span = getattr(lf, "update_current_span", None)
+                if callable(update_span):
+                    update_span(level="ERROR", status_message=status_message)
+                else:
+                    update_generation = getattr(lf, "update_current_generation", None)
+                    if callable(update_generation):
+                        update_generation(level="ERROR", status_message=status_message)
     except Exception:
         logger.debug("Failed to report error to Langfuse", exc_info=True)
 

--- a/telegram_bot/middlewares/fsm_cancel.py
+++ b/telegram_bot/middlewares/fsm_cancel.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, cast
 
 from aiogram import BaseMiddleware
 from aiogram.fsm.context import FSMContext
-from aiogram.types import Message
+from aiogram.types import Message, TelegramObject
 
 from telegram_bot.keyboards.client_keyboard import build_client_keyboard
 
@@ -20,15 +20,26 @@ class FSMCancelMiddleware(BaseMiddleware):
 
     async def __call__(
         self,
-        handler: Callable[[Message, dict[str, Any]], Awaitable[Any]],
-        event: Message,
+        handler: Callable[[TelegramObject, dict[str, Any]], Awaitable[Any]],
+        event: TelegramObject,
         data: dict[str, Any],
     ) -> Any:
+        msg: Message | None
+        if isinstance(event, Message):
+            msg = event
+        elif hasattr(event, "text") and hasattr(event, "answer"):
+            msg = cast(Message, event)
+        else:
+            msg = None
+
+        if msg is None:
+            return await handler(event, data)
+
         state: FSMContext | None = data.get("state")
         if not state:
             return await handler(event, data)
 
-        text = (event.text or "").strip().lower()
+        text = (msg.text or "").strip().lower()
         if text not in _CANCEL_TRIGGERS:
             return await handler(event, data)
 
@@ -37,7 +48,7 @@ class FSMCancelMiddleware(BaseMiddleware):
             return await handler(event, data)
 
         await state.clear()
-        await event.answer(
+        await msg.answer(
             "😊 Заявка отменена. Когда будете готовы — мы на связи!",
             reply_markup=build_client_keyboard(),
         )

--- a/telegram_bot/services/apartment_extraction_pipeline.py
+++ b/telegram_bot/services/apartment_extraction_pipeline.py
@@ -78,7 +78,14 @@ class ApartmentExtractionPipeline:
         )
         return ApartmentSearchFilters(
             hard=hard,
-            soft=SoftPreferences(),
+            soft=SoftPreferences(
+                near_sea=False,
+                spacious=False,
+                budget_friendly=False,
+                high_floor=False,
+                quiet=False,
+                sort_bias="relevance",
+            ),
             meta=ExtractionMeta(
                 source="regex",
                 confidence=getattr(parsed, "confidence", "LOW"),

--- a/telegram_bot/services/apartment_llm_extractor.py
+++ b/telegram_bot/services/apartment_llm_extractor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any, cast
 
 import instructor
 from openai import AsyncOpenAI
@@ -110,7 +111,7 @@ class ApartmentLlmExtractor:
 
         result: ApartmentSearchFilters = await self._client.chat.completions.create(
             model=self._model,
-            messages=messages,
+            messages=cast(Any, messages),
             response_model=ApartmentSearchFilters,
             max_retries=2,
         )

--- a/telegram_bot/services/apartments_service.py
+++ b/telegram_bot/services/apartments_service.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+from typing import cast
+from uuid import UUID
 
 from qdrant_client import models
 
@@ -200,13 +202,14 @@ class ApartmentsService:
 
         # Дедупликация: исключить уже показанные ID на границе цены
         if exclude_ids:
-            has_id_cond = models.HasIdCondition(has_id=exclude_ids)
+            exclude_ids_typed: list[int | str | UUID] = list(exclude_ids)
+            has_id_cond = models.HasIdCondition(has_id=exclude_ids_typed)
             if qdrant_filter is None:
                 qdrant_filter = models.Filter(must_not=[has_id_cond])
             else:
                 existing_must_not = list(qdrant_filter.must_not or [])
                 existing_must_not.append(has_id_cond)
-                qdrant_filter.must_not = existing_must_not
+                qdrant_filter.must_not = cast(list[models.Condition], existing_must_not)
 
         records, _ = await self._qdrant.client.scroll(
             collection_name=self._qdrant.collection_name,

--- a/telegram_bot/services/topic_service.py
+++ b/telegram_bot/services/topic_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 
 if TYPE_CHECKING:
@@ -58,6 +58,6 @@ class TopicService:
             return existing
 
         forum_topic = await bot.create_forum_topic(chat_id=chat_id, name=topic_name)
-        thread_id = forum_topic.message_thread_id
+        thread_id = cast(int, forum_topic.message_thread_id)
         await self.save_thread(user_id, expert_id, thread_id)
         return thread_id

--- a/tests/unit/handlers/test_demo_handler.py
+++ b/tests/unit/handlers/test_demo_handler.py
@@ -48,6 +48,17 @@ class TestDemoFlow:
         assert sent.kwargs.get("reply_markup") is not None
 
     @pytest.mark.asyncio
+    async def test_demo_apartments_without_message_returns_cleanly(self) -> None:
+        callback = AsyncMock(spec=CallbackQuery)
+        callback.answer = AsyncMock()
+        callback.message = None
+        state = AsyncMock(spec=FSMContext)
+
+        await handle_demo_apartments(callback, state)
+
+        state.set_state.assert_awaited_once_with(DemoStates.waiting_query)
+
+    @pytest.mark.asyncio
     async def test_demo_search_calls_pipeline(self) -> None:
         message = AsyncMock()
         message.text = "двушка до 100к"

--- a/tests/unit/ingestion/test_state_manager_behavior.py
+++ b/tests/unit/ingestion/test_state_manager_behavior.py
@@ -68,6 +68,19 @@ def _make_state_row(
 
 
 # ---------------------------------------------------------------------------
+# SQL identifier hardening
+# ---------------------------------------------------------------------------
+
+
+class TestSqlIdentifierValidation:
+    """Verify SQL table identifier validation guard."""
+
+    def test_rejects_unsafe_identifier(self) -> None:
+        with pytest.raises(ValueError, match="Unsafe SQL identifier"):
+            UnifiedStateManager._safe_identifier("ingestion_state;DROP TABLE users")
+
+
+# ---------------------------------------------------------------------------
 # should_process_sync — hash comparison behavior
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/middlewares/test_fsm_cancel.py
+++ b/tests/unit/middlewares/test_fsm_cancel.py
@@ -76,6 +76,15 @@ class TestFSMCancelMiddleware:
         handler.assert_awaited_once()
 
     @pytest.mark.asyncio()
+    async def test_non_message_event_passthrough(self, middleware):
+        event = object()
+        handler = AsyncMock()
+
+        await middleware(handler, event, {})
+
+        handler.assert_awaited_once_with(event, {})
+
+    @pytest.mark.asyncio()
     async def test_no_text_passes_through(self, middleware):
         msg = _make_message(None)
         state = _make_state("PhoneCollectorStates:waiting_phone")

--- a/tests/unit/test_error_handler.py
+++ b/tests/unit/test_error_handler.py
@@ -113,6 +113,33 @@ class TestHandleError:
         # Neither path should have triggered answer()
         mock_answer.assert_not_called()
 
+    async def test_updates_langfuse_span_status_when_trace_active(self) -> None:
+        """Active traces should mark the current span as failed for observability."""
+        from telegram_bot.middlewares.error_handler import handle_error
+
+        mock_update = MagicMock()
+        mock_update.message = None
+        mock_update.callback_query = None
+
+        mock_event = MagicMock()
+        mock_event.exception = RuntimeError("span failure")
+        mock_event.update = mock_update
+
+        mock_lf = MagicMock(spec=["get_current_trace_id", "update_current_span"])
+        mock_lf.get_current_trace_id.return_value = "trace-123"
+        mock_lf.update_current_span = MagicMock()
+
+        with (
+            patch("telegram_bot.observability.get_client", return_value=mock_lf),
+            patch("telegram_bot.middlewares.error_handler.logger"),
+        ):
+            await handle_error(mock_event)
+
+        mock_lf.update_current_span.assert_called_once()
+        call_kwargs = mock_lf.update_current_span.call_args.kwargs
+        assert call_kwargs["level"] == "ERROR"
+        assert call_kwargs["status_message"] == "RuntimeError: span failure"
+
 
 class TestSetupErrorHandler:
     """Tests for setup_error_handler registration."""


### PR DESCRIPTION
## Summary
- auto-fix current mypy blockers across middleware, services, dialogs, and bot call paths
- harden ingestion state manager SQL usage by switching to static table SQL and adding identifier validation guard
- add regression tests for new safe branches in FSM cancel middleware, demo handler, and SQL identifier guard

## Validation
- `uv run ruff check src/ telegram_bot/ tests/unit/middlewares/test_fsm_cancel.py tests/unit/handlers/test_demo_handler.py tests/unit/ingestion/test_state_manager_behavior.py`
- `uv run mypy src/ telegram_bot/ --ignore-missing-imports --no-error-summary`
- `uv run bandit -r src/ telegram_bot/ -c pyproject.toml` (no high/medium findings; remaining low-level existing warnings)
- `uv run pytest tests/unit/middlewares/test_fsm_cancel.py tests/unit/test_error_handler.py tests/unit/handlers/test_demo_handler.py tests/unit/dialogs/test_filter_dialog.py tests/unit/test_handoff_i18n.py tests/unit/ingestion/test_state_manager_behavior.py tests/unit/services/test_apartment_llm_extractor.py tests/unit/services/test_apartments_service.py tests/unit/services/test_topic_service.py -q`

Refs #978