### PR TITLE
fix(docker): downgrade langfuse runtimes from Python 3.14 to 3.13 (#1307)

### DIFF
--- a/Dockerfile.ingestion
+++ b/Dockerfile.ingestion
@@ -7,7 +7,7 @@
 # Build stage
 # =============================================================================
 # Pin uv version — checked 2026-02-09
-FROM ghcr.io/astral-sh/uv:0.9-python3.14-bookworm-slim@sha256:7cf77f594be8042dab6daa9fe326f90962252268b4f120a7f5dccce4d947e6c1 AS builder
+FROM ghcr.io/astral-sh/uv:0.9-python3.13-bookworm-slim@sha256:531f855bda2c73cd6ef67d56b733b357cea384185b3022bd09f05e002cd144ca AS builder
 
 WORKDIR /app
 
@@ -43,7 +43,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # =============================================================================
 # Runtime stage
 # =============================================================================
-FROM python:3.14-slim-bookworm@sha256:2e256d0381371566ed96980584957ed31297f437569b79b0e5f7e17f2720e53a AS runtime
+FROM python:3.13-slim-bookworm@sha256:bb73517d48bd32016e15eade0c009b2724ec3a025a9975b5cd9b251d0dcadb33 AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/yastman/rag"
 

--- a/mini_app/Dockerfile
+++ b/mini_app/Dockerfile
@@ -2,7 +2,7 @@
 # Mini App FastAPI backend — uv sync pattern (2026 best practices)
 
 # ====== BUILD STAGE ======
-FROM ghcr.io/astral-sh/uv:0.9-python3.14-bookworm-slim@sha256:7cf77f594be8042dab6daa9fe326f90962252268b4f120a7f5dccce4d947e6c1 AS builder
+FROM ghcr.io/astral-sh/uv:0.9-python3.13-bookworm-slim@sha256:531f855bda2c73cd6ef67d56b733b357cea384185b3022bd09f05e002cd144ca AS builder
 
 WORKDIR /app
 
@@ -31,7 +31,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --extra mini-app
 
 # ====== RUNTIME STAGE ======
-FROM python:3.14-slim-bookworm@sha256:2e256d0381371566ed96980584957ed31297f437569b79b0e5f7e17f2720e53a AS runtime
+FROM python:3.13-slim-bookworm@sha256:bb73517d48bd32016e15eade0c009b2724ec3a025a9975b5cd9b251d0dcadb33 AS runtime
 
 WORKDIR /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,8 +193,8 @@ exclude = [
 line-length = 100
 indent-width = 4
 
-# Target Python 3.14 (aligned with Docker runtime)
-target-version = "py314"
+# Target Python 3.13 (aligned with Docker runtime; #1307)
+target-version = "py313"
 
 # =============================================================================
 # LINTING RULES
@@ -260,6 +260,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 "src/ingestion/docling_client.py" = ["ASYNC240"]  # Legacy ingestion (replaced by unified pipeline)
 "src/ingestion/gdrive_flow.py" = ["ASYNC240"]     # Legacy ingestion (replaced by unified pipeline)
 "src/ingestion/service.py" = ["ASYNC240"]          # Legacy ingestion (replaced by unified pipeline)
+"src/ingestion/unified/targets/qdrant_hybrid_target.py" = ["RUF100"]  # Unused noqa:UP037 — UP037 only triggers at py314+
 "*.py" = ["ARG001"]               # Allow unused function arguments (common in callbacks)
 
 # Import sorting configuration (isort replacement)
@@ -298,7 +299,7 @@ docstring-code-line-length = "dynamic"
 # Run: mypy .
 
 [tool.mypy]
-python_version = "3.14"
+python_version = "3.13"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false  # Set to true for strict mode
@@ -330,7 +331,7 @@ skips = ["B101"]  # Skip assert_used (common in tests)
 
 [tool.pylint.main]
 # Python version for compatibility checks
-py-version = "3.14"
+py-version = "3.13"
 
 # Files/directories to exclude
 ignore = ["legacy", "tests", ".venv", "__pycache__"]

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -2,7 +2,7 @@
 # RAG API — uv sync pattern (2026 best practices)
 
 # ====== BUILD STAGE ======
-FROM ghcr.io/astral-sh/uv:0.9-python3.14-bookworm-slim@sha256:7cf77f594be8042dab6daa9fe326f90962252268b4f120a7f5dccce4d947e6c1 AS builder
+FROM ghcr.io/astral-sh/uv:0.9-python3.13-bookworm-slim@sha256:531f855bda2c73cd6ef67d56b733b357cea384185b3022bd09f05e002cd144ca AS builder
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --extra voice
 
 # ====== RUNTIME STAGE ======
-FROM python:3.14-slim-bookworm@sha256:2e256d0381371566ed96980584957ed31297f437569b79b0e5f7e17f2720e53a AS runtime
+FROM python:3.13-slim-bookworm@sha256:bb73517d48bd32016e15eade0c009b2724ec3a025a9975b5cd9b251d0dcadb33 AS runtime
 
 WORKDIR /app
 

--- a/telegram_bot/Dockerfile
+++ b/telegram_bot/Dockerfile
@@ -2,7 +2,7 @@
 # Telegram Bot — uv sync pattern (2026 best practices)
 
 # ====== BUILD STAGE ======
-FROM ghcr.io/astral-sh/uv:0.9-python3.14-bookworm-slim@sha256:7cf77f594be8042dab6daa9fe326f90962252268b4f120a7f5dccce4d947e6c1 AS builder
+FROM ghcr.io/astral-sh/uv:0.9-python3.13-bookworm-slim@sha256:531f855bda2c73cd6ef67d56b733b357cea384185b3022bd09f05e002cd144ca AS builder
 
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
@@ -30,7 +30,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev
 
 # ====== RUNTIME STAGE ======
-FROM python:3.14-slim-bookworm@sha256:2e256d0381371566ed96980584957ed31297f437569b79b0e5f7e17f2720e53a AS runtime
+FROM python:3.13-slim-bookworm@sha256:bb73517d48bd32016e15eade0c009b2724ec3a025a9975b5cd9b251d0dcadb33 AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/yastman/rag"
 

--- a/tests/unit/test_docker_static_validation.py
+++ b/tests/unit/test_docker_static_validation.py
@@ -24,6 +24,16 @@ DOCKERFILES = [
     "mini_app/Dockerfile",
 ]
 
+# Images that import telegram_bot.observability (which imports langfuse) must not
+# use Python 3.14 because langfuse SDK exercises Pydantic v1 compatibility code
+# that is incompatible with Python 3.14.
+_LANGFUSE_RUNTIME_DOCKERFILES = [
+    "telegram_bot/Dockerfile",
+    "mini_app/Dockerfile",
+    "src/api/Dockerfile",
+    "Dockerfile.ingestion",
+]
+
 COMPOSE_CI_ENV = Path("tests/fixtures/compose.ci.env")
 
 
@@ -101,4 +111,21 @@ def test_compose_dev_config_renders_with_full_profile() -> None:
     )
     assert result.returncode == 0, (
         f"Compose dev config with --profile full failed:\n{result.stderr}"
+    )
+
+
+@pytest.mark.parametrize("dockerfile", _LANGFUSE_RUNTIME_DOCKERFILES)
+def test_langfuse_dockerfile_does_not_use_python314(dockerfile: str) -> None:
+    """Langfuse SDK uses Pydantic v1 compatibility that crashes under Python 3.14.
+
+    Regression test for #1307: bot and mini-app-api containers fail to start
+    because `from langfuse import Langfuse` raises
+    `pydantic.v1.errors.ConfigError` on Python 3.14.
+    """
+    text = Path(dockerfile).read_text()
+    assert "python3.14" not in text, (
+        f"{dockerfile} uses Python 3.14 runtime which is incompatible with langfuse SDK"
+    )
+    assert "python:3.14" not in text, (
+        f"{dockerfile} uses Python 3.14 runtime which is incompatible with langfuse SDK"
     )


### PR DESCRIPTION
## Summary

Fixes local `dev` bot/mini-app Langfuse SDK import crash caused by Pydantic v1 incompatibility with Python 3.14.

### Problem
`dev_bot_1` and `dev_mini-app-api_1` crash on startup with:
```
pydantic.v1.errors.ConfigError: unable to infer type for attribute "description"
UserWarning: Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.
```

Langfuse SDK v4 exercises Pydantic v1 compatibility code that is not compatible with Python 3.14.

### Changes
- Downgrade builder and runtime base images from Python 3.14 → 3.13 for all Dockerfiles that copy `telegram_bot/` (which imports `langfuse`):
  - `telegram_bot/Dockerfile`
  - `mini_app/Dockerfile`
  - `src/api/Dockerfile`
  - `Dockerfile.ingestion`
- Add static regression test `test_langfuse_dockerfile_does_not_use_python314` to prevent reintroducing an unsupported Python runtime for langfuse-importing images.

### Verification
- `uv run pytest tests/unit/test_docker_static_validation.py tests/unit/test_compose_config.py` — passes
- `make check` — passes

### Runtime verification (orchestrator)
```bash
COMPOSE_PROJECT_NAME=dev COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file .env -f compose.yml -f compose.dev.yml --profile ml --profile bot --compatibility up -d --build bot mini-app-api
docker logs --tail 80 dev_bot_1
docker logs --tail 80 dev_mini-app-api_1
docker compose --env-file .env -f compose.yml -f compose.dev.yml --profile ml --profile bot --compatibility ps
```

### Notes
- Does **not** touch LiveKit, voice services, or `compose.yml` LiveKit services.
- Runtime verification must use canonical `COMPOSE_PROJECT_NAME=dev`.