### PR TITLE
fix: graceful GraphRecursionError handling in voice and RAG API

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -15,6 +15,7 @@ from typing import Any, cast
 
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
+from langgraph.errors import GraphRecursionError
 
 from src.api.schemas import QueryRequest, QueryResponse
 from telegram_bot.observability import observe
@@ -196,7 +197,46 @@ async def _execute_query(req: QueryRequest) -> QueryResponse:
     }
 
     with propagate_attributes(**trace_kwargs):
-        result = await app.state.graph.ainvoke(state)
+        try:
+            result = await app.state.graph.ainvoke(state)
+        except GraphRecursionError:
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            lf = get_client()
+            if lf is not None:
+                lf.update_current_span(
+                    input=req.query,
+                    output="recursion_limit_reached",
+                    metadata={
+                        "source": req.channel,
+                        "query_type": "ERROR",
+                        "error_reason": "recursion_limit",
+                    },
+                )
+                fallback_response = (
+                    "Запрос слишком сложный — достигнут лимит обработки. Попробуйте упростить его."
+                )
+                fallback_result: dict[str, Any] = {
+                    "input_type": "api",
+                    "query_type": "ERROR",
+                    "pipeline_wall_ms": elapsed_ms,
+                    "e2e_latency_ms": elapsed_ms,
+                    "user_perceived_wall_ms": elapsed_ms,
+                    "cache_hit": False,
+                    "search_results_count": 0,
+                    "rerank_applied": False,
+                    "response": fallback_response,
+                }
+                write_langfuse_scores(lf, fallback_result)
+            return QueryResponse(
+                response=fallback_response,
+                query_type="ERROR",
+                cache_hit=False,
+                documents_count=0,
+                rerank_applied=False,
+                latency_ms=round(elapsed_ms, 1),
+                context=[],
+            )
+
         lf = get_client()
         if lf is not None:
             lf.update_current_span(

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -29,6 +29,7 @@ from aiogram.types import (
     Message,
 )
 from aiogram.utils.chat_action import ChatActionSender
+from langgraph.errors import GraphRecursionError
 
 from src.retrieval.topic_classifier import get_query_topic_hint
 
@@ -3847,6 +3848,27 @@ class PropertyBot:
                         logger.debug("Failed to write voice error scores", exc_info=True)
                     return
                 raise
+            except GraphRecursionError:
+                logger.warning(
+                    "Voice pipeline recursion limit exceeded (user=%s, session=%s)",
+                    state.get("user_id"),
+                    state.get("session_id"),
+                    exc_info=True,
+                )
+                await message.answer(
+                    "Запрос слишком сложный — достигнут лимит обработки. "
+                    "Попробуйте упростить его или отправить текстом."
+                )
+                try:
+                    _write_voice_error_scores(
+                        get_client(),
+                        trace_id=state.get("trace_id", ""),
+                        voice_duration_s=voice.duration,
+                        error_reason="recursion_limit",
+                    )
+                except Exception:
+                    logger.debug("Failed to write voice error scores", exc_info=True)
+                return
             except Exception as e:
                 if result is None:
                     # Checkpointer/storage cleanup can fail after nodes complete.

--- a/tests/unit/api/test_rag_api_runtime.py
+++ b/tests/unit/api/test_rag_api_runtime.py
@@ -48,7 +48,7 @@ if importlib.util.find_spec("fastapi") is None:
     _FASTAPI_SHIM_ACTIVE = True
 
 from src.api.main import app, generic_error_handler, lifespan, query
-from src.api.schemas import QueryRequest
+from src.api.schemas import QueryRequest, QueryResponse
 
 
 if _FASTAPI_SHIM_ACTIVE:
@@ -313,3 +313,64 @@ async def test_generic_error_handler_uses_langfuse_trace_id_when_available() -> 
     mock_logger.exception.assert_called_once_with(
         "Unhandled error in RAG API", extra={"trace_id": "trace-abc-123"}
     )
+
+
+async def test_query_returns_fallback_on_graph_recursion_error() -> None:
+    """GraphRecursionError must return a valid QueryResponse fallback, not 500."""
+    from langgraph.errors import GraphRecursionError
+
+    class _FailingGraph:
+        async def ainvoke(self, state: dict) -> dict:
+            raise GraphRecursionError("recursion limit exceeded")
+
+    app.state.graph = _FailingGraph()
+    app.state.max_rewrite_attempts = 1
+
+    lf = MagicMock()
+    lf.update_current_span = MagicMock()
+
+    with (
+        patch("telegram_bot.observability.propagate_attributes", return_value=nullcontext()),
+        patch("telegram_bot.observability.get_client", return_value=lf),
+        patch("telegram_bot.scoring.write_langfuse_scores") as mock_write_scores,
+    ):
+        response = await query(QueryRequest(query="test", user_id=1))
+
+    assert isinstance(response, QueryResponse)
+    assert "лимит" in response.response.lower() or "limit" in response.response.lower()
+    assert response.query_type == "ERROR"
+    assert response.documents_count == 0
+    assert response.latency_ms >= 0
+    # Observability: span should still be updated and scores written
+    lf.update_current_span.assert_called_once()
+    mock_write_scores.assert_called_once()
+
+
+async def test_query_graph_recursion_error_preserves_trace_context() -> None:
+    """GraphRecursionError fallback should preserve trace/span behavior."""
+    from langgraph.errors import GraphRecursionError
+
+    class _FailingGraph:
+        async def ainvoke(self, state: dict) -> dict:
+            raise GraphRecursionError("recursion limit exceeded")
+
+    app.state.graph = _FailingGraph()
+    app.state.max_rewrite_attempts = 1
+
+    lf = MagicMock()
+    lf.update_current_span = MagicMock()
+
+    with (
+        patch("telegram_bot.observability.propagate_attributes", return_value=nullcontext()),
+        patch("telegram_bot.observability.get_client", return_value=lf),
+    ):
+        await query(QueryRequest(query="complex", user_id=42, session_id="sess-1"))
+
+    call_kwargs = lf.update_current_span.call_args.kwargs
+    assert call_kwargs["input"] == "complex"
+    assert (
+        "recursion" in str(call_kwargs.get("output", "")).lower()
+        or "limit" in str(call_kwargs.get("output", "")).lower()
+    )
+    assert call_kwargs["metadata"]["source"] == "api"
+    assert call_kwargs["metadata"]["query_type"] == "ERROR"

--- a/tests/unit/test_bot_handlers_query.py
+++ b/tests/unit/test_bot_handlers_query.py
@@ -1,0 +1,144 @@
+"""Unit tests for bot query/voice handler edge cases (#1250 recursion limit)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+pytest.importorskip("aiogram", reason="aiogram not installed")
+
+from telegram_bot.bot import PropertyBot
+from telegram_bot.config import BotConfig
+
+
+@pytest.fixture
+def mock_config(monkeypatch):
+    """Create mock bot config."""
+    monkeypatch.delenv("CLIENT_DIRECT_PIPELINE_ENABLED", raising=False)
+    monkeypatch.delenv("KOMMO_ACCESS_TOKEN", raising=False)
+    return BotConfig(
+        _env_file=None,
+        telegram_token="test-token",
+        voyage_api_key="voyage-key",
+        llm_api_key="llm-key",
+        llm_base_url="https://api.example.com/v1",
+        llm_model="gpt-4o-mini",
+        qdrant_url="http://localhost:6333",
+        qdrant_api_key="qdrant-key",
+        qdrant_collection="test_collection",
+        redis_url="redis://localhost:6379",
+        realestate_database_url="postgresql://postgres:postgres@127.0.0.1:1/realestate",
+        rerank_provider="none",
+    )
+
+
+def _create_bot(mock_config):
+    """Create PropertyBot with all deps mocked."""
+    with (
+        patch("telegram_bot.bot.Bot"),
+        patch("telegram_bot.integrations.cache.CacheLayerManager"),
+        patch("telegram_bot.integrations.embeddings.BGEM3HybridEmbeddings"),
+        patch("telegram_bot.integrations.embeddings.BGEM3SparseEmbeddings"),
+        patch("telegram_bot.services.qdrant.QdrantService"),
+        patch("telegram_bot.graph.config.GraphConfig.create_llm"),
+        patch("telegram_bot.graph.config.GraphConfig.create_supervisor_llm"),
+    ):
+        return PropertyBot(mock_config)
+
+
+def _make_voice_message():
+    """Create a mock voice message."""
+    message = MagicMock()
+    message.from_user = MagicMock(id=12345)
+    message.chat = MagicMock(id=12345)
+    message.bot = MagicMock()
+    message.bot.send_chat_action = AsyncMock()
+    message.bot.get_file = AsyncMock()
+    message.bot.download_file = AsyncMock()
+    message.answer = AsyncMock()
+    message.voice = MagicMock()
+    message.voice.file_id = "file123"
+    message.voice.duration = 5
+    file_mock = MagicMock()
+    file_mock.file_path = "voice/file.ogg"
+    message.bot.get_file.return_value = file_mock
+    return message
+
+
+def _make_typing_cm():
+    """Create a mock ChatActionSender.typing() context manager."""
+    mock_cm = AsyncMock()
+    mock_cm.__aenter__ = AsyncMock()
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+    return mock_cm
+
+
+class TestHandleVoiceRecursionLimit:
+    """Test handle_voice GraphRecursionError handling — #1250."""
+
+    async def test_recursion_limit_sends_graceful_message(self, mock_config):
+        """GraphRecursionError should send a graceful 'limit reached' message."""
+        bot = _create_bot(mock_config)
+
+        from langgraph.errors import GraphRecursionError
+
+        mock_graph = AsyncMock()
+        mock_graph.ainvoke = AsyncMock(side_effect=GraphRecursionError("recursion limit exceeded"))
+
+        with (
+            patch("telegram_bot.bot.build_graph", return_value=mock_graph),
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.write_langfuse_scores") as mock_write_scores,
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot._write_voice_error_scores") as mock_error_scores,
+        ):
+            message = _make_voice_message()
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_voice(message)
+
+        # User should receive graceful limit-reached message, not generic error
+        message.answer.assert_called()
+        limit_msg_sent = any(
+            "лимит" in str(call).lower() or "limit" in str(call).lower()
+            for call in message.answer.call_args_list
+        )
+        assert limit_msg_sent, "Expected graceful recursion-limit message to user"
+
+        # Error scores should be written with recursion_limit reason
+        mock_error_scores.assert_called_once()
+        call_kwargs = mock_error_scores.call_args.kwargs
+        assert call_kwargs.get("error_reason") == "recursion_limit"
+        assert call_kwargs.get("voice_duration_s") == 5
+
+        # write_langfuse_scores should NOT be called because there is no result state
+        mock_write_scores.assert_not_called()
+
+    async def test_recursion_limit_logs_with_session_context(self, mock_config, caplog):
+        """GraphRecursionError should be logged with session/user context."""
+        bot = _create_bot(mock_config)
+
+        from langgraph.errors import GraphRecursionError
+
+        mock_graph = AsyncMock()
+        mock_graph.ainvoke = AsyncMock(side_effect=GraphRecursionError("recursion limit exceeded"))
+
+        caplog.set_level("INFO")
+        with (
+            patch("telegram_bot.bot.build_graph", return_value=mock_graph),
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot._write_voice_error_scores"),
+        ):
+            message = _make_voice_message()
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_voice(message)
+
+        # Log should contain user/session context for observability
+        assert any(
+            "recursion" in record.message.lower() or "limit" in record.message.lower()
+            for record in caplog.records
+        ), "Expected log mention of recursion limit"


### PR DESCRIPTION
## Summary
- Catch `langgraph.errors.GraphRecursionError` at voice handler and RAG API graph invocation boundaries.
- Voice handler logs with session/user context, sends a graceful "processing limit reached" message, and writes Langfuse error scores.
- RAG API returns a valid `QueryResponse` fallback instead of raising unhandled 500, while preserving trace/span score behavior.
- Add focused unit tests for both voice and API recursion-limit paths.

## Test Plan
- `uv run pytest tests/unit/test_bot_handlers_query.py tests/unit/api/test_rag_api_runtime.py -q` — 13 passed
- `uv run pytest tests/integration/test_graph_paths.py -n auto --dist=worksteal -q` — 15 passed
- `make check` — ruff + mypy clean

Fixes #1250