### PR TITLE
fix: remove broken Makefile targets and fix validate-traces compose contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help install install-dev install-all lint format type-check security test test-full test-cov clean all-checks \
-	test-preflight test-smoke test-smoke-routing test-load test-load-ci test-load-eviction \
-	test-load-update-baseline test-all-smoke-load smoke-fast smoke-zoo \
+	test-preflight test-smoke test-load-eviction \
+	smoke-fast smoke-zoo \
 	monitoring-up monitoring-down monitoring-logs monitoring-status monitoring-test-alert \
 	rclone-install sync-drive-install sync-drive-run sync-drive-status \
 	ingest-dir ingest-status ingest-services \
@@ -294,33 +294,10 @@ test-smoke: ## Run smoke tests (requires live services)
 	uv run pytest tests/smoke/ -v --tb=short
 	@echo "$(GREEN)✓ Smoke tests complete$(NC)"
 
-test-smoke-routing: ## Run smoke routing tests only (no deps)
-	@echo "$(BLUE)Running smoke routing tests...$(NC)"
-	uv run pytest tests/smoke/test_smoke_routing.py -v
-	@echo "$(GREEN)✓ Routing tests complete$(NC)"
-
-test-load: ## Run load tests (live services)
-	@echo "$(BLUE)Running load tests...$(NC)"
-	uv run pytest tests/load/test_load_conversations.py -v -s
-	@echo "$(GREEN)✓ Load tests complete$(NC)"
-
-test-load-ci: ## Run load tests in CI (mocked, fast)
-	@echo "$(BLUE)Running load tests (CI mode)...$(NC)"
-	LOAD_USE_MOCKS=1 LOAD_CHAT_COUNT=5 uv run pytest tests/load/test_load_conversations.py -v
-	@echo "$(GREEN)✓ Load tests (CI) complete$(NC)"
-
 test-load-eviction: ## Run Redis eviction tests
 	@echo "$(BLUE)Running Redis eviction tests...$(NC)"
 	uv run pytest tests/load/test_load_redis_eviction.py -v -s
 	@echo "$(GREEN)✓ Redis eviction tests complete$(NC)"
-
-test-load-update-baseline: ## Update load test baseline
-	@echo "$(BLUE)Updating baseline...$(NC)"
-	uv run pytest tests/load/test_load_conversations.py -v --update-baseline
-	@echo "$(GREEN)✓ Baseline updated$(NC)"
-
-test-all-smoke-load: test-preflight test-smoke test-load ## Full smoke+load suite
-	@echo "$(GREEN)✓✓✓ All smoke+load tests complete$(NC)"
 
 smoke-fast: ## Quick zoo smoke (~30 sec, bash only)
 	@echo "$(BLUE)Running quick zoo smoke...$(NC)"
@@ -941,14 +918,14 @@ qdrant-backup: ## Create Qdrant collection snapshots (all collections)
 
 validate-traces: ## Full rebuild + trace validation + report
 	@echo "$(BLUE)Full rebuild + validation...$(NC)"
-	$(COMPOSE_CMD) build --no-cache bot litellm bge-m3
-	$(COMPOSE_CMD) --profile core --profile bot --profile ml up -d --wait
+	$(LOCAL_COMPOSE_CMD) build --no-cache bot litellm bge-m3
+	$(LOCAL_COMPOSE_CMD) --profile bot --profile ml up -d --wait
 	uv run python scripts/validate_traces.py --report
 	@echo "$(GREEN)Validation complete — see docs/reports/$(NC)"
 
 validate-traces-fast: ## No rebuild; trace validation fails if required trace families are missing
 	@echo "$(BLUE)Fast validation (no rebuild)...$(NC)"
-	$(COMPOSE_CMD) --profile core --profile bot --profile ml up -d --wait
+	$(LOCAL_COMPOSE_CMD) --profile bot --profile ml up -d --wait
 	uv run python scripts/validate_traces.py --report
 	@echo "$(GREEN)Validation complete — see docs/reports/$(NC)"
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -89,8 +89,7 @@ make test-preflight          # Qdrant/Redis config checks
 
 ### Load / chaos / nightly
 ```bash
-make test-load               # live services
-make test-load-ci            # mocked/fast CI mode
+make test-load-eviction      # Redis eviction tests
 make test-nightly            # chaos + smoke + slow unit
 ```
 

--- a/tests/unit/test_makefile_contract.py
+++ b/tests/unit/test_makefile_contract.py
@@ -114,3 +114,49 @@ def test_local_ps_uses_all_services() -> None:
     assert "$(LOCAL_ALL_SERVICES)" in block, (
         "local-ps must reference $(LOCAL_ALL_SERVICES) for coherence"
     )
+
+
+# --- Makefile drift contract tests ---
+
+
+def test_makefile_targets_refer_only_to_existing_test_files() -> None:
+    """Every test file path referenced by a Makefile target must exist."""
+    text = _makefile_text()
+    # Find pytest invocations with explicit test file paths
+    referenced = set(re.findall(r"pytest\s+([\w\-/]+\.py)", text))
+    missing = []
+    for ref in referenced:
+        if not Path(ref).exists():
+            missing.append(ref)
+    assert not missing, (
+        f"Makefile references missing test files: {missing}. "
+        "Remove or rewrite the affected targets."
+    )
+
+
+def test_makefile_does_not_use_invalid_core_profile() -> None:
+    """`core` is not a defined Compose profile; targets must not reference it."""
+    text = _makefile_text()
+    matches = list(re.finditer(r"--profile\s+core", text))
+    assert not matches, (
+        f"Makefile references invalid Compose profile 'core' at position(s) "
+        f"{[m.start() for m in matches]}. Use existing profiles (bot, ml, obs, ingest, voice, full) "
+        f"or unprofiled services via $(LOCAL_COMPOSE_CMD) up -d."
+    )
+
+
+def test_validate_traces_targets_use_local_compose_cmd() -> None:
+    """Trace validation targets must use the local Compose contract (LOCAL_COMPOSE_CMD)."""
+    text = _makefile_text()
+    for target in ("validate-traces", "validate-traces-fast"):
+        block_match = re.search(
+            rf"^{re.escape(target)}:.*?(?=^[A-Za-z0-9_.-]+:|\Z)",
+            text,
+            re.MULTILINE | re.DOTALL,
+        )
+        assert block_match, f"{target} target not found in Makefile"
+        block = block_match.group(0)
+        assert "$(LOCAL_COMPOSE_CMD)" in block, (
+            f"{target} must use $(LOCAL_COMPOSE_CMD) to respect the local Compose contract "
+            f"(compose.yml:compose.dev.yml with env-file handling)."
+        )


### PR DESCRIPTION
## Summary
Fix confirmed Makefile command drift from the local audit:

- Remove `test-smoke-routing` (referenced missing `tests/smoke/test_smoke_routing.py`)
- Remove `test-load`, `test-load-ci`, `test-load-update-baseline` (referenced missing `tests/load/test_load_conversations.py`)
- Remove `test-all-smoke-load` (depended on broken `test-load`)
- Fix `validate-traces` and `validate-traces-fast` to use `$(LOCAL_COMPOSE_CMD)` instead of `$(COMPOSE_CMD)`
- Remove invalid `--profile core` from `validate-traces` targets (`core` is not a defined Compose profile)
- Add Makefile contract tests to catch missing test file drift and invalid Compose profile drift
- Update `tests/README.md` to remove references to removed targets

## Verification
- `uv run pytest tests/unit/test_makefile_contract.py -q` passes (12/12)
- Static check confirms no references to missing test files or `--profile core` in Makefile or reserved docs
- `make check` passes