### PR TITLE
docs: align local env contract

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -52,6 +52,8 @@ make local-ps
 make local-down
 ```
 
+For local development, the canonical local env file is `.env` in the repo root. `.env.local` is not auto-loaded by the documented `make` and `uv run` workflows.
+
 ## Service Endpoints (Host)
 
 | Service | URL/Port |
@@ -129,8 +131,8 @@ make test-bot-health
 ## Source Of Truth
 
 - `main` in Git is the official deployment source of truth for VPS.
-- Standard flow: work locally, push to `dev` or a feature branch, open a PR to `main`, and merge the PR.
-- Only merges to `main` should trigger VPS auto-deploy through GitHub Actions.
+- Current branch workflow uses feature branches that merge into `dev` first; recent merged PR history and CI both include `dev`.
+- Only pushes to `main` should trigger VPS auto-deploy through GitHub Actions.
 - `make deploy-bot` prints the official PR-based deploy flow; it does not push directly to `main`.
 - Use `make deploy-vps-local` or `./scripts/deploy-vps.sh` only as fallback/manual recovery when GitHub-driven deploy is unavailable.
 - Do not treat `/opt/rag-fresh` on the server as an editable working copy; it is a deployment target.

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -131,8 +131,8 @@ make test-bot-health
 ## Source Of Truth
 
 - `main` in Git is the official deployment source of truth for VPS.
-- Current branch workflow uses feature branches that merge into `dev` first; recent merged PR history and CI both include `dev`.
-- Only pushes to `main` should trigger VPS auto-deploy through GitHub Actions.
+- Standard flow: work locally, push to `dev` or a feature branch, open a PR to `main`, and merge the PR.
+- Only merges to `main` should trigger VPS auto-deploy through GitHub Actions.
 - `make deploy-bot` prints the official PR-based deploy flow; it does not push directly to `main`.
 - Use `make deploy-vps-local` or `./scripts/deploy-vps.sh` only as fallback/manual recovery when GitHub-driven deploy is unavailable.
 - Do not treat `/opt/rag-fresh` on the server as an editable working copy; it is a deployment target.

--- a/Makefile
+++ b/Makefile
@@ -755,7 +755,7 @@ monitoring-status: ## Show monitoring stack status
 
 monitoring-test-alert: ## Send a test alert to verify Telegram integration
 	@echo "$(BLUE)Sending test alert...$(NC)"
-	@# Load local env (repo uses .env -> .env.local symlink) so `make` works without manual `source`.
+	@# Load the canonical local .env file so `make` works without manual `source`.
 	@set -a; [ -f ./.env ] && . ./.env; set +a; \
 	if [ -z "$$TELEGRAM_ALERTING_BOT_TOKEN" ] || [ -z "$$TELEGRAM_ALERTING_CHAT_ID" ]; then \
 		echo "$(RED)Error: TELEGRAM_ALERTING_BOT_TOKEN and TELEGRAM_ALERTING_CHAT_ID must be set$(NC)"; \

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ uv sync
 cp .env.example .env   # Fill in API keys (see below)
 ```
 
+For local development, the canonical environment file is `.env` in the repo root. `.env.local` is not loaded automatically by the bot, `make`, or `uv run` entry points.
+
 ### 2. Start Services
 
 ```bash

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -15,6 +15,8 @@ uv sync
 cp .env.example .env
 ```
 
+For local development, the canonical environment file is `.env` in the repo root. `.env.local` is legacy/manual-only and is not auto-loaded by local commands.
+
 Minimum env for bot profile:
 - `TELEGRAM_BOT_TOKEN`
 - `LITELLM_MASTER_KEY`

--- a/docs/superpowers/plans/2026-04-21-env-contract-cleanup-plan.md
+++ b/docs/superpowers/plans/2026-04-21-env-contract-cleanup-plan.md
@@ -1,0 +1,74 @@
+# Env Contract Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `.env` the explicit canonical local environment file and remove stale `.env.local`/symlink drift from docs and tooling.
+
+**Architecture:** Keep runtime behavior unchanged by preserving `.env` as the file loaded by local commands and `BotConfig`. Add a focused regression test for the documented contract, then update the small set of docs/comments that currently imply a different local setup.
+
+**Tech Stack:** Python, pytest, Makefile, Markdown docs
+
+---
+
+### Task 1: Guard the local env contract
+
+**Files:**
+- Modify: `tests/unit/test_env_example.py`
+- Test: `tests/unit/test_env_example.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a focused test that asserts the local workflow documentation/tooling references `.env` as the canonical file and does not mention `.env.local` symlink loading.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_env_example.py -q`
+Expected: FAIL because current repo text still contains the stale `.env -> .env.local symlink` comment.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update the smallest set of repo files to remove the stale `.env.local` symlink guidance and document `.env` as the canonical local env file.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/test_env_example.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Makefile README.md DOCKER.md docs/LOCAL-DEVELOPMENT.md tests/unit/test_env_example.py docs/superpowers/plans/2026-04-21-env-contract-cleanup-plan.md
+git commit -m "docs: align local env contract"
+```
+
+### Task 2: Verify the touched contract end-to-end
+
+**Files:**
+- Modify: `Makefile`
+- Modify: `README.md`
+- Modify: `DOCKER.md`
+- Modify: `docs/LOCAL-DEVELOPMENT.md`
+- Test: `tests/unit/test_env_example.py`
+- Test: `tests/unit/test_k8s_secret_templates.py`
+
+- [ ] **Step 1: Run focused regression suite**
+
+Run: `uv run pytest tests/unit/test_env_example.py tests/unit/test_k8s_secret_templates.py -q`
+Expected: PASS
+
+- [ ] **Step 2: Run repo checks relevant to touched files**
+
+Run: `uv run pytest tests/unit/test_env_example.py -q`
+Expected: PASS
+
+- [ ] **Step 3: Review diff for accidental runtime changes**
+
+Run: `git diff -- Makefile README.md DOCKER.md docs/LOCAL-DEVELOPMENT.md tests/unit/test_env_example.py`
+Expected: documentation/comment/test-only cleanup; no unrelated behavior changes
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Makefile README.md DOCKER.md docs/LOCAL-DEVELOPMENT.md tests/unit/test_env_example.py
+git commit -m "docs: align local env contract"
+```

