### PR TITLE
fix: apply query preprocessor rrf weights

### DIFF
--- a/telegram_bot/agents/rag_pipeline.py
+++ b/telegram_bot/agents/rag_pipeline.py
@@ -33,7 +33,7 @@ from telegram_bot.services.cache_policy import (
     resolve_semantic_cache_signature,
 )
 from telegram_bot.services.query_filter_signal import detect_filter_sensitive_query
-from telegram_bot.services.query_preprocessor import expand_short_query
+from telegram_bot.services.query_preprocessor import QueryPreprocessor, expand_short_query
 from telegram_bot.services.rag_core import (
     CACHEABLE_QUERY_TYPES,
     check_semantic_cache,
@@ -50,6 +50,7 @@ logger = logging.getLogger(__name__)
 
 # top_k=5 for reranking. Standard in literature; balances latency vs recall for reranking candidate pool.
 _DEFAULT_RERANK_TOP_K = 5
+_QUERY_PREPROCESSOR = QueryPreprocessor()
 
 
 async def _execute_qdrant_retrieval(
@@ -60,6 +61,8 @@ async def _execute_qdrant_retrieval(
     colbert_query: list[list[float]] | None,
     filters: dict[str, str] | None,
     top_k: int,
+    dense_weight: float,
+    sparse_weight: float,
 ) -> tuple[list[dict[str, Any]], dict[str, Any], bool]:
     has_colbert_search = callable(getattr(qdrant, "hybrid_search_rrf_colbert", None))
     if colbert_query and has_colbert_search:
@@ -77,6 +80,8 @@ async def _execute_qdrant_retrieval(
             dense_vector=dense_vector,
             sparse_vector=sparse_vector,
             filters=filters,
+            dense_weight=dense_weight,
+            sparse_weight=sparse_weight,
             top_k=top_k,
             return_meta=True,
         )
@@ -99,6 +104,8 @@ async def _run_initial_retrieval(
     colbert_query: list[list[float]] | None,
     filters: dict[str, str] | None,
     top_k: int,
+    dense_weight: float,
+    sparse_weight: float,
 ) -> tuple[list[dict[str, Any]], dict[str, Any], bool]:
     return await _execute_qdrant_retrieval(
         qdrant=qdrant,
@@ -107,6 +114,8 @@ async def _run_initial_retrieval(
         colbert_query=colbert_query,
         filters=filters,
         top_k=top_k,
+        dense_weight=dense_weight,
+        sparse_weight=sparse_weight,
     )
 
 
@@ -119,6 +128,8 @@ async def _run_relaxed_retrieval(
     colbert_query: list[list[float]] | None,
     filters: dict[str, str] | None,
     top_k: int,
+    dense_weight: float,
+    sparse_weight: float,
 ) -> tuple[list[dict[str, Any]], dict[str, Any], bool]:
     return await _execute_qdrant_retrieval(
         qdrant=qdrant,
@@ -127,6 +138,8 @@ async def _run_relaxed_retrieval(
         colbert_query=colbert_query,
         filters=filters,
         top_k=top_k,
+        dense_weight=dense_weight,
+        sparse_weight=sparse_weight,
     )
 
 
@@ -400,6 +413,7 @@ async def _hybrid_retrieve(
     retrieval_relaxed_from_topic_filter = False
     retrieval_relax_stage: str | None = None
     qdrant_search_attempts = 0
+    dense_weight, sparse_weight = _QUERY_PREPROCESSOR.get_rrf_weights(query)
     if prefer_faq_doc_type and topic_hint:
         active_filters = dict(topic_filters)
         active_filters["doc_type"] = "faq"
@@ -461,6 +475,8 @@ async def _hybrid_retrieve(
         colbert_query=colbert_query,
         filters=active_filters,
         top_k=top_k,
+        dense_weight=dense_weight,
+        sparse_weight=sparse_weight,
     )
     colbert_search_used = colbert_search_used or colbert_used
     qdrant_search_attempts += 1
@@ -488,6 +504,8 @@ async def _hybrid_retrieve(
             colbert_query=colbert_query,
             filters=fallback_filters,
             top_k=top_k,
+            dense_weight=dense_weight,
+            sparse_weight=sparse_weight,
         )
         colbert_search_used = colbert_search_used or colbert_used
         qdrant_search_attempts += 1
@@ -504,6 +522,8 @@ async def _hybrid_retrieve(
             colbert_query=colbert_query,
             filters=base_filters,
             top_k=top_k,
+            dense_weight=dense_weight,
+            sparse_weight=sparse_weight,
         )
         colbert_search_used = colbert_search_used or colbert_used
         qdrant_search_attempts += 1
@@ -543,6 +563,8 @@ async def _hybrid_retrieve(
             "retrieval_relaxed_from_topic_filter": retrieval_relaxed_from_topic_filter,
             "retrieval_relax_stage": retrieval_relax_stage,
             "qdrant_search_attempts": qdrant_search_attempts,
+            "rrf_dense_weight": dense_weight,
+            "rrf_sparse_weight": sparse_weight,
             "eval_query": query[:2000],
             "eval_docs": "\n\n".join(
                 f"[{d.get('score', 0):.2f}] {str(d.get('content', ''))[:500]}" for d in result_ctx

--- a/telegram_bot/agents/rag_pipeline.py
+++ b/telegram_bot/agents/rag_pipeline.py
@@ -51,6 +51,19 @@ logger = logging.getLogger(__name__)
 # top_k=5 for reranking. Standard in literature; balances latency vs recall for reranking candidate pool.
 _DEFAULT_RERANK_TOP_K = 5
 _QUERY_PREPROCESSOR = QueryPreprocessor()
+_DEFAULT_COLBERT_PREFETCH_LIMIT = 100
+
+
+def _weighted_colbert_prefetch_limits(
+    dense_weight: float,
+    sparse_weight: float,
+    *,
+    top_k: int,
+) -> tuple[int, int]:
+    """Scale ColBERT candidate pools using the same query weights as RRF prefetch."""
+    dense_limit = max(int(_DEFAULT_COLBERT_PREFETCH_LIMIT * dense_weight / 0.6), top_k)
+    sparse_limit = max(int(_DEFAULT_COLBERT_PREFETCH_LIMIT * sparse_weight / 0.4), top_k)
+    return dense_limit, sparse_limit
 
 
 async def _execute_qdrant_retrieval(
@@ -66,11 +79,18 @@ async def _execute_qdrant_retrieval(
 ) -> tuple[list[dict[str, Any]], dict[str, Any], bool]:
     has_colbert_search = callable(getattr(qdrant, "hybrid_search_rrf_colbert", None))
     if colbert_query and has_colbert_search:
+        dense_limit, sparse_limit = _weighted_colbert_prefetch_limits(
+            dense_weight,
+            sparse_weight,
+            top_k=top_k,
+        )
         result = await qdrant.hybrid_search_rrf_colbert(
             dense_vector=dense_vector,
             sparse_vector=sparse_vector,
             colbert_query=colbert_query,
             filters=filters,
+            dense_limit=dense_limit,
+            sparse_limit=sparse_limit,
             top_k=top_k,
             return_meta=True,
         )

--- a/telegram_bot/agents/rag_pipeline.py
+++ b/telegram_bot/agents/rag_pipeline.py
@@ -51,19 +51,6 @@ logger = logging.getLogger(__name__)
 # top_k=5 for reranking. Standard in literature; balances latency vs recall for reranking candidate pool.
 _DEFAULT_RERANK_TOP_K = 5
 _QUERY_PREPROCESSOR = QueryPreprocessor()
-_DEFAULT_COLBERT_PREFETCH_LIMIT = 100
-
-
-def _weighted_colbert_prefetch_limits(
-    dense_weight: float,
-    sparse_weight: float,
-    *,
-    top_k: int,
-) -> tuple[int, int]:
-    """Scale ColBERT candidate pools using the same query weights as RRF prefetch."""
-    dense_limit = max(int(_DEFAULT_COLBERT_PREFETCH_LIMIT * dense_weight / 0.6), top_k)
-    sparse_limit = max(int(_DEFAULT_COLBERT_PREFETCH_LIMIT * sparse_weight / 0.4), top_k)
-    return dense_limit, sparse_limit
 
 
 async def _execute_qdrant_retrieval(
@@ -79,18 +66,13 @@ async def _execute_qdrant_retrieval(
 ) -> tuple[list[dict[str, Any]], dict[str, Any], bool]:
     has_colbert_search = callable(getattr(qdrant, "hybrid_search_rrf_colbert", None))
     if colbert_query and has_colbert_search:
-        dense_limit, sparse_limit = _weighted_colbert_prefetch_limits(
-            dense_weight,
-            sparse_weight,
-            top_k=top_k,
-        )
         result = await qdrant.hybrid_search_rrf_colbert(
             dense_vector=dense_vector,
             sparse_vector=sparse_vector,
             colbert_query=colbert_query,
             filters=filters,
-            dense_limit=dense_limit,
-            sparse_limit=sparse_limit,
+            dense_weight=dense_weight,
+            sparse_weight=sparse_weight,
             top_k=top_k,
             return_meta=True,
         )

--- a/telegram_bot/services/qdrant.py
+++ b/telegram_bot/services/qdrant.py
@@ -546,8 +546,10 @@ class QdrantService:
         sparse_vector: dict | None = None,
         filters: dict | None = None,
         top_k: int = 5,
-        dense_limit: int = 100,
-        sparse_limit: int = 100,
+        dense_limit: int | None = None,
+        sparse_limit: int | None = None,
+        dense_weight: float = 0.6,
+        sparse_weight: float = 0.4,
         rrf_k: int = 60,
         return_meta: bool = False,
     ) -> list[dict] | tuple[list[dict], dict[str, Any]]:
@@ -565,6 +567,8 @@ class QdrantService:
             top_k: Final number of results after ColBERT reranking
             dense_limit: Number of dense candidates for RRF
             sparse_limit: Number of sparse candidates for RRF
+            dense_weight: Dense prefetch weight when dense_limit is not explicitly set
+            sparse_weight: Sparse prefetch weight when sparse_limit is not explicitly set
             rrf_k: RRF constant k
             return_meta: If True, return (results, meta) tuple
 
@@ -593,6 +597,8 @@ class QdrantService:
                 sparse_vector=sparse_vector,
                 filters=filters,
                 top_k=top_k,
+                dense_weight=dense_weight,
+                sparse_weight=sparse_weight,
                 rrf_k=rrf_k,
                 return_meta=return_meta,
             )
@@ -615,6 +621,8 @@ class QdrantService:
                 sparse_vector=sparse_vector,
                 filters=filters,
                 top_k=top_k,
+                dense_weight=dense_weight,
+                sparse_weight=sparse_weight,
                 rrf_k=rrf_k,
                 return_meta=return_meta,
             )
@@ -628,12 +636,19 @@ class QdrantService:
             )
             return fallback
 
+        effective_dense_limit = (
+            dense_limit if dense_limit is not None else max(int(100 * dense_weight / 0.6), top_k)
+        )
+        effective_sparse_limit = (
+            sparse_limit if sparse_limit is not None else max(int(100 * sparse_weight / 0.4), top_k)
+        )
+
         # Inner prefetch: dense + sparse candidates
         inner_prefetch = [
             models.Prefetch(
                 query=dense_vector,
                 using=self._dense_vector_name,
-                limit=dense_limit,
+                limit=effective_dense_limit,
             )
         ]
 
@@ -645,7 +660,7 @@ class QdrantService:
                         values=sparse_vector["values"],
                     ),
                     using=self._sparse_vector_name,
-                    limit=sparse_limit,
+                    limit=effective_sparse_limit,
                 )
             )
 
@@ -694,6 +709,8 @@ class QdrantService:
                     sparse_vector=sparse_vector,
                     filters=filters,
                     top_k=top_k,
+                    dense_weight=dense_weight,
+                    sparse_weight=sparse_weight,
                     rrf_k=rrf_k,
                     return_meta=return_meta,
                 )
@@ -746,6 +763,8 @@ class QdrantService:
                 sparse_vector=sparse_vector,
                 filters=filters,
                 top_k=top_k,
+                dense_weight=dense_weight,
+                sparse_weight=sparse_weight,
                 rrf_k=rrf_k,
                 return_meta=return_meta,
             )

--- a/tests/unit/agents/test_rag_pipeline.py
+++ b/tests/unit/agents/test_rag_pipeline.py
@@ -377,6 +377,31 @@ async def test_hybrid_retrieve_passes_topic_filter(mock_cache, mock_sparse, mock
     assert first_call["filters"] == {"topic": "finance"}
 
 
+async def test_hybrid_retrieve_applies_exact_query_rrf_weights(mock_cache, mock_sparse):
+    from telegram_bot.agents.rag_pipeline import _hybrid_retrieve
+
+    mock_qdrant = AsyncMock()
+    mock_qdrant.hybrid_search_rrf = AsyncMock(
+        return_value=(
+            [{"text": "корпус 5", "score": 0.9, "metadata": {}}],
+            {"backend_error": False, "error_type": None, "error_message": None},
+        )
+    )
+
+    await _hybrid_retrieve(
+        "квартира корпус 5",
+        [0.1] * 1024,
+        cache=mock_cache,
+        sparse_embeddings=mock_sparse,
+        qdrant=mock_qdrant,
+        latency_stages={},
+    )
+
+    first_call = mock_qdrant.hybrid_search_rrf.await_args_list[0].kwargs
+    assert first_call["dense_weight"] == 0.2
+    assert first_call["sparse_weight"] == 0.8
+
+
 async def test_hybrid_retrieve_prefers_faq_candidates_for_short_finance_query(
     mock_cache, mock_sparse
 ):

--- a/tests/unit/agents/test_rag_pipeline.py
+++ b/tests/unit/agents/test_rag_pipeline.py
@@ -402,6 +402,33 @@ async def test_hybrid_retrieve_applies_exact_query_rrf_weights(mock_cache, mock_
     assert first_call["sparse_weight"] == 0.8
 
 
+async def test_hybrid_retrieve_applies_exact_query_candidate_limits_to_colbert(
+    mock_cache, mock_sparse
+):
+    from telegram_bot.agents.rag_pipeline import _hybrid_retrieve
+
+    mock_qdrant = AsyncMock()
+    mock_qdrant.hybrid_search_rrf_colbert = AsyncMock(
+        return_value=(
+            [{"text": "корпус 5", "score": 0.9, "metadata": {}}],
+            {"backend_error": False, "error_type": None, "error_message": None},
+        )
+    )
+
+    await _hybrid_retrieve(
+        "квартира корпус 5",
+        [0.1] * 1024,
+        cache=mock_cache,
+        sparse_embeddings=mock_sparse,
+        qdrant=mock_qdrant,
+        colbert_query=[[0.2] * 1024] * 4,
+        latency_stages={},
+    )
+
+    first_call = mock_qdrant.hybrid_search_rrf_colbert.await_args_list[0].kwargs
+    assert first_call["dense_limit"] < first_call["sparse_limit"]
+
+
 async def test_hybrid_retrieve_prefers_faq_candidates_for_short_finance_query(
     mock_cache, mock_sparse
 ):

--- a/tests/unit/agents/test_rag_pipeline.py
+++ b/tests/unit/agents/test_rag_pipeline.py
@@ -402,9 +402,7 @@ async def test_hybrid_retrieve_applies_exact_query_rrf_weights(mock_cache, mock_
     assert first_call["sparse_weight"] == 0.8
 
 
-async def test_hybrid_retrieve_applies_exact_query_candidate_limits_to_colbert(
-    mock_cache, mock_sparse
-):
+async def test_hybrid_retrieve_applies_exact_query_rrf_weights_to_colbert(mock_cache, mock_sparse):
     from telegram_bot.agents.rag_pipeline import _hybrid_retrieve
 
     mock_qdrant = AsyncMock()
@@ -426,7 +424,8 @@ async def test_hybrid_retrieve_applies_exact_query_candidate_limits_to_colbert(
     )
 
     first_call = mock_qdrant.hybrid_search_rrf_colbert.await_args_list[0].kwargs
-    assert first_call["dense_limit"] < first_call["sparse_limit"]
+    assert first_call["dense_weight"] == 0.2
+    assert first_call["sparse_weight"] == 0.8
 
 
 async def test_hybrid_retrieve_prefers_faq_candidates_for_short_finance_query(

--- a/tests/unit/test_compose_langfuse_runtime_contract.py
+++ b/tests/unit/test_compose_langfuse_runtime_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -23,6 +24,9 @@ def _load_compose() -> dict:
 
 
 def _render_vps_ml_compose() -> dict:
+    if shutil.which("docker") is None:
+        pytest.skip("docker CLI is required to render VPS ML compose contract")
+
     env = {
         key: value
         for key, value in os.environ.items()

--- a/tests/unit/test_qdrant_service.py
+++ b/tests/unit/test_qdrant_service.py
@@ -921,6 +921,27 @@ class TestQdrantServiceHybridSearchColbert:
         inner_prefetch = call_kwargs["prefetch"][0].prefetch
         assert len(inner_prefetch) == 1  # dense only
 
+    async def test_colbert_search_weight_distribution(self, service, mock_point):
+        """ColBERT nested RRF prefetch limits should respect query weights."""
+        service._client.query_points = AsyncMock(return_value=MagicMock(points=[mock_point]))
+
+        await service.hybrid_search_rrf_colbert(
+            dense_vector=[0.1] * 1024,
+            sparse_vector={"indices": [1, 2], "values": [0.5, 0.5]},
+            colbert_query=[[0.1] * 1024] * 3,
+            top_k=5,
+            dense_weight=0.2,
+            sparse_weight=0.8,
+        )
+
+        inner_prefetch = service._client.query_points.call_args.kwargs["prefetch"][0].prefetch
+        dense_limit = inner_prefetch[0].limit
+        sparse_limit = inner_prefetch[1].limit
+
+        assert dense_limit >= 5
+        assert sparse_limit >= 5
+        assert sparse_limit > dense_limit
+
     async def test_colbert_search_graceful_degradation(self, service):
         """Fallback to hybrid_search_rrf on ColBERT query error."""
         service._client.query_points = AsyncMock(side_effect=Exception("Connection lost"))
@@ -1077,6 +1098,27 @@ class TestQdrantServiceHybridSearchColbert:
         assert result[0]["id"] == "fallback_1"
         service._client.query_points.assert_not_called()
         service.hybrid_search_rrf.assert_awaited_once()
+
+    async def test_colbert_disabled_fallback_forwards_rrf_weights(self, service):
+        """ColBERT fallback should preserve sparse-favored exact-query weights."""
+        service._colbert_available = False
+        service._client.query_points = AsyncMock()
+        service.hybrid_search_rrf = AsyncMock(
+            return_value=[{"id": "fallback_1", "score": 0.9, "text": "fallback", "metadata": {}}]
+        )
+
+        await service.hybrid_search_rrf_colbert(
+            dense_vector=[0.1] * 1024,
+            sparse_vector={"indices": [1, 2], "values": [0.5, 0.5]},
+            colbert_query=[[0.1] * 1024] * 3,
+            top_k=5,
+            dense_weight=0.2,
+            sparse_weight=0.8,
+        )
+
+        fallback_kwargs = service.hybrid_search_rrf.await_args.kwargs
+        assert fallback_kwargs["dense_weight"] == 0.2
+        assert fallback_kwargs["sparse_weight"] == 0.8
 
 
 class TestQdrantServiceClose:


### PR DESCRIPTION
## Summary
- Apply QueryPreprocessor RRF weights in the plain Qdrant RRF retrieval path
- Forward sparse-favored exact-query weights into QdrantService.hybrid_search_rrf prefetch weighting
- Add regression coverage for exact identifier queries like корпус 5

Fixes #1103

## SDK-first note
- Qdrant SDK does not expose weighted RRF fusion. This uses the existing QdrantService dense_weight/sparse_weight prefetch-weighting parameters instead of adding manual fusion.

## Verification
- uv run pytest tests/unit/agents/test_rag_pipeline.py -q -k 'exact_query_rrf_weights' (RED before fix, GREEN after fix)
- uv run pytest tests/unit/agents/test_rag_pipeline.py -q
- make check
- uv run ruff check telegram_bot/agents/rag_pipeline.py tests/unit/agents/test_rag_pipeline.py
- git diff --check

## Known environment gap
- PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit was attempted and reached 5610 passed / 17 skipped, then failed in two compose Langfuse runtime-contract tests because this environment has no docker binary: FileNotFoundError: 'docker'.