### PR TITLE
Stabilize pytest runtime for native WSL and simplify observability aliases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -364,6 +364,7 @@ addopts = """
     -ra
     --strict-markers
     --strict-config
+    --capture=sys
     --dist=loadscope
 """
 testpaths = ["tests"]

--- a/telegram_bot/observability.py
+++ b/telegram_bot/observability.py
@@ -30,10 +30,10 @@ from langfuse import (
 
 from src.security.pii_redaction import PIIRedactor
 from telegram_bot.observability_bootstrap import (
-    disable_otel_exporter as _bootstrap_disable_otel_exporter,
+    disable_otel_exporter as _disable_otel_exporter,
 )
 from telegram_bot.observability_bootstrap import (
-    is_endpoint_reachable as _bootstrap_is_endpoint_reachable,
+    is_endpoint_reachable as _is_endpoint_reachable,
 )
 
 
@@ -50,16 +50,6 @@ _MODEL_LIST_PAGE_SIZE = 100
 _pii_redactor = PIIRedactor()
 
 _langfuse_endpoint_warned = False
-
-
-def _is_endpoint_reachable(url: str, *, timeout: float = 2.0) -> bool:
-    """Compatibility wrapper used by unit tests and init flow."""
-    return _bootstrap_is_endpoint_reachable(url, timeout=timeout)
-
-
-def _disable_otel_exporter() -> None:
-    """Compatibility wrapper used by unit tests and init flow."""
-    _bootstrap_disable_otel_exporter()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -718,3 +718,14 @@ class TestInitializeLangfuseCallsDisableOtel:
 
         assert result is None
         mock_disable.assert_called_once()
+
+
+class TestObservabilityBootstrapAliases:
+    """Observability should expose bootstrap helpers without local proxy wrappers."""
+
+    def test_bootstrap_helpers_are_direct_aliases(self):
+        import telegram_bot.observability as observability
+        import telegram_bot.observability_bootstrap as bootstrap
+
+        assert observability._is_endpoint_reachable is bootstrap.is_endpoint_reachable
+        assert observability._disable_otel_exporter is bootstrap.disable_otel_exporter

--- a/tests/unit/test_pytest_runtime_defaults.py
+++ b/tests/unit/test_pytest_runtime_defaults.py
@@ -1,0 +1,15 @@
+"""Runtime defaults for pytest in WSL environments."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+def test_pytest_defaults_force_sys_capture() -> None:
+    """Global pytest config should avoid fd-capture tempfile issues on WSL."""
+    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    addopts = str(data["tool"]["pytest"]["ini_options"]["addopts"])
+
+    assert "--capture=sys" in addopts


### PR DESCRIPTION
Summary\n- make pytest default to --capture=sys to avoid fd-capture tempfile failures when WSL inherits Windows TMP/TEMP paths\n- remove local proxy wrappers in telegram_bot.observability and use direct aliases to bootstrap helpers\n- add regression coverage for both defaults and aliasing behavior\n\nVerification\n- uv run pytest tests/unit/test_pytest_runtime_defaults.py -q\n- uv run pytest tests/unit/test_observability.py::TestObservabilityBootstrapAliases::test_bootstrap_helpers_are_direct_aliases tests/unit/test_pytest_runtime_defaults.py -q\n- make check\n- PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit