### PR TITLE
fix(k8s): align secret template with k3s deploy flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -969,12 +969,14 @@ k3s-down: ## Delete all k3s resources
 	kubectl delete -k k8s/overlays/full/ --ignore-not-found
 
 k3s-secrets: ## Create k8s secrets from k8s/secrets/.env
-	kubectl create secret generic api-keys --from-env-file=k8s/secrets/.env -n rag --dry-run=client -o yaml | kubectl apply -f -
-	kubectl create secret generic db-credentials \
-		--from-literal=POSTGRES_USER=postgres \
-		--from-literal=POSTGRES_PASSWORD=postgres \
-		--from-literal=POSTGRES_DB=postgres \
-		-n rag --dry-run=client -o yaml | kubectl apply -f -
+	@set -a; . k8s/secrets/.env; set +a; \
+		: "$${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required in k8s/secrets/.env}"; \
+		kubectl create secret generic api-keys --from-env-file=k8s/secrets/.env -n rag --dry-run=client -o yaml | kubectl apply -f -; \
+		kubectl create secret generic db-credentials \
+			--from-literal=POSTGRES_USER=postgres \
+			--from-literal=POSTGRES_PASSWORD=$$POSTGRES_PASSWORD \
+			--from-literal=POSTGRES_DB=postgres \
+			-n rag --dry-run=client -o yaml | kubectl apply -f -
 
 k3s-ingest-start: ## Scale ingestion to 1 replica
 	kubectl scale deployment ingestion -n rag --replicas=1

--- a/Makefile
+++ b/Makefile
@@ -969,14 +969,21 @@ k3s-down: ## Delete all k3s resources
 	kubectl delete -k k8s/overlays/full/ --ignore-not-found
 
 k3s-secrets: ## Create k8s secrets from k8s/secrets/.env
-	@set -a; . k8s/secrets/.env; set +a; \
-		: "$${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required in k8s/secrets/.env}"; \
-		kubectl create secret generic api-keys --from-env-file=k8s/secrets/.env -n rag --dry-run=client -o yaml | kubectl apply -f -; \
-		kubectl create secret generic db-credentials \
-			--from-literal=POSTGRES_USER=postgres \
-			--from-literal=POSTGRES_PASSWORD=$$POSTGRES_PASSWORD \
-			--from-literal=POSTGRES_DB=postgres \
-			-n rag --dry-run=client -o yaml | kubectl apply -f -
+	@tmp_api_keys=$$(mktemp); \
+		tmp_db_credentials=$$(mktemp); \
+		trap 'rm -f "$$tmp_api_keys" "$$tmp_db_credentials"' EXIT; \
+		grep -v '^POSTGRES_PASSWORD=' k8s/secrets/.env > "$$tmp_api_keys"; \
+		POSTGRES_PASSWORD=$$(awk -F= '/^POSTGRES_PASSWORD=/{sub(/^[^=]*=/,""); print; found=1; exit} END{if(!found) exit 1}' k8s/secrets/.env) || { \
+			echo "POSTGRES_PASSWORD is required in k8s/secrets/.env" >&2; \
+			exit 1; \
+		}; \
+		[ -n "$$POSTGRES_PASSWORD" ] || { \
+			echo "POSTGRES_PASSWORD is required in k8s/secrets/.env" >&2; \
+			exit 1; \
+		}; \
+		printf 'POSTGRES_USER=postgres\nPOSTGRES_PASSWORD=%s\nPOSTGRES_DB=postgres\n' "$$POSTGRES_PASSWORD" > "$$tmp_db_credentials"; \
+		kubectl create secret generic api-keys --from-env-file="$$tmp_api_keys" -n rag --dry-run=client -o yaml | kubectl apply -f -; \
+		kubectl create secret generic db-credentials --from-env-file="$$tmp_db_credentials" -n rag --dry-run=client -o yaml | kubectl apply -f -
 
 k3s-ingest-start: ## Scale ingestion to 1 replica
 	kubectl scale deployment ingestion -n rag --replicas=1

--- a/k8s/base/bot/deployment.yaml
+++ b/k8s/base/bot/deployment.yaml
@@ -161,8 +161,13 @@ spec:
             - name: MANAGER_HOT_LEAD_DEDUPE_SEC
               value: "3600"
             # Real Estate DB
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-credentials
+                  key: POSTGRES_PASSWORD
             - name: REALESTATE_DATABASE_URL
-              value: "postgresql://postgres:postgres@postgres:5432/realestate"
+              value: "postgresql://postgres:$(POSTGRES_PASSWORD)@postgres:5432/realestate"
           resources:
             requests:
               memory: 128Mi

