### PR TITLE
fix: convert HandoffData to Pydantic and add retry decorator to kommo_tokens

### DIFF
--- a/docs/ADD_NEW_RAG_NODE.md
+++ b/docs/ADD_NEW_RAG_NODE.md
@@ -1,0 +1,182 @@
+# Adding a New RAG Node
+
+Guide for extending the LangGraph pipeline with a new node.
+
+## When to Add a Node
+
+Add a new node when:
+- You need a distinct step in the pipeline with its own logic
+- The node needs its own Langfuse tracing
+- The node has stateful operations that should be checkpointed
+- You need conditional routing based on node output
+
+For simple transformations within existing logic, prefer inline functions.
+
+## Step-by-Step
+
+### 1. Create the Node File
+
+Create `telegram_bot/graph/nodes/your_node.py`:
+
+```python
+"""Your node description."""
+
+from typing import Any
+
+from telegram_bot.observability import observe
+
+
+@observe(name="node-your_node", capture_input=False, capture_output=False)
+async def your_node(state: dict[str, Any], context: Any) -> dict[str, Any]:
+    """Process state and return updates.
+
+    Args:
+        state: Current RAGState
+        context: GraphContext DI container
+
+    Returns:
+        Dict of state updates (merged via | operator)
+    """
+    # Your logic here
+    result = await context.some_service.do_something(state["query"])
+
+    return {
+        "your_field": result,
+        # Optional: add to trace
+        "trace_context": {"your_node_output": result},
+    }
+```
+
+### 2. Add State Fields
+
+If your node adds new state fields, update `telegram_bot/graph/state.py`:
+
+```python
+class RAGState(TypedDict):
+    # ... existing fields ...
+
+    # Your new field
+    your_field: str | None
+```
+
+### 3. Register in Graph Builder
+
+In `telegram_bot/graph/graph.py`:
+
+```python
+from .nodes.your_node import your_node
+
+def build_graph(...) -> CompiledGraph:
+    # ... existing code ...
+
+    graph.add_node("your_node", your_node)
+
+    # Add edges
+    graph.add_edge("existing_node", "your_node")
+    # OR conditional edge:
+    graph.add_conditional_edges(
+        "existing_node",
+        route_your_node,
+        {
+            "your_node": lambda s: s.get("condition"),
+            "other_node": lambda s: not s.get("condition"),
+        }
+    )
+
+    return graph.compile(...)
+```
+
+### 4. Add Route Function (if conditional)
+
+```python
+def route_your_node(state: RAGState) -> str:
+    """Return next node name based on state."""
+    if state.get("your_field"):
+        return "next_node"
+    return "fallback_node"
+```
+
+### 5. Update Type Annotations
+
+If using `GraphContext` for DI, update `telegram_bot/graph/context.py`:
+
+```python
+class GraphContext(TypedDict):
+    # ... existing fields ...
+    your_service: YourServiceType
+```
+
+## Node Template
+
+```python
+"""Node description."""
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from telegram_bot.observability import ObserveContext
+else:
+    ObserveContext = Any
+
+from telegram_bot.observability import observe
+
+
+@observe(name="node-{node_name}", capture_input=False, capture_output=False)
+async def {node_name}_node(
+    state: dict[str, Any],
+    context: ObserveContext,
+) -> dict[str, Any]:
+    """Short description of what this node does.
+
+    Args:
+        state: Current RAGState
+        context: GraphContext DI container
+
+    Returns:
+        State updates to merge
+    """
+    # 1. Extract inputs from state
+    # 2. Do work (use context for dependencies)
+    # 3. Return state updates
+    return {"output_field": "value"}
+```
+
+## Checklist
+
+- [ ] Create node file in `telegram_bot/graph/nodes/`
+- [ ] Add `@observe` decorator with unique name
+- [ ] Update `RAGState` in `state.py` if adding fields
+- [ ] Add node to graph in `graph.py`
+- [ ] Add edge(s) from previous node(s)
+- [ ] Add conditional routing if needed
+- [ ] Add route function if conditional
+- [ ] Update `GraphContext` if using DI
+- [ ] Add unit test in `tests/unit/telegram_bot/graph/`
+- [ ] Run `make check` and `make test-unit`
+
+## Example: Adding a Sentiment Node
+
+```python
+# telegram_bot/graph/nodes/sentiment.py
+@observe(name="node-sentiment", capture_input=False, capture_output=False)
+async def sentiment_node(state: dict, context: Any) -> dict:
+    sentiment = await context.sentiment_analyzer.analyze(state["query"])
+    return {"sentiment": sentiment, "query_sentiment": sentiment}
+```
+
+Then in `graph.py`:
+```python
+graph.add_node("sentiment", sentiment_node)
+graph.add_edge("classify", "sentiment")
+graph.add_edge("sentiment", "guard")
+```
+
+## Code Locations
+
+| File | Purpose |
+|------|---------|
+| `telegram_bot/graph/graph.py` | Graph builder + route functions |
+| `telegram_bot/graph/state.py` | RAGState TypedDict |
+| `telegram_bot/graph/context.py` | GraphContext DI container |
+| `telegram_bot/observability.py` | @observe decorator |
+| `tests/unit/telegram_bot/graph/` | Node tests |

--- a/docs/ADRS.md
+++ b/docs/ADRS.md
@@ -1,0 +1,242 @@
+# Architecture Decision Records (ADRs)
+
+Documenting significant architectural decisions.
+
+---
+
+## ADR-001: TypedDict for Graph State (not Pydantic)
+
+**Status:** Accepted
+**Date:** 2024-01-15
+
+### Context
+
+LangGraph's `StateGraph` supports generic types. We needed a state definition that:
+- Works with LangGraph's reducer system
+- Is serializable for checkpointing
+- Integrates with mypy strict mode
+
+### Decision
+
+Use `TypedDict` for all graph state, not Pydantic models.
+
+```python
+class RAGState(TypedDict):
+    query: str
+    query_type: str | None
+    # ... fields
+```
+
+### Rationale
+
+- LangGraph's `@operator`装饰器 works natively with TypedDict
+- Reducers (`Annotated[list, add_messages]`) require TypedDict
+- Checkpointing serializes state; TypedDict is naturally serializable
+- Pydantic v2 `BaseModel` adds overhead and doesn't integrate as cleanly
+
+### Consequences
+
+**Positive:**
+- Native LangGraph integration
+- Simple serialization for Redis checkpointer
+- Type checking with mypy
+
+**Negative:**
+- No runtime validation at state boundaries
+- Must manually validate at node entry points
+
+---
+
+## ADR-002: RRF Fusion over Semantic Search Only
+
+**Status:** Accepted
+**Date:** 2024-02-20
+
+### Context
+
+We need high-quality retrieval for real estate queries. Dense embeddings alone miss exact keyword matches (property IDs, prices, neighborhoods).
+
+### Decision
+
+Hybrid search with RRF (Reciprocal Rank Fusion):
+1. Dense vector search (BGE-M3)
+2. Sparse/bm42 keyword search
+3. Fused via RRF with k=60
+
+### Rationale
+
+- RRF is robust to relevance score differences between methods
+- Captures semantic meaning AND exact keywords
+- No training required
+- Works with any vector DB supporting hybrid queries
+
+### Consequences
+
+**Positive:**
+- Handles both "2-bedroom apartment" (semantic) and "Apt #123" (keyword)
+- Robust to embedding quality variations
+- Simple implementation in Qdrant
+
+**Negative:**
+- Two embedding calls per query (dense + sparse)
+- Slightly more complex than pure semantic
+
+---
+
+## ADR-003: RedisVL for Semantic Cache
+
+**Status:** Accepted
+**Date:** 2024-03-10
+
+### Context
+
+We need sub-millisecond cache lookups for repeated/similar queries. Traditional exact-match cache misses on paraphrases.
+
+### Decision
+
+Two-tier semantic cache using RedisVL:
+1. **Embeddings cache:** Skip re-encoding repeated queries
+2. **Results cache:** Skip retrieval for semantically similar queries
+
+### Rationale
+
+- RedisVL provides vector similarity search within Redis
+- Distance thresholds tuned per query type (FAQ vs GENERAL)
+- Shared Redis instance with existing cache infrastructure
+- No separate cache service needed
+
+### Consequences
+
+**Positive:**
+- ~60% cache hit rate in production
+- Sub-ms lookup latency
+- Embedding reuse across queries
+
+**Negative:**
+- Redis memory for vector storage
+- Threshold tuning required per query type
+
+---
+
+## ADR-004: Interrupt-based HITL Pattern
+
+**Status:** Accepted
+**Date:** 2024-04-05
+
+### Context
+
+CRM operations (create lead, schedule viewing) require human approval before execution. We needed a pattern that:
+- Pauses graph execution reliably
+- Persists state across bot restarts
+- Allows supervisor to approve from Telegram
+
+### Decision
+
+LangGraph `interrupt()` with Redis-persisted `HandoffState`:
+
+```
+Tool call → interrupt() → Redis state → Supervisor notification
+                                              ↓
+                                    User approval/rejection
+                                              ↓
+                              Command(resume=) → Graph resumes
+```
+
+### Rationale
+
+- `interrupt()` is native to LangGraph checkpointing
+- Redis persistence survives bot restarts
+- Telegram inline keyboards for approval UI
+- Simple state machine (waiting → approved/rejected)
+
+### Consequences
+
+**Positive:**
+- Reliable pause/resume
+- Supervisor can approve from mobile Telegram
+- State survives crashes
+
+**Negative:**
+- Supervisor must be available (300s timeout)
+- Extra Redis keys to manage
+
+---
+
+## ADR-005: BGE-M3 for All Embeddings
+
+**Status:** Accepted
+**Date:** 2024-05-12
+
+### Context
+
+We need embeddings that support:
+- Dense vectors for semantic search
+- Sparse vectors for keyword matching
+- ColBERT-style late interaction for reranking
+
+### Decision
+
+Use BGE-M3 exclusively:
+- `encode/dense` → 1024-dim dense vectors
+- `encode/sparse` → bm42-style sparse vectors
+- `encode/colbert` → Late interaction vectors
+
+### Rationale
+
+- Single model for all embedding needs
+- Self-hosted (no API costs)
+- Dense + sparse in one model
+- ColBERT support for reranking
+
+### Consequences
+
+**Positive:**
+- No model switching overhead
+- Unified embedding pipeline
+- Cost-effective (self-hosted)
+
+**Negative:**
+- BGE-M3 is ~5GB RAM
+- Slower than lightweight embedding models
+- Must manage BGE-M3 service
+
+---
+
+## ADR-006: LiteLLM for LLM Abstraction
+
+**Status:** Accepted
+**Date:** 2024-06-01
+
+### Context
+
+We use multiple LLM providers (OpenAI, Cerebras, Groq). Direct SDK integration would couple code to provider specifics.
+
+### Decision
+
+Route all LLM calls through LiteLLM proxy:
+```
+Code → LiteLLM → OpenAI/Cerebras/Groq
+```
+
+### Rationale
+
+- Single interface for all providers
+- Easy provider switching via env vars
+- Built-in retry/timeout handling
+- Langfuse integration via `langfuse.openai.AsyncOpenAI`
+
+### Consequences
+
+**Positive:**
+- Provider-agnostic code
+- Simple fallback configuration
+- Centralized LLM observability
+
+**Negative:**
+- Additional hop (latency)
+- LiteLLM must be running
+- Provider-specific quirks may leak through
+
+---
+
+*To add new ADRs: create `docs/adr/ADR-NNN-title.md` with status, context, decision, rationale, and consequences.*

