### PR TITLE
Fixes #1341 — local compose commands fall back to CI env fixture

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -54,6 +54,8 @@ make local-down
 
 For local development, the canonical local env file is `.env` in the repo root. `.env.local` is not auto-loaded by the documented `make` and `uv run` workflows.
 
+Local `make` targets that use `$(LOCAL_COMPOSE_CMD)` automatically fall back to `tests/fixtures/compose.ci.env` when `.env` is absent. This lets commands like `make docker-ps` and profile-gated `up` targets render Compose config without real secrets.
+
 ## Service Endpoints (Host)
 
 | Service | URL/Port |

--- a/Makefile
+++ b/Makefile
@@ -411,7 +411,8 @@ clean: ## Clean up cache files and build artifacts
 # Common compose command with --compatibility to enforce deploy.resources.limits
 COMPOSE_CMD := docker compose --compatibility
 LOCAL_COMPOSE_FILE := compose.yml:compose.dev.yml
-LOCAL_COMPOSE_CMD := COMPOSE_FILE=$(LOCAL_COMPOSE_FILE) $(COMPOSE_CMD)
+# Local dev env fallback: use .env if present, otherwise safe CI fixture values
+LOCAL_COMPOSE_CMD := COMPOSE_FILE=$(LOCAL_COMPOSE_FILE) $(COMPOSE_CMD) --env-file $$( [ -f .env ] && echo .env || echo tests/fixtures/compose.ci.env )
 
 .PHONY: docker-core-up docker-bot-up docker-obs-up docker-ai-up docker-ingest-up docker-voice-up docker-full-up docker-down docker-ps
 

--- a/tests/unit/test_docker_static_validation.py
+++ b/tests/unit/test_docker_static_validation.py
@@ -76,3 +76,29 @@ def test_compose_vps_config_renders() -> None:
         text=True,
     )
     assert result.returncode == 0, f"Compose VPS config failed:\n{result.stderr}"
+
+
+@pytest.mark.skipif(not _docker_available(), reason="Docker not available")
+def test_compose_dev_config_renders_with_full_profile() -> None:
+    """Profile-gated services must not fail merely because required env vars are unset (#1341)."""
+    result = subprocess.run(
+        [
+            "docker",
+            "compose",
+            "--env-file",
+            str(COMPOSE_CI_ENV),
+            "-f",
+            "compose.yml",
+            "-f",
+            "compose.dev.yml",
+            "--profile",
+            "full",
+            "config",
+            "--quiet",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"Compose dev config with --profile full failed:\n{result.stderr}"
+    )

--- a/tests/unit/test_local_compose_contract.py
+++ b/tests/unit/test_local_compose_contract.py
@@ -58,3 +58,19 @@ def test_docker_docs_default_stack_mentions_mini_app_services() -> None:
     assert "- `mini-app-frontend`" in text, (
         "DOCKER.md must list mini-app-frontend in the default stack"
     )
+
+
+def test_local_compose_cmd_uses_env_file_fallback() -> None:
+    text = MAKEFILE.read_text(encoding="utf-8")
+    assert "LOCAL_COMPOSE_CMD" in text
+    assert "--env-file" in text, (
+        "Makefile LOCAL_COMPOSE_CMD must specify --env-file so local compose commands "
+        "can render config even when .env is absent"
+    )
+    assert "compose.ci.env" in text, (
+        "Makefile must fall back to tests/fixtures/compose.ci.env when .env is absent"
+    )
+    assert (
+        "$$([ -f .env ] && echo .env || echo tests/fixtures/compose.ci.env)" in text
+        or "[ -f .env ] && echo .env || echo tests/fixtures/compose.ci.env" in text
+    ), "Makefile must evaluate the env-file fallback at recipe runtime"


### PR DESCRIPTION
## Summary

Local dev compose workflows (`make docker-ps`, profile-gated `up` targets, etc.) failed when no `.env` was present because profile-gated services in `compose.yml` use `${VAR:?required}` interpolation.

## Changes

- `Makefile`: `LOCAL_COMPOSE_CMD` now appends `--env-file` with a shell fallback: `.env` if present, otherwise `tests/fixtures/compose.ci.env`
- Add unit test asserting the env-file fallback is present in `Makefile`
- Add docker static test rendering dev config with `--profile full` using the CI env fixture
- Document the fallback behavior in `DOCKER.md`

## Preservation of production strictness

- `compose.yml` is unchanged
- Production deploy paths (`compose.vps.yml`, `scripts/validate_prod_env.sh`, k8s) are unchanged
- Only local/dev `make` targets are affected

## Verification

- `make check` passes
- `tests/unit/test_local_compose_contract.py` passes
- `tests/unit/test_docker_static_validation.py` passes (Docker-dependent tests skip when unavailable)