### PR TITLE
docs: refresh tests/README.md with current tiers and commands

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,99 +1,197 @@
 # Tests
 
+This directory contains the full test pyramid for the contextual RAG system.
+For test-writing conventions, see [`docs/engineering/test-writing-guide.md`](../docs/engineering/test-writing-guide.md).
+
 ## Directory Structure
 
 ```
 tests/
-├── conftest.py          # Shared fixtures
-├── unit/                # Fast tests, no external deps (mocked)
-├── integration/         # Require running services (Qdrant, Redis, etc.)
-├── e2e/                 # End-to-end pipeline tests
-├── smoke/               # Quick health checks
-├── benchmark/           # Performance comparisons (RRF vs DBSF, etc.)
-├── baseline/            # Langfuse baseline metrics
+├── conftest.py          # Shared fixtures and hooks
+├── unit/                # Fast, isolated tests (mocked/no external deps)
+├── contract/            # Static contracts: trace families, span coverage, error shapes
+├── integration/         # Service-aware paths and real component interaction
+├── smoke/               # Quick health checks against live services
 ├── eval/                # RAG evaluation (RAGAS, ground_truth.json)
-├── load/                # Load testing
-├── legacy/              # Deprecated tests
-└── data/                # Test fixtures and datasets
+├── baseline/            # Langfuse baseline metrics and threshold checks
+├── benchmark/           # Performance comparisons (RRF vs DBSF, parser vs Docling, etc.)
+├── observability/       # Trace/contract CLI and collector infrastructure tests
+├── chaos/               # Resilience tests (service failures, LLM fallbacks)
+├── load/                # Load/throughput and Redis eviction tests
+├── e2e/                 # End-to-end pipeline and Telegram E2E tests
+├── fixtures/            # Shared test data and CI env stubs (e.g., compose.ci.env)
+└── data/                # Test datasets and generated assets
 ```
+
+## Test Tiers
+
+### Local-fast checks (no Docker required)
+These are the default gate for PRs and local development.
+
+| Tier | Location | What it proves | Typical duration |
+|------|----------|----------------|------------------|
+| Unit | `tests/unit/` | Isolated logic with mocks/fakes | Seconds |
+| Contract | `tests/contract/` | Trace/schema contracts via static analysis | Seconds |
+
+### Heavy / runtime checks (services or credentials required)
+Run these selectively, not on every save.
+
+| Tier | Location | What it proves | Typical duration |
+|------|----------|----------------|------------------|
+| Integration | `tests/integration/` | Real service interaction (Qdrant, Redis, APIs) | Minutes |
+| Smoke | `tests/smoke/` | Live service health and routing sanity | Minutes |
+| Eval | `tests/eval/` | RAG quality (faithfulness, relevance) | Minutes |
+| Baseline | `tests/baseline/` | Observability metric regressions | Minutes |
+| Benchmark | `tests/benchmark/` | Parser/reranker throughput comparisons | Varies |
+| Observability | `tests/observability/` | Trace collector/manager infrastructure | Varies |
+| Chaos | `tests/chaos/` | Degraded-service behavior and fallbacks | Minutes |
+| Load | `tests/load/` | Concurrent throughput and cache eviction | Minutes |
+| E2E | `tests/e2e/` | Full-stack pipeline and Telegram flows | Slow |
 
 ## Commands
 
+### Quick checks (lint + types)
 ```bash
-# Run all tests
+make check
+```
+
+### Fast test gate (unit + critical graph paths)
+```bash
 make test
-
-# Unit tests only (fast, no deps)
-make test-unit
-# or
-pytest tests/unit/ -v
-
-# Integration tests (requires services)
-pytest tests/integration/ -v
-
-# Specific test file
-pytest tests/unit/test_cache_service.py -v
-
-# Run failed tests only
-pytest --lf
-
-# With coverage
-make test-cov
 ```
 
-## Test Categories
+### Core unit tests (parallel, default local gate)
+```bash
+PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit
+```
 
-| Category | Location | Requires | Speed |
-|----------|----------|----------|-------|
-| Unit | `tests/unit/` | Nothing (mocked) | Fast |
-| Integration | `tests/integration/` | Docker services | Medium |
-| E2E | `tests/e2e/` | Full stack | Slow |
-| Smoke | `tests/smoke/` | Services | Fast |
-| Benchmark | `tests/benchmark/` | Services | Varies |
-| Eval | `tests/eval/` | LLM + Qdrant | Slow |
-| Baseline | `tests/baseline/` | Langfuse | Medium |
+### Focused run (preferred while developing)
+```bash
+uv run pytest tests/unit/test_<module>.py -q
+```
 
