### PR TITLE
Fix local startup reliability and extraction contract

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -620,6 +620,7 @@ class PropertyBot:
         self._topic_manager: Any = None
         self._miniapp_subscriber_task: asyncio.Task[None] | None = None
         self._polling_lock: RedisPollingLock | None = None
+        self._polling_lock_task: asyncio.Task[None] | None = None
         self._polling_lock_owner: str | None = None
 
         # Track initialization state
@@ -4826,8 +4827,36 @@ class PropertyBot:
             )
             self._polling_lock_owner = f"{socket.gethostname()}:{os.getpid()}"
             await self._polling_lock.acquire(self._polling_lock_owner)
+            self._polling_lock_task = asyncio.create_task(
+                self._polling_lock_heartbeat(),
+                name="polling-lock-heartbeat",
+            )
 
-        await self.dp.start_polling(self.bot)
+        try:
+            await self.dp.start_polling(self.bot)
+        finally:
+            if self._polling_lock_task is not None:
+                self._polling_lock_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._polling_lock_task
+                self._polling_lock_task = None
+
+    async def _polling_lock_heartbeat(self) -> None:
+        """Keep the Redis lease alive while polling is active."""
+        if self._polling_lock is None:
+            return
+
+        refresh_interval = max(1, self._polling_lock.ttl_sec // 3)
+        try:
+            while True:
+                await asyncio.sleep(refresh_interval)
+                await self._polling_lock.refresh()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Polling lock heartbeat failed; stopping polling")
+            with contextlib.suppress(Exception):
+                await self.dp.stop_polling()
 
     async def stop(self):
         """Stop bot and cleanup."""
@@ -4837,9 +4866,14 @@ class PropertyBot:
             with contextlib.suppress(asyncio.CancelledError):
                 await self._miniapp_subscriber_task
             self._miniapp_subscriber_task = None
+        if self._polling_lock_task is not None:
+            self._polling_lock_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._polling_lock_task
+            self._polling_lock_task = None
         if self._polling_lock is not None and self._polling_lock_owner is not None:
             try:
-                await self._polling_lock.release(self._polling_lock_owner)
+                await self._polling_lock.release()
             except Exception:
                 logger.warning("Failed to release polling lock cleanly", exc_info=True)
             finally:

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -6,7 +6,9 @@ import inspect
 import io
 import json
 import logging
+import os
 import re
+import socket
 import time
 import uuid
 import warnings
@@ -34,6 +36,7 @@ from .handlers.handoff import (
     HandoffStates,
     start_qualification,
 )
+from .integrations.polling_lock import RedisPollingLock
 from .keyboards.client_keyboard import (
     parse_menu_button,
 )
@@ -59,6 +62,7 @@ from .services.handoff_state import HandoffData, HandoffState
 from .services.metrics import PipelineMetrics
 from .services.redis_monitor import RedisHealthMonitor
 from .services.topic_service import TopicService
+from .startup_status import StartupReport, StartupSeverity, StartupSignal
 
 
 if TYPE_CHECKING:
@@ -615,6 +619,8 @@ class PropertyBot:
         self._deeplink_redis: Any | None = None
         self._topic_manager: Any = None
         self._miniapp_subscriber_task: asyncio.Task[None] | None = None
+        self._polling_lock: RedisPollingLock | None = None
+        self._polling_lock_owner: str | None = None
 
         # Track initialization state
         self._cache_initialized = False
@@ -4319,6 +4325,7 @@ class PropertyBot:
     async def start(self):
         """Start bot polling."""
         logger.info("Starting bot...")
+        startup_report = StartupReport()
 
         # Initialize cache at startup
         if not self._cache_initialized:
@@ -4341,6 +4348,14 @@ class PropertyBot:
         except Exception:
             logger.warning("Redis checkpointer init failed, using in-memory", exc_info=True)
             self._checkpointer = create_fallback_checkpointer()
+            startup_report.add(
+                StartupSignal(
+                    source="conversation_memory",
+                    severity=StartupSeverity.DEGRADED,
+                    summary="Redis checkpointer unavailable, using in-memory fallback",
+                    remediation="restore Redis connectivity for persistent conversation memory",
+                )
+            )
 
         # Agent/voice checkpointer — Redis with TTL for bounded retention (#424).
         try:
@@ -4357,6 +4372,14 @@ class PropertyBot:
         except Exception:
             logger.warning("Agent Redis checkpointer init failed, using in-memory", exc_info=True)
             self._agent_checkpointer = create_fallback_checkpointer()
+            startup_report.add(
+                StartupSignal(
+                    source="agent_memory",
+                    severity=StartupSeverity.DEGRADED,
+                    summary="Agent Redis checkpointer unavailable, using in-memory fallback",
+                    remediation="restore Redis connectivity for persistent agent state",
+                )
+            )
 
         # Initialize topic service (forum topics mapping — user+expert → thread_id)
         import redis.asyncio as aioredis
@@ -4394,6 +4417,14 @@ class PropertyBot:
         except Exception:
             logger.warning("History service init failed, /history disabled", exc_info=True)
             self._history_service = None
+            startup_report.add(
+                StartupSignal(
+                    source="history",
+                    severity=StartupSeverity.DEGRADED,
+                    summary="/history disabled because history service initialization failed",
+                    remediation="restore Qdrant history collection and embeddings dependencies",
+                )
+            )
 
         # Initialize Kommo CRM client if enabled (#420: fail-safe, must not block startup)
         if self.config.kommo_enabled and self.config.kommo_subdomain:
@@ -4543,6 +4574,14 @@ class PropertyBot:
                     logger.exception("Failed to start nurturing scheduler")
         except Exception:
             logger.warning("PostgreSQL pool init failed, user features disabled", exc_info=True)
+            startup_report.add(
+                StartupSignal(
+                    source="postgres_runtime",
+                    severity=StartupSeverity.DEGRADED,
+                    summary="PostgreSQL pool unavailable, user features disabled",
+                    remediation="restore PostgreSQL connectivity for favorites, search events, and user services",
+                )
+            )
 
         # Initialize session summary worker (#445)
         self._session_summary_worker: Any | None = None
@@ -4715,9 +4754,17 @@ class PropertyBot:
         logger.info("aiogram-dialog setup complete")
 
         # Preflight dependency checks
-        from .preflight import check_dependencies
+        from .preflight import PreflightError, check_dependencies
 
-        await check_dependencies(self.config)
+        try:
+            preflight_result = await check_dependencies(self.config, log_summary=False)
+        except PreflightError as exc:
+            startup_report.merge(exc.report)
+            logger.error(startup_report.render())
+            raise
+        preflight_report = getattr(preflight_result, "report", None)
+        if isinstance(preflight_report, StartupReport):
+            startup_report.merge(preflight_report)
 
         # Start Redis health monitor (background task, every 5 min)
         await self._redis_monitor.start()
@@ -4765,6 +4812,21 @@ class PropertyBot:
                 self._miniapp_subscriber_loop(), name="miniapp-pubsub"
             )
 
