### PR TITLE
test(ingestion): cover unified ingestion state and flow paths

### DIFF
--- a/docs/superpowers/plans/2026-04-29-issue-1091-ingestion-unified-coverage.md
+++ b/docs/superpowers/plans/2026-04-29-issue-1091-ingestion-unified-coverage.md
@@ -1,0 +1,138 @@
+# Issue 1091 Unified Ingestion Coverage Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task. Use `superpowers:test-driven-development`, `superpowers:requesting-code-review`, and `superpowers:verification-before-completion` before commit.
+
+**Goal:** Add deterministic unit coverage for unified ingestion state transitions, flow wiring, and target connector state/write paths without changing ingestion identity or runtime semantics unless a test exposes a real defect.
+
+**Architecture:** This is a test-coverage issue. Keep production changes minimal and only when a new test reveals an existing correctness bug. Split work by test ownership so part workers can run in parallel without shared files.
+
+**Tech Stack:** pytest, unittest.mock, async mocks, CocoIndex-gated tests with `pytest.importorskip("cocoindex")`, existing `UnifiedStateManager`, `flow.py`, and `QdrantHybridTargetConnector`.
+
+---
+
+## Smart Routing
+
+Lane: `Full plan` because issue #1091 is `lane:plan-needed`, touches ingestion runtime contracts, and spans state manager, flow, and target connector coverage.
+
+Execution shape:
+- `W-1091-state`: state manager transition and concurrency tests only.
+- `W-1091-flow`: flow/manifest wiring tests only.
+- `W-1091-target`: target connector state/write path tests only.
+- `W-1091-final`: merge part branches, run focused checks, create PR against `dev`.
+
+Parallelization guard:
+- Workers must use separate git worktrees and branches.
+- Part workers must not create PRs.
+- Part workers own disjoint test files; no shared file edits.
+
+## Repository Constraints
+
+- Root `AGENTS.md` applies.
+- `src/ingestion/unified/AGENTS.override.md` applies to ingestion runtime contracts.
+- Preserve deterministic/resumable ingestion behavior.
+- Do not alter collection names, manifest identity, content hashing, or file identity semantics unless a failing regression proves a bug.
+- For test-only changes, run focused pytest first, then `make check`. Final worker/orchestrator decides whether broad `make test-unit` is needed based on CI and runtime-surface changes.
+
+## Worker Slices
+
+### Task 1: State Manager Transitions
+
+**Owner:** `W-1091-state`
+
+**Files:**
+- Create or modify only: `tests/unit/ingestion/test_state_manager_transitions.py`
+
+**Acceptance Criteria:**
+- Cover async transition SQL for `pending/new -> processing -> indexed`.
+- Cover `processing/error -> error` retry bookkeeping and truncation through existing async method behavior.
+- Cover concurrent async updates deterministically with mock pool calls, without a real database.
+- Cover `sync_context()` cleanup: pool is closed and manager pool/runner are reset after context exit.
+- Do not edit production code unless a test exposes a real defect.
+
+**Suggested Tests:**
+- `test_mark_processing_upserts_processing_for_new_file`
+- `test_processing_to_indexed_resets_error_and_retry_fields`
+- `test_mark_error_updates_retry_backoff_atomically`
+- `test_concurrent_mark_processing_updates_all_file_ids`
+- `test_sync_context_closes_pool_and_resets_runner`
+
+**Commands:**
+- `uv run pytest tests/unit/ingestion/test_state_manager_transitions.py -q`
+- `make check`
+
+### Task 2: Flow And Manifest Wiring
+
+**Owner:** `W-1091-flow`
+
+**Files:**
+- Create or modify only: `tests/unit/ingestion/test_unified_flow_wiring.py`
+
+**Acceptance Criteria:**
+- Cover manifest directory selection via `UnifiedConfig.effective_manifest_dir()` in `build_flow()`.
+- Cover `file_id_from_content()` passes content hash to manifest and remains rename-stable via manifest lookup.
+- Cover `build_flow()` closes an existing registered flow before opening a replacement.
+- Cover `run_once()` trace behavior for success and error paths.
+- Tests must be deterministic and skip cleanly if `cocoindex` extra is unavailable.
+
+**Suggested Tests:**
+- `test_build_flow_uses_effective_manifest_dir`
+- `test_file_id_from_content_passes_content_hash_to_manifest`
+- `test_build_flow_closes_registered_flow_before_reopen`
+- `test_run_once_records_error_status_when_update_fails`
+- If a close-on-error regression is found, add a focused test and minimal production fix.
+
+**Commands:**
+- `uv run pytest tests/unit/ingestion/test_unified_flow_wiring.py -q`
+- `make check`
+
+### Task 3: Target Connector State/Writer Paths
+
+**Owner:** `W-1091-target`
+
+**Files:**
+- Create or modify only: `tests/unit/ingestion/test_qdrant_hybrid_target_state_paths.py`
+
+**Acceptance Criteria:**
+- Cover delete mutation calls writer delete and marks state deleted.
+- Cover upsert skips parse/write when `should_process_sync()` returns `False`.
+- Cover empty parser chunks marks indexed with zero chunks.
+- Cover writer errors call `mark_error_sync()` and optionally DLQ when retry count reaches max.
+- Tests must patch writer/docling/content hash and avoid real Qdrant, Postgres, Docling, or embedding services.
+- Tests must skip cleanly if `cocoindex` extra is unavailable.
+
+**Suggested Tests:**
+- `test_handle_delete_deletes_points_and_marks_deleted`
+- `test_handle_upsert_skips_unchanged_file_before_parsing`
+- `test_handle_upsert_empty_chunks_marks_indexed_zero`
+- `test_handle_upsert_writer_error_marks_error`
+- `test_handle_upsert_moves_to_dlq_after_max_retries`
+
+**Commands:**
+- `uv run pytest tests/unit/ingestion/test_qdrant_hybrid_target_state_paths.py -q`
+- `make check`
+
+### Task 4: Final Integration
+
+**Owner:** `W-1091-final`
+
+**Files:**
+- Existing plan file.
+- Test files from part workers.
+- Minimal production files only if part workers exposed/fixed a real defect.
+
+**Steps:**
+- Merge `origin/fix/1091-state-tests`, `origin/fix/1091-flow-tests`, and `origin/fix/1091-target-tests` into `fix/1091-ingestion-coverage`.
+- Resolve conflicts conservatively. Do not rewrite worker tests unless needed for integration.
+- Run focused suite:
+  - `uv run pytest tests/unit/ingestion/test_state_manager_transitions.py tests/unit/ingestion/test_unified_flow_wiring.py tests/unit/ingestion/test_qdrant_hybrid_target_state_paths.py -q`
+- Run `make check`.
+- If production behavior changed under `src/ingestion/unified/**`, also run:
+  - `python -m src.ingestion.unified.cli preflight`
+  - `make ingest-unified-status`
+- Create PR against `dev` with `Closes #1091`.
+
+**Done Definition:**
+- Plan committed before implementation.
+- Each part branch has focused tests and `make check` evidence in DONE JSON.
+- Final PR targets `dev`, links `Closes #1091`, and includes verification evidence.
+- Orchestrator performs diff review and fresh verification before merge.

