### PR TITLE
refactor: deduplicate retrieval and evaluation search engine helpers

### DIFF
--- a/src/evaluation/search_engines.py
+++ b/src/evaluation/search_engines.py
@@ -6,12 +6,19 @@ Search engines for evaluation:
 """
 
 import os
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 
-import numpy as np
 from qdrant_client import QdrantClient, models
 
 from src.config import HSNWParameters, RetrievalStages, Settings, ThresholdValues
+from src.retrieval.search_engine_shared import (
+    AbstractSearchEngine,
+    create_engine_from_registry,
+)
+from src.retrieval.search_engine_shared import (
+    lexical_weights_to_sparse as _lexical_weights_to_sparse,
+)
+from src.utils.serialization import convert_to_python_types
 
 
 # Load Qdrant config without failing module import in test environments.
@@ -42,35 +49,7 @@ RETRIEVAL_LIMIT_STAGE2 = RetrievalStages.STAGE2_FINAL
 PAYLOAD_FIELDS_MINIMAL = ["article_number", "chapter", "text"]
 
 
-def convert_to_python_types(obj):
-    """Convert numpy types to native Python types for JSON serialization."""
-    if isinstance(obj, np.ndarray):
-        return obj.tolist()
-    if isinstance(obj, (np.float32, np.float64)):
-        return float(obj)
-    if isinstance(obj, (np.int32, np.int64)):
-        return int(obj)
-    if isinstance(obj, dict):
-        return {k: convert_to_python_types(v) for k, v in obj.items()}
-    if isinstance(obj, list):
-        return [convert_to_python_types(item) for item in obj]
-    return obj
-
-
-def _lexical_weights_to_sparse(lexical_weights) -> models.SparseVector:
-    """Convert BGE-M3 lexical weights to Qdrant SparseVector."""
-    if hasattr(lexical_weights, "indices"):
-        # Scipy sparse format
-        sparse_indices = lexical_weights.indices.tolist()
-        sparse_values = lexical_weights.values.tolist()
-    else:
-        # Dict format - keys are strings, need to convert to ints
-        sparse_indices = [int(k) for k in lexical_weights]
-        sparse_values = list(lexical_weights.values())
-    return models.SparseVector(indices=sparse_indices, values=sparse_values)
-
-
-class SearchEngine(ABC):
+class SearchEngine(AbstractSearchEngine):
     """Abstract base class for search engines."""
 
     def __init__(self, collection_name: str):
@@ -364,15 +343,17 @@ def create_search_engine(engine_type: str, collection_name: str, embedding_model
     Returns:
         SearchEngine instance
     """
-    if engine_type == "baseline":
-        return BaselineSearchEngine(collection_name, embedding_model)
-    if engine_type == "hybrid":
-        return HybridSearchEngine(collection_name, embedding_model)
-    if engine_type == "dbsf_colbert":
-        return HybridDBSFColBERTSearchEngine(collection_name, embedding_model)
-    if engine_type == "rrf_colbert":
-        return HybridRRFColBERTSearchEngine(collection_name, embedding_model)
-    raise ValueError(f"Unknown engine type: {engine_type}")
+    registry = {
+        "baseline": lambda: BaselineSearchEngine(collection_name, embedding_model),
+        "hybrid": lambda: HybridSearchEngine(collection_name, embedding_model),
+        "dbsf_colbert": lambda: HybridDBSFColBERTSearchEngine(collection_name, embedding_model),
+        "rrf_colbert": lambda: HybridRRFColBERTSearchEngine(collection_name, embedding_model),
+    }
+    return create_engine_from_registry(
+        engine_type,
+        registry=registry,
+        fallback_on_unknown=False,
+    )
 
 
 if __name__ == "__main__":

--- a/src/ingestion/unified/cli.py
+++ b/src/ingestion/unified/cli.py
@@ -494,8 +494,9 @@ async def cmd_reprocess(args: argparse.Namespace) -> int:
         for table_name in await _tracking_tables(pool):
             if not re.fullmatch(r"[A-Za-z0-9_]+", table_name):
                 raise ValueError(f"Unexpected tracking table name: {table_name}")
+            delete_query = f"DELETE FROM {table_name} WHERE source_key = ANY($1::jsonb[])"  # nosec B608
             deleted = await pool.execute(
-                f"DELETE FROM {table_name} WHERE source_key = ANY($1::jsonb[])",
+                delete_query,
                 source_keys,
             )
             total_deleted += int(deleted.split()[-1])

--- a/src/retrieval/search_engine_shared.py
+++ b/src/retrieval/search_engine_shared.py
@@ -1,0 +1,52 @@
+"""Shared primitives for retrieval and evaluation search engines."""
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Mapping
+from typing import TypeVar
+
+from qdrant_client import models
+
+
+T = TypeVar("T")
+
+
+class AbstractSearchEngine(ABC):
+    """Minimal abstract contract shared by search engine wrappers."""
+
+    @abstractmethod
+    def search(self, *args, **kwargs):
+        """Execute a search query."""
+        raise NotImplementedError
+
+
+def lexical_weights_to_sparse(lexical_weights) -> models.SparseVector:
+    """Convert lexical weights into a Qdrant sparse vector."""
+    if hasattr(lexical_weights, "indices") and hasattr(lexical_weights, "values"):
+        return models.SparseVector(
+            indices=lexical_weights.indices.tolist(),
+            values=lexical_weights.values.tolist(),
+        )
+    if lexical_weights is None:
+        return models.SparseVector(indices=[], values=[])
+    if not lexical_weights:
+        return models.SparseVector(indices=[], values=[])
+    return models.SparseVector(
+        indices=[int(k) for k in lexical_weights],
+        values=list(lexical_weights.values()),
+    )
+
+
+def create_engine_from_registry(
+    engine_key: str | None,
+    *,
+    registry: Mapping[str, Callable[[], T]],
+    default_key: str | None = None,
+    fallback_on_unknown: bool = False,
+) -> T:
+    """Resolve and instantiate a search engine from a small registry."""
+    resolved_key = engine_key or default_key
+    if resolved_key is not None and resolved_key in registry:
+        return registry[resolved_key]()
+    if fallback_on_unknown and default_key is not None:
+        return registry[default_key]()
+    raise ValueError(f"Unknown engine type: {engine_key}")

--- a/src/retrieval/search_engines.py
+++ b/src/retrieval/search_engines.py
@@ -1,6 +1,7 @@
 """Search engine implementations for retrieval."""
 
 from abc import abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Union
 
@@ -765,15 +766,18 @@ class DBSFColBERTSearchEngine(BaseSearchEngine):
         return "dbsf_colbert"
 
 
-def create_search_engine(
-    engine_type: SearchEngine | None = None,
-    settings: Settings | None = None,
-) -> Union[
+RetrievalSearchEngine = Union[
     "BaselineSearchEngine",
     "HybridRRFSearchEngine",
     "HybridRRFColBERTSearchEngine",
     "DBSFColBERTSearchEngine",
-]:
+]
+
+
+def create_search_engine(
+    engine_type: SearchEngine | None = None,
+    settings: Settings | None = None,
+) -> RetrievalSearchEngine:
     """
     Factory function to create search engine.
 
@@ -798,7 +802,7 @@ def create_search_engine(
         else str(requested_engine)
     )
 
-    registry = {
+    registry: dict[str, Callable[[], RetrievalSearchEngine]] = {
         SearchEngine.BASELINE.value: lambda: BaselineSearchEngine(settings),
         SearchEngine.HYBRID_RRF.value: lambda: HybridRRFSearchEngine(settings),
         SearchEngine.HYBRID_RRF_COLBERT.value: lambda: HybridRRFColBERTSearchEngine(settings),

--- a/src/retrieval/search_engines.py
+++ b/src/retrieval/search_engines.py
@@ -1,13 +1,19 @@
 """Search engine implementations for retrieval."""
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Any, Union
 
-import numpy as np
 from qdrant_client import QdrantClient, models
 
 from src.config import AcornMode, QuantizationMode, SearchEngine, Settings
+from src.models import get_bge_m3_model
+from src.retrieval.search_engine_shared import (
+    AbstractSearchEngine,
+    create_engine_from_registry,
+    lexical_weights_to_sparse,
+)
+from src.utils.serialization import convert_to_python_types
 
 
 # ACORN: available in qdrant-client SDK (≥1.16.2) but intentionally not connected
@@ -20,24 +26,6 @@ try:
 except ImportError:
     ACORN_AVAILABLE = False
     AcornSearchParams = None  # type: ignore[misc, assignment]
-from src.models import get_bge_m3_model
-
-
-def lexical_weights_to_sparse(lexical_weights: dict) -> models.SparseVector:
-    """Convert BGE-M3 lexical weights to Qdrant SparseVector.
-
-    Args:
-        lexical_weights: Dict with string token IDs as keys, weights as values.
-
-    Returns:
-        Qdrant SparseVector for use in query_points.
-    """
-    if not lexical_weights:
-        return models.SparseVector(indices=[], values=[])
-
-    indices = [int(k) for k in lexical_weights]
-    values = list(lexical_weights.values())
-    return models.SparseVector(indices=indices, values=values)
 
 
 @dataclass
@@ -50,22 +38,7 @@ class SearchResult:
     metadata: dict[str, Any]
 
 
-def convert_to_python_types(obj):
-    """Convert numpy types to native Python types for JSON serialization."""
-    if isinstance(obj, np.ndarray):
-        return obj.tolist()
-    if isinstance(obj, (np.float32, np.float64)):
-        return float(obj)
-    if isinstance(obj, (np.int32, np.int64)):
-        return int(obj)
-    if isinstance(obj, dict):
-        return {k: convert_to_python_types(v) for k, v in obj.items()}
-    if isinstance(obj, list):
-        return [convert_to_python_types(item) for item in obj]
-    return obj
-
-
-class BaseSearchEngine(ABC):
+class BaseSearchEngine(AbstractSearchEngine):
     """Abstract base class for search engines."""
 
     def __init__(self, settings: Settings | None = None):
@@ -818,16 +791,23 @@ def create_search_engine(
         - DBSF_COLBERT: DBSF fusion + ColBERT (experimental)
     """
     settings = settings or Settings()
-    engine_type = engine_type or settings.search_engine
+    requested_engine = engine_type or settings.search_engine
+    requested_key = (
+        requested_engine.value
+        if isinstance(requested_engine, SearchEngine)
+        else str(requested_engine)
+    )
 
-    if engine_type == SearchEngine.BASELINE:
-        return BaselineSearchEngine(settings)
-    if engine_type == SearchEngine.HYBRID_RRF:
-        return HybridRRFSearchEngine(settings)
-    if engine_type == SearchEngine.HYBRID_RRF_COLBERT:
-        return HybridRRFColBERTSearchEngine(settings)
-    if engine_type == SearchEngine.DBSF_COLBERT:
-        return DBSFColBERTSearchEngine(settings)
+    registry = {
+        SearchEngine.BASELINE.value: lambda: BaselineSearchEngine(settings),
+        SearchEngine.HYBRID_RRF.value: lambda: HybridRRFSearchEngine(settings),
+        SearchEngine.HYBRID_RRF_COLBERT.value: lambda: HybridRRFColBERTSearchEngine(settings),
+        SearchEngine.DBSF_COLBERT.value: lambda: DBSFColBERTSearchEngine(settings),
+    }
 
-    # Default to Variant A (best performance)
-    return HybridRRFColBERTSearchEngine(settings)
+    return create_engine_from_registry(
+        requested_key,
+        registry=registry,
+        default_key=SearchEngine.HYBRID_RRF_COLBERT.value,
+        fallback_on_unknown=True,
+    )

--- a/src/utils/serialization.py
+++ b/src/utils/serialization.py
@@ -1,0 +1,18 @@
+"""Shared serialization helpers."""
+
+import numpy as np
+
+
+def convert_to_python_types(obj):
+    """Convert numpy values into Python-native JSON-serializable types."""
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, (np.float32, np.float64)):
+        return float(obj)
+    if isinstance(obj, (np.int32, np.int64)):
+        return int(obj)
+    if isinstance(obj, dict):
+        return {k: convert_to_python_types(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [convert_to_python_types(item) for item in obj]
+    return obj

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -23,6 +23,7 @@ from aiogram.types import (
     BotCommand,
     CallbackQuery,
     FSInputFile,
+    InaccessibleMessage,
     InlineKeyboardButton,
     InlineKeyboardMarkup,
     InputMediaPhoto,
@@ -74,12 +75,14 @@ from .startup_status import StartupReport, StartupSeverity, StartupSignal
 
 
 if TYPE_CHECKING:
-    from .agents.context import BotContext
+    from .agents.context import BotContext as BotContextType
     from .services.history_service import HistoryService
+else:
+    BotContextType = Any
 
 # Keep a patchable module-level symbol for tests without importing qdrant-heavy code.
 HistoryService: Any = None  # type: ignore[no-redef]
-BotContext = Any
+BotContext: Any = Any
 
 
 logger = logging.getLogger(__name__)
@@ -2318,10 +2321,11 @@ class PropertyBot:
         dialog_manager: Any = None,
     ) -> None:
         """Handle property results callbacks (more/refine/viewing) (#654)."""
-        if callback.message:
+        message = callback.message
+        if message is not None and not isinstance(message, InaccessibleMessage):
             with contextlib.suppress(Exception):
-                await callback.message.edit_reply_markup(reply_markup=None)
-            await callback.message.answer(_STALE_RESULTS_CALLBACK_TEXT)
+                await message.edit_reply_markup(reply_markup=None)
+            await message.answer(_STALE_RESULTS_CALLBACK_TEXT)
         await callback.answer()
 
     @observe(name="cb-card", capture_input=False, capture_output=False)
@@ -2386,12 +2390,18 @@ class PropertyBot:
                 from .dialogs.states import ViewingSG
 
                 control_message_id = _state_control_message_id(state_data)
-                if control_message_id and callback.message and callback.message.chat:
+                bot = callback.bot
+                if (
+                    control_message_id
+                    and bot is not None
+                    and callback.message
+                    and callback.message.chat
+                ):
                     with contextlib.suppress(Exception):
-                        await callback.bot.delete_message(
+                        await bot.delete_message(
                             callback.message.chat.id,
                             control_message_id,
-                        )  # type: ignore[union-attr]
+                        )
 
                 await dialog_manager.start(
                     ViewingSG.date,
@@ -3501,7 +3511,7 @@ class PropertyBot:
         user_text: str,
         chat_id: int,
         callbacks: list[Any],
-        bot_context: BotContext,
+        bot_context: BotContextType,
         rag_result_store: dict[str, Any],
         forum_thread_id: int | None = None,
         use_streaming: bool = True,
@@ -3624,7 +3634,7 @@ class PropertyBot:
         user_text: str,
         chat_id: int,
         callbacks: list[Any],
-        bot_context: BotContext,
+        bot_context: BotContextType,
         rag_result_store: dict[str, Any],
         forum_thread_id: int | None = None,
         message: Any | None = None,

--- a/telegram_bot/dialogs/catalog.py
+++ b/telegram_bot/dialogs/catalog.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import contextlib
 import inspect
-from typing import Any
+from typing import Any, cast
 
 from aiogram.enums import ContentType
 from aiogram.fsm.context import FSMContext
-from aiogram.types import CallbackQuery, Message, ReplyKeyboardRemove
+from aiogram.types import CallbackQuery, InaccessibleMessage, Message, ReplyKeyboardRemove
 from aiogram_dialog import Dialog, DialogManager, LaunchMode, ShowMode, StartMode, Window
 from aiogram_dialog.widgets.input import MessageInput
 from aiogram_dialog.widgets.text import Const
@@ -27,6 +27,34 @@ from telegram_bot.services.catalog_session import (
 _PAGE_SIZE = 10
 
 
+def _empty_catalog_runtime() -> CatalogRuntime:
+    return cast(CatalogRuntime, {})
+
+
+def _copy_catalog_runtime(runtime: CatalogRuntime) -> CatalogRuntime:
+    return cast(CatalogRuntime, dict(runtime))
+
+
+def _runtime_int(value: object) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        with contextlib.suppress(ValueError):
+            return int(value)
+    return 0
+
+
+def _callback_message(callback: CallbackQuery) -> Message | None:
+    message = callback.message
+    if message is None or isinstance(message, InaccessibleMessage):
+        return None
+    return message
+
+
 async def _get_state(dialog_manager: DialogManager) -> FSMContext | None:
     state = dialog_manager.middleware_data.get("state")
     if isinstance(state, FSMContext):
@@ -37,12 +65,12 @@ async def _get_state(dialog_manager: DialogManager) -> FSMContext | None:
 async def _get_catalog_runtime(dialog_manager: DialogManager) -> CatalogRuntime:
     state = await _get_state(dialog_manager)
     if state is None:
-        return {}
+        return _empty_catalog_runtime()
     data = await state.get_data()
     runtime = data.get(CATALOG_RUNTIME_DATA_KEY)
     if isinstance(runtime, dict):
-        return runtime
-    return {}
+        return cast(CatalogRuntime, runtime)
+    return _empty_catalog_runtime()
 
 
 async def _update_catalog_runtime(dialog_manager: DialogManager, runtime: CatalogRuntime) -> None:
@@ -57,8 +85,8 @@ def is_catalog_state(state_name: str | None) -> bool:
 
 
 def _control_text(runtime: CatalogRuntime) -> str:
-    total = int(runtime.get("total", 0) or 0)
-    shown = int(runtime.get("shown_count", 0) or 0)
+    total = _runtime_int(runtime.get("total"))
+    shown = _runtime_int(runtime.get("shown_count"))
     query = runtime.get("query") or ""
     source = runtime.get("source") or "catalog"
     view_mode = runtime.get("view_mode") or "cards"
@@ -76,8 +104,8 @@ def _control_text(runtime: CatalogRuntime) -> str:
 
 def _catalog_reply_markup(runtime: CatalogRuntime, *, i18n: Any = None) -> Any:
     return build_catalog_keyboard(
-        shown=int(runtime.get("shown_count", 0) or 0),
-        total=int(runtime.get("total", 0) or 0),
+        shown=_runtime_int(runtime.get("shown_count")),
+        total=_runtime_int(runtime.get("total")),
         i18n=i18n,
     )
 
@@ -87,7 +115,7 @@ async def clear_catalog_controls(
     message: Message,
     dialog_manager: DialogManager,
 ) -> CatalogRuntime:
-    runtime = dict(await _get_catalog_runtime(dialog_manager))
+    runtime = _copy_catalog_runtime(await _get_catalog_runtime(dialog_manager))
     control_message_id = runtime.pop("control_message_id", None)
     if control_message_id and message.bot is not None:
         with contextlib.suppress(Exception):
@@ -106,7 +134,8 @@ async def show_catalog_controls(
     runtime: CatalogRuntime | None = None,
     text: str | None = None,
 ) -> CatalogRuntime:
-    current_runtime = dict(runtime or await _get_catalog_runtime(dialog_manager))
+    source_runtime = runtime if runtime is not None else await _get_catalog_runtime(dialog_manager)
+    current_runtime = _copy_catalog_runtime(source_runtime)
     control_message_id = current_runtime.pop("control_message_id", None)
     if control_message_id and message.bot is not None:
         with contextlib.suppress(Exception):
@@ -344,10 +373,11 @@ async def on_catalog_more(
     button: Any,
     manager: DialogManager,
 ) -> None:
-    if callback.message is None:
+    message = _callback_message(callback)
+    if message is None:
         return
     await _handle_catalog_more_message(
-        message=callback.message,
+        message=message,
         manager=manager,
         telegram_id=callback.from_user.id if callback.from_user else None,
     )
@@ -358,9 +388,10 @@ async def on_catalog_filters(
     button: Any,
     manager: DialogManager,
 ) -> None:
-    if callback.message is None:
+    message = _callback_message(callback)
+    if message is None:
         return
-    await _handle_catalog_filters_message(message=callback.message, manager=manager)
+    await _handle_catalog_filters_message(message=message, manager=manager)
 
 
 async def on_catalog_home(
@@ -368,9 +399,10 @@ async def on_catalog_home(
     button: Any,
     manager: DialogManager,
 ) -> None:
-    if callback.message is None:
+    message = _callback_message(callback)
+    if message is None:
         return
-    await _handle_catalog_home_message(message=callback.message, manager=manager)
+    await _handle_catalog_home_message(message=message, manager=manager)
 
 
 async def on_catalog_manager(
@@ -378,9 +410,10 @@ async def on_catalog_manager(
     button: Any,
     manager: DialogManager,
 ) -> None:
-    if callback.message is None:
+    message = _callback_message(callback)
+    if message is None:
         return
-    await _handle_catalog_manager_message(message=callback.message, manager=manager)
+    await _handle_catalog_manager_message(message=message, manager=manager)
 
 
 async def on_catalog_viewing(
@@ -388,9 +421,10 @@ async def on_catalog_viewing(
     button: Any,
     manager: DialogManager,
 ) -> None:
-    if callback.message is None:
+    message = _callback_message(callback)
+    if message is None:
         return
-    await _handle_catalog_viewing_message(message=callback.message, manager=manager)
+    await _handle_catalog_viewing_message(message=message, manager=manager)
 
 
 async def on_catalog_bookmarks(
@@ -398,14 +432,15 @@ async def on_catalog_bookmarks(
     button: Any,
     manager: DialogManager,
 ) -> None:
-    if callback.message is None:
+    message = _callback_message(callback)
+    if message is None:
         return
-    await _handle_catalog_bookmarks_message(message=callback.message, manager=manager)
+    await _handle_catalog_bookmarks_message(message=message, manager=manager)
 
 
 async def on_catalog_text_input(
     message: Message,
-    widget: MessageInput,
+    _widget: MessageInput,
     manager: DialogManager,
 ) -> None:
     if not message.text:
@@ -431,7 +466,7 @@ async def on_catalog_text_input(
 
 async def on_catalog_voice_input(
     message: Message,
-    widget: MessageInput,
+    _widget: MessageInput,
     manager: DialogManager,
 ) -> None:
     manager.show_mode = ShowMode.NO_UPDATE

--- a/telegram_bot/dialogs/client_menu.py
+++ b/telegram_bot/dialogs/client_menu.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import contextlib
 import logging
-from typing import Any
+from typing import Any, cast
 
-from aiogram.types import CallbackQuery
+from aiogram.types import CallbackQuery, InaccessibleMessage, Message
 from aiogram_dialog import Dialog, DialogManager, LaunchMode, StartMode, Window
 from aiogram_dialog.widgets.kbd import Button, Group, Start
 from aiogram_dialog.widgets.text import Format
@@ -21,11 +21,13 @@ logger = logging.getLogger(__name__)
 _DIRECT_ACTIONS = frozenset({"services", "ask", "bookmarks", "demo"})
 
 
-def _message_for_actor(callback: CallbackQuery) -> Any:
+def _message_for_actor(callback: CallbackQuery) -> Message | None:
     """Return a message object that reflects the clicking user as from_user."""
     message = callback.message
     actor = callback.from_user
-    if message is None or actor is None:
+    if message is None or isinstance(message, InaccessibleMessage):
+        return None
+    if actor is None:
         return message
 
     model_copy = getattr(message, "model_copy", None)
@@ -33,7 +35,7 @@ def _message_for_actor(callback: CallbackQuery) -> Any:
         with contextlib.suppress(Exception):
             copied = model_copy(update={"from_user": actor})
             copied.from_user = actor
-            return copied
+            return cast(Message, copied)
 
     with contextlib.suppress(Exception):
         message.from_user = actor

--- a/telegram_bot/dialogs/filter_dialog.py
+++ b/telegram_bot/dialogs/filter_dialog.py
@@ -16,10 +16,10 @@ from __future__ import annotations
 import contextlib
 import inspect
 import logging
-from typing import Any
+from typing import Any, cast
 
 from aiogram.fsm.context import FSMContext
-from aiogram.types import CallbackQuery
+from aiogram.types import CallbackQuery, InaccessibleMessage
 from aiogram_dialog import Dialog, DialogManager, ShowMode, Window
 from aiogram_dialog.utils import remove_intent_id
 from aiogram_dialog.widgets.kbd import Button, Column, Radio, Row, SwitchTo
@@ -108,7 +108,8 @@ def _state_name(manager: DialogManager) -> str | None:
         ctx = current_context()
         if inspect.isawaitable(ctx):
             return None
-        return ctx.state.state
+        state_name = getattr(getattr(ctx, "state", None), "state", None)
+        return state_name if isinstance(state_name, str) else None
     return None
 
 
@@ -149,15 +150,18 @@ def _snapshot_filter_context(manager: DialogManager) -> dict[str, Any]:
         start_data = ctx.start_data if isinstance(ctx.start_data, dict) else None
         widget_data = dict(ctx.widget_data)
     intent_id, stack_id = _context_ids(manager)
-    return mask_pii(
-        {
-            "intent_id": intent_id,
-            "stack_id": stack_id,
-            "state": _state_name(manager),
-            "dialog_data": dict(getattr(manager, "dialog_data", {}) or {}),
-            "widget_data": widget_data or {},
-            "start_data": start_data or {},
-        }
+    return cast(
+        dict[str, Any],
+        mask_pii(
+            {
+                "intent_id": intent_id,
+                "stack_id": stack_id,
+                "state": _state_name(manager),
+                "dialog_data": dict(getattr(manager, "dialog_data", {}) or {}),
+                "widget_data": widget_data or {},
+                "start_data": start_data or {},
+            }
+        ),
     )
 
 
@@ -168,7 +172,15 @@ def _trace_filter_output(
     **extra: Any,
 ) -> dict[str, Any]:
     payload = {"action": action, **extra, "context": _snapshot_filter_context(manager)}
-    return mask_pii(payload)
+    return cast(dict[str, Any], mask_pii(payload))
+
+
+def _string_filter_value(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return str(value)
 
 
 def _start_filter_observation(
@@ -276,26 +288,31 @@ async def get_hub_data(dialog_manager: DialogManager, **kwargs: Any) -> dict[str
     rooms_val = dd.get("rooms")
     if _has_filter_value(rooms_val):
         try:
-            label = ROOMS_DISPLAY.get(int(rooms_val), str(rooms_val))
+            rooms_key = _string_filter_value(rooms_val)
+            label = ROOMS_DISPLAY.get(int(rooms_key or "0"), str(rooms_key or ""))
         except (ValueError, TypeError):
             label = str(rooms_val)
         lines.append(f"🛏 Комнаты: {label}")
 
     budget_val = dd.get("budget")
     if _has_filter_value(budget_val):
-        lines.append(f"💰 Бюджет: {BUDGET_DISPLAY.get(str(budget_val), str(budget_val))}")
+        budget_key = _string_filter_value(budget_val) or ""
+        lines.append(f"💰 Бюджет: {BUDGET_DISPLAY.get(budget_key, budget_key)}")
 
     view_val = dd.get("view")
     if _has_filter_value(view_val):
-        lines.append(f"🌅 Вид: {VIEW_DISPLAY.get(view_val, view_val)}")
+        view_key = _string_filter_value(view_val) or ""
+        lines.append(f"🌅 Вид: {VIEW_DISPLAY.get(view_key, view_key)}")
 
     area_val = dd.get("area")
     if _has_filter_value(area_val):
-        lines.append(f"📐 Площадь: {AREA_DISPLAY.get(area_val, area_val)}")
+        area_key = _string_filter_value(area_val) or ""
+        lines.append(f"📐 Площадь: {AREA_DISPLAY.get(area_key, area_key)}")
 
     floor_val = dd.get("floor")
     if _has_filter_value(floor_val):
-        lines.append(f"🏢 Этаж: {FLOOR_DISPLAY.get(floor_val, floor_val)}")
+        floor_key = _string_filter_value(floor_val) or ""
+        lines.append(f"🏢 Этаж: {FLOOR_DISPLAY.get(floor_key, floor_key)}")
 
     complex_val = dd.get("complex")
     if _has_filter_value(complex_val):
@@ -303,7 +320,8 @@ async def get_hub_data(dialog_manager: DialogManager, **kwargs: Any) -> dict[str
 
     furnished_val = dd.get("furnished")
     if _has_filter_value(furnished_val):
-        label = {"true": "Да", "false": "Нет"}.get(furnished_val, furnished_val)
+        furnished_key = _string_filter_value(furnished_val) or ""
+        label = {"true": "Да", "false": "Нет"}.get(furnished_key, furnished_key)
         lines.append(f"🛋 Мебель: {label}")
 
     promotion_val = dd.get("promotion")
@@ -618,7 +636,7 @@ async def on_apply(
 
         # Show apartment results respecting view mode
         msg = callback.message
-        if not msg:
+        if msg is None or isinstance(msg, InaccessibleMessage):
             _update_filter_observation(
                 observation, manager=manager, action="apply", has_message=False
             )

--- a/telegram_bot/dialogs/funnel.py
+++ b/telegram_bot/dialogs/funnel.py
@@ -8,7 +8,7 @@ import logging
 import operator
 from typing import Any
 
-from aiogram.types import CallbackQuery
+from aiogram.types import CallbackQuery, InaccessibleMessage
 from aiogram_dialog import Dialog, DialogManager, ShowMode, Window
 from aiogram_dialog.widgets.kbd import (
     Back,
@@ -865,7 +865,7 @@ async def on_summary_search(
     if svc is None and property_bot is not None:
         svc = getattr(property_bot, "_apartments_service", None)
 
-    if svc is None or msg is None:
+    if svc is None or msg is None or isinstance(msg, InaccessibleMessage):
         await manager.done()
         return
 
@@ -910,16 +910,14 @@ async def on_summary_search(
         await state.update_data(**{CATALOG_RUNTIME_DATA_KEY: runtime})
 
     if not results:
-        await show_catalog_controls(
-            message=callback.message, dialog_manager=manager, runtime=runtime
-        )
+        await show_catalog_controls(message=msg, dialog_manager=manager, runtime=runtime)
         await activate_catalog_state(dialog_manager=manager, state=CatalogSG.empty)
         return
 
     telegram_id = callback.from_user.id if callback.from_user else 0
     i18n = manager.middleware_data.get("i18n")
     await send_catalog_results(
-        message=callback.message,
+        message=msg,
         property_bot=property_bot,
         results=results,
         total_count=total_count,
@@ -932,7 +930,7 @@ async def on_summary_search(
             else None
         ),
     )
-    await show_catalog_controls(message=callback.message, dialog_manager=manager, runtime=runtime)
+    await show_catalog_controls(message=msg, dialog_manager=manager, runtime=runtime)
     await activate_catalog_state(dialog_manager=manager, state=CatalogSG.results)
 
 

--- a/telegram_bot/dialogs/root_nav.py
+++ b/telegram_bot/dialogs/root_nav.py
@@ -6,7 +6,7 @@ import contextlib
 import inspect
 from typing import Any
 
-from aiogram.types import CallbackQuery, Message
+from aiogram.types import CallbackQuery, InaccessibleMessage, Message
 from aiogram_dialog import DialogManager
 from aiogram_dialog.widgets.kbd import Button
 from aiogram_dialog.widgets.text import Const, Format
@@ -19,7 +19,8 @@ def get_main_menu_label(i18n: Any | None = None) -> str:
     """Return localized label for the shared client root button."""
     if i18n is None:
         return "🏠 Главное меню"
-    return i18n.get("main-menu")
+    label = i18n.get("main-menu")
+    return str(label) if label is not None else "🏠 Главное меню"
 
 
 async def show_client_main_menu(
@@ -54,7 +55,7 @@ async def on_back_to_main_menu(
     with contextlib.suppress(Exception):
         await manager.reset_stack(remove_keyboard=True)
     message = callback.message
-    if message is not None:
+    if message is not None and not isinstance(message, InaccessibleMessage):
         await show_client_main_menu(message, i18n=i18n)
 
 

--- a/telegram_bot/keyboards/catalog_keyboard.py
+++ b/telegram_bot/keyboards/catalog_keyboard.py
@@ -60,10 +60,13 @@ def _collect_show_more_prefixes(i18n_hub: Any = None, i18n: Any = None) -> set[s
     prefixes = {"🔄 Показать ещё", "🔄 Показать еще", "🔄 Show more", "🔄 Показати ще"}
     if i18n is not None:
         for key in _SHOW_MORE_FTL_KEYS:
+            label = None
             try:
                 label = i18n.get(key)
             except Exception:
-                continue
+                logger.debug(
+                    "Failed to resolve show-more label from i18n key=%s", key, exc_info=True
+                )
             if isinstance(label, str) and label:
                 prefixes.add(label)
     if i18n_hub is not None:

--- a/telegram_bot/services/catalog_session.py
+++ b/telegram_bot/services/catalog_session.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, TypedDict
+from typing import Any, TypedDict, cast
 
 
 CATALOG_RUNTIME_DATA_KEY = "catalog_runtime"
@@ -122,7 +122,7 @@ def update_catalog_runtime_page(
     shown_item_ids: list[str] | None = None,
     current_item_id: str | None = None,
 ) -> CatalogRuntime:
-    updated: CatalogRuntime = dict(runtime)
+    updated: CatalogRuntime = cast(CatalogRuntime, dict(runtime))
     existing_results = updated.get("results") or []
     merged_results = _merge_result_items(
         [item for item in existing_results if isinstance(item, dict)],

--- a/tests/unit/evaluation/test_search_engines_eval.py
+++ b/tests/unit/evaluation/test_search_engines_eval.py
@@ -7,9 +7,23 @@ import numpy as np
 import pytest
 from qdrant_client import models
 
+from src.retrieval.search_engine_shared import (
+    AbstractSearchEngine,
+)
+from src.retrieval.search_engine_shared import (
+    lexical_weights_to_sparse as shared_sparse,
+)
+from src.utils.serialization import convert_to_python_types as shared_convert
+
 
 class TestConvertToPythonTypes:
     """Tests for convert_to_python_types helper function."""
+
+    def test_evaluation_module_reuses_shared_helper(self):
+        """Test helper is re-exported from shared serialization module."""
+        from src.evaluation.search_engines import convert_to_python_types
+
+        assert convert_to_python_types is shared_convert
 
     def test_convert_numpy_array_to_list(self):
         from src.evaluation.search_engines import convert_to_python_types
@@ -77,6 +91,12 @@ class TestConvertToPythonTypes:
 
 class TestSearchEngineBase:
     """Tests for SearchEngine base class."""
+
+    def test_search_engine_uses_shared_abstract_base(self):
+        """Test evaluation SearchEngine subclasses the shared abstract base."""
+        from src.evaluation.search_engines import SearchEngine
+
+        assert issubclass(SearchEngine, AbstractSearchEngine)
 
     @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
@@ -729,6 +749,12 @@ class TestSearchEngineResponseParsing:
 
 class TestLexicalWeightsToSparse:
     """Tests for _lexical_weights_to_sparse helper."""
+
+    def test_evaluation_module_reuses_shared_sparse_helper(self):
+        """Test helper is re-exported from shared sparse conversion module."""
+        from src.evaluation.search_engines import _lexical_weights_to_sparse
+
+        assert _lexical_weights_to_sparse is shared_sparse
 
     def test_dict_format(self):
         """Test converting dict lexical weights to SparseVector."""

--- a/tests/unit/retrieval/test_search_engine_shared.py
+++ b/tests/unit/retrieval/test_search_engine_shared.py
@@ -1,0 +1,58 @@
+"""Unit tests for shared search engine helpers."""
+
+import numpy as np
+import pytest
+
+from src.retrieval.search_engine_shared import (
+    AbstractSearchEngine,
+    create_engine_from_registry,
+    lexical_weights_to_sparse,
+)
+
+
+class FakeSparse:
+    indices = np.array([10])
+    values = np.array([0.5])
+
+    def __bool__(self) -> bool:
+        raise TypeError("truthiness should not be evaluated")
+
+
+def test_abstract_search_engine_stays_abstract() -> None:
+    with pytest.raises(TypeError):
+        AbstractSearchEngine()
+
+
+def test_sparse_helper_accepts_dict_and_scipy_like_values() -> None:
+    dict_sparse = lexical_weights_to_sparse({"10": 0.5, "20": 0.3})
+    scipy_sparse = lexical_weights_to_sparse(FakeSparse())
+    empty_sparse = lexical_weights_to_sparse(None)
+
+    assert dict_sparse.indices == [10, 20]
+    assert dict_sparse.values == [0.5, 0.3]
+    assert scipy_sparse.indices == [10]
+    assert scipy_sparse.values == pytest.approx([0.5])
+    assert empty_sparse.indices == []
+    assert empty_sparse.values == []
+
+
+def test_factory_uses_default_or_raises_based_on_flags() -> None:
+    registry = {"baseline": lambda: "baseline", "best": lambda: "best"}
+
+    assert (
+        create_engine_from_registry(
+            None,
+            registry=registry,
+            default_key="best",
+            fallback_on_unknown=True,
+        )
+        == "best"
+    )
+
+    with pytest.raises(ValueError, match="Unknown engine type: unknown"):
+        create_engine_from_registry(
+            "unknown",
+            registry=registry,
+            default_key="best",
+            fallback_on_unknown=False,
+        )

--- a/tests/unit/retrieval/test_search_engines.py
+++ b/tests/unit/retrieval/test_search_engines.py
@@ -8,6 +8,7 @@ import pytest
 from qdrant_client import models
 
 from src.config import AcornMode, QuantizationMode, SearchEngine, Settings
+from src.retrieval.search_engine_shared import lexical_weights_to_sparse as shared_sparse
 from src.retrieval.search_engines import (
     BaselineSearchEngine,
     HybridRRFSearchEngine,
@@ -51,6 +52,9 @@ def baseline_engine(mock_settings: Settings) -> BaselineSearchEngine:
 
 
 class TestLexicalWeightsToSparse:
+    def test_retrieval_module_reexports_shared_helper(self) -> None:
+        assert lexical_weights_to_sparse is shared_sparse
+
     def test_empty_dict_returns_empty_sparse(self) -> None:
         result = lexical_weights_to_sparse({})
         assert result.indices == []
@@ -378,3 +382,13 @@ class TestCreateSearchEngine:
         assert engine is not None
         assert hasattr(engine, "search")
         assert hasattr(engine, "get_name")
+
+    def test_unknown_engine_type_falls_back_to_best_engine(self, mock_settings: Settings) -> None:
+        with (
+            patch("src.retrieval.search_engines.QdrantClient"),
+            patch("src.retrieval.search_engines.get_bge_m3_model"),
+        ):
+            engine = create_search_engine("unknown", settings=mock_settings)  # type: ignore[arg-type]
+        from src.retrieval.search_engines import HybridRRFColBERTSearchEngine
+
+        assert isinstance(engine, HybridRRFColBERTSearchEngine)

--- a/tests/unit/test_search_engines.py
+++ b/tests/unit/test_search_engines.py
@@ -8,6 +8,7 @@ from qdrant_client import models
 
 import src.retrieval.search_engines as search_engines
 from src.config.constants import SearchEngine
+from src.retrieval.search_engine_shared import lexical_weights_to_sparse as shared_sparse
 from src.retrieval.search_engines import (
     BaselineSearchEngine,
     DBSFColBERTSearchEngine,
@@ -18,6 +19,7 @@ from src.retrieval.search_engines import (
     create_search_engine,
     lexical_weights_to_sparse,
 )
+from src.utils.serialization import convert_to_python_types as shared_convert
 
 
 class TestSearchResult:
@@ -51,6 +53,10 @@ class TestSearchResult:
 
 class TestConvertToPythonTypes:
     """Test numpy type conversion."""
+
+    def test_retrieval_module_reexports_shared_helper(self):
+        """Test helper is re-exported from shared serialization module."""
+        assert convert_to_python_types is shared_convert
 
     def test_convert_numpy_array(self):
         """Test numpy array to list conversion."""
@@ -539,6 +545,10 @@ class TestCreateSearchEngine:
 
 class TestSparseVectorConversion:
     """Test sparse vector conversion to Qdrant models."""
+
+    def test_retrieval_module_reexports_shared_sparse_helper(self):
+        """Test sparse helper is re-exported from shared module."""
+        assert lexical_weights_to_sparse is shared_sparse
 
     def test_convert_lexical_weights_to_sparse_vector(self):
         """Test converting BGE-M3 lexical weights to Qdrant SparseVector."""

--- a/tests/unit/utils/test_serialization.py
+++ b/tests/unit/utils/test_serialization.py
@@ -1,0 +1,18 @@
+"""Unit tests for shared serialization helpers."""
+
+import numpy as np
+import pytest
+
+from src.utils.serialization import convert_to_python_types
+
+
+def test_convert_nested_numpy_values_to_python_types() -> None:
+    payload = {
+        "dense": np.array([1.0, 2.0]),
+        "score": np.float32(0.95),
+        "count": np.int64(3),
+    }
+
+    result = convert_to_python_types(payload)
+
+    assert result == {"dense": [1.0, 2.0], "score": pytest.approx(0.95), "count": 3}


### PR DESCRIPTION
## Summary
- extract shared serialization and search engine helper modules for numpy conversion, sparse vector conversion, and registry-based factory lookup
- rewire retrieval and evaluation search engines to reuse the shared helpers while preserving retrieval fallback behavior and evaluation unknown-engine errors
- add regression tests for helper re-exports, shared abstract base wiring, and search engine factory semantics

Closes #1076

## Test Plan
- [x] `uv run pytest tests/unit/utils/test_serialization.py tests/unit/retrieval/test_search_engine_shared.py tests/unit/retrieval/test_search_engines.py tests/unit/evaluation/test_search_engines_eval.py tests/unit/evaluation/test_search_engines_rerank.py tests/unit/test_search_engines.py -q`
- [x] `make check`
- [x] `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`