### PR TITLE
test(kommo): add deterministic error, token, lead operation and score sync coverage (#1090)

### DIFF
--- a/docs/superpowers/plans/2026-04-30-issue-1090-kommo-coverage.md
+++ b/docs/superpowers/plans/2026-04-30-issue-1090-kommo-coverage.md
@@ -1,0 +1,103 @@
+# Issue 1090 Kommo Coverage Plan
+
+> **For agentic workers:** Use `superpowers:executing-plans`, `superpowers:test-driven-development`, `superpowers:requesting-code-review`, and `superpowers:verification-before-completion`.
+
+**Goal:** Add deterministic Kommo CRM error, token, lead operation, and lead-score sync coverage without real Kommo/Redis/network calls.
+
+**Architecture:** Coverage-only work split into disjoint test files. Keep production code unchanged unless a focused test exposes a real defect.
+
+**Tech Stack:** pytest, pytest-httpx/httpx mocks, AsyncMock, tenacity wait patching already used in Kommo tests.
+
+---
+
+## Routing
+
+Lane: `Full plan` because #1090 is `lane:plan-needed`, business-critical CRM behavior, and spans request errors, OAuth token lifecycle, and lead operations.
+
+Workers:
+- `W-1090-errors`: request/HTTP error and retry behavior.
+- `W-1090-tokens`: OAuth token edge cases.
+- `W-1090-leads`: lead operations and lead-score sync edge cases.
+- `W-1090-final`: integrate branches, verify, create PR.
+
+## Constraints
+
+- Root `AGENTS.md` and `telegram_bot/AGENTS.override.md` apply.
+- Preserve service boundaries: tests target `telegram_bot/services/**`.
+- Do not add dependencies.
+- Use existing Kommo client/token store patterns.
+- Coverage-only TDD: characterization tests for existing behavior; red phase is optional unless a real defect is found.
+- Part workers must not create PRs.
+
+## Worker Slices
+
+### Task 1: Request Error/Retry Coverage
+
+**Owner:** `W-1090-errors`
+
+**Files:**
+- Create: `tests/unit/services/test_kommo_client_error_paths.py`
+
+**Acceptance Criteria:**
+- 400 Bad Request raises `httpx.HTTPStatusError` and does not force-refresh.
+- 429 Rate Limit retries through `_request` tenacity policy with wait disabled.
+- 500/503 retries through `_request` tenacity policy with wait disabled.
+- Network timeout/transport error retries and then succeeds.
+- 401 refresh failure from no refresh token re-raises original 401 HTTPStatusError.
+
+**Commands:**
+- `uv run pytest tests/unit/services/test_kommo_client_error_paths.py -q`
+- `make check`
+
+### Task 2: OAuth Token Edge Coverage
+
+**Owner:** `W-1090-tokens`
+
+**Files:**
+- Create: `tests/unit/services/test_kommo_tokens_edge_cases.py`
+
+**Acceptance Criteria:**
+- `force_refresh()` raises `RuntimeError` when no refresh token is stored.
+- `_exchange_auth_code()` rejects malformed token payloads without saving.
+- `_refresh_tokens()` rejects malformed refresh payloads without saving.
+- `_token_request()` rejects non-dict JSON response.
+- `_load_tokens()` decodes mixed bytes/str Redis hash values.
+
+**Commands:**
+- `uv run pytest tests/unit/services/test_kommo_tokens_edge_cases.py -q`
+- `make check`
+
+### Task 3: Lead Operations And Score Sync Coverage
+
+**Owner:** `W-1090-leads`
+
+**Files:**
+- Create: `tests/unit/services/test_kommo_client_lead_operations_edges.py`
+- Create: `tests/unit/services/test_lead_score_sync_edges.py`
+
+**Acceptance Criteria:**
+- `create_lead()` sends alias-aware payload list and parses embedded lead.
+- `update_lead()` sends PATCH payload with excluded `None` fields.
+- `search_leads()` preserves embedded contacts without mutating caller-owned payload unexpectedly.
+- `update_lead_score()` propagates idempotency header.
+- `sync_pending_lead_scores()` continues after one failed score and syncs later records.
+
+**Commands:**
+- `uv run pytest tests/unit/services/test_kommo_client_lead_operations_edges.py tests/unit/services/test_lead_score_sync_edges.py -q`
+- `make check`
+
+### Task 4: Final Integration
+
+**Owner:** `W-1090-final`
+
+**Steps:**
+- Merge `origin/fix/1090-errors-tests`, `origin/fix/1090-token-tests`, and `origin/fix/1090-lead-tests`.
+- Run focused tests from all new files.
+- Run `make check`.
+- Create PR against `dev` with `Closes #1090`.
+
+**Done Definition:**
+- Plan exists before implementation.
+- Part branches have focused verification evidence.
+- PR targets `dev`, links #1090, and includes verification.
+- Orchestrator reviews diff and checks CI before merge.

--- a/tests/unit/services/test_kommo_client_error_paths.py
+++ b/tests/unit/services/test_kommo_client_error_paths.py
@@ -1,0 +1,103 @@
+"""Tests for KommoClient error and retry paths (#1090)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from tenacity import wait_none
+
+
+_DUMMY_REQ = httpx.Request("GET", "https://test-co.kommo.com/api/v4/leads/1")
+
+
+@pytest.fixture
+def mock_token_store():
+    store = AsyncMock()
+    store.get_valid_token = AsyncMock(return_value="test-token")
+    store.force_refresh = AsyncMock(return_value="refreshed-token")
+    return store
+
+
+@pytest.fixture
+def kommo_client(mock_token_store):
+    from telegram_bot.services.kommo_client import KommoClient
+
+    return KommoClient(subdomain="test-co", token_store=mock_token_store)
+
+
+async def test_400_bad_request_raises_http_error_without_force_refresh(
+    kommo_client, mock_token_store, httpx_mock
+):
+    """400 Bad Request raises HTTPStatusError and does not call force_refresh."""
+    httpx_mock.add_response(
+        url="https://test-co.kommo.com/api/v4/leads/1",
+        status_code=400,
+    )
+
+    with pytest.raises(httpx.HTTPStatusError, match="400"):
+        await kommo_client.get_lead(1)
+
+    mock_token_store.force_refresh.assert_not_called()
+
+
+async def test_429_retries_and_succeeds(kommo_client):
+    """429 retries and then succeeds."""
+    resp_429 = httpx.Response(429, headers={"Retry-After": "1"}, request=_DUMMY_REQ)
+    resp_200 = httpx.Response(200, json={"id": 1, "name": "Lead"}, request=_DUMMY_REQ)
+    with (
+        patch.object(kommo_client._request.retry, "wait", wait_none()),
+        patch.object(kommo_client._client, "request", side_effect=[resp_429, resp_200]),
+    ):
+        lead = await kommo_client.get_lead(1)
+        assert lead.id == 1
+
+
+async def test_503_retries_and_succeeds(kommo_client):
+    """503 retries and then succeeds."""
+    resp_503 = httpx.Response(503, request=_DUMMY_REQ)
+    resp_200 = httpx.Response(200, json={"id": 1, "name": "Lead"}, request=_DUMMY_REQ)
+    with (
+        patch.object(kommo_client._request.retry, "wait", wait_none()),
+        patch.object(kommo_client._client, "request", side_effect=[resp_503, resp_200]),
+    ):
+        lead = await kommo_client.get_lead(1)
+        assert lead.id == 1
+
+
+async def test_read_timeout_retries_and_succeeds(kommo_client):
+    """httpx.ReadTimeout retries and then succeeds."""
+    resp_200 = httpx.Response(200, json={"id": 1, "name": "Lead"}, request=_DUMMY_REQ)
+    with (
+        patch.object(kommo_client._request.retry, "wait", wait_none()),
+        patch.object(
+            kommo_client._client,
+            "request",
+            side_effect=[httpx.ReadTimeout("timed out"), httpx.ReadTimeout("timed out"), resp_200],
+        ),
+    ):
+        lead = await kommo_client.get_lead(1)
+        assert lead.id == 1
+
+
+async def test_401_with_force_refresh_runtime_error_raises_original_401(
+    mock_token_store, httpx_mock
+):
+    """401 with force_refresh raising RuntimeError raises the original 401 HTTPStatusError."""
+    from telegram_bot.services.kommo_client import KommoClient
+
+    mock_token_store.force_refresh = AsyncMock(
+        side_effect=RuntimeError("No refresh_token available for Kommo.")
+    )
+    client = KommoClient(subdomain="test-co", token_store=mock_token_store)
+
+    httpx_mock.add_response(
+        url="https://test-co.kommo.com/api/v4/leads/1",
+        status_code=401,
+    )
+
+    with pytest.raises(httpx.HTTPStatusError, match="401"):
+        await client.get_lead(1)
+
+    mock_token_store.force_refresh.assert_called_once()

--- a/tests/unit/services/test_kommo_client_lead_operations_edges.py
+++ b/tests/unit/services/test_kommo_client_lead_operations_edges.py
@@ -1,0 +1,115 @@
+"""Edge-case tests for KommoClient lead operations (#1090)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from telegram_bot.services.kommo_client import KommoClient
+from telegram_bot.services.kommo_models import LeadCreate, LeadUpdate
+
+
+@pytest.fixture
+def mock_token_store():
+    """Mock KommoTokenStore."""
+    store = AsyncMock()
+    store.get_valid_token = AsyncMock(return_value="test-token")
+    store.force_refresh = AsyncMock(return_value="refreshed-token")
+    return store
+
+
+@pytest.fixture
+def kommo_client(mock_token_store):
+    """KommoClient with mocked token store."""
+    return KommoClient(subdomain="test-co", token_store=mock_token_store)
+
+
+async def test_create_lead_sends_alias_aware_single_item_list(kommo_client, httpx_mock):
+    """create_lead sends alias-aware single-item list payload and parses embedded lead."""
+    httpx_mock.add_response(
+        url="https://test-co.kommo.com/api/v4/leads",
+        method="POST",
+        json={"_embedded": {"leads": [{"id": 77, "name": "Alias Lead", "price": 150000}]}},
+    )
+
+    lead = await kommo_client.create_lead(LeadCreate(name="Alias Lead", budget=150000))
+
+    request = httpx_mock.get_request(url="https://test-co.kommo.com/api/v4/leads", method="POST")
+    sent = request.content.decode()
+    assert sent == '[{"name":"Alias Lead","price":150000}]'
+    assert lead.id == 77
+    assert lead.budget == 150000
+
+
+async def test_update_lead_excludes_none_fields(kommo_client, httpx_mock):
+    """update_lead sends PATCH payload excluding None fields."""
+    httpx_mock.add_response(
+        url="https://test-co.kommo.com/api/v4/leads/99",
+        method="PATCH",
+        json={"id": 99, "name": "Updated Lead", "price": 75000},
+    )
+
+    lead = await kommo_client.update_lead(99, LeadUpdate(name=None, budget=75000))
+
+    request = httpx_mock.get_request(
+        url="https://test-co.kommo.com/api/v4/leads/99", method="PATCH"
+    )
+    sent = request.content.decode()
+    assert sent == '{"price":75000}'
+    assert lead.id == 99
+    assert lead.budget == 75000
+
+
+async def test_search_leads_with_contacts_parses_embedded_and_does_not_mutate_original_response(
+    kommo_client, httpx_mock
+):
+    """search_leads(with_contacts=True) parses embedded contacts and does not mutate the original response dict object supplied to the mock."""
+    import re
+
+    original_response = {
+        "_embedded": {
+            "leads": [
+                {
+                    "id": 30,
+                    "name": "Deal With Contacts",
+                    "_embedded": {"contacts": [{"id": 8, "name": "Alice"}]},
+                }
+            ]
+        }
+    }
+
+    httpx_mock.add_response(
+        url=re.compile(r".*\/leads"),
+        json=original_response,
+    )
+
+    leads = await kommo_client.search_leads(with_contacts=True)
+
+    assert len(leads) == 1
+    assert leads[0].contacts is not None
+    assert leads[0].contacts[0]["name"] == "Alice"
+    # Original dict must be unchanged
+    assert original_response["_embedded"]["leads"][0]["_embedded"] == {
+        "contacts": [{"id": 8, "name": "Alice"}]
+    }
+
+
+async def test_update_lead_score_propagates_idempotency_key(kommo_client, httpx_mock):
+    """update_lead_score propagates X-Idempotency-Key header."""
+    httpx_mock.add_response(
+        url="https://test-co.kommo.com/api/v4/leads/555",
+        method="PATCH",
+        json={"id": 555},
+    )
+
+    await kommo_client.update_lead_score(
+        lead_id=555,
+        payload={"custom_fields_values": []},
+        idempotency_key="key-123",
+    )
+
+    request = httpx_mock.get_request(
+        url="https://test-co.kommo.com/api/v4/leads/555", method="PATCH"
+    )
+    assert request.headers["X-Idempotency-Key"] == "key-123"

--- a/tests/unit/services/test_kommo_tokens_edge_cases.py
+++ b/tests/unit/services/test_kommo_tokens_edge_cases.py
@@ -1,0 +1,147 @@
+"""Edge-case tests for Kommo OAuth2 token store (Redis-backed)."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_redis():
+    """Create a mock async Redis client."""
+    redis = AsyncMock()
+    redis.hgetall = AsyncMock(return_value={})
+    redis.hset = AsyncMock()
+    redis.close = AsyncMock()
+    return redis
+
+
+@pytest.fixture
+def token_store(mock_redis):
+    from telegram_bot.services.kommo_tokens import KommoTokenStore
+
+    return KommoTokenStore(
+        redis=mock_redis,
+        client_id="test_client_id",
+        client_secret="test_secret",
+        subdomain="testcompany",
+        redirect_uri="https://example.com/callback",
+    )
+
+
+class TestKommoTokenStoreEdgeCases:
+    async def test_force_refresh_raises_when_no_refresh_token(self, token_store, mock_redis):
+        """force_refresh() raises RuntimeError when Redis has no refresh token."""
+        mock_redis.hgetall.return_value = {
+            b"access_token": b"only_access",
+        }
+        with pytest.raises(RuntimeError, match="No refresh_token available for Kommo"):
+            await token_store.force_refresh()
+
+    async def test_force_refresh_raises_when_redis_empty(self, token_store, mock_redis):
+        """force_refresh() raises RuntimeError when Redis is empty."""
+        mock_redis.hgetall.return_value = {}
+        with pytest.raises(RuntimeError, match="No refresh_token available for Kommo"):
+            await token_store.force_refresh()
+
+    async def test_exchange_auth_code_rejects_missing_access_token(self, token_store):
+        """_exchange_auth_code() rejects missing access_token and does not save."""
+        with (
+            patch.object(token_store, "_token_request", new_callable=AsyncMock) as mock_request,
+            patch.object(token_store, "_save_tokens", new_callable=AsyncMock) as mock_save,
+        ):
+            mock_request.return_value = {
+                "refresh_token": "rt",
+                "expires_in": 3600,
+            }
+            with pytest.raises(RuntimeError, match="Invalid OAuth2 token response from Kommo"):
+                await token_store._exchange_auth_code("auth_code_123")
+            mock_save.assert_not_called()
+
+    async def test_exchange_auth_code_rejects_missing_refresh_token(self, token_store):
+        """_exchange_auth_code() rejects missing refresh_token and does not save."""
+        with (
+            patch.object(token_store, "_token_request", new_callable=AsyncMock) as mock_request,
+            patch.object(token_store, "_save_tokens", new_callable=AsyncMock) as mock_save,
+        ):
+            mock_request.return_value = {
+                "access_token": "at",
+                "expires_in": 3600,
+            }
+            with pytest.raises(RuntimeError, match="Invalid OAuth2 token response from Kommo"):
+                await token_store._exchange_auth_code("auth_code_123")
+            mock_save.assert_not_called()
+
+    async def test_exchange_auth_code_rejects_missing_expires_in(self, token_store):
+        """_exchange_auth_code() rejects missing/invalid expires_in and does not save."""
+        with (
+            patch.object(token_store, "_token_request", new_callable=AsyncMock) as mock_request,
+            patch.object(token_store, "_save_tokens", new_callable=AsyncMock) as mock_save,
+        ):
+            mock_request.return_value = {
+                "access_token": "at",
+                "refresh_token": "rt",
+                "expires_in": 0,
+            }
+            with pytest.raises(RuntimeError, match="Invalid OAuth2 token response from Kommo"):
+                await token_store._exchange_auth_code("auth_code_123")
+            mock_save.assert_not_called()
+
+    async def test_refresh_tokens_rejects_malformed_response(self, token_store):
+        """_refresh_tokens() rejects malformed refresh response and does not save."""
+        with (
+            patch.object(token_store, "_token_request", new_callable=AsyncMock) as mock_request,
+            patch.object(token_store, "_save_tokens", new_callable=AsyncMock) as mock_save,
+        ):
+            mock_request.return_value = {
+                "access_token": "",
+                "refresh_token": "",
+                "expires_in": 0,
+            }
+            with pytest.raises(RuntimeError, match="Invalid OAuth2 refresh response from Kommo"):
+                await token_store._refresh_tokens("old_refresh")
+            mock_save.assert_not_called()
+
+    async def test_token_request_rejects_non_dict_json(self, token_store):
+        """_token_request() rejects non-dict JSON response."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = ["not", "a", "dict"]
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "telegram_bot.services.kommo_tokens.httpx.AsyncClient", return_value=mock_client
+        ):
+            with pytest.raises(RuntimeError, match="Unexpected Kommo OAuth2 response shape"):
+                await token_store._token_request({"grant_type": "authorization_code"})
+
+    async def test_load_tokens_decodes_mixed_bytes_and_str(self, token_store, mock_redis):
+        """_load_tokens() decodes mixed bytes/str Redis hash values."""
+        future_ts = str(int(time.time()) + 3600)
+        mock_redis.hgetall.return_value = {
+            b"access_token": "str_value",
+            "refresh_token": b"bytes_value",
+            "expires_at": future_ts,
+        }
+        result = await token_store._load_tokens()
+        assert result is not None
+        assert result["access_token"] == "str_value"
+        assert result["refresh_token"] == "bytes_value"
+        assert result["expires_at"] == future_ts
+
+    async def test_load_tokens_decodes_bytes_keys_and_values(self, token_store, mock_redis):
+        """_load_tokens() handles all-bytes Redis hash."""
+        mock_redis.hgetall.return_value = {
+            b"access_token": b"at",
+            b"refresh_token": b"rt",
+        }
+        result = await token_store._load_tokens()
+        assert result is not None
+        assert result["access_token"] == "at"
+        assert result["refresh_token"] == "rt"

--- a/tests/unit/services/test_lead_score_sync_edges.py
+++ b/tests/unit/services/test_lead_score_sync_edges.py
@@ -1,0 +1,54 @@
+"""Edge-case tests for lead_score_sync (#1090)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from telegram_bot.services.lead_score_sync import sync_pending_lead_scores
+
+
+@pytest.mark.asyncio
+async def test_sync_pending_lead_scores_continues_after_failed_record() -> None:
+    """sync_pending_lead_scores continues after one failed record and syncs a later record."""
+    scoring_store = AsyncMock()
+    kommo_client = AsyncMock()
+    scoring_store.list_pending_sync.return_value = [
+        SimpleNamespace(
+            lead_id=1,
+            session_id="s1",
+            score_value=10,
+            score_band="cold",
+            kommo_lead_id=9001,
+        ),
+        SimpleNamespace(
+            lead_id=2,
+            session_id="s2",
+            score_value=95,
+            score_band="hot",
+            kommo_lead_id=9002,
+        ),
+    ]
+    # First call fails, second succeeds
+    kommo_client.update_lead_score.side_effect = [
+        RuntimeError("kommo down"),
+        None,
+    ]
+
+    result = await sync_pending_lead_scores(
+        scoring_store=scoring_store,
+        kommo_client=kommo_client,
+        score_field_id=1001,
+        band_field_id=1002,
+    )
+
+    assert result == {"synced": 1, "failed": 1, "skipped": 0}
+    assert kommo_client.update_lead_score.await_count == 2
+    # Verify second record was synced
+    second_call = kommo_client.update_lead_score.await_args_list[1].kwargs
+    assert second_call["lead_id"] == 9002
+    assert second_call["idempotency_key"] == "lead-score:2:s2:95:hot"
+    scoring_store.mark_synced.assert_awaited_once_with(lead_id=2)
+    scoring_store.mark_failed.assert_awaited_once_with(lead_id=1, error="kommo_error")


### PR DESCRIPTION
## Summary
Integrates the already-completed Kommo coverage part branches into a single clean PR against `dev`.

- Adds plan: `docs/superpowers/plans/2026-04-30-issue-1090-kommo-coverage.md`
- Adds error/retry path tests: `tests/unit/services/test_kommo_client_error_paths.py`
- Adds token edge-case tests: `tests/unit/services/test_kommo_tokens_edge_cases.py`
- Adds lead operation edge tests: `tests/unit/services/test_kommo_client_lead_operations_edges.py`
- Adds lead-score sync edge tests: `tests/unit/services/test_lead_score_sync_edges.py`

## Test Plan
- Focused Kommo tests: `19 passed`
- `make check`: passed (ruff + mypy clean)
- `make test-unit`: attempted; 26 failures and 15 errors observed, all in pre-existing voyage/ingestion baseline unrelated to Kommo (#1090 changes only add tests, no production code changes)

Closes #1090