### PR TITLE
fix(demo): clear DemoStates.waiting_query after legacy search completes (#1298)

### DIFF
--- a/telegram_bot/handlers/demo_handler.py
+++ b/telegram_bot/handlers/demo_handler.py
@@ -203,6 +203,7 @@ async def _run_demo_search(
                 "К сожалению, ничего не найдено по вашему запросу.\n"
                 "Попробуйте изменить параметры или напишите другой запрос."
             )
+            await state.set_state(None)
         return
 
     runtime = build_catalog_runtime(
@@ -234,6 +235,8 @@ async def _run_demo_search(
     if dialog_manager is not None:
         await show_catalog_controls(message=message, dialog_manager=dialog_manager, runtime=runtime)
         await activate_catalog_state(dialog_manager=dialog_manager, state=CatalogSG.results)
+    else:
+        await state.set_state(None)
 
 
 async def handle_demo_search_voice(

--- a/tests/unit/dialogs/test_demo_catalog.py
+++ b/tests/unit/dialogs/test_demo_catalog.py
@@ -410,6 +410,59 @@ def test_demo_dialog_has_voice_input() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Task 7: Legacy demo state must be cleared so catalog keyboard doesn't loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_demo_exit_clears_fsm_state() -> None:
+    """After legacy _run_demo_search (dialog_manager=None), FSM state is cleared
+    so that subsequent '🏠 Главное меню' catalog keyboard text is NOT
+    re-interpreted as a new apartment query."""
+    from telegram_bot.handlers.demo_handler import _run_demo_search
+
+    msg = _make_message()
+    state = _make_state()
+
+    svc = _make_svc(results=[_APT] * 5, total=15)
+
+    await _run_demo_search(
+        "двушка",
+        msg,
+        state,
+        pipeline=_make_pipeline(),
+        apartments_service=svc,
+        dialog_manager=None,
+    )
+
+    state.set_state.assert_awaited_once_with(None)
+
+
+@pytest.mark.asyncio
+async def test_dialog_demo_exit_does_not_clear_raw_fsm() -> None:
+    """Dialog-managed path must NOT touch raw FSM state; dialog manages lifecycle."""
+    from telegram_bot.handlers.demo_handler import _run_demo_search
+
+    msg = _make_message()
+    state = _make_state()
+    manager = AsyncMock()
+    manager.middleware_data = {}
+
+    svc = _make_svc(results=[_APT] * 5, total=15)
+
+    await _run_demo_search(
+        "двушка",
+        msg,
+        state,
+        pipeline=_make_pipeline(),
+        apartments_service=svc,
+        dialog_manager=manager,
+    )
+
+    state.set_state.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
 # Task 8: Full flow integration test
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/handlers/test_demo_handler.py
+++ b/tests/unit/handlers/test_demo_handler.py
@@ -262,6 +262,53 @@ class TestDemoVoiceFlow:
         )
 
 
+class TestDemoStateClear:
+    @pytest.mark.asyncio
+    async def test_demo_search_text_clears_state_when_no_dialog_manager(self) -> None:
+        """Legacy demo text handler must clear FSM state after search completes."""
+        message = AsyncMock()
+        message.text = "двушка до 100к"
+        state = AsyncMock(spec=FSMContext)
+
+        pipeline = AsyncMock()
+        from telegram_bot.services.apartment_models import (
+            ApartmentSearchFilters,
+            ExtractionMeta,
+            HardFilters,
+        )
+
+        pipeline.extract.return_value = ApartmentSearchFilters(
+            hard=HardFilters(rooms=2, max_price_eur=100000),
+            meta=ExtractionMeta(source="llm", confidence="HIGH"),
+        )
+        apartments_service = AsyncMock()
+        apartments_service.scroll_with_filters.return_value = (
+            [
+                {
+                    "payload": {
+                        "complex_name": "Test",
+                        "rooms": 2,
+                        "price_eur": 95000,
+                        "area_m2": 60,
+                        "city": "Солнечный берег",
+                    },
+                    "id": "1",
+                }
+            ],
+            1,
+            95000.0,
+            ["1"],
+        )
+
+        await handle_demo_search_text(
+            message,
+            state,
+            pipeline=pipeline,
+            apartments_service=apartments_service,
+        )
+        state.set_state.assert_awaited_once_with(None)
+
+
 class TestHandleVoiceStateFilter:
     """Main handle_voice must NOT intercept voice during active FSM states."""
 

--- a/tests/unit/handlers/test_demo_search.py
+++ b/tests/unit/handlers/test_demo_search.py
@@ -432,6 +432,120 @@ class TestKwargsPassthrough:
             pipeline.extract.assert_awaited_once()
 
 
+class TestDemoStateClear:
+    @pytest.mark.asyncio
+    async def test_run_demo_search_clears_fsm_without_dialog_manager(self) -> None:
+        """Legacy path (dialog_manager=None) must clear DemoStates.waiting_query."""
+        from telegram_bot.handlers.demo_handler import _run_demo_search
+
+        message = AsyncMock()
+        message.text = "двушка"
+        state = AsyncMock()
+        pipeline = AsyncMock()
+        pipeline.extract.return_value = ApartmentSearchFilters(
+            hard=HardFilters(rooms=2),
+            meta=ExtractionMeta(source="llm", confidence="HIGH"),
+        )
+        apartments_service = AsyncMock()
+        apartments_service.scroll_with_filters.return_value = (
+            [
+                {
+                    "payload": {
+                        "complex_name": "Test",
+                        "rooms": 2,
+                        "price_eur": 95000,
+                        "area_m2": 60,
+                        "city": "Солнечный берег",
+                    },
+                    "id": "1",
+                }
+            ],
+            1,
+            95000.0,
+            ["1"],
+        )
+
+        await _run_demo_search(
+            "двушка",
+            message,
+            state,
+            pipeline=pipeline,
+            apartments_service=apartments_service,
+            dialog_manager=None,
+        )
+        state.set_state.assert_awaited_once_with(None)
+
+    @pytest.mark.asyncio
+    async def test_run_demo_search_clears_fsm_without_dialog_manager_empty_results(self) -> None:
+        """Legacy path must clear state even when search returns 0 results."""
+        from telegram_bot.handlers.demo_handler import _run_demo_search
+
+        message = AsyncMock()
+        message.text = "пентхаус в Бургасе"
+        state = AsyncMock()
+        pipeline = AsyncMock()
+        pipeline.extract.return_value = ApartmentSearchFilters(
+            hard=HardFilters(),
+            meta=ExtractionMeta(source="llm", confidence="HIGH"),
+        )
+        apartments_service = AsyncMock()
+        apartments_service.scroll_with_filters.return_value = ([], 0, None, [])
+
+        await _run_demo_search(
+            "пентхаус в Бургасе",
+            message,
+            state,
+            pipeline=pipeline,
+            apartments_service=apartments_service,
+            dialog_manager=None,
+        )
+        state.set_state.assert_awaited_once_with(None)
+
+    @pytest.mark.asyncio
+    async def test_run_demo_search_preserves_fsm_with_dialog_manager(self) -> None:
+        """Dialog-managed path must NOT clear state; dialog handles its own lifecycle."""
+        from telegram_bot.handlers.demo_handler import _run_demo_search
+
+        message = AsyncMock()
+        message.text = "двушка"
+        state = AsyncMock()
+        pipeline = AsyncMock()
+        pipeline.extract.return_value = ApartmentSearchFilters(
+            hard=HardFilters(rooms=2),
+            meta=ExtractionMeta(source="llm", confidence="HIGH"),
+        )
+        apartments_service = AsyncMock()
+        apartments_service.scroll_with_filters.return_value = (
+            [
+                {
+                    "payload": {
+                        "complex_name": "Test",
+                        "rooms": 2,
+                        "price_eur": 95000,
+                        "area_m2": 60,
+                        "city": "Солнечный берег",
+                    },
+                    "id": "1",
+                }
+            ],
+            1,
+            95000.0,
+            ["1"],
+        )
+        dialog_manager = AsyncMock()
+        dialog_manager.middleware_data = {}
+
+        await _run_demo_search(
+            "двушка",
+            message,
+            state,
+            pipeline=pipeline,
+            apartments_service=apartments_service,
+            dialog_manager=dialog_manager,
+        )
+        state.set_state.assert_not_awaited()
+
+
 class TestDemoSearchObservability:
     def test_run_demo_search_is_observed(self) -> None:
         """_run_demo_search must be @observe-decorated (span: demo-search)."""


### PR DESCRIPTION
## Summary
Fixes #1298 — legacy demo apartment-search sticky FSM state.

## Root Cause
In the legacy demo path (`dialog_manager=None`), `_run_demo_search` stored `catalog_runtime` and sent the catalog reply keyboard but never cleared the raw aiogram FSM state (`DemoStates.waiting_query`). This caused subsequent "🏠 Главное меню" (and other catalog keyboard texts) to be re-interpreted as new apartment queries instead of exiting search mode.

## Changes
- **Production fix** (`telegram_bot/handlers/demo_handler.py`):
  - After result handling completes in the legacy `dialog_manager is None` path, call `await state.set_state(None)` in both empty-results and non-empty-results branches.
  - Dialog-managed path (`dialog_manager is not None`) is preserved; handoff to `CatalogSG` remains untouched.
- **Regression tests**:
  - `tests/unit/handlers/test_demo_search.py` — 3 new tests covering legacy state clear (with/without results) and dialog path preservation.
  - `tests/unit/handlers/test_demo_handler.py` — 1 new test covering handler-level state clear.
  - `tests/unit/dialogs/test_demo_catalog.py` — 2 new tests covering legacy vs. dialog path behavior.

## Verification
- `uv run pytest tests/unit/handlers/test_demo_search.py tests/unit/handlers/test_demo_handler.py tests/unit/dialogs/test_demo_catalog.py` — **56 passed**
- `make check` — **ruff + mypy clean**