### PR TITLE
refactor(llm): replace custom JSON parsing with Instructor SDK (#1230)

### DIFF
--- a/telegram_bot/services/llm.py
+++ b/telegram_bot/services/llm.py
@@ -3,22 +3,42 @@
 Prefer telegram_bot.services.generate_response for active runtime paths.
 """
 
-import json
 import logging
-import re
 import warnings
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from typing import Any
 
+import instructor
 import openai
 from langfuse.openai import AsyncOpenAI
+from pydantic import BaseModel, Field, field_validator
 
 
 logger = logging.getLogger(__name__)
 
 # Default confidence threshold for triggering fallback response
 LOW_CONFIDENCE_THRESHOLD = 0.3
+
+
+class ConfidenceResponse(BaseModel):
+    """Pydantic model for LLM confidence extraction via Instructor.
+
+    Confidence is clamped to [0.0, 1.0] to preserve legacy clamp semantics:
+    values outside this range are accepted but clipped, not rejected.
+    """
+
+    answer: str = Field(description="Generated answer text")
+    confidence: float = Field(
+        default=0.5,
+        description="Confidence score — clamped to [0.0, 1.0] to match legacy behavior",
+    )
+
+    @field_validator("confidence", mode="before")
+    @classmethod
+    def _clamp_confidence(cls, v: float) -> float:
+        """Clamp confidence to [0.0, 1.0], preserving legacy clamp semantics."""
+        return max(0.0, min(1.0, float(v)))
 
 
 @dataclass
@@ -64,6 +84,13 @@ class LLMService:
             max_retries=2,
             timeout=60.0,
         )
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=("Client should be an instance of openai.OpenAI or openai.AsyncOpenAI.*"),
+                category=UserWarning,
+            )
+            self._instructor_client = instructor.from_openai(self.client)
 
     async def generate_answer(
         self,
@@ -108,6 +135,23 @@ class LLMService:
                 {"role": "user", "content": user_content},
             ]
 
+            if with_confidence:
+                response_model = await self._instructor_client.chat.completions.create(
+                    model=self.model,
+                    messages=messages,  # type: ignore[arg-type]
+                    response_model=ConfidenceResponse,
+                    max_retries=2,
+                    temperature=0.7,
+                    max_tokens=4096,
+                    name="generate-answer",  # type: ignore[call-overload]  # langfuse kwarg
+                )
+                return ConfidenceResult(
+                    answer=response_model.answer,
+                    confidence=response_model.confidence,
+                    is_low_confidence=response_model.confidence < self.low_confidence_threshold,
+                    raw_response=None,
+                )
+
             response = await self.client.chat.completions.create(
                 model=self.model,
                 messages=messages,  # type: ignore[arg-type]
@@ -117,12 +161,7 @@ class LLMService:
             )
 
             message = response.choices[0].message
-            raw_answer = message.content or ""
-
-            if with_confidence:
-                return self._parse_confidence_response(raw_answer, question, context_chunks)
-
-            return raw_answer
+            return message.content or ""
 
         except (openai.APITimeoutError, openai.APIConnectionError) as e:
             logger.error(f"LLM API timeout/connection: {e}")
@@ -168,39 +207,6 @@ class LLMService:
             "- 0.0-0.3: Ответ не основан на контексте или контекст нерелевантен\n\n"
             "Если контекст не содержит релевантной информации, установи confidence < 0.5."
         )
-
-    def _parse_confidence_response(
-        self, raw_response: str, question: str, context_chunks: list[dict[str, Any]]
-    ) -> ConfidenceResult:
-        """Parse LLM response with confidence scoring."""
-        try:
-            json_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", raw_response, re.DOTALL)
-            if json_match:
-                json_str = json_match.group(1)
-            else:
-                json_match = re.search(r"\{[^{}]*\"answer\"[^{}]*\}", raw_response, re.DOTALL)
-                json_str = json_match.group(0) if json_match else raw_response.strip()
-
-            data = json.loads(json_str)
-            answer = data.get("answer", raw_response)
-            confidence = float(data.get("confidence", 0.5))
-            confidence = max(0.0, min(1.0, confidence))
-
-            return ConfidenceResult(
-                answer=answer,
-                confidence=confidence,
-                is_low_confidence=confidence < self.low_confidence_threshold,
-                raw_response=raw_response,
-            )
-
-        except (json.JSONDecodeError, ValueError, KeyError) as e:
-            logger.warning(f"Failed to parse confidence response: {e}")
-            return ConfidenceResult(
-                answer=raw_response,
-                confidence=0.5,
-                is_low_confidence=False,
-                raw_response=raw_response,
-            )
 
     async def stream_answer(
         self,

--- a/telegram_bot/services/query_analyzer.py
+++ b/telegram_bot/services/query_analyzer.py
@@ -3,12 +3,14 @@
 Uses OpenAI SDK via Langfuse drop-in replacement for auto-tracing.
 """
 
-import json
 import logging
+import warnings
 from typing import Any
 
+import instructor
 import openai
 from langfuse.openai import AsyncOpenAI
+from pydantic import BaseModel, Field
 
 from telegram_bot.integrations.prompt_manager import get_prompt
 
@@ -47,6 +49,19 @@ SYSTEM_PROMPT = """Ты QueryAnalyzer для системы поиска нед�
 4. ОБЯЗАТЕЛЬНО возвращай валидный JSON"""
 
 
+class QueryAnalysisResult(BaseModel):
+    """Pydantic model for query analysis extraction via Instructor."""
+
+    filters: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Extracted filters from user query",
+    )
+    semantic_query: str = Field(
+        default="",
+        description="Semantic query for embedding search",
+    )
+
+
 class QueryAnalyzer:
     """Analyze user queries to extract structured filters and semantic query."""
 
@@ -60,6 +75,13 @@ class QueryAnalyzer:
             max_retries=2,
             timeout=30.0,
         )
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=("Client should be an instance of openai.OpenAI or openai.AsyncOpenAI.*"),
+                category=UserWarning,
+            )
+            self._instructor_client = instructor.from_openai(self.client)
 
     async def analyze(self, query: str) -> dict[str, Any]:
         """Analyze query and extract filters + semantic query.
@@ -72,46 +94,21 @@ class QueryAnalyzer:
         """
         try:
             system_prompt = get_prompt("query-analysis", fallback=SYSTEM_PROMPT)
-            response = await self.client.chat.completions.create(
+            result = await self._instructor_client.chat.completions.create(
                 model=self.model,
                 messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": f"Запрос пользователя: {query}"},
                 ],
-                response_format={"type": "json_object"},  # type: ignore[arg-type]
+                response_model=QueryAnalysisResult,
+                max_retries=2,
                 temperature=0.0,
                 max_tokens=1000,
                 name="query-analysis",  # type: ignore[call-overload]  # langfuse kwarg
             )
 
-            content = response.choices[0].message.content
-
-            if content is None:
-                logger.warning(
-                    "QueryAnalyzer: LLM returned None content. model=%s",
-                    self.model,
-                )
-                return {"filters": {}, "semantic_query": query}
-
-            try:
-                analysis = json.loads(content)
-            except (json.JSONDecodeError, TypeError) as e:
-                logger.error(
-                    "QueryAnalyzer: failed to parse JSON: %s. Raw: %s",
-                    e,
-                    content[:500],
-                )
-                return {"filters": {}, "semantic_query": query}
-
-            if not isinstance(analysis, dict):
-                logger.warning(
-                    "QueryAnalyzer: non-dict JSON: type=%s",
-                    type(analysis).__name__,
-                )
-                return {"filters": {}, "semantic_query": query}
-
-            filters = analysis.get("filters", {})
-            semantic_query = analysis.get("semantic_query", query)
+            filters = result.filters
+            semantic_query = result.semantic_query or query
 
             logger.info("QueryAnalyzer: filters=%s, semantic_query=%s", filters, semantic_query)
             return {"filters": filters, "semantic_query": semantic_query}

--- a/tests/chaos/test_llm_fallback.py
+++ b/tests/chaos/test_llm_fallback.py
@@ -3,13 +3,18 @@
 Tests verify graceful degradation when LLM services fail.
 """
 
-import json
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
-from telegram_bot.services.llm import LOW_CONFIDENCE_THRESHOLD, ConfidenceResult, LLMService
+from telegram_bot.services.llm import (
+    LOW_CONFIDENCE_THRESHOLD,
+    ConfidenceResponse,
+    ConfidenceResult,
+    LLMService,
+)
 
 
 pytestmark = [
@@ -105,11 +110,13 @@ class TestLLMHTTPErrors:
 class TestLLMResponseParsing:
     """Tests for LLM response parsing failures."""
 
-    async def test_malformed_json_response_handled(self, httpx_mock: HTTPXMock):
-        """Verify handling of malformed JSON in LLM response."""
-        httpx_mock.add_response(json={"choices": [{"message": {"content": "not json response"}}]})
-
+    async def test_malformed_json_response_handled(self):
+        """Verify handling of Instructor validation failure (formerly JSON parsing)."""
         service = LLMService(api_key="test-key")
+        service._instructor_client = AsyncMock()
+        service._instructor_client.chat.completions.create = AsyncMock(
+            side_effect=Exception("Instructor validation failed")
+        )
 
         result = await service.generate_answer(
             "Query",
@@ -117,22 +124,18 @@ class TestLLMResponseParsing:
             with_confidence=True,
         )
 
-        # Should return result with default confidence (parsing failed)
+        # Instructor failure falls through to generic exception → fallback
         assert isinstance(result, ConfidenceResult)
-        assert result.answer == "not json response"
-        assert result.confidence == 0.5  # Default on parse failure
+        assert result.confidence == 0.0
+        assert result.is_low_confidence is True
 
-    async def test_missing_confidence_field_handled(self, httpx_mock: HTTPXMock):
-        """Verify handling when confidence field is missing."""
-        httpx_mock.add_response(
-            json={
-                "choices": [
-                    {"message": {"content": json.dumps({"answer": "Response without confidence"})}}
-                ]
-            }
-        )
-
+    async def test_missing_confidence_field_handled(self):
+        """Verify default confidence used when field is missing from response."""
         service = LLMService(api_key="test-key")
+        service._instructor_client = AsyncMock()
+        service._instructor_client.chat.completions.create = AsyncMock(
+            return_value=ConfidenceResponse(answer="Response without confidence", confidence=0.5)
+        )
 
         result = await service.generate_answer(
             "Query",
@@ -141,19 +144,15 @@ class TestLLMResponseParsing:
         )
 
         assert isinstance(result, ConfidenceResult)
-        assert result.confidence == 0.5  # Default when missing
+        assert result.confidence == 0.5  # Pydantic default when missing
 
-    async def test_invalid_confidence_value_clamped(self, httpx_mock: HTTPXMock):
+    async def test_invalid_confidence_value_clamped(self):
         """Verify invalid confidence values are clamped to valid range."""
-        httpx_mock.add_response(
-            json={
-                "choices": [
-                    {"message": {"content": json.dumps({"answer": "Test", "confidence": 1.5})}}
-                ]
-            }
-        )
-
         service = LLMService(api_key="test-key")
+        service._instructor_client = AsyncMock()
+        service._instructor_client.chat.completions.create = AsyncMock(
+            return_value=ConfidenceResponse(answer="Test", confidence=1.5)
+        )
 
         result = await service.generate_answer(
             "Query",
@@ -161,6 +160,7 @@ class TestLLMResponseParsing:
             with_confidence=True,
         )
 
+        # 1.5 is clamped to 1.0 by the ConfidenceResponse field_validator
         assert result.confidence == 1.0  # Clamped to max
 
 

--- a/tests/unit/services/test_query_analyzer.py
+++ b/tests/unit/services/test_query_analyzer.py
@@ -1,19 +1,11 @@
-"""Unit tests for QueryAnalyzer service (OpenAI SDK)."""
+"""Unit tests for QueryAnalyzer service (Instructor SDK)."""
 
-import json
 from unittest.mock import AsyncMock, MagicMock
 
 import openai
 import pytest
 
-from telegram_bot.services.query_analyzer import QueryAnalyzer
-
-
-def _mock_completion(content: str) -> MagicMock:
-    """Helper: create a mock ChatCompletion response."""
-    mock_response = MagicMock()
-    mock_response.choices = [MagicMock(message=MagicMock(content=content))]
-    return mock_response
+from telegram_bot.services.query_analyzer import QueryAnalysisResult, QueryAnalyzer
 
 
 # =============================================================================
@@ -71,22 +63,19 @@ class TestQueryAnalyzerAnalyze:
 
     @pytest.fixture
     def analyzer(self):
-        """Create QueryAnalyzer with mocked OpenAI client."""
+        """Create QueryAnalyzer with mocked Instructor client."""
         analyzer = QueryAnalyzer(
             api_key="test-api-key", base_url="http://localhost:8000", model="gpt-4o-mini"
         )
-        analyzer.client = AsyncMock()
+        analyzer._instructor_client = AsyncMock()
         return analyzer
 
     async def test_analyze_returns_filters_and_semantic_query(self, analyzer):
-        response_content = json.dumps(
-            {
-                "filters": {"price": {"lt": 100000}, "city": "Несебр"},
-                "semantic_query": "уютная квартира с хорошим ремонтом",
-            }
-        )
-        analyzer.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion(response_content)
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
+            return_value=QueryAnalysisResult(
+                filters={"price": {"lt": 100000}, "city": "Несебр"},
+                semantic_query="уютная квартира с хорошим ремонтом",
+            )
         )
 
         result = await analyzer.analyze("квартира до 100000 евро в Несебре с хорошим ремонтом")
@@ -96,66 +85,62 @@ class TestQueryAnalyzerAnalyze:
         assert result["filters"] == {"price": {"lt": 100000}, "city": "Несебр"}
         assert result["semantic_query"] == "уютная квартира с хорошим ремонтом"
 
-    async def test_analyze_calls_openai_sdk(self, analyzer):
-        response_content = json.dumps({"filters": {}, "semantic_query": "test query"})
-        analyzer.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion(response_content)
+    async def test_analyze_calls_instructor_sdk(self, analyzer):
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
+            return_value=QueryAnalysisResult(filters={}, semantic_query="test query")
         )
 
         await analyzer.analyze("test query")
 
-        analyzer.client.chat.completions.create.assert_called_once()
+        analyzer._instructor_client.chat.completions.create.assert_called_once()
 
-    async def test_analyze_uses_json_response_format(self, analyzer):
-        response_content = json.dumps({"filters": {}, "semantic_query": "test"})
-        analyzer.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion(response_content)
+    async def test_analyze_uses_instructor_response_model(self, analyzer):
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
+            return_value=QueryAnalysisResult(filters={}, semantic_query="test")
         )
 
         await analyzer.analyze("test query")
 
-        call_kwargs = analyzer.client.chat.completions.create.call_args[1]
-        assert call_kwargs["response_format"] == {"type": "json_object"}
+        call_kwargs = analyzer._instructor_client.chat.completions.create.call_args[1]
+        assert call_kwargs["response_model"] is QueryAnalysisResult
+        assert call_kwargs["max_retries"] == 2
 
     async def test_analyze_uses_zero_temperature(self, analyzer):
-        response_content = json.dumps({"filters": {}, "semantic_query": "test"})
-        analyzer.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion(response_content)
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
+            return_value=QueryAnalysisResult(filters={}, semantic_query="test")
         )
 
         await analyzer.analyze("test query")
 
-        call_kwargs = analyzer.client.chat.completions.create.call_args[1]
+        call_kwargs = analyzer._instructor_client.chat.completions.create.call_args[1]
         assert call_kwargs["temperature"] == 0.0
 
     async def test_analyze_sends_query_in_user_message(self, analyzer):
-        response_content = json.dumps({"filters": {}, "semantic_query": "test"})
-        analyzer.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion(response_content)
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
+            return_value=QueryAnalysisResult(filters={}, semantic_query="test")
         )
 
         test_query = "квартира в Солнечном берегу до 50000 евро"
         await analyzer.analyze(test_query)
 
-        call_kwargs = analyzer.client.chat.completions.create.call_args[1]
+        call_kwargs = analyzer._instructor_client.chat.completions.create.call_args[1]
         messages = call_kwargs["messages"]
         user_message = next(m for m in messages if m["role"] == "user")
         assert test_query in user_message["content"]
 
     async def test_analyze_uses_specified_model(self, analyzer):
-        response_content = json.dumps({"filters": {}, "semantic_query": "test"})
-        analyzer.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion(response_content)
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
+            return_value=QueryAnalysisResult(filters={}, semantic_query="test")
         )
 
         await analyzer.analyze("test query")
 
-        call_kwargs = analyzer.client.chat.completions.create.call_args[1]
+        call_kwargs = analyzer._instructor_client.chat.completions.create.call_args[1]
         assert call_kwargs["model"] == "gpt-4o-mini"
 
-    async def test_analyze_fallback_on_json_parse_error(self, analyzer):
-        analyzer.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion("not valid json {")
+    async def test_analyze_fallback_on_instructor_error(self, analyzer):
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
+            side_effect=Exception("Instructor validation failed")
         )
 
         original_query = "квартира в Бургасе"
@@ -165,7 +150,7 @@ class TestQueryAnalyzerAnalyze:
         assert result["semantic_query"] == original_query
 
     async def test_analyze_fallback_on_api_connection_error(self, analyzer):
-        analyzer.client.chat.completions.create = AsyncMock(
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
             side_effect=openai.APIConnectionError(request=MagicMock())
         )
 
@@ -179,7 +164,7 @@ class TestQueryAnalyzerAnalyze:
         mock_resp = MagicMock()
         mock_resp.status_code = 429
         mock_resp.headers = {}
-        analyzer.client.chat.completions.create = AsyncMock(
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
             side_effect=openai.RateLimitError(
                 message="Rate limited",
                 response=mock_resp,
@@ -194,7 +179,7 @@ class TestQueryAnalyzerAnalyze:
         assert result["semantic_query"] == original_query
 
     async def test_analyze_fallback_on_timeout_error(self, analyzer):
-        analyzer.client.chat.completions.create = AsyncMock(
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
             side_effect=openai.APITimeoutError(request=MagicMock())
         )
 
@@ -205,9 +190,8 @@ class TestQueryAnalyzerAnalyze:
         assert result["semantic_query"] == original_query
 
     async def test_analyze_returns_empty_filters_when_none_found(self, analyzer):
-        response_content = json.dumps({"filters": {}, "semantic_query": "красивая квартира у моря"})
-        analyzer.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion(response_content)
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
+            return_value=QueryAnalysisResult(filters={}, semantic_query="красивая квартира у моря")
         )
 
         result = await analyzer.analyze("красивая квартира у моря")
@@ -216,9 +200,8 @@ class TestQueryAnalyzerAnalyze:
         assert result["semantic_query"] == "красивая квартира у моря"
 
     async def test_analyze_handles_missing_semantic_query_in_response(self, analyzer):
-        response_content = json.dumps({"filters": {"price": {"lt": 50000}}})
-        analyzer.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion(response_content)
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
+            return_value=QueryAnalysisResult(filters={"price": {"lt": 50000}}, semantic_query="")
         )
 
         original_query = "квартира до 50000 евро"
@@ -228,9 +211,8 @@ class TestQueryAnalyzerAnalyze:
         assert result["semantic_query"] == original_query
 
     async def test_analyze_handles_missing_filters_in_response(self, analyzer):
-        response_content = json.dumps({"semantic_query": "уютная квартира"})
-        analyzer.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion(response_content)
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
+            return_value=QueryAnalysisResult(semantic_query="уютная квартира")
         )
 
         result = await analyzer.analyze("уютная квартира")
@@ -239,20 +221,17 @@ class TestQueryAnalyzerAnalyze:
         assert result["semantic_query"] == "уютная квартира"
 
     async def test_analyze_with_complex_filters(self, analyzer):
-        response_content = json.dumps(
-            {
-                "filters": {
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
+            return_value=QueryAnalysisResult(
+                filters={
                     "price": {"lt": 100000, "gt": 50000},
                     "rooms": 2,
                     "city": "Солнечный берег",
                     "area": {"gte": 50},
                     "distance_to_sea": {"lt": 500},
                 },
-                "semantic_query": "квартира с хорошим ремонтом",
-            }
-        )
-        analyzer.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion(response_content)
+                semantic_query="квартира с хорошим ремонтом",
+            )
         )
 
         result = await analyzer.analyze(
@@ -264,22 +243,20 @@ class TestQueryAnalyzerAnalyze:
         assert result["filters"]["city"] == "Солнечный берег"
 
     async def test_analyze_sets_max_tokens(self, analyzer):
-        response_content = json.dumps({"filters": {}, "semantic_query": "test"})
-        analyzer.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion(response_content)
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
+            return_value=QueryAnalysisResult(filters={}, semantic_query="test")
         )
 
         await analyzer.analyze("test query")
 
-        call_kwargs = analyzer.client.chat.completions.create.call_args[1]
+        call_kwargs = analyzer._instructor_client.chat.completions.create.call_args[1]
         assert call_kwargs["max_tokens"] == 1000
 
     async def test_analyze_with_unicode_query(self, analyzer):
-        response_content = json.dumps(
-            {"filters": {"city": "Варна"}, "semantic_query": "квартира с мебелью"}
-        )
-        analyzer.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion(response_content)
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
+            return_value=QueryAnalysisResult(
+                filters={"city": "Варна"}, semantic_query="квартира с мебелью"
+            )
         )
 
         result = await analyzer.analyze("Ищу квартиру с мебелью в Варне")
@@ -287,17 +264,9 @@ class TestQueryAnalyzerAnalyze:
         assert result["filters"]["city"] == "Варна"
         assert result["semantic_query"] == "квартира с мебелью"
 
-    async def test_analyze_handles_none_content(self, analyzer):
-        analyzer.client.chat.completions.create = AsyncMock(return_value=_mock_completion(None))
-
-        result = await analyzer.analyze("test query")
-
-        assert result["filters"] == {}
-        assert result["semantic_query"] == "test query"
-
-    async def test_analyze_handles_non_dict_json(self, analyzer):
-        analyzer.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion("[1, 2, 3]")
+    async def test_analyze_handles_instructor_failure(self, analyzer):
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
+            side_effect=Exception("Instructor failed")
         )
 
         result = await analyzer.analyze("test query")
@@ -336,13 +305,13 @@ class TestQueryAnalyzerFlow:
             api_key="test-key", base_url="http://localhost:8000", model="gpt-4o"
         )
 
-        response_content = json.dumps(
-            {"filters": {"price": {"lt": 75000}}, "semantic_query": "квартира у моря"}
+        analyzer._instructor_client = AsyncMock()
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
+            return_value=QueryAnalysisResult(
+                filters={"price": {"lt": 75000}}, semantic_query="квартира у моря"
+            )
         )
-        analyzer.client = AsyncMock()
-        analyzer.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion(response_content)
-        )
+        analyzer.client = AsyncMock()  # needed for close() assertion
 
         assert analyzer.api_key == "test-key"
         assert analyzer.base_url == "http://localhost:8000"
@@ -357,16 +326,14 @@ class TestQueryAnalyzerFlow:
 
     async def test_multiple_queries(self):
         analyzer = QueryAnalyzer(api_key="test-key", base_url="http://localhost:8000")
-        analyzer.client = AsyncMock()
+        analyzer._instructor_client = AsyncMock()
 
         responses = [
-            _mock_completion(
-                json.dumps({"filters": {"city": "Несебр"}, "semantic_query": "студия"})
-            ),
-            _mock_completion(json.dumps({"filters": {"rooms": 2}, "semantic_query": "квартира"})),
-            _mock_completion(json.dumps({"filters": {}, "semantic_query": "апартамент у моря"})),
+            QueryAnalysisResult(filters={"city": "Несебр"}, semantic_query="студия"),
+            QueryAnalysisResult(filters={"rooms": 2}, semantic_query="квартира"),
+            QueryAnalysisResult(filters={}, semantic_query="апартамент у моря"),
         ]
-        analyzer.client.chat.completions.create = AsyncMock(side_effect=responses)
+        analyzer._instructor_client.chat.completions.create = AsyncMock(side_effect=responses)
 
         result1 = await analyzer.analyze("студия в Несебре")
         result2 = await analyzer.analyze("двухкомнатная квартира")
@@ -375,19 +342,16 @@ class TestQueryAnalyzerFlow:
         assert result1["filters"] == {"city": "Несебр"}
         assert result2["filters"] == {"rooms": 2}
         assert result3["filters"] == {}
-        assert analyzer.client.chat.completions.create.call_count == 3
+        assert analyzer._instructor_client.chat.completions.create.call_count == 3
 
     async def test_error_recovery(self):
         analyzer = QueryAnalyzer(api_key="test-key", base_url="http://localhost:8000")
-        analyzer.client = AsyncMock()
+        analyzer._instructor_client = AsyncMock()
 
-        success_response = _mock_completion(
-            json.dumps({"filters": {"city": "Бургас"}, "semantic_query": "квартира"})
-        )
-        analyzer.client.chat.completions.create = AsyncMock(
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
             side_effect=[
                 openai.APIConnectionError(request=MagicMock()),
-                success_response,
+                QueryAnalysisResult(filters={"city": "Бургас"}, semantic_query="квартира"),
             ]
         )
 

--- a/tests/unit/test_guardrails.py
+++ b/tests/unit/test_guardrails.py
@@ -4,12 +4,16 @@ Tests confidence scoring and low confidence fallback in LLMService.
 Off-topic detection is now handled by classify_node in the LangGraph pipeline.
 """
 
-import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from telegram_bot.services.llm import LOW_CONFIDENCE_THRESHOLD, ConfidenceResult, LLMService
+from telegram_bot.services.llm import (
+    LOW_CONFIDENCE_THRESHOLD,
+    ConfidenceResponse,
+    ConfidenceResult,
+    LLMService,
+)
 
 
 pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
@@ -77,11 +81,10 @@ class TestConfidenceScoring:
 
     async def test_generate_answer_with_confidence(self, sample_chunks):
         """Test generate_answer returns ConfidenceResult when with_confidence=True."""
-        response_json = json.dumps({"answer": "Found an apartment", "confidence": 0.85})
         service = LLMService(api_key="test-key")
-        service.client = AsyncMock()
-        service.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion(response_json)
+        service._instructor_client = AsyncMock()
+        service._instructor_client.chat.completions.create = AsyncMock(
+            return_value=ConfidenceResponse(answer="Found an apartment", confidence=0.85)
         )
 
         result = await service.generate_answer(
@@ -110,11 +113,10 @@ class TestConfidenceScoring:
 
     async def test_low_confidence_detection(self, sample_chunks):
         """Test is_low_confidence is True when confidence < threshold."""
-        response_json = json.dumps({"answer": "Uncertain answer", "confidence": 0.2})
         service = LLMService(api_key="test-key")
-        service.client = AsyncMock()
-        service.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion(response_json)
+        service._instructor_client = AsyncMock()
+        service._instructor_client.chat.completions.create = AsyncMock(
+            return_value=ConfidenceResponse(answer="Uncertain answer", confidence=0.2)
         )
 
         result = await service.generate_answer("Query", sample_chunks, with_confidence=True)
@@ -122,94 +124,86 @@ class TestConfidenceScoring:
         assert result.is_low_confidence is True
         assert result.confidence < LOW_CONFIDENCE_THRESHOLD
 
-    async def test_confidence_parsing_from_markdown_json(self, sample_chunks):
-        """Test parsing confidence from JSON wrapped in markdown code blocks."""
-        response = """```json
-{"answer": "Markdown wrapped", "confidence": 0.75}
-```"""
+    async def test_instructor_validation_fallback(self, sample_chunks):
+        """Test fallback when Instructor fails after retries."""
         service = LLMService(api_key="test-key")
-        service.client = AsyncMock()
-        service.client.chat.completions.create = AsyncMock(return_value=_mock_completion(response))
-
-        result = await service.generate_answer("Query", sample_chunks, with_confidence=True)
-
-        assert result.answer == "Markdown wrapped"
-        assert result.confidence == 0.75
-
-    async def test_confidence_clamped_to_valid_range(self, sample_chunks):
-        """Test confidence values outside 0-1 are clamped."""
-        response_json = json.dumps({"answer": "Test", "confidence": 1.5})
-        service = LLMService(api_key="test-key")
-        service.client = AsyncMock()
-        service.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion(response_json)
+        service._instructor_client = AsyncMock()
+        service._instructor_client.chat.completions.create = AsyncMock(
+            side_effect=Exception("Instructor validation failed")
         )
 
         result = await service.generate_answer("Query", sample_chunks, with_confidence=True)
 
+        assert isinstance(result, ConfidenceResult)
+        assert result.confidence == 0.0
+        assert result.is_low_confidence is True
+
+    async def test_instructor_uses_response_model(self, sample_chunks):
+        """Test that Instructor create is called with response_model."""
+        service = LLMService(api_key="test-key")
+        service._instructor_client = AsyncMock()
+        service._instructor_client.chat.completions.create = AsyncMock(
+            return_value=ConfidenceResponse(answer="Test", confidence=0.6)
+        )
+
+        await service.generate_answer("Query", sample_chunks, with_confidence=True)
+
+        call_kwargs = service._instructor_client.chat.completions.create.call_args[1]
+        assert call_kwargs["response_model"] is ConfidenceResponse
+        assert call_kwargs["max_retries"] == 2
+
+    async def test_confidence_clamped_to_valid_range(self, sample_chunks):
+        """Test confidence values outside [0,1] are clamped, not rejected.
+
+        The ConfidenceResponse Pydantic model uses a field_validator that
+        clamps to [0.0, 1.0], preserving legacy clamp semantics.
+        """
+        service = LLMService(api_key="test-key")
+        service._instructor_client = AsyncMock()
+        # Construct with out-of-range value - validator clamps during init
+        service._instructor_client.chat.completions.create = AsyncMock(
+            return_value=ConfidenceResponse(answer="Test", confidence=1.5)
+        )
+
+        result = await service.generate_answer("Query", sample_chunks, with_confidence=True)
+
+        # 1.5 is clamped to 1.0 by the field_validator
         assert result.confidence == 1.0
 
     async def test_negative_confidence_clamped(self, sample_chunks):
-        """Test negative confidence is clamped to 0."""
-        response_json = json.dumps({"answer": "Test", "confidence": -0.5})
+        """Test negative confidence is clamped to 0.0, not rejected."""
         service = LLMService(api_key="test-key")
-        service.client = AsyncMock()
-        service.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion(response_json)
+        service._instructor_client = AsyncMock()
+        service._instructor_client.chat.completions.create = AsyncMock(
+            return_value=ConfidenceResponse(answer="Test", confidence=-0.5)
         )
 
         result = await service.generate_answer("Query", sample_chunks, with_confidence=True)
 
+        # -0.5 is clamped to 0.0 by the field_validator
         assert result.confidence == 0.0
 
 
 class TestConfidenceParsingEdgeCases:
-    """Tests for edge cases in confidence response parsing."""
+    """Tests for edge cases in confidence response parsing via Instructor."""
 
     @pytest.fixture
     def sample_chunks(self):
         return [{"text": "Test", "metadata": {}, "score": 0.9}]
 
-    async def test_malformed_json_returns_raw_response(self, sample_chunks):
-        """Test malformed JSON returns raw response with default confidence."""
+    async def test_instructor_failure_returns_fallback(self, sample_chunks):
+        """Test Instructor failure returns fallback with zero confidence."""
         service = LLMService(api_key="test-key")
-        service.client = AsyncMock()
-        service.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion("Not JSON at all")
+        service._instructor_client = AsyncMock()
+        service._instructor_client.chat.completions.create = AsyncMock(
+            side_effect=Exception("Instructor failed")
         )
 
         result = await service.generate_answer("Query", sample_chunks, with_confidence=True)
 
-        assert result.answer == "Not JSON at all"
-        assert result.confidence == 0.5  # Default on parse failure
-
-    async def test_missing_answer_field(self, sample_chunks):
-        """Test missing answer field uses raw response."""
-        response_json = json.dumps({"confidence": 0.8})
-        service = LLMService(api_key="test-key")
-        service.client = AsyncMock()
-        service.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion(response_json)
-        )
-
-        result = await service.generate_answer("Query", sample_chunks, with_confidence=True)
-
-        # Should use raw response as answer
-        assert result.confidence == 0.8
-
-    async def test_missing_confidence_uses_default(self, sample_chunks):
-        """Test missing confidence field uses default value."""
-        response_json = json.dumps({"answer": "Answer only"})
-        service = LLMService(api_key="test-key")
-        service.client = AsyncMock()
-        service.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion(response_json)
-        )
-
-        result = await service.generate_answer("Query", sample_chunks, with_confidence=True)
-
-        assert result.answer == "Answer only"
-        assert result.confidence == 0.5  # Default when missing
+        assert isinstance(result, ConfidenceResult)
+        assert result.confidence == 0.0
+        assert result.is_low_confidence is True
 
 
 class TestLowConfidenceResponse:
@@ -264,13 +258,12 @@ class TestGuardrailsIntegration:
 
     async def test_high_confidence_answer_returned_as_is(self, sample_chunks):
         """Test high confidence answers are returned without modification."""
-        response_json = json.dumps(
-            {"answer": "Great apartment in Sofia for 45000€", "confidence": 0.9}
-        )
         service = LLMService(api_key="test-key")
-        service.client = AsyncMock()
-        service.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion(response_json)
+        service._instructor_client = AsyncMock()
+        service._instructor_client.chat.completions.create = AsyncMock(
+            return_value=ConfidenceResponse(
+                answer="Great apartment in Sofia for 45000€", confidence=0.9
+            )
         )
 
         result = await service.generate_answer(


### PR DESCRIPTION
## Summary
- Replaced custom `json.loads` / regex-based JSON parsing of LLM output with Instructor SDK (`instructor.from_openai` + `chat.completions.create(response_model=...)`).
- `ConfidenceResponse` uses a Pydantic validator/clamp to preserve legacy confidence semantics; no custom JSON parsing remains in the LLM response path.
- Updated related tests to exercise the Instructor extraction path.

## Test Plan
- [x] `uv run pytest tests/unit/test_guardrails.py tests/unit/services/test_query_analyzer.py tests/chaos/test_llm_fallback.py` — 62 passed, 0 failures
- [x] `make check` — Ruff and MyPy clean
- [ ] Full `make test-unit` — 6 pre-existing collection errors in ingestion/index tests (Pydantic V1 compat), unrelated to this PR

Fixes #1230