--- a/k8s/base/ingestion/deployment.yaml
+++ b/k8s/base/ingestion/deployment.yaml
@@ -56,8 +56,13 @@ spec:
           env:
             - name: GDRIVE_SYNC_DIR
               value: /data/drive-sync
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-credentials
+                  key: POSTGRES_PASSWORD
             - name: INGESTION_DATABASE_URL
-              value: postgresql://postgres:postgres@postgres:5432/cocoindex
+              value: postgresql://postgres:$(POSTGRES_PASSWORD)@postgres:5432/cocoindex
             - name: QDRANT_URL
               value: http://qdrant:6333
             - name: DOCLING_URL

--- a/k8s/secrets/.env.example
+++ b/k8s/secrets/.env.example
@@ -1,6 +1,9 @@
-# k8s secrets — copy to .env, fill values, then:
-# kubectl create secret generic api-keys --from-env-file=k8s/secrets/.env -n rag
-# kubectl create secret generic db-credentials --from-literal=POSTGRES_USER=postgres --from-literal=POSTGRES_PASSWORD=postgres --from-literal=POSTGRES_DB=postgres -n rag
+# k8s secrets — copy to .env, fill values, then run:
+# make k3s-secrets
+#
+# The same k8s/secrets/.env file is used to generate both:
+# - api-keys
+# - db-credentials
 
 TELEGRAM_BOT_TOKEN=
 LITELLM_MASTER_KEY=
@@ -14,3 +17,6 @@ LANGFUSE_HOST=
 KOMMO_ACCESS_TOKEN=
 KOMMO_CLIENT_ID=
 KOMMO_CLIENT_SECRET=
+
+# db-credentials
+POSTGRES_PASSWORD=

--- a/k8s/secrets/.env.example
+++ b/k8s/secrets/.env.example
@@ -2,8 +2,8 @@
 # make k3s-secrets
 #
 # The same k8s/secrets/.env file is used to generate both:
-# - api-keys
-# - db-credentials
+# - api-keys (all entries except POSTGRES_PASSWORD)
+# - db-credentials (POSTGRES_PASSWORD + fixed postgres user/db)
 
 TELEGRAM_BOT_TOKEN=
 LITELLM_MASTER_KEY=
@@ -18,5 +18,5 @@ KOMMO_ACCESS_TOKEN=
 KOMMO_CLIENT_ID=
 KOMMO_CLIENT_SECRET=
 
-# db-credentials
+# db-credentials only
 POSTGRES_PASSWORD=

--- a/scripts/check_image_drift.py
+++ b/scripts/check_image_drift.py
@@ -8,7 +8,7 @@ indicate stale containers running older/different image versions.
 Usage:
     python scripts/check_image_drift.py                         # Human-readable
     python scripts/check_image_drift.py --json                  # JSON output
-    python scripts/check_image_drift.py -f docker-compose.vps.yml  # Custom file
+    python scripts/check_image_drift.py -f compose.vps.yml      # Custom file
     python scripts/check_image_drift.py --fix                   # Show fix commands
 
 Exit codes:
