### PR TITLE
Release dev to main after prod locale and smoke fixes

### DIFF
--- a/scripts/test_release_health_vps.sh
+++ b/scripts/test_release_health_vps.sh
@@ -126,22 +126,23 @@ else
   warn "mini app endpoint check skipped (REQUIRE_MINI_APP_ENDPOINT=${REQUIRE_MINI_APP_ENDPOINT})"
 fi
 
-HANDOFF_ENABLED="${HANDOFF_ENABLED:-false}"
-
-if [ "$HANDOFF_ENABLED" = "true" ]; then
-  log "Handoff release smoke"
+handoff_runtime_env="$(
   docker compose exec -T bot python - <<'PY'
 import os
 
-handoff_enabled = os.getenv("HANDOFF_ENABLED", "false")
-managers_group_id = os.getenv("MANAGERS_GROUP_ID", "")
-
-assert handoff_enabled == "true", "HANDOFF_ENABLED is not true in bot container"
-assert managers_group_id, "MANAGERS_GROUP_ID missing in bot container"
-print("  ok: handoff env contract present in bot container")
+print(f"HANDOFF_ENABLED={os.getenv('HANDOFF_ENABLED', 'false')}")
+print(f"MANAGERS_GROUP_ID={os.getenv('MANAGERS_GROUP_ID', '')}")
 PY
+)"
+handoff_enabled_runtime="$(printf '%s\n' "$handoff_runtime_env" | awk -F= '/^HANDOFF_ENABLED=/{print $2}')"
+managers_group_id_runtime="$(printf '%s\n' "$handoff_runtime_env" | awk -F= '/^MANAGERS_GROUP_ID=/{print $2}')"
+
+if [ "$handoff_enabled_runtime" = "true" ]; then
+  log "Handoff release smoke"
+  [ -n "$managers_group_id_runtime" ] || fail "MANAGERS_GROUP_ID missing in bot container"
+  printf '  ok: handoff env contract present in bot container\n'
 else
-  warn "handoff smoke skipped (HANDOFF_ENABLED=${HANDOFF_ENABLED})"
+  warn "handoff smoke skipped (HANDOFF_ENABLED=${handoff_enabled_runtime})"
 fi
 
 log "Release smoke passed"

--- a/telegram_bot/dialogs/handoff.py
+++ b/telegram_bot/dialogs/handoff.py
@@ -104,7 +104,7 @@ async def _on_contact_chat(
     user_id = callback.from_user.id
     display_name = callback.from_user.full_name or "User"
     username = callback.from_user.username
-    locale = "ru"
+    locale = manager.middleware_data.get("locale", "ru")
 
     # Tell aiogram-dialog NOT to touch the message after done().
     manager.show_mode = ShowMode.NO_UPDATE

--- a/telegram_bot/locales/en/messages.ftl
+++ b/telegram_bot/locales/en/messages.ftl
@@ -158,6 +158,7 @@ kb-viewing = 📅 Book a Viewing
 kb-manager = 👤 Contact manager
 kb-ask = 💬 Ask a Question
 kb-bookmarks = 📌 My Bookmarks
+kb-demo = 🎯 Demo
 
 # Welcome (#660)
 welcome-text =

--- a/telegram_bot/locales/uk/messages.ftl
+++ b/telegram_bot/locales/uk/messages.ftl
@@ -158,6 +158,7 @@ kb-viewing = 📅 Запис на огляд
 kb-manager = 👤 Зв'язатися з менеджером
 kb-ask = 💬 Задати питання
 kb-bookmarks = 📌 Мої закладки
+kb-demo = 🎯 Демонстрація
 
 # Welcome (#660)
 welcome-text =

--- a/telegram_bot/middlewares/i18n.py
+++ b/telegram_bot/middlewares/i18n.py
@@ -86,17 +86,30 @@ class I18nMiddleware(BaseMiddleware):
     ) -> Any:
         user = data.get("event_from_user")
         locale = self._default_locale
+        locale_loaded_from_storage = False
 
         if user is not None:
-            # Try loading from DB/cache via UserService
+            # Resolve locale from the persisted user record when available.
+            # This keeps message and callback flows on the same language path.
             if self._user_service is not None:
                 try:
-                    locale = await self._user_service.get_locale(telegram_id=user.id)
+                    stored_user = await self._user_service.get_or_create(
+                        telegram_id=user.id,
+                        first_name=getattr(user, "first_name", None),
+                        language_code=getattr(user, "language_code", None),
+                    )
+                    if stored_user is not None and stored_user.locale:
+                        locale = stored_user.locale
+                        locale_loaded_from_storage = True
                 except Exception:
                     logger.debug("Failed to get locale for user %s", user.id, exc_info=True)
 
             # Fallback: detect from Telegram language_code
-            if locale == self._default_locale and user.language_code:
+            if (
+                not locale_loaded_from_storage
+                and locale == self._default_locale
+                and user.language_code
+            ):
                 from telegram_bot.services.user_service import detect_locale
 
                 locale = detect_locale(user.language_code)

