### PR TITLE
fix: degrade Kommo 401 gracefully in phone collection (#1300)

### DIFF
--- a/telegram_bot/handlers/phone_collector.py
+++ b/telegram_bot/handlers/phone_collector.py
@@ -8,6 +8,7 @@ import logging
 import time
 from typing import Any
 
+import httpx
 from aiogram import F, Router
 from aiogram.enums import ContentType
 from aiogram.fsm.context import FSMContext
@@ -266,6 +267,15 @@ async def _process_valid_phone(
                     complete_till=due,
                 )
             )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 401:
+                logger.warning(
+                    "CRM degraded: Kommo 401 Unauthorized for phone=%s "
+                    "(local/test credentials expected)",
+                    phone,
+                )
+            else:
+                logger.exception("CRM lead creation failed for phone=%s", phone)
         except Exception:
             logger.exception("CRM lead creation failed for phone=%s", phone)
 

--- a/tests/unit/handlers/test_phone_crm_integration.py
+++ b/tests/unit/handlers/test_phone_crm_integration.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 
 from telegram_bot.services.kommo_models import Contact, Lead, Note, Task
@@ -117,6 +118,30 @@ async def test_graceful_on_kommo_error(mock_kommo, mock_message, mock_state, moc
     mock_message.answer.assert_awaited_once()
     text = mock_message.answer.call_args[0][0]
     assert "Заявка оформлена" in text
+
+
+async def test_graceful_on_kommo_401(mock_kommo, mock_message, mock_state, mock_config, caplog):
+    """Kommo 401 is handled as a known degraded state: user gets success, log is warning."""
+    from telegram_bot.handlers.phone_collector import on_phone_received
+
+    req = httpx.Request("GET", "https://test.kommo.com/api/v4/contacts")
+    resp = httpx.Response(401, request=req)
+    exc = httpx.HTTPStatusError("401 Unauthorized", request=req, response=resp)
+    mock_kommo.upsert_contact.side_effect = exc
+
+    with patch(
+        "telegram_bot.services.content_loader.load_services_config", return_value=mock_config
+    ):
+        with caplog.at_level("DEBUG", logger="telegram_bot.handlers.phone_collector"):
+            await on_phone_received(mock_message, mock_state, kommo_client=mock_kommo)
+
+    mock_message.answer.assert_awaited_once()
+    text = mock_message.answer.call_args[0][0]
+    assert "Заявка оформлена" in text
+
+    # 401 should be logged as warning, not error with traceback
+    assert any("401" in rec.message and rec.levelname == "WARNING" for rec in caplog.records)
+    assert not any(rec.levelname == "ERROR" for rec in caplog.records)
 
 
 async def test_source_tracking_in_lead_name(mock_kommo, mock_message, mock_state, mock_config):


### PR DESCRIPTION
## Summary

Fixes #1300.

Kommo 401 Unauthorized during phone collection was logged as an unclassified ERROR with a full traceback, even though local/test environments with invalid credentials are an expected condition. This change degrades 401 explicitly without the scary stack trace, while preserving diagnostics for real CRM failures.

## Changes

- `telegram_bot/handlers/phone_collector.py`: Catch `httpx.HTTPStatusError` specifically; log Kommo 401 as `WARNING` (degraded state) instead of `ERROR` with traceback. Generic CRM exceptions still use `logger.exception` for full diagnostics.
- `tests/unit/handlers/test_phone_crm_integration.py`: Add regression test verifying 401 produces a user-facing success message and a WARNING-level log without ERROR.

## Verification

- Focused pytest: 77 passed
- `make check`: passed