### PR TITLE
docs: concise folder index READMEs for code surfaces

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -36,7 +36,7 @@ Contains all non-transport logic: document ingestion, vector search, model conte
 
 ## Boundaries
 
-- **`src/` must not depend on `telegram_bot/`**. All Telegram-specific code lives in `telegram_bot/`.
+- **Shared/domain `src/` modules should stay Telegram-agnostic.** `src/api/` is an explicit adapter exception: it reuses the Telegram LangGraph pipeline (graph, state, observability, scoring) until that pipeline is extracted into a shared location.
 - **Ingestion determinism and resumability** are owned by `src/ingestion/` and `src/ingestion/unified/`. Do not change manifest identity, hashing, or collection semantics without careful review.
 - **LangGraph state contracts** are defined in `telegram_bot/graph/state.py`; `src/api/` reuses the same pipeline but does not redefine state shapes.
 

--- a/src/README.md
+++ b/src/README.md
@@ -4,7 +4,7 @@ Shared domain, retrieval, ingestion, and API code for the contextual RAG system.
 
 ## Purpose
 
-Contains all non-transport logic: document ingestion, vector search, model contextualization, evaluation, and the standalone RAG API. `telegram_bot/` imports from here; nothing in `src/` imports from `telegram_bot/`.
+Contains all non-transport logic: document ingestion, vector search, model contextualization, evaluation, and the standalone RAG API. `telegram_bot/` imports from here; most of `src/` stays Telegram-agnostic. `src/api/` is an adapter that intentionally reuses the Telegram LangGraph pipeline (via `telegram_bot.graph.graph.build_graph()`) until that pipeline is extracted into a shared location.
 
 ## Entrypoints
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,63 @@
+# src/
+
+Shared domain, retrieval, ingestion, and API code for the contextual RAG system.
+
+## Purpose
+
+Contains all non-transport logic: document ingestion, vector search, model contextualization, evaluation, and the standalone RAG API. `telegram_bot/` imports from here; nothing in `src/` imports from `telegram_bot/`.
+
+## Entrypoints
+
+| Surface | Entrypoint | Role |
+|---------|------------|------|
+| Ingestion (legacy) | `src.ingestion.service` | High-level ingestion service wrapper |
+| Ingestion (current) | `src.ingestion.unified.cli` | CocoIndex-based unified pipeline CLI |
+| Retrieval | `src.retrieval.create_search_engine` | Factory for search engine variants |
+| API | `src.api.main:app` | FastAPI application for HTTP RAG queries |
+| Voice | `src.voice.agent` | LiveKit voice agent (deferred) |
+| Evaluation | `src.evaluation.smoke_test` | Smoke tests and RAG quality evaluation |
+
+## Directory Guide
+
+| Directory | Concern |
+|-----------|---------|
+| `api/` | FastAPI RAG API — thin wrapper around LangGraph pipeline |
+| `config/` | Shared settings, constants, and Qdrant collection policy |
+| `contextualization/` | Claude-based contextualized embedding generation |
+| `core/` | Legacy RAG pipeline orchestrator |
+| `evaluation/` | Smoke tests, RAGAS, AB tests, Langfuse integration |
+| `governance/` | Compliance and policy helpers |
+| `ingestion/` | Document parsing, chunking, indexing, unified pipeline |
+| `models/` | BGE-M3 contextualized embedding model wrappers |
+| `retrieval/` | Search engines (baseline, hybrid RRF, DBSF+ColBERT) |
+| `security/` | Security utilities |
+| `utils/` | Shared helpers |
+| `voice/` | LiveKit voice agent and SIP setup (deferred by default) |
+
+## Boundaries
+
+- **`src/` must not depend on `telegram_bot/`**. All Telegram-specific code lives in `telegram_bot/`.
+- **Ingestion determinism and resumability** are owned by `src/ingestion/` and `src/ingestion/unified/`. Do not change manifest identity, hashing, or collection semantics without careful review.
+- **LangGraph state contracts** are defined in `telegram_bot/graph/state.py`; `src/api/` reuses the same pipeline but does not redefine state shapes.
+
+## Related Runtime Services
+
+- **Qdrant** — vector database (used by retrieval, ingestion, and history)
+- **PostgreSQL** — CocoIndex state for unified ingestion
+- **Redis** — caching and rate limiting (used indirectly via `telegram_bot/` services)
+- **BGE-M3 / Voyage** — embedding providers
+- **Docling** — document parsing
+- **Langfuse** — tracing and evaluation (optional)
+- **LiveKit** — voice infrastructure (deferred/off by default)
+
+## Focused Checks
+
+```bash
+make check
+pytest src/retrieval/ src/ingestion/unified/ src/api/
+```
+
+## See Also
+
+- [`../telegram_bot/README.md`](../telegram_bot/README.md) — Telegram transport layer
+- [`../DOCKER.md`](../DOCKER.md) — Docker orchestration and service dependencies

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1,0 +1,47 @@
+# src/api/
+
+FastAPI RAG API — HTTP wrapper around the LangGraph pipeline.
+
+## Purpose
+
+Exposes a single synchronous RAG endpoint (`POST /query`) and a readiness probe (`GET /health`) for external integrations (mini app, voice, third-party clients).
+
+## Entrypoints
+
+| Entrypoint | Role |
+|------------|------|
+| [`main.py`](./main.py) `app` | FastAPI application with lifespan initialization |
+| [`main.py`](./main.py) `query()` | `POST /query` — runs RAG via the LangGraph pipeline |
+| [`main.py`](./main.py) `health()` | `GET /health` — readiness probe |
+| [`schemas.py`](./schemas.py) | Pydantic request/response models |
+
+## Boundaries
+
+- **Thin wrapper**: the API delegates 100 % of RAG logic to `telegram_bot.graph.graph.build_graph()`. No retrieval or generation logic lives here.
+- **No Telegram imports** in request handling. The API is transport-agnostic.
+- Observability parity with the bot: Langfuse traces and scores are written the same way.
+
+## Runtime Services
+
+- **Qdrant** — vector search
+- **Redis** — semantic cache
+- **BGE-M3** — embeddings
+- **Langfuse** — tracing (optional)
+
+## Focused Checks
+
+```bash
+# Type-check
+make check
+
+# API tests
+pytest src/api/
+
+# Health check (when running)
+curl http://localhost:8000/health
+```
+
+## See Also
+
+- [`../telegram_bot/graph/`](../telegram_bot/graph/) — LangGraph pipeline implementation
+- [`../telegram_bot/services/`](../telegram_bot/services/) — Services reused by the API lifespan

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -38,7 +38,7 @@ make check
 pytest src/api/
 
 # Health check (when running)
