### PR TITLE
fix: sync k8s runtime config with compose

### DIFF
--- a/k8s/base/configmaps/litellm-config.yaml
+++ b/k8s/base/configmaps/litellm-config.yaml
@@ -63,6 +63,10 @@ data:
     router_settings:
       retry_policy:
         retry_count: 2
+      # Model-group fallbacks on upstream/provider errors
+      fallbacks:
+        - gpt-4o-mini: [gpt-4o-mini-cerebras-oss, gpt-4o-mini-fallback, gpt-4o-mini-openai]
+        - gpt-oss-120b: [gpt-4o-mini-cerebras-oss, gpt-4o-mini-fallback, gpt-4o-mini-openai]
 
     litellm_settings:
       request_timeout: 600
@@ -71,9 +75,6 @@ data:
       drop_params: true
       success_callback: ["langfuse"]
       failure_callback: ["langfuse"]
-      fallbacks:
-        - gpt-4o-mini: [gpt-4o-mini-cerebras-oss, gpt-4o-mini-fallback, gpt-4o-mini-openai]
-        - gpt-oss-120b: [gpt-4o-mini-cerebras-oss, gpt-4o-mini-fallback, gpt-4o-mini-openai]
 
     environment_variables:
       LANGFUSE_PUBLIC_KEY: os.environ/LANGFUSE_PUBLIC_KEY

--- a/k8s/base/litellm/deployment.yaml
+++ b/k8s/base/litellm/deployment.yaml
@@ -26,7 +26,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: litellm
-          image: ghcr.io/berriai/litellm:main-v1.81.3-stable
+          image: ghcr.io/berriai/litellm:main-v1.81.14-stable
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/k8s/base/qdrant/deployment.yaml
+++ b/k8s/base/qdrant/deployment.yaml
@@ -20,7 +20,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: qdrant
-          image: qdrant/qdrant:v1.16.2
+          image: qdrant/qdrant:v1.17.0
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/k8s/base/redis/deployment.yaml
+++ b/k8s/base/redis/deployment.yaml
@@ -20,7 +20,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: redis
-          image: redis:8.6.0
+          image: redis:8.6.1
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/unit/test_k8s_image_version_sync.py
+++ b/tests/unit/test_k8s_image_version_sync.py
@@ -1,0 +1,48 @@
+"""Guard against image tag drift between compose and k8s core services."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).parents[2]
+COMPOSE = ROOT / "compose.yml"
+K8S_BASE = ROOT / "k8s" / "base"
+
+
+def _load_yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text())
+
+
+def _strip_digest(image: str) -> str:
+    return image.split("@", 1)[0]
+
+
+def _compose_image(service: str) -> str:
+    compose = _load_yaml(COMPOSE)
+    return _strip_digest(compose["services"][service]["image"])
+
+
+def _k8s_image(deployment_path: Path, container_name: str) -> str:
+    deployment = _load_yaml(deployment_path)
+    containers = deployment["spec"]["template"]["spec"]["containers"]
+    container = next(c for c in containers if c["name"] == container_name)
+    return _strip_digest(container["image"])
+
+
+@pytest.mark.parametrize(
+    ("service", "deployment", "container"),
+    [
+        ("qdrant", K8S_BASE / "qdrant" / "deployment.yaml", "qdrant"),
+        ("redis", K8S_BASE / "redis" / "deployment.yaml", "redis"),
+        ("litellm", K8S_BASE / "litellm" / "deployment.yaml", "litellm"),
+    ],
+)
+def test_k8s_image_matches_compose(service: str, deployment: Path, container: str) -> None:
+    assert _k8s_image(deployment, container) == _compose_image(service), (
+        f"{service} image drift: compose={_compose_image(service)!r}, "
+        f"k8s={_k8s_image(deployment, container)!r}"
+    )


### PR DESCRIPTION
## Summary
- sync qdrant, redis, and litellm k8s image tags with compose-pinned versions
- add a regression test that catches compose vs k8s image drift for those services
- sync the k8s LiteLLM ConfigMap fallback routing with docker/litellm/config.yaml so config parity tests pass again

## Test Plan
- [x] make check
- [x] PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit
- [x] uv run pytest tests/unit/test_litellm_config_sync.py -q
- [x] kubectl kustomize --load-restrictor=LoadRestrictionsNone k8s/overlays/core >/dev/null
- [x] kubectl kustomize --load-restrictor=LoadRestrictionsNone k8s/overlays/bot >/dev/null
- [x] kubectl kustomize --load-restrictor=LoadRestrictionsNone k8s/overlays/full >/dev/null

Closes #1071