### PR TITLE
fix(trace): propagate Langfuse trace context from agent to RAG pipeline (#1253)

### DIFF
--- a/telegram_bot/agents/rag_pipeline.py
+++ b/telegram_bot/agents/rag_pipeline.py
@@ -17,6 +17,7 @@ Orchestrator: rag_pipeline() wires steps with rewrite loop.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import logging
 import time
@@ -921,8 +922,7 @@ async def _cache_store(
 # ---------------------------------------------------------------------------
 
 
-@observe(name="rag-pipeline", capture_input=False, capture_output=False)
-async def rag_pipeline(
+async def _rag_pipeline_impl(
     query: str,
     *,
     user_id: int,
@@ -1276,6 +1276,71 @@ async def rag_pipeline(
         }
     )
     return result
+
+
+async def rag_pipeline(
+    query: str,
+    *,
+    user_id: int,
+    session_id: str,
+    query_type: str = "GENERAL",
+    original_query: str = "",
+    cache: Any,
+    embeddings: Any,
+    sparse_embeddings: Any,
+    qdrant: Any,
+    reranker: Any | None = None,
+    llm: Any | None = None,
+    agent_role: str | None = None,
+    state_contract: PreAgentStateContract | None = None,
+    pre_computed_embedding: list[float] | None = None,
+    pre_computed_sparse: Any = None,
+    pre_computed_colbert: list[list[float]] | None = None,
+    semantic_cache_already_checked: bool = False,
+    skip_rewrite: bool = False,
+    langfuse_trace_id: str | None = None,
+) -> dict[str, Any]:
+    """Execute RAG pipeline with explicit Langfuse trace linking.
+
+    Wraps :func:`_rag_pipeline_impl` in ``start_as_current_observation`` so
+    pipeline observations are nested under the caller's trace when
+    *langfuse_trace_id* is provided.
+    """
+    lf = get_client()
+    trace_kwargs: dict[str, Any] = {}
+    if langfuse_trace_id:
+        trace_kwargs["trace_context"] = {"trace_id": langfuse_trace_id}
+
+    observation_ctx: Any = contextlib.nullcontext()
+    if lf is not None:
+        with contextlib.suppress(Exception):
+            observation_ctx = lf.start_as_current_observation(
+                as_type="span",
+                name="rag-pipeline",
+                **trace_kwargs,
+            )
+
+    with observation_ctx:
+        return await _rag_pipeline_impl(
+            query,
+            user_id=user_id,
+            session_id=session_id,
+            query_type=query_type,
+            original_query=original_query,
+            cache=cache,
+            embeddings=embeddings,
+            sparse_embeddings=sparse_embeddings,
+            qdrant=qdrant,
+            reranker=reranker,
+            llm=llm,
+            agent_role=agent_role,
+            state_contract=state_contract,
+            pre_computed_embedding=pre_computed_embedding,
+            pre_computed_sparse=pre_computed_sparse,
+            pre_computed_colbert=pre_computed_colbert,
+            semantic_cache_already_checked=semantic_cache_already_checked,
+            skip_rewrite=skip_rewrite,
+        )
 
 
 def _assemble_context(

--- a/telegram_bot/agents/rag_tool.py
+++ b/telegram_bot/agents/rag_tool.py
@@ -157,6 +157,7 @@ async def rag_search(
                 result_store.get("semantic_cache_already_checked")
             )
 
+        trace_id = lf.get_current_trace_id() or ""
         invoke_start = time.perf_counter()
         result = await rag_pipeline(
             query,
@@ -176,6 +177,7 @@ async def rag_search(
             pre_computed_sparse=pre_computed_sparse,
             pre_computed_colbert=pre_computed_colbert,
             semantic_cache_already_checked=semantic_cache_already_checked,
+            langfuse_trace_id=trace_id,
         )
         pipeline_wall_ms = (time.perf_counter() - invoke_start) * 1000
 

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -586,7 +586,7 @@ class PropertyBot:
             from .services.apartment_llm_extractor import ApartmentLlmExtractor
 
             _apt_llm = ApartmentLlmExtractor(llm=self._llm, model=config.apartment_extraction_model)
-        except ImportError, ModuleNotFoundError:
+        except (ImportError, ModuleNotFoundError):
             logger.warning(
                 "ApartmentLlmExtractor unavailable, falling back to regex-only extraction",
                 exc_info=True,
@@ -1068,7 +1068,7 @@ class PropertyBot:
 
         try:
             payload = json.loads(raw)
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             if message:
                 await message.answer("Ошибка обработки ссылки.")
             else:
@@ -1208,7 +1208,7 @@ class PropertyBot:
                     data = json.loads(raw_msg["data"])
                     uuid_str = data["uuid"]
                     user_id = int(data["user_id"])
-                except ValueError, TypeError, KeyError:
+                except (ValueError, TypeError, KeyError):
                     logger.warning("Invalid miniapp:start message: %s", raw_msg["data"])
                     continue
 

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -586,7 +586,7 @@ class PropertyBot:
             from .services.apartment_llm_extractor import ApartmentLlmExtractor
 
             _apt_llm = ApartmentLlmExtractor(llm=self._llm, model=config.apartment_extraction_model)
-        except (ImportError, ModuleNotFoundError):
+        except ImportError, ModuleNotFoundError:
             logger.warning(
                 "ApartmentLlmExtractor unavailable, falling back to regex-only extraction",
                 exc_info=True,
@@ -1068,7 +1068,7 @@ class PropertyBot:
 
         try:
             payload = json.loads(raw)
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             if message:
                 await message.answer("Ошибка обработки ссылки.")
             else:
@@ -1208,7 +1208,7 @@ class PropertyBot:
                     data = json.loads(raw_msg["data"])
                     uuid_str = data["uuid"]
                     user_id = int(data["user_id"])
-                except (ValueError, TypeError, KeyError):
+                except ValueError, TypeError, KeyError:
                     logger.warning("Invalid miniapp:start message: %s", raw_msg["data"])
                     continue
 
@@ -3208,7 +3208,12 @@ class PropertyBot:
             )
 
             # Initialize handler inside propagation context so it inherits session/user/tags.
-            langfuse_handler = create_callback_handler()
+            # Link agent graph observations to the current trace via explicit trace_context (#1253).
+            lf = get_client()
+            tid = lf.get_current_trace_id() or ""
+            langfuse_handler = create_callback_handler(
+                trace_context={"trace_id": tid} if tid else None
+            )
             callbacks = [langfuse_handler] if langfuse_handler else []
             async with ChatActionSender.typing(bot=bot, chat_id=message.chat.id):
                 response_text, result = await self._astream_supervisor_with_recovery(
@@ -3421,6 +3426,8 @@ class PropertyBot:
                         )
                     except Exception:
                         logger.warning("Failed to store semantic cache in text path", exc_info=True)
+
+            filter_signature = None
 
             # Wall-time for the full pipeline
             wall_ms = (time.perf_counter() - pipeline_start) * 1000

--- a/tests/integration/test_service_chain_agent_tools.py
+++ b/tests/integration/test_service_chain_agent_tools.py
@@ -106,3 +106,44 @@ async def test_manager_service_chain_includes_history_and_crm_tools():
         assert "rag_search" in names
         assert "history_search" in names
         assert "crm_get_my_leads" in names
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_supervisor_passes_langfuse_trace_context_to_callback_handler():
+    """_handle_query_supervisor should link agent CallbackHandler to current trace (#1253)."""
+    bot = _create_bot()
+    bot._resolve_user_role = AsyncMock(return_value="client")
+    bot._ainvoke_supervisor_with_recovery = AsyncMock(
+        return_value={"messages": [MagicMock(content="ok")]}
+    )
+
+    message = MagicMock()
+    message.text = "test query"
+    message.chat = MagicMock(id=12345)
+    message.from_user = MagicMock(id=12345)
+    message.bot = MagicMock()
+    message.bot.send_chat_action = AsyncMock()
+    message.answer = AsyncMock()
+
+    mock_lf = MagicMock()
+    mock_lf.get_current_trace_id = MagicMock(return_value="trace-supervisor-789")
+
+    created_agent = MagicMock()
+    created_agent.ainvoke = AsyncMock(return_value={"messages": [MagicMock(content="ok")]})
+    with (
+        patch("telegram_bot.bot.propagate_attributes", return_value=nullcontext()),
+        patch("telegram_bot.bot.get_client", return_value=mock_lf),
+        patch("telegram_bot.bot.classify_query", return_value="OFF_TOPIC"),
+        patch("telegram_bot.bot.create_callback_handler") as mock_create_handler,
+        patch("telegram_bot.bot.ChatActionSender") as mock_cas,
+        patch("telegram_bot.bot.create_bot_agent", return_value=created_agent),
+        patch("telegram_bot.agents.utility_tools.get_utility_tools", return_value=[]),
+    ):
+        mock_cas.typing.return_value = _make_typing_cm()
+        mock_create_handler.return_value = None
+        await bot._handle_query_supervisor(message=message, pipeline_start=0.0)
+
+        mock_create_handler.assert_called_once()
+        call_kwargs = mock_create_handler.call_args.kwargs
+        assert call_kwargs.get("trace_context") == {"trace_id": "trace-supervisor-789"}

--- a/tests/unit/agents/test_rag_tool.py
+++ b/tests/unit/agents/test_rag_tool.py
@@ -486,3 +486,45 @@ async def test_rag_search_falls_back_to_query_when_no_original(bot_context):
     # Guard should use the tool query as fallback
     guard_state = mock_guard.call_args[0][0]
     assert guard_state["messages"][0]["content"] == "цены на квартиры"
+
+
+async def test_rag_search_propagates_langfuse_trace_id_to_pipeline(bot_context):
+    """rag_search passes captured langfuse_trace_id into rag_pipeline (#1253)."""
+    from telegram_bot.agents.rag_tool import rag_search
+
+    mock_lf = MagicMock()
+    mock_lf.get_current_trace_id = MagicMock(return_value="trace-abc-123")
+
+    with (
+        patch(
+            "telegram_bot.agents.rag_tool.rag_pipeline",
+            new_callable=AsyncMock,
+            return_value=_pipeline_result(),
+        ) as mock_pipeline,
+        patch("telegram_bot.agents.rag_tool.get_client", return_value=mock_lf),
+    ):
+        await rag_search.ainvoke({"query": "test"}, config=_make_config(bot_context))
+
+    assert mock_pipeline.call_count == 1
+    assert mock_pipeline.call_args.kwargs["langfuse_trace_id"] == "trace-abc-123"
+
+
+async def test_rag_search_passes_none_trace_id_when_not_available(bot_context):
+    """rag_search passes empty string trace_id when get_current_trace_id returns None."""
+    from telegram_bot.agents.rag_tool import rag_search
+
+    mock_lf = MagicMock()
+    mock_lf.get_current_trace_id = MagicMock(return_value=None)
+
+    with (
+        patch(
+            "telegram_bot.agents.rag_tool.rag_pipeline",
+            new_callable=AsyncMock,
+            return_value=_pipeline_result(),
+        ) as mock_pipeline,
+        patch("telegram_bot.agents.rag_tool.get_client", return_value=mock_lf),
+    ):
+        await rag_search.ainvoke({"query": "test"}, config=_make_config(bot_context))
+
+    assert mock_pipeline.call_count == 1
+    assert mock_pipeline.call_args.kwargs["langfuse_trace_id"] == ""

--- a/tests/unit/test_bot_handlers_direct.py
+++ b/tests/unit/test_bot_handlers_direct.py
@@ -1,0 +1,123 @@
+"""Direct unit tests for bot handler trace propagation (#1253)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from telegram_bot.bot import PropertyBot
+from telegram_bot.config import BotConfig
+
+
+def _make_config() -> BotConfig:
+    return BotConfig(
+        _env_file=None,
+        telegram_token="test-token",
+        voyage_api_key="voyage-key",
+        llm_api_key="llm-key",
+        llm_base_url="https://api.example.com/v1",
+        llm_model="gpt-4o-mini",
+        qdrant_url="http://localhost:6333",
+        qdrant_api_key="qdrant-key",
+        qdrant_collection="test_collection",
+        redis_url="redis://localhost:6379",
+        rerank_provider="none",
+    )
+
+
+def _create_bot() -> PropertyBot:
+    cfg = _make_config()
+    with (
+        patch("telegram_bot.bot.Bot"),
+        patch("telegram_bot.integrations.cache.CacheLayerManager"),
+        patch("telegram_bot.integrations.embeddings.BGEM3HybridEmbeddings"),
+        patch("telegram_bot.integrations.embeddings.BGEM3SparseEmbeddings"),
+        patch("telegram_bot.services.qdrant.QdrantService"),
+        patch("telegram_bot.graph.config.GraphConfig.create_llm"),
+        patch("telegram_bot.graph.config.GraphConfig.create_supervisor_llm"),
+    ):
+        return PropertyBot(cfg)
+
+
+def _make_typing_cm():
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock()
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+@pytest.mark.asyncio
+async def test_handle_query_passes_trace_context_to_callback_handler():
+    """handle_query should pass current trace_id to agent CallbackHandler (#1253)."""
+    bot = _create_bot()
+    bot._resolve_user_role = AsyncMock(return_value="client")
+    bot._ainvoke_supervisor_with_recovery = AsyncMock(
+        return_value={"messages": [MagicMock(content="ok")]}
+    )
+
+    mock_lf = MagicMock()
+    mock_lf.get_current_trace_id = MagicMock(return_value="trace-handler-123")
+
+    mock_agent = AsyncMock()
+    mock_agent.ainvoke = AsyncMock(return_value={"messages": [MagicMock(content="ok")]})
+
+    with (
+        patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+        patch("telegram_bot.bot.get_client", return_value=mock_lf),
+        patch("telegram_bot.bot.propagate_attributes"),
+        patch("telegram_bot.bot.create_callback_handler") as mock_create_handler,
+    ):
+        message = MagicMock()
+        message.text = "test query"
+        message.chat = MagicMock(id=12345)
+        message.from_user = MagicMock(id=12345)
+        message.bot = MagicMock()
+        message.bot.send_chat_action = AsyncMock()
+        message.answer = AsyncMock()
+
+        with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+            mock_cas.typing.return_value = _make_typing_cm()
+            await bot.handle_query(message)
+
+    mock_create_handler.assert_called_once()
+    assert mock_create_handler.call_args.kwargs["trace_context"] == {
+        "trace_id": "trace-handler-123"
+    }
+
+
+@pytest.mark.asyncio
+async def test_handle_query_omits_trace_context_when_no_trace_id():
+    """When no trace_id is available, callback handler should not receive trace_context."""
+    bot = _create_bot()
+    bot._resolve_user_role = AsyncMock(return_value="client")
+    bot._ainvoke_supervisor_with_recovery = AsyncMock(
+        return_value={"messages": [MagicMock(content="ok")]}
+    )
+
+    mock_lf = MagicMock()
+    mock_lf.get_current_trace_id = MagicMock(return_value="")
+
+    mock_agent = AsyncMock()
+    mock_agent.ainvoke = AsyncMock(return_value={"messages": [MagicMock(content="ok")]})
+
+    with (
+        patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+        patch("telegram_bot.bot.get_client", return_value=mock_lf),
+        patch("telegram_bot.bot.propagate_attributes"),
+        patch("telegram_bot.bot.create_callback_handler") as mock_create_handler,
+    ):
+        message = MagicMock()
+        message.text = "test query"
+        message.chat = MagicMock(id=12345)
+        message.from_user = MagicMock(id=12345)
+        message.bot = MagicMock()
+        message.bot.send_chat_action = AsyncMock()
+        message.answer = AsyncMock()
+
+        with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+            mock_cas.typing.return_value = _make_typing_cm()
+            await bot.handle_query(message)
+
+    mock_create_handler.assert_called_once()
+    assert mock_create_handler.call_args.kwargs.get("trace_context") is None


### PR DESCRIPTION
## Summary
- Link agent graph and RAG pipeline observations to the same Langfuse trace using SDK-native `start_as_current_observation(trace_context=...)`.
- `rag_search` captures the current trace id and passes it to `rag_pipeline`.
- `rag_pipeline` wraps its body in an explicit observation tied to the caller's trace id.
- `bot.py` passes `trace_context` to `create_callback_handler` so the SDK agent graph nests under the parent trace.
- Fix pre-existing `UnboundLocalError` for `filter_signature` when `response_text` is empty.

## Test Plan
- `uv run pytest tests/unit/agents/test_rag_tool.py tests/integration/test_service_chain_agent_tools.py tests/unit/test_bot_handlers_direct.py -q` — all pass
- `uv run pytest tests/integration/test_graph_paths.py -n auto --dist=worksteal -q` — all pass
- `make check` — clean

## Related Issue
Closes #1253