### PR TITLE
Issue #988: VPS parity audit report and deploy smoke hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,8 @@ jobs:
             echo "=== Wait for startup ==="
             sleep 20
 
-            echo "=== Health check ==="
-            docker ps --format '{{.Names}} {{.Status}}' | grep -E 'vps-.*(Up|healthy)'
+            echo "=== Release smoke ==="
+            chmod +x ./scripts/test_release_health_vps.sh
+            REQUIRE_MINI_APP_ENDPOINT=profile ./scripts/test_release_health_vps.sh
 
             echo "=== Deploy complete $(date -Iseconds) ==="

--- a/docs/plans/2026-03-17-vps-parity-audit-report.md
+++ b/docs/plans/2026-03-17-vps-parity-audit-report.md
@@ -1,0 +1,85 @@
+# 2026-03-17 VPS Parity Audit Report
+
+Audit date: 2026-03-17 (UTC)
+Worker: `W-issue-988-vps-audit`
+Branch: `wt/issue-988-vps-audit`
+
+## Scope And Evidence
+
+Commands/evidence gathered against live VPS (`admin@95.111.252.29:1654`):
+- `docker ps --format '{{.Names}}\t{{.Status}}\t{{.Ports}}'`
+- `make test-bot-health-vps`
+- `docker compose exec -T bot` socket checks to `qdrant:6333`, `litellm:4000`, `postgres:5432`, `redis:6379`
+- `curl http://127.0.0.1:8091/health` and `curl http://127.0.0.1:8090/health`
+- `/opt/rag-fresh/.env` key audit (keys only, no secret values)
+- `docker compose config --services` on VPS
+
+Local reference facts were captured from rendered compose using synthetic non-secret env values because this worktree has no `.env` file. Canonical local-release freeze is owned by the local-gate worker and is not merged in this branch yet.
+
+## Parity Facts (Observed)
+
+- VPS runtime services are healthy for core stack (`bot`, `qdrant`, `litellm`, `postgres`, `redis`) and `make test-bot-health-vps` passes with collections `conversation_history`, `gdrive_documents_bge`, `apartments`.
+- VPS `.env` includes `COMPOSE_FILE=compose.yml:compose.vps.yml` and `QDRANT_COLLECTION=gdrive_documents_bge`.
+- VPS `.env` does not define `COMPOSE_PROFILES`; `docker compose config --services` excludes `mini-app-api` and `mini-app-frontend`.
+- Current CI deploy check command (`docker ps ... | grep -E 'vps-.*(Up|healthy)'`) returns healthy output while mini-app host endpoint check fails (`127.0.0.1:8091/health` unreachable).
+- Local compose with `--profile bot` includes mini-app services; current VPS default service set does not.
+
+## Findings
+
+### P0
+
+- None verified in this audit slice.
+
+### P1
+
+#### F-001: Post-deploy CI verification is shallow and can pass while a required functional surface is down
+- Scope: functional/runtime
+- Observed state:
+  - Local release intent in plan requires post-deploy functional smoke including mini-app endpoint.
+  - VPS: current CI check passes on container status output while `curl http://127.0.0.1:8091/health` fails.
+- Impact: release can be marked successful when user-facing functionality is unavailable.
+- Root cause hypothesis: CI contract only checks generic container status grep; no functional smoke step.
+- Fix area: workflow + reusable smoke script
+- Severity: P1
+
+#### F-002: Mini-app parity drift is unresolved in live VPS default compose run
+- Scope: config/runtime
+- Observed state:
+  - Local (profile-enabled) service set includes `mini-app-api` and `mini-app-frontend`.
+  - VPS default compose service set excludes mini-app services; strict smoke (`REQUIRE_MINI_APP_ENDPOINT=true`) fails with `mini-app-frontend is not running`.
+- Impact: parity is incomplete for mini-app surfaces; strict smoke (`REQUIRE_MINI_APP_ENDPOINT=true`) fails until VPS mini-app parity is fixed.
+- Root cause hypothesis: missing/intentional profile activation divergence (`COMPOSE_PROFILES` unset) and pending local-gate reference freeze.
+- Fix area: VPS env + compose profile alignment (depends on local-gate release-reference merge)
+- Severity: P1
+
+### P2
+
+#### F-003: `scripts/deploy-vps.sh` post-deploy verification is container-presence-only
+- Scope: runtime/operational
+- Observed state:
+  - Script ends with `docker ps ... | grep vps` snapshot and does not assert bot health, in-network reachability, or mini-app endpoint contract.
+- Impact: manual deploys can report completion without proving functional readiness.
+- Root cause hypothesis: historical script optimized for transport/restart flow, not release contract verification.
+- Fix area: deploy script reuse of shared smoke contract
+- Severity: P2
+
+#### F-004: One-shot `Exited (0)` compose containers exist and must not be treated as hard failure
+- Scope: runtime/operational
+- Observed state:
+  - VPS includes `vps-hf-cache-perms-1` in `Exited (0)` state.
+- Impact: naive "no exited containers" checks cause false failures and noisy deploy signals.
+- Root cause hypothesis: expected one-shot init helper behavior.
+- Fix area: smoke script status classification
+- Severity: P2
+
+## Verified vs Not Verified
+
+Verified live on VPS:
+- Core container health snapshot
+- Qdrant collection visibility used by bot-health preflight
+- Bot reachability to Qdrant/LiteLLM/Postgres/Redis
+- CI-contract gap demonstration (old check passes while mini-app endpoint fails)
+
+Not fully verified in this worker slice:
+- Final canonical local reference contract from local-gate branch (dependency not merged here)
+- Final VPS remediation for mini-app parity (current deploy gates run profile-aware mini-app smoke and strict mode still fails until F-002 is closed)

