### PR TITLE
fix(docs): correct stale README findings from audit

### DIFF
--- a/data/demo/README.md
+++ b/data/demo/README.md
@@ -7,7 +7,7 @@ Demo data files for local indexing pipeline tests.
 This directory holds sample documents used to verify the ingestion pipeline end-to-end.
 Data files are excluded from Git (see `.gitignore`) to avoid committing large binaries.
 
-Typical files placed here:
+Typical local filenames you can place here (these are not committed):
 - `demo_BG.csv` — Sample property listings
 - `info_bg_home.docx` — Sample company contact document
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,9 @@ Start here if you are reviewing the project for hiring, portfolio, or collaborat
 
 - [`docs/PROJECT_STACK.md`](PROJECT_STACK.md) — System architecture and subsystem map.
 - [`docs/BOT_ARCHITECTURE.md`](BOT_ARCHITECTURE.md) — Bot layer architecture.
+- [`docs/BOT_INTERNAL_STRUCTURE.md`](BOT_INTERNAL_STRUCTURE.md) — Bot internal component structure.
 - [`docs/PIPELINE_OVERVIEW.md`](PIPELINE_OVERVIEW.md) — Ingestion, query, and voice runtime flows.
+- [`docs/ADD_NEW_RAG_NODE.md`](ADD_NEW_RAG_NODE.md) — Guide for adding a new RAG graph node.
 - [`docs/PIPELINE_ROUTING.md`](PIPELINE_ROUTING.md) — Query routing and state machine design.
 - [`docs/CONTEXTUALIZED_EMBEDDINGS.md`](CONTEXTUALIZED_EMBEDDINGS.md) — Embedding strategy and contextualization.
 - [`docs/RAG_API.md`](RAG_API.md) — FastAPI RAG API contract.
@@ -26,6 +28,8 @@ Start here if you are reviewing the project for hiring, portfolio, or collaborat
 
 - [`DOCKER.md`](../DOCKER.md) — Docker Compose profiles, service map, env requirements.
 - [`docs/LOCAL-DEVELOPMENT.md`](LOCAL-DEVELOPMENT.md) — Local setup and validation guide.
+- [`docs/ONBOARDING.md`](ONBOARDING.md) — Onboarding guide.
+- [`docs/ONBOARDING_CHECKLIST.md`](ONBOARDING_CHECKLIST.md) — Onboarding checklist.
 - [`services/README.md`](../services/README.md) — Local service containers (BGE-M3, Docling, user-base).
 - [`docker/README.md`](../docker/README.md) — Helper runtime assets (configs, scripts, monitoring rules).
 - [`k8s/README.md`](../k8s/README.md) — Partial k3s manifests, overlays, and deploy commands.
@@ -33,6 +37,8 @@ Start here if you are reviewing the project for hiring, portfolio, or collaborat
 - [`docs/GDRIVE_INGESTION.md`](GDRIVE_INGESTION.md) — Google Drive sync runbook.
 - [`docs/QDRANT_STACK.md`](QDRANT_STACK.md) — Vector collections, schema, and operations.
 - [`docs/ALERTING.md`](ALERTING.md) — Loki/Alertmanager setup.
+- [`docs/INFRA_ISSUES_REPORT_1113_1126.md`](INFRA_ISSUES_REPORT_1113_1126.md) — Infrastructure issues report.
+- [`docs/TROUBLESHOOTING_CACHE.md`](TROUBLESHOOTING_CACHE.md) — Cache troubleshooting guide.
 - [`docs/runbooks/`](runbooks/) — Incident-specific runbooks.
 
 ## Quality & Evaluation
@@ -45,6 +51,7 @@ Start here if you are reviewing the project for hiring, portfolio, or collaborat
 
 - [`docs/SDK_MIGRATION_AUDIT_2026-03-13.md`](SDK_MIGRATION_AUDIT_2026-03-13.md) — Canonical SDK keeper stack.
 - [`docs/SDK_MIGRATION_ROADMAP_2026-03-13.md`](SDK_MIGRATION_ROADMAP_2026-03-13.md) — Post-audit execution order.
