### PR TITLE
feat: retrieval quality improvements for short intent queries (#956)

### DIFF
--- a/src/ingestion/unified/qdrant_writer.py
+++ b/src/ingestion/unified/qdrant_writer.py
@@ -231,10 +231,10 @@ class QdrantHybridWriter:
             "modified_time": file_metadata.get("modified_time"),
             "content_hash": file_metadata.get("content_hash"),
         }
-        metadata["topic"] = classify_chunk_topic(getattr(chunk, "text", ""))
+        metadata["topic"] = classify_chunk_topic(getattr(chunk, "text", "")).value
         metadata["doc_type"] = classify_doc_type(
             source_path, str(file_metadata.get("mime_type", ""))
-        )
+        ).value
 
         # Clean None values
         metadata = {k: v for k, v in metadata.items() if v is not None}

--- a/telegram_bot/agents/rag_pipeline.py
+++ b/telegram_bot/agents/rag_pipeline.py
@@ -579,6 +579,13 @@ async def _rerank(
         rerank_applied = False
         rerank_cache_hit = False
 
+    if len(reranked_docs) >= 3:
+        top_scores = [float(doc.get("score", 0.0)) for doc in reranked_docs[:3]]
+        lead_gap = detect_score_gap(top_scores[:2])
+        tail_gap = detect_score_gap(top_scores[1:3])
+        if not bool(lead_gap["confident"]) and bool(tail_gap["confident"]):
+            reranked_docs = reranked_docs[:2]
+
     elapsed = time.perf_counter() - t0
     logger.info(
         "rerank: %d → %d docs, applied=%s cache_hit=%s (%.3fs)",

--- a/telegram_bot/agents/rag_pipeline.py
+++ b/telegram_bot/agents/rag_pipeline.py
@@ -320,7 +320,14 @@ async def _hybrid_retrieve(
     # Step 3: Hybrid search via Qdrant SDK (RRF fusion or ColBERT server-side rerank)
     _has_colbert_search = callable(getattr(qdrant, "hybrid_search_rrf_colbert", None))
     colbert_search_used = False
+    normalized_query = query.strip().lower()
+    query_word_count = len(normalized_query.split()) if normalized_query else 0
+    prefer_faq_doc_type = topic_hint == "finance" and 0 < query_word_count <= 2
     filters = {"topic": topic_hint} if topic_hint else None
+    relaxed_filters: dict[str, str] | None = None
+    if prefer_faq_doc_type and topic_hint:
+        filters = {"topic": topic_hint, "doc_type": "faq"}
+        relaxed_filters = {"topic": topic_hint}
 
     if colbert_query and _has_colbert_search:
         logger.info("metric", extra={"metric_name": "colbert_rerank_attempted", "value": 1})
@@ -352,6 +359,31 @@ async def _hybrid_retrieve(
             "metric",
             extra={"metric_name": "topic_filter_fallback", "value": 1},
         )
+        fallback_filters = relaxed_filters if relaxed_filters is not None else None
+        if colbert_query and _has_colbert_search:
+            qdrant_result = await qdrant.hybrid_search_rrf_colbert(
+                dense_vector=dense_vector,
+                sparse_vector=sparse_vector,
+                colbert_query=colbert_query,
+                filters=fallback_filters,
+                top_k=top_k,
+                return_meta=True,
+            )
+        else:
+            qdrant_result = await qdrant.hybrid_search_rrf(
+                dense_vector=dense_vector,
+                sparse_vector=sparse_vector,
+                filters=fallback_filters,
+                top_k=top_k,
+                return_meta=True,
+            )
+        if isinstance(qdrant_result, tuple) and len(qdrant_result) == 2:
+            results, search_meta = qdrant_result
+        else:
+            results = qdrant_result
+            search_meta = {"backend_error": False, "error_type": None, "error_message": None}
+
+    if relaxed_filters is not None and len(results) < 3:
         if colbert_query and _has_colbert_search:
             qdrant_result = await qdrant.hybrid_search_rrf_colbert(
                 dense_vector=dense_vector,

--- a/telegram_bot/agents/rag_pipeline.py
+++ b/telegram_bot/agents/rag_pipeline.py
@@ -24,6 +24,7 @@ from typing import Any
 
 from src.retrieval.topic_classifier import detect_score_gap, get_query_topic_hint
 from telegram_bot.observability import get_client, observe
+from telegram_bot.services.query_preprocessor import expand_short_query
 from telegram_bot.services.rag_core import (
     CACHEABLE_QUERY_TYPES,
     check_semantic_cache,
@@ -581,6 +582,26 @@ async def _rewrite_query(
     Returns dict with rewritten_query, rewrite_count, rewrite_effective, and latency.
     """
     t0 = time.perf_counter()
+    topic_hint = get_query_topic_hint(query)
+    expanded_query = expand_short_query(
+        query,
+        topic_hint=topic_hint.value if topic_hint is not None else None,
+    )
+    if expanded_query != query:
+        elapsed = time.perf_counter() - t0
+        logger.info(
+            "rewrite: deterministic expansion '%s' → '%s' (%.3fs)",
+            query,
+            expanded_query,
+            elapsed,
+        )
+        return {
+            "rewritten_query": expanded_query,
+            "rewrite_count": rewrite_count + 1,
+            "rewrite_effective": True,
+            "rewrite_provider_model": "deterministic_short_query_expansion",
+            "latency_stages": {**latency_stages, "rewrite": elapsed},
+        }
 
     try:
         from telegram_bot.graph.config import GraphConfig

--- a/telegram_bot/services/query_preprocessor.py
+++ b/telegram_bot/services/query_preprocessor.py
@@ -16,6 +16,23 @@ from telegram_bot.integrations.prompt_manager import get_prompt
 
 logger = logging.getLogger(__name__)
 
+_SHORT_FINANCE_QUERY_EXPANSIONS: dict[str, str] = {
+    "рассрочки": "какие варианты рассрочки при покупке квартиры",
+    "рассрочка": "какие варианты рассрочки при покупке квартиры",
+}
+
+
+def expand_short_query(query: str, *, topic_hint: str | None = None) -> str:
+    """Expand short intent queries using deterministic templates."""
+    normalized = query.strip().lower()
+    if not normalized:
+        return query
+    if topic_hint != "finance":
+        return query
+    if len(normalized.split()) > 2:
+        return query
+    return _SHORT_FINANCE_QUERY_EXPANSIONS.get(normalized, query)
+
 
 class HyDEGenerator:
     """Hypothetical Document Embeddings (HyDE) generator.

--- a/tests/fixtures/retrieval/retrieval_quality_cases.yaml
+++ b/tests/fixtures/retrieval/retrieval_quality_cases.yaml
@@ -1,0 +1,8 @@
+- query: "рассрочки"
+  expected_topic: finance
+  should_include_doc_types: ["faq"]
+  should_exclude_topics_from_top3: ["legal"]
+
+- query: "виды ВНЖ в Болгарии"
+  expected_topic: legal
+  should_include_topics_in_top3: ["legal"]

--- a/tests/unit/agents/test_rag_pipeline.py
+++ b/tests/unit/agents/test_rag_pipeline.py
@@ -222,7 +222,7 @@ async def test_hybrid_retrieve_passes_topic_filter(mock_cache, mock_sparse, mock
     from telegram_bot.agents.rag_pipeline import _hybrid_retrieve
 
     await _hybrid_retrieve(
-        "рассрочка",
+        "какие есть варианты рассрочки",
         [0.1] * 1024,
         cache=mock_cache,
         sparse_embeddings=mock_sparse,
@@ -233,6 +233,34 @@ async def test_hybrid_retrieve_passes_topic_filter(mock_cache, mock_sparse, mock
 
     first_call = mock_qdrant.hybrid_search_rrf.await_args_list[0].kwargs
     assert first_call["filters"] == {"topic": "finance"}
+
+
+async def test_hybrid_retrieve_prefers_faq_candidates_for_short_finance_query(
+    mock_cache, mock_sparse
+):
+    from telegram_bot.agents.rag_pipeline import _hybrid_retrieve
+
+    mock_qdrant = AsyncMock()
+    mock_qdrant.hybrid_search_rrf = AsyncMock(
+        return_value=(
+            [{"text": "FAQ рассрочка", "score": 0.9, "metadata": {"doc_type": "faq"}}],
+            {"backend_error": False, "error_type": None, "error_message": None},
+        )
+    )
+
+    result = await _hybrid_retrieve(
+        "рассрочки",
+        [0.1] * 1024,
+        cache=mock_cache,
+        sparse_embeddings=mock_sparse,
+        qdrant=mock_qdrant,
+        topic_hint="finance",
+        latency_stages={},
+    )
+
+    assert result["search_results_count"] > 0
+    first_call = mock_qdrant.hybrid_search_rrf.await_args_list[0].kwargs
+    assert first_call["filters"] == {"topic": "finance", "doc_type": "faq"}
 
 
 async def test_hybrid_retrieve_omits_topic_filter_by_default(mock_cache, mock_sparse, mock_qdrant):
@@ -271,7 +299,7 @@ async def test_hybrid_retrieve_retries_without_topic_filter_when_results_too_sma
     )
 
     result = await _hybrid_retrieve(
-        "рассрочка",
+        "какие есть варианты рассрочки",
         [0.1] * 1024,
         cache=mock_cache,
         sparse_embeddings=mock_sparse,

--- a/tests/unit/agents/test_rag_pipeline.py
+++ b/tests/unit/agents/test_rag_pipeline.py
@@ -441,6 +441,22 @@ async def test_rewrite_query_llm_fails():
     assert result["rewrite_count"] == 1
 
 
+async def test_short_finance_query_expands_before_rewrite_loop():
+    from telegram_bot.agents.rag_pipeline import _rewrite_query
+
+    fake_llm = MagicMock()
+    fake_llm.chat.completions.create = AsyncMock(side_effect=RuntimeError("LLM should not be used"))
+
+    result = await _rewrite_query(
+        "рассрочки",
+        0,
+        llm=fake_llm,
+        latency_stages={},
+    )
+
+    assert result["rewritten_query"] != "рассрочки"
+
+
 # ---------------------------------------------------------------------------
 # _cache_store tests
 # ---------------------------------------------------------------------------

--- a/tests/unit/agents/test_rag_pipeline.py
+++ b/tests/unit/agents/test_rag_pipeline.py
@@ -424,6 +424,20 @@ async def test_rerank_uses_cache_hit(mock_reranker):
     mock_reranker.rerank.assert_not_awaited()
 
 
+async def test_grade_or_rerank_drops_weak_tail_when_gap_is_small():
+    from telegram_bot.agents.rag_pipeline import _rerank
+
+    docs = [
+        {"score": 1.0, "text": "finance faq"},
+        {"score": 0.95, "text": "finance note"},
+        {"score": 0.52, "text": "ВНЖ"},
+    ]
+    result = await _rerank("рассрочки", docs, reranker=None, latency_stages={})
+
+    assert len(result["documents"]) == 2
+    assert all("ВНЖ" not in d["text"] for d in result["documents"])
+
+
 # ---------------------------------------------------------------------------
 # _rewrite_query tests
 # ---------------------------------------------------------------------------

--- a/tests/unit/retrieval/test_topic_classifier.py
+++ b/tests/unit/retrieval/test_topic_classifier.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import yaml  # type: ignore[import-untyped]
+
 from src.retrieval.topic_classifier import (
     DocType,
     TopicLabel,
@@ -54,3 +58,20 @@ def test_detect_score_gap_marks_clear_winner_confident() -> None:
     result = detect_score_gap([0.62, 0.40, 0.39])
 
     assert result["confident"] is True
+
+
+def test_query_topic_hints_match_retrieval_quality_fixture() -> None:
+    fixture_path = (
+        Path(__file__).resolve().parents[2]
+        / "fixtures"
+        / "retrieval"
+        / "retrieval_quality_cases.yaml"
+    )
+    cases = yaml.safe_load(fixture_path.read_text(encoding="utf-8"))
+    assert isinstance(cases, list)
+
+    topic_by_label = {label.value: label for label in TopicLabel}
+    for case in cases:
+        query = case["query"]
+        expected_topic = topic_by_label[case["expected_topic"]]
+        assert get_query_topic_hint(query) == expected_topic

--- a/tests/unit/test_qdrant_service.py
+++ b/tests/unit/test_qdrant_service.py
@@ -69,6 +69,22 @@ class TestQdrantServiceQuantization:
         call_kwargs = service._client.query_points.call_args.kwargs
         assert call_kwargs.get("search_params") is None
 
+    async def test_hybrid_search_builds_topic_and_doc_type_filters(self, service):
+        """Hybrid search maps topic/doc_type filters to metadata payload keys."""
+        mock_point = _make_mock_point()
+        service._client.query_points = AsyncMock(return_value=MagicMock(points=[mock_point]))
+
+        await service.hybrid_search_rrf(
+            dense_vector=[0.1] * 1024,
+            filters={"topic": "finance", "doc_type": "faq"},
+        )
+
+        query_filter = service._client.query_points.call_args.kwargs["query_filter"]
+        assert query_filter is not None
+        must_keys = [condition.key for condition in query_filter.must]
+        assert "metadata.topic" in must_keys
+        assert "metadata.doc_type" in must_keys
+
     async def test_quantization_params_values(self, service):
         """Test that ignore/rescore/oversampling values are correctly set."""
         mock_point = _make_mock_point()


### PR DESCRIPTION
Summary:\n- add retrieval-quality fixture baseline and fixture-backed topic-hint test\n- add deterministic short finance-query expansion before LLM rewrite loop\n- add topic/doc-type-aware retrieval shaping for short finance queries\n- add post-rerank weak-tail trimming guard using score-gap heuristic\n\nVerification:\n- uv run pytest tests/unit/retrieval/test_topic_classifier.py tests/unit/agents/test_rag_pipeline.py -q\n- uv run pytest tests/unit/test_qdrant_service.py tests/unit/agents/test_rag_pipeline.py -q\n\nRefs #956