### PR TITLE
docs: clean reviewer/hiring entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
-# Contextual RAG Pipeline
+# AI Real Estate Automation Platform
 
-**AI-powered Telegram bot for real estate — RAG search, apartment finder, voice calls, CRM automation**
+**Telegram + RAG + apartment search + CRM automation + voice + production-like AI infrastructure**
 
 [![CI](https://github.com/yastman/rag/actions/workflows/ci.yml/badge.svg)](https://github.com/yastman/rag/actions/workflows/ci.yml)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
@@ -13,9 +13,12 @@
 
 ---
 
-## What is this?
+## What Is This?
 
-A **production system** that lets real estate clients ask questions in natural language via Telegram — about properties, legal processes, immigration, and more — and get accurate, sourced answers powered by RAG.
+An AI-native real-estate automation platform that lets clients ask questions in
+natural language via Telegram, search apartment listings, move qualified leads
+into Kommo CRM workflows, and use the same RAG stack from text and voice
+channels.
 
 **The problem:** Real estate agencies drown in repetitive client questions across Telegram, phone, and CRM. Agents spend hours answering the same things.
 
@@ -23,9 +26,38 @@ A **production system** that lets real estate clients ask questions in natural l
 - Answers knowledge-base questions with source citations (RAG)
 - Searches apartment listings with natural language — *"2-bedroom in Sofia under €80k"*
 - Scores and nurtures leads automatically via CRM integration
-- Handles voice calls with a LiveKit-powered voice agent
+- Supports Telegram voice input and a LiveKit-powered voice agent path
+- Runs as a Docker Compose based local/VPS stack with observability, ingestion,
+  vector search, and local ML services
 
-> This runs in production, handles real users, and deploys automatically via CI/CD to a VPS.
+> The primary runtime is Docker Compose on local/VPS environments. k3s manifests
+> exist for core services as an incremental migration path, not full parity with
+> the Compose stack.
+
+---
+
+## For Reviewers
+
+If you have limited time, read the repository in this order:
+
+1. [Portfolio case study](docs/portfolio/resume-case-study.md) — concise
+   project narrative, feature cards, trade-offs, and honest limitations.
+2. [Project guide](docs/review/PROJECT_GUIDE.md) — folder map and subsystem ownership.
+3. `telegram_bot/graph/` — LangGraph orchestration and routing.
+4. `telegram_bot/agents/` and `telegram_bot/services/` — CRM tools, apartment
+   search, cache, lead scoring, handoff, and business logic.
+5. `src/ingestion/unified/` — deterministic document ingestion and Qdrant writes.
+6. `compose.yml`, `compose.dev.yml`, `compose.vps.yml`, and [DOCKER.md](DOCKER.md)
+   — runtime architecture.
+
+Safe review notes:
+
+- Do not run production deploy scripts or real CRM write paths without a
+  dedicated review environment.
+- Start with [ACCESS_FOR_REVIEWERS.md](docs/review/ACCESS_FOR_REVIEWERS.md) before
+  executing commands.
+- GitHub repository presentation checklist lives in
+  [GITHUB_REPO_SETUP.md](docs/review/GITHUB_REPO_SETUP.md).
 
 ---
 
@@ -47,7 +79,7 @@ graph TB
         QC[Query Classifier]
         QC -->|Knowledge| RAG[RAG Pipeline]
         QC -->|Apartment| APT["Apartment Search<br/>regex filters → hybrid search"]
-        QC -->|CRM Action| AG["LangGraph Agent<br/>8 CRM tools"]
+        QC -->|CRM Action| AG["LangGraph Agent<br/>CRM tools"]
     end
 
     subgraph "Retrieval"
@@ -84,23 +116,35 @@ graph TB
 ### Hybrid Search with ColBERT Reranking
 Dense + sparse vectors fused via RRF, with optional ColBERT multi-vector reranking — all server-side in Qdrant. No external reranking API needed.
 
-### Zero-Cost Apartment Search
-Natural language queries like *"3 rooms in Burgas under 100k"* are parsed with regex first (zero LLM cost). LLM extraction kicks in only for complex queries. Results come from hybrid vector search over property listings.
+### Cheap-First Apartment Search
+Natural language queries like *"3 rooms in Burgas under 100k"* use
+deterministic regex parsing for common filters before falling back to LLM
+extraction for complex queries. Results come from hybrid vector search over
+property listings.
 
 ### Agentic RAG with CRM Tools
-LangGraph state graph with 8 tools: create leads, schedule viewings, search history, escalate to human agent. Full HITL (human-in-the-loop) support via `interrupt()`.
+LangGraph state graph with CRM tools for leads, contacts, tasks, notes, and
+history. Write operations use HITL confirmation via `interrupt()`.
 
 ### Multi-Level Semantic Cache
-Two-tier caching via RedisVL: embedding cache (skip re-encoding) + query result cache (skip retrieval + generation). Distance thresholds tuned per query type. ~60% hit rate in production.
+Tiered caching via RedisVL: semantic answer cache, embedding caches, search
+result cache, and rerank result cache. Distance thresholds are tuned per query
+type.
 
 ### Voice Assistant
-LiveKit Agents + ElevenLabs TTS + OpenAI STT. Handles inbound SIP calls, routes through the same RAG pipeline, responds with natural speech.
+LiveKit agent path with ElevenLabs STT/TTS and shared RAG API integration. SIP
+support is represented as outbound trunk provisioning; inbound call routing
+should be described only after a dedicated production review.
 
-### Full Observability
-Every LLM call, retrieval, and cache hit/miss traced in Langfuse. 14 RAG quality scores computed per query. Loki + Alertmanager for infrastructure monitoring.
+### Observability
+Langfuse traces and quality/operational scores cover RAG, latency, cache,
+rerank, voice, security, CRM, history, nurturing, and source attribution when
+observability is configured. Loki + Alertmanager are available for local/dev
+monitoring.
 
-### i18n Ready
-Three languages (ru/uk/en) via Fluent `.ftl` files. Locale auto-detection with fallback chains.
+### Partial i18n
+Three language bundles (ru/uk/en) via Fluent `.ftl` files. Some operational and
+dialog strings are still hardcoded and should be treated as an ongoing migration.
 
 ### Unified Ingestion
 CocoIndex pipeline: Docling parses PDFs/DOCX → semantic chunking → BGE-M3 dense+sparse embeddings → Qdrant. Incremental updates, resumable.
@@ -112,16 +156,16 @@ CocoIndex pipeline: Docling parses PDFs/DOCX → semantic chunking → BGE-M3 de
 | Layer | Technology | Why |
 |-------|-----------|-----|
 | **LLM** | Any model via LiteLLM | Provider-agnostic, easy switching |
-| **Embeddings** | BGE-M3 (self-hosted) | Dense + sparse + ColBER in one model, no API costs |
+| **Embeddings** | BGE-M3 (self-hosted) | Dense + sparse + ColBERT in one model, no API costs |
 | **Vector DB** | Qdrant | Native RRF fusion, ColBERT support, server-side reranking |
 | **Cache** | Redis + RedisVL | Semantic similarity cache, sub-ms latency |
 | **Bot** | aiogram 3 + aiogram-dialog | Async, dialog state machines, inline keyboards |
 | **Pipeline** | LangGraph | State graph with tools, checkpointing, HITL |
 | **Ingestion** | CocoIndex + Docling | Deterministic, resumable, multi-format parsing |
 | **Voice** | LiveKit Agents | WebRTC + SIP, plugin ecosystem |
-| **Observability** | Langfuse + Loki | LLM tracing + log aggregation + alerting |
+| **Observability** | Langfuse + Loki | LLM tracing + local/dev log aggregation + alerting |
 | **Database** | PostgreSQL | Lead scoring, graph checkpoints, user data |
-| **Deployment** | Docker Compose / k3s | Dev → VPS with CI/CD auto-deploy |
+| **Deployment** | Docker Compose / partial k3s | Local/VPS Compose primary, k3s core-service manifests |
 
 ---
 
@@ -151,7 +195,7 @@ make run-bot           # Run bot natively (fast iteration, no Docker rebuild)
 
 For native bot runs, `REDIS_URL` is optional in local development: when it is unset, the bot derives `redis://:REDIS_PASSWORD@localhost:6379` from `REDIS_PASSWORD` so it matches the password-protected Redis started by `make local-up`.
 
-`make test-bot-health` validates the published local prerequisites used by native bot runs. The authoritative startup preflight still runs in [`telegram_bot/preflight.py`](/home/user/projects/rag-fresh-issue-1198/telegram_bot/preflight.py) when the bot starts. That runtime preflight still owns the repo-local BGE-M3 contract because BGE-M3 is a service this repository depends on directly, not a generic upstream SDK health path.
+`make test-bot-health` validates the published local prerequisites used by native bot runs. The authoritative startup preflight still runs in [`telegram_bot/preflight.py`](telegram_bot/preflight.py) when the bot starts. That runtime preflight still owns the repo-local BGE-M3 contract because BGE-M3 is a service this repository depends on directly, not a generic upstream SDK health path.
 
 ### 3. Or Run Everything in Docker
 
@@ -246,6 +290,11 @@ CI is intentionally lightweight. It should stay fast and is used as a guardrail 
 
 | Document | Description |
 |----------|-------------|
+| [Reviewer Access Guide](docs/review/ACCESS_FOR_REVIEWERS.md) | Safe review path, commands, and boundaries for people with repo access |
+| [Project Guide](docs/review/PROJECT_GUIDE.md) | Folder map, subsystem ownership, and where the important code lives |
+| [Portfolio Case Study](docs/portfolio/resume-case-study.md) | Resume-ready project narrative and feature highlights |
+| [GitHub Repo Setup](docs/review/GITHUB_REPO_SETUP.md) | Repository metadata, topics, branch protection, release, and hygiene checklist |
+| [Docs Index](docs/README.md) | Concise map of all major documentation areas |
 | [DOCKER.md](DOCKER.md) | Docker Compose profiles, service map, env requirements |
 | [Architecture](docs/PROJECT_STACK.md) | System architecture and subsystem map |
 | [Pipeline Overview](docs/PIPELINE_OVERVIEW.md) | Ingestion, query, and voice runtime flows |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,52 @@
+# Documentation Index
+
+This is a concise map of the major documentation areas in this repository.
+
+## Reviewer Entry Points
+
+Start here if you are reviewing the project for hiring, portfolio, or collaboration:
+
+- [`README.md`](../README.md) — Project overview, architecture diagram, quick start, and reviewer path.
+- [`docs/portfolio/resume-case-study.md`](portfolio/resume-case-study.md) — Resume-ready case study with feature cards and honest limitations.
+- [`docs/review/PROJECT_GUIDE.md`](review/PROJECT_GUIDE.md) — Folder map and subsystem ownership.
+- [`docs/review/ACCESS_FOR_REVIEWERS.md`](review/ACCESS_FOR_REVIEWERS.md) — Safe commands and boundaries.
+- [`docs/review/GITHUB_REPO_SETUP.md`](review/GITHUB_REPO_SETUP.md) — Repository metadata and hygiene checklist.
+
+## Architecture & Design
+
+- [`docs/PROJECT_STACK.md`](PROJECT_STACK.md) — System architecture and subsystem map.
+- [`docs/BOT_ARCHITECTURE.md`](BOT_ARCHITECTURE.md) — Bot layer architecture.
+- [`docs/PIPELINE_OVERVIEW.md`](PIPELINE_OVERVIEW.md) — Ingestion, query, and voice runtime flows.
+- [`docs/PIPELINE_ROUTING.md`](PIPELINE_ROUTING.md) — Query routing and state machine design.
+- [`docs/CONTEXTUALIZED_EMBEDDINGS.md`](CONTEXTUALIZED_EMBEDDINGS.md) — Embedding strategy and contextualization.
+- [`docs/RAG_API.md`](RAG_API.md) — FastAPI RAG API contract.
+- [`docs/API_REFERENCE.md`](API_REFERENCE.md) — API reference.
+
+## Operations & Runbooks
+
+- [`DOCKER.md`](../DOCKER.md) — Docker Compose profiles, service map, env requirements.
+- [`docs/LOCAL-DEVELOPMENT.md`](LOCAL-DEVELOPMENT.md) — Local setup and validation guide.
+- [`docs/INGESTION.md`](INGESTION.md) — Unified ingestion guide and troubleshooting.
+- [`docs/GDRIVE_INGESTION.md`](GDRIVE_INGESTION.md) — Google Drive sync runbook.
+- [`docs/QDRANT_STACK.md`](QDRANT_STACK.md) — Vector collections, schema, and operations.
+- [`docs/ALERTING.md`](ALERTING.md) — Loki/Alertmanager setup.
+- [`docs/runbooks/`](runbooks/) — Incident-specific runbooks.
+
+## Quality & Evaluation
+
+- [`docs/RAG_QUALITY_SCORES.md`](RAG_QUALITY_SCORES.md) — Scoring taxonomy and trace expectations.
+- [`docs/DEVELOPER_GUIDE.md`](DEVELOPER_GUIDE.md) — Development conventions and test guidance.
+- [`docs/ADRS.md`](ADRS.md) — Architecture decision records.
+
+## Migration & SDK
+
+- [`docs/SDK_MIGRATION_AUDIT_2026-03-13.md`](SDK_MIGRATION_AUDIT_2026-03-13.md) — Canonical SDK keeper stack.
+- [`docs/SDK_MIGRATION_ROADMAP_2026-03-13.md`](SDK_MIGRATION_ROADMAP_2026-03-13.md) — Post-audit execution order.
+
+## Engineering Notes
+
+- [`docs/ERROR_RESPONSES.md`](ERROR_RESPONSES.md) — Error response taxonomy.
+- [`docs/HITL.md`](HITL.md) — Human-in-the-loop design.
+- [`docs/HITL_CRM_FLOW.md`](HITL_CRM_FLOW.md) — CRM-specific HITL flow.
+- [`docs/CACHE_DEGRADATION.md`](CACHE_DEGRADATION.md) — Cache failure modes.
+- [`docs/CLIENT_PIPELINE.md`](CLIENT_PIPELINE.md) — Client pipeline details.

--- a/docs/portfolio/resume-case-study.md
+++ b/docs/portfolio/resume-case-study.md
@@ -1,0 +1,289 @@
+# AI Real Estate Automation Platform - Resume Case Study
+
+This document is a resume/portfolio source file. It summarizes the project as a
+case study, not as developer setup documentation.
+
+## One-Line Positioning
+
+AI-native real-estate automation platform combining Telegram, RAG search,
+apartment matching, CRM automation, voice input, observability, and Dockerized
+AI infrastructure.
+
+## Resume Summary - English
+
+Built a production-like AI real-estate automation platform with Telegram bot,
+RAG search, natural-language apartment search, Kommo CRM workflows, voice input,
+and Docker Compose based local/VPS infrastructure. Implemented self-hosted BGE-M3
+embeddings, Qdrant hybrid retrieval with dense/sparse/ColBERT vectors, tiered
+Redis caching, semantic conversation memory, CRM lead automation with
+human-in-the-loop confirmation, Langfuse tracing, gold-set/evaluation tooling,
+and unified document ingestion. The system includes 20+ Docker services,
+local/dev observability and monitoring, and 400+ test files.
+
+## Resume Summary - Russian
+
+Разработал AI-native платформу автоматизации для real estate: Telegram-бот,
+RAG-поиск, подбор объектов по естественному языку, интеграция с Kommo CRM,
+голосовой ввод и Docker-инфраструктура для локального/VPS запуска. Реализовал
+self-hosted BGE-M3 embeddings, Qdrant hybrid retrieval с dense/sparse/ColBERT
+векторами, многоуровневое Redis-кеширование, семантическую память диалогов,
+автоматизацию лидов в CRM с human-in-the-loop подтверждением, Langfuse
+трассировку, gold-set/evaluation tooling и unified ingestion документов.
+
+## Best Resume Bullets
+
+- Built an AI automation platform for real-estate workflows with Telegram,
+  voice, CRM, RAG, apartment search, and mini-app surfaces.
+- Implemented self-hosted retrieval infrastructure using BGE-M3 and Qdrant:
+  dense vectors, sparse BM42 vectors, and ColBERT multivector reranking.
+- Designed a tiered Redis cache for semantic answers, embeddings, search
+  results, and rerank results to reduce latency and LLM cost.
+- Connected AI conversations to Kommo CRM: lead/contact/task/note tools, lead
+  scoring, manager workflows, and HITL approval before write operations.
+- Added Langfuse observability with traces, prompt metadata, quality and
+  operational scores, latency/cache/rerank metrics, trace validation, and
+  evaluation tooling.
+- Built a deterministic ingestion pipeline: Google Drive/local files, Docling
+  parsing, chunking, BGE-M3 embeddings, Qdrant upserts/deletes, Postgres state,
+  retries, and DLQ.
+- Dockerized the system with Compose profiles for bot, ingestion, voice, ML
+  observability, monitoring, and full-stack runtime; k3s manifests cover core
+  services as an incremental migration path.
+
+## Feature Cards
+
+### 1. LangGraph RAG Pipeline
+
+**Problem:** Real-estate clients ask repeated questions about properties, legal
+processes, documents, and company workflows. Static FAQ answers are not enough.
+
+**Implementation:** Built a LangGraph pipeline with classification, prompt
+injection guard, cache check, retrieval, grading, reranking, query rewriting,
+generation, cache store, response, and optional summarization.
+
+**Impact:** The system behaves like a stateful AI workflow, not a simple LLM
+wrapper. It can route easy, off-topic, knowledge, apartment, and CRM-related
+queries through different paths.
+
+### 2. Self-Hosted Qdrant + BGE-M3 Retrieval
+
+**Problem:** RAG quality, privacy, and cost depend heavily on the retrieval
+stack. API-only embeddings are expensive and less controllable.
+
+**Implementation:** Added a local BGE-M3 FastAPI service running `BAAI/bge-m3`
+with endpoints for `/encode/dense`, `/encode/sparse`, `/encode/colbert`,
+`/encode/hybrid`, `/rerank`, `/health`, and `/metrics`. Qdrant stores named
+vectors: `dense` 1024-dim cosine vectors, `bm42` sparse vectors with IDF, and
+`colbert` multivectors with MaxSim.
+
+**Impact:** One self-hosted model provides semantic search, lexical search, and
+late-interaction reranking. This reduces vendor dependency and makes embedding
+cost predictable.
+
+### 3. Qdrant Schema And Ops
+
+**Problem:** Vector search can fail silently when schemas drift or collections
+miss required vectors.
+
+**Implementation:** Added Qdrant bootstrap, schema check, strict mode,
+collection aliases, ColBERT coverage checks, and resumable ColBERT backfill.
+Ingestion uses deterministic point IDs and replace semantics by `file_id`.
+
+**Impact:** Retrieval infrastructure is operated like a real subsystem, with
+schema validation, guardrails, and blue/green-ready collection aliases.
+
+### 4. Tiered Redis Cache
+
+**Problem:** RAG systems are expensive and slow when every request recomputes
+embeddings, retrieval, reranking, and LLM output.
+
+**Implementation:** Built a tiered Redis cache:
+semantic answer cache, dense embedding cache, sparse embedding cache, search
+results cache, and rerank results cache. Conversation history also uses Redis
+lists for short-term state.
+
+**Impact:** The system can skip unnecessary BGE-M3, Qdrant, rerank, and LLM
+work. This shows cost-aware AI engineering, not just prompt usage.
+
+### 5. Semantic Dialogue Memory
+
+**Problem:** AI assistants lose context when each message is treated as a
+stateless request.
+
+**Implementation:** Added Qdrant-backed conversation history. Each Q&A turn is
+embedded and stored with user/session metadata, then searched semantically with
+user isolation. There is also a history sub-graph for retrieve, grade, rewrite,
+and summarize behavior.
+
+**Impact:** Managers and AI workflows can recover previous client context,
+summarize sessions, and support better handoff.
+
+### 6. Kommo CRM Automation
+
+**Problem:** Leads from Telegram conversations can be lost if they are not
+converted into CRM records and follow-up tasks.
+
+**Implementation:** Integrated Kommo CRM tools for getting deals, creating and
+updating leads, upserting contacts, adding notes, creating tasks, linking
+contacts to deals, searching leads, reading manager leads/tasks, and updating
+contacts. Write operations require HITL confirmation for lead/contact mutations.
+
+**Impact:** The bot connects AI conversations to real sales workflow: lead
+capture, qualification, follow-up, and manager handoff.
+
+### 7. Natural-Language Apartment Search
+
+**Problem:** Users describe what they want in natural language or voice instead
+of filling structured filters.
+
+**Implementation:** Built an apartment extraction pipeline that converts queries
+into structured filters such as city, complex, rooms, price, area, floor, view,
+and furnishing. The pipeline uses cached extraction, LLM extraction, and a
+deterministic regex fallback. Search results support catalog navigation,
+pagination, cards, favorites, and viewing flow.
+
+**Impact:** Users can search with phrases like "2-bedroom near the sea under
+120k", while the system still applies structured filters and avoids unnecessary
+LLM work when deterministic parsing is enough.
+
+### 8. Voice Input And Voice Agent
+
+**Problem:** Real-estate clients may prefer voice messages or phone-like flows
+instead of text.
+
+**Implementation:** Added Telegram voice input and a LiveKit RTC voice path
+with ElevenLabs STT/TTS. The voice agent calls the same RAG API used by other
+channels and propagates Langfuse trace IDs for continuity. SIP support is
+represented as outbound trunk provisioning rather than a fully documented
+inbound call-routing flow.
+
+**Impact:** One AI workflow works across text, Telegram voice, and voice-agent
+channels.
+
+### 9. Unified Document Ingestion
+
+**Problem:** RAG quality depends on reliable document ingestion, not only on the
+chatbot layer.
+
+**Implementation:** Built a unified ingestion pipeline: Google Drive/local
+files, stable file identity, Docling parsing, chunking, BGE-M3 embeddings,
+Qdrant upsert/delete, Postgres state, retries, DLQ, and status commands. On
+local BGE-M3, ingestion uses `/encode/hybrid` to get dense, sparse, and ColBERT
+vectors in one model pass.
+
+**Impact:** Knowledge-base updates are deterministic, resumable, and observable.
+
+### 10. Langfuse Observability And Prompt Management
+
+**Problem:** AI workflows are hard to debug without traces, scores, and prompt
+version visibility.
+
+**Implementation:** Integrated Langfuse tracing and scores for RAG/API/voice/
+ingestion paths. The project tracks latency, cache hits, rerank usage, LLM
+usage, TTFT, token metrics, grounding, sources, security alerts, history search,
+and CRM tool results. Prompt management uses Langfuse `get_prompt(...)`,
+prompt labels, cached prompt retrieval, fallback prompts, `prompt_source`, and
+`prompt_version` metadata on spans.
+
+**Impact:** The system can be improved from traces and metrics rather than
+manual guessing. Prompt behavior is version-aware and fallback-safe, with
+graceful no-op behavior when Langfuse is not configured or unreachable.
+
+### 11. Gold Sets, Evaluation, And Experiments
+
+**Problem:** RAG changes need regression checks against expected answers and
+routing behavior.
+
+**Implementation:** Added evaluation assets and commands:
+`tests/eval/ground_truth.json`, `tests/eval/agent_routing_golden.yaml`,
+baseline metric collection from Langfuse, RAGAS evaluation commands,
+gold-set sync to Langfuse datasets, experiment runners, trace export, score
+config setup, judge calibration, and trace validation. The checked-in
+ground-truth fixture currently contains 55 samples; generation scripts can
+produce larger corpus-derived datasets.
+
+**Impact:** Retrieval, generation, routing, and prompt changes can be compared
+against gold data and Langfuse experiment/baseline metrics.
+
+### 12. Dockerized Production-Like Runtime
+
+**Problem:** AI projects often work only as local scripts and are hard to run as
+a system.
+
+**Implementation:** Created Docker Compose profiles for core services, bot,
+ingestion, voice, ML observability, monitoring, and full runtime. The stack
+includes Postgres, Redis, Qdrant, BGE-M3, USER2-base, Docling, LiteLLM, bot,
+RAG API, LiveKit, mini app, Langfuse, ClickHouse, MinIO, Loki, Promtail, and
+Alertmanager. The primary VPS path is GitHub Actions plus Docker Compose; k3s
+manifests exist for core services but do not yet cover the full Compose stack.
+
+**Impact:** The project demonstrates operational thinking: service boundaries,
+healthchecks, profiles, resource limits, pinned images, local/VPS workflows, and
+monitoring. The Loki/Alertmanager stack is best described as local/dev
+monitoring unless production deployment evidence is added.
+
+## Technical Highlights
+
+- **LLM orchestration:** LangGraph, LiteLLM, Langfuse OpenAI integration.
+- **Retrieval:** Qdrant Query API, RRF fusion, dense/sparse vectors, ColBERT
+  multivectors, MaxSim rerank.
+- **Embeddings:** self-hosted `BAAI/bge-m3`, local `deepvk/USER2-base` service
+  for Russian semantic vectorizer/cache scenarios, optional Voyage paths.
+- **Caching:** RedisVL semantic cache, embeddings cache, sparse cache, search
+  cache, rerank cache.
+- **CRM:** Kommo tools, lead/contact/task/note workflows, HITL approvals,
+  manager flows, lead scoring sync.
+- **Voice:** Telegram voice input, LiveKit voice agent, shared RAG API.
+- **Ingestion:** CocoIndex, Docling, BGE-M3, Qdrant writer, Postgres state/DLQ.
+- **Observability:** Langfuse traces, scores, prompt metadata,
+  Loki/Alertmanager for local/dev monitoring, trace validation.
+- **Evaluation:** gold sets, RAGAS, Langfuse datasets/experiments, baseline
+  metrics, judge calibration scripts.
+- **Ops:** Docker Compose profiles, healthchecks, pinned images, non-root
+  runtime users, VPS Docker Compose deployment path, partial k3s manifests.
+
+## Interview Talking Points
+
+1. **Why BGE-M3?**
+   It gives dense, sparse, and ColBERT vectors from one self-hosted model. This
+   reduces cost and supports hybrid retrieval without multiple embedding vendors.
+
+2. **Why Qdrant?**
+   Qdrant supports named vectors, sparse vectors, multivectors, Query API
+   prefetch/fusion flows, and server-side ColBERT-style reranking.
+
+3. **How is cost controlled?**
+   The project avoids LLM calls when possible: classification, deterministic
+   apartment parsing fallback, semantic cache, embeddings cache, search cache,
+   rerank cache, and local embeddings.
+
+4. **How are CRM writes made safe?**
+   CRM write tools use human-in-the-loop confirmation before creating/updating
+   leads, contacts, or other important records.
+
+5. **How do you debug quality issues?**
+   Langfuse traces and scores show retrieval path, cache behavior, rerank usage,
+   LLM usage, latency, grounding, prompt source/version, and CRM/history events.
+
+6. **What makes this more than a chatbot?**
+   It has ingestion, retrieval infrastructure, CRM automation, voice channel,
+   memory, evaluation, observability, and Dockerized runtime services.
+
+## Honest Limitations / Next Improvements
+
+- Fix and revalidate local Langfuse ML profile startup for the pinned ClickHouse
+  image.
+- Keep k3s wording conservative until manifests cover Langfuse, monitoring,
+  mini app, voice, and ingestion runtime parity with Compose.
+- Treat Loki/Alertmanager as local/dev monitoring unless production VPS
+  evidence is added.
+- Add CI or release-gate wiring for `validate_traces.py` and RAGAS evaluation
+  instead of keeping them as mostly manual quality tools.
+- Add a prompt-version A/B harness using Langfuse labels and dataset
+  experiments.
+- Add screenshots or short demo videos for Telegram, CRM handoff, Langfuse
+  traces, and apartment search.
+- Publish a small sanitized demo dataset so recruiters can run a safe subset.
+- Add a short architecture diagram optimized for non-engineers.
+- Add quantified metrics if available: cache hit rate, latency before/after
+  cache, number of indexed documents, successful CRM flows, and RAG eval scores.

--- a/docs/review/ACCESS_FOR_REVIEWERS.md
+++ b/docs/review/ACCESS_FOR_REVIEWERS.md
@@ -1,0 +1,76 @@
+# Access For Reviewers
+
+Use this file when someone receives repository access for technical review,
+portfolio review, or hiring evaluation.
+
+## Recommended Review Path
+
+If you have 10 minutes:
+
+1. Read `README.md`.
+2. Read `docs/portfolio/resume-case-study.md`.
+3. Skim `docs/review/PROJECT_GUIDE.md`.
+4. Inspect `telegram_bot/graph/` for LangGraph orchestration.
+5. Inspect `telegram_bot/agents/` and `telegram_bot/services/` for product logic.
+6. Inspect `src/ingestion/unified/` for ingestion architecture.
+7. Inspect `compose.yml` and `DOCKER.md` for runtime architecture.
+
+If you have more time:
+
+- Review `docs/QDRANT_STACK.md` for vector schema and ColBERT operations.
+- Review `docs/INGESTION.md` and `docs/GDRIVE_INGESTION.md`.
+- Review `docs/RAG_QUALITY_SCORES.md`.
+- Review `tests/unit/`, `tests/contract/`, and `tests/eval/`.
+
+## Safe Commands
+
+These commands are intended for local review and should not call production
+systems when the environment is configured safely:
+
+```bash
+uv sync
+make check
+uv run pytest tests/unit
+COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility config --services
+COMPOSE_FILE=compose.yml:compose.vps.yml docker compose --compatibility config --services
+```
+
+For a narrower first pass, prefer focused tests around the subsystem being
+reviewed, then `make check`.
+
+## Do Not Run Without Coordination
+
+- production deploy scripts
+- real Kommo CRM write flows
+- commands that require production `.env`
+- VPS/k3s deploy commands
+- destructive Docker or database cleanup commands
+- ingestion against real production documents
+
+## Environment Rules
+
+- Use `.env.example` as the public contract.
+- Do not request or inspect production `.env` files for code review.
+- Use fake/demo credentials for local inspection.
+- Treat Telegram, Kommo, Langfuse, LiveKit, and cloud credentials as external
+  secrets, not repository content.
+
+## What To Look At For Senior-Level Review
+
+- State and routing contracts in `telegram_bot/graph/`.
+- SDK/native API usage in `telegram_bot/integrations/` and `telegram_bot/services/`.
+- Cheap-first apartment parsing in `telegram_bot/services/filter_extractor.py`.
+- HITL safety boundaries in `telegram_bot/agents/hitl.py` and CRM tools.
+- Ingestion determinism in `src/ingestion/unified/manifest.py` and
+  `src/ingestion/unified/state_manager.py`.
+- Runtime contract and healthchecks in Compose files.
+- Evaluation and observability wiring in Langfuse-related scripts/tests.
+
+## Known Limitations To Keep In Mind
+
+- k3s manifests are partial and should not be treated as full Compose parity.
+- local/dev monitoring exists through Loki/Alertmanager; production monitoring
+  evidence should be reviewed separately.
+- RAGAS and trace validation tooling exists, but some gates are manual rather
+  than CI-enforced.
+- Some user-facing strings remain outside Fluent localization files.

--- a/docs/review/GITHUB_REPO_SETUP.md
+++ b/docs/review/GITHUB_REPO_SETUP.md
@@ -1,0 +1,113 @@
+# GitHub Repository Setup
+
+This checklist is for making the repository understandable and safe when access
+is shared with recruiters, technical interviewers, or collaborators.
+
+## Repository Metadata
+
+Recommended GitHub sidebar description:
+
+> AI real-estate automation platform: Telegram bot, RAG, apartment search, CRM
+> workflows, voice agent, Langfuse observability, and Dockerized AI runtime.
+
+Recommended topics:
+
+```text
+rag
+langgraph
+telegram-bot
+qdrant
+langfuse
+fastapi
+docker
+real-estate
+ai-agents
+crm
+kommo
+voice-ai
+```
+
+Recommended homepage link:
+
+- a live demo, sanitized demo video, or `docs/portfolio/resume-case-study.md`
+  rendered through GitHub.
+
+## Default Review Entry Points
+
+Pin or link these prominently:
+
+- `README.md`
+- `docs/portfolio/resume-case-study.md`
+- `docs/review/PROJECT_GUIDE.md`
+- `docs/review/ACCESS_FOR_REVIEWERS.md`
+- `DOCKER.md`
+
+## Branch And Release Hygiene
+
+Recommended setup:
+
+- default branch: `main` for public portfolio repos, or document clearly if
+  `dev` is the active integration branch.
+- protect the default branch.
+- require PRs for changes.
+- require fast CI checks before merge.
+- disallow force pushes to protected branches.
+- create a review snapshot tag such as `portfolio-review-2026-05`.
+
+If the everyday integration branch is not `main`, explain that in `README.md`
+and keep PR/release instructions consistent.
+
+## CI Expectations
+
+Minimum useful checks:
+
+- lint and format
+- type checking
+- focused unit tests
+- Compose config validation for runtime-sensitive changes
+- secret scanning friendly repository layout
+
+For this repository, local verification remains stronger than CI. README should
+say that CI is a guardrail and local `make check` plus focused tests are the
+primary evidence for code changes.
+
+## Security And Sanitization
+
+Before granting external access:
+
+- verify no `.env`, tokens, SSH keys, database dumps, or production logs are in
+  the repository.
+- verify screenshots and docs do not expose client data or real credentials.
+- keep `.env.example` complete but non-secret.
+- avoid publishing VPS IPs, private hostnames, or deploy keys.
+- review Git history if real secrets were ever committed.
+
+Recommended files:
+
+- `.env.example`
+- `SECURITY.md`
+- `docs/review/ACCESS_FOR_REVIEWERS.md`
+
+## README Checklist
+
+The README should answer these in under one minute:
+
+- What is the project?
+- What business problem does it solve?
+- What are the main subsystems?
+- What is technically interesting?
+- How should a reviewer inspect it safely?
+- Which docs explain the architecture?
+- What are the honest limitations?
+
+## Portfolio Review Checklist
+
+Before sending a repository link, verify:
+
+- `README.md` has a reviewer path.
+- `docs/review/PROJECT_GUIDE.md` maps important folders.
+- `docs/review/ACCESS_FOR_REVIEWERS.md` says what is safe to run.
+- `docs/portfolio/resume-case-study.md` is accurate and conservative.
+- outdated claims are removed or softened.
+- `git status` does not include accidental secrets, logs, dumps, or local-only
+  scratch files intended to stay private.

--- a/docs/review/PROJECT_GUIDE.md
+++ b/docs/review/PROJECT_GUIDE.md
@@ -1,0 +1,126 @@
+# Project Guide
+
+This guide is for reviewers who need to understand the repository quickly
+without reading every file. It complements the portfolio summary in
+`docs/portfolio/resume-case-study.md`.
+
+## What This Project Is
+
+AI real-estate automation platform with:
+
+- Telegram bot workflows for clients and managers
+- contextual RAG over real-estate knowledge
+- natural-language apartment search
+- Kommo CRM automation and lead scoring
+- Telegram voice input and LiveKit voice-agent path
+- unified document ingestion into Qdrant
+- Langfuse tracing, scoring, prompt management, and evaluation tooling
+- Docker Compose based local/VPS runtime
+
+## Recommended Reading Path
+
+1. `README.md` for the project overview and architecture diagram.
+2. `docs/portfolio/resume-case-study.md` for the resume-style narrative.
+3. `telegram_bot/graph/` for LangGraph routing and state contracts.
+4. `telegram_bot/agents/` for CRM tools, HITL, history search, and agent setup.
+5. `telegram_bot/services/` for business logic, cache, Kommo, apartment search,
+   lead scoring, and handoff services.
+6. `src/ingestion/unified/` for ingestion determinism, state, DLQ, and Qdrant writes.
+7. `src/voice/` for LiveKit voice agent and shared RAG API integration.
+8. `compose.yml`, `compose.dev.yml`, `compose.vps.yml`, and `DOCKER.md` for runtime architecture.
+
+## Folder Map
+
+### `telegram_bot/`
+
+Main Telegram product surface. Contains aiogram handlers, dialog flows,
+middlewares, LangGraph orchestration, CRM/agent integrations, localization,
+and bot startup/preflight logic.
+
+### `telegram_bot/graph/`
+
+LangGraph RAG runtime: state, nodes, conditional edges, cache/retrieval/rerank/
+generation flow, and routing contracts.
+
+### `telegram_bot/agents/`
+
+Agent-facing tools and orchestration: CRM tools, apartment tools, HITL
+interrupts, history search, and agent factory/prompt wiring.
+
+### `telegram_bot/services/`
+
+Business services and integration logic: apartment search/filtering, Kommo
+client, lead scoring, handoff state, cache behavior, hot-lead notifications,
+and RAG service helpers.
+
+### `telegram_bot/dialogs/` and `telegram_bot/handlers/`
+
+User and manager interaction layer: menus, catalog, viewing flow, CRM task
+dialogs, phone collection, handoff, and command/message handlers.
+
+### `src/ingestion/unified/`
+
+Unified ingestion pipeline: Google Drive/local file identity, Docling parsing,
+chunking, manifest/state handling, Qdrant writes, retries, and DLQ behavior.
+
+### `src/voice/`
+
+LiveKit voice agent path, transcript persistence, RAG API client, SIP setup,
+and voice observability helpers.
+
+### `mini_app/`
+
+Telegram Mini App backend and frontend. Treat this as a lightweight entry
+surface, not full parity with the Telegram bot.
+
+### `services/`
+
+Local service containers and helper APIs, including BGE-M3 and USER2-base
+embedding services.
+
+### `compose*.yml`, `docker/`, `DOCKER.md`
+
+Docker Compose runtime. Compose is the primary local/VPS operating path. k3s
+manifests exist separately but are not full parity with the Compose service set.
+
+### `k8s/`
+
+Partial k3s manifests for core services. Use conservative wording when
+describing k3s support.
+
+### `tests/`
+
+Unit, contract, integration, smoke, evaluation, and baseline tests. Local
+verification is the release authority; CI is intentionally lighter.
+
+### `docs/`
+
+Architecture docs, runbooks, engineering notes, test-writing guidance, SDK
+registry, and portfolio material.
+
+## High-Signal Files
+
+- `telegram_bot/graph/graph.py`
+- `telegram_bot/graph/state.py`
+- `telegram_bot/agents/crm_tools.py`
+- `telegram_bot/agents/hitl.py`
+- `telegram_bot/services/apartments_service.py`
+- `telegram_bot/services/filter_extractor.py`
+- `telegram_bot/integrations/cache.py`
+- `telegram_bot/scoring.py`
+- `telegram_bot/integrations/prompt_manager.py`
+- `src/ingestion/unified/cli.py`
+- `src/ingestion/unified/state_manager.py`
+- `src/voice/agent.py`
+- `compose.yml`
+- `DOCKER.md`
+
+## Honest Scope Notes
+
+- Docker Compose is the primary runtime path; k3s is partial.
+- Loki/Alertmanager are local/dev monitoring unless production evidence is
+  added.
+- HITL applies to CRM write operations, not every possible state transition.
+- The Mini App is a lightweight entry point and not full apartment-search parity.
+- Some i18n migration work remains because not every user-facing string is in
+  Fluent files.


### PR DESCRIPTION
## Summary
- Update README.md with conservative claims and a first-screen reviewer section linking to review docs.
- Add docs/README.md as a concise documentation index.
- Add docs/review/ACCESS_FOR_REVIEWERS.md with safe review paths and commands.
- Add docs/review/PROJECT_GUIDE.md with folder map and subsystem ownership.
- Add docs/review/GITHUB_REPO_SETUP.md with repository hygiene checklist.
- Add docs/portfolio/resume-case-study.md suitable for job/interview context.

## Acceptance
- All links in README point to files created in this PR.
- Claims are conservative: no full production k3s parity, exact benchmark scores, or unverified enterprise features.
- No unrelated docs archive/workflow/test moves.