### PR TITLE
docs: docker truth audit — correct local-up list, fix validation cmd, add missing Dockerfile test

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ For local development, the canonical environment file is `.env` in the repo root
 ### 2. Start Services
 
 ```bash
-make local-up    # Redis, Qdrant, BGE-M3, Docling, LiteLLM
+make local-up    # Redis, Qdrant, BGE-M3, LiteLLM
 make test-bot-health   # Local helper: Redis, Qdrant, LiteLLM + optional Postgres note
 make run-bot           # Run bot natively (fast iteration, no Docker rebuild)
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -63,7 +63,7 @@ Ingestion service wrapper assets.
 
 ```bash
 # Verify Compose still resolves all configs correctly
-COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --env-file tests/fixtures/compose.ci.env --compatibility config > /dev/null
+COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml --compatibility config > /dev/null
 
 # Check image pins match running containers
 make verify-compose-images

--- a/docker/README.md
+++ b/docker/README.md
@@ -63,7 +63,7 @@ Ingestion service wrapper assets.
 
 ```bash
 # Verify Compose still resolves all configs correctly
-COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility config > /dev/null
+COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --env-file tests/fixtures/compose.ci.env --compatibility config > /dev/null
 
 # Check image pins match running containers
 make verify-compose-images

--- a/tests/unit/test_docker_static_validation.py
+++ b/tests/unit/test_docker_static_validation.py
@@ -22,6 +22,7 @@ DOCKERFILES = [
     "services/docling/Dockerfile",
     "src/voice/Dockerfile",
     "mini_app/Dockerfile",
+    "mini_app/frontend/Dockerfile",
 ]
 
 # Images that import telegram_bot.observability (which imports langfuse) must not


### PR DESCRIPTION
## Summary

Audit and update Docker/local-runtime documentation so `DOCKER.md` remains the canonical truth and local docs point to it without duplication.

## Changes

- **README.md**: Remove `Docling` from `make local-up` comment. `local-up` only starts `redis qdrant bge-m3 litellm`; `docling` is brought up via `local-up-ingest`.
- **docker/README.md**: Add `--env-file tests/fixtures/compose.ci.env` to the Compose validation command so it renders deterministically without relying on a local `.env` file.
- **tests/unit/test_docker_static_validation.py**: Add `mini_app/frontend/Dockerfile` to the existence check list (used by Compose for the `mini-app-frontend` service).

## Verification

- `COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml --compatibility config --services` ✅
- `rg` check for absolute paths / stale patterns ✅
- `uv run pytest tests/unit/test_docker_static_validation.py -q` — 20 passed ✅
- `make check` ✅
- `git diff --check` ✅