-## Running Services
+### Contract tests (no Docker)
+```bash
+make test-contract
+```
+
+### Integration tests (requires services)
+```bash
+make test-integration        # graph paths only (~5s, no Docker)
+make test-integration-full   # all integration tests (requires Docker)
+```
+
+### Smoke tests (requires live services)
+```bash
+make test-smoke
+make test-preflight          # Qdrant/Redis config checks
+```
+
+### Load / chaos / nightly
+```bash
+make test-load               # live services
+make test-load-ci            # mocked/fast CI mode
+make test-nightly            # chaos + smoke + slow unit
+```
+
+### E2E
+```bash
+make e2e-test                # pytest E2E suite (live services)
+make e2e-telegram-test       # Telegram userbot runner
+```
+
+### RAG evaluation
+```bash
+make eval-rag                # RAGAS on ground_truth.json
+make eval-rag-quick          # 10-sample subset
+make eval-rag-full           # RAGAS + DeepEval
+```
+
+### Baseline / observability
+```bash
+make baseline-smoke          # smoke with Langfuse tracing
+make baseline-compare        # compare against a baseline tag
+```
+
+### Compose validation (for runtime-impacting changes)
+When changing `compose*.yml`, Dockerfiles, or service definitions, verify the effective config:
 
 ```bash
-make docker-up    # Start Qdrant, Redis, LiteLLM, etc.
-make docker-down  # Stop services
+COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility config --services
+COMPOSE_FILE=compose.yml:compose.vps.yml docker compose --compatibility config --services
 ```
+
+CI uses `tests/fixtures/compose.ci.env` for interpolation validation:
+```bash
+COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml config --quiet
+```
+
+### Other useful commands
+```bash
+make test-cov                # coverage report
+make test-lf                 # last failed only
+make test-profile            # slowest tests
+make test-store-durations    # update .test_durations for CI sharding
+```
+
+## Markers
+
+Markers are defined in `pyproject.toml`. Common ones:
+
+- `unit` — core unit tests
+- `integration` — integration tests
+- `slow` — tests taking > 5 seconds
+- `smoke` — smoke tests
+- `benchmark` — benchmark comparisons
+- `chaos` — resilience/failure injection
+- `load` — load/performance tests
+- `e2e` — end-to-end tests
+- `requires_extras` — needs optional dependencies (skipped in core tier)
+- `kommo` — live Kommo CRM tests (requires token)
+
+See `pyproject.toml` for the full marker list (including exclusions for old API tests).
 
 ## Key Test Files
 
 | File | Description |
 |------|-------------|
-| `unit/test_cache_service.py` | CacheService with mocked Redis |
 | `unit/test_qdrant_service.py` | QdrantService with mocked client |
 | `unit/test_voyage_service.py` | VoyageService with mocked API |
 | `unit/test_small_to_big.py` | Small-to-big chunk expansion |
 | `unit/test_ragas_evaluation.py` | RAG evaluation metrics |
+| `unit/test_local_compose_contract.py` | Compose config validation |
+| `contract/test_trace_families_contract.py` | Required trace family coverage |
+| `contract/test_span_coverage_contract.py` | Span coverage gates |
+| `integration/test_graph_paths.py` | LangGraph path validation (no Docker) |
 | `integration/test_qdrant_connection.py` | Real Qdrant connection |
-| `eval/ground_truth.json` | 55 Q&A pairs for evaluation |
+| `smoke/test_preflight.py` | Qdrant/Redis preflight checks |
+| `eval/ground_truth.json` | Q&A pairs for RAG evaluation |
 
 ## Writing Tests
 
-- **Unit tests**: Mock external services with `pytest-mock`
-- **Integration tests**: Use real services, mark with `@pytest.mark.integration`
-- Use fixtures from `conftest.py` for common setup
-- Follow AAA pattern: Arrange, Act, Assert
+- **Default guide**: [`docs/engineering/test-writing-guide.md`](../docs/engineering/test-writing-guide.md)
+- **Unit tests**: Mock external services; keep them fast and deterministic.
+- **Integration tests**: Use real services; mark with `@pytest.mark.integration`.
+- **Heavy tests**: Do not move live-service scenarios into the local fast lane.
+- **Reuse**: Search existing coverage before adding new files (`rg -n "<behavior>" tests/`).
+- **Fixtures**: Use `conftest.py` for shared setup; keep scopes narrow.
 
 ## Test Naming
 
 ```
-test_<module>_<behavior>.py       # File
-test_<method>_<scenario>()        # Function
+test_<feature>.py                  # File
+test_<behavior>_<expected>()       # Function
 ```
 
 Example:
 ```python
-# tests/unit/test_cache_service.py
 def test_store_embedding_creates_hash():
     """Embedding storage creates unique hash key."""
     ...
 ```
 
----
+## Notes
 
-**Last Updated**: 2026-02-02
+- The full heavy suite (chaos, load, E2E, benchmark) is not required for every commit; run the fast gate (`make test` or `make test-unit`) locally.
+- The old deprecated directory is no longer collected (`norecursedirs` in `pyproject.toml`).
+- `docker-up` is an alias for `docker-core-up`; prefer `make local-up` for local development.


### PR DESCRIPTION
## Summary
- Refresh `tests/README.md` to reflect the current test directory structure and tier definitions.
- Replace stale references to `legacy/`, `test_cache_service.py`, `make docker-up` as the main path, and the old "Last Updated" footer.
- Add missing tiers: `contract`, `observability`, `chaos`.
- Distinguish local-fast checks from heavy/runtime checks.
- Align commands with repo guidance (`make check`, `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`, focused `uv run pytest`, Compose validation).
- Reference `docs/engineering/test-writing-guide.md` as the default test-writing guide.

## Test Plan
- Verified `git diff --check` passes.
- Verified no stale substrings remain (`legacy`, `test_cache_service.py`, `make docker-up`, `Last Updated`).
- Verified required content is present (`make check`, `test-unit`, `docs/engineering/test-writing-guide.md`, `contract`, `integration`, `smoke`, `eval`).
- `make check` skipped: docs-only; no code/runtime behavior changed.