### PR TITLE
docs: add service and mini-app README indexes

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -74,3 +74,4 @@ make verify-compose-images
 - [`../DOCKER.md`](../DOCKER.md) — Full Compose operations guide.
 - [`../docs/LOCAL-DEVELOPMENT.md`](../docs/LOCAL-DEVELOPMENT.md) — Local setup and validation.
 - [`../docs/ALERTING.md`](../docs/ALERTING.md) — Loki/Alertmanager setup details.
+- [`../services/README.md`](../services/README.md) — Service container index (bge-m3, docling, user-base).

--- a/mini_app/README.md
+++ b/mini_app/README.md
@@ -1,0 +1,60 @@
+# Mini App
+
+Telegram Mini App backend and frontend for the FortNoks real-estate workflow.
+
+## Purpose
+
+Provides a web UI inside Telegram for users to start expert chats, submit phone leads, and retrieve UI configuration. The backend is a FastAPI service; the frontend is a React + Vite SPA served by nginx.
+
+## Backend
+
+- **Entrypoint**: [`api.py`](api.py)
+- **Dockerfile**: [`Dockerfile`](Dockerfile)
+- **Service name**: `mini-app-api`
+- **Profile**: — (default, unprofiled)
+- **Compose project**: `dev` (see [`../DOCKER.md`](../DOCKER.md) for contract details)
+- **Local port**: `8090` (mapped in `compose.dev.yml`)
+- **Health**: `GET http://localhost:8090/health`
+
+### API Surface
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/api/config` | GET | UI questions + experts list |
+| `/api/start-expert` | POST | Store deep-link payload and return `start_link` |
+| `/api/phone` | POST | Collect phone and create CRM lead |
+| `/api/log` | POST | Frontend remote logging sink |
+| `/health` | GET | Service health |
+
+### Quick Start
+
+```bash
+COMPOSE_FILE=compose.yml:compose.dev.yml docker compose up -d mini-app-api
+curl -fsS http://localhost:8090/health
+```
+
+## Frontend
+
+See [`frontend/README.md`](frontend/README.md).
+
+## Tests & Checks
+
+```bash
+# Backend unit tests
+uv run pytest tests/unit/mini_app/ tests/unit/test_bot_mini_app.py tests/unit/test_mini_app_dockerfile_build_deps.py -v
+
+# Frontend unit tests
+cd mini_app/frontend && npm run test
+```
+
+## Owner Boundaries
+
+- **Backend**: FastAPI app, Redis pub/sub bridge to the bot, CRM phone lead submission
+- **Frontend**: React SPA, Telegram Mini App SDK integration, static build consumed by `mini-app-frontend` container
+
+Do not change the exposed port (`8090`), healthcheck path, or API response shapes without updating the frontend callers and Compose health checks.
+
+## See Also
+
+- [`frontend/README.md`](frontend/README.md) — Frontend build, dev server, and test details.
+- [`../DOCKER.md`](../DOCKER.md) — Compose operations and service map.

--- a/mini_app/frontend/README.md
+++ b/mini_app/frontend/README.md
@@ -1,0 +1,50 @@
+# Mini App Frontend
+
+React + Vite SPA for the Telegram Mini App.
+
+## Purpose
+
+Renders the expert-selection UI, deep-link flow, and phone-capture form inside Telegram. Built as static assets and served by nginx in the `mini-app-frontend` container.
+
+## Entrypoint
+
+- **Application**: [`src/main.tsx`](src/main.tsx)
+- **Dockerfile**: [`Dockerfile`](Dockerfile)
+- **Nginx config**: [`nginx.conf`](nginx.conf)
+
+## Docker
+
+- **Service name**: `mini-app-frontend`
+- **Profile**: — (default, unprofiled)
+- **Compose project**: `dev` (see [`../../DOCKER.md`](../../DOCKER.md) for contract details)
+- **Local port**: `8091` (host) mapped from container port `80`
+- **Health**: `GET http://localhost:8091/health` (nginx internal)
+
+## Local Development
+
+```bash
+cd mini_app/frontend
+npm ci
+npm run dev        # Vite dev server (proxies /api to localhost:8090)
+npm run build      # Production build → dist/
+npm run test       # Vitest unit tests
+```
+
+## Tests & Checks
+
+```bash
+# Frontend unit tests (vitest)
+npm run test
+
+# Dockerfile / runtime contract tests
+uv run pytest tests/unit/mini_app/test_frontend_runtime_contract.py -v
+uv run pytest tests/unit/test_mini_app_dockerfile_build_deps.py -v
+```
+
+## Owner Boundaries
+
+- React component tree, state management (Zustand), routing
+- Telegram Mini App SDK integration (`@tma.js/sdk-react`)
+- Build artifact generation and nginx static serving
+
+Do not change the build output directory (`dist/`), nginx listen port, or healthcheck path without updating the `mini-app-frontend` Compose service.