+- [`docs/SDK_CANONICAL_REMEDIATION_REPORT_2026-03-15.md`](SDK_CANONICAL_REMEDIATION_REPORT_2026-03-15.md) — SDK canonical remediation report.
 
 ## Engineering Notes
 

--- a/src/ingestion/README.md
+++ b/src/ingestion/README.md
@@ -6,7 +6,7 @@ Document ingestion: parsing, chunking, embedding, and indexing into Qdrant.
 
 Turn raw documents (PDF, DOCX, CSV, etc.) into searchable vector chunks. Two paths exist:
 
-1. **Legacy path** (`pdf_parser.py`, `chunker.py`, `indexer.py`, `gdrive_flow.py`) — standalone scripts, being phased out.
+1. **Legacy path** (`chunker.py`, `indexer.py`, `gdrive_flow.py`) — standalone scripts, being phased out.
 2. **Current path** (`unified/`) — CocoIndex-based incremental pipeline with deterministic file identity and replace semantics.
 
 ## Entrypoints
@@ -51,8 +51,8 @@ Turn raw documents (PDF, DOCX, CSV, etc.) into searchable vector chunks. Two pat
 # Unified pipeline dry-run
 python -m src.ingestion.unified.cli run --dry-run
 
-# ColBERT backfill status
-python -m src.ingestion.unified.cli colbert-status
+# Status check
+python -m src.ingestion.unified.cli status
 
 # Tests
 pytest src/ingestion/unified/

--- a/src/ingestion/unified/README.md
+++ b/src/ingestion/unified/README.md
@@ -10,7 +10,7 @@ Incremental, resumable document ingestion with stable file identity and hybrid v
 
 | Entrypoint | Role |
 |------------|------|
-| [`cli.py`](./cli.py) `main()` | CLI: `run`, `watch`, `backfill`, `status`, `inspect` |
+| [`cli.py`](./cli.py) `main()` | CLI: `run`, `run --watch`, `backfill-colbert`, `status`, `preflight` |
 | [`flow.py`](./flow.py) `build_flow()` | Assemble the CocoIndex flow for a given config |
 | [`flow.py`](./flow.py) `run_once()` | Single-pass ingestion |
 | [`flow.py`](./flow.py) `run_watch()` | Continuous watch mode via `FlowLiveUpdater` |
@@ -50,10 +50,10 @@ Incremental, resumable document ingestion with stable file identity and hybrid v
 python -m src.ingestion.unified.cli run --dry-run
 
 # Watch mode
-python -m src.ingestion.unified.cli watch
+python -m src.ingestion.unified.cli run --watch
 
 # Backfill ColBERT vectors
-python -m src.ingestion.unified.cli colbert-backfill
+python -m src.ingestion.unified.cli backfill-colbert
 
 # Tests
 pytest src/ingestion/unified/

--- a/src/retrieval/README.md
+++ b/src/retrieval/README.md
@@ -10,7 +10,7 @@ Execute hybrid and dense vector searches against Qdrant, with optional reranking
 
 | File | Purpose |
 |------|---------|
-| [`__init__.py`](./__init__.py) | Exports `create_search_engine`, `SearchResult`, `rerank_results` |
+| [`__init__.py`](./__init__.py) | Exports `create_search_engine` and search engine classes |
 | [`search_engines.py`](./search_engines.py) | 4 search variants: Baseline, HybridRRF, HybridRRFColBERT, DBSFColBERT |
 | [`search_engine_shared.py`](./search_engine_shared.py) | Shared primitives: sparse vector conversion, result shaping |
 | [`reranker.py`](./reranker.py) | Cross-encoder reranking (ms-marco-MiniLM, +10-15% NDCG) |

