### PR TITLE
fix(check_image_drift): use Docker Compose native env-file handling and CI fixture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1024,10 +1024,10 @@ k3s-push-%: ## Build and push a versioned GHCR image: make k3s-push-bot K3S_IMAG
 .PHONY: verify-compose-images verify-compose-images-json
 
 verify-compose-images: ## Check running containers match compose-pinned images
-	@uv run python scripts/check_image_drift.py --fix
+	@uv run python scripts/check_image_drift.py -f compose.yml -f compose.dev.yml --fix
 
 verify-compose-images-json: ## Check image drift (JSON output for CI)
-	@uv run python scripts/check_image_drift.py --json
+	@uv run python scripts/check_image_drift.py -f compose.yml -f compose.dev.yml --json
 
 # =============================================================================
 # GIT HYGIENE

--- a/scripts/check_image_drift.py
+++ b/scripts/check_image_drift.py
@@ -9,6 +9,7 @@ Usage:
     python scripts/check_image_drift.py                         # Human-readable
     python scripts/check_image_drift.py --json                  # JSON output
     python scripts/check_image_drift.py -f compose.vps.yml      # Custom file
+    python scripts/check_image_drift.py -f compose.yml -f compose.dev.yml  # Multiple files
     python scripts/check_image_drift.py --fix                   # Show fix commands
 
 Exit codes:
@@ -88,6 +89,7 @@ class DriftReport:
     """Aggregated drift findings."""
 
     compose_file: str
+    compose_files: list[str] = field(default_factory=list)
     checked: list[DriftResult] = field(default_factory=list)
     skipped_build: list[str] = field(default_factory=list)
     skipped_not_running: list[str] = field(default_factory=list)
@@ -112,46 +114,34 @@ def _run(cmd: list[str], *, check: bool = True) -> str:
     return result.stdout.strip()
 
 
-def get_compose_services(compose_file: str) -> dict[str, dict[str, object]]:
+def get_compose_services(compose_files: list[str], env_file: str) -> dict[str, dict[str, object]]:
     """Parse compose file via `docker compose config` for normalized output."""
     try:
-        out = _run(
-            [
-                "docker",
-                "compose",
-                "-f",
-                compose_file,
-                "config",
-                "--format",
-                "json",
-            ]
-        )
+        cmd = ["docker", "compose", "--env-file", env_file]
+        for f in compose_files:
+            cmd.extend(["-f", f])
+        cmd.extend(["config", "--format", "json"])
+        out = _run(cmd)
         data: dict[str, object] = json.loads(out)
         services: dict[str, dict[str, object]] = data.get("services", {})  # type: ignore[assignment]
         return services
     except subprocess.CalledProcessError as exc:
-        print(f"Error: cannot parse {compose_file}: {exc.stderr}", file=sys.stderr)
+        files_str = ":".join(compose_files)
+        print(f"Error: cannot parse {files_str}: {exc.stderr}", file=sys.stderr)
         sys.exit(2)
     except json.JSONDecodeError:
         print("Error: invalid JSON from docker compose config", file=sys.stderr)
         sys.exit(2)
 
 
-def get_running_containers(compose_file: str) -> dict[str, dict]:
+def get_running_containers(compose_files: list[str], env_file: str) -> dict[str, dict]:
     """Get running containers for this compose project."""
     try:
-        out = _run(
-            [
-                "docker",
-                "compose",
-                "-f",
-                compose_file,
-                "ps",
-                "--format",
-                "json",
-            ],
-            check=False,
-        )
+        cmd = ["docker", "compose", "--env-file", env_file]
+        for f in compose_files:
+            cmd.extend(["-f", f])
+        cmd.extend(["ps", "--format", "json"])
+        out = _run(cmd, check=False)
         if not out:
             return {}
         # docker compose ps --format json can return one JSON per line or an array
@@ -165,7 +155,7 @@ def get_running_containers(compose_file: str) -> dict[str, dict]:
             if svc:
                 containers[svc] = c
         return containers
