### PR TITLE
fix(livekit): remove hardcoded secret fallback and add contract tests (#1124)

### DIFF
--- a/docker/livekit/livekit.yaml
+++ b/docker/livekit/livekit.yaml
@@ -6,4 +6,4 @@ rtc:
   port_range_end: 50100
   use_external_ip: true
 keys:
-  APIznMMRmVpwTj2: ${LIVEKIT_API_SECRET:-secret}
+  APIznMMRmVpwTj2: ${LIVEKIT_API_SECRET}

--- a/tests/unit/test_compose_runtime_contract.py
+++ b/tests/unit/test_compose_runtime_contract.py
@@ -10,6 +10,7 @@ import yaml
 ROOT = Path(__file__).parents[2]
 BASE_COMPOSE = ROOT / "compose.yml"
 LIVEKIT_URL_EXPR = "${LIVEKIT_URL:-ws://livekit-server:7880}"
+LIVEKIT_CONFIG = ROOT / "docker" / "livekit" / "livekit.yaml"
 
 
 def _load_compose() -> dict:
@@ -36,3 +37,17 @@ def test_livekit_sip_uses_env_driven_livekit_url_everywhere() -> None:
 
     assert environment["LIVEKIT_WS_URL"] == LIVEKIT_URL_EXPR
     assert f"ws_url: {LIVEKIT_URL_EXPR}" in environment["SIP_CONFIG_BODY"]
+
+
+def test_livekit_server_receives_api_secret() -> None:
+    compose = _load_compose()
+    environment = compose["services"]["livekit-server"]["environment"]
+
+    assert environment["LIVEKIT_API_SECRET"] == "${LIVEKIT_API_SECRET:-}"
+
+
+def test_livekit_template_secret_has_no_hardcoded_fallback() -> None:
+    config_text = LIVEKIT_CONFIG.read_text()
+
+    assert "${LIVEKIT_API_SECRET:-secret}" not in config_text
+    assert "LIVEKIT_API_SECRET" in config_text


### PR DESCRIPTION
Closes #1124

## Changes
- Remove the silent `:-secret` fallback from `docker/livekit/livekit.yaml` so the config template no longer hardcodes a default when `LIVEKIT_API_SECRET` is missing or empty.
- Add regression tests verifying `livekit-server` receives `LIVEKIT_API_SECRET` from Compose and that the `livekit.yaml` template has no hardcoded fallback.

## Verification
- `uv run pytest tests/unit/test_compose_runtime_contract.py -q` passes
- `COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml config --quiet` succeeds
- `make check` passes