### PR TITLE
fix: cut over catalog ownership to CatalogSG runtime

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -203,6 +203,19 @@ def _state_apartment_results(state_data: dict[str, Any]) -> list[dict[str, Any]]
     return []
 
 
+def _state_control_message_id(state_data: dict[str, Any]) -> int | None:
+    runtime = state_data.get("catalog_runtime")
+    if isinstance(runtime, dict):
+        control_message_id = runtime.get("control_message_id")
+        if isinstance(control_message_id, int):
+            return control_message_id
+
+    footer_msg_id = state_data.get("apartment_footer_msg_id")
+    if isinstance(footer_msg_id, int):
+        return footer_msg_id
+    return None
+
+
 def _split_telegram_response(text: str, limit: int = _TELEGRAM_MESSAGE_LIMIT) -> list[str]:
     """Split text into Telegram-safe chunks without importing the full client pipeline."""
     if not text:
@@ -2349,11 +2362,13 @@ class PropertyBot:
 
                 from .dialogs.states import ViewingSG
 
-                # Delete footer message to avoid visual clutter during dialog
-                footer_msg_id = state_data.get("apartment_footer_msg_id")
-                if footer_msg_id and callback.message and callback.message.chat:
+                control_message_id = _state_control_message_id(state_data)
+                if control_message_id and callback.message and callback.message.chat:
                     with contextlib.suppress(Exception):
-                        await callback.bot.delete_message(callback.message.chat.id, footer_msg_id)  # type: ignore[union-attr]
+                        await callback.bot.delete_message(
+                            callback.message.chat.id,
+                            control_message_id,
+                        )  # type: ignore[union-attr]
 
                 await dialog_manager.start(
                     ViewingSG.date,
@@ -2565,6 +2580,10 @@ class PropertyBot:
                 next_offset=None,
             )
             state_data = await state.get_data()
+            control_message_id = _state_control_message_id(state_data)
+            if control_message_id is not None and message.bot is not None:
+                with contextlib.suppress(Exception):
+                    await message.bot.delete_message(message.chat.id, control_message_id)
             cleaned_state = clear_legacy_catalog_state(state_data)
             cleaned_state["catalog_runtime"] = runtime
 

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -2544,7 +2544,11 @@ class PropertyBot:
 
     @observe(name="telegram-rag-query")
     async def handle_query(
-        self, message: Message, locale: str = "ru", state: FSMContext | None = None
+        self,
+        message: Message,
+        locale: str = "ru",
+        state: FSMContext | None = None,
+        dialog_manager: Any = None,
     ):
         """Handle user query via supervisor graph (#310: supervisor-only)."""
         pipeline_start = time.perf_counter()
@@ -2592,6 +2596,7 @@ class PropertyBot:
             state=state,
             forum_thread_id=forum_thread_id,
             expert_id=expert_id,
+            dialog_manager=dialog_manager,
         )
         update_kwargs: dict[str, Any] = {"output": {"response": response_text or ""}}
         if root_trace_metadata:
@@ -2627,6 +2632,7 @@ class PropertyBot:
         user_text: str,
         message: Message,
         state: FSMContext | None = None,
+        dialog_manager: Any = None,
     ) -> str | None:
         """C+ fast path: regex filters -> hybrid search -> generate. No agent loop (#629)."""
         from .services.apartments_service import check_escalation
@@ -2703,58 +2709,55 @@ class PropertyBot:
         if not generated.get("response_sent"):
             await self._send_markdown_chunks(message, response_text)
 
-        # Store results in FSMContext and send property cards (#654)
+        # Cut over free-text apartment sessions to the shared dialog-owned catalog runtime.
         if state is not None and results:
-            await state.update_data(
-                apartment_results=results,
-                apartment_query=user_text,
-                apartment_offset=0,
-                bookmarks_context=False,
-                apartment_total=len(results),
-                apartment_next_offset=None,
-                apartment_filters=None,
+            from .dialogs.catalog import activate_catalog_state, show_catalog_controls
+            from .dialogs.states import CatalogSG
+            from .services.catalog_rendering import send_catalog_results
+            from .services.catalog_session import (
+                build_catalog_runtime,
+                clear_legacy_catalog_state,
             )
-            page = results[:_APARTMENT_PAGE_SIZE]
-            for card_result in page:
-                await self._send_property_card(
-                    message,
-                    card_result,
-                    message.from_user.id,  # type: ignore[union-attr]
+
+            runtime = build_catalog_runtime(
+                query=user_text,
+                source="free_text",
+                filters=filters or {},
+                view_mode="cards",
+                results=results,
+                total=len(results),
+                next_offset=None,
+            )
+            state_data = await state.get_data()
+            cleaned_state = clear_legacy_catalog_state(state_data)
+            cleaned_state["catalog_runtime"] = runtime
+
+            maybe_set_data = getattr(state, "set_data", None)
+            if inspect.iscoroutinefunction(maybe_set_data):
+                await maybe_set_data(cleaned_state)
+            await state.update_data(**cleaned_state)
+
+            telegram_id = message.from_user.id if message.from_user else 0
+            await send_catalog_results(
+                message=message,
+                property_bot=self,
+                results=results,
+                total_count=len(results),
+                view_mode=runtime.get("view_mode", "cards"),
+                shown_start=1,
+                telegram_id=telegram_id,
+            )
+            if dialog_manager is not None:
+                dialog_manager.middleware_data.setdefault("state", state)
+                await show_catalog_controls(
+                    message=message,
+                    dialog_manager=dialog_manager,
+                    runtime=runtime,
                 )
-            shown = len(page)
-            total = len(results)
-            _has_more = total > _APARTMENT_PAGE_SIZE
-            _footer_rows2: list[list[InlineKeyboardButton]] = []
-            if _has_more:
-                _footer_rows2.append(
-                    [
-                        InlineKeyboardButton(
-                            text=f"🔄 Показать ещё ({max(total - shown, 0)} осталось)",
-                            callback_data=ResultsCB(action="more").pack(),
-                        )
-                    ]
+                await activate_catalog_state(
+                    dialog_manager=dialog_manager,
+                    state=CatalogSG.results,
                 )
-            _footer_rows2.append(
-                [
-                    InlineKeyboardButton(
-                        text="⚙️ Изменить параметры",
-                        callback_data=ResultsCB(action="refine").pack(),
-                    )
-                ]
-            )
-            _footer_rows2.append(
-                [
-                    InlineKeyboardButton(
-                        text="📅 Запись на осмотр",
-                        callback_data=ResultsCB(action="viewing").pack(),
-                    )
-                ]
-            )
-            footer_msg = await message.answer(
-                f"Найдено {total} апартаментов (показаны 1–{shown})",
-                reply_markup=InlineKeyboardMarkup(inline_keyboard=_footer_rows2),
-            )
-            await state.update_data(apartment_footer_msg_id=footer_msg.message_id)
 
         return response_text
 
@@ -2769,6 +2772,7 @@ class PropertyBot:
         query_type: str,
         rag_result_store: dict[str, Any],
         state: FSMContext | None = None,
+        dialog_manager: Any = None,
     ) -> str | None:
         """Thin wrapper: delegates to run_client_pipeline (see pipelines/client.py).
 
@@ -2784,6 +2788,7 @@ class PropertyBot:
                 user_text=user_text,
                 message=message,
                 state=state,
+                dialog_manager=dialog_manager,
             )
             if apt_answer is not None:
                 return apt_answer
@@ -2820,6 +2825,7 @@ class PropertyBot:
         state: FSMContext | None = None,
         forum_thread_id: int | None = None,
         expert_id: str | None = None,
+        dialog_manager: Any = None,
     ) -> str:
         """Handle query via create_agent SDK (#413 — replaces build_supervisor_graph)."""
         from src.retrieval.topic_classifier import get_query_topic_hint
@@ -3131,6 +3137,7 @@ class PropertyBot:
                             query_type=query_type,
                             rag_result_store=rag_result_store,
                             state=state,
+                            dialog_manager=dialog_manager,
                         )
                         if pipeline_answer is not None:
                             if root_trace_metadata is not None:

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -76,6 +76,7 @@ logger = logging.getLogger(__name__)
 _CHECKPOINT_NS_VOICE = "tg:voice:v1"
 _FEEDBACK_CONFIRMATION_TTL_S = 5.0
 _APARTMENT_PAGE_SIZE = 5
+_STALE_RESULTS_CALLBACK_TEXT = "Это устаревшая кнопка. Используйте актуальное меню ниже."
 _TELEGRAM_MESSAGE_LIMIT = 4096
 _NO_RAG_QUERY_TYPES: frozenset[str] = frozenset({"CHITCHAT", "OFF_TOPIC"})
 _AGENT_DRAFT_INTERVAL: float = 0.2  # seconds between sendMessageDraft calls
@@ -2281,176 +2282,11 @@ class PropertyBot:
         dialog_manager: Any = None,
     ) -> None:
         """Handle property results callbacks (more/refine/viewing) (#654)."""
-        # Resolve action from CallbackData or legacy string
-        if callback_data is not None:
-            action = callback_data.action
-        else:
-            data = callback.data or ""
-            parts = data.split(":", 1)
-            action = parts[1] if len(parts) > 1 else ""
-
-        if action == "more":
-            state_data = await state.get_data()
-            results = state_data.get("apartment_results")
-            offset = state_data.get("apartment_offset", 0)
-            if not results:
-                await callback.answer("Нет сохранённых результатов")
-                return
-            apartment_total = state_data.get("apartment_total", len(results))
-            apartment_total_value = (
-                apartment_total if isinstance(apartment_total, int) else len(results)
-            )
-            apartment_next_offset = state_data.get("apartment_next_offset")
-            apartment_filters = state_data.get("apartment_filters")
-            apartment_scroll_seen_ids = state_data.get("apartment_scroll_seen_ids")
-            new_offset = offset + _APARTMENT_PAGE_SIZE
-
-            # Funnel flow stores only the first page; lazily append more pages on demand.
-            if new_offset >= len(results):
-                apartments_service = getattr(self, "_apartments_service", None)
-                can_fetch_more = (
-                    apartment_filters is not None
-                    and apartments_service is not None
-                    and len(results) < apartment_total_value
-                )
-                if can_fetch_more:
-                    # Qdrant may return None offset while more rows still exist in count().
-                    # In that case, fetch a wider prefix from start and replace cached list.
-                    backfill_from_start = apartment_next_offset is None
-                    scroll_limit = (
-                        new_offset + _APARTMENT_PAGE_SIZE
-                        if backfill_from_start
-                        else _APARTMENT_PAGE_SIZE
-                    )
-                    scroll_offset = None if backfill_from_start else apartment_next_offset
-                    try:
-                        (
-                            extra_results,
-                            total_count,
-                            next_offset,
-                            page_ids,
-                        ) = await apartments_service.scroll_with_filters(  # type: ignore[union-attr]
-                            filters=apartment_filters,
-                            limit=scroll_limit,
-                            start_from=scroll_offset,
-                            exclude_ids=apartment_scroll_seen_ids or None,
-                        )
-                    except Exception:
-                        logger.exception("Failed to fetch next results page")
-                    else:
-                        if extra_results:
-                            if backfill_from_start and len(extra_results) >= len(results):
-                                results = list(extra_results)
-                            else:
-                                results = _merge_results(results, extra_results)
-                            apartment_total = total_count
-                            apartment_total_value = (
-                                total_count if isinstance(total_count, int) else len(results)
-                            )
-                            apartment_next_offset = next_offset
-                            await state.update_data(
-                                apartment_results=results,
-                                apartment_total=apartment_total,
-                                apartment_next_offset=apartment_next_offset,
-                                apartment_scroll_seen_ids=page_ids,
-                            )
-                if new_offset >= len(results):
-                    await callback.answer("Все результаты уже показаны")
-                    return
-            page = results[new_offset : new_offset + _APARTMENT_PAGE_SIZE]
-            for result in page:
-                if callback.message:
-                    await self._send_property_card(callback.message, result, callback.from_user.id)  # type: ignore[arg-type]
-            shown = len(page)
-            shown_total = new_offset + shown
-            total = apartment_total_value
-            has_more = shown_total < total
-            if callback.message:
-                _footer_rows: list[list[InlineKeyboardButton]] = []
-                if has_more:
-                    _footer_rows.append(
-                        [
-                            InlineKeyboardButton(
-                                text=f"🔄 Показать ещё ({max(total - shown_total, 0)} осталось)",
-                                callback_data=ResultsCB(action="more").pack(),
-                            )
-                        ]
-                    )
-                _footer_rows.append(
-                    [
-                        InlineKeyboardButton(
-                            text="⚙️ Изменить параметры",
-                            callback_data=ResultsCB(action="refine").pack(),
-                        )
-                    ]
-                )
-                _footer_rows.append(
-                    [
-                        InlineKeyboardButton(
-                            text="📅 Запись на осмотр",
-                            callback_data=ResultsCB(action="viewing").pack(),
-                        )
-                    ]
-                )
-                footer_msg = await callback.message.answer(
-                    f"Найдено {total} апартаментов (показаны {new_offset + 1}–{shown_total})",
-                    reply_markup=InlineKeyboardMarkup(inline_keyboard=_footer_rows),
-                )
-                await state.update_data(
-                    apartment_offset=new_offset,
-                    apartment_footer_msg_id=footer_msg.message_id,
-                )
-            else:
-                await state.update_data(apartment_offset=new_offset)
-            await callback.answer()
-        elif action == "refine":
-            await state.update_data(apartment_results=None, apartment_offset=0)
-            if callback.message:
-                await callback.message.answer(
-                    "Опишите, какие апартаменты вы ищете, и я подберу варианты."
-                )
-            await callback.answer()
-        elif action == "viewing":
-            state_data = await state.get_data()
-            results = state_data.get("apartment_results", [])
-            # Первые 5 результатов как контекст для CRM заметки
-            viewing_objs = []
-            for r in results[:5]:
-                if isinstance(r, dict):
-                    p = r.get("payload", {})
-                    viewing_objs.append(
-                        {
-                            "id": r.get("id", ""),
-                            "complex_name": p.get("complex_name", ""),
-                            "property_type": p.get("property_type", ""),
-                            "area_m2": p.get("area_m2", 0),
-                            "price_eur": p.get("price_eur", 0),
-                        }
-                    )
-            if dialog_manager is not None:
-                from aiogram_dialog import ShowMode, StartMode
-
-                from .dialogs.states import ViewingSG
-
-                # Delete footer message to keep chat clean
-                if callback.message:
-                    with contextlib.suppress(Exception):
-                        await callback.message.delete()  # type: ignore[union-attr]
-
-                await dialog_manager.start(
-                    ViewingSG.date,
-                    mode=StartMode.RESET_STACK,
-                    show_mode=ShowMode.DELETE_AND_SEND,
-                    data={"selected_objects": viewing_objs},
-                )
-            else:
-                from .handlers.phone_collector import start_phone_collection
-
-                await start_phone_collection(
-                    callback, state, service_key="viewing", viewing_objects=viewing_objs or None
-                )
-        else:
-            await callback.answer()
+        if callback.message:
+            with contextlib.suppress(Exception):
+                await callback.message.edit_reply_markup(reply_markup=None)
+            await callback.message.answer(_STALE_RESULTS_CALLBACK_TEXT)
+        await callback.answer()
 
     @observe(name="cb-card", capture_input=False, capture_output=False)
     async def handle_card_callback(

--- a/telegram_bot/services/catalog_session.py
+++ b/telegram_bot/services/catalog_session.py
@@ -6,6 +6,16 @@ from typing import Any, TypedDict
 
 
 CATALOG_RUNTIME_DATA_KEY = "catalog_runtime"
+LEGACY_CATALOG_STATE_KEYS = (
+    "apartment_results",
+    "apartment_query",
+    "apartment_offset",
+    "apartment_total",
+    "apartment_next_offset",
+    "apartment_filters",
+    "apartment_scroll_seen_ids",
+    "apartment_footer_msg_id",
+)
 
 
 class CatalogRuntime(TypedDict, total=False):
@@ -94,6 +104,13 @@ def build_catalog_runtime(
         "origin_context": dict(origin_context or {}),
     }
     return runtime
+
+
+def clear_legacy_catalog_state(state_data: dict[str, Any]) -> dict[str, Any]:
+    cleaned = dict(state_data)
+    for key in LEGACY_CATALOG_STATE_KEYS:
+        cleaned.pop(key, None)
+    return cleaned
 
 
 def update_catalog_runtime_page(

--- a/tests/unit/services/test_catalog_session.py
+++ b/tests/unit/services/test_catalog_session.py
@@ -2,6 +2,7 @@
 
 from telegram_bot.services.catalog_session import (
     build_catalog_runtime,
+    clear_legacy_catalog_state,
     update_catalog_runtime_page,
 )
 
@@ -57,3 +58,41 @@ def test_catalog_states_exist() -> None:
     assert hasattr(CatalogSG, "results")
     assert hasattr(CatalogSG, "empty")
     assert hasattr(CatalogSG, "details")
+
+
+def test_clear_legacy_catalog_state_removes_parallel_browsing_keys() -> None:
+    cleaned = clear_legacy_catalog_state(
+        {
+            "catalog_runtime": {"query": "двушка", "results": [{"id": "apt-1"}]},
+            "apartment_results": [{"id": "legacy"}],
+            "apartment_offset": 10,
+            "apartment_total": 42,
+            "apartment_next_offset": "cursor",
+            "apartment_filters": {"rooms": 2},
+            "apartment_footer_msg_id": 777,
+            "bookmark_message_ids": [100],
+        }
+    )
+
+    assert cleaned["catalog_runtime"]["query"] == "двушка"
+    assert "apartment_results" not in cleaned
+    assert "apartment_offset" not in cleaned
+    assert "apartment_total" not in cleaned
+    assert "apartment_next_offset" not in cleaned
+    assert "apartment_filters" not in cleaned
+    assert "apartment_footer_msg_id" not in cleaned
+    assert cleaned["bookmark_message_ids"] == [100]
+
+
+def test_clear_legacy_catalog_state_keeps_unrelated_keys() -> None:
+    cleaned = clear_legacy_catalog_state(
+        {
+            "catalog_runtime": {"source": "free_text"},
+            "bookmark_message_ids": [55],
+            "other_key": "keep-me",
+        }
+    )
+
+    assert cleaned["catalog_runtime"]["source"] == "free_text"
+    assert cleaned["bookmark_message_ids"] == [55]
+    assert cleaned["other_key"] == "keep-me"

--- a/tests/unit/test_bot_entry_points_crm.py
+++ b/tests/unit/test_bot_entry_points_crm.py
@@ -176,12 +176,12 @@ async def test_cta_get_offer_passes_service_key() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Test: results:viewing -> viewing_objects built from apartment_results
+# Test: results:viewing legacy route -> stale compat only
 # ---------------------------------------------------------------------------
 
 
-async def test_results_viewing_passes_objects_context() -> None:
-    """results:viewing -> viewing_objects contains first 5 results from FSM state."""
+async def test_results_viewing_is_stale_compat_only() -> None:
+    """results:viewing should no longer invoke phone collection from legacy callbacks."""
     bot = _create_bot()
     results = [
         {
@@ -204,15 +204,10 @@ async def test_results_viewing_passes_objects_context() -> None:
     ) as mock_collect:
         await bot.handle_results_callback(cb, state)
 
-    mock_collect.assert_awaited_once()
-    kwargs = mock_collect.call_args[1]
-    assert kwargs["service_key"] == "viewing"
-    viewing_objects = kwargs["viewing_objects"]
-    assert viewing_objects is not None
-    assert len(viewing_objects) == 5
-    assert viewing_objects[0]["id"] == "prop-0"
-    assert viewing_objects[0]["complex_name"] == "Complex 0"
-    assert viewing_objects[4]["id"] == "prop-4"
+    mock_collect.assert_not_awaited()
+    cb.message.answer.assert_awaited_once_with(
+        "Это устаревшая кнопка. Используйте актуальное меню ниже."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_callback_fsm_regression.py
+++ b/tests/unit/test_callback_fsm_regression.py
@@ -122,81 +122,50 @@ def _fav_bot(favorites: list | None = None) -> PropertyBot:
 
 
 # ---------------------------------------------------------------------------
-# 1. Callback-flow: multi-page pagination (results:more)
+# 1. Callback-flow: stale legacy results callbacks
 # ---------------------------------------------------------------------------
 
 
-class TestMultiPagePagination:
-    """Verify pagination across multiple results:more clicks."""
+class TestLegacyResultsCompat:
+    """Legacy results buttons should only show stale compatibility guidance."""
 
-    async def test_page2_of_12_shows_5_cards_and_has_more(self) -> None:
-        """12 results, offset=0 -> page2: 5 cards + footer, has_more=True."""
+    async def test_results_more_is_stale_when_results_exist(self) -> None:
         bot = _create_bot()
         bot._send_property_card = AsyncMock()
-        results = _make_results(12)
-        state = _make_state({"apartment_results": results, "apartment_offset": 0})
+        state = _make_state({"apartment_results": _make_results(12), "apartment_offset": 0})
         cb = _make_callback("results:more")
 
         await bot.handle_results_callback(cb, state)
 
-        assert bot._send_property_card.await_count == 5
-        assert cb.message.answer.await_count == 1
-        state.update_data.assert_awaited_once()
-        update_kwargs = state.update_data.await_args.kwargs
-        assert update_kwargs["apartment_offset"] == _PAGE_SIZE
-        assert "apartment_footer_msg_id" in update_kwargs
-        footer_call = cb.message.answer.call_args
-        assert "показаны 6–10" in footer_call.args[0]
-
-    async def test_page3_of_12_shows_2_cards_no_more(self) -> None:
-        """12 results, offset=5 -> page3: 2 cards + footer, has_more=False."""
-        bot = _create_bot()
-        bot._send_property_card = AsyncMock()
-        results = _make_results(12)
-        state = _make_state({"apartment_results": results, "apartment_offset": 5})
-        cb = _make_callback("results:more")
-
-        await bot.handle_results_callback(cb, state)
-
-        assert bot._send_property_card.await_count == 2
-        assert cb.message.answer.await_count == 1
-        state.update_data.assert_awaited_once()
-        update_kwargs = state.update_data.await_args.kwargs
-        assert update_kwargs["apartment_offset"] == 10
-        assert "apartment_footer_msg_id" in update_kwargs
-        footer_call = cb.message.answer.call_args
-        assert "показаны 11–12" in footer_call.args[0]
-
-    async def test_page4_of_12_exhausted(self) -> None:
-        """12 results, offset=10 -> new_offset=15 >= 12 -> 'all shown'."""
-        bot = _create_bot()
-        bot._send_property_card = AsyncMock()
-        results = _make_results(12)
-        state = _make_state({"apartment_results": results, "apartment_offset": 10})
-        cb = _make_callback("results:more")
-
-        await bot.handle_results_callback(cb, state)
-
-        cb.answer.assert_awaited_once_with(
-            "\u0412\u0441\u0435 \u0440\u0435\u0437\u0443\u043b\u044c\u0442\u0430\u0442\u044b \u0443\u0436\u0435 \u043f\u043e\u043a\u0430\u0437\u0430\u043d\u044b"
+        cb.message.answer.assert_awaited_once_with(
+            "Это устаревшая кнопка. Используйте актуальное меню ниже."
         )
-        cb.message.answer.assert_not_called()
+        state.update_data.assert_not_awaited()
         bot._send_property_card.assert_not_awaited()
 
-    async def test_exact_boundary_10_results(self) -> None:
-        """10 results, offset=0 -> page2: 5 cards, has_more=False."""
+    async def test_results_more_is_stale_at_end_of_legacy_state(self) -> None:
         bot = _create_bot()
         bot._send_property_card = AsyncMock()
-        results = _make_results(10)
-        state = _make_state({"apartment_results": results, "apartment_offset": 0})
+        state = _make_state({"apartment_results": _make_results(12), "apartment_offset": 10})
         cb = _make_callback("results:more")
 
         await bot.handle_results_callback(cb, state)
 
-        assert bot._send_property_card.await_count == 5
-        assert cb.message.answer.await_count == 1
-        footer_call = cb.message.answer.call_args
-        assert "показаны 6–10" in footer_call.args[0]
+        cb.message.answer.assert_awaited_once_with(
+            "Это устаревшая кнопка. Используйте актуальное меню ниже."
+        )
+        bot._send_property_card.assert_not_awaited()
+
+    async def test_results_more_is_stale_without_results(self) -> None:
+        bot = _create_bot()
+        state = _make_state({"apartment_results": None, "apartment_offset": 0})
+        cb = _make_callback("results:more")
+
+        await bot.handle_results_callback(cb, state)
+
+        cb.message.answer.assert_awaited_once_with(
+            "Это устаревшая кнопка. Используйте актуальное меню ниже."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -224,15 +193,15 @@ class TestRefineStaleButton:
         )
 
     async def test_refine_clears_then_more_fails_gracefully(self) -> None:
-        """After refine, results:more -> 'no results' (not crash)."""
+        """After refine, stale more button still gets compat guidance, not old pagination."""
         bot = _create_bot()
         state = _make_state({"apartment_results": None, "apartment_offset": 0})
         cb = _make_callback("results:more")
 
         await bot.handle_results_callback(cb, state)
 
-        cb.answer.assert_awaited_once_with(
-            "\u041d\u0435\u0442 \u0441\u043e\u0445\u0440\u0430\u043d\u0451\u043d\u043d\u044b\u0445 \u0440\u0435\u0437\u0443\u043b\u044c\u0442\u0430\u0442\u043e\u0432"
+        cb.message.answer.assert_awaited_once_with(
+            "Это устаревшая кнопка. Используйте актуальное меню ниже."
         )
 
 
@@ -242,10 +211,10 @@ class TestRefineStaleButton:
 
 
 class TestViewingDialog:
-    """Contract: viewing delegates to ViewingSG dialog via dialog_manager."""
+    """Legacy results:viewing should be compat-only; favorites still open ViewingSG."""
 
     async def test_results_viewing_starts_dialog(self) -> None:
-        """results:viewing -> dialog_manager.start(ViewingSG.date, data={selected_objects})."""
+        """results:viewing should no longer enter ViewingSG."""
         bot = _create_bot()
         state = _make_state()
         cb = _make_callback("results:viewing")
@@ -253,13 +222,13 @@ class TestViewingDialog:
 
         await bot.handle_results_callback(cb, state, dialog_manager=dialog_manager)
 
-        dialog_manager.start.assert_awaited_once()
-        from telegram_bot.dialogs.states import ViewingSG
-
-        assert dialog_manager.start.call_args.args[0] == ViewingSG.date
+        dialog_manager.start.assert_not_awaited()
+        cb.message.answer.assert_awaited_once_with(
+            "Это устаревшая кнопка. Используйте актуальное меню ниже."
+        )
 
     async def test_results_viewing_fallback_no_dialog_manager(self) -> None:
-        """results:viewing without dialog_manager -> fallback to phone_collector."""
+        """results:viewing without dialog_manager should not reach phone_collector anymore."""
         bot = _create_bot()
         state = _make_state()
         cb = _make_callback("results:viewing")
@@ -270,8 +239,9 @@ class TestViewingDialog:
         ) as mock_collect:
             await bot.handle_results_callback(cb, state)
 
-        mock_collect.assert_awaited_once_with(
-            cb, state, service_key="viewing", viewing_objects=None
+        mock_collect.assert_not_awaited()
+        cb.message.answer.assert_awaited_once_with(
+            "Это устаревшая кнопка. Используйте актуальное меню ниже."
         )
 
     async def test_fav_viewing_starts_dialog(self) -> None:
@@ -400,37 +370,18 @@ class TestMalformedStateFavAdd:
 
 
 # ---------------------------------------------------------------------------
-# 5. Footer contract: shown/total/has_more consistency
+# 5. Legacy results footer contract removed
 # ---------------------------------------------------------------------------
 
 
 class TestFooterContract:
-    """Verify correct shown/total/has_more combinations per page."""
+    """Legacy footer flows should now only point users to the fresh catalog controls."""
 
-    @pytest.mark.parametrize(
-        "total,offset,exp_cards,exp_range,exp_has_more",
-        [
-            (12, 0, 5, "показаны 6–10", True),
-            (12, 5, 2, "показаны 11–12", False),
-            (10, 0, 5, "показаны 6–10", False),
-            (6, 0, 1, "показаны 6–6", False),
-            (7, 0, 2, "показаны 6–7", False),
-        ],
-        ids=[
-            "mid-page-has-more",
-            "last-partial-page",
-            "exact-boundary",
-            "single-card-last",
-            "two-cards-last",
-        ],
-    )
-    async def test_footer_text_and_card_count(
+    @pytest.mark.parametrize("total,offset", [(12, 0), (12, 5), (10, 0), (6, 0), (7, 0)])
+    async def test_results_more_always_returns_stale_guidance(
         self,
         total: int,
         offset: int,
-        exp_cards: int,
-        exp_range: str,
-        exp_has_more: bool,
     ) -> None:
         bot = _create_bot()
         bot._send_property_card = AsyncMock()
@@ -440,43 +391,29 @@ class TestFooterContract:
 
         await bot.handle_results_callback(cb, state)
 
-        assert bot._send_property_card.await_count == exp_cards
-        assert cb.message.answer.await_count == 1
-        footer_call = cb.message.answer.call_args
-        assert exp_range in footer_call.args[0]
-        footer_markup = footer_call.kwargs["reply_markup"]
-        callbacks = [btn.callback_data for row in footer_markup.inline_keyboard for btn in row]
-        if exp_has_more:
-            assert "results:more" in callbacks
-        else:
-            assert "results:more" not in callbacks
-
-    async def test_no_duplicate_cards_edge_page(self) -> None:
-        """Each card sent exactly once on partial last page."""
-        bot = _create_bot()
-        bot._send_property_card = AsyncMock()
-        results = _make_results(7)
-        state = _make_state({"apartment_results": results, "apartment_offset": 0})
-        cb = _make_callback("results:more")
-
-        await bot.handle_results_callback(cb, state)
-
-        sent_ids = [call.args[1]["id"] for call in bot._send_property_card.await_args_list]
-        assert sent_ids == ["prop-5", "prop-6"]
-
-    async def test_single_result_no_more_page(self) -> None:
-        """1 total result, offset=0 -> 'all shown' (page 1 was initial display)."""
-        bot = _create_bot()
-        bot._send_property_card = AsyncMock()
-        results = _make_results(1)
-        state = _make_state({"apartment_results": results, "apartment_offset": 0})
-        cb = _make_callback("results:more")
-
-        await bot.handle_results_callback(cb, state)
-
-        cb.answer.assert_awaited_once_with(
-            "\u0412\u0441\u0435 \u0440\u0435\u0437\u0443\u043b\u044c\u0442\u0430\u0442\u044b "
-            "\u0443\u0436\u0435 \u043f\u043e\u043a\u0430\u0437\u0430\u043d\u044b"
+        cb.message.answer.assert_awaited_once_with(
+            "Это устаревшая кнопка. Используйте актуальное меню ниже."
         )
-        cb.message.answer.assert_not_called()
         bot._send_property_card.assert_not_awaited()
+
+    async def test_results_more_does_not_emit_partial_page_cards(self) -> None:
+        bot = _create_bot()
+        bot._send_property_card = AsyncMock()
+        state = _make_state({"apartment_results": _make_results(7), "apartment_offset": 0})
+        cb = _make_callback("results:more")
+
+        await bot.handle_results_callback(cb, state)
+
+        assert bot._send_property_card.await_args_list == []
+
+    async def test_single_result_legacy_button_uses_stale_guidance(self) -> None:
+        bot = _create_bot()
+        bot._send_property_card = AsyncMock()
+        state = _make_state({"apartment_results": _make_results(1), "apartment_offset": 0})
+        cb = _make_callback("results:more")
+
+        await bot.handle_results_callback(cb, state)
+
+        cb.message.answer.assert_awaited_once_with(
+            "Это устаревшая кнопка. Используйте актуальное меню ниже."
+        )

--- a/tests/unit/test_card_callbacks.py
+++ b/tests/unit/test_card_callbacks.py
@@ -54,9 +54,11 @@ def _make_callback(data: str, user_id: int = 12345) -> MagicMock:
     cb.data = data
     cb.from_user = MagicMock(id=user_id)
     cb.answer = AsyncMock()
+    cb.bot = MagicMock(delete_message=AsyncMock())
     cb.message = MagicMock()
     cb.message.answer = AsyncMock()
     cb.message.answer_media_group = AsyncMock()
+    cb.message.chat = MagicMock(id=456)
     return cb
 
 
@@ -222,3 +224,22 @@ async def test_card_viewing_starts_dialog_with_edit_mode() -> None:
     dialog_manager.start.assert_awaited_once()
     call_kwargs = dialog_manager.start.call_args.kwargs
     assert call_kwargs.get("show_mode") == ShowMode.DELETE_AND_SEND
+
+
+@pytest.mark.asyncio
+async def test_card_viewing_deletes_catalog_control_message_when_runtime_present() -> None:
+    bot = _create_bot()
+    state = _make_state(
+        {
+            "catalog_runtime": {
+                "results": [_sample_result("prop-42")],
+                "control_message_id": 777,
+            }
+        }
+    )
+    callback = _make_callback("card:viewing:prop-42")
+    dialog_manager = AsyncMock()
+
+    await bot.handle_card_callback(callback, state, dialog_manager=dialog_manager)
+
+    callback.bot.delete_message.assert_awaited_once_with(456, 777)

--- a/tests/unit/test_catalog_cutover.py
+++ b/tests/unit/test_catalog_cutover.py
@@ -121,3 +121,45 @@ async def test_apartment_fast_path_bootstraps_catalog_runtime_and_dialog() -> No
     assert runtime["results"][0]["id"] == "apt-1"
     assert "apartment_results" not in update_kwargs
     dialog_manager.start.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fast_path_deletes_legacy_footer_before_catalog_controls() -> None:
+    bot = _create_bot()
+    bot._cache.store_embedding = AsyncMock()
+    bot._cache.store_sparse_embedding = AsyncMock()
+    bot._apartments_service.search_with_filters = AsyncMock(
+        return_value=([_sample_result("apt-1")], 1)
+    )
+    bot._embeddings.aembed_hybrid_with_colbert = AsyncMock(
+        return_value=([0.1], {"indices": [], "values": []}, None)
+    )
+    bot._send_property_card = AsyncMock()
+    bot._apartment_pipeline.extract = AsyncMock(
+        return_value=SimpleNamespace(
+            meta=SimpleNamespace(confidence="HIGH", semantic_remainder=""),
+            hard=SimpleNamespace(to_filters_dict=dict),
+        )
+    )
+
+    state = _make_state({"apartment_footer_msg_id": 888})
+    dialog_manager = AsyncMock()
+    dialog_manager.middleware_data = {"state": state}
+    message = _make_message()
+    message.bot = MagicMock(delete_message=AsyncMock())
+
+    with (
+        patch("telegram_bot.services.apartments_service.check_escalation", return_value=False),
+        patch(
+            "telegram_bot.services.generate_response.generate_response",
+            new=AsyncMock(return_value={"response": "ok", "response_sent": True}),
+        ),
+    ):
+        await bot._handle_apartment_fast_path(
+            user_text="двушка",
+            message=message,
+            state=state,
+            dialog_manager=dialog_manager,
+        )
+
+    message.bot.delete_message.assert_awaited_once_with(message.chat.id, 888)

--- a/tests/unit/test_catalog_cutover.py
+++ b/tests/unit/test_catalog_cutover.py
@@ -1,0 +1,123 @@
+"""Regression tests for catalog ownership cutover."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from telegram_bot.bot import PropertyBot
+from telegram_bot.config import BotConfig
+
+
+def _make_config() -> BotConfig:
+    return BotConfig(
+        _env_file=None,
+        telegram_token="test-token",
+        voyage_api_key="voyage-key",
+        llm_api_key="llm-key",
+        llm_base_url="https://api.example.com/v1",
+        llm_model="gpt-4o-mini",
+        qdrant_url="http://localhost:6333",
+        qdrant_api_key="qdrant-key",
+        qdrant_collection="test_collection",
+        redis_url="redis://localhost:6379",
+        realestate_database_url="postgresql://postgres:postgres@127.0.0.1:1/realestate",
+        rerank_provider="none",
+    )
+
+
+def _create_bot() -> PropertyBot:
+    config = _make_config()
+    with (
+        patch("telegram_bot.bot.Bot"),
+        patch("telegram_bot.integrations.cache.CacheLayerManager"),
+        patch("telegram_bot.integrations.embeddings.BGEM3HybridEmbeddings"),
+        patch("telegram_bot.integrations.embeddings.BGEM3SparseEmbeddings"),
+        patch("telegram_bot.services.qdrant.QdrantService"),
+        patch("telegram_bot.graph.config.GraphConfig.create_llm"),
+        patch("telegram_bot.graph.config.GraphConfig.create_supervisor_llm"),
+    ):
+        return PropertyBot(config)
+
+
+def _sample_result(property_id: str = "apt-1") -> dict:
+    return {
+        "id": property_id,
+        "score": 0.95,
+        "payload": {
+            "complex_name": "Ocean Vista",
+            "city": "Dubai",
+            "property_type": "Apartment",
+            "floor": 5,
+            "area_m2": 55,
+            "view_primary": "Sea",
+            "view_tags": ["Sea"],
+            "price_eur": 250000,
+        },
+    }
+
+
+def _make_state(data: dict | None = None) -> MagicMock:
+    state = MagicMock()
+    state.get_data = AsyncMock(return_value=data or {})
+    state.update_data = AsyncMock()
+    state.set_data = AsyncMock()
+    return state
+
+
+def _make_message() -> MagicMock:
+    message = MagicMock()
+    message.answer = AsyncMock(return_value=MagicMock(message_id=999, delete=AsyncMock()))
+    message.from_user = MagicMock(id=123)
+    message.chat = MagicMock(id=456)
+    message.bot = MagicMock(delete_message=AsyncMock())
+    return message
+
+
+@pytest.mark.asyncio
+async def test_apartment_fast_path_bootstraps_catalog_runtime_and_dialog() -> None:
+    bot = _create_bot()
+    bot._cache.store_embedding = AsyncMock()
+    bot._cache.store_sparse_embedding = AsyncMock()
+    bot._apartments_service.search_with_filters = AsyncMock(
+        return_value=([_sample_result("apt-1")], 1)
+    )
+    bot._embeddings.aembed_hybrid_with_colbert = AsyncMock(
+        return_value=([0.1], {"indices": [], "values": []}, None)
+    )
+    bot._send_property_card = AsyncMock()
+    bot._apartment_pipeline.extract = AsyncMock(
+        return_value=SimpleNamespace(
+            meta=SimpleNamespace(confidence="HIGH", semantic_remainder=""),
+            hard=SimpleNamespace(to_filters_dict=dict),
+        )
+    )
+
+    state = _make_state({"apartment_footer_msg_id": 777, "apartment_results": [{"id": "old"}]})
+    dialog_manager = AsyncMock()
+    dialog_manager.middleware_data = {"state": state}
+    message = _make_message()
+
+    with (
+        patch("telegram_bot.services.apartments_service.check_escalation", return_value=False),
+        patch(
+            "telegram_bot.services.generate_response.generate_response",
+            new=AsyncMock(return_value={"response": "ok", "response_sent": True}),
+        ),
+    ):
+        result = await bot._handle_apartment_fast_path(
+            user_text="двушка",
+            message=message,
+            state=state,
+            dialog_manager=dialog_manager,
+        )
+
+    assert result is not None
+    update_kwargs = state.update_data.await_args.kwargs
+    runtime = update_kwargs["catalog_runtime"]
+    assert runtime["source"] == "free_text"
+    assert runtime["results"][0]["id"] == "apt-1"
+    assert "apartment_results" not in update_kwargs
+    dialog_manager.start.assert_awaited_once()

--- a/tests/unit/test_catalog_handler.py
+++ b/tests/unit/test_catalog_handler.py
@@ -37,6 +37,12 @@ def test_bot_no_longer_registers_catalog_reply_keyboard_path() -> None:
     assert "include_router(catalog_router)" not in source
 
 
+def test_results_callback_route_is_compat_only_not_primary_catalog_owner() -> None:
+    source = Path("telegram_bot/bot.py").read_text()
+    assert "handle_results_callback" in source
+    assert "CatalogSG.results" in source
+
+
 @pytest.mark.asyncio
 async def test_catalog_more_loads_next_page_and_updates_runtime() -> None:
     from aiogram_dialog import ShowMode, StartMode

--- a/tests/unit/test_results_callbacks.py
+++ b/tests/unit/test_results_callbacks.py
@@ -1,23 +1,16 @@
-"""Unit tests for handle_results_callback (#654)."""
+"""Unit tests for stale legacy results callbacks (#654)."""
 
 from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 
 pytest.importorskip("aiogram", reason="aiogram not installed")
 
-from unittest.mock import AsyncMock, MagicMock, patch
-
 from telegram_bot.bot import PropertyBot
 from telegram_bot.config import BotConfig
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-_PAGE_SIZE = 5  # must match _APARTMENT_PAGE_SIZE in bot.py
 
 
 def _make_config() -> BotConfig:
@@ -58,9 +51,7 @@ def _make_callback(data: str = "results:more", user_id: int = 12345) -> MagicMoc
     cb.answer = AsyncMock()
     cb.message = MagicMock()
     cb.message.answer = AsyncMock()
-    cb.message.answer_photo = AsyncMock()
-    cb.message.answer_media_group = AsyncMock()
-    cb.message.delete = AsyncMock()
+    cb.message.edit_reply_markup = AsyncMock()
     return cb
 
 
@@ -68,191 +59,47 @@ def _make_state(data: dict | None = None) -> MagicMock:
     state = MagicMock()
     state.get_data = AsyncMock(return_value=data or {})
     state.update_data = AsyncMock()
-    state.clear = AsyncMock()
     return state
 
 
 def _make_results(n: int = 8) -> list[dict]:
-    return [
-        {
-            "id": f"prop-{i}",
-            "score": 0.9 - i * 0.01,
-            "payload": {
-                "complex_name": f"Complex {i}",
-                "city": "Dubai",
-                "property_type": "Apartment",
-                "floor": i + 1,
-                "area_m2": 60 + i * 5,
-                "view_tags": ["Sea"],
-                "view_primary": "Sea",
-                "price_eur": 200000 + i * 10000,
-            },
-        }
-        for i in range(n)
-    ]
+    return [{"id": f"prop-{i}", "payload": {"complex_name": f"Complex {i}"}} for i in range(n)]
 
 
-# ---------------------------------------------------------------------------
-# Tests: results:more
-# ---------------------------------------------------------------------------
-
-
-async def test_results_more_shows_next_page() -> None:
-    """8 results, offset=0 → sends 3 cards + 1 footer, updates offset to PAGE_SIZE."""
+@pytest.mark.asyncio
+async def test_results_more_is_stale_compat_only() -> None:
     bot = _create_bot()
     bot._send_property_card = AsyncMock()
-    results = _make_results(8)
-    state = _make_state({"apartment_results": results, "apartment_offset": 0})
+    state = _make_state({"apartment_results": _make_results(8), "apartment_offset": 0})
     callback = _make_callback("results:more")
 
     await bot.handle_results_callback(callback, state)
 
-    # 3 remaining cards via helper + 1 footer message via answer
-    assert bot._send_property_card.await_count == 3
-    assert callback.message.answer.await_count == 1
-    state.update_data.assert_awaited_once()
-    update_kwargs = state.update_data.await_args.kwargs
-    assert update_kwargs["apartment_offset"] == _PAGE_SIZE
-    assert "apartment_footer_msg_id" in update_kwargs
+    callback.message.answer.assert_awaited_once_with(
+        "Это устаревшая кнопка. Используйте актуальное меню ниже."
+    )
+    bot._send_property_card.assert_not_awaited()
+    state.update_data.assert_not_awaited()
     callback.answer.assert_awaited_once_with()
 
 
-async def test_results_more_no_results_in_state() -> None:
-    """No apartment_results in state → answer with error message."""
-    bot = _create_bot()
-    bot._send_property_card = AsyncMock()
-    state = _make_state({})
-    callback = _make_callback("results:more")
-
-    await bot.handle_results_callback(callback, state)
-
-    callback.answer.assert_awaited_once_with("Нет сохранённых результатов")
-    callback.message.answer.assert_not_called()
-    bot._send_property_card.assert_not_awaited()
-
-
-async def test_results_more_exhausted() -> None:
-    """offset == len(results) → answer 'all shown'."""
-    bot = _create_bot()
-    bot._send_property_card = AsyncMock()
-    results = _make_results(5)
-    state = _make_state({"apartment_results": results, "apartment_offset": 5})
-    callback = _make_callback("results:more")
-
-    await bot.handle_results_callback(callback, state)
-
-    callback.answer.assert_awaited_once_with("Все результаты уже показаны")
-    callback.message.answer.assert_not_called()
-    bot._send_property_card.assert_not_awaited()
-
-
-async def test_results_more_fetches_next_scroll_page_for_funnel_state() -> None:
-    """When funnel stored only first page, results:more loads next page from scroll API."""
-    bot = _create_bot()
-    bot._send_property_card = AsyncMock()
-    all_results = _make_results(8)
-    first_page = all_results[:_PAGE_SIZE]
-    next_page = all_results[_PAGE_SIZE:]
-    bot._apartments_service = MagicMock()
-    next_page_ids = [r["id"] for r in next_page]
-    bot._apartments_service.scroll_with_filters = AsyncMock(
-        return_value=(next_page, 8, None, next_page_ids)
-    )
-
-    state = _make_state(
-        {
-            "apartment_results": first_page,
-            "apartment_offset": 0,
-            "apartment_total": 8,
-            "apartment_next_offset": "offset-2",
-            "apartment_filters": {"city": "Бургас"},
-        }
-    )
-    callback = _make_callback("results:more")
-
-    await bot.handle_results_callback(callback, state)
-
-    bot._apartments_service.scroll_with_filters.assert_awaited_once_with(
-        filters={"city": "Бургас"},
-        limit=_PAGE_SIZE,
-        start_from="offset-2",
-        exclude_ids=None,
-    )
-    assert bot._send_property_card.await_count == 3
-    assert callback.message.answer.await_count == 1
-    assert state.update_data.await_count == 2
-    first_call = state.update_data.await_args_list[0].kwargs
-    assert first_call["apartment_total"] == 8
-    assert first_call["apartment_next_offset"] is None
-    assert len(first_call["apartment_results"]) == 8
-    second_call = state.update_data.await_args_list[1].kwargs
-    assert second_call["apartment_offset"] == _PAGE_SIZE
-    assert "apartment_footer_msg_id" in second_call
-    callback.answer.assert_awaited_once_with()
-
-
-async def test_results_more_backfills_from_start_when_next_offset_missing() -> None:
-    """If next_offset is None but total_count says more, fetch wider prefix and avoid duplicates."""
-    bot = _create_bot()
-    bot._send_property_card = AsyncMock()
-    all_results = _make_results(8)
-    first_page = all_results[:_PAGE_SIZE]
-    bot._apartments_service = MagicMock()
-    all_page_ids = [r["id"] for r in all_results]
-    bot._apartments_service.scroll_with_filters = AsyncMock(
-        return_value=(all_results, 8, None, all_page_ids)
-    )
-
-    state = _make_state(
-        {
-            "apartment_results": first_page,
-            "apartment_offset": 0,
-            "apartment_total": 8,
-            "apartment_next_offset": None,
-            "apartment_filters": {"city": "Бургас"},
-        }
-    )
-    callback = _make_callback("results:more")
-
-    await bot.handle_results_callback(callback, state)
-
-    bot._apartments_service.scroll_with_filters.assert_awaited_once_with(
-        filters={"city": "Бургас"},
-        limit=_PAGE_SIZE * 2,
-        start_from=None,
-        exclude_ids=None,
-    )
-    sent_ids = [call.args[1]["id"] for call in bot._send_property_card.await_args_list]
-    assert sent_ids == ["prop-5", "prop-6", "prop-7"]
-    first_call = state.update_data.await_args_list[0].kwargs
-    assert len(first_call["apartment_results"]) == 8
-
-
-# ---------------------------------------------------------------------------
-# Tests: results:refine
-# ---------------------------------------------------------------------------
-
-
-async def test_results_refine_clears_state() -> None:
-    """results:refine → clears results from state, sends prompt, answers callback."""
+@pytest.mark.asyncio
+async def test_results_refine_is_stale_compat_only() -> None:
     bot = _create_bot()
     state = _make_state({"apartment_results": _make_results(3)})
     callback = _make_callback("results:refine")
 
     await bot.handle_results_callback(callback, state)
 
-    state.update_data.assert_awaited_once_with(apartment_results=None, apartment_offset=0)
-    callback.message.answer.assert_awaited_once()
+    callback.message.answer.assert_awaited_once_with(
+        "Это устаревшая кнопка. Используйте актуальное меню ниже."
+    )
+    state.update_data.assert_not_awaited()
     callback.answer.assert_awaited_once_with()
 
 
-# ---------------------------------------------------------------------------
-# Tests: results:viewing
-# ---------------------------------------------------------------------------
-
-
-async def test_results_viewing_delegates() -> None:
-    """results:viewing → starts ViewingSG.date dialog via dialog_manager."""
+@pytest.mark.asyncio
+async def test_results_viewing_is_stale_compat_only() -> None:
     bot = _create_bot()
     state = _make_state({"apartment_results": _make_results(3)})
     callback = _make_callback("results:viewing")
@@ -260,45 +107,8 @@ async def test_results_viewing_delegates() -> None:
 
     await bot.handle_results_callback(callback, state, dialog_manager=dialog_manager)
 
-    dialog_manager.start.assert_awaited_once()
-    from aiogram_dialog import ShowMode
-
-    from telegram_bot.dialogs.states import ViewingSG
-
-    call_args = dialog_manager.start.call_args
-    assert call_args.args[0] == ViewingSG.date
-    assert call_args.kwargs.get("show_mode") == ShowMode.DELETE_AND_SEND
-    start_data = call_args.kwargs.get("data", {})
-    assert "selected_objects" in start_data
-
-
-async def test_results_viewing_fallback_phone_collector() -> None:
-    """results:viewing without dialog_manager → falls back to start_phone_collection."""
-    bot = _create_bot()
-    state = _make_state()
-    callback = _make_callback("results:viewing")
-
-    with patch(
-        "telegram_bot.handlers.phone_collector.start_phone_collection",
-        new=AsyncMock(),
-    ) as mock_collect:
-        await bot.handle_results_callback(callback, state)
-
-    mock_collect.assert_awaited_once()
-
-
-# ---------------------------------------------------------------------------
-# Tests: unknown action
-# ---------------------------------------------------------------------------
-
-
-async def test_results_unknown_action() -> None:
-    """Unknown results: action → just answer callback."""
-    bot = _create_bot()
-    state = _make_state()
-    callback = _make_callback("results:unknown_xyz")
-
-    await bot.handle_results_callback(callback, state)
-
-    callback.answer.assert_awaited_once()
-    callback.message.answer.assert_not_called()
+    dialog_manager.start.assert_not_awaited()
+    callback.message.answer.assert_awaited_once_with(
+        "Это устаревшая кнопка. Используйте актуальное меню ниже."
+    )
+    callback.answer.assert_awaited_once_with()

--- a/tests/unit/test_results_pagination_bugs.py
+++ b/tests/unit/test_results_pagination_bugs.py
@@ -1,10 +1,4 @@
-"""Regression tests for handle_results_callback pagination bugs (#948).
-
-Bugs fixed:
-1. offset=scroll_offset → start_from=scroll_offset
-2. 3-tuple unpack → 4-tuple (captures page_ids)
-3. exclude_ids not passed from state
-"""
+"""Compatibility tests for stale legacy results callbacks."""
 
 from __future__ import annotations
 
@@ -17,13 +11,6 @@ pytest.importorskip("aiogram", reason="aiogram not installed")
 
 from telegram_bot.bot import PropertyBot
 from telegram_bot.config import BotConfig
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-_PAGE_SIZE = 5  # must match _APARTMENT_PAGE_SIZE in bot.py
 
 
 def _make_config() -> BotConfig:
@@ -57,15 +44,14 @@ def _create_bot() -> PropertyBot:
         return PropertyBot(config)
 
 
-def _make_callback(user_id: int = 12345) -> MagicMock:
+def _make_callback() -> MagicMock:
     cb = MagicMock()
     cb.data = "results:more"
-    cb.from_user = MagicMock(id=user_id)
+    cb.from_user = MagicMock(id=12345)
     cb.answer = AsyncMock()
     cb.message = MagicMock()
     cb.message.answer = AsyncMock()
-    cb.message.answer_photo = AsyncMock()
-    cb.message.answer_media_group = AsyncMock()
+    cb.message.edit_reply_markup = AsyncMock()
     return cb
 
 
@@ -76,172 +62,27 @@ def _make_state(data: dict) -> MagicMock:
     return state
 
 
-_APT = {"id": "apt-1", "payload": {"price_eur": 55000, "complex_name": "Test"}}
-
-
-# ---------------------------------------------------------------------------
-# Bug #1: start_from parameter name
-# ---------------------------------------------------------------------------
-
-
-class TestScrollStartFromParameter:
-    async def test_scroll_with_filters_called_with_start_from_not_offset(self):
-        """scroll_with_filters must use start_from=, not offset= (#948 bug 1)."""
-        bot = _create_bot()
-        mock_svc = MagicMock()
-        scroll_return = ([_APT] * 5, 20, 65000.0, ["apt-1", "apt-2"])
-        mock_svc.scroll_with_filters = AsyncMock(return_value=scroll_return)
-        bot._apartments_service = mock_svc
-
-        # State: current page full → triggers lazy fetch
-        first_page = [_APT] * _PAGE_SIZE
-        state_data = {
-            "apartment_results": first_page,
-            "apartment_offset": 0,
-            "apartment_total": 20,
-            "apartment_next_offset": 55000.0,
-            "apartment_filters": {"city": "Солнечный берег"},
-            "apartment_scroll_seen_ids": [],
-        }
-        state = _make_state(state_data)
-        cb = _make_callback()
-
-        from telegram_bot.callback_data import ResultsCB
-
-        cb_data = ResultsCB(action="more")
-
-        with patch.object(bot, "_send_property_card", new=AsyncMock()):
-            await bot.handle_results_callback(cb, state, callback_data=cb_data)
-
-        mock_svc.scroll_with_filters.assert_awaited_once()
-        call_kwargs = mock_svc.scroll_with_filters.call_args.kwargs
-        # Bug #1: must use start_from=, not offset=
-        assert "start_from" in call_kwargs, (
-            "scroll_with_filters must be called with start_from= parameter, not offset="
-        )
-        assert "offset" not in call_kwargs, "scroll_with_filters must NOT use offset= parameter"
-        assert call_kwargs["start_from"] == 55000.0
-
-
-# ---------------------------------------------------------------------------
-# Bug #2: 4-tuple unpack (page_ids captured)
-# ---------------------------------------------------------------------------
-
-
-class TestScrollFourTupleUnpack:
-    async def test_page_ids_saved_to_state_after_scroll(self):
-        """page_ids from 4-tuple must be saved to state as apartment_scroll_seen_ids (#948 bug 2)."""
-        bot = _create_bot()
-        mock_svc = MagicMock()
-        new_page_ids = ["apt-10", "apt-11", "apt-12"]
-        scroll_return = ([_APT] * 3, 20, 70000.0, new_page_ids)
-        mock_svc.scroll_with_filters = AsyncMock(return_value=scroll_return)
-        bot._apartments_service = mock_svc
-
-        first_page = [_APT] * _PAGE_SIZE
-        state_data = {
-            "apartment_results": first_page,
-            "apartment_offset": 0,
-            "apartment_total": 20,
-            "apartment_next_offset": 55000.0,
-            "apartment_filters": {},
-            "apartment_scroll_seen_ids": [],
-        }
-        state = _make_state(state_data)
-        cb = _make_callback()
-
-        from telegram_bot.callback_data import ResultsCB
-
-        cb_data = ResultsCB(action="more")
-
-        with patch.object(bot, "_send_property_card", new=AsyncMock()):
-            await bot.handle_results_callback(cb, state, callback_data=cb_data)
-
-        state.update_data.assert_awaited()
-        # Find the call that stores apartment data
-        update_calls = state.update_data.call_args_list
-        stored_ids = None
-        for call in update_calls:
-            kw = call.kwargs
-            if "apartment_scroll_seen_ids" in kw:
-                stored_ids = kw["apartment_scroll_seen_ids"]
-                break
-        assert stored_ids == new_page_ids, (
-            f"page_ids {new_page_ids!r} must be stored as apartment_scroll_seen_ids, got {stored_ids!r}"
-        )
-
-
-# ---------------------------------------------------------------------------
-# Bug #3: exclude_ids passed from state
-# ---------------------------------------------------------------------------
-
-
-class TestScrollExcludeIds:
-    async def test_exclude_ids_passed_from_state(self):
-        """exclude_ids must be passed from state's apartment_scroll_seen_ids (#948 bug 3)."""
-        bot = _create_bot()
-        mock_svc = MagicMock()
-        scroll_return = ([_APT] * 5, 20, 70000.0, ["apt-new"])
-        mock_svc.scroll_with_filters = AsyncMock(return_value=scroll_return)
-        bot._apartments_service = mock_svc
-
-        seen_ids = ["apt-5", "apt-6", "apt-7"]
-        first_page = [_APT] * _PAGE_SIZE
-        state_data = {
-            "apartment_results": first_page,
+@pytest.mark.asyncio
+async def test_results_more_stale_compat_does_not_call_scroll_with_filters() -> None:
+    bot = _create_bot()
+    bot._apartments_service = MagicMock()
+    bot._apartments_service.scroll_with_filters = AsyncMock()
+    state = _make_state(
+        {
+            "apartment_results": [{"id": "apt-1"}],
             "apartment_offset": 0,
             "apartment_total": 20,
             "apartment_next_offset": 55000.0,
             "apartment_filters": {"rooms": 2},
-            "apartment_scroll_seen_ids": seen_ids,
+            "apartment_scroll_seen_ids": ["apt-1"],
         }
-        state = _make_state(state_data)
-        cb = _make_callback()
+    )
+    callback = _make_callback()
 
-        from telegram_bot.callback_data import ResultsCB
+    await bot.handle_results_callback(callback, state)
 
-        cb_data = ResultsCB(action="more")
-
-        with patch.object(bot, "_send_property_card", new=AsyncMock()):
-            await bot.handle_results_callback(cb, state, callback_data=cb_data)
-
-        mock_svc.scroll_with_filters.assert_awaited_once()
-        call_kwargs = mock_svc.scroll_with_filters.call_args.kwargs
-        # Bug #3: exclude_ids must be passed
-        assert "exclude_ids" in call_kwargs, (
-            "scroll_with_filters must be called with exclude_ids= parameter"
-        )
-        assert call_kwargs["exclude_ids"] == seen_ids, (
-            f"exclude_ids must equal apartment_scroll_seen_ids={seen_ids!r}"
-        )
-
-    async def test_exclude_ids_is_none_when_seen_ids_empty(self):
-        """When no seen_ids in state, exclude_ids must be None (not empty list)."""
-        bot = _create_bot()
-        mock_svc = MagicMock()
-        scroll_return = ([_APT] * 5, 20, 70000.0, ["apt-new"])
-        mock_svc.scroll_with_filters = AsyncMock(return_value=scroll_return)
-        bot._apartments_service = mock_svc
-
-        first_page = [_APT] * _PAGE_SIZE
-        state_data = {
-            "apartment_results": first_page,
-            "apartment_offset": 0,
-            "apartment_total": 20,
-            "apartment_next_offset": 55000.0,
-            "apartment_filters": {},
-            "apartment_scroll_seen_ids": [],
-        }
-        state = _make_state(state_data)
-        cb = _make_callback()
-
-        from telegram_bot.callback_data import ResultsCB
-
-        cb_data = ResultsCB(action="more")
-
-        with patch.object(bot, "_send_property_card", new=AsyncMock()):
-            await bot.handle_results_callback(cb, state, callback_data=cb_data)
-
-        call_kwargs = mock_svc.scroll_with_filters.call_args.kwargs
-        # Empty list → None (falsy guard)
-        assert call_kwargs.get("exclude_ids") is None
+    bot._apartments_service.scroll_with_filters.assert_not_awaited()
+    state.update_data.assert_not_awaited()
+    callback.message.answer.assert_awaited_once_with(
+        "Это устаревшая кнопка. Используйте актуальное меню ниже."
+    )


### PR DESCRIPTION
Closes #1038
Closes #1040

## Summary

- routes free-text apartment fast-path searches into the shared `CatalogSG + catalog_runtime` ownership path instead of reviving legacy `apartment_*` browsing state
- downgrades legacy `results:*` callbacks to stale-compat only, so old inline buttons no longer paginate, refine, or open viewing flows
- cleans up stale legacy footer/control messages during cutover while keeping card and favorites metadata sourced from shared catalog runtime results

Legacy `results:*` callbacks are now stale-compat only.

## Validation

- `uv run pytest -q tests/unit/services/test_catalog_session.py tests/unit/test_catalog_cutover.py tests/unit/test_catalog_handler.py tests/unit/test_results_callbacks.py tests/unit/test_results_pagination_bugs.py tests/unit/test_card_callbacks.py tests/unit/test_favorites_callbacks.py tests/unit/dialogs/test_funnel.py tests/unit/dialogs/test_demo_catalog.py`
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`

## Notes

- `make test-unit` passed with 17 skips from optional extras that are not installed in this environment (`fastapi`, `cocoindex`, `livekit`, `ragas`, `pandas`).
- Old open-but-already-fixed backlog hygiene items were not included in this PR.
