### PR TITLE
fix(api): return structured errors from RAG API generic handler

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import time
+import uuid
 from contextlib import asynccontextmanager
 from typing import Any, cast
 
@@ -93,7 +94,29 @@ app = FastAPI(title="RAG API", version="0.1.0", lifespan=lifespan)
 async def generic_error_handler(_request: Any, _exc: Exception) -> JSONResponse:
     """Return structured error response for unhandled exceptions."""
     logger.exception("Unhandled error in RAG API")
-    return JSONResponse(status_code=500, content={"error": "Internal server error"})
+
+    trace_id = None
+    try:
+        from telegram_bot.observability import get_client
+
+        lf = get_client()
+        if lf is not None:
+            trace_id = lf.get_current_trace_id()
+    except Exception:
+        pass
+
+    if not trace_id:
+        trace_id = uuid.uuid4().hex
+
+    return JSONResponse(
+        status_code=500,
+        content={
+            "error": "internal_error",
+            "message": "Internal server error",
+            "trace_id": trace_id,
+            "recoverable": False,
+        },
+    )
 
 
 @app.get("/health")

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -93,8 +93,6 @@ app = FastAPI(title="RAG API", version="0.1.0", lifespan=lifespan)
 @app.exception_handler(Exception)
 async def generic_error_handler(_request: Any, _exc: Exception) -> JSONResponse:
     """Return structured error response for unhandled exceptions."""
-    logger.exception("Unhandled error in RAG API")
-
     trace_id = None
     try:
         from telegram_bot.observability import get_client
@@ -103,10 +101,12 @@ async def generic_error_handler(_request: Any, _exc: Exception) -> JSONResponse:
         if lf is not None:
             trace_id = lf.get_current_trace_id()
     except Exception:
-        pass
+        logger.debug("Unable to resolve Langfuse trace id for RAG API error", exc_info=True)
 
     if not trace_id:
         trace_id = uuid.uuid4().hex
+
+    logger.exception("Unhandled error in RAG API", extra={"trace_id": trace_id})
 
     return JSONResponse(
         status_code=500,

--- a/tests/unit/api/test_rag_api_runtime.py
+++ b/tests/unit/api/test_rag_api_runtime.py
@@ -280,7 +280,11 @@ async def test_lifespan_unknown_rerank_provider_logs_and_closes_embeddings() -> 
 
 async def test_generic_error_handler_returns_structured_payload() -> None:
     """Unhandled exceptions must return a stable structured error with trace id."""
-    with patch("src.api.main.logger") as mock_logger:
+    with (
+        patch("telegram_bot.observability.get_client", return_value=None),
+        patch("src.api.main.uuid.uuid4", return_value=SimpleNamespace(hex="fallback-trace-id")),
+        patch("src.api.main.logger") as mock_logger,
+    ):
         response = await generic_error_handler(None, RuntimeError("boom"))
 
     assert response.status_code == 500
@@ -288,8 +292,10 @@ async def test_generic_error_handler_returns_structured_payload() -> None:
     assert content["error"] == "internal_error"
     assert content["message"] == "Internal server error"
     assert content["recoverable"] is False
-    assert isinstance(content["trace_id"], str) and content["trace_id"]
-    mock_logger.exception.assert_called_once()
+    assert content["trace_id"] == "fallback-trace-id"
+    mock_logger.exception.assert_called_once_with(
+        "Unhandled error in RAG API", extra={"trace_id": "fallback-trace-id"}
+    )
 
 
 async def test_generic_error_handler_uses_langfuse_trace_id_when_available() -> None:
@@ -299,8 +305,11 @@ async def test_generic_error_handler_uses_langfuse_trace_id_when_available() -> 
 
     with (
         patch("telegram_bot.observability.get_client", return_value=mock_lf),
-        patch("src.api.main.logger"),
+        patch("src.api.main.logger") as mock_logger,
     ):
         response = await generic_error_handler(None, ValueError("bad input"))
 
     assert response.content["trace_id"] == "trace-abc-123"
+    mock_logger.exception.assert_called_once_with(
+        "Unhandled error in RAG API", extra={"trace_id": "trace-abc-123"}
+    )

--- a/tests/unit/api/test_rag_api_runtime.py
+++ b/tests/unit/api/test_rag_api_runtime.py
@@ -47,7 +47,7 @@ if importlib.util.find_spec("fastapi") is None:
     sys.modules["fastapi.responses"] = fake_fastapi_responses
     _FASTAPI_SHIM_ACTIVE = True
 
-from src.api.main import app, lifespan, query
+from src.api.main import app, generic_error_handler, lifespan, query
 from src.api.schemas import QueryRequest
 
 
@@ -276,3 +276,31 @@ async def test_lifespan_unknown_rerank_provider_logs_and_closes_embeddings() -> 
     mock_warning.assert_called_once()
     closable_embeddings.aclose.assert_awaited_once()
     closable_sparse.aclose.assert_awaited_once()
+
+
+async def test_generic_error_handler_returns_structured_payload() -> None:
+    """Unhandled exceptions must return a stable structured error with trace id."""
+    with patch("src.api.main.logger") as mock_logger:
+        response = await generic_error_handler(None, RuntimeError("boom"))
+
+    assert response.status_code == 500
+    content = response.content
+    assert content["error"] == "internal_error"
+    assert content["message"] == "Internal server error"
+    assert content["recoverable"] is False
+    assert isinstance(content["trace_id"], str) and content["trace_id"]
+    mock_logger.exception.assert_called_once()
+
+
+async def test_generic_error_handler_uses_langfuse_trace_id_when_available() -> None:
+    """If a Langfuse trace is active, its trace id should be exposed to the client."""
+    mock_lf = MagicMock()
+    mock_lf.get_current_trace_id.return_value = "trace-abc-123"
+
+    with (
+        patch("telegram_bot.observability.get_client", return_value=mock_lf),
+        patch("src.api.main.logger"),
+    ):
+        response = await generic_error_handler(None, ValueError("bad input"))
+
+    assert response.content["trace_id"] == "trace-abc-123"


### PR DESCRIPTION
## Summary
- Structured 500 error responses from the generic exception handler in `src/api/main.py`
- Adds `error` code, `message`, `trace_id`, and `recoverable` fields
- Uses active Langfuse trace_id when available; falls back to a uuid4 hex correlation id
- Preserves server-side exception logging
- Adds focused unit tests verifying payload shape and trace_id fallback

Closes #1097