### PR TITLE
fix(preflight): close issue #1198 sdk-first contract gaps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,7 +344,7 @@ test-redis: ## Verify Redis Query Engine is available
 
 .PHONY: test-bot-health test-bot-health-vps
 
-test-bot-health: ## Preflight: verify local bot runtime prerequisites (Redis/Qdrant/LLM + Postgres note)
+test-bot-health: ## Preflight: verify local native-bot prerequisites (Redis/Qdrant/LiteLLM + optional Postgres note)
 	@echo "$(BLUE)Running bot health preflight...$(NC)"
 	@./scripts/test_bot_health.sh
 	@echo "$(GREEN)✓ Bot health preflight passed$(NC)"

--- a/README.md
+++ b/README.md
@@ -145,11 +145,13 @@ For local development, the canonical environment file is `.env` in the repo root
 
 ```bash
 make local-up    # Redis, Qdrant, BGE-M3, Docling, LiteLLM
-make test-bot-health
-make run-bot     # Run bot natively (fast iteration, no Docker rebuild)
+make test-bot-health   # Local helper: Redis, Qdrant, LiteLLM + optional Postgres note
+make run-bot           # Run bot natively (fast iteration, no Docker rebuild)
 ```
 
 For native bot runs, `REDIS_URL` is optional in local development: when it is unset, the bot derives `redis://:REDIS_PASSWORD@localhost:6379` from `REDIS_PASSWORD` so it matches the password-protected Redis started by `make local-up`.
+
+`make test-bot-health` validates the published local prerequisites used by native bot runs. The authoritative startup preflight still runs in [`telegram_bot/preflight.py`](/home/user/projects/rag-fresh-issue-1198/telegram_bot/preflight.py) when the bot starts. That runtime preflight still owns the repo-local BGE-M3 contract because BGE-M3 is a service this repository depends on directly, not a generic upstream SDK health path.
 
 ### 3. Or Run Everything in Docker
 

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -59,15 +59,13 @@ Bot preflight:
 make test-bot-health
 ```
 
-`make test-bot-health` resolves `QDRANT_COLLECTION` in this order:
-1. exported shell env (`QDRANT_COLLECTION`)
-2. `.env` value
-3. compose default from `compose.yml` (`gdrive_documents_bge`)
+`make test-bot-health` is a local helper for the published native bot prerequisites:
+- Redis via the same `BotConfig` + `redis.from_url(...)` path used by native startup
+- Qdrant via `BotConfig.get_collection_name()` + `qdrant-client`
+- LiteLLM via proxy readiness (`/health/readiness`)
+- optional localhost Postgres note without turning DB reachability into a hard failure
 
-For Redis it uses this native-run order:
-1. exported shell env (`REDIS_URL`)
-2. `.env` value (`REDIS_URL=...`)
-3. derived local default from `REDIS_PASSWORD` as `redis://:REDIS_PASSWORD@localhost:6379`
+The authoritative startup preflight still lives in [`telegram_bot/preflight.py`](/home/user/projects/rag-fresh-issue-1198/telegram_bot/preflight.py) and runs when you start the bot. That runtime preflight also keeps the repo-local BGE-M3 health and warmup contract, because BGE-M3 is not a generic upstream SDK probe in this repo.
 
 ## 4. Development Gates
 