-curl http://localhost:8000/health
+curl http://localhost:8080/health
 ```
 
 ## See Also

--- a/src/ingestion/README.md
+++ b/src/ingestion/README.md
@@ -1,215 +1,66 @@
-# Ingestion Module
+# src/ingestion/
 
-> **Парсинг, чанкинг и индексация документов в Qdrant**
+Document ingestion: parsing, chunking, embedding, and indexing into Qdrant.
 
----
+## Purpose
 
-## 📂 Скрипты
+Turn raw documents (PDF, DOCX, CSV, etc.) into searchable vector chunks. Two paths exist:
 
-### 1. **pdf_parser.py** - PDF парсер (PyMuPDF)
+1. **Legacy path** (`pdf_parser.py`, `chunker.py`, `indexer.py`, `gdrive_flow.py`) — standalone scripts, being phased out.
+2. **Current path** (`unified/`) — CocoIndex-based incremental pipeline with deterministic file identity and replace semantics.
 
-**Что делает:** Парсит PDF документы через PyMuPDF (fitz)
+## Entrypoints
 
-**Класс:** `PDFParser`
+| Entrypoint | Role |
+|------------|------|
+| `src.ingestion.service` | High-level service for directory and Google Drive ingestion (legacy wrapper) |
+| `src.ingestion.unified.cli` | Unified pipeline CLI: `run`, `watch`, `backfill`, `status` |
+| `src.ingestion.unified.flow` `build_flow()` / `run_once()` / `run_watch()` | CocoIndex flow assembly and execution |
+| `src.ingestion.unified.qdrant_writer` `QdrantHybridWriter` | Writes hybrid vectors (dense + sparse + ColBERT) to Qdrant |
 
-**Поддерживаемые форматы:** `.pdf`, `.docx`, `.epub`, `.txt`
+## Key Files
 
-**Output:** `ParsedDocument` (filename, title, content, num_pages, metadata)
+| File | Purpose |
+|------|---------|
+| [`chunker.py`](./chunker.py) | Document chunking strategies (fixed, semantic, sliding window) |
+| [`document_parser.py`](./document_parser.py) | Docling-based document parsing |
+| [`service.py`](./service.py) | Legacy ingestion service wrapper |
+| [`unified/config.py`](./unified/config.py) | Unified pipeline configuration |
+| [`unified/flow.py`](./unified/flow.py) | CocoIndex flow definition |
+| [`unified/manifest.py`](./unified/manifest.py) | Content-hash-based stable file identity |
+| [`unified/qdrant_writer.py`](./unified/qdrant_writer.py) | Qdrant upsert/delete with payload contract |
+| [`unified/state_manager.py`](./unified/state_manager.py) | Ingestion state and resume tracking |
+| [`unified/targets/qdrant_hybrid_target.py`](./unified/targets/qdrant_hybrid_target.py) | Custom CocoIndex target connector |
 
-**Использование:**
-```python
-from src.ingestion import PDFParser
+## Boundaries
 
-parser = PDFParser()
-doc = parser.parse_file("document.pdf")
-print(doc.content)
-```
+- **Ingestion determinism and resumability** are critical. File identity uses content hashes (`manifest.py`); renames/moves do not create duplicates.
+- **Do not change collection schema**, manifest hashing, or payload contract without updating downstream retrieval assumptions.
+- `QdrantHybridWriter` enforces replace semantics: a file re-ingestion deletes old chunks before inserting new ones.
 
-**Статус:** ⚠️ Устаревает - планируется замена на Docling
+## Related Runtime Services
 
----
+- **Qdrant** — target vector database
+- **PostgreSQL** — CocoIndex flow state database
+- **BGE-M3** — dense + sparse embeddings (or Voyage when configured)
+- **Docling** — document parsing (HTTP or native backend)
 
-### 2. **csv_to_qdrant.py** - CSV → Qdrant индексатор
+## Focused Checks
 
-**Что делает:** Прямая индексация CSV файлов в Qdrant (standalone)
-
-**Класс:** `CSVToQdrantIndexer`
-
-**Workflow:**
-1. Читает CSV файл
-2. Конвертирует строки в natural language text
-3. Генерирует BGE-M3 embeddings (1024-dim)
-4. Индексирует в Qdrant с metadata
-
-**CLI:**
 ```bash
