### PR TITLE
fix(compose): remove invalid ClickHouse --listen_host CLI flag (#1340)

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -465,9 +465,6 @@ services:
     stop_grace_period: 30s
     logging: *default-logging
     user: "101:101"
-    command: >
-      clickhouse-server
-      --listen_host=0.0.0.0
     environment:
       CLICKHOUSE_DB: default
       CLICKHOUSE_USER: clickhouse

--- a/tests/unit/test_compose_runtime_contract.py
+++ b/tests/unit/test_compose_runtime_contract.py
@@ -51,3 +51,15 @@ def test_livekit_template_secret_has_no_hardcoded_fallback() -> None:
 
     assert "${LIVEKIT_API_SECRET:-secret}" not in config_text
     assert "LIVEKIT_API_SECRET" in config_text
+
+
+def test_clickhouse_command_has_no_invalid_listen_host_flag() -> None:
+    """ClickHouse 26.3.9 rejects --listen_host as a CLI flag; config file is the correct mechanism."""
+    compose = _load_compose()
+    clickhouse = compose["services"]["clickhouse"]
+    command = clickhouse.get("command", "")
+
+    assert "--listen_host=0.0.0.0" not in str(command), (
+        "compose.yml: clickhouse --listen_host=0.0.0.0 is not a valid CLI flag in ClickHouse 26.3.9 "
+        "and causes a crash-loop (issue #1340). Remove it and rely on the image default config."
+    )


### PR DESCRIPTION
## Summary
ClickHouse 26.3.9 rejects `--listen_host=0.0.0.0` as a CLI flag and crash-loops with `Unknown option specified: listen_host=0.0.0.0`. The image default config already binds to 0.0.0.0, so the explicit flag is unnecessary and harmful.

## Changes
- Remove `command:` block from `clickhouse` service in `compose.yml`
- Add regression test `test_clickhouse_command_has_no_invalid_listen_host_flag` to prevent re-adding invalid CLI flags

## Verification
- ClickHouse container starts healthy without the invalid flag
- `make check` passes
- All compose contract tests pass (100 tests)

Fixes #1340