### PR TITLE
fix(graph): initialize RAGState messages as HumanMessage (#1251)

### DIFF
--- a/telegram_bot/graph/state.py
+++ b/telegram_bot/graph/state.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from typing import Annotated, Any, TypedDict
 
+from langchain_core.messages import HumanMessage
 from langgraph.graph.message import add_messages
 
 
@@ -100,7 +101,7 @@ class RAGState(TypedDict):
 def make_initial_state(user_id: int, session_id: str, query: str) -> dict[str, Any]:
     """Create initial state for a new RAG pipeline invocation."""
     return {
-        "messages": [{"role": "user", "content": query}],
+        "messages": [HumanMessage(content=query)],
         "user_id": user_id,
         "session_id": session_id,
         "query_type": "",

--- a/tests/unit/evaluation/test_run_experiment.py
+++ b/tests/unit/evaluation/test_run_experiment.py
@@ -14,10 +14,13 @@ def test_build_rag_task_returns_callable():
 
 
 def test_build_eval_state_contains_required_rag_fields():
+    from langchain_core.messages import HumanMessage
+
     from scripts.eval.run_experiment import _build_eval_state
 
     state = _build_eval_state("What is X?")
-    assert state["messages"][-1]["content"] == "What is X?"
+    assert isinstance(state["messages"][-1], HumanMessage)
+    assert state["messages"][-1].content == "What is X?"
     assert state["user_id"] == 0
     assert state["session_id"].startswith("eval-")
 
@@ -42,4 +45,4 @@ def test_build_rag_task_invokes_graph():
     assert result["answer"] == "Test answer"
     assert "Doc 1" in result["context"]
     called_state = mock_graph.ainvoke.await_args.args[0]
-    assert called_state["messages"][-1]["content"] == "What is X?"
+    assert called_state["messages"][-1].content == "What is X?"

--- a/tests/unit/graph/test_state.py
+++ b/tests/unit/graph/test_state.py
@@ -54,12 +54,14 @@ class TestRAGState:
         assert state["query_type"] == ""
 
     def test_messages_contains_user_query(self):
+        from langchain_core.messages import HumanMessage
+
         from telegram_bot.graph.state import make_initial_state
 
         state = make_initial_state(user_id=1, session_id="s-1", query="Привет!")
         msg = state["messages"][0]
-        assert msg["role"] == "user"
-        assert msg["content"] == "Привет!"
+        assert isinstance(msg, HumanMessage)
+        assert msg.content == "Привет!"
 
     def test_initial_state_has_max_rewrite_attempts(self):
         """Initial state includes max_rewrite_attempts=1."""


### PR DESCRIPTION
## Summary
- `make_initial_state()` now initializes `RAGState["messages"]` with a `langchain_core.messages.HumanMessage` instead of an OpenAI-style dict.
- Updated `tests/unit/graph/test_state.py` to assert SDK-native message type and `.content` accessor.
- Existing graph nodes (classify, guard, rewrite, rerank) already tolerate both message objects and dicts.

## Test Plan
- `uv run pytest tests/unit/graph/test_state.py tests/unit/graph/test_summarize_node.py -q` ✅
- `uv run pytest tests/integration/test_graph_paths.py -n auto --dist=worksteal -q` ✅
- `make check` ✅

Fixes #1251