### PR TITLE
Fix strict grounded safety and cache reuse policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,10 @@ QDRANT_HISTORY_COLLECTION=conversation_history
 # Docling API (optional)
 DOCLING_URL=http://localhost:5001
 
+# Unified Google Drive ingestion (required for ingestion service / VPS deploys)
+GDRIVE_SYNC_DIR=/absolute/path/to/drive-sync
+GDRIVE_COLLECTION_NAME=gdrive_documents_bge
+
 # =============================================================================
 # DEV STACK CONFIGURATION
 # =============================================================================

--- a/.env.local.example
+++ b/.env.local.example
@@ -10,6 +10,8 @@ GROQ_API_KEY=gsk_your-groq-key
 # === Local Services (docker-compose.local.yml) ===
 QDRANT_URL=http://localhost:6333
 QDRANT_API_KEY=  # Пустой для локальной разработки
+GDRIVE_SYNC_DIR=/absolute/path/to/drive-sync
+GDRIVE_COLLECTION_NAME=gdrive_documents_bge
 BGE_M3_URL=http://localhost:8001
 DOCLING_URL=http://localhost:5001
 REDIS_URL=redis://localhost:6379

--- a/compose.yml
+++ b/compose.yml
@@ -420,7 +420,12 @@ services:
       - BGE_M3_CONCURRENCY=1
       - MANIFEST_DIR=/data/manifest
     volumes:
-      - ${GDRIVE_SYNC_DIR:-~/drive-sync}:/data/drive-sync:ro
+      - type: bind
+        source: ${GDRIVE_SYNC_DIR:?GDRIVE_SYNC_DIR is required}
+        target: /data/drive-sync
+        read_only: true
+        bind:
+          create_host_path: false
       - ingestion-manifest:/data/manifest
     depends_on:
       postgres:

--- a/docker/rclone/crontab
+++ b/docker/rclone/crontab
@@ -1,3 +1,3 @@
 # Google Drive sync - every 5 minutes
 # Install: sudo cp docker/rclone/crontab /etc/cron.d/rclone-sync
-*/5 * * * * root /opt/scripts/sync-drive.sh >> /var/log/rclone-cron.log 2>&1
+*/5 * * * * root . /etc/rag-fresh/rclone-sync.env && /opt/scripts/sync-drive.sh >> /var/log/rclone-cron.log 2>&1

--- a/docker/rclone/gdrive-manifest.sh
+++ b/docker/rclone/gdrive-manifest.sh
@@ -7,18 +7,22 @@
 
 set -euo pipefail
 
-MANIFEST_DIR="/data/drive-sync"
+MANIFEST_DIR="${GDRIVE_SYNC_DIR:?GDRIVE_SYNC_DIR is required}"
+RCLONE_CONFIG_FILE="${RCLONE_CONFIG_FILE:?RCLONE_CONFIG_FILE is required}"
 TMP_FILE="${MANIFEST_DIR}/.gdrive_manifest.json.tmp"
 OUT_FILE="${MANIFEST_DIR}/.gdrive_manifest.json"
 LOG_FILE="/var/log/rclone-manifest.log"
-RCLONE_CONFIG="/home/user/projects/rag-fresh/docker/rclone/rclone.conf"
+RCLONE_REMOTE="${RCLONE_REMOTE:-gdrive:RAG}"
+
+mkdir -p "$MANIFEST_DIR"
+mkdir -p "$(dirname "$LOG_FILE")"
 
 echo "$(date): Generating Drive manifest" >> "$LOG_FILE"
 
 # root_folder_id in rclone.conf makes gdrive: scoped to that folder.
 # lsjson returns: Path, Name, Size, MimeType, ModTime, ID, etc.
-rclone lsjson gdrive: \
-  --config "$RCLONE_CONFIG" \
+rclone lsjson "$RCLONE_REMOTE" \
+  --config "$RCLONE_CONFIG_FILE" \
   --recursive \
   --files-only \
   --metadata \

--- a/docker/rclone/sync-drive.sh
+++ b/docker/rclone/sync-drive.sh
@@ -7,10 +7,11 @@
 
 set -euo pipefail
 
-SYNC_DIR="${GDRIVE_SYNC_DIR:-$HOME/drive-sync}"
+SYNC_DIR="${GDRIVE_SYNC_DIR:?GDRIVE_SYNC_DIR is required}"
+RCLONE_CONFIG_FILE="${RCLONE_CONFIG_FILE:?RCLONE_CONFIG_FILE is required}"
 LOG_FILE="${HOME}/.local/log/rclone-sync.log"
 LOCK_FILE="/tmp/rclone-sync.lock"
-RCLONE_REMOTE="gdrive:RAG"
+RCLONE_REMOTE="${RCLONE_REMOTE:-gdrive:RAG}"
 
 # Ensure log directory exists
 mkdir -p "$(dirname "$LOG_FILE")"
@@ -22,6 +23,7 @@ flock -n 200 || { echo "$(date): Sync already running" >> "$LOG_FILE"; exit 0; }
 echo "$(date): Starting Drive sync" >> "$LOG_FILE"
 
 rclone sync "$RCLONE_REMOTE" "$SYNC_DIR" \
+  --config "$RCLONE_CONFIG_FILE" \
   --drive-export-formats docx,xlsx,pptx \
   --fast-list \
   --delete-after \

--- a/src/ingestion/unified/cli.py
+++ b/src/ingestion/unified/cli.py
@@ -7,6 +7,7 @@ import logging
 import os
 import sys
 from collections.abc import Mapping
+from pathlib import Path
 
 from dotenv import load_dotenv
 
@@ -28,6 +29,28 @@ def setup_logging(verbose: bool = False) -> None:
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("httpcore").setLevel(logging.WARNING)
     logging.getLogger("cocoindex").setLevel(logging.INFO)
+
+
+def _inspect_sync_dir(
+    sync_dir: Path, supported_extensions: frozenset[str]
+) -> dict[str, int | bool]:
+    """Inspect ingestion source directory health."""
+    exists = sync_dir.exists()
+    is_dir = sync_dir.is_dir()
+    supported_files = 0
+
+    if exists and is_dir:
+        supported_files = sum(
+            1
+            for path in sync_dir.rglob("*")
+            if path.is_file() and path.suffix.lower() in supported_extensions
+        )
+
+    return {
+        "exists": exists,
+        "is_dir": is_dir,
+        "supported_files": supported_files,
+    }
 
 
 @observe(name="ingestion-cli-run", capture_input=False, capture_output=False)
@@ -70,6 +93,7 @@ async def cmd_status(args: argparse.Namespace) -> int:
     try:
         stats = await manager.get_stats()
         dlq_count = await manager.get_dlq_count()
+        sync_info = _inspect_sync_dir(config.sync_dir, config.supported_extensions)
 
         print("\n=== Ingestion Status ===")
         total = sum(stats.values())
@@ -80,6 +104,12 @@ async def cmd_status(args: argparse.Namespace) -> int:
         print(f"\n  DLQ: {dlq_count} items")
         print(f"  Collection: {config.collection_name}")
         print(f"  Sync dir: {config.sync_dir}")
+        if sync_info["exists"] and sync_info["is_dir"]:
+            print(f"  Supported files: {sync_info['supported_files']}")
+        elif not sync_info["exists"]:
+            print("  Supported files: n/a (sync dir missing)")
+        else:
+            print("  Supported files: n/a (sync dir is not a directory)")
     finally:
         await manager.close()
 
@@ -97,6 +127,7 @@ async def cmd_preflight(args: argparse.Namespace) -> int:
     try_update_ingestion_trace(command="preflight", status="started")
     timeout = httpx.Timeout(float(os.getenv("BGE_M3_TIMEOUT", "60")))
     results: dict[str, bool] = {}
+    sync_info = _inspect_sync_dir(config.sync_dir, config.supported_extensions)
 
     async with httpx.AsyncClient(timeout=timeout) as client:
         # Qdrant reachable + collection exists
@@ -166,6 +197,18 @@ async def cmd_preflight(args: argparse.Namespace) -> int:
     else:
         results["env_vars"] = True
         print("  [OK] All required env vars set")
+
+    if not sync_info["exists"]:
+        results["sync_dir"] = False
+        print(f"  [FAIL] Sync dir missing: {config.sync_dir}")
+    elif not sync_info["is_dir"]:
+        results["sync_dir"] = False
+        print(f"  [FAIL] Sync dir is not a directory: {config.sync_dir}")
+    else:
+        results["sync_dir"] = True
+        print(
+            f"  [OK] Sync dir: {config.sync_dir} ({sync_info['supported_files']} supported files)"
+        )
 
     # Summary
     ok = sum(1 for v in results.values() if v)

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -28,6 +28,8 @@ from aiogram.types import (
 )
 from aiogram.utils.chat_action import ChatActionSender
 