+        if startup_report.final_severity is StartupSeverity.FAILED:
+            logger.error(startup_report.render())
+        elif startup_report.final_severity is StartupSeverity.DEGRADED:
+            logger.warning(startup_report.render())
+        else:
+            logger.info(startup_report.render())
+
+        if self._cache.redis is not None:
+            self._polling_lock = RedisPollingLock(
+                redis=self._cache.redis,
+                key="telegram-bot:polling",
+            )
+            self._polling_lock_owner = f"{socket.gethostname()}:{os.getpid()}"
+            await self._polling_lock.acquire(self._polling_lock_owner)
+
         await self.dp.start_polling(self.bot)
 
     async def stop(self):
@@ -4775,6 +4837,14 @@ class PropertyBot:
             with contextlib.suppress(asyncio.CancelledError):
                 await self._miniapp_subscriber_task
             self._miniapp_subscriber_task = None
+        if self._polling_lock is not None and self._polling_lock_owner is not None:
+            try:
+                await self._polling_lock.release(self._polling_lock_owner)
+            except Exception:
+                logger.warning("Failed to release polling lock cleanly", exc_info=True)
+            finally:
+                self._polling_lock = None
+                self._polling_lock_owner = None
         await self._redis_monitor.stop()
         await self._cache.close()
         await self._qdrant.close()

--- a/telegram_bot/integrations/polling_lock.py
+++ b/telegram_bot/integrations/polling_lock.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import inspect
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 
@@ -14,22 +14,44 @@ class RedisPollingLock:
     redis: Any
     key: str
     ttl_sec: int = 90
+    _lock: Any | None = field(init=False, default=None, repr=False)
 
     async def _call(self, method_name: str, *args: Any, **kwargs: Any) -> Any:
-        method = getattr(self.redis, method_name)
+        method = getattr(self._lock, method_name)
         result = method(*args, **kwargs)
         if inspect.isawaitable(result):
             return await result
         return result
 
+    async def _create_backend_lock(self) -> Any:
+        result = self.redis.lock(
+            self.key,
+            timeout=self.ttl_sec,
+            blocking=False,
+            thread_local=False,
+        )
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
     async def acquire(self, owner: str) -> None:
-        created = await self._call("set", self.key, owner, ex=self.ttl_sec, nx=True)
+        self._lock = await self._create_backend_lock()
+        created = await self._call("acquire", token=owner)
         if not created:
