### PR TITLE
fix: remove runtime deprecated colbert reranker

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -27,7 +27,6 @@ async def lifespan(app: FastAPI):
     from telegram_bot.graph.config import GraphConfig
     from telegram_bot.graph.graph import build_graph
     from telegram_bot.integrations.cache import CacheLayerManager
-    from telegram_bot.services.colbert_reranker import ColbertRerankerService
     from telegram_bot.services.qdrant import QdrantService
 
     cfg = GraphConfig.from_env()
@@ -51,7 +50,7 @@ async def lifespan(app: FastAPI):
 
     reranker = None
     if cfg.rerank_provider == "colbert":
-        reranker = ColbertRerankerService(base_url=cfg.bge_m3_url)
+        logger.info("Reranking via server-side Qdrant ColBERT path")
     elif cfg.rerank_provider != "none":
         logger.warning("Unknown RERANK_PROVIDER=%s, reranking disabled", cfg.rerank_provider)
     llm = cfg.create_llm()

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -11,7 +11,6 @@ import re
 import socket
 import time
 import uuid
-import warnings
 from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote, urlparse
 
@@ -560,19 +559,12 @@ class PropertyBot:
         )
         self._apartments_service = ApartmentsService(qdrant=self._qdrant_apartments)
 
-        # Rerank provider (feature flag)
+        # Rerank provider (feature flag). "colbert" keeps the existing
+        # server-side Qdrant ColBERT path and does not instantiate the
+        # deprecated client-side reranker service.
         self._reranker = None
         if config.rerank_provider == "colbert":
-            from .services.colbert_reranker import ColbertRerankerService
-
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    "ignore",
-                    message="ColbertRerankerService is deprecated.*",
-                    category=DeprecationWarning,
-                )
-                self._reranker = ColbertRerankerService(base_url=config.bge_m3_url)
-            logger.info("Using ColbertRerankerService for reranking")
+            logger.info("Reranking via server-side Qdrant ColBERT path")
         elif config.rerank_provider == "none":
             logger.info("Reranking disabled")
 

--- a/tests/unit/api/test_rag_api_runtime.py
+++ b/tests/unit/api/test_rag_api_runtime.py
@@ -200,6 +200,39 @@ async def test_lifespan_respects_rerank_provider_none() -> None:
     mock_colbert.assert_not_called()
 
 
+async def test_lifespan_keeps_colbert_runtime_server_side() -> None:
+    fake_cfg = SimpleNamespace(
+        redis_url="redis://localhost:6379",
+        cache_thresholds={"GENERAL": 0.08},
+        cache_ttl={"GENERAL": 3600},
+        qdrant_url="http://qdrant:6333",
+        qdrant_collection="test_collection",
+        bge_m3_url="http://bge-m3:8000",
+        rerank_provider="colbert",
+        max_rewrite_attempts=2,
+    )
+    fake_cfg.create_embeddings = MagicMock(return_value=SimpleNamespace())
+    fake_cfg.create_sparse_embeddings = MagicMock(return_value=SimpleNamespace())
+    fake_cfg.create_llm = MagicMock(return_value=MagicMock())
+
+    fake_cache = AsyncMock()
+    fake_qdrant = AsyncMock()
+    fake_graph = MagicMock()
+
+    with (
+        patch("telegram_bot.graph.config.GraphConfig.from_env", return_value=fake_cfg),
+        patch("telegram_bot.integrations.cache.CacheLayerManager", return_value=fake_cache),
+        patch("telegram_bot.services.qdrant.QdrantService", return_value=fake_qdrant),
+        patch("telegram_bot.graph.graph.build_graph", return_value=fake_graph) as mock_build_graph,
+        patch("telegram_bot.services.colbert_reranker.ColbertRerankerService") as mock_colbert,
+    ):
+        async with lifespan(app):
+            assert app.state.max_rewrite_attempts == 2
+
+    assert mock_build_graph.call_args.kwargs["reranker"] is None
+    mock_colbert.assert_not_called()
+
+
 async def test_lifespan_unknown_rerank_provider_logs_and_closes_embeddings() -> None:
     closable_embeddings = SimpleNamespace(aclose=AsyncMock())
     closable_sparse = SimpleNamespace(aclose=AsyncMock())

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -233,6 +233,24 @@ class TestPropertyBotInit:
         # First call is main collection (with timeout), second is apartments
         assert mock_qdrant.call_args_list[0].kwargs["timeout"] == 7
 
+    def test_init_keeps_colbert_runtime_server_side(self, mock_config):
+        """PropertyBot should not instantiate deprecated client-side ColBERT reranker."""
+        mock_config.rerank_provider = "colbert"
+        with (
+            patch("telegram_bot.bot.Bot"),
+            patch("telegram_bot.integrations.cache.CacheLayerManager"),
+            patch("telegram_bot.integrations.embeddings.BGEM3HybridEmbeddings"),
+            patch("telegram_bot.integrations.embeddings.BGEM3SparseEmbeddings"),
+            patch("telegram_bot.services.qdrant.QdrantService"),
+            patch("telegram_bot.graph.config.GraphConfig.create_llm"),
+            patch("telegram_bot.graph.config.GraphConfig.create_supervisor_llm"),
+            patch("telegram_bot.services.colbert_reranker.ColbertRerankerService") as mock_colbert,
+        ):
+            bot = PropertyBot(mock_config)
+
+        assert bot._reranker is None
+        mock_colbert.assert_not_called()
+
 
 class TestCommandHandlers:
     """Test command handlers."""


### PR DESCRIPTION
## Summary
- stop instantiating the deprecated ColbertRerankerService in bot and API runtime wiring
- keep `RERANK_PROVIDER=colbert` as the server-side Qdrant ColBERT path
- add regression tests for PropertyBot init and API lifespan runtime behavior

## Test Plan
- [x] uv run pytest tests/unit/api/test_rag_api_runtime.py -q
- [x] uv run pytest tests/unit/test_bot_handlers.py -q -k "colbert_runtime_server_side or PropertyBotInit"
- [x] uv run pytest tests/integration/test_graph_paths.py -n auto --dist=worksteal -q
- [x] make check
- [x] PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit