### PR TITLE
docs: fix audit license drift and README graph wording

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Yaroslav Bolotov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ make docker-full-up    # All 23 services
 telegram_bot/              # Telegram bot (aiogram 3 + aiogram-dialog)
 ├── handlers/              #   Message & callback handlers
 ├── services/              #   Business logic (search, LLM, cache, apartments, CRM)
-├── graph/                 #   LangGraph voice RAG pipeline (11 nodes)
+├── graph/                 #   LangGraph voice RAG pipeline
 ├── agents/                #   Sub-agents (history search, HITL)
 ├── dialogs/               #   Dialog UI (menus, filters, settings)
 ├── integrations/          #   External clients (Redis, Postgres, Langfuse)

--- a/tests/unit/test_readme_license_contract.py
+++ b/tests/unit/test_readme_license_contract.py
@@ -1,0 +1,35 @@
+"""Static contract tests for README.md and LICENSE consistency."""
+
+import re
+from pathlib import Path
+
+
+README = Path("README.md")
+LICENSE = Path("LICENSE")
+
+
+def test_license_file_exists() -> None:
+    assert LICENSE.is_file(), "LICENSE file must exist"
+
+
+def test_license_is_mit() -> None:
+    text = LICENSE.read_text(encoding="utf-8")
+    assert "MIT License" in text, "LICENSE must declare MIT License"
+    assert "Permission is hereby granted" in text, "LICENSE must contain MIT permission text"
+
+
+def test_readme_links_to_license() -> None:
+    text = README.read_text(encoding="utf-8")
+    assert "[MIT License](LICENSE)" in text, "README must link to LICENSE via MIT License anchor"
+
+
+def test_readme_does_not_use_brittle_node_count() -> None:
+    text = README.read_text(encoding="utf-8")
+    # Exact parenthetical node counts like "(11 nodes)" are brittle because
+    # the graph node count varies by configuration (guard and summarize are
+    # conditional). We allow descriptive adjectives but not exact counts.
+    match = re.search(r"\(\d+\s+nodes?\)", text)
+    assert match is None, (
+        f"README must not contain brittle exact node counts like {match.group(0)!r}; "
+        "use non-fragile wording instead"
+    )


### PR DESCRIPTION
## Summary
- Adds missing MIT `LICENSE` file to resolve README badge/link drift.
- Removes the brittle exact node count `(11 nodes)` from the `telegram_bot/graph/` README description; the actual graph node count is configuration-dependent (guard and summarize nodes are conditional).
- Adds a small static contract test (`tests/unit/test_readme_license_contract.py`) ensuring `LICENSE` exists, declares MIT, is linked from `README.md`, and does not contain brittle exact node counts.

## Verification
- `test -f LICENSE` ✓
- `make check` ✓
- `uv run pytest tests/unit/test_readme_license_contract.py -q` — 4 passed ✓
- `git diff --check` — clean ✓