### PR TITLE
fix: remove stale UP037 noqa and RUF100 per-file ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,7 +260,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 "src/ingestion/docling_client.py" = ["ASYNC240"]  # Legacy ingestion (replaced by unified pipeline)
 "src/ingestion/gdrive_flow.py" = ["ASYNC240"]     # Legacy ingestion (replaced by unified pipeline)
 "src/ingestion/service.py" = ["ASYNC240"]          # Legacy ingestion (replaced by unified pipeline)
-"src/ingestion/unified/targets/qdrant_hybrid_target.py" = ["RUF100"]  # Unused noqa:UP037 — UP037 only triggers at py314+
+
 "*.py" = ["ARG001"]               # Allow unused function arguments (common in callbacks)
 
 # Import sorting configuration (isort replacement)

--- a/src/ingestion/unified/targets/qdrant_hybrid_target.py
+++ b/src/ingestion/unified/targets/qdrant_hybrid_target.py
@@ -69,7 +69,7 @@ class QdrantHybridTargetSpec(TargetSpec):
     pipeline_version: str = "v3.2.1"
 
     @classmethod
-    def from_config(cls, config: UnifiedConfig) -> "QdrantHybridTargetSpec":  # noqa: UP037
+    def from_config(cls, config: UnifiedConfig) -> "QdrantHybridTargetSpec":
         """Create spec from UnifiedConfig."""
         return cls(
             qdrant_url=config.qdrant_url,


### PR DESCRIPTION
Fixes #1351

- Remove unused `# noqa: UP037` from `qdrant_hybrid_target.py`
- Remove `RUF100` per-file ignore from `pyproject.toml`