### PR TITLE
Force VPS deploy to recreate rebuilt services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,8 @@ jobs:
             echo "=== Rebuild changed images ==="
             docker compose build
 
-            echo "=== Restart changed services ==="
-            docker compose --compatibility up -d
+            echo "=== Restart services from rebuilt images ==="
+            docker compose --compatibility up -d --force-recreate
 
             echo "=== Wait for startup ==="
             sleep 20

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -203,11 +203,11 @@ fi
 # =============================================================================
 # Step 5: Start services
 # =============================================================================
-log "Starting services..."
+log "Starting services from rebuilt images..."
 if ! $DRY_RUN; then
-    ssh_cmd "cd ${VPS_DIR} && export COMPOSE_FILE=${VPS_COMPOSE_FILE} && docker compose --compatibility up -d"
+    ssh_cmd "cd ${VPS_DIR} && export COMPOSE_FILE=${VPS_COMPOSE_FILE} && docker compose --compatibility up -d --force-recreate"
 else
-    info "[dry-run] Would run: docker compose --compatibility up -d"
+    info "[dry-run] Would run: docker compose --compatibility up -d --force-recreate"
 fi
 
 # =============================================================================

--- a/tests/unit/test_release_gate_contract.py
+++ b/tests/unit/test_release_gate_contract.py
@@ -32,10 +32,28 @@ def test_ci_deploy_runs_prod_env_preflight_before_build() -> None:
     assert workflow.index("./scripts/validate_prod_env.sh") < workflow.index("docker compose build")
 
 
+def test_ci_deploy_force_recreates_services_after_build() -> None:
+    """CI deploy must recreate services so rebuilt images actually reach runtime."""
+    workflow = CI_WORKFLOW.read_text()
+    assert "docker compose --compatibility up -d --force-recreate" in workflow
+    assert workflow.index("docker compose build") < workflow.index(
+        "docker compose --compatibility up -d --force-recreate"
+    )
+
+
 def test_manual_deploy_uses_strict_mini_app_release_smoke() -> None:
     """Manual VPS deploy must use the same strict release contract as CI."""
     script = DEPLOY_SCRIPT.read_text()
     assert "REQUIRE_MINI_APP_ENDPOINT=true ./scripts/test_release_health_vps.sh" in script
+
+
+def test_manual_deploy_force_recreates_services_after_build() -> None:
+    """Manual deploy must recreate services so rebuilt images replace stale containers."""
+    script = DEPLOY_SCRIPT.read_text()
+    assert "docker compose --compatibility up -d --force-recreate" in script
+    assert script.index("docker compose build") < script.index(
+        "docker compose --compatibility up -d --force-recreate"
+    )
 
 
 def test_release_gate_script_contains_handoff_contract() -> None:


### PR DESCRIPTION
## Summary
- force service recreation after docker compose rebuilds in both CI deploy and manual VPS deploy script
- add release contract tests so false-green deploys with stale containers fail review
- addresses observed prod drift where `origin/main` was updated but `vps_bot_1` kept running an older image

## Verification
- uv run pytest tests/unit/test_release_gate_contract.py -q
- make check
- PYTEST_ADDOPTS="-n auto --dist=worksteal" make test-unit

Refs #1011
Refs #1017