--- a/services/README.md
+++ b/services/README.md
@@ -3,50 +3,56 @@
 This directory contains standalone service containers that support the RAG runtime.
 They are referenced from the main [`compose.yml`](../compose.yml) and started as part of the Docker Compose stack.
 
+> For Compose operations, profiles, and env requirements, see [`../DOCKER.md`](../DOCKER.md).
+
 ## Services
 
-### `bge-m3-api/` — Multi-Vector Embedding Service
+| Service | Purpose | Entrypoint | Docker service | Profile | Local URL |
+|---|---|---|---|---|---|
+| `bge-m3-api/` | Multi-vector embeddings (dense, sparse, ColBERT) | [`app.py`](bge-m3-api/app.py) | `bge-m3` | — (default) | http://localhost:8000 |
+| `docling/` | Document parsing (PDF → markdown/HTML) | `docling-serve` | `docling` | — (default) | http://localhost:5001 |
+| `user-base/` | Russian dense embeddings (USER2-base) | [`main.py`](user-base/main.py) | `user-base` | — (default) | http://localhost:8003 |
 
-- **Role**: Generates dense, sparse, and ColBERT embeddings via the BGE-M3 model for document ingestion and query contextualization.
-- **Entrypoint**: [`services/bge-m3-api/app.py`](bge-m3-api/app.py)
-- **Dockerfile**: [`services/bge-m3-api/Dockerfile`](bge-m3-api/Dockerfile)
-- **Runtime**: uv-synced multi-stage build (Python 3.14, non-root user, Prometheus metrics exposed)
-- **Health**: `http://localhost:8000/health`
+## Quick Validation
 
-### `docling/` — Document Parsing Service
-
-- **Role**: Converts PDFs and other documents into structured markdown/HTML for the unified ingestion pipeline.
-- **Entrypoint**: `docling-serve` (Docling CLI serve mode, configured via environment)
-- **Dockerfile**: [`services/docling/Dockerfile`](docling/Dockerfile)
-- **Runtime**: CPU-only PyTorch build with uv lockfile, non-root `docling` user
-- **Health**: `http://localhost:5001/health`
-
-### `user-base/` — Russian Dense Embedding Service
-
-- **Role**: Generates dense vectors using `deepvk/USER2-base` for Russian-language semantic matching.
-- **Entrypoint**: [`services/user-base/main.py`](user-base/main.py)
-- **Dockerfile**: [`services/user-base/Dockerfile`](user-base/Dockerfile)
-- **Runtime**: uv-synced multi-stage build, optional ONNX backend via `EMBEDDING_BACKEND=onnx`
-- **Health**: `http://localhost:8003/health` (container-internal: port `8000`)
-
-## Validation Boundaries
-
-These containers are safe to validate independently:
+Build and health-check a single service:
 
 ```bash
-# Build and health-check a single service
+# bge-m3
 COMPOSE_FILE=compose.yml:compose.dev.yml docker compose build bge-m3
 COMPOSE_FILE=compose.yml:compose.dev.yml docker compose up -d bge-m3
 curl -fsS http://localhost:8000/health
 
+# docling
 COMPOSE_FILE=compose.yml:compose.dev.yml docker compose build docling
 COMPOSE_FILE=compose.yml:compose.dev.yml docker compose up -d docling
 curl -fsS http://localhost:5001/health
 
+# user-base
 COMPOSE_FILE=compose.yml:compose.dev.yml docker compose build user-base
 COMPOSE_FILE=compose.yml:compose.dev.yml docker compose up -d user-base
 curl -fsS http://localhost:8003/health
 ```
+
+## Tests & Checks
+
+| Service | Unit tests | Dockerfile checks | Smoke tests |
+|---|---|---|---|
+| `bge-m3` | `tests/unit/test_bge_m3_endpoints.py`, `tests/unit/test_bge_m3_rerank.py` | `tests/unit/test_docker_static_validation.py` | `tests/smoke/test_zoo_smoke.py` |
+| `docling` | `tests/unit/test_docling*.py` | `tests/unit/test_dockerfile_docling_sync.py` | — |
+| `user-base` | `tests/unit/test_userbase_endpoints.py` | `tests/unit/test_userbase_dockerfile_permissions.py`, `tests/unit/test_dockerfile_python_abi.py` | `tests/smoke/test_zoo_smoke.py` |
+
+Run all relevant unit tests:
+
+```bash
+make test-unit
+```
+
+## Owner Boundaries
+
+- **bge-m3-api**: embedding model serving, metrics export, healthchecks
+- **docling**: document conversion, no persistent state (read-only root with `./data/docling` mount)
+- **user-base**: Russian-language dense vector generation, optional ONNX backend via `EMBEDDING_BACKEND=onnx`
 
 Do not modify the application code in these directories without also verifying the corresponding Compose health checks and `make verify-compose-images` after image pin updates.
 