+            self._lock = None
             raise PollingLockBusy(
                 f"Polling lock {self.key!r} is already held; stop the other bot instance first"
             )
 
-    async def release(self, owner: str) -> None:
-        current = await self._call("get", self.key)
-        if current == owner:
-            await self._call("delete", self.key)
+    async def refresh(self) -> None:
+        if self._lock is None:
+            raise RuntimeError("Polling lock is not acquired")
+        await self._call("reacquire")
+
+    async def release(self) -> None:
+        if self._lock is None:
+            return
+        try:
+            await self._call("release")
+        finally:
+            self._lock = None

--- a/telegram_bot/integrations/polling_lock.py
+++ b/telegram_bot/integrations/polling_lock.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from typing import Any
+
+
+class PollingLockBusy(RuntimeError):
+    """Raised when another polling owner is already active."""
+
+
+@dataclass(slots=True)
+class RedisPollingLock:
+    redis: Any
+    key: str
+    ttl_sec: int = 90
+
+    async def _call(self, method_name: str, *args: Any, **kwargs: Any) -> Any:
+        method = getattr(self.redis, method_name)
+        result = method(*args, **kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+    async def acquire(self, owner: str) -> None:
+        created = await self._call("set", self.key, owner, ex=self.ttl_sec, nx=True)
+        if not created:
+            raise PollingLockBusy(
+                f"Polling lock {self.key!r} is already held; stop the other bot instance first"
+            )
+
+    async def release(self, owner: str) -> None:
+        current = await self._call("get", self.key)
+        if current == owner:
+            await self._call("delete", self.key)

--- a/telegram_bot/logging_config.py
+++ b/telegram_bot/logging_config.py
@@ -101,6 +101,9 @@ def setup_logging(
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("httpcore").setLevel(logging.WARNING)
     logging.getLogger("aiogram").setLevel(logging.INFO)
+    logging.getLogger("aiogram_dialog").setLevel(logging.WARNING)
+    logging.getLogger("aiogram_dialog.manager").setLevel(logging.WARNING)
+    logging.getLogger("aiogram_dialog.manager.message_manager").setLevel(logging.WARNING)
     logging.getLogger("qdrant_client").setLevel(logging.WARNING)
 
     logging.info(

--- a/telegram_bot/main.py
+++ b/telegram_bot/main.py
@@ -21,6 +21,7 @@ from tenacity import (
 
 from .bot import PropertyBot
 from .config import BotConfig
+from .integrations.polling_lock import PollingLockBusy
 from .logging_config import setup_logging
 from .observability import initialize_langfuse
 
@@ -77,7 +78,7 @@ async def main():
 
     try:
         await _start_with_retry()
-    except (TelegramUnauthorizedError, TelegramConflictError):
+    except (TelegramUnauthorizedError, TelegramConflictError, PollingLockBusy):
         logger.error("Fatal Telegram error — check bot token or stop other instances")
         raise
     except KeyboardInterrupt:

--- a/telegram_bot/preflight.py
+++ b/telegram_bot/preflight.py
@@ -13,6 +13,7 @@ from qdrant_client import AsyncQdrantClient, models
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from .config import BotConfig
+from .startup_status import DependencyCheckResult, StartupReport, StartupSeverity, StartupSignal
 
 
 logger = logging.getLogger(__name__)
@@ -73,17 +74,48 @@ DEP_CLASSIFICATION: dict[str, DepLevel] = {
     "langfuse": DepLevel.OPTIONAL,
 }
 
+_DEP_REMEDIATION: dict[str, str] = {
+    "redis": "start Redis and verify REDIS_PASSWORD / redis_url",
+    "redis_cache": "restore Redis cache write/read path",
+    "qdrant": "start Qdrant and verify collection configuration",
+    "bge_m3": "start BGE-M3 and verify /health and encode endpoints",
+    "postgres": "start PostgreSQL or accept degraded user-feature mode",
+    "litellm": "start LiteLLM or accept degraded generation path",
+    "langfuse": "restore Langfuse credentials/connectivity or accept disabled tracing",
+}
+
 
 class PreflightError(SystemExit):
     """Raised when a CRITICAL dependency is unreachable after retries."""
 
-    def __init__(self, failed_deps: list[str]):
+    def __init__(self, failed_deps: list[str], report: StartupReport | None = None):
         self.failed_deps = failed_deps
+        self.report = report or StartupReport()
         msg = (
             f"CRITICAL preflight failure — cannot start bot. "
             f"Unreachable after {CRITICAL_RETRIES} attempts: {', '.join(failed_deps)}"
         )
         super().__init__(msg)
+
+
+def _build_dependency_report(results: dict[str, bool]) -> StartupReport:
+    report = StartupReport()
+    for dep_name, passed in results.items():
+        if passed:
+            continue
+        level = DEP_CLASSIFICATION.get(dep_name, DepLevel.OPTIONAL)
+        severity = (
+            StartupSeverity.FAILED if level == DepLevel.CRITICAL else StartupSeverity.DEGRADED
+        )
+        report.add(
+            StartupSignal(
+                source=dep_name,
+                severity=severity,
+                summary=f"{level.value} dependency unavailable",
+                remediation=_DEP_REMEDIATION.get(dep_name),
+            )
+        )
+    return report
 
 
 async def _check_redis_deep(redis_url: str) -> tuple[bool, dict[str, str]]:
@@ -461,7 +493,11 @@ async def _check_critical_with_retry(
         return False
 
 
-async def check_dependencies(config: BotConfig) -> dict[str, bool]:
+async def check_dependencies(
+    config: BotConfig,
+    *,
+    log_summary: bool = True,
+) -> DependencyCheckResult:
     """Check all bot dependencies with retry logic for CRITICAL ones.
 
     CRITICAL deps (redis, qdrant, bge_m3) are retried up to CRITICAL_RETRIES
@@ -502,11 +538,20 @@ async def check_dependencies(config: BotConfig) -> dict[str, bool]:
                     logger.warning("Preflight WARN: %s [OPTIONAL] — %s", dep_name, e)
                     results[dep_name] = False
 
-    # Log summary
+    # Log per-dependency status
     for dep_name, passed in results.items():
         level = DEP_CLASSIFICATION.get(dep_name, DepLevel.OPTIONAL)
         status = "OK" if passed else "FAIL"
         logger.info("Preflight %s: %s [%s]", status, dep_name, level.value)
+
+    report = _build_dependency_report(results)
+    if log_summary:
+        if report.final_severity is StartupSeverity.FAILED:
+            logger.error(report.render())
+        elif report.final_severity is StartupSeverity.DEGRADED:
+            logger.warning(report.render())
+        else:
+            logger.info(report.render())
 
     # Enforce critical deps
     critical_failures = [
@@ -515,20 +560,6 @@ async def check_dependencies(config: BotConfig) -> dict[str, bool]:
         if not passed and DEP_CLASSIFICATION.get(name) == DepLevel.CRITICAL
     ]
     if critical_failures:
-        raise PreflightError(critical_failures)
+        raise PreflightError(critical_failures, report=report)
 
-    # Warn about optional failures
-    optional_failures = [
-        name
-        for name, passed in results.items()
-        if not passed and DEP_CLASSIFICATION.get(name) == DepLevel.OPTIONAL
-    ]
-    if optional_failures:
-        logger.warning(
-            "Preflight: optional deps unavailable (bot will continue): %s",
-            optional_failures,
-        )
-    else:
-        logger.info("Preflight: all dependencies OK")
-
-    return results
+    return DependencyCheckResult(results, report=report)

--- a/telegram_bot/services/apartment_llm_extractor.py
+++ b/telegram_bot/services/apartment_llm_extractor.py
@@ -38,6 +38,8 @@ Crown Fort Club, Green Fort Suites, Premier Fort Suites, Nessebar Fort Residence
   - НЕ ПУТАТЬ: "трехкомнатный"→rooms 3, "трёшка"→rooms 4
   - студия→rooms 1
 - "у моря" = near_sea preference, НЕ view_tags (если не сказано "вид на море")
+- Если вид не указан, верни view_tags=[]
+- Никогда не возвращай null для массивов
 - "недорого"/"бюджетно" = budget_friendly preference + sort_bias="price_asc"
 - "просторная" = spacious preference + min_area_m2 >= 60
 - Если не уверен — оставь None, не выдумывай"""
@@ -123,11 +125,12 @@ class ApartmentLlmExtractor:
             max_retries=2,
         )
 
-        # Post-validation: clear city if not in our valid set
-        if result.hard.city is not None and result.hard.city not in _VALID_CITIES:
-            result = result.model_copy(
-                update={"hard": result.hard.model_copy(update={"city": None})}
-            )
+        # Re-validate hard filters so bypassed test fixtures using model_construct
+        # still go through the same normalization/default contract as runtime payloads.
+        hard_payload = result.hard.model_dump()
+        if hard_payload.get("city") is not None and hard_payload["city"] not in _VALID_CITIES:
+            hard_payload["city"] = None
+        result = result.model_copy(update={"hard": HardFilters.model_validate(hard_payload)})
 
         # Set extraction source
         return result.model_copy(update={"meta": result.meta.model_copy(update={"source": source})})

--- a/telegram_bot/services/apartment_models.py
+++ b/telegram_bot/services/apartment_models.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field, replace
 from typing import Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 # --- View normalization ---
@@ -383,6 +383,14 @@ class HardFilters(BaseModel):
     is_furnished: bool | None = Field(
         default=None, description="С мебелью (true) / без мебели (false). None если не указано."
     )
+
+    @field_validator("view_tags", mode="before")
+    @classmethod
+    def normalize_view_tags(cls, value: object) -> object:
+        """Treat null-like values as an empty list for extractor compatibility."""
+        if value is None:
+            return []
+        return value
 
     @model_validator(mode="after")
     def fix_ranges(self) -> HardFilters:

--- a/telegram_bot/startup_status.py
+++ b/telegram_bot/startup_status.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class StartupSeverity(StrEnum):
+    OK = "OK"
+    DEGRADED = "DEGRADED"
+    FAILED = "FAILED"
+
+
+@dataclass(slots=True)
+class StartupSignal:
+    source: str
+    severity: StartupSeverity
+    summary: str
+    remediation: str | None = None
+
+
+@dataclass(slots=True)
+class StartupReport:
+    signals: list[StartupSignal] = field(default_factory=list)
+
+    def add(self, signal: StartupSignal) -> None:
+        self.signals.append(signal)
+
+    def merge(self, other: StartupReport | None) -> None:
+        if other is None:
+            return
+        self.signals.extend(other.signals)
+
+    @property
+    def final_severity(self) -> StartupSeverity:
+        if any(signal.severity is StartupSeverity.FAILED for signal in self.signals):
+            return StartupSeverity.FAILED
+        if any(signal.severity is StartupSeverity.DEGRADED for signal in self.signals):
+            return StartupSeverity.DEGRADED
+        return StartupSeverity.OK
+
+    def render(self) -> str:
+        lines = [f"Startup verdict: {self.final_severity.value}"]
+        if not self.signals:
+            lines.append("- startup checks passed")
+            return "\n".join(lines)
+
+        for signal in self.signals:
+            line = f"- {signal.source}: {signal.summary}"
+            if signal.remediation:
+                line = f"{line} | remediation: {signal.remediation}"
+            lines.append(line)
+        return "\n".join(lines)
+
+
+class DependencyCheckResult(dict[str, bool]):
+    """Dict-like dependency result with attached startup report."""
+
+    def __init__(
+        self,
+        results: Mapping[str, bool] | None = None,
+        *,
+        report: StartupReport | None = None,
+    ) -> None:
+        super().__init__(results or {})
+        self.report = report or StartupReport()

--- a/tests/unit/integrations/test_polling_lock.py
+++ b/tests/unit/integrations/test_polling_lock.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -7,21 +7,49 @@ from telegram_bot.integrations.polling_lock import PollingLockBusy, RedisPolling
 
 @pytest.mark.asyncio
 async def test_acquire_raises_when_lock_already_exists() -> None:
-    redis = AsyncMock()
-    redis.set = AsyncMock(return_value=False)
+    backend_lock = MagicMock()
+    backend_lock.acquire = AsyncMock(return_value=False)
+    redis = MagicMock()
+    redis.lock.return_value = backend_lock
     lock = RedisPollingLock(redis=redis, key="bot:polling", ttl_sec=90)
 
     with pytest.raises(PollingLockBusy):
         await lock.acquire(owner="host:123")
 
+    redis.lock.assert_called_once_with(
+        "bot:polling",
+        timeout=90,
+        blocking=False,
+        thread_local=False,
+    )
+    backend_lock.acquire.assert_awaited_once_with(token="host:123")
+
+
+@pytest.mark.asyncio
+async def test_refresh_reacquires_owned_lock() -> None:
+    backend_lock = MagicMock()
+    backend_lock.acquire = AsyncMock(return_value=True)
+    backend_lock.reacquire = AsyncMock(return_value=True)
+    redis = MagicMock()
+    redis.lock.return_value = backend_lock
+    lock = RedisPollingLock(redis=redis, key="bot:polling", ttl_sec=90)
+
+    await lock.acquire(owner="host:123")
+    await lock.refresh()
+
+    backend_lock.reacquire.assert_awaited_once_with()
+
 
 @pytest.mark.asyncio
 async def test_release_deletes_only_owned_lock() -> None:
-    redis = AsyncMock()
-    redis.get = AsyncMock(return_value="host:123")
-    redis.delete = AsyncMock()
+    backend_lock = MagicMock()
+    backend_lock.acquire = AsyncMock(return_value=True)
+    backend_lock.release = AsyncMock()
+    redis = MagicMock()
+    redis.lock.return_value = backend_lock
     lock = RedisPollingLock(redis=redis, key="bot:polling", ttl_sec=90)
 
-    await lock.release(owner="host:123")
+    await lock.acquire(owner="host:123")
+    await lock.release()
 
-    redis.delete.assert_awaited_once_with("bot:polling")
+    backend_lock.release.assert_awaited_once_with()

--- a/tests/unit/integrations/test_polling_lock.py
+++ b/tests/unit/integrations/test_polling_lock.py
@@ -1,0 +1,27 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from telegram_bot.integrations.polling_lock import PollingLockBusy, RedisPollingLock
+
+
+@pytest.mark.asyncio
+async def test_acquire_raises_when_lock_already_exists() -> None:
+    redis = AsyncMock()
+    redis.set = AsyncMock(return_value=False)
+    lock = RedisPollingLock(redis=redis, key="bot:polling", ttl_sec=90)
+
+    with pytest.raises(PollingLockBusy):
+        await lock.acquire(owner="host:123")
+
+
+@pytest.mark.asyncio
+async def test_release_deletes_only_owned_lock() -> None:
+    redis = AsyncMock()
+    redis.get = AsyncMock(return_value="host:123")
+    redis.delete = AsyncMock()
+    lock = RedisPollingLock(redis=redis, key="bot:polling", ttl_sec=90)
+
+    await lock.release(owner="host:123")
+
+    redis.delete.assert_awaited_once_with("bot:polling")

--- a/tests/unit/services/test_apartment_llm_extractor.py
+++ b/tests/unit/services/test_apartment_llm_extractor.py
@@ -85,6 +85,19 @@ class TestApartmentLlmExtractor:
         result = await extractor.extract(query="солнечный берег двушка")
         assert result.hard.city == "Солнечный берег"
 
+    async def test_extract_coerces_null_view_tags_from_llm(self) -> None:
+        bad_result = ApartmentSearchFilters.model_construct(
+            hard=HardFilters.model_construct(view_tags=None),
+            meta=ExtractionMeta(source="llm"),
+        )
+        extractor = ApartmentLlmExtractor.__new__(ApartmentLlmExtractor)
+        extractor._client = AsyncMock()
+        extractor._client.chat.completions.create = AsyncMock(return_value=bad_result)
+        extractor._model = "gpt-4o-mini"
+
+        result = await extractor.extract(query="квартира без уточнения вида")
+        assert result.hard.view_tags == []
+
 
 class TestMergeExtractionResults:
     def test_regex_wins_for_numbers(self) -> None:
@@ -158,3 +171,7 @@ class TestGetSystemPrompt:
         """EXTRACTION_SYSTEM_PROMPT must remain importable for backward compatibility."""
         assert EXTRACTION_SYSTEM_PROMPT
         assert "Солнечный берег" in EXTRACTION_SYSTEM_PROMPT
+
+    def test_system_prompt_forbids_null_view_tags(self) -> None:
+        assert "view_tags=[]" in EXTRACTION_SYSTEM_PROMPT
+        assert "Никогда не возвращай null для массивов" in EXTRACTION_SYSTEM_PROMPT

--- a/tests/unit/services/test_apartment_models.py
+++ b/tests/unit/services/test_apartment_models.py
@@ -8,6 +8,7 @@ import pytest
 from telegram_bot.services.apartment_models import (
     ApartmentQueryParseResult,
     ApartmentRecord,
+    HardFilters,
     compute_confidence,
 )
 
@@ -198,6 +199,12 @@ class TestApartmentQueryParseResult:
         assert filters["rooms"] == 2
         assert filters["price_eur"]["lte"] == 200000.0
         assert "area_m2" not in filters
+
+
+class TestHardFilters:
+    def test_view_tags_none_is_normalized_to_empty_list(self) -> None:
+        filters = HardFilters.model_validate({"view_tags": None})
+        assert filters.view_tags == []
 
 
 class TestComputeConfidence:

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from telegram_bot.bot import PropertyBot, make_session_id
 from telegram_bot.config import BotConfig
+from telegram_bot.startup_status import DependencyCheckResult, StartupReport
 
 
 @pytest.fixture
@@ -1491,6 +1492,34 @@ class TestBotLifecycle:
 
         bot._cache.initialize.assert_not_called()
 
+    async def test_start_logs_one_final_startup_summary(self, mock_config, caplog):
+        """Startup should emit one final verdict block for degraded startup."""
+        bot, _ = _create_bot(mock_config)
+        bot._cache = MagicMock()
+        bot._cache.initialize = AsyncMock()
+        bot._cache.redis = MagicMock()
+        bot.dp = MagicMock()
+        bot.dp.start_polling = AsyncMock()
+        bot._redis_monitor = MagicMock()
+        bot._redis_monitor.start = AsyncMock()
+        bot.bot = MagicMock()
+        bot.bot.set_my_commands = AsyncMock()
+        bot.bot.set_chat_menu_button = AsyncMock()
+
+        result = DependencyCheckResult({"redis": True}, report=StartupReport())
+
+        with (
+            patch(
+                "telegram_bot.preflight.check_dependencies",
+                new_callable=AsyncMock,
+                return_value=result,
+            ),
+            caplog.at_level(logging.INFO),
+        ):
+            await bot.start()
+
+        assert caplog.text.count("Startup verdict:") == 1
+
     async def test_stop_closes_services(self, mock_config):
         """Test that stop() closes all services."""
         bot, _ = _create_bot(mock_config)
@@ -1588,6 +1617,31 @@ class TestBotLifecycle:
 
         # Should not raise
         await bot.stop()
+
+    async def test_stop_releases_polling_lock(self, mock_config):
+        """stop() releases the polling lock when the current instance owns it."""
+        bot, _ = _create_bot(mock_config)
+        bot._cache = MagicMock()
+        bot._cache.close = AsyncMock()
+        bot._qdrant = MagicMock()
+        bot._qdrant.close = AsyncMock()
+        bot._embeddings = MagicMock()
+        bot._embeddings.aclose = AsyncMock()
+        bot._sparse = MagicMock()
+        bot._sparse.aclose = AsyncMock()
+        bot._reranker = None
+        bot.bot = MagicMock()
+        bot.bot.session = MagicMock()
+        bot.bot.session.close = AsyncMock()
+        bot._redis_monitor = MagicMock()
+        bot._redis_monitor.stop = AsyncMock()
+        polling_lock = AsyncMock()
+        bot._polling_lock = polling_lock
+        bot._polling_lock_owner = "host:123"
+
+        await bot.stop()
+
+        polling_lock.release.assert_awaited_once_with("host:123")
 
 
 class TestAgentCheckpointerLifecycle:

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -1520,6 +1520,41 @@ class TestBotLifecycle:
 
         assert caplog.text.count("Startup verdict:") == 1
 
+    async def test_start_starts_polling_lock_heartbeat_when_redis_available(self, mock_config):
+        """start() should create a polling lock heartbeat task after acquiring the lock."""
+        bot, _ = _create_bot(mock_config)
+        bot._cache = MagicMock()
+        bot._cache.initialize = AsyncMock()
+        bot._cache.redis = MagicMock()
+        bot.dp = MagicMock()
+        bot.dp.start_polling = AsyncMock()
+        bot._redis_monitor = MagicMock()
+        bot._redis_monitor.start = AsyncMock()
+        bot.bot = MagicMock()
+        bot.bot.set_my_commands = AsyncMock()
+        bot.bot.set_chat_menu_button = AsyncMock()
+
+        polling_lock = AsyncMock()
+        polling_lock.ttl_sec = 90
+        created_task_names: list[str | None] = []
+
+        def fake_create_task(coro, *, name=None):
+            created_task_names.append(name)
+            coro.close()
+            task = asyncio.Future()
+            task.set_result(None)
+            return task
+
+        with (
+            patch("telegram_bot.preflight.check_dependencies", new_callable=AsyncMock),
+            patch("telegram_bot.bot.RedisPollingLock", return_value=polling_lock),
+            patch("telegram_bot.bot.asyncio.create_task", side_effect=fake_create_task),
+        ):
+            await bot.start()
+
+        polling_lock.acquire.assert_awaited_once()
+        assert "polling-lock-heartbeat" in created_task_names
+
     async def test_stop_closes_services(self, mock_config):
         """Test that stop() closes all services."""
         bot, _ = _create_bot(mock_config)
@@ -1641,7 +1676,21 @@ class TestBotLifecycle:
 
         await bot.stop()
 
-        polling_lock.release.assert_awaited_once_with("host:123")
+        polling_lock.release.assert_awaited_once_with()
+
+    async def test_polling_lock_heartbeat_stops_polling_on_refresh_failure(self, mock_config):
+        """Heartbeat failures should stop polling so the lease cannot silently expire."""
+        bot, _ = _create_bot(mock_config)
+        bot._polling_lock = AsyncMock()
+        bot._polling_lock.ttl_sec = 90
+        bot._polling_lock.refresh = AsyncMock(side_effect=RuntimeError("redis lost"))
+        bot.dp = MagicMock()
+        bot.dp.stop_polling = AsyncMock()
+
+        with patch("telegram_bot.bot.asyncio.sleep", new=AsyncMock()):
+            await bot._polling_lock_heartbeat()
+
+        bot.dp.stop_polling.assert_awaited_once_with()
 
 
 class TestAgentCheckpointerLifecycle:

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -341,6 +341,9 @@ class TestSetupLogging:
         assert logging.getLogger("httpx").level == logging.WARNING
         assert logging.getLogger("httpcore").level == logging.WARNING
         assert logging.getLogger("aiogram").level == logging.INFO
+        assert logging.getLogger("aiogram_dialog").level == logging.WARNING
+        assert logging.getLogger("aiogram_dialog.manager").level == logging.WARNING
+        assert logging.getLogger("aiogram_dialog.manager.message_manager").level == logging.WARNING
         assert logging.getLogger("qdrant_client").level == logging.WARNING
 
     def test_setup_logging_logs_configuration(self):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -209,3 +209,46 @@ class TestMainFunction:
 
             mock_property_bot_instance.start.assert_awaited_once()
             mock_property_bot_instance.stop.assert_awaited_once()
+
+    async def test_main_propagates_polling_lock_busy(self):
+        """Polling lock conflicts should fail fast without retry."""
+        from telegram_bot.integrations.polling_lock import PollingLockBusy
+
+        mock_property_bot_instance = AsyncMock()
+        mock_property_bot_instance.start = AsyncMock(side_effect=PollingLockBusy("lock busy"))
+        mock_property_bot = MagicMock(return_value=mock_property_bot_instance)
+        mock_bot_config = MagicMock()
+        mock_setup_logging = MagicMock()
+
+        mock_bot_mod = MagicMock()
+        mock_bot_mod.PropertyBot = mock_property_bot
+
+        mock_config_mod = MagicMock()
+        mock_config_mod.BotConfig = mock_bot_config
+
+        mock_logging_config_mod = MagicMock()
+        mock_logging_config_mod.setup_logging = mock_setup_logging
+
+        mock_config_instance = MagicMock()
+        mock_config_instance.telegram_token = "test-token"
+        mock_config_instance.llm_api_key = "test-api-key"
+        mock_bot_config.return_value = mock_config_instance
+
+        with (
+            patch.dict(
+                sys.modules,
+                {
+                    "telegram_bot.bot": mock_bot_mod,
+                    "telegram_bot.config": mock_config_mod,
+                    "telegram_bot.logging_config": mock_logging_config_mod,
+                },
+            ),
+            patch("telegram_bot.observability._is_endpoint_reachable", return_value=True),
+        ):
+            from telegram_bot import main as main_module
+
+            with pytest.raises(PollingLockBusy, match="lock busy"):
+                await main_module.main()
+
+            mock_property_bot_instance.start.assert_awaited_once()
+            mock_property_bot_instance.stop.assert_awaited_once()

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -15,6 +15,7 @@ from telegram_bot.preflight import (
     _verify_cache_synthetic,
     check_dependencies,
 )
+from telegram_bot.startup_status import StartupReport
 
 
 # ---------------------------------------------------------------------------
@@ -63,6 +64,10 @@ class TestPreflightError:
     def test_message_mentions_retry_count(self):
         err = PreflightError(["redis"])
         assert str(CRITICAL_RETRIES) in str(err)
+
+    def test_report_attribute_defaults_to_startup_report(self):
+        err = PreflightError(["redis"])
+        assert isinstance(err.report, StartupReport)
 
 
 class TestColbertCoverageWarnThreshold:
@@ -462,6 +467,7 @@ class TestCheckDependencies:
             await check_dependencies(config)
 
         assert "redis" in exc_info.value.failed_deps
+        assert exc_info.value.report.final_severity.name == "FAILED"
 
     async def test_optional_failure_does_not_raise(self):
         config = _make_config()

--- a/tests/unit/test_startup_status.py
+++ b/tests/unit/test_startup_status.py
@@ -1,0 +1,32 @@
+from telegram_bot.startup_status import StartupReport, StartupSeverity, StartupSignal
+
+
+def test_report_is_failed_when_critical_signal_present() -> None:
+    report = StartupReport()
+    report.add(
+        StartupSignal(
+            source="redis",
+            severity=StartupSeverity.FAILED,
+            summary="Redis unavailable",
+            remediation="start redis",
+        )
+    )
+
+    assert report.final_severity is StartupSeverity.FAILED
+
+
+def test_report_renders_single_compact_summary_block() -> None:
+    report = StartupReport()
+    report.add(
+        StartupSignal(
+            source="history",
+            severity=StartupSeverity.DEGRADED,
+            summary="/history disabled",
+            remediation="restore qdrant history collection",
+        )
+    )
+
+    text = report.render()
+
+    assert "Startup verdict: DEGRADED" in text
+    assert "/history disabled" in text


### PR DESCRIPTION
## Summary
- add a Redis-backed polling lock so duplicate local bot instances fail fast instead of entering competing polling loops
- add a structured startup verdict with degraded/fatal signals, and reduce noisy aiogram-dialog metadata logging during startup
- normalize apartment extraction hard filters so `view_tags` never returns `null` and revalidate normalized payloads after LLM extraction

## Test Plan
- [x] `make check`
- [x] `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
- [x] `uv run pytest tests/unit/test_bot_handlers.py tests/unit/test_startup_status.py -q`

Closes #1030
Closes #1031
Closes #1032
Closes #1033