--- a/tests/unit/test_env_example.py
+++ b/tests/unit/test_env_example.py
@@ -30,6 +30,8 @@ def test_local_env_contract_uses_root_dotenv_as_canonical_file() -> None:
     assert "cp .env.example .env" in readme
     assert "cp .env.example .env" in local_dev
     assert "canonical local env file is `.env`" in docker_doc
+    assert ".env.local` is not loaded automatically" in readme
+    assert ".env.local` is legacy/manual-only and is not auto-loaded" in local_dev
     assert 'env_file=".env"' in bot_config
     assert "uv run --env-file .env python -m telegram_bot.main" in makefile
     assert "[ -f ./.env ] && . ./.env" in makefile

--- a/tests/unit/test_env_example.py
+++ b/tests/unit/test_env_example.py
@@ -19,6 +19,19 @@ def _parse_env_example() -> set[str]:
     return keys
 
 
+def test_local_env_contract_uses_root_dotenv_as_canonical_file() -> None:
+    """Local docs/tooling should consistently point to the root .env file."""
+    readme = Path("README.md").read_text(encoding="utf-8")
+    local_dev = Path("docs/LOCAL-DEVELOPMENT.md").read_text(encoding="utf-8")
+    docker_doc = Path("DOCKER.md").read_text(encoding="utf-8")
+    makefile = Path("Makefile").read_text(encoding="utf-8")
+
+    assert "cp .env.example .env" in readme
+    assert "cp .env.example .env" in local_dev
+    assert "canonical local env file is `.env`" in docker_doc
+    assert ".env -> .env.local symlink" not in makefile
+
+
 class TestEnvExampleCompleteness:
     """Env example must document all CRM and manager config vars."""
 

--- a/tests/unit/test_env_example.py
+++ b/tests/unit/test_env_example.py
@@ -25,11 +25,18 @@ def test_local_env_contract_uses_root_dotenv_as_canonical_file() -> None:
     local_dev = Path("docs/LOCAL-DEVELOPMENT.md").read_text(encoding="utf-8")
     docker_doc = Path("DOCKER.md").read_text(encoding="utf-8")
     makefile = Path("Makefile").read_text(encoding="utf-8")
+    bot_config = Path("telegram_bot/config.py").read_text(encoding="utf-8")
 
     assert "cp .env.example .env" in readme
     assert "cp .env.example .env" in local_dev
     assert "canonical local env file is `.env`" in docker_doc
+    assert 'env_file=".env"' in bot_config
+    assert "uv run --env-file .env python -m telegram_bot.main" in makefile
+    assert "[ -f ./.env ] && . ./.env" in makefile
+    assert ".env.local" not in bot_config
+    assert ".env.local" not in makefile
     assert ".env -> .env.local symlink" not in makefile
+    assert "feature branches that merge into `dev` first" not in docker_doc
 
 
 class TestEnvExampleCompleteness:

--- a/tests/unit/test_env_example.py
+++ b/tests/unit/test_env_example.py
@@ -36,7 +36,6 @@ def test_local_env_contract_uses_root_dotenv_as_canonical_file() -> None:
     assert ".env.local" not in bot_config
     assert ".env.local" not in makefile
     assert ".env -> .env.local symlink" not in makefile
-    assert "feature branches that merge into `dev` first" not in docker_doc
 
 
 class TestEnvExampleCompleteness:


### PR DESCRIPTION
## Summary
- document `.env` as the canonical local env file in local runtime docs
- remove the stale `.env -> .env.local symlink` comment from `Makefile`
- add a regression test that guards the local env contract
- record the short implementation plan used for this cleanup

## Verification
- `uv run pytest tests/unit/test_env_example.py -q`
- `uv run pytest tests/unit/test_env_example.py tests/unit/test_k8s_secret_templates.py -q`

## Notes
- current repo workflow evidence points to feature branches merging into `dev` first, while VPS deploy remains tied to pushes on `main`