### PR TITLE
fix: finish local bot runtime contract refresh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,7 +344,7 @@ test-redis: ## Verify Redis Query Engine is available
 
 .PHONY: test-bot-health test-bot-health-vps
 
-test-bot-health: ## Preflight: verify Qdrant collection + LLM (local dev, ports published)
+test-bot-health: ## Preflight: verify local bot runtime prerequisites (Redis/Qdrant/LLM + Postgres note)
 	@echo "$(BLUE)Running bot health preflight...$(NC)"
 	@./scripts/test_bot_health.sh
 	@echo "$(GREEN)✓ Bot health preflight passed$(NC)"

--- a/compose.yml
+++ b/compose.yml
@@ -502,9 +502,23 @@ services:
     image: redis:8.6.2@sha256:1f073813b641755b70b0200da64131bbeeb4ec5b633ca67772229b49820caafa
     restart: unless-stopped
     logging: *default-logging
-    command: redis-server --requirepass ${LANGFUSE_REDIS_PASSWORD:-}
+    command:
+      - /bin/sh
+      - -ec
+      - |
+        if [ -n "${LANGFUSE_REDIS_PASSWORD:-}" ]; then
+          exec redis-server --requirepass "$LANGFUSE_REDIS_PASSWORD"
+        fi
+        exec redis-server
     healthcheck:
-      test: ["CMD", "redis-cli", "-a", "${LANGFUSE_REDIS_PASSWORD:-}", "ping"]
+      test:
+        - CMD-SHELL
+        - |
+          if [ -n "${LANGFUSE_REDIS_PASSWORD+x}" ] && [ -n "$LANGFUSE_REDIS_PASSWORD" ]; then
+            redis-cli -a "$LANGFUSE_REDIS_PASSWORD" ping | grep -q PONG
+          else
+            redis-cli ping | grep -q PONG
+          fi
       interval: 5s
       timeout: 5s
       retries: 3

--- a/scripts/test_bot_health.sh
+++ b/scripts/test_bot_health.sh
@@ -72,6 +72,34 @@ finally:
 PY
 echo "✓ Redis auth OK"
 
+# Postgres: report the REAL_ESTATE_DATABASE_URL localhost:5432 contract used by
+# native bot startup without turning optional DB reachability into a hard fail.
+uv run --no-sync python - <<'PY'
+from telegram_bot.config import BotConfig
+import socket
+from urllib.parse import urlparse
+
+config = BotConfig()
+parsed = urlparse(config.realestate_database_url)
+host = parsed.hostname or ""
+port = parsed.port or 5432
+
+if host in {"localhost", "127.0.0.1"}:
+    try:
+        with socket.create_connection((host, port), timeout=1):
+            print(f"✓ Postgres reachable for native bot startup: {host}:{port}")
+    except OSError as exc:
+        print(
+            f"! Postgres unreachable at {host}:{port} "
+            f"(optional for native bot runs): {exc}"
+        )
+else:
+    print(
+        f"i Postgres DSN points to {host or 'remote host'}:{port}; "
+        "skipping local localhost:5432 contract check"
+    )
+PY
+
 # Qdrant: target collection exists (match bot's suffix rules)
 base_collection="$QDRANT_COLLECTION"
 base_collection="${base_collection%_binary}"

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -99,6 +99,7 @@ _STALE_RESULTS_CALLBACK_TEXT = "Это устаревшая кнопка. Исп
 _TELEGRAM_MESSAGE_LIMIT = 4096
 _NO_RAG_QUERY_TYPES: frozenset[str] = frozenset({"CHITCHAT", "OFF_TOPIC"})
 _AGENT_DRAFT_INTERVAL: float = 0.2  # seconds between sendMessageDraft calls
+_POLLING_LOCK_MAX_REFRESH_FAILURES = 3
 
 
 def create_bot_agent(*args: Any, **kwargs: Any) -> Any:
@@ -4634,109 +4635,126 @@ class PropertyBot:
                 self._kommo_client = None
 
         # Initialize PostgreSQL pool for realestate DB