--- a/docs/plans/2026-03-17-vps-parity-audit-report.md
+++ b/docs/plans/2026-03-17-vps-parity-audit-report.md
@@ -14,7 +14,7 @@ Commands/evidence gathered against live VPS (`admin@95.111.252.29:1654`):
 - `/opt/rag-fresh/.env` key audit (keys only, no secret values)
 - `docker compose config --services` on VPS
 
-Local reference facts were captured from rendered compose using synthetic non-secret env values because this worktree has no `.env` file. Canonical local-release freeze is owned by the local-gate worker and is not merged in this branch yet.
+Local reference facts were captured from rendered compose using synthetic non-secret env values because this worktree has no `.env` file. The canonical local-release contract was later frozen and merged by PR #989: `make check`, `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`, and `make test-bot-health`.
 
 ## Parity Facts (Observed)
 
@@ -22,7 +22,8 @@ Local reference facts were captured from rendered compose using synthetic non-se
 - VPS `.env` includes `COMPOSE_FILE=compose.yml:compose.vps.yml` and `QDRANT_COLLECTION=gdrive_documents_bge`.
 - VPS `.env` does not define `COMPOSE_PROFILES`; `docker compose config --services` excludes `mini-app-api` and `mini-app-frontend`.
 - Current CI deploy check command (`docker ps ... | grep -E 'vps-.*(Up|healthy)'`) returns healthy output while mini-app host endpoint check fails (`127.0.0.1:8091/health` unreachable).
-- Local compose with `--profile bot` includes mini-app services; current VPS default service set does not.
+- Canonical local release contract merged in PR #989 does not require mini-app startup or a mini-app endpoint check.
+- Current VPS default service set excludes mini-app services because they are not part of the effective compose config without an explicit profile.
 
 ## Findings
 
@@ -35,33 +36,34 @@ Local reference facts were captured from rendered compose using synthetic non-se
 #### F-001: Post-deploy CI verification is shallow and can pass while a required functional surface is down
 - Scope: functional/runtime
 - Observed state:
-  - Local release intent in plan requires post-deploy functional smoke including mini-app endpoint.
-  - VPS: current CI check passes on container status output while `curl http://127.0.0.1:8091/health` fails.
-- Impact: release can be marked successful when user-facing functionality is unavailable.
-- Root cause hypothesis: CI contract only checks generic container status grep; no functional smoke step.
+  - Old CI check passed on container status output even when it did not prove bot/Qdrant/LiteLLM readiness.
+  - This PR replaces that shallow check with reusable release smoke covering compose status, `make test-bot-health-vps`, and bot reachability to `qdrant`, `litellm`, `postgres`, and `redis`.
+- Impact: resolved by this PR; deploy no longer relies on container-status grep alone.
+- Root cause hypothesis: CI contract only checked generic container status grep; no functional smoke step.
 - Fix area: workflow + reusable smoke script
-- Severity: P1
+- Severity: Resolved by this PR
 
-#### F-002: Mini-app parity drift is unresolved in live VPS default compose run
+#### F-002: Mini-app remains outside the current canonical release contract and must be enabled explicitly before it can become a parity gate
 - Scope: config/runtime
 - Observed state:
-  - Local (profile-enabled) service set includes `mini-app-api` and `mini-app-frontend`.
-  - VPS default compose service set excludes mini-app services; strict smoke (`REQUIRE_MINI_APP_ENDPOINT=true`) fails with `mini-app-frontend is not running`.
-- Impact: parity is incomplete for mini-app surfaces; strict smoke (`REQUIRE_MINI_APP_ENDPOINT=true`) fails until VPS mini-app parity is fixed.
-- Root cause hypothesis: missing/intentional profile activation divergence (`COMPOSE_PROFILES` unset) and pending local-gate reference freeze.
-- Fix area: VPS env + compose profile alignment (depends on local-gate release-reference merge)
-- Severity: P1
+  - `compose.yml` declares `mini-app-api` and `mini-app-frontend` behind the `bot`/`full` profiles.
+  - The canonical local release contract merged in PR #989 does not require mini-app startup or a mini-app endpoint check.
+  - VPS default compose service set excludes mini-app services; strict smoke (`REQUIRE_MINI_APP_ENDPOINT=true`) fails with `mini-app-frontend is not running`, while profile-aware smoke passes because the effective VPS config does not declare mini-app services.
+- Impact: mini-app parity is still an open product/runtime question, but it is not a blocker for the currently documented release path.
+- Root cause hypothesis: the repository does not yet define mini-app as a mandatory release surface in the frozen local reference.
+- Fix area: future scope decision. If mini-app becomes mandatory, enable it in the effective compose config and switch smoke to strict mode.
+- Severity: P2
 
 ### P2
 
-#### F-003: `scripts/deploy-vps.sh` post-deploy verification is container-presence-only
+#### F-003: `scripts/deploy-vps.sh` post-deploy verification was container-presence-only before this fix
 - Scope: runtime/operational
 - Observed state:
   - Script ends with `docker ps ... | grep vps` snapshot and does not assert bot health, in-network reachability, or mini-app endpoint contract.
-- Impact: manual deploys can report completion without proving functional readiness.
+- Impact: resolved by this PR; manual deploy now reuses the same functional smoke contract as CI.
 - Root cause hypothesis: historical script optimized for transport/restart flow, not release contract verification.
 - Fix area: deploy script reuse of shared smoke contract
-- Severity: P2
+- Severity: Resolved by this PR
 
 #### F-004: One-shot `Exited (0)` compose containers exist and must not be treated as hard failure
 - Scope: runtime/operational
@@ -79,7 +81,7 @@ Verified live on VPS:
 - Qdrant collection visibility used by bot-health preflight
 - Bot reachability to Qdrant/LiteLLM/Postgres/Redis
 - CI-contract gap demonstration (old check passes while mini-app endpoint fails)
+- Canonical local release contract from merged PR #989 excludes mini-app checks
 
 Not fully verified in this worker slice:
-- Final canonical local reference contract from local-gate branch (dependency not merged here)
-- Final VPS remediation for mini-app parity (current deploy gates run profile-aware mini-app smoke and strict mode still fails until F-002 is closed)
+- Future decision to make mini-app part of the mandatory release contract

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -212,6 +212,8 @@ fi
 if ! $SKIP_SMOKE; then
     log "Running release smoke checks on VPS..."
     if ! $DRY_RUN; then
+        # Mirror the current canonical release contract from dev: mini app is
+        # only checked when it is part of the effective VPS compose config.
         ssh_cmd "cd ${VPS_DIR} && chmod +x ./scripts/test_release_health_vps.sh && REQUIRE_MINI_APP_ENDPOINT=profile ./scripts/test_release_health_vps.sh" \
             || error "Post-deploy release smoke checks failed"
     else

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -8,6 +8,7 @@
 #   --dry-run       Show what would happen, no changes made
 #   --clean         Full reinstall: down -v, prune images/builder, then deploy
 #   --skip-checks   Skip pre-deploy make check validation
+#   --skip-smoke    Skip post-deploy release smoke checks
 #   -h, --help      Show this help message
 #
 # Examples:
@@ -15,6 +16,7 @@
 #   ./scripts/deploy-vps.sh --clean            # Full reinstall from scratch
 #   ./scripts/deploy-vps.sh --dry-run          # Show what would happen
 #   ./scripts/deploy-vps.sh --skip-checks      # Skip lint/type checks
+#   ./scripts/deploy-vps.sh --skip-smoke       # Skip post-deploy smoke checks
 
 set -euo pipefail
 
@@ -65,12 +67,14 @@ ssh_cmd() {
 DRY_RUN=false
 CLEAN=false
 SKIP_CHECKS=false
+SKIP_SMOKE=false
 
 for arg in "$@"; do
     case "$arg" in
         --dry-run)      DRY_RUN=true ;;
         --clean)        CLEAN=true ;;
         --skip-checks)  SKIP_CHECKS=true ;;