--- a/src/ingestion/unified/flow.py
+++ b/src/ingestion/unified/flow.py
@@ -196,11 +196,11 @@ def build_flow(config: UnifiedConfig | None = None) -> cocoindex.Flow:
 def run_once(config: UnifiedConfig | None = None) -> None:
     """Run ingestion once (single pass)."""
     try_update_ingestion_trace(command="flow-run-once", status="started")
+    flow: cocoindex.Flow | None = None
     try:
         flow = build_flow(config)
         flow.setup()
         flow.update(print_stats=True)
-        flow.close()
     except Exception as exc:
         try_update_ingestion_trace(
             command="flow-run-once",
@@ -208,6 +208,9 @@ def run_once(config: UnifiedConfig | None = None) -> None:
             metadata={"error_type": type(exc).__name__},
         )
         raise
+    finally:
+        if flow is not None:
+            flow.close()
     try_update_ingestion_trace(command="flow-run-once", status="completed")
 
 

--- a/tests/unit/ingestion/test_qdrant_hybrid_target_state_paths.py
+++ b/tests/unit/ingestion/test_qdrant_hybrid_target_state_paths.py
@@ -1,0 +1,186 @@
+"""State-path tests for QdrantHybridTargetConnector."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+pytestmark = [
+    pytest.mark.requires_extras,
+    pytest.mark.skipif(
+        importlib.util.find_spec("cocoindex") is None,
+        reason="cocoindex not installed (ingest extra)",
+    ),
+]
+
+
+def _mutation(tmp_path: Path):
+    from src.ingestion.unified.targets.qdrant_hybrid_target import QdrantHybridTargetValues
+
+    file_path = tmp_path / "doc.txt"
+    file_path.write_text("hello", encoding="utf-8")
+    return QdrantHybridTargetValues(
+        abs_path=str(file_path),
+        source_path="docs/doc.txt",
+        file_name="doc.txt",
+        mime_type="text/plain",
+        file_size=5,
+    )
+
+
+def test_handle_delete_deletes_points_and_marks_deleted() -> None:
+    from src.ingestion.unified.targets.qdrant_hybrid_target import (
+        QdrantHybridTargetConnector,
+        QdrantHybridTargetSpec,
+    )
+
+    writer = MagicMock()
+    state_manager = MagicMock()
+    spec = QdrantHybridTargetSpec(collection_name="target_collection")
+
+    with patch.object(QdrantHybridTargetConnector, "_get_writer", return_value=writer):
+        QdrantHybridTargetConnector._handle_delete_with_state(spec, "file-1", state_manager)
+
+    writer.delete_file_sync.assert_called_once_with("file-1", "target_collection")
+    state_manager.mark_deleted_sync.assert_called_once_with("file-1")
+
+
+def test_handle_upsert_skips_unchanged_file_before_parsing(tmp_path: Path) -> None:
+    from src.ingestion.unified.targets.qdrant_hybrid_target import (
+        QdrantHybridTargetConnector,
+        QdrantHybridTargetSpec,
+    )
+
+    writer = MagicMock()
+    docling = MagicMock()
+    state_manager = MagicMock()
+    state_manager.should_process_sync.return_value = False
+    mutation = _mutation(tmp_path)
+    spec = QdrantHybridTargetSpec(collection_name="target_collection")
+
+    with (
+        patch.object(QdrantHybridTargetConnector, "_get_writer", return_value=writer),
+        patch.object(QdrantHybridTargetConnector, "_get_docling", return_value=docling),
+        patch(
+            "src.ingestion.unified.targets.qdrant_hybrid_target.compute_content_hash",
+            return_value="hash-1",
+        ),
+    ):
+        QdrantHybridTargetConnector._handle_upsert_with_state(
+            spec, "file-1", mutation, state_manager
+        )
+
+    state_manager.should_process_sync.assert_called_once_with("file-1", "hash-1")
+    state_manager.upsert_state_sync.assert_not_called()
+    docling.chunk_file_sync.assert_not_called()
+    writer.upsert_chunks_sync.assert_not_called()
+
+
+def test_handle_upsert_empty_chunks_marks_indexed_zero(tmp_path: Path) -> None:
+    from src.ingestion.unified.targets.qdrant_hybrid_target import (
+        QdrantHybridTargetConnector,
+        QdrantHybridTargetSpec,
+    )
+
+    writer = MagicMock()
+    docling = MagicMock()
+    docling.chunk_file_sync.return_value = []
+    state_manager = MagicMock()
+    state_manager.should_process_sync.return_value = True
+    mutation = _mutation(tmp_path)
+    spec = QdrantHybridTargetSpec(collection_name="target_collection")
+
+    with (
+        patch.object(QdrantHybridTargetConnector, "_get_writer", return_value=writer),
+        patch.object(QdrantHybridTargetConnector, "_get_docling", return_value=docling),
+        patch(
+            "src.ingestion.unified.targets.qdrant_hybrid_target.compute_content_hash",
+            return_value="hash-1",
+        ),
+    ):
+        QdrantHybridTargetConnector._handle_upsert_with_state(
+            spec, "file-1", mutation, state_manager
+        )
+
+    state_manager.upsert_state_sync.assert_called_once()
+    state_manager.mark_indexed_sync.assert_called_once_with("file-1", 0, "hash-1")
+    writer.upsert_chunks_sync.assert_not_called()
+
+
+def test_handle_upsert_writer_error_marks_error(tmp_path: Path) -> None:
+    from src.ingestion.unified.qdrant_writer import WriteStats
+    from src.ingestion.unified.targets.qdrant_hybrid_target import (
+        QdrantHybridTargetConnector,
+        QdrantHybridTargetSpec,
+    )
+
+    writer = MagicMock()
+    writer.upsert_chunks_sync.return_value = WriteStats(errors=["qdrant failed"])
+    docling = MagicMock()
+    docling.chunk_file_sync.return_value = [object()]
+    docling.to_ingestion_chunks.return_value = [MagicMock()]
+    state_manager = MagicMock()
+    state_manager.should_process_sync.return_value = True
+    state_manager.get_state_sync.return_value = SimpleNamespace(retry_count=0)
+    mutation = _mutation(tmp_path)
+    spec = QdrantHybridTargetSpec(collection_name="target_collection")
+
+    with (
+        patch.object(QdrantHybridTargetConnector, "_get_writer", return_value=writer),
+        patch.object(QdrantHybridTargetConnector, "_get_docling", return_value=docling),
+        patch(
+            "src.ingestion.unified.targets.qdrant_hybrid_target.compute_content_hash",
+            return_value="hash-1",
+        ),
+    ):
+        QdrantHybridTargetConnector._handle_upsert_with_state(
+            spec, "file-1", mutation, state_manager
+        )
+
+    state_manager.mark_error_sync.assert_called_once()
+    state_manager.add_to_dlq_sync.assert_not_called()
+
+
+def test_handle_upsert_moves_to_dlq_after_max_retries(tmp_path: Path) -> None:
+    from src.ingestion.unified.qdrant_writer import WriteStats
+    from src.ingestion.unified.targets.qdrant_hybrid_target import (
+        QdrantHybridTargetConnector,
+        QdrantHybridTargetSpec,
+    )
+
+    writer = MagicMock()
+    writer.upsert_chunks_sync.return_value = WriteStats(errors=["qdrant failed"])
+    docling = MagicMock()
+    docling.chunk_file_sync.return_value = [object()]
+    docling.to_ingestion_chunks.return_value = [MagicMock()]
+    state_manager = MagicMock()
+    state_manager.should_process_sync.return_value = True
+    state_manager.get_state_sync.return_value = SimpleNamespace(retry_count=3)
+    mutation = _mutation(tmp_path)
+    spec = QdrantHybridTargetSpec(collection_name="target_collection", max_retries=3)
+
+    with (
+        patch.object(QdrantHybridTargetConnector, "_get_writer", return_value=writer),
+        patch.object(QdrantHybridTargetConnector, "_get_docling", return_value=docling),
+        patch(
+            "src.ingestion.unified.targets.qdrant_hybrid_target.compute_content_hash",
+            return_value="hash-1",
+        ),
+    ):
+        QdrantHybridTargetConnector._handle_upsert_with_state(
+            spec, "file-1", mutation, state_manager
+        )
+
+    state_manager.mark_error_sync.assert_called_once()
+    state_manager.add_to_dlq_sync.assert_called_once()
+    assert state_manager.add_to_dlq_sync.call_args.kwargs == {
+        "file_id": "file-1",
+        "error_type": "Exception",
+        "error_message": "qdrant failed",
+        "payload": {"source_path": "docs/doc.txt"},
+    }

--- a/tests/unit/ingestion/test_state_manager_transitions.py
+++ b/tests/unit/ingestion/test_state_manager_transitions.py
@@ -1,0 +1,103 @@
+"""Transition-focused tests for UnifiedStateManager.
+
+These tests cover state transition SQL and sync cleanup behavior without a
+real Postgres connection.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.ingestion.unified.state_manager import UnifiedStateManager
+
+
+@pytest.fixture
+def mock_pool() -> AsyncMock:
+    pool = AsyncMock()
+    pool.execute = AsyncMock()
+    pool.fetch = AsyncMock(return_value=[])
+    pool.fetchrow = AsyncMock(return_value=None)
+    pool.close = AsyncMock()
+    return pool
+
+
+@pytest.fixture
+def manager(mock_pool: AsyncMock) -> UnifiedStateManager:
+    return UnifiedStateManager(pool=mock_pool)
+
+
+async def test_mark_processing_upserts_processing_for_new_file(
+    manager: UnifiedStateManager,
+    mock_pool: AsyncMock,
+) -> None:
+    await manager.mark_processing("file-a")
+
+    mock_pool.execute.assert_awaited_once()
+    sql, file_id = mock_pool.execute.await_args.args
+    assert "INSERT INTO ingestion_state" in sql
+    assert "processing" in sql
+    assert "ON CONFLICT" in sql
+    assert file_id == "file-a"
+
+
+async def test_mark_indexed_resets_error_retry_fields(
+    manager: UnifiedStateManager,
+    mock_pool: AsyncMock,
+) -> None:
+    await manager.mark_indexed("file-a", chunk_count=12, content_hash="hash-a")
+
+    mock_pool.execute.assert_awaited_once()
+    args = mock_pool.execute.await_args.args
+    sql = args[0]
+    assert "status = 'indexed'" in sql
+    assert "error_message = NULL" in sql
+    assert "retry_count = 0" in sql
+    assert "retry_after = NULL" in sql
+    assert args[1:] == ("file-a", 12, "hash-a")
+
+
+async def test_mark_error_updates_retry_backoff_atomically(
+    manager: UnifiedStateManager,
+    mock_pool: AsyncMock,
+) -> None:
+    await manager.mark_error("file-a", "x" * 1500)
+
+    mock_pool.execute.assert_awaited_once()
+    args = mock_pool.execute.await_args.args
+    sql = args[0]
+    assert "status = 'error'" in sql
+    assert "retry_count = retry_count + 1" in sql
+    assert "retry_after = NOW()" in sql
+    assert "POWER" in sql
+    assert args[1] == "file-a"
+    assert len(args[2]) == 1000
+
+
+async def test_concurrent_mark_processing_records_all_file_ids(
+    manager: UnifiedStateManager,
+    mock_pool: AsyncMock,
+) -> None:
+    file_ids = [f"file-{i}" for i in range(5)]
+
+    await asyncio.gather(*(manager.mark_processing(file_id) for file_id in file_ids))
+
+    seen_file_ids = [call.args[1] for call in mock_pool.execute.await_args_list]
+    assert sorted(seen_file_ids) == file_ids
+
+
+def test_sync_context_closes_pool_and_resets_runner(mock_pool: AsyncMock) -> None:
+    create_pool = AsyncMock(return_value=mock_pool)
+
+    with patch("asyncpg.create_pool", new=create_pool):
+        manager = UnifiedStateManager(database_url="postgresql://localhost/test")
+        with manager.sync_context():
+            assert manager.should_process_sync("file-a", "hash-a") is True
+            assert manager._runner is not None
+            assert manager._pool is mock_pool
+
+        assert manager._runner is None
+        assert manager._pool is None
+        mock_pool.close.assert_awaited_once()

