### PR TITLE
fix: add postgres shutdown grace period

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -23,6 +23,7 @@ services:
   postgres:
     image: pgvector/pgvector:pg17
     restart: unless-stopped
+    stop_grace_period: 30s
     logging: *default-logging
     environment:
       POSTGRES_USER: postgres

--- a/docs/superpowers/plans/2026-04-02-issue-1081-postgres-shutdown-plan.md
+++ b/docs/superpowers/plans/2026-04-02-issue-1081-postgres-shutdown-plan.md
@@ -1,0 +1,58 @@
+# Issue #1081 Postgres Shutdown Safety Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent unclean PostgreSQL shutdowns in local/VPS compose flows by guaranteeing Docker gives the database enough time to flush WAL and exit cleanly before sending SIGKILL.
+
+**Architecture:** Keep the fix at the compose contract layer instead of changing application code. Add a regression test that asserts `postgres` declares an explicit shutdown grace period, then add the minimal `compose.yml` change and verify both rendered config and a recreated container expose the expected timeout.
+
+**Tech Stack:** Docker Compose, pytest, YAML-based compose tests
+
+---
+
+### Task 1: Lock the shutdown contract with a regression test
+
+**Files:**
+- Modify: `tests/unit/test_compose_config.py`
+- Test: `tests/unit/test_compose_config.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test that asserts `compose.yml` declares `services.postgres.stop_grace_period` and that the duration is comfortably above the current 1-second runtime timeout.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_compose_config.py -q`
+Expected: FAIL because `postgres` currently has no `stop_grace_period`.
+
+### Task 2: Implement the compose fix
+
+**Files:**
+- Modify: `compose.yml`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add an explicit `stop_grace_period` to `services.postgres` in `compose.yml`. Keep the blast radius narrow: no unrelated runtime changes, no new abstractions.
+
+- [ ] **Step 4: Run targeted tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_compose_config.py tests/unit/test_compose.py tests/unit/test_docker_compose_profiles.py tests/unit/test_compose_langfuse.py -q`
+Expected: PASS
+
+### Task 3: Verify effective runtime behavior
+
+**Files:**
+- Modify: `compose.yml` (already above)
+
+- [ ] **Step 5: Verify rendered compose config**
+
+Run: `COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility config | sed -n '/^  postgres:/,/^  [a-zA-Z0-9_-]\\+:/p'`
+Expected: rendered `postgres` block includes `stop_grace_period`.
+
+- [ ] **Step 6: Recreate postgres and inspect live timeout**
+
+Run: `COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility up -d --force-recreate postgres`
+
+Then run: `docker inspect dev_postgres_1 --format 'StopTimeout={{json .Config.StopTimeout}} StopSignal={{json .Config.StopSignal}}'`
+
+Expected: `StopTimeout` is no longer `1`, and the container keeps the Postgres image stop signal.

--- a/tests/unit/test_compose_config.py
+++ b/tests/unit/test_compose_config.py
@@ -235,6 +235,19 @@ class TestModelServiceHealthcheckGrace:
         )
 
 
+class TestPostgresShutdownSafety:
+    """Stateful Postgres must get enough time to exit cleanly before Docker kills it."""
+
+    def test_postgres_has_explicit_stop_grace_period(self, vps: dict) -> None:
+        postgres = vps["services"]["postgres"]
+        stop_grace_period = postgres.get("stop_grace_period")
+        assert stop_grace_period, "postgres.stop_grace_period is required for graceful WAL flush"
+        assert _duration_to_seconds(stop_grace_period) >= 30, (
+            "postgres.stop_grace_period must be >=30s to avoid forced kills during shutdown; "
+            f"got {stop_grace_period!r}"
+        )
+
+
 class TestMiniAppVpsParity:
     """Mini app must be part of the default VPS runtime stack."""
 


### PR DESCRIPTION
## Summary
- add an explicit `postgres.stop_grace_period` compose contract to reduce forced shutdown risk
- add a compose regression test that enforces a >=30s shutdown grace period for Postgres
- include the implementation plan for issue #1081

## Test Plan
- `uv run pytest tests/unit/test_compose_config.py -q`
- `uv run pytest tests/unit/test_compose.py tests/unit/test_docker_compose_profiles.py tests/unit/test_compose_langfuse.py -q`
- `docker compose` verification could not be run here because `docker` is unavailable in this environment