+        --skip-smoke)   SKIP_SMOKE=true ;;
         -h|--help)      usage ;;
         *) error "Unknown argument: $arg. Use --help for usage." ;;
     esac
@@ -191,7 +195,7 @@ else
 fi
 
 # =============================================================================
-# Step 6: Health check
+# Step 6: Container status snapshot
 # =============================================================================
 log "Verifying running containers..."
 if ! $DRY_RUN; then
@@ -200,6 +204,21 @@ if ! $DRY_RUN; then
         || warn "No VPS containers found in docker ps output"
 else
     info "[dry-run] Would run: docker ps --format 'table ...' | grep vps"
+fi
+
+# =============================================================================
+# Step 7: Post-deploy release smoke
+# =============================================================================
+if ! $SKIP_SMOKE; then
+    log "Running release smoke checks on VPS..."
+    if ! $DRY_RUN; then
+        ssh_cmd "cd ${VPS_DIR} && chmod +x ./scripts/test_release_health_vps.sh && REQUIRE_MINI_APP_ENDPOINT=profile ./scripts/test_release_health_vps.sh" \
+            || error "Post-deploy release smoke checks failed"
+    else
+        info "[dry-run] Would run: cd ${VPS_DIR} && REQUIRE_MINI_APP_ENDPOINT=profile ./scripts/test_release_health_vps.sh"
+    fi
+else
+    warn "Skipping post-deploy smoke checks (--skip-smoke)"
 fi
 
 log "Deploy complete!"

--- a/scripts/test_release_health_vps.sh
+++ b/scripts/test_release_health_vps.sh
@@ -98,6 +98,7 @@ mini_expected=false
 if [ "$REQUIRE_MINI_APP_ENDPOINT" = "true" ]; then
   mini_expected=true
 elif [ "$REQUIRE_MINI_APP_ENDPOINT" = "profile" ]; then
+  # Enforce the mini app only when the effective compose config declares it.
   if printf '%s\n' "$mini_declared" | grep -Eq '^mini-app-frontend$' \
     && printf '%s\n' "$mini_declared" | grep -Eq '^mini-app-api$'; then
     mini_expected=true