--- a/docs/BOT_ARCHITECTURE.md
+++ b/docs/BOT_ARCHITECTURE.md
@@ -1,0 +1,121 @@
+# PropertyBot Architecture
+
+**File:** `telegram_bot/bot.py` (5013 lines)
+
+Main Telegram bot entry point combining aiogram 3 dispatcher with LangGraph pipeline.
+
+## High-Level Structure
+
+```
+PropertyBot class (472+)
+    ├── __init__() — bot, dispatcher, services init
+    ├── _register_routers() — handler registration
+    ├── _setup_dialogs() — aiogram-dialog setup
+    ├── _setup_middlewares() — middleware chain
+    └── run() — start polling
+```
+
+## Key Classes
+
+### `PropertyBot`
+
+Main bot orchestrator. Initializes:
+- `Bot` instance with configured token
+- `Dispatcher` with FSM storage (Redis or memory)
+- All service layers (cache, embeddings, LLM, Qdrant)
+- Graph pipeline via `build_graph()`
+
+### Lazy Import Wrappers
+
+| Function | Wraps | Purpose |
+|----------|-------|---------|
+| `create_bot_agent()` | `agents/agent.py:create_bot_agent` | Agent factory for tests |
+| `build_graph()` | `graph/graph.py:build_graph` | Graph builder for tests |
+| `classify_query()` | `graph/nodes/classify.py:classify_query` | Query classifier for tests |
+| `detect_injection()` | `graph/nodes/guard.py:detect_injection` | Injection detector for tests |
+
+## Key Functions
+
+| Function | Lines | Purpose |
+|----------|-------|---------|
+| `_stream_agent_to_draft()` | 129–185 | Stream agent output to Telegram drafts |
+| `_merge_results()` | 187–206 | Deduplicate search results |
+| `_state_apartment_results()` | 207–220 | Extract apartment list from state |
+| `_split_telegram_response()` | 235–247 | Split long messages at 4096 char limit |
+| `_supervisor_thread_id()` | 248–254 | Build forum thread ID for supervisor |
+| `_delete_checkpointer_thread()` | 255–271 | Cleanup stale checkpoint threads |
+| `_extract_current_turn()` | 272–287 | Extract last user/assistant turn |
+| `_build_trace_metadata()` | 288–329 | Build Langfuse trace metadata |
+| `_write_voice_error_scores()` | 330–351 | Score voice errors in Langfuse |
+| `_is_post_pipeline_cleanup_error()` | 352–388 | Detect cleanup errors |
+| `_is_checkpointer_runtime_error()` | 389–416 | Detect checkpoint errors |
+| `_extract_stream_chunk_text()` | 417–443 | Extract text from stream chunks |
+
+## Module Imports
+
+**Core aiogram:**
+- `Bot`, `Dispatcher` from aiogram
+- `F` filters for routing
+- `Command`, `CommandStart`, `StateFilter` filters
+- `FSMContext`, `CallbackQuery`, `Message` types
+
+**Business services:**
+- `src.retrieval.topic_classifier` — query topic hint
+- `telegram_bot.handlers.handoff` — HITL qualification
+- `telegram_bot.services.cache_policy` — semantic cache
+- `telegram_bot.services.handoff_state` — HandoffData, HandoffState
+- `telegram_bot.services.metrics` — PipelineMetrics
+- `telegram_bot.scoring` — compute/write scores
+
+## Constants
+
+| Constant | Value | Purpose |
+|----------|-------|---------|
+| `_CHECKPOINT_NS_VOICE` | `"tg:voice:v1"` | Voice checkpoint namespace |
+| `_FEEDBACK_CONFIRMATION_TTL_S` | `5.0` | Feedback confirmation window |
+| `_APARTMENT_PAGE_SIZE` | `5` | Apartments per page |
+| `_STALE_RESULTS_CALLBACK_TEXT` | Russian | Stale button warning |
+| `_TELEGRAM_MESSAGE_LIMIT` | `4096` | Telegram message char limit |
+| `_NO_RAG_QUERY_TYPES` | `{"CHITCHAT", "OFF_TOPIC"}` | Queries bypass RAG |
+| `_AGENT_DRAFT_INTERVAL` | `0.2` | Seconds between draft updates |
+
+## Handler Registration Order
+
+1. Menu button handlers (`F.text.in_`)
+2. FSM handlers
+3. Catch-all (`StateFilter(None)`)
+
+## FSM States
+
+Defined in `telegram_bot/handlers/handoff.py`:
+- `HandoffStates` — qualification flow states
+
+## Middleware Chain
+
+1. `setup_error_handler` — exception → user-friendly message
+2. `setup_throttling_middleware` — rate limiting
+3. `FSMCancelMiddleware` — cancel FSM on /cancel
+4. `LangfuseContextMiddleware` — trace context injection
+
+## Graph Integration
+
+`PropertyBot` builds the LangGraph pipeline via `build_graph()`:
+
+```
+START → classify → guard → cache_check → retrieve → grade
+                           ↓                           ↓
+                      chitchat/off-topic          rerank/rewrite/generate
+                           ↓                           ↓
+                         respond ←←←←←←←←← cache_store ←←←←←←
+```
+
+## Testing Pattern
+
+Lazy wrappers allow patching without importing heavy dependencies:
+
+```python
+from telegram_bot import bot
+
+# Patch for tests
+bot.build_graph = mock_build_graph
+```

