### PR TITLE
ci: enforce strict mini-app release smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,6 @@ jobs:
 
             echo "=== Release smoke ==="
             chmod +x ./scripts/test_release_health_vps.sh
-            REQUIRE_MINI_APP_ENDPOINT=profile ./scripts/test_release_health_vps.sh
+            REQUIRE_MINI_APP_ENDPOINT=true ./scripts/test_release_health_vps.sh
 
             echo "=== Deploy complete $(date -Iseconds) ==="

--- a/docs/plans/2026-03-17-vps-parity-audit-design.md
+++ b/docs/plans/2026-03-17-vps-parity-audit-design.md
@@ -112,7 +112,7 @@ Verify actual product behavior, not just infrastructure:
 - bot can see the intended Qdrant collection
 - LiteLLM responds correctly
 - mini app frontend is reachable and usable
-- mini app backend responds correctly if required
+- mini app backend responds correctly
 - ingestion can write to the expected target collection if part of the required stack
 - observability path is not silently broken if Langfuse is required
 
@@ -157,7 +157,7 @@ Fix all local release blockers in `dev`:
 - restore green `make check`
 - restore green `make test-unit`
 - restore green `make test-bot-health`
-- fix or explain `mini-app-frontend` unhealthy state if mini app is part of the required stack
+- fix `mini-app-frontend` unhealthy state because mini app is part of the required stack
 
 This phase is mandatory because local runtime is the source of truth.
 
@@ -204,7 +204,7 @@ Required post-deploy checks:
 
 - `docker compose ps`
 - `make test-bot-health-vps`
-- mini app endpoint verification if required
+- mini app endpoint verification
 - targeted log scan for `bot`, `litellm`, `mini-app-frontend`, `mini-app-api`, `ingestion`
 
 ## 7. Release Policy
@@ -224,13 +224,14 @@ Local release-gate should include:
 - `make check`
 - `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
 - `make test-bot-health`
-- required local functional smoke
+- required local functional smoke, including mini app parity when the full release surface is claimed
 
 VPS release-gate should include:
 
 - `docker compose ps`
 - `make test-bot-health-vps`
-- required VPS functional smoke
+- mini app frontend and API smoke
+- targeted VPS functional smoke for other release-critical services
 
 ## 8. Required Repo Changes
 

--- a/docs/plans/2026-03-17-vps-parity-audit-report.md
+++ b/docs/plans/2026-03-17-vps-parity-audit-report.md
@@ -22,14 +22,24 @@ Local reference facts were captured from rendered compose using synthetic non-se
 - VPS `.env` includes `COMPOSE_FILE=compose.yml:compose.vps.yml` and `QDRANT_COLLECTION=gdrive_documents_bge`.
 - VPS `.env` does not define `COMPOSE_PROFILES`; `docker compose config --services` excludes `mini-app-api` and `mini-app-frontend`.
 - Current CI deploy check command (`docker ps ... | grep -E 'vps-.*(Up|healthy)'`) returns healthy output while mini-app host endpoint check fails (`127.0.0.1:8091/health` unreachable).
-- Canonical local release contract merged in PR #989 does not require mini-app startup or a mini-app endpoint check.
+- Issue #991 and the blocking PR #990 review establish that VPS release success requires mini-app parity as part of the full release surface.
 - Current VPS default service set excludes mini-app services because they are not part of the effective compose config without an explicit profile.
 
 ## Findings
 
 ### P0
 
-- None verified in this audit slice.
+#### F-002: Mini-app parity is part of the VPS release contract, but the current VPS default service set omits mini-app services
+- Scope: config/runtime/functional
+- Observed state:
+  - `compose.yml` declares `mini-app-api` and `mini-app-frontend` behind the `bot`/`full` profiles.
+  - VPS `.env` does not define `COMPOSE_PROFILES`, and `docker compose config --services` excludes both mini-app services.
+  - Strict smoke (`REQUIRE_MINI_APP_ENDPOINT=true`) fails with `mini-app-frontend is not running`.
+  - PR #990 blocking review and issue #991 require release-critical smoke to fail honestly until mini-app parity is restored.
+- Impact: the current VPS default stack cannot satisfy the required release contract, so any deploy path that reports success without strict mini-app smoke is a false green.
+- Root cause hypothesis: the effective VPS compose config omits release-critical mini-app services while the deploy gate previously used a profile-aware downgrade path.
+- Fix area: release gate now; compose/runtime parity follow-up remains required outside this worker scope.
+- Severity: P0
 
 ### P1
 
@@ -43,24 +53,13 @@ Local reference facts were captured from rendered compose using synthetic non-se
 - Fix area: workflow + reusable smoke script
 - Severity: Resolved by this PR
 
-#### F-002: Mini-app remains outside the current canonical release contract and must be enabled explicitly before it can become a parity gate
-- Scope: config/runtime
-- Observed state:
-  - `compose.yml` declares `mini-app-api` and `mini-app-frontend` behind the `bot`/`full` profiles.
-  - The canonical local release contract merged in PR #989 does not require mini-app startup or a mini-app endpoint check.
-  - VPS default compose service set excludes mini-app services; strict smoke (`REQUIRE_MINI_APP_ENDPOINT=true`) fails with `mini-app-frontend is not running`, while profile-aware smoke passes because the effective VPS config does not declare mini-app services.
-- Impact: mini-app parity is still an open product/runtime question, but it is not a blocker for the currently documented release path.
-- Root cause hypothesis: the repository does not yet define mini-app as a mandatory release surface in the frozen local reference.
-- Fix area: future scope decision. If mini-app becomes mandatory, enable it in the effective compose config and switch smoke to strict mode.
-- Severity: P2
-
 ### P2
 
 #### F-003: `scripts/deploy-vps.sh` post-deploy verification was container-presence-only before this fix
 - Scope: runtime/operational
 - Observed state:
   - Script ends with `docker ps ... | grep vps` snapshot and does not assert bot health, in-network reachability, or mini-app endpoint contract.
-- Impact: resolved by this PR; manual deploy now reuses the same functional smoke contract as CI.
+- Impact: resolved by this PR; manual deploy now reuses the same strict functional smoke contract as CI.
 - Root cause hypothesis: historical script optimized for transport/restart flow, not release contract verification.
 - Fix area: deploy script reuse of shared smoke contract
 - Severity: Resolved by this PR
@@ -81,7 +80,7 @@ Verified live on VPS:
 - Qdrant collection visibility used by bot-health preflight
 - Bot reachability to Qdrant/LiteLLM/Postgres/Redis
 - CI-contract gap demonstration (old check passes while mini-app endpoint fails)
-- Canonical local release contract from merged PR #989 excludes mini-app checks
+- Strict mini-app smoke fails against the current VPS default service set
 
 Not fully verified in this worker slice:
-- Future decision to make mini-app part of the mandatory release contract
+- Compose/runtime changes needed to restore mini-app parity on VPS

--- a/docs/plans/2026-03-17-vps-parity-fix-plan.md
+++ b/docs/plans/2026-03-17-vps-parity-fix-plan.md
@@ -522,6 +522,8 @@ Run it manually on VPS first and confirm the current workflow does not yet provi
 
 Update `.github/workflows/ci.yml` so deploy verification executes the stronger smoke check after `docker compose up -d`.
 
+Use strict mini-app smoke in release-critical callers (`REQUIRE_MINI_APP_ENDPOINT=true`) so deploy reports fail until VPS parity is fixed.
+
 **Step 3: Verify the workflow logic locally where possible**
 
 Run shell commands equivalent to the workflow’s SSH script against VPS.

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -212,12 +212,11 @@ fi
 if ! $SKIP_SMOKE; then
     log "Running release smoke checks on VPS..."
     if ! $DRY_RUN; then
-        # Mirror the current canonical release contract from dev: mini app is
-        # only checked when it is part of the effective VPS compose config.
-        ssh_cmd "cd ${VPS_DIR} && chmod +x ./scripts/test_release_health_vps.sh && REQUIRE_MINI_APP_ENDPOINT=profile ./scripts/test_release_health_vps.sh" \
+        # Release-critical deploy smoke must fail if mini-app parity is broken.
+        ssh_cmd "cd ${VPS_DIR} && chmod +x ./scripts/test_release_health_vps.sh && REQUIRE_MINI_APP_ENDPOINT=true ./scripts/test_release_health_vps.sh" \
             || error "Post-deploy release smoke checks failed"
     else
-        info "[dry-run] Would run: cd ${VPS_DIR} && REQUIRE_MINI_APP_ENDPOINT=profile ./scripts/test_release_health_vps.sh"
+        info "[dry-run] Would run: cd ${VPS_DIR} && REQUIRE_MINI_APP_ENDPOINT=true ./scripts/test_release_health_vps.sh"
     fi
 else
     warn "Skipping post-deploy smoke checks (--skip-smoke)"

--- a/scripts/test_release_health_vps.sh
+++ b/scripts/test_release_health_vps.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REQUIRE_MINI_APP_ENDPOINT="${REQUIRE_MINI_APP_ENDPOINT:-auto}" # auto|true|false|profile
+REQUIRE_MINI_APP_ENDPOINT="${REQUIRE_MINI_APP_ENDPOINT:-auto}" # auto|true|false
 MINI_APP_FRONTEND_URL="${MINI_APP_FRONTEND_URL:-http://127.0.0.1:8091/health}"
 COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-vps}"
 
@@ -26,9 +26,9 @@ if ! command -v make >/dev/null 2>&1; then
 fi
 
 case "$REQUIRE_MINI_APP_ENDPOINT" in
-  auto|true|false|profile) ;;
+  auto|true|false) ;;
   *)
-    fail "REQUIRE_MINI_APP_ENDPOINT must be one of: auto,true,false,profile"
+    fail "REQUIRE_MINI_APP_ENDPOINT must be one of: auto,true,false"
     ;;
 esac
 
@@ -92,17 +92,10 @@ if failed:
     sys.exit(1)
 PY
 
-mini_declared="$(docker compose config --services 2>/dev/null | grep -E '^mini-app-(api|frontend)$' || true)"
 mini_running="$(docker compose ps mini-app-api mini-app-frontend --status running --services 2>/dev/null || true)"
 mini_expected=false
 if [ "$REQUIRE_MINI_APP_ENDPOINT" = "true" ]; then
   mini_expected=true
-elif [ "$REQUIRE_MINI_APP_ENDPOINT" = "profile" ]; then
-  # Enforce the mini app only when the effective compose config declares it.
-  if printf '%s\n' "$mini_declared" | grep -Eq '^mini-app-frontend$' \
-    && printf '%s\n' "$mini_declared" | grep -Eq '^mini-app-api$'; then
-    mini_expected=true
-  fi
 elif [ "$REQUIRE_MINI_APP_ENDPOINT" = "auto" ] && [ -n "$mini_running" ]; then
   mini_expected=true
 fi

--- a/tests/unit/test_release_gate_contract.py
+++ b/tests/unit/test_release_gate_contract.py
@@ -1,0 +1,31 @@
+"""Regression tests for the VPS release gate contract."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+DEPLOY_SCRIPT = ROOT / "scripts" / "deploy-vps.sh"
+RELEASE_SMOKE_SCRIPT = ROOT / "scripts" / "test_release_health_vps.sh"
+
+
+def test_release_smoke_script_does_not_allow_profile_mode() -> None:
+    """Release smoke must not keep the profile-aware downgrade path."""
+    script = RELEASE_SMOKE_SCRIPT.read_text()
+    assert "auto|true|false" in script
+    assert "profile" not in script, (
+        "scripts/test_release_health_vps.sh still supports 'profile', "
+        "which lets release-critical callers skip strict mini-app parity."
+    )
+
+
+def test_ci_deploy_uses_strict_mini_app_release_smoke() -> None:
+    """CI deploy must fail when mini-app parity is broken."""
+    workflow = CI_WORKFLOW.read_text()
+    assert "REQUIRE_MINI_APP_ENDPOINT=true ./scripts/test_release_health_vps.sh" in workflow
+
+
+def test_manual_deploy_uses_strict_mini_app_release_smoke() -> None:
+    """Manual VPS deploy must use the same strict release contract as CI."""
+    script = DEPLOY_SCRIPT.read_text()
+    assert "REQUIRE_MINI_APP_ENDPOINT=true ./scripts/test_release_health_vps.sh" in script


### PR DESCRIPTION
## Summary
- switch CI and manual VPS deploy smoke to `REQUIRE_MINI_APP_ENDPOINT=true`
- remove the `profile` downgrade path from `scripts/test_release_health_vps.sh`
- align VPS parity audit/fix docs with mini-app parity as part of the release contract
- add a focused regression test for the strict gate contract

## Verification
- `uv run pytest tests/unit/test_release_gate_contract.py -q`
- `bash -n scripts/deploy-vps.sh`
- `bash -n scripts/test_release_health_vps.sh`

## Risks / Dependencies
- Expected cross-slice dependency: strict smoke will fail until the runtime worker restores mini-app parity on VPS and resolves the current `mini-app-api` build/runtime issues.