### PR TITLE
[codex] restore native local bot preflight contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,9 @@ MKL_NUM_THREADS=4
 POSTGRES_PASSWORD=postgres  # Change in production!
 REDIS_PASSWORD=dev_redis_pass  # Change in production!
 REDIS_MAXMEMORY=512mb  # dev: 512mb, VPS: 256mb (default in compose.yml)
+# Native local bot runs infer redis://:$(REDIS_PASSWORD)@localhost:6379 automatically
+# when REDIS_URL is unset. Override REDIS_URL only if you need a non-default host/port/db.
+# REDIS_URL=redis://:dev_redis_pass@localhost:6379/0
 
 # =============================================================================
 # REQUIRED FOR ML PROFILE (make docker-ml-up, langfuse)

--- a/Makefile
+++ b/Makefile
@@ -344,7 +344,7 @@ test-redis: ## Verify Redis Query Engine is available
 
 .PHONY: test-bot-health test-bot-health-vps
 
-test-bot-health: ## Preflight: verify Qdrant collection + LLM (local dev, ports published)
+test-bot-health: ## Preflight: verify Redis + Qdrant + LLM (local dev, native bot contract)
 	@echo "$(BLUE)Running bot health preflight...$(NC)"
 	@./scripts/test_bot_health.sh
 	@echo "$(GREEN)✓ Bot health preflight passed$(NC)"

--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ cp .env.example .env   # Fill in API keys (see below)
 
 ```bash
 make local-up    # Redis, Qdrant, BGE-M3, Docling, LiteLLM
-make run-bot     # Run bot natively (fast iteration, no Docker rebuild)
+make test-bot-health  # Native bot preflight: Redis + Qdrant + LLM
+make run-bot          # Run bot natively (fast iteration, no Docker rebuild)
 ```
 
 ### 3. Or Run Everything in Docker

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -29,11 +29,10 @@ Secret model by compose file:
 ## 2. Start Services
 
 ```bash
-# Core services (default compose set)
-make docker-up
-
-# Bot runtime
-make docker-bot-up
+# Minimal native bot stack
+make local-up
+make test-bot-health
+make run-bot
 
 # Optional profiles
 make docker-ml-up
@@ -57,10 +56,14 @@ Bot preflight:
 make test-bot-health
 ```
 
-`make test-bot-health` resolves `QDRANT_COLLECTION` in this order:
-1. exported shell env (`QDRANT_COLLECTION`)
-2. `.env` value
-3. compose default from `compose.yml` (`gdrive_documents_bge`)
+`make test-bot-health` now reuses the bot's native `telegram_bot.preflight.check_dependencies(...)`
+path instead of a separate shell-only probe. That means it validates the same Redis auth contract,
+Qdrant collection path, and LLM endpoint that `make run-bot` will use next.
+
+Native Redis contract:
+- If `REDIS_URL` is unset and `REDIS_PASSWORD` is set, `BotConfig` automatically uses
+  `redis://:$(REDIS_PASSWORD)@localhost:6379` for host-native runs.
+- Set `REDIS_URL` explicitly only when you need a non-default host, port, credentials, or DB index.
 
 ## 4. Development Gates
 