--- a/tests/unit/handlers/test_handoff_qualification.py
+++ b/tests/unit/handlers/test_handoff_qualification.py
@@ -1,7 +1,13 @@
 """Tests for handoff qualification dialog (aiogram-dialog migration)."""
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
 from telegram_bot.dialogs.handoff import (
     _GOAL_OPTIONS,
+    _on_contact_chat,
     handoff_dialog,
 )
 from telegram_bot.dialogs.states import HandoffSG
@@ -104,3 +110,30 @@ def test_start_qualification_accepts_dialog_manager():
 
     sig = inspect.signature(start_qualification)
     assert "dialog_manager" in sig.parameters
+
+
+@pytest.mark.asyncio
+async def test_on_contact_chat_uses_middleware_locale_for_handoff_completion():
+    property_bot = MagicMock()
+    property_bot._complete_handoff = AsyncMock()
+
+    callback = MagicMock()
+    callback.from_user = SimpleNamespace(id=7, full_name="Test User", username="tester")
+    callback.message = AsyncMock()
+    callback.message.edit_text = AsyncMock()
+
+    manager = MagicMock()
+    manager.start_data = {}
+    manager.dialog_data = {"goal": "consult"}
+    manager.middleware_data = {
+        "property_bot": property_bot,
+        "state": AsyncMock(),
+        "locale": "en",
+    }
+    manager.done = AsyncMock()
+    manager.show_mode = None
+
+    await _on_contact_chat(callback, MagicMock(), manager)
+
+    kwargs = property_bot._complete_handoff.await_args.kwargs
+    assert kwargs["locale"] == "en"

--- a/tests/unit/keyboards/test_client_keyboard.py
+++ b/tests/unit/keyboards/test_client_keyboard.py
@@ -11,6 +11,7 @@ from telegram_bot.keyboards.client_keyboard import (
     get_menu_button_texts,
     parse_menu_button,
 )
+from telegram_bot.middlewares.i18n import create_translator_hub
 
 
 # --- Fallback (no i18n) tests ---
@@ -143,6 +144,7 @@ def test_parse_with_i18n_hub():
         "kb-manager": "👤 Менеджер",
         "kb-ask": "💬 Задати питання",
         "kb-bookmarks": "📌 Мої закладки",
+        "kb-demo": "🎯 Демонстрація",
     }.get(key, key)
     mock_hub.get_translator_by_locale.return_value = mock_translator
 
@@ -247,6 +249,7 @@ def test_get_menu_button_texts_includes_localized_labels():
                 "kb-manager": "👤 Менеджер",
                 "kb-ask": "💬 Задать вопрос",
                 "kb-bookmarks": "📌 Мои закладки",
+                "kb-demo": "🎯 Демонстрация",
             },
             "uk": {
                 "kb-search": "🏠 Підібрати квартиру",
@@ -255,6 +258,7 @@ def test_get_menu_button_texts_includes_localized_labels():
                 "kb-manager": "👤 Менеджер",
                 "kb-ask": "💬 Задати питання",
                 "kb-bookmarks": "📌 Мої закладки",
+                "kb-demo": "🎯 Демонстрація",
             },
             "en": {
                 "kb-search": "🏠 Find Apartment",
@@ -263,6 +267,7 @@ def test_get_menu_button_texts_includes_localized_labels():
                 "kb-manager": "👤 Manager",
                 "kb-ask": "💬 Ask a Question",
                 "kb-bookmarks": "📌 My Bookmarks",
+                "kb-demo": "🎯 Demo",
             },
         }[locale]
         translator.get.side_effect = lambda key, **_kw: mapping.get(key, key)
@@ -274,3 +279,14 @@ def test_get_menu_button_texts_includes_localized_labels():
     assert "🔑 Послуги" in texts
     assert "🏠 Find Apartment" in texts
     assert "🔑 Услуги" in texts
+    assert "🎯 Demo" in texts
+
+
+def test_client_keyboard_keys_exist_in_all_locales():
+    hub = create_translator_hub()
+
+    for locale in ("ru", "en", "uk"):
+        translator = hub.get_translator_by_locale(locale)
+        for key in _ACTION_IDS:
+            result = translator.get(key)
+            assert result != key, f"Missing key '{key}' in locale '{locale}'"

--- a/tests/unit/middlewares/test_i18n.py
+++ b/tests/unit/middlewares/test_i18n.py
@@ -55,7 +55,7 @@ def test_translator_uk(hub):
 
 def test_translator_menu_keys(hub):
     """All menu keys exist in all locales."""
-    keys = ["menu-search", "menu-settings", "menu-faq", "back", "close"]
+    keys = ["menu-search", "menu-settings", "menu-faq", "back", "close", "kb-demo"]
     for locale in ("ru", "en", "uk"):
         t = hub.get_translator_by_locale(locale)
         for key in keys:

--- a/tests/unit/test_i18n_middleware.py
+++ b/tests/unit/test_i18n_middleware.py
@@ -99,12 +99,13 @@ class TestI18nMiddlewareCall:
     async def test_uses_user_service_for_locale(self):
         hub = self._make_hub()
         user_service = MagicMock()
