### PR TITLE
fix(search): increase _DEFAULT_RERANK_TOP_K from 3 to 5 and cache key prefix to 64 dims

### DIFF
--- a/telegram_bot/agents/rag_pipeline.py
+++ b/telegram_bot/agents/rag_pipeline.py
@@ -45,8 +45,8 @@ from telegram_bot.services.rag_core import (
 
 logger = logging.getLogger(__name__)
 
-# top_k=3 for reranking. Saves ~20ms vs top_k=5 while capturing most relevant docs via ColBERT semantic similarity.
-_DEFAULT_RERANK_TOP_K = 3
+# top_k=5 for reranking. Standard in literature; balances latency vs recall for reranking candidate pool.
+_DEFAULT_RERANK_TOP_K = 5
 
 
 async def _execute_qdrant_retrieval(

--- a/telegram_bot/integrations/cache.py
+++ b/telegram_bot/integrations/cache.py
@@ -627,7 +627,7 @@ class CacheLayerManager:
                 "filters_count": len(filters or {}),
             }
         )
-        key = _hash(str(embedding_prefix[:10]) + json.dumps(filters, sort_keys=True, default=str))
+        key = _hash(str(embedding_prefix[:64]) + json.dumps(filters, sort_keys=True, default=str))
         result = await self.get_exact("search", key)
         lf.update_current_span(
             output={"hit": result is not None, "results_count": len(result or [])}
@@ -650,7 +650,7 @@ class CacheLayerManager:
                 "results_count": len(results),
             }
         )
-        key = _hash(str(embedding_prefix[:10]) + json.dumps(filters, sort_keys=True, default=str))
+        key = _hash(str(embedding_prefix[:64]) + json.dumps(filters, sort_keys=True, default=str))
         await self.store_exact("search", key, results)
         lf.update_current_span(output={"stored": True, "results_count": len(results)})
 


### PR DESCRIPTION
## Summary
- Increase `_DEFAULT_RERANK_TOP_K` from 3 to 5 for reranking candidate pool (standard in literature)
- Increase search results cache key embedding prefix from 10 to 64 dimensions to reduce collision risk

## Fixes
- Fixes #1114 - `_DEFAULT_RERANK_TOP_K=3` was too restrictive for reranking candidate pool
- Fixes #1110 - Search results cache key used only 10/1024 embedding dimensions, causing collision risk

## Test plan
- [x] All 59 cache layer tests pass
- [x] All 299 agent tests pass  
- [x] All 489 graph/pipeline tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)