### PR TITLE
fix(local-dev): remove docling from default local-up services and add local-up-ingest target (#1282)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -483,12 +483,18 @@ qa: all-checks test ## Full quality assurance
 # Local Development (compose.yml + compose.dev.yml via COMPOSE_FILE env)
 # =============================================================================
 
-.PHONY: local-up local-down local-logs local-ps local-build run-bot bot
-LOCAL_SERVICES := redis qdrant bge-m3 docling litellm
+.PHONY: local-up local-up-ingest local-down local-logs local-ps local-build run-bot bot
+LOCAL_SERVICES := redis qdrant bge-m3 litellm
+LOCAL_INGEST_SERVICES := docling
+LOCAL_ALL_SERVICES := $(LOCAL_SERVICES) $(LOCAL_INGEST_SERVICES)
 
 local-up:  ## Start local Docker services (bot runs via make run-bot)
 	$(LOCAL_COMPOSE_CMD) up -d $(LOCAL_SERVICES)
 	@echo "$(GREEN)✓ Local services started. Run bot: make run-bot$(NC)"
+
+local-up-ingest:  ## Start local services + docling for ingestion workflows
+	$(LOCAL_COMPOSE_CMD) up -d $(LOCAL_ALL_SERVICES)
+	@echo "$(GREEN)✓ Local services + docling started$(NC)"
 
 run-bot:  ## Run bot locally (requires: make local-up)
 	uv run --env-file .env python -m telegram_bot.main
@@ -498,14 +504,14 @@ bot:  ## Alias: run bot and tee output to logs/bot-run.log
 	uv run --env-file .env python -m telegram_bot.main 2>&1 | tee logs/bot-run.log; echo '[COMPLETE]'
 
 local-down:  ## Stop local Docker services
-	$(LOCAL_COMPOSE_CMD) stop $(LOCAL_SERVICES) || true
-	$(LOCAL_COMPOSE_CMD) rm -f $(LOCAL_SERVICES) || true
+	$(LOCAL_COMPOSE_CMD) stop $(LOCAL_ALL_SERVICES) || true
+	$(LOCAL_COMPOSE_CMD) rm -f $(LOCAL_ALL_SERVICES) || true
 
 local-logs:  ## View local Docker logs
-	$(LOCAL_COMPOSE_CMD) logs -f $(LOCAL_SERVICES)
+	$(LOCAL_COMPOSE_CMD) logs -f $(LOCAL_ALL_SERVICES)
 
 local-ps:  ## Show local Docker status
-	$(LOCAL_COMPOSE_CMD) ps $(LOCAL_SERVICES)
+	$(LOCAL_COMPOSE_CMD) ps $(LOCAL_ALL_SERVICES)
 
 local-build:  ## Rebuild local Docker services
 	$(LOCAL_COMPOSE_CMD) build bge-m3 docling

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -121,6 +121,14 @@ make local-ps
 make local-down
 ```
 
+For ingestion workflows that require docling:
+
+```bash
+make local-up-ingest
+make local-ps
+make local-down
+```
+
 ## 7. Common Issues
 
 - `docker-bot-up` fails immediately: missing required env variables in `.env`.

--- a/tests/unit/test_local_compose_contract.py
+++ b/tests/unit/test_local_compose_contract.py
@@ -27,6 +27,7 @@ def test_local_dev_docker_targets_use_local_compose_override() -> None:
         "docker-down",
         "docker-ps",
         "local-up",
+        "local-up-ingest",
         "local-down",
         "local-logs",
         "local-ps",

--- a/tests/unit/test_makefile_contract.py
+++ b/tests/unit/test_makefile_contract.py
@@ -1,0 +1,85 @@
+import re
+from pathlib import Path
+
+
+MAKEFILE = Path("Makefile")
+
+
+def _makefile_text() -> str:
+    return MAKEFILE.read_text(encoding="utf-8")
+
+
+def test_local_services_excludes_docling() -> None:
+    text = _makefile_text()
+    match = re.search(r"^LOCAL_SERVICES\s*:=\s*(.+)$", text, re.MULTILINE)
+    assert match, "LOCAL_SERVICES not found in Makefile"
+    services = match.group(1).strip().split()
+    assert "docling" not in services, f"docling must not be in LOCAL_SERVICES (found {services!r})"
+
+
+def test_local_ingest_services_includes_docling() -> None:
+    text = _makefile_text()
+    match = re.search(r"^LOCAL_INGEST_SERVICES\s*:=\s*(.+)$", text, re.MULTILINE)
+    assert match, "LOCAL_INGEST_SERVICES not found in Makefile"
+    services = match.group(1).strip().split()
+    assert "docling" in services, f"docling must be in LOCAL_INGEST_SERVICES (found {services!r})"
+
+
+def test_local_all_services_combines_both_sets() -> None:
+    text = _makefile_text()
+    match = re.search(r"^LOCAL_ALL_SERVICES\s*:=\s*(.+)$", text, re.MULTILINE)
+    assert match, "LOCAL_ALL_SERVICES not found in Makefile"
+    definition = match.group(1).strip()
+    assert "$(LOCAL_SERVICES)" in definition, "LOCAL_ALL_SERVICES must reference $(LOCAL_SERVICES)"
+    assert "$(LOCAL_INGEST_SERVICES)" in definition, (
+        "LOCAL_ALL_SERVICES must reference $(LOCAL_INGEST_SERVICES)"
+    )
+
+
+def test_local_up_ingest_target_exists() -> None:
+    text = _makefile_text()
+    assert re.search(r"^local-up-ingest:", text, re.MULTILINE), (
+        "local-up-ingest target must exist in Makefile"
+    )
+
+
+def test_local_down_uses_all_services() -> None:
+    text = _makefile_text()
+    block_match = re.search(
+        r"^local-down:.*?(?=^[A-Za-z0-9_.-]+:|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert block_match, "local-down target not found"
+    block = block_match.group(0)
+    assert "$(LOCAL_ALL_SERVICES)" in block, (
+        "local-down must reference $(LOCAL_ALL_SERVICES) for coherence"
+    )
+
+
+def test_local_logs_uses_all_services() -> None:
+    text = _makefile_text()
+    block_match = re.search(
+        r"^local-logs:.*?(?=^[A-Za-z0-9_.-]+:|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert block_match, "local-logs target not found"
+    block = block_match.group(0)
+    assert "$(LOCAL_ALL_SERVICES)" in block, (
+        "local-logs must reference $(LOCAL_ALL_SERVICES) for coherence"
+    )
+
+
+def test_local_ps_uses_all_services() -> None:
+    text = _makefile_text()
+    block_match = re.search(
+        r"^local-ps:.*?(?=^[A-Za-z0-9_.-]+:|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert block_match, "local-ps target not found"
+    block = block_match.group(0)
+    assert "$(LOCAL_ALL_SERVICES)" in block, (
+        "local-ps must reference $(LOCAL_ALL_SERVICES) for coherence"
+    )


### PR DESCRIPTION
## Summary

Remove `docling` from the default `make local-up` service set and add a dedicated `make local-up-ingest` target for ingestion workflows.

## Changes

- `LOCAL_SERVICES` now excludes `docling` (was `redis qdrant bge-m3 docling litellm`, now `redis qdrant bge-m3 litellm`)
- Added `LOCAL_INGEST_SERVICES := docling` and `LOCAL_ALL_SERVICES` combining both sets
- Added `local-up-ingest` target for workflows that need docling
- Updated `local-down`, `local-logs`, `local-ps` to use `LOCAL_ALL_SERVICES` for coherence
- Added `test_makefile_contract.py` with focused contract tests
- Updated `docs/LOCAL-DEVELOPMENT.md` to mention `local-up-ingest`

## Verification

- `uv run pytest tests/unit/test_local_compose_contract.py tests/unit/test_makefile_contract.py -q` ✓
- `COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml config --services` ✓
- `make check` ✓

Fixes #1282