### PR TITLE
refactor: consolidate duplicated retry decorators into shared module

### DIFF
--- a/telegram_bot/services/_retry.py
+++ b/telegram_bot/services/_retry.py
@@ -6,6 +6,8 @@ Consolidates retry logic from kommo_client and bge_m3_client.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 import httpx
 from tenacity import (
@@ -19,6 +21,7 @@ from tenacity import (
 
 
 logger = logging.getLogger(__name__)
+RetryWrappedFn = TypeVar("RetryWrappedFn", bound=Callable[..., Any])
 
 # Transient transport errors worth retrying
 RETRYABLE_TRANSPORT_ERRORS = (
@@ -47,7 +50,7 @@ def make_retry_decorator(
     max_: float = 8.0,
     jitter: float = 2.0,
     max_attempts: int = 3,
-) -> type[retry]:
+) -> Callable[[RetryWrappedFn], RetryWrappedFn]:
     """Factory for retry decorators with common configuration.
 
     Args:
@@ -58,7 +61,7 @@ def make_retry_decorator(
         jitter: Maximum jitter in seconds
         max_attempts: Maximum retry attempts
     """
-    retry_predicate = retry_if_exception_type(RETRYABLE_TRANSPORT_ERRORS)
+    retry_predicate: Any = retry_if_exception_type(RETRYABLE_TRANSPORT_ERRORS)
     if retry_on_http_status:
         retry_predicate = retry_predicate | retry_if_exception(_retryable_http_status)
 

--- a/telegram_bot/services/_retry.py
+++ b/telegram_bot/services/_retry.py
@@ -1,0 +1,91 @@
+"""Shared retry decorators for HTTP clients.
+
+Consolidates retry logic from kommo_client and bge_m3_client.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
+
+
+logger = logging.getLogger(__name__)
+
+# Transient transport errors worth retrying
+RETRYABLE_TRANSPORT_ERRORS = (
+    httpx.RemoteProtocolError,
+    httpx.ConnectError,
+    httpx.ReadTimeout,
+    httpx.ConnectTimeout,
+    httpx.PoolTimeout,
+)
+
+# Kommo-specific: also retry on certain HTTP status codes
+RETRYABLE_HTTP_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
+
+def _retryable_http_status(exc: BaseException) -> bool:
+    if not isinstance(exc, httpx.HTTPStatusError):
+        return False
+    return exc.response.status_code in RETRYABLE_HTTP_STATUS_CODES
+
+
+def make_retry_decorator(
+    *,
+    retry_on_transport: bool = True,
+    retry_on_http_status: bool = False,
+    initial: float = 1.0,
+    max_: float = 8.0,
+    jitter: float = 2.0,
+    max_attempts: int = 3,
+) -> type[retry]:
+    """Factory for retry decorators with common configuration.
+
+    Args:
+        retry_on_transport: Include transport errors (ConnectTimeout, etc.)
+        retry_on_http_status: Include HTTP 5xx/429 status codes
+        initial: Initial wait time in seconds
+        max_: Maximum wait time in seconds
+        jitter: Maximum jitter in seconds
+        max_attempts: Maximum retry attempts
+    """
+    retry_predicate = retry_if_exception_type(RETRYABLE_TRANSPORT_ERRORS)
+    if retry_on_http_status:
+        retry_predicate = retry_predicate | retry_if_exception(_retryable_http_status)
+
+    return retry(
+        retry=retry_predicate,
+        wait=wait_exponential_jitter(initial=initial, max=max_, jitter=jitter),
+        stop=stop_after_attempt(max_attempts),
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+        reraise=True,
+    )
+
+
+# Convenience decorators matching original configurations
+kommo_retry = make_retry_decorator(
+    retry_on_transport=True,
+    retry_on_http_status=True,
+    initial=1,
+    max_=8,
+    jitter=2,
+    max_attempts=3,
+)
+
+bge_retry = make_retry_decorator(
+    retry_on_transport=True,
+    retry_on_http_status=False,
+    initial=0.5,
+    max_=4,
+    jitter=1,
+    max_attempts=3,
+)

--- a/telegram_bot/services/_retry.py
+++ b/telegram_bot/services/_retry.py
@@ -44,7 +44,6 @@ def _retryable_http_status(exc: BaseException) -> bool:
 
 def make_retry_decorator(
     *,
-    retry_on_transport: bool = True,
     retry_on_http_status: bool = False,
     initial: float = 1.0,
     max_: float = 8.0,
@@ -54,7 +53,6 @@ def make_retry_decorator(
     """Factory for retry decorators with common configuration.
 
     Args:
-        retry_on_transport: Include transport errors (ConnectTimeout, etc.)
         retry_on_http_status: Include HTTP 5xx/429 status codes
         initial: Initial wait time in seconds
         max_: Maximum wait time in seconds
@@ -76,7 +74,6 @@ def make_retry_decorator(
 
 # Convenience decorators matching original configurations
 kommo_retry = make_retry_decorator(
-    retry_on_transport=True,
     retry_on_http_status=True,
     initial=1,
     max_=8,
@@ -85,7 +82,6 @@ kommo_retry = make_retry_decorator(
 )
 
 bge_retry = make_retry_decorator(
-    retry_on_transport=True,
     retry_on_http_status=False,
     initial=0.5,
     max_=4,

--- a/telegram_bot/services/bge_m3_client.py
+++ b/telegram_bot/services/bge_m3_client.py
@@ -11,40 +11,14 @@ Centralizes: httpx client lifecycle, retry/timeout policy, response parsing.
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass, field
 from typing import Any
 
 import httpx
-from tenacity import (
-    before_sleep_log,
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential_jitter,
-)
 
 from telegram_bot.observability import get_client, observe
+from telegram_bot.services._retry import bge_retry
 
-
-logger = logging.getLogger(__name__)
-
-# Transient transport errors worth retrying
-RETRYABLE_ERRORS = (
-    httpx.RemoteProtocolError,
-    httpx.ConnectError,
-    httpx.ReadTimeout,
-    httpx.ConnectTimeout,
-    httpx.PoolTimeout,
-)
-
-_bge_retry = retry(
-    retry=retry_if_exception_type(RETRYABLE_ERRORS),
-    wait=wait_exponential_jitter(initial=0.5, max=4, jitter=1),
-    stop=stop_after_attempt(3),
-    before_sleep=before_sleep_log(logger, logging.WARNING),
-    reraise=True,
-)
 
 DEFAULT_TIMEOUT = httpx.Timeout(connect=5.0, read=30.0, write=5.0, pool=5.0)
 DEFAULT_BATCH_SIZE = 32
@@ -131,7 +105,7 @@ class BGEM3Client:
         return self._client
 
     @observe(name="bge-m3-encode-dense", capture_input=False, capture_output=False)
-    @_bge_retry
+    @bge_retry
     async def encode_dense(self, texts: list[str]) -> DenseResult:
         """Encode texts to dense vectors via /encode/dense."""
         lf = get_client()
@@ -168,7 +142,7 @@ class BGEM3Client:
         return DenseResult(vectors=all_vecs, processing_time=processing_time)
 
     @observe(name="bge-m3-encode-sparse", capture_input=False, capture_output=False)
-    @_bge_retry
+    @bge_retry
     async def encode_sparse(self, texts: list[str]) -> SparseResult:
         """Encode texts to sparse vectors via /encode/sparse."""
         lf = get_client()
@@ -201,7 +175,7 @@ class BGEM3Client:
         return SparseResult(weights=all_weights, processing_time=processing_time)
 
     @observe(name="bge-m3-encode-hybrid", capture_input=False, capture_output=False)
-    @_bge_retry
+    @bge_retry
     async def encode_hybrid(self, texts: list[str]) -> HybridResult:
         """Encode texts to dense + sparse via /encode/hybrid (single call)."""
         lf = get_client()
@@ -239,7 +213,7 @@ class BGEM3Client:
         return result
 
     @observe(name="bge-m3-rerank", capture_input=False, capture_output=False)
-    @_bge_retry
+    @bge_retry
     async def rerank(self, query: str, documents: list[str], top_k: int = 5) -> RerankResult:
         """Rerank documents via ColBERT MaxSim /rerank endpoint."""
         lf = get_client()
@@ -280,7 +254,7 @@ class BGEM3Client:
         return result
 
     @observe(name="bge-m3-encode-colbert", capture_input=False, capture_output=False)
-    @_bge_retry
+    @bge_retry
     async def encode_colbert(self, texts: list[str]) -> ColbertResult:
         """Encode texts to ColBERT multivectors via /encode/colbert."""
         lf = get_client()

--- a/telegram_bot/services/kommo_client.py
+++ b/telegram_bot/services/kommo_client.py
@@ -10,16 +10,9 @@ import logging
 from typing import TYPE_CHECKING, Any, cast
 
 import httpx
-from tenacity import (
-    before_sleep_log,
-    retry,
-    retry_if_exception,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential_jitter,
-)
 
 from telegram_bot.observability import observe
+from telegram_bot.services._retry import kommo_retry
 from telegram_bot.services.kommo_models import (
     Contact,
     ContactCreate,
@@ -40,23 +33,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-RETRYABLE = (httpx.ConnectError, httpx.ReadTimeout, httpx.ConnectTimeout, httpx.PoolTimeout)
-
-
-def _retryable_http_status(exc: BaseException) -> bool:
-    if not isinstance(exc, httpx.HTTPStatusError):
-        return False
-    return exc.response.status_code in {429, 500, 502, 503, 504}
-
-
-_kommo_retry = retry(
-    retry=retry_if_exception_type(RETRYABLE) | retry_if_exception(_retryable_http_status),
-    wait=wait_exponential_jitter(initial=1, max=8, jitter=2),
-    stop=stop_after_attempt(3),
-    before_sleep=before_sleep_log(logger, logging.WARNING),
-    reraise=True,
-)
-
 
 class KommoClient:
     """Async Kommo CRM API adapter with auto-refresh OAuth2."""
@@ -72,7 +48,7 @@ class KommoClient:
             headers={"Content-Type": "application/json"},
         )
 
-    @_kommo_retry
+    @kommo_retry
     async def _request(self, method: str, path: str, **kwargs: Any) -> dict:
         """Execute request with auto-refresh on 401."""
         token = await self._token_store.get_valid_token()


### PR DESCRIPTION
## Summary
- Extract duplicated retry logic into shared `telegram_bot/services/_retry.py`.
- Reuse the shared helper from BGE M3 and Kommo service code.

## Test Plan
- Not run in this git cleanup pass