-    except (subprocess.CalledProcessError, json.JSONDecodeError):
+    except subprocess.CalledProcessError, json.JSONDecodeError:
         return {}
 
 
@@ -219,12 +209,15 @@ def get_container_image_digest(container_id: str) -> tuple[str, str]:
         return "", ""
 
 
-def check_drift(compose_file: str) -> DriftReport:
+def check_drift(compose_files: list[str], env_file: str) -> DriftReport:
     """Compare compose-pinned images against running containers."""
-    report = DriftReport(compose_file=compose_file)
+    report = DriftReport(
+        compose_file=":".join(compose_files),
+        compose_files=compose_files,
+    )
 
-    services = get_compose_services(compose_file)
-    containers = get_running_containers(compose_file)
+    services = get_compose_services(compose_files, env_file)
+    containers = get_running_containers(compose_files, env_file)
 
     for svc_name, svc_config in sorted(services.items()):
         image_str = svc_config.get("image", "")
@@ -318,15 +311,19 @@ def print_report(report: DriftReport, *, show_fix: bool = False) -> None:
     if show_fix and report.drifted:
         drifted_names = [r.service for r in report.drifted]
         names_str = " ".join(drifted_names)
+        if report.compose_files:
+            file_flags = " ".join(f"-f {f}" for f in report.compose_files)
+        else:
+            file_flags = f"-f {compose}"
         print("\n\033[36mFix commands:\033[0m")
         print("  # Pull fresh images")
-        print(f"  docker compose -f {compose} pull {names_str}")
+        print(f"  docker compose {file_flags} pull {names_str}")
         print("  # Recreate drifted containers")
-        print(f"  docker compose -f {compose} up -d --force-recreate {names_str}")
+        print(f"  docker compose {file_flags} up -d --force-recreate {names_str}")
         print("  # Or recreate all:")
-        print(f"  docker compose -f {compose} down --remove-orphans")
-        print(f"  docker compose -f {compose} pull")
-        print(f"  docker compose -f {compose} up -d")
+        print(f"  docker compose {file_flags} down --remove-orphans")
+        print(f"  docker compose {file_flags} pull")
+        print(f"  docker compose {file_flags} up -d")
 
     # Summary
     print(f"\n{'─' * 60}")
