### PR TITLE
docs: add reviewer-friendly READMEs for runtime/deployment zones

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,76 @@
+# Docker Helper Assets
+
+This directory contains configuration files, scripts, and initialization assets used by the Docker Compose runtime. It does **not** contain the Compose files themselves—see [`../compose.yml`](../compose.yml), [`../compose.dev.yml`](../compose.dev.yml), [`../compose.vps.yml`](../compose.vps.yml), and [`../DOCKER.md`](../DOCKER.md) for service definitions and operations.
+
+## Layout
+
+### `litellm/`
+
+LiteLLM Proxy configuration that defines the model routing, fallbacks, and provider aliases used by the bot and voice agent.
+
+- **`config.yaml`** — Model list (Cerebras, Groq, OpenAI), fallback chains, rate limits, and key management. Referenced as a Compose ConfigMap/volume mount.
+
+### `livekit/`
+
+LiveKit server configuration for the voice-agent path.
+
+- **`livekit.yaml`** — API keys, port bindings, and RTC settings. The `LIVEKIT_API_SECRET` is interpolated from environment at runtime.
+
+### `monitoring/`
+
+Observability stack configuration for local/dev alerting and log aggregation.
+
+- **`loki.yaml`** — Loki log aggregation server config (filesystem storage, Ruler alerting).
+- **`promtail.yaml`** — Promtail agent config that scrapes Docker container logs and pushes to Loki.
+- **`alertmanager.yaml`** — Alertmanager routing and receivers (Telegram integration).
+- **`rules/`** — Loki alerting rules:
+  - `infrastructure.yaml`
+  - `telegram-bot.yaml`
+  - `ingestion.yaml`
+  - `extended-services.yaml`
+
+### `postgres/init/`
+
+Database initialization scripts executed on first Postgres startup.
+
+- **`00-init-databases.sql`** — Creates application databases.
+- **`02-cocoindex.sql`** — CocoIndex ingestion schema.
+- **`03-unified-ingestion-alter.sql`** — Unified ingestion extensions.
+- **`04-voice-schema.sql`** — Voice agent transcript schema.
+- **`05-realestate-schema.sql`** — Real-estate domain tables.
+- **`06-lead-scoring-sync.sql`** — Lead scoring sync schema.
+- **`07-nurturing-funnel-analytics.sql`** — Funnel analytics schema.
+- **`08-user-favorites.sql`** — User favorites schema.
+
+### `rclone/`
+
+Google Drive sync scripts and cron configuration for document ingestion.
+
+- **`sync-drive.sh`** — rclone-based Drive sync script.
+- **`gdrive-manifest.sh`** — Manifest generation for synced files.
+- **`rclone.conf`** — Example rclone remote configuration.
+- **`crontab`** — Cron schedule for automated sync.
+
+> Install via `make sync-drive-install` after filling in `GDRIVE_SYNC_DIR` and `RCLONE_CONFIG_FILE`.
+
+### `ingestion/`
+
+Ingestion service wrapper assets.
+
+- **`entrypoint.sh`** — Entrypoint script for the unified ingestion container.
+
+## Validation
+
+```bash
+# Verify Compose still resolves all configs correctly
+COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility config > /dev/null
+
+# Check image pins match running containers
+make verify-compose-images
+```
+
+## See Also
+
+- [`../DOCKER.md`](../DOCKER.md) — Full Compose operations guide.
+- [`../docs/LOCAL-DEVELOPMENT.md`](../docs/LOCAL-DEVELOPMENT.md) — Local setup and validation.
+- [`../docs/ALERTING.md`](../docs/ALERTING.md) — Loki/Alertmanager setup details.

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,9 @@ Start here if you are reviewing the project for hiring, portfolio, or collaborat
 
 - [`DOCKER.md`](../DOCKER.md) — Docker Compose profiles, service map, env requirements.
 - [`docs/LOCAL-DEVELOPMENT.md`](LOCAL-DEVELOPMENT.md) — Local setup and validation guide.
