### PR TITLE
fix(dev): raise Langfuse web memory limit to 1G to prevent Node.js heap OOM (#1307)

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -106,6 +106,10 @@ services:
       LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: miniosecret
       LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: miniosecret
       REDIS_AUTH: ${LANGFUSE_REDIS_PASSWORD:-langfuseredis}
+    deploy:
+      resources:
+        limits:
+          memory: 1G
 
   ingestion:
     profiles: ["ingest", "full"]

--- a/tests/unit/test_compose_config.py
+++ b/tests/unit/test_compose_config.py
@@ -213,6 +213,16 @@ class TestVpsSecurityBaseline:
         )
 
 
+def _memory_to_mb(raw: str) -> int:
+    """Parse Docker memory limit string (e.g. '512M', '1G', '1536M') to megabytes."""
+    raw = str(raw).strip().upper()
+    match = re.fullmatch(r"(\d+)([MG])", raw)
+    assert match, f"Unsupported memory limit format: {raw!r}"
+    value = int(match.group(1))
+    unit = match.group(2)
+    return value * 1024 if unit == "G" else value
+
+
 def _duration_to_seconds(raw: str) -> int:
     match = re.fullmatch(r"(\d+)([smh])", str(raw).strip())
     assert match, f"Unsupported duration format: {raw!r}"
@@ -287,3 +297,36 @@ class TestHandoffComposeContract:
         bot_env = vps["services"]["bot"]["environment"]
         assert "HANDOFF_ENABLED" in bot_env
         assert "MANAGERS_GROUP_ID" in bot_env
+
+
+# =============================================================================
+# #1307 — Langfuse web memory contract
+# =============================================================================
+
+
+class TestLangfuseWebMemoryContract:
+    """Langfuse web service must have sufficient memory to avoid Node.js heap OOM (#1307)."""
+
+    def test_dev_langfuse_web_memory_limit_is_sufficient(self, dev: dict) -> None:
+        """Dev langfuse web needs at least 1G memory to avoid heap limit crashes."""
+        langfuse = dev["services"]["langfuse"]
+        memory_limit = (
+            langfuse.get("deploy", {}).get("resources", {}).get("limits", {}).get("memory")
+        )
+        assert memory_limit, "langfuse web must have a deploy.resources.limits.memory setting"
+        mb = _memory_to_mb(memory_limit)
+        assert mb >= 1024, (
+            f"langfuse web memory limit must be >= 1G (1024M) to prevent Node.js heap OOM; "
+            f"got {memory_limit!r} ({mb}M)"
+        )
+
+    def test_base_langfuse_web_memory_limit_is_unchanged(self, vps: dict) -> None:
+        """Base compose intentionally keeps 512M for VPS; dev override raises it locally."""
+        langfuse = vps["services"]["langfuse"]
+        memory_limit = (
+            langfuse.get("deploy", {}).get("resources", {}).get("limits", {}).get("memory")
+        )
+        assert memory_limit == "512M", (
+            f"base compose.yml langfuse memory must remain 512M for VPS; "
+            f"dev-only increase belongs in compose.dev.yml. Got {memory_limit!r}"
+        )


### PR DESCRIPTION
## Summary
- Fixes local dev Langfuse web startup instability caused by Node.js heap OOM under the default 512M Docker memory limit.
- Adds a `compose.dev.yml` override raising `langfuse` web memory to 1G, keeping the 512M baseline in `compose.yml` for VPS parity.
- Adds static tests locking the dev >=1G / base 512M memory contract to prevent regressions.

## Test Plan
- `COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml --compatibility config --services` renders correctly
- `uv run pytest tests/unit/test_compose_config.py tests/unit/test_docker_static_validation.py` — 45/45 pass
- `make check` — clean