### PR TITLE
feat(docker): add static validation for Docker/Compose (#1243)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,14 +47,17 @@ jobs:
         run: |
           curl -sL -o /tmp/hadolint https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
           chmod +x /tmp/hadolint
-          /tmp/hadolint src/api/Dockerfile
-          /tmp/hadolint Dockerfile.ingestion
-          /tmp/hadolint telegram_bot/Dockerfile
-          /tmp/hadolint services/bge-m3-api/Dockerfile
-          /tmp/hadolint services/user-base/Dockerfile
-          /tmp/hadolint services/docling/Dockerfile
-          /tmp/hadolint src/voice/Dockerfile
-          /tmp/hadolint mini_app/Dockerfile
+          for f in \
+            src/api/Dockerfile \
+            Dockerfile.ingestion \
+            telegram_bot/Dockerfile \
+            services/bge-m3-api/Dockerfile \
+            services/user-base/Dockerfile \
+            services/docling/Dockerfile \
+            src/voice/Dockerfile \
+            mini_app/Dockerfile; do
+            /tmp/hadolint --failure-threshold error "$f"
+          done
 
       - name: Gitleaks secret scan
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,38 @@ jobs:
       - name: Type check
         run: uv run --python 3.14 mypy src/ telegram_bot/ --ignore-missing-imports --no-error-summary
 
+      - name: Validate Compose configs
+        run: |
+          COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml config --quiet
+          COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.vps.yml config --quiet
+
+      - name: Hadolint Dockerfile lint
+        run: |
+          curl -sL -o /tmp/hadolint https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
+          chmod +x /tmp/hadolint
+          /tmp/hadolint src/api/Dockerfile
+          /tmp/hadolint Dockerfile.ingestion
+          /tmp/hadolint telegram_bot/Dockerfile
+          /tmp/hadolint services/bge-m3-api/Dockerfile
+          /tmp/hadolint services/user-base/Dockerfile
+          /tmp/hadolint services/docling/Dockerfile
+          /tmp/hadolint src/voice/Dockerfile
+          /tmp/hadolint mini_app/Dockerfile
+
+      - name: Gitleaks secret scan
+        run: |
+          curl -sL -o /tmp/gitleaks.tar.gz https://github.com/gitleaks/gitleaks/releases/download/v8.23.1/gitleaks_8.23.1_linux_x64.tar.gz
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          cat > /tmp/gitleaks.toml << 'EOF'
+          [allowlist]
+          paths = [
+            '''\.env\.example$''',
+            '''k8s/secrets/\.env\.example$''',
+            '''tests/unit/test_topic_service_init\.py$''',
+          ]
+          EOF
+          /tmp/gitleaks detect --source . --no-git --config /tmp/gitleaks.toml --verbose
+
       - name: Set up Python for tests
         run: uv python install 3.12
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -110,6 +110,7 @@ repos:
         language: docker_image
         files: Dockerfile.*|.*Dockerfile
         pass_filenames: true
+        args: ["--failure-threshold", "error"]
 
   # =============================================================================
   # PRE-PUSH HOOKS (Run before git push)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,17 +83,33 @@ repos:
   #       args:
   #         - --config-file=pyproject.toml
 
-  # Optional: bandit for security issues
-  # Uncomment to enable security scanning
-  # - repo: https://github.com/PyCQA/bandit
-  #   rev: '1.7.10'
-  #   hooks:
-  #     - id: bandit
-  #       name: Bandit Security Linter
-  #       args:
-  #         - -c
-  #         - pyproject.toml
-  #       additional_dependencies: ["bandit[toml]"]
+  # Bandit for security issues
+  - repo: https://github.com/PyCQA/bandit
+    rev: '1.7.10'
+    hooks:
+      - id: bandit
+        name: Bandit Security Linter
+        args:
+          - -c
+          - pyproject.toml
+        additional_dependencies: ["bandit[toml]"]
+
+  # Gitleaks for secret scanning
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.23.1
+    hooks:
+      - id: gitleaks
+        name: Gitleaks secret scanner
+
+  # Hadolint for Dockerfile linting (requires Docker)
+  - repo: local
+    hooks:
+      - id: hadolint
+        name: Hadolint Dockerfile linter
+        entry: hadolint/hadolint:v2.12.0
+        language: docker_image
+        files: Dockerfile.*|.*Dockerfile
+        pass_filenames: true
 
   # =============================================================================
   # PRE-PUSH HOOKS (Run before git push)

--- a/tests/unit/test_docker_static_validation.py
+++ b/tests/unit/test_docker_static_validation.py
@@ -1,0 +1,78 @@
+"""Static Docker/Compose validation tests (#1243).
+
+These tests validate Docker/Compose configuration without starting live services.
+Docker availability is checked at runtime; tests skip gracefully when absent.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+DOCKERFILES = [
+    "src/api/Dockerfile",
+    "Dockerfile.ingestion",
+    "telegram_bot/Dockerfile",
+    "services/bge-m3-api/Dockerfile",
+    "services/user-base/Dockerfile",
+    "services/docling/Dockerfile",
+    "src/voice/Dockerfile",
+    "mini_app/Dockerfile",
+]
+
+COMPOSE_CI_ENV = Path("tests/fixtures/compose.ci.env")
+
+
+def _docker_available() -> bool:
+    return shutil.which("docker") is not None
+
+
+@pytest.mark.parametrize("dockerfile", DOCKERFILES)
+def test_dockerfile_exists(dockerfile: str) -> None:
+    assert Path(dockerfile).is_file(), f"{dockerfile} not found"
+
+
+@pytest.mark.skipif(not _docker_available(), reason="Docker not available")
+def test_compose_dev_config_renders() -> None:
+    result = subprocess.run(
+        [
+            "docker",
+            "compose",
+            "--env-file",
+            str(COMPOSE_CI_ENV),
+            "-f",
+            "compose.yml",
+            "-f",
+            "compose.dev.yml",
+            "config",
+            "--quiet",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"Compose dev config failed:\n{result.stderr}"
+
+
+@pytest.mark.skipif(not _docker_available(), reason="Docker not available")
+def test_compose_vps_config_renders() -> None:
+    result = subprocess.run(
+        [
+            "docker",
+            "compose",
+            "--env-file",
+            str(COMPOSE_CI_ENV),
+            "-f",
+            "compose.yml",
+            "-f",
+            "compose.vps.yml",
+            "config",
+            "--quiet",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"Compose VPS config failed:\n{result.stderr}"

--- a/tests/unit/test_dockerfile_python_abi.py
+++ b/tests/unit/test_dockerfile_python_abi.py
@@ -90,3 +90,13 @@ def test_voice_dockerfile_python_version_consistency() -> None:
         f"src/voice/Dockerfile: builder Python {builder_ver} != runtime Python {runtime_ver}. "
         "Binary wheels compiled for one version break on another."
     )
+
+
+def test_mini_app_dockerfile_python_version_consistency() -> None:
+    text = Path("mini_app/Dockerfile").read_text(encoding="utf-8")
+    builder_ver = _get_builder_python_version(text)
+    runtime_ver = _get_runtime_python_version(text)
+    assert builder_ver == runtime_ver, (
+        f"mini_app/Dockerfile: builder Python {builder_ver} != runtime Python {runtime_ver}. "
+        "Binary wheels compiled for one version break on another."
+    )


### PR DESCRIPTION
Fixes #1243

## Summary
- Add `mini_app/Dockerfile` to Python ABI consistency test
- Add hadolint, gitleaks, and bandit to pre-commit hooks
- Validate Compose configs (dev + vps) in CI lint job
- Add hadolint Dockerfile lint and gitleaks secret scan to CI
- Add deterministic Compose config tests with graceful Docker skip

## Verification
- `uv run pytest tests/unit/test_dockerfile_python_abi.py tests/unit/test_docker_compose_profiles.py tests/unit/test_docker_compose_env.py tests/unit/test_docker_static_validation.py -q` passes
- `COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml config --quiet` passes
- `COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.vps.yml config --quiet` passes
- `make check` passes
