### PR TITLE
docs: update Docker docs after PRs #1346-#1348

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -10,6 +10,10 @@ This document is the source of truth for containerized local/dev/VPS runtime in 
 | `compose.dev.yml` | Development overrides (ports, profile gating, local defaults) | Local development and integration testing |
 | `compose.vps.yml` | VPS production-like overrides | Server deployment and operations |
 
+## Compose Project Name
+
+The canonical local Compose project name is `dev`. `COMPOSE_PROJECT_NAME=dev` is set in `tests/fixtures/compose.ci.env`, which is the fallback env file used by local `make` targets when `.env` is absent. There is only one local stack; do not create worktree-named Docker projects.
+
 ## Compose Profiles (`compose.yml` + `compose.dev.yml`)
 
 Default `up` (no profile) starts unprofiled services:
@@ -23,7 +27,7 @@ Optional profiles add scoped services:
 | --- | --- |
 | `bot` | `litellm`, `bot` |
 | `ingest` | `ingestion` |
-| `voice` | `rag-api`, `livekit-server`, `livekit-sip`, `voice-agent`, `litellm` |
+| `voice` | `rag-api`, `livekit-server`, `livekit-sip`, `voice-agent`, `litellm` — **intentionally separate/off for now** |
 | `ml` | `clickhouse`, `minio`, `redis-langfuse`, `langfuse-worker`, `langfuse` |
 | `obs` | `loki`, `promtail`, `alertmanager` |
 | `full` | all profile-gated services |
@@ -163,7 +167,7 @@ COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility logs -f 
 COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility build bot litellm bge-m3
 COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility up -d --force-recreate bot litellm bge-m3
 
-# Image drift check against compose-pinned images
+# Image drift check against compose-pinned images (uses compose.yml + compose.dev.yml + tests/fixtures/compose.ci.env)
 make verify-compose-images
 ```
 
@@ -172,3 +176,5 @@ make verify-compose-images
 - Compose resources are started with `--compatibility` in `Makefile` to apply `deploy.resources.limits` locally.
 - Images are pinned by tag+digest in compose files; update pins explicitly.
 - Local and profile workflows use the canonical local compose set: `compose.yml:compose.dev.yml`.
+- Docker runtime for images that import `telegram_bot.observability` (and therefore `langfuse`) uses Python 3.13. Local native development may still use the repo's `uv` environment (Python 3.11+).
+- The `voice` profile (LiveKit, SIP, voice agent) is intentionally not part of the current local bring-up. Bring it up separately only when explicitly needed.

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ CocoIndex pipeline: Docling parses PDFs/DOCX → semantic chunking → BGE-M3 de
 ### Prerequisites
 
 - Python 3.11+ (3.12 recommended), [uv](https://docs.astral.sh/uv/), Docker
+  - Docker runtime for Langfuse-importing services uses Python 3.13; local `uv` environment may use a different Python version
 
 ### 1. Install & Configure
 
@@ -212,7 +213,7 @@ make docker-full-up    # All 23 services
 | ML/Observability | `make docker-ml-up` | Langfuse, ClickHouse, MinIO |
 | Monitoring | `make monitoring-up` | Loki, Promtail, Alertmanager |
 | Ingestion | `make docker-ingest-up` | Unified ingestion service |
-| Voice | `make docker-voice-up` | RAG API, LiveKit, SIP, Voice Agent |
+| Voice | `make docker-voice-up` | RAG API, LiveKit, SIP, Voice Agent — **intentionally off by default** |
 
 </details>
 

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -69,7 +69,7 @@ make test-bot-health
 - LiteLLM via proxy readiness (`/health/readiness`)
 - optional localhost Postgres note without turning DB reachability into a hard failure
 
-The authoritative startup preflight still lives in [`telegram_bot/preflight.py`](/home/user/projects/rag-fresh-issue-1198/telegram_bot/preflight.py) and runs when you start the bot. That runtime preflight also keeps the repo-local BGE-M3 health and warmup contract, because BGE-M3 is not a generic upstream SDK probe in this repo.
+The authoritative startup preflight still lives in [`telegram_bot/preflight.py`](../telegram_bot/preflight.py) and runs when you start the bot. That runtime preflight also keeps the repo-local BGE-M3 health and warmup contract, because BGE-M3 is not a generic upstream SDK probe in this repo.
 
 ## 4. Development Gates
 
@@ -104,7 +104,7 @@ lf --host "$LANGFUSE_HOST" traces list --name rag-api-query --limit 1
 
 Docker images that import `telegram_bot.observability` (and therefore `langfuse`) run on Python 3.13. Local native development via `uv` may use a different Python version (3.11+ supported, 3.12 recommended).
 
-## 7. Running Components Without Docker Wrapper
+## 6. Running Components Without Docker Wrapper
 
 ```bash
 # Telegram bot
