### PR TITLE
fix: add stop_grace_period to postgres and listen_host to clickhouse

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -23,6 +23,7 @@ services:
   postgres:
     image: pgvector/pgvector:pg17
     restart: unless-stopped
+    stop_grace_period: 30s
     logging: *default-logging
     environment:
       POSTGRES_USER: postgres
@@ -452,6 +453,9 @@ services:
     restart: unless-stopped
     logging: *default-logging
     user: "101:101"
+    command: >
+      clickhouse-server
+      --listen_host=0.0.0.0
     environment:
       CLICKHOUSE_DB: default
       CLICKHOUSE_USER: clickhouse

--- a/k8s/base/postgres/deployment.yaml
+++ b/k8s/base/postgres/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: postgres
 spec:
   replicas: 1
+  progressDeadlineSeconds: 600
   strategy:
     type: Recreate  # PVC is RWO — no rolling update for stateful
   selector:
@@ -14,6 +15,7 @@ spec:
       labels:
         app: postgres
     spec:
+      terminationGracePeriodSeconds: 60
       securityContext:
         seccompProfile:
           type: RuntimeDefault
@@ -39,6 +41,10 @@ spec:
               cpu: 50m
             limits:
               memory: 512Mi
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5 && pg_ctl stop -D /var/lib/postgresql/data -m fast -t 30 || true"]
           livenessProbe:
             exec:
               command: ["pg_isready", "-U", "postgres"]


### PR DESCRIPTION
## Summary
- Harden local/runtime shutdown behavior for Postgres.
- Align ClickHouse listen host configuration in infra manifests.

## Test Plan
- Not run in this git cleanup pass
