### PR TITLE
refactor: extract callback handlers from PropertyBot monolith

### DIFF
--- a/telegram_bot/handlers/favorites_callbacks.py
+++ b/telegram_bot/handlers/favorites_callbacks.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import contextlib
 import logging
-from typing import TYPE_CHECKING, Any
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
 
 from aiogram import F, Router
 from aiogram.fsm.context import FSMContext
-from aiogram.types import CallbackQuery
+from aiogram.types import CallbackQuery, InaccessibleMessage
 
 from telegram_bot.callback_data import FavoriteCB
 
@@ -19,6 +20,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _STALE_RESULTS_CALLBACK_TEXT = "Это устаревшая кнопка. Используйте актуальное меню ниже."
+
+
+@dataclass
+class _LegacyFavoriteCB:
+    apartment_id: str
 
 
 def _state_apartment_results(state_data: dict[str, Any]) -> list[dict[str, Any]]:
@@ -85,11 +91,12 @@ async def handle_fav_add(
     )
     if result:
         await callback.answer("Добавлено в закладки")
-        if callback.message:
+        message = callback.message
+        if message is not None and not isinstance(message, InaccessibleMessage):
             from telegram_bot.keyboards.property_card import build_card_buttons
 
             with contextlib.suppress(Exception):
-                await callback.message.edit_reply_markup(  # type: ignore[union-attr]
+                await message.edit_reply_markup(
                     reply_markup=build_card_buttons(property_id, is_favorited=True)
                 )
     else:
@@ -129,14 +136,22 @@ async def handle_fav_remove(
     is_bookmark_message = (
         isinstance(callback_message_id, int) and callback_message_id in bookmark_message_ids
     )
-    if in_search_results and not is_bookmark_message and callback.message:
+    message = callback.message
+    if (
+        in_search_results
+        and not is_bookmark_message
+        and message is not None
+        and not isinstance(message, InaccessibleMessage)
+    ):
         with contextlib.suppress(Exception):
-            await callback.message.edit_reply_markup(
+            await message.edit_reply_markup(
                 reply_markup=build_card_buttons_for_results(property_id, is_favorited=False)
             )
-    elif is_bookmark_message and callback.message:
+    elif (
+        is_bookmark_message and message is not None and not isinstance(message, InaccessibleMessage)
+    ):
         with contextlib.suppress(Exception):
-            await callback.message.delete()
+            await message.delete()
     await callback.answer("Удалено из закладок")
 
 
@@ -249,39 +264,24 @@ async def handle_favorite_callback(
 
     # Dispatch to specific handlers
     if action == "add":
-        # Build FavoriteCB-like object for handle_fav_add
-        class _FakeFavoriteCB:
-            def __init__(self, apt_id):
-                self.apartment_id = apt_id
-
         await handle_fav_add(
             callback,
             state,
-            callback_data=_FakeFavoriteCB(property_id) if property_id else None,
+            callback_data=cast(FavoriteCB, _LegacyFavoriteCB(property_id)) if property_id else None,
             favorites_service=favorites_service,
         )
     elif action == "remove":
-
-        class _FakeFavoriteCB:
-            def __init__(self, apt_id):
-                self.apartment_id = apt_id
-
         await handle_fav_remove(
             callback,
             state,
-            callback_data=_FakeFavoriteCB(property_id) if property_id else None,
+            callback_data=cast(FavoriteCB, _LegacyFavoriteCB(property_id)) if property_id else None,
             favorites_service=favorites_service,
         )
     elif action == "viewing":
-
-        class _FakeFavoriteCB:
-            def __init__(self, apt_id):
-                self.apartment_id = apt_id
-
         await handle_fav_viewing(
             callback,
             state,
-            callback_data=_FakeFavoriteCB(property_id) if property_id else None,
+            callback_data=cast(FavoriteCB, _LegacyFavoriteCB(property_id)) if property_id else None,
             favorites_service=favorites_service,
         )
     elif action == "viewing_all":

--- a/telegram_bot/handlers/favorites_callbacks.py
+++ b/telegram_bot/handlers/favorites_callbacks.py
@@ -1,0 +1,299 @@
+"""Favorite callback handlers — fav:add/remove/viewing/viewing_all (#628)."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from typing import TYPE_CHECKING, Any
+
+from aiogram import F, Router
+from aiogram.fsm.context import FSMContext
+from aiogram.types import CallbackQuery
+
+from telegram_bot.callback_data import FavoriteCB
+
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+_STALE_RESULTS_CALLBACK_TEXT = "Это устаревшая кнопка. Используйте актуальное меню ниже."
+
+
+def _state_apartment_results(state_data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract apartment results from state data, checking catalog_runtime first."""
+    if not isinstance(state_data, dict):
+        return []
+    catalog_runtime = state_data.get("catalog_runtime")
+    if catalog_runtime and isinstance(catalog_runtime, dict):
+        results = catalog_runtime.get("results")
+        if isinstance(results, list):
+            return results
+    results = state_data.get("apartment_results")
+    if isinstance(results, list):
+        return results
+    return []
+
+
+async def handle_fav_add(
+    callback: CallbackQuery,
+    state: FSMContext,
+    callback_data: FavoriteCB | None = None,
+    favorites_service: Any | None = None,
+) -> None:
+    """Handle fav:add:{property_id} — add to favorites (#628)."""
+    if not callback.from_user:
+        await callback.answer()
+        return
+    property_id = callback_data.apartment_id if callback_data is not None else ""
+    if not property_id:
+        await callback.answer()
+        return
+
+    if favorites_service is None:
+        await callback.answer("Закладки недоступны")
+        return
+
+    state_data = await state.get_data()
+    apt_results = _state_apartment_results(state_data)
+    matched = next(
+        (r for r in apt_results if isinstance(r, dict) and r.get("id") == property_id),
+        None,
+    )
+    if matched:
+        payload = matched.get("payload")
+        if not isinstance(payload, dict):
+            property_data: dict[str, Any] = {}
+        else:
+            p = payload
+            property_data = {
+                "complex_name": p.get("complex_name", ""),
+                "location": p.get("city", ""),
+                "property_type": p.get("property_type", ""),
+                "floor": p.get("floor", 0),
+                "area_m2": p.get("area_m2", 0),
+                "view": ", ".join(p.get("view_tags", [])) or p.get("view_primary", ""),
+                "price_eur": p.get("price_eur", 0),
+            }
+    else:
+        property_data = {}
+    result = await favorites_service.add(
+        telegram_id=callback.from_user.id,
+        property_id=property_id,
+        property_data=property_data,
+    )
+    if result:
+        await callback.answer("Добавлено в закладки")
+        if callback.message:
+            from telegram_bot.keyboards.property_card import build_card_buttons
+
+            with contextlib.suppress(Exception):
+                await callback.message.edit_reply_markup(  # type: ignore[union-attr]
+                    reply_markup=build_card_buttons(property_id, is_favorited=True)
+                )
+    else:
+        await callback.answer("Уже в закладках")
+
+
+async def handle_fav_remove(
+    callback: CallbackQuery,
+    state: FSMContext,
+    callback_data: FavoriteCB | None = None,
+    favorites_service: Any | None = None,
+) -> None:
+    """Handle fav:remove:{property_id} — remove from favorites (#628)."""
+    if not callback.from_user:
+        await callback.answer()
+        return
+    property_id = callback_data.apartment_id if callback_data is not None else ""
+    if not property_id:
+        await callback.answer()
+        return
+
+    if favorites_service is None:
+        await callback.answer("Закладки недоступны")
+        return
+
+    await favorites_service.remove(telegram_id=callback.from_user.id, property_id=property_id)
+    state_data = await state.get_data()
+    apt_results = _state_apartment_results(state_data)
+    in_search_results = any(isinstance(r, dict) and r.get("id") == property_id for r in apt_results)
+    raw_bookmark_ids = state_data.get("bookmark_message_ids")
+    bookmark_message_ids = (
+        {mid for mid in raw_bookmark_ids if isinstance(mid, int)}
+        if isinstance(raw_bookmark_ids, list)
+        else set()
+    )
+    callback_message_id = getattr(callback.message, "message_id", None)
+    is_bookmark_message = (
+        isinstance(callback_message_id, int) and callback_message_id in bookmark_message_ids
+    )
+    if in_search_results and not is_bookmark_message and callback.message:
+        with contextlib.suppress(Exception):
+            await callback.message.edit_reply_markup(
+                reply_markup=build_card_buttons_for_results(property_id, is_favorited=False)
+            )
+    elif is_bookmark_message and callback.message:
+        with contextlib.suppress(Exception):
+            await callback.message.delete()
+    await callback.answer("Удалено из закладок")
+
+
+def build_card_buttons_for_results(property_id: str, is_favorited: bool) -> Any:
+    """Build card buttons for search results (used when favorites state changes)."""
+    from telegram_bot.keyboards.property_card import build_card_buttons
+
+    return build_card_buttons(property_id, is_favorited=is_favorited)
+
+
+async def handle_fav_viewing(
+    callback: CallbackQuery,
+    state: FSMContext,
+    callback_data: FavoriteCB | None = None,
+    favorites_service: Any | None = None,
+) -> None:
+    """Handle fav:viewing:{property_id} — request viewing for favorited property."""
+    if not callback.from_user:
+        await callback.answer()
+        return
+    property_id = callback_data.apartment_id if callback_data is not None else ""
+    if not property_id:
+        await callback.answer()
+        return
+
+    from telegram_bot.handlers.phone_collector import start_phone_collection
+
+    viewing_objects: list[dict[str, Any]] = []
+
+    if favorites_service is not None:
+        fav_items = await favorites_service.list(telegram_id=callback.from_user.id)
+        for fav in fav_items:
+            if fav.property_id == property_id:
+                d = fav.property_data
+                viewing_objects.append(
+                    {
+                        "id": fav.property_id,
+                        "complex_name": d.get("complex_name", ""),
+                        "property_type": d.get("property_type", ""),
+                        "area_m2": d.get("area_m2", 0),
+                        "price_eur": d.get("price_eur", 0),
+                    }
+                )
+                break
+
+    await start_phone_collection(
+        callback,
+        state,
+        service_key="viewing",
+        viewing_objects=viewing_objects,
+    )
+
+
+async def handle_fav_viewing_all(
+    callback: CallbackQuery,
+    state: FSMContext,
+    favorites_service: Any | None = None,
+) -> None:
+    """Handle fav:viewing_all — request viewing for all favorited properties."""
+    if not callback.from_user:
+        await callback.answer()
+        return
+
+    from telegram_bot.handlers.phone_collector import start_phone_collection
+
+    viewing_objects: list[dict[str, Any]] = []
+
+    if favorites_service is not None:
+        fav_items = await favorites_service.list(telegram_id=callback.from_user.id)
+        for fav in fav_items:
+            d = fav.property_data
+            viewing_objects.append(
+                {
+                    "id": fav.property_id,
+                    "complex_name": d.get("complex_name", ""),
+                    "property_type": d.get("property_type", ""),
+                    "area_m2": d.get("area_m2", 0),
+                    "price_eur": d.get("price_eur", 0),
+                }
+            )
+
+    await start_phone_collection(
+        callback,
+        state,
+        service_key="viewing",
+        viewing_objects=viewing_objects,
+    )
+
+
+async def handle_favorite_callback(
+    callback: CallbackQuery,
+    state: FSMContext,
+    callback_data: FavoriteCB | None = None,
+    favorites_service: Any | None = None,
+) -> None:
+    """Main entry point for fav:* callbacks — delegates to specific handlers (#628)."""
+    data = callback.data or ""
+
+    # Parse callback data for legacy string-based calls
+    if callback_data is not None and hasattr(callback_data, "action"):
+        action = callback_data.action
+        property_id = getattr(callback_data, "apartment_id", None) or ""
+    else:
+        parts = data.split(":", 2)
+        if len(parts) < 2:
+            await callback.answer()
+            return
+        action = parts[1]
+        property_id = parts[2] if len(parts) > 2 else ""
+
+    # Dispatch to specific handlers
+    if action == "add":
+        # Build FavoriteCB-like object for handle_fav_add
+        class _FakeFavoriteCB:
+            def __init__(self, apt_id):
+                self.apartment_id = apt_id
+
+        await handle_fav_add(
+            callback,
+            state,
+            callback_data=_FakeFavoriteCB(property_id) if property_id else None,
+            favorites_service=favorites_service,
+        )
+    elif action == "remove":
+
+        class _FakeFavoriteCB:
+            def __init__(self, apt_id):
+                self.apartment_id = apt_id
+
+        await handle_fav_remove(
+            callback,
+            state,
+            callback_data=_FakeFavoriteCB(property_id) if property_id else None,
+            favorites_service=favorites_service,
+        )
+    elif action == "viewing":
+
+        class _FakeFavoriteCB:
+            def __init__(self, apt_id):
+                self.apartment_id = apt_id
+
+        await handle_fav_viewing(
+            callback,
+            state,
+            callback_data=_FakeFavoriteCB(property_id) if property_id else None,
+            favorites_service=favorites_service,
+        )
+    elif action == "viewing_all":
+        await handle_fav_viewing_all(callback, state, favorites_service=favorites_service)
+    else:
+        await callback.answer()
+
+
+def create_favorites_router() -> Router:
+    """Create router with favorites callback handlers."""
+    router = Router(name="favorites")
+
+    router.callback_query(F.data.startswith("fav:"))(handle_favorite_callback)
+
+    return router

--- a/telegram_bot/handlers/results_callbacks.py
+++ b/telegram_bot/handlers/results_callbacks.py
@@ -1,0 +1,176 @@
+"""Results and card callback handlers — pagination, viewing requests (#654, #722)."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from typing import TYPE_CHECKING, Any
+
+from aiogram import F, Router
+from aiogram.fsm.context import FSMContext
+from aiogram.types import CallbackQuery, InaccessibleMessage
+
+from telegram_bot.callback_data import ResultsCB
+
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+_STALE_RESULTS_CALLBACK_TEXT = "Это устаревшая кнопка. Используйте актуальное меню ниже."
+
+
+def _state_apartment_results(state_data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract apartment results from state data, checking catalog_runtime first."""
+    if not isinstance(state_data, dict):
+        return []
+    catalog_runtime = state_data.get("catalog_runtime")
+    if catalog_runtime and isinstance(catalog_runtime, dict):
+        results = catalog_runtime.get("results")
+        if isinstance(results, list):
+            return results
+    results = state_data.get("apartment_results")
+    if isinstance(results, list):
+        return results
+    return []
+
+
+def _state_control_message_id(state_data: dict[str, Any]) -> int | None:
+    """Extract control message ID from state data."""
+    if not isinstance(state_data, dict):
+        return None
+    catalog_runtime = state_data.get("catalog_runtime")
+    if catalog_runtime and isinstance(catalog_runtime, dict):
+        return catalog_runtime.get("control_message_id")
+    return None
+
+
+async def handle_results_callback(
+    callback: CallbackQuery,
+    state: FSMContext,
+    callback_data: ResultsCB | None = None,
+) -> None:
+    """Handle property results callbacks (more/refine/viewing) (#654)."""
+    message = callback.message
+    if message is not None and not isinstance(message, InaccessibleMessage):
+        with contextlib.suppress(Exception):
+            await message.edit_reply_markup(reply_markup=None)
+        await message.answer(_STALE_RESULTS_CALLBACK_TEXT)
+    await callback.answer()
+
+
+async def handle_card_callback(
+    callback: CallbackQuery,
+    state: FSMContext,
+    dialog_manager: Any | None = None,
+    favorites_service: Any | None = None,
+) -> None:
+    """Handle card action callbacks: card:viewing, card:ask (#722)."""
+    from telegram_bot.handlers.phone_collector import start_phone_collection
+
+    data = callback.data or ""
+    parts = data.split(":", 2)
+    if len(parts) < 3 or not callback.from_user:
+        await callback.answer()
+        return
+
+    action = parts[1]  # "viewing" or "ask"
+    property_id = parts[2]
+
+    state_data = await state.get_data()
+    apt_results = _state_apartment_results(state_data)
+    matched = next(
+        (r for r in apt_results if isinstance(r, dict) and r.get("id") == property_id),
+        None,
+    )
+    viewing_objects: list[dict] = []
+    if matched:
+        p = matched.get("payload", {})
+        viewing_objects.append(
+            {
+                "id": property_id,
+                "complex_name": p.get("complex_name", ""),
+                "property_type": p.get("property_type", ""),
+                "area_m2": p.get("area_m2", 0),
+                "price_eur": p.get("price_eur", 0),
+            }
+        )
+    else:
+        if favorites_service is not None:
+            fav_items = await favorites_service.list(telegram_id=callback.from_user.id)
+            for fav in fav_items:
+                if fav.property_id == property_id:
+                    d = fav.property_data
+                    viewing_objects.append(
+                        {
+                            "id": fav.property_id,
+                            "complex_name": d.get("complex_name", ""),
+                            "property_type": d.get("property_type", ""),
+                            "area_m2": d.get("area_m2", 0),
+                            "price_eur": d.get("price_eur", 0),
+                        }
+                    )
+                    break
+
+    if action == "viewing":
+        if dialog_manager is not None:
+            from aiogram_dialog import ShowMode, StartMode
+
+            from telegram_bot.dialogs.states import ViewingSG
+
+            control_message_id = _state_control_message_id(state_data)
+            bot = callback.bot
+            if (
+                control_message_id
+                and bot is not None
+                and callback.message
+                and callback.message.chat
+            ):
+                with contextlib.suppress(Exception):
+                    await bot.delete_message(
+                        callback.message.chat.id,
+                        control_message_id,
+                    )
+
+            await dialog_manager.start(
+                ViewingSG.date,
+                mode=StartMode.RESET_STACK,
+                show_mode=ShowMode.DELETE_AND_SEND,
+                data={"selected_objects": viewing_objects},
+            )
+        else:
+            await start_phone_collection(
+                callback,
+                state,
+                service_key="viewing",
+                viewing_objects=viewing_objects,
+            )
+    elif action == "ask":
+        from telegram_bot.handlers.phone_collector import start_phone_collection
+
+        if dialog_manager is not None:
+            from aiogram_dialog import StartMode
+
+            from telegram_bot.dialogs.states import ViewingSG
+
+            await dialog_manager.start(ViewingSG.date, mode=StartMode.RESET_STACK)
+        else:
+            await start_phone_collection(
+                callback,
+                state,
+                service_key="question",
+                viewing_objects=viewing_objects,
+            )
+    else:
+        await callback.answer()
+
+
+def create_results_callback_router() -> Router:
+    """Create router with results and card callback handlers."""
+    router = Router(name="results_callbacks")
+
+    router.callback_query(ResultsCB.filter())(handle_results_callback)
+    router.callback_query(F.data.startswith("card:"))(handle_card_callback)
+
+    return router

--- a/telegram_bot/handlers/results_callbacks.py
+++ b/telegram_bot/handlers/results_callbacks.py
@@ -42,7 +42,9 @@ def _state_control_message_id(state_data: dict[str, Any]) -> int | None:
         return None
     catalog_runtime = state_data.get("catalog_runtime")
     if catalog_runtime and isinstance(catalog_runtime, dict):
-        return catalog_runtime.get("control_message_id")
+        control_message_id = catalog_runtime.get("control_message_id")
+        if isinstance(control_message_id, int):
+            return control_message_id
     return None
 
 

--- a/telegram_bot/handlers/service_callbacks.py
+++ b/telegram_bot/handlers/service_callbacks.py
@@ -1,0 +1,111 @@
+"""Service and CTA callback handlers — service cards, offers (#628)."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from aiogram import F, Router
+from aiogram.fsm.context import FSMContext
+from aiogram.types import CallbackQuery
+
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_service_callback(
+    callback: CallbackQuery,
+    i18n: Any | None = None,
+) -> None:
+    """Handle service menu inline button clicks (#628)."""
+    from telegram_bot.keyboards.services_keyboard import (
+        build_service_card_buttons,
+        build_services_menu,
+        parse_service_callback,
+    )
+    from telegram_bot.services.content_loader import get_service_card
+
+    parsed = parse_service_callback(callback.data or "")
+    if parsed is None:
+        await callback.answer()
+        return
+
+    action, param = parsed
+
+    if action == "back":
+        if callback.message:
+            await callback.message.delete()  # type: ignore[union-attr]
+        await callback.answer()
+
+    elif action == "menu":
+        if i18n is not None:
+            text = i18n.get("services-menu-text")
+        else:
+            text = "Выберите услугу, чтобы узнать подробнее:"
+        kb = build_services_menu(i18n=i18n)
+        if callback.message:
+            await callback.message.edit_text(text, reply_markup=kb)  # type: ignore[union-attr]
+        await callback.answer()
+
+    elif action == "service" and param:
+        svc = get_service_card(param)
+        if svc:
+            kb = build_service_card_buttons(param, i18n=i18n)
+            ftl_key = f"svc-{param.replace('_', '-')}-card"
+            card_text = (i18n.get(ftl_key) if i18n is not None else None) or svc.get(
+                "card_text", ""
+            )
+            if callback.message:
+                await callback.message.edit_text(card_text, reply_markup=kb)  # type: ignore[union-attr]
+        await callback.answer()
+
+    else:
+        await callback.answer()
+
+
+async def handle_cta_callback(
+    callback: CallbackQuery,
+    state: FSMContext,
+    dialog_manager: Any | None = None,
+    forum_bridge: Any | None = None,
+) -> None:
+    """Handle CTA button clicks (get_offer, manager) (#628)."""
+    from telegram_bot.handlers.handoff import start_qualification
+    from telegram_bot.handlers.phone_collector import start_phone_collection
+    from telegram_bot.keyboards.services_keyboard import parse_service_callback
+
+    parsed = parse_service_callback(callback.data or "")
+    if parsed is None:
+        await callback.answer()
+        return
+
+    action, param = parsed
+
+    if action == "get_offer":
+        await start_phone_collection(callback, state, service_key=param or "unknown")
+    elif action == "manager":
+        if forum_bridge is not None:
+            # Forum Topics enabled — skip goal step, context already known (#730).
+            await start_qualification(
+                callback,
+                state=state,
+                dialog_manager=dialog_manager,
+                goal="services",
+            )
+        else:
+            await start_phone_collection(callback, state, service_key="manager")
+    else:
+        await callback.answer()
+
+
+def create_service_callback_router() -> Router:
+    """Create router with service callback handlers."""
+    router = Router(name="service_callbacks")
+
+    router.callback_query(F.data.startswith("svc:"))(handle_service_callback)
+    router.callback_query(F.data.startswith("cta:"))(handle_cta_callback)
+
+    return router

--- a/tests/unit/test_service_callbacks.py
+++ b/tests/unit/test_service_callbacks.py
@@ -1,0 +1,378 @@
+"""Unit tests for service and CTA callback handlers."""
+
+from __future__ import annotations
+
+import pytest
+
+
+pytest.importorskip("aiogram", reason="aiogram not installed")
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _make_config():
+    """Create mock bot config."""
+    from telegram_bot.config import BotConfig
+
+    return BotConfig(
+        _env_file=None,
+        telegram_token="test-token",
+        voyage_api_key="voyage-key",
+        llm_api_key="llm-key",
+        llm_base_url="https://api.example.com/v1",
+        llm_model="gpt-4o-mini",
+        qdrant_url="http://localhost:6333",
+        qdrant_api_key="qdrant-key",
+        qdrant_collection="test_collection",
+        redis_url="redis://localhost:6379",
+        realestate_database_url="postgresql://postgres:postgres@127.0.0.1:1/realestate",
+        rerank_provider="none",
+    )
+
+
+def _create_bot():
+    """Create PropertyBot with deps mocked."""
+    from telegram_bot.bot import PropertyBot
+
+    config = _make_config()
+    with (
+        patch("telegram_bot.bot.Bot"),
+        patch("telegram_bot.integrations.cache.CacheLayerManager"),
+        patch("telegram_bot.integrations.embeddings.BGEM3HybridEmbeddings"),
+        patch("telegram_bot.integrations.embeddings.BGEM3SparseEmbeddings"),
+        patch("telegram_bot.services.qdrant.QdrantService"),
+        patch("telegram_bot.graph.config.GraphConfig.create_llm"),
+        patch("telegram_bot.graph.config.GraphConfig.create_supervisor_llm"),
+    ):
+        return PropertyBot(config)
+
+
+def _make_callback(data: str, user_id: int = 12345) -> MagicMock:
+    """Create a mock callback query."""
+    cb = MagicMock()
+    cb.data = data
+    cb.from_user = MagicMock(id=user_id)
+    cb.answer = AsyncMock()
+    cb.message = MagicMock()
+    cb.message.answer = AsyncMock()
+    cb.message.edit_text = AsyncMock()
+    cb.message.edit_reply_markup = AsyncMock()
+    cb.message.delete = AsyncMock()
+    return cb
+
+
+def _make_state(data: dict | None = None) -> MagicMock:
+    """Create a mock FSM state."""
+    state = MagicMock()
+    state.get_data = AsyncMock(return_value=data or {})
+    state.get_state = AsyncMock(return_value="SomeState:other")
+    state.update_data = AsyncMock()
+    state.set_state = AsyncMock()
+    state.clear = AsyncMock()
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Tests: handle_service_callback
+# ---------------------------------------------------------------------------
+
+
+async def test_service_callback_back_deletes_message():
+    """svc:back should delete the message."""
+    bot = _create_bot()
+
+    cb = _make_callback("svc:back")
+    i18n = MagicMock()
+
+    await bot.handle_service_callback(cb, i18n=i18n)
+
+    cb.message.delete.assert_awaited_once()
+    cb.answer.assert_awaited_once()
+
+
+async def test_service_callback_menu_shows_services_menu():
+    """svc:menu should show the services menu."""
+    bot = _create_bot()
+
+    cb = _make_callback("svc:menu")
+    i18n = MagicMock()
+    i18n.get.return_value = "Choose a service:"
+
+    with patch("telegram_bot.keyboards.services_keyboard.build_services_menu") as mock_build_menu:
+        mock_menu = MagicMock()
+        mock_build_menu.return_value = mock_menu
+        await bot.handle_service_callback(cb, i18n=i18n)
+
+    cb.message.edit_text.assert_awaited_once()
+    i18n.get.assert_called_with("services-menu-text")
+
+
+async def test_service_callback_service_shows_card():
+    """svc:service:key should show the service card."""
+    bot = _create_bot()
+
+    cb = _make_callback("svc:service:passive_income")
+    i18n = MagicMock()
+    i18n.get.return_value = None
+
+    mock_card = {"card_text": "Passive income description"}
+
+    with patch("telegram_bot.services.content_loader.get_service_card", return_value=mock_card):
+        with patch(
+            "telegram_bot.keyboards.services_keyboard.build_service_card_buttons"
+        ) as mock_build_buttons:
+            mock_buttons = MagicMock()
+            mock_build_buttons.return_value = mock_buttons
+            await bot.handle_service_callback(cb, i18n=i18n)
+
+    cb.message.edit_text.assert_awaited_once()
+
+
+async def test_service_callback_unknown_action_answers_empty():
+    """Unknown svc:action should answer with no alert."""
+    bot = _create_bot()
+
+    cb = _make_callback("svc:unknown:action")
+
+    await bot.handle_service_callback(cb)
+
+    cb.answer.assert_awaited_once()
+
+
+async def test_service_callback_no_message_no_crash():
+    """svc:back with no message should not crash."""
+    bot = _create_bot()
+
+    cb = _make_callback("svc:back")
+    cb.message = None
+    i18n = MagicMock()
+
+    # Should not raise
+    await bot.handle_service_callback(cb, i18n=i18n)
+
+    cb.answer.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests: handle_cta_callback
+# ---------------------------------------------------------------------------
+
+
+async def test_cta_callback_get_offer_starts_phone_collection():
+    """cta:get_offer should start phone collection."""
+    bot = _create_bot()
+
+    cb = _make_callback("cta:get_offer:some_service")
+    state = _make_state()
+
+    with patch(
+        "telegram_bot.handlers.phone_collector.start_phone_collection", new_callable=AsyncMock
+    ) as mock_phone:
+        await bot.handle_cta_callback(cb, state)
+
+    mock_phone.assert_awaited_once()
+    call_kwargs = mock_phone.call_args.kwargs
+    assert call_kwargs.get("service_key") == "some_service"
+
+
+async def test_cta_callback_manager_without_forum_bridge_calls_phone_collection():
+    """cta:manager without forum_bridge should call start_phone_collection."""
+    bot = _create_bot()
+    bot._forum_bridge = None
+
+    cb = _make_callback("cta:manager")
+    state = _make_state()
+
+    with patch(
+        "telegram_bot.handlers.phone_collector.start_phone_collection", new_callable=AsyncMock
+    ) as mock_phone:
+        await bot.handle_cta_callback(cb, state)
+
+    mock_phone.assert_awaited_once()
+    call_kwargs = mock_phone.call_args.kwargs
+    assert call_kwargs.get("service_key") == "manager"
+
+
+async def test_cta_callback_manager_without_forum_bridge_starts_phone_collection():
+    """cta:manager without forum_bridge should start phone collection."""
+    bot = _create_bot()
+    bot._forum_bridge = None
+
+    cb = _make_callback("cta:manager")
+    state = _make_state()
+
+    with patch(
+        "telegram_bot.handlers.phone_collector.start_phone_collection", new_callable=AsyncMock
+    ) as mock_phone:
+        await bot.handle_cta_callback(cb, state)
+
+    mock_phone.assert_awaited_once()
+    call_kwargs = mock_phone.call_args.kwargs
+    assert call_kwargs.get("service_key") == "manager"
+
+
+async def test_cta_callback_unknown_action_answers_empty():
+    """Unknown cta:action should answer with no alert."""
+    bot = _create_bot()
+
+    cb = _make_callback("cta:unknown")
+    state = _make_state()
+
+    await bot.handle_cta_callback(cb, state)
+
+    cb.answer.assert_awaited_once()
+
+
+async def test_cta_callback_malformed_data_answers_empty():
+    """Malformed cta:data should answer with no alert."""
+    bot = _create_bot()
+
+    cb = _make_callback("cta:")
+    state = _make_state()
+
+    # Should not raise
+    await bot.handle_cta_callback(cb, state)
+
+    cb.answer.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests: handle_results_callback
+# ---------------------------------------------------------------------------
+
+
+async def test_results_callback_answers_with_stale_text():
+    """Results callback should answer with stale button text."""
+    bot = _create_bot()
+
+    cb = _make_callback("results:more")
+    state = _make_state()
+
+    await bot.handle_results_callback(cb, state)
+
+    cb.message.edit_reply_markup.assert_awaited_once_with(reply_markup=None)
+    cb.message.answer.assert_awaited_once()
+    # Verify stale text was sent
+    call_args = cb.message.answer.call_args
+    assert "устаревшая" in call_args.args[0].lower() or "актуальное" in call_args.args[0].lower()
+
+
+async def test_results_callback_no_message_no_crash():
+    """Results callback with no message should not crash."""
+    bot = _create_bot()
+
+    cb = _make_callback("results:more")
+    cb.message = None
+    state = _make_state()
+
+    # Should not raise
+    await bot.handle_results_callback(cb, state)
+
+
+# ---------------------------------------------------------------------------
+# Tests: handle_fav_viewing
+# ---------------------------------------------------------------------------
+
+
+async def test_fav_viewing_starts_phone_collection():
+    """fav:viewing:{id} should start phone collection with viewing objects."""
+    bot = _create_bot()
+    bot._favorites_service = MagicMock()
+    mock_fav_item = MagicMock()
+    mock_fav_item.property_id = "prop-42"
+    mock_fav_item.property_data = {
+        "complex_name": "Test Property",
+        "property_type": "Apartment",
+        "area_m2": 50,
+        "price_eur": 100000,
+    }
+    bot._favorites_service.list = AsyncMock(return_value=[mock_fav_item])
+
+    cb = _make_callback("fav:viewing:prop-42")
+    state = _make_state()
+
+    callback_data = MagicMock()
+    callback_data.apartment_id = "prop-42"
+
+    with patch(
+        "telegram_bot.handlers.phone_collector.start_phone_collection", new_callable=AsyncMock
+    ) as mock_phone:
+        await bot.handle_fav_viewing(cb, state, callback_data=callback_data)
+
+    mock_phone.assert_awaited_once()
+    call_kwargs = mock_phone.call_args.kwargs
+    assert call_kwargs.get("service_key") == "viewing"
+    assert len(call_kwargs.get("viewing_objects", [])) > 0
+
+
+async def test_fav_viewing_no_favorites_service_answers_unavailable():
+    """fav:viewing without favorites_service should answer unavailable."""
+    bot = _create_bot()
+    bot._favorites_service = None
+
+    cb = _make_callback("fav:viewing:prop-42")
+    state = _make_state()
+
+    callback_data = MagicMock()
+    callback_data.apartment_id = "prop-42"
+
+    await bot.handle_fav_viewing(cb, state, callback_data=callback_data)
+
+    cb.answer.assert_awaited_once_with("Закладки недоступны")
+
+
+# ---------------------------------------------------------------------------
+# Tests: handle_fav_viewing_all
+# ---------------------------------------------------------------------------
+
+
+async def test_fav_viewing_all_starts_phone_collection_with_all_favorites():
+    """fav:viewing_all should start phone collection with all favorites."""
+    bot = _create_bot()
+    bot._favorites_service = MagicMock()
+
+    mock_fav1 = MagicMock()
+    mock_fav1.property_id = "prop-1"
+    mock_fav1.property_data = {
+        "complex_name": "Property 1",
+        "property_type": "Apt",
+        "area_m2": 40,
+        "price_eur": 50000,
+    }
+
+    mock_fav2 = MagicMock()
+    mock_fav2.property_id = "prop-2"
+    mock_fav2.property_data = {
+        "complex_name": "Property 2",
+        "property_type": "Studio",
+        "area_m2": 30,
+        "price_eur": 40000,
+    }
+
+    bot._favorites_service.list = AsyncMock(return_value=[mock_fav1, mock_fav2])
+
+    cb = _make_callback("fav:viewing_all")
+    state = _make_state()
+
+    with patch(
+        "telegram_bot.handlers.phone_collector.start_phone_collection", new_callable=AsyncMock
+    ) as mock_phone:
+        await bot.handle_fav_viewing_all(cb, state)
+
+    mock_phone.assert_awaited_once()
+    call_kwargs = mock_phone.call_args.kwargs
+    assert call_kwargs.get("service_key") == "viewing"
+    assert len(call_kwargs.get("viewing_objects", [])) == 2
+
+
+async def test_fav_viewing_all_no_favorites_service_answers_unavailable():
+    """fav:viewing_all without favorites_service should answer unavailable."""
+    bot = _create_bot()
+    bot._favorites_service = None
+
+    cb = _make_callback("fav:viewing_all")
+    state = _make_state()
+
+    await bot.handle_fav_viewing_all(cb, state)
+
+    cb.answer.assert_awaited_once_with("Закладки недоступны")


### PR DESCRIPTION
## Summary
- Split PropertyBot callback handling into focused handler modules.
- Add unit coverage for service callback behavior.

## Test Plan
- Not run in this git cleanup pass