--- a/tests/unit/ingestion/test_unified_flow_wiring.py
+++ b/tests/unit/ingestion/test_unified_flow_wiring.py
@@ -1,0 +1,125 @@
+"""Focused wiring tests for unified ingestion flow."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+pytestmark = [
+    pytest.mark.requires_extras,
+    pytest.mark.skipif(
+        importlib.util.find_spec("cocoindex") is None,
+        reason="cocoindex not installed (ingest extra)",
+    ),
+]
+
+
+def test_build_flow_uses_effective_manifest_dir(tmp_path: Path) -> None:
+    from src.ingestion.unified.config import UnifiedConfig
+    from src.ingestion.unified.flow import build_flow
+
+    sync_dir = tmp_path / "sync"
+    manifest_dir = tmp_path / "manifest"
+    config = UnifiedConfig(sync_dir=sync_dir, manifest_dir=manifest_dir)
+
+    with (
+        patch("cocoindex.init"),
+        patch("src.ingestion.unified.flow.flow_names", return_value=[]),
+        patch("cocoindex.open_flow", return_value=MagicMock()),
+        patch("src.ingestion.unified.flow.GDriveManifest") as manifest_cls,
+    ):
+        build_flow(config)
+
+    manifest_cls.assert_called_once_with(manifest_dir)
+    assert manifest_dir.exists()
+
+
+def test_file_id_from_content_passes_content_hash_to_manifest() -> None:
+    import src.ingestion.unified.flow as flow_module
+    from src.ingestion.unified.manifest import compute_content_hash_from_bytes
+
+    original = flow_module._manifest
+    manifest = MagicMock()
+    manifest.get_or_create_id.return_value = "stable-id"
+
+    try:
+        flow_module._manifest = manifest
+        result = flow_module.file_id_from_content("docs/a.pdf", b"payload")
+    finally:
+        flow_module._manifest = original
+
+    assert result == "stable-id"
+    manifest.get_or_create_id.assert_called_once_with(
+        "docs/a.pdf",
+        compute_content_hash_from_bytes(b"payload"),
+    )
+
+
+def test_build_flow_closes_existing_registered_flow(tmp_path: Path) -> None:
+    from src.ingestion.unified.config import UnifiedConfig
+    from src.ingestion.unified.flow import _flow_name_for, build_flow
+
+    config = UnifiedConfig(sync_dir=tmp_path, collection_name="existing_collection")
+    flow_name = _flow_name_for(config)
+    existing_flow = MagicMock()
+
+    with (
+        patch("cocoindex.init"),
+        patch("src.ingestion.unified.flow.flow_names", return_value=[flow_name]),
+        patch("src.ingestion.unified.flow.flow_by_name", return_value=existing_flow) as by_name,
+        patch("cocoindex.open_flow", return_value=MagicMock()),
+        patch("src.ingestion.unified.flow.GDriveManifest"),
+    ):
+        build_flow(config)
+
+    by_name.assert_called_once_with(flow_name)
+    existing_flow.close.assert_called_once()
+
+
+def test_run_once_records_error_status_and_closes_flow() -> None:
+    from src.ingestion.unified.flow import run_once
+
+    flow = MagicMock()
+    flow.update.side_effect = RuntimeError("boom")
+
+    with (
+        patch("src.ingestion.unified.flow.build_flow", return_value=flow),
+        patch("src.ingestion.unified.flow.try_update_ingestion_trace") as update_trace,
+    ):
+        with pytest.raises(RuntimeError, match="boom"):
+            run_once()
+
+    flow.setup.assert_called_once()
+    flow.update.assert_called_once_with(print_stats=True)
+    flow.close.assert_called_once()
+    assert update_trace.call_args_list[0].kwargs == {
+        "command": "flow-run-once",
+        "status": "started",
+    }
+    assert update_trace.call_args_list[1].kwargs == {
+        "command": "flow-run-once",
+        "status": "error",
+        "metadata": {"error_type": "RuntimeError"},
+    }
+
+
+def test_run_once_records_completed_status_after_success() -> None:
+    from src.ingestion.unified.flow import run_once
+
+    flow = MagicMock()
+
+    with (
+        patch("src.ingestion.unified.flow.build_flow", return_value=flow),
+        patch("src.ingestion.unified.flow.try_update_ingestion_trace") as update_trace,
+    ):
+        run_once()
+
+    flow.close.assert_called_once()
+    assert update_trace.call_args_list[-1].kwargs == {
+        "command": "flow-run-once",
+        "status": "completed",
+    }


### PR DESCRIPTION
## Summary
- add focused state-manager transition coverage for unified ingestion state updates and sync cleanup
- add flow wiring coverage for manifest directory selection, file id hashing, existing flow replacement, and run_once tracing
- add hybrid target state-path coverage for delete, unchanged skip, empty chunks, writer errors, and DLQ handling
- fix `run_once()` to close an opened flow when setup/update raises

Closes #1091

## Verification
- `uv run pytest tests/unit/ingestion/test_state_manager_transitions.py tests/unit/ingestion/test_unified_flow_wiring.py tests/unit/ingestion/test_qdrant_hybrid_target_state_paths.py -q` -> 5 passed, 10 skipped locally because `cocoindex` extra is not installed
- `make check` -> Ruff OK, MyPy OK
- `make ingest-unified-status` -> OK, reports indexed=12, DLQ=0; sync dir missing as existing local env condition
- `uv run python -m src.ingestion.unified.cli preflight` -> NOT READY due missing `/home/user/drive-sync`; Qdrant, BGE-M3 dense/sparse, and Docling checks passed
