### PR TITLE
fix: align compose runtime contracts for vps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,12 +87,14 @@ DOCLING_URL=http://localhost:5001
 # Unified Google Drive ingestion (required for ingestion service / VPS deploys)
 GDRIVE_SYNC_DIR=/absolute/path/to/drive-sync
 GDRIVE_COLLECTION_NAME=gdrive_documents_bge
+INGESTION_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/cocoindex
 
 # =============================================================================
 # DEV STACK CONFIGURATION
 # =============================================================================
 
 # Telegram Bot (TELEGRAM_BOT_TOKEN defined above in required section)
+BOT_USERNAME=
 LLM_BASE_URL=http://localhost:4000
 LLM_MODEL=gpt-4o-mini
 CLIENT_DIRECT_PIPELINE_ENABLED=true

--- a/compose.yml
+++ b/compose.yml
@@ -476,7 +476,7 @@ services:
     restart: unless-stopped
     logging: *default-logging
     entrypoint: sh
-    command: -c 'mkdir -p /data/langfuse && minio server --address ":9000" /data'
+    command: -c 'mkdir -p /data/langfuse && minio server --address ":9000" --console-address ":9001" /data'
     environment:
       MINIO_ROOT_USER: minio
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-}
@@ -760,11 +760,11 @@ services:
     environment:
       LIVEKIT_API_KEY: ${LIVEKIT_API_KEY:-}
       LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET:-}