-python src/ingestion/csv_to_qdrant.py \
-    --input demo_BG.csv \
-    --collection bulgarian_properties \
-    --recreate
+# Unified pipeline dry-run
+python -m src.ingestion.unified.cli run --dry-run
+
+# ColBERT backfill status
+python -m src.ingestion.unified.cli colbert-status
+
+# Tests
+pytest src/ingestion/unified/
+make check
 ```
 
-**Статус:** ⚠️ Дубликат - планируется удаление после рефакторинга
+## See Also
 
----
-
-### 3. **chunker.py** - Стратегии чанкинга
-
-**Что делает:** Разбивает документы на chunks для индексации
-
-**Класс:** `DocumentChunker`
-
-**Стратегии:**
-- `FIXED_SIZE` - Фиксированный размер (512 chars, 128 overlap)
-- `SEMANTIC` - По семантическим границам (параграфы, секции)
-- `SLIDING_WINDOW` - Скользящее окно с overlap
-
-**Output:** `List[Chunk]` с metadata (text, document_name, article_number, order)
-
-**Использование:**
-```python
-from src.ingestion import DocumentChunker
-from src.ingestion.chunker import ChunkingStrategy
-
-chunker = DocumentChunker(
-    chunk_size=512,
-    overlap=128,
-    strategy=ChunkingStrategy.SEMANTIC
-)
-
-chunks = chunker.chunk_text(
-    text=document.content,
-    document_name="document.pdf",
-    article_number="1"
-)
-```
-
-**Статус:** ✅ Активен
-
----
-
-### 4. **indexer.py** - Индексация в Qdrant
-
-**Что делает:** Индексирует chunks в Qdrant vector database
-
-**Класс:** `DocumentIndexer`
-
-**Возможности:**
-- BGE-M3 embeddings (1024-dim)
-- Batch processing
-- Automatic collection creation
-- Payload indexes (article_number, document_name)
-- Async processing
-
-**Workflow:**
-```python
-from src.ingestion import DocumentIndexer
-
-indexer = DocumentIndexer()
-
-# Создать коллекцию
-indexer.create_collection("my_collection", recreate=False)
-
-# Индексировать chunks
-stats = await indexer.index_chunks(
-    chunks=chunks,
-    collection_name="my_collection",
-    batch_size=32
-)
-
-print(f"Indexed: {stats.indexed_chunks} chunks")
-```
-
-**Статус:** ✅ Активен
-
----
-
-## 🔄 Типичный Pipeline
-
-```python
-from src.ingestion import PDFParser, DocumentChunker, DocumentIndexer
-
-# 1. Парсинг
-parser = PDFParser()
-doc = parser.parse_file("document.pdf")
-
-# 2. Чанкинг
-chunker = DocumentChunker(chunk_size=512, overlap=128)
-chunks = chunker.chunk_text(
-    text=doc.content,
-    document_name=doc.filename,
-    article_number="1"
-)
-
-# 3. Индексация
-indexer = DocumentIndexer()
-await indexer.index_chunks(
-    chunks=chunks,
-    collection_name="legal_documents"
-)
-```
-
----
-
-## 🎯 Планируемые изменения
-
-### Рефакторинг на Docling
-
-**Цель:** Универсальный парсер для всех форматов
-
-**План:**
-1. ✅ Изучена документация Docling через MCP Context7
-2. ⏳ Обновить `pdf_parser.py` → `document_parser.py` (Docling-based)
-3. ⏳ Удалить `csv_to_qdrant.py` (дубликат)
-4. ⏳ Обновить импорты в `__init__.py` и `pipeline.py`
-
-**Преимущества Docling:**
-- Автоматическое определение формата (PDF, CSV, DOCX, HTML, etc.)
-- Лучший парсинг таблиц и структуры
-- Единый интерфейс для всех форматов
-- Chunking из коробки
-
----
-
-## 📊 Статистика
-
-| Скрипт | Размер | Строк кода | Статус |
-|--------|--------|-----------|--------|
-| pdf_parser.py | 3.4K | ~127 | ⚠️ Устаревает |
-| csv_to_qdrant.py | 9.6K | ~280 | ⚠️ Дубликат |
-| chunker.py | 7.0K | ~229 | ✅ Активен |
-| indexer.py | 7.1K | ~219 | ✅ Активен |
-
----
-
-## 🔗 Связанные модули
-
-- **src/retrieval/** - Поиск по проиндексированным документам
-- **src/config/** - Конфигурация (Settings, VectorDimensions)
-- **src/core/pipeline.py** - Использует PDFParser, DocumentChunker, DocumentIndexer
-
----
-
-## 🚀 Быстрые команды
-
-### Проверить текущую коллекцию
-```python
-indexer = DocumentIndexer()
-stats = indexer.get_collection_stats("legal_documents")
-print(stats)
-```
-
-### Batch индексация
-```bash
-# Использовать существующий workflow из pipeline.py
-python -c "
-from src.core import RAGPipeline
-pipeline = RAGPipeline()
-# pipeline имеет indexer, chunker, parser
-"
-```
-
----
-
-**Last Updated:** 2025-11-04
-**Maintainer:** yastman
+- [`./unified/README.md`](./unified/README.md) — Detailed unified pipeline docs
+- [`../retrieval/`](../retrieval/) — Search engines that consume ingested data
+- [`../../docs/engineering/test-writing-guide.md`](../../docs/engineering/test-writing-guide.md) — Test conventions

--- a/src/ingestion/unified/README.md
+++ b/src/ingestion/unified/README.md
@@ -1,0 +1,66 @@
+# src/ingestion/unified/
+
+CocoIndex-based unified ingestion pipeline.
+
+## Purpose
+
+Incremental, resumable document ingestion with stable file identity and hybrid vector writes to Qdrant. Replaces the legacy `gdrive_flow.py` and standalone indexer scripts.
+
+## Entrypoints
+
+| Entrypoint | Role |
+|------------|------|
+| [`cli.py`](./cli.py) `main()` | CLI: `run`, `watch`, `backfill`, `status`, `inspect` |
+| [`flow.py`](./flow.py) `build_flow()` | Assemble the CocoIndex flow for a given config |
+| [`flow.py`](./flow.py) `run_once()` | Single-pass ingestion |
+| [`flow.py`](./flow.py) `run_watch()` | Continuous watch mode via `FlowLiveUpdater` |
+| [`qdrant_writer.py`](./qdrant_writer.py) `QdrantHybridWriter.write_file()` | Write a single file's chunks to Qdrant |
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| [`config.py`](./config.py) | `UnifiedConfig` — paths, Qdrant, Docling, BGE-M3/Voyage settings |
+| [`flow.py`](./flow.py) | CocoIndex flow: LocalFile source → transforms → QdrantHybridTarget |
+| [`manifest.py`](./manifest.py) | `GDriveManifest` — content-hash → stable UUID mapping (rename/move safe) |
+| [`qdrant_writer.py`](./qdrant_writer.py) | Batch hybrid upserts and per-file delete/replace |
+| [`state_manager.py`](./state_manager.py) | File state tracking for resume and idempotency |
+| [`colbert_backfill.py`](./colbert_backfill.py) | Backfill ColBERT multivectors for existing chunks |
+| [`targets/qdrant_hybrid_target.py`](./targets/qdrant_hybrid_target.py) | Custom CocoIndex target connector |
+
+## Boundaries
+
+- **Deterministic identity**: `manifest.py` uses `content_hash` as the primary key. Renamed or moved files reuse the same `file_id` and do not create duplicates.
+- **Replace semantics**: re-ingesting a file deletes its old chunks (by `file_id`) before inserting new ones.
+- **Payload contract**: `qdrant_writer.py` writes a consistent payload schema expected by retrieval. Changing fields here requires a coordinated change in `telegram_bot/services/qdrant.py` and `src/retrieval/`.
+- **Do not change hashing or collection semantics** without a migration plan; downstream retrieval and history depend on stable point identities.
+
+## Related Runtime Services
+
+- **Qdrant** — vector database target
+- **PostgreSQL** — CocoIndex flow state (`INGESTION_DATABASE_URL`)
+- **BGE-M3** — local dense + sparse embeddings (default)
+- **Voyage** — cloud dense embeddings (optional, `USE_LOCAL_DENSE_EMBEDDINGS=false`)
+- **Docling** — document parsing (`DOCLING_BACKEND`: `docling_http` or `docling_native`)
+
+## Focused Checks
+
+```bash
+# Run once (dry-run)
+python -m src.ingestion.unified.cli run --dry-run
+
+# Watch mode
+python -m src.ingestion.unified.cli watch
+
+# Backfill ColBERT vectors
+python -m src.ingestion.unified.cli colbert-backfill
+
+# Tests
+pytest src/ingestion/unified/
+make check
+```
+
+## See Also
+
+- [`../README.md`](../README.md) — Ingestion overview
+- [`../../../docs/engineering/test-writing-guide.md`](../../../docs/engineering/test-writing-guide.md) — Test conventions

--- a/src/retrieval/README.md
+++ b/src/retrieval/README.md
@@ -1,37 +1,63 @@
-# retrieval/
+# src/retrieval/
 
-Search engine implementations: baseline, hybrid RRF, ColBERT reranking.
+Search engine implementations for vector retrieval.
+
+## Purpose
+
+Execute hybrid and dense vector searches against Qdrant, with optional reranking. Consumes chunks produced by `src/ingestion/`.
 
 ## Files
 
 | File | Purpose |
 |------|---------|
-| [\_\_init\_\_.py](./__init__.py) | Exports create_search_engine, SearchResult, rerank_results |
-| [search_engines.py](./search_engines.py) | 4 search variants: Baseline, HybridRRF, HybridRRFColBERT, DBSFColBERT |
-| [reranker.py](./reranker.py) | Cross-encoder reranking (ms-marco-MiniLM, +10-15% NDCG) |
+| [`__init__.py`](./__init__.py) | Exports `create_search_engine`, `SearchResult`, `rerank_results` |
+| [`search_engines.py`](./search_engines.py) | 4 search variants: Baseline, HybridRRF, HybridRRFColBERT, DBSFColBERT |
+| [`search_engine_shared.py`](./search_engine_shared.py) | Shared primitives: sparse vector conversion, result shaping |
+| [`reranker.py`](./reranker.py) | Cross-encoder reranking (ms-marco-MiniLM, +10-15% NDCG) |
+| [`topic_classifier.py`](./topic_classifier.py) | Lightweight topic/doc-type classification for retrieval tuning |
 
 ## Search Engine Variants
 
-| Engine | Method | Recall@1 | Latency |
-|--------|--------|----------|---------|
-| `BaselineSearchEngine` | Dense only | 91.3% | ~0.5s |
-| `HybridRRFSearchEngine` | Dense + Sparse (RRF) | 92.5% | ~0.7s |
-| `HybridRRFColBERTSearchEngine` | Dense + Sparse + ColBERT | 94.0% | ~1.0s |
-| `DBSFColBERTSearchEngine` | DBSF + ColBERT | 93.5% | ~0.9s |
+| Engine | Method | Typical Latency |
+|--------|--------|-----------------|
+| `BaselineSearchEngine` | Dense only | ~0.5s |
+| `HybridRRFSearchEngine` | Dense + Sparse (RRF) | ~0.7s |
+| `HybridRRFColBERTSearchEngine` | Dense + Sparse + ColBERT rerank | ~1.0s |
+| `DBSFColBERTSearchEngine` | DBSF + ColBERT | ~0.9s |
 
-## Usage
+## Entrypoints
 
-```python
-from src.retrieval import create_search_engine
-from src.config import Settings, SearchEngine
+| Entrypoint | Role |
+|------------|------|
+| `src.retrieval.create_search_engine(settings)` | Factory that returns the configured engine |
+| `search_engines.py` engine classes | Direct instantiation for evaluation and testing |
 
-settings = Settings(search_engine=SearchEngine.HYBRID_RRF_COLBERT)
-engine = create_search_engine(settings)
+## Boundaries
 
-results = engine.search(query_embedding, top_k=10)
+- Retrieval code is **query-only**. It must not write to Qdrant or modify collections.
+- **Score shapes and payload fields** are coupled to `src/ingestion/unified/qdrant_writer.py`. If the ingestion payload contract changes, retrieval filters and result parsing may need updates.
+- `topic_classifier.py` is advisory only; retrieval must still work when classification returns `None`.
+
+## Related Runtime Services
+
+- **Qdrant** — vector database
+- **BGE-M3** — embeddings provider (local REST)
+- **Voyage** — alternative embeddings provider
+
+## Focused Checks
+
+```bash
+# Unit tests
+pytest src/retrieval/
+
+# Type-check
+make check
+
+# Evaluation AB test (heavy, requires populated collection)
+python -m src.evaluation.run_ab_test --help
 ```
 
-## Related
+## See Also
 
-- [src/models/](../models/) — BGE-M3 embedding model
-- [telegram_bot/services/qdrant.py](../../telegram_bot/services/qdrant.py) — Async Qdrant service
+- [`../ingestion/`](../ingestion/) — Chunk production and payload contract
+- [`../../telegram_bot/services/qdrant.py`](../../telegram_bot/services/qdrant.py) — Async Qdrant service used by the bot

--- a/src/voice/README.md
+++ b/src/voice/README.md
@@ -23,7 +23,7 @@ Provides a voice interface to the RAG system using LiveKit Agents. The agent han
 
 - The voice agent is a **separate transport surface**. It calls the RAG API (`src/api/`) rather than embedding retrieval logic directly.
 - If LiveKit SDK is unavailable, imports degrade gracefully with stub classes.
-- No direct dependency on `telegram_bot/` code.
+- Voice reuses `telegram_bot.observability` for Langfuse tracing but calls the RAG API (`src/api/`) for all retrieval and generation logic.
 
 ## Related Runtime Services
 

--- a/src/voice/README.md
+++ b/src/voice/README.md
@@ -1,0 +1,48 @@
+# src/voice/
+
+LiveKit Voice Agent — outbound calls with RAG Q&A.
+
+> **Status: Deferred / off by default.**
+>
+> LiveKit services (`livekit-server`, `livekit-sip`, `voice-agent`) are gated behind Docker Compose profiles (`voice`, `full`). They are **not started** in the default `docker compose up` bring-up. To enable voice, explicitly activate the profile: `docker compose --profile voice up`.
+
+## Purpose
+
+Provides a voice interface to the RAG system using LiveKit Agents. The agent handles SIP calls, transcribes speech, queries the RAG API, and synthesizes responses.
+
+## Entrypoints
+
+| Entrypoint | Role |
+|------------|------|
+| [`agent.py`](./agent.py) | LiveKit agent implementation with graceful import fallback |
+| [`rag_api_client.py`](./rag_api_client.py) | HTTP client to the RAG API (`src/api/`) |
+| [`sip_setup.py`](./sip_setup.py) | SIP trunk configuration helpers |
+| [`transcript_store.py`](./transcript_store.py) | Call transcript persistence |
+
+## Boundaries
+
+- The voice agent is a **separate transport surface**. It calls the RAG API (`src/api/`) rather than embedding retrieval logic directly.
+- If LiveKit SDK is unavailable, imports degrade gracefully with stub classes.
+- No direct dependency on `telegram_bot/` code.
+
+## Related Runtime Services
+
+- **LiveKit Server** — WebRTC/media routing (`livekit-server`)
+- **LiveKit SIP** — SIP trunk bridge (`livekit-sip`)
+- **RAG API** — `src/api/main.py` (voice agent queries this)
+- **Langfuse** — voice session tracing (optional)
+
+## Focused Checks
+
+```bash
+# Import check (works even without LiveKit SDK installed)
+python -c "from src.voice.agent import PropertyVoiceAgent; print('ok')"
+
+# Type-check
+make check
+```
+
+## See Also
+
+- [`../api/`](../api/) — RAG API that the voice agent consumes
+- [`../../DOCKER.md`](../../DOCKER.md) — Docker profiles and service orchestration

--- a/telegram_bot/README.md
+++ b/telegram_bot/README.md
@@ -1,182 +1,63 @@
-# Telegram RAG Bot для недвижимости в Болгарии
+# telegram_bot/
 
-Бот на основе RAG (Retrieval-Augmented Generation) для поиска квартир в Болгарии через Telegram.
+Telegram transport layer and bot orchestration for the contextual RAG system.
 
-## 🏗️ Архитектура
+## Purpose
 
