### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug Report
+description: Report a real product bug in the contextual RAG system.
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. If you are reviewing this repo for hiring/portfolio purposes, see [`docs/review/ACCESS_FOR_REVIEWERS.md`](../../docs/review/ACCESS_FOR_REVIEWERS.md) first.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened? What did you expect?
+      placeholder: A clear, concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction Steps
+      description: How can someone else reproduce this?
+      placeholder: |
+        1. Start services with `make local-up`
+        2. Run `make test-bot-health`
+        3. Observe error ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Local dev, Docker, VPS, or CI?
+      placeholder: |
+        - OS: Ubuntu 22.04
+        - Docker version: 24.x
+        - Branch: dev
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Trace IDs
+      description: Relevant log snippets or Langfuse trace IDs.
+      placeholder: Paste logs or trace links here.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-report checks
+      description: Please confirm the following before submitting.
+      options:
+        - label: I searched existing issues for duplicates.
+          required: true
+        - label: I ran `make check` and the bug persists.
+          required: false
+        - label: I can reproduce this on the latest `dev` branch.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: Reviewer Access Guide
-    url: https://github.com/yastman/rag-fresh/blob/dev/docs/review/ACCESS_FOR_REVIEWERS.md
+    url: https://github.com/yastman/rag/blob/dev/docs/review/ACCESS_FOR_REVIEWERS.md
     about: If you are reviewing this repo for hiring or portfolio evaluation, start here.
   - name: Project Guide
-    url: https://github.com/yastman/rag-fresh/blob/dev/docs/review/PROJECT_GUIDE.md
+    url: https://github.com/yastman/rag/blob/dev/docs/review/PROJECT_GUIDE.md
     about: High-level architecture and subsystem map.
   - name: Test Writing Guide
-    url: https://github.com/yastman/rag-fresh/blob/dev/docs/engineering/test-writing-guide.md
+    url: https://github.com/yastman/rag/blob/dev/docs/engineering/test-writing-guide.md
     about: Conventions for writing and placing tests in this repo.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Reviewer Access Guide
+    url: https://github.com/yastman/rag-fresh/blob/dev/docs/review/ACCESS_FOR_REVIEWERS.md
+    about: If you are reviewing this repo for hiring or portfolio evaluation, start here.
+  - name: Project Guide
+    url: https://github.com/yastman/rag-fresh/blob/dev/docs/review/PROJECT_GUIDE.md
+    about: High-level architecture and subsystem map.
+  - name: Test Writing Guide
+    url: https://github.com/yastman/rag-fresh/blob/dev/docs/engineering/test-writing-guide.md
+    about: Conventions for writing and placing tests in this repo.

--- a/.github/ISSUE_TEMPLATE/docs_cleanup.yml
+++ b/.github/ISSUE_TEMPLATE/docs_cleanup.yml
@@ -1,0 +1,35 @@
+name: Documentation / Portfolio Cleanup
+description: Suggest a repo polish task, documentation fix, or portfolio improvement.
+labels: [documentation]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for typo fixes, README improvements, portfolio formatting, or any task that improves repo presentation without changing runtime behavior.
+
+        For test-writing conventions, see [`docs/engineering/test-writing-guide.md`](../../docs/engineering/test-writing-guide.md). For Docker/runtime docs, see [`DOCKER.md`](../../DOCKER.md).
+  - type: textarea
+    id: scope
+    attributes:
+      label: What needs improvement?
+      description: Which file or section is affected?
+      placeholder: "e.g., README.md Docker section is outdated after compose.dev.yml changes"
+    validations:
+      required: true
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed change
+      description: What should it say or look like instead?
+      placeholder: A concise description of the fix or improvement.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: This change does not affect runtime code, tests, or deployment logic.
+          required: true
+        - label: I have checked `tests/README.md` for any related test implications.
+          required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,53 @@
+## Summary
+
+What does this PR do and why?
+
+## Scope
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor
+- [ ] Documentation / portfolio cleanup
+- [ ] Infrastructure / deploy
+
+## Files touched
+
+List the main files or modules changed (one per line):
+- `...`
+
+## Validation
+
+What did you run to verify this change?
+
+- [ ] `make check`
+- [ ] `make test-unit`
+- [ ] `make test`
+- [ ] Focused pytest on touched files (`uv run pytest <path> -q`)
+- [ ] Other: ___________
+
+If any check above was skipped, state the reason explicitly:
+> ___________
+
+## Runtime Impact
+
+Does this change affect Docker Compose, k8s manifests, service startup, or production deploy?
+
+- [ ] No runtime impact
+- [ ] Compose file change (`compose.yml`, `compose.dev.yml`, `compose.vps.yml`)
+- [ ] Dockerfile or build change
+- [ ] k8s manifest change
+- [ ] Environment variable or secret contract change
+- [ ] Database migration or collection schema change
+
+If runtime-impacting, note the verification you ran (e.g., `COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility config --services`):
+> ___________
+
+## Screenshots / Demo
+
+If this PR changes UI, Telegram flows, or visual output, attach screenshots or a short demo.
+
+## Reviewer Notes
+
+- Anything non-obvious about the implementation?
+- Any trade-offs or follow-up work?
+- Relevant docs: [`docs/review/ACCESS_FOR_REVIEWERS.md`](docs/review/ACCESS_FOR_REVIEWERS.md), [`docs/engineering/test-writing-guide.md`](docs/engineering/test-writing-guide.md), [`DOCKER.md`](DOCKER.md), [`tests/README.md`](tests/README.md)


### PR DESCRIPTION
## Summary
Add GitHub issue and pull request templates so external reviewers and collaborators see a tidy, intentional repo workflow.

## Scope
- [x] Documentation / portfolio cleanup

## Files touched
- `.github/ISSUE_TEMPLATE/config.yml`
- `.github/ISSUE_TEMPLATE/bug_report.yml`
- `.github/ISSUE_TEMPLATE/docs_cleanup.yml`
- `.github/pull_request_template.md`

## Validation
- `git diff --check` — clean
- `find .github/ISSUE_TEMPLATE -type f | sort` — 3 templates present
- `rg` verified required doc references (`ACCESS_FOR_REVIEWERS`, `test-writing-guide`, `DOCKER.md`, `tests/README.md`, `runtime impact`, `Validation`)
- `make check` skipped: templates-only; no code/runtime behavior changed

## Runtime Impact
- [x] No runtime impact

## Reviewer Notes
- Templates are concise and repo-specific.
- Blank issues are disabled; reporters are guided to docs or structured templates.