### PR TITLE
fix: harden VPS Google Drive ingestion pipeline (batch 1)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -78,6 +78,8 @@ scripts/
 
 # Docker configs (not needed in image)
 docker/
+!docker/ingestion/
+!docker/ingestion/entrypoint.sh
 
 # Services (separate builds)
 services/

--- a/.env.example
+++ b/.env.example
@@ -125,11 +125,14 @@ MAX_CONTEXT_TOKENS=8000
 # OPENAI_API_KEY is already defined above
 
 # Langfuse (optional - for LLM tracing)
-# Local dev default points to dockerized Langfuse on :3001.
-# On VPS without local Langfuse, set LANGFUSE_HOST=https://cloud.langfuse.com
+# LANGFUSE_HOST is for host-side tools and browser-accessible local dev.
+# Containerized services use LANGFUSE_DOCKER_HOST and default to the Docker network alias.
+# On VPS without local Langfuse, set both LANGFUSE_HOST and LANGFUSE_DOCKER_HOST
+# to the same reachable value (for example https://cloud.langfuse.com).
 LANGFUSE_PUBLIC_KEY=pk-lf-dev
 LANGFUSE_SECRET_KEY=sk-lf-dev
 LANGFUSE_HOST=http://localhost:3001
+LANGFUSE_DOCKER_HOST=http://langfuse:3000
 # Isolate traces by environment in Langfuse UI (prod/staging/dev). Optional.
 # LANGFUSE_TRACING_ENVIRONMENT=staging
 # Flush config (defaults match Langfuse SDK: flush_at=512, flush_interval=5.0s). Optional.

--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,10 @@ QDRANT_HISTORY_COLLECTION=conversation_history
 # Docling API (optional)
 DOCLING_URL=http://localhost:5001
 
+# Unified Google Drive ingestion (required for ingestion service / VPS deploys)
+GDRIVE_SYNC_DIR=/absolute/path/to/drive-sync
+GDRIVE_COLLECTION_NAME=gdrive_documents_bge
+
 # =============================================================================
 # DEV STACK CONFIGURATION
 # =============================================================================

--- a/.env.local.example
+++ b/.env.local.example
@@ -10,6 +10,8 @@ GROQ_API_KEY=gsk_your-groq-key
 # === Local Services (docker-compose.local.yml) ===
 QDRANT_URL=http://localhost:6333
 QDRANT_API_KEY=  # Пустой для локальной разработки
+GDRIVE_SYNC_DIR=/absolute/path/to/drive-sync
+GDRIVE_COLLECTION_NAME=gdrive_documents_bge
 BGE_M3_URL=http://localhost:8001
 DOCLING_URL=http://localhost:5001
 REDIS_URL=redis://localhost:6379

--- a/Dockerfile.ingestion
+++ b/Dockerfile.ingestion
@@ -47,11 +47,11 @@ FROM python:3.12-slim-bookworm AS runtime
 
 WORKDIR /app
 
-# Install runtime deps (procps for healthcheck)
+# Install runtime deps (procps for healthcheck, gosu for privilege drop)
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
-    apt-get update && apt-get install -y --no-install-recommends procps
+    apt-get update && apt-get install -y --no-install-recommends procps gosu
 
 # Create non-root user BEFORE copying files
 RUN useradd -m -u 1000 ingestion
@@ -66,10 +66,12 @@ COPY --from=builder --chown=ingestion:ingestion /app/.venv /app/.venv
 COPY --chown=ingestion:ingestion pyproject.toml uv.lock ./
 COPY --chown=ingestion:ingestion src/ ./src/
 COPY --chown=ingestion:ingestion telegram_bot/ ./telegram_bot/
+COPY docker/ingestion/entrypoint.sh /usr/local/bin/ingestion-entrypoint.sh
 
-USER ingestion
+RUN chmod +x /usr/local/bin/ingestion-entrypoint.sh
 
-ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
+ENV PATH="/app/.venv/bin:${PATH}" \
+    UV_PROJECT_ENVIRONMENT=/app/.venv \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
@@ -78,5 +80,5 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
 
 STOPSIGNAL SIGTERM
 
-ENTRYPOINT ["/app/.venv/bin/python", "-m", "src.ingestion.unified.cli"]
+ENTRYPOINT ["/usr/local/bin/ingestion-entrypoint.sh"]
 CMD ["run", "--watch"]

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 	rclone-install sync-drive-install sync-drive-run sync-drive-status \
 	ingest-dir ingest-gdrive ingest-status ingest-services \
 	ingest-gdrive-setup ingest-gdrive-run ingest-gdrive-watch ingest-gdrive-status \
-	ingest-unified ingest-unified-watch ingest-unified-status ingest-unified-reprocess ingest-unified-logs \
+	ingest-unified-preflight ingest-unified-bootstrap ingest-unified ingest-unified-watch ingest-unified-status ingest-unified-reprocess ingest-unified-logs \
 	lock update update-pkg reinstall setup-hooks \
 	qdrant-backup \
 	git-hygiene git-hygiene-fix repo-cleanup repo-cleanup-force \
