### PR TITLE
feat: add handoff feature flag config contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -222,6 +222,7 @@ MANAGER_HOT_LEAD_DEDUPE_SEC=3600
 REALESTATE_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/realestate
 
 # ── Handoff (Forum Topics) ──────────────────────────────────────
+# HANDOFF_ENABLED=false
 # MANAGERS_GROUP_ID=-1001234567890   # Supergroup with Topics enabled
 # HANDOFF_TTL_HOURS=24
 # HANDOFF_SUMMARY_MIN_MESSAGES=3

--- a/telegram_bot/config.py
+++ b/telegram_bot/config.py
@@ -1,8 +1,16 @@
 """Bot configuration."""
 
+import os
 from typing import Annotated
 
-from pydantic import AliasChoices, BeforeValidator, Field, SecretStr, field_validator
+from pydantic import (
+    AliasChoices,
+    BeforeValidator,
+    Field,
+    SecretStr,
+    field_validator,
+    model_validator,
+)
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 from src.config.qdrant_policy import resolve_collection_name
@@ -566,6 +574,10 @@ class BotConfig(BaseSettings):
     )
 
     # ── Handoff (Forum Topics) ──────────────────────────────────────
+    handoff_enabled: EmptyStrBool = Field(
+        default=False,
+        validation_alias=AliasChoices("handoff_enabled", "HANDOFF_ENABLED"),
+    )
     managers_group_id: int | None = Field(
         default=None,
         validation_alias=AliasChoices("managers_group_id", "MANAGERS_GROUP_ID"),
@@ -605,6 +617,22 @@ class BotConfig(BaseSettings):
         if isinstance(v, list):
             return [int(x) for x in v]
         return []
+
+    @model_validator(mode="after")
+    def validate_handoff_contract(self) -> "BotConfig":
+        handoff_flag = os.getenv("HANDOFF_ENABLED")
+
+        if handoff_flag is None and self.managers_group_id is not None:
+            self.handoff_enabled = True
+            return self
+
+        if not self.handoff_enabled:
+            self.managers_group_id = None
+            return self
+
+        if self.managers_group_id is None:
+            raise ValueError("HANDOFF_ENABLED=true but MANAGERS_GROUP_ID is missing")
+        return self
 
     def get_collection_name(self) -> str:
         """Get collection name based on quantization mode.

--- a/tests/unit/config/test_bot_config_settings.py
+++ b/tests/unit/config/test_bot_config_settings.py
@@ -140,3 +140,12 @@ class TestBotConfigIsPydanticSettings:
 
         cfg = BotConfig(_env_file=None)
         assert cfg.client_direct_pipeline_enabled is False
+
+    def test_handoff_enabled_empty_env_treated_as_false(self, monkeypatch):
+        """Empty handoff flag should be treated as disabled."""
+        monkeypatch.setenv("HANDOFF_ENABLED", "")
+
+        from telegram_bot.config import BotConfig
+
+        cfg = BotConfig(_env_file=None)
+        assert cfg.handoff_enabled is False

--- a/tests/unit/test_config_handoff.py
+++ b/tests/unit/test_config_handoff.py
@@ -1,4 +1,70 @@
+import pytest
+from pydantic import ValidationError
+
 from telegram_bot.config import BotConfig
+
+
+def test_handoff_enabled_defaults_to_false(monkeypatch):
+    monkeypatch.delenv("HANDOFF_ENABLED", raising=False)
+    monkeypatch.delenv("MANAGERS_GROUP_ID", raising=False)
+    cfg = BotConfig(telegram_bot_token="test:token", _env_file=None)
+    assert cfg.handoff_enabled is False
+
+
+def test_handoff_enabled_reads_env(monkeypatch):
+    monkeypatch.setenv("HANDOFF_ENABLED", "true")
+    monkeypatch.setenv("MANAGERS_GROUP_ID", "-1001234567890")
+    cfg = BotConfig(telegram_bot_token="test:token", _env_file=None)
+    assert cfg.handoff_enabled is True
+
+
+def test_handoff_enabled_requires_managers_group_id(monkeypatch):
+    monkeypatch.setenv("HANDOFF_ENABLED", "true")
+    monkeypatch.delenv("MANAGERS_GROUP_ID", raising=False)
+
+    with pytest.raises(
+        ValidationError, match="HANDOFF_ENABLED=true but MANAGERS_GROUP_ID is missing"
+    ):
+        BotConfig(telegram_bot_token="test:token", _env_file=None)
+
+
+def test_handoff_enabled_allows_valid_managers_group_id(monkeypatch):
+    monkeypatch.setenv("HANDOFF_ENABLED", "true")
+    monkeypatch.setenv("MANAGERS_GROUP_ID", "-1001234567890")
+
+    cfg = BotConfig(telegram_bot_token="test:token", _env_file=None)
+
+    assert cfg.handoff_enabled is True
+    assert cfg.managers_group_id == -1001234567890
+
+
+def test_handoff_disabled_does_not_require_managers_group_id(monkeypatch):
+    monkeypatch.setenv("HANDOFF_ENABLED", "false")
+    monkeypatch.delenv("MANAGERS_GROUP_ID", raising=False)
+
+    cfg = BotConfig(telegram_bot_token="test:token", _env_file=None)
+
+    assert cfg.handoff_enabled is False
+
+
+def test_handoff_disabled_ignores_managers_group_id(monkeypatch):
+    monkeypatch.setenv("HANDOFF_ENABLED", "false")
+    monkeypatch.setenv("MANAGERS_GROUP_ID", "-1001234567890")
+
+    cfg = BotConfig(telegram_bot_token="test:token", _env_file=None)
+
+    assert cfg.handoff_enabled is False
+    assert cfg.managers_group_id is None
+
+
+def test_handoff_legacy_managers_group_id_keeps_handoff_enabled(monkeypatch):
+    monkeypatch.delenv("HANDOFF_ENABLED", raising=False)
+    monkeypatch.setenv("MANAGERS_GROUP_ID", "-1001234567890")
+
+    cfg = BotConfig(telegram_bot_token="test:token", _env_file=None)
+
+    assert cfg.handoff_enabled is True
+    assert cfg.managers_group_id == -1001234567890
 
 
 def test_handoff_config_defaults(monkeypatch):
@@ -19,6 +85,7 @@ def test_handoff_config_defaults(monkeypatch):
 
 def test_handoff_config_from_env(monkeypatch):
     """Handoff config reads from environment variables."""
+    monkeypatch.setenv("HANDOFF_ENABLED", "true")
     monkeypatch.setenv("MANAGERS_GROUP_ID", "-1001234567890")
     monkeypatch.setenv("HANDOFF_TTL_HOURS", "12")
     monkeypatch.setenv("HANDOFF_SUMMARY_MIN_MESSAGES", "5")
@@ -26,6 +93,7 @@ def test_handoff_config_from_env(monkeypatch):
         telegram_bot_token="test:token",
         _env_file=None,
     )
+    assert cfg.handoff_enabled is True
     assert cfg.managers_group_id == -1001234567890
     assert cfg.handoff_ttl_hours == 12
     assert cfg.handoff_summary_min_messages == 5


### PR DESCRIPTION
## Summary
- add `handoff_enabled` to `BotConfig` with empty-string-safe parsing and startup contract validation
- preserve legacy `MANAGERS_GROUP_ID`-only environments while making explicit `HANDOFF_ENABLED=false` disable handoff by clearing the runtime gate
- document the feature flag in `.env.example` and extend the existing config test suites for default, enabled, disabled, empty-env, and legacy compatibility paths

## Verification
- `uv run pytest tests/unit/test_config_handoff.py::test_handoff_enabled_defaults_to_false -vv`
- `uv run pytest tests/unit/test_config_handoff.py::test_handoff_enabled_requires_managers_group_id -vv`
- `uv run pytest tests/unit/config/test_bot_config_settings.py::TestBotConfigIsPydanticSettings::test_handoff_enabled_empty_env_treated_as_false -vv`
- `uv run pytest tests/unit/test_config_handoff.py::test_handoff_disabled_ignores_managers_group_id -vv`
- `uv run pytest tests/unit/test_config_handoff.py::test_handoff_legacy_managers_group_id_keeps_handoff_enabled -vv`
- `uv run pytest tests/unit/test_config_handoff.py tests/unit/config/test_bot_config_settings.py -vv`

## Notes
- `telegram_bot/main.py` was inspected only; `BotConfig()` is still constructed before `PropertyBot(config)` and other startup side effects.
- `codex review --base dev` surfaced and drove two fixes: honoring explicit disable via `managers_group_id=None`, and preserving legacy deployments when `HANDOFF_ENABLED` is unset. A final rerun of the review tool was interrupted by a usage-limit error after the code fixes were already applied.