@@ -375,8 +375,8 @@ def main() -> None:
     parser.add_argument(
         "-f",
         "--file",
-        default="docker-compose.dev.yml",
-        help="Compose file to check (default: docker-compose.dev.yml)",
+        default="compose.yml",
+        help="Compose file to check (default: compose.yml)",
     )
     parser.add_argument(
         "--json",

--- a/tests/unit/test_check_image_drift.py
+++ b/tests/unit/test_check_image_drift.py
@@ -1,0 +1,29 @@
+"""Regression tests for the image drift CLI defaults."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+SCRIPT = ROOT / "scripts" / "check_image_drift.py"
+
+
+def test_help_uses_current_default_compose_file() -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "default: compose.yml" in result.stdout
+    assert "docker-compose.dev.yml" not in result.stdout
+
+
+def test_script_examples_use_current_compose_filenames() -> None:
+    content = SCRIPT.read_text()
+    assert "docker-compose.dev.yml" not in content
+    assert "docker-compose.vps.yml" not in content
+    assert "compose.vps.yml" in content

--- a/tests/unit/test_k8s_secret_templates.py
+++ b/tests/unit/test_k8s_secret_templates.py
@@ -1,6 +1,14 @@
 """Regression tests for the k3s secret template and generation flow."""
 
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
 from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import yaml
 
 
 API_KEYS_REQUIRED = {
@@ -14,6 +22,7 @@ API_KEYS_REQUIRED = {
     "KOMMO_CLIENT_ID",
     "KOMMO_CLIENT_SECRET",
 }
+ROOT = Path(__file__).parents[2]
 
 
 def _load_env_example_keys() -> set[str]:
@@ -27,6 +36,85 @@ def _load_env_example_keys() -> set[str]:
     return keys
 
 
+def _load_container_env(path: Path, container_name: str) -> dict[str, dict[str, object]]:
+    deployment = yaml.safe_load(path.read_text())
+    containers = deployment["spec"]["template"]["spec"]["containers"]
+    container = next(item for item in containers if item["name"] == container_name)
+    return {entry["name"]: entry for entry in container.get("env", [])}
+
+
+def _run_make_k3s_secrets(env_text: str) -> tuple[subprocess.CompletedProcess[str], str, str]:
+    with TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        env_path = root / "k8s" / "secrets" / ".env"
+        env_path.parent.mkdir(parents=True)
+        env_path.write_text(env_text)
+        makefile_path = root / "Makefile"
+        makefile_path.write_text((ROOT / "Makefile").read_text())
+
+        fake_bin = root / "fake-bin"
+        fake_bin.mkdir()
+        kubectl_path = fake_bin / "kubectl"
+        kubectl_path.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -euo pipefail
+
+                log_dir="${FAKE_KUBECTL_LOG_DIR:?}"
+
+                if [ "$1" = "create" ] && [ "$2" = "secret" ] && [ "$3" = "generic" ]; then
+                    name="$4"
+                    env_file=""
+                    for arg in "$@"; do
+                        case "$arg" in
+                            --from-env-file=*)
+                                env_file="${arg#--from-env-file=}"
+                                ;;
+                        esac
+                    done
+                    if [ -n "$env_file" ]; then
+                        cp "$env_file" "$log_dir/$name.env"
+                    fi
+                    printf 'apiVersion: v1\\nkind: Secret\\nmetadata:\\n  name: %s\\n' "$name"
+                    exit 0
+                fi
+
+                if [ "$1" = "apply" ] && [ "$2" = "-f" ] && [ "$3" = "-" ]; then
+                    cat >/dev/null
+                    exit 0
+                fi
+
+                echo "unexpected kubectl invocation: $*" >&2
+                exit 1
+                """
+            )
+        )
+        kubectl_path.chmod(0o755)
+
+        log_dir = root / "kubectl-log"
+        log_dir.mkdir()
+
+        result = subprocess.run(
+            ["make", "k3s-secrets"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=root,
+            env={
+                **os.environ,
+                "PATH": f"{fake_bin}:{os.environ['PATH']}",
+                "FAKE_KUBECTL_LOG_DIR": str(log_dir),
+            },
+        )
+
+        api_keys_path = log_dir / "api-keys.env"
+        db_credentials_path = log_dir / "db-credentials.env"
+        api_keys = api_keys_path.read_text() if api_keys_path.exists() else ""
+        db_credentials = db_credentials_path.read_text() if db_credentials_path.exists() else ""
+        return result, api_keys, db_credentials
+
+
 def test_env_example_documents_current_api_keys_contract() -> None:
     keys = _load_env_example_keys()
     assert keys >= API_KEYS_REQUIRED
@@ -37,8 +125,43 @@ def test_env_example_documents_postgres_password_for_db_credentials() -> None:
     assert "POSTGRES_PASSWORD" in keys
 
 
-def test_make_k3s_secrets_uses_env_postgres_password() -> None:
-    makefile = Path("Makefile").read_text()
-    assert "set -a; . k8s/secrets/.env; set +a;" in makefile
-    assert "--from-literal=POSTGRES_PASSWORD=$$POSTGRES_PASSWORD" in makefile
-    assert "--from-literal=POSTGRES_PASSWORD=postgres" not in makefile
+def test_make_k3s_secrets_preserves_literal_postgres_password() -> None:
+    result, api_keys, db_credentials = _run_make_k3s_secrets(
+        "LITELLM_MASTER_KEY=test-key\nPOSTGRES_PASSWORD=pa$$word\n"
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "POSTGRES_PASSWORD=pa$$word" in db_credentials
+    assert "POSTGRES_PASSWORD" not in api_keys
+    assert "LITELLM_MASTER_KEY=test-key" in api_keys
+
+
+def test_make_k3s_secrets_requires_postgres_password() -> None:
+    result, _, _ = _run_make_k3s_secrets("LITELLM_MASTER_KEY=test-key\n")
+
+    assert result.returncode != 0
+    assert "POSTGRES_PASSWORD is required" in result.stderr
+
+
+def test_bot_deployment_uses_db_secret_password_in_database_url() -> None:
+    env = _load_container_env(ROOT / "k8s" / "base" / "bot" / "deployment.yaml", "bot")
+
+    assert env["POSTGRES_PASSWORD"]["valueFrom"]["secretKeyRef"] == {
+        "name": "db-credentials",
+        "key": "POSTGRES_PASSWORD",
+    }
+    assert env["REALESTATE_DATABASE_URL"]["value"] == (
+        "postgresql://postgres:$(POSTGRES_PASSWORD)@postgres:5432/realestate"
+    )
+
+
+def test_ingestion_deployment_uses_db_secret_password_in_database_url() -> None:
+    env = _load_container_env(ROOT / "k8s" / "base" / "ingestion" / "deployment.yaml", "ingestion")
+
+    assert env["POSTGRES_PASSWORD"]["valueFrom"]["secretKeyRef"] == {
+        "name": "db-credentials",
+        "key": "POSTGRES_PASSWORD",
+    }
+    assert env["INGESTION_DATABASE_URL"]["value"] == (
+        "postgresql://postgres:$(POSTGRES_PASSWORD)@postgres:5432/cocoindex"
+    )

--- a/tests/unit/test_k8s_secret_templates.py
+++ b/tests/unit/test_k8s_secret_templates.py
@@ -1,0 +1,44 @@
+"""Regression tests for the k3s secret template and generation flow."""
+
+from pathlib import Path
+
+
+API_KEYS_REQUIRED = {
+    "TELEGRAM_BOT_TOKEN",
+    "LITELLM_MASTER_KEY",
+    "REDIS_PASSWORD",
+    "LANGFUSE_PUBLIC_KEY",
+    "LANGFUSE_SECRET_KEY",
+    "LANGFUSE_HOST",
+    "KOMMO_ACCESS_TOKEN",
+    "KOMMO_CLIENT_ID",
+    "KOMMO_CLIENT_SECRET",
+}
+
+
+def _load_env_example_keys() -> set[str]:
+    path = Path("k8s/secrets/.env.example")
+    keys: set[str] = set()
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            key = line.split("=", 1)[0]
+            keys.add(key)
+    return keys
+
+
+def test_env_example_documents_current_api_keys_contract() -> None:
+    keys = _load_env_example_keys()
+    assert keys >= API_KEYS_REQUIRED
+
+
+def test_env_example_documents_postgres_password_for_db_credentials() -> None:
+    keys = _load_env_example_keys()
+    assert "POSTGRES_PASSWORD" in keys
+
+
+def test_make_k3s_secrets_uses_env_postgres_password() -> None:
+    makefile = Path("Makefile").read_text()
+    assert "set -a; . k8s/secrets/.env; set +a;" in makefile
+    assert "--from-literal=POSTGRES_PASSWORD=$$POSTGRES_PASSWORD" in makefile
+    assert "--from-literal=POSTGRES_PASSWORD=postgres" not in makefile


### PR DESCRIPTION
## Summary
- finish the remaining #1071 follow-up after PR #1084 by documenting `POSTGRES_PASSWORD` in `k8s/secrets/.env.example`
- make `make k3s-secrets` source `POSTGRES_PASSWORD` from `k8s/secrets/.env` instead of hardcoding `postgres`
- add regression coverage for the k8s secret-template / db-credentials contract and for the image-drift CLI default compose file

## Test Plan
- [x] `uv run pytest tests/unit/test_k8s_secret_templates.py tests/unit/test_k8s_bot_env.py tests/unit/test_k8s_image_version_sync.py -q`
- [x] `uv run pytest tests/unit/test_check_image_drift.py -q`
- [x] `kubectl kustomize --load-restrictor=LoadRestrictionsNone k8s/overlays/core >/dev/null`
- [x] `kubectl kustomize --load-restrictor=LoadRestrictionsNone k8s/overlays/bot >/dev/null`
- [x] `kubectl kustomize --load-restrictor=LoadRestrictionsNone k8s/overlays/ingest >/dev/null`
- [x] `kubectl kustomize --load-restrictor=LoadRestrictionsNone k8s/overlays/full >/dev/null`
- [x] `set -a; . /home/user/projects/rag-fresh/.env; set +a; COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility config --services`
- [x] `set -a; . /home/user/projects/rag-fresh/.env; set +a; COMPOSE_FILE=compose.yml:compose.vps.yml docker compose --compatibility config --services`
- [x] `make check`
- [x] `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
- [x] `set -a; . /home/user/projects/rag-fresh/.env; set +a; make verify-compose-images`

## Notes
- `docs/plans/2026-04-01-issue-1071-k8s-secrets-followup-plan.md` remains local-only and is not part of this PR.

Refs #1071