-```
-User Query → Filter Extraction → BGE-M3 Embedding → Qdrant Search → LLM Answer → Telegram
-```
+Handles Telegram updates (text, voice, callbacks), delegates all retrieval and generation to pipelines, and surfaces answers back to users. Keeps transport concerns separate from domain logic.
 
-## 🚀 Быстрый старт
+## Entrypoints
 
-### 1. Установка зависимостей
+| Entrypoint | Role |
+|------------|------|
+| [`main.py`](./main.py) `main()` | CLI entry point: configures logging, initializes Langfuse, starts `PropertyBot` with retry |
+| [`bot.py`](./bot.py) `PropertyBot` | Bot lifecycle, handlers, and dispatcher wiring |
+| [`graph/graph.py`](./graph/graph.py) `build_graph()` | LangGraph RAG pipeline assembly (cache → rewrite → retrieve → grade → respond) |
+| [`agents/rag_pipeline.py`](./agents/rag_pipeline.py) | Agent SDK RAG functions (alternative to full LangGraph) |
+| [`pipelines/client.py`](./pipelines/client.py) | Client-direct non-RAG and RAG paths for simple queries |
+| [`preflight.py`](./preflight.py) | Startup health checks (Redis, Qdrant, Langfuse) |
 
-```bash
-cd telegram_bot
-pip install -r requirements.txt
-```
+## Boundaries
 
-### 2. Настройка .env
+- **Transport does not absorb retrieval/domain logic.** `bot.py` handlers call into `graph`, `agents`, or `pipelines/client`; they do not query Qdrant or run LLM prompts directly.
+- **LangGraph state contracts** (`graph/state.py`) must be preserved when adding new nodes or edges.
+- **Ingestion determinism** is owned by `src/ingestion/`; bot code must not modify collection schemas or manifest identity.
 
-Скопируй `.env.example` в `.env` и заполни:
+## Related Runtime Services
 
-```bash
-cp .env.example .env
-nano .env
-```
+- **Qdrant** — vector search (collections: documents, apartments, history)
+- **Redis** — caching, throttling, user context
+- **BGE-M3** — dense + sparse embeddings (local REST API)
+- **Langfuse** — tracing and observability (optional, graceful degradation)
+- **LiveKit** — voice calls (see `src/voice/`; deferred by default)
 
-**Обязательно:**
-- `TELEGRAM_BOT_TOKEN` - токен от @BotFather
-- `OPENAI_API_KEY` - API ключ OpenAI (или другого LLM)
-
-**Опционально (если не localhost):**
-- `BGE_M3_URL` - URL BGE-M3 API
-- `QDRANT_URL` - URL Qdrant
-- `QDRANT_COLLECTION` - название коллекции
-
-### 3. Создание бота в Telegram
-
-1. Открой @BotFather в Telegram
-2. Отправь `/newbot`
-3. Укажи имя и username бота
-4. Скопируй токен в `.env`
-
-### 4. Запуск бота
+## Focused Checks
 
 ```bash
-python -m telegram_bot.main
+# Lint and type-check
+make check
+
+# Unit tests for graph state and pipeline logic
+pytest telegram_bot/graph/state_contract.py telegram_bot/pipelines/
+
+# Preflight smoke test
+python -m telegram_bot.preflight
 ```
 
-Или из корня проекта:
+## Directory Guide
 
-```bash
-cd /home/admin/contextual_rag
-python -m telegram_bot.main
-```
+| Directory | Concern |
+|-----------|---------|
+| `agents/` | Agent SDK tools and RAG pipeline functions |
+| `dialogs/` | Funnel dialogs and filter extraction UI |
+| `graph/` | LangGraph runtime: nodes, edges, state, context |
+| `integrations/` | Langfuse, embeddings, cache, prompt manager |
+| `middlewares/` | Aiogram middlewares (throttling, errors, Langfuse trace root) |
+| `pipelines/` | Client-direct pipeline entrypoints |
+| `services/` | Bot services (Qdrant, cache, query analysis, response generation) |
 
-## 📝 Примеры запросов
+## See Also
 
