### PR TITLE
Fix mini app VPS parity and API build

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -319,7 +319,6 @@ services:
     build:
       context: .
       dockerfile: mini_app/Dockerfile
-    profiles: ["bot", "full"]
     restart: unless-stopped
     logging: *default-logging
     environment:
@@ -362,7 +361,6 @@ services:
     build:
       context: ./mini_app/frontend
       dockerfile: Dockerfile
-    profiles: ["bot", "full"]
     restart: unless-stopped
     logging: *default-logging
     depends_on:

--- a/mini_app/Dockerfile
+++ b/mini_app/Dockerfile
@@ -10,6 +10,10 @@ ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
     UV_PYTHON_DOWNLOADS=0
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential && \
+    rm -rf /var/lib/apt/lists/*
+
 # Deps layer (cached separately from code)
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \

--- a/tests/unit/test_compose_config.py
+++ b/tests/unit/test_compose_config.py
@@ -232,3 +232,16 @@ class TestModelServiceHealthcheckGrace:
             f"{svc_name}.healthcheck.start_period must be >=300s for cold model downloads; "
             f"got {start_period!r}"
         )
+
+
+class TestMiniAppVpsParity:
+    """Mini app must be part of the default VPS runtime stack."""
+
+    @pytest.mark.parametrize("svc_name", ["mini-app-api", "mini-app-frontend"])
+    def test_vps_mini_app_service_is_not_profile_gated(self, vps: dict, svc_name: str) -> None:
+        """Default VPS compose up must include both mini-app services."""
+        svc = vps["services"][svc_name]
+        assert not svc.get("profiles"), (
+            f"{svc_name} must not declare optional profiles in compose.yml; "
+            "default VPS compose up skips profiled services"
+        )

--- a/tests/unit/test_mini_app_dockerfile_build_deps.py
+++ b/tests/unit/test_mini_app_dockerfile_build_deps.py
@@ -1,0 +1,17 @@
+"""Regression test for mini app API build dependencies."""
+
+from pathlib import Path
+
+
+def test_mini_app_dockerfile_installs_build_essential_before_uv_sync() -> None:
+    text = Path("mini_app/Dockerfile").read_text(encoding="utf-8")
+
+    toolchain_install = "apt-get install -y --no-install-recommends build-essential"
+    first_sync = "uv sync --frozen --no-dev --no-install-project --extra mini-app"
+
+    assert toolchain_install in text, (
+        "mini_app/Dockerfile builder must install build-essential for source builds"
+    )
+    assert text.index(toolchain_install) < text.index(first_sync), (
+        "mini_app/Dockerfile must install build-essential before uv sync resolves mini-app dependencies"
+    )


### PR DESCRIPTION
## Summary
- remove mini-app profile gates from `compose.yml` so default VPS compose includes the mini app
- install `build-essential` in the mini-app API builder stage so Python 3.14 source builds for `regex`/`tiktoken` succeed
- add focused regressions for the VPS mini-app compose contract and Dockerfile build toolchain

## Verification
- `uv run pytest tests/unit/test_compose_config.py tests/unit/test_mini_app_dockerfile_build_deps.py -q`
- `POSTGRES_PASSWORD=x REDIS_PASSWORD=x LITELLM_MASTER_KEY=x TELEGRAM_BOT_TOKEN=x ENCRYPTION_KEY=x SALT=x NEXTAUTH_SECRET=x BOT_USERNAME=testbot docker compose build mini-app-api`
- `POSTGRES_PASSWORD=x REDIS_PASSWORD=x LITELLM_MASTER_KEY=x TELEGRAM_BOT_TOKEN=x ENCRYPTION_KEY=x SALT=x NEXTAUTH_SECRET=x BOT_USERNAME=testbot docker compose -f compose.yml -f compose.vps.yml --dry-run up --no-start`

## Notes
- `codex review --base dev` could not complete because the local Codex review quota was exhausted.
