### PR TITLE
Fix VPS auto-deploy health checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
             git fetch origin main
             git reset --hard origin/main
 
+            echo "=== Normalize bind-mounted config permissions ==="
+            chmod 644 ./docker/litellm/config.yaml
+
             echo "=== Rebuild changed images ==="
             docker compose build
 

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -181,6 +181,16 @@ if $CLEAN; then
 fi
 
 # =============================================================================
+# Step 3a: Normalize bind-mounted config permissions on VPS
+# =============================================================================
+log "Normalizing bind-mounted config permissions..."
+if ! $DRY_RUN; then
+    ssh_cmd "chmod 644 ${VPS_DIR}/docker/litellm/config.yaml"
+else
+    info "[dry-run] Would run: chmod 644 ${VPS_DIR}/docker/litellm/config.yaml"
+fi
+
+# =============================================================================
 # Step 4: Build images on VPS
 # =============================================================================
 log "Building Docker images on VPS..."

--- a/scripts/test_release_health_vps.sh
+++ b/scripts/test_release_health_vps.sh
@@ -111,7 +111,7 @@ if [ "$mini_expected" = "true" ]; then
     fail "mini-app-api is not running"
   fi
 
-  docker compose exec -T mini-app-frontend wget -qO- http://localhost/health >/dev/null \
+  docker compose exec -T mini-app-frontend wget -qO- http://127.0.0.1/health >/dev/null \
     || fail "mini-app-frontend internal /health failed"
   docker compose exec -T mini-app-api python - <<'PY'
 import urllib.request


### PR DESCRIPTION
## Summary
- normalize the LiteLLM bind-mounted config permissions during VPS deploys
- fix the VPS release smoke check for mini-app frontend to probe 127.0.0.1 instead of localhost
- keep the manual deploy script aligned with the GitHub Actions deploy path

## Verification
- bash -n scripts/deploy-vps.sh
- bash -n scripts/test_release_health_vps.sh
- uv run python - <<'PY'
from pathlib import Path
import yaml
yaml.safe_load(Path('.github/workflows/ci.yml').read_text())
print('YAML_OK')
PY
- REQUIRE_MINI_APP_ENDPOINT=true ssh vps 'cd /opt/rag-fresh && export COMPOSE_FILE=compose.yml:compose.vps.yml && REQUIRE_MINI_APP_ENDPOINT=true bash -s' < scripts/test_release_health_vps.sh
- ssh vps 'cd /opt/rag-fresh && export COMPOSE_FILE=compose.yml:compose.vps.yml && docker compose exec -T mini-app-frontend wget -qO- http://127.0.0.1/health >/dev/null && curl -fsS http://127.0.0.1:8091/health >/dev/null'