@@ -379,8 +376,14 @@ def main() -> None:
     parser.add_argument(
         "-f",
         "--file",
-        default="compose.yml",
+        action="append",
+        default=None,
         help="Compose file to check (default: compose.yml)",
+    )
+    parser.add_argument(
+        "--env-file",
+        default="tests/fixtures/compose.ci.env",
+        help="Env file for compose variable interpolation (default: tests/fixtures/compose.ci.env)",
     )
     parser.add_argument(
         "--json",
@@ -395,19 +398,23 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    compose_path = Path(args.file)
-    if not compose_path.exists():
-        print(f"Error: {args.file} not found", file=sys.stderr)
-        sys.exit(2)
+    compose_files = args.file or ["compose.yml"]
+    env_file = args.env_file
+
+    for f in compose_files:
+        compose_path = Path(f)
+        if not compose_path.exists():
+            print(f"Error: {f} not found", file=sys.stderr)
+            sys.exit(2)
 
     # Verify docker is available (lightweight check)
     try:
         _run(["docker", "version", "--format", "{{.Server.Version}}"], check=True)
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    except subprocess.CalledProcessError, FileNotFoundError:
         print("Error: docker is not available or not running", file=sys.stderr)
         sys.exit(2)
 
-    report = check_drift(args.file)
+    report = check_drift(compose_files, env_file)
 
     if args.json_output:
         print_json(report)

--- a/scripts/check_image_drift.py
+++ b/scripts/check_image_drift.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import subprocess
+import subprocess  # nosec B404
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -110,7 +110,7 @@ class DriftReport:
 
 def _run(cmd: list[str], *, check: bool = True) -> str:
     """Run a command and return stripped stdout."""
-    result = subprocess.run(cmd, capture_output=True, text=True, check=check)
+    result = subprocess.run(cmd, capture_output=True, text=True, check=check)  # nosec B603
     return result.stdout.strip()
 
 
@@ -155,7 +155,7 @@ def get_running_containers(compose_files: list[str], env_file: str) -> dict[str,
             if svc:
                 containers[svc] = c
         return containers
-    except subprocess.CalledProcessError, json.JSONDecodeError:
+    except (subprocess.CalledProcessError, json.JSONDecodeError):  # fmt: skip
         return {}
 
 
@@ -410,7 +410,7 @@ def main() -> None:
     # Verify docker is available (lightweight check)
     try:
         _run(["docker", "version", "--format", "{{.Server.Version}}"], check=True)
-    except subprocess.CalledProcessError, FileNotFoundError:
+    except (subprocess.CalledProcessError, FileNotFoundError):  # fmt: skip
         print("Error: docker is not available or not running", file=sys.stderr)
         sys.exit(2)
 

--- a/tests/fixtures/compose.ci.env
+++ b/tests/fixtures/compose.ci.env
@@ -1,4 +1,5 @@
 # Non-secret values for deterministic Docker Compose config rendering in tests.
+COMPOSE_PROJECT_NAME=dev
 CLICKHOUSE_PASSWORD=test-clickhouse-password
 ENCRYPTION_KEY=test-encryption-key
 GDRIVE_SYNC_DIR=/tmp/rag-fresh-compose-ci-drive-sync

--- a/tests/unit/test_check_image_drift.py
+++ b/tests/unit/test_check_image_drift.py
@@ -90,6 +90,17 @@ def test_main_exits_zero_when_checked_containers_have_no_drift(
     assert exc_info.value.code == 0
 
 
+def test_compose_ci_env_fixture_has_project_name() -> None:
+    """Blocker 2: verify the CI env fixture sets COMPOSE_PROJECT_NAME=dev so that
+    docker compose ps targets the canonical dev project from any worktree."""
+    env_path = ROOT / "tests" / "fixtures" / "compose.ci.env"
+    content = env_path.read_text()
+    lines = [line.strip() for line in content.splitlines()]
+    assert any(line == "COMPOSE_PROJECT_NAME=dev" for line in lines), (
+        f"{env_path} must contain COMPOSE_PROJECT_NAME=dev"
+    )
+
+
 def test_help_shows_default_env_file() -> None:
     result = subprocess.run(
         [sys.executable, str(SCRIPT), "--help"],

--- a/tests/unit/test_check_image_drift.py
+++ b/tests/unit/test_check_image_drift.py
@@ -46,7 +46,9 @@ def test_main_exits_nonzero_when_no_running_containers_checked(
 ) -> None:
     module = _load_module()
     monkeypatch.setattr(module, "_run", lambda *_args, **_kwargs: "27.0.0")
-    monkeypatch.setattr(module, "check_drift", lambda _compose: module.DriftReport("compose.yml"))
+    monkeypatch.setattr(
+        module, "check_drift", lambda *_args, **_kwargs: module.DriftReport("compose.yml")
+    )
     monkeypatch.setattr(sys, "argv", [str(SCRIPT)])
 
     with pytest.raises(SystemExit) as exc_info:
@@ -63,7 +65,7 @@ def test_main_exits_zero_when_checked_containers_have_no_drift(
     monkeypatch.setattr(
         module,
         "check_drift",
-        lambda _compose: module.DriftReport(
+        lambda *_args, **_kwargs: module.DriftReport(
             "compose.yml",
             checked=[
                 module.DriftResult(
@@ -86,3 +88,13 @@ def test_main_exits_zero_when_checked_containers_have_no_drift(
         module.main()
 
     assert exc_info.value.code == 0
+
+
+def test_help_shows_default_env_file() -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "tests/fixtures/compose.ci.env" in result.stdout


### PR DESCRIPTION
Fixes #1337

- Add --env-file CLI option defaulting to tests/fixtures/compose.ci.env
- Allow multiple compose files via repeated -f flags
- Update Makefile verify-compose-images targets to use compose.yml:compose.dev.yml
- Update tests for new CLI options and signatures