### PR TITLE
fix: sanitize hidden citations and unify Telegram HTML responses

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -2573,20 +2573,10 @@ class PropertyBot:
         *,
         reply_markup: Any | None = None,
     ) -> None:
-        """Send long Telegram response in chunks with Markdown fallback."""
-        chunks = list(_split_telegram_response(text))
-        for i, chunk in enumerate(chunks):
-            is_last = i == len(chunks) - 1
-            markup = reply_markup if is_last else None
-            try:
-                await message.answer(chunk, parse_mode="Markdown", reply_markup=markup)
-            except Exception:
-                logger.warning("Markdown parse failed in text path, falling back")
-                try:
-                    await message.answer(chunk, reply_markup=markup)
-                except Exception:
-                    logger.exception("Failed to send text response chunk")
-                    await message.answer(chunk)
+        """Send long Telegram response in chunks with Telegram HTML formatting."""
+        from telegram_bot.services.telegram_formatting import send_html_messages
+
+        await send_html_messages(message, text, reply_markup=reply_markup)
 
     async def _handle_apartment_fast_path(
         self,
@@ -3296,7 +3286,7 @@ class PropertyBot:
                     reply_markup = ctx.history_reply_markup
 
                 # Build source attribution
-                sources_text = ""
+                sources_html = ""
                 documents = rag_result_store.get("documents", [])
                 if (
                     self._graph_config.show_sources
@@ -3309,58 +3299,64 @@ class PropertyBot:
                 ):
                     from telegram_bot.graph.nodes.respond import _MAX_SOURCES, format_sources
 
-                    sources_text = format_sources(documents)
+                    sources_html = format_sources(documents)
                     rag_result_store["sources_count"] = min(len(documents), _MAX_SOURCES)
-
-                full_response = response_text + sources_text if sources_text else response_text
 
                 # Send via DraftStreamer (supports forum thread routing)
                 from telegram_bot.services.draft_streamer import DraftStreamer
+                from telegram_bot.services.telegram_formatting import (
+                    build_html_messages,
+                    send_html_messages,
+                )
+
+                html_messages = build_html_messages(response_text, sources_html=sources_html)
 
                 if message.chat.type == "private":
                     draft_streamer = rag_result_store.get("_draft_streamer")
                     try:
-                        if draft_streamer is None:
+                        if draft_streamer is None and len(html_messages) == 1:
                             draft_streamer = DraftStreamer(
                                 bot=self.bot,
                                 chat_id=message.chat.id,
                                 thread_id=forum_thread_id,
                             )
-                        await draft_streamer.finalize(
-                            full_response,
-                            parse_mode="Markdown",
-                            reply_markup=reply_markup,
-                        )
+                        if draft_streamer is not None and len(html_messages) == 1:
+                            await draft_streamer.finalize(
+                                html_messages[0],
+                                parse_mode="HTML",
+                                reply_markup=reply_markup,
+                            )
+                        else:
+                            await send_html_messages(
+                                message,
+                                response_text,
+                                sources_html=sources_html,
+                                reply_markup=reply_markup,
+                            )
                         ctx.response_sent = True
                     except Exception:
                         logger.warning("DraftStreamer failed, falling back to message.answer")
                         try:
-                            await message.answer(
-                                full_response,
-                                parse_mode="Markdown",
+                            await send_html_messages(
+                                message,
+                                response_text,
+                                sources_html=sources_html,
                                 reply_markup=reply_markup,
                             )
                             ctx.response_sent = True
                         except Exception:
                             logger.exception("Failed to send text response")
-                            await message.answer(full_response)
+                            if response_text:
+                                await message.answer(response_text)
                             ctx.response_sent = True
                 else:
-                    # Send with Markdown, fallback to plain text
-                    chunks = list(_split_telegram_response(full_response))
-                    for i, chunk in enumerate(chunks):
-                        is_last = i == len(chunks) - 1
-                        markup = reply_markup if is_last else None
-                        try:
-                            await message.answer(chunk, parse_mode="Markdown", reply_markup=markup)
-                        except Exception:
-                            logger.warning("Markdown parse failed in text path, falling back")
-                            try:
-                                await message.answer(chunk, reply_markup=markup)
-                            except Exception:
-                                logger.exception("Failed to send text response chunk")
-                                await message.answer(chunk)
-                    if chunks:
+                    await send_html_messages(
+                        message,
+                        response_text,
+                        sources_html=sources_html,
+                        reply_markup=reply_markup,
+                    )
+                    if html_messages:
                         ctx.response_sent = True
 
             # Store final agent response in semantic cache for cacheable query types.

--- a/telegram_bot/graph/nodes/respond.py
+++ b/telegram_bot/graph/nodes/respond.py
@@ -1,8 +1,4 @@
-"""respond_node — sends the final response to the user via Telegram.
-
-Sends with Markdown parse_mode, falls back to plain text on parse error.
-Attaches feedback buttons when trace_id is available (#229).
-"""
+"""respond_node — sends the final response to the user via Telegram."""
 
 from __future__ import annotations
 
@@ -11,6 +7,11 @@ import time
 from typing import Any
 
 from telegram_bot.observability import get_client, observe
+from telegram_bot.services.telegram_formatting import (
+    format_answer_html,
+    format_sources_html,
+    send_html_messages,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -43,23 +44,8 @@ def _extract_sent_message_ref(state: dict[str, Any]) -> tuple[int, int] | None:
 
 
 def format_sources(documents: list[dict[str, Any]], max_sources: int = _MAX_SOURCES) -> str:
-    """Format source documents as Telegram Markdown footnotes (#225)."""
-    if not documents:
-        return ""
-
-    parts: list[str] = []
-    for i, doc in enumerate(documents[:max_sources], 1):
-        meta = doc.get("metadata", {})
-        title = meta.get("title", "Документ")
-        city = meta.get("city", "")
-        score = doc.get("score", 0)
-        line = f"`[{i}]` {title}"
-        if city:
-            line += f" — {city}"
-        line += f" _(рел: {score:.2f})_"
-        parts.append(line)
-
-    return "\n\n\U0001f4ce *Источники:*\n" + "\n".join(parts)
+    """Format source documents as Telegram HTML attribution."""
+    return format_sources_html(documents, max_sources=max_sources)
 
 
 @observe(name="node-respond", capture_input=False, capture_output=False)
@@ -114,13 +100,13 @@ async def respond_node(state: dict[str, Any]) -> dict[str, Any]:
         if sent_ref is not None and bot is not None:
             chat_id, message_id = sent_ref
             if sources_text:
-                full_text = response + sources_text
+                full_text = format_answer_html(response) + sources_text
                 try:
                     await bot.edit_message_text(
                         text=full_text,
                         chat_id=chat_id,
                         message_id=message_id,
-                        parse_mode="Markdown",
+                        parse_mode="HTML",
                         reply_markup=reply_markup,
                     )
                 except Exception:
@@ -170,26 +156,23 @@ async def respond_node(state: dict[str, Any]) -> dict[str, Any]:
         }
 
     # Non-streaming path: append sources to response before sending
-    full_response = response + sources_text if sources_text else response
-
     delivered = False
     used_markdown = False
     if message is not None:
         try:
-            await message.answer(full_response, parse_mode="Markdown", reply_markup=reply_markup)
-            delivered = True
-            used_markdown = True
-        except Exception:
-            logger.warning("Markdown parse failed, falling back to plain text")
-            try:
-                await message.answer(full_response, reply_markup=reply_markup)
-                delivered = True
-            except Exception as e:
-                logger.exception("Failed to send response")
-                lf.update_current_span(
-                    level="ERROR",
-                    status_message=f"Telegram send failed: {str(e)[:200]}",
-                )
+            delivered = await send_html_messages(
+                message,
+                response,
+                sources_html=sources_text,
+                reply_markup=reply_markup,
+                reply_to_user_text=state.get("query", ""),
+            )
+        except Exception as e:
+            logger.exception("Failed to send response")
+            lf.update_current_span(
+                level="ERROR",
+                status_message=f"Telegram send failed: {str(e)[:200]}",
+            )
 
     elapsed = time.perf_counter() - t0
     lf.update_current_span(

--- a/telegram_bot/pipelines/client.py
+++ b/telegram_bot/pipelines/client.py
@@ -20,6 +20,7 @@ from telegram_bot.scoring import score, write_langfuse_scores
 from telegram_bot.services.generate_response import generate_response
 from telegram_bot.services.grounding_policy import get_grounding_mode
 from telegram_bot.services.history_service import HistoryService
+from telegram_bot.services.telegram_formatting import send_html_messages
 from telegram_bot.services.types import PipelineResult
 
 
@@ -147,26 +148,36 @@ def _split_telegram_response(text: str, limit: int = _TELEGRAM_MESSAGE_LIMIT) ->
     return [text[i : i + limit] for i in range(0, len(text), limit)]
 
 
+async def _send_html_chunks(
+    message: Any,
+    text: str,
+    *,
+    reply_markup: Any | None = None,
+    reply_to_user_text: str | None = None,
+) -> None:
+    """Send response in chunks with Telegram HTML formatting."""
+    await send_html_messages(
+        message,
+        text,
+        reply_markup=reply_markup,
+        reply_to_user_text=reply_to_user_text,
+    )
+
+
 async def _send_markdown_chunks(
     message: Any,
     text: str,
     *,
     reply_markup: Any | None = None,
+    reply_to_user_text: str | None = None,
 ) -> None:
-    """Send response in chunks with Markdown parse_mode fallback."""
-    chunks = _split_telegram_response(text)
-    for i, chunk in enumerate(chunks):
-        is_last = i == len(chunks) - 1
-        markup = reply_markup if is_last else None
-        try:
-            await message.answer(chunk, parse_mode="Markdown", reply_markup=markup)
-        except Exception:
-            logger.warning("Markdown parse failed in client pipeline, falling back")
-            try:
-                await message.answer(chunk, reply_markup=markup)
-            except Exception:
-                logger.exception("Failed to send response chunk in client pipeline")
-                await message.answer(chunk)
+    """Backward-compatible alias for the old sender name."""
+    await _send_html_chunks(
+        message,
+        text,
+        reply_markup=reply_markup,
+        reply_to_user_text=reply_to_user_text,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -229,7 +240,7 @@ async def run_client_pipeline(
     # --- Step a) Classify gate ---
     if query_type in _NO_RAG_QUERY_TYPES:
         response_text = _build_non_rag_response(query_type)
-        await _send_markdown_chunks(message, response_text)
+        await _send_html_chunks(message, response_text, reply_to_user_text=user_text)
         latency_ms = (time.perf_counter() - pipeline_start) * 1000
         return PipelineResult(
             answer=response_text,
@@ -349,18 +360,20 @@ async def run_client_pipeline(
 
         reply_markup = build_feedback_keyboard(trace_id)
 
-    sources_text = ""
+    sources_html = ""
     documents_list: list[Any] = result.get("documents", [])
     sources_required = bool(getattr(config, "show_sources", False) or grounding_mode == "strict")
     if sources_required and documents_list:
-        sources_text = format_sources(documents_list)
+        sources_html = format_sources(documents_list)
         result["sources_count"] = min(len(documents_list), _MAX_SOURCES)
 
     response_already_sent = result.get("response_sent", False)
     if response_already_sent:
         # Streaming already delivered the main response; only send sources if applicable.
-        if sources_text:
-            await _send_markdown_chunks(message, sources_text, reply_markup=reply_markup)
+        if sources_html:
+            await send_html_messages(
+                message, "", sources_html=sources_html, reply_markup=reply_markup
+            )
         elif reply_markup:
             # Attach feedback keyboard to the streamed message (#745).
             ref = result.get("sent_message")
@@ -377,8 +390,13 @@ async def run_client_pipeline(
                         exc_info=True,
                     )
     else:
-        full_response = response_text + sources_text if sources_text else response_text
-        await _send_markdown_chunks(message, full_response, reply_markup=reply_markup)
+        await send_html_messages(
+            message,
+            response_text,
+            sources_html=sources_html,
+            reply_markup=reply_markup,
+            reply_to_user_text=user_text,
+        )
 
     # --- Step f) Post-process ---
     wall_ms = (time.perf_counter() - pipeline_start) * 1000

--- a/telegram_bot/services/generate_response.py
+++ b/telegram_bot/services/generate_response.py
@@ -6,6 +6,7 @@ import contextlib
 import hashlib
 import inspect
 import logging
+import re
 import time
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -23,6 +24,10 @@ from telegram_bot.services.grounding_policy import (
 )
 from telegram_bot.services.metrics import PipelineMetrics
 from telegram_bot.services.response_style_detector import ResponseStyleDetector
+from telegram_bot.services.telegram_formatting import (
+    build_reply_parameters,
+    format_answer_html,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -122,6 +127,16 @@ def _build_system_prompt_with_config(domain: str) -> tuple[str, dict[str, Any]]:
 
 def _format_context(documents: list[dict[str, Any]], max_docs: int = _MAX_CONTEXT_DOCS) -> str:
     """Format top-N retrieved documents into LLM context string."""
+    return _format_context_for_mode(documents, max_docs=max_docs, sources_enabled=True)
+
+
+def _format_context_for_mode(
+    documents: list[dict[str, Any]],
+    max_docs: int = _MAX_CONTEXT_DOCS,
+    *,
+    sources_enabled: bool,
+) -> str:
+    """Format top-N retrieved documents into LLM context string for current source mode."""
     if not documents:
         return "Релевантной информации не найдено."
 
@@ -139,9 +154,35 @@ def _format_context(documents: list[dict[str, Any]], max_docs: int = _MAX_CONTEX
         if "price" in metadata:
             meta_str += f"Цена: {metadata['price']:,}€\n"
 
-        parts.append(f"[Объект {i}] (релевантность: {score:.2f})\n{meta_str}{text}")
+        if sources_enabled:
+            header = f"[Объект {i}] (релевантность: {score:.2f})"
+        else:
+            header = "Фрагмент контекста"
+        parts.append(f"{header}\n{meta_str}{text}")
 
     return "\n\n---\n\n".join(parts)
+
+
+_INLINE_CITATION_RE = re.compile(r"\s*\[(?:\d{1,2}(?:\s*,\s*\d{1,2})*)\]")
+_OBJECT_LABEL_RE = re.compile(r"\s*\[Объект\s+\d+\]")
+_TRAILING_CITATION_SUFFIX_RE = re.compile(r"\s+(?:\d{1,2})(?:\.)?\s*$")
+
+
+def _sanitize_response_text(answer: str, *, sources_enabled: bool) -> str:
+    """Strip citation-like artifacts from user-visible text when sources are disabled."""
+    if sources_enabled or not answer:
+        return answer
+
+    sanitized_lines: list[str] = []
+    for raw_line in answer.splitlines():
+        line = _OBJECT_LABEL_RE.sub("", raw_line)
+        line = _INLINE_CITATION_RE.sub("", line)
+        if not re.match(r"^\s*\d+\.\s", line):
+            line = _TRAILING_CITATION_SUFFIX_RE.sub("", line)
+        sanitized_lines.append(line.rstrip())
+
+    sanitized = "\n".join(sanitized_lines).strip()
+    return sanitized or answer.strip()
 
 
 def _build_fallback_response(documents: list[dict[str, Any]]) -> str:
@@ -268,6 +309,7 @@ async def _generate_streaming(
     max_tokens: int = 0,
     lf_client: Any | None = None,
     temperature: float = 0.7,
+    sanitize_response: Callable[[str], str] | None = None,
 ) -> tuple[str, str, float, float | None, float | None, dict[str, int] | None, Any]:
     """Stream LLM response to Telegram via native sendMessageDraft (Bot API 9.5).
 
@@ -351,27 +393,42 @@ async def _generate_streaming(
     except Exception:
         if accumulated:
             # Draft showed partial text — try to finalize as real message
+            final_text = sanitize_response(accumulated) if sanitize_response else accumulated
             sent_msg = None
             with contextlib.suppress(Exception):
-                sent_msg = await message.answer(accumulated)
-            raise StreamingPartialDeliveryError(sent_msg, accumulated) from None
+                sent_msg = await message.answer(
+                    format_answer_html(final_text),
+                    parse_mode="HTML",
+                    reply_parameters=build_reply_parameters(
+                        message,
+                        getattr(message, "text", "") or "",
+                    ),
+                )
+            raise StreamingPartialDeliveryError(sent_msg, final_text) from None
         raise
 
     if not accumulated:
         raise ValueError("Streaming produced empty response")
 
+    final_text = sanitize_response(accumulated) if sanitize_response else accumulated
+    reply_parameters = build_reply_parameters(message, getattr(message, "text", "") or "")
+
     # Final message — persisted in chat history
     try:
-        sent_msg = await message.answer(accumulated, parse_mode="Markdown")
+        sent_msg = await message.answer(
+            format_answer_html(final_text),
+            parse_mode="HTML",
+            reply_parameters=reply_parameters,
+        )
     except Exception:
         try:
-            sent_msg = await message.answer(accumulated)
+            sent_msg = await message.answer(final_text, reply_parameters=reply_parameters)
         except Exception:
             logger.warning("Failed to send final streaming message")
             sent_msg = None
 
     return (
-        accumulated,
+        final_text,
         actual_model,
         ttft_ms,
         completion_tokens,
@@ -402,7 +459,7 @@ async def generate_response(
     lf_client: Any | None = None,
     get_lf_client: Callable[[], Any] | None = None,
     max_context_docs: int = _MAX_CONTEXT_DOCS,
-    format_context: Callable[[list[dict[str, Any]], int], str] = _format_context,
+    format_context: Callable[..., str] = _format_context,
     select_recent_history: Callable[[list[Any], int], list[Any]] = _select_recent_history,
     build_system_prompt: Callable[[str], str] = _build_system_prompt,
     ensure_history_instruction: Callable[[str], str] = _ensure_history_instruction,
@@ -430,7 +487,6 @@ async def generate_response(
     docs = documents or []
     raw_history = raw_messages or []
     messages = select_recent_history(raw_history, _MAX_HISTORY_MESSAGES)
-    context = format_context(docs, max_context_docs)
 
     # Derive query from last message if caller didn't pass explicit query.
     effective_query = query
@@ -445,6 +501,11 @@ async def generate_response(
     detector = style_detector or _detector
     style_info = detector.detect(effective_query)
     sources_enabled = bool(getattr(config, "show_sources", False) or grounding_mode == "strict")
+    format_params = inspect.signature(format_context).parameters
+    if "sources_enabled" in format_params:
+        context = format_context(docs, max_context_docs, sources_enabled=sources_enabled)
+    else:
+        context = format_context(docs, max_context_docs)
 
     # Curated span metadata
     lf_client.update_current_span(
@@ -579,6 +640,11 @@ async def generate_response(
                     stream_kwargs["lf_client"] = lf_client
                 if "temperature" in params:
                     stream_kwargs["temperature"] = effective_temperature
+                if "sanitize_response" in params:
+                    stream_kwargs["sanitize_response"] = lambda text: _sanitize_response_text(
+                        text,
+                        sources_enabled=sources_enabled,
+                    )
                 stream_result = await generate_streaming(
                     llm,
                     config,
@@ -639,6 +705,7 @@ async def generate_response(
                     )
                     t_llm_end = time.monotonic()
                     answer = response_obj.choices[0].message.content or ""
+                    answer = _sanitize_response_text(answer, sources_enabled=sources_enabled)
                     actual_model = (
                         getattr(response_obj, "model", config.llm_model) or config.llm_model
                     )
@@ -653,7 +720,7 @@ async def generate_response(
                     delivered = False
                     if sent_msg is not None:
                         try:
-                            await sent_msg.edit_text(answer, parse_mode="Markdown")
+                            await sent_msg.edit_text(format_answer_html(answer), parse_mode="HTML")
                             delivered = True
                         except Exception:
                             try:
@@ -667,7 +734,14 @@ async def generate_response(
                                 )
                     if not delivered:
                         try:
-                            sent_msg = await message.answer(answer, parse_mode="Markdown")
+                            sent_msg = await message.answer(
+                                format_answer_html(answer),
+                                parse_mode="HTML",
+                                reply_parameters=build_reply_parameters(
+                                    message,
+                                    getattr(message, "text", "") or effective_query,
+                                ),
+                            )
                             delivered = True
                         except Exception:
                             try:
@@ -698,6 +772,7 @@ async def generate_response(
                     )
                     t_llm_end = time.monotonic()
                     answer = response_obj.choices[0].message.content or ""
+                    answer = _sanitize_response_text(answer, sources_enabled=sources_enabled)
                     actual_model = (
                         getattr(response_obj, "model", config.llm_model) or config.llm_model
                     )
@@ -723,6 +798,7 @@ async def generate_response(
             )
             t_llm_end = time.monotonic()
             answer = response_obj.choices[0].message.content or ""
+            answer = _sanitize_response_text(answer, sources_enabled=sources_enabled)
             actual_model = getattr(response_obj, "model", config.llm_model) or config.llm_model
             # For non-streaming: TTFT = entire call duration (one-shot completion)
             ttft_ms = (t_llm_end - t_llm_start) * 1000

--- a/telegram_bot/services/telegram_formatting.py
+++ b/telegram_bot/services/telegram_formatting.py
@@ -1,0 +1,179 @@
+"""Telegram HTML formatting and delivery helpers for answer text."""
+
+from __future__ import annotations
+
+import html
+import logging
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+
+_TELEGRAM_MESSAGE_LIMIT = 4096
+_LONG_ANSWER_THRESHOLD = 900
+_QUOTE_THRESHOLD = 120
+_QUOTE_MAX_LEN = 220
+
+
+def _escape_html(text: str) -> str:
+    return html.escape(text, quote=False)
+
+
+def format_answer_html(text: str) -> str:
+    """Render plain answer text into Telegram-safe HTML."""
+    cleaned = (text or "").strip()
+    if not cleaned:
+        return ""
+
+    paragraphs = [part.strip() for part in cleaned.split("\n\n") if part.strip()]
+    if len(cleaned) >= _LONG_ANSWER_THRESHOLD and len(paragraphs) >= 3:
+        lead = "\n\n".join(_escape_html(part) for part in paragraphs[:2])
+        details = "\n\n".join(_escape_html(part) for part in paragraphs[2:])
+        return f"{lead}\n\n<blockquote expandable>{details}</blockquote>"
+
+    return _escape_html(cleaned)
+
+
+def format_sources_html(documents: list[dict[str, Any]], max_sources: int = 5) -> str:
+    """Format source documents as Telegram HTML attribution."""
+    if not documents:
+        return ""
+
+    lines: list[str] = []
+    for i, doc in enumerate(documents[:max_sources], 1):
+        meta = doc.get("metadata", {})
+        title = _escape_html(str(meta.get("title", "Документ")))
+        city = str(meta.get("city", "") or "").strip()
+        score = float(doc.get("score", 0) or 0)
+        line = f"[{i}] {title}"
+        if city:
+            line += f" — {_escape_html(city)}"
+        line += f" (рел: {score:.2f})"
+        lines.append(line)
+
+    body = "\n".join(lines)
+    tag = "blockquote expandable" if len(body) > 180 or len(lines) > 2 else "blockquote"
+    return f"\n\n📎 <b>Источники:</b>\n<{tag}>{body}</{tag.split()[0]}>"
+
+
+def build_reply_parameters(message: Any, user_text: str) -> Any | None:
+    """Build Telegram reply quote params for long/complex user questions."""
+    if not isinstance(user_text, str):
+        return None
+    text = user_text.strip()
+    message_id = getattr(message, "message_id", None)
+    if not isinstance(message_id, int):
+        return None
+    if len(text) < _QUOTE_THRESHOLD and "\n" not in text and text.count("?") <= 1:
+        return None
+
+    try:
+        from aiogram.types import ReplyParameters
+    except Exception:
+        return None
+
+    normalized = " ".join(text.split())
+    if len(normalized) > _QUOTE_MAX_LEN:
+        normalized = normalized[: _QUOTE_MAX_LEN - 3].rstrip() + "..."
+
+    return ReplyParameters(
+        message_id=message_id,
+        quote=_escape_html(normalized),
+        quote_parse_mode="HTML",
+    )
+
+
+def _split_plain_text(text: str, limit: int = _TELEGRAM_MESSAGE_LIMIT) -> list[str]:
+    """Split long plain text into Telegram-safe chunks before HTML formatting."""
+    cleaned = (text or "").strip()
+    if not cleaned:
+        return []
+    if len(cleaned) <= limit:
+        return [cleaned]
+
+    paragraphs = cleaned.split("\n\n")
+    chunks: list[str] = []
+    current = ""
+
+    for paragraph in paragraphs:
+        candidate = paragraph if not current else f"{current}\n\n{paragraph}"
+        if len(candidate) <= limit:
+            current = candidate
+            continue
+
+        if current:
+            chunks.append(current)
+            current = ""
+
+        if len(paragraph) <= limit:
+            current = paragraph
+            continue
+
+        for i in range(0, len(paragraph), limit):
+            chunks.append(paragraph[i : i + limit])
+
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def build_html_messages(
+    answer_text: str,
+    *,
+    sources_html: str = "",
+    limit: int = _TELEGRAM_MESSAGE_LIMIT,
+) -> list[str]:
+    """Build one or more HTML messages from raw answer text plus optional sources block."""
+    chunks = _split_plain_text(answer_text, limit=limit)
+    if not chunks:
+        return [sources_html.lstrip()] if sources_html else []
+
+    rendered = [format_answer_html(chunk) for chunk in chunks]
+    if not sources_html:
+        return rendered
+
+    if len(rendered[-1]) + len(sources_html) <= limit:
+        rendered[-1] = rendered[-1] + sources_html
+    else:
+        rendered.append(sources_html.lstrip())
+    return rendered
+
+
+async def send_html_messages(
+    message: Any,
+    answer_text: str,
+    *,
+    sources_html: str = "",
+    reply_markup: Any | None = None,
+    reply_to_user_text: str | None = None,
+) -> bool:
+    """Send formatted HTML response in one or more messages."""
+    html_messages = build_html_messages(answer_text, sources_html=sources_html)
+    if not html_messages:
+        return False
+
+    reply_parameters = (
+        build_reply_parameters(message, reply_to_user_text or "") if reply_to_user_text else None
+    )
+
+    for index, html_text in enumerate(html_messages):
+        is_first = index == 0
+        is_last = index == len(html_messages) - 1
+        kwargs: dict[str, Any] = {"parse_mode": "HTML"}
+        if is_last:
+            kwargs["reply_markup"] = reply_markup
+        if is_first and reply_parameters is not None:
+            kwargs["reply_parameters"] = reply_parameters
+
+        try:
+            await message.answer(html_text, **kwargs)
+        except Exception:
+            logger.warning("HTML parse failed, falling back to plain text")
+            plain_kwargs = dict(kwargs)
+            plain_kwargs.pop("parse_mode", None)
+            try:
+                await message.answer(html.unescape(html_text), **plain_kwargs)
+            except Exception:
+                logger.exception("Failed to send formatted response chunk")
+                await message.answer(html.unescape(html_text))
+    return True

--- a/telegram_bot/services/telegram_formatting.py
+++ b/telegram_bot/services/telegram_formatting.py
@@ -60,6 +60,7 @@ def build_reply_parameters(message: Any, user_text: str) -> Any | None:
     """Build Telegram reply quote params for long/complex user questions."""
     if not isinstance(user_text, str):
         return None
+    original_text = user_text
     text = user_text.strip()
     message_id = getattr(message, "message_id", None)
     if not isinstance(message_id, int):
@@ -72,13 +73,15 @@ def build_reply_parameters(message: Any, user_text: str) -> Any | None:
     except Exception:
         return None
 
-    normalized = " ".join(text.split())
-    if len(normalized) > _QUOTE_MAX_LEN:
-        normalized = normalized[: _QUOTE_MAX_LEN - 3].rstrip() + "..."
+    # Telegram requires `quote` to be an exact substring of the original message.
+    # Keep the original whitespace and truncate by prefix only, without adding ellipsis.
+    quote_text = original_text
+    if len(quote_text) > _QUOTE_MAX_LEN:
+        quote_text = quote_text[:_QUOTE_MAX_LEN]
 
     return ReplyParameters(
         message_id=message_id,
-        quote=_escape_html(normalized),
+        quote=_escape_html(quote_text),
         quote_parse_mode="HTML",
     )
 

--- a/tests/unit/graph/test_generate_node.py
+++ b/tests/unit/graph/test_generate_node.py
@@ -688,7 +688,7 @@ class TestGenerateNodeStreaming:
         assert message.answer.await_args_list[0].args[0] == "Квартира в Несебре "
         sent_msg.edit_text.assert_awaited_once_with(
             "Fallback complete answer.",
-            parse_mode="Markdown",
+            parse_mode="HTML",
         )
 
     async def test_stream_error_partial_and_final_delivery_fails_falls_back_to_respond_node(

--- a/tests/unit/graph/test_respond_node.py
+++ b/tests/unit/graph/test_respond_node.py
@@ -23,7 +23,7 @@ _SAMPLE_DOCS = [
 
 
 class TestRespondNode:
-    async def test_sends_markdown(self):
+    async def test_sends_html(self):
         message = AsyncMock()
         state = make_initial_state(user_id=1, session_id="s", query="test")
         state["response"] = "**Bold** answer"
@@ -32,13 +32,13 @@ class TestRespondNode:
         result = await respond_node(state)
 
         message.answer.assert_awaited_once_with(
-            "**Bold** answer", parse_mode="Markdown", reply_markup=None
+            "**Bold** answer", parse_mode="HTML", reply_markup=None
         )
         assert "respond" in result["latency_stages"]
 
     async def test_fallback_to_plain_text(self):
         message = AsyncMock()
-        # First call (Markdown) raises, second call (plain) succeeds
+        # First call (HTML) raises, second call (plain) succeeds
         message.answer.side_effect = [Exception("parse error"), None]
         state = make_initial_state(user_id=1, session_id="s", query="test")
         state["response"] = "bad *markdown"
@@ -200,9 +200,9 @@ class TestFormatSources:
 
     def test_formats_sources_with_city(self):
         result = format_sources(_SAMPLE_DOCS)
-        assert "*Источники:*" in result
-        assert "`[1]` Апартамент Несебр — Несебр" in result
-        assert "`[2]` Студия с видом — Равда" in result
+        assert "<b>Источники:</b>" in result
+        assert "[1] Апартамент Несебр — Несебр" in result
+        assert "[2] Студия с видом — Равда" in result
         assert "0.92" in result
         assert "0.87" in result
 
@@ -214,8 +214,8 @@ class TestFormatSources:
             {"text": f"Doc {i}", "score": 0.5, "metadata": {"title": f"Doc {i}"}} for i in range(10)
         ]
         result = format_sources(docs, max_sources=3)
-        assert "`[3]`" in result
-        assert "`[4]`" not in result
+        assert "[3] Doc 2" in result
+        assert "[4]" not in result
 
     def test_missing_city(self):
         docs = [{"text": "t", "score": 0.5, "metadata": {"title": "NoCity"}}]
@@ -241,7 +241,7 @@ class TestRespondNodeSourceAttribution:
 
         sent_text = message.answer.call_args[0][0]
         assert "Answer text" in sent_text
-        assert "*Источники:*" in sent_text
+        assert "<b>Источники:</b>" in sent_text
         assert "Апартамент Несебр" in sent_text
         assert result["sources_count"] == 2
 
@@ -263,7 +263,7 @@ class TestRespondNodeSourceAttribution:
         message.bot.edit_message_text.assert_awaited_once()
         edit_kwargs = message.bot.edit_message_text.call_args.kwargs
         assert "Streamed answer" in edit_kwargs["text"]
-        assert "*Источники:*" in edit_kwargs["text"]
+        assert "<b>Источники:</b>" in edit_kwargs["text"]
         assert result["sources_count"] == 2
 
     async def test_no_sources_for_chitchat(self):

--- a/tests/unit/pipelines/test_client_pipeline.py
+++ b/tests/unit/pipelines/test_client_pipeline.py
@@ -622,7 +622,7 @@ class TestPipelineFullFlow:
             _patch_observability(lf),
             _patch_rag_pipeline(rag_result),
             _patch_generate_response(gen_result),
-            patch("telegram_bot.pipelines.client._send_markdown_chunks", send_chunks),
+            patch("telegram_bot.pipelines.client.send_html_messages", send_chunks),
             patch(
                 "telegram_bot.pipelines.client.format_sources",
                 return_value="\n\nИсточники:\n[1] ВНЖ",
@@ -648,7 +648,8 @@ class TestPipelineFullFlow:
         assert result.answer == "Подтвержденный ответ."
         send_text = send_chunks.await_args.args[1]
         assert "Подтвержденный ответ." in send_text
-        assert "Источники:" in send_text
+        assert "Источники:" not in send_text
+        assert send_chunks.await_args.kwargs["sources_html"] == "\n\nИсточники:\n[1] ВНЖ"
 
     async def test_pipeline_passes_message_to_generate_response(self):
         """generate_response must receive message= so streaming can be enabled (#571)."""

--- a/tests/unit/services/test_generate_response.py
+++ b/tests/unit/services/test_generate_response.py
@@ -771,7 +771,7 @@ async def test_partial_stream_recovery_edits_existing_message_instead_of_sending
     assert message.answer.await_count == 1
     sent_msg.edit_text.assert_awaited_once_with(
         "Полный ответ после recovery",
-        parse_mode="Markdown",
+        parse_mode="HTML",
     )
 
 

--- a/tests/unit/services/test_telegram_formatting.py
+++ b/tests/unit/services/test_telegram_formatting.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import html
+from types import SimpleNamespace
+
+from telegram_bot.services.telegram_formatting import (
+    _QUOTE_MAX_LEN,
+    build_reply_parameters,
+)
+
+
+def test_build_reply_parameters_preserves_exact_substring_for_multiline_text() -> None:
+    message = SimpleNamespace(message_id=42)
+    user_text = "Первая строка\nВторая <строка>  с  пробелами?\nТретья строка"
+
+    reply_parameters = build_reply_parameters(message, user_text)
+
+    assert reply_parameters is not None
+    assert reply_parameters.message_id == 42
+    assert reply_parameters.quote_parse_mode == "HTML"
+    assert reply_parameters.quote == html.escape(user_text, quote=False)
+
+
+def test_build_reply_parameters_truncates_without_ellipsis() -> None:
+    message = SimpleNamespace(message_id=42)
+    user_text = "Очень длинный вопрос? " + ("данные " * 80)
+
+    reply_parameters = build_reply_parameters(message, user_text)
+
+    assert reply_parameters is not None
+    assert not reply_parameters.quote.endswith("...")
+
+    unescaped_quote = html.unescape(reply_parameters.quote)
+    assert len(unescaped_quote) == _QUOTE_MAX_LEN
+    assert user_text.startswith(unescaped_quote)

--- a/tests/unit/test_bot_scores.py
+++ b/tests/unit/test_bot_scores.py
@@ -909,7 +909,7 @@ class TestTextPathFeedbackButtons:
         answer_calls = message.answer.call_args_list
         assert len(answer_calls) > 0
         last_call = answer_calls[-1]
-        assert last_call.kwargs.get("parse_mode") == "Markdown"
+        assert last_call.kwargs.get("parse_mode") == "HTML"
 
     async def test_chitchat_response_no_feedback_keyboard(self, mock_config):
         """CHITCHAT response should NOT include feedback keyboard."""


### PR DESCRIPTION
## Summary
- remove numbered retrieval labels and citation instruction from model-visible context when sources are disabled
- add final response sanitizer for leaked citation fragments and move text delivery to a shared Telegram HTML formatter
- use HTML source blocks, expandable blockquotes for long answers, and quoted replies for longer user questions

## Testing
- make check
- PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit
