### PR TITLE
test: raise coverage for callback handler modules (#1264)

### DIFF
--- a/tests/unit/test_favorites_callbacks.py
+++ b/tests/unit/test_favorites_callbacks.py
@@ -307,3 +307,331 @@ async def test_fav_toggle_handles_message_not_modified() -> None:
 
     await bot.handle_favorite_callback(callback, state)
     callback.answer.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Direct module-level handler tests (#1264)
+# ---------------------------------------------------------------------------
+
+from telegram_bot.handlers.favorites_callbacks import (
+    create_favorites_router,
+    handle_fav_add,
+    handle_fav_remove,
+    handle_fav_viewing,
+    handle_fav_viewing_all,
+    handle_favorite_callback,
+)
+
+
+def _make_direct_callback(data: str = "fav:add:prop-42", user_id: int = 12345) -> MagicMock:
+    cb = MagicMock()
+    cb.data = data
+    cb.from_user = MagicMock(id=user_id)
+    cb.answer = AsyncMock()
+    cb.message = MagicMock()
+    cb.message.message_id = 100
+    cb.message.answer = AsyncMock()
+    cb.message.delete = AsyncMock()
+    cb.message.edit_reply_markup = AsyncMock()
+    return cb
+
+
+def _make_direct_state(data: dict | None = None) -> MagicMock:
+    state = MagicMock()
+    state.get_data = AsyncMock(return_value=data or {})
+    state.update_data = AsyncMock()
+    state.clear = AsyncMock()
+    return state
+
+
+def _make_direct_fav_cb(action: str = "add", apartment_id: str = "prop-42") -> MagicMock:
+    cb = MagicMock()
+    cb.action = action
+    cb.apartment_id = apartment_id
+    return cb
+
+
+# handle_fav_add
+async def test_direct_fav_add_no_user() -> None:
+    cb = _make_direct_callback()
+    cb.from_user = None
+    state = _make_direct_state()
+    await handle_fav_add(cb, state)
+    cb.answer.assert_awaited_once()
+
+
+async def test_direct_fav_add_missing_property_id() -> None:
+    cb = _make_direct_callback()
+    state = _make_direct_state()
+    callback_data = _make_direct_fav_cb(action="add", apartment_id="")
+    await handle_fav_add(cb, state, callback_data=callback_data)
+    cb.answer.assert_awaited_once()
+
+
+async def test_direct_fav_add_no_favorites_service() -> None:
+    cb = _make_direct_callback()
+    state = _make_direct_state()
+    callback_data = _make_direct_fav_cb(action="add", apartment_id="prop-42")
+    await handle_fav_add(cb, state, callback_data=callback_data, favorites_service=None)
+    cb.answer.assert_awaited_once_with("Закладки недоступны")
+
+
+async def test_direct_fav_add_success_with_metadata() -> None:
+    cb = _make_direct_callback("fav:add:prop-42")
+    state = _make_direct_state({"apartment_results": [_sample_result("prop-42")]})
+    callback_data = _make_direct_fav_cb(action="add", apartment_id="prop-42")
+    favorites_service = MagicMock()
+    favorites_service.add = AsyncMock(return_value={"id": 1})
+    await handle_fav_add(
+        cb, state, callback_data=callback_data, favorites_service=favorites_service
+    )
+    favorites_service.add.assert_awaited_once()
+    call_kwargs = favorites_service.add.call_args.kwargs
+    assert call_kwargs["property_data"]["complex_name"] == "Ocean Vista"
+    cb.answer.assert_awaited_once_with("Добавлено в закладки")
+
+
+async def test_direct_fav_add_duplicate() -> None:
+    cb = _make_direct_callback("fav:add:prop-42")
+    state = _make_direct_state({"apartment_results": [_sample_result("prop-42")]})
+    callback_data = _make_direct_fav_cb(action="add", apartment_id="prop-42")
+    favorites_service = MagicMock()
+    favorites_service.add = AsyncMock(return_value=None)
+    await handle_fav_add(
+        cb, state, callback_data=callback_data, favorites_service=favorites_service
+    )
+    cb.answer.assert_awaited_once_with("Уже в закладках")
+
+
+async def test_direct_fav_add_catalog_runtime_results() -> None:
+    cb = _make_direct_callback("fav:add:prop-42")
+    state = _make_direct_state({"catalog_runtime": {"results": [_sample_result("prop-42")]}})
+    callback_data = _make_direct_fav_cb(action="add", apartment_id="prop-42")
+    favorites_service = MagicMock()
+    favorites_service.add = AsyncMock(return_value={"id": 1})
+    await handle_fav_add(
+        cb, state, callback_data=callback_data, favorites_service=favorites_service
+    )
+    call_kwargs = favorites_service.add.call_args.kwargs
+    assert call_kwargs["property_data"]["complex_name"] == "Ocean Vista"
+
+
+# handle_fav_remove
+async def test_direct_fav_remove_no_user() -> None:
+    cb = _make_direct_callback("fav:remove:prop-42")
+    cb.from_user = None
+    state = _make_direct_state()
+    await handle_fav_remove(cb, state)
+    cb.answer.assert_awaited_once()
+
+
+async def test_direct_fav_remove_missing_property_id() -> None:
+    cb = _make_direct_callback("fav:remove:prop-42")
+    state = _make_direct_state()
+    callback_data = _make_direct_fav_cb(action="remove", apartment_id="")
+    await handle_fav_remove(cb, state, callback_data=callback_data)
+    cb.answer.assert_awaited_once()
+
+
+async def test_direct_fav_remove_no_favorites_service() -> None:
+    cb = _make_direct_callback("fav:remove:prop-42")
+    state = _make_direct_state()
+    callback_data = _make_direct_fav_cb(action="remove", apartment_id="prop-42")
+    await handle_fav_remove(cb, state, callback_data=callback_data, favorites_service=None)
+    cb.answer.assert_awaited_once_with("Закладки недоступны")
+
+
+async def test_direct_fav_remove_in_search_results() -> None:
+    cb = _make_direct_callback("fav:remove:prop-42")
+    state = _make_direct_state({"apartment_results": [_sample_result("prop-42")]})
+    callback_data = _make_direct_fav_cb(action="remove", apartment_id="prop-42")
+    favorites_service = MagicMock()
+    favorites_service.remove = AsyncMock()
+    await handle_fav_remove(
+        cb, state, callback_data=callback_data, favorites_service=favorites_service
+    )
+    favorites_service.remove.assert_awaited_once()
+    cb.message.edit_reply_markup.assert_awaited_once()
+    cb.answer.assert_awaited_once_with("Удалено из закладок")
+
+
+async def test_direct_fav_remove_bookmark_message() -> None:
+    cb = _make_direct_callback("fav:remove:prop-42")
+    cb.message.message_id = 200
+    state = _make_direct_state({"bookmark_message_ids": [200]})
+    callback_data = _make_direct_fav_cb(action="remove", apartment_id="prop-42")
+    favorites_service = MagicMock()
+    favorites_service.remove = AsyncMock()
+    await handle_fav_remove(
+        cb, state, callback_data=callback_data, favorites_service=favorites_service
+    )
+    cb.message.delete.assert_awaited_once()
+    cb.answer.assert_awaited_once_with("Удалено из закладок")
+
+
+# handle_fav_viewing
+async def test_direct_fav_viewing_no_user() -> None:
+    cb = _make_direct_callback("fav:viewing:prop-42")
+    cb.from_user = None
+    state = _make_direct_state()
+    callback_data = _make_direct_fav_cb(action="viewing", apartment_id="prop-42")
+    await handle_fav_viewing(cb, state, callback_data=callback_data)
+    cb.answer.assert_awaited_once()
+
+
+async def test_direct_fav_viewing_missing_property_id() -> None:
+    cb = _make_direct_callback("fav:viewing:prop-42")
+    state = _make_direct_state()
+    callback_data = _make_direct_fav_cb(action="viewing", apartment_id="")
+    await handle_fav_viewing(cb, state, callback_data=callback_data)
+    cb.answer.assert_awaited_once()
+
+
+async def test_direct_fav_viewing_no_favorites_service() -> None:
+    cb = _make_direct_callback("fav:viewing:prop-42")
+    state = _make_direct_state()
+    callback_data = _make_direct_fav_cb(action="viewing", apartment_id="prop-42")
+    with patch(
+        "telegram_bot.handlers.phone_collector.start_phone_collection", new_callable=AsyncMock
+    ) as mock_phone:
+        await handle_fav_viewing(cb, state, callback_data=callback_data, favorites_service=None)
+        mock_phone.assert_awaited_once()
+        assert mock_phone.call_args.kwargs["viewing_objects"] == []
+
+
+async def test_direct_fav_viewing_success() -> None:
+    cb = _make_direct_callback("fav:viewing:prop-42")
+    state = _make_direct_state()
+    callback_data = _make_direct_fav_cb(action="viewing", apartment_id="prop-42")
+    favorites_service = MagicMock()
+    mock_fav = MagicMock()
+    mock_fav.property_id = "prop-42"
+    mock_fav.property_data = {
+        "complex_name": "Test Property",
+        "property_type": "Apartment",
+        "area_m2": 50,
+        "price_eur": 100000,
+    }
+    favorites_service.list = AsyncMock(return_value=[mock_fav])
+    with patch(
+        "telegram_bot.handlers.phone_collector.start_phone_collection", new_callable=AsyncMock
+    ) as mock_phone:
+        await handle_fav_viewing(
+            cb, state, callback_data=callback_data, favorites_service=favorites_service
+        )
+        mock_phone.assert_awaited_once()
+        assert len(mock_phone.call_args.kwargs["viewing_objects"]) == 1
+        assert mock_phone.call_args.kwargs["service_key"] == "viewing"
+
+
+# handle_fav_viewing_all
+async def test_direct_fav_viewing_all_no_user() -> None:
+    cb = _make_direct_callback("fav:viewing_all")
+    cb.from_user = None
+    state = _make_direct_state()
+    await handle_fav_viewing_all(cb, state)
+    cb.answer.assert_awaited_once()
+
+
+async def test_direct_fav_viewing_all_no_favorites_service() -> None:
+    cb = _make_direct_callback("fav:viewing_all")
+    state = _make_direct_state()
+    with patch(
+        "telegram_bot.handlers.phone_collector.start_phone_collection", new_callable=AsyncMock
+    ) as mock_phone:
+        await handle_fav_viewing_all(cb, state, favorites_service=None)
+        mock_phone.assert_awaited_once()
+        assert mock_phone.call_args.kwargs["viewing_objects"] == []
+
+
+async def test_direct_fav_viewing_all_success() -> None:
+    cb = _make_direct_callback("fav:viewing_all")
+    state = _make_direct_state()
+    favorites_service = MagicMock()
+    mock_fav = MagicMock()
+    mock_fav.property_id = "prop-1"
+    mock_fav.property_data = {
+        "complex_name": "Test Property",
+        "property_type": "Apartment",
+        "area_m2": 50,
+        "price_eur": 100000,
+    }
+    favorites_service.list = AsyncMock(return_value=[mock_fav])
+    with patch(
+        "telegram_bot.handlers.phone_collector.start_phone_collection", new_callable=AsyncMock
+    ) as mock_phone:
+        await handle_fav_viewing_all(cb, state, favorites_service=favorites_service)
+        mock_phone.assert_awaited_once()
+        assert len(mock_phone.call_args.kwargs["viewing_objects"]) == 1
+        assert mock_phone.call_args.kwargs["service_key"] == "viewing"
+
+
+# handle_favorite_callback
+async def test_direct_handle_favorite_callback_malformed_data() -> None:
+    cb = _make_direct_callback("fav")
+    state = _make_direct_state()
+    await handle_favorite_callback(cb, state)
+    cb.answer.assert_awaited_once()
+
+
+async def test_direct_handle_favorite_callback_unknown_action() -> None:
+    cb = _make_direct_callback("fav:unknown:prop-42")
+    state = _make_direct_state()
+    await handle_favorite_callback(cb, state)
+    cb.answer.assert_awaited_once()
+
+
+async def test_direct_handle_favorite_callback_add() -> None:
+    cb = _make_direct_callback("fav:add:prop-42")
+    state = _make_direct_state({"apartment_results": [_sample_result("prop-42")]})
+    favorites_service = MagicMock()
+    favorites_service.add = AsyncMock(return_value={"id": 1})
+    await handle_favorite_callback(cb, state, favorites_service=favorites_service)
+    favorites_service.add.assert_awaited_once()
+
+
+async def test_direct_handle_favorite_callback_remove() -> None:
+    cb = _make_direct_callback("fav:remove:prop-42")
+    state = _make_direct_state({"apartment_results": [_sample_result("prop-42")]})
+    favorites_service = MagicMock()
+    favorites_service.remove = AsyncMock()
+    await handle_favorite_callback(cb, state, favorites_service=favorites_service)
+    favorites_service.remove.assert_awaited_once()
+
+
+async def test_direct_handle_favorite_callback_viewing() -> None:
+    cb = _make_direct_callback("fav:viewing:prop-42")
+    state = _make_direct_state()
+    favorites_service = MagicMock()
+    mock_fav = MagicMock()
+    mock_fav.property_id = "prop-42"
+    mock_fav.property_data = {
+        "complex_name": "Test",
+        "property_type": "Apt",
+        "area_m2": 50,
+        "price_eur": 100000,
+    }
+    favorites_service.list = AsyncMock(return_value=[mock_fav])
+    with patch(
+        "telegram_bot.handlers.phone_collector.start_phone_collection", new_callable=AsyncMock
+    ) as mock_phone:
+        await handle_favorite_callback(cb, state, favorites_service=favorites_service)
+        mock_phone.assert_awaited_once()
+
+
+async def test_direct_handle_favorite_callback_viewing_all() -> None:
+    cb = _make_direct_callback("fav:viewing_all")
+    state = _make_direct_state()
+    favorites_service = MagicMock()
+    favorites_service.list = AsyncMock(return_value=[])
+    with patch(
+        "telegram_bot.handlers.phone_collector.start_phone_collection", new_callable=AsyncMock
+    ) as mock_phone:
+        await handle_favorite_callback(cb, state, favorites_service=favorites_service)
+        mock_phone.assert_awaited_once()
+
+
+# create_favorites_router
+def test_create_favorites_router() -> None:
+    router = create_favorites_router()
+    assert router.name == "favorites"

--- a/tests/unit/test_results_callbacks.py
+++ b/tests/unit/test_results_callbacks.py
@@ -112,3 +112,203 @@ async def test_results_viewing_is_stale_compat_only() -> None:
         "Это устаревшая кнопка. Используйте актуальное меню ниже."
     )
     callback.answer.assert_awaited_once_with()
+
+
+# ---------------------------------------------------------------------------
+# Direct module-level handler tests (#1264)
+# ---------------------------------------------------------------------------
+
+from telegram_bot.handlers.results_callbacks import (
+    create_results_callback_router,
+    handle_card_callback,
+    handle_results_callback,
+)
+
+
+def _make_direct_cb(data: str = "results:more", user_id: int = 12345) -> MagicMock:
+    cb = MagicMock()
+    cb.data = data
+    cb.from_user = MagicMock(id=user_id)
+    cb.answer = AsyncMock()
+    cb.message = MagicMock()
+    cb.message.answer = AsyncMock()
+    cb.message.edit_reply_markup = AsyncMock()
+    cb.message.delete = AsyncMock()
+    cb.message.chat = MagicMock(id=999)
+    cb.bot = AsyncMock()
+    return cb
+
+
+def _make_direct_state(data: dict | None = None) -> MagicMock:
+    state = MagicMock()
+    state.get_data = AsyncMock(return_value=data or {})
+    state.update_data = AsyncMock()
+    return state
+
+
+# handle_results_callback
+async def test_direct_results_callback_stale() -> None:
+    cb = _make_direct_cb("results:more")
+    state = _make_direct_state()
+    await handle_results_callback(cb, state)
+    cb.message.edit_reply_markup.assert_awaited_once_with(reply_markup=None)
+    cb.message.answer.assert_awaited_once()
+    cb.answer.assert_awaited_once()
+
+
+async def test_direct_results_callback_no_message() -> None:
+    cb = _make_direct_cb("results:more")
+    cb.message = None
+    state = _make_direct_state()
+    await handle_results_callback(cb, state)
+    cb.answer.assert_awaited_once()
+
+
+# handle_card_callback
+async def test_direct_card_callback_invalid_data() -> None:
+    cb = _make_direct_cb("card:viewing")
+    state = _make_direct_state()
+    await handle_card_callback(cb, state)
+    cb.answer.assert_awaited_once()
+
+
+async def test_direct_card_callback_no_from_user() -> None:
+    cb = _make_direct_cb("card:viewing:prop-42")
+    cb.from_user = None
+    state = _make_direct_state()
+    await handle_card_callback(cb, state)
+    cb.answer.assert_awaited_once()
+
+
+async def test_direct_card_callback_viewing_with_dialog_manager() -> None:
+    cb = _make_direct_cb("card:viewing:prop-42")
+    state = _make_direct_state(
+        {
+            "apartment_results": [
+                {
+                    "id": "prop-42",
+                    "payload": {
+                        "complex_name": "X",
+                        "property_type": "Apt",
+                        "area_m2": 50,
+                        "price_eur": 100000,
+                    },
+                }
+            ]
+        }
+    )
+    dialog_manager = AsyncMock()
+    with patch(
+        "telegram_bot.handlers.phone_collector.start_phone_collection", new_callable=AsyncMock
+    ) as mock_phone:
+        await handle_card_callback(cb, state, dialog_manager=dialog_manager)
+        dialog_manager.start.assert_awaited_once()
+        mock_phone.assert_not_awaited()
+
+
+async def test_direct_card_callback_viewing_without_dialog_manager() -> None:
+    cb = _make_direct_cb("card:viewing:prop-42")
+    state = _make_direct_state(
+        {
+            "apartment_results": [
+                {
+                    "id": "prop-42",
+                    "payload": {
+                        "complex_name": "X",
+                        "property_type": "Apt",
+                        "area_m2": 50,
+                        "price_eur": 100000,
+                    },
+                }
+            ]
+        }
+    )
+    with patch(
+        "telegram_bot.handlers.phone_collector.start_phone_collection", new_callable=AsyncMock
+    ) as mock_phone:
+        await handle_card_callback(cb, state)
+        mock_phone.assert_awaited_once()
+        assert mock_phone.call_args.kwargs["service_key"] == "viewing"
+
+
+async def test_direct_card_callback_ask_with_dialog_manager() -> None:
+    cb = _make_direct_cb("card:ask:prop-42")
+    state = _make_direct_state()
+    dialog_manager = AsyncMock()
+    with patch(
+        "telegram_bot.handlers.phone_collector.start_phone_collection", new_callable=AsyncMock
+    ) as mock_phone:
+        await handle_card_callback(cb, state, dialog_manager=dialog_manager)
+        dialog_manager.start.assert_awaited_once()
+        mock_phone.assert_not_awaited()
+
+
+async def test_direct_card_callback_ask_without_dialog_manager() -> None:
+    cb = _make_direct_cb("card:ask:prop-42")
+    state = _make_direct_state()
+    with patch(
+        "telegram_bot.handlers.phone_collector.start_phone_collection", new_callable=AsyncMock
+    ) as mock_phone:
+        await handle_card_callback(cb, state)
+        mock_phone.assert_awaited_once()
+        assert mock_phone.call_args.kwargs["service_key"] == "question"
+
+
+async def test_direct_card_callback_matched_from_favorites() -> None:
+    cb = _make_direct_cb("card:viewing:prop-42")
+    state = _make_direct_state()
+    favorites_service = MagicMock()
+    mock_fav = MagicMock()
+    mock_fav.property_id = "prop-42"
+    mock_fav.property_data = {
+        "complex_name": "Fav",
+        "property_type": "Studio",
+        "area_m2": 30,
+        "price_eur": 50000,
+    }
+    favorites_service.list = AsyncMock(return_value=[mock_fav])
+    with patch(
+        "telegram_bot.handlers.phone_collector.start_phone_collection", new_callable=AsyncMock
+    ) as mock_phone:
+        await handle_card_callback(cb, state, favorites_service=favorites_service)
+        mock_phone.assert_awaited_once()
+        assert mock_phone.call_args.kwargs["viewing_objects"][0]["complex_name"] == "Fav"
+
+
+async def test_direct_card_callback_control_message_delete() -> None:
+    cb = _make_direct_cb("card:viewing:prop-42")
+    cb.message.chat.id = 999
+    state = _make_direct_state(
+        {
+            "catalog_runtime": {
+                "results": [
+                    {
+                        "id": "prop-42",
+                        "payload": {
+                            "complex_name": "X",
+                            "property_type": "Apt",
+                            "area_m2": 50,
+                            "price_eur": 100000,
+                        },
+                    }
+                ],
+                "control_message_id": 555,
+            }
+        }
+    )
+    dialog_manager = AsyncMock()
+    await handle_card_callback(cb, state, dialog_manager=dialog_manager)
+    cb.bot.delete_message.assert_awaited_once_with(999, 555)
+
+
+async def test_direct_card_callback_unknown_action() -> None:
+    cb = _make_direct_cb("card:unknown:prop-42")
+    state = _make_direct_state()
+    await handle_card_callback(cb, state)
+    cb.answer.assert_awaited_once()
+
+
+# create_results_callback_router
+def test_create_results_callback_router() -> None:
+    router = create_results_callback_router()
+    assert router.name == "results_callbacks"

--- a/tests/unit/test_service_callbacks.py
+++ b/tests/unit/test_service_callbacks.py
@@ -376,3 +376,169 @@ async def test_fav_viewing_all_no_favorites_service_answers_unavailable():
     await bot.handle_fav_viewing_all(cb, state)
 
     cb.answer.assert_awaited_once_with("Закладки недоступны")
+
+
+# ---------------------------------------------------------------------------
+# Direct module-level handler tests (#1264)
+# ---------------------------------------------------------------------------
+
+from telegram_bot.handlers.service_callbacks import (
+    create_service_callback_router,
+    handle_cta_callback,
+    handle_service_callback,
+)
+
+
+def _make_direct_cb(data: str = "svc:back", user_id: int = 12345) -> MagicMock:
+    cb = MagicMock()
+    cb.data = data
+    cb.from_user = MagicMock(id=user_id)
+    cb.answer = AsyncMock()
+    cb.message = MagicMock()
+    cb.message.answer = AsyncMock()
+    cb.message.edit_text = AsyncMock()
+    cb.message.edit_reply_markup = AsyncMock()
+    cb.message.delete = AsyncMock()
+    return cb
+
+
+def _make_direct_state(data: dict | None = None) -> MagicMock:
+    state = MagicMock()
+    state.get_data = AsyncMock(return_value=data or {})
+    state.update_data = AsyncMock()
+    return state
+
+
+# handle_service_callback
+async def test_direct_service_callback_parsed_none() -> None:
+    cb = _make_direct_cb("unknown")
+    await handle_service_callback(cb)
+    cb.answer.assert_awaited_once()
+
+
+async def test_direct_service_callback_back_with_message() -> None:
+    cb = _make_direct_cb("svc:back")
+    await handle_service_callback(cb)
+    cb.message.delete.assert_awaited_once()
+    cb.answer.assert_awaited_once()
+
+
+async def test_direct_service_callback_back_no_message() -> None:
+    cb = _make_direct_cb("svc:back")
+    cb.message = None
+    await handle_service_callback(cb)
+    cb.answer.assert_awaited_once()
+
+
+async def test_direct_service_callback_menu_with_i18n() -> None:
+    cb = _make_direct_cb("svc:menu")
+    i18n = MagicMock()
+    i18n.get.return_value = "Choose:"
+    with patch("telegram_bot.keyboards.services_keyboard.build_services_menu") as mock_build:
+        mock_kb = MagicMock()
+        mock_build.return_value = mock_kb
+        await handle_service_callback(cb, i18n=i18n)
+        cb.message.edit_text.assert_awaited_once()
+        i18n.get.assert_called_with("services-menu-text")
+
+
+async def test_direct_service_callback_menu_without_i18n() -> None:
+    cb = _make_direct_cb("svc:menu")
+    with patch("telegram_bot.keyboards.services_keyboard.build_services_menu") as mock_build:
+        mock_kb = MagicMock()
+        mock_build.return_value = mock_kb
+        await handle_service_callback(cb, i18n=None)
+        cb.message.edit_text.assert_awaited_once()
+
+
+async def test_direct_service_callback_service_with_card() -> None:
+    cb = _make_direct_cb("svc:service:passive_income")
+    i18n = MagicMock()
+    i18n.get.return_value = None
+    with patch(
+        "telegram_bot.services.content_loader.get_service_card",
+        return_value={"card_text": "Desc"},
+    ):
+        with patch(
+            "telegram_bot.keyboards.services_keyboard.build_service_card_buttons"
+        ) as mock_build:
+            mock_kb = MagicMock()
+            mock_build.return_value = mock_kb
+            await handle_service_callback(cb, i18n=i18n)
+            cb.message.edit_text.assert_awaited_once()
+
+
+async def test_direct_service_callback_service_no_card() -> None:
+    cb = _make_direct_cb("svc:service:passive_income")
+    with patch("telegram_bot.services.content_loader.get_service_card", return_value=None):
+        await handle_service_callback(cb)
+        cb.message.edit_text.assert_not_awaited()
+        cb.answer.assert_awaited_once()
+
+
+async def test_direct_service_callback_unknown_action() -> None:
+    cb = _make_direct_cb("svc:unknown")
+    await handle_service_callback(cb)
+    cb.answer.assert_awaited_once()
+
+
+# handle_cta_callback
+async def test_direct_cta_callback_parsed_none() -> None:
+    cb = _make_direct_cb("unknown")
+    state = _make_direct_state()
+    await handle_cta_callback(cb, state)
+    cb.answer.assert_awaited_once()
+
+
+async def test_direct_cta_callback_get_offer() -> None:
+    cb = _make_direct_cb("cta:get_offer:some_service")
+    state = _make_direct_state()
+    with patch(
+        "telegram_bot.handlers.phone_collector.start_phone_collection", new_callable=AsyncMock
+    ) as mock_phone:
+        await handle_cta_callback(cb, state)
+        mock_phone.assert_awaited_once()
+        assert mock_phone.call_args.kwargs["service_key"] == "some_service"
+
+
+async def test_direct_cta_callback_manager_with_forum_bridge() -> None:
+    cb = _make_direct_cb("cta:manager")
+    state = _make_direct_state()
+    forum_bridge = MagicMock()
+    with patch(
+        "telegram_bot.handlers.handoff.start_qualification", new_callable=AsyncMock
+    ) as mock_qual:
+        await handle_cta_callback(cb, state, forum_bridge=forum_bridge)
+        mock_qual.assert_awaited_once()
+        assert mock_qual.call_args.kwargs["goal"] == "services"
+
+
+async def test_direct_cta_callback_manager_without_forum_bridge() -> None:
+    cb = _make_direct_cb("cta:manager")
+    state = _make_direct_state()
+    with patch(
+        "telegram_bot.handlers.phone_collector.start_phone_collection", new_callable=AsyncMock
+    ) as mock_phone:
+        await handle_cta_callback(cb, state, forum_bridge=None)
+        mock_phone.assert_awaited_once()
+        assert mock_phone.call_args.kwargs["service_key"] == "manager"
+
+
+async def test_direct_cta_callback_unknown_action() -> None:
+    cb = _make_direct_cb("cta:unknown")
+    state = _make_direct_state()
+    await handle_cta_callback(cb, state)
+    cb.answer.assert_awaited_once()
+
+
+async def test_direct_cta_callback_malformed_data() -> None:
+    cb = _make_direct_cb("cta:")
+    state = _make_direct_state()
+    await handle_cta_callback(cb, state)
+    cb.answer.assert_awaited_once()
+
+
+# create_service_callback_router
+def test_create_service_callback_router() -> None:
+    router = create_service_callback_router()
+    assert router.name == "service_callbacks"


### PR DESCRIPTION
Fixes #1264

## Summary

- Adds direct module-level tests for `telegram_bot.handlers.favorites_callbacks`.
- Adds direct module-level tests for `telegram_bot.handlers.results_callbacks`.
- Adds direct module-level tests for `telegram_bot.handlers.service_callbacks`.
- Raises focused coverage for the three handler modules from roughly 0% to 93.58%.

## Verification

- `uv run pytest tests/unit/test_favorites_callbacks.py tests/unit/test_results_callbacks.py tests/unit/test_service_callbacks.py -q`
- `uv run pytest tests/unit/test_favorites_callbacks.py tests/unit/test_results_callbacks.py tests/unit/test_service_callbacks.py --cov=telegram_bot.handlers.favorites_callbacks --cov=telegram_bot.handlers.results_callbacks --cov=telegram_bot.handlers.service_callbacks --cov-report=term-missing -q`
- `make check`
