### PR TITLE
[codex] fix semantic cache follow-up guards

### DIFF
--- a/telegram_bot/agents/rag_pipeline.py
+++ b/telegram_bot/agents/rag_pipeline.py
@@ -28,6 +28,7 @@ from telegram_bot.pipelines.state_contract import PreAgentStateContract
 from telegram_bot.services.cache_policy import (
     SEMANTIC_CACHE_SCHEMA_VERSION,
     build_cacheability_decision,
+    is_contextual_query,
     maybe_store_semantic_response,
     resolve_semantic_cache_signature,
 )
@@ -209,8 +210,11 @@ async def _cache_check(
         }
 
     # Step 2: Check semantic cache via shared core
-    if semantic_cache_already_checked or (
-        semantic_cache_filter_sensitive and semantic_cache_filter_signature is None
+    contextual_query = is_contextual_query(query)
+    if (
+        semantic_cache_already_checked
+        or contextual_query
+        or (semantic_cache_filter_sensitive and semantic_cache_filter_signature is None)
     ):
         hit, cached = False, None
     else:
@@ -845,7 +849,7 @@ async def _cache_store(
             grounding_mode="normal",
             documents=[{"text": response}],
             cache_hit=False,
-            contextual=False,
+            contextual=is_contextual_query(query),
             grade_confidence=1.0,
             confidence_threshold=0.0,
             schema_version=SEMANTIC_CACHE_SCHEMA_VERSION,

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -62,6 +62,7 @@ from .services.business_hours import is_business_hours
 from .services.cache_policy import (
     SEMANTIC_CACHE_SCHEMA_VERSION,
     build_cacheability_decision,
+    is_contextual_query,
     maybe_store_semantic_response,
     resolve_semantic_cache_signature,
 )
@@ -2910,8 +2911,10 @@ class PropertyBot:
                         topic_hint=topic_hint,
                     )
                     filter_signal = detect_filter_sensitive_query(user_text)
+                    contextual_query = is_contextual_query(user_text)
                     rag_result_store["filter_sensitive"] = filter_signal.is_filter_sensitive
                     rag_result_store["filter_signal_reasons"] = list(filter_signal.reasons)
+                    rag_result_store["contextual_query"] = contextual_query
                     rag_result_store["topic_hint"] = topic_hint or ""
                     rag_result_store["grounding_mode"] = grounding_mode
                     if grounding_mode == "strict":
@@ -2931,7 +2934,9 @@ class PropertyBot:
                             )
                             rag_result_store["semantic_cache_filter_signature"] = filter_signature
                     cached = None
-                    if filter_signal.is_filter_sensitive and filter_signature is None:
+                    if contextual_query or (
+                        filter_signal.is_filter_sensitive and filter_signature is None
+                    ):
                         rag_result_store["semantic_cache_already_checked"] = True
                     else:
                         check_start = time.perf_counter()
@@ -3370,7 +3375,7 @@ class PropertyBot:
                     grounding_mode=grounding_mode_value,
                     documents=rag_result_store.get("documents", []),
                     cache_hit=bool(rag_result_store.get("cache_hit", False)),
-                    contextual=False,
+                    contextual=is_contextual_query(user_text),
                     grade_confidence=float(rag_result_store.get("grade_confidence", 0.0) or 0.0),
                     confidence_threshold=confidence_threshold,
                     schema_version=SEMANTIC_CACHE_SCHEMA_VERSION,

--- a/telegram_bot/graph/nodes/cache.py
+++ b/telegram_bot/graph/nodes/cache.py
@@ -19,6 +19,7 @@ from telegram_bot.observability import get_client, observe
 from telegram_bot.services.cache_policy import (
     SEMANTIC_CACHE_SCHEMA_VERSION,
     build_cacheability_decision,
+    is_contextual_query,
     maybe_store_semantic_response,
     resolve_semantic_cache_signature,
 )