@@ -24,6 +24,8 @@ GREEN := \033[0;32m
 YELLOW := \033[0;33m
 RED := \033[0;31m
 NC := \033[0m # No Color
+
+ENV_LOAD = if [ -f .env ]; then set -a; . ./.env; set +a; fi;
 
 help: ## Show this help message
 	@echo "$(BLUE)Contextual RAG v2.0.1 - Development Commands$(NC)"
@@ -764,22 +766,39 @@ rclone-install: ## Install rclone
 
 sync-drive-install: ## Install rclone cron job
 	@echo "$(BLUE)Installing rclone cron...$(NC)"
-	sudo mkdir -p /opt/scripts /opt/credentials /data/drive-sync
-	sudo cp docker/rclone/sync-drive.sh /opt/scripts/
-	sudo cp docker/rclone/gdrive-manifest.sh /opt/scripts/
-	sudo chmod +x /opt/scripts/sync-drive.sh /opt/scripts/gdrive-manifest.sh
-	sudo cp docker/rclone/crontab /etc/cron.d/rclone-sync
+	@$(ENV_LOAD) \
+	: "$${GDRIVE_SYNC_DIR:?GDRIVE_SYNC_DIR is required}"; \
+	: "$${RCLONE_CONFIG_FILE:?RCLONE_CONFIG_FILE is required}"; \
+	test -f "$${RCLONE_CONFIG_FILE}" || { echo "$(RED)Error: RCLONE_CONFIG_FILE not found at $${RCLONE_CONFIG_FILE}$(NC)"; exit 1; }; \
+	sudo mkdir -p /opt/scripts /opt/credentials /etc/rag-fresh "$${GDRIVE_SYNC_DIR}"; \
+	sudo cp docker/rclone/sync-drive.sh /opt/scripts/; \
+	sudo cp docker/rclone/gdrive-manifest.sh /opt/scripts/; \
+	sudo chmod +x /opt/scripts/sync-drive.sh /opt/scripts/gdrive-manifest.sh; \
+	printf 'GDRIVE_SYNC_DIR=%s\nRCLONE_CONFIG_FILE=%s\nRCLONE_REMOTE=%s\n' \
+	  "$${GDRIVE_SYNC_DIR}" "$${RCLONE_CONFIG_FILE}" "$${RCLONE_REMOTE:-gdrive:RAG}" | \
+	  sudo tee /etc/rag-fresh/rclone-sync.env >/dev/null; \
+	sudo chmod 600 /etc/rag-fresh/rclone-sync.env; \
+	sudo cp docker/rclone/crontab /etc/cron.d/rclone-sync; \
 	sudo chmod 644 /etc/cron.d/rclone-sync
 	@echo "$(GREEN)✓ Cron installed$(NC)"
 
 sync-drive-run: ## Run Drive sync manually
 	@echo "$(BLUE)Syncing Google Drive...$(NC)"
+	@$(ENV_LOAD) \
+	: "$${GDRIVE_SYNC_DIR:?GDRIVE_SYNC_DIR is required}"; \
+	: "$${RCLONE_CONFIG_FILE:?RCLONE_CONFIG_FILE is required}"; \
+	test -f "$${RCLONE_CONFIG_FILE}" || { echo "$(RED)Error: RCLONE_CONFIG_FILE not found at $${RCLONE_CONFIG_FILE}$(NC)"; exit 1; }; \
 	/opt/scripts/sync-drive.sh
 	@echo "$(GREEN)✓ Sync complete$(NC)"
 
 sync-drive-status: ## Show sync status and recent files
 	@echo "$(BLUE)Recent synced files:$(NC)"
-	@ls -lt /data/drive-sync 2>/dev/null | head -20 || echo "No files synced yet"
+	@$(ENV_LOAD) \
+	if [ -n "$${GDRIVE_SYNC_DIR:-}" ] && [ -d "$${GDRIVE_SYNC_DIR}" ]; then \
+	  ls -lt "$${GDRIVE_SYNC_DIR}" 2>/dev/null | head -20; \
+	else \
+	  echo "No files synced yet"; \
+	fi
 	@echo ""
 	@echo "$(BLUE)Last sync log:$(NC)"
 	@tail -10 /var/log/rclone-sync.log 2>/dev/null || echo "No logs yet"
@@ -808,13 +827,15 @@ endif
 	uv run python -m telegram_bot.services.ingestion_cocoindex ingest-dir "$(DIR)"
 	@echo "$(GREEN)✓ Directory ingestion complete$(NC)"
 
-ingest-gdrive: ## [DEPRECATED] Use ingest-gdrive-run instead (rclone + CocoIndex pipeline)
+ingest-gdrive: ## [DEPRECATED] Use unified ingestion targets instead
 	@echo "$(RED)⚠ make ingest-gdrive is deprecated.$(NC)"
 	@echo "  GDrive ingestion now uses rclone sync + CocoIndex pipeline."
 	@echo "  Use one of:"
-	@echo "    make ingest-gdrive-run    # Run ingestion once"
-	@echo "    make ingest-gdrive-watch  # Continuous watch mode"
-	@echo "    make ingest-gdrive-status # Collection stats"
+	@echo "    make ingest-unified-preflight"
+	@echo "    make ingest-unified-bootstrap"
+	@echo "    make ingest-unified"
+	@echo "    make ingest-unified-watch"
+	@echo "    make ingest-unified-status"
 	@exit 1
 
 ingest-status: ## Show collection statistics
@@ -827,58 +848,61 @@ ingest-services: ## Index curated services.yaml content into Qdrant
 	@echo "$(GREEN)✓ services.yaml indexing complete$(NC)"
 
 # =============================================================================
-# GOOGLE DRIVE INGESTION (rclone + watcher pipeline)
+# GOOGLE DRIVE INGESTION COMPATIBILITY ALIASES
 # =============================================================================
 
 .PHONY: ingest-gdrive-setup ingest-gdrive-run ingest-gdrive-watch ingest-gdrive-status
 
-ingest-gdrive-setup: ## Setup GDrive collection in Qdrant (scalar + binary)
-	@echo "$(BLUE)Creating Qdrant collections...$(NC)"
-	uv run python scripts/setup_scalar_collection.py --source gdrive_documents
-	uv run python scripts/setup_binary_collection.py --source gdrive_documents
-	@echo "$(GREEN)✓ Collections ready$(NC)"
+ingest-gdrive-setup: ## [DEPRECATED] Alias to ingest-unified-bootstrap
+	@echo "$(YELLOW)Deprecated: use make ingest-unified-bootstrap$(NC)"
+	@$(MAKE) ingest-unified-bootstrap
 
-ingest-gdrive-run: ## Run GDrive ingestion once
-	@echo "$(BLUE)Running GDrive ingestion...$(NC)"
-	uv run python -m src.ingestion.gdrive_flow --once
-	@echo "$(GREEN)✓ Ingestion complete$(NC)"
+ingest-gdrive-run: ## [DEPRECATED] Alias to ingest-unified
+	@echo "$(YELLOW)Deprecated: use make ingest-unified$(NC)"
+	@$(MAKE) ingest-unified
 
-ingest-gdrive-watch: ## Run GDrive ingestion continuously (watch mode)
-	@echo "$(BLUE)Starting GDrive watch mode...$(NC)"
-	uv run python -m src.ingestion.gdrive_flow --watch
+ingest-gdrive-watch: ## [DEPRECATED] Alias to ingest-unified-watch
+	@echo "$(YELLOW)Deprecated: use make ingest-unified-watch$(NC)"
+	@$(MAKE) ingest-unified-watch
 
-ingest-gdrive-status: ## Show GDrive collection stats
-	@echo "$(BLUE)GDrive collection stats:$(NC)"
-	@uv run python -c "from qdrant_client import QdrantClient; c=QdrantClient('http://localhost:6333'); \
-		[print(f'  {n}: {c.get_collection(n).points_count} points') if c.collection_exists(n) else print(f'  {n}: not found') \
-		for n in ['gdrive_documents_scalar', 'gdrive_documents_binary']]"
+ingest-gdrive-status: ## [DEPRECATED] Alias to ingest-unified-status
+	@echo "$(YELLOW)Deprecated: use make ingest-unified-status$(NC)"
+	@$(MAKE) ingest-unified-status
 
 # =============================================================================
 # UNIFIED INGESTION PIPELINE (v3.2.1)
 # =============================================================================
 
-.PHONY: ingest-unified ingest-unified-watch ingest-unified-status ingest-unified-reprocess ingest-unified-logs
+.PHONY: ingest-unified-preflight ingest-unified-bootstrap ingest-unified ingest-unified-watch ingest-unified-status ingest-unified-reprocess ingest-unified-logs
+
+ingest-unified-preflight: ## Check unified ingestion dependencies and source path
+	@echo "$(BLUE)Running unified ingestion preflight...$(NC)"
+	@$(ENV_LOAD) uv run python -m src.ingestion.unified.cli preflight
+
+ingest-unified-bootstrap: ## Create/validate unified ingestion collection schema
+	@echo "$(BLUE)Bootstrapping unified ingestion collection...$(NC)"
+	@$(ENV_LOAD) uv run python -m src.ingestion.unified.cli bootstrap --require-colbert
 
 ingest-unified: ## Run unified ingestion once
 	@echo "$(BLUE)Running unified ingestion (CocoIndex)...$(NC)"
-	@if [ -f .env ]; then set -a; . ./.env; set +a; fi; uv run python -m src.ingestion.unified.cli run
+	@$(ENV_LOAD) uv run python -m src.ingestion.unified.cli run
 	@echo "$(GREEN)✓ Ingestion complete$(NC)"
 
 ingest-unified-watch: ## Run unified ingestion continuously (watch mode)
 	@echo "$(BLUE)Starting unified ingestion watch mode...$(NC)"
-	@if [ -f .env ]; then set -a; . ./.env; set +a; fi; uv run python -m src.ingestion.unified.cli run --watch
+	@$(ENV_LOAD) uv run python -m src.ingestion.unified.cli run --watch
 
 ingest-unified-status: ## Show unified ingestion status
 	@echo "$(BLUE)Unified ingestion status:$(NC)"
-	@if [ -f .env ]; then set -a; . ./.env; set +a; fi; uv run python -m src.ingestion.unified.cli status
+	@$(ENV_LOAD) uv run python -m src.ingestion.unified.cli status
 
 ingest-unified-reprocess: ## Reprocess all error files
 	@echo "$(BLUE)Reprocessing error files...$(NC)"
-	@if [ -f .env ]; then set -a; . ./.env; set +a; fi; uv run python -m src.ingestion.unified.cli reprocess --errors
+	@$(ENV_LOAD) uv run python -m src.ingestion.unified.cli reprocess --errors
 	@echo "$(GREEN)✓ Reprocess queued$(NC)"
 
 ingest-unified-logs: ## Show ingestion service logs
-	docker logs dev-ingestion -f --tail 100
+	docker compose logs ingestion -f --tail 100
 
 # =============================================================================
 # QDRANT BACKUP

--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ CI is intentionally lightweight. It should stay fast and is used as a guardrail 
 | [Local Development](docs/LOCAL-DEVELOPMENT.md) | Local setup and validation guide |
 | [Qdrant Stack](docs/QDRANT_STACK.md) | Vector collections, schema, operations |
 | [Ingestion Runbook](docs/INGESTION.md) | Unified ingestion guide and troubleshooting |
+| [Google Drive Sync Runbook](docs/GDRIVE_INGESTION.md) | Google Drive -> local mirror -> unified ingestion contract |
+| [VPS Recovery Runbook](docs/runbooks/vps-gdrive-ingestion-recovery.md) | Recover empty sync mount / empty collection incidents on VPS |
 | [SDK Migration Audit](docs/SDK_MIGRATION_AUDIT_2026-03-13.md) | Canonical SDK keeper stack and bounded follow-up work |
 | [SDK Migration Roadmap](docs/SDK_MIGRATION_ROADMAP_2026-03-13.md) | Post-audit execution order and guardrails |
 | [Alerting](docs/ALERTING.md) | Loki/Alertmanager setup |

--- a/compose.yml
+++ b/compose.yml
@@ -199,8 +199,8 @@ services:
       # Langfuse v3 OTEL (Docker internal network)
       LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
-      LANGFUSE_HOST: ${LANGFUSE_HOST:-http://langfuse:3000}
-      LANGFUSE_OTEL_HOST: ${LANGFUSE_HOST:-http://langfuse:3000}
+      LANGFUSE_HOST: ${LANGFUSE_DOCKER_HOST:-http://langfuse:3000}
+      LANGFUSE_OTEL_HOST: ${LANGFUSE_DOCKER_HOST:-http://langfuse:3000}
       # Database disabled — config.yaml is source of truth for local dev
       # DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/litellm
     command: ["--config", "/app/config.yaml"]
@@ -261,7 +261,7 @@ services:
       # Langfuse observability (optional — bot degrades gracefully)
       LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
-      LANGFUSE_HOST: ${LANGFUSE_HOST:-http://langfuse:3000}
+      LANGFUSE_HOST: ${LANGFUSE_DOCKER_HOST:-http://langfuse:3000}
       LANGFUSE_TRACING_ENVIRONMENT: "${LANGFUSE_TRACING_ENVIRONMENT:-}"
       LANGFUSE_FLUSH_AT: "${LANGFUSE_FLUSH_AT:-512}"
       LANGFUSE_FLUSH_INTERVAL: "${LANGFUSE_FLUSH_INTERVAL:-5.0}"
@@ -344,7 +344,7 @@ services:
       LLM_MODEL: gpt-4o-mini
       LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
-      LANGFUSE_HOST: ${LANGFUSE_HOST:-http://langfuse:3000}
+      LANGFUSE_HOST: ${LANGFUSE_DOCKER_HOST:-http://langfuse:3000}
       REALESTATE_DATABASE_URL: "postgresql://postgres:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/realestate"
       KOMMO_ENABLED: "${KOMMO_ENABLED:-false}"
       KOMMO_SUBDOMAIN: "${KOMMO_SUBDOMAIN:-}"
@@ -359,6 +359,7 @@ services:
         condition: service_healthy
       litellm:
         condition: service_healthy
+        required: false
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8090/health', timeout=5)"]
       interval: 30s
@@ -407,7 +408,7 @@ services:
     environment:
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-}
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY:-}
-      - LANGFUSE_HOST=${LANGFUSE_HOST:-http://langfuse:3000}
+      - LANGFUSE_HOST=${LANGFUSE_DOCKER_HOST:-http://langfuse:3000}
       - GDRIVE_SYNC_DIR=/data/drive-sync
       - INGESTION_DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/cocoindex
       - QDRANT_URL=http://qdrant:6333
@@ -711,7 +712,7 @@ services:
       RERANK_PROVIDER: colbert
       LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
-      LANGFUSE_HOST: ${LANGFUSE_HOST:-http://langfuse:3000}
+      LANGFUSE_HOST: ${LANGFUSE_DOCKER_HOST:-http://langfuse:3000}
     depends_on:
       redis:
         condition: service_healthy
@@ -806,7 +807,7 @@ services:
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/postgres
       LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
-      LANGFUSE_HOST: ${LANGFUSE_HOST:-http://langfuse:3000}
+      LANGFUSE_HOST: ${LANGFUSE_DOCKER_HOST:-http://langfuse:3000}
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8081')\" || exit 1"]
       interval: 15s

--- a/compose.yml
+++ b/compose.yml
@@ -420,7 +420,12 @@ services:
       - BGE_M3_CONCURRENCY=1
       - MANIFEST_DIR=/data/manifest
     volumes:
-      - ${GDRIVE_SYNC_DIR:-~/drive-sync}:/data/drive-sync:ro
+      - type: bind
+        source: ${GDRIVE_SYNC_DIR:?GDRIVE_SYNC_DIR is required}
+        target: /data/drive-sync
+        read_only: true
+        bind:
+          create_host_path: false
       - ingestion-manifest:/data/manifest
     depends_on:
       postgres:

--- a/docker/ingestion/entrypoint.sh
+++ b/docker/ingestion/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+manifest_dir="${MANIFEST_DIR:-/data/manifest}"
+
+mkdir -p "$manifest_dir"
+chown -R ingestion:ingestion "$manifest_dir"
+
+exec gosu ingestion /app/.venv/bin/python -m src.ingestion.unified.cli "$@"

--- a/docker/rclone/crontab
+++ b/docker/rclone/crontab
@@ -1,3 +1,3 @@
 # Google Drive sync - every 5 minutes
 # Install: sudo cp docker/rclone/crontab /etc/cron.d/rclone-sync
-*/5 * * * * root /opt/scripts/sync-drive.sh >> /var/log/rclone-cron.log 2>&1
+*/5 * * * * root . /etc/rag-fresh/rclone-sync.env && /opt/scripts/sync-drive.sh >> /var/log/rclone-cron.log 2>&1

--- a/docker/rclone/gdrive-manifest.sh
+++ b/docker/rclone/gdrive-manifest.sh
@@ -7,18 +7,22 @@
 
 set -euo pipefail
 
-MANIFEST_DIR="/data/drive-sync"
+MANIFEST_DIR="${GDRIVE_SYNC_DIR:?GDRIVE_SYNC_DIR is required}"
+RCLONE_CONFIG_FILE="${RCLONE_CONFIG_FILE:?RCLONE_CONFIG_FILE is required}"
 TMP_FILE="${MANIFEST_DIR}/.gdrive_manifest.json.tmp"
 OUT_FILE="${MANIFEST_DIR}/.gdrive_manifest.json"
 LOG_FILE="/var/log/rclone-manifest.log"
-RCLONE_CONFIG="/home/user/projects/rag-fresh/docker/rclone/rclone.conf"
+RCLONE_REMOTE="${RCLONE_REMOTE:-gdrive:RAG}"
+
+mkdir -p "$MANIFEST_DIR"
+mkdir -p "$(dirname "$LOG_FILE")"
 
 echo "$(date): Generating Drive manifest" >> "$LOG_FILE"
 
 # root_folder_id in rclone.conf makes gdrive: scoped to that folder.
 # lsjson returns: Path, Name, Size, MimeType, ModTime, ID, etc.
-rclone lsjson gdrive: \
-  --config "$RCLONE_CONFIG" \
+rclone lsjson "$RCLONE_REMOTE" \
+  --config "$RCLONE_CONFIG_FILE" \
   --recursive \
   --files-only \
   --metadata \

--- a/docker/rclone/sync-drive.sh
+++ b/docker/rclone/sync-drive.sh
@@ -7,10 +7,11 @@
 
 set -euo pipefail
 
-SYNC_DIR="${GDRIVE_SYNC_DIR:-$HOME/drive-sync}"
+SYNC_DIR="${GDRIVE_SYNC_DIR:?GDRIVE_SYNC_DIR is required}"
+RCLONE_CONFIG_FILE="${RCLONE_CONFIG_FILE:?RCLONE_CONFIG_FILE is required}"
 LOG_FILE="${HOME}/.local/log/rclone-sync.log"
 LOCK_FILE="/tmp/rclone-sync.lock"
-RCLONE_REMOTE="gdrive:RAG"
+RCLONE_REMOTE="${RCLONE_REMOTE:-gdrive:RAG}"
 
 # Ensure log directory exists
 mkdir -p "$(dirname "$LOG_FILE")"
@@ -22,6 +23,7 @@ flock -n 200 || { echo "$(date): Sync already running" >> "$LOG_FILE"; exit 0; }
 echo "$(date): Starting Drive sync" >> "$LOG_FILE"
 
 rclone sync "$RCLONE_REMOTE" "$SYNC_DIR" \
+  --config "$RCLONE_CONFIG_FILE" \
   --drive-export-formats docx,xlsx,pptx \
   --fast-list \
   --delete-after \

--- a/docs/GDRIVE_INGESTION.md
+++ b/docs/GDRIVE_INGESTION.md
@@ -1,53 +1,50 @@
 # Google Drive Ingestion Pipeline
 
-Always-on document ingestion from Google Drive to Qdrant for hybrid search.
+Canonical runtime path for knowledge-base documents:
 
-## Architecture
-
-```
+```text
 Google Drive
-    │
-    ▼ (rclone sync, cron 5min)
-/data/drive-sync/
-    │
-    ▼ (stateful watcher, poll 60s + sqlite state)
-docling-serve:5001 (chunking)
-    │
-    ├── Voyage voyage-4-large (1024-dim dense)
-    └── FastEmbed BM42 (sparse)
-    │
-    ▼
-Qdrant (quantization via suffix)
-Collections: gdrive_documents_scalar / gdrive_documents_binary
+  -> rclone sync (cron / manual)
+  -> GDRIVE_SYNC_DIR on host
+  -> /data/drive-sync in ingestion container
+  -> CocoIndex LocalFile source
+  -> Docling parse + chunk
+  -> BGE-M3 embeddings
+  -> Qdrant collection gdrive_documents_bge
 ```
+
+The old `gdrive_documents_scalar` and `gdrive_documents_binary` collections are no longer the active runtime path.
+
+## Runtime Contract
+
+- Google Drive is copied locally first through `rclone`.
+- Unified ingestion reads only from the local sync directory.
+- The ingestion container bind-mounts `GDRIVE_SYNC_DIR` into `/data/drive-sync`.
+- Compose now uses fail-fast bind mounting. If the host path is missing, startup fails instead of creating an empty directory.
+- The canonical target collection is `gdrive_documents_bge`.
 
 ## Quick Start
 
 ### 1. Install rclone
 
 ```bash
-# Official install script
 curl https://rclone.org/install.sh | sudo bash
+```
 
-# Or via Makefile
+Or:
+
+```bash
 make rclone-install
 ```
 
-### 2. Setup Google Cloud Service Account
+### 2. Prepare Google Drive access
 
-1. Go to [Google Cloud Console](https://console.cloud.google.com/)
-2. Enable Google Drive API
-3. Create Service Account:
-   - Go to "IAM & Admin" > "Service Accounts"
-   - Create new service account
-   - Grant "Viewer" role (read-only)
-   - Create JSON key and download
-4. Save key to `/opt/credentials/gdrive-service-account.json`
-5. Share your Drive folder with the service account email
+1. Create a Google Cloud service account with Drive read-only access.
+2. Download the JSON key to a secure host path such as `/opt/credentials/gdrive-service-account.json`.
+3. Share the target Drive folder with the service account email.
+4. Create an rclone config file on the host and point it at that service account key.
 
-### 3. Configure rclone
-
-Edit `docker/rclone/rclone.conf`:
+Example rclone config:
 
 ```ini
 [gdrive]
@@ -57,171 +54,103 @@ service_account_file = /opt/credentials/gdrive-service-account.json
 root_folder_id = YOUR_FOLDER_ID_HERE
 ```
 
-Get `root_folder_id` from Drive folder URL:
-`https://drive.google.com/drive/folders/YOUR_FOLDER_ID_HERE`
+### 3. Configure environment
 
-Test configuration:
+Set these variables in `.env` or the host environment:
+
+| Variable | Example | Description |
+|----------|---------|-------------|
+| `GDRIVE_SYNC_DIR` | `/opt/rag-fresh/drive-sync` | Host path used for the local Google Drive mirror |
+| `RCLONE_CONFIG_FILE` | `/opt/credentials/rclone.conf` | Host path to the rclone config file |
+| `RCLONE_REMOTE` | `gdrive:RAG` | Remote/folder to sync |
+| `GDRIVE_COLLECTION_NAME` | `gdrive_documents_bge` | Canonical Qdrant collection |
+
+Validate the remote before installing cron:
 
 ```bash
-rclone ls gdrive: --config docker/rclone/rclone.conf
+rclone ls "$RCLONE_REMOTE" --config "$RCLONE_CONFIG_FILE"
 ```
 
-### 4. Install cron job
+### 4. Install sync scripts and cron
 
 ```bash
 make sync-drive-install
 ```
 
-This creates:
-- `/opt/scripts/sync-drive.sh` - Sync script
-- `/opt/scripts/gdrive-manifest.sh` - Manifest generator (stable file IDs)
-- `/etc/cron.d/rclone-sync` - Cron job (every 5 min)
+This installs:
+- `/opt/scripts/sync-drive.sh`
+- `/opt/scripts/gdrive-manifest.sh`
+- `/etc/cron.d/rclone-sync`
+- `/etc/rag-fresh/rclone-sync.env`
 
-### 5. Setup Qdrant collections
+### 5. Seed the local mirror
 
 ```bash
-make ingest-gdrive-setup
+make sync-drive-run
+make sync-drive-status
 ```
 
-### 6. Run ingestion
+Do not start ingestion until `GDRIVE_SYNC_DIR` contains the expected files.
+
+### 6. Bootstrap and run ingestion
 
 ```bash
-# Once
-make ingest-gdrive-run
+make ingest-unified-preflight
+make ingest-unified-bootstrap
+make ingest-unified
+```
 
-# Continuous (watch mode)
-make ingest-gdrive-watch
+For continuous mode:
+
+```bash
+make ingest-unified-watch
 ```
 
 ## Supported File Types
 
-| Extension | Source | Notes |
-|-----------|--------|-------|
-| .pdf | Direct / Google Slides | OCR available |
-| .docx | Direct / Google Docs | Full support |
-| .xlsx | Direct / Google Sheets | Tables parsed |
-| .pptx | Direct | Slides as pages |
-| .md | Direct | Native |
-| .txt | Direct | Native |
+The unified pipeline accepts the document formats configured in `src/ingestion/unified/config.py`.
+Typical knowledge-base inputs include `.pdf`, `.docx`, `.xlsx`, `.pptx`, `.md`, and `.txt`.
 
-## rclone Export Formats
-
-Google Workspace files are exported automatically:
+Google Workspace files are exported by `rclone` into Office-compatible formats:
 
 | Google Type | Export Format |
 |-------------|---------------|
-| Google Docs | .docx |
-| Google Sheets | .xlsx |
-| Google Slides | .pptx |
+| Google Docs | `.docx` |
+| Google Sheets | `.xlsx` |
+| Google Slides | `.pptx` |
 
-Configure in `docker/rclone/sync-drive.sh`:
+## Identity And Replace Semantics
 
-```bash
---drive-export-formats docx,xlsx,pptx
-```
+- `gdrive-manifest.sh` writes `.gdrive_manifest.json` into `GDRIVE_SYNC_DIR`.
+- The unified pipeline builds stable `file_id` values from file content and manifest metadata.
+- When a file changes, ingestion replaces all chunks for that `file_id`.
+- When a file disappears from the sync directory, ingestion deletes the corresponding Qdrant points.
 
-## Collection Schema
-
-**Vectors (both collections):**
-- `dense`: 1024-dim, cosine, quantization depends on collection (`*_scalar` / `*_binary`)
-- `bm42`: sparse, IDF modifier
-
-**Payload indexes:**
-- `file_id` (keyword) - Stable ID from Drive or path hash
-- `file_name` (keyword)
-- `mime_type` (keyword)
-- `source_path` (keyword)
-
-## Replace Semantics
-
-When a file changes:
-1. DELETE all points where `file_id = X`
-2. UPSERT new chunks
-
-Point IDs are deterministic: `uuid5(file_id + chunk_location)`
-
-## File ID Stability (Manifest)
-
-The manifest script (`gdrive-manifest.sh`) generates `.gdrive_manifest.json` with Drive file IDs. This ensures:
-- Renames in Drive don't create duplicates
-- Moves in Drive don't break indexing
-- Stable identity across sync cycles
-
-## Deletions
-
-If a file disappears from `/data/drive-sync` (deleted/renamed/moved in Drive → rclone sync), the watcher detects it via persistent state and deletes all points for that `file_id`.
-
-## Makefile Targets
+## Operator Commands
 
 | Target | Description |
 |--------|-------------|
-| `make rclone-install` | Install rclone |
-| `make sync-drive-install` | Install cron job + scripts |
-| `make sync-drive-run` | Manual sync |
-| `make sync-drive-status` | Show sync status |
-| `make ingest-gdrive-setup` | Create Qdrant collections |
-| `make ingest-gdrive-run` | Run ingestion once |
-| `make ingest-gdrive-watch` | Run continuous watch |
-| `make ingest-gdrive-status` | Show collection stats |
+| `make sync-drive-install` | Install sync scripts and cron |
+| `make sync-drive-run` | Run a sync cycle immediately |
+| `make sync-drive-status` | Inspect local mirror and recent logs |
+| `make ingest-unified-preflight` | Validate env, sync dir, and services |
+| `make ingest-unified-bootstrap` | Create or validate `gdrive_documents_bge` schema |
+| `make ingest-unified` | Run one ingestion pass |
+| `make ingest-unified-watch` | Run continuous ingestion |
+| `make ingest-unified-status` | Show unified ingestion state |
+| `make ingest-unified-logs` | Tail ingestion container logs |
 
-## Monitoring
-
-```bash
-# Check sync status
-make sync-drive-status
-
-# Check collection
-make ingest-gdrive-status
-
-# View logs
-tail -f /var/log/rclone-sync.log
-tail -f /var/log/rclone-manifest.log
-```
+Legacy `make ingest-gdrive-*` targets still exist only as compatibility aliases and now forward to the unified commands above.
 
 ## Troubleshooting
 
-| Issue | Solution |
-|-------|----------|
-| Sync not running | Check cron: `crontab -l`, `cat /etc/cron.d/rclone-sync` |
-| Permission denied | Service account needs folder access (share folder with SA email) |
-| `root_folder_id` not found | Get ID from Drive folder URL |
-| Docling timeout | Use async endpoint for large PDFs |
-| Voyage 429 | Reduce batch size, add delays |
-| Too many non-doc files | Tighten allowlist in `sync-drive.sh` |
-| Files not syncing | Check `rclone ls gdrive:` works |
+| Issue | Check |
+|-------|-------|
+| Qdrant collection exists but has `0 points` | Verify `GDRIVE_SYNC_DIR` is populated before debugging Qdrant |
+| `preflight` fails on sync dir | Confirm `GDRIVE_SYNC_DIR` exists and is a directory |
+| Ingestion says `No input data` | Check the host path, then the container mount at `/data/drive-sync` |
+| Sync not running | Check `/etc/cron.d/rclone-sync` and `/var/log/rclone-sync.log` |
+| `RCLONE_CONFIG_FILE` not found | Fix the host path in `.env` or `/etc/rag-fresh/rclone-sync.env` |
+| Qdrant looks empty from VPS host | Query from the Docker network if port `6333` is not published on the host |
 
-## Environment Variables
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `GDRIVE_SYNC_DIR` | `/data/drive-sync` | Synced files location |
-| `GDRIVE_COLLECTION_NAME` | `gdrive_documents_binary` | Target Qdrant collection |
-| `QDRANT_URL` | `http://localhost:6333` | Qdrant server |
-| `DOCLING_URL` | `http://localhost:5001` | Docling server |
-| `VOYAGE_API_KEY` | - | Required for embeddings |
-
-## File Structure
-
-```
-docker/rclone/
-├── rclone.conf          # rclone configuration
-├── sync-drive.sh        # Sync script (→ /opt/scripts/)
-├── gdrive-manifest.sh   # Manifest script (→ /opt/scripts/)
-└── crontab              # Cron job (→ /etc/cron.d/)
-
-/data/drive-sync/        # Synced files
-├── .gdrive_manifest.json  # Drive file ID mapping
-└── ...                    # Your documents
-
-/var/log/
-├── rclone-sync.log      # Sync logs
-├── rclone-cron.log      # Cron output
-└── rclone-manifest.log  # Manifest logs
-```
-
-## Security Notes
-
-- Service account JSON contains credentials - never commit to git
-- Use `drive.readonly` scope for read-only access
-- Share only specific folders, not entire Drive
-- Consider IP restrictions on service account if available
+For the full VPS recovery sequence, see `docs/runbooks/vps-gdrive-ingestion-recovery.md`.

--- a/docs/INGESTION.md
+++ b/docs/INGESTION.md
@@ -22,6 +22,12 @@ This project currently uses a unified CocoIndex-based ingestion pipeline as the 
 ## Core Commands
 
 ```bash
+# Validate dependencies, env, and source directory
+make ingest-unified-preflight
+
+# Create or validate the runtime collection schema
+make ingest-unified-bootstrap
+
 # One-shot run
 make ingest-unified
 
@@ -33,6 +39,9 @@ make ingest-unified-status
 
 # Reprocess files in error state
 make ingest-unified-reprocess
+
+# Container logs
+make ingest-unified-logs
 ```
 
 Direct CLI equivalents:
@@ -72,6 +81,8 @@ make validate-traces-fast
 Commonly used:
 - `GDRIVE_SYNC_DIR`
 - `GDRIVE_COLLECTION_NAME`
+- `RCLONE_CONFIG_FILE`
+- `RCLONE_REMOTE`
 - `USE_LOCAL_DENSE_EMBEDDINGS`
 - `BGE_M3_TIMEOUT`
 - `BGE_M3_CONCURRENCY`
@@ -86,6 +97,9 @@ make docker-ingest-up
 make ingest-unified-logs
 ```
 
+The service mounts `GDRIVE_SYNC_DIR` into `/data/drive-sync` with fail-fast bind-mount semantics.
+If the host path is missing, `docker compose` now fails instead of silently creating an empty directory.
+
 ## Legacy Commands
 
 `make ingest-gdrive` is deprecated. Use unified ingestion commands above for active development.
@@ -93,5 +107,7 @@ make ingest-unified-logs
 ## Troubleshooting
 
 - `preflight` fails on Qdrant: confirm collection exists or run `bootstrap`.
+- `preflight` fails on sync dir: confirm `GDRIVE_SYNC_DIR` exists, is a directory, and contains supported files.
 - `status` shows only errors: run `reprocess --errors`, then inspect Docling/BGE-M3 logs.
 - No files processed: verify `GDRIVE_SYNC_DIR` mount/path and allowed file extensions.
+- Collection exists but has `0 points`: verify the Google Drive sync host path is populated before debugging Qdrant.

--- a/docs/PIPELINE_OVERVIEW.md
+++ b/docs/PIPELINE_OVERVIEW.md
@@ -61,6 +61,17 @@ uv run python -m src.ingestion.unified.cli run --watch
 uv run python -m src.ingestion.unified.cli status
 ```
 
+Common operator entrypoints:
+
+```bash
+make sync-drive-status
+make ingest-unified-preflight
+make ingest-unified-bootstrap
+make ingest-unified
+make ingest-unified-watch
+make ingest-unified-status
+```
+
 ## 4) Voice Flow
 
 Source code: `src/voice/agent.py` + `src/api/main.py`.
@@ -87,6 +98,9 @@ Runtime path:
 ```bash
 make docker-up
 make docker-bot-up
+make sync-drive-status
+make ingest-unified-preflight
+make ingest-unified-bootstrap
 make ingest-unified
 make validate-traces-fast
 make monitoring-up

--- a/docs/QDRANT_STACK.md
+++ b/docs/QDRANT_STACK.md
@@ -120,6 +120,8 @@ Snapshots are created via `scripts/qdrant_snapshot.py`.
 
 - Empty retrieval results: verify `QDRANT_COLLECTION` matches existing collection.
 - Ingestion writes fail: run `src.ingestion.unified.cli preflight` to confirm reachability.
+- Collection exists but has `0 points`: verify the Google Drive sync directory is populated before treating this as a Qdrant issue.
+- On VPS, host `localhost:6333` may be unavailable when Qdrant is only exposed inside the Docker network; inspect from a sibling container or use `docker compose exec`.
 - ColBERT schema drift: run `src.ingestion.unified.cli schema-check --require-colbert`.
 - Low ColBERT coverage: run `src.ingestion.unified.cli coverage-check --min-ratio 0.995`.
 - Interrupted backfill: rerun `src.ingestion.unified.cli backfill-colbert --resume` to continue from `.colbert_backfill_checkpoint.json`.

--- a/docs/runbooks/vps-gdrive-ingestion-recovery.md
+++ b/docs/runbooks/vps-gdrive-ingestion-recovery.md
@@ -1,0 +1,104 @@
+# VPS Google Drive Ingestion Recovery
+
+Use this runbook when `gdrive_documents_bge` exists but stays empty, or when ingestion reports `No input data`.
+
+## Expected Contract
+
+The production path is:
+
+```text
+Google Drive -> rclone sync on host -> GDRIVE_SYNC_DIR -> /data/drive-sync in container -> unified ingestion -> gdrive_documents_bge
+```
+
+If the host sync directory is missing or empty, Qdrant may still have a valid collection with `0 points`.
+
+## 1. Check Host Environment
+
+Confirm the configured sync path and rclone config:
+
+```bash
+grep -E '^(GDRIVE_SYNC_DIR|RCLONE_CONFIG_FILE|RCLONE_REMOTE)=' .env
+sudo cat /etc/rag-fresh/rclone-sync.env
+```
+
+The paths in `.env`, cron env, and Compose must point to the same host files.
+
+## 2. Verify The Host Sync Directory
+
+```bash
+ls -la "$GDRIVE_SYNC_DIR"
+find "$GDRIVE_SYNC_DIR" -maxdepth 2 -type f | head -50
+```
+
+Failure modes:
+- Path missing: recreate the intended directory and fix the mount contract or deployment env.
+- Path exists but is empty: rclone is not syncing data.
+- Path contains only manifest/log files: remote or allowlist is wrong.
+
+## 3. Verify rclone Directly
+
+```bash
+rclone ls "$RCLONE_REMOTE" --config "$RCLONE_CONFIG_FILE"
+make sync-drive-run
+tail -100 /var/log/rclone-sync.log
+tail -100 /var/log/rclone-manifest.log
+```
+
+If `rclone ls` fails, fix credentials, folder sharing, or `root_folder_id` before touching ingestion.
+
+## 4. Verify The Container Mount
+
+```bash
+docker compose exec ingestion sh -lc 'ls -la /data/drive-sync && find /data/drive-sync -maxdepth 2 -type f | head -50'
+```
+
+Interpretation:
+- Host path has files, container path empty: bind mount contract is broken.
+- Both host and container are empty: sync is the root cause.
+
+## 5. Verify Preflight And Bootstrap
+
+```bash
+make ingest-unified-preflight
+make ingest-unified-bootstrap
+make ingest-unified-status
+```
+
+`preflight` should now fail early if `GDRIVE_SYNC_DIR` is missing or invalid.
+
+## 6. Verify Qdrant From The Correct Network
+
+If `localhost:6333` on the VPS host is not published, query Qdrant from Docker instead:
+
+```bash
+docker compose exec qdrant curl -fsS http://localhost:6333/collections
+docker compose exec qdrant curl -fsS http://localhost:6333/collections/gdrive_documents_bge
+```
+
+Do not treat a missing host port as proof that the collection is absent.
+
+## 7. Re-run Ingestion
+
+Once the sync directory is populated:
+
+```bash
+make ingest-unified
+make ingest-unified-status
+make ingest-unified-logs
+```
+
+Then verify point counts:
+
+```bash
+docker compose exec qdrant curl -fsS http://localhost:6333/collections/gdrive_documents_bge
+```
+
+## Fast Diagnosis Matrix
+
+| Symptom | Likely Cause | First Check |
+|---------|--------------|-------------|
+| `No input data` in ingestion logs | Empty or missing host sync dir | `ls -la "$GDRIVE_SYNC_DIR"` |
+| Qdrant collection exists but `0 points` | Sync never populated local mirror | `make sync-drive-status` |
+| Host `curl localhost:6333` fails | Port not published on host | `docker compose exec qdrant curl ...` |
+| Compose starts ingestion with empty mount | Old short bind syntax silently created host path | Rendered `docker compose config` |
+| Cron runs but no files appear | Broken `RCLONE_CONFIG_FILE` or remote | `rclone ls "$RCLONE_REMOTE" --config "$RCLONE_CONFIG_FILE"` |

--- a/src/ingestion/cocoindex_flow.py
+++ b/src/ingestion/cocoindex_flow.py
@@ -233,6 +233,38 @@ def create_document_flow(
     return document_ingestion_flow
 
 
+def _run_update_all_flows_blocking(options: Any) -> None:
+    """Run CocoIndex async updates from sync code, even inside a live event loop."""
+
+    async def _update() -> None:
+        await cocoindex.update_all_flows_async(options)
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.run(_update())
+        return
+
+    result: dict[str, BaseException | None] = {"error": None}
+
+    def _runner() -> None:
+        try:
+            asyncio.run(_update())
+        except BaseException as exc:  # pragma: no cover - exercised via caller error surface
+            result["error"] = exc
+
+    thread = threading.Thread(
+        target=_runner,
+        name="cocoindex-flow-blocking-runner",
+        daemon=False,
+    )
+    thread.start()
+    thread.join()
+
+    if result["error"] is not None:
+        raise result["error"]
+
+
 def setup_and_run_flow(
     source_path: str,
     config: FlowConfig | None = None,
@@ -269,9 +301,7 @@ def setup_and_run_flow(
 
         # Run the flow
         if blocking:
-            asyncio.run(
-                cocoindex.update_all_flows_async(cocoindex.FlowLiveUpdaterOptions(live_mode=False))
-            )
+            _run_update_all_flows_blocking(cocoindex.FlowLiveUpdaterOptions(live_mode=False))
         else:
             threading.Thread(
                 target=lambda: asyncio.run(

--- a/src/ingestion/cocoindex_flow.py
+++ b/src/ingestion/cocoindex_flow.py
@@ -7,11 +7,14 @@ and data lineage features.
 Milestone J: Document Ingestion Pipeline (2026-02-02)
 """
 
+import asyncio
 import logging
 import os
+import threading
 from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Any
+from urllib.parse import urlparse
 
 import numpy as np
 from numpy.typing import NDArray
@@ -200,16 +203,23 @@ def create_document_flow(
                 )
 
         # Export to Qdrant
+        parsed_qdrant_url = urlparse(config.qdrant_url)
+        grpc_host = parsed_qdrant_url.hostname or "localhost"
+        grpc_port = parsed_qdrant_url.port or 6333
         qdrant_connection = cocoindex.targets.QdrantConnection(
-            url=config.qdrant_url,
+            grpc_url=f"{grpc_host}:{grpc_port + 1}",
             api_key=config.qdrant_api_key,
+        )
+        qdrant_connection_ref = cocoindex.auth_registry.add_auth_entry(
+            f"document_ingestion_qdrant_{config.collection_name}",
+            qdrant_connection,
         )
 
         doc_embeddings.export(
             "document_embeddings",
             cocoindex.targets.Qdrant(
                 collection_name=config.collection_name,
-                connection=qdrant_connection,
+                connection=qdrant_connection_ref,
             ),
             primary_key_fields=["file_name", "location"],
             vector_indexes=[
@@ -259,9 +269,19 @@ def setup_and_run_flow(
 
         # Run the flow
         if blocking:
-            cocoindex.update_all_flows()
+            asyncio.run(
+                cocoindex.update_all_flows_async(cocoindex.FlowLiveUpdaterOptions(live_mode=False))
+            )
         else:
-            cocoindex.update_all_flows_async()
+            threading.Thread(
+                target=lambda: asyncio.run(
+                    cocoindex.update_all_flows_async(
+                        cocoindex.FlowLiveUpdaterOptions(live_mode=True)
+                    )
+                ),
+                name="cocoindex-flow-updater",
+                daemon=True,
+            ).start()
 
         return {
             "success": True,

--- a/src/ingestion/docling_native.py
+++ b/src/ingestion/docling_native.py
@@ -3,18 +3,30 @@
 from __future__ import annotations
 
 import logging
+from importlib import import_module
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from src.ingestion.docling_client import DoclingChunk, DoclingClient, DoclingConfig
 
 
 logger = logging.getLogger(__name__)
 
-try:
-    from docling.document_converter import DocumentConverter
-except ModuleNotFoundError:  # pragma: no cover - exercised in unit tests via injected converter
-    DocumentConverter = Any  # type: ignore[assignment]
+if TYPE_CHECKING:
+    from docling.document_converter import DocumentConverter as DocumentConverterType
+else:
+    DocumentConverterType = Any
+
+
+def _load_runtime_document_converter() -> Any | None:
+    try:
+        module = import_module("docling.document_converter")
+    except ModuleNotFoundError:  # pragma: no cover - exercised in unit tests via injected converter
+        return None
+    return getattr(module, "DocumentConverter", None)
+
+
+RuntimeDocumentConverter: Any | None = _load_runtime_document_converter()
 
 
 class NativeDoclingAdapter(DoclingClient):
@@ -24,20 +36,20 @@ class NativeDoclingAdapter(DoclingClient):
         self,
         *,
         max_tokens: int = 512,
-        converter: DocumentConverter | Any | None = None,
+        converter: DocumentConverterType | None = None,
     ) -> None:
         super().__init__(DoclingConfig(max_tokens=max_tokens))
         self._converter = converter
         self._max_tokens = max_tokens
 
-    def _get_converter(self) -> DocumentConverter | Any:
+    def _get_converter(self) -> DocumentConverterType:
         if self._converter is None:
-            if DocumentConverter is Any:
+            if RuntimeDocumentConverter is None:
                 raise RuntimeError(
                     "docling is not installed; docling_native backend requires the optional "
                     "docling dependency"
                 )
-            self._converter = DocumentConverter()
+            self._converter = RuntimeDocumentConverter()
         return self._converter
 
     def chunk_file_sync(

--- a/src/ingestion/document_parser.py
+++ b/src/ingestion/document_parser.py
@@ -175,12 +175,12 @@ class UniversalDocumentParser:
         doc = pymupdf.open(filepath)
 
         # Extract text from all pages
+        num_pages = doc.page_count
         text_parts = []
-        for page in doc:
-            text_parts.append(page.get_text())
+        for page_number in range(num_pages):
+            text_parts.append(doc.load_page(page_number).get_text())
 
         content = "\n".join(text_parts)
-        num_pages = len(doc)
 
         # Extract metadata
         metadata = {

--- a/src/ingestion/unified/cli.py
+++ b/src/ingestion/unified/cli.py
@@ -200,7 +200,9 @@ async def cmd_preflight(args: argparse.Namespace) -> int:
                 print(f"  [FAIL] Docling ({config.docling_url}) — {e}")
 
     # Required env vars
-    required_vars = ["QDRANT_URL", "BGE_M3_URL", "DOCLING_URL", "INGESTION_DATABASE_URL"]
+    required_vars = ["QDRANT_URL", "BGE_M3_URL", "INGESTION_DATABASE_URL"]
+    if config.docling_backend != "docling_native":
+        required_vars.append("DOCLING_URL")
     missing = [v for v in required_vars if not os.getenv(v)]
     if missing:
         results["env_vars"] = False

--- a/src/ingestion/unified/cli.py
+++ b/src/ingestion/unified/cli.py
@@ -5,6 +5,7 @@ import argparse
 import asyncio
 import logging
 import os
+import re
 import sys
 from collections.abc import Mapping
 from pathlib import Path
@@ -121,6 +122,7 @@ async def cmd_preflight(args: argparse.Namespace) -> int:
     """Check that all ingestion dependencies are reachable."""
     import httpx
 
+    from src.ingestion.docling_native import NativeDoclingAdapter
     from src.ingestion.unified.config import UnifiedConfig
 
     config = UnifiedConfig()
@@ -176,17 +178,26 @@ async def cmd_preflight(args: argparse.Namespace) -> int:
             results["bge_m3_sparse"] = False
             print(f"  [FAIL] BGE-M3 sparse ({config.bge_m3_url}) — {e}")
 
-        # Docling service
-        try:
-            resp = await client.get(f"{config.docling_url}/health")
-            results["docling"] = resp.status_code == 200
-            if results["docling"]:
-                print(f"  [OK] Docling ({config.docling_url})")
-            else:
-                print(f"  [FAIL] Docling — HTTP {resp.status_code}")
-        except Exception as e:
-            results["docling"] = False
-            print(f"  [FAIL] Docling ({config.docling_url}) — {e}")
+        # Docling backend
+        if config.docling_backend == "docling_native":
+            try:
+                NativeDoclingAdapter(max_tokens=config.max_tokens_per_chunk)._get_converter()
+                results["docling"] = True
+                print("  [OK] Docling native backend available")
+            except Exception as e:
+                results["docling"] = False
+                print(f"  [FAIL] Docling native backend — {e}")
+        else:
+            try:
+                resp = await client.get(f"{config.docling_url}/health")
+                results["docling"] = resp.status_code == 200
+                if results["docling"]:
+                    print(f"  [OK] Docling ({config.docling_url})")
+                else:
+                    print(f"  [FAIL] Docling — HTTP {resp.status_code}")
+            except Exception as e:
+                results["docling"] = False
+                print(f"  [FAIL] Docling ({config.docling_url}) — {e}")
 
     # Required env vars
     required_vars = ["QDRANT_URL", "BGE_M3_URL", "DOCLING_URL", "INGESTION_DATABASE_URL"]
@@ -461,6 +472,49 @@ async def cmd_reprocess(args: argparse.Namespace) -> int:
     from src.ingestion.unified.config import UnifiedConfig
     from src.ingestion.unified.state_manager import UnifiedStateManager
 
+    async def _tracking_tables(pool) -> list[str]:
+        rows = await pool.fetch(
+            """
+            SELECT tablename
+            FROM pg_tables
+            WHERE schemaname = 'public'
+              AND tablename LIKE 'unified\\_\\_ingest\\_%\\_\\_cocoindex\\_tracking' ESCAPE '\\'
+            """
+        )
+        return [row["tablename"] for row in rows]
+
+    async def _purge_tracking_rows(pool, source_paths: list[str]) -> int:
+        if not source_paths:
+            return 0
+
+        total_deleted = 0
+        source_keys = [f'"{source_path}"' for source_path in source_paths]
+        for table_name in await _tracking_tables(pool):
+            if not re.fullmatch(r"[A-Za-z0-9_]+", table_name):
+                raise ValueError(f"Unexpected tracking table name: {table_name}")
+            deleted = await pool.execute(
+                f"DELETE FROM {table_name} WHERE source_key = ANY($1::jsonb[])",
+                source_keys,
+            )
+            total_deleted += int(deleted.split()[-1])
+        return total_deleted
+
+    def _touch_source_files(sync_dir: Path, source_paths: list[str]) -> int:
+        touched = 0
+        for source_path in source_paths:
+            relative = Path(source_path)
+            candidates = [
+                relative,
+                sync_dir / relative,
+                sync_dir.parent / relative,
+            ]
+            for candidate in candidates:
+                if candidate.exists() and candidate.is_file():
+                    candidate.touch()
+                    touched += 1
+                    break
+        return touched
+
     config = UnifiedConfig()
     manager = UnifiedStateManager(database_url=config.database_url)
 
@@ -468,23 +522,44 @@ async def cmd_reprocess(args: argparse.Namespace) -> int:
         pool = await manager._get_pool()
 
         if args.file_id:
-            # Reset specific file
-            await pool.execute(
-                "UPDATE ingestion_state SET status = 'pending', retry_count = 0, "
-                "retry_after = NULL WHERE file_id = $1",
+            rows = await pool.fetch(
+                "SELECT source_path FROM ingestion_state WHERE file_id = $1",
                 args.file_id,
             )
-            print(f"Reset file: {args.file_id}")
-        elif args.errors:
-            # Reset all errors
+            source_paths = [row["source_path"] for row in rows if row["source_path"]]
+            await pool.execute(
+                "UPDATE ingestion_state SET status = 'pending', retry_count = 0, "
+                "retry_after = NULL, error_message = NULL WHERE file_id = $1",
+                args.file_id,
+            )
+            purged = await _purge_tracking_rows(pool, source_paths)
+            touched = _touch_source_files(config.sync_dir, source_paths)
+            print(
+                f"Reset file: {args.file_id} "
+                f"(purged tracking rows: {purged}, touched files: {touched})"
+            )
+        else:
+            target_status = "error" if args.errors else "pending" if args.pending else None
+            if target_status is None:
+                print("Specify --file-id, --errors, or --pending")
+                return 1
+
+            rows = await pool.fetch(
+                "SELECT source_path FROM ingestion_state WHERE status = $1",
+                target_status,
+            )
+            source_paths = [row["source_path"] for row in rows if row["source_path"]]
             result = await pool.execute(
                 "UPDATE ingestion_state SET status = 'pending', retry_count = 0, "
-                "retry_after = NULL WHERE status = 'error'"
+                "retry_after = NULL, error_message = NULL WHERE status = $1",
+                target_status,
             )
-            print(f"Reset error files: {result}")
-        else:
-            print("Specify --file-id or --errors")
-            return 1
+            purged = await _purge_tracking_rows(pool, source_paths)
+            touched = _touch_source_files(config.sync_dir, source_paths)
+            print(
+                f"Reset {target_status} files: {result} "
+                f"(purged tracking rows: {purged}, touched files: {touched})"
+            )
     finally:
         await manager.close()
 
@@ -638,6 +713,7 @@ def main() -> int:
     reprocess_p = subparsers.add_parser("reprocess", help="Reprocess files")
     reprocess_p.add_argument("--file-id", help="Specific file ID")
     reprocess_p.add_argument("--errors", action="store_true", help="All error files")
+    reprocess_p.add_argument("--pending", action="store_true", help="All pending files")
 
     args = parser.parse_args()
     setup_logging(args.verbose)

--- a/src/ingestion/unified/cli.py
+++ b/src/ingestion/unified/cli.py
@@ -7,6 +7,7 @@ import logging
 import os
 import sys
 from collections.abc import Mapping
+from pathlib import Path
 
 from dotenv import load_dotenv
 
@@ -28,6 +29,28 @@ def setup_logging(verbose: bool = False) -> None:
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("httpcore").setLevel(logging.WARNING)
     logging.getLogger("cocoindex").setLevel(logging.INFO)
+
+
+def _inspect_sync_dir(
+    sync_dir: Path, supported_extensions: frozenset[str]
+) -> dict[str, int | bool]:
+    """Inspect ingestion source directory health."""
+    exists = sync_dir.exists()
+    is_dir = sync_dir.is_dir()
+    supported_files = 0
+
+    if exists and is_dir:
+        supported_files = sum(
+            1
+            for path in sync_dir.rglob("*")
+            if path.is_file() and path.suffix.lower() in supported_extensions
+        )
+
+    return {
+        "exists": exists,
+        "is_dir": is_dir,
+        "supported_files": supported_files,
+    }
 
 
 @observe(name="ingestion-cli-run", capture_input=False, capture_output=False)
@@ -70,6 +93,7 @@ async def cmd_status(args: argparse.Namespace) -> int:
     try:
         stats = await manager.get_stats()
         dlq_count = await manager.get_dlq_count()
+        sync_info = _inspect_sync_dir(config.sync_dir, config.supported_extensions)
 
         print("\n=== Ingestion Status ===")
         total = sum(stats.values())
@@ -80,6 +104,12 @@ async def cmd_status(args: argparse.Namespace) -> int:
         print(f"\n  DLQ: {dlq_count} items")
         print(f"  Collection: {config.collection_name}")
         print(f"  Sync dir: {config.sync_dir}")
+        if sync_info["exists"] and sync_info["is_dir"]:
+            print(f"  Supported files: {sync_info['supported_files']}")
+        elif not sync_info["exists"]:
+            print("  Supported files: n/a (sync dir missing)")
+        else:
+            print("  Supported files: n/a (sync dir is not a directory)")
     finally:
         await manager.close()
 
@@ -97,6 +127,7 @@ async def cmd_preflight(args: argparse.Namespace) -> int:
     try_update_ingestion_trace(command="preflight", status="started")
     timeout = httpx.Timeout(float(os.getenv("BGE_M3_TIMEOUT", "60")))
     results: dict[str, bool] = {}
+    sync_info = _inspect_sync_dir(config.sync_dir, config.supported_extensions)
 
     async with httpx.AsyncClient(timeout=timeout) as client:
         # Qdrant reachable + collection exists
@@ -166,6 +197,18 @@ async def cmd_preflight(args: argparse.Namespace) -> int:
     else:
         results["env_vars"] = True
         print("  [OK] All required env vars set")
+
+    if not sync_info["exists"]:
+        results["sync_dir"] = False
+        print(f"  [FAIL] Sync dir missing: {config.sync_dir}")
+    elif not sync_info["is_dir"]:
+        results["sync_dir"] = False
+        print(f"  [FAIL] Sync dir is not a directory: {config.sync_dir}")
+    else:
+        results["sync_dir"] = True
+        print(
+            f"  [OK] Sync dir: {config.sync_dir} ({sync_info['supported_files']} supported files)"
+        )
 
     # Summary
     ok = sum(1 for v in results.values() if v)

--- a/src/ingestion/unified/qdrant_writer.py
+++ b/src/ingestion/unified/qdrant_writer.py
@@ -27,8 +27,8 @@ logger = logging.getLogger(__name__)
 # Namespace for deterministic UUID generation
 NAMESPACE_GDRIVE = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 
-# Qdrant default max payload size (32 MB).  Points exceeding this are skipped.
-QDRANT_MAX_PAYLOAD_BYTES = 32 * 1024 * 1024
+# Keep request bodies below Qdrant's 32MB JSON limit with safety headroom.
+QDRANT_UPSERT_MAX_REQUEST_BYTES = 28 * 1024 * 1024
 
 
 @dataclass
@@ -284,6 +284,90 @@ class QdrantHybridWriter:
             "file_id": file_id,  # Flat for fast delete
         }
 
+    @staticmethod
+    def _point_to_jsonable(point: PointStruct) -> dict[str, Any]:
+        """Convert a PointStruct into a JSON-serializable dict for size estimation."""
+        if hasattr(point, "model_dump"):
+            return point.model_dump(mode="json", exclude_none=True)
+        if hasattr(point, "dict"):
+            return point.dict(exclude_none=True)
+        return {
+            "id": point.id,
+            "vector": point.vector,
+            "payload": point.payload,
+        }
+
+    @classmethod
+    def _estimate_point_request_bytes(cls, point: PointStruct) -> int:
+        """Estimate serialized request bytes for a single point."""
+        return len(
+            _json.dumps(
+                cls._point_to_jsonable(point),
+                separators=(",", ":"),
+                ensure_ascii=False,
+            ).encode("utf-8")
+        )
+
+    def _upsert_points_in_batches(
+        self,
+        *,
+        collection_name: str,
+        points: list[PointStruct],
+        source_path: str,
+    ) -> int:
+        """Upsert points in request-size-safe batches."""
+        if not points:
+            return 0
+
+        total_upserted = 0
+        batch: list[PointStruct] = []
+        batch_bytes = 2  # JSON array brackets
+        batch_index = 1
+
+        for point in points:
+            point_bytes = self._estimate_point_request_bytes(point)
+            if point_bytes > QDRANT_UPSERT_MAX_REQUEST_BYTES:
+                raise ValueError(
+                    f"Single point request {point_bytes / 1024 / 1024:.1f}MB exceeds "
+                    f"safe Qdrant limit {QDRANT_UPSERT_MAX_REQUEST_BYTES / 1024 / 1024:.0f}MB "
+                    f"for {source_path}"
+                )
+
+            separator_bytes = 1 if batch else 0
+            if (
+                batch
+                and batch_bytes + separator_bytes + point_bytes > QDRANT_UPSERT_MAX_REQUEST_BYTES
+            ):
+                self.client.upsert(collection_name=collection_name, points=batch)
+                logger.info(
+                    "Upserted batch %d for %s: %d points (~%.1fMB)",
+                    batch_index,
+                    source_path,
+                    len(batch),
+                    batch_bytes / 1024 / 1024,
+                )
+                total_upserted += len(batch)
+                batch = [point]
+                batch_bytes = 2 + point_bytes
+                batch_index += 1
+                continue
+
+            batch.append(point)
+            batch_bytes += separator_bytes + point_bytes
+
+        if batch:
+            self.client.upsert(collection_name=collection_name, points=batch)
+            logger.info(
+                "Upserted batch %d for %s: %d points (~%.1fMB)",
+                batch_index,
+                source_path,
+                len(batch),
+                batch_bytes / 1024 / 1024,
+            )
+            total_upserted += len(batch)
+
+        return total_upserted
+
     @observe(name="ingestion-qdrant-delete-file", capture_input=False, capture_output=False)
     async def delete_file(self, file_id: str, collection_name: str) -> int:
         """Delete all points for a file.
@@ -394,26 +478,12 @@ class QdrantHybridWriter:
                 )
                 points.append(point)
 
-            # Step 5: Payload size guard
-            payload_size = len(_json.dumps([p.payload for p in points]).encode())
-            if payload_size > QDRANT_MAX_PAYLOAD_BYTES:
-                msg = (
-                    f"Payload {payload_size / 1024 / 1024:.1f}MB exceeds "
-                    f"Qdrant limit {QDRANT_MAX_PAYLOAD_BYTES / 1024 / 1024:.0f}MB "
-                    f"for {source_path} ({len(points)} chunks) — skipping"
-                )
-                logger.warning(msg)
-                stats.errors = [msg]
-                try_update_ingestion_trace(
-                    command="qdrant-upsert-chunks",
-                    status="error",
-                    metadata={"collection": collection_name, "error_type": "PayloadTooLarge"},
-                )
-                return stats
-
-            # Step 6: Upsert
-            self.client.upsert(collection_name=collection_name, points=points)
-            stats.points_upserted = len(points)
+            # Step 5: Upsert in request-size-safe batches
+            stats.points_upserted = self._upsert_points_in_batches(
+                collection_name=collection_name,
+                points=points,
+                source_path=source_path,
+            )
 
             logger.info(
                 f"Upserted {stats.points_upserted} points for {source_path} "
@@ -541,21 +611,12 @@ class QdrantHybridWriter:
                 )
                 points.append(point)
 
-            # Step 5: Payload size guard — skip oversized batches
-            payload_size = len(_json.dumps([p.payload for p in points]).encode())
-            if payload_size > QDRANT_MAX_PAYLOAD_BYTES:
-                msg = (
-                    f"Payload {payload_size / 1024 / 1024:.1f}MB exceeds "
-                    f"Qdrant limit {QDRANT_MAX_PAYLOAD_BYTES / 1024 / 1024:.0f}MB "
-                    f"for {source_path} ({len(points)} chunks) — skipping"
-                )
-                logger.warning(msg)
-                stats.errors = [msg]
-                return stats
-
-            # Step 6: Upsert (sync)
-            self.client.upsert(collection_name=collection_name, points=points)
-            stats.points_upserted = len(points)
+            # Step 5: Upsert in request-size-safe batches
+            stats.points_upserted = self._upsert_points_in_batches(
+                collection_name=collection_name,
+                points=points,
+                source_path=source_path,
+            )
 
             logger.info(
                 f"Upserted {stats.points_upserted} points for {source_path} "

--- a/tests/unit/ingestion/test_qdrant_writer_behavior.py
+++ b/tests/unit/ingestion/test_qdrant_writer_behavior.py
@@ -443,7 +443,7 @@ class TestUpsertChunksSyncEdgeCases:
     def test_oversized_payload_skipped_with_error(
         self, writer_voyage, mock_qdrant_client, mock_voyage, mock_bge_client
     ):
-        """Payload exceeding QDRANT_MAX_PAYLOAD_BYTES is skipped, not sent to Qdrant."""
+        """Single-point requests above the safe limit are skipped, not sent to Qdrant."""
         mock_qdrant_client.count.return_value = MagicMock(count=0)
         mock_voyage._client.embed.return_value = MagicMock(embeddings=[[0.1] * 1024])
         mock_bge_client.encode_sparse.return_value = MagicMock(
@@ -454,6 +454,63 @@ class TestUpsertChunksSyncEdgeCases:
         huge_text = "x" * (35 * 1024 * 1024)
         chunk = _make_chunk(text=huge_text)
         stats = writer_voyage.upsert_chunks_sync([chunk], "f", "/big.pdf", {}, "col")
+
+        assert stats.errors is not None
+        assert "exceeds" in stats.errors[0]
+        assert stats.points_upserted == 0
+        mock_qdrant_client.upsert.assert_not_called()
+
+    def test_upsert_is_split_into_multiple_requests_when_batch_is_too_large(
+        self, writer_voyage, mock_qdrant_client, mock_voyage, mock_bge_client
+    ):
+        """Request-size batching should split points into multiple upsert() calls."""
+        mock_qdrant_client.count.return_value = MagicMock(count=0)
+        mock_voyage._client.embed.return_value = MagicMock(embeddings=[[0.1] * 1024] * 3)
+        mock_bge_client.encode_sparse.return_value = MagicMock(
+            weights=[{"indices": [1], "values": [0.5]}] * 3
+        )
+
+        chunks = [_make_chunk(text=f"text {i}", order=i) for i in range(3)]
+        with (
+            patch.object(
+                QdrantHybridWriter,
+                "_estimate_point_request_bytes",
+                side_effect=[300, 300, 300],
+            ),
+            patch(
+                "src.ingestion.unified.qdrant_writer.QDRANT_UPSERT_MAX_REQUEST_BYTES",
+                700,
+            ),
+        ):
+            stats = writer_voyage.upsert_chunks_sync(chunks, "f", "/split.md", {}, "col")
+
+        assert stats.errors is None
+        assert stats.points_upserted == 3
+        assert mock_qdrant_client.upsert.call_count == 2
+        first_points = mock_qdrant_client.upsert.call_args_list[0].kwargs["points"]
+        second_points = mock_qdrant_client.upsert.call_args_list[1].kwargs["points"]
+        assert len(first_points) == 2
+        assert len(second_points) == 1
+
+    def test_single_point_larger_than_request_limit_is_rejected(
+        self, writer_voyage, mock_qdrant_client, mock_voyage, mock_bge_client
+    ):
+        """A single point larger than the request limit should fail fast."""
+        mock_qdrant_client.count.return_value = MagicMock(count=0)
+        mock_voyage._client.embed.return_value = MagicMock(embeddings=[[0.1] * 1024])
+        mock_bge_client.encode_sparse.return_value = MagicMock(
+            weights=[{"indices": [1], "values": [0.5]}]
+        )
+
+        chunk = _make_chunk(text="single point", order=0)
+        with (
+            patch.object(QdrantHybridWriter, "_estimate_point_request_bytes", return_value=1024),
+            patch(
+                "src.ingestion.unified.qdrant_writer.QDRANT_UPSERT_MAX_REQUEST_BYTES",
+                512,
+            ),
+        ):
+            stats = writer_voyage.upsert_chunks_sync([chunk], "f", "/big.md", {}, "col")
 
         assert stats.errors is not None
         assert "exceeds" in stats.errors[0]

--- a/tests/unit/ingestion/test_unified_cli.py
+++ b/tests/unit/ingestion/test_unified_cli.py
@@ -200,12 +200,16 @@ class TestCmdPreflight:
             "INGESTION_DATABASE_URL": "postgresql://test@localhost/db",
         },
     )
-    async def test_all_checks_pass(self, args, capsys):
+    async def test_all_checks_pass(self, args, capsys, tmp_path):
         mock_client = AsyncMock()
         mock_client.get.return_value = _ok_response({"result": {"points_count": 42}})
         mock_client.post.return_value = _ok_response()
 
-        config = _make_config()
+        sync_dir = tmp_path / "sync"
+        sync_dir.mkdir()
+        (sync_dir / "knowledge.md").write_text("# test", encoding="utf-8")
+
+        config = _make_config(sync_dir=sync_dir)
         with (
             patch("src.ingestion.unified.config.UnifiedConfig", return_value=config),
             patch("httpx.AsyncClient") as MockClient,

--- a/tests/unit/ingestion/test_unified_cli.py
+++ b/tests/unit/ingestion/test_unified_cli.py
@@ -44,6 +44,7 @@ class TestArgParsing:
         reprocess_p = subparsers.add_parser("reprocess")
         reprocess_p.add_argument("--file-id")
         reprocess_p.add_argument("--errors", action="store_true")
+        reprocess_p.add_argument("--pending", action="store_true")
 
         return parser.parse_args(list(argv))
 
@@ -93,11 +94,19 @@ class TestArgParsing:
         assert args.command == "reprocess"
         assert args.file_id == "abc123"
         assert args.errors is False
+        assert args.pending is False
 
     def test_reprocess_errors(self):
         args = self._parse("reprocess", "--errors")
         assert args.errors is True
         assert args.file_id is None
+        assert args.pending is False
+
+    def test_reprocess_pending(self):
+        args = self._parse("reprocess", "--pending")
+        assert args.pending is True
+        assert args.file_id is None
+        assert args.errors is False
 
     def test_verbose_flag(self):
         args = self._parse("-v", "run")
@@ -294,6 +303,46 @@ class TestCmdPreflight:
         assert result == 1
         output = capsys.readouterr().out
         assert "[FAIL]" in output
+
+    @patch.dict(
+        "os.environ",
+        {
+            "QDRANT_URL": "http://qdrant:6333",
+            "BGE_M3_URL": "http://bge:8000",
+            "INGESTION_DATABASE_URL": "postgresql://test@localhost/db",
+        },
+    )
+    async def test_native_docling_backend_skips_http_healthcheck(self, args, capsys, tmp_path):
+        mock_client = AsyncMock()
+        mock_client.get.return_value = _ok_response({"result": {"points_count": 42}})
+        mock_client.post.return_value = _ok_response()
+
+        sync_dir = tmp_path / "sync"
+        sync_dir.mkdir()
+        (sync_dir / "knowledge.md").write_text("# test", encoding="utf-8")
+
+        config = _make_config(sync_dir=sync_dir)
+        config.docling_backend = "docling_native"
+
+        with (
+            patch("src.ingestion.unified.config.UnifiedConfig", return_value=config),
+            patch("src.ingestion.docling_native.NativeDoclingAdapter") as MockAdapter,
+            patch("httpx.AsyncClient") as MockClient,
+        ):
+            MockAdapter.return_value._get_converter.return_value = object()
+            mock_ctx = AsyncMock()
+            mock_ctx.__aenter__.return_value = mock_client
+            mock_ctx.__aexit__.return_value = False
+            MockClient.return_value = mock_ctx
+
+            from src.ingestion.unified.cli import cmd_preflight
+
+            result = await cmd_preflight(args)
+
+        assert result == 0
+        output = capsys.readouterr().out
+        assert "Docling native backend available" in output
+        mock_client.get.assert_called_once()
 
     async def test_missing_env_vars_warned(self, args, capsys):
         mock_client = AsyncMock()
@@ -519,6 +568,11 @@ class TestCmdReprocess:
     async def test_reprocess_file_id(self):
         config = _make_config()
         pool = AsyncMock()
+        pool.fetch.side_effect = [
+            [{"source_path": "drive-sync/Test/abc.md"}],
+            [{"tablename": "unified__ingest_a7bb25__cocoindex_tracking"}],
+        ]
+        pool.execute.side_effect = ["UPDATE 1", "DELETE 1"]
         manager = AsyncMock()
         manager._get_pool.return_value = pool
 
@@ -532,19 +586,30 @@ class TestCmdReprocess:
             from src.ingestion.unified.cli import cmd_reprocess
 
             args = argparse.Namespace(
-                command="reprocess", file_id="abc123", errors=False, verbose=False
+                command="reprocess",
+                file_id="abc123",
+                errors=False,
+                pending=False,
+                verbose=False,
             )
             result = await cmd_reprocess(args)
 
         assert result == 0
-        pool.execute.assert_awaited_once()
-        sql_call = pool.execute.call_args
-        assert "abc123" in sql_call.args
+        assert pool.fetch.await_count == 2
+        assert pool.execute.await_count == 2
+        update_call = pool.execute.await_args_list[0]
+        delete_call = pool.execute.await_args_list[1]
+        assert "abc123" in update_call.args
+        assert "DELETE FROM unified__ingest" in delete_call.args[0]
 
     async def test_reprocess_errors(self):
         config = _make_config()
         pool = AsyncMock()
-        pool.execute.return_value = "UPDATE 5"
+        pool.fetch.side_effect = [
+            [{"source_path": "drive-sync/Test/err.md"}],
+            [{"tablename": "unified__ingest_a7bb25__cocoindex_tracking"}],
+        ]
+        pool.execute.side_effect = ["UPDATE 5", "DELETE 1"]
         manager = AsyncMock()
         manager._get_pool.return_value = pool
 
@@ -557,12 +622,53 @@ class TestCmdReprocess:
         ):
             from src.ingestion.unified.cli import cmd_reprocess
 
-            args = argparse.Namespace(command="reprocess", file_id=None, errors=True, verbose=False)
+            args = argparse.Namespace(
+                command="reprocess",
+                file_id=None,
+                errors=True,
+                pending=False,
+                verbose=False,
+            )
             result = await cmd_reprocess(args)
 
         assert result == 0
-        sql_call = pool.execute.call_args
-        assert "error" in sql_call.args[0]
+        update_call = pool.execute.await_args_list[0]
+        delete_call = pool.execute.await_args_list[1]
+        assert update_call.args[1] == "error"
+        assert "DELETE FROM unified__ingest" in delete_call.args[0]
+
+    async def test_reprocess_pending(self):
+        config = _make_config()
+        pool = AsyncMock()
+        pool.fetch.side_effect = [
+            [{"source_path": "drive-sync/Test/pending.md"}],
+            [{"tablename": "unified__ingest_a7bb25__cocoindex_tracking"}],
+        ]
+        pool.execute.side_effect = ["UPDATE 3", "DELETE 1"]
+        manager = AsyncMock()
+        manager._get_pool.return_value = pool
+
+        with (
+            patch("src.ingestion.unified.config.UnifiedConfig", return_value=config),
+            patch(
+                "src.ingestion.unified.state_manager.UnifiedStateManager",
+                return_value=manager,
+            ),
+        ):
+            from src.ingestion.unified.cli import cmd_reprocess
+
+            args = argparse.Namespace(
+                command="reprocess",
+                file_id=None,
+                errors=False,
+                pending=True,
+                verbose=False,
+            )
+            result = await cmd_reprocess(args)
+
+        assert result == 0
+        update_call = pool.execute.await_args_list[0]
+        assert update_call.args[1] == "pending"
 
     async def test_reprocess_no_args_returns_1(self, capsys):
         config = _make_config()
@@ -579,13 +685,17 @@ class TestCmdReprocess:
             from src.ingestion.unified.cli import cmd_reprocess
 
             args = argparse.Namespace(
-                command="reprocess", file_id=None, errors=False, verbose=False
+                command="reprocess",
+                file_id=None,
+                errors=False,
+                pending=False,
+                verbose=False,
             )
             result = await cmd_reprocess(args)
 
         assert result == 1
         output = capsys.readouterr().out
-        assert "Specify --file-id or --errors" in output
+        assert "Specify --file-id, --errors, or --pending" in output
 
     async def test_reprocess_closes_manager(self):
         config = _make_config()
@@ -601,7 +711,13 @@ class TestCmdReprocess:
         ):
             from src.ingestion.unified.cli import cmd_reprocess
 
-            args = argparse.Namespace(command="reprocess", file_id="x", errors=False, verbose=False)
+            args = argparse.Namespace(
+                command="reprocess",
+                file_id="x",
+                errors=False,
+                pending=False,
+                verbose=False,
+            )
             await cmd_reprocess(args)
 
         manager.close.assert_awaited_once()

--- a/tests/unit/ingestion/test_unified_cli.py
+++ b/tests/unit/ingestion/test_unified_cli.py
@@ -3,6 +3,7 @@
 
 import argparse
 import logging
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -168,7 +169,13 @@ def _make_config(**overrides):
     config.bge_m3_url = overrides.get("bge_m3_url", "http://bge:8000")
     config.docling_url = overrides.get("docling_url", "http://docling:5001")
     config.database_url = overrides.get("database_url", "postgresql://test@localhost/db")
-    config.sync_dir = overrides.get("sync_dir", "/tmp/sync")
+    config.sync_dir = overrides.get("sync_dir", Path("/tmp/sync"))
+    config.supported_extensions = overrides.get(
+        "supported_extensions",
+        frozenset(
+            {".pdf", ".docx", ".doc", ".xlsx", ".pptx", ".md", ".txt", ".html", ".htm", ".csv"}
+        ),
+    )
     return config
 
 
@@ -313,6 +320,39 @@ class TestCmdPreflight:
         assert "[WARN]" in output
         assert "Missing env vars" in output
 
+    @patch.dict(
+        "os.environ",
+        {
+            "QDRANT_URL": "http://qdrant:6333",
+            "BGE_M3_URL": "http://bge:8000",
+            "DOCLING_URL": "http://docling:5001",
+            "INGESTION_DATABASE_URL": "postgresql://test@localhost/db",
+        },
+    )
+    async def test_sync_dir_missing_fails(self, args, capsys, tmp_path):
+        mock_client = AsyncMock()
+        mock_client.get.return_value = _ok_response({"result": {"points_count": 0}})
+        mock_client.post.return_value = _ok_response()
+
+        config = _make_config(sync_dir=tmp_path / "missing-sync")
+        with (
+            patch("src.ingestion.unified.config.UnifiedConfig", return_value=config),
+            patch("httpx.AsyncClient") as MockClient,
+        ):
+            mock_ctx = AsyncMock()
+            mock_ctx.__aenter__.return_value = mock_client
+            mock_ctx.__aexit__.return_value = False
+            MockClient.return_value = mock_ctx
+
+            from src.ingestion.unified.cli import cmd_preflight
+
+            result = await cmd_preflight(args)
+
+        assert result == 1
+        output = capsys.readouterr().out
+        assert "Sync dir" in output
+        assert "[FAIL]" in output
+
 
 # ---------------------------------------------------------------------------
 # cmd_status
@@ -393,6 +433,34 @@ class TestCmdStatus:
             await cmd_status(args)
 
         manager.close.assert_awaited_once()
+
+    async def test_status_reports_supported_file_count(self, args, capsys, tmp_path):
+        sync_dir = tmp_path / "sync"
+        sync_dir.mkdir()
+        (sync_dir / "one.pdf").write_text("pdf")
+        (sync_dir / "two.docx").write_text("docx")
+        (sync_dir / "ignored.tmp").write_text("tmp")
+
+        config = _make_config(collection_name="test_col", sync_dir=sync_dir)
+        manager = AsyncMock()
+        manager.get_stats.return_value = {"indexed": 2}
+        manager.get_dlq_count.return_value = 0
+
+        with (
+            patch("src.ingestion.unified.config.UnifiedConfig", return_value=config),
+            patch(
+                "src.ingestion.unified.state_manager.UnifiedStateManager",
+                return_value=manager,
+            ),
+        ):
+            from src.ingestion.unified.cli import cmd_status
+
+            result = await cmd_status(args)
+
+        assert result == 0
+        output = capsys.readouterr().out
+        assert "Sync dir:" in output
+        assert "Supported files: 2" in output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/ingestion/test_unified_cli.py
+++ b/tests/unit/ingestion/test_unified_cli.py
@@ -310,7 +310,11 @@ class TestCmdPreflight:
             "QDRANT_URL": "http://qdrant:6333",
             "BGE_M3_URL": "http://bge:8000",
             "INGESTION_DATABASE_URL": "postgresql://test@localhost/db",
+            "RAG_TESTING": "true",
+            "LANGFUSE_TRACING_ENABLED": "false",
+            "OTEL_SDK_DISABLED": "true",
         },
+        clear=True,
     )
     async def test_native_docling_backend_skips_http_healthcheck(self, args, capsys, tmp_path):
         mock_client = AsyncMock()

--- a/tests/unit/test_cocoindex_flow.py
+++ b/tests/unit/test_cocoindex_flow.py
@@ -6,6 +6,7 @@ without requiring the actual CocoIndex library.
 Milestone J: Document Ingestion Pipeline (2026-02-02)
 """
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
@@ -180,6 +181,25 @@ class TestSetupAndRunFlow:
         assert result["flow_name"] == "DocumentIngestion"
         assert result["source_path"] == "/test/path"
         assert result["collection"] == "test_collection"
+
+    def test_successful_flow_execution_inside_running_event_loop(self):
+        """Blocking mode should still work when the caller already has an event loop."""
+
+        async def _run_inside_loop():
+            with patch.object(cocoindex_flow, "COCOINDEX_AVAILABLE", True):
+                mock_flow = MagicMock()
+                with patch.object(cocoindex_flow, "create_document_flow", return_value=mock_flow):
+                    mock_cocoindex = MagicMock()
+                    mock_cocoindex.update_all_flows_async = AsyncMock(return_value={})
+                    with patch.object(cocoindex_flow, "cocoindex", mock_cocoindex):
+                        config = FlowConfig(collection_name="test_collection")
+                        result = setup_and_run_flow("/test/path", config=config)
+
+            assert result["success"] is True
+            assert result["flow_name"] == "DocumentIngestion"
+            mock_cocoindex.update_all_flows_async.assert_awaited_once()
+
+        asyncio.run(_run_inside_loop())
 
     def test_handles_exception(self):
         """Test handling of exceptions during flow execution."""

--- a/tests/unit/test_cocoindex_flow.py
+++ b/tests/unit/test_cocoindex_flow.py
@@ -171,6 +171,7 @@ class TestSetupAndRunFlow:
             mock_flow = MagicMock()
             with patch.object(cocoindex_flow, "create_document_flow", return_value=mock_flow):
                 mock_cocoindex = MagicMock()
+                mock_cocoindex.update_all_flows_async = AsyncMock(return_value={})
                 with patch.object(cocoindex_flow, "cocoindex", mock_cocoindex):
                     config = FlowConfig(collection_name="test_collection")
                     result = setup_and_run_flow("/test/path", config=config)

--- a/tests/unit/test_compose_langfuse.py
+++ b/tests/unit/test_compose_langfuse.py
@@ -106,6 +106,15 @@ class TestLangfuseSecretPosture:
             f"got: {val!r}"
         )
 
+    @pytest.mark.parametrize("service", SERVICES_WITH_DEV_DEFAULTS)
+    def test_base_compose_uses_docker_specific_host_var(self, compose_base: dict, service: str):
+        env = _get_service_env(compose_base, service)
+        val = str(env.get("LANGFUSE_HOST", ""))
+        assert "LANGFUSE_DOCKER_HOST" in val, (
+            f"compose.yml: {service}.LANGFUSE_HOST must use LANGFUSE_DOCKER_HOST to avoid "
+            f"host localhost values leaking into containers, got: {val!r}"
+        )
+
 
 class TestLitellmCallbacks:
     """LiteLLM config must have langfuse callbacks configured."""


### PR DESCRIPTION
## Summary
- add fail-fast sync source validation to unified ingestion CLI status/preflight
- harden the ingestion Compose bind mount contract with explicit `GDRIVE_SYNC_DIR` and `create_host_path: false`
- standardize rclone sync/manifest scripts and cron around `GDRIVE_SYNC_DIR` and `RCLONE_CONFIG_FILE`

## Scope
This PR is batch 1 for #1052 and covers Tasks 1-3 from the implementation plan.
Remaining work for #1052 stays open and will follow in separate batches:
- Makefile operator flow alignment
- docs cleanup and canonical runtime guidance
- VPS recovery runbook
- broader verification

## Test Plan
- [x] `uv run pytest tests/unit/ingestion/test_unified_cli.py -k "sync_dir_missing or supported_file_count" -v` (with `uv sync --extra ingest` in the feature workspace)
- [x] `docker compose --profile full --env-file /home/user/projects/rag-fresh/.env config` and verified rendered `/data/drive-sync` bind mount includes `create_host_path: false`
- [x] `bash -n docker/rclone/sync-drive.sh`
- [x] `bash -n docker/rclone/gdrive-manifest.sh`

## References
- Closes symptom regression work under #1001
- Part of #1052
