### PR TITLE
fix: align local release gate contracts (#988)

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -6,10 +6,11 @@ This document is the source of truth for containerized local/dev/VPS runtime in 
 
 | File | Scope | Typical use |
 | --- | --- | --- |
-| `docker-compose.dev.yml` | Full development stack with profiles | Local development and integration testing |
-| `docker-compose.vps.yml` | VPS production-like stack | Server deployment and operations |
+| `compose.yml` | Secure baseline for all services | Shared base for local and VPS |
+| `compose.dev.yml` | Development overrides (ports, profile gating, local defaults) | Local development and integration testing |
+| `compose.vps.yml` | VPS production-like overrides | Server deployment and operations |
 
-## Compose Profiles (`docker-compose.dev.yml`)
+## Compose Profiles (`compose.yml` + `compose.dev.yml`)
 
 Default `up` (no profile) starts unprofiled services:
 - `postgres`, `redis`, `qdrant`, `bge-m3`, `user-base`, `docling`
@@ -23,7 +24,6 @@ Optional profiles add scoped services:
 | `voice` | `rag-api`, `livekit-server`, `livekit-sip`, `voice-agent`, `litellm` |
 | `ml` | `clickhouse`, `minio`, `redis-langfuse`, `langfuse-worker`, `langfuse` |
 | `obs` | `loki`, `promtail`, `alertmanager` |
-| `security` | `llm-guard` |
 | `full` | all profile-gated services |
 
 ## Makefile Shortcuts
@@ -101,6 +101,22 @@ curl -fsS http://localhost:5001/health
 curl -fsS http://localhost:4000/health/liveliness
 curl -fsS http://localhost:3100/ready
 curl -fsS http://localhost:9093/-/healthy
+
+# Preflight gate for retrieval + LLM connectivity
+make test-bot-health
+```
+
+`make test-bot-health` resolves `QDRANT_COLLECTION` in the same order as local Docker runtime intent:
+1. exported shell env (`QDRANT_COLLECTION`)
+2. `.env` value (`QDRANT_COLLECTION=...`)
+3. compose default from `compose.yml` (currently `gdrive_documents_bge`)
+
+## Local Release Gate
+
+```bash
+make check
+PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit
+make test-bot-health
 ```
 
 ## Common Operations
@@ -108,11 +124,11 @@ curl -fsS http://localhost:9093/-/healthy
 ```bash
 # Logs
 make monitoring-logs
-docker compose --compatibility -f docker-compose.dev.yml logs -f bot litellm qdrant
+COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility logs -f bot litellm qdrant
 
 # Rebuild selected services
-docker compose --compatibility -f docker-compose.dev.yml build bot litellm bge-m3
-docker compose --compatibility -f docker-compose.dev.yml up -d --force-recreate bot litellm bge-m3
+COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility build bot litellm bge-m3
+COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility up -d --force-recreate bot litellm bge-m3
 
 # Image drift check against compose-pinned images
 make verify-compose-images
@@ -122,4 +138,4 @@ make verify-compose-images
 
 - Compose resources are started with `--compatibility` in `Makefile` to apply `deploy.resources.limits` locally.
 - Images are pinned by tag+digest in compose files; update pins explicitly.
-- Local and profile workflows use the same canonical file: `docker-compose.dev.yml`.
+- Local and profile workflows use the canonical local compose set: `compose.yml:compose.dev.yml`.

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -19,6 +19,7 @@ Minimum env for bot profile:
 - `TELEGRAM_BOT_TOKEN`
 - `LITELLM_MASTER_KEY`
 - at least one provider key: `CEREBRAS_API_KEY` or `GROQ_API_KEY` or `OPENAI_API_KEY`
+- optional `QDRANT_COLLECTION` (defaults to `gdrive_documents_bge` from `compose.yml` if unset)
 
 Secret model by compose file:
 - `compose.yml` is the secure baseline: no predictable built-in secret defaults.
@@ -56,11 +57,19 @@ Bot preflight:
 make test-bot-health
 ```
 
+`make test-bot-health` resolves `QDRANT_COLLECTION` in this order:
+1. exported shell env (`QDRANT_COLLECTION`)
+2. `.env` value
+3. compose default from `compose.yml` (`gdrive_documents_bge`)
+
 ## 4. Development Gates
+
+Local release gate:
 
 ```bash
 make check
 PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit
+make test-bot-health
 ```
 
 Optional broader gates:
@@ -97,7 +106,7 @@ uv run uvicorn src.api.main:app --host 0.0.0.0 --port 8080
 
 ## 6. Minimal Stack (Fast Iteration)
 
-Use the `local-*` shortcuts (they now run a minimal subset from `docker-compose.dev.yml`) when full dev stack is unnecessary:
+Use the `local-*` shortcuts (they now run a minimal subset from `compose.yml:compose.dev.yml`) when full dev stack is unnecessary:
 
 ```bash
 make local-up

--- a/scripts/test_bot_health.sh
+++ b/scripts/test_bot_health.sh
@@ -1,8 +1,42 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+resolve_qdrant_collection() {
+  local dotenv_value compose_default
+
+  if [ -n "${QDRANT_COLLECTION:-}" ]; then
+    printf '%s\n' "$QDRANT_COLLECTION"
+    return 0
+  fi
+
+  if [ -f "$PROJECT_ROOT/.env" ]; then
+    dotenv_value=$(
+      sed -nE "s/^[[:space:]]*(export[[:space:]]+)?QDRANT_COLLECTION[[:space:]]*=[[:space:]]*['\"]?([^'\"#[:space:]]+)['\"]?.*$/\\2/p" "$PROJECT_ROOT/.env" \
+        | tail -n1
+    )
+    if [ -n "$dotenv_value" ]; then
+      printf '%s\n' "$dotenv_value"
+      return 0
+    fi
+  fi
+
+  compose_default=$(
+    sed -nE "s/^[[:space:]]*QDRANT_COLLECTION:[[:space:]]*\\$\\{QDRANT_COLLECTION:-([^}]+)\\}[[:space:]]*$/\\1/p" "$PROJECT_ROOT/compose.yml" \
+      | head -n1
+  )
+  if [ -n "$compose_default" ]; then
+    printf '%s\n' "$compose_default"
+    return 0
+  fi
+
+  printf '%s\n' "gdrive_documents_bge"
+}
+
 QDRANT_URL=${QDRANT_URL:-http://localhost:6333}
-QDRANT_COLLECTION=${QDRANT_COLLECTION:-contextual_bulgaria_voyage}
+QDRANT_COLLECTION=$(resolve_qdrant_collection)
 QDRANT_QUANTIZATION_MODE=${QDRANT_QUANTIZATION_MODE:-off}
 LLM_BASE_URL=${LLM_BASE_URL:-${LITELLM_BASE_URL:-http://localhost:4000}}
 

--- a/tests/unit/test_docker_compose_profiles.py
+++ b/tests/unit/test_docker_compose_profiles.py
@@ -52,8 +52,9 @@ def test_compose_includes_expected_profile_groups():
         for p in service.get("profiles", []) or []:
             explicit_profiles.add(str(p))
 
-    required = {"bot", "ml", "obs", "eval", "ingest", "voice", "full"}
-    assert required.issubset(explicit_profiles)
+    required = {"bot", "ml", "obs", "ingest", "voice", "full"}
+    missing = required.difference(explicit_profiles)
+    assert not missing, f"Missing required compose profile groups: {sorted(missing)}"
 
 
 def test_core_services_are_always_enabled():


### PR DESCRIPTION
## Summary
- fix `tests/unit/test_docker_compose_profiles.py::test_compose_includes_expected_profile_groups` to match canonical compose profile groups (`bot`, `ml`, `obs`, `ingest`, `voice`, `full`) and report missing groups explicitly
- align `scripts/test_bot_health.sh` with local Docker runtime collection selection order: shell env -> `.env` -> `compose.yml` default
- freeze canonical local release reference in docs (`DOCKER.md`, `docs/LOCAL-DEVELOPMENT.md`) including compose file set and required local release-gate commands

## Verification
- `uv run pytest tests/unit/test_docker_compose_profiles.py::test_compose_includes_expected_profile_groups -vv`
- `make test-bot-health`
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
- `make test-bot-health`

## Risks
- `.env` parsing in `scripts/test_bot_health.sh` is intentionally simple and expects standard `KEY=value` formatting for `QDRANT_COLLECTION`
- docs now reference the canonical local compose set (`compose.yml:compose.dev.yml`); future compose contract changes should keep docs and test contract in sync