+- [`services/README.md`](../services/README.md) — Local service containers (BGE-M3, Docling, user-base).
+- [`docker/README.md`](../docker/README.md) — Helper runtime assets (configs, scripts, monitoring rules).
+- [`k8s/README.md`](../k8s/README.md) — Partial k3s manifests, overlays, and deploy commands.
 - [`docs/INGESTION.md`](INGESTION.md) — Unified ingestion guide and troubleshooting.
 - [`docs/GDRIVE_INGESTION.md`](GDRIVE_INGESTION.md) — Google Drive sync runbook.
 - [`docs/QDRANT_STACK.md`](QDRANT_STACK.md) — Vector collections, schema, and operations.

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,100 @@
+# K3s Deployment (Partial)
+
+This directory contains Kubernetes manifests for a **partial** k3s deployment path. Docker Compose is the primary local and VPS runtime; k3s support is maintained for core services but does not yet have full parity with the Compose service set.
+
+## Honest Scope
+
+- **What works**: Core databases, ML services, bot, and ingestion can run on a single-node k3s cluster.
+- **What is missing**: Some optional profiles (observability, voice SIP, Mini App frontend) may not be fully represented or tested under k3s.
+- **Image policy**: k3s uses versioned GitHub Container Registry images (`ghcr.io/yastman/rag-*`) instead of local `rag/*:latest` tags. See [`../DOCKER.md`](../DOCKER.md) for image names and the publish workflow.
+
+## Directory Layout
+
+### `base/`
+
+Reusable base manifests. These are environment-agnostic and should not contain hardcoded secrets.
+
+- **`namespace.yaml`** — `rag` namespace.
+- **`configmaps/`** — Postgres init SQL and LiteLLM config as ConfigMaps.
+- **`postgres/`** — PVC, Deployment, Service.
+- **`redis/`** — PVC, Deployment, Service.
+- **`qdrant/`** — PVC, Deployment, Service.
+- **`docling/`** — PVC, Deployment, Service.
+- **`bge-m3/`** — Deployment, Service.
+- **`user-base/`** — Deployment, Service.
+- **`litellm/`** — Deployment, Service.
+- **`bot/`** — Deployment.
+- **`ingestion/`** — Deployment.
+- **`kustomization.yaml`** — Aggregates all base resources.
+
+### `overlays/`
+
+Environment-specific Kustomize overlays. Each overlay layers additional resources or patches on top of `base/`.
+
+| Overlay | Scope | Includes |
+|---|---|---|
+| `core/` | Databases only | Postgres, Redis, Qdrant |
+| `bot/` | Bot runtime | Core + BGE-M3 + user-base + LiteLLM + bot |
+| `ingest/` | Ingestion runtime | Core + Docling + BGE-M3 + ingestion |
+| `full/` | Everything in `base/` | All base manifests |
+
+Apply an overlay with:
+
+```bash
+kubectl apply -k k8s/overlays/core/ --load-restrictor=LoadRestrictionsNone
+kubectl apply -k k8s/overlays/bot/ --load-restrictor=LoadRestrictionsNone
+kubectl apply -k k8s/overlays/ingest/ --load-restrictor=LoadRestrictionsNone
+kubectl apply -k k8s/overlays/full/
+```
+
+### `secrets/`
+
+Secret template for the cluster.
+
+- **`.env.example`** — Example secret values. Copy to `.env`, fill values, then run `make k3s-secrets` to create Kubernetes secrets (`api-keys` and `db-credentials`).
+
+### `k3s-config.yaml`
+
+Single-node k3s server configuration for VPS deployment (secrets encryption, log rotation, eviction thresholds, etcd snapshots). Install to `/etc/rancher/k3s/config.yaml` before running the k3s installer.
+
+## Makefile Commands
+
+```bash
+# Deploy stacks
+make k3s-core      # core databases
+make k3s-bot       # bot stack
+make k3s-ingest    # ingestion stack
+make k3s-full      # everything
+
+# Operational helpers
+make k3s-status    # pod status
+make k3s-logs SVC=bot
+make k3s-down      # tear down
+make k3s-secrets   # create secrets from k8s/secrets/.env
+make k3s-ingest-start
+make k3s-ingest-stop
+
+# Build and push versioned images
+make k3s-push-bot K3S_IMAGE_TAG=v2.14.0
+make k3s-push-ingest K3S_IMAGE_TAG=v2.14.0
+```
+
+## Validation
+
+When a cluster is available:
+
+```bash
+make k3s-status
+```
+
+For Compose parity checks (the primary runtime):
+
+```bash
+make verify-compose-images
+COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility config --services
+```
+
+## See Also
+
+- [`../DOCKER.md`](../DOCKER.md) — Primary Compose runtime guide and image publishing workflow.
+- [`../docs/LOCAL-DEVELOPMENT.md`](../docs/LOCAL-DEVELOPMENT.md) — Local development setup.

