### PR TITLE
fix(observability): guard Langfuse SDK import for Python 3.14 graceful degradation

### DIFF
--- a/telegram_bot/observability.py
+++ b/telegram_bot/observability.py
@@ -9,24 +9,12 @@ ensure credentials from `.env`/environment are applied before first tracing.
 """
 
 import atexit
+import contextlib
 import json
 import logging
 import os
 from datetime import UTC, datetime
 from typing import Any
-
-from langfuse import (
-    Langfuse,
-)
-from langfuse import (
-    get_client as _real_get_client,
-)
-from langfuse import (
-    observe as _real_observe,
-)
-from langfuse import (
-    propagate_attributes as _real_propagate,
-)
 
 from src.security.pii_redaction import PIIRedactor
 from telegram_bot.observability_bootstrap import (
@@ -39,9 +27,6 @@ from telegram_bot.observability_bootstrap import (
 
 logger = logging.getLogger(__name__)
 
-_langfuse_client: Langfuse | None = None
-_langfuse_init_attempted = False
-
 _MAX_PII_TEXT_LENGTH = 4000
 _MODEL_DEFINITIONS_ENV = "LANGFUSE_MODEL_DEFINITIONS_JSON"
 _MODEL_SYNC_ENABLED_ENV = "LANGFUSE_MODEL_SYNC_ENABLED"
@@ -50,6 +35,54 @@ _MODEL_LIST_PAGE_SIZE = 100
 _pii_redactor = PIIRedactor()
 
 _langfuse_endpoint_warned = False
+
+
+# ---------------------------------------------------------------------------
+# Guarded Langfuse SDK import (graceful degradation under Python 3.14)
+# ---------------------------------------------------------------------------
+
+try:
+    from langfuse import Langfuse
+    from langfuse import get_client as _real_get_client
+    from langfuse import observe as _real_observe
+    from langfuse import propagate_attributes as _real_propagate
+
+    _LANGFUSE_AVAILABLE = True
+    _LANGFUSE_IMPORT_ERROR = None
+except Exception as _e:
+    _LANGFUSE_AVAILABLE = False
+    _LANGFUSE_IMPORT_ERROR = _e
+
+    class Langfuse:  # type: ignore[no-redef]
+        """Placeholder that raises the original import error on instantiation."""
+
+        def __init__(self, *args, **kwargs):
+            raise _LANGFUSE_IMPORT_ERROR
+
+    def _real_observe(*args, **kwargs):
+        """No-op decorator factory."""
+
+        def decorator(func):
+            return func
+
+        if args and callable(args[0]) and not kwargs:
+            return args[0]
+        return decorator
+
+    def _real_get_client():  # type: ignore[misc]
+        return None
+
+    @contextlib.contextmanager
+    def _real_propagate(**kwargs):  # type: ignore[misc]
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Module state
+# ---------------------------------------------------------------------------
+
+_langfuse_client: Langfuse | None = None
+_langfuse_init_attempted = False
 
 
 # ---------------------------------------------------------------------------
@@ -340,6 +373,14 @@ def initialize_langfuse(
     if _langfuse_init_attempted and _langfuse_client is None and not force:
         return None
 
+    if not _LANGFUSE_AVAILABLE:
+        _langfuse_client = None
+        if not _langfuse_init_attempted:
+            logger.warning("Langfuse SDK unavailable (import failed): %s", _LANGFUSE_IMPORT_ERROR)
+        _langfuse_init_attempted = True
+        _disable_otel_exporter()
+        return None
+
     resolved_public_key = _resolve_config_value(public_key, "LANGFUSE_PUBLIC_KEY")
     resolved_secret_key = _resolve_config_value(secret_key, "LANGFUSE_SECRET_KEY")
     resolved_host = _resolve_config_value(host, "LANGFUSE_HOST")
@@ -412,6 +453,8 @@ def create_callback_handler(
 
     Returns None when Langfuse is not configured or handler init fails.
     """
+    if not _LANGFUSE_AVAILABLE:
+        return None
     if get_langfuse_client() is None:
         return None
 

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -5,6 +5,8 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 class TestMaskPii:
     """Tests for mask_pii function."""
@@ -729,3 +731,96 @@ class TestObservabilityBootstrapAliases:
 
         assert observability._is_endpoint_reachable is bootstrap.is_endpoint_reachable
         assert observability._disable_otel_exporter is bootstrap.disable_otel_exporter
+
+
+@pytest.fixture
+def observability_without_langfuse():
+    """Simulate langfuse import failure and provide the reloaded observability module."""
+    import importlib
+    import sys
+
+    original_langfuse = sys.modules.pop("langfuse", None)
+    broken = type(
+        "BrokenLangfuse",
+        (),
+        {
+            "__getattr__": lambda _self, _name: (_ for _ in ()).throw(
+                ImportError("simulated pydantic.v1 error")
+            )
+        },
+    )()
+
+    sys.modules["langfuse"] = broken
+    if "telegram_bot.observability" in sys.modules:
+        del sys.modules["telegram_bot.observability"]
+
+    obs = importlib.import_module("telegram_bot.observability")
+
+    yield obs
+
+    # Restore
+    if original_langfuse is not None:
+        sys.modules["langfuse"] = original_langfuse
+    else:
+        sys.modules.pop("langfuse", None)
+    if "telegram_bot.observability" in sys.modules:
+        del sys.modules["telegram_bot.observability"]
+    importlib.import_module("telegram_bot.observability")
+
+
+class TestLangfuseImportFailure:
+    """Tests for graceful degradation when langfuse SDK fails to import."""
+
+    def test_observe_fallback_no_parens(self, observability_without_langfuse):
+        """@observe without parentheses should return the original function."""
+
+        @observability_without_langfuse.observe
+        def my_func():
+            return 42
+
+        assert my_func() == 42
+
+    def test_observe_fallback_with_parens(self, observability_without_langfuse):
+        """@observe() should return the original function."""
+
+        @observability_without_langfuse.observe()
+        def my_func():
+            return 42
+
+        assert my_func() == 42
+
+    def test_observe_fallback_with_kwargs(self, observability_without_langfuse):
+        """@observe(name='test') should return the original function."""
+
+        @observability_without_langfuse.observe(name="test")
+        def my_func():
+            return 42
+
+        assert my_func() == 42
+
+    def test_get_client_returns_none(self, observability_without_langfuse):
+        """get_client should return None when langfuse import fails."""
+        assert observability_without_langfuse.get_client() is None
+
+    def test_propagate_attributes_is_noop(self, observability_without_langfuse):
+        """propagate_attributes should be a no-op context manager."""
+        with observability_without_langfuse.propagate_attributes(session_id="s", user_id="u"):
+            pass
+
+    def test_initialize_langfuse_returns_none(self, observability_without_langfuse):
+        """initialize_langfuse should return None and not raise."""
+        assert observability_without_langfuse.initialize_langfuse() is None
+
+    def test_create_callback_handler_returns_none(self, observability_without_langfuse):
+        """create_callback_handler should return None when langfuse import fails."""
+        assert observability_without_langfuse.create_callback_handler() is None
+
+    def test_langfuse_placeholder_raises_on_init(self, observability_without_langfuse):
+        """Langfuse fallback class should raise the original import error."""
+        with pytest.raises(ImportError, match=r"simulated pydantic\.v1 error"):
+            observability_without_langfuse.Langfuse()
+
+    def test_traced_pipeline_works_with_fallback(self, observability_without_langfuse):
+        """traced_pipeline should work when propagate_attributes is a fallback."""
+        with observability_without_langfuse.traced_pipeline(session_id="s", user_id="u"):
+            pass


### PR DESCRIPTION
## Summary
- Fixes #1296: local bot stack crashes importing Langfuse under Python 3.14.
- Moves top-level `langfuse` imports into a guarded try/except block.
- When the SDK import fails, observability degrades gracefully with no-op fallbacks for `observe`, `get_client`, `propagate_attributes`, and a placeholder `Langfuse` class.
- `initialize_langfuse()` logs a warning once, disables OTEL exporter, and returns `None` when the SDK is unavailable.
- `create_callback_handler()` returns `None` early when the SDK is unavailable.
- Adds 9 tests that simulate Langfuse import failure without globally corrupting unrelated modules.

## Test Plan
- [x] `uv run pytest tests/unit/test_observability.py -q` — 50/50 pass (41 existing + 9 new)
- [x] `uv run python -c "import telegram_bot.observability as obs; print(callable(...))"` — exports are callable
- [x] `make check` — ruff + mypy clean
- [x] `COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --env-file tests/fixtures/compose.ci.env --compatibility config --services` — valid compose config
- [x] Docker images for `bot`, `rag-api`, `mini-app-api` build successfully; runtime imports verified inside built image