### PR TITLE
docs(review): clarify private-repo reviewer path and dev branch workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ make test-unit   # Unit tests (parallel via pytest-xdist)
 make test-full   # Full suite: parallel-safe tiers first, live/stateful tiers after
 ```
 
-Local verification is the release authority for this repo. Run the full test suite from the working tree before merging to `main` or deploying to VPS.
+Local verification is the release authority for this repo. Run the full test suite from the working tree before merging to `dev` (the active integration branch) or deploying to VPS.
 
 CI is intentionally lightweight. It should stay fast and is used as a guardrail for lint, format, type-check, security, and other short checks, not as the authoritative full-suite signal.
 

--- a/docs/review/ACCESS_FOR_REVIEWERS.md
+++ b/docs/review/ACCESS_FOR_REVIEWERS.md
@@ -3,6 +3,10 @@
 Use this file when someone receives repository access for technical review,
 portfolio review, or hiring evaluation.
 
+> **Start here.** Read this file first, then `README.md` and
+> `docs/review/PROJECT_GUIDE.md`, before running any commands or inspecting
+> code folders.
+
 ## Recommended Review Path
 
 If you have 10 minutes:
@@ -25,15 +29,16 @@ If you have more time:
 ## Safe Commands
 
 These commands are intended for local review and should not call production
-systems when the environment is configured safely:
+systems when the environment is configured safely. Approximate run times on a
+modern laptop:
 
-```bash
-uv sync
-make check
-uv run pytest tests/unit
-COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility config --services
-COMPOSE_FILE=compose.yml:compose.vps.yml docker compose --compatibility config --services
-```
+| Command | ~Duration | What it proves |
+|---------|-----------|----------------|
+| `uv sync` | 30–60 s | Dependencies resolve and lock |
+| `make check` | 45–90 s | Lint and type-check pass |
+| `uv run pytest tests/unit` | 1–3 min | Unit tests pass |
+| `COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility config --services` | <5 s | Dev Compose config is valid |
+| `COMPOSE_FILE=compose.yml:compose.vps.yml docker compose --compatibility config --services` | <5 s | VPS Compose config is valid |
 
 For a narrower first pass, prefer focused tests around the subsystem being
 reviewed, then `make check`.
@@ -54,6 +59,12 @@ reviewed, then `make check`.
 - Use fake/demo credentials for local inspection.
 - Treat Telegram, Kommo, Langfuse, LiveKit, and cloud credentials as external
   secrets, not repository content.
+
+## Branch Context
+
+- `dev` is the active integration branch; `main` lags behind and is used for
+  stable snapshots. Reviewers inspecting recent work should look at `dev` and
+  open PRs against it.
 
 ## What To Look At For Senior-Level Review
 

--- a/docs/review/GITHUB_REPO_SETUP.md
+++ b/docs/review/GITHUB_REPO_SETUP.md
@@ -44,18 +44,18 @@ Pin or link these prominently:
 
 ## Branch And Release Hygiene
 
-Recommended setup:
+For **this** repository:
 
-- default branch: `main` for public portfolio repos, or document clearly if
-  `dev` is the active integration branch.
-- protect the default branch.
-- require PRs for changes.
+- active integration branch: `dev` (reviewers should look here for recent work).
+- stable snapshot branch: `main` (lags behind `dev`).
+- protect both branches.
+- require PRs against `dev` for changes.
 - require fast CI checks before merge.
 - disallow force pushes to protected branches.
 - create a review snapshot tag such as `portfolio-review-2026-05`.
 
-If the everyday integration branch is not `main`, explain that in `README.md`
-and keep PR/release instructions consistent.
+Keep PR and release instructions consistent: if the everyday integration branch
+is `dev`, every doc that mentions merging should say `dev`, not `main`.
 
 ## CI Expectations
 

--- a/docs/review/PROJECT_GUIDE.md
+++ b/docs/review/PROJECT_GUIDE.md
@@ -19,6 +19,16 @@ AI real-estate automation platform with:
 
 ## Recommended Reading Path
 
+**10 minutes:** `README.md` → `docs/portfolio/resume-case-study.md` → skim this guide.
+
+**30 minutes:** add `telegram_bot/graph/`, `telegram_bot/agents/`, and
+`telegram_bot/services/`.
+
+**Deep dive:** add `src/ingestion/unified/`, `src/voice/`, `compose*.yml`,
+`DOCKER.md`, and the test directories.
+
+Ordered list for sequential reading:
+
 1. `README.md` for the project overview and architecture diagram.
 2. `docs/portfolio/resume-case-study.md` for the resume-style narrative.
 3. `telegram_bot/graph/` for LangGraph routing and state contracts.


### PR DESCRIPTION
## Summary
- Clarify that `dev` is the active integration branch across reviewer docs and README.
- Add explicit "Start here" guidance and command runtime estimates to `ACCESS_FOR_REVIEWERS.md`.
- Add 10-min / 30-min / deep-dive time budgets to `PROJECT_GUIDE.md`.
- Update `GITHUB_REPO_SETUP.md` branch guidance from generic to repo-specific.

## Verification
- `git diff --check` clean
- All reserved files verified present
- Pre-commit hooks passed (docs-only change)