--- a/docs/CACHE_DEGRADATION.md
+++ b/docs/CACHE_DEGRADATION.md
@@ -1,0 +1,93 @@
+# Cache Degradation Behavior
+
+Multi-tier semantic caching with graceful degradation when cache fails.
+
+## Cache Tiers
+
+### Tier 1: Embeddings Cache (RedisVL)
+- **Purpose:** Skip re-encoding of repeated queries
+- **Key:** `embeddings:v5` index
+- **TTL:** 7 days
+- **Lookup:** Query text → cached embedding vector
+
+### Tier 2: Semantic Result Cache (RedisVL)
+- **Purpose:** Skip retrieval + generation for similar queries
+- **Key:** `sem:v5:bge1024` index
+- **Threshold:** Varies by query type (see below)
+- **TTL:** Per query type (configurable)
+
+## Per-Query-Type Thresholds
+
+| Query Type | Distance Threshold | Rationale |
+|------------|-------------------|-----------|
+| `FAQ` | 0.12 | High precision required |
+| `GENERAL` | 0.08 | Balanced |
+| `APARTMENT` | 0.10 | Price/location specificity |
+| `CHITCHAT` | 0.15 | Lenient matching |
+| `OFF_TOPIC` | 1.0 | Bypass cache entirely |
+
+**Note:** Thresholds are on RRF scale (~0.005–0.15), NOT cosine similarity [0-1].
+
+## Degradation Modes
+
+### Mode 1: Cache Unavailable (Redis Down)
+- Embeddings cache miss → re-encode
+- Semantic cache miss → proceed without caching
+- **User impact:** Slower response, no cache benefits
+- **Monitoring:** `cache_errors` metric
+
+### Mode 2: Embedding Service Down
+- Cannot compute embedding → bypass cache lookup
+- Proceed to full retrieval pipeline
+- **User impact:** Full latency, no cache hit possible
+
+### Mode 3: Qdrant Unavailable
+- Cache hit → attempt to use cached response
+- Cache miss → fail with error
+- **User impact:** Degraded quality if cache miss
+
+## Cache Key Structure
+
+```
+# Embeddings cache
+Index: embeddings:v5
+Schema: text (str), embedding (dense[1024])
+
+# Semantic result cache
+Index: sem:v5:bge1024
+Schema: query_text, query_type, language, response, sources, metadata
+```
+
+## Forcing Cache Bypass
+
+Set `cache_scope=disabled` in request to bypass all caching:
+
+```python
+# In graph state
+state["cache_scope"] = "disabled"
+```
+
+## Monitoring
+
+| Metric | Description |
+|--------|-------------|
+| `cache_hit_total` | Total cache hits by type |
+| `cache_miss_total` | Total cache misses by type |
+| `cache_error_total` | Cache errors by tier |
+| `cache_latency_ms` | Cache operation latency |
+
+## Configuration
+
+Environment variables:
+- `REDIS_PASSWORD` — Redis auth (required)
+- `CACHE_TTL_DEFAULT` — Default TTL in seconds
+- `CACHE_EMBEDDING_TTL` — Embeddings cache TTL (default: 604800 = 7 days)
+
+## Code Locations
+
+| File | Purpose |
+|------|---------|
+| `telegram_bot/integrations/cache.py` | CacheLayerManager |
+| `telegram_bot/services/cache_policy.py` | Cacheability decisions |
+| `telegram_bot/graph/nodes/cache_check.py` | Cache lookup node |
+| `telegram_bot/graph/nodes/cache_store.py` | Cache write node |

--- a/docs/ERROR_RESPONSES.md
+++ b/docs/ERROR_RESPONSES.md
@@ -1,0 +1,187 @@
+# Error Response Reference
+
+Standardized error responses across the system.
+
+## Telegram Bot Errors
+
+### Handler Errors
+
+Errors in message/callback handlers are caught by `setup_error_handler` middleware and returned as user-friendly messages.
+
+```python
+# telegram_bot/middlewares/error_handler.py
+async def error_handler(event, next):
+    try:
+        return await next(event)
+    except Exception as e:
+        # Send user-friendly message
+        await event.reply(f"⚠️ Error: {get_user_message(e)}")
+        # Re-raise for logging
+        raise
+```
+
+### User-Facing Error Messages
+
+| Error Type | User Message | Technical Details |
+|------------|--------------|-------------------|
+| `RedisConnectionError` | "Service temporarily unavailable" | Logged, not shown |
+| `QdrantTimeout` | "Search timed out, try again" | Logged |
+| `LLMError` | "AI service error, try again" | Traced in Langfuse |
+| `ValidationError` | "Invalid input" | Logged |
+| `Unauthorized` | "Please start over: /start" | FSM reset |
+
+### FSM Errors
+
+| Error | Cause | Recovery |
+|-------|-------|----------|
+| `FSMConflictError` | Concurrent updates | Retry with fresh state |
+| `StateNotFound` | Redis key expired | `/start` to re-init |
+| `FSMCancelError` | User sent `/cancel` | Normal flow |
+
+## RAG API Errors
+
+### HTTP Status Codes
+
+| Status | Meaning | Response Body |
+|--------|---------|---------------|
+| 200 | Success | `QueryResponse` |
+| 422 | Validation error | `{"detail": [...]}` |
+| 500 | Internal error | `{"error": "Internal server error"}` |
+
+### Error Response Schema
+
+```python
+class ErrorResponse(BaseModel):
+    error: str
+    detail: str | None = None
+    trace_id: str | None = None  # Langfuse trace ID for debugging
+```
+
+### Langfuse Trace Linking
+
+500 errors include `trace_id` in response for debugging:
+
+```json
+{
+  "error": "Internal server error",
+  "trace_id": "abc123-def456"
+}
+```
+
+Search Langfuse UI for this trace ID.
+
+## Graph Pipeline Errors
+
+### Node-Level Errors
+
+Errors in nodes are caught and logged but don't crash the graph:
+
+```python
+@observe(name="node-retrieve")
+async def retrieve_node(state, context):
+    try:
+        return await _do_retrieval(state)
+    except Exception as e:
+        logger.exception("Retrieval failed")
+        return {"error": str(e), "retrieve_failed": True}
+```
+
+### Graceful Degradation
+
+| Node Failure | Behavior |
+|--------------|----------|
+| `retrieve` | Proceed without context, use LLM knowledge |
+| `rerank` | Skip reranking, use raw retrieval order |
+| `generate` | Return error message |
+| `cache_check` | Bypass cache, proceed to retrieval |
+
+### Critical Errors (No Degradation)
+
+| Node Failure | Behavior |
+|--------------|----------|
+| `classify` | Default to `KNOWLEDGE` type |
+| `guard` | Default to `pass` (allow query) |
+
+## CRM Errors
+
+### Kommo API Errors
+
+```python
+# telegram_bot/services/kommo_client.py
+class KommoError(Exception):
+    pass
+
+class KommoAuthError(KommoError):
+    """OAuth token expired or invalid."""
+    pass
+
+class KommoRateLimitError(KommoError):
+    """Rate limit exceeded."""
+    pass
+```
+
+| Error | User Impact | Recovery |
+|-------|-------------|----------|
+| `KommoAuthError` | Lead actions fail | Manual retry |
+| `KommoRateLimitError` | Temporary failure | Auto-retry after delay |
+| `KommoNotFoundError` | Lead not found | Show error to user |
+| `KommoValidationError` | Invalid data | Show validation error |
+
+### Handoff Errors
+
+| Error | Behavior |
+|-------|----------|
+| `HandoffTimeout` | Auto-reject after 300s |
+| `HandoffStateCorrupt` | Reject and log |
+| `RedisConnectionError` | Handoff fails, user notified |
+
+## Ingestion Errors
+
+### Docling Errors
+
+| Error | Impact | Recovery |
+|-------|--------|----------|
+| `ParseError` | Document skipped | Check DLQ |
+| `ChunkError` | Partial ingestion | Ingest valid chunks |
+| `EmbeddingError` | Retry with backoff | 3 retries |
+
+### Qdrant Write Errors
+
+| Error | Impact | Recovery |
+|-------|--------|----------|
+| `CollectionNotFound` | Fatal | Run bootstrap |
+| `DimensionMismatch` | Fatal | Check embedding config |
+| `WriteTimeout` | Retry | Auto-retry 3x |
+
+## Logging and Tracing
+
+All errors are:
+1. Logged with full stack trace
+2. Traced in Langfuse (if in pipeline context)
+3. Shown to user as friendly message (Telegram only)
+
+```python
+# Error logging format
+logger.error(
+    "Error in {function}",
+    extra={"error": str(e), "traceback": traceback.format_exc()}
+)
+```
+
+## Debugging Errors
+
+1. **Telegram bot errors:** Check Langfuse trace for the query
+2. **API errors:** Look for `trace_id` in 500 response
+3. **Handoff errors:** Check Redis keys `handoff:*`
+4. **Ingestion errors:** Check DLQ in PostgreSQL
+
+```bash
+# Check recent errors in Langfuse
+make validate-traces-fast
+
+# Check handoff state
+redis-cli GET "handoff:{thread_id}"
+
+# Check DLQ
+uv run python -m src.ingestion.unified.cli status
+```

--- a/docs/HITL_CRM_FLOW.md
+++ b/docs/HITL_CRM_FLOW.md
@@ -1,0 +1,98 @@
+# HITL CRM Flow
+
+Human-in-the-loop (HITL) pattern for CRM operations requiring human approval.
+
+## Architecture
+
+```
+User → Telegram Bot → LangGraph Agent
+                         ↓
+                   CRM Tool Call
+                         ↓
+                   interrupt() ← HITL trigger
+                         ↓
+                   Bot waits...
+                         ↓
+Human approves/rejects in Telegram
+                         ↓
+                  Command(resume=)
+                         ↓
+                  Graph resumes
+```
+
+## HITL Trigger Points
+
+CRM tools that trigger HITL via `interrupt()`:
+
+| Tool | Trigger Condition |
+|------|-------------------|
+| `create_lead` | All lead creation |
+| `schedule_viewing` | All viewing scheduling |
+| `transfer_lead` | Lead ownership transfer |
+| `update_lead_status` | Status changes to qualified |
+
+## Flow States
+
+Defined in `telegram_bot/services/handoff_state.py`:
+
+```python
+class HandoffState(TypedDict):
+    """HITL state persisted in Redis."""
+    state: str                    # "waiting", "approved", "rejected"
+    lead_id: int | None
+    action: str                   # "create_lead", "schedule_viewing", etc.
+    payload: dict                 # Action parameters
+    supervisor_chat_id: int       # Where to send approval request
+    created_at: float
+    expires_at: float
+```
+
+## HandoffData Schema
+
+```python
+class HandoffData(TypedDict):
+    """Passed through graph state for HITL decisions."""
+    is_handoff: bool
+    handoff_reason: str | None
+    lead_id: int | None
+    action: str | None
+    qualification_score: float | None
+```
+
+## Supervisor Notification
+
+When `interrupt()` fires:
+1. Graph execution pauses
+2. Supervisor thread receives notification with action details
+3. Supervisor approves/rejects via inline keyboard
+4. `Command(resume=...)` fires with decision
+
+## Redis Keys
+
+| Key Pattern | TTL | Content |
+|-------------|-----|---------|
+| `handoff:{thread_id}` | 300s | Serialized HandoffState |
+| `kommo:oauth:tokens` | long-lived | OAuth tokens (shared) |
+
+## Code Locations
+
+| File | Purpose |
+|------|---------|
+| `telegram_bot/agents/hitl.py` | `interrupt()` wrapper and handlers |
+| `telegram_bot/services/handoff_state.py` | State definitions |
+| `telegram_bot/handlers/handoff.py` | Handoff FSM states and handlers |
+| `telegram_bot/graph/nodes/` | Nodes that may trigger HITL |
+
+## Error Handling
+
+If supervisor times out (300s TTL):
+- Action is automatically rejected
+- User receives timeout message
+- Graph resumes with `rejected` state
+
+## Testing
+
+```bash
+# Test HITL flow
+uv run pytest tests/unit/telegram_bot/test_handoff.py -v
+```

