### PR TITLE
fix: finalize services.yaml indexing closeout (#901)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -821,7 +821,7 @@ ingest-status: ## Show collection statistics
 
 ingest-services: ## Index curated services.yaml content into Qdrant
 	@echo "$(BLUE)Indexing services.yaml content...$(NC)"
-	@if [ -f .env ]; then set -a; . ./.env; set +a; fi; uv run python scripts/index_services.py
+	@if [ -f .env ]; then set -a; . ./.env; set +a; fi; uv run python -m scripts.index_services
 	@echo "$(GREEN)✓ services.yaml indexing complete$(NC)"
 
 # =============================================================================


### PR DESCRIPTION
## Summary\n- fix [0;34mIndexing services.yaml content...[0m 
Indexed 5 services into gdrive_documents_bge
[0;32m✓ services.yaml indexing complete[0m  module invocation to run through \n- keep services.yaml indexing path and tests green\n\n## Verification\n- uv run pytest tests/unit/test_index_services.py tests/unit/retrieval/test_topic_classifier.py -q\n- make ingest-services\n\nRefs #901