### PR TITLE
fix: restore langfuse dependency restart propagation

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -516,12 +516,16 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+        restart: true
       minio:
         condition: service_healthy
+        restart: true
       redis-langfuse:
         condition: service_healthy
+        restart: true
       clickhouse:
         condition: service_healthy
+        restart: true
     environment: &langfuse-env
       # Database
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/langfuse
@@ -575,12 +579,16 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+        restart: true
       minio:
         condition: service_healthy
+        restart: true
       redis-langfuse:
         condition: service_healthy
+        restart: true
       clickhouse:
         condition: service_healthy
+        restart: true
       langfuse-worker:
         condition: service_started
     environment:

--- a/docs/plans/2026-04-01-open-issues-triage-snapshot.md
+++ b/docs/plans/2026-04-01-open-issues-triage-snapshot.md
@@ -32,14 +32,16 @@ Lane labels record provisional triage on the retrieval date above, and `Needs di
 - [x] `#1074` `audit: compose.vps.yml — broken overrides and missing BOT_USERNAME`
   implemented in local branch `issue-1074-compose-vps-audit`, verified with
   compose/runtime checks, and issue closed on `2026-04-02`.
-- [ ] Next recommended task: `#1080` `langfuse не может подключиться к postgres, clickhouse, redis`
+- [x] `#1080` `langfuse не может подключиться к postgres, clickhouse, redis`
+  implemented in local branch `issue-1080-fix`, verified with compose runtime
+  checks, `make check`, and `make test-unit`; issue closed on `2026-04-02`.
+- [ ] Next recommended task: `#1081` `postgres: 7 аварийных остановок, WAL corruption, autovacuum failures`
   Treat this as `Plan needed`; it remains `OPEN`.
 
 ## Quick execution
 
 ## Plan needed
 - `#1073` `chore: dependency updates — version audit April 2026`
-- `#1080` `langfuse не может подключиться к postgres, clickhouse, redis`
 - `#1081` `postgres: 7 аварийных остановок, WAL corruption, autovacuum failures`
 - `#1082` `clickhouse: IPv6 bind failures + lock contention до 200 сек`
 - `#1083` `qdrant: telemetry reporting failed + invalid vector name queries`

--- a/tests/unit/test_compose_langfuse_runtime_contract.py
+++ b/tests/unit/test_compose_langfuse_runtime_contract.py
@@ -1,0 +1,83 @@
+"""Regression tests for the Langfuse compose runtime contract (#1080)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).parents[2]
+COMPOSE = ROOT / "compose.yml"
+
+LANGFUSE_SERVICES = ("langfuse-worker", "langfuse")
+STATEFUL_DEPS = ("postgres", "clickhouse", "minio", "redis-langfuse")
+
+
+def _load_compose() -> dict:
+    return yaml.safe_load(COMPOSE.read_text())
+
+
+def _depends_on(compose: dict, service: str, dependency: str) -> dict:
+    svc = compose["services"][service]
+    depends = svc.get("depends_on")
+    assert isinstance(depends, dict), f"{service}.depends_on must use long syntax"
+    assert dependency in depends, f"{service}.depends_on is missing {dependency}"
+
+    dep = depends[dependency]
+    assert isinstance(dep, dict), f"{service}.depends_on.{dependency} must use long syntax"
+    return dep
+
+
+@pytest.fixture(scope="module")
+def compose() -> dict:
+    return _load_compose()
+
+
+class TestLangfuseRuntimeContract:
+    """Langfuse services must restart cleanly after dependent stateful services recreate."""
+
+    @pytest.mark.parametrize("service", LANGFUSE_SERVICES)
+    def test_restart_propagation_is_limited_to_stateful_dependencies(
+        self,
+        compose: dict,
+        service: str,
+    ) -> None:
+        depends = compose["services"][service]["depends_on"]
+        assert isinstance(depends, dict), f"{service}.depends_on must use long syntax"
+
+        restart_enabled = {
+            dependency
+            for dependency, config in depends.items()
+            if isinstance(config, dict) and config.get("restart") is True
+        }
+        assert restart_enabled == set(STATEFUL_DEPS), (
+            f"{service}.depends_on restart propagation must be limited to {STATEFUL_DEPS}, "
+            f"got {sorted(restart_enabled)}"
+        )
+
+    @pytest.mark.parametrize("service", LANGFUSE_SERVICES)
+    @pytest.mark.parametrize("dependency", STATEFUL_DEPS)
+    def test_stateful_dependencies_are_healthy_and_restart_propagates(
+        self,
+        compose: dict,
+        service: str,
+        dependency: str,
+    ) -> None:
+        dep = _depends_on(compose, service, dependency)
+        assert dep.get("condition") == "service_healthy", (
+            f"{service}.depends_on.{dependency} must wait for service_healthy"
+        )
+        assert dep.get("restart") is True, (
+            f"{service}.depends_on.{dependency} must set restart: true to follow dependency recreation"
+        )
+
+    def test_web_depends_on_worker_without_restart_propagation(self, compose: dict) -> None:
+        dep = _depends_on(compose, "langfuse", "langfuse-worker")
+        assert dep.get("condition") == "service_started", (
+            "langfuse.depends_on.langfuse-worker must use condition: service_started"
+        )
+        assert dep.get("restart") is not True, (
+            "langfuse.depends_on.langfuse-worker must not set restart: true"
+        )


### PR DESCRIPTION
## Summary
- add a regression test that requires Langfuse and Langfuse worker to use restart propagation on stateful dependency edges only
- add `restart: true` to the Langfuse `depends_on` entries for postgres, clickhouse, minio, and redis-langfuse
- update the open-issues triage snapshot and close issue #1080, setting #1081 as the next recommended task

## Test Plan
- [x] `uv run pytest tests/unit/test_compose_langfuse.py tests/unit/test_compose_langfuse_runtime_contract.py -q`
- [x] `COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --env-file ../../.env --profile ml --compatibility up -d clickhouse minio redis-langfuse langfuse-worker langfuse postgres`
- [x] verify post-restart Langfuse health at `/api/public/health` and in-container DNS resolution for postgres/clickhouse/redis-langfuse
- [x] `make check`
- [x] `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