--- a/docs/ONBOARDING_CHECKLIST.md
+++ b/docs/ONBOARDING_CHECKLIST.md
@@ -1,0 +1,164 @@
+# Onboarding Checklist
+
+New developer setup guide for the contextual RAG pipeline.
+
+## Prerequisites
+
+- [ ] Python 3.11+ (3.12 recommended)
+- [ ] [uv](https://docs.astral.sh/uv/) installed
+- [ ] Docker and Docker Compose
+- [ ] Telegram Bot Token (from [@BotFather](https://t.me/BotFather))
+- [ ] IDE with Python support (VS Code, PyCharm, etc.)
+
+## 1. Repository Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/yastman/rag.git
+cd rag
+
+# Install dependencies
+uv sync
+```
+
+## 2. Environment Configuration
+
+```bash
+# Copy environment template
+cp .env.example .env
+
+# Edit .env with your values:
+# Required:
+# - TELEGRAM_BOT_TOKEN
+# - OPENAI_API_KEY (or LLM_BASE_URL for LiteLLM)
+# - REDIS_PASSWORD
+# - LANGFUSE_PUBLIC_KEY
+# - LANGFUSE_SECRET_KEY
+# - LANGFUSE_HOST
+```
+
+## 3. Service Startup
+
+```bash
+# Start core services (Redis, Qdrant, BGE-M3)
+make local-up
+
+# Verify services are running
+docker compose ps
+```
+
+## 4. Bot Startup
+
+```bash
+# Run bot in development mode
+make run-bot
+
+# Or run via uv directly
+uv run python -m telegram_bot.main
+```
+
+## 5. Validation
+
+```bash
+# Run linting and type checking
+make check
+
+# Run unit tests
+make test-unit
+
+# Run full test suite
+make test-full
+```
+
+## 6. Key Files to Understand
+
+| File | Purpose |
+|------|---------|
+| `README.md` | Project overview |
+| `AGENTS.md` | Developer guidelines |
+| `telegram_bot/bot.py` | Main bot entry point |
+| `telegram_bot/graph/graph.py` | LangGraph pipeline |
+| `docs/PIPELINE_OVERVIEW.md` | Runtime flows |
+| `docs/engineering/sdk-registry.md` | SDK patterns |
+
+## 7. Understanding the Pipeline
+
+1. Read `docs/PIPELINE_OVERVIEW.md`
+2. Read `docs/BOT_ARCHITECTURE.md`
+3. Read `telegram_bot/graph/graph.py` (build_graph function)
+4. Trace through a query: classify → guard → cache_check → retrieve → grade → rerank/generate → respond
+
+## 8. Common Tasks
+
+### Run specific tests
+```bash
+uv run pytest tests/unit/telegram_bot/ -v -k "test_name"
+```
+
+### Add a new dependency
+```bash
+uv add package_name
+# Then update docs/engineering/sdk-registry.md
+```
+
+### Run ingestion
+```bash
+make ingest-unified-preflight
+make ingest-unified-bootstrap
+make ingest-unified
+```
+
+### Check Langfuse traces
+```bash
+# Local Langfuse at http://localhost:3000
+open http://localhost:3000
+```
+
+## 9. Code Patterns to Follow
+
+- **State management:** Use TypedDict for graph state, not Pydantic
+- **DI:** Use GraphContext for service dependencies
+- **Tracing:** Always use `@observe` decorator on node functions
+- **Error handling:** Let exceptions propagate; middleware handles user messages
+- **Testing:** Unit tests for nodes, integration tests for flows
+
+## 10. Getting Help
+
+- Read `docs/engineering/issue-triage.md` for debugging workflow
+- Check existing docs in `docs/`
+- Search code with `grepai` MCP tools
+- Ask in team chat with context
+
+## Optional: Voice Agent Setup
+
+If working on voice features:
+
+```bash
+# Start voice services
+make docker-voice-up
+
+# Set additional env vars:
+# - ELEVENLABS_API_KEY
+# - LIVEKIT_URL
+# - LIVEKIT_API_KEY
+# - LIVEKIT_API_SECRET
+```
+
+## Optional: Mini App Setup
+
+If working on the mini app:
+
+```bash
+cd mini_app
+npm install
+npm run dev
+```
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Redis connection refused | `docker compose up -d redis` |
+| Qdrant timeout | `QDRANT_TIMEOUT=30` |
+| MyPy errors | `make check` to identify issues |
+| Import errors | `uv sync` to ensure dependencies installed |

--- a/docs/PIPELINE_ROUTING.md
+++ b/docs/PIPELINE_ROUTING.md
@@ -1,0 +1,114 @@
+# Pipeline Routing
+
+Query routing logic through the LangGraph pipeline.
+
+## Routing Flow
+
+```
+START
+  ↓
+classify (QueryClassifier)
+  ↓
+┌───────────────────────────────────────┐
+│ Route by query_type:                  │
+│                                       │
+│ CHITCHAT → respond → END              │
+│ OFF_TOPIC → respond → END            │
+│ _NO_RAG_QUERY_TYPES → respond → END   │
+│ otherwise → guard → ...                │
+└───────────────────────────────────────┘
+  ↓
+guard (ContentFilter)
+  ↓ (pass)
+┌───────────────────────────────────────┐
+│ cache_check (SemanticCache)           │
+│   hit → respond → END                 │
+│   miss → retrieve → ...               │
+└───────────────────────────────────────┘
+  ↓
+retrieve (QdrantHybridSearch)
+  ↓
+grade (DocumentGrader)
+  ↓
+┌───────────────────────────────────────┐
+│ Grade result:                        │
+│   hallucination → rewrite → retrieve  │
+│   irrelevant → rewrite → retrieve     │
+│   relevant → rerank/rewrite/generate  │
+└───────────────────────────────────────┘
+  ↓
+rerank (ColBERT Reranker) — optional
+  ↓
+generate (LLM)
+  ↓
+cache_store (if enabled)
+  ↓
+respond (Telegram sender)
+  ↓
+summarize — only if checkpointer enabled
+  ↓
+END
+```
+
+## Query Type Classification
+
+| Query Type | Handler | Cacheable |
+|------------|---------|-----------|
+| `APARTMENT` | Apartment search | Yes |
+| `KNOWLEDGE` | RAG retrieval | Yes |
+| `CRM` | Agent tools | Partial |
+| `CHITCHAT` | Direct response | No |
+| `OFF_TOPIC` | Direct response | No |
+| `VOICE` | Voice agent | Yes |
+
+## Route Functions
+
+| Function | Location | Returns |
+|----------|----------|---------|
+| `route_after_classify` | `graph/graph.py` | Next node name |
+| `route_after_guard` | `graph/graph.py` | Next node name |
+| `route_after_cache_check` | `graph/graph.py` | Next node name |
+| `route_after_grade` | `graph/graph.py` | Next node name |
+| `route_after_rerank` | `graph/graph.py` | Next node name |
+
+## Rewrite Loop
+
+Queries that fail grade checks enter a rewrite loop:
+
+```
+retrieve → grade → fail → rewrite → retrieve (up to max_rewrite_attempts)
+```
+
+- `max_rewrite_attempts`: configurable (default: 1)
+- Prevents infinite loops with recursion limit
+
+## Conditional Edges
+
+Edges are defined via conditional functions in `build_graph()`:
+
+```python
+graph.add_conditional_edges(
+    node,
+    route_function,
+    {
+        "rerank": lambda s: s.get("query_type") == "APARTMENT",
+        "generate": lambda s: s.get("query_type") == "KNOWLEDGE",
+        ...
+    }
+)
+```
+
+## Code Locations
+
+| File | Purpose |
+|------|---------|
+| `telegram_bot/graph/graph.py` | Graph building + route functions |
+| `telegram_bot/graph/nodes/classify.py` | Query classification |
+| `telegram_bot/graph/nodes/guard.py` | Content filtering |
+| `telegram_bot/graph/nodes/cache_check.py` | Cache lookup |
+| `telegram_bot/graph/nodes/retrieve.py` | Retrieval |
+| `telegram_bot/graph/nodes/grade.py` | Document grading |
+| `telegram_bot/graph/nodes/rerank.py` | ColBERT rerank |
+| `telegram_bot/graph/nodes/rewrite.py` | Query rewrite |
+| `telegram_bot/graph/nodes/generate.py` | LLM generation |
+| `telegram_bot/graph/nodes/respond.py` | Response delivery |

--- a/docs/RAG_API.md
+++ b/docs/RAG_API.md
@@ -1,0 +1,122 @@
+# RAG API Reference
+
+FastAPI service wrapping the LangGraph pipeline for external query execution.
+
+**Entry point:** `src/api/main.py`
+**Port:** 8080 (production via Docker), 8000 (dev via uvicorn)
+
+## Endpoints
+
+### `GET /health`
+
+Readiness probe. Returns immediately without checking downstream services.
+
+**Response:**
+```json
+{ "status": "ok" }
+```
+
+---
+
+### `POST /query`
+
+Execute a RAG query through the full LangGraph pipeline.
+
+**Request body:** `QueryRequest`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `query` | string | required | User query text (1–4096 chars) |
+| `user_id` | int | 0 | Optional user identifier |
+| `session_id` | string | "" | Optional session identifier |
+| `channel` | string | "api" | Source channel: `api`, `voice`, `telegram` |
+| `langfuse_trace_id` | string | null | Optional Langfuse trace ID for cross-trace linking |
+
+**Response:** `QueryResponse`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `response` | string | Generated answer |
+| `query_type` | string | Classified query type (e.g., `APARTMENT`, `KNOWLEDGE`, `CHITCHAT`) |
+| `cache_hit` | bool | Whether semantic cache was hit |
+| `documents_count` | int | Number of retrieved documents |
+| `rerank_applied` | bool | Whether reranking was applied |
+| `latency_ms` | float | Total pipeline latency in milliseconds |
+| `context` | list[dict] | Retrieved context documents (for evaluation) |
+
+**Example request:**
+```bash
+curl -X POST http://localhost:8080/query \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "What are the requirements for permanent residency?",
+    "user_id": 12345,
+    "channel": "api"
+  }'
+```
+
+**Example response:**
+```json
+{
+  "response": "Permanent residency in Bulgaria requires...",
+  "query_type": "KNOWLEDGE",
+  "cache_hit": false,
+  "documents_count": 5,
+  "rerank_applied": true,
+  "latency_ms": 847.3,
+  "context": [
+    {"id": "doc-123", "text": "...", "score": 0.92},
+    {"id": "doc-456", "text": "...", "score": 0.88}
+  ]
+}
+```
+
+---
+
+## Error Responses
+
+| Status | Body | Cause |
+|--------|------|-------|
+| 422 | Validation error | Invalid request body |
+| 500 | `{"error": "Internal server error"}` | Unhandled exception |
+
+For 500 errors, check Langfuse traces for the corresponding `rag-api-query` trace.
+
+---
+
+## Architecture
+
+```
+POST /query
+    ↓
+FastAPI lifespan initializes:
+  - GraphConfig.from_env()
+  - CacheLayerManager (Redis)
+  - QdrantService
+  - Embeddings (BGE-M3)
+  - LLM (via LiteLLM)
+    ↓
+build_graph() from telegram_bot/graph/graph.py
+    ↓
+ainvoke() with RAGState
+    ↓
+Returns QueryResponse with context
+```
+
+---
+
+## Observability
+
+- Trace family: `rag-api-query`
+- Langfuse scores written via `write_langfuse_scores()`
+- `langfuse_trace_id` propagation for cross-trace linking with voice sessions
+
+---
+
+## Running Locally
+
+```bash
+uv run uvicorn src.api.main:app --host 0.0.0.0 --port 8080
+# Or via make:
+make docker-bot-up
+```

--- a/docs/RAG_QUALITY_SCORES.md
+++ b/docs/RAG_QUALITY_SCORES.md
@@ -1,0 +1,114 @@
+# RAG Quality Scores
+
+Observability metrics written to Langfuse for every query.
+
+## Score Writing
+
+Scores are computed and written via `telegram_bot/scoring.py`:
+- `write_langfuse_scores()` — main query scores
+- `write_history_scores()` — history search scores
+- `write_crm_scores()` — CRM tool usage scores
+
+## Main Query Scores
+
+| Score | Type | Description |
+|-------|------|-------------|
+| `query_type` | numeric | Query type weight: CHITCHAT=0, OFF_TOPIC=0, others=1-2 |
+| `latency_total_ms` | numeric | End-to-end latency |
+| `semantic_cache_hit` | boolean | Semantic result cache hit |
+| `embeddings_cache_hit` | boolean | Embeddings cache hit |
+| `search_cache_hit` | boolean | Search cache hit |
+| `rerank_applied` | boolean | ColBERT reranking was applied |
+| `rerank_cache_hit` | boolean | Rerank results served from cache |
+| `results_count` | numeric | Number of search results |
+| `no_results` | boolean | No results returned |
+| `llm_used` | boolean | LLM generation was called |
+| `confidence_score` | numeric | Grade confidence (RRF scale) |
+| `llm_ttft_ms` | numeric | Time to first token |
+| `llm_response_duration_ms` | numeric | LLM generation duration |
+| `streaming_enabled` | boolean | Streaming was enabled |
+| `llm_timeout` | boolean | LLM timeout occurred |
+| `llm_stream_recovery` | boolean | Stream recovery was triggered |
+| `llm_decode_ms` | numeric | LLM decode time (if available) |
+| `llm_decode_unavailable` | boolean | Decode time not available |
+| `llm_tps` | numeric | Tokens per second (if available) |
+| `llm_tps_unavailable` | boolean | TPS not available |
+| `llm_queue_ms` | numeric | Queue time (if available) |
+| `llm_queue_unavailable` | boolean | Queue time not available |
+| `answer_words` | numeric | Word count of generated answer |
+| `answer_chars` | numeric | Character count of answer |
+| `answer_to_question_ratio` | numeric | Answer length vs question length |
+| `response_style_applied` | numeric | Style: short=0, balanced=1, detailed=2 |
+| `input_type` | categorical | `text` or `voice` |
+| `stt_duration_ms` | numeric | Speech-to-text duration (voice only) |
+| `voice_duration_s` | numeric | Voice input duration (voice only) |
+| `bge_embed_error` | boolean | Embedding service error occurred |
+| `bge_embed_latency_ms` | numeric | Embedding latency |
+| `security_alert` | boolean | Prompt injection detected |
+| `injection_risk_score` | numeric | Injection risk score (0-1) |
+| `injection_pattern` | categorical | Type of injection pattern detected |
+| `llm_calls_total` | numeric | Total LLM calls in query |
+| `summarize_ms` | numeric | Summarization node latency |
+| `memory_messages_count` | numeric | Messages in conversation memory |
+| `summarization_triggered` | boolean | Conversation was summarized |
+| `grounded` | boolean | Answer grounded in retrieved context |
+| `legal_answer_safe` | boolean | No legal disclaimers needed |
+| `semantic_cache_safe_reuse` | boolean | Cache reuse was safe |
+| `safe_fallback_used` | boolean | Safe fallback response used |
+| `checkpointer_overhead_proxy_ms` | numeric | Checkpoint overhead proxy |
+| `nurturing_batch_size` | numeric | Nurturing batch size |
+| `nurturing_sent_count` | numeric | Nurturing messages sent |
+| `funnel_conversion_rate` | numeric | Funnel conversion rate |
+| `funnel_dropoff_rate` | numeric | Funnel drop-off rate |
+| `sources_shown` | boolean | Sources were shown in response |
+| `sources_count` | numeric | Number of sources shown |
+
+## History Search Scores
+
+Written via `write_history_scores()` for `/history` searches:
+
+| Score | Type | Description |
+|-------|------|-------------|
+| `history_search_count` | numeric | Number of history results |
+| `history_search_latency_ms` | numeric | History search latency |
+| `history_search_empty` | numeric | 1 if no results, 0 otherwise |
+| `history_backend` | categorical | Search backend used |
+
+## CRM Scores
+
+Written via `write_crm_scores()` when CRM tools are invoked:
+
+| Score | Type | Description |
+|-------|------|-------------|
+| `crm_tool_used` | boolean | Any CRM tool was called |
+| `crm_tools_count` | numeric | Total CRM tool calls |
+| `crm_tools_success` | numeric | Successful CRM operations |
+| `crm_tools_error` | numeric | Failed CRM operations |
+
+## Query Type Weights
+
+| Query Type | Weight | Notes |
+|------------|--------|-------|
+| `CHITCHAT` | 0.0 | No RAG needed |
+| `OFF_TOPIC` | 0.0 | No RAG needed |
+| `SIMPLE` | 1.0 | Simple query |
+| `GENERAL` | 1.0 | General knowledge |
+| `FAQ` | 1.0 | FAQ query |
+| `ENTITY` | 1.0 | Entity lookup |
+| `STRUCTURED` | 2.0 | Structured extraction |
+| `COMPLEX` | 2.0 | Complex query |
+
+## Validation
+
+Required trace families validated by `make validate-traces-fast`:
+- `rag-api-query`
+- `voice-session`
+- `ingestion-cli-run`
+
+## Code Locations
+
+| File | Purpose |
+|------|---------|
+| `telegram_bot/scoring.py` | Score computation and writing |
+| `telegram_bot/observability.py` | Langfuse client setup |
+| `docker/monitoring/rules/` | Alert rules |

--- a/telegram_bot/services/handoff_state.py
+++ b/telegram_bot/services/handoff_state.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 import json
 import logging
 import time
-from dataclasses import dataclass, field
+from typing import Any
 
+from pydantic import BaseModel, Field
 from redis.asyncio import Redis
 
 
@@ -21,17 +22,16 @@ _PREFIX = "handoff"
 _TOPIC_PREFIX = "topic_map"
 
 
-@dataclass
-class HandoffData:
+class HandoffData(BaseModel):
     """State for an active handoff session."""
 
     client_id: int
     topic_id: int
     mode: str = "human_waiting"  # bot | human_waiting | human
     lead_id: int | None = None
-    created_at: float = field(default_factory=time.time)
+    created_at: float = Field(default_factory=time.time)
     manager_joined_at: float | None = None
-    qualification: dict[str, str] = field(default_factory=dict)
+    qualification: dict[str, str] = Field(default_factory=dict)
 
     def to_redis_dict(self) -> dict[str, str]:
         return {
@@ -45,7 +45,7 @@ class HandoffData:
         }
 
     @classmethod
-    def from_redis_dict(cls, raw: dict[str, str]) -> HandoffData:
+    def from_redis_dict(cls, raw: dict[str, Any]) -> HandoffData:
         return cls(
             client_id=int(raw["client_id"]),
             topic_id=int(raw["topic_id"]),

--- a/telegram_bot/services/kommo_tokens.py
+++ b/telegram_bot/services/kommo_tokens.py
@@ -11,9 +11,25 @@ import time
 from typing import Any, Protocol, cast, runtime_checkable
 
 import httpx
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
 
 
 logger = logging.getLogger(__name__)
+
+# Retryable errors for token operations
+_RETRYABLE_TOKEN_ERRORS = (
+    httpx.ConnectError,
+    httpx.ReadTimeout,
+    httpx.ConnectTimeout,
+    httpx.PoolTimeout,
+    httpx.HTTPStatusError,
+)
 
 
 @runtime_checkable
@@ -176,8 +192,15 @@ class KommoTokenStore:
         )
         return access_token
 
+    @retry(
+        retry=retry_if_exception_type(_RETRYABLE_TOKEN_ERRORS),
+        wait=wait_exponential_jitter(initial=1, max=8, jitter=2),
+        stop=stop_after_attempt(3),
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+        reraise=True,
+    )
     async def _token_request(self, payload: dict) -> dict:
-        """POST to Kommo OAuth2 token endpoint."""
+        """POST to Kommo OAuth2 token endpoint with retry."""
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.post(self._token_url, json=payload)
             response.raise_for_status()


### PR DESCRIPTION
## Summary
- Convert `HandoffData` handling to a Pydantic-backed shape.
- Add retry protection around Kommo token operations.

## Test Plan
- Not run in this git cleanup pass
