### PR TITLE
fix: harden semantic cache degraded response policy

### DIFF
--- a/telegram_bot/agents/rag_pipeline.py
+++ b/telegram_bot/agents/rag_pipeline.py
@@ -25,6 +25,11 @@ from typing import Any, cast
 from src.retrieval.topic_classifier import detect_score_gap, get_query_topic_hint
 from telegram_bot.observability import get_client, observe
 from telegram_bot.pipelines.state_contract import PreAgentStateContract
+from telegram_bot.services.cache_policy import (
+    SEMANTIC_CACHE_SCHEMA_VERSION,
+    build_cacheability_decision,
+    maybe_store_semantic_response,
+)
 from telegram_bot.services.query_preprocessor import expand_short_query
 from telegram_bot.services.rag_core import (
     CACHEABLE_QUERY_TYPES,
@@ -785,26 +790,48 @@ async def _cache_store(
     start = time.perf_counter()
 
     stored_semantic = False
-    if response and query_embedding:
-        if query_type in CACHEABLE_QUERY_TYPES:
-            try:
-                await cache.store_semantic(
-                    query=query,
-                    response=response,
-                    vector=query_embedding,
-                    query_type=query_type,
-                    cache_scope="rag",
-                    agent_role=agent_role,
-                )
-                stored_semantic = True
-            except Exception as exc:
-                # RedisVLError, RedisSearchError, SchemaValidationError, or any unexpected
-                # error from store_semantic must never lose the response (#524).
-                logger.warning(
-                    "cache_store: semantic store failed, response preserved: %s: %s",
-                    type(exc).__name__,
-                    exc,
-                )
+    if response and query_embedding and query_type in CACHEABLE_QUERY_TYPES:
+        # Legacy helper kept as a thin delegate so tests and older callsites do not
+        # carry a second cache-policy implementation.
+        decision = build_cacheability_decision(
+            result={
+                "response": response,
+                "grounded": True,
+                "legal_answer_safe": True,
+                "semantic_cache_safe_reuse": True,
+                "fallback_used": False,
+                "safe_fallback_used": False,
+                "llm_provider_model": "",
+                "llm_timeout": False,
+            },
+            query_type=query_type,
+            grounding_mode="normal",
+            documents=[{"text": response}],
+            cache_hit=False,
+            contextual=False,
+            grade_confidence=1.0,
+            confidence_threshold=0.0,
+            schema_version=SEMANTIC_CACHE_SCHEMA_VERSION,
+        )
+        try:
+            stored_semantic = await maybe_store_semantic_response(
+                cache=cache,
+                query=query,
+                response=response,
+                vector=query_embedding,
+                query_type=query_type,
+                cache_scope="rag",
+                decision=decision,
+                agent_role=agent_role,
+            )
+        except Exception as exc:
+            # RedisVLError, RedisSearchError, SchemaValidationError, or any unexpected
+            # error from store_semantic must never lose the response (#524).
+            logger.warning(
+                "cache_store: semantic store failed, response preserved: %s: %s",
+                type(exc).__name__,
+                exc,
+            )
 
         if stored_semantic:
             logger.info("cache_store: stored=semantic (type=%s)", query_type)

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -59,8 +59,13 @@ from .scoring import (
     write_langfuse_scores,
 )
 from .services.business_hours import is_business_hours
+from .services.cache_policy import (
+    SEMANTIC_CACHE_SCHEMA_VERSION,
+    build_cacheability_decision,
+    maybe_store_semantic_response,
+)
 from .services.forum_bridge import ForumBridge
-from .services.grounding_policy import get_grounding_mode, semantic_cache_safe_reuse_allowed
+from .services.grounding_policy import get_grounding_mode
 from .services.handoff_state import HandoffData, HandoffState
 from .services.metrics import PipelineMetrics
 from .services.redis_monitor import RedisHealthMonitor
@@ -3311,6 +3316,31 @@ class PropertyBot:
             # even when the agent reformulated the query for retrieval (#504).
             if self._cache and response_text:
                 query_type = str(rag_result_store.get("query_type", "") or "")
+                grounding_mode_value = str(
+                    rag_result_store.get("grounding_mode", "normal") or "normal"
+                )
+                raw_threshold = getattr(self.config, "relevance_threshold_rrf", 0.005)
+                confidence_threshold = (
+                    float(raw_threshold) if isinstance(raw_threshold, int | float) else 0.005
+                )
+                decision = build_cacheability_decision(
+                    result={
+                        **rag_result_store,
+                        "response": response_text,
+                    },
+                    query_type=query_type,
+                    grounding_mode=grounding_mode_value,
+                    documents=rag_result_store.get("documents", []),
+                    cache_hit=bool(rag_result_store.get("cache_hit", False)),
+                    contextual=False,
+                    grade_confidence=float(rag_result_store.get("grade_confidence", 0.0) or 0.0),
+                    confidence_threshold=confidence_threshold,
+                    schema_version=SEMANTIC_CACHE_SCHEMA_VERSION,
+                )
+                rag_result_store["response_state"] = decision.response_state
+                rag_result_store["degraded_reason"] = decision.degraded_reason
+                rag_result_store["cache_eligible"] = decision.cache_eligible
+                rag_result_store["store_reason"] = decision.store_reason
                 # Prefer cache_key_embedding (original query vector) over query_embedding
                 # (retrieval/rewritten vector) to avoid check/store vector mismatch.
                 store_vector = rag_result_store.get("cache_key_embedding") or rag_result_store.get(
@@ -3318,40 +3348,19 @@ class PropertyBot:
                 )
                 if (
                     query_type in CACHEABLE_QUERY_TYPES
-                    and not rag_result_store.get("cache_hit", False)
                     and isinstance(store_vector, list)
                     and bool(store_vector)
-                    and semantic_cache_safe_reuse_allowed(
-                        grounding_mode=str(
-                            rag_result_store.get("grounding_mode", "normal") or "normal"
-                        ),
-                        grounded=bool(rag_result_store.get("grounded", True)),
-                        legal_answer_safe=bool(rag_result_store.get("legal_answer_safe", True)),
-                        semantic_cache_safe_reuse=bool(
-                            rag_result_store.get("semantic_cache_safe_reuse", True)
-                        ),
-                        safe_fallback_used=bool(rag_result_store.get("safe_fallback_used", False)),
-                    )
                 ):
                     try:
-                        await self._cache.store_semantic(
+                        await maybe_store_semantic_response(
+                            cache=self._cache,
                             query=message.text or "",
                             response=response_text,
                             vector=store_vector,
                             query_type=query_type,
                             cache_scope="rag",
+                            decision=decision,
                             agent_role=role,
-                            metadata={
-                                "grounding_mode": str(
-                                    rag_result_store.get("grounding_mode", "normal") or "normal"
-                                ),
-                                "legal_answer_safe": bool(
-                                    rag_result_store.get("legal_answer_safe", True)
-                                ),
-                                "semantic_cache_safe_reuse": bool(
-                                    rag_result_store.get("semantic_cache_safe_reuse", True)
-                                ),
-                            },
                         )
                     except Exception:
                         logger.warning("Failed to store semantic cache in text path", exc_info=True)

--- a/telegram_bot/graph/nodes/cache.py
+++ b/telegram_bot/graph/nodes/cache.py
@@ -16,6 +16,11 @@ from langgraph.runtime import Runtime
 
 from telegram_bot.graph.context import GraphContext
 from telegram_bot.observability import get_client, observe
+from telegram_bot.services.cache_policy import (
+    SEMANTIC_CACHE_SCHEMA_VERSION,
+    build_cacheability_decision,
+    maybe_store_semantic_response,
+)
 from telegram_bot.services.metrics import PipelineMetrics
 from telegram_bot.services.rag_core import (
     CACHEABLE_QUERY_TYPES,
@@ -213,28 +218,39 @@ async def cache_store_node(
     )
     start = time.perf_counter()
 
-    # Store in semantic cache if we have both response and embedding (allowlisted types only)
+    # Store in semantic cache if we have both response and embedding.
     stored_semantic = False
-    if response and embedding:
-        if query_type in CACHEABLE_QUERY_TYPES:
-            try:
-                # Voice path: agent_role intentionally omitted (no role context in graph state).
-                await cache.store_semantic(
-                    query=query,
-                    response=response,
-                    vector=embedding,
-                    query_type=query_type,
-                    cache_scope="rag",
-                )
-                stored_semantic = True
-            except Exception as exc:
-                # RedisVLError, RedisSearchError, SchemaValidationError, or any unexpected
-                # error from store_semantic must never lose the response (#524).
-                logger.warning(
-                    "cache_store: semantic store failed, response preserved: %s: %s",
-                    type(exc).__name__,
-                    exc,
-                )
+    if response and embedding and query_type in CACHEABLE_QUERY_TYPES:
+        decision = build_cacheability_decision(
+            result=state,
+            query_type=query_type,
+            grounding_mode=str(state.get("grounding_mode", "normal") or "normal"),
+            documents=state.get("documents", []),
+            cache_hit=bool(state.get("cache_hit", False)),
+            contextual=False,
+            grade_confidence=float(state.get("grade_confidence", 0.0) or 0.0),
+            confidence_threshold=0.0,
+            schema_version=SEMANTIC_CACHE_SCHEMA_VERSION,
+        )
+        try:
+            # Voice path: agent_role intentionally omitted (no role context in graph state).
+            stored_semantic = await maybe_store_semantic_response(
+                cache=cache,
+                query=query,
+                response=response,
+                vector=embedding,
+                query_type=query_type,
+                cache_scope="rag",
+                decision=decision,
+            )
+        except Exception as exc:
+            # RedisVLError, RedisSearchError, SchemaValidationError, or any unexpected
+            # error from store_semantic must never lose the response (#524).
+            logger.warning(
+                "cache_store: semantic store failed, response preserved: %s: %s",
+                type(exc).__name__,
+                exc,
+            )
 
         if stored_semantic:
             logger.info("cache_store: stored=semantic (type=%s)", query_type)

--- a/telegram_bot/graph/state.py
+++ b/telegram_bot/graph/state.py
@@ -53,6 +53,8 @@ class RAGState(TypedDict):
     llm_decode_ms: float | None
     llm_tps: float | None
     llm_queue_ms: float | None
+    fallback_used: bool
+    safe_fallback_used: bool
     llm_timeout: bool
     llm_stream_recovery: bool
     streaming_enabled: bool
@@ -135,6 +137,8 @@ def make_initial_state(user_id: int, session_id: str, query: str) -> dict[str, A
         "llm_decode_ms": None,
         "llm_tps": None,
         "llm_queue_ms": None,
+        "fallback_used": False,
+        "safe_fallback_used": False,
         "llm_timeout": False,
         "llm_stream_recovery": False,
         "streaming_enabled": False,

--- a/telegram_bot/integrations/cache.py
+++ b/telegram_bot/integrations/cache.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 CACHE_VERSION = "v5"
-SEMANTIC_CACHE_VERSION = "v6"
+SEMANTIC_CACHE_VERSION = "v7"
 
 # Default TTLs per exact-cache tier (seconds)
 DEFAULT_TTLS: dict[str, int] = {
@@ -91,6 +91,9 @@ def _create_semantic_cache(
                 {"name": "agent_role", "type": "tag"},
                 {"name": "grounding_mode", "type": "tag"},
                 {"name": "semantic_cache_safe_reuse", "type": "tag"},
+                {"name": "response_state", "type": "tag"},
+                {"name": "cache_eligible", "type": "tag"},
+                {"name": "schema_version", "type": "tag"},
             ],
         )
         logger.info("SemanticCache initialized (threshold=%.2f, ttl=%ds)", distance_threshold, ttl)
@@ -288,6 +291,10 @@ class CacheLayerManager:
                 filter_expr = filter_expr & (Tag("user_id") == str(user_id))
             if cache_scope is not None:
                 filter_expr = filter_expr & (Tag("cache_scope") == cache_scope)
+                if cache_scope == "rag":
+                    filter_expr = filter_expr & (Tag("response_state") == "ok")
+                    filter_expr = filter_expr & (Tag("cache_eligible") == "true")
+                    filter_expr = filter_expr & (Tag("schema_version") == SEMANTIC_CACHE_VERSION)
             if agent_role is not None:
                 filter_expr = filter_expr & (Tag("agent_role") == agent_role)
             if grounding_mode is not None:
@@ -404,6 +411,12 @@ class CacheLayerManager:
                 filters["semantic_cache_safe_reuse"] = str(
                     bool(metadata["semantic_cache_safe_reuse"])
                 ).lower()
+            if "response_state" in metadata:
+                filters["response_state"] = str(metadata["response_state"])
+            if "cache_eligible" in metadata:
+                filters["cache_eligible"] = str(bool(metadata["cache_eligible"])).lower()
+            if "schema_version" in metadata:
+                filters["schema_version"] = str(metadata["schema_version"])
         try:
             await self.semantic_cache.astore(
                 prompt=query,

--- a/telegram_bot/pipelines/client.py
+++ b/telegram_bot/pipelines/client.py
@@ -17,11 +17,13 @@ from telegram_bot.graph.nodes.respond import _MAX_SOURCES, format_sources
 from telegram_bot.observability import get_client, observe
 from telegram_bot.pipelines.state_contract import coerce_pre_agent_state_contract
 from telegram_bot.scoring import score, write_langfuse_scores
-from telegram_bot.services.generate_response import generate_response
-from telegram_bot.services.grounding_policy import (
-    get_grounding_mode,
-    semantic_cache_safe_reuse_allowed,
+from telegram_bot.services.cache_policy import (
+    SEMANTIC_CACHE_SCHEMA_VERSION,
+    build_cacheability_decision,
+    maybe_store_semantic_response,
 )
+from telegram_bot.services.generate_response import generate_response
+from telegram_bot.services.grounding_policy import get_grounding_mode
 from telegram_bot.services.history_service import HistoryService
 from telegram_bot.services.telegram_formatting import send_html_messages
 from telegram_bot.services.types import PipelineResult
@@ -135,24 +137,6 @@ def _safe_langfuse_env(config: Any) -> str:
 def _is_contextual_query(user_text: str) -> bool:
     """Return True if query contains follow-up pronouns / contextual references."""
     return bool(_CONTEXTUAL_RE.search(user_text))
-
-
-def _semantic_cache_metadata(result: dict[str, Any], grounding_mode: str) -> dict[str, Any]:
-    return {
-        "grounding_mode": grounding_mode,
-        "legal_answer_safe": bool(result.get("legal_answer_safe", True)),
-        "semantic_cache_safe_reuse": bool(result.get("semantic_cache_safe_reuse", True)),
-    }
-
-
-def _strict_cache_safe_to_store(result: dict[str, Any], grounding_mode: str) -> bool:
-    return semantic_cache_safe_reuse_allowed(
-        grounding_mode=grounding_mode,
-        grounded=bool(result.get("grounded", True)),
-        legal_answer_safe=bool(result.get("legal_answer_safe", True)),
-        semantic_cache_safe_reuse=bool(result.get("semantic_cache_safe_reuse", True)),
-        safe_fallback_used=bool(result.get("safe_fallback_used", False)),
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -431,6 +415,28 @@ async def run_client_pipeline(
     topic_hint_value = topic_hint if isinstance(topic_hint, str) else ""
     result_grounding_mode: Any = result.get("grounding_mode")
     grounding_mode_value = result_grounding_mode if isinstance(result_grounding_mode, str) else ""
+    store_vector = result.get("cache_key_embedding") or result.get("query_embedding")
+    grade_confidence = float(result.get("grade_confidence", 0.0))
+    raw_threshold = getattr(config, "relevance_threshold_rrf", _CONFIDENCE_THRESHOLD)
+    confidence_threshold = (
+        float(raw_threshold) if isinstance(raw_threshold, Real) else _CONFIDENCE_THRESHOLD
+    )
+    decision = build_cacheability_decision(
+        result=result,
+        query_type=query_type,
+        grounding_mode=grounding_mode_value,
+        documents=documents_list,
+        cache_hit=bool(result.get("cache_hit", False)),
+        contextual=_is_contextual_query(user_text),
+        grade_confidence=grade_confidence,
+        confidence_threshold=confidence_threshold,
+        schema_version=SEMANTIC_CACHE_SCHEMA_VERSION,
+    )
+    result["response_state"] = decision.response_state
+    result["degraded_reason"] = decision.degraded_reason
+    result["cache_eligible"] = decision.cache_eligible
+    result["store_reason"] = decision.store_reason
+
     trace_metadata = {
         "route": "client_direct",
         "pipeline_mode": "client_direct",
@@ -443,6 +449,9 @@ async def run_client_pipeline(
         "legal_answer_safe": bool(result.get("legal_answer_safe", True)),
         "semantic_cache_safe_reuse": bool(result.get("semantic_cache_safe_reuse", True)),
         "safe_fallback_used": bool(result.get("safe_fallback_used", False)),
+        "response_state": decision.response_state,
+        "degraded_reason": decision.degraded_reason,
+        "cache_eligible": decision.cache_eligible,
         "collection": _safe_collection_name(config),
         "environment": _safe_langfuse_env(config),
         "pipeline_wall_ms": wall_ms,
@@ -451,37 +460,17 @@ async def run_client_pipeline(
     }
     _store.update(trace_metadata)
 
-    # Cache store — apply guards: type, contextual, confidence, source presence.
-    store_vector = result.get("cache_key_embedding") or result.get("query_embedding")
-    grade_confidence = float(result.get("grade_confidence", 0.0))
-    raw_threshold = getattr(config, "relevance_threshold_rrf", _CONFIDENCE_THRESHOLD)
-    confidence_threshold = (
-        float(raw_threshold) if isinstance(raw_threshold, Real) else _CONFIDENCE_THRESHOLD
-    )
-
-    should_store = (
-        cache
-        and response_text
-        and query_type in _PIPELINE_STORE_TYPES
-        and not result.get("cache_hit", False)
-        and isinstance(store_vector, list)
-        and bool(store_vector)
-        and not _is_contextual_query(user_text)
-        and grade_confidence >= confidence_threshold
-        and bool(documents_list)
-        and _strict_cache_safe_to_store(result, grounding_mode_value)
-    )
-
-    if should_store:
+    if cache and isinstance(store_vector, list) and bool(store_vector):
         try:
-            await cache.store_semantic(
+            await maybe_store_semantic_response(
+                cache=cache,
                 query=user_text,
                 response=response_text,
                 vector=store_vector,
                 query_type=query_type,
                 cache_scope="rag",
+                decision=decision,
                 agent_role=role,
-                metadata=_semantic_cache_metadata(result, grounding_mode_value),
             )
         except Exception:
             logger.warning("Failed to store semantic cache in client pipeline", exc_info=True)

--- a/telegram_bot/services/cache_policy.py
+++ b/telegram_bot/services/cache_policy.py
@@ -8,6 +8,7 @@ from telegram_bot.services.grounding_policy import semantic_cache_safe_reuse_all
 
 
 _SEMANTIC_CACHEABLE_QUERY_TYPES = {"ENTITY", "FAQ", "GENERAL", "STRUCTURED"}
+SEMANTIC_CACHE_SCHEMA_VERSION = "v7"
 
 
 @dataclass(slots=True, frozen=True)
@@ -53,13 +54,13 @@ def build_cacheability_decision(
     confidence_threshold: float,
     schema_version: str,
 ) -> SemanticCacheDecision:
-    del grade_confidence, confidence_threshold
-
     normalized_query_type = _normalize_query_type(query_type)
     response_state, degraded_reason = _classify_response_state(result)
+    response_text = str(result.get("response", "") or "").strip()
     grounded = bool(result.get("grounded", False))
     legal_answer_safe = bool(result.get("legal_answer_safe", False))
     safe_reuse_flag = bool(result.get("semantic_cache_safe_reuse", False))
+    meets_confidence_gate = grade_confidence >= confidence_threshold
 
     strict_safe_reuse = semantic_cache_safe_reuse_allowed(
         grounding_mode=grounding_mode,
@@ -72,10 +73,12 @@ def build_cacheability_decision(
     cache_eligible = all(
         (
             response_state == "ok",
+            bool(response_text),
             not cache_hit,
             not contextual,
             normalized_query_type in _SEMANTIC_CACHEABLE_QUERY_TYPES,
             bool(documents),
+            meets_confidence_gate,
             strict_safe_reuse,
         )
     )
@@ -85,6 +88,7 @@ def build_cacheability_decision(
         "created_at": int(time()),
         "degraded_reason": degraded_reason,
         "grounding_mode": grounding_mode,
+        "legal_answer_safe": legal_answer_safe,
         "provider_model": str(result.get("llm_provider_model", "") or ""),
         "query_type": normalized_query_type,
         "response_state": response_state,

--- a/telegram_bot/services/cache_policy.py
+++ b/telegram_bot/services/cache_policy.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from time import time
+from typing import Any
+
+from telegram_bot.services.grounding_policy import semantic_cache_safe_reuse_allowed
+
+
+_SEMANTIC_CACHEABLE_QUERY_TYPES = {"ENTITY", "FAQ", "GENERAL", "STRUCTURED"}
+
+
+@dataclass(slots=True, frozen=True)
+class SemanticCacheDecision:
+    response_state: str
+    degraded_reason: str | None
+    cache_eligible: bool
+    metadata: dict[str, Any]
+    store_reason: str
+
+
+def _normalize_query_type(query_type: str) -> str:
+    return str(query_type or "").strip().upper()
+
+
+def _classify_response_state(result: dict[str, Any]) -> tuple[str, str | None]:
+    response_text = str(result.get("response", "") or "").strip()
+    fallback_used = bool(result.get("fallback_used", False))
+    safe_fallback_used = bool(result.get("safe_fallback_used", False))
+    provider_model = str(result.get("llm_provider_model", "") or "")
+    llm_timeout = bool(result.get("llm_timeout", False))
+
+    if safe_fallback_used:
+        return "safe_fallback", "safe_fallback"
+    if fallback_used or provider_model == "fallback":
+        return "fallback", "provider_fallback"
+    if not response_text:
+        return "error", "empty_response"
+    if llm_timeout:
+        return "degraded", "timeout"
+    return "ok", None
+
+
+def build_cacheability_decision(
+    *,
+    result: dict[str, Any],
+    query_type: str,
+    grounding_mode: str,
+    documents: list[dict[str, Any]],
+    cache_hit: bool,
+    contextual: bool,
+    grade_confidence: float,
+    confidence_threshold: float,
+    schema_version: str,
+) -> SemanticCacheDecision:
+    del grade_confidence, confidence_threshold
+
+    normalized_query_type = _normalize_query_type(query_type)
+    response_state, degraded_reason = _classify_response_state(result)
+    grounded = bool(result.get("grounded", False))
+    legal_answer_safe = bool(result.get("legal_answer_safe", False))
+    safe_reuse_flag = bool(result.get("semantic_cache_safe_reuse", False))
+
+    strict_safe_reuse = semantic_cache_safe_reuse_allowed(
+        grounding_mode=grounding_mode,
+        grounded=grounded,
+        legal_answer_safe=legal_answer_safe,
+        semantic_cache_safe_reuse=safe_reuse_flag,
+        safe_fallback_used=bool(result.get("safe_fallback_used", False)),
+    )
+
+    cache_eligible = all(
+        (
+            response_state == "ok",
+            not cache_hit,
+            not contextual,
+            normalized_query_type in _SEMANTIC_CACHEABLE_QUERY_TYPES,
+            bool(documents),
+            strict_safe_reuse,
+        )
+    )
+
+    metadata = {
+        "cache_eligible": cache_eligible,
+        "created_at": int(time()),
+        "degraded_reason": degraded_reason,
+        "grounding_mode": grounding_mode,
+        "provider_model": str(result.get("llm_provider_model", "") or ""),
+        "query_type": normalized_query_type,
+        "response_state": response_state,
+        "schema_version": schema_version,
+        "semantic_cache_safe_reuse": safe_reuse_flag,
+    }
+    store_reason = (
+        "store_allowed" if cache_eligible else f"skip_{degraded_reason or response_state}"
+    )
+
+    return SemanticCacheDecision(
+        response_state=response_state,
+        degraded_reason=degraded_reason,
+        cache_eligible=cache_eligible,
+        metadata=metadata,
+        store_reason=store_reason,
+    )
+
+
+async def maybe_store_semantic_response(
+    *,
+    cache: Any,
+    query: str,
+    response: str,
+    vector: list[float],
+    query_type: str,
+    cache_scope: str,
+    decision: SemanticCacheDecision,
+    agent_role: str | None = None,
+) -> bool:
+    if cache_scope != "rag":
+        return False
+    if not str(response or "").strip():
+        return False
+    if not decision.cache_eligible:
+        return False
+
+    await cache.store_semantic(
+        query=query,
+        response=response,
+        vector=vector,
+        query_type=query_type,
+        cache_scope=cache_scope,
+        agent_role=agent_role,
+        metadata=decision.metadata,
+    )
+    return True

--- a/telegram_bot/services/generate_response.py
+++ b/telegram_bot/services/generate_response.py
@@ -186,6 +186,15 @@ def _sanitize_response_text(answer: str, *, sources_enabled: bool) -> str:
     return sanitized or answer.strip()
 
 
+def _ensure_generation_signal_defaults(result: dict[str, Any]) -> dict[str, Any]:
+    """Normalize raw cacheability signals across every generation return path."""
+    llm_provider_model = str(result.get("llm_provider_model", "") or "")
+    result.setdefault("fallback_used", llm_provider_model == "fallback")
+    result.setdefault("safe_fallback_used", False)
+    result.setdefault("llm_timeout", False)
+    return result
+
+
 def _build_fallback_response(documents: list[dict[str, Any]]) -> str:
     """Build fallback response from retrieved documents when LLM fails."""
     if not documents:
@@ -547,36 +556,38 @@ async def generate_response(
                 "response_sent": False,
             }
         )
-        return {
-            "response": answer,
-            "response_sent": False,
-            "sent_message": None,
-            "llm_provider_model": "safe_fallback",
-            "llm_ttft_ms": 0.0,
-            "llm_response_duration_ms": elapsed * 1000,
-            "llm_stream_only_ttft_ms": None,
-            "llm_ttft_drift_ms": None,
-            "llm_call_count": max(0, int(llm_call_count)),
-            "latency_stages": {**current_latency, "generate": elapsed},
-            "llm_decode_ms": None,
-            "llm_tps": None,
-            "llm_queue_ms": None,
-            "llm_timeout": False,
-            "llm_stream_recovery": False,
-            "streaming_enabled": False,
-            "response_style": style_info.style,
-            "response_difficulty": style_info.difficulty,
-            "response_style_reasoning": style_info.reasoning,
-            "answer_words": len(answer.split()),
-            "answer_chars": len(answer),
-            "answer_to_question_ratio": len(answer.split()) / max(style_info.word_count, 1),
-            "response_policy_mode": "safe_fallback",
-            "grounding_mode": grounding_mode,
-            "safe_fallback_used": True,
-            "grounded": False,
-            "legal_answer_safe": False,
-            "semantic_cache_safe_reuse": False,
-        }
+        return _ensure_generation_signal_defaults(
+            {
+                "response": answer,
+                "response_sent": False,
+                "sent_message": None,
+                "llm_provider_model": "safe_fallback",
+                "llm_ttft_ms": 0.0,
+                "llm_response_duration_ms": elapsed * 1000,
+                "llm_stream_only_ttft_ms": None,
+                "llm_ttft_drift_ms": None,
+                "llm_call_count": max(0, int(llm_call_count)),
+                "latency_stages": {**current_latency, "generate": elapsed},
+                "llm_decode_ms": None,
+                "llm_tps": None,
+                "llm_queue_ms": None,
+                "llm_timeout": False,
+                "llm_stream_recovery": False,
+                "streaming_enabled": False,
+                "response_style": style_info.style,
+                "response_difficulty": style_info.difficulty,
+                "response_style_reasoning": style_info.reasoning,
+                "answer_words": len(answer.split()),
+                "answer_chars": len(answer),
+                "answer_to_question_ratio": len(answer.split()) / max(style_info.word_count, 1),
+                "response_policy_mode": "safe_fallback",
+                "grounding_mode": grounding_mode,
+                "safe_fallback_used": True,
+                "grounded": False,
+                "legal_answer_safe": False,
+                "semantic_cache_safe_reuse": False,
+            }
+        )
 
     style_enabled = bool(getattr(config, "response_style_enabled", False))
     shadow_mode = bool(getattr(config, "response_style_shadow_mode", False))
@@ -924,35 +935,37 @@ async def generate_response(
     current_latency = latency_stages or {}
     current_llm_calls = max(0, int(llm_call_count))
 
-    return {
-        "response": answer,
-        "response_sent": response_sent,
-        "sent_message": sent_message_ref,
-        "llm_provider_model": actual_model,
-        "llm_ttft_ms": ttft_ms,
-        "llm_response_duration_ms": elapsed * 1000,
-        "llm_stream_only_ttft_ms": stream_only_ttft_ms,
-        "llm_ttft_drift_ms": llm_ttft_drift_ms,
-        "llm_call_count": current_llm_calls + 1,
-        "latency_stages": {**current_latency, "generate": elapsed},
-        # Latency breakdown (#147)
-        "llm_decode_ms": llm_decode_ms,
-        "llm_tps": llm_tps,
-        "llm_queue_ms": llm_queue_ms,
-        "llm_timeout": hard_timeout,
-        "llm_stream_recovery": stream_recovery,
-        "streaming_enabled": streaming_was_enabled,
-        # Response length control (#129)
-        "response_style": style_info.style,
-        "response_difficulty": style_info.difficulty,
-        "response_style_reasoning": style_info.reasoning,
-        "answer_words": answer_words,
-        "answer_chars": answer_chars,
-        "answer_to_question_ratio": ratio,
-        "response_policy_mode": response_policy_mode,
-        "grounding_mode": grounding_mode,
-        "safe_fallback_used": False,
-        "grounded": True,
-        "legal_answer_safe": legal_answer_safe,
-        "semantic_cache_safe_reuse": legal_answer_safe,
-    }
+    return _ensure_generation_signal_defaults(
+        {
+            "response": answer,
+            "response_sent": response_sent,
+            "sent_message": sent_message_ref,
+            "llm_provider_model": actual_model,
+            "llm_ttft_ms": ttft_ms,
+            "llm_response_duration_ms": elapsed * 1000,
+            "llm_stream_only_ttft_ms": stream_only_ttft_ms,
+            "llm_ttft_drift_ms": llm_ttft_drift_ms,
+            "llm_call_count": current_llm_calls + 1,
+            "latency_stages": {**current_latency, "generate": elapsed},
+            # Latency breakdown (#147)
+            "llm_decode_ms": llm_decode_ms,
+            "llm_tps": llm_tps,
+            "llm_queue_ms": llm_queue_ms,
+            "llm_timeout": hard_timeout,
+            "llm_stream_recovery": stream_recovery,
+            "streaming_enabled": streaming_was_enabled,
+            # Response length control (#129)
+            "response_style": style_info.style,
+            "response_difficulty": style_info.difficulty,
+            "response_style_reasoning": style_info.reasoning,
+            "answer_words": answer_words,
+            "answer_chars": answer_chars,
+            "answer_to_question_ratio": ratio,
+            "response_policy_mode": response_policy_mode,
+            "grounding_mode": grounding_mode,
+            "safe_fallback_used": False,
+            "grounded": True,
+            "legal_answer_safe": legal_answer_safe,
+            "semantic_cache_safe_reuse": legal_answer_safe,
+        }
+    )

--- a/tests/integration/test_graph_paths.py
+++ b/tests/integration/test_graph_paths.py
@@ -343,6 +343,9 @@ async def test_path_general_uses_semantic_cache():
     mocks["cache"].check_semantic.assert_awaited_once()
     # Semantic cache IS stored after generate
     mocks["cache"].store_semantic.assert_awaited_once()
+    metadata = mocks["cache"].store_semantic.await_args.kwargs["metadata"]
+    assert metadata["response_state"] == "ok"
+    assert metadata["cache_eligible"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -393,6 +396,41 @@ async def test_path_happy_retrieve_rerank_generate():
 
     # Cache stored (semantic only — memory owned by checkpointer)
     mocks["cache"].store_semantic.assert_awaited_once()
+    metadata = mocks["cache"].store_semantic.await_args.kwargs["metadata"]
+    assert metadata["response_state"] == "ok"
+    assert metadata["cache_eligible"] is True
+
+
+@pytest.mark.integration
+async def test_path_generate_fallback_does_not_store_semantic():
+    """LLM fallback still returns a response, but semantic cache store is skipped."""
+    mocks = _make_graph_mocks()
+    mocks["llm"].chat.completions.create = AsyncMock(side_effect=Exception("LLM unavailable"))
+    mock_gc = _make_mock_graph_config(mocks["llm"])
+
+    with _patch_graph_configs(mock_gc):
+        graph = build_graph(
+            cache=mocks["cache"],
+            embeddings=mocks["embeddings"],
+            sparse_embeddings=mocks["sparse_embeddings"],
+            qdrant=mocks["qdrant"],
+            reranker=mocks["reranker"],
+            llm=mocks["llm"],
+            message=mocks["message"],
+        )
+
+    state = make_initial_state(
+        user_id=11, session_id="test-fallback-no-store", query="квартира в Несебре у моря"
+    )
+
+    with traced_pipeline(session_id="test-fallback-no-store", user_id="integration"):
+        with _patch_graph_configs(mock_gc):
+            result = await graph.ainvoke(state)
+
+    assert result["response"]
+    assert result["llm_provider_model"] == "fallback"
+    assert result["fallback_used"] is True
+    mocks["cache"].store_semantic.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/graph/test_cache_nodes.py
+++ b/tests/unit/graph/test_cache_nodes.py
@@ -267,19 +267,24 @@ class TestCacheStoreNode:
         state["query_type"] = "FAQ"
         state["query_embedding"] = [0.1] * 1024
         state["response"] = "generated answer"
+        state["documents"] = [{"text": "doc", "score": 0.9, "metadata": {}}]
+        state["grade_confidence"] = 0.9
 
         cache = AsyncMock()
         cache.store_semantic = AsyncMock()
 
         result = await cache_store_node(state, _make_runtime(cache=cache))
 
-        cache.store_semantic.assert_awaited_once_with(
-            query="test query",
-            response="generated answer",
-            vector=[0.1] * 1024,
-            query_type="FAQ",
-            cache_scope="rag",
-        )
+        cache.store_semantic.assert_awaited_once()
+        call_kwargs = cache.store_semantic.await_args.kwargs
+        assert call_kwargs["query"] == "test query"
+        assert call_kwargs["response"] == "generated answer"
+        assert call_kwargs["vector"] == [0.1] * 1024
+        assert call_kwargs["query_type"] == "FAQ"
+        assert call_kwargs["cache_scope"] == "rag"
+        assert call_kwargs["metadata"]["response_state"] == "ok"
+        assert call_kwargs["metadata"]["cache_eligible"] is True
+        assert call_kwargs["metadata"]["schema_version"] == "v7"
         assert result["response"] == "generated answer"
 
     async def test_general_stores_to_semantic_cache(self):
@@ -288,6 +293,8 @@ class TestCacheStoreNode:
         state["query_type"] = "GENERAL"
         state["query_embedding"] = [0.1] * 1024
         state["response"] = "generated answer"
+        state["documents"] = [{"text": "doc", "score": 0.9, "metadata": {}}]
+        state["grade_confidence"] = 0.9
 
         cache = AsyncMock()
         cache.store_semantic = AsyncMock()
@@ -303,6 +310,8 @@ class TestCacheStoreNode:
         state["query_type"] = "FAQ"
         state["query_embedding"] = [0.1] * 1024
         state["response"] = "generated answer"
+        state["documents"] = [{"text": "doc", "score": 0.9, "metadata": {}}]
+        state["grade_confidence"] = 0.9
 
         cache = AsyncMock()
         cache.store_semantic = AsyncMock()
@@ -318,6 +327,8 @@ class TestCacheStoreNode:
         state["query_type"] = "FAQ"
         state["query_embedding"] = [0.1] * 1024
         state["response"] = "generated answer"
+        state["documents"] = [{"text": "doc", "score": 0.9, "metadata": {}}]
+        state["grade_confidence"] = 0.9
 
         cache = AsyncMock()
         cache.store_semantic = AsyncMock()
@@ -346,6 +357,25 @@ class TestCacheStoreNode:
         state["query_type"] = "GENERAL"
         state["query_embedding"] = None
         state["response"] = "answer"
+
+        cache = AsyncMock()
+        cache.store_semantic = AsyncMock()
+
+        await cache_store_node(state, _make_runtime(cache=cache))
+
+        cache.store_semantic.assert_not_awaited()
+
+    async def test_cache_store_node_skips_provider_fallback_response(self):
+        state = make_initial_state(user_id=1, session_id="s1", query="test query")
+        state["query_type"] = "FAQ"
+        state["query_embedding"] = [0.1] * 1024
+        state["response"] = "⚠️ fallback text"
+        state["documents"] = [{"text": "doc", "score": 0.9, "metadata": {}}]
+        state["grade_confidence"] = 0.9
+        state["fallback_used"] = True
+        state["safe_fallback_used"] = False
+        state["llm_provider_model"] = "fallback"
+        state["llm_timeout"] = True
 
         cache = AsyncMock()
         cache.store_semantic = AsyncMock()

--- a/tests/unit/graph/test_generate_node.py
+++ b/tests/unit/graph/test_generate_node.py
@@ -821,6 +821,8 @@ class TestGenerateNodeProviderMetadata:
             result = await generate_node(state)
 
         assert result["llm_provider_model"] == "fallback"
+        assert result["fallback_used"] is True
+        assert result["safe_fallback_used"] is False
         assert result["llm_ttft_ms"] == 0.0
         assert result["llm_response_duration_ms"] > 0
 

--- a/tests/unit/integrations/test_cache_layers.py
+++ b/tests/unit/integrations/test_cache_layers.py
@@ -76,7 +76,7 @@ class TestCacheLayerManagerInit:
     def test_cache_versions_reflect_schema_boundaries(self):
         """Semantic cache schema changed, but exact-cache namespaces stay stable."""
         assert CACHE_VERSION == "v5"
-        assert SEMANTIC_CACHE_VERSION == "v6"
+        assert SEMANTIC_CACHE_VERSION == "v7"
 
 
 class TestCacheLayerManagerInitialize:
@@ -702,6 +702,32 @@ class TestScopeRoleIsolation:
         assert call_kwargs["filters"]["semantic_cache_safe_reuse"] == "true"
         assert call_kwargs["metadata"]["grounding_mode"] == "strict"
 
+    async def test_store_semantic_includes_response_state_cache_eligible_and_schema_version(
+        self, _ensure_redisvl_filter_mock
+    ):
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        mgr.semantic_cache = AsyncMock()
+        mgr.semantic_cache.astore = AsyncMock()
+        mgr.cache_ttl = {"FAQ": 86400}
+
+        await mgr.store_semantic(
+            query="test",
+            response="answer",
+            vector=[0.1] * 1024,
+            query_type="FAQ",
+            cache_scope="rag",
+            metadata={
+                "response_state": "ok",
+                "cache_eligible": True,
+                "schema_version": "v7",
+            },
+        )
+
+        call_kwargs = mgr.semantic_cache.astore.call_args[1]
+        assert call_kwargs["filters"]["response_state"] == "ok"
+        assert call_kwargs["filters"]["cache_eligible"] == "true"
+        assert call_kwargs["filters"]["schema_version"] == "v7"
+
     async def test_check_semantic_passes_scope_filter(self, _ensure_redisvl_filter_mock):
         """check_semantic with cache_scope passes filter_expression."""
         mgr = CacheLayerManager(redis_url="redis://localhost:6379")
@@ -719,6 +745,40 @@ class TestScopeRoleIsolation:
         )
 
         assert result == "scoped answer"
+        call_kwargs = mgr.semantic_cache.acheck.call_args[1]
+        assert call_kwargs.get("filter_expression") is not None
+
+    async def test_check_semantic_rag_scope_requires_ok_eligible_current_schema(self):
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        mgr.semantic_cache = AsyncMock()
+        mgr.semantic_cache.acheck = AsyncMock(
+            return_value=[{"response": "scoped answer", "vector_distance": 0.05}]
+        )
+        mgr.cache_thresholds = {"FAQ": 0.12}
+
+        seen_tag_names: list[str] = []
+
+        class _SpyTag:
+            def __init__(self, name: str):
+                self.name = name
+                seen_tag_names.append(name)
+
+            def __eq__(self, _other):
+                return self
+
+            def __and__(self, _other):
+                return self
+
+        with patch("redisvl.query.filter.Tag", _SpyTag):
+            result = await mgr.check_semantic(
+                query="test",
+                vector=[0.1] * 1024,
+                query_type="FAQ",
+                cache_scope="rag",
+            )
+
+        assert result == "scoped answer"
+        assert {"response_state", "cache_eligible", "schema_version"}.issubset(set(seen_tag_names))
         call_kwargs = mgr.semantic_cache.acheck.call_args[1]
         assert call_kwargs.get("filter_expression") is not None
 

--- a/tests/unit/integrations/test_event_stream.py
+++ b/tests/unit/integrations/test_event_stream.py
@@ -120,6 +120,8 @@ class TestCacheStoreNodeEventStream:
         state["query_type"] = "FAQ"  # Must be cacheable type (FAQ/ENTITY/STRUCTURED)
         state["query_embedding"] = [0.1] * 1024
         state["response"] = "answer"
+        state["documents"] = [{"text": "doc", "score": 0.9, "metadata": {}}]
+        state["grade_confidence"] = 0.9
 
         cache = AsyncMock()
         cache.store_semantic = AsyncMock()

--- a/tests/unit/pipelines/test_client_pipeline.py
+++ b/tests/unit/pipelines/test_client_pipeline.py
@@ -1078,11 +1078,63 @@ class TestCacheStoreGuards:
             )
 
         mock_cache.store_semantic.assert_called_once()
-        assert mock_cache.store_semantic.await_args.kwargs["metadata"] == {
-            "grounding_mode": "strict",
-            "legal_answer_safe": True,
-            "semantic_cache_safe_reuse": True,
+        metadata = mock_cache.store_semantic.await_args.kwargs["metadata"]
+        assert metadata["grounding_mode"] == "strict"
+        assert metadata["legal_answer_safe"] is True
+        assert metadata["semantic_cache_safe_reuse"] is True
+        assert metadata["response_state"] == "ok"
+        assert metadata["cache_eligible"] is True
+        assert metadata["schema_version"] == "v7"
+
+    async def test_provider_fallback_skips_cache_store_even_without_safe_fallback(self):
+        msg = _make_message()
+        lf = _make_lf_client()
+        mock_cache = AsyncMock()
+
+        rag_result = {
+            "response": "",
+            "cache_hit": False,
+            "documents": [{"metadata": {"title": "Doc"}, "score": 0.9}],
+            "grade_confidence": _CONFIDENCE_THRESHOLD + 0.1,
+            "llm_call_count": 0,
+            "latency_stages": {},
+            "cache_key_embedding": [0.1, 0.2, 0.3],
         }
+        gen_result = {
+            "response": "⚠️ fallback text",
+            "response_sent": False,
+            "fallback_used": True,
+            "safe_fallback_used": False,
+            "llm_provider_model": "fallback",
+            "llm_timeout": True,
+            "grounded": False,
+            "legal_answer_safe": False,
+            "semantic_cache_safe_reuse": False,
+        }
+
+        with (
+            _patch_observability(lf),
+            _patch_rag_pipeline(rag_result),
+            _patch_generate_response(gen_result),
+            patch("telegram_bot.pipelines.client.write_langfuse_scores"),
+            patch("telegram_bot.pipelines.client.score"),
+        ):
+            await run_client_pipeline(
+                user_text="Расскажи про рынок в Несебре",
+                user_id=1,
+                session_id="s1",
+                message=msg,
+                cache=mock_cache,
+                embeddings=MagicMock(),
+                sparse_embeddings=MagicMock(),
+                qdrant=MagicMock(),
+                reranker=None,
+                llm=None,
+                config=_make_config(),
+                query_type="GENERAL",
+            )
+
+        mock_cache.store_semantic.assert_not_called()
 
     async def test_strict_mode_unsafe_result_skips_cache_store(self):
         msg = _make_message()
@@ -1184,6 +1236,9 @@ class TestCacheStoreGuards:
         metadata = mock_cache.store_semantic.await_args.kwargs["metadata"]
         assert metadata["grounding_mode"] == "strict"
         assert metadata["semantic_cache_safe_reuse"] is True
+        assert metadata["response_state"] == "ok"
+        assert metadata["cache_eligible"] is True
+        assert metadata["schema_version"] == "v7"
 
     async def test_structured_query_type_stores_cache(self):
         """STRUCTURED query type is in _PIPELINE_STORE_TYPES, so cache store is enabled."""

--- a/tests/unit/pipelines/test_client_pipeline.py
+++ b/tests/unit/pipelines/test_client_pipeline.py
@@ -1053,7 +1053,17 @@ class TestCacheStoreGuards:
             "latency_stages": {},
             "cache_key_embedding": [0.1, 0.2, 0.3],
         }
-        gen_result = {"response": "Good answer", "response_sent": False}
+        gen_result = {
+            "response": "Good answer",
+            "response_sent": False,
+            "grounded": True,
+            "legal_answer_safe": True,
+            "semantic_cache_safe_reuse": True,
+            "safe_fallback_used": False,
+            "llm_provider_model": "gpt-4.1",
+            "fallback_used": False,
+            "llm_timeout": False,
+        }
 
         with (
             _patch_observability(lf),

--- a/tests/unit/services/test_cache_policy.py
+++ b/tests/unit/services/test_cache_policy.py
@@ -1,0 +1,57 @@
+from telegram_bot.services.cache_policy import build_cacheability_decision
+
+
+def test_build_cacheability_decision_marks_provider_fallback_non_cacheable() -> None:
+    decision = build_cacheability_decision(
+        result={
+            "response": "⚠️ Сервис временно недоступен",
+            "fallback_used": True,
+            "safe_fallback_used": False,
+            "llm_provider_model": "fallback",
+            "llm_timeout": True,
+            "grounded": False,
+            "legal_answer_safe": False,
+            "semantic_cache_safe_reuse": False,
+        },
+        query_type="FAQ",
+        grounding_mode="strict",
+        documents=[{"text": "doc"}],
+        cache_hit=False,
+        contextual=False,
+        grade_confidence=0.9,
+        confidence_threshold=0.005,
+        schema_version="v7",
+    )
+
+    assert decision.response_state == "fallback"
+    assert decision.degraded_reason == "provider_fallback"
+    assert decision.cache_eligible is False
+    assert decision.metadata["cache_eligible"] is False
+    assert decision.metadata["response_state"] == "fallback"
+
+
+def test_build_cacheability_decision_marks_ok_response_cacheable() -> None:
+    decision = build_cacheability_decision(
+        result={
+            "response": "Подтвержденный ответ.",
+            "fallback_used": False,
+            "safe_fallback_used": False,
+            "llm_provider_model": "gpt-4.1",
+            "llm_timeout": False,
+            "grounded": True,
+            "legal_answer_safe": True,
+            "semantic_cache_safe_reuse": True,
+        },
+        query_type="FAQ",
+        grounding_mode="strict",
+        documents=[{"text": "doc"}],
+        cache_hit=False,
+        contextual=False,
+        grade_confidence=0.9,
+        confidence_threshold=0.005,
+        schema_version="v7",
+    )
+
+    assert decision.response_state == "ok"
+    assert decision.cache_eligible is True
+    assert decision.metadata["schema_version"] == "v7"

--- a/tests/unit/services/test_generate_response.py
+++ b/tests/unit/services/test_generate_response.py
@@ -170,6 +170,8 @@ async def test_generate_response_fallback_on_llm_error() -> None:
         )
 
     assert "временно недоступен" in result["response"]
+    assert result["fallback_used"] is True
+    assert result["safe_fallback_used"] is False
     assert result["llm_provider_model"] == "fallback"
     assert result["llm_timeout"] is True
 
@@ -188,7 +190,10 @@ async def test_generate_response_returns_safe_fallback_when_strict_mode_has_weak
         raw_messages=[{"role": "user", "content": "виды внж в болгарии"}],
     )
 
+    assert result["fallback_used"] is False
     assert result["safe_fallback_used"] is True
+    assert result["llm_provider_model"] == "safe_fallback"
+    assert result["llm_timeout"] is False
     assert result["grounded"] is False
     assert result["legal_answer_safe"] is False
     client.chat.completions.create.assert_not_awaited()

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -4022,6 +4022,111 @@ def _make_cc_callback_query(data: str, user_id: int = 12345):
     return cq
 
 
+class TestTextPathSemanticCachePolicy:
+    async def test_text_path_provider_fallback_skips_semantic_store(self, mock_config):
+        bot, _ = _create_bot(mock_config)
+        bot._cache = AsyncMock()
+        bot._cache.get_embedding = AsyncMock(return_value=[0.1, 0.2, 0.3])
+        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
+        bot._cache.check_semantic = AsyncMock(return_value=None)
+        bot._cache.store_embedding = AsyncMock()
+        bot._cache.store_semantic = AsyncMock()
+        message = _make_text_message("расскажи про рынок в Несебре")
+
+        def _agent_side_effect(state, config=None, **kw):
+            cfg = config or kw.get("config", {})
+            store = cfg.get("configurable", {}).get("rag_result_store")
+            if isinstance(store, dict):
+                store.update(
+                    {
+                        "query_type": "GENERAL",
+                        "query_embedding": [0.1, 0.2, 0.3],
+                        "documents": [{"text": "doc", "score": 0.9, "metadata": {}}],
+                        "cache_hit": False,
+                        "grade_confidence": 0.9,
+                        "grounding_mode": "normal",
+                        "fallback_used": True,
+                        "safe_fallback_used": False,
+                        "llm_provider_model": "fallback",
+                        "llm_timeout": True,
+                        "grounded": False,
+                        "legal_answer_safe": False,
+                        "semantic_cache_safe_reuse": False,
+                    }
+                )
+            return _mock_agent_result(messages=[MagicMock(content="Ответ агентом")])
+
+        mock_agent = AsyncMock()
+        mock_agent.ainvoke = AsyncMock(side_effect=_agent_side_effect)
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+            patch("telegram_bot.bot.classify_query", return_value="GENERAL"),
+        ):
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        bot._cache.store_semantic.assert_not_awaited()
+
+    async def test_text_path_ok_result_stores_semantic_with_decision_metadata(self, mock_config):
+        bot, _ = _create_bot(mock_config)
+        bot._cache = AsyncMock()
+        bot._cache.get_embedding = AsyncMock(return_value=[0.1, 0.2, 0.3])
+        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
+        bot._cache.check_semantic = AsyncMock(return_value=None)
+        bot._cache.store_embedding = AsyncMock()
+        bot._cache.store_semantic = AsyncMock()
+        message = _make_text_message("какие документы нужны для внж")
+
+        def _agent_side_effect(state, config=None, **kw):
+            cfg = config or kw.get("config", {})
+            store = cfg.get("configurable", {}).get("rag_result_store")
+            if isinstance(store, dict):
+                store.update(
+                    {
+                        "query_type": "FAQ",
+                        "query_embedding": [0.1, 0.2, 0.3],
+                        "documents": [{"text": "doc", "score": 0.9, "metadata": {}}],
+                        "cache_hit": False,
+                        "grade_confidence": 0.9,
+                        "grounding_mode": "strict",
+                        "fallback_used": False,
+                        "safe_fallback_used": False,
+                        "llm_provider_model": "gpt-4.1",
+                        "llm_timeout": False,
+                        "grounded": True,
+                        "legal_answer_safe": True,
+                        "semantic_cache_safe_reuse": True,
+                    }
+                )
+            return _mock_agent_result(messages=[MagicMock(content="Ответ агентом")])
+
+        mock_agent = AsyncMock()
+        mock_agent.ainvoke = AsyncMock(side_effect=_agent_side_effect)
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+            patch("telegram_bot.bot.classify_query", return_value="FAQ"),
+        ):
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        bot._cache.store_semantic.assert_awaited_once()
+        metadata = bot._cache.store_semantic.await_args.kwargs["metadata"]
+        assert metadata["grounding_mode"] == "strict"
+        assert metadata["response_state"] == "ok"
+        assert metadata["cache_eligible"] is True
+        assert metadata["schema_version"] == "v7"
+
+
 class TestClearCacheCommand:
     """Tests for /clearcache command and callback handler."""
 

--- a/tests/unit/test_bot_scores.py
+++ b/tests/unit/test_bot_scores.py
@@ -1069,7 +1069,13 @@ class TestTextPathSemanticCacheStore:
                         "query_type": "FAQ",
                         "query_embedding": [0.1, 0.2, 0.3],
                         "cache_hit": False,
-                        "documents": [],
+                        "documents": [{"text": "doc", "score": 0.9, "metadata": {}}],
+                        "grade_confidence": 0.9,
+                        "grounding_mode": "strict",
+                        "grounded": True,
+                        "legal_answer_safe": True,
+                        "semantic_cache_safe_reuse": True,
+                        "safe_fallback_used": False,
                     }
                 )
             return _mock_agent_result(messages=[MagicMock(content="Ответ агентом")])
@@ -1117,7 +1123,8 @@ class TestTextPathSemanticCacheStore:
                         "query_type": "GENERAL",
                         "query_embedding": [0.1, 0.2, 0.3],
                         "cache_hit": False,
-                        "documents": [],
+                        "documents": [{"text": "doc", "score": 0.9, "metadata": {}}],
+                        "grade_confidence": 0.9,
                     }
                 )
             return _mock_agent_result(messages=[MagicMock(content="Ответ агентом")])
@@ -1209,6 +1216,8 @@ class TestTextPathSemanticCacheStore:
                         "query_type": "FAQ",
                         "query_embedding": [0.1, 0.2, 0.3],
                         "cache_hit": False,
+                        "documents": [{"text": "doc", "score": 0.9, "metadata": {}}],
+                        "grade_confidence": 0.9,
                         "grounding_mode": "strict",
                         "grounded": True,
                         "legal_answer_safe": True,


### PR DESCRIPTION
## Summary
- add a shared semantic cache policy module and route text/graph RAG semantic stores through one canonical decision helper
- standardize generation fallback signals, block degraded/provider-fallback responses from semantic cache reuse, and bump semantic cache schema to `v7`
- add unit and integration regressions for metadata tagging, graph paths, and semantic cache hardening behavior

## Test Plan
- [x] `make check`
- [x] `uv run pytest tests/integration/test_graph_paths.py -n auto --dist=worksteal -q`
- [x] `uv run pytest tests/smoke/test_smoke_bge_litellm_cache.py -q -k semantic_cache_read_write_cycle` (`SKIP`: semantic cache infra unavailable)
- [x] `rg -n "store_semantic\\(" telegram_bot`
- [ ] `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`

## Notes
- `make test-unit` is still red only because of 2 pre-existing unrelated failures in `tests/unit/test_litellm_config_sync.py`.
- The same 2 failures reproduce on the source `dev` workspace outside this branch, so they are not introduced by this PR.
- Repo workflow currently appears to integrate feature PRs into `dev` even though `.github/workflows/ci.yml` only listens to pull requests against `main`.