--- a/services/bge-m3-api/README.md
+++ b/services/bge-m3-api/README.md
@@ -15,7 +15,7 @@ Used by the ingestion pipeline and query contextualization to produce multi-vect
 
 - **Service name**: `bge-m3`
 - **Profile**: — (default, unprofiled)
-- **Compose project**: `dev` (see [`../DOCKER.md`](../DOCKER.md) for contract details)
+- **Compose project**: `dev` (see [`../../DOCKER.md`](../../DOCKER.md) for contract details)
 - **Local port**: `8000` (mapped in `compose.dev.yml`)
 - **Health**: `GET http://localhost:8000/health`
 - **Metrics**: Prometheus metrics exposed internally (ASGI app mounted at `/metrics`)

--- a/services/bge-m3-api/README.md
+++ b/services/bge-m3-api/README.md
@@ -1,0 +1,49 @@
+# BGE-M3 Multi-Vector Embedding Service
+
+Standalone FastAPI service that generates dense, sparse, and ColBERT embeddings via the BGE-M3 model.
+
+## Purpose
+
+Used by the ingestion pipeline and query contextualization to produce multi-vector representations for RAG retrieval.
+
+## Entrypoint
+
+- **Application**: [`app.py`](app.py)
+- **Dockerfile**: [`Dockerfile`](Dockerfile)
+
+## Docker
+
+- **Service name**: `bge-m3`
+- **Profile**: — (default, unprofiled)
+- **Compose project**: `dev` (see [`../DOCKER.md`](../DOCKER.md) for contract details)
+- **Local port**: `8000` (mapped in `compose.dev.yml`)
+- **Health**: `GET http://localhost:8000/health`
+- **Metrics**: Prometheus metrics exposed internally (ASGI app mounted at `/metrics`)
+
+## Quick Start
+
+```bash
+COMPOSE_FILE=compose.yml:compose.dev.yml docker compose up -d bge-m3
+curl -fsS http://localhost:8000/health
+```
+
+## Tests & Checks
+
+```bash
+# Unit tests
+uv run pytest tests/unit/test_bge_m3_endpoints.py tests/unit/test_bge_m3_rerank.py -v
+
+# Dockerfile validation
+uv run pytest tests/unit/test_docker_static_validation.py -v -k bge-m3
+
+# Smoke (requires running service)
+uv run pytest tests/smoke/test_zoo_smoke.py -v -k bge_m3
+```
+
+## Owner Boundaries
+
+- Model loading, warmup, and inference lifecycle
+- Prometheus metrics (`bge_encode_requests_total`, `bge_encode_seconds`, etc.)
+- Healthcheck endpoint
+
+Do not change the port, healthcheck path, or metrics shape without updating `compose.yml` and downstream consumers in `src/retrieval/`.

--- a/services/docling/README.md
+++ b/services/docling/README.md
@@ -15,7 +15,7 @@ Feeds the unified ingestion pipeline with structured text extracted from uploade
 
 - **Service name**: `docling`
 - **Profile**: — (default, unprofiled)
-- **Compose project**: `dev` (see [`../DOCKER.md`](../DOCKER.md) for contract details)
+- **Compose project**: `dev` (see [`../../DOCKER.md`](../../DOCKER.md) for contract details)
 - **Local port**: `5001` (mapped in `compose.dev.yml`)
 - **Health**: `GET http://localhost:5001/health`
 