--- a/services/README.md
+++ b/services/README.md
@@ -1,0 +1,56 @@
+# Local Service Containers
+
+This directory contains standalone service containers that support the RAG runtime.
+They are referenced from the main [`compose.yml`](../compose.yml) and started as part of the Docker Compose stack.
+
+## Services
+
+### `bge-m3-api/` — Multi-Vector Embedding Service
+
+- **Role**: Generates dense, sparse, and ColBERT embeddings via the BGE-M3 model for document ingestion and query contextualization.
+- **Entrypoint**: [`services/bge-m3-api/app.py`](bge-m3-api/app.py)
+- **Dockerfile**: [`services/bge-m3-api/Dockerfile`](bge-m3-api/Dockerfile)
+- **Runtime**: uv-synced multi-stage build (Python 3.14, non-root user, Prometheus metrics exposed)
+- **Health**: `http://localhost:8000/health`
+
+### `docling/` — Document Parsing Service
+
+- **Role**: Converts PDFs and other documents into structured markdown/HTML for the unified ingestion pipeline.
+- **Entrypoint**: `docling-serve` (Docling CLI serve mode, configured via environment)
+- **Dockerfile**: [`services/docling/Dockerfile`](docling/Dockerfile)
+- **Runtime**: CPU-only PyTorch build with uv lockfile, non-root `docling` user
+- **Health**: `http://localhost:5001/health`
+
+### `user-base/` — Russian Dense Embedding Service
+
+- **Role**: Generates dense vectors using `deepvk/USER2-base` for Russian-language semantic matching.
+- **Entrypoint**: [`services/user-base/main.py`](user-base/main.py)
+- **Dockerfile**: [`services/user-base/Dockerfile`](user-base/Dockerfile)
+- **Runtime**: uv-synced multi-stage build, optional ONNX backend via `EMBEDDING_BACKEND=onnx`
+- **Health**: `http://localhost:8000/health`
+
+## Validation Boundaries
+
+These containers are safe to validate independently:
+
+```bash
+# Build and health-check a single service
+docker compose build bge-m3
+docker compose up -d bge-m3
+curl -fsS http://localhost:8000/health
+
+docker compose build docling
+docker compose up -d docling
+curl -fsS http://localhost:5001/health
+
+docker compose build user-base
+docker compose up -d user-base
+curl -fsS http://localhost:8000/health
+```
+
+Do not modify the application code in these directories without also verifying the corresponding Compose health checks and `make verify-compose-images` after image pin updates.
+
+## See Also
+
+- [`../DOCKER.md`](../DOCKER.md) — Compose profiles, env requirements, and service map.
+- [`../docs/LOCAL-DEVELOPMENT.md`](../docs/LOCAL-DEVELOPMENT.md) — Local setup and validation flow.

--- a/services/README.md
+++ b/services/README.md
@@ -27,7 +27,7 @@ They are referenced from the main [`compose.yml`](../compose.yml) and started as
 - **Entrypoint**: [`services/user-base/main.py`](user-base/main.py)
 - **Dockerfile**: [`services/user-base/Dockerfile`](user-base/Dockerfile)
 - **Runtime**: uv-synced multi-stage build, optional ONNX backend via `EMBEDDING_BACKEND=onnx`
-- **Health**: `http://localhost:8000/health`
+- **Health**: `http://localhost:8003/health` (container-internal: port `8000`)
 
 ## Validation Boundaries
 
@@ -35,17 +35,17 @@ These containers are safe to validate independently:
 
 ```bash
 # Build and health-check a single service
-docker compose build bge-m3
-docker compose up -d bge-m3
+COMPOSE_FILE=compose.yml:compose.dev.yml docker compose build bge-m3
+COMPOSE_FILE=compose.yml:compose.dev.yml docker compose up -d bge-m3
 curl -fsS http://localhost:8000/health
 
-docker compose build docling
-docker compose up -d docling
+COMPOSE_FILE=compose.yml:compose.dev.yml docker compose build docling
+COMPOSE_FILE=compose.yml:compose.dev.yml docker compose up -d docling
 curl -fsS http://localhost:5001/health
 
-docker compose build user-base
-docker compose up -d user-base
-curl -fsS http://localhost:8000/health
+COMPOSE_FILE=compose.yml:compose.dev.yml docker compose build user-base
+COMPOSE_FILE=compose.yml:compose.dev.yml docker compose up -d user-base
+curl -fsS http://localhost:8003/health
 ```
 
 Do not modify the application code in these directories without also verifying the corresponding Compose health checks and `make verify-compose-images` after image pin updates.


### PR DESCRIPTION
## Summary

Adds reviewer-friendly README files for the main runtime/deployment zones and updates the docs index.

- `services/README.md` — local service containers (`bge-m3-api`, `docling`, `user-base`), their role, entrypoints/Dockerfiles, and safe validation boundaries.
- `docker/README.md` — helper runtime assets under `docker/` (LiteLLM config, LiveKit config, monitoring configs/rules, Postgres init SQL, rclone/ingestion scripts). Points readers to `DOCKER.md` for Compose operations.
- `k8s/README.md` — partial k3s scope with honest parity notes: base manifests, overlays (`core`, `bot`, `ingest`, `full`), secrets example, validation commands, and non-parity with Compose.
- `docs/README.md` — links to the new READMEs in the Operations & Runbooks section.

No runtime manifests, Dockerfiles, Compose files, tests, or application code are changed.