### PR TITLE
fix(catalog): route home button before search and mirror root_nav reset (#1298)

### DIFF
--- a/telegram_bot/dialogs/catalog.py
+++ b/telegram_bot/dialogs/catalog.py
@@ -292,9 +292,14 @@ async def _handle_catalog_home_message(
     manager: DialogManager,
 ) -> None:
     await clear_catalog_controls(message=message, dialog_manager=manager)
+    state = await _get_state(manager)
+    if state is not None:
+        maybe_clear = state.clear()
+        if inspect.isawaitable(maybe_clear):
+            await maybe_clear
     manager.show_mode = ShowMode.NO_UPDATE
     with contextlib.suppress(Exception):
-        await manager.done()
+        await manager.reset_stack(remove_keyboard=True)
     await show_client_main_menu(message, i18n=manager.middleware_data.get("i18n"))
 
 
@@ -445,7 +450,12 @@ async def on_catalog_text_input(
 ) -> None:
     if not message.text:
         return
-    if await dispatch_catalog_text_action(message=message, manager=manager):
+    i18n_hub = manager.middleware_data.get("i18n_hub")
+    if i18n_hub is None:
+        property_bot = manager.middleware_data.get("property_bot")
+        if property_bot is not None:
+            i18n_hub = getattr(property_bot, "_i18n_hub", None)
+    if await dispatch_catalog_text_action(message=message, manager=manager, i18n_hub=i18n_hub):
         return
 
     manager.show_mode = ShowMode.NO_UPDATE

--- a/tests/unit/dialogs/test_catalog_dialog.py
+++ b/tests/unit/dialogs/test_catalog_dialog.py
@@ -51,7 +51,8 @@ async def test_catalog_home_restores_client_reply_keyboard() -> None:
 
     await on_catalog_home(callback, MagicMock(), manager)
 
-    manager.done.assert_awaited_once()
+    state.clear.assert_awaited_once()
+    manager.reset_stack.assert_awaited_once_with(remove_keyboard=True)
     callback.message.answer.assert_awaited()
 
 

--- a/tests/unit/dialogs/test_demo_catalog.py
+++ b/tests/unit/dialogs/test_demo_catalog.py
@@ -23,6 +23,7 @@ def _make_state(data: dict | None = None) -> MagicMock:
     state.get_data = AsyncMock(return_value=data or {})
     state.update_data = AsyncMock()
     state.set_state = AsyncMock()
+    state.clear = AsyncMock()
     return state
 
 
@@ -350,7 +351,8 @@ async def test_catalog_exit_returns_to_main_menu() -> None:
     from telegram_bot.dialogs.catalog import on_catalog_home
 
     manager = AsyncMock()
-    manager.middleware_data = {"state": _make_state(), "i18n": None}
+    state = _make_state()
+    manager.middleware_data = {"state": state, "i18n": None}
     callback = MagicMock()
     callback.message = _make_message()
     callback.message.bot = MagicMock(delete_message=AsyncMock())
@@ -358,7 +360,8 @@ async def test_catalog_exit_returns_to_main_menu() -> None:
 
     await on_catalog_home(callback, MagicMock(), manager)
 
-    manager.done.assert_awaited_once()
+    state.clear.assert_awaited_once()
+    manager.reset_stack.assert_awaited_once_with(remove_keyboard=True)
     callback.message.answer.assert_awaited()
 
 

--- a/tests/unit/test_catalog_handler.py
+++ b/tests/unit/test_catalog_handler.py
@@ -12,6 +12,7 @@ def _make_state(data: dict) -> MagicMock:
     state = MagicMock()
     state.get_data = AsyncMock(return_value=data)
     state.update_data = AsyncMock()
+    state.clear = AsyncMock()
     return state
 
 
@@ -205,3 +206,31 @@ async def test_catalog_text_input_routes_actions_before_search() -> None:
         await on_catalog_text_input(message, MagicMock(), manager)
 
     search_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_catalog_text_input_routes_home_before_search() -> None:
+    """Regression #1298: '🏠 Главное меню' must not fall through to _run_demo_search."""
+    from telegram_bot.dialogs.catalog import on_catalog_text_input
+
+    message = MagicMock()
+    message.text = "🏠 Главное меню"
+    message.answer = AsyncMock(return_value=MagicMock(delete=AsyncMock()))
+    message.chat = MagicMock(id=456)
+    message.bot = MagicMock(delete_message=AsyncMock())
+    message.from_user = MagicMock(first_name="Test")
+    state = _make_state({"catalog_runtime": {"filters": {}}})
+    manager = AsyncMock()
+    manager.middleware_data = {
+        "state": state,
+        "i18n": None,
+    }
+
+    with patch(
+        "telegram_bot.handlers.demo_handler._run_demo_search", new=AsyncMock()
+    ) as search_mock:
+        await on_catalog_text_input(message, MagicMock(), manager)
+
+    search_mock.assert_not_awaited()
+    state.clear.assert_awaited_once()
+    manager.reset_stack.assert_awaited_once_with(remove_keyboard=True)


### PR DESCRIPTION
## Summary
Fixes the sticky apartment-search mode bug where pressing 🏠 Главное меню while in catalog text input fell through to `_run_demo_search` instead of exiting catalog mode.

## Changes
- `on_catalog_text_input` now passes `i18n_hub` to `dispatch_catalog_text_action` so translated catalog keyboard labels resolve correctly in the active MessageInput path.
- `_handle_catalog_home_message` mirrors `root_nav.on_back_to_main_menu`:
  - Clears aiogram FSM state via `state.clear()`
  - Resets full dialog stack via `manager.reset_stack(remove_keyboard=True)` instead of only `manager.done()`
- Adds regression test ensuring 🏠 Главное меню does not fall through to `_run_demo_search`.
- Updates existing `catalog_home` tests to assert `state.clear` and `reset_stack`.

## Verification
- Focused unit tests: `pytest tests/unit/test_catalog_handler.py tests/unit/dialogs/test_catalog_dialog.py tests/unit/dialogs/test_demo_catalog.py tests/unit/keyboards/test_catalog_keyboard.py` — 36 passed
- Baseline: `make check` — passed