--- a/services/docling/README.md
+++ b/services/docling/README.md
@@ -1,0 +1,44 @@
+# Docling Document Parsing Service
+
+Standalone container running `docling-serve` for converting PDFs and other documents into structured markdown/HTML.
+
+## Purpose
+
+Feeds the unified ingestion pipeline with structured text extracted from uploaded or synced documents.
+
+## Entrypoint
+
+- **Application**: `docling-serve` (Docling CLI serve mode, configured via environment)
+- **Dockerfile**: [`Dockerfile`](Dockerfile)
+
+## Docker
+
+- **Service name**: `docling`
+- **Profile**: — (default, unprofiled)
+- **Compose project**: `dev` (see [`../DOCKER.md`](../DOCKER.md) for contract details)
+- **Local port**: `5001` (mapped in `compose.dev.yml`)
+- **Health**: `GET http://localhost:5001/health`
+
+## Quick Start
+
+```bash
+COMPOSE_FILE=compose.yml:compose.dev.yml docker compose up -d docling
+curl -fsS http://localhost:5001/health
+```
+
+## Tests & Checks
+
+```bash
+# Unit tests
+uv run pytest tests/unit/test_docling*.py -v
+
+# Dockerfile sync validation
+uv run pytest tests/unit/test_dockerfile_docling_sync.py -v
+```
+
+## Owner Boundaries
+
+- Document conversion backend (`dlparse_v2` PDF backend, accurate table mode)
+- No persistent application state; relies on `./data/docling` volume mount and `docling_cache` volume
+
+Do not change `UVICORN_PORT`, `DOCLING_BACKEND`, or volume mounts without updating `compose.yml` and ingestion pipeline tests.

--- a/services/user-base/README.md
+++ b/services/user-base/README.md
@@ -15,7 +15,7 @@ Provides high-quality Russian dense embeddings (768-dim) for retrieval and seman
 
 - **Service name**: `user-base`
 - **Profile**: — (default, unprofiled)
-- **Compose project**: `dev` (see [`../DOCKER.md`](../DOCKER.md) for contract details)
+- **Compose project**: `dev` (see [`../../DOCKER.md`](../../DOCKER.md) for contract details)
 - **Local port**: `8003` (host) mapped from container port `8000`
 - **Health**: `GET http://localhost:8003/health`
 

--- a/services/user-base/README.md
+++ b/services/user-base/README.md
@@ -1,0 +1,52 @@
+# USER2-base Russian Dense Embedding Service
+
+Standalone FastAPI service for generating dense vectors using `deepvk/USER2-base` for Russian-language semantic matching.
+
+## Purpose
+
+Provides high-quality Russian dense embeddings (768-dim) for retrieval and semantic search paths that need native-language coverage beyond BGE-M3.
+
+## Entrypoint
+
+- **Application**: [`main.py`](main.py)
+- **Dockerfile**: [`Dockerfile`](Dockerfile)
+
+## Docker
+
+- **Service name**: `user-base`
+- **Profile**: — (default, unprofiled)
+- **Compose project**: `dev` (see [`../DOCKER.md`](../DOCKER.md) for contract details)
+- **Local port**: `8003` (host) mapped from container port `8000`
+- **Health**: `GET http://localhost:8003/health`
+
+## Quick Start
+
+```bash
+COMPOSE_FILE=compose.yml:compose.dev.yml docker compose up -d user-base
+curl -fsS http://localhost:8003/health
+```
+
+## Optional ONNX Backend
+
+Set `EMBEDDING_BACKEND=onnx` for ~1.5–3× CPU inference speedup (requires `onnxruntime` + `optimum`).
+
+## Tests & Checks
+
+```bash
+# Unit tests
+uv run pytest tests/unit/test_userbase_endpoints.py -v
+
+# Dockerfile validation
+uv run pytest tests/unit/test_userbase_dockerfile_permissions.py tests/unit/test_dockerfile_python_abi.py -v -k user-base
+
+# Smoke (requires running service)
+uv run pytest tests/smoke/test_zoo_smoke.py -v -k user_base
+```
+
+## Owner Boundaries
+
+- Model load, warmup, and dense embedding inference
+- Optional ONNX backend switching
+- Healthcheck endpoint
+
+Do not change the internal port (`8000`) or healthcheck path without updating `compose.yml` and downstream vectorizer clients.


### PR DESCRIPTION
## Summary

Add concise operational READMEs for each major service surface so every folder has a clear index of purpose, entrypoints, Docker service/port, tests, and owner boundaries.

## Changes

- `services/README.md` — updated index with service table, quick validation commands, and test matrix
- `services/bge-m3-api/README.md` — new: purpose, entrypoint, port 8000, tests, owner boundaries
- `services/docling/README.md` — new: purpose, entrypoint, port 5001, tests, owner boundaries
- `services/user-base/README.md` — new: purpose, entrypoint, port 8003, tests, owner boundaries
- `mini_app/README.md` — new: backend API surface, tests, owner boundaries
- `mini_app/frontend/README.md` — new: frontend build/dev/test details
- `docker/README.md` — added cross-reference to `services/README.md`

## Scope

- Docker contract details are referenced (not duplicated) from `DOCKER.md`
- LiveKit/voice intentionally out of scope
- Root README, `DOCKER.md`, and `docs/LOCAL-DEVELOPMENT.md` untouched

## Verification

- `make check` passed
- `git diff --check` clean