### PR TITLE
Release dev to main

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -91,6 +91,7 @@ services:
 
   bge-m3:
     <<: *security-defaults
+    image: "${COMPOSE_PROJECT_NAME:-dev}_bge-m3"
     build:
       context: ./services/bge-m3-api
       dockerfile: Dockerfile
@@ -119,6 +120,7 @@ services:
 
   user-base:
     <<: *security-defaults
+    image: "${COMPOSE_PROJECT_NAME:-dev}_user-base"
     build:
       context: ./services/user-base
       dockerfile: Dockerfile
@@ -145,6 +147,7 @@ services:
 
   docling:
     <<: *security-defaults
+    image: "${COMPOSE_PROJECT_NAME:-dev}_docling"
     build:
       context: ./services/docling
       dockerfile: Dockerfile
@@ -220,6 +223,7 @@ services:
 
   bot:
     <<: *security-defaults
+    image: "${COMPOSE_PROJECT_NAME:-dev}_bot"
     build:
       context: .
       dockerfile: telegram_bot/Dockerfile
@@ -324,6 +328,7 @@ services:
 
   mini-app-api:
     <<: *security-defaults
+    image: "${COMPOSE_PROJECT_NAME:-dev}_mini-app-api"
     build:
       context: .
       dockerfile: mini_app/Dockerfile
@@ -366,6 +371,7 @@ services:
           memory: 256M
 
   mini-app-frontend:
+    image: "${COMPOSE_PROJECT_NAME:-dev}_mini-app-frontend"
     build:
       context: ./mini_app/frontend
       dockerfile: Dockerfile
@@ -390,6 +396,7 @@ services:
   # =============================================================================
 
   ingestion:
+    image: "${COMPOSE_PROJECT_NAME:-dev}_ingestion"
     build:
       context: .
       dockerfile: Dockerfile.ingestion

--- a/tests/unit/test_compose.py
+++ b/tests/unit/test_compose.py
@@ -72,6 +72,24 @@ def test_compose_yml_has_no_ports():
         )
 
 
+def test_custom_build_services_have_stable_explicit_image_names():
+    """Custom build services must pin image names to COMPOSE_PROJECT_NAME with underscores."""
+    data = load_yaml("compose.yml")
+    expected = {
+        "bge-m3": "${COMPOSE_PROJECT_NAME:-dev}_bge-m3",
+        "user-base": "${COMPOSE_PROJECT_NAME:-dev}_user-base",
+        "docling": "${COMPOSE_PROJECT_NAME:-dev}_docling",
+        "bot": "${COMPOSE_PROJECT_NAME:-dev}_bot",
+        "mini-app-api": "${COMPOSE_PROJECT_NAME:-dev}_mini-app-api",
+        "mini-app-frontend": "${COMPOSE_PROJECT_NAME:-dev}_mini-app-frontend",
+        "ingestion": "${COMPOSE_PROJECT_NAME:-dev}_ingestion",
+    }
+    for svc_name, image in expected.items():
+        assert data["services"][svc_name]["image"] == image, (
+            f"{svc_name} image must be pinned to {image!r} to avoid build/runtime tag drift"
+        )
+
+
 def test_compose_dev_has_colbert_rerank():
     """Dev override must enable ColBERT reranking."""
     data = load_yaml("compose.dev.yml")


### PR DESCRIPTION
## Summary
- pin explicit Compose image names to COMPOSE_PROJECT_NAME-based tags
- keep deploy/runtime image resolution stable across rebuild and recreate cycles
- preserve prior force-recreate deploy behavior so VPS picks up fresh images

## Test Plan
- [x] make check
- [x] PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit
- [x] uv run pytest tests/unit/test_compose.py tests/unit/test_compose_config.py tests/unit/test_release_gate_contract.py -q