-        user_service.get_locale = AsyncMock(return_value="uk")
+        user_service.get_or_create = AsyncMock(return_value=MagicMock(locale="uk"))
         mw = I18nMiddleware(hub=hub, user_service=user_service)
 
         user = MagicMock(spec=User)
         user.id = 42
         user.language_code = "uk"
+        user.first_name = "Test"
 
         handler = AsyncMock(return_value=None)
         event = MagicMock(spec=Message)
@@ -113,17 +114,22 @@ class TestI18nMiddlewareCall:
         await mw(handler, event, data)
 
         assert data["locale"] == "uk"
-        user_service.get_locale.assert_called_once_with(telegram_id=42)
+        user_service.get_or_create.assert_called_once_with(
+            telegram_id=42,
+            first_name="Test",
+            language_code="uk",
+        )
 
     async def test_fallback_to_language_code(self):
         hub = self._make_hub()
         user_service = MagicMock()
-        user_service.get_locale = AsyncMock(return_value="ru")  # returns default
+        user_service.get_or_create = AsyncMock(return_value=None)
         mw = I18nMiddleware(hub=hub, user_service=user_service, default_locale="ru")
 
         user = MagicMock(spec=User)
         user.id = 99
         user.language_code = "en"
+        user.first_name = "Test"
 
         handler = AsyncMock(return_value=None)
         event = MagicMock(spec=Message)
@@ -141,12 +147,13 @@ class TestI18nMiddlewareCall:
     async def test_user_service_exception_fallback(self):
         hub = self._make_hub()
         user_service = MagicMock()
-        user_service.get_locale = AsyncMock(side_effect=RuntimeError("db down"))
+        user_service.get_or_create = AsyncMock(side_effect=RuntimeError("db down"))
         mw = I18nMiddleware(hub=hub, user_service=user_service, default_locale="ru")
 
         user = MagicMock(spec=User)
         user.id = 7
         user.language_code = None
+        user.first_name = "Test"
 
         handler = AsyncMock(return_value=None)
         event = MagicMock(spec=Message)
@@ -154,6 +161,25 @@ class TestI18nMiddlewareCall:
 
         # Should not raise; fall back to default locale
         await mw(handler, event, data)
+        assert data["locale"] == "ru"
+
+    async def test_existing_user_locale_beats_telegram_language_code(self):
+        hub = self._make_hub()
+        user_service = MagicMock()
+        user_service.get_or_create = AsyncMock(return_value=MagicMock(locale="ru"))
+        mw = I18nMiddleware(hub=hub, user_service=user_service, default_locale="ru")
+
+        user = MagicMock(spec=User)
+        user.id = 123
+        user.language_code = "en"
+        user.first_name = "Test"
+
+        handler = AsyncMock(return_value=None)
+        event = MagicMock(spec=Message)
+        data: dict = {"event_from_user": user}
+
+        await mw(handler, event, data)
+
         assert data["locale"] == "ru"
 
     async def test_no_user_uses_default_locale(self):

--- a/tests/unit/test_release_gate_contract.py
+++ b/tests/unit/test_release_gate_contract.py
@@ -49,7 +49,8 @@ def test_release_gate_script_contains_handoff_contract() -> None:
 def test_release_smoke_checks_handoff_contract_when_enabled() -> None:
     """Release smoke must validate handoff env presence when the feature is enabled."""
     script = RELEASE_SMOKE_SCRIPT.read_text()
-    assert 'HANDOFF_ENABLED="${HANDOFF_ENABLED:-false}"' in script
+    assert "HANDOFF_ENABLED={os.getenv('HANDOFF_ENABLED', 'false')}" in script
+    assert "handoff_enabled_runtime" in script
     assert "MANAGERS_GROUP_ID" in script
 
 
@@ -57,3 +58,10 @@ def test_release_smoke_logs_when_handoff_smoke_is_skipped() -> None:
     """Release smoke must log when the handoff-specific branch is skipped."""
     script = RELEASE_SMOKE_SCRIPT.read_text()
     assert "handoff smoke skipped" in script
+
+
+def test_release_smoke_reads_handoff_gate_from_bot_runtime_env() -> None:
+    """Release smoke must key off container runtime env, not the host shell env."""
+    script = RELEASE_SMOKE_SCRIPT.read_text()
+    assert "docker compose exec -T bot python - <<'PY'" in script
+    assert 'HANDOFF_ENABLED="${HANDOFF_ENABLED:-false}"' not in script


### PR DESCRIPTION
## Summary
- release current `dev` into `main` after PR #1018
- includes the handoff config contract and the follow-up fixes for prod locale + release smoke gating

## Verification
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
- targeted regressions for i18n/handoff/release smoke passed in the review session

## Follow-up
- after merge and canonical `main -> GitHub Actions -> VPS` deploy, run the live prod Telegram E2E `/start -> manager handoff -> state/topic`
- close #1011 only if that live path is green