@@ -117,7 +117,7 @@ uv run python -m src.ingestion.unified.cli run --watch
 uv run uvicorn src.api.main:app --host 0.0.0.0 --port 8080
 ```
 
-## 8. Minimal Stack (Fast Iteration)
+## 7. Minimal Stack (Fast Iteration)
 
 Use the `local-*` shortcuts (they now run a minimal subset from `compose.yml:compose.dev.yml`) when full dev stack is unnecessary:
 
@@ -137,7 +137,7 @@ make local-ps
 make local-down
 ```
 
-## 9. Common Issues
+## 8. Common Issues
 
 - `docker-bot-up` fails immediately: missing required env variables in `.env`.
 - Slow first startup: BGE-M3 and Docling warm up and cache models.

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -23,6 +23,8 @@ Minimum env for bot profile:
 - at least one provider key: `CEREBRAS_API_KEY` or `GROQ_API_KEY` or `OPENAI_API_KEY`
 - optional `QDRANT_COLLECTION` (defaults to `gdrive_documents_bge` from `compose.yml` if unset)
 
+The canonical local Compose project name is `dev`. `COMPOSE_PROJECT_NAME=dev` is set in `tests/fixtures/compose.ci.env`, which `make` targets use as a fallback when `.env` is absent. Do not create worktree-named Docker projects.
+
 Secret model by compose file:
 - `compose.yml` is the secure baseline: no predictable built-in secret defaults.
 - `compose.dev.yml` may provide local-only defaults for development convenience (`pk-lf-dev`, `sk-lf-dev`, `clickhouse`, `miniosecret`, `langfuseredis`, `devkey`).
@@ -40,8 +42,10 @@ make docker-bot-up
 # Optional profiles
 make docker-ml-up
 make docker-ingest-up
-make docker-voice-up
 make monitoring-up
+
+# Voice is intentionally off by default; start separately when needed:
+# make docker-voice-up
 ```
 
 ## 3. Validate Runtime
@@ -96,7 +100,11 @@ If Langfuse CLI returns `401` or points to wrong host, run with explicit host:
 lf --host "$LANGFUSE_HOST" traces list --name rag-api-query --limit 1
 ```
 
-## 5. Running Components Without Docker Wrapper
+## 5. Python Runtime Note
+
+Docker images that import `telegram_bot.observability` (and therefore `langfuse`) run on Python 3.13. Local native development via `uv` may use a different Python version (3.11+ supported, 3.12 recommended).
+
+## 7. Running Components Without Docker Wrapper
 
 ```bash
 # Telegram bot
@@ -109,7 +117,7 @@ uv run python -m src.ingestion.unified.cli run --watch
 uv run uvicorn src.api.main:app --host 0.0.0.0 --port 8080
 ```
 
-## 6. Minimal Stack (Fast Iteration)
+## 8. Minimal Stack (Fast Iteration)
 
 Use the `local-*` shortcuts (they now run a minimal subset from `compose.yml:compose.dev.yml`) when full dev stack is unnecessary:
 
@@ -129,7 +137,7 @@ make local-ps
 make local-down
 ```
 
-## 7. Common Issues
+## 9. Common Issues
 
 - `docker-bot-up` fails immediately: missing required env variables in `.env`.
 - Slow first startup: BGE-M3 and Docling warm up and cache models.

--- a/tests/unit/test_docker_static_validation.py
+++ b/tests/unit/test_docker_static_validation.py
@@ -129,3 +129,16 @@ def test_langfuse_dockerfile_does_not_use_python314(dockerfile: str) -> None:
     assert "python:3.14" not in text, (
         f"{dockerfile} uses Python 3.14 runtime which is incompatible with langfuse SDK"
     )
+
+
+@pytest.mark.parametrize("dockerfile", _LANGFUSE_RUNTIME_DOCKERFILES)
+def test_langfuse_dockerfile_uses_python313(dockerfile: str) -> None:
+    """Langfuse-importing app images must use Python 3.13 runtime (#1346-#1348).
+
+    Docker runtime is pinned to 3.13 while repo native dev may still use
+    a local uv environment with a different Python version.
+    """
+    text = Path(dockerfile).read_text()
+    assert "python3.13" in text or "python:3.13" in text, (
+        f"{dockerfile} must use Python 3.13 runtime for langfuse SDK compatibility"
+    )


### PR DESCRIPTION
## Summary

- Document canonical `COMPOSE_PROJECT_NAME=dev` and one-local-stack rule (no worktree-named Docker projects)
- Mark voice profile as intentionally separate/off for now
- Note Python 3.13 Docker runtime for langfuse-importing images vs local uv environment
- Update `verify-compose-images` description to mention CI fixture
- Add test asserting Python 3.13 in langfuse-importing Dockerfiles

## Verification

- `make check` passes
- `uv run pytest tests/unit/test_docker_static_validation.py` passes (19/19)
- `git diff --check` clean