### PR TITLE
chore: add narrow mypy strictness pilot (#858)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -304,6 +304,10 @@ explicit_package_bases = true  # Resolve duplicate module names in services/
 module = "FlagEmbedding.*"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "src.retrieval.topic_classifier"
+disallow_untyped_defs = true
+
 # =============================================================================
 # BANDIT CONFIGURATION (Security Linting)
 # =============================================================================


### PR DESCRIPTION
Summary:\n- re-baseline stale #858 framing\n- add targeted mypy strictness override for src.retrieval.topic_classifier\n\nVerification:\n- uv run mypy src/retrieval/topic_classifier.py src/ingestion/unified/qdrant_writer.py --ignore-missing-imports --no-error-summary\n- uv run pytest tests/unit/retrieval/test_topic_classifier.py -q\n\nRefs #858