### PR TITLE
refactor(handoff): replace manual JSON serialization with native Pydantic v2

### DIFF
--- a/telegram_bot/services/handoff_state.py
+++ b/telegram_bot/services/handoff_state.py
@@ -54,19 +54,7 @@ class HandoffData(BaseModel):
 
     def to_redis_dict(self) -> dict[str, str]:
         payload = self.model_dump(mode="json")
-        return {
-            "client_id": str(payload["client_id"]),
-            "topic_id": str(payload["topic_id"]),
-            "mode": str(payload["mode"]),
-            "lead_id": str(payload["lead_id"]) if payload["lead_id"] is not None else "",
-            "created_at": str(payload["created_at"]),
-            "manager_joined_at": (
-                str(payload["manager_joined_at"])
-                if payload["manager_joined_at"] is not None
-                else ""
-            ),
-            "qualification": str(payload["qualification"]),
-        }
+        return {k: "" if v is None else str(v) for k, v in payload.items()}
 
     @classmethod
     def from_redis_dict(cls, raw: dict[str, str]) -> HandoffData:

--- a/tests/unit/services/test_handoff_state.py
+++ b/tests/unit/services/test_handoff_state.py
@@ -23,6 +23,26 @@ def test_handoff_data_to_redis_dict():
     assert d["topic_id"] == "456"
     assert d["mode"] == "human_waiting"
     assert "created_at" in d
+    assert d["lead_id"] == ""
+    assert d["manager_joined_at"] == ""
+    assert d["qualification"] == "{}"
+
+
+def test_handoff_data_to_redis_dict_full():
+    data = HandoffData(
+        client_id=123,
+        topic_id=456,
+        mode="human",
+        lead_id=789,
+        qualification={"goal": "buy", "budget": "50-100"},
+    )
+    d = data.to_redis_dict()
+    assert d["client_id"] == "123"
+    assert d["topic_id"] == "456"
+    assert d["mode"] == "human"
+    assert d["lead_id"] == "789"
+    assert d["manager_joined_at"] == ""
+    assert d["qualification"] == '{"goal":"buy","budget":"50-100"}'
 
 
 def test_handoff_data_from_redis_dict():


### PR DESCRIPTION
## Summary
- Replaced 13-line manual field-by-field conversion in `HandoffData.to_redis_dict()` with compact native Pydantic v2 serialization
- Uses `model_dump(mode="json")` + generic `str()` conversion
- `qualification` field already leverages `@field_serializer(when_used="json")` — no custom JSON logic needed
- Completes the Pydantic v2 round-trip: `to_redis_dict()` now pairs symmetrically with existing `from_redis_dict()` (`model_validate()`)
- Added unit-test assertions for optional fields (`lead_id`, `manager_joined_at`, `qualification`) and a new full-population test case

## Test Plan
- [x] `pytest tests/unit/services/test_handoff_state.py` — 8 passed
- [x] `pytest tests/unit/handlers/test_handoff_integration.py` — 1 passed
- [x] `make check` — Ruff + MyPy clean
- [x] Backward compatibility verified: Redis hash format is identical

Fixes #1094