### PR TITLE
fix(pre-push): make default pre-push fast sanity gate, add manual local-pr-ready

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -129,9 +129,9 @@ repos:
         pass_filenames: false
         stages: [pre-commit]
 
-      - id: mypy
-        name: MyPy Type Checker
-        entry: uv run mypy src/ telegram_bot/ --ignore-missing-imports --no-error-summary
+      - id: local-pre-push
+        name: Fast local pre-push sanity gate
+        entry: make local-pre-push
         language: system
         pass_filenames: false
         stages: [pre-push]

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ local-pre-push: ## Fast local pre-push sanity gate (check + compose validate)
 	./scripts/local_pre_push.sh
 	@echo "$(GREEN)✓ Fast local pre-push sanity gate passed$(NC)"
 
-local-pr-ready: ## Full PR readiness gate (fast gate + unit tests) — run manually
+local-pr-ready: ## Full PR readiness gate (fast gate + unit tests) - run manually
 	@echo "$(BLUE)Running full PR readiness gate...$(NC)"
 	./scripts/local_pre_push.sh
 	@echo "$(BLUE)Running core unit tests...$(NC)"
@@ -146,7 +146,7 @@ format-check: ## Check if code is formatted
 
 type-check: ## Run MyPy type checking
 	@echo "$(BLUE)Running MyPy type checking...$(NC)"
-	uv run mypy src/ --ignore-missing-imports
+	uv run mypy src/ telegram_bot/ --ignore-missing-imports --no-error-summary
 	@echo "$(GREEN)✓ Type check complete$(NC)"
 
 pylint: ## Run Pylint (comprehensive linting)

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,18 @@ setup-hooks: ## Install pre-commit hooks
 	uv run pre-commit install --hook-type pre-push
 	@echo "$(GREEN)✓ Pre-commit hooks installed$(NC)"
 
+local-pre-push: ## Fast local pre-push sanity gate (check + compose validate)
+	@echo "$(BLUE)Running fast local pre-push sanity gate...$(NC)"
+	./scripts/local_pre_push.sh
+	@echo "$(GREEN)✓ Fast local pre-push sanity gate passed$(NC)"
+
+local-pr-ready: ## Full PR readiness gate (fast gate + unit tests) — run manually
+	@echo "$(BLUE)Running full PR readiness gate...$(NC)"
+	./scripts/local_pre_push.sh
+	@echo "$(BLUE)Running core unit tests...$(NC)"
+	make test-unit
+	@echo "$(GREEN)✓ Full PR readiness gate passed$(NC)"
+
 # =============================================================================
 # CODE QUALITY CHECKS
 # =============================================================================

--- a/scripts/local_pre_push.sh
+++ b/scripts/local_pre_push.sh
@@ -9,6 +9,18 @@ cd "$(git rev-parse --show-toplevel)"
 echo "==> Running make check..."
 make check
 
+if ! command -v docker >/dev/null 2>&1; then
+  echo "WARN: Docker CLI not found; skipping Compose config validation."
+  echo "==> Fast local pre-push sanity gate passed."
+  exit 0
+fi
+
+if ! docker compose version >/dev/null 2>&1; then
+  echo "WARN: Docker Compose not available; skipping Compose config validation."
+  echo "==> Fast local pre-push sanity gate passed."
+  exit 0
+fi
+
 echo "==> Validating Compose configs (dev + VPS)..."
 COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml config --quiet
 COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.vps.yml config --quiet

--- a/scripts/local_pre_push.sh
+++ b/scripts/local_pre_push.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Fast local pre-push sanity gate: lightweight checks before code leaves the machine.
+# Called by pre-commit pre-push hook and can be run manually via:
+#   make local-pre-push
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "==> Running make check..."
+make check
+
+echo "==> Validating Compose configs (dev + VPS)..."
+COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml config --quiet
+COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.vps.yml config --quiet
+
+echo "==> Fast local pre-push sanity gate passed."


### PR DESCRIPTION
## Summary
Revises the local pre-push gate so the default automatic hook is lightweight and does not run unit tests.

## Changes
- Default make local-pre-push runs make check as the required gate.
- make check now preserves the previous pre-push mypy coverage for src/ and telegram_bot/.
- Docker Compose config validation runs when Docker Compose is available.
- If Docker CLI or Docker Compose is unavailable, the pre-push gate prints a warning and skips Compose validation after make check passes.
- Added make local-pr-ready as an explicit manual target for full PR readiness (fast gate + make test-unit).
- Updated hook name and comments to use fast local pre-push sanity gate instead of CI-grade.

## Verification
- python3 -c "import yaml; yaml.safe_load(open('.pre-commit-config.yaml'))" - passed
- uv run pre-commit validate-config - passed
- make local-pre-push - passed locally; Docker CLI was unavailable, so Compose validation was skipped with a warning after make check passed
- make -n local-pr-ready - passed
- git diff --check - passed

Fixes #1343