-        try:
-            import asyncpg
-
-            test_conn: Any | None = None
+        postgres_available = (
+            preflight_result.get("postgres", True) if isinstance(preflight_result, dict) else True
+        )
+        if postgres_available:
             try:
-                # Validate DB exists before creating pool (avoid traceback spam #570)
-                test_conn = await asyncpg.connect(self.config.realestate_database_url, timeout=5)
-            except asyncpg.InvalidCatalogNameError:
-                target_db = self._extract_database_name(self.config.realestate_database_url)
-                if target_db is None:
-                    raise
-                logger.warning(
-                    "PostgreSQL database %s missing; attempting auto-create",
-                    target_db,
-                )
-                if not await self._ensure_postgres_database_exists(asyncpg, target_db):
-                    raise
-                test_conn = await asyncpg.connect(self.config.realestate_database_url, timeout=5)
-            finally:
-                if test_conn is not None:
-                    await test_conn.close()
+                import asyncpg
 
-            self._pg_pool = await asyncpg.create_pool(
-                self.config.realestate_database_url,
-                min_size=0,
-                max_size=5,
-                timeout=5,
-            )
-            logger.info("PostgreSQL pool ready (realestate)")
-            await self._ensure_realestate_schema()
-            logger.info("PostgreSQL schema ready (realestate)")
-
-            from .services.user_service import UserService
-
-            self._user_service = UserService(pool=self._pg_pool)
-
-            # Initialize lead scoring store (#384)
-            from .services.lead_scoring_store import LeadScoringStore
-
-            self._lead_scoring_store = LeadScoringStore(pool=self._pg_pool)
-            logger.info("Lead scoring store ready")
-
-            # Initialize favorites service (#628)
-            from .services.favorites_service import FavoritesService
-
-            self._favorites_service = FavoritesService(pool=self._pg_pool)
-            logger.info("Favorites service ready")
-
-            from .services.search_event_store import SearchEventStore
-
-            self._search_event_store = SearchEventStore(pool=self._pg_pool)
-            logger.info("Search event store ready")
-
-            # Initialize hot lead notifier (#402)
-            if self.config.manager_ids and self._cache.redis is not None:
+                test_conn: Any | None = None
                 try:
-                    from .services.hot_lead_notifier import HotLeadNotifier
-
-                    self._hot_lead_notifier = HotLeadNotifier(
-                        bot=self.bot,
-                        cache=self._cache,
-                        manager_ids=self.config.manager_ids,
-                        dedupe_ttl_sec=self.config.manager_hot_lead_dedupe_sec,
+                    # Validate DB exists before creating pool (avoid traceback spam #570)
+                    test_conn = await asyncpg.connect(
+                        self.config.realestate_database_url, timeout=5
                     )
-                    logger.info("Hot lead notifier ready (managers=%s)", self.config.manager_ids)
-                except Exception:
-                    logger.exception("Failed to initialize hot lead notifier")
-
-            # Initialize nurturing scheduler (#390)
-            if self.config.nurturing_enabled:
-                try:
-                    from .services.funnel_analytics_service import FunnelAnalyticsService
-                    from .services.nurturing_scheduler import NurturingScheduler
-                    from .services.nurturing_service import NurturingService
-
-                    nurturing_svc = NurturingService(
-                        pool=self._pg_pool,
-                        bot=self.bot if self.config.nurturing_dispatch_enabled else None,
-                        qdrant=self._qdrant if self.config.nurturing_dispatch_enabled else None,
-                        llm=self._llm if self.config.nurturing_dispatch_enabled else None,
+                except asyncpg.InvalidCatalogNameError:
+                    target_db = self._extract_database_name(self.config.realestate_database_url)
+                    if target_db is None:
+                        raise
+                    logger.warning(
+                        "PostgreSQL database %s missing; attempting auto-create",
+                        target_db,
                     )
-                    analytics_svc = FunnelAnalyticsService(pool=self._pg_pool)
-                    self._nurturing_service = nurturing_svc
-                    self._funnel_analytics_service = analytics_svc
-                    self._nurturing_scheduler = NurturingScheduler(
-                        nurturing_service=nurturing_svc,
-                        analytics_service=analytics_svc,
-                        lease_store=None,
-                        config=self.config,
+                    if not await self._ensure_postgres_database_exists(asyncpg, target_db):
+                        raise
+                    test_conn = await asyncpg.connect(
+                        self.config.realestate_database_url, timeout=5
                     )
-                    await self._nurturing_scheduler.start()
-                    logger.info("Nurturing scheduler started")
-                except Exception:
-                    logger.exception("Failed to start nurturing scheduler")
-        except Exception:
-            logger.warning("PostgreSQL pool init failed, user features disabled", exc_info=True)
-            startup_report.add(
-                StartupSignal(
-                    source="postgres_runtime",
-                    severity=StartupSeverity.DEGRADED,
-                    summary="PostgreSQL pool unavailable, user features disabled",
-                    remediation="restore PostgreSQL connectivity for favorites, search events, and user services",
+                finally:
+                    if test_conn is not None:
+                        await test_conn.close()
+
+                self._pg_pool = await asyncpg.create_pool(
+                    self.config.realestate_database_url,
+                    min_size=0,
+                    max_size=5,
+                    timeout=5,
                 )
+                logger.info("PostgreSQL pool ready (realestate)")
+                await self._ensure_realestate_schema()
+                logger.info("PostgreSQL schema ready (realestate)")
+
+                from .services.user_service import UserService
+
+                self._user_service = UserService(pool=self._pg_pool)
+
+                # Initialize lead scoring store (#384)
+                from .services.lead_scoring_store import LeadScoringStore
+
+                self._lead_scoring_store = LeadScoringStore(pool=self._pg_pool)
+                logger.info("Lead scoring store ready")
+
+                # Initialize favorites service (#628)
+                from .services.favorites_service import FavoritesService
+
+                self._favorites_service = FavoritesService(pool=self._pg_pool)
+                logger.info("Favorites service ready")
+
+                from .services.search_event_store import SearchEventStore
+
+                self._search_event_store = SearchEventStore(pool=self._pg_pool)
+                logger.info("Search event store ready")
+
+                # Initialize hot lead notifier (#402)
+                if self.config.manager_ids and self._cache.redis is not None:
+                    try:
+                        from .services.hot_lead_notifier import HotLeadNotifier
+
+                        self._hot_lead_notifier = HotLeadNotifier(
+                            bot=self.bot,
+                            cache=self._cache,
+                            manager_ids=self.config.manager_ids,
+                            dedupe_ttl_sec=self.config.manager_hot_lead_dedupe_sec,
+                        )
+                        logger.info(
+                            "Hot lead notifier ready (managers=%s)", self.config.manager_ids
+                        )
+                    except Exception:
+                        logger.exception("Failed to initialize hot lead notifier")
+
+                # Initialize nurturing scheduler (#390)
+                if self.config.nurturing_enabled:
+                    try:
+                        from .services.funnel_analytics_service import FunnelAnalyticsService
+                        from .services.nurturing_scheduler import NurturingScheduler
+                        from .services.nurturing_service import NurturingService
+
+                        nurturing_svc = NurturingService(
+                            pool=self._pg_pool,
+                            bot=self.bot if self.config.nurturing_dispatch_enabled else None,
+                            qdrant=self._qdrant if self.config.nurturing_dispatch_enabled else None,
+                            llm=self._llm if self.config.nurturing_dispatch_enabled else None,
+                        )
+                        analytics_svc = FunnelAnalyticsService(pool=self._pg_pool)
+                        self._nurturing_service = nurturing_svc
+                        self._funnel_analytics_service = analytics_svc
+                        self._nurturing_scheduler = NurturingScheduler(
+                            nurturing_service=nurturing_svc,
+                            analytics_service=analytics_svc,
+                            lease_store=None,
+                            config=self.config,
+                        )
+                        await self._nurturing_scheduler.start()
+                        logger.info("Nurturing scheduler started")
+                    except Exception:
+                        logger.exception("Failed to start nurturing scheduler")
+            except Exception:
+                logger.warning("PostgreSQL pool init failed, user features disabled", exc_info=True)
+                startup_report.add(
+                    StartupSignal(
+                        source="postgres_runtime",
+                        severity=StartupSeverity.DEGRADED,
+                        summary="PostgreSQL pool unavailable, user features disabled",
+                        remediation=(
+                            "restore PostgreSQL connectivity for favorites, search events, "
+                            "and user services"
+                        ),
+                    )
+                )
+        else:
+            logger.info(
+                "Skipping PostgreSQL pool init because preflight already marked it unavailable"
             )
 
         # Initialize session summary worker (#445)
@@ -4989,16 +5007,32 @@ class PropertyBot:
             return
 
         refresh_interval = max(1, self._polling_lock.ttl_sec // 3)
+        consecutive_failures = 0
         try:
             while True:
                 await asyncio.sleep(refresh_interval)
-                await self._polling_lock.refresh()
+                try:
+                    await self._polling_lock.refresh()
+                except Exception:
+                    consecutive_failures += 1
+                    if consecutive_failures < _POLLING_LOCK_MAX_REFRESH_FAILURES:
+                        logger.warning(
+                            "Polling lock heartbeat refresh failed (%d/%d); retrying",
+                            consecutive_failures,
+                            _POLLING_LOCK_MAX_REFRESH_FAILURES,
+                            exc_info=True,
+                        )
+                        continue
+                    logger.exception(
+                        "Polling lock heartbeat failed %d times; stopping polling",
+                        _POLLING_LOCK_MAX_REFRESH_FAILURES,
+                    )
+                    with contextlib.suppress(Exception):
+                        await self.dp.stop_polling()
+                    return
+                consecutive_failures = 0
         except asyncio.CancelledError:
             raise
-        except Exception:
-            logger.exception("Polling lock heartbeat failed; stopping polling")
-            with contextlib.suppress(Exception):
-                await self.dp.stop_polling()
 
     async def stop(self):
         """Stop bot and cleanup."""

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -99,7 +99,8 @@ _STALE_RESULTS_CALLBACK_TEXT = "Это устаревшая кнопка. Исп
 _TELEGRAM_MESSAGE_LIMIT = 4096
 _NO_RAG_QUERY_TYPES: frozenset[str] = frozenset({"CHITCHAT", "OFF_TOPIC"})
 _AGENT_DRAFT_INTERVAL: float = 0.2  # seconds between sendMessageDraft calls
-_POLLING_LOCK_MAX_REFRESH_FAILURES = 3
+# Heartbeat runs every ttl/3, so a third consecutive miss can consume the full lease.
+_POLLING_LOCK_MAX_REFRESH_FAILURES = 2
 
 
 def create_bot_agent(*args: Any, **kwargs: Any) -> Any:

--- a/telegram_bot/preflight.py
+++ b/telegram_bot/preflight.py
@@ -86,6 +86,20 @@ _DEP_REMEDIATION: dict[str, str] = {
 }
 
 
+def _postgres_local_remediation(database_url: str) -> str | None:
+    """Return a clearer hint when native local Postgres is the optional target."""
+    parsed = urlparse(database_url)
+    if parsed.hostname not in {"localhost", "127.0.0.1"}:
+        return None
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    return (
+        f"Postgres unreachable at {host}:{port}; this is optional for native bot runs. "
+        "If you need user features locally, start a compose stack that publishes Postgres "
+        "via compose.yml:compose.dev.yml."
+    )
+
+
 class PreflightError(SystemExit):
     """Raised when a CRITICAL dependency is unreachable after retries."""
 
@@ -446,7 +460,11 @@ async def _check_single_dep(
             )
             return False
         except Exception as exc:
-            logger.warning("Preflight WARN: Postgres unreachable — %s", exc)
+            remediation = _postgres_local_remediation(config.realestate_database_url)
+            if remediation:
+                logger.warning("Preflight WARN: %s — %s", remediation, exc)
+            else:
+                logger.warning("Preflight WARN: Postgres unreachable — %s", exc)
             return False
 
     if name == "litellm":

--- a/telegram_bot/preflight.py
+++ b/telegram_bot/preflight.py
@@ -456,9 +456,10 @@ async def _check_single_dep(
                 await conn.close()
         except asyncpg.InvalidCatalogNameError:
             logger.warning(
-                "Preflight WARN: Postgres database does not exist (user features will use defaults)"
+                "Preflight WARN: Postgres database does not exist yet; startup may auto-create "
+                "it before enabling user features"
             )
-            return False
+            return True
         except Exception as exc:
             remediation = _postgres_local_remediation(config.realestate_database_url)
             if remediation:

--- a/tests/unit/scripts/test_bot_health_script.py
+++ b/tests/unit/scripts/test_bot_health_script.py
@@ -17,3 +17,11 @@ def test_bot_health_keeps_litellm_liveliness_probe() -> None:
     """The LLM preflight should keep the liveliness endpoint check path."""
     text = SCRIPT.read_text(encoding="utf-8")
     assert "/health/liveliness" in text
+
+
+def test_bot_health_reports_local_postgres_expectation() -> None:
+    """The local preflight should surface the optional localhost Postgres contract."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "REAL_ESTATE_DATABASE_URL" in text
+    assert "localhost:5432" in text
+    assert "optional" in text.lower()

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -1861,18 +1861,19 @@ class TestBotLifecycle:
 
         bot.dp.stop_polling.assert_not_awaited()
 
-    async def test_polling_lock_heartbeat_stops_after_retry_budget(self, mock_config):
-        """Repeated heartbeat failures should still stop polling after the retry budget."""
+    async def test_polling_lock_heartbeat_stops_before_lease_can_expire(self, mock_config):
+        """Two missed refreshes must stop polling before a third interval can expire the lease."""
         bot, _ = _create_bot(mock_config)
         bot._polling_lock = AsyncMock()
         bot._polling_lock.ttl_sec = 3
-        bot._polling_lock.refresh = AsyncMock(side_effect=[RuntimeError("redis lost")] * 3)
+        bot._polling_lock.refresh = AsyncMock(side_effect=[RuntimeError("redis lost")] * 2)
         bot.dp = MagicMock()
         bot.dp.stop_polling = AsyncMock()
 
         with patch("telegram_bot.bot.asyncio.sleep", new=AsyncMock()):
             await bot._polling_lock_heartbeat()
 
+        assert bot._polling_lock.refresh.await_count == 2
         bot.dp.stop_polling.assert_awaited_once_with()
 
 

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -1686,6 +1686,39 @@ class TestBotLifecycle:
         polling_lock.acquire.assert_awaited_once()
         assert "polling-lock-heartbeat" in created_task_names
 
+    async def test_start_skips_postgres_pool_when_preflight_already_failed(self, mock_config):
+        """Startup should not probe Postgres again after authoritative preflight failure."""
+        bot, _ = _create_bot(mock_config)
+        bot._cache = MagicMock()
+        bot._cache.initialize = AsyncMock()
+        bot._cache.redis = MagicMock()
+        bot.dp = MagicMock()
+        bot.dp.start_polling = AsyncMock()
+        bot._redis_monitor = MagicMock()
+        bot._redis_monitor.start = AsyncMock()
+        bot.bot = MagicMock()
+        bot.bot.set_my_commands = AsyncMock()
+        bot.bot.set_chat_menu_button = AsyncMock()
+
+        result = DependencyCheckResult(
+            {"redis": True, "postgres": False},
+            report=StartupReport(),
+        )
+
+        with (
+            patch(
+                "telegram_bot.preflight.check_dependencies",
+                new_callable=AsyncMock,
+                return_value=result,
+            ),
+            patch("asyncpg.connect", new_callable=AsyncMock) as mock_connect,
+            patch("asyncpg.create_pool", new_callable=AsyncMock) as mock_pool,
+        ):
+            await bot.start()
+
+        mock_connect.assert_not_awaited()
+        mock_pool.assert_not_awaited()
+
     async def test_stop_closes_services(self, mock_config):
         """Test that stop() closes all services."""
         bot, _ = _create_bot(mock_config)
@@ -1809,12 +1842,31 @@ class TestBotLifecycle:
 
         polling_lock.release.assert_awaited_once_with()
 
-    async def test_polling_lock_heartbeat_stops_polling_on_refresh_failure(self, mock_config):
-        """Heartbeat failures should stop polling so the lease cannot silently expire."""
+    async def test_polling_lock_heartbeat_retries_transient_failures(self, mock_config):
+        """One transient refresh failure must not stop polling immediately."""
         bot, _ = _create_bot(mock_config)
         bot._polling_lock = AsyncMock()
-        bot._polling_lock.ttl_sec = 90
-        bot._polling_lock.refresh = AsyncMock(side_effect=RuntimeError("redis lost"))
+        bot._polling_lock.ttl_sec = 3
+        bot._polling_lock.refresh = AsyncMock(
+            side_effect=[RuntimeError("redis lost"), None, asyncio.CancelledError()]
+        )
+        bot.dp = MagicMock()
+        bot.dp.stop_polling = AsyncMock()
+
+        with (
+            patch("telegram_bot.bot.asyncio.sleep", new=AsyncMock()),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await bot._polling_lock_heartbeat()
+
+        bot.dp.stop_polling.assert_not_awaited()
+
+    async def test_polling_lock_heartbeat_stops_after_retry_budget(self, mock_config):
+        """Repeated heartbeat failures should still stop polling after the retry budget."""
+        bot, _ = _create_bot(mock_config)
+        bot._polling_lock = AsyncMock()
+        bot._polling_lock.ttl_sec = 3
+        bot._polling_lock.refresh = AsyncMock(side_effect=[RuntimeError("redis lost")] * 3)
         bot.dp = MagicMock()
         bot.dp.stop_polling = AsyncMock()
 

--- a/tests/unit/test_compose_langfuse.py
+++ b/tests/unit/test_compose_langfuse.py
@@ -65,6 +65,19 @@ SERVICES_WITH_DEV_DEFAULTS = ["bot", "litellm", "rag-api", "voice-agent", "inges
 class TestLangfuseSecretPosture:
     """Base compose avoids predictable secrets; dev compose restores convenience defaults."""
 
+    def test_base_redis_langfuse_command_is_safe_without_password(self, compose_base: dict):
+        command = compose_base["services"]["redis-langfuse"]["command"]
+        assert "redis-server --requirepass ${LANGFUSE_REDIS_PASSWORD:-}" not in str(command), (
+            "compose.yml: redis-langfuse command must not render a bare --requirepass when "
+            "LANGFUSE_REDIS_PASSWORD is unset"
+        )
+
+    def test_base_redis_langfuse_healthcheck_handles_optional_password(self, compose_base: dict):
+        test_cmd = compose_base["services"]["redis-langfuse"]["healthcheck"]["test"]
+        assert "${LANGFUSE_REDIS_PASSWORD:-}" not in str(test_cmd), (
+            "compose.yml: redis-langfuse healthcheck must not require an empty password arg"
+        )
+
     @pytest.mark.parametrize("service", SERVICES_WITH_DEV_DEFAULTS)
     def test_base_compose_has_no_dev_public_key_default(self, compose_base: dict, service: str):
         env = _get_service_env(compose_base, service)

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -765,7 +765,7 @@ class TestQdrantPreflightClient:
 
 
 class TestPostgresPreflight:
-    """Postgres preflight check validates database existence."""
+    """Postgres preflight check validates connectivity without blocking recovery paths."""
 
     async def test_postgres_check_passes_when_db_exists(self):
         """Preflight passes when Postgres connection succeeds."""
@@ -780,8 +780,8 @@ class TestPostgresPreflight:
             result = await _check_single_dep("postgres", config, client)
             assert result is True
 
-    async def test_postgres_check_fails_when_db_missing(self):
-        """Preflight fails when database does not exist."""
+    async def test_postgres_check_allows_missing_db_recovery(self, caplog):
+        """Missing DB should stay recoverable so startup can run the auto-create path."""
         import asyncpg as real_asyncpg
 
         config = _make_config(realestate_database_url="postgresql://u:p@localhost/realestate")
@@ -795,7 +795,8 @@ class TestPostgresPreflight:
 
             client = AsyncMock()
             result = await _check_single_dep("postgres", config, client)
-            assert result is False
+            assert result is True
+            assert "auto-create" in caplog.text.lower()
 
     async def test_postgres_in_dep_classification_as_optional(self):
         """Postgres is OPTIONAL — bot degrades without it."""

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -204,6 +204,26 @@ class TestCheckRedisDeep:
         assert details["keyspace_db0"] == "empty"
 
 
+class TestPostgresRemediation:
+    async def test_local_connection_refused_logs_local_runtime_remediation(self, caplog):
+        config = _make_config(realestate_database_url="postgresql://u:p@localhost:5432/realestate")
+        client = AsyncMock()
+
+        with (
+            patch(
+                "telegram_bot.preflight.asyncpg.connect",
+                AsyncMock(side_effect=ConnectionRefusedError(111, "Connection refused")),
+            ),
+            caplog.at_level("WARNING"),
+        ):
+            result = await _check_single_dep("postgres", config, client)
+
+        assert result is False
+        assert "localhost:5432" in caplog.text
+        assert "optional for native bot runs" in caplog.text
+        assert "compose.yml:compose.dev.yml" in caplog.text
+
+
 # ===========================================================================
 # _verify_cache_synthetic
 # ===========================================================================


### PR DESCRIPTION
## Summary
- harden base `redis-langfuse` wiring so empty `LANGFUSE_REDIS_PASSWORD` no longer renders a broken local Redis command/healthcheck
- reuse authoritative preflight output for optional Postgres startup, add clearer localhost remediation, and retry polling-lock refresh before stopping polling
- extend local bot health coverage with the Redis auth contract and explicit optional localhost Postgres diagnostics, plus owner tests for the new runtime guards

Closes #1206.

## Test Plan
- `uv run pytest tests/unit/test_local_compose_contract.py tests/unit/scripts/test_bot_health_script.py tests/unit/config/test_bot_config_settings.py tests/unit/test_compose_langfuse.py tests/unit/test_compose_langfuse_runtime_contract.py tests/unit/test_preflight.py tests/unit/test_bot_handlers.py -q`
- `POSTGRES_PASSWORD=x REDIS_PASSWORD=x TELEGRAM_BOT_TOKEN=x LITELLM_MASTER_KEY=x OPENAI_API_KEY=x LLM_API_KEY=x NEXTAUTH_SECRET=x SALT=x ENCRYPTION_KEY=x LIVEKIT_API_KEY=x LIVEKIT_API_SECRET=x GDRIVE_SYNC_DIR=/tmp COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility config --services`
- `POSTGRES_PASSWORD=x REDIS_PASSWORD=x TELEGRAM_BOT_TOKEN=x LITELLM_MASTER_KEY=x OPENAI_API_KEY=x LLM_API_KEY=x NEXTAUTH_SECRET=x SALT=x ENCRYPTION_KEY=x LIVEKIT_API_KEY=x LIVEKIT_API_SECRET=x GDRIVE_SYNC_DIR=/tmp COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility --profile ml config | rg 'published: \"3001\"|published: \"6380\"|CMD-SHELL' -n`
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
- `make test-bot-health`