@@ -117,7 +118,8 @@ async def cache_check_node(
     # Voice path has no user role — agent_role omitted so voice responses are
     # shared across roles within the same cache_scope="rag" bucket.
     filter_sensitive, filter_signature = _resolve_graph_filter_signature(state, query)
-    if filter_sensitive and filter_signature is None:
+    contextual_query = is_contextual_query(query)
+    if contextual_query or (filter_sensitive and filter_signature is None):
         hit, cached = False, None
     else:
         hit, cached = await check_semantic_cache(
@@ -254,7 +256,7 @@ async def cache_store_node(
             grounding_mode=str(state.get("grounding_mode", "normal") or "normal"),
             documents=state.get("documents", []),
             cache_hit=bool(state.get("cache_hit", False)),
-            contextual=False,
+            contextual=is_contextual_query(query),
             grade_confidence=float(state.get("grade_confidence", 0.0) or 0.0),
             confidence_threshold=0.0,
             schema_version=SEMANTIC_CACHE_SCHEMA_VERSION,

--- a/telegram_bot/pipelines/client.py
+++ b/telegram_bot/pipelines/client.py
@@ -6,7 +6,6 @@ Steps: classify → agent intent gate → RAG → generate → send → post-pro
 from __future__ import annotations
 
 import logging
-import re
 import time
 from numbers import Real
 from typing import Any
@@ -20,6 +19,7 @@ from telegram_bot.scoring import score, write_langfuse_scores
 from telegram_bot.services.cache_policy import (
     SEMANTIC_CACHE_SCHEMA_VERSION,
     build_cacheability_decision,
+    is_contextual_query,
     maybe_store_semantic_response,
     resolve_semantic_cache_signature,
 )
@@ -39,14 +39,6 @@ _NO_RAG_QUERY_TYPES: frozenset[str] = frozenset({"CHITCHAT", "OFF_TOPIC"})
 _PIPELINE_STORE_TYPES: frozenset[str] = frozenset({"FAQ", "GENERAL", "ENTITY", "STRUCTURED"})
 
 _TELEGRAM_MESSAGE_LIMIT = 4096
-
-# Contextual follow-up indicators — queries referencing prior turns are not cacheable.
-_CONTEXTUAL_RE = re.compile(
-    r"\b(подробнее|первый|первую|первое|второй|вторую|второе|третий|третью|третье"
-    r"|это|тот|та|те|они|ещё|другие|другой|другую|следующий|следующую|предыдущий|предыдущую"
-    r"|оба|обе|тот же|та же|то же)\b",
-    re.IGNORECASE,
-)
 
 # Fallback confidence threshold for semantic cache store guard.
 _CONFIDENCE_THRESHOLD = 0.005
@@ -137,7 +129,7 @@ def _safe_langfuse_env(config: Any) -> str:
 
 def _is_contextual_query(user_text: str) -> bool:
     """Return True if query contains follow-up pronouns / contextual references."""
-    return bool(_CONTEXTUAL_RE.search(user_text))
+    return is_contextual_query(user_text)
 
 
 # ---------------------------------------------------------------------------

--- a/telegram_bot/services/cache_policy.py
+++ b/telegram_bot/services/cache_policy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from time import time
 from typing import Any
@@ -10,6 +11,30 @@ from telegram_bot.services.query_filter_signal import build_filter_signature
 
 _SEMANTIC_CACHEABLE_QUERY_TYPES = {"ENTITY", "FAQ", "GENERAL", "STRUCTURED"}
 SEMANTIC_CACHE_SCHEMA_VERSION = "v8"
+_CONTEXTUAL_RE = re.compile(
+    r"\b(?:"
+    r"расскажи\s+подробнее(?:\s+(?:об|про)\s+(?:этом|этой|этих|этот|эту|них)\s+\w+)?"
+    r"|покажи\s+подробнее(?:\s+(?:об|про)\s+(?:этом|этой|этих|этот|эту|них)\s+\w+)?"
+    r"|объясни\s+подробнее(?:\s+(?:об|про)\s+(?:этом|этой|этих|этот|эту|них)\s+\w+)?"
+    r"|подробнее\s+об\s+(?:этом|этих|них)\s+\w+"
+    r"|подробнее\s+об\s+этой\s+\w+"
+    r"|подробнее\s+про\s+(?:этот|эту|эти|них)\s+\w+"
+    r"|перв(?:ый|ую|ое)\s+(?:вариант|объект)"
+    r"|втор(?:ой|ую|ое)\s+(?:вариант|объект)"
+    r"|трет(?:ий|ью|ье)\s+(?:вариант|объект)"
+    r"|это\s+(?:правильн\w*|тот\s+же|та\s+же|то\s+же|вариант|объект)"
+    r"|тот\s+же\s+(?:вариант|объект)"
+    r"|та\s+же\s+(?:квартира|сделка|локация|планировка|цена)"
+    r"|то\s+же(?:\s+самое)?"
+    r"|они"
+    r"|другие\s+есть"
+    r"|друг(?:ой|ую)\s+(?:вариант|объект)"
+    r"|ещ[её]\s+вариант\w*\s+есть"
+    r"|следующ(?:ий|ую|ее)\s+(?:вариант|объект)"
+    r"|предыдущ(?:ий|ую|ее)\s+(?:вариант|объект)"
+    r")\b",
+    re.IGNORECASE,
+)
 
 
 @dataclass(slots=True, frozen=True)
@@ -117,6 +142,11 @@ def resolve_semantic_cache_signature(
     if explicit_signature:
         return explicit_signature
     return build_filter_signature(filters)
+
+
+def is_contextual_query(query: str) -> bool:
+    """Return True for follow-up queries that depend on prior conversational context."""
+    return bool(_CONTEXTUAL_RE.search(query))
 
 
 async def maybe_store_semantic_response(

--- a/telegram_bot/services/query_filter_signal.py
+++ b/telegram_bot/services/query_filter_signal.py
@@ -5,9 +5,33 @@ from dataclasses import dataclass
 from typing import Any
 
 
-_CITY_RE = re.compile(r"\b(несеб\w*|варн\w*|бургас\w*|солнечн\w*\s+берег\w*)\b", re.IGNORECASE)
+_CITY_RE = re.compile(
+    r"\b("
+    r"несеб\w*"
+    r"|варн\w*"
+    r"|бургас\w*"
+    r"|солнечн\w*\s+берег\w*"
+    r"|свети\s+влас\w*"
+    r"|свят\w+\s+влас\w*"
+    r"|эленит\w*"
+    r"|помори\w*"
+    r"|созопол\w*"
+    r"|софи\w*"
+    r")\b",
+    re.IGNORECASE,
+)
 _PRICE_RE = re.compile(r"\b(до|от|дешевле|дороже|меньше|больше)\s*\d", re.IGNORECASE)
-_ROOMS_RE = re.compile(r"\b(студия|однушк|двушк|тр[её]шк|\d+\s*комн)\b", re.IGNORECASE)
+_ROOMS_RE = re.compile(
+    r"\b("
+    r"студи\w*"
+    r"|однушк\w*"
+    r"|двушк\w*"
+    r"|тр[её]шк\w*"
+    r"|\d+[\s-]*комн\w*"
+    r"|(?:одно|дв(?:у|ух)|тр[её]х|четыр[её]х|пяти)комнат\w*"
+    r")\b",
+    re.IGNORECASE,
+)
 _AREA_RE = re.compile(r"\b\d+\s*(м2|м²|кв)\b", re.IGNORECASE)
 _CURRENCY_RE = re.compile(r"\b(евро|€|eur|доллар|usd)\b", re.IGNORECASE)
 _FLOOR_RE = re.compile(r"\b(?:\d+\s*этаж\w*|на\s+\d+)\b", re.IGNORECASE)

--- a/telegram_bot/services/rag_core.py
+++ b/telegram_bot/services/rag_core.py
@@ -14,6 +14,8 @@ import asyncio
 import logging
 from typing import Any
 
+from telegram_bot.services.cache_policy import is_contextual_query
+
 
 logger = logging.getLogger(__name__)
 
@@ -288,6 +290,8 @@ async def check_semantic_cache(
         - response: The cached response string, or None on miss
     """
     if query_type not in CACHEABLE_QUERY_TYPES:
+        return (False, None)
+    if is_contextual_query(query):
         return (False, None)
 
     cached = await cache.check_semantic(

--- a/tests/unit/agents/test_rag_pipeline.py
+++ b/tests/unit/agents/test_rag_pipeline.py
@@ -216,6 +216,26 @@ async def test_cache_check_passes_filter_signature(mock_cache, mock_embeddings):
     assert call_kwargs.get("filter_signature") == "city=Несебр"
 
 
+async def test_cache_check_skips_contextual_follow_up_lookup(mock_cache, mock_embeddings):
+    from telegram_bot.agents.rag_pipeline import _cache_check
+
+    mock_cache.get_embedding = AsyncMock(return_value=[0.1] * 1024)
+    mock_cache.check_semantic = AsyncMock(return_value="cached answer")
+
+    result = await _cache_check(
+        "расскажи подробнее",
+        "FAQ",
+        42,
+        cache=mock_cache,
+        embeddings=mock_embeddings,
+        latency_stages={},
+    )
+
+    assert result["cache_hit"] is False
+    assert result["cached_response"] is None
+    mock_cache.check_semantic.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # _hybrid_retrieve tests
 # ---------------------------------------------------------------------------
@@ -822,6 +842,23 @@ async def test_cache_store_skips_non_cacheable(mock_cache):
         "hello",
         [0.1] * 1024,
         "CHITCHAT",
+        42,
+        cache=mock_cache,
+        latency_stages={},
+    )
+
+    assert result["stored_semantic"] is False
+    mock_cache.store_semantic.assert_not_called()
+
+
+async def test_cache_store_skips_contextual_follow_up(mock_cache):
+    from telegram_bot.agents.rag_pipeline import _cache_store
+
+    result = await _cache_store(
+        "расскажи подробнее",
+        "Ответ про квартиры",
+        [0.1] * 1024,
+        "FAQ",
         42,
         cache=mock_cache,
         latency_stages={},

--- a/tests/unit/graph/test_cache_nodes.py
+++ b/tests/unit/graph/test_cache_nodes.py
@@ -182,6 +182,22 @@ class TestCacheCheckNode:
         assert result["cached_response"] is None
         cache.check_semantic.assert_not_awaited()
 
+    async def test_contextual_follow_up_skips_semantic_cache_lookup(self):
+        state = make_initial_state(user_id=1, session_id="s1", query="расскажи подробнее")
+        state["query_type"] = "FAQ"
+
+        cache = AsyncMock()
+        cache.get_embedding = AsyncMock(return_value=[0.2] * 1024)
+        cache.check_semantic = AsyncMock(return_value="cached answer")
+
+        embeddings = AsyncMock()
+
+        result = await cache_check_node(state, _make_runtime(cache=cache, embeddings=embeddings))
+
+        assert result["cache_hit"] is False
+        assert result["cached_response"] is None
+        cache.check_semantic.assert_not_awaited()
+
     async def test_filter_sensitive_query_passes_signature_to_semantic_cache_lookup(self):
         state = make_initial_state(user_id=1, session_id="s1", query="квартира в Несебре")
         state["query_type"] = "FAQ"
@@ -399,6 +415,21 @@ class TestCacheStoreNode:
         await cache_store_node(state, _make_runtime(cache=cache))
 
         assert cache.store_semantic.await_args.kwargs["filter_signature"] == "city=Несебр"
+
+    async def test_contextual_follow_up_skips_semantic_cache_store(self):
+        state = make_initial_state(user_id=1, session_id="s1", query="расскажи подробнее")
+        state["query_type"] = "FAQ"
+        state["query_embedding"] = [0.1] * 1024
+        state["response"] = "generated answer"
+        state["documents"] = [{"text": "doc", "score": 0.9, "metadata": {}}]
+        state["grade_confidence"] = 0.9
+
+        cache = AsyncMock()
+        cache.store_semantic = AsyncMock()
+
+        await cache_store_node(state, _make_runtime(cache=cache))
+
+        cache.store_semantic.assert_not_awaited()
 
     async def test_skips_store_if_no_response(self):
         state = make_initial_state(user_id=1, session_id="s1", query="test query")

--- a/tests/unit/pipelines/test_client_pipeline.py
+++ b/tests/unit/pipelines/test_client_pipeline.py
@@ -120,12 +120,16 @@ class TestDetectAgentIntent:
 class TestIsContextualQuery:
     def test_contextual_pronouns_detected(self):
         assert _is_contextual_query("расскажи подробнее об этом объекте") is True
+        assert _is_contextual_query("подробнее про этот объект") is True
+        assert _is_contextual_query("подробнее об этой квартире") is True
         assert _is_contextual_query("первый вариант") is True
         assert _is_contextual_query("а другие есть?") is True
 
     def test_non_contextual_query(self):
         assert _is_contextual_query("Какие квартиры в центре Москвы?") is False
         assert _is_contextual_query("Цена однокомнатной квартиры") is False
+        assert _is_contextual_query("квартира на первом этаже") is False
+        assert _is_contextual_query("подробнее о квартире в Софии") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_query_filter_signal.py
+++ b/tests/unit/services/test_query_filter_signal.py
@@ -63,6 +63,24 @@ def test_detect_filter_sensitive_query_for_extractor_supported_forms(
     assert reason in signal.reasons
 
 
+@pytest.mark.parametrize(
+    ("query", "reason"),
+    [
+        ("квартира в Софии", "city"),
+        ("апартамент в Свети Власе", "city"),
+        ("двухкомнатная квартира в Созополе", "rooms"),
+        ("трехкомнатная квартира у моря", "rooms"),
+        ("однокомнатная квартира в Несебре", "rooms"),
+    ],
+)
+def test_detect_filter_sensitive_query_for_supported_apartment_city_and_room_forms(
+    query: str, reason: str
+) -> None:
+    signal = detect_filter_sensitive_query(query)
+    assert signal.is_filter_sensitive is True
+    assert reason in signal.reasons
+
+
 def test_build_filter_signature_sorts_keys_and_nested_ranges() -> None:
     signature = build_filter_signature({"price": {"lte": 80000}, "city": "Несебр"})
     assert signature == "city=Несебр|price.lte=80000"

--- a/tests/unit/services/test_rag_core.py
+++ b/tests/unit/services/test_rag_core.py
@@ -423,6 +423,21 @@ class TestCheckSemanticCache:
         assert hit is False
         assert response is None
 
+    async def test_contextual_follow_up_skips_cache_lookup(self):
+        cache = AsyncMock()
+        cache.check_semantic = AsyncMock(return_value="cached answer")
+
+        hit, response = await check_semantic_cache(
+            "расскажи подробнее",
+            [0.1] * 10,
+            "FAQ",
+            cache=cache,
+        )
+
+        assert hit is False
+        assert response is None
+        cache.check_semantic.assert_not_awaited()
+
     async def test_agent_role_passed_to_cache(self):
         """agent_role kwarg is forwarded to cache.check_semantic."""
         cache = AsyncMock()

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -3749,6 +3749,29 @@ class TestPreAgentCacheCheck:
         bot._cache.check_semantic.assert_not_awaited()
         mock_agent.ainvoke.assert_awaited_once()
 
+    async def test_pre_agent_contextual_follow_up_skips_semantic_lookup(self, mock_config):
+        bot, _ = _create_bot(mock_config)
+        test_embedding = [0.5] * 10
+        self._setup_cache_mocks(bot, embedding=test_embedding, cached_response="unsafe cache hit")
+
+        mock_agent = AsyncMock()
+        mock_agent.ainvoke = AsyncMock(return_value=_mock_agent_result())
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+            patch("telegram_bot.bot.classify_query", return_value="FAQ"),
+        ):
+            message = _make_text_message("расскажи подробнее")
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        bot._cache.check_semantic.assert_not_awaited()
+        mock_agent.ainvoke.assert_awaited_once()
+
     async def test_pre_agent_cache_skip_chitchat(self, mock_config):
         """CHITCHAT query type skips pre-agent cache entirely — no embedding computed (#563)."""
         bot, _ = _create_bot(mock_config)
@@ -4740,6 +4763,51 @@ class TestTextPathSemanticCachePolicy:
         assert bot._cache.store_semantic.await_args.kwargs["filter_signature"] == "city=Несебр"
         trace_metadata = mock_lf.update_current_span.call_args.kwargs["metadata"]
         assert trace_metadata["filter_signature"] == "city=Несебр"
+
+    async def test_text_path_contextual_follow_up_skips_semantic_store(self, mock_config):
+        bot, _ = _create_bot(mock_config)
+        bot._cache = AsyncMock()
+        bot._cache.get_embedding = AsyncMock(return_value=[0.1, 0.2, 0.3])
+        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
+        bot._cache.check_semantic = AsyncMock(return_value=None)
+        bot._cache.store_embedding = AsyncMock()
+        bot._cache.store_semantic = AsyncMock()
+        message = _make_text_message("расскажи подробнее")
+
+        def _agent_side_effect(state, config=None, **kw):
+            cfg = config or kw.get("config", {})
+            store = cfg.get("configurable", {}).get("rag_result_store")
+            if isinstance(store, dict):
+                store.update(
+                    {
+                        "query_type": "FAQ",
+                        "query_embedding": [0.1, 0.2, 0.3],
+                        "documents": [{"text": "doc", "score": 0.9, "metadata": {}}],
+                        "cache_hit": False,
+                        "grade_confidence": 0.9,
+                        "grounding_mode": "normal",
+                        "grounded": True,
+                        "legal_answer_safe": True,
+                        "semantic_cache_safe_reuse": True,
+                    }
+                )
+            return _mock_agent_result(messages=[MagicMock(content="Ответ агентом")])
+
+        mock_agent = AsyncMock()
+        mock_agent.ainvoke = AsyncMock(side_effect=_agent_side_effect)
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+            patch("telegram_bot.bot.classify_query", return_value="FAQ"),
+        ):
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        bot._cache.store_semantic.assert_not_awaited()
 
 
 class TestClearCacheCommand:

--- a/tests/unit/test_dependency_workflow.py
+++ b/tests/unit/test_dependency_workflow.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 def test_renovate_base_branch_is_dev() -> None:
     data = json.loads(Path("renovate.json").read_text(encoding="utf-8"))
-    assert data["baseBranches"] == ["dev"]
+    assert data.get("baseBranchPatterns") == ["dev"]
+    assert "baseBranches" not in data
 
 
 def test_ci_validates_pull_requests_for_dev() -> None:


### PR DESCRIPTION
## Summary
- expand filter-sensitive query detection for supported apartment city and room forms
- move contextual semantic-cache follow-up guards into shared cache policy and apply them consistently to lookup and store paths
- add regression coverage for contextual follow-ups and filter-aware cache partitioning

## Why
- pre-agent filter extraction could be skipped for supported apartment forms, leaving semantic cache filter-blind
- contextual follow-ups could still hit or store into shared semantic cache in bot/graph paths
- the contextual detector needed narrower phrase handling to avoid suppressing valid first-turn apartment queries

## Validation
- env UV_CACHE_DIR=/tmp/uv-cache-rag-fresh TMPDIR=/tmp TMP=/tmp TEMP=/tmp PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/unit/services/test_query_filter_signal.py tests/unit/services/test_rag_core.py tests/unit/graph/test_cache_nodes.py tests/unit/agents/test_rag_pipeline.py tests/unit/pipelines/test_client_pipeline.py tests/unit/test_bot_handlers.py::TestPreAgentCacheCheck tests/unit/test_bot_handlers.py::TestTextPathSemanticCachePolicy -q