+from src.retrieval.topic_classifier import get_query_topic_hint
+
 from .callback_data import FavoriteCB, FeedbackCB, FeedbackReasonCB, ResultsCB
 from .config import BotConfig
 from .handlers.handoff import (
@@ -55,6 +57,7 @@ from .scoring import (
 )
 from .services.business_hours import is_business_hours
 from .services.forum_bridge import ForumBridge
+from .services.grounding_policy import get_grounding_mode, semantic_cache_safe_reuse_allowed
 from .services.handoff_state import HandoffData, HandoffState
 from .services.metrics import PipelineMetrics
 from .services.redis_monitor import RedisHealthMonitor
@@ -274,6 +277,9 @@ def _build_trace_metadata(result: dict[str, Any]) -> dict[str, Any]:
     return {
         "input_type": result.get("input_type", "text"),
         "query_type": result.get("query_type", ""),
+        "topic_hint": result.get("topic_hint", ""),
+        "grounding_mode": result.get("grounding_mode", ""),
+        "grade_confidence": float(result.get("grade_confidence", 0.0) or 0.0),
         "pipeline_wall_ms": result.get("pipeline_wall_ms"),
         "pre_agent_ms": result.get("pre_agent_ms"),
         "e2e_latency_ms": result.get("e2e_latency_ms"),
@@ -289,6 +295,11 @@ def _build_trace_metadata(result: dict[str, Any]) -> dict[str, Any]:
         "response_policy_mode": result.get("response_policy_mode"),
         "answer_words": result.get("answer_words"),
         "answer_to_question_ratio": result.get("answer_to_question_ratio"),
+        "sources_count": int(result.get("sources_count", 0) or 0),
+        "grounded": result.get("grounded", True),
+        "legal_answer_safe": result.get("legal_answer_safe", True),
+        "semantic_cache_safe_reuse": result.get("semantic_cache_safe_reuse", True),
+        "safe_fallback_used": result.get("safe_fallback_used", False),
         # Voice transcription (#151)
         "stt_duration_ms": result.get("stt_duration_ms"),
         # Embedding resilience (#210)
@@ -2683,7 +2694,6 @@ class PropertyBot:
         dialog_manager: Any = None,
     ) -> str:
         """Handle query via create_agent SDK (#413 — replaces build_supervisor_graph)."""
-        from src.retrieval.topic_classifier import get_query_topic_hint
 
         from .agents.agent import LOCALE_TO_LANGUAGE
         from .agents.apartment_tools import apartment_search
@@ -2834,6 +2844,12 @@ class PropertyBot:
                     rag_result_store["pre_agent_embed_ms"] = (
                         time.perf_counter() - embed_start
                     ) * 1000
+                    topic_hint_label = get_query_topic_hint(user_text)
+                    topic_hint = topic_hint_label.value if topic_hint_label is not None else None
+                    grounding_mode = get_grounding_mode(
+                        query_type=query_type,
+                        topic_hint=topic_hint,
+                    )
                     check_start = time.perf_counter()
                     cached = await self._cache.check_semantic(
                         query=user_text,
@@ -2841,6 +2857,8 @@ class PropertyBot:
                         query_type=query_type,
                         cache_scope="rag",
                         agent_role=role,
+                        grounding_mode=grounding_mode if grounding_mode == "strict" else None,
+                        require_safe_reuse=grounding_mode == "strict",
                     )
                     rag_result_store["pre_agent_cache_check_ms"] = (
                         time.perf_counter() - check_start
@@ -3283,6 +3301,17 @@ class PropertyBot:
                     and not rag_result_store.get("cache_hit", False)
                     and isinstance(store_vector, list)
                     and bool(store_vector)
+                    and semantic_cache_safe_reuse_allowed(
+                        grounding_mode=str(
+                            rag_result_store.get("grounding_mode", "normal") or "normal"
+                        ),
+                        grounded=bool(rag_result_store.get("grounded", True)),
+                        legal_answer_safe=bool(rag_result_store.get("legal_answer_safe", True)),
+                        semantic_cache_safe_reuse=bool(
+                            rag_result_store.get("semantic_cache_safe_reuse", True)
+                        ),
+                        safe_fallback_used=bool(rag_result_store.get("safe_fallback_used", False)),
+                    )
                 ):
                     try:
                         await self._cache.store_semantic(
@@ -3292,6 +3321,17 @@ class PropertyBot:
                             query_type=query_type,
                             cache_scope="rag",
                             agent_role=role,
+                            metadata={
+                                "grounding_mode": str(
+                                    rag_result_store.get("grounding_mode", "normal") or "normal"
+                                ),
+                                "legal_answer_safe": bool(
+                                    rag_result_store.get("legal_answer_safe", True)
+                                ),
+                                "semantic_cache_safe_reuse": bool(
+                                    rag_result_store.get("semantic_cache_safe_reuse", True)
+                                ),
+                            },
                         )
                     except Exception:
                         logger.warning("Failed to store semantic cache in text path", exc_info=True)
@@ -3306,6 +3346,17 @@ class PropertyBot:
                 input={"query": message.text},
                 metadata={
                     "pipeline_mode": "sdk_agent",
+                    "query_type": rag_result_store.get("query_type", ""),
+                    "topic_hint": rag_result_store.get("topic_hint", ""),
+                    "grounding_mode": rag_result_store.get("grounding_mode", ""),
+                    "grade_confidence": float(rag_result_store.get("grade_confidence", 0.0) or 0.0),
+                    "sources_count": int(rag_result_store.get("sources_count", 0) or 0),
+                    "grounded": bool(rag_result_store.get("grounded", True)),
+                    "legal_answer_safe": bool(rag_result_store.get("legal_answer_safe", True)),
+                    "semantic_cache_safe_reuse": bool(
+                        rag_result_store.get("semantic_cache_safe_reuse", True)
+                    ),
+                    "safe_fallback_used": bool(rag_result_store.get("safe_fallback_used", False)),
                     "pipeline_wall_ms": wall_ms,
                     "pre_agent_ms": pre_agent_ms,
                     "pre_agent_embed_ms": rag_result_store.get("pre_agent_embed_ms"),
@@ -3317,6 +3368,21 @@ class PropertyBot:
                 root_trace_metadata.update(
                     {
                         "pipeline_mode": "sdk_agent",
+                        "query_type": rag_result_store.get("query_type", ""),
+                        "topic_hint": rag_result_store.get("topic_hint", ""),
+                        "grounding_mode": rag_result_store.get("grounding_mode", ""),
+                        "grade_confidence": float(
+                            rag_result_store.get("grade_confidence", 0.0) or 0.0
+                        ),
+                        "sources_count": int(rag_result_store.get("sources_count", 0) or 0),
+                        "grounded": bool(rag_result_store.get("grounded", True)),
+                        "legal_answer_safe": bool(rag_result_store.get("legal_answer_safe", True)),
+                        "semantic_cache_safe_reuse": bool(
+                            rag_result_store.get("semantic_cache_safe_reuse", True)
+                        ),
+                        "safe_fallback_used": bool(
+                            rag_result_store.get("safe_fallback_used", False)
+                        ),
                         "pipeline_wall_ms": wall_ms,
                         "pre_agent_ms": pre_agent_ms,
                         "pre_agent_embed_ms": rag_result_store.get("pre_agent_embed_ms"),

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -2850,6 +2850,15 @@ class PropertyBot:
                         query_type=query_type,
                         topic_hint=topic_hint,
                     )
+                    rag_result_store["topic_hint"] = topic_hint or ""
+                    rag_result_store["grounding_mode"] = grounding_mode
+                    if grounding_mode == "strict":
+                        # Strict-mode cache hits are only allowed for reusable safe answers,
+                        # so keep those observability fields on the early-return path too.
+                        rag_result_store.setdefault("grounded", True)
+                        rag_result_store.setdefault("legal_answer_safe", True)
+                        rag_result_store.setdefault("semantic_cache_safe_reuse", True)
+                        rag_result_store.setdefault("safe_fallback_used", False)
                     check_start = time.perf_counter()
                     cached = await self._cache.check_semantic(
                         query=user_text,
@@ -2887,19 +2896,36 @@ class PropertyBot:
                             reply_markup=reply_markup,
                         )
                         wall_ms = (time.perf_counter() - pipeline_start) * 1000
+                        cache_trace_metadata = {
+                            "pipeline_mode": "pre_agent_cache",
+                            "pipeline_wall_ms": wall_ms,
+                            "pre_agent_ms": pre_agent_ms,
+                            "pre_agent_embed_ms": rag_result_store.get("pre_agent_embed_ms"),
+                            "pre_agent_cache_check_ms": rag_result_store.get(
+                                "pre_agent_cache_check_ms"
+                            ),
+                            "e2e_latency_ms": wall_ms,
+                            "topic_hint": rag_result_store.get("topic_hint", ""),
+                            "grounding_mode": rag_result_store.get("grounding_mode", ""),
+                            "grade_confidence": float(
+                                rag_result_store.get("grade_confidence", 0.0) or 0.0
+                            ),
+                            "sources_count": int(rag_result_store.get("sources_count", 0) or 0),
+                            "grounded": bool(rag_result_store.get("grounded", True)),
+                            "legal_answer_safe": bool(
+                                rag_result_store.get("legal_answer_safe", True)
+                            ),
+                            "semantic_cache_safe_reuse": bool(
+                                rag_result_store.get("semantic_cache_safe_reuse", True)
+                            ),
+                            "safe_fallback_used": bool(
+                                rag_result_store.get("safe_fallback_used", False)
+                            ),
+                        }
                         lf.update_current_trace(
                             input={"query": user_text},
                             output={"response": cached},
-                            metadata={
-                                "pipeline_mode": "pre_agent_cache",
-                                "pipeline_wall_ms": wall_ms,
-                                "pre_agent_ms": pre_agent_ms,
-                                "pre_agent_embed_ms": rag_result_store.get("pre_agent_embed_ms"),
-                                "pre_agent_cache_check_ms": rag_result_store.get(
-                                    "pre_agent_cache_check_ms"
-                                ),
-                                "e2e_latency_ms": wall_ms,
-                            },
+                            metadata=cache_trace_metadata,
                         )
                         if tid:
                             score(lf, tid, name="pre_agent_cache_hit", value=1, data_type="BOOLEAN")
@@ -2912,20 +2938,7 @@ class PropertyBot:
                             )
                             score(lf, tid, name="user_role", value=role, data_type="CATEGORICAL")
                         if root_trace_metadata is not None:
-                            root_trace_metadata.update(
-                                {
-                                    "pipeline_mode": "pre_agent_cache",
-                                    "pipeline_wall_ms": wall_ms,
-                                    "pre_agent_ms": pre_agent_ms,
-                                    "pre_agent_embed_ms": rag_result_store.get(
-                                        "pre_agent_embed_ms"
-                                    ),
-                                    "pre_agent_cache_check_ms": rag_result_store.get(
-                                        "pre_agent_cache_check_ms"
-                                    ),
-                                    "e2e_latency_ms": wall_ms,
-                                }
-                            )
+                            root_trace_metadata.update(cache_trace_metadata)
                         return cached
                     # MISS: stash all embeddings so rag_pipeline can skip recomputation (#571)
                     logger.debug("Pre-agent cache MISS (type=%s): %.60s", query_type, user_text)

--- a/telegram_bot/integrations/cache.py
+++ b/telegram_bot/integrations/cache.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 CACHE_VERSION = "v5"
+SEMANTIC_CACHE_VERSION = "v6"
 
 # Default TTLs per exact-cache tier (seconds)
 DEFAULT_TTLS: dict[str, int] = {
@@ -77,7 +78,7 @@ def _create_semantic_cache(
         from redisvl.extensions.cache.llm import SemanticCache
 
         cache = SemanticCache(
-            name=f"sem:{CACHE_VERSION}:bge1024",
+            name=f"sem:{SEMANTIC_CACHE_VERSION}:bge1024",
             redis_url=redis_url,
             ttl=ttl,
             distance_threshold=distance_threshold,
@@ -765,7 +766,7 @@ class CacheLayerManager:
             elif hasattr(self.semantic_cache, "clear"):
                 self.semantic_cache.clear()
             elif self.redis:
-                pattern = f"sem:{CACHE_VERSION}:*"
+                pattern = f"sem:{SEMANTIC_CACHE_VERSION}:*"
                 keys = [key async for key in self.redis.scan_iter(match=pattern)]
                 if keys:
                     await self.redis.delete(*keys)

--- a/telegram_bot/integrations/cache.py
+++ b/telegram_bot/integrations/cache.py
@@ -88,6 +88,8 @@ def _create_semantic_cache(
                 {"name": "user_id", "type": "tag"},
                 {"name": "cache_scope", "type": "tag"},
                 {"name": "agent_role", "type": "tag"},
+                {"name": "grounding_mode", "type": "tag"},
+                {"name": "semantic_cache_safe_reuse", "type": "tag"},
             ],
         )
         logger.info("SemanticCache initialized (threshold=%.2f, ttl=%ds)", distance_threshold, ttl)
@@ -236,6 +238,8 @@ class CacheLayerManager:
         user_id: int | None = None,
         cache_scope: str | None = None,
         agent_role: str | None = None,
+        grounding_mode: str | None = None,
+        require_safe_reuse: bool = False,
         cache_timeout: float = 0.3,
     ) -> str | None:
         """Check semantic cache with query-type-specific threshold.
@@ -261,6 +265,8 @@ class CacheLayerManager:
                 "has_user_id": user_id is not None,
                 "has_cache_scope": cache_scope is not None,
                 "has_agent_role": agent_role is not None,
+                "grounding_mode": grounding_mode,
+                "require_safe_reuse": require_safe_reuse,
                 "cache_timeout_s": cache_timeout,
                 "query_length": len(query),
                 "vector_dim": len(vector),
@@ -283,6 +289,10 @@ class CacheLayerManager:
                 filter_expr = filter_expr & (Tag("cache_scope") == cache_scope)
             if agent_role is not None:
                 filter_expr = filter_expr & (Tag("agent_role") == agent_role)
+            if grounding_mode is not None:
+                filter_expr = filter_expr & (Tag("grounding_mode") == grounding_mode)
+            if require_safe_reuse:
+                filter_expr = filter_expr & (Tag("semantic_cache_safe_reuse") == "true")
             start = time.time()
 
             try:
@@ -356,6 +366,7 @@ class CacheLayerManager:
         user_id: int | None = None,
         cache_scope: str | None = None,
         agent_role: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         """Store query-response pair in semantic cache."""
         lf = get_client()
@@ -366,6 +377,7 @@ class CacheLayerManager:
                 "has_user_id": user_id is not None,
                 "has_cache_scope": cache_scope is not None,
                 "has_agent_role": agent_role is not None,
+                "metadata_keys": sorted((metadata or {}).keys()),
                 "query_length": len(query),
                 "response_length": len(response),
                 "vector_dim": len(vector),
@@ -383,12 +395,21 @@ class CacheLayerManager:
             filters["cache_scope"] = cache_scope
         if agent_role is not None:
             filters["agent_role"] = agent_role
+        if metadata:
+            grounding_mode = metadata.get("grounding_mode")
+            if isinstance(grounding_mode, str) and grounding_mode:
+                filters["grounding_mode"] = grounding_mode
+            if "semantic_cache_safe_reuse" in metadata:
+                filters["semantic_cache_safe_reuse"] = str(
+                    bool(metadata["semantic_cache_safe_reuse"])
+                ).lower()
         try:
             await self.semantic_cache.astore(
                 prompt=query,
                 response=response,
                 vector=vector,
                 filters=filters,
+                metadata=metadata,
                 ttl=ttl,
             )
             logger.debug(

--- a/telegram_bot/pipelines/client.py
+++ b/telegram_bot/pipelines/client.py
@@ -18,7 +18,10 @@ from telegram_bot.observability import get_client, observe
 from telegram_bot.pipelines.state_contract import coerce_pre_agent_state_contract
 from telegram_bot.scoring import score, write_langfuse_scores
 from telegram_bot.services.generate_response import generate_response
-from telegram_bot.services.grounding_policy import get_grounding_mode
+from telegram_bot.services.grounding_policy import (
+    get_grounding_mode,
+    semantic_cache_safe_reuse_allowed,
+)
 from telegram_bot.services.history_service import HistoryService
 from telegram_bot.services.telegram_formatting import send_html_messages
 from telegram_bot.services.types import PipelineResult
@@ -132,6 +135,24 @@ def _safe_langfuse_env(config: Any) -> str:
 def _is_contextual_query(user_text: str) -> bool:
     """Return True if query contains follow-up pronouns / contextual references."""
     return bool(_CONTEXTUAL_RE.search(user_text))
+
+
+def _semantic_cache_metadata(result: dict[str, Any], grounding_mode: str) -> dict[str, Any]:
+    return {
+        "grounding_mode": grounding_mode,
+        "legal_answer_safe": bool(result.get("legal_answer_safe", True)),
+        "semantic_cache_safe_reuse": bool(result.get("semantic_cache_safe_reuse", True)),
+    }
+
+
+def _strict_cache_safe_to_store(result: dict[str, Any], grounding_mode: str) -> bool:
+    return semantic_cache_safe_reuse_allowed(
+        grounding_mode=grounding_mode,
+        grounded=bool(result.get("grounded", True)),
+        legal_answer_safe=bool(result.get("legal_answer_safe", True)),
+        semantic_cache_safe_reuse=bool(result.get("semantic_cache_safe_reuse", True)),
+        safe_fallback_used=bool(result.get("safe_fallback_used", False)),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -344,6 +365,11 @@ async def run_client_pipeline(
             latency_stages=result.get("latency_stages", {}),
             llm_call_count=int(result.get("llm_call_count", 0) or 0),
             grounding_mode=grounding_mode,
+            grade_confidence=(
+                float(result["grade_confidence"])
+                if isinstance(result.get("grade_confidence"), Real)
+                else None
+            ),
             config=config,
             message=message,
         )
@@ -411,6 +437,12 @@ async def run_client_pipeline(
         "query_type": query_type,
         "topic_hint": topic_hint_value,
         "grounding_mode": grounding_mode_value,
+        "grade_confidence": float(result.get("grade_confidence", 0.0) or 0.0),
+        "sources_count": int(result.get("sources_count", 0) or 0),
+        "grounded": bool(result.get("grounded", True)),
+        "legal_answer_safe": bool(result.get("legal_answer_safe", True)),
+        "semantic_cache_safe_reuse": bool(result.get("semantic_cache_safe_reuse", True)),
+        "safe_fallback_used": bool(result.get("safe_fallback_used", False)),
         "collection": _safe_collection_name(config),
         "environment": _safe_langfuse_env(config),
         "pipeline_wall_ms": wall_ms,
@@ -437,6 +469,7 @@ async def run_client_pipeline(
         and not _is_contextual_query(user_text)
         and grade_confidence >= confidence_threshold
         and bool(documents_list)
+        and _strict_cache_safe_to_store(result, grounding_mode_value)
     )
 
     if should_store:
@@ -448,6 +481,7 @@ async def run_client_pipeline(
                 query_type=query_type,
                 cache_scope="rag",
                 agent_role=role,
+                metadata=_semantic_cache_metadata(result, grounding_mode_value),
             )
         except Exception:
             logger.warning("Failed to store semantic cache in client pipeline", exc_info=True)

--- a/telegram_bot/services/generate_response.py
+++ b/telegram_bot/services/generate_response.py
@@ -20,6 +20,7 @@ from telegram_bot.integrations.prompt_templates import (
 from telegram_bot.observability import get_client, observe
 from telegram_bot.services.grounding_policy import (
     build_safe_fallback_response,
+    is_strict_grounding_safe,
     should_safe_fallback,
 )
 from telegram_bot.services.metrics import PipelineMetrics
@@ -453,6 +454,7 @@ async def generate_response(
     latency_stages: dict[str, float] | None = None,
     llm_call_count: int = 0,
     grounding_mode: str = "normal",
+    grade_confidence: float | None = None,
     message: Any | None = None,
     config: Any | None = None,
     get_config: Callable[[], Any] | None = None,
@@ -501,6 +503,11 @@ async def generate_response(
     detector = style_detector or _detector
     style_info = detector.detect(effective_query)
     sources_enabled = bool(getattr(config, "show_sources", False) or grounding_mode == "strict")
+    legal_answer_safe = grounding_mode != "strict" or is_strict_grounding_safe(
+        documents=docs,
+        sources_enabled=sources_enabled,
+        grade_confidence=grade_confidence,
+    )
     format_params = inspect.signature(format_context).parameters
     if "sources_enabled" in format_params:
         context = format_context(docs, max_context_docs, sources_enabled=sources_enabled)
@@ -523,6 +530,8 @@ async def generate_response(
         grounding_mode=grounding_mode,
         documents=docs,
         sources_enabled=sources_enabled,
+        grade_confidence=grade_confidence,
+        legal_answer_safe=legal_answer_safe,
     ):
         elapsed = time.monotonic() - t0
         PipelineMetrics.get().record("generate", elapsed * 1000)
@@ -944,6 +953,6 @@ async def generate_response(
         "grounding_mode": grounding_mode,
         "safe_fallback_used": False,
         "grounded": True,
-        "legal_answer_safe": True,
-        "semantic_cache_safe_reuse": True,
+        "legal_answer_safe": legal_answer_safe,
+        "semantic_cache_safe_reuse": legal_answer_safe,
     }

--- a/telegram_bot/services/grounding_policy.py
+++ b/telegram_bot/services/grounding_policy.py
@@ -4,11 +4,48 @@ from typing import Any
 
 
 STRICT_TOPICS = {"legal", "relocation", "immigration"}
+STRICT_QUERY_TYPES = {"LEGAL", "RELOCATION", "IMMIGRATION"}
+STRICT_GROUNDING_CONFIDENCE_THRESHOLD = 0.5
+
+
+def is_high_risk_grounding_request(*, query_type: str, topic_hint: str | None) -> bool:
+    normalized_query_type = query_type.strip().upper()
+    normalized_topic_hint = topic_hint.strip().lower() if isinstance(topic_hint, str) else None
+    return normalized_query_type in STRICT_QUERY_TYPES or normalized_topic_hint in STRICT_TOPICS
 
 
 def get_grounding_mode(*, query_type: str, topic_hint: str | None) -> str:
-    _ = query_type
-    return "strict" if topic_hint in STRICT_TOPICS else "normal"
+    return (
+        "strict"
+        if is_high_risk_grounding_request(query_type=query_type, topic_hint=topic_hint)
+        else "normal"
+    )
+
+
+def is_strict_grounding_safe(
+    *,
+    documents: list[dict[str, Any]],
+    sources_enabled: bool,
+    grade_confidence: float | None = None,
+) -> bool:
+    if not documents or not sources_enabled:
+        return False
+    if grade_confidence is None:
+        return True
+    return grade_confidence >= STRICT_GROUNDING_CONFIDENCE_THRESHOLD
+
+
+def semantic_cache_safe_reuse_allowed(
+    *,
+    grounding_mode: str,
+    grounded: bool,
+    legal_answer_safe: bool,
+    semantic_cache_safe_reuse: bool,
+    safe_fallback_used: bool,
+) -> bool:
+    if grounding_mode != "strict":
+        return True
+    return grounded and legal_answer_safe and semantic_cache_safe_reuse and not safe_fallback_used
 
 
 def should_safe_fallback(
@@ -16,10 +53,18 @@ def should_safe_fallback(
     grounding_mode: str,
     documents: list[dict[str, Any]],
     sources_enabled: bool,
+    grade_confidence: float | None = None,
+    legal_answer_safe: bool | None = None,
 ) -> bool:
     if grounding_mode != "strict":
         return False
-    return len(documents) == 0 or not sources_enabled
+    if legal_answer_safe is not None:
+        return not legal_answer_safe
+    return not is_strict_grounding_safe(
+        documents=documents,
+        sources_enabled=sources_enabled,
+        grade_confidence=grade_confidence,
+    )
 
 
 def build_safe_fallback_response(documents: list[dict[str, Any]]) -> str:

--- a/tests/unit/ingestion/test_unified_cli.py
+++ b/tests/unit/ingestion/test_unified_cli.py
@@ -3,6 +3,7 @@
 
 import argparse
 import logging
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -168,7 +169,13 @@ def _make_config(**overrides):
     config.bge_m3_url = overrides.get("bge_m3_url", "http://bge:8000")
     config.docling_url = overrides.get("docling_url", "http://docling:5001")
     config.database_url = overrides.get("database_url", "postgresql://test@localhost/db")
-    config.sync_dir = overrides.get("sync_dir", "/tmp/sync")
+    config.sync_dir = overrides.get("sync_dir", Path("/tmp/sync"))
+    config.supported_extensions = overrides.get(
+        "supported_extensions",
+        frozenset(
+            {".pdf", ".docx", ".doc", ".xlsx", ".pptx", ".md", ".txt", ".html", ".htm", ".csv"}
+        ),
+    )
     return config
 
 
@@ -313,6 +320,39 @@ class TestCmdPreflight:
         assert "[WARN]" in output
         assert "Missing env vars" in output
 
+    @patch.dict(
+        "os.environ",
+        {
+            "QDRANT_URL": "http://qdrant:6333",
+            "BGE_M3_URL": "http://bge:8000",
+            "DOCLING_URL": "http://docling:5001",
+            "INGESTION_DATABASE_URL": "postgresql://test@localhost/db",
+        },
+    )
+    async def test_sync_dir_missing_fails(self, args, capsys, tmp_path):
+        mock_client = AsyncMock()
+        mock_client.get.return_value = _ok_response({"result": {"points_count": 0}})
+        mock_client.post.return_value = _ok_response()
+
+        config = _make_config(sync_dir=tmp_path / "missing-sync")
+        with (
+            patch("src.ingestion.unified.config.UnifiedConfig", return_value=config),
+            patch("httpx.AsyncClient") as MockClient,
+        ):
+            mock_ctx = AsyncMock()
+            mock_ctx.__aenter__.return_value = mock_client
+            mock_ctx.__aexit__.return_value = False
+            MockClient.return_value = mock_ctx
+
+            from src.ingestion.unified.cli import cmd_preflight
+
+            result = await cmd_preflight(args)
+
+        assert result == 1
+        output = capsys.readouterr().out
+        assert "Sync dir" in output
+        assert "[FAIL]" in output
+
 
 # ---------------------------------------------------------------------------
 # cmd_status
@@ -393,6 +433,34 @@ class TestCmdStatus:
             await cmd_status(args)
 
         manager.close.assert_awaited_once()
+
+    async def test_status_reports_supported_file_count(self, args, capsys, tmp_path):
+        sync_dir = tmp_path / "sync"
+        sync_dir.mkdir()
+        (sync_dir / "one.pdf").write_text("pdf")
+        (sync_dir / "two.docx").write_text("docx")
+        (sync_dir / "ignored.tmp").write_text("tmp")
+
+        config = _make_config(collection_name="test_col", sync_dir=sync_dir)
+        manager = AsyncMock()
+        manager.get_stats.return_value = {"indexed": 2}
+        manager.get_dlq_count.return_value = 0
+
+        with (
+            patch("src.ingestion.unified.config.UnifiedConfig", return_value=config),
+            patch(
+                "src.ingestion.unified.state_manager.UnifiedStateManager",
+                return_value=manager,
+            ),
+        ):
+            from src.ingestion.unified.cli import cmd_status
+
+            result = await cmd_status(args)
+
+        assert result == 0
+        output = capsys.readouterr().out
+        assert "Sync dir:" in output
+        assert "Supported files: 2" in output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/integrations/test_cache_layers.py
+++ b/tests/unit/integrations/test_cache_layers.py
@@ -675,6 +675,31 @@ class TestScopeRoleIsolation:
         assert call_kwargs["filters"]["cache_scope"] == "rag"
         assert call_kwargs["filters"]["agent_role"] == "client"
 
+    async def test_store_semantic_includes_strict_grounding_filters_and_metadata(
+        self, _ensure_redisvl_filter_mock
+    ):
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        mgr.semantic_cache = AsyncMock()
+        mgr.semantic_cache.astore = AsyncMock()
+        mgr.cache_ttl = {"FAQ": 86400}
+
+        await mgr.store_semantic(
+            query="test",
+            response="answer",
+            vector=[0.1] * 1024,
+            query_type="FAQ",
+            cache_scope="rag",
+            metadata={
+                "grounding_mode": "strict",
+                "semantic_cache_safe_reuse": True,
+            },
+        )
+
+        call_kwargs = mgr.semantic_cache.astore.call_args[1]
+        assert call_kwargs["filters"]["grounding_mode"] == "strict"
+        assert call_kwargs["filters"]["semantic_cache_safe_reuse"] == "true"
+        assert call_kwargs["metadata"]["grounding_mode"] == "strict"
+
     async def test_check_semantic_passes_scope_filter(self, _ensure_redisvl_filter_mock):
         """check_semantic with cache_scope passes filter_expression."""
         mgr = CacheLayerManager(redis_url="redis://localhost:6379")
@@ -692,6 +717,29 @@ class TestScopeRoleIsolation:
         )
 
         assert result == "scoped answer"
+        call_kwargs = mgr.semantic_cache.acheck.call_args[1]
+        assert call_kwargs.get("filter_expression") is not None
+
+    async def test_check_semantic_passes_strict_safe_reuse_filter(
+        self, _ensure_redisvl_filter_mock
+    ):
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        mgr.semantic_cache = AsyncMock()
+        mgr.semantic_cache.acheck = AsyncMock(
+            return_value=[{"response": "strict answer", "vector_distance": 0.02}]
+        )
+        mgr.cache_thresholds = {"FAQ": 0.12}
+
+        result = await mgr.check_semantic(
+            query="test",
+            vector=[0.1] * 1024,
+            query_type="FAQ",
+            cache_scope="rag",
+            grounding_mode="strict",
+            require_safe_reuse=True,
+        )
+
+        assert result == "strict answer"
         call_kwargs = mgr.semantic_cache.acheck.call_args[1]
         assert call_kwargs.get("filter_expression") is not None
 

--- a/tests/unit/integrations/test_cache_layers.py
+++ b/tests/unit/integrations/test_cache_layers.py
@@ -11,6 +11,7 @@ from redisvl.exceptions import RedisSearchError, RedisVLError, SchemaValidationE
 
 from telegram_bot.integrations.cache import (
     CACHE_VERSION,
+    SEMANTIC_CACHE_VERSION,
     CacheLayerManager,
     _normalize_query_for_cache,
 )
@@ -72,9 +73,10 @@ class TestCacheLayerManagerInit:
         assert mgr.cache_thresholds["FAQ"] == 0.15
         assert mgr.cache_thresholds["GENERAL"] == 0.10
 
-    def test_cache_version_bumped_for_scope_role_schema(self):
-        """Schema changed with cache_scope/agent_role tag filters, so index version must be bumped."""
+    def test_cache_versions_reflect_schema_boundaries(self):
+        """Semantic cache schema changed, but exact-cache namespaces stay stable."""
         assert CACHE_VERSION == "v5"
+        assert SEMANTIC_CACHE_VERSION == "v6"
 
 
 class TestCacheLayerManagerInitialize:

--- a/tests/unit/observability/test_trace_contracts.py
+++ b/tests/unit/observability/test_trace_contracts.py
@@ -397,6 +397,30 @@ class TestBuildTraceMetadataContract:
         assert metadata["embedding_error"] is False
         assert metadata["memory_messages_count"] == 0
 
+    def test_grounding_decision_fields_present(self):
+        from telegram_bot.bot import _build_trace_metadata
+
+        metadata = _build_trace_metadata(
+            {
+                "topic_hint": "legal",
+                "grounding_mode": "strict",
+                "grade_confidence": 0.91,
+                "sources_count": 2,
+                "grounded": True,
+                "legal_answer_safe": True,
+                "semantic_cache_safe_reuse": True,
+                "safe_fallback_used": False,
+            }
+        )
+        assert metadata["topic_hint"] == "legal"
+        assert metadata["grounding_mode"] == "strict"
+        assert metadata["grade_confidence"] == 0.91
+        assert metadata["sources_count"] == 2
+        assert metadata["grounded"] is True
+        assert metadata["legal_answer_safe"] is True
+        assert metadata["semantic_cache_safe_reuse"] is True
+        assert metadata["safe_fallback_used"] is False
+
     def test_memory_messages_count_from_messages_list(self):
         from telegram_bot.bot import _build_trace_metadata
 

--- a/tests/unit/pipelines/test_client_pipeline.py
+++ b/tests/unit/pipelines/test_client_pipeline.py
@@ -535,6 +535,12 @@ class TestPipelineFullFlow:
         assert metadata["query_type"] == "FAQ"
         assert metadata["topic_hint"] == "legal"
         assert metadata["grounding_mode"] == "strict"
+        assert metadata["grade_confidence"] == 0.7
+        assert metadata["sources_count"] == 1
+        assert metadata["grounded"] is True
+        assert metadata["legal_answer_safe"] is True
+        assert metadata["semantic_cache_safe_reuse"] is True
+        assert metadata["safe_fallback_used"] is False
 
     async def test_pipeline_passes_strict_grounding_mode_to_generate_response(self):
         """Legal topic should force strict grounding mode in generation step."""
@@ -1074,6 +1080,112 @@ class TestCacheStoreGuards:
             )
 
         mock_cache.store_semantic.assert_called_once()
+        assert mock_cache.store_semantic.await_args.kwargs["metadata"] == {
+            "grounding_mode": "strict",
+            "legal_answer_safe": True,
+            "semantic_cache_safe_reuse": True,
+        }
+
+    async def test_strict_mode_unsafe_result_skips_cache_store(self):
+        msg = _make_message()
+        lf = _make_lf_client()
+        mock_cache = AsyncMock()
+
+        rag_result = {
+            "response": "",
+            "cache_hit": False,
+            "documents": [{"metadata": {"title": "Doc"}, "score": 0.9}],
+            "grade_confidence": _CONFIDENCE_THRESHOLD + 0.1,
+            "llm_call_count": 0,
+            "latency_stages": {},
+            "cache_key_embedding": [0.1, 0.2, 0.3],
+            "topic_hint": "legal",
+        }
+        gen_result = {
+            "response": "Нужна ручная проверка.",
+            "response_sent": False,
+            "grounding_mode": "strict",
+            "grounded": False,
+            "legal_answer_safe": False,
+            "semantic_cache_safe_reuse": False,
+            "safe_fallback_used": True,
+        }
+
+        with (
+            _patch_observability(lf),
+            _patch_rag_pipeline(rag_result),
+            _patch_generate_response(gen_result),
+            patch("telegram_bot.pipelines.client.write_langfuse_scores"),
+            patch("telegram_bot.pipelines.client.score"),
+        ):
+            await run_client_pipeline(
+                user_text="Какие документы нужны для ВНЖ?",
+                user_id=1,
+                session_id="s1",
+                message=msg,
+                cache=mock_cache,
+                embeddings=MagicMock(),
+                sparse_embeddings=MagicMock(),
+                qdrant=MagicMock(),
+                reranker=None,
+                llm=None,
+                config=_make_config(),
+                query_type="FAQ",
+            )
+
+        mock_cache.store_semantic.assert_not_called()
+
+    async def test_strict_mode_safe_result_stores_cache_with_safety_metadata(self):
+        msg = _make_message()
+        lf = _make_lf_client()
+        mock_cache = AsyncMock()
+
+        rag_result = {
+            "response": "",
+            "cache_hit": False,
+            "documents": [{"metadata": {"title": "Doc"}, "score": 0.9}],
+            "grade_confidence": _CONFIDENCE_THRESHOLD + 0.1,
+            "llm_call_count": 0,
+            "latency_stages": {},
+            "cache_key_embedding": [0.1, 0.2, 0.3],
+            "topic_hint": "legal",
+        }
+        gen_result = {
+            "response": "Подтвержденный ответ.",
+            "response_sent": False,
+            "grounding_mode": "strict",
+            "grounded": True,
+            "legal_answer_safe": True,
+            "semantic_cache_safe_reuse": True,
+            "safe_fallback_used": False,
+        }
+
+        with (
+            _patch_observability(lf),
+            _patch_rag_pipeline(rag_result),
+            _patch_generate_response(gen_result),
+            patch("telegram_bot.pipelines.client.write_langfuse_scores"),
+            patch("telegram_bot.pipelines.client.score"),
+        ):
+            await run_client_pipeline(
+                user_text="Какие документы нужны для ВНЖ?",
+                user_id=1,
+                session_id="s1",
+                message=msg,
+                cache=mock_cache,
+                embeddings=MagicMock(),
+                sparse_embeddings=MagicMock(),
+                qdrant=MagicMock(),
+                reranker=None,
+                llm=None,
+                config=_make_config(),
+                query_type="FAQ",
+            )
+
+        mock_cache.store_semantic.assert_called_once()
+        metadata = mock_cache.store_semantic.await_args.kwargs["metadata"]
+        assert metadata["grounding_mode"] == "strict"
+        assert metadata["semantic_cache_safe_reuse"] is True
 
     async def test_structured_query_type_stores_cache(self):
         """STRUCTURED query type is in _PIPELINE_STORE_TYPES, so cache store is enabled."""

--- a/tests/unit/retrieval/test_topic_classifier.py
+++ b/tests/unit/retrieval/test_topic_classifier.py
@@ -14,7 +14,11 @@ from src.retrieval.topic_classifier import (
     detect_score_gap,
     get_query_topic_hint,
 )
-from telegram_bot.services.grounding_policy import get_grounding_mode
+from telegram_bot.services.grounding_policy import (
+    get_grounding_mode,
+    semantic_cache_safe_reuse_allowed,
+    should_safe_fallback,
+)
 
 
 def test_classify_chunk_topic_finance() -> None:
@@ -59,6 +63,36 @@ def test_grounding_mode_is_strict_for_legal_query() -> None:
 
 def test_grounding_mode_is_normal_for_generic_property_query() -> None:
     assert get_grounding_mode(query_type="GENERAL", topic_hint=None) == "normal"
+
+
+def test_grounding_mode_is_strict_for_explicit_high_risk_query_type() -> None:
+    assert get_grounding_mode(query_type="legal", topic_hint=None) == "strict"
+
+
+def test_should_safe_fallback_when_strict_mode_has_docs_but_low_confidence() -> None:
+    assert (
+        should_safe_fallback(
+            grounding_mode="strict",
+            documents=[{"id": "1"}],
+            sources_enabled=True,
+            grade_confidence=0.1,
+            legal_answer_safe=False,
+        )
+        is True
+    )
+
+
+def test_semantic_cache_safe_reuse_allowed_blocks_unsafe_strict_entry() -> None:
+    assert (
+        semantic_cache_safe_reuse_allowed(
+            grounding_mode="strict",
+            grounded=True,
+            legal_answer_safe=False,
+            semantic_cache_safe_reuse=False,
+            safe_fallback_used=False,
+        )
+        is False
+    )
 
 
 def test_detect_score_gap_marks_dense_cluster_not_confident() -> None:

--- a/tests/unit/services/test_generate_response.py
+++ b/tests/unit/services/test_generate_response.py
@@ -195,6 +195,29 @@ async def test_generate_response_returns_safe_fallback_when_strict_mode_has_weak
 
 
 @pytest.mark.asyncio
+async def test_generate_response_returns_safe_fallback_when_strict_mode_has_low_confidence() -> (
+    None
+):
+    config, client = _make_non_streaming_config()
+    lf = MagicMock()
+
+    result = await generate_response(
+        query="виды внж в болгарии",
+        documents=[{"text": "Документ", "score": 0.2, "metadata": {"title": "ВНЖ"}}],
+        grounding_mode="strict",
+        grade_confidence=0.1,
+        config=config,
+        lf_client=lf,
+        raw_messages=[{"role": "user", "content": "виды внж в болгарии"}],
+    )
+
+    assert result["safe_fallback_used"] is True
+    assert result["legal_answer_safe"] is False
+    assert result["semantic_cache_safe_reuse"] is False
+    client.chat.completions.create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_generate_response_strict_mode_does_not_degrade_only_because_show_sources_disabled() -> (
     None
 ):

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -3570,6 +3570,29 @@ class TestPreAgentCacheCheck:
         assert len(check_calls) >= 1
         assert check_calls[0].kwargs.get("agent_role") == "client"
 
+    async def test_pre_agent_cache_hit_requires_safe_reuse_for_strict_query(self, mock_config):
+        bot, _ = _create_bot(mock_config)
+        self._setup_cache_mocks(bot, cached_response=None)
+
+        mock_agent = AsyncMock()
+        mock_agent.ainvoke = AsyncMock(return_value=_mock_agent_result())
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+            patch("telegram_bot.bot.classify_query", return_value="FAQ"),
+        ):
+            message = _make_text_message("Какие документы нужны для ВНЖ?")
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        kwargs = bot._cache.check_semantic.call_args.kwargs
+        assert kwargs["grounding_mode"] == "strict"
+        assert kwargs["require_safe_reuse"] is True
+
     async def test_pre_agent_ttl_desync_heals_sparse_via_hybrid_colbert(self, mock_config):
         """When embedding cached but sparse expired, heals via aembed_hybrid_with_colbert (#637)."""
         bot, _ = _create_bot(mock_config)

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -3227,6 +3227,42 @@ class TestPreAgentCacheCheck:
         assert score_map["query_type"]["value"] == "FAQ"
         assert score_map["query_type"]["data_type"] == "CATEGORICAL"
 
+    async def test_pre_agent_cache_hit_includes_strict_grounding_metadata(self, mock_config):
+        bot, _ = _create_bot(mock_config)
+        self._setup_cache_mocks(bot, cached_response="Ответ из кеша")
+
+        mock_agent = AsyncMock()
+        mock_lf = MagicMock()
+        mock_lf.get_current_trace_id = MagicMock(return_value="trace-strict-cache")
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.get_client", return_value=mock_lf),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+            patch("telegram_bot.bot.classify_query", return_value="FAQ"),
+            patch("telegram_bot.bot.score"),
+        ):
+            message = _make_text_message("Какие документы нужны для ВНЖ?")
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        metadata_payloads = [
+            c.kwargs.get("metadata", {})
+            for c in mock_lf.update_current_trace.call_args_list
+            if "metadata" in c.kwargs
+        ]
+        pre_agent_meta = next(
+            m for m in metadata_payloads if m.get("pipeline_mode") == "pre_agent_cache"
+        )
+        assert pre_agent_meta["topic_hint"] == "legal"
+        assert pre_agent_meta["grounding_mode"] == "strict"
+        assert pre_agent_meta["grounded"] is True
+        assert pre_agent_meta["legal_answer_safe"] is True
+        assert pre_agent_meta["semantic_cache_safe_reuse"] is True
+        assert pre_agent_meta["safe_fallback_used"] is False
+
     async def test_pre_agent_cache_skip_off_topic(self, mock_config):
         """OFF_TOPIC query type skips pre-agent cache entirely (#563)."""
         bot, _ = _create_bot(mock_config)

--- a/tests/unit/test_bot_scores.py
+++ b/tests/unit/test_bot_scores.py
@@ -746,6 +746,66 @@ class TestHistoryScores:
         assert any(m.get("pipeline_wall_ms") is not None for m in metadata_payloads)
         assert any(m.get("pre_agent_ms") is not None for m in metadata_payloads)
 
+    async def test_sdk_agent_trace_metadata_includes_grounding_safety_fields(self, mock_config):
+        mock_lf = MagicMock()
+        mock_lf.update_current_trace = MagicMock()
+        mock_lf.create_score = MagicMock()
+        mock_lf.get_current_trace_id = MagicMock(return_value="trace-safe-1")
+
+        bot = _create_bot(mock_config)
+        bot._cache = AsyncMock()
+        bot._cache.get_embedding = AsyncMock(return_value=[0.1, 0.2, 0.3])
+        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
+        bot._cache.check_semantic = AsyncMock(return_value=None)
+        bot._cache.store_semantic = AsyncMock()
+        message = _make_message("какие документы нужны для внж")
+
+        def _agent_side_effect(state, config=None, **kw):
+            cfg = config or kw.get("config", {})
+            store = cfg.get("configurable", {}).get("rag_result_store")
+            if isinstance(store, dict):
+                store.update(
+                    {
+                        "query_type": "FAQ",
+                        "topic_hint": "legal",
+                        "grounding_mode": "strict",
+                        "grade_confidence": 0.91,
+                        "sources_count": 2,
+                        "grounded": True,
+                        "legal_answer_safe": True,
+                        "semantic_cache_safe_reuse": True,
+                        "safe_fallback_used": False,
+                    }
+                )
+            return _mock_agent_result(messages=[MagicMock(content="Ответ агентом")])
+
+        mock_agent = AsyncMock()
+        mock_agent.ainvoke = AsyncMock(side_effect=_agent_side_effect)
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.get_client", return_value=mock_lf),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+            patch("telegram_bot.bot.ChatActionSender") as mock_cas,
+        ):
+            mock_cas.typing.return_value = _make_typing_cm()
+            await bot.handle_query(message)
+
+        metadata_payloads = [
+            c.kwargs.get("metadata", {})
+            for c in mock_lf.update_current_trace.call_args_list
+            if "metadata" in c.kwargs
+        ]
+        sdk_agent_meta = next(m for m in metadata_payloads if m.get("pipeline_mode") == "sdk_agent")
+        assert sdk_agent_meta["grounding_mode"] == "strict"
+        assert sdk_agent_meta["grade_confidence"] == 0.91
+        assert sdk_agent_meta["sources_count"] == 2
+        assert sdk_agent_meta["grounded"] is True
+        assert sdk_agent_meta["legal_answer_safe"] is True
+        assert sdk_agent_meta["semantic_cache_safe_reuse"] is True
+        assert sdk_agent_meta["safe_fallback_used"] is False
+
 
 class TestCheckpointerOverheadScore:
     """Test checkpointer_overhead_proxy_ms score (#159)."""
@@ -1078,6 +1138,103 @@ class TestTextPathSemanticCacheStore:
         bot._cache.store_semantic.assert_called_once()
         kwargs = bot._cache.store_semantic.call_args.kwargs
         assert kwargs["query_type"] == "GENERAL"
+
+    async def test_strict_unsafe_result_skips_text_path_semantic_cache_store(self, mock_config):
+        mock_lf = MagicMock()
+        mock_lf.update_current_trace = MagicMock()
+        mock_lf.create_score = MagicMock()
+        mock_lf.get_current_trace_id = MagicMock(return_value="trace-abc-123")
+
+        bot = _create_bot(mock_config)
+        bot._cache = AsyncMock()
+        bot._cache.get_embedding = AsyncMock(return_value=[0.1, 0.2, 0.3])
+        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
+        bot._cache.check_semantic = AsyncMock(return_value=None)
+        bot._cache.store_semantic = AsyncMock()
+        message = _make_message("какие документы нужны для внж")
+
+        def _agent_side_effect(state, config=None, **kw):
+            cfg = config or kw.get("config", {})
+            store = cfg.get("configurable", {}).get("rag_result_store")
+            if isinstance(store, dict):
+                store.update(
+                    {
+                        "query_type": "FAQ",
+                        "query_embedding": [0.1, 0.2, 0.3],
+                        "cache_hit": False,
+                        "grounding_mode": "strict",
+                        "grounded": False,
+                        "legal_answer_safe": False,
+                        "semantic_cache_safe_reuse": False,
+                        "safe_fallback_used": True,
+                    }
+                )
+            return _mock_agent_result(messages=[MagicMock(content="Ответ агентом")])
+
+        mock_agent = AsyncMock()
+        mock_agent.ainvoke = AsyncMock(side_effect=_agent_side_effect)
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.get_client", return_value=mock_lf),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+            patch("telegram_bot.bot.ChatActionSender") as mock_cas,
+        ):
+            mock_cas.typing.return_value = _make_typing_cm()
+            await bot.handle_query(message)
+
+        bot._cache.store_semantic.assert_not_called()
+
+    async def test_strict_safe_result_stores_text_path_cache_metadata(self, mock_config):
+        mock_lf = MagicMock()
+        mock_lf.update_current_trace = MagicMock()
+        mock_lf.create_score = MagicMock()
+        mock_lf.get_current_trace_id = MagicMock(return_value="trace-abc-123")
+
+        bot = _create_bot(mock_config)
+        bot._cache = AsyncMock()
+        bot._cache.get_embedding = AsyncMock(return_value=[0.1, 0.2, 0.3])
+        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
+        bot._cache.check_semantic = AsyncMock(return_value=None)
+        bot._cache.store_semantic = AsyncMock()
+        message = _make_message("какие документы нужны для внж")
+
+        def _agent_side_effect(state, config=None, **kw):
+            cfg = config or kw.get("config", {})
+            store = cfg.get("configurable", {}).get("rag_result_store")
+            if isinstance(store, dict):
+                store.update(
+                    {
+                        "query_type": "FAQ",
+                        "query_embedding": [0.1, 0.2, 0.3],
+                        "cache_hit": False,
+                        "grounding_mode": "strict",
+                        "grounded": True,
+                        "legal_answer_safe": True,
+                        "semantic_cache_safe_reuse": True,
+                        "safe_fallback_used": False,
+                    }
+                )
+            return _mock_agent_result(messages=[MagicMock(content="Ответ агентом")])
+
+        mock_agent = AsyncMock()
+        mock_agent.ainvoke = AsyncMock(side_effect=_agent_side_effect)
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.get_client", return_value=mock_lf),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+            patch("telegram_bot.bot.ChatActionSender") as mock_cas,
+        ):
+            mock_cas.typing.return_value = _make_typing_cm()
+            await bot.handle_query(message)
+
+        bot._cache.store_semantic.assert_called_once()
+        metadata = bot._cache.store_semantic.call_args.kwargs["metadata"]
+        assert metadata["grounding_mode"] == "strict"
+        assert metadata["semantic_cache_safe_reuse"] is True
 
 
 class TestExtractCurrentTurn:


### PR DESCRIPTION
## Summary
- harden strict grounding decisions so low-confidence or unsafe grounded answers fall back safely without generating new model output
- gate strict-mode semantic cache read and write paths with RedisVL metadata filters instead of custom cache storage logic
- extend Langfuse trace metadata with grounding safety fields and add regression coverage for client, bot, cache, and response paths

## Test Plan
- [x] `uv run pytest tests/unit/retrieval/test_topic_classifier.py tests/unit/services/test_generate_response.py tests/unit/pipelines/test_client_pipeline.py tests/unit/integrations/test_cache_layers.py tests/unit/observability/test_trace_contracts.py tests/unit/test_bot_handlers.py tests/unit/test_bot_scores.py -q`
- [x] `make check`
- [x] `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`

Closes #1005
Closes #1006