-**По цене:**
-- Дешевле 100 000 евро
-- От 80к до 150к
-- Не дороже 100000
-
-**По комнатам:**
-- 3-комнатные квартиры
-- Студия
-- Двухкомнатная
-
-**По городу:**
-- В Солнечный берег
-- Несебр
-
-**Комбинированные:**
-- Трехкомнатная в Солнечный берег до 120к
-- Студия дешевле 60000 евро
-
-## 🛠️ Компоненты
-
-### Services
-
-- **EmbeddingService** - генерация embeddings через BGE-M3 API
-- **RetrieverService** - поиск в Qdrant с фильтрами
-- **generate_response()** - каноничный runtime-путь генерации ответов
-- **CacheService** - 4-уровневое кеширование (semantic, embeddings, analyzer, search)
-- **QueryAnalyzer** - анализ запросов и извлечение фильтров через LLM
-- **UserContextService** - управление контекстом пользователя (CESC)
-- **CESCPersonalizer** - персонализация кешированных ответов (CESC)
-
-### Фильтры
-
-Автоматически извлекаются:
-- Цена (lt, gt, range)
-- Количество комнат
-- Город
-- Площадь
-
-## 📊 Логи
-
-Логи выводятся в stdout с уровнем INFO:
-
-```
-14:23:45 - telegram_bot.bot - INFO - Query from 123456789: покажи студии
-14:23:45 - telegram_bot.bot - INFO - Extracted filters: {'rooms': 1}
-14:23:46 - telegram_bot.bot - INFO - Generated embedding: 1024-dim
-14:23:46 - telegram_bot.bot - INFO - Found 2 results
-```
-
-## 🔧 Конфигурация
-
-Все параметры в `config.py`:
-
-```python
-top_k: int = 5  # Количество результатов из Qdrant
-min_score: float = 0.5  # Минимальный score релевантности
-```
-
-## 🐛 Отладка
-
-1. Проверь, что сервисы запущены:
-```bash
-curl http://localhost:8001/health  # BGE-M3
-curl http://localhost:6333  # Qdrant
-```
-
-2. Проверь коллекцию Qdrant:
-```bash
-python test_filtering.py
-```
-
-3. Логи бота:
-```bash
-python -m telegram_bot.main 2>&1 | tee bot.log
-```
-
-## 📦 Структура проекта
-
-```
-telegram_bot/
-├── __init__.py
-├── main.py              # Точка входа
-├── bot.py               # Основная логика бота
-├── config.py            # Конфигурация
-├── middlewares.py       # Throttling, error handling
-├── services/
-│   ├── __init__.py      # Exports
-│   ├── embeddings.py    # BGE-M3 API
-│   ├── retriever.py     # Qdrant поиск
-│   ├── llm.py           # LLM генерация (streaming)
-│   ├── cache.py         # 4-tier caching
-│   ├── query_analyzer.py    # Query analysis via LLM
-│   ├── user_context.py  # CESC: User preferences (NEW)
-│   └── cesc.py          # CESC: Personalization (NEW)
-├── requirements.txt
-└── README.md
-```
-
-## 🔐 Безопасность
-
-- Никогда не коммить `.env` файл
-- Используй `.env.example` как шаблон
-- API ключи хранятся только локально
-- Бот работает через Telegram API (зашифровано)
-
-## 🚀 Production
-
-Для production используй:
-
-1. **Systemd service:**
-```bash
-sudo systemctl enable telegram-bot
-sudo systemctl start telegram-bot
-```
-
-2. **Docker:**
-```bash
-docker build -t telegram-bot .
-docker run -d --env-file .env telegram-bot
-```
-
-3. **Webhook mode** (вместо polling):
-Измени `bot.py` для использования webhook вместо long polling.
+- [`../DOCKER.md`](../DOCKER.md) — Docker bring-up and service dependencies
+- [`../src/retrieval/`](../src/retrieval/) — Search engine implementations
+- [`../src/ingestion/`](../src/ingestion/) — Document ingestion pipeline

--- a/telegram_bot/middlewares/README.md
+++ b/telegram_bot/middlewares/README.md
@@ -1,16 +1,39 @@
 # middlewares/
 
-Aiogram middlewares for Telegram bot: error handling and rate limiting.
+Aiogram middlewares for the Telegram bot: observability, error handling, and rate limiting.
+
+## Purpose
+
+Wrap every Telegram update in cross-cutting concerns before handlers run.
 
 ## Files
 
 | File | Purpose |
 |------|---------|
-| [\_\_init\_\_.py](./__init__.py) | Middleware exports |
-| [error_handler.py](./error_handler.py) | Centralized exception handling with user-friendly error messages |
-| [throttling.py](./throttling.py) | Rate limiting using TTLCache (1.5s window, admin bypass) |
+| [`__init__.py`](./__init__.py) | Middleware exports |
+| [`langfuse_middleware.py`](./langfuse_middleware.py) | Creates a Langfuse trace root for every Telegram update (outer middleware) |
+| [`error_handler.py`](./error_handler.py) | Centralized exception handling with user-friendly error messages and Langfuse error reporting |
+| [`throttling.py`](./throttling.py) | Rate limiting using TTLCache (1.5s window, admin bypass) |
 
-## Related
+## Boundaries
 
-- [telegram_bot/services/](../services/) — Bot services
-- [telegram_bot/bot.py](../bot.py) — Bot handlers
+- Middlewares are **transport-layer only**. They must not contain retrieval logic, LLM calls, or business rules.
+- `LangfuseContextMiddleware` is installed as **outer middleware** so the trace wraps the full handler lifetime.
+- Error handler reports to Langfuse best-effort; failures must not break the user-facing response.
+
+## Related Runtime Services
+
+- **Langfuse** — trace creation and error span updates
+- **Redis** — throttling cache backend
+
+## Focused Checks
+
+```bash
+pytest telegram_bot/middlewares/
+make check
+```
+
+## See Also
+
+- [`../bot.py`](../bot.py) — Bot handlers where middlewares are registered
+- [`../services/`](../services/) — Bot services called by handlers

--- a/telegram_bot/services/README.md
+++ b/telegram_bot/services/README.md
@@ -1,27 +1,57 @@
 # services/
 
-Bot services for RAG pipeline: embeddings, search, caching, query processing.
+Bot services for RAG pipeline: embeddings, search, caching, query processing, and response generation.
+
+## Purpose
+
+Pure computation and I/O wrapper modules used by Telegram handlers and the API. No Telegram transport code lives here.
 
 ## Files
 
 | File | Purpose |
 |------|---------|