@@ -117,6 +115,8 @@ Use the `local-*` shortcuts (they now run a minimal subset from `compose.yml:com
 
 ```bash
 make local-up
+make test-bot-health
+make run-bot
 make local-ps
 make local-down
 ```

--- a/docs/ONBOARDING_CHECKLIST.md
+++ b/docs/ONBOARDING_CHECKLIST.md
@@ -43,7 +43,7 @@ cp .env.example .env
 # Start core services (Redis, Qdrant, BGE-M3)
 make local-up
 
-# Verify the native bot contract before startup
+# Verify the published local prerequisites for native bot startup
 make test-bot-health
 ```
 
@@ -58,6 +58,8 @@ uv run python -m telegram_bot.main
 ```
 
 If you do set `REDIS_URL` manually for native runs, it must include the Redis password. Otherwise the bot derives the local URL from `REDIS_PASSWORD`.
+
+`make test-bot-health` is the local helper for Redis/Qdrant/LiteLLM plus the optional localhost Postgres note. The full startup preflight still runs in [`telegram_bot/preflight.py`](/home/user/projects/rag-fresh-issue-1198/telegram_bot/preflight.py) when the bot starts, and that runtime path keeps the repo-local BGE-M3 health contract.
 
 ## 5. Validation
 

--- a/scripts/test_bot_health.sh
+++ b/scripts/test_bot_health.sh
@@ -1,43 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-PROJECT_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
-
-resolve_qdrant_collection() {
-  local dotenv_value compose_default
-
-  if [ -n "${QDRANT_COLLECTION:-}" ]; then
-    printf '%s\n' "$QDRANT_COLLECTION"
-    return 0
-  fi
-
-  if [ -f "$PROJECT_ROOT/.env" ]; then
-    dotenv_value=$(
-      sed -nE "s/^[[:space:]]*(export[[:space:]]+)?QDRANT_COLLECTION[[:space:]]*=[[:space:]]*['\"]?([^'\"#[:space:]]+)['\"]?.*$/\\2/p" "$PROJECT_ROOT/.env" \
-        | tail -n1
-    )
-    if [ -n "$dotenv_value" ]; then
-      printf '%s\n' "$dotenv_value"
-      return 0
-    fi
-  fi
-
-  compose_default=$(
-    sed -nE "s/^[[:space:]]*QDRANT_COLLECTION:[[:space:]]*\\$\\{QDRANT_COLLECTION:-([^}]+)\\}[[:space:]]*$/\\1/p" "$PROJECT_ROOT/compose.yml" \
-      | head -n1
-  )
-  if [ -n "$compose_default" ]; then
-    printf '%s\n' "$compose_default"
-    return 0
-  fi
-
-  printf '%s\n' "gdrive_documents_bge"
-}
-
-QDRANT_URL=${QDRANT_URL:-http://localhost:6333}
-QDRANT_COLLECTION=$(resolve_qdrant_collection)
-QDRANT_QUANTIZATION_MODE=${QDRANT_QUANTIZATION_MODE:-off}
 LLM_BASE_URL=${LLM_BASE_URL:-${LITELLM_BASE_URL:-http://localhost:4000}}
 
 fail() {
@@ -100,31 +63,34 @@ else:
     )
 PY
 
-# Qdrant: target collection exists (match bot's suffix rules)
-base_collection="$QDRANT_COLLECTION"
-base_collection="${base_collection%_binary}"
-base_collection="${base_collection%_scalar}"
-collection_to_check="$base_collection"
-if [ "$QDRANT_QUANTIZATION_MODE" = "scalar" ]; then
-  collection_to_check="${base_collection}_scalar"
-elif [ "$QDRANT_QUANTIZATION_MODE" = "binary" ]; then
-  collection_to_check="${base_collection}_binary"
-fi
+# Qdrant: use the same BotConfig + qdrant-client collection contract as native bot startup
+uv run --no-sync python - <<'PY' || fail "Qdrant is unreachable or the configured collection is missing"
+from telegram_bot.config import BotConfig
+from qdrant_client import QdrantClient
 
-collections=$(curl -fsS "$QDRANT_URL/collections" | tr -d '\n') || fail "Qdrant is unreachable at $QDRANT_URL"
-if ! echo "$collections" | grep -q "\"name\"\s*:\s*\"$collection_to_check\""; then
-  fail "Qdrant collection '$collection_to_check' not found (mode=$QDRANT_QUANTIZATION_MODE)"
-fi
-echo "✓ Qdrant collection exists: $collection_to_check (mode=$QDRANT_QUANTIZATION_MODE)"
+config = BotConfig()
+client = QdrantClient(
+    url=config.qdrant_url,
+    api_key=config.qdrant_api_key if config.qdrant_url.startswith("https://") else None,
+    timeout=config.qdrant_timeout,
+)
+collection = config.get_collection_name()
+try:
+    if not client.collection_exists(collection):
+        raise RuntimeError(f"Qdrant collection '{collection}' not found")
+    print(f"✓ Qdrant collection exists for native bot startup: {collection}")
+finally:
+    client.close()
+PY
 
 # LiteLLM/LLM connectivity
 normalized_llm_base_url="$(strip_trailing_slash "$LLM_BASE_URL")"
 health_base_url="${normalized_llm_base_url%/v1}"
 models_url="$normalized_llm_base_url/models"
-health_url="$health_base_url/health/liveliness"
+health_url="$health_base_url/health/readiness"
 
 if curl -fsS "$health_url" >/dev/null; then
-  echo "✓ LLM health OK: $health_url"
+  echo "✓ LiteLLM readiness OK: $health_url"
 else
   # Fallback for OpenAI-compatible endpoints.
   curl -fsS "$models_url" >/dev/null || fail "LLM endpoint not responding at $LLM_BASE_URL"

--- a/telegram_bot/preflight.py
+++ b/telegram_bot/preflight.py
@@ -79,9 +79,9 @@ _DEP_REMEDIATION: dict[str, str] = {
     "redis": "start Redis and verify REDIS_PASSWORD / redis_url",
     "redis_cache": "restore Redis cache write/read path",
     "qdrant": "start Qdrant and verify collection configuration",
-    "bge_m3": "start BGE-M3 and verify /health and encode endpoints",
+    "bge_m3": "start the repo-local BGE-M3 service and verify /health and /encode/dense",
     "postgres": "start PostgreSQL or accept degraded user-feature mode",
-    "litellm": "start LiteLLM or accept degraded generation path",
+    "litellm": "restore LiteLLM proxy readiness or accept degraded generation path",
     "langfuse": "restore Langfuse credentials/connectivity or accept disabled tracing",
 }
 
@@ -266,12 +266,6 @@ async def _verify_cache_synthetic(redis_url: str) -> tuple[bool, list[str]]:
         await r.aclose()
 
 
-def _is_collection_not_found(exc: Exception) -> bool:
-    """Return True when the exception indicates a missing Qdrant collection (HTTP 404)."""
-    msg = str(exc).lower()
-    return "not found" in msg or "doesn't exist" in msg or "404" in msg
-
-
 async def _ensure_qdrant_collection(qdrant: AsyncQdrantClient, collection_name: str) -> None:
     """Create Qdrant collection with the standard BGE-M3 vector schema.
 
@@ -333,6 +327,28 @@ async def _check_single_dep(
             prefer_grpc=True,
         )
         try:
+            exists = await qdrant.collection_exists(collection)
+            if not exists:
+                logger.warning(
+                    "Preflight WARN: Qdrant collection %s not found via SDK existence check; "
+                    "creating default schema",
+                    collection,
+                )
+                try:
+                    await _ensure_qdrant_collection(qdrant, collection)
+                    logger.info(
+                        "Preflight Qdrant: collection %s created (empty, ready for ingestion)",
+                        collection,
+                    )
+                    return True
+                except Exception as create_exc:
+                    logger.error(
+                        "Preflight FAIL: Qdrant — could not create collection %s: %s",
+                        collection,
+                        create_exc,
+                    )
+                    return False
+
             info = await qdrant.get_collection(collection)
             logger.info(
                 "Preflight Qdrant: collection=%s, points=%s",
@@ -403,25 +419,6 @@ async def _check_single_dep(
 
             return True
         except Exception as exc:
-            if _is_collection_not_found(exc):
-                logger.warning(
-                    "Preflight WARN: Qdrant collection %s not found — creating with default schema",
-                    collection,
-                )
-                try:
-                    await _ensure_qdrant_collection(qdrant, collection)
-                    logger.info(
-                        "Preflight Qdrant: collection %s created (empty, ready for ingestion)",
-                        collection,
-                    )
-                    return True
-                except Exception as create_exc:
-                    logger.error(
-                        "Preflight FAIL: Qdrant — could not create collection %s: %s",
-                        collection,
-                        create_exc,
-                    )
-                    return False
             logger.error("Preflight FAIL: Qdrant — %s", exc)
             return False
         finally:
@@ -430,9 +427,9 @@ async def _check_single_dep(
     if name == "bge_m3":
         resp = await client.get(f"{config.bge_m3_url}/health")
         if resp.status_code != 200:
-            logger.error("Preflight FAIL: BGE-M3 — %s", resp.status_code)
+            logger.error("Preflight FAIL: BGE-M3 repo-local health contract — %s", resp.status_code)
             return False
-        # Warm encode to ensure model is loaded and warmed
+        # Warm encode to verify the repo-local model service is actually ready to serve embeddings.
         warmup_resp = await client.post(
             f"{config.bge_m3_url}/encode/dense",
             json={"texts": ["preflight warmup"], "max_length": 64, "batch_size": 1},
@@ -440,9 +437,15 @@ async def _check_single_dep(
         )
         if warmup_resp.status_code == 200:
             data = warmup_resp.json()
-            logger.info("Preflight BGE-M3 warmup OK (%.3fs)", data.get("processing_time", 0))
+            logger.info(
+                "Preflight BGE-M3 repo-local warmup OK (%.3fs)",
+                data.get("processing_time", 0),
+            )
         else:
-            logger.warning("Preflight BGE-M3 warmup failed: %s", warmup_resp.status_code)
+            logger.warning(
+                "Preflight BGE-M3 repo-local warmup failed: %s",
+                warmup_resp.status_code,
+            )
         return True
 
     if name == "postgres":
@@ -471,9 +474,9 @@ async def _check_single_dep(
     if name == "litellm":
         # Health endpoint is at proxy root, not under /v1
         base = config.llm_base_url.rstrip("/").removesuffix("/v1")
-        resp = await client.get(f"{base}/health/liveliness")
+        resp = await client.get(f"{base}/health/readiness")
         if resp.status_code != 200:
-            logger.error("Preflight FAIL: LiteLLM — %s", resp.status_code)
+            logger.error("Preflight FAIL: LiteLLM proxy readiness — %s", resp.status_code)
             return False
         return True
 

--- a/tests/unit/scripts/test_bot_health_script.py
+++ b/tests/unit/scripts/test_bot_health_script.py
@@ -13,10 +13,17 @@ def test_bot_health_uses_botconfig_and_redis_sdk_for_auth_contract() -> None:
     assert "redis.from_url(config.redis_url" in text
 
 
-def test_bot_health_keeps_litellm_liveliness_probe() -> None:
-    """The LLM preflight should keep the liveliness endpoint check path."""
+def test_bot_health_uses_qdrant_client_and_botconfig_collection_contract() -> None:
+    """Qdrant preflight should reuse BotConfig collection logic via qdrant-client."""
     text = SCRIPT.read_text(encoding="utf-8")
-    assert "/health/liveliness" in text
+    assert "from qdrant_client import QdrantClient" in text
+    assert "config.get_collection_name()" in text
+
+
+def test_bot_health_uses_litellm_readiness_probe() -> None:
+    """The LLM preflight should use the readiness endpoint check path."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "/health/readiness" in text
 
 
 def test_bot_health_reports_local_postgres_expectation() -> None:

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -335,7 +335,7 @@ class TestCheckSingleDep:
         assert result is True
         mock_verify.assert_awaited_once_with(config.redis_url)
 
-    async def test_qdrant_collection_ok(self):
+    async def test_qdrant_uses_collection_exists_before_get_collection(self):
         config = _make_config(qdrant_collection="test_col", effective_collection="test_col_scalar")
         client = AsyncMock(spec=httpx.AsyncClient)
 
@@ -344,6 +344,7 @@ class TestCheckSingleDep:
         mock_info.config.params.vectors = {"dense": MagicMock(), "colbert": MagicMock()}
         mock_info.config.params.sparse_vectors = {"bm42": MagicMock()}
         mock_qdrant_client = AsyncMock()
+        mock_qdrant_client.collection_exists = AsyncMock(return_value=True)
         mock_qdrant_client.get_collection = AsyncMock(return_value=mock_info)
         mock_qdrant_client.close = AsyncMock()
 
@@ -352,6 +353,7 @@ class TestCheckSingleDep:
 
         assert result is True
         config.get_collection_name.assert_called_once_with()
+        mock_qdrant_client.collection_exists.assert_awaited_once_with("test_col_scalar")
         mock_qdrant_client.get_collection.assert_awaited_once_with("test_col_scalar")
         mock_qdrant_client.close.assert_awaited_once()
 
@@ -412,7 +414,7 @@ class TestCheckSingleDep:
         result = await _check_single_dep("bge_m3", config, client)
         assert result is True
 
-    async def test_litellm_health_ok(self):
+    async def test_litellm_health_uses_readiness(self):
         config = _make_config()
         mock_resp = MagicMock()
         mock_resp.status_code = 200
@@ -422,7 +424,7 @@ class TestCheckSingleDep:
         result = await _check_single_dep("litellm", config, client)
 
         assert result is True
-        client.get.assert_awaited_once_with(f"{config.llm_base_url}/health/liveliness")
+        client.get.assert_awaited_once_with(f"{config.llm_base_url}/health/readiness")
 
     async def test_litellm_non_200_fails(self):
         config = _make_config()
@@ -836,13 +838,12 @@ class TestPostgresOptionalBehavior:
 class TestQdrantPreflightEnsureCollection:
     """Preflight auto-creates Qdrant collection when it is missing."""
 
-    async def test_creates_collection_when_not_found(self):
-        """When collection missing (not-found error), preflight creates it and returns True."""
+    async def test_qdrant_creates_missing_collection_when_collection_exists_is_false(self):
+        """Missing collection should trigger create via collection_exists(), not exception parsing."""
         config = _make_config()
         mock_qdrant = AsyncMock()
-        mock_qdrant.get_collection = AsyncMock(
-            side_effect=Exception("Not found: Collection `test_col` doesn't exist!")
-        )
+        mock_qdrant.collection_exists = AsyncMock(return_value=False)
+        mock_qdrant.get_collection = AsyncMock()
         mock_qdrant.create_collection = AsyncMock()
         mock_qdrant.close = AsyncMock()
 
@@ -851,27 +852,16 @@ class TestQdrantPreflightEnsureCollection:
             result = await _check_single_dep("qdrant", config, client)
 
         assert result is True
+        mock_qdrant.collection_exists.assert_awaited_once_with("test_col")
+        mock_qdrant.get_collection.assert_not_awaited()
         mock_qdrant.create_collection.assert_awaited_once()
-
-    async def test_returns_true_after_auto_create(self):
-        """Returns True after successfully creating missing collection (404 variant)."""
-        config = _make_config()
-        mock_qdrant = AsyncMock()
-        mock_qdrant.get_collection = AsyncMock(side_effect=Exception("status_code=404"))
-        mock_qdrant.create_collection = AsyncMock()
-        mock_qdrant.close = AsyncMock()
-
-        with patch("telegram_bot.preflight.AsyncQdrantClient", return_value=mock_qdrant):
-            client = AsyncMock()
-            result = await _check_single_dep("qdrant", config, client)
-
-        assert result is True
 
     async def test_fails_when_create_also_raises(self):
         """Returns False when collection missing AND create_collection also fails."""
         config = _make_config()
         mock_qdrant = AsyncMock()
-        mock_qdrant.get_collection = AsyncMock(side_effect=Exception("Not found"))
+        mock_qdrant.collection_exists = AsyncMock(return_value=False)
+        mock_qdrant.get_collection = AsyncMock()
         mock_qdrant.create_collection = AsyncMock(side_effect=Exception("Permission denied"))
         mock_qdrant.close = AsyncMock()
 
@@ -885,6 +875,7 @@ class TestQdrantPreflightEnsureCollection:
         """Connection-refused and other non-404 errors fail without attempting create."""
         config = _make_config()
         mock_qdrant = AsyncMock()
+        mock_qdrant.collection_exists = AsyncMock(return_value=True)
         mock_qdrant.get_collection = AsyncMock(side_effect=Exception("Connection refused"))
         mock_qdrant.create_collection = AsyncMock()
         mock_qdrant.close = AsyncMock()
@@ -900,7 +891,8 @@ class TestQdrantPreflightEnsureCollection:
         """Auto-created collection has dense, colbert (multivector), and bm42 vectors."""
         config = _make_config(qdrant_collection="gdrive_documents_bge")
         mock_qdrant = AsyncMock()
-        mock_qdrant.get_collection = AsyncMock(side_effect=Exception("Not found"))
+        mock_qdrant.collection_exists = AsyncMock(return_value=False)
+        mock_qdrant.get_collection = AsyncMock()
         mock_qdrant.create_collection = AsyncMock()
         mock_qdrant.close = AsyncMock()
 


### PR DESCRIPTION
## Summary
- move remaining Qdrant checks to official client paths and SDK existence checks
- switch LiteLLM health contract from liveliness to readiness and align the local bot health helper
- clarify docs around the local helper versus authoritative runtime preflight

## Test Plan
- [x] uv run pytest tests/unit/test_preflight.py -q
- [x] uv run pytest tests/unit/scripts/test_bot_health_script.py -q
- [x] uv run pytest tests/unit/test_local_compose_contract.py -q
- [x] make check
- [x] PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit

Fixes #1198
Supersedes #1209