### PR TITLE
Fix bge-m3 Docker lxml system deps

### DIFF
--- a/services/bge-m3-api/Dockerfile
+++ b/services/bge-m3-api/Dockerfile
@@ -14,7 +14,8 @@ WORKDIR /app
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
-    apt-get update && apt-get install -y --no-install-recommends gcc g++ libgomp1
+    apt-get update && apt-get install -y --no-install-recommends \
+    gcc g++ libgomp1 libxml2-dev libxslt1-dev zlib1g-dev
 
 # Deps layer
 RUN --mount=type=cache,target=/root/.cache/uv \
@@ -32,7 +33,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # ====== RUNTIME STAGE ======
 FROM python:3.14-slim-bookworm AS runtime
 
-RUN apt-get update && apt-get install -y --no-install-recommends libgomp1 \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgomp1 libxml2 libxslt1.1 zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1001 appgroup && \


### PR DESCRIPTION
## Summary
- add the missing libxml2/libxslt/zlib build dependencies to the bge-m3 builder image
- add the matching runtime libraries so the compiled lxml extension can import in the final image
- verify the Docker build path and runtime lxml import for services/bge-m3-api

## Verification
- docker build -t issue-998-bge-m3-test -f services/bge-m3-api/Dockerfile services/bge-m3-api
- docker run --rm issue-998-bge-m3-test python -c "import lxml.etree as et; print(et.LIBXML_VERSION, et.LIBXSLT_VERSION)"