### PR TITLE
Fix citation leakage when sources are hidden

### DIFF
--- a/telegram_bot/graph/nodes/generate.py
+++ b/telegram_bot/graph/nodes/generate.py
@@ -120,7 +120,12 @@ def _build_system_prompt(domain: str) -> str:
     return get_prompt("generate", fallback=_GENERATE_FALLBACK, variables={"domain": domain})
 
 
-def _format_context(documents: list[dict[str, Any]], max_docs: int = _MAX_CONTEXT_DOCS) -> str:
+def _format_context(
+    documents: list[dict[str, Any]],
+    max_docs: int = _MAX_CONTEXT_DOCS,
+    *,
+    sources_enabled: bool = True,
+) -> str:
     """Format top-N retrieved documents into LLM context string."""
     if not documents:
         return "Релевантной информации не найдено."
@@ -138,7 +143,8 @@ def _format_context(documents: list[dict[str, Any]], max_docs: int = _MAX_CONTEX
         if "price" in metadata:
             meta_str += f"Цена: {metadata['price']:,}€\n"
 
-        parts.append(f"[Объект {i}]\n{meta_str}{text}")
+        header = f"[Объект {i}]" if sources_enabled else "Фрагмент контекста"
+        parts.append(f"{header}\n{meta_str}{text}")
 
     return "\n\n---\n\n".join(parts)
 

--- a/tests/unit/graph/test_generate_node.py
+++ b/tests/unit/graph/test_generate_node.py
@@ -1255,6 +1255,26 @@ class TestGenerateNodeCitationInstruction:
         system_msg = messages[0]["content"]
         assert "[Объект 1] = [1]" not in system_msg
 
+    async def test_context_omits_object_labels_when_sources_disabled(self) -> None:
+        """Model-visible context must not contain numbered object labels when sources are hidden."""
+        from telegram_bot.graph.nodes.generate import generate_node
+
+        mock_config, mock_client = _make_mock_config()
+        mock_config.show_sources = False
+        state = _make_state_with_docs()
+
+        with patch(
+            "telegram_bot.graph.nodes.generate._get_config",
+            return_value=mock_config,
+        ):
+            await generate_node(state)
+
+        call_kwargs = mock_client.chat.completions.create.call_args
+        messages = call_kwargs.kwargs.get("messages") or call_kwargs[1].get("messages")
+        user_msg = messages[-1]["content"]
+        assert "Фрагмент контекста" in user_msg
+        assert "[Объект 1]" not in user_msg
+
     async def test_no_citation_instruction_without_documents(self) -> None:
         """No citation instruction when documents are empty."""
         from telegram_bot.graph.nodes.generate import generate_node

--- a/tests/unit/services/test_generate_response.py
+++ b/tests/unit/services/test_generate_response.py
@@ -218,6 +218,48 @@ async def test_generate_response_strict_mode_does_not_degrade_only_because_show_
 
 
 @pytest.mark.asyncio
+async def test_generate_response_strips_citation_artifacts_when_sources_disabled() -> None:
+    config, client = _make_non_streaming_config(
+        answer="Потребуется также счёт в болгарском банке 1.\nИ подтверждение дохода [2]."
+    )
+    config.show_sources = False
+    lf = MagicMock()
+
+    result = await generate_response(
+        query="Что нужно для ВНЖ?",
+        documents=[{"text": "Документ", "score": 0.91, "metadata": {"title": "ВНЖ"}}],
+        config=config,
+        lf_client=lf,
+        raw_messages=[{"role": "user", "content": "Что нужно для ВНЖ?"}],
+    )
+
+    assert result["response"] == (
+        "Потребуется также счёт в болгарском банке\nИ подтверждение дохода."
+    )
+    client.chat.completions.create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_generate_response_keeps_citations_when_sources_enabled() -> None:
+    config, client = _make_non_streaming_config(
+        answer="Потребуется также счёт в болгарском банке [1]."
+    )
+    config.show_sources = True
+    lf = MagicMock()
+
+    result = await generate_response(
+        query="Что нужно для ВНЖ?",
+        documents=[{"text": "Документ", "score": 0.91, "metadata": {"title": "ВНЖ"}}],
+        config=config,
+        lf_client=lf,
+        raw_messages=[{"role": "user", "content": "Что нужно для ВНЖ?"}],
+    )
+
+    assert result["response"] == "Потребуется также счёт в болгарском банке [1]."
+    client.chat.completions.create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_generate_response_streaming_sets_response_sent_and_message_ref() -> None:
     config, client = _make_non_streaming_config()
     config.streaming_enabled = True


### PR DESCRIPTION
## Summary
- stop exposing numbered `[Объект N]` labels to the graph generation path when `show_sources=false`
- keep explicit source labels only for source-enabled mode while preserving the existing shared generate-response sanitizer
- add regression coverage for hidden-source graph prompts and final answer cleanup of trailing `1.` / `[2]` artifacts

## Test Plan
- [x] `uv run pytest tests/unit/graph/test_generate_node.py tests/unit/services/test_generate_response.py -q`
- [x] `make check`
- [x] `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`

Closes #1008