-| [\_\_init\_\_.py](./__init__.py) | Public API exports (VoyageService, CacheService, QdrantService, etc.) |
-| [voyage.py](./voyage.py) | Voyage AI unified gateway: embeddings (voyage-4-large/lite) + reranking (rerank-2.5) |
-| [cache.py](./cache.py) | Multi-level cache: semantic LLM answers, embeddings, search results, rerank, conversation |
-| [qdrant.py](./qdrant.py) | Qdrant smart gateway: RRF fusion, score boosting, MMR diversity, binary quantization |
-| [query_preprocessor.py](./query_preprocessor.py) | Rule-based preprocessing: translit normalization (Latin→Cyrillic), dynamic RRF weights |
-| [query_router.py](./query_router.py) | Query classification (CHITCHAT/SIMPLE/COMPLEX) to skip RAG for greetings |
-| [cesc.py](./cesc.py) | Context-Enabled Semantic Cache personalizer with lazy routing |
-| [llm.py](./llm.py) | LLM answer generation (OpenAI-compatible) with streaming and fallback |
-| [retriever.py](./retriever.py) | Dense vector search in Qdrant with dynamic filters |
-| [query_analyzer.py](./query_analyzer.py) | LLM-based filter extraction (price, city, rooms) from natural language |
-| [user_context.py](./user_context.py) | User preferences extraction via LLM, stored in Redis with 30-day TTL |
-| [embeddings.py](./embeddings.py) | BGE-M3 embedding service via HTTP API (legacy, prefer VoyageService) |
-| [filter_extractor.py](./filter_extractor.py) | Rule-based filter extraction: price ranges, rooms, city, distance to sea |
+| [`__init__.py`](./__init__.py) | Public API exports (VoyageService, CacheService, QdrantService, etc.) |
+| [`voyage.py`](./voyage.py) | Voyage AI gateway: embeddings + reranking |
+| [`cache.py`](./cache.py) | Multi-level cache (semantic, embeddings, search, rerank, conversation) |
+| [`qdrant.py`](./qdrant.py) | Async Qdrant gateway: hybrid search, RRF, ColBERT, binary quantization |
+| [`query_preprocessor.py`](./query_preprocessor.py) | Rule-based preprocessing: translit normalization, dynamic RRF weights |
+| [`query_router.py`](./query_router.py) | Query classification (CHITCHAT/SIMPLE/COMPLEX) to skip RAG for greetings |
+| [`query_analyzer.py`](./query_analyzer.py) | LLM-based filter extraction (price, city, rooms) from natural language |
+| [`generate_response.py`](./generate_response.py) | Canonical response generation with Langfuse prompt management |
+| [`rag_core.py`](./rag_core.py) | Shared RAG core functions (no Langfuse spans, no metrics) |
+| [`cesc.py`](./cesc.py) | Context-Enabled Semantic Cache personalizer |
+| [`llm.py`](./llm.py) | LLM answer generation with streaming and fallback |
+| [`retriever.py`](./retriever.py) | Dense vector search in Qdrant with dynamic filters |
+| [`user_context.py`](./user_context.py) | User preferences extraction, stored in Redis with 30-day TTL |
+| [`embeddings.py`](./embeddings.py) | BGE-M3 embedding service via HTTP API (legacy, prefer VoyageService) |
+| [`filter_extractor.py`](./filter_extractor.py) | Rule-based filter extraction: price ranges, rooms, city, distance to sea |
+| [`apartment_llm_extractor.py`](./apartment_llm_extractor.py) | LLM-based apartment data extraction |
+| [`ingestion_cocoindex.py`](./ingestion_cocoindex.py) | Thin wrapper around `src.ingestion.service` for bot-side ingestion commands |
 
-## Related
+## Boundaries
 
-- [telegram_bot/middlewares/](../middlewares/) — Error handling, throttling
-- [src/retrieval/](../../src/retrieval/) — Search engine implementations
-- [CLAUDE.md](../../CLAUDE.md) — Architecture overview
+- Services are **stateless** except for Redis-backed caches; they do not own conversation memory (LangGraph checkpointer does).
+- **No Telegram transport imports** in this directory. Services receive plain data and return plain data.
+- `rag_core.py` is the lowest-level shared layer: no observability, no metrics, pure computation.
+
+## Related Runtime Services
+
+- **Qdrant** — vector database queries
+- **Redis** — cache tiers and user context storage
+- **BGE-M3 / Voyage** — embedding providers
+- **Langfuse** — prompt management and observability (optional)
+
+## Focused Checks
+
+```bash
+# Unit tests for services
+pytest telegram_bot/services/
+
+# Type-check
+make check
+```
+
+## See Also
+
+- [`../middlewares/`](../middlewares/) — Error handling, throttling, Langfuse trace root
+- [`../../src/retrieval/`](../../src/retrieval/) — Search engine implementations


### PR DESCRIPTION
## Summary

Add/update concise folder index READMEs so workers and humans can route changes without reading the whole tree.

## Changes

- `telegram_bot/README.md` — rewrite as routing doc (purpose, entrypoints, boundaries, runtime services, checks)
- `telegram_bot/services/README.md` — expand with boundaries, runtime services, focused checks
- `telegram_bot/middlewares/README.md` — add Langfuse middleware and boundary notes
- `src/README.md` — **new** package overview with entrypoints and directory guide
- `src/api/README.md` — **new** FastAPI RAG API index
- `src/ingestion/README.md` — update to reference unified pipeline as current path
- `src/ingestion/unified/README.md` — **new** CocoIndex unified pipeline index
- `src/retrieval/README.md` — update with boundaries, checks, and runtime services
- `src/voice/README.md` — **new** LiveKit voice agent (explicitly marked deferred/off by default)

## Invariants Preserved

- Telegram transport does not absorb retrieval/domain logic
- Ingestion determinism and resumability
- LangGraph state contracts

## Verification

- `make check` ✅
- `git diff --check` ✅