### PR TITLE
feat: add exhaustive list coverage mode for knowledge RAG

### DIFF
--- a/docs/plans/2026-03-25-semantic-cache-degraded-response-hardening-design.md
+++ b/docs/plans/2026-03-25-semantic-cache-degraded-response-hardening-design.md
@@ -53,6 +53,7 @@ This leaves three concrete failure modes:
 Primary goals:
 
 - Define one semantic-cache eligibility policy for all write paths.
+- Define one canonical application-level store entrypoint for `cache_scope="rag"`.
 - Distinguish `successful but reusable` from `successful transport-level delivery`.
 - Add read-side metadata enforcement so bad historical entries are not reused.
 - Preserve the existing service boundaries: generation emits signals, cache policy decides reuse, cache integration enforces storage and lookup constraints.
@@ -71,6 +72,11 @@ Observed repo facts:
 
 - Exact cache namespaces are versioned by `CACHE_VERSION = "v5"`.
 - Semantic cache already has its own schema boundary via `SEMANTIC_CACHE_VERSION = "v6"`.
+- Primary RAG semantic writes currently happen from multiple application paths, including:
+  - `telegram_bot/pipelines/client.py`
+  - `telegram_bot/agents/rag_pipeline.py`
+  - `telegram_bot/graph/nodes/cache.py`
+  - `telegram_bot/bot.py`
 - Semantic cache currently uses RedisVL tag filters for:
   - `query_type`
   - `language`
@@ -80,6 +86,7 @@ Observed repo facts:
   - `grounding_mode`
   - `semantic_cache_safe_reuse`
 - Existing tests currently assume broad store behavior on graph cache-store paths, so the behavioral contract will need to change deliberately.
+- `telegram_bot/agents/history_tool.py` also writes semantic cache entries, but in `cache_scope="history"`. That path is not the primary subject of this hardening and should remain explicitly out of scope unless we choose to extend the same contract to history summaries later.
 
 These findings make a semantic-schema bump an accepted repo-native mechanism, not an exceptional migration.
 
@@ -90,6 +97,7 @@ These findings make a semantic-schema bump an accepted repo-native mechanism, no
 3. Write-side guard prevents new poison; read-side guard protects against old poison.
 4. Cacheability must be decided in one policy function, not re-derived ad hoc in multiple call sites.
 5. Metadata fields must be useful for lookup filtering, targeted purge, and observability.
+6. For `cache_scope="rag"`, application code should have one canonical semantic-store entrypoint above the cache adapter.
 
 ## Target Cacheability Contract
 
@@ -119,9 +127,11 @@ Recommended meanings:
 
 ## Response Classification Rules
 
-The generation layer remains responsible for emitting signals, not for deciding cache writes.
+The generation layer remains responsible for emitting raw degradation signals, not for deciding cache writes.
 
-The generation result should be normalized into `response_state` using the existing signals:
+`response_state`, `degraded_reason`, and `cache_eligible` must be derived from one normalization/decision helper. No other layer should invent `response_state` independently.
+
+The normalization helper should map the existing raw signals into `response_state` using rules such as:
 
 - `safe_fallback_used=True` -> `response_state="safe_fallback"`
 - `fallback_used=True` -> `response_state="fallback"`
@@ -132,14 +142,31 @@ The generation result should be normalized into `response_state` using the exist
 
 `degraded_reason` should be set even when the pipeline continues successfully from the user perspective.
 
+`cache_eligible` must be derived from the same decision object that computes `response_state`. It must not be set independently in call sites or stored as a second hand-maintained truth.
+
 ## Unified Cache Policy
 
-Add a single policy module, preferably `telegram_bot/services/cache_policy.py`, with two public helpers:
+Add a single policy module, preferably `telegram_bot/services/cache_policy.py`, with a decision builder and one canonical RAG store helper:
 
-- `is_cacheable_response(...) -> bool`
-- `build_semantic_cache_metadata(...) -> dict[str, Any]`
+- `build_cacheability_decision(...) -> SemanticCacheDecision`
+- `maybe_store_semantic_response(...) -> bool`
 
-This module should own the full write-side decision.
+Recommended `SemanticCacheDecision` contents:
+
+- `response_state`
+- `degraded_reason`
+- `cache_eligible`
+- `metadata`
+- `store_reason`
+
+This module should own the full write-side decision for the primary RAG path.
+
+For `cache_scope="rag"`, business code should not call `cache.store_semantic(...)` directly. Instead:
+
+- `maybe_store_semantic_response(...)` is the only application-level entrypoint allowed to decide whether a RAG answer is stored
+- `CacheLayerManager.store_semantic(...)` remains the low-level adapter sink once a store is already authorized
+
+This removes the current duplication between `client.py`, `rag_pipeline.py`, `graph/nodes/cache.py`, and `bot.py`.
 
 Semantic cache store is allowed only when all of the following are true:
 
@@ -186,6 +213,8 @@ Extend semantic cache `filterable_fields` to include:
 
 `degraded_reason` may remain metadata-only unless operational querying in Redis search is required.
 
+Because RedisVL `filterable_fields` participate in index initialization/schema shape, expanding these lookup tags should be treated as a schema boundary. In this repo, that means a semantic cache version bump rather than a mixed old/new namespace.
+
 Recommended tag strategy:
 
 - use filterable tags only for fields needed during lookup or broad operational isolation
@@ -197,17 +226,25 @@ Recommended tag strategy:
 
 Responsibilities:
 
-- emit stable degradation signals
-- normalize `response_state` and `degraded_reason` into the result dict
+- emit stable raw degradation signals
 - avoid deciding semantic cache policy directly
+
+### `telegram_bot/services/cache_policy.py`
+
+Responsibilities:
+
+- normalize raw generation signals into `response_state` and `degraded_reason`
+- derive `cache_eligible` from the same decision object
+- build semantic cache metadata
+- provide the single canonical `maybe_store_semantic_response(...)` entrypoint for `cache_scope="rag"`
 
 ### `telegram_bot/pipelines/client.py`
 
 Responsibilities:
 
 - stop owning bespoke semantic-cache policy logic
-- call shared cache policy helper
-- pass normalized metadata into `store_semantic(...)`
+- call shared `maybe_store_semantic_response(...)`
+- stop calling `cache.store_semantic(...)` directly for RAG answers
 
 ### `telegram_bot/agents/rag_pipeline.py`
 
@@ -215,13 +252,22 @@ Responsibilities:
 
 - adopt the same shared cacheability policy as the direct client path
 - stop broad unconditional semantic-store behavior
+- stop calling `cache.store_semantic(...)` directly for RAG answers
 
 ### `telegram_bot/graph/nodes/cache.py`
 
 Responsibilities:
 
-- either consume precomputed cacheability signals from graph state or call the same shared helper before storing
+- either consume a precomputed `SemanticCacheDecision` from graph state or call the same shared helper before storing
 - preserve current graph-node contract shape while tightening store eligibility
+- stop serving as an independent source of semantic-cache policy
+
+### `telegram_bot/bot.py`
+
+Responsibilities:
+
+- remove ad hoc RAG-side semantic store logic
+- delegate to the shared RAG semantic-store helper instead of maintaining its own allowlist and grounding checks
 
 ### `telegram_bot/integrations/cache.py`
 
@@ -234,16 +280,28 @@ Responsibilities:
 
 ## Rollout Strategy
 
-Use a two-step rollout:
+Use a three-step rollout:
 
-1. Stop writing new poisoned entries.
-2. Remove or isolate historical poisoned entries.
+1. Implement the new policy and metadata contract.
+2. Bump the semantic cache namespace as part of the same change.
+3. Clean up old poisoned or obsolete entries opportunistically.
+
+The semantic cache version bump is mandatory for this work, not optional. Reasons:
+
+- new `filterable_fields` change the effective lookup schema
+- the new read contract depends on metadata older entries do not have
+- the repo already uses versioned semantic namespaces for this kind of boundary
+
+Expected effect of the bump:
+
+- old entries without the new metadata become unreadable by design because they live in the old namespace
+- this is a desired isolation outcome, not an accidental cache miss regression
 
 Operational cleanup options:
 
 ### Option A: Targeted purge
 
-Use when there is a small known set of poisoned prompts or entry IDs.
+Use when there is a small known set of poisoned prompts or entry IDs and we want to remove them immediately from the old namespace or reclaim space after the version bump.
 
 Benefits:
 
@@ -257,7 +315,7 @@ Limitations:
 
 ### Option B: Semantic schema/version bump
 
-Increment `SEMANTIC_CACHE_VERSION` when there is uncertainty about the extent of poisoning or when the RedisVL filter schema changes materially.
+Increment `SEMANTIC_CACHE_VERSION` in this change set and treat it as part of the migration, not as a fallback contingency.
 
 Benefits:
 
@@ -271,8 +329,8 @@ Limitations:
 
 Recommendation:
 
-- use targeted purge for immediate known bad entries
-- use semantic version bump if there is any doubt about hidden historical poison or when new lookup tags are introduced
+- always use semantic version bump in this work
+- optionally use targeted purge for known-bad entries or old-namespace cleanup
 
 ## Negative Cache Position
 
@@ -353,13 +411,12 @@ These tradeoffs are acceptable because the current behavior optimizes hit rate a
 ## Implementation Sequence
 
 1. Add cache policy helper and response-state normalization.
-2. Wire policy into `client.py`.
-3. Wire policy into graph/RAG store paths.
-4. Extend RedisVL semantic schema and read filters.
+2. Replace direct RAG semantic-store call sites with the shared canonical helper.
+3. Extend RedisVL semantic schema and read filters.
+4. Bump `SEMANTIC_CACHE_VERSION`.
 5. Add tests for store-block and read-block behavior.
-6. Purge known poisoned entries.
-7. Bump `SEMANTIC_CACHE_VERSION` if schema/filter changes or if historical poisoning scope is uncertain.
-8. Run validation and monitor semantic metrics after rollout.
+6. Purge known poisoned entries or old namespace keys as operational cleanup.
+7. Run validation and monitor semantic metrics after rollout.
 
 ## Acceptance Criteria
 

--- a/docs/plans/2026-03-25-semantic-cache-degraded-response-hardening-design.md
+++ b/docs/plans/2026-03-25-semantic-cache-degraded-response-hardening-design.md
@@ -1,0 +1,373 @@
+# Semantic Cache Degraded Response Hardening Design
+
+Date: 2026-03-25
+Branch: `dev`
+Scope: `telegram_bot/` semantic cache write/read policy, degraded-response handling, RedisVL metadata filters, rollout and observability
+
+## Purpose
+
+This design defines the target hardening for the application's semantic cache so degraded, fallback, and error-like responses do not enter or survive inside the normal semantic reuse path.
+
+The immediate trigger is a cache poisoning risk for queries such as `виды внж в болгарии`, where a degraded answer can be reused across semantically similar prompts. This is materially worse than poisoning an exact cache because the blast radius extends to paraphrases and related formulations.
+
+The target state is:
+
+- semantic cache stores only successful, reusable answers
+- degraded or fallback answers never enter the primary semantic cache
+- already-poisoned entries can be blocked on read and removed operationally
+- cacheability logic is decided once and reused across all write paths
+- telemetry makes poisoning visible before users report it
+
+## External Baseline
+
+As of March 2026, the external guidance still aligns with this direction:
+
+- Google Apigee continues to document caching error responses as an anti-pattern and recommends excluding them from normal response caching except for tightly controlled, temporary cases.
+- Google Cloud CDN continues to model negative caching as a separate policy with separate TTL controls by status code.
+- RedisVL continues to document semantic cache as a lookup/store system with TTL, tags, filters, and targeted entry deletion.
+- OpenAI prompt caching remains an exact-prefix input cache and does not replace application-level output cacheability policy.
+
+References:
+
+- https://cloud.google.com/apigee/docs/api-platform/antipatterns/caching-error
+- https://docs.cloud.google.com/cdn/docs/using-negative-caching
+- https://docs.redisvl.com/en/latest/user_guide/03_llmcache.html
+- https://developers.openai.com/api/docs/guides/prompt-caching
+
+## Problem Statement
+
+Current protection is asymmetric.
+
+- The direct client path in `telegram_bot/pipelines/client.py` already applies several write-side guards, including grounding checks and `safe_fallback_used`.
+- The graph path in `telegram_bot/agents/rag_pipeline.py` and `telegram_bot/graph/nodes/cache.py` still stores broadly when response and embedding exist.
+- The cache layer in `telegram_bot/integrations/cache.py` supports tag filters, but the schema does not yet encode full degraded-state eligibility.
+
+This leaves three concrete failure modes:
+
+1. A degraded answer is written through one path even if another path would have blocked it.
+2. An old poisoned entry remains readable because read-side filtering is weaker than write-side policy.
+3. Incident recovery relies on TTL rather than explicit invalidation or versioning.
+
+## Design Goals
+
+Primary goals:
+
+- Define one semantic-cache eligibility policy for all write paths.
+- Distinguish `successful but reusable` from `successful transport-level delivery`.
+- Add read-side metadata enforcement so bad historical entries are not reused.
+- Preserve the existing service boundaries: generation emits signals, cache policy decides reuse, cache integration enforces storage and lookup constraints.
+- Keep rollout operationally safe with targeted purge and semantic schema version bump support.
+
+Non-goals:
+
+- Replacing RedisVL or Redis.
+- Redesigning the retrieval pipeline.
+- Introducing a full negative-cache subsystem in the first patch.
+- Mixing transport-layer Telegram logic into cache policy.
+
+## Current Architecture Findings
+
+Observed repo facts:
+
+- Exact cache namespaces are versioned by `CACHE_VERSION = "v5"`.
+- Semantic cache already has its own schema boundary via `SEMANTIC_CACHE_VERSION = "v6"`.
+- Semantic cache currently uses RedisVL tag filters for:
+  - `query_type`
+  - `language`
+  - `user_id`
+  - `cache_scope`
+  - `agent_role`
+  - `grounding_mode`
+  - `semantic_cache_safe_reuse`
+- Existing tests currently assume broad store behavior on graph cache-store paths, so the behavioral contract will need to change deliberately.
+
+These findings make a semantic-schema bump an accepted repo-native mechanism, not an exceptional migration.
+
+## Architectural Principles
+
+1. The semantic cache is a reuse store for valid answers, not a persistence sink for any emitted text.
+2. Application-level degraded responses are operationally equivalent to cache-excluded error responses.
+3. Write-side guard prevents new poison; read-side guard protects against old poison.
+4. Cacheability must be decided in one policy function, not re-derived ad hoc in multiple call sites.
+5. Metadata fields must be useful for lookup filtering, targeted purge, and observability.
+
+## Target Cacheability Contract
+
+Every semantic cache candidate should be normalized into a cacheability contract with these minimum fields:
+
+- `response_state`
+  - `ok`
+  - `degraded`
+  - `fallback`
+  - `safe_fallback`
+  - `error`
+- `cache_eligible`
+- `provider_model`
+- `degraded_reason`
+- `grounding_mode`
+- `semantic_cache_safe_reuse`
+- `created_at`
+- `schema_version`
+
+Recommended meanings:
+
+- `response_state` describes the application-level quality of the answer, not the transport outcome.
+- `cache_eligible` is the final policy verdict for semantic reuse.
+- `provider_model` preserves the actual provider/model string or `"fallback"`.
+- `degraded_reason` is a short operational code such as `llm_failure`, `timeout`, `provider_fallback`, `safe_fallback`, `empty_response`, or `partial_recovery`.
+- `schema_version` allows future read isolation and controlled invalidation.
+
+## Response Classification Rules
+
+The generation layer remains responsible for emitting signals, not for deciding cache writes.
+
+The generation result should be normalized into `response_state` using the existing signals:
+
+- `safe_fallback_used=True` -> `response_state="safe_fallback"`
+- `fallback_used=True` -> `response_state="fallback"`
+- `llm_provider_model=="fallback"` -> `response_state="fallback"`
+- `llm_timeout=True` with fallback content -> `response_state="degraded"` or `fallback`, depending on emitted result
+- empty or truncated unusable output -> `response_state="error"` or `degraded`
+- normal grounded or ordinary answer -> `response_state="ok"`
+
+`degraded_reason` should be set even when the pipeline continues successfully from the user perspective.
+
+## Unified Cache Policy
+
+Add a single policy module, preferably `telegram_bot/services/cache_policy.py`, with two public helpers:
+
+- `is_cacheable_response(...) -> bool`
+- `build_semantic_cache_metadata(...) -> dict[str, Any]`
+
+This module should own the full write-side decision.
+
+Semantic cache store is allowed only when all of the following are true:
+
+- response text is non-empty
+- request was not already served from semantic cache
+- query type is allowlisted for semantic caching
+- request is not contextual/follow-up if the current path already treats contextual queries as non-cacheable
+- retrieval and grounding quality gates pass
+- required documents are present for that query class
+- `fallback_used == false`
+- `safe_fallback_used == false`
+- `llm_provider_model != "fallback"`
+- `response_state == "ok"`
+- `cache_eligible == true`
+
+This policy replaces fragmented local checks in write call sites.
+
+## Read-Side Enforcement
+
+The cache integration layer should filter semantic hits so entries are reused only when they remain policy-valid.
+
+Minimum read-side requirements:
+
+- `cache_eligible == true`
+- `response_state == "ok"`
+- current `schema_version` matches the active semantic cache contract
+
+Additional existing strict-grounding behavior remains valid:
+
+- when strict grounding requires safe reuse, `semantic_cache_safe_reuse == "true"` stays part of the filter
+
+Read-side enforcement matters because:
+
+- write policy protects the future
+- read policy protects the present from already-bad historical entries
+
+## RedisVL Schema Changes
+
+Extend semantic cache `filterable_fields` to include:
+
+- `response_state`
+- `cache_eligible`
+- `schema_version`
+
+`degraded_reason` may remain metadata-only unless operational querying in Redis search is required.
+
+Recommended tag strategy:
+
+- use filterable tags only for fields needed during lookup or broad operational isolation
+- keep explanatory fields in metadata when they are not part of lookup policy
+
+## Component Changes
+
+### `telegram_bot/services/generate_response.py`
+
+Responsibilities:
+
+- emit stable degradation signals
+- normalize `response_state` and `degraded_reason` into the result dict
+- avoid deciding semantic cache policy directly
+
+### `telegram_bot/pipelines/client.py`
+
+Responsibilities:
+
+- stop owning bespoke semantic-cache policy logic
+- call shared cache policy helper
+- pass normalized metadata into `store_semantic(...)`
+
+### `telegram_bot/agents/rag_pipeline.py`
+
+Responsibilities:
+
+- adopt the same shared cacheability policy as the direct client path
+- stop broad unconditional semantic-store behavior
+
+### `telegram_bot/graph/nodes/cache.py`
+
+Responsibilities:
+
+- either consume precomputed cacheability signals from graph state or call the same shared helper before storing
+- preserve current graph-node contract shape while tightening store eligibility
+
+### `telegram_bot/integrations/cache.py`
+
+Responsibilities:
+
+- add new semantic cache filterable fields
+- enforce read-side metadata filtering
+- preserve current versioned namespace pattern
+- expose or document targeted clear/drop workflows when needed for incident response
+
+## Rollout Strategy
+
+Use a two-step rollout:
+
+1. Stop writing new poisoned entries.
+2. Remove or isolate historical poisoned entries.
+
+Operational cleanup options:
+
+### Option A: Targeted purge
+
+Use when there is a small known set of poisoned prompts or entry IDs.
+
+Benefits:
+
+- minimal cache disruption
+- useful for immediate incident response
+
+Limitations:
+
+- relies on accurate identification of all poisoned entries
+- easy to miss semantically related stale entries
+
+### Option B: Semantic schema/version bump
+
+Increment `SEMANTIC_CACHE_VERSION` when there is uncertainty about the extent of poisoning or when the RedisVL filter schema changes materially.
+
+Benefits:
+
+- strongest isolation boundary
+- simple operational rollback path
+- already aligns with repo conventions
+
+Limitations:
+
+- cold-start hit-rate reset for the semantic tier
+
+Recommendation:
+
+- use targeted purge for immediate known bad entries
+- use semantic version bump if there is any doubt about hidden historical poison or when new lookup tags are introduced
+
+## Negative Cache Position
+
+Negative caching should not be implemented by writing degraded responses into the primary semantic cache.
+
+If the system later needs incident-time request suppression, do it as a separate namespace with:
+
+- short TTL
+- separate metrics
+- explicit read path
+- explicit semantics different from normal answer reuse
+
+This is a later enhancement, not a dependency for the first hardening patch.
+
+## Observability
+
+Add cache-policy-aware telemetry:
+
+- `semantic_hit`
+- `semantic_miss`
+- `semantic_store_ok`
+- `semantic_store_blocked_noncacheable`
+- `semantic_store_blocked_degraded`
+- `semantic_read_blocked_metadata`
+- `semantic_poison_purge_count`
+
+Recommended dimensions:
+
+- `query_type`
+- `grounding_mode`
+- `response_state`
+- `degraded_reason`
+- `provider_model`
+- `cache_scope`
+
+Alerting worth adding later:
+
+- sudden spike in `semantic_store_blocked_degraded`
+- sudden drop in `semantic_hit` after rollout beyond expected cold-start window
+- elevated share of `response_state != ok` for strict-grounding topics
+
+## Validation Plan
+
+Required validation areas:
+
+### Unit tests
+
+- cache policy helper accepts clean `ok` responses
+- cache policy helper rejects fallback, safe fallback, degraded, timeout, and empty-response cases
+- client path passes metadata and blocks non-cacheable writes
+- graph path blocks writes for degraded results
+- cache integration applies new read-side filters
+- poisoned historical entry is not returned when metadata marks it non-eligible
+
+### Integration tests
+
+- `miss -> generate ok -> store -> hit`
+- `miss -> generate degraded -> no store`
+- strict-grounding path still requires safe reuse where applicable
+
+### Repo checks
+
+- `make check`
+- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
+- targeted cache/search suites under `tests/unit/`
+- affected integration tests for graph paths and cache behavior
+
+## Risks And Tradeoffs
+
+Expected tradeoffs:
+
+- semantic hit rate may dip initially because degraded answers will no longer be reused
+- some current tests will need contract updates because they assert broad store behavior
+- introducing new RedisVL tags may require a semantic schema bump
+
+These tradeoffs are acceptable because the current behavior optimizes hit rate at the expense of correctness and incident recovery.
+
+## Implementation Sequence
+
+1. Add cache policy helper and response-state normalization.
+2. Wire policy into `client.py`.
+3. Wire policy into graph/RAG store paths.
+4. Extend RedisVL semantic schema and read filters.
+5. Add tests for store-block and read-block behavior.
+6. Purge known poisoned entries.
+7. Bump `SEMANTIC_CACHE_VERSION` if schema/filter changes or if historical poisoning scope is uncertain.
+8. Run validation and monitor semantic metrics after rollout.
+
+## Acceptance Criteria
+
+The design is satisfied when:
+
+- degraded or fallback answers are never written to the primary semantic cache
+- semantic reads return only `response_state="ok"` and `cache_eligible=true` entries
+- client and graph paths share one cacheability policy
+- known poisoned entries are no longer reusable
+- semantic cache contract changes are versioned safely
+- tests cover both prevention of new poison and blocking of old poison

--- a/docs/superpowers/specs/2026-03-25-exhaustive-list-rag-design.md
+++ b/docs/superpowers/specs/2026-03-25-exhaustive-list-rag-design.md
@@ -1,0 +1,386 @@
+# Exhaustive List Coverage for Knowledge RAG
+
+Date: 2026-03-25
+Status: Approved design
+Scope: Telegram knowledge/RAG answer path only
+
+## Summary
+
+The current knowledge RAG path under-answers enumeration-style questions such as "какие еще есть виды" or "напиши полный список". The root cause is primarily generation policy, not missing source data:
+
+- retrieval already finds relevant chunks containing multiple valid variants
+- the current Langfuse `generate` prompt strongly optimizes for brevity
+- top retrieval results can be dominated by chunks from one source document
+
+The fix should be delivered in two small rollouts:
+
+1. Add `needs_coverage` plus a dedicated Langfuse prompt path `generate_exhaustive_list`
+2. Add coverage-oriented retrieval grouping in Qdrant for this mode
+
+MMR is explicitly deferred unless grouping alone proves insufficient.
+
+## Problem Statement
+
+For questions that imply exhaustive enumeration, the current system often returns only the first one or two variants even when retrieval contains more.
+
+Observed failure mode:
+
+- top retrieved chunks contain the expected answers
+- the first chunk often starts with the first visible option, biasing generation
+- the current prompt instructs the model to be short, avoid listing everything, and keep responses visually compact
+
+As a result, the user gets a polished but incomplete answer.
+
+## Goals
+
+- Return fuller answers for enumeration-style knowledge questions
+- Preserve current behavior for normal concise knowledge questions
+- Keep rollout risk low by separating generation policy changes from retrieval diversification
+- Add observability so coverage mode can be measured and tuned safely
+
+## Non-Goals
+
+- No redesign of the entire RAG pipeline
+- No global intent framework for every bot LLM feature
+- No new LLM classifier for coverage detection
+- No MMR-enabled full reranking pipeline in the first two PRs
+- No changes to apartment search, CRM flows, voice-specific prompts, or unrelated agents
+
+## Current State
+
+### Generation
+
+The active knowledge generation path is `telegram_bot.services.generate_response.generate_response`.
+
+Current behavior:
+
+- uses `generate` prompt from Langfuse when style mode is off
+- allows prompt config overrides such as `temperature` and `max_tokens`
+- applies response-style logic before final prompt assembly
+
+Current prompt policy is optimized for short Telegram responses and conflicts with exhaustive-list questions.
+
+### Retrieval
+
+The active retrieval path is `telegram_bot.graph.nodes.retrieve.retrieve_node`.
+
+Current behavior:
+
+- retrieves hybrid results via Qdrant
+- can use ColBERT server-side reranking when query vectors are available
+- does not apply grouping in the default path
+- does not apply MMR in the default path
+
+This allows several chunks from the same source document to dominate the final context.
+
+## Design Overview
+
+The design introduces a narrow knowledge-RAG-only coverage mode.
+
+Coverage mode is activated when the question strongly implies exhaustive enumeration. When active:
+
+- generation routes to a dedicated Langfuse prompt policy
+- retrieval prefers document diversity over raw top-k chunk dominance
+- observability records whether the mode was used and how much source diversity reached generation
+
+The mode is intentionally explicit and limited in scope.
+
+## Rollout 1: Coverage-Aware Generation
+
+### New runtime signal
+
+Add a boolean flag:
+
+- `needs_coverage: bool`
+
+Optional internal normalized intent name:
+
+- `exhaustive_list`
+
+This signal is used only in the knowledge/RAG path in the first rollout.
+
+### Detection strategy
+
+Detection should be deterministic and cheap. Use rule-based heuristics, not an LLM classifier.
+
+Starting trigger patterns:
+
+- `какие виды`
+- `какие варианты`
+- `какие еще есть`
+- `полный список`
+- `перечисли все`
+- `все основания`
+- `все способы`
+
+The detector should bias toward precision over recall at first. False negatives are acceptable in rollout 1. False positives are more dangerous because they will expand answers unexpectedly.
+
+### Prompt routing
+
+When `needs_coverage` is false:
+
+- preserve existing prompt selection behavior
+
+When `needs_coverage` is true:
+
+- bypass the concise prompt path
+- fetch a separate prompt from Langfuse using prompt name `generate_exhaustive_list`
+
+Important constraint:
+
+- use prompt name for task routing
+- keep Langfuse labels for environment and experiment routing, not task semantics
+
+This matches Langfuse prompt versioning guidance. Prompt names should represent distinct task contracts, while labels should remain suitable for `production`, `staging`, or experimental rollout labels.
+
+### Prompt contract for `generate_exhaustive_list`
+
+The new prompt should:
+
+- explicitly enumerate all relevant variants found in context
+- group closely related variants
+- remove duplicates and near-duplicates
+- prefer completeness over brevity
+- state clearly when the answer is limited to what is found in the knowledge base
+
+The prompt should not include constraints such as:
+
+- no more than 4 items
+- keep response within 450-700 characters
+- do not list everything
+
+The prompt should still preserve:
+
+- grounding to context only
+- same-language response behavior
+- concise honesty when the base is incomplete
+
+### Precedence over response style
+
+Coverage mode must override short/balanced/detailed response style routing. Otherwise the existing style contract will keep shrinking exhaustive answers.
+
+Rule:
+
+- if `needs_coverage=true`, use `generate_exhaustive_list`
+- only if `needs_coverage=false`, allow normal response-style prompt routing
+
+### Observability additions
+
+Add span metadata for:
+
+- `needs_coverage`
+- `coverage_mode`
+- `prompt_name`
+- `prompt_source`
+- `prompt_version`
+- `distinct_doc_count`
+- `documents_count`
+- `answer_chars`
+- `answer_words`
+
+If practical, also log a cheap completeness proxy such as:
+
+- `answer_list_item_count`
+
+This rollout should make prompt behavior measurable before retrieval changes begin.
+
+## Rollout 2: Coverage Retrieval in Qdrant
+
+### Goal
+
+Reduce context domination by one document when coverage mode is active.
+
+### Retrieval strategy
+
+Only for `needs_coverage=true`, switch from ordinary retrieval to coverage retrieval.
+
+Coverage retrieval behavior:
+
+- widen the candidate pool
+- prefer unique source documents
+- limit per-document chunk dominance
+- keep implementation compatible with the existing Qdrant query path
+
+### Primary mechanism: grouping
+
+Use Qdrant grouping by document identifier where available.
+
+Initial parameters:
+
+- `group_by=document_id` or stable equivalent payload field
+- `group_size=2`
+- `final_limit=10`
+- widened candidate pool around `40`
+
+Why grouping first:
+
+- it directly targets the observed failure mode
+- it matches Qdrant guidance for chunked-document search
+- it has a smaller blast radius than introducing MMR immediately
+
+### Fallback mechanism: post-query cap
+
+If a stable `document_id` field is not consistently present in payloads, apply a local fallback cap after retrieval:
+
+- keep at most 2-3 chunks per logical document
+
+This fallback should be deterministic and preserve original ranking order as much as possible.
+
+### MMR policy
+
+MMR should not be enabled by default in rollout 2.
+
+Enable MMR only if post-grouping analysis still shows:
+
+- too few unique source documents
+- many near-duplicate chunks from different documents
+- insufficient coverage on the golden enumeration set
+
+If MMR is introduced later, it should run on an already widened candidate pool and be guarded by observability.
+
+## Data Flow
+
+### Normal knowledge question
+
+1. detect `needs_coverage=false`
+2. run normal retrieval
+3. run normal prompt routing
+4. generate concise answer
+
+### Enumeration-style knowledge question
+
+1. detect `needs_coverage=true`
+2. run coverage retrieval
+3. route to `generate_exhaustive_list`
+4. generate coverage-oriented answer
+
+## File-Level Change Plan
+
+### Rollout 1
+
+- `telegram_bot/services/generate_response.py`
+  - integrate `needs_coverage`
+  - route to `generate_exhaustive_list`
+  - give coverage mode priority over style mode
+  - add observability fields
+- `telegram_bot/integrations/prompt_manager.py`
+  - no contract change required, but reuse prompt/version metadata cleanly
+- optional small helper file or local helper in generation path
+  - heuristic detector for enumeration-style requests
+
+### Rollout 2
+
+- `telegram_bot/graph/nodes/retrieve.py`
+  - branch into coverage retrieval mode when `needs_coverage=true`
+- `telegram_bot/services/qdrant.py`
+  - expose grouping-friendly retrieval parameters in the active API
+  - add observability for grouping results and distinct documents
+- optional helper for post-query per-document capping if payload grouping is not stable
+
+## Validation Plan
+
+### Golden set
+
+Create a focused golden set of coverage questions, for example:
+
+- `какие виды`
+- `какие варианты`
+- `какие еще есть`
+- `полный список`
+- `перечисли все`
+- `все основания`
+
+The golden set should be specific to knowledge-base coverage questions, not mixed into generic QA-only evaluation.
+
+### Langfuse evaluation
+
+Use Langfuse prompt versions plus datasets/experiments to compare:
+
+- `generate`
+- `generate_exhaustive_list`
+
+Do this before promoting the new prompt version to production labels.
+
+### Retrieval validation
+
+Measure:
+
+- unique source document count
+- top-N dominance by a single document
+- coverage of expected answer variants on the golden set
+
+### Regression guardrails
+
+Verify that ordinary short knowledge questions remain concise and do not drift into list-heavy answers.
+
+## Risks
+
+### False positive coverage detection
+
+If the heuristic is too broad, too many questions will trigger longer answers.
+
+Mitigation:
+
+- start with high-precision phrases
+- log trigger reason in observability
+
+### Weak or inconsistent document identifier
+
+Grouping depends on a stable payload field.
+
+Mitigation:
+
+- inspect payloads first
+- fall back to local per-document cap logic if needed
+
+### Over-grouping
+
+Aggressive grouping may hide useful adjacent chunks from the same document.
+
+Mitigation:
+
+- start with `group_size=2`
+- validate on golden coverage questions
+
+### Prompt over-expansion
+
+Coverage prompt may become too verbose for Telegram.
+
+Mitigation:
+
+- require grouped, deduplicated output
+- keep answer structure disciplined even while allowing more items
+
+## Decision Log
+
+- Chosen approach: two short rollouts, generation first, retrieval second
+- Rejected for now: full retrieval redesign with immediate MMR integration
+- Rejected for now: global bot-wide intent contract
+- Rejected for now: LLM-based coverage detection
+
+## Shipping Order
+
+### PR1
+
+- `needs_coverage`
+- `generate_exhaustive_list`
+- coverage-mode priority over style routing
+- observability
+- Langfuse experiment on golden set
+
+### PR2
+
+- grouping-based coverage retrieval
+- per-document cap fallback if needed
+- retrieval observability
+- reevaluate golden set
+
+### Possible PR3 only if needed
+
+- MMR for residual redundancy after grouping
+
+## Open Questions
+
+- What payload field should be treated as the canonical document identifier in the current Qdrant collection?
+- Should the detector be limited to Russian initially, or include English/Ukrainian trigger phrases from the start?
+- Should coverage mode enforce source display automatically when a list is generated, or remain independent from `show_sources`?

--- a/telegram_bot/graph/nodes/generate.py
+++ b/telegram_bot/graph/nodes/generate.py
@@ -347,6 +347,7 @@ async def generate_node(state: RAGState, *, message: Any | None = None) -> dict[
 
     return await _generate_response_service(
         query=query,
+        needs_coverage=bool(state.get("needs_coverage")),
         documents=documents,
         retrieved_context=state.get("retrieved_context", []),
         raw_messages=raw_messages,

--- a/telegram_bot/graph/nodes/retrieve.py
+++ b/telegram_bot/graph/nodes/retrieve.py
@@ -25,6 +25,25 @@ from telegram_bot.services.rag_core import build_retrieved_context as _build_ret
 logger = logging.getLogger(__name__)
 
 
+def _build_search_cache_profile(
+    *,
+    needs_coverage: bool,
+    use_colbert: bool,
+    top_k: int,
+) -> dict[str, Any]:
+    if needs_coverage:
+        return {
+            "mode": "coverage",
+            "top_k": 10,
+            "group_by": "metadata.doc_id",
+            "group_size": 2,
+            "prefetch_multiplier": 7,
+        }
+    if use_colbert:
+        return {"mode": "colbert", "top_k": top_k}
+    return {"mode": "rrf", "top_k": top_k}
+
+
 def _distinct_doc_count(results: list[dict[str, Any]]) -> int:
     return len(
         {
@@ -70,6 +89,13 @@ async def retrieve_node(
     coverage_decision = detect_coverage_mode(query)
     needs_coverage = bool(state.get("needs_coverage")) or coverage_decision.needs_coverage
     effective_top_k = 10 if needs_coverage else top_k
+    colbert_query = state.get("colbert_query")
+    _has_colbert_search = callable(getattr(qdrant, "hybrid_search_rrf_colbert", None))
+    search_cache_profile = _build_search_cache_profile(
+        needs_coverage=needs_coverage,
+        use_colbert=bool(colbert_query and _has_colbert_search),
+        top_k=effective_top_k,
+    )
 
     # Curated span metadata (replaces auto-captured full state)
     lf = get_client()
@@ -125,7 +151,7 @@ async def retrieve_node(
     start = time.perf_counter()
 
     # Step 1: Check search cache
-    cached_results = await cache.get_search_results(dense_vector)
+    cached_results = await cache.get_search_results(dense_vector, search_cache_profile)
     if cached_results is not None:
         if needs_coverage:
             cached_results = cap_results_per_doc(cached_results, max_per_doc=2)
@@ -141,7 +167,7 @@ async def retrieve_node(
                 "needs_coverage": needs_coverage,
                 "coverage_reason": coverage_decision.reason,
                 "distinct_doc_count": distinct_doc_count,
-                "coverage_grouping_applied": False,
+                "coverage_grouping_applied": needs_coverage,
                 "duration_ms": round(latency * 1000, 1),
                 # Full data for Langfuse managed evaluators (#386)
                 "eval_query": query[:2000],
@@ -172,9 +198,6 @@ async def retrieve_node(
             await cache.store_sparse_embedding(query, sparse_vector)
 
     # Step 3: Hybrid search via Qdrant SDK
-    colbert_query = state.get("colbert_query")
-    _has_colbert_search = callable(getattr(qdrant, "hybrid_search_rrf_colbert", None))
-
     if needs_coverage:
         qdrant_result = await qdrant.hybrid_search_rrf(
             dense_vector=dense_vector,
@@ -217,7 +240,7 @@ async def retrieve_node(
 
     # Step 4: Cache results (only on successful backend response)
     if results and not search_meta.get("backend_error", False):
-        await cache.store_search_results(dense_vector, None, results)
+        await cache.store_search_results(dense_vector, search_cache_profile, results)
 
     latency = time.perf_counter() - start
     PipelineMetrics.get().record("retrieve", latency * 1000)

--- a/telegram_bot/graph/nodes/retrieve.py
+++ b/telegram_bot/graph/nodes/retrieve.py
@@ -17,11 +17,21 @@ from langgraph.runtime import Runtime
 
 from telegram_bot.graph.context import GraphContext
 from telegram_bot.observability import get_client, observe
+from telegram_bot.services.coverage_mode import cap_results_per_doc, detect_coverage_mode
 from telegram_bot.services.metrics import PipelineMetrics
 from telegram_bot.services.rag_core import build_retrieved_context as _build_retrieved_context
 
 
 logger = logging.getLogger(__name__)
+
+
+def _distinct_doc_count(results: list[dict[str, Any]]) -> int:
+    return len(
+        {
+            str((doc.get("metadata", {}) or {}).get("doc_id") or doc.get("id") or "")
+            for doc in results
+        }
+    )
 
 
 @observe(name="node-retrieve", capture_input=False, capture_output=False)
@@ -57,6 +67,9 @@ async def retrieve_node(
         if hasattr(last_msg, "content")
         else (last_msg.get("content", "") if isinstance(last_msg, dict) else "")
     )
+    coverage_decision = detect_coverage_mode(query)
+    needs_coverage = bool(state.get("needs_coverage")) or coverage_decision.needs_coverage
+    effective_top_k = 10 if needs_coverage else top_k
 
     # Curated span metadata (replaces auto-captured full state)
     lf = get_client()
@@ -66,7 +79,9 @@ async def retrieve_node(
             "query_len": len(query),
             "query_hash": hashlib.sha256(query.encode()).hexdigest()[:8],
             "query_type": state.get("query_type"),
-            "top_k": top_k,
+            "top_k": effective_top_k,
+            "needs_coverage": needs_coverage,
+            "coverage_reason": coverage_decision.reason,
         }
     )
 
@@ -112,14 +127,21 @@ async def retrieve_node(
     # Step 1: Check search cache
     cached_results = await cache.get_search_results(dense_vector)
     if cached_results is not None:
+        if needs_coverage:
+            cached_results = cap_results_per_doc(cached_results, max_per_doc=2)
         latency = time.perf_counter() - start
         PipelineMetrics.get().record("retrieve", latency * 1000)
         logger.info("retrieve HIT search cache (%.3fs, %d docs)", latency, len(cached_results))
         cached_ctx = _build_retrieved_context(cached_results)
+        distinct_doc_count = _distinct_doc_count(cached_results)
         lf.update_current_span(
             output={
                 "results_count": len(cached_results),
                 "search_cache_hit": True,
+                "needs_coverage": needs_coverage,
+                "coverage_reason": coverage_decision.reason,
+                "distinct_doc_count": distinct_doc_count,
+                "coverage_grouping_applied": False,
                 "duration_ms": round(latency * 1000, 1),
                 # Full data for Langfuse managed evaluators (#386)
                 "eval_query": query[:2000],
@@ -139,6 +161,7 @@ async def retrieve_node(
             "retrieval_backend_error": False,
             "retrieval_error_type": None,
             "retrieved_context": _build_retrieved_context(cached_results),
+            "needs_coverage": needs_coverage,
         }
 
     # Step 2: Get sparse embedding (cached or compute)
@@ -152,7 +175,18 @@ async def retrieve_node(
     colbert_query = state.get("colbert_query")
     _has_colbert_search = callable(getattr(qdrant, "hybrid_search_rrf_colbert", None))
 
-    if colbert_query and _has_colbert_search:
+    if needs_coverage:
+        qdrant_result = await qdrant.hybrid_search_rrf(
+            dense_vector=dense_vector,
+            sparse_vector=sparse_vector,
+            top_k=10,
+            prefetch_multiplier=7,
+            group_by="metadata.doc_id",
+            group_size=2,
+            return_meta=True,
+        )
+        rerank_applied = False
+    elif colbert_query and _has_colbert_search:
         # 3-stage: dense+sparse -> RRF -> ColBERT MaxSim (server-side)
         qdrant_result = await qdrant.hybrid_search_rrf_colbert(
             dense_vector=dense_vector,
@@ -178,6 +212,9 @@ async def retrieve_node(
         results = qdrant_result
         search_meta = {"backend_error": False, "error_type": None, "error_message": None}
 
+    if needs_coverage and results:
+        results = cap_results_per_doc(results, max_per_doc=2)
+
     # Step 4: Cache results (only on successful backend response)
     if results and not search_meta.get("backend_error", False):
         await cache.store_search_results(dense_vector, None, results)
@@ -188,12 +225,17 @@ async def retrieve_node(
 
     scores = [d.get("score", 0) for d in results if isinstance(d, dict)]
     result_ctx = _build_retrieved_context(results)
+    distinct_doc_count = _distinct_doc_count(results)
     lf.update_current_span(
         output={
             "results_count": len(results),
             "top_score": round(scores[0], 4) if scores else None,
             "min_score": round(scores[-1], 4) if scores else None,
             "search_cache_hit": False,
+            "needs_coverage": needs_coverage,
+            "coverage_reason": coverage_decision.reason,
+            "distinct_doc_count": distinct_doc_count,
+            "coverage_grouping_applied": needs_coverage,
             "retrieval_backend_error": search_meta.get("backend_error", False),
             "retrieval_error_type": search_meta.get("error_type"),
             "duration_ms": round(latency * 1000, 1),
@@ -215,6 +257,7 @@ async def retrieve_node(
         "retrieval_backend_error": search_meta.get("backend_error", False),
         "retrieval_error_type": search_meta.get("error_type"),
         "retrieved_context": _build_retrieved_context(results),
+        "needs_coverage": needs_coverage,
     }
     # Persist re-computed embedding for downstream nodes (grade, cache_store)
     if state.get("query_embedding") is None and dense_vector:

--- a/telegram_bot/graph/state.py
+++ b/telegram_bot/graph/state.py
@@ -17,6 +17,7 @@ class RAGState(TypedDict):
     user_id: int
     session_id: str
     query_type: str
+    needs_coverage: bool
     cache_hit: bool
     cached_response: str | None
     query_embedding: list[float] | None
@@ -99,6 +100,7 @@ def make_initial_state(user_id: int, session_id: str, query: str) -> dict[str, A
         "user_id": user_id,
         "session_id": session_id,
         "query_type": "",
+        "needs_coverage": False,
         "cache_hit": False,
         "cached_response": None,
         "query_embedding": None,

--- a/telegram_bot/services/coverage_mode.py
+++ b/telegram_bot/services/coverage_mode.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CoverageDecision:
+    needs_coverage: bool
+    reason: str | None = None
+
+
+_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("какие виды", re.compile(r"\bкакие\s+виды\b", re.IGNORECASE)),
+    ("какие варианты", re.compile(r"\bкакие\s+варианты\b", re.IGNORECASE)),
+    ("какие еще есть", re.compile(r"\bкакие\s+еще\s+есть\b", re.IGNORECASE)),
+    ("полный список", re.compile(r"\bполный\s+список\b", re.IGNORECASE)),
+    ("перечисли все", re.compile(r"\bперечисли\s+все\b", re.IGNORECASE)),
+    ("все основания", re.compile(r"\bвсе\s+основан", re.IGNORECASE)),
+    ("все способы", re.compile(r"\bвсе\s+способы\b", re.IGNORECASE)),
+)
+
+
+def detect_coverage_mode(query: str) -> CoverageDecision:
+    text = (query or "").strip()
+    if not text:
+        return CoverageDecision(False, None)
+
+    for label, pattern in _PATTERNS:
+        if pattern.search(text):
+            return CoverageDecision(True, f"regex:{label}")
+
+    return CoverageDecision(False, None)
+
+
+def cap_results_per_doc(
+    results: list[dict[str, Any]],
+    *,
+    max_per_doc: int = 2,
+    metadata_key: str = "doc_id",
+) -> list[dict[str, Any]]:
+    counts: dict[str, int] = defaultdict(int)
+    capped: list[dict[str, Any]] = []
+
+    for doc in results:
+        metadata = doc.get("metadata", {}) or {}
+        doc_key = str(metadata.get(metadata_key) or doc.get("id") or "")
+        if counts[doc_key] >= max_per_doc:
+            continue
+        counts[doc_key] += 1
+        capped.append(doc)
+
+    return capped

--- a/telegram_bot/services/generate_response.py
+++ b/telegram_bot/services/generate_response.py
@@ -18,6 +18,7 @@ from telegram_bot.integrations.prompt_templates import (
     get_token_limit,
 )
 from telegram_bot.observability import get_client, observe
+from telegram_bot.services.coverage_mode import detect_coverage_mode
 from telegram_bot.services.grounding_policy import (
     build_safe_fallback_response,
     is_strict_grounding_safe,
@@ -94,6 +95,12 @@ _GENERATE_FALLBACK = (
     "ЕСЛИ ИНФОРМАЦИИ НЕ ХВАТАЕТ:\n"
     "Скажи это спокойно и предметно, затем укажи, что именно стоит уточнить. "
     "Например: бюджет, цель покупки, тип объекта, основание ВНЖ, срок рассрочки, статус объекта."
+)
+_EXHAUSTIVE_GENERATE_FALLBACK = (
+    "Ты — консультант по {{domain}}. "
+    "Если вопрос подразумевает множественность, перечисли все найденные в контексте "
+    "релевантные варианты, сгруппируй близкие пункты и убери дубли. "
+    "Если база покрывает не все варианты, скажи, что перечислены только найденные в базе основания."
 )
 
 
@@ -502,6 +509,8 @@ async def generate_response(
 
     detector = style_detector or _detector
     style_info = detector.detect(effective_query)
+    coverage_decision = detect_coverage_mode(effective_query)
+    needs_coverage = coverage_decision.needs_coverage
     sources_enabled = bool(getattr(config, "show_sources", False) or grounding_mode == "strict")
     legal_answer_safe = grounding_mode != "strict" or is_strict_grounding_safe(
         documents=docs,
@@ -523,6 +532,8 @@ async def generate_response(
             "context_docs_count": len(docs),
             "streaming_enabled": bool(message is not None and config.streaming_enabled),
             "grounding_mode": grounding_mode,
+            "needs_coverage": needs_coverage,
+            "coverage_reason": coverage_decision.reason,
         }
     )
 
@@ -545,6 +556,9 @@ async def generate_response(
                 "safe_fallback_used": True,
                 "grounded": False,
                 "response_sent": False,
+                "needs_coverage": needs_coverage,
+                "coverage_mode": "exhaustive_list" if needs_coverage else "default",
+                "coverage_reason": coverage_decision.reason,
             }
         )
         return {
@@ -576,15 +590,37 @@ async def generate_response(
             "grounded": False,
             "legal_answer_safe": False,
             "semantic_cache_safe_reuse": False,
+            "needs_coverage": needs_coverage,
         }
 
     style_enabled = bool(getattr(config, "response_style_enabled", False))
     shadow_mode = bool(getattr(config, "response_style_shadow_mode", False))
     legacy_max_tokens = int(config.generate_max_tokens)
-    use_style = style_enabled and not shadow_mode
 
     prompt_config: dict[str, Any] = {}
-    if use_style:
+    prompt_name = "generate"
+    use_style = False
+    if needs_coverage:
+        system_prompt, prompt_config = get_prompt_with_config(
+            "generate_exhaustive_list",
+            fallback=_EXHAUSTIVE_GENERATE_FALLBACK,
+            variables={"domain": config.domain},
+        )
+        if "max_tokens" in prompt_config:
+            max_tokens = min(int(prompt_config["max_tokens"]), legacy_max_tokens)
+        else:
+            max_tokens = legacy_max_tokens
+        response_policy_mode = "coverage"
+        prompt_name = "generate_exhaustive_list"
+    else:
+        use_style = style_enabled and not shadow_mode
+        response_policy_mode = (
+            "enforced" if use_style else ("shadow" if shadow_mode else "disabled")
+        )
+
+    if needs_coverage:
+        pass
+    elif use_style:
         style_system_prompt = style_prompt_builder(
             style=style_info.style,
             difficulty=style_info.difficulty,
@@ -860,6 +896,17 @@ async def generate_response(
         "eval_query": effective_query[:2000],
         "eval_answer": answer[:3000],
         "eval_context": eval_context,
+        "needs_coverage": needs_coverage,
+        "coverage_mode": "exhaustive_list" if needs_coverage else "default",
+        "coverage_reason": coverage_decision.reason,
+        "prompt_name": prompt_name,
+        "documents_count": len(docs),
+        "distinct_doc_count": len(
+            {
+                str((doc.get("metadata", {}) or {}).get("doc_id") or doc.get("id") or "")
+                for doc in docs
+            }
+        ),
     }
     if usage_details:
         span_output["token_usage"] = {
@@ -916,7 +963,6 @@ async def generate_response(
     answer_chars = len(answer)
     question_words = style_info.word_count
     ratio = answer_words / max(question_words, 1)
-    response_policy_mode = "enforced" if use_style else ("shadow" if shadow_mode else "disabled")
 
     sent_message_ref = (
         extract_sent_message_ref(sent_msg) if response_sent and sent_msg is not None else None
@@ -955,4 +1001,5 @@ async def generate_response(
         "grounded": True,
         "legal_answer_safe": legal_answer_safe,
         "semantic_cache_safe_reuse": legal_answer_safe,
+        "needs_coverage": needs_coverage,
     }

--- a/telegram_bot/services/generate_response.py
+++ b/telegram_bot/services/generate_response.py
@@ -455,6 +455,7 @@ def _extract_queue_ms_from_provider_headers(response_obj: Any | None) -> float |
 async def generate_response(
     *,
     query: str,
+    needs_coverage: bool = False,
     documents: list[dict[str, Any]],
     retrieved_context: list[dict[str, Any]] | None = None,
     raw_messages: list[Any] | None = None,
@@ -510,7 +511,10 @@ async def generate_response(
     detector = style_detector or _detector
     style_info = detector.detect(effective_query)
     coverage_decision = detect_coverage_mode(effective_query)
-    needs_coverage = coverage_decision.needs_coverage
+    needs_coverage = bool(needs_coverage) or coverage_decision.needs_coverage
+    coverage_reason = coverage_decision.reason or (
+        "state:needs_coverage" if needs_coverage else None
+    )
     sources_enabled = bool(getattr(config, "show_sources", False) or grounding_mode == "strict")
     legal_answer_safe = grounding_mode != "strict" or is_strict_grounding_safe(
         documents=docs,
@@ -518,10 +522,15 @@ async def generate_response(
         grade_confidence=grade_confidence,
     )
     format_params = inspect.signature(format_context).parameters
+    effective_max_context_docs = len(docs) if needs_coverage else max_context_docs
     if "sources_enabled" in format_params:
-        context = format_context(docs, max_context_docs, sources_enabled=sources_enabled)
+        context = format_context(
+            docs,
+            effective_max_context_docs,
+            sources_enabled=sources_enabled,
+        )
     else:
-        context = format_context(docs, max_context_docs)
+        context = format_context(docs, effective_max_context_docs)
 
     # Curated span metadata
     lf_client.update_current_span(
@@ -533,7 +542,7 @@ async def generate_response(
             "streaming_enabled": bool(message is not None and config.streaming_enabled),
             "grounding_mode": grounding_mode,
             "needs_coverage": needs_coverage,
-            "coverage_reason": coverage_decision.reason,
+            "coverage_reason": coverage_reason,
         }
     )
 
@@ -558,7 +567,7 @@ async def generate_response(
                 "response_sent": False,
                 "needs_coverage": needs_coverage,
                 "coverage_mode": "exhaustive_list" if needs_coverage else "default",
-                "coverage_reason": coverage_decision.reason,
+                "coverage_reason": coverage_reason,
             }
         )
         return {
@@ -898,7 +907,7 @@ async def generate_response(
         "eval_context": eval_context,
         "needs_coverage": needs_coverage,
         "coverage_mode": "exhaustive_list" if needs_coverage else "default",
-        "coverage_reason": coverage_decision.reason,
+        "coverage_reason": coverage_reason,
         "prompt_name": prompt_name,
         "documents_count": len(docs),
         "distinct_doc_count": len(

--- a/tests/integration/test_graph_paths.py
+++ b/tests/integration/test_graph_paths.py
@@ -786,6 +786,64 @@ class TestConversationMemory:
 
 
 # ---------------------------------------------------------------------------
+# Path 8b: GENERAL coverage query → grouped RRF, bypass ColBERT
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_path_general_coverage_query_uses_grouped_rrf():
+    """Coverage query should force grouped RRF even when ColBERT path is available."""
+    mocks = _make_graph_mocks(
+        qdrant_results=[
+            {
+                "text": "По работе",
+                "score": 0.95,
+                "id": "1",
+                "metadata": {"doc_id": "a"},
+            },
+            {
+                "text": "Digital Nomad",
+                "score": 0.92,
+                "id": "2",
+                "metadata": {"doc_id": "b"},
+            },
+        ],
+        llm_response="Полный список найденных оснований.",
+    )
+    mocks["embeddings"].aembed_hybrid_with_colbert = AsyncMock(
+        return_value=([0.1] * 1024, {"indices": [1, 5], "values": [0.5, 0.3]}, [[0.2] * 1024] * 4)
+    )
+    mocks["qdrant"].hybrid_search_rrf_colbert = AsyncMock()
+    mock_gc = _make_mock_graph_config(mocks["llm"])
+
+    with _patch_graph_configs(mock_gc):
+        graph = build_graph(
+            cache=mocks["cache"],
+            embeddings=mocks["embeddings"],
+            sparse_embeddings=mocks["sparse_embeddings"],
+            qdrant=mocks["qdrant"],
+            reranker=mocks["reranker"],
+            llm=mocks["llm"],
+            message=mocks["message"],
+        )
+
+    state = make_initial_state(
+        user_id=1,
+        session_id="coverage-path",
+        query="какие еще есть виды внж в болгарии? напиши полный список",
+    )
+
+    with _patch_graph_configs(mock_gc):
+        result = await graph.ainvoke(state)
+
+    assert result["needs_coverage"] is True
+    kwargs = mocks["qdrant"].hybrid_search_rrf.await_args.kwargs
+    assert kwargs["group_by"] == "metadata.doc_id"
+    assert kwargs["group_size"] == 2
+    mocks["qdrant"].hybrid_search_rrf_colbert.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
 # Path 9: classify → cache_check(ColBERT embed) → retrieve(ColBERT search)
 #        → grade(relevant, rerank_applied=True) → generate → cache_store → respond
 # ---------------------------------------------------------------------------

--- a/tests/unit/graph/test_observe_payloads.py
+++ b/tests/unit/graph/test_observe_payloads.py
@@ -154,6 +154,42 @@ class TestCuratedSpanPayloads:
         assert "query_hash" in input_payload
         assert len(input_payload["query_hash"]) == 8
 
+    async def test_retrieve_node_logs_distinct_doc_count_for_coverage_query(self):
+        from telegram_bot.graph.nodes.retrieve import retrieve_node
+        from telegram_bot.graph.state import make_initial_state
+
+        state = make_initial_state(
+            user_id=1,
+            session_id="s1",
+            query="какие еще есть виды внж в болгарии? напиши полный список",
+        )
+        state["query_type"] = "GENERAL"
+        state["query_embedding"] = [0.1] * 1024
+
+        docs = [
+            {"id": "1", "text": "Doc A1", "score": 0.9, "metadata": {"doc_id": "a"}},
+            {"id": "2", "text": "Doc B1", "score": 0.8, "metadata": {"doc_id": "b"}},
+        ]
+
+        cache = AsyncMock()
+        cache.get_search_results = AsyncMock(return_value=None)
+        cache.get_sparse_embedding = AsyncMock(return_value={"indices": [1], "values": [0.5]})
+        cache.store_search_results = AsyncMock()
+
+        qdrant = AsyncMock()
+        qdrant.hybrid_search_rrf = AsyncMock(return_value=(docs, {"backend_error": False}))
+
+        mock_lf = MagicMock()
+        with patch("telegram_bot.graph.nodes.retrieve.get_client", return_value=mock_lf):
+            await retrieve_node(
+                state,
+                _rt(cache=cache, sparse_embeddings=AsyncMock(), qdrant=qdrant),
+            )
+
+        payloads = _extract_span_payloads(mock_lf)
+        _assert_no_forbidden_keys(payloads, "node-retrieve")
+        assert any("distinct_doc_count" in payload for payload in payloads)
+
     async def test_generate_node_curated_payload(self):
         from unittest.mock import patch as _patch
 
@@ -194,6 +230,53 @@ class TestCuratedSpanPayloads:
             "generate_node must call update_current_span for input and output"
         )
         _assert_no_forbidden_keys(payloads, "node-generate")
+
+    async def test_generate_node_logs_coverage_metadata(self):
+        from unittest.mock import patch as _patch
+
+        from telegram_bot.graph.nodes.generate import generate_node
+        from telegram_bot.graph.state import make_initial_state
+
+        state = make_initial_state(
+            user_id=1,
+            session_id="s1",
+            query="перечисли все виды внж в Болгарии",
+        )
+        state["query_type"] = "GENERAL"
+        state["documents"] = [
+            {"text": "Large doc " * 200, "score": 0.9, "metadata": {"doc_id": "a"}},
+        ]
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Answer."
+        mock_response = MagicMock(choices=[mock_choice])
+        mock_response.model = "gpt-4o-mini"
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        mock_config = MagicMock()
+        mock_config.domain = "test"
+        mock_config.llm_model = "gpt-4o-mini"
+        mock_config.llm_temperature = 0.7
+        mock_config.generate_max_tokens = 2048
+        mock_config.streaming_enabled = False
+        mock_config.create_llm.return_value = mock_client
+
+        mock_lf = MagicMock()
+        with (
+            _patch("telegram_bot.graph.nodes.generate._get_config", return_value=mock_config),
+            _patch("telegram_bot.graph.nodes.generate.get_client", return_value=mock_lf),
+        ):
+            await generate_node(state)
+
+        payloads = _extract_span_payloads(mock_lf)
+        _assert_no_forbidden_keys(payloads, "node-generate")
+        assert any(
+            payload.get("needs_coverage") is True
+            or payload.get("coverage_mode") == "exhaustive_list"
+            for payload in payloads
+        )
 
     async def test_cache_check_node_curated_payload(self):
         from telegram_bot.graph.nodes.cache import cache_check_node

--- a/tests/unit/graph/test_observe_payloads.py
+++ b/tests/unit/graph/test_observe_payloads.py
@@ -278,6 +278,23 @@ class TestCuratedSpanPayloads:
             for payload in payloads
         )
 
+    async def test_generate_node_passes_state_coverage_override_to_service(self):
+        from unittest.mock import patch as _patch
+
+        from telegram_bot.graph.nodes.generate import generate_node
+        from telegram_bot.graph.state import make_initial_state
+
+        state = make_initial_state(user_id=1, session_id="s1", query="какие еще есть виды внж")
+        state["needs_coverage"] = True
+        state["messages"] = [{"role": "user", "content": "основания для внж в болгарии"}]
+
+        mock_service = AsyncMock(return_value={"response": "ok", "needs_coverage": True})
+
+        with _patch("telegram_bot.graph.nodes.generate._generate_response_service", mock_service):
+            await generate_node(state)
+
+        assert mock_service.await_args.kwargs["needs_coverage"] is True
+
     async def test_cache_check_node_curated_payload(self):
         from telegram_bot.graph.nodes.cache import cache_check_node
         from telegram_bot.graph.state import make_initial_state

--- a/tests/unit/graph/test_retrieve_node.py
+++ b/tests/unit/graph/test_retrieve_node.py
@@ -450,6 +450,67 @@ class TestRetrieveNodeColbert:
 
         assert [doc["id"] for doc in result["documents"]] == ["1", "2", "4"]
 
+    async def test_search_cache_is_partitioned_between_coverage_and_colbert_profiles(self) -> None:
+        stored: dict[tuple[tuple[float, ...], str], list[dict]] = {}
+
+        def _cache_key(vec: list[float], filters: dict | None) -> tuple[tuple[float, ...], str]:
+            return (tuple(round(v, 3) for v in vec[:10]), str(filters))
+
+        async def _get_search_results(vec: list[float], filters: dict | None = None):
+            return stored.get(_cache_key(vec, filters))
+
+        async def _store_search_results(
+            vec: list[float], filters: dict | None, results: list[dict]
+        ):
+            stored[_cache_key(vec, filters)] = results
+
+        cache = AsyncMock()
+        cache.get_search_results = AsyncMock(side_effect=_get_search_results)
+        cache.store_search_results = AsyncMock(side_effect=_store_search_results)
+        cache.get_sparse_embedding = AsyncMock(return_value={"indices": [1], "values": [0.5]})
+
+        qdrant = AsyncMock()
+        qdrant.hybrid_search_rrf = AsyncMock(
+            return_value=(
+                [
+                    {"id": "1", "text": "A1", "score": 0.95, "metadata": {"doc_id": "a"}},
+                    {"id": "2", "text": "A2", "score": 0.94, "metadata": {"doc_id": "a"}},
+                    {"id": "3", "text": "B1", "score": 0.90, "metadata": {"doc_id": "b"}},
+                ],
+                _OK_META,
+            )
+        )
+        qdrant.hybrid_search_rrf_colbert = AsyncMock(
+            return_value=(
+                [{"id": "9", "text": "colbert", "score": 99.0, "metadata": {"doc_id": "z"}}],
+                _OK_META,
+            )
+        )
+
+        coverage_state = make_initial_state(user_id=1, session_id="s1", query="основания для внж")
+        coverage_state["query_type"] = "GENERAL"
+        coverage_state["query_embedding"] = [0.1] * 1024
+        coverage_state["needs_coverage"] = True
+
+        await retrieve_node(
+            coverage_state,
+            _make_runtime(cache=cache, sparse_embeddings=AsyncMock(), qdrant=qdrant),
+        )
+
+        normal_state = make_initial_state(user_id=2, session_id="s2", query="основания для внж")
+        normal_state["query_type"] = "GENERAL"
+        normal_state["query_embedding"] = [0.1] * 1024
+        normal_state["colbert_query"] = [[0.2] * 1024]
+
+        result = await retrieve_node(
+            normal_state,
+            _make_runtime(cache=cache, sparse_embeddings=AsyncMock(), qdrant=qdrant),
+        )
+
+        assert result["search_cache_hit"] is False
+        assert [doc["id"] for doc in result["documents"]] == ["9"]
+        qdrant.hybrid_search_rrf_colbert.assert_awaited_once()
+
     async def test_retrieve_uses_colbert_search_when_available(self):
         """When colbert_query in state, uses hybrid_search_rrf_colbert."""
         mock_cache = AsyncMock()

--- a/tests/unit/graph/test_retrieve_node.py
+++ b/tests/unit/graph/test_retrieve_node.py
@@ -389,6 +389,67 @@ class TestRetrieveNode:
 class TestRetrieveNodeColbert:
     """Tests for ColBERT server-side search in retrieve_node."""
 
+    async def test_coverage_query_uses_grouped_rrf_and_bypasses_colbert(self) -> None:
+        state = make_initial_state(
+            user_id=1,
+            session_id="s1",
+            query="какие еще есть виды внж в болгарии? напиши полный список",
+        )
+        state["query_type"] = "GENERAL"
+        state["query_embedding"] = [0.1] * 1024
+        state["colbert_query"] = [[0.1, 0.2]]
+
+        cache = AsyncMock()
+        cache.get_search_results = AsyncMock(return_value=None)
+        cache.get_sparse_embedding = AsyncMock(return_value={"indices": [1], "values": [0.5]})
+        cache.store_search_results = AsyncMock()
+
+        sparse_embeddings = AsyncMock()
+
+        qdrant = AsyncMock()
+        qdrant.hybrid_search_rrf = AsyncMock(return_value=(_make_docs(4), _OK_META))
+        qdrant.hybrid_search_rrf_colbert = AsyncMock()
+
+        result = await retrieve_node(
+            state,
+            _make_runtime(cache=cache, sparse_embeddings=sparse_embeddings, qdrant=qdrant),
+        )
+
+        kwargs = qdrant.hybrid_search_rrf.await_args.kwargs
+        assert result["needs_coverage"] is True
+        assert kwargs["group_by"] == "metadata.doc_id"
+        assert kwargs["group_size"] == 2
+        assert kwargs["top_k"] == 10
+        assert kwargs["prefetch_multiplier"] == 7
+        qdrant.hybrid_search_rrf_colbert.assert_not_awaited()
+
+    async def test_coverage_query_caps_results_per_doc_after_retrieval(self) -> None:
+        state = make_initial_state(user_id=1, session_id="s1", query="перечисли все основания")
+        state["query_type"] = "GENERAL"
+        state["query_embedding"] = [0.1] * 1024
+
+        docs = [
+            {"id": "1", "text": "A1", "score": 0.95, "metadata": {"doc_id": "a"}},
+            {"id": "2", "text": "A2", "score": 0.94, "metadata": {"doc_id": "a"}},
+            {"id": "3", "text": "A3", "score": 0.93, "metadata": {"doc_id": "a"}},
+            {"id": "4", "text": "B1", "score": 0.90, "metadata": {"doc_id": "b"}},
+        ]
+
+        cache = AsyncMock()
+        cache.get_search_results = AsyncMock(return_value=None)
+        cache.get_sparse_embedding = AsyncMock(return_value={"indices": [1], "values": [0.5]})
+        cache.store_search_results = AsyncMock()
+
+        qdrant = AsyncMock()
+        qdrant.hybrid_search_rrf = AsyncMock(return_value=(docs, _OK_META))
+
+        result = await retrieve_node(
+            state,
+            _make_runtime(cache=cache, sparse_embeddings=AsyncMock(), qdrant=qdrant),
+        )
+
+        assert [doc["id"] for doc in result["documents"]] == ["1", "2", "4"]
+
     async def test_retrieve_uses_colbert_search_when_available(self):
         """When colbert_query in state, uses hybrid_search_rrf_colbert."""
         mock_cache = AsyncMock()

--- a/tests/unit/services/test_coverage_mode.py
+++ b/tests/unit/services/test_coverage_mode.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from telegram_bot.graph.state import make_initial_state
+from telegram_bot.services.coverage_mode import cap_results_per_doc, detect_coverage_mode
+
+
+def test_detect_coverage_mode_matches_enumeration_query() -> None:
+    decision = detect_coverage_mode(
+        "какие еще есть виды внж в болгарии? напиши полный список всех вариантов"
+    )
+
+    assert decision.needs_coverage is True
+    assert decision.reason.startswith("regex:")
+
+
+def test_detect_coverage_mode_ignores_normal_specific_question() -> None:
+    decision = detect_coverage_mode("сколько стоит студия в Несебре?")
+
+    assert decision.needs_coverage is False
+    assert decision.reason is None
+
+
+def test_cap_results_per_doc_preserves_order_and_limits_duplicates() -> None:
+    docs = [
+        {"id": "1", "metadata": {"doc_id": "a"}, "score": 0.95},
+        {"id": "2", "metadata": {"doc_id": "a"}, "score": 0.92},
+        {"id": "3", "metadata": {"doc_id": "a"}, "score": 0.91},
+        {"id": "4", "metadata": {"doc_id": "b"}, "score": 0.80},
+    ]
+
+    result = cap_results_per_doc(docs, max_per_doc=2)
+
+    assert [doc["id"] for doc in result] == ["1", "2", "4"]
+
+
+def test_make_initial_state_defaults_needs_coverage_false() -> None:
+    state = make_initial_state(user_id=1, session_id="s1", query="обычный вопрос")
+
+    assert state["needs_coverage"] is False

--- a/tests/unit/services/test_generate_response.py
+++ b/tests/unit/services/test_generate_response.py
@@ -291,6 +291,61 @@ async def test_generate_response_logs_coverage_prompt_metadata() -> None:
 
 
 @pytest.mark.asyncio
+async def test_generate_response_honors_explicit_coverage_override() -> None:
+    from unittest.mock import ANY
+
+    config, _client = _make_non_streaming_config(answer="Полный список оснований.")
+    lf = MagicMock()
+
+    with patch(
+        "telegram_bot.services.generate_response.get_prompt_with_config",
+        return_value=("EXHAUSTIVE PROMPT", {"temperature": 0.2, "max_tokens": 512}),
+    ) as mock_get_prompt:
+        result = await generate_response(
+            query="основания для внж в болгарии",
+            documents=[{"text": "Контекст", "score": 0.9, "metadata": {"doc_id": "a"}}],
+            config=config,
+            lf_client=lf,
+            raw_messages=[{"role": "user", "content": "основания для внж в болгарии"}],
+            needs_coverage=True,
+        )
+
+    assert result["needs_coverage"] is True
+    mock_get_prompt.assert_called_once_with(
+        "generate_exhaustive_list",
+        fallback=ANY,
+        variables={"domain": "недвижимость"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_response_coverage_mode_includes_all_retrieved_docs_in_prompt() -> None:
+    config, client = _make_non_streaming_config(answer="Полный список.")
+    lf = MagicMock()
+    docs = [
+        {"text": f"Doc {i}", "score": 0.95 - i * 0.01, "metadata": {"doc_id": str(i)}}
+        for i in range(8)
+    ]
+
+    with patch(
+        "telegram_bot.services.generate_response.get_prompt_with_config",
+        return_value=("EXHAUSTIVE PROMPT", {"temperature": 0.2, "max_tokens": 512}),
+    ):
+        result = await generate_response(
+            query="перечисли все основания для внж",
+            documents=docs,
+            config=config,
+            lf_client=lf,
+            raw_messages=[{"role": "user", "content": "перечисли все основания для внж"}],
+        )
+
+    assert result["needs_coverage"] is True
+    user_prompt = client.chat.completions.create.await_args.kwargs["messages"][-1]["content"]
+    assert user_prompt.count("[Объект ") == 8
+    assert "Doc 7" in user_prompt
+
+
+@pytest.mark.asyncio
 async def test_generate_response_strict_mode_does_not_degrade_only_because_show_sources_disabled() -> (
     None
 ):

--- a/tests/unit/services/test_generate_response.py
+++ b/tests/unit/services/test_generate_response.py
@@ -218,6 +218,79 @@ async def test_generate_response_returns_safe_fallback_when_strict_mode_has_low_
 
 
 @pytest.mark.asyncio
+async def test_generate_response_routes_coverage_query_to_exhaustive_prompt() -> None:
+    from unittest.mock import ANY
+
+    config, _client = _make_non_streaming_config(answer="Полный список оснований.")
+    lf = MagicMock()
+
+    with patch(
+        "telegram_bot.services.generate_response.get_prompt_with_config",
+        side_effect=[
+            ("EXHAUSTIVE PROMPT", {"temperature": 0.2, "max_tokens": 512}),
+        ],
+    ) as mock_get_prompt:
+        result = await generate_response(
+            query="какие еще есть виды внж в болгарии? напиши полный список",
+            documents=[{"text": "Контекст", "score": 0.9, "metadata": {"doc_id": "a"}}],
+            config=config,
+            lf_client=lf,
+            raw_messages=[{"role": "user", "content": "какие еще есть виды внж"}],
+        )
+
+    assert result["needs_coverage"] is True
+    assert result["response"] == "Полный список оснований."
+    mock_get_prompt.assert_called_once_with(
+        "generate_exhaustive_list",
+        fallback=ANY,
+        variables={"domain": "недвижимость"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_response_coverage_mode_bypasses_style_prompt_builder() -> None:
+    config, _client = _make_non_streaming_config(answer="Развернутый список.")
+    config.response_style_enabled = True
+    lf = MagicMock()
+    style_prompt_builder = MagicMock(side_effect=AssertionError("style builder must be skipped"))
+
+    result = await generate_response(
+        query="перечисли все виды внж",
+        documents=[{"text": "Контекст", "score": 0.9, "metadata": {"doc_id": "a"}}],
+        config=config,
+        lf_client=lf,
+        style_prompt_builder=style_prompt_builder,
+        raw_messages=[{"role": "user", "content": "перечисли все виды внж"}],
+    )
+
+    assert result["needs_coverage"] is True
+    style_prompt_builder.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generate_response_logs_coverage_prompt_metadata() -> None:
+    config, _client = _make_non_streaming_config(answer="Ответ.")
+    lf = MagicMock()
+
+    with patch(
+        "telegram_bot.services.generate_response.get_prompt_with_config",
+        return_value=("EXHAUSTIVE PROMPT", {"temperature": 0.2, "max_tokens": 512}),
+    ):
+        await generate_response(
+            query="полный список оснований для ВНЖ",
+            documents=[{"text": "Контекст", "score": 0.9, "metadata": {"doc_id": "a"}}],
+            config=config,
+            lf_client=lf,
+            raw_messages=[{"role": "user", "content": "полный список оснований для ВНЖ"}],
+        )
+
+    assert any(
+        call.kwargs.get("output", {}).get("prompt_name") == "generate_exhaustive_list"
+        for call in lf.update_current_span.call_args_list
+    )
+
+
+@pytest.mark.asyncio
 async def test_generate_response_strict_mode_does_not_degrade_only_because_show_sources_disabled() -> (
     None
 ):


### PR DESCRIPTION
## Summary
- add coverage-mode detection and explicit `needs_coverage` state for enumeration-style knowledge queries
- route coverage queries to `generate_exhaustive_list` and add lightweight coverage observability in generation and retrieval
- use grouped RRF with per-document caps for coverage retrieval and lock behavior with unit/integration regressions

## Test Plan
- [x] `uv run pytest tests/unit/services/test_coverage_mode.py tests/unit/services/test_generate_response.py tests/unit/graph/test_retrieve_node.py tests/unit/graph/test_observe_payloads.py tests/integration/test_graph_paths.py -q` (77 passed)
- [x] `make check`
- [ ] `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit` currently fails outside this rollout in `tests/unit/test_litellm_config_sync.py` due docker/k8s LiteLLM config drift

## Notes
- recent merged PR history is dev-first, so this PR targets `dev` even though current CI workflow only triggers on PRs to `main`