-      LIVEKIT_WS_URL: ws://livekit-server:7880
+      LIVEKIT_WS_URL: ${LIVEKIT_URL:-ws://livekit-server:7880}
       SIP_CONFIG_BODY: |
         api_key: ${LIVEKIT_API_KEY:-}
         api_secret: ${LIVEKIT_API_SECRET:-}
-        ws_url: ws://livekit-server:7880
+        ws_url: ${LIVEKIT_URL:-ws://livekit-server:7880}
         redis:
           address: redis:6379
           password: ${REDIS_PASSWORD:?REDIS_PASSWORD is required}
@@ -799,7 +799,7 @@ services:
     restart: unless-stopped
     logging: *default-logging
     environment:
-      LIVEKIT_URL: ws://livekit-server:7880
+      LIVEKIT_URL: ${LIVEKIT_URL:-ws://livekit-server:7880}
       LIVEKIT_API_KEY: ${LIVEKIT_API_KEY:-}
       LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET:-}
       ELEVEN_API_KEY: ${ELEVENLABS_API_KEY:-}

--- a/docs/plans/2026-04-01-open-issues-triage-snapshot.md
+++ b/docs/plans/2026-04-01-open-issues-triage-snapshot.md
@@ -15,18 +15,30 @@ Lane labels record provisional triage on the retrieval date above, and `Needs di
 
 - [x] `#1075` `audit: remove unused imports in __init__.py files [priority:high]`
   implemented in `PR #1087`, merged into `dev` at `780f996af465b4506153036b06255185284b27f6`.
-- [ ] Next recommended task: `#1076` `audit: deduplicate convert_to_python_types and create_search_engine [priority:high]`
-  Treat this as `Plan needed`, not `Quick execution`, because it spans shared retrieval/evaluation code paths and test surfaces.
+- [x] `#1076` `audit: deduplicate convert_to_python_types and create_search_engine [priority:high]`
+  implemented in `PR #1127`, merged into `dev` and closed on `2026-04-01`.
+- [x] `#1071` `fix: sync Docker and k8s image versions + complete k8s secrets template`
+  completed by merged `dev` PRs `#1084` (`2026-04-01T12:39:34Z`) and `#1129`
+  (`2026-04-01T15:51:44Z`); issue closed on `2026-04-02`.
+- [x] `#1078` `audit: filter extractors — shared base class and constants [priority:medium]`
+  implemented in `PR #1130`, merged into `dev` at `2026-04-02T14:17:32Z`.
+- [x] `#1079` `audit: dead code removal`
+  implemented in `PR #1131`, merged into `dev` at `2026-04-02T14:31:37Z`;
+  issue closed on `2026-04-02`.
+- [ ] `#1073` `chore: dependency updates — version audit April 2026`
+  verified local changes were preserved in stash
+  `autosave: issue-1073-deps-audit before branch cleanup`; issue reopened on
+  `2026-04-02` pending reintegration.
+- [x] `#1074` `audit: compose.vps.yml — broken overrides and missing BOT_USERNAME`
+  implemented in local branch `issue-1074-compose-vps-audit`, verified with
+  compose/runtime checks, and issue closed on `2026-04-02`.
+- [ ] Next recommended task: `#1080` `langfuse не может подключиться к postgres, clickhouse, redis`
+  Treat this as `Plan needed`; it remains `OPEN`.
 
 ## Quick execution
-- `#1078` `audit: filter extractors — shared base class and constants [priority:medium]`
-- `#1079` `audit: dead code removal`
 
 ## Plan needed
-- `#1076` `audit: deduplicate convert_to_python_types and create_search_engine [priority:high]`
-- `#1071` `fix: sync Docker and k8s image versions + complete k8s secrets template`
 - `#1073` `chore: dependency updates — version audit April 2026`
-- `#1074` `audit: compose.vps.yml — broken overrides and missing BOT_USERNAME`
 - `#1080` `langfuse не может подключиться к postgres, clickhouse, redis`
 - `#1081` `postgres: 7 аварийных остановок, WAL corruption, autovacuum failures`
 - `#1082` `clickhouse: IPv6 bind failures + lock contention до 200 сек`

--- a/docs/superpowers/plans/2026-04-02-issue-1074-compose-vps-runtime-plan.md
+++ b/docs/superpowers/plans/2026-04-02-issue-1074-compose-vps-runtime-plan.md
@@ -1,0 +1,92 @@
+# Issue #1074 Compose VPS Runtime Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the current runtime-contract gaps behind `#1074` by correcting the base compose/env configuration that VPS and local runtime both rely on, while avoiding stale fixes for issue points that are no longer true.
+
+**Architecture:** First codify the actual current contract in tests: `.env.example` must document required runtime vars, and base `compose.yml` must provide the MinIO console address plus environment-driven LiveKit URLs instead of hardcoded values. Then apply the minimal config edits and verify the merged VPS compose still resolves cleanly with dummy required env values.
+
+**Tech Stack:** Docker Compose, YAML, `.env.example`, `pytest`, `uv`
+
+---
+
+### Task 1: Lock the missing env/example contract
+
+**Files:**
+- Modify: `tests/unit/test_env_example.py`
+- Modify: `.env.example`
+
+- [ ] **Step 1: Write failing env-example assertions**
+
+Add assertions that `.env.example` contains:
+- `BOT_USERNAME`
+- `INGESTION_DATABASE_URL`
+
+- [ ] **Step 2: Run RED**
+
+Run: `uv run pytest tests/unit/test_env_example.py -q`
+
+Expected: fail because those variables are not currently documented in `.env.example`.
+
+- [ ] **Step 3: Add the missing env variables**
+
+Document both variables in `.env.example` in the relevant sections without inventing unrelated new required secrets.
+
+- [ ] **Step 4: Run GREEN**
+
+Run: `uv run pytest tests/unit/test_env_example.py -q`
+
+Expected: pass.
+
+### Task 2: Lock the compose runtime contract
+
+**Files:**
+- Create: `tests/unit/test_compose_runtime_contract.py`
+- Modify: `compose.yml`
+
+- [ ] **Step 1: Write failing compose-contract tests**
+
+Add focused tests asserting:
+- base `compose.yml` MinIO command includes `--console-address ":9001"`
+- `voice-agent` uses `${LIVEKIT_URL:-ws://livekit-server:7880}`
+- `livekit-sip` uses `${LIVEKIT_URL:-ws://livekit-server:7880}` for both `LIVEKIT_WS_URL` and `SIP_CONFIG_BODY`
+
+- [ ] **Step 2: Run RED**
+
+Run: `uv run pytest tests/unit/test_compose_runtime_contract.py -q`
+
+Expected: fail on the current hardcoded/higher-drift config.
+
+- [ ] **Step 3: Apply the minimal compose fix**
+
+Update `compose.yml` only:
+- add MinIO console address to the base command
+- replace hardcoded LiveKit websocket URLs with `${LIVEKIT_URL:-ws://livekit-server:7880}`
+
+- [ ] **Step 4: Run GREEN**
+
+Run: `uv run pytest tests/unit/test_compose_runtime_contract.py -q`
+
+Expected: pass.
+
+### Task 3: Verify VPS runtime shape and finish tracking
+
+**Files:**
+- Modify: `docs/plans/2026-04-01-open-issues-triage-snapshot.md`
+
+- [ ] **Step 1: Run targeted runtime verification**
+
+Run:
+- `export POSTGRES_PASSWORD=x REDIS_PASSWORD=x TELEGRAM_BOT_TOKEN=x LITELLM_MASTER_KEY=x OPENAI_API_KEY=x NEXTAUTH_SECRET=x SALT=x ENCRYPTION_KEY=x LIVEKIT_API_KEY=x LIVEKIT_API_SECRET=x GDRIVE_SYNC_DIR=/tmp; COMPOSE_FILE=compose.yml:compose.vps.yml docker compose --compatibility config --services`
+- `make verify-compose-images` (only if it does not require live running services; otherwise skip and state why)
+- `make check`
+- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
+
+Expected: compose resolves, checks pass, and no new runtime regressions appear.
+
+- [ ] **Step 2: Mark the shared triage snapshot**
+
+If the implementation is complete and verified, update `docs/plans/2026-04-01-open-issues-triage-snapshot.md`:
+- move `#1074` out of `Plan needed`
+- add an execution update entry with concrete completion details
+- switch `Next recommended task` to the next open issue in order

--- a/tests/unit/test_compose_runtime_contract.py
+++ b/tests/unit/test_compose_runtime_contract.py
@@ -1,0 +1,38 @@
+"""Regression checks for compose runtime contracts behind issue #1074."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).parents[2]
+BASE_COMPOSE = ROOT / "compose.yml"
+LIVEKIT_URL_EXPR = "${LIVEKIT_URL:-ws://livekit-server:7880}"
+
+
+def _load_compose() -> dict:
+    return yaml.safe_load(BASE_COMPOSE.read_text())
+
+
+def test_minio_base_command_exposes_console_address() -> None:
+    compose = _load_compose()
+    command = compose["services"]["minio"]["command"]
+
+    assert '--console-address ":9001"' in command
+
+
+def test_voice_agent_uses_env_driven_livekit_url() -> None:
+    compose = _load_compose()
+    environment = compose["services"]["voice-agent"]["environment"]
+
+    assert environment["LIVEKIT_URL"] == LIVEKIT_URL_EXPR
+
+
+def test_livekit_sip_uses_env_driven_livekit_url_everywhere() -> None:
+    compose = _load_compose()
+    environment = compose["services"]["livekit-sip"]["environment"]
+
+    assert environment["LIVEKIT_WS_URL"] == LIVEKIT_URL_EXPR
+    assert f"ws_url: {LIVEKIT_URL_EXPR}" in environment["SIP_CONFIG_BODY"]

--- a/tests/unit/test_env_example.py
+++ b/tests/unit/test_env_example.py
@@ -46,6 +46,11 @@ class TestEnvExampleCompleteness:
 
     REQUIRED_DB_VARS = [
         "REALESTATE_DATABASE_URL",
+        "INGESTION_DATABASE_URL",
+    ]
+
+    REQUIRED_RUNTIME_VARS = [
+        "BOT_USERNAME",
     ]
 
     @pytest.mark.parametrize("var", REQUIRED_CRM_VARS)
@@ -60,5 +65,10 @@ class TestEnvExampleCompleteness:
 
     @pytest.mark.parametrize("var", REQUIRED_DB_VARS)
     def test_db_var_in_env_example(self, var: str):
+        keys = _parse_env_example()
+        assert var in keys, f"{var} missing from .env.example"
+
+    @pytest.mark.parametrize("var", REQUIRED_RUNTIME_VARS)
+    def test_runtime_var_in_env_example(self, var: str):
         keys = _parse_env_example()
         assert var in keys, f"{var} missing from .env.example"


### PR DESCRIPTION
## Summary
- document missing runtime variables in `.env.example` (`BOT_USERNAME`, `INGESTION_DATABASE_URL`)
- align base `compose.yml` runtime contracts for MinIO and LiveKit URLs
- add regression coverage for env-example completeness and compose runtime contracts
- update the open-issues triage snapshot so `#1074` is marked done and `#1080` is next

## Test Plan
- [x] `uv run pytest tests/unit/test_env_example.py tests/unit/test_compose_runtime_contract.py tests/unit/test_compose_config.py tests/unit/test_compose_langfuse.py tests/unit/test_docker_compose_env.py -q`
- [x] `COMPOSE_FILE=compose.yml:compose.vps.yml docker compose --compatibility config --services` with dummy required env values
- [x] `make check`
- [x] `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`

## Notes
- `#1073` is intentionally not included here; it was reopened and its local work was preserved in stash for later reintegration.
- `make verify-compose-images` was not run because it checks drift against running containers, not static compose correctness.

Refs #1074