--- a/src/voice/README.md
+++ b/src/voice/README.md
@@ -36,7 +36,7 @@ Provides a voice interface to the RAG system using LiveKit Agents. The agent han
 
 ```bash
 # Import check (works even without LiveKit SDK installed)
-python -c "from src.voice.agent import PropertyVoiceAgent; print('ok')"
+python -c "from src.voice.agent import VoiceBot; print('ok')"
 
 # Type-check
 make check

--- a/telegram_bot/README.md
+++ b/telegram_bot/README.md
@@ -38,7 +38,7 @@ Handles Telegram updates (text, voice, callbacks), delegates all retrieval and g
 make check
 
 # Unit tests for graph state and pipeline logic
-pytest telegram_bot/graph/state_contract.py telegram_bot/pipelines/
+pytest telegram_bot/graph/state.py telegram_bot/pipelines/
 
 # Preflight smoke test
 python -m telegram_bot.preflight

--- a/telegram_bot/services/README.md
+++ b/telegram_bot/services/README.md
@@ -12,18 +12,12 @@ Pure computation and I/O wrapper modules used by Telegram handlers and the API. 
 |------|---------|
 | [`__init__.py`](./__init__.py) | Public API exports (VoyageService, CacheService, QdrantService, etc.) |
 | [`voyage.py`](./voyage.py) | Voyage AI gateway: embeddings + reranking |
-| [`cache.py`](./cache.py) | Multi-level cache (semantic, embeddings, search, rerank, conversation) |
 | [`qdrant.py`](./qdrant.py) | Async Qdrant gateway: hybrid search, RRF, ColBERT, binary quantization |
 | [`query_preprocessor.py`](./query_preprocessor.py) | Rule-based preprocessing: translit normalization, dynamic RRF weights |
-| [`query_router.py`](./query_router.py) | Query classification (CHITCHAT/SIMPLE/COMPLEX) to skip RAG for greetings |
 | [`query_analyzer.py`](./query_analyzer.py) | LLM-based filter extraction (price, city, rooms) from natural language |
 | [`generate_response.py`](./generate_response.py) | Canonical response generation with Langfuse prompt management |
 | [`rag_core.py`](./rag_core.py) | Shared RAG core functions (no Langfuse spans, no metrics) |
-| [`cesc.py`](./cesc.py) | Context-Enabled Semantic Cache personalizer |
 | [`llm.py`](./llm.py) | LLM answer generation with streaming and fallback |
-| [`retriever.py`](./retriever.py) | Dense vector search in Qdrant with dynamic filters |
-| [`user_context.py`](./user_context.py) | User preferences extraction, stored in Redis with 30-day TTL |
-| [`embeddings.py`](./embeddings.py) | BGE-M3 embedding service via HTTP API (legacy, prefer VoyageService) |
 | [`filter_extractor.py`](./filter_extractor.py) | Rule-based filter extraction: price ranges, rooms, city, distance to sea |
 | [`apartment_llm_extractor.py`](./apartment_llm_extractor.py) | LLM-based apartment data extraction |
 | [`ingestion_cocoindex.py`](./ingestion_cocoindex.py) | Thin wrapper around `src.ingestion.service` for bot-side ingestion commands |

--- a/tests/unit/test_readme_audit_contract.py
+++ b/tests/unit/test_readme_audit_contract.py
@@ -1,0 +1,103 @@
+"""
+Static contract test for README audit findings.
+
+Prevents stale README drift by asserting that reserved README files
+match current source-tree facts.
+"""
+
+import pathlib
+
+import pytest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+class TestServicesReadme:
+    def test_no_stale_file_references(self):
+        text = _read("telegram_bot/services/README.md")
+        stale = [
+            "cache.py",
+            "query_router.py",
+            "cesc.py",
+            "retriever.py",
+            "user_context.py",
+            "embeddings.py",
+        ]
+        for name in stale:
+            assert f"[{name}]" not in text, f"Stale file reference {name} found"
+
+
+class TestVoiceReadme:
+    def test_voicebot_import_check(self):
+        text = _read("src/voice/README.md")
+        assert "VoiceBot" in text
+        assert "PropertyVoiceAgent" not in text
+
+
+class TestIngestionReadme:
+    def test_no_pdf_parser_reference(self):
+        text = _read("src/ingestion/README.md")
+        assert "pdf_parser.py" not in text
+
+    def test_status_command_not_colbert_status(self):
+        text = _read("src/ingestion/README.md")
+        assert "colbert-status" not in text
+        assert "python -m src.ingestion.unified.cli status" in text
+
+
+class TestUnifiedReadme:
+    def test_watch_mode_is_run_watch(self):
+        text = _read("src/ingestion/unified/README.md")
+        assert "python -m src.ingestion.unified.cli run --watch" in text
+        # standalone "watch" as a subcommand should not appear
+        lines = text.splitlines()
+        for line in lines:
+            if "cli watch" in line and "run --watch" not in line:
+                pytest.fail(f"Standalone watch command found: {line}")
+
+    def test_backfill_colbert_command(self):
+        text = _read("src/ingestion/unified/README.md")
+        assert "backfill-colbert" in text
+        assert "colbert-backfill" not in text
+
+
+class TestTelegramBotReadme:
+    def test_state_py_not_state_contract_py(self):
+        text = _read("telegram_bot/README.md")
+        assert "telegram_bot/graph/state.py" in text
+        assert "telegram_bot/graph/state_contract.py" not in text
+
+
+class TestRetrievalReadme:
+    def test_exports_match_actual_init(self):
+        text = _read("src/retrieval/README.md")
+        assert "SearchResult" not in text
+        assert "rerank_results" not in text
+        assert "search engine classes" in text
+
+
+class TestDocsReadme:
+    def test_missing_root_docs_indexed(self):
+        text = _read("docs/README.md")
+        required = [
+            "BOT_INTERNAL_STRUCTURE.md",
+            "ONBOARDING.md",
+            "ONBOARDING_CHECKLIST.md",
+            "INFRA_ISSUES_REPORT_1113_1126.md",
+            "TROUBLESHOOTING_CACHE.md",
+            "SDK_CANONICAL_REMEDIATION_REPORT_2026-03-15.md",
+            "ADD_NEW_RAG_NODE.md",
+        ]
+        for name in required:
+            assert name in text, f"Missing doc index entry for {name}"
+
+
+class TestDataDemoReadme:
+    def test_explicit_not_committed_wording(self):
+        text = _read("data/demo/README.md")
+        assert "not committed" in text or "not tracked" in text


### PR DESCRIPTION
## Summary

Fixes confirmed stale README findings from the local audit by aligning README facts with the current source tree.

## Changes

- `telegram_bot/services/README.md` — removed non-existent file references (`cache.py`, `query_router.py`, `cesc.py`, `retriever.py`, `user_context.py`, `embeddings.py`)
- `src/voice/README.md` — fixed import check to reference `VoiceBot` instead of `PropertyVoiceAgent`
- `src/ingestion/README.md` — removed stale `pdf_parser.py` legacy mention and corrected `colbert-status` → `status`
- `src/ingestion/unified/README.md` — fixed CLI commands (`watch` → `run --watch`, `colbert-backfill` → `backfill-colbert`)
- `telegram_bot/README.md` — corrected focused check path from `state_contract.py` to `state.py`
- `src/retrieval/README.md` — fixed `__init__.py` exports description to match actual exports
- `docs/README.md` — added missing root doc index entries
- `data/demo/README.md` — clarified that demo filenames are examples, not committed files
- `tests/unit/test_readme_audit_contract.py` — added static contract test to prevent drift from returning

## Verification

- [x] Focused source verification for each edited README claim
- [x] Markdown link check passed for all edited READMEs
- [x] `tests/unit/test_readme_audit_contract.py` passes (10/10)
- [x] `git diff --check` clean
- [x] `make check` passed