### PR TITLE
Release handoff locale fix to main

### DIFF
--- a/telegram_bot/dialogs/handoff.py
+++ b/telegram_bot/dialogs/handoff.py
@@ -26,15 +26,26 @@ _GOAL_OPTIONS: list[tuple[str, str]] = [
 ]
 
 
+def _resolve_i18n_context(
+    dialog_manager: DialogManager,
+    kwargs: dict[str, Any],
+) -> tuple[Any | None, str | None]:
+    """Prefer the current getter context over potentially stale manager middleware data."""
+    current_middleware = kwargs.get("middleware_data") or {}
+    manager_middleware = getattr(dialog_manager, "middleware_data", None) or {}
+    middleware = current_middleware or manager_middleware
+
+    i18n = kwargs.get("i18n") or middleware.get("i18n")
+    locale = kwargs.get("locale") or middleware.get("locale")
+    return i18n, locale
+
+
 # ── Getters ──────────────────────────────────────────────────────
 
 
 async def _goal_getter(dialog_manager: DialogManager, **kwargs: Any) -> dict[str, Any]:
     """Provide goal options with i18n support."""
-    middleware = getattr(dialog_manager, "middleware_data", None) or kwargs.get(
-        "middleware_data", {}
-    )
-    i18n = middleware.get("i18n")
+    i18n, _locale = _resolve_i18n_context(dialog_manager, kwargs)
     if i18n:
         items = [
             (i18n.get("handoff-goal-search"), "search"),
@@ -51,10 +62,7 @@ async def _goal_getter(dialog_manager: DialogManager, **kwargs: Any) -> dict[str
 
 async def _contact_getter(dialog_manager: DialogManager, **kwargs: Any) -> dict[str, Any]:
     """Provide contact prompt with i18n support."""
-    middleware = getattr(dialog_manager, "middleware_data", None) or kwargs.get(
-        "middleware_data", {}
-    )
-    i18n = middleware.get("i18n")
+    i18n, _locale = _resolve_i18n_context(dialog_manager, kwargs)
     if i18n:
         prompt = i18n.get("handoff-contact-prompt")
         btn_chat = i18n.get("handoff-contact-chat")
@@ -89,7 +97,7 @@ async def _on_goal_selected(
 
 async def _on_contact_chat(
     callback: CallbackQuery,
-    button: Button,
+    _button: Button,
     manager: DialogManager,
 ) -> None:
     """Complete qualification with chat — trigger handoff via PropertyBot."""
@@ -105,6 +113,12 @@ async def _on_contact_chat(
     display_name = callback.from_user.full_name or "User"
     username = callback.from_user.username
     locale = manager.middleware_data.get("locale", "ru")
+    i18n = manager.middleware_data.get("i18n")
+    if i18n is None and property_bot is not None:
+        hub = getattr(property_bot, "_i18n_hub", None)
+        if hub is not None:
+            with contextlib.suppress(Exception):
+                i18n = hub.get_translator_by_locale(locale)
 
     # Tell aiogram-dialog NOT to touch the message after done().
     manager.show_mode = ShowMode.NO_UPDATE
@@ -113,7 +127,12 @@ async def _on_contact_chat(
     # Replace dialog message with status text (removes inline buttons).
     if msg and hasattr(msg, "edit_text"):
         with contextlib.suppress(Exception):
-            await msg.edit_text("💬 Соединяю с менеджером...")
+            connecting_text = (
+                i18n.get("handoff-connecting")
+                if i18n is not None
+                else "💬 Соединяю с менеджером..."
+            )
+            await msg.edit_text(connecting_text)
 
     if property_bot is None:
         logger.warning("property_bot not in middleware_data, cannot complete handoff")

--- a/telegram_bot/middlewares/i18n.py
+++ b/telegram_bot/middlewares/i18n.py
@@ -20,6 +20,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _resolve_event_user(event: Any, data: dict[str, Any]) -> Any | None:
+    """Resolve the acting Telegram user from middleware data or the event itself."""
+    user = data.get("event_from_user")
+    if user is not None:
+        return user
+    return getattr(event, "from_user", None)
+
+
 def create_translator_hub(
     *,
     locales_dir: Path | None = None,
@@ -84,7 +92,7 @@ class I18nMiddleware(BaseMiddleware):
         event: TelegramObject,
         data: dict[str, Any],
     ) -> Any:
-        user = data.get("event_from_user")
+        user = _resolve_event_user(event, data)
         locale = self._default_locale
         locale_loaded_from_storage = False
 

--- a/tests/unit/handlers/test_handoff_qualification.py
+++ b/tests/unit/handlers/test_handoff_qualification.py
@@ -7,6 +7,8 @@ import pytest
 
 from telegram_bot.dialogs.handoff import (
     _GOAL_OPTIONS,
+    _contact_getter,
+    _goal_getter,
     _on_contact_chat,
     handoff_dialog,
 )
@@ -16,6 +18,7 @@ from telegram_bot.handlers.handoff import (
     parse_qual_callback,
     start_qualification,
 )
+from telegram_bot.middlewares.i18n import create_translator_hub
 
 
 def test_parse_qual_callback_goal():
@@ -113,6 +116,43 @@ def test_start_qualification_accepts_dialog_manager():
 
 
 @pytest.mark.asyncio
+async def test_goal_getter_prefers_current_middleware_context():
+    hub = create_translator_hub()
+    ru_i18n = hub.get_translator_by_locale("ru")
+    en_i18n = hub.get_translator_by_locale("en")
+
+    manager = MagicMock()
+    manager.middleware_data = {"i18n": ru_i18n, "locale": "ru"}
+
+    result = await _goal_getter(
+        manager,
+        middleware_data={"i18n": en_i18n, "locale": "en"},
+    )
+
+    assert result["prompt"] == "📋 What topic are you interested in?"
+    assert result["goals"][2][0] == "💬 Consultation"
+
+
+@pytest.mark.asyncio
+async def test_contact_getter_prefers_current_middleware_context():
+    hub = create_translator_hub()
+    ru_i18n = hub.get_translator_by_locale("ru")
+    en_i18n = hub.get_translator_by_locale("en")
+
+    manager = MagicMock()
+    manager.middleware_data = {"i18n": ru_i18n, "locale": "ru"}
+
+    result = await _contact_getter(
+        manager,
+        middleware_data={"i18n": en_i18n, "locale": "en"},
+    )
+
+    assert result["prompt"] == "How would you prefer to be contacted?"
+    assert result["btn_chat"] == "💬 Chat with manager"
+    assert result["btn_back"] == "Back"
+
+
+@pytest.mark.asyncio
 async def test_on_contact_chat_uses_middleware_locale_for_handoff_completion():
     property_bot = MagicMock()
     property_bot._complete_handoff = AsyncMock()
@@ -137,3 +177,33 @@ async def test_on_contact_chat_uses_middleware_locale_for_handoff_completion():
 
     kwargs = property_bot._complete_handoff.await_args.kwargs
     assert kwargs["locale"] == "en"
+
+
+@pytest.mark.asyncio
+async def test_on_contact_chat_localizes_connecting_message():
+    hub = create_translator_hub()
+    property_bot = MagicMock()
+    property_bot._complete_handoff = AsyncMock()
+
+    callback = MagicMock()
+    callback.from_user = SimpleNamespace(id=7, full_name="Test User", username="tester")
+    callback.message = AsyncMock()
+    callback.message.edit_text = AsyncMock()
+
+    manager = MagicMock()
+    manager.start_data = {}
+    manager.dialog_data = {"goal": "consult"}
+    manager.middleware_data = {
+        "property_bot": property_bot,
+        "state": AsyncMock(),
+        "locale": "en",
+        "i18n": hub.get_translator_by_locale("en"),
+    }
+    manager.done = AsyncMock()
+    manager.show_mode = None
+
+    await _on_contact_chat(callback, MagicMock(), manager)
+
+    callback.message.edit_text.assert_awaited_once_with(
+        "Connecting you with a manager. While you wait — I can answer questions!"
+    )

--- a/tests/unit/test_i18n_middleware.py
+++ b/tests/unit/test_i18n_middleware.py
@@ -193,6 +193,31 @@ class TestI18nMiddlewareCall:
 
         assert data["locale"] == "en"
 
+    async def test_falls_back_to_event_from_user_when_data_key_missing(self):
+        hub = self._make_hub()
+        user_service = MagicMock()
+        user_service.get_or_create = AsyncMock(return_value=MagicMock(locale="ru"))
+        mw = I18nMiddleware(hub=hub, user_service=user_service, default_locale="en")
+
+        user = MagicMock(spec=User)
+        user.id = 321
+        user.language_code = "en"
+        user.first_name = "Test"
+
+        event = MagicMock(spec=Message)
+        event.from_user = user
+        handler = AsyncMock(return_value=None)
+        data: dict = {}
+
+        await mw(handler, event, data)
+
+        assert data["locale"] == "ru"
+        user_service.get_or_create.assert_called_once_with(
+            telegram_id=321,
+            first_name="Test",
+            language_code="en",
+        )
+
 
 class TestSetupI18nMiddleware:
     """Test that setup_i18n_middleware accepts only 3 params."""


### PR DESCRIPTION
## Summary
- release the handoff locale fix from `dev` to `main`
- removes mixed-locale prompts in client manager handoff flow
- keeps handoff state/topic completion path unchanged

## Included fix
- handoff dialog getters prefer current aiogram-dialog middleware context
- i18n middleware falls back to `event.from_user` when injected user key is missing
- final connecting status uses localized `handoff-connecting` text

## Verification on dev branch
- uv run pytest tests/unit/test_i18n_middleware.py tests/unit/handlers/test_handoff_qualification.py tests/unit/test_handoff_i18n.py tests/unit/middlewares/test_i18n.py -q
- make check
- PYTEST_ADDOPTS="-n auto --dist=worksteal" make test-unit

Refs #1017
Refs #1011