@@ -110,6 +113,8 @@ Use the `local-*` shortcuts (they now run a minimal subset from `compose.yml:com
 
 ```bash
 make local-up
+make test-bot-health
+make run-bot
 make local-ps
 make local-down
 ```
@@ -117,5 +122,6 @@ make local-down
 ## 7. Common Issues
 
 - `docker-bot-up` fails immediately: missing required env variables in `.env`.
+- `make test-bot-health` fails on Redis auth: check `REDIS_PASSWORD` or set an explicit host-native `REDIS_URL`.
 - Slow first startup: BGE-M3 and Docling warm up and cache models.
 - Ingestion status empty: verify `GDRIVE_SYNC_DIR` and collection bootstrap.

--- a/docs/ONBOARDING_CHECKLIST.md
+++ b/docs/ONBOARDING_CHECKLIST.md
@@ -43,8 +43,8 @@ cp .env.example .env
 # Start core services (Redis, Qdrant, BGE-M3)
 make local-up
 
-# Verify services are running
-docker compose ps
+# Verify the native bot contract before startup
+make test-bot-health
 ```
 
 ## 4. Bot Startup

--- a/scripts/test_bot_health.sh
+++ b/scripts/test_bot_health.sh
@@ -3,85 +3,29 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PROJECT_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+cd "$PROJECT_ROOT"
 
-resolve_qdrant_collection() {
-  local dotenv_value compose_default
+exec uv run python - <<'PY'
+import asyncio
+import logging
 
-  if [ -n "${QDRANT_COLLECTION:-}" ]; then
-    printf '%s\n' "$QDRANT_COLLECTION"
-    return 0
-  fi
+import httpx
 
-  if [ -f "$PROJECT_ROOT/.env" ]; then
-    dotenv_value=$(
-      sed -nE "s/^[[:space:]]*(export[[:space:]]+)?QDRANT_COLLECTION[[:space:]]*=[[:space:]]*['\"]?([^'\"#[:space:]]+)['\"]?.*$/\\2/p" "$PROJECT_ROOT/.env" \
-        | tail -n1
-    )
-    if [ -n "$dotenv_value" ]; then
-      printf '%s\n' "$dotenv_value"
-      return 0
-    fi
-  fi
+from telegram_bot.config import BotConfig
+from telegram_bot.preflight import _check_single_dep, check_dependencies
 
-  compose_default=$(
-    sed -nE "s/^[[:space:]]*QDRANT_COLLECTION:[[:space:]]*\\$\\{QDRANT_COLLECTION:-([^}]+)\\}[[:space:]]*$/\\1/p" "$PROJECT_ROOT/compose.yml" \
-      | head -n1
-  )
-  if [ -n "$compose_default" ]; then
-    printf '%s\n' "$compose_default"
-    return 0
-  fi
 
-  printf '%s\n' "gdrive_documents_bge"
-}
+logging.basicConfig(level=logging.INFO, format="%(message)s")
 
-QDRANT_URL=${QDRANT_URL:-http://localhost:6333}
-QDRANT_COLLECTION=$(resolve_qdrant_collection)
-QDRANT_QUANTIZATION_MODE=${QDRANT_QUANTIZATION_MODE:-off}
-LLM_BASE_URL=${LLM_BASE_URL:-${LITELLM_BASE_URL:-http://localhost:4000}}
 
-fail() {
-  echo "FAIL: $1" >&2
-  exit 1
-}
+async def main() -> None:
+    config = BotConfig()
+    await check_dependencies(config, log_summary=True)
+    async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
+        litellm_ok = await _check_single_dep("litellm", config, client)
+    if not litellm_ok:
+        raise SystemExit("make test-bot-health requires LiteLLM to be healthy")
 
-strip_trailing_slash() {
-  printf '%s' "${1%/}"
-}
 
-if ! command -v curl >/dev/null 2>&1; then
-  fail "curl is required"
-fi
-
-# Qdrant: target collection exists (match bot's suffix rules)
-base_collection="$QDRANT_COLLECTION"
-base_collection="${base_collection%_binary}"
-base_collection="${base_collection%_scalar}"
-collection_to_check="$base_collection"
-if [ "$QDRANT_QUANTIZATION_MODE" = "scalar" ]; then
-  collection_to_check="${base_collection}_scalar"
-elif [ "$QDRANT_QUANTIZATION_MODE" = "binary" ]; then
-  collection_to_check="${base_collection}_binary"
-fi
-
-collections=$(curl -fsS "$QDRANT_URL/collections" | tr -d '\n') || fail "Qdrant is unreachable at $QDRANT_URL"
-if ! echo "$collections" | grep -q "\"name\"\s*:\s*\"$collection_to_check\""; then
-  fail "Qdrant collection '$collection_to_check' not found (mode=$QDRANT_QUANTIZATION_MODE)"
-fi
-echo "✓ Qdrant collection exists: $collection_to_check (mode=$QDRANT_QUANTIZATION_MODE)"
-
-# LiteLLM/LLM connectivity
-normalized_llm_base_url="$(strip_trailing_slash "$LLM_BASE_URL")"
-health_base_url="${normalized_llm_base_url%/v1}"
-models_url="$normalized_llm_base_url/models"
-health_url="$health_base_url/health/liveliness"
-
-if curl -fsS "$health_url" >/dev/null; then
-  echo "✓ LLM health OK: $health_url"
-else
-  # Fallback for OpenAI-compatible endpoints.
-  curl -fsS "$models_url" >/dev/null || fail "LLM endpoint not responding at $LLM_BASE_URL"
-  echo "✓ LLM models OK: $models_url"
-fi
-
-exit 0
+asyncio.run(main())
+PY

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -4465,6 +4465,19 @@ class PropertyBot:
         logger.info("Starting bot...")
         startup_report = StartupReport()
 
+        # Authoritative dependency preflight should run before Redis-backed startup work.
+        from .preflight import PreflightError, check_dependencies
+
+        try:
+            preflight_result = await check_dependencies(self.config, log_summary=False)
+        except PreflightError as exc:
+            startup_report.merge(exc.report)
+            logger.error(startup_report.render())
+            raise
+        preflight_report = getattr(preflight_result, "report", None)
+        if isinstance(preflight_report, StartupReport):
+            startup_report.merge(preflight_report)
+
         # Initialize cache at startup
         if not self._cache_initialized:
             logger.info("Initializing cache service...")
@@ -4890,19 +4903,6 @@ class PropertyBot:
 
         aiogram_setup_dialogs(self.dp)
         logger.info("aiogram-dialog setup complete")
-
-        # Preflight dependency checks
-        from .preflight import PreflightError, check_dependencies
-
-        try:
-            preflight_result = await check_dependencies(self.config, log_summary=False)
-        except PreflightError as exc:
-            startup_report.merge(exc.report)
-            logger.error(startup_report.render())
-            raise
-        preflight_report = getattr(preflight_result, "report", None)
-        if isinstance(preflight_report, StartupReport):
-            startup_report.merge(preflight_report)
 
         # Start Redis health monitor (background task, every 5 min)
         await self._redis_monitor.start()

--- a/telegram_bot/config.py
+++ b/telegram_bot/config.py
@@ -25,6 +25,21 @@ def _empty_str_to_false(v: object) -> object:
 EmptyStrBool = Annotated[bool, BeforeValidator(_empty_str_to_false)]
 
 
+def _inject_local_redis_password(
+    redis_url: str,
+    *,
+    redis_password: SecretStr | None,
+    redis_url_explicit: bool,
+) -> str:
+    """Align host-native local Redis URL with compose auth defaults."""
+    password = redis_password.get_secret_value().strip() if redis_password is not None else ""
+    if redis_url_explicit or not password:
+        return redis_url
+    if "@" in redis_url or redis_url != "redis://localhost:6379":
+        return redis_url
+    return redis_url.replace("redis://", f"redis://:{password}@", 1)
+
+
 class BotConfig(BaseSettings):
     """Telegram bot configuration."""
 
@@ -43,6 +58,10 @@ class BotConfig(BaseSettings):
     # Services
     bge_m3_url: str = Field(
         default="http://localhost:8000", validation_alias=AliasChoices("bge_m3_url", "BGE_M3_URL")
+    )
+    redis_password: SecretStr = Field(
+        default=SecretStr(""),
+        validation_alias=AliasChoices("redis_password", "REDIS_PASSWORD"),
     )
     redis_url: str = Field(
         default="redis://localhost:6379", validation_alias=AliasChoices("redis_url", "REDIS_URL")
@@ -619,6 +638,11 @@ class BotConfig(BaseSettings):
 
     @model_validator(mode="after")
     def validate_handoff_contract(self) -> "BotConfig":
+        self.redis_url = _inject_local_redis_password(
+            self.redis_url,
+            redis_password=self.redis_password,
+            redis_url_explicit="redis_url" in self.model_fields_set,
+        )
         if self.handoff_enabled and self.managers_group_id is None:
             raise ValueError("HANDOFF_ENABLED=true but MANAGERS_GROUP_ID is missing")
         return self

--- a/telegram_bot/preflight.py
+++ b/telegram_bot/preflight.py
@@ -308,7 +308,8 @@ async def _check_single_dep(
         return cache_ok
 
     if name == "qdrant":
-        collection = config.qdrant_collection
+        getter = getattr(config, "get_collection_name", None)
+        collection = getter() if callable(getter) else config.qdrant_collection
         scheme = urlparse(config.qdrant_url).scheme.lower()
         effective_key = config.qdrant_api_key if scheme == "https" else None
         qdrant = AsyncQdrantClient(

--- a/tests/unit/config/test_bot_config_settings.py
+++ b/tests/unit/config/test_bot_config_settings.py
@@ -149,3 +149,35 @@ class TestBotConfigIsPydanticSettings:
 
         cfg = BotConfig(_env_file=None)
         assert cfg.handoff_enabled is False
+
+    def test_redis_url_infers_password_for_local_default(self, monkeypatch):
+        """Host-native local default should inherit REDIS_PASSWORD when URL is implicit."""
+        monkeypatch.delenv("REDIS_URL", raising=False)
+        monkeypatch.setenv("REDIS_PASSWORD", "dev_redis_pass")
+
+        from telegram_bot.config import BotConfig
+
+        cfg = BotConfig(_env_file=None)
+        assert cfg.redis_url == "redis://:dev_redis_pass@localhost:6379"
+
+    def test_explicit_redis_url_wins_over_password_inference(self, monkeypatch):
+        """Explicit REDIS_URL must not be rewritten by local password inference."""
+        monkeypatch.setenv("REDIS_URL", "redis://cache.internal:6380/0")
+        monkeypatch.setenv("REDIS_PASSWORD", "dev_redis_pass")
+
+        from telegram_bot.config import BotConfig
+
+        cfg = BotConfig(_env_file=None)
+        assert cfg.redis_url == "redis://cache.internal:6380/0"
+
+    def test_redis_url_infers_password_loaded_from_env_file(self, monkeypatch, tmp_path):
+        """REDIS_PASSWORD loaded by BaseSettings from dotenv must drive local URL inference."""
+        monkeypatch.delenv("REDIS_URL", raising=False)
+        monkeypatch.delenv("REDIS_PASSWORD", raising=False)
+        env_file = tmp_path / ".env.bot"
+        env_file.write_text("REDIS_PASSWORD=dotenv_secret\n", encoding="utf-8")
+
+        from telegram_bot.config import BotConfig
+
+        cfg = BotConfig(_env_file=env_file)
+        assert cfg.redis_url == "redis://:dotenv_secret@localhost:6379"

--- a/tests/unit/scripts/test_test_bot_health.py
+++ b/tests/unit/scripts/test_test_bot_health.py
@@ -1,0 +1,32 @@
+"""Static contract tests for scripts/test_bot_health.sh."""
+
+from pathlib import Path
+
+
+SCRIPT = Path("scripts/test_bot_health.sh")
+
+
+def test_test_bot_health_uses_native_bot_preflight() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert "telegram_bot.config" in text
+    assert "telegram_bot.preflight" in text
+    assert "check_dependencies" in text
+
+
+def test_test_bot_health_does_not_reference_custom_helper_module() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert "scripts.test_bot_health" not in text, (
+        "test_bot_health.sh must call the existing bot preflight directly instead of "
+        "routing through a custom helper module"
+    )
+
+
+def test_test_bot_health_explicitly_gates_litellm() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert '"litellm"' in text and "_check_single_dep" in text, (
+        "test_bot_health.sh must explicitly fail when LiteLLM is unavailable, "
+        "because bot startup treats it as optional but the local health contract does not"
+    )

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from telegram_bot.bot import PropertyBot, make_session_id
 from telegram_bot.config import BotConfig
+from telegram_bot.preflight import PreflightError
 from telegram_bot.services.error_utils import walk_traceback_frames
 from telegram_bot.startup_status import DependencyCheckResult, StartupReport
 
@@ -1652,6 +1653,28 @@ class TestBotLifecycle:
 
         polling_lock.acquire.assert_awaited_once()
         assert "polling-lock-heartbeat" in created_task_names
+
+    async def test_start_stops_before_redis_init_on_critical_preflight_failure(self, mock_config):
+        """Critical preflight must abort before cache/checkpointer initialization."""
+        bot, _ = _create_bot(mock_config)
+        bot._cache = MagicMock()
+        bot._cache.initialize = AsyncMock()
+
+        startup_report = StartupReport()
+
+        with (
+            patch(
+                "telegram_bot.preflight.check_dependencies",
+                new_callable=AsyncMock,
+                side_effect=PreflightError(["redis"], report=startup_report),
+            ),
+            patch("telegram_bot.integrations.memory.create_redis_checkpointer") as mock_create_cp,
+        ):
+            with pytest.raises(PreflightError):
+                await bot.start()
+
+        bot._cache.initialize.assert_not_awaited()
+        mock_create_cp.assert_not_called()
 
     async def test_stop_closes_services(self, mock_config):
         """Test that stop() closes all services."""

--- a/tests/unit/test_dependency_workflow.py
+++ b/tests/unit/test_dependency_workflow.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 def test_renovate_base_branch_is_dev() -> None:
     data = json.loads(Path("renovate.json").read_text(encoding="utf-8"))
-    assert data["baseBranches"] == ["dev"]
+    assert data["baseBranchPatterns"] == ["dev"]
 
 
 def test_ci_validates_pull_requests_for_dev() -> None:

--- a/tests/unit/test_local_compose_contract.py
+++ b/tests/unit/test_local_compose_contract.py
@@ -57,3 +57,10 @@ def test_docker_docs_default_stack_mentions_mini_app_services() -> None:
     assert "- `mini-app-frontend`" in text, (
         "DOCKER.md must list mini-app-frontend in the default stack"
     )
+
+
+def test_test_bot_health_help_mentions_redis_qdrant_llm() -> None:
+    text = MAKEFILE.read_text(encoding="utf-8")
+    assert "test-bot-health: ## Preflight: verify Redis + Qdrant + LLM" in text, (
+        "test-bot-health help text must describe the real local native-run dependencies"
+    )

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -36,6 +36,8 @@ def _make_config(**overrides) -> MagicMock:
     cfg.realestate_database_url = overrides.get(
         "realestate_database_url", "postgresql://postgres:postgres@localhost:5432/realestate"
     )
+    effective_collection = overrides.get("effective_collection", cfg.qdrant_collection)
+    cfg.get_collection_name = MagicMock(return_value=effective_collection)
     return cfg
 
 
@@ -314,7 +316,7 @@ class TestCheckSingleDep:
         mock_verify.assert_awaited_once_with(config.redis_url)
 
     async def test_qdrant_collection_ok(self):
-        config = _make_config()
+        config = _make_config(qdrant_collection="test_col", effective_collection="test_col_scalar")
         client = AsyncMock(spec=httpx.AsyncClient)
 
         mock_info = MagicMock()
@@ -329,7 +331,8 @@ class TestCheckSingleDep:
             result = await _check_single_dep("qdrant", config, client)
 
         assert result is True
-        mock_qdrant_client.get_collection.assert_awaited_once_with(config.qdrant_collection)
+        config.get_collection_name.assert_called_once_with()
+        mock_qdrant_client.get_collection.assert_awaited_once_with("test_col_scalar")
         mock_qdrant_client.close.assert_awaited_once()
 
     async def test_qdrant_connection_error_fails(self):


### PR DESCRIPTION
## Summary
- restore the native local bot contract for `#1195` by moving authoritative preflight ahead of Redis-backed startup and reusing bot-native checks in `make test-bot-health`
- infer host-native `REDIS_URL` from `REDIS_PASSWORD` through `BotConfig` / `BaseSettings`, including dotenv-loaded values, while preserving explicit `REDIS_URL`
- make Qdrant preflight use the effective quantized collection name and hard-gate LiteLLM in `test-bot-health`

## Test Plan
- [x] `uv run pytest tests/unit/config/test_bot_config_settings.py tests/unit/test_preflight.py tests/unit/test_bot_handlers.py tests/unit/scripts/test_test_bot_health.py tests/unit/test_local_compose_contract.py -q -k 'redis_url or qdrant_collection_ok or litellm or critical_preflight_failure or test_bot_health'`
- [x] `make check`
- [x] `make test-bot-health`
- [x] `timeout 25 make bot` (early preflight passed; subsequent stop was due to an already-held polling lock, not this change)

## Known Issue
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit` is still red on the existing unrelated workflow-drift test `tests/unit/test_dependency_workflow.py::test_renovate_base_branch_is_dev`
