### PR TITLE
fix: enforce handoff release gate contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,10 @@ jobs:
             echo "=== Normalize bind-mounted config permissions ==="
             chmod 644 ./docker/litellm/config.yaml
 
+            echo "=== Validate production env ==="
+            chmod +x ./scripts/validate_prod_env.sh
+            ./scripts/validate_prod_env.sh
+
             echo "=== Rebuild changed images ==="
             docker compose build
 

--- a/scripts/test_release_health_vps.sh
+++ b/scripts/test_release_health_vps.sh
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+if [ -f "${REPO_ROOT}/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "${REPO_ROOT}/.env"
+  set +a
+fi
+
 REQUIRE_MINI_APP_ENDPOINT="${REQUIRE_MINI_APP_ENDPOINT:-auto}" # auto|true|false
 MINI_APP_FRONTEND_URL="${MINI_APP_FRONTEND_URL:-http://127.0.0.1:8091/health}"
 COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-vps}"
+HANDOFF_ENABLED="${HANDOFF_ENABLED:-false}"
 export COMPOSE_FILE="${COMPOSE_FILE:-compose.yml:compose.vps.yml}"
 
 log() {
@@ -124,6 +135,23 @@ PY
   log "Mini app endpoint OK: $MINI_APP_FRONTEND_URL"
 else
   warn "mini app endpoint check skipped (REQUIRE_MINI_APP_ENDPOINT=${REQUIRE_MINI_APP_ENDPOINT})"
+fi
+
+if [ "$HANDOFF_ENABLED" = "true" ]; then
+  log "Handoff release smoke"
+  docker compose exec -T bot python - <<'PY'
+import os
+import sys
+
+handoff_enabled = os.getenv("HANDOFF_ENABLED", "false")
+managers_group_id = os.getenv("MANAGERS_GROUP_ID", "")
+
+assert handoff_enabled == "true", "HANDOFF_ENABLED is not true in bot container"
+assert managers_group_id, "MANAGERS_GROUP_ID missing in bot container"
+print("  ok: handoff env contract present in bot container")
+PY
+else
+  warn "handoff smoke skipped (HANDOFF_ENABLED=${HANDOFF_ENABLED})"
 fi
 
 log "Release smoke passed"

--- a/scripts/validate_prod_env.sh
+++ b/scripts/validate_prod_env.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+if [ ! -f .env ]; then
+  echo ".env is required for production env validation" >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1091
+. ./.env
+set +a
+
+handoff_enabled="${HANDOFF_ENABLED:-false}"
+managers_group_id="${MANAGERS_GROUP_ID:-}"
+
+if [ "${handoff_enabled}" = "true" ] && [ -z "${managers_group_id}" ]; then
+  echo "HANDOFF_ENABLED=true but MANAGERS_GROUP_ID is missing in production env" >&2
+  exit 1
+fi
+
+docker compose --env-file .env -f compose.yml -f compose.vps.yml config >/dev/null

--- a/tests/unit/test_release_gate_contract.py
+++ b/tests/unit/test_release_gate_contract.py
@@ -25,7 +25,35 @@ def test_ci_deploy_uses_strict_mini_app_release_smoke() -> None:
     assert "REQUIRE_MINI_APP_ENDPOINT=true ./scripts/test_release_health_vps.sh" in workflow
 
 
+def test_ci_deploy_runs_prod_env_preflight_before_build() -> None:
+    """CI deploy must validate the production env contract before docker compose build."""
+    workflow = CI_WORKFLOW.read_text()
+    assert "./scripts/validate_prod_env.sh" in workflow
+    assert workflow.index("./scripts/validate_prod_env.sh") < workflow.index("docker compose build")
+
+
 def test_manual_deploy_uses_strict_mini_app_release_smoke() -> None:
     """Manual VPS deploy must use the same strict release contract as CI."""
     script = DEPLOY_SCRIPT.read_text()
     assert "REQUIRE_MINI_APP_ENDPOINT=true ./scripts/test_release_health_vps.sh" in script
+
+
+def test_release_gate_script_contains_handoff_contract() -> None:
+    """The production env preflight script must enforce the handoff contract."""
+    script = (ROOT / "scripts" / "validate_prod_env.sh").read_text()
+    assert "HANDOFF_ENABLED" in script
+    assert "MANAGERS_GROUP_ID" in script
+    assert "docker compose --env-file .env -f compose.yml -f compose.vps.yml config" in script
+
+
+def test_release_smoke_checks_handoff_contract_when_enabled() -> None:
+    """Release smoke must validate handoff env presence when the feature is enabled."""
+    script = RELEASE_SMOKE_SCRIPT.read_text()
+    assert 'HANDOFF_ENABLED="${HANDOFF_ENABLED:-false}"' in script
+    assert "MANAGERS_GROUP_ID" in script
+
+
+def test_release_smoke_logs_when_handoff_smoke_is_skipped() -> None:
+    """Release smoke must log when the handoff-specific branch is skipped."""
+    script = RELEASE_SMOKE_SCRIPT.read_text()
+    assert "handoff smoke skipped" in script


### PR DESCRIPTION
## Summary
- add a production env preflight script for the handoff contract
- run that preflight in CI before `docker compose build`
- extend VPS release smoke with handoff-aware env validation and regressions in the existing release-gate test file

## Verification
- `uv run pytest tests/unit/test_release_gate_contract.py::test_ci_deploy_runs_prod_env_preflight_before_build -vv`
- `uv run pytest tests/unit/test_release_gate_contract.py::test_release_gate_script_contains_handoff_contract -vv`
- `uv run pytest tests/unit/test_release_gate_contract.py::test_release_smoke_checks_handoff_contract_when_enabled -vv`
- `uv run pytest tests/unit/test_release_gate_contract.py::test_release_smoke_logs_when_handoff_smoke_is_skipped -vv`
- `uv run pytest tests/unit/test_release_gate_contract.py -vv`
- `uv run pytest tests/unit/test_config_handoff.py tests/unit/config/test_bot_config_settings.py tests/unit/test_compose_config.py tests/unit/test_release_gate_contract.py -vv`
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit` (fails on existing unrelated timeout in `tests/unit/ingestion/test_qdrant_writer_behavior.py::TestUpsertChunksSyncEdgeCases::test_oversized_payload_skipped_with_error` via `src/retrieval/topic_classifier.py`)

## Notes
- `scripts/deploy-vps.sh` was reviewed only to confirm it still invokes `scripts/test_release_health_vps.sh` after startup; no changes were made.
- `codex review --base dev` could not complete because the local Codex review command hit its usage limit.