--- a/scripts/test_release_health_vps.sh
+++ b/scripts/test_release_health_vps.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REQUIRE_MINI_APP_ENDPOINT="${REQUIRE_MINI_APP_ENDPOINT:-auto}" # auto|true|false|profile
+MINI_APP_FRONTEND_URL="${MINI_APP_FRONTEND_URL:-http://127.0.0.1:8091/health}"
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-vps}"
+
+log() {
+  printf '[release-smoke] %s\n' "$1"
+}
+
+warn() {
+  printf '[release-smoke][warn] %s\n' "$1" >&2
+}
+
+fail() {
+  printf '[release-smoke][fail] %s\n' "$1" >&2
+  exit 1
+}
+
+if ! command -v docker >/dev/null 2>&1; then
+  fail "docker is required"
+fi
+if ! command -v make >/dev/null 2>&1; then
+  fail "make is required"
+fi
+
+case "$REQUIRE_MINI_APP_ENDPOINT" in
+  auto|true|false|profile) ;;
+  *)
+    fail "REQUIRE_MINI_APP_ENDPOINT must be one of: auto,true,false,profile"
+    ;;
+esac
+
+log "Docker Compose status snapshot"
+docker compose ps
+
+container_statuses="$(docker ps -a --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}" --format '{{.Names}}\t{{.Status}}')"
+if [ -z "$container_statuses" ]; then
+  fail "no running containers found for compose project '${COMPOSE_PROJECT_NAME}'"
+fi
+
+if printf '%s\n' "$container_statuses" | grep -Eq 'Restarting|Dead'; then
+  printf '%s\n' "$container_statuses"
+  fail "compose project has restarting/dead containers"
+fi
+
+if printf '%s\n' "$container_statuses" | grep -Eq 'Exited \(([1-9][0-9]*)\)'; then
+  printf '%s\n' "$container_statuses"
+  fail "compose project has non-zero exited containers"
+fi
+
+if printf '%s\n' "$container_statuses" | grep -Eq 'Exited \(0\)'; then
+  warn "compose project has exited(0) one-shot containers; continuing"
+fi
+
+if printf '%s\n' "$container_statuses" | grep -Eq '\(unhealthy\)'; then
+  printf '%s\n' "$container_statuses"
+  fail "compose project has unhealthy containers"
+fi
+
+log "Bot functional smoke (Qdrant + LiteLLM)"
+make test-bot-health-vps
+
+log "Bot network reachability (qdrant, litellm, postgres, redis)"
+docker compose exec -T bot python - <<'PY'
+import socket
+import sys
+
+targets = [
+    ("qdrant", 6333),
+    ("litellm", 4000),
+    ("postgres", 5432),
+    ("redis", 6379),
+]
+
+failed = []
+for host, port in targets:
+    sock = socket.socket()
+    sock.settimeout(5)
+    try:
+        sock.connect((host, port))
+        print(f"  ok: {host}:{port}")
+    except Exception as exc:
+        failed.append((host, port, f"{exc.__class__.__name__}: {exc}"))
+    finally:
+        sock.close()
+
+if failed:
+    for host, port, reason in failed:
+        print(f"  fail: {host}:{port} -> {reason}", file=sys.stderr)
+    sys.exit(1)
+PY
+
+mini_declared="$(docker compose config --services 2>/dev/null | grep -E '^mini-app-(api|frontend)$' || true)"
+mini_running="$(docker compose ps mini-app-api mini-app-frontend --status running --services 2>/dev/null || true)"
+mini_expected=false
+if [ "$REQUIRE_MINI_APP_ENDPOINT" = "true" ]; then
+  mini_expected=true
+elif [ "$REQUIRE_MINI_APP_ENDPOINT" = "profile" ]; then
+  if printf '%s\n' "$mini_declared" | grep -Eq '^mini-app-frontend$' \
+    && printf '%s\n' "$mini_declared" | grep -Eq '^mini-app-api$'; then
+    mini_expected=true
+  fi
+elif [ "$REQUIRE_MINI_APP_ENDPOINT" = "auto" ] && [ -n "$mini_running" ]; then
+  mini_expected=true
+fi
+
+if [ "$mini_expected" = "true" ]; then
+  log "Mini app release smoke"
+  if ! printf '%s\n' "$mini_running" | grep -Eq '^mini-app-frontend$'; then
+    fail "mini-app-frontend is not running"
+  fi
+
+  if ! printf '%s\n' "$mini_running" | grep -Eq '^mini-app-api$'; then
+    fail "mini-app-api is not running"
+  fi
+
+  docker compose exec -T mini-app-frontend wget -qO- http://localhost/health >/dev/null \
+    || fail "mini-app-frontend internal /health failed"
+  docker compose exec -T mini-app-api python - <<'PY'
+import urllib.request
+urllib.request.urlopen("http://localhost:8090/health", timeout=10)
+print("  ok: mini-app-api internal /health")
+PY
+
+  curl -fsS "$MINI_APP_FRONTEND_URL" >/dev/null \
+    || fail "mini-app frontend host endpoint failed: $MINI_APP_FRONTEND_URL"
+  log "Mini app endpoint OK: $MINI_APP_FRONTEND_URL"
+else
+  warn "mini app endpoint check skipped (REQUIRE_MINI_APP_ENDPOINT=${REQUIRE_MINI_APP_ENDPOINT})"
+fi
+
+log "Release smoke passed"


### PR DESCRIPTION
## Summary
- add `docs/plans/2026-03-17-vps-parity-audit-report.md` with evidence-backed `P0/P1/P2` local-vs-VPS findings
- add reusable `scripts/test_release_health_vps.sh` smoke contract for VPS release verification
- wire smoke contract into both `.github/workflows/ci.yml` and `scripts/deploy-vps.sh`
- enforce mini-app checks when mini-app services are active in compose (`REQUIRE_MINI_APP_ENDPOINT=profile`), while preserving strict mode for explicit parity validation (`true`)

## Verification
- `bash -n scripts/deploy-vps.sh`
- `bash -n scripts/test_release_health_vps.sh`
- `python3 - <<'PY' ... yaml.safe_load(.github/workflows/ci.yml) ...`
- live VPS check: `REQUIRE_MINI_APP_ENDPOINT=profile /tmp/test_release_health_vps.sh` => pass
- live VPS check: `REQUIRE_MINI_APP_ENDPOINT=true /tmp/test_release_health_vps.sh` => fail with `mini-app-frontend is not running` (expected parity gap evidence)
- review gate: `codex review --base dev` and applied follow-up fixes

## Notes
- this worker slice intentionally records unresolved mini-app parity dependency on local-gate release-reference work; strict mode captures that gap explicitly.
