### PR TITLE
fix(trace): populate root telegram-message trace input/output (#1363)

### DIFF
--- a/telegram_bot/middlewares/langfuse_middleware.py
+++ b/telegram_bot/middlewares/langfuse_middleware.py
@@ -7,13 +7,34 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from aiogram import BaseMiddleware
-from aiogram.types import TelegramObject
+from aiogram.types import CallbackQuery, Message, TelegramObject
 
 from telegram_bot.observability import get_client, propagate_attributes
 from telegram_bot.tracing_context import classify_action, make_session_id
 
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_event_input(event: TelegramObject, action_type: str) -> dict[str, Any]:
+    """Build a safe, concise input dict from a Telegram event.
+
+    PII masking is delegated to the Langfuse SDK mask layer; this helper only
+    extracts coarse action/text metadata so the root trace is not empty.
+    """
+    if isinstance(event, Message):
+        text = event.text or event.caption or ""
+        return {
+            "action": action_type,
+            "content_type": event.content_type,
+            "text_preview": text[:500] if text else "",
+        }
+    if isinstance(event, CallbackQuery):
+        return {
+            "action": action_type,
+            "callback_data": (event.data or "")[:200],
+        }
+    return {"action": action_type}
 
 
 class LangfuseContextMiddleware(BaseMiddleware):
@@ -44,6 +65,7 @@ class LangfuseContextMiddleware(BaseMiddleware):
             lf.start_as_current_observation(
                 as_type="span",
                 name=f"telegram-{action_type}",
+                input=_extract_event_input(event, action_type),
             ),
             propagate_attributes(
                 session_id=session_id,

--- a/telegram_bot/services/telegram_formatting.py
+++ b/telegram_bot/services/telegram_formatting.py
@@ -6,6 +6,8 @@ import html
 import logging
 from typing import Any
 
+from telegram_bot.observability import get_client
+
 
 logger = logging.getLogger(__name__)
 
@@ -142,6 +144,40 @@ def build_html_messages(
     return rendered
 
 
+def _record_langfuse_response_output(answer_text: str, chunks_count: int) -> None:
+    """Best-effort update of the current Langfuse trace/span output after a send.
+
+    Uses ``update_current_trace`` when present, falls back to ``update_current_span``,
+    and is a no-op when the client or method is missing so Telegram sending never
+    breaks because of observability.
+    """
+    lf = get_client()
+    if lf is None:
+        return
+
+    output = {
+        "response_preview": (answer_text or "")[:800],
+        "chunks_count": chunks_count,
+    }
+
+    update_trace = getattr(lf, "update_current_trace", None)
+    if callable(update_trace):
+        try:
+            update_trace(output=output)
+            return
+        except Exception:
+            logger.debug(
+                "update_current_trace failed, falling back to update_current_span", exc_info=True
+            )
+
+    update_span = getattr(lf, "update_current_span", None)
+    if callable(update_span):
+        try:
+            update_span(output=output)
+        except Exception:
+            logger.debug("update_current_span failed", exc_info=True)
+
+
 async def send_html_messages(
     message: Any,
     answer_text: str,
@@ -179,4 +215,9 @@ async def send_html_messages(
             except Exception:
                 logger.exception("Failed to send formatted response chunk")
                 await message.answer(html.unescape(html_text))
+
+    try:
+        _record_langfuse_response_output(answer_text, len(html_messages))
+    except Exception:
+        logger.debug("Failed to record Langfuse output", exc_info=True)
     return True

--- a/tests/unit/middlewares/test_langfuse_middleware.py
+++ b/tests/unit/middlewares/test_langfuse_middleware.py
@@ -25,6 +25,7 @@ def message_event():
 
     msg = MagicMock(spec=Message)
     msg.text = "/start"
+    msg.content_type = "text"
     return msg
 
 
@@ -72,6 +73,11 @@ async def test_creates_span_when_langfuse_enabled(middleware, handler, message_e
     mock_lf.start_as_current_observation.assert_called_once_with(
         as_type="span",
         name="telegram-cmd-start",
+        input={
+            "action": "cmd-start",
+            "content_type": "text",
+            "text_preview": "/start",
+        },
     )
     mock_propagate.assert_called_once()
     call_kwargs = mock_propagate.call_args[1]
@@ -117,4 +123,8 @@ async def test_callback_action_type(middleware, handler, event_data):
     mock_lf.start_as_current_observation.assert_called_once_with(
         as_type="span",
         name="telegram-callback-fav",
+        input={
+            "action": "callback-fav",
+            "callback_data": "fav:add:123",
+        },
     )

--- a/tests/unit/test_langfuse_context_middleware.py
+++ b/tests/unit/test_langfuse_context_middleware.py
@@ -1,0 +1,198 @@
+"""Unit tests for LangfuseContextMiddleware input extraction and root trace setup."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from telegram_bot.middlewares.langfuse_middleware import (
+    LangfuseContextMiddleware,
+    _extract_event_input,
+)
+
+
+pytest.importorskip("aiogram", reason="aiogram not installed")
+
+from aiogram.types import CallbackQuery, Message
+
+
+class TestExtractEventInput:
+    def test_message_text(self):
+        msg = MagicMock(spec=Message)
+        msg.text = "Hello world"
+        msg.caption = None
+        msg.content_type = "text"
+        result = _extract_event_input(msg, "message")
+        assert result == {
+            "action": "message",
+            "content_type": "text",
+            "text_preview": "Hello world",
+        }
+
+    def test_message_caption_fallback(self):
+        msg = MagicMock(spec=Message)
+        msg.text = None
+        msg.caption = "Photo caption"
+        msg.content_type = "photo"
+        result = _extract_event_input(msg, "message")
+        assert result == {
+            "action": "message",
+            "content_type": "photo",
+            "text_preview": "Photo caption",
+        }
+
+    def test_message_empty_text(self):
+        msg = MagicMock(spec=Message)
+        msg.text = None
+        msg.caption = None
+        msg.content_type = "contact"
+        result = _extract_event_input(msg, "message")
+        assert result == {
+            "action": "message",
+            "content_type": "contact",
+            "text_preview": "",
+        }
+
+    def test_message_text_truncated(self):
+        msg = MagicMock(spec=Message)
+        msg.text = "x" * 1000
+        msg.caption = None
+        msg.content_type = "text"
+        result = _extract_event_input(msg, "cmd-start")
+        assert result["text_preview"] == "x" * 500
+        assert result["action"] == "cmd-start"
+
+    def test_callback_query(self):
+        cb = MagicMock(spec=CallbackQuery)
+        cb.data = "menu:search"
+        result = _extract_event_input(cb, "callback-menu")
+        assert result == {
+            "action": "callback-menu",
+            "callback_data": "menu:search",
+        }
+
+    def test_callback_query_long_data(self):
+        cb = MagicMock(spec=CallbackQuery)
+        cb.data = "x" * 300
+        result = _extract_event_input(cb, "callback")
+        assert result["callback_data"] == "x" * 200
+
+    def test_unknown_event(self):
+        event = MagicMock()
+        result = _extract_event_input(event, "update")
+        assert result == {"action": "update"}
+
+
+class TestLangfuseContextMiddleware:
+    @pytest.fixture
+    def middleware(self) -> LangfuseContextMiddleware:
+        return LangfuseContextMiddleware()
+
+    async def test_no_langfuse_client_passes_through(self, middleware: LangfuseContextMiddleware):
+        handler = AsyncMock(return_value="result")
+        event = MagicMock(spec=Message)
+        data = {"event_from_user": MagicMock(id=123), "event_chat": MagicMock(id=456)}
+
+        with patch("telegram_bot.middlewares.langfuse_middleware.get_client", return_value=None):
+            result = await middleware(handler, event, data)
+
+        assert result == "result"
+        handler.assert_called_once_with(event, data)
+
+    async def test_root_observation_started_with_input(self, middleware: LangfuseContextMiddleware):
+        handler = AsyncMock(return_value="handler_result")
+        msg = MagicMock(spec=Message)
+        msg.text = "user query"
+        msg.caption = None
+        msg.content_type = "text"
+        data = {"event_from_user": MagicMock(id=123), "event_chat": MagicMock(id=456)}
+
+        mock_lf = MagicMock()
+        mock_obs_ctx = MagicMock()
+        mock_lf.start_as_current_observation.return_value = mock_obs_ctx
+
+        with (
+            patch(
+                "telegram_bot.middlewares.langfuse_middleware.get_client",
+                return_value=mock_lf,
+            ),
+            patch("telegram_bot.middlewares.langfuse_middleware.propagate_attributes") as mock_prop,
+        ):
+            result = await middleware(handler, msg, data)
+
+        assert result == "handler_result"
+        mock_lf.start_as_current_observation.assert_called_once()
+        call_kwargs = mock_lf.start_as_current_observation.call_args.kwargs
+        assert call_kwargs["as_type"] == "span"
+        assert call_kwargs["name"] == "telegram-message"
+        assert call_kwargs["input"] == {
+            "action": "message",
+            "content_type": "text",
+            "text_preview": "user query",
+        }
+        mock_prop.assert_called_once()
+        handler.assert_called_once_with(msg, data)
+
+    async def test_callback_observation_started_with_input(
+        self, middleware: LangfuseContextMiddleware
+    ):
+        handler = AsyncMock(return_value="handler_result")
+        cb = MagicMock(spec=CallbackQuery)
+        cb.data = "filter:apply"
+        data = {"event_from_user": MagicMock(id=789), "event_chat": None}
+
+        mock_lf = MagicMock()
+        mock_obs_ctx = MagicMock()
+        mock_lf.start_as_current_observation.return_value = mock_obs_ctx
+
+        with (
+            patch(
+                "telegram_bot.middlewares.langfuse_middleware.get_client",
+                return_value=mock_lf,
+            ),
+            patch("telegram_bot.middlewares.langfuse_middleware.propagate_attributes") as mock_prop,
+        ):
+            result = await middleware(handler, cb, data)
+
+        assert result == "handler_result"
+        call_kwargs = mock_lf.start_as_current_observation.call_args.kwargs
+        assert call_kwargs["name"] == "telegram-callback-filter"
+        assert call_kwargs["input"] == {
+            "action": "callback-filter",
+            "callback_data": "filter:apply",
+        }
+        mock_prop.assert_called_once()
+
+    async def test_uses_user_id_when_chat_missing(self, middleware: LangfuseContextMiddleware):
+        handler = AsyncMock(return_value="result")
+        event = MagicMock(spec=Message)
+        event.text = None
+        event.caption = None
+        event.content_type = "text"
+        user = MagicMock(id=42)
+        data = {"event_from_user": user, "event_chat": None}
+
+        mock_lf = MagicMock()
+        mock_obs_ctx = MagicMock()
+        mock_lf.start_as_current_observation.return_value = mock_obs_ctx
+
+        with (
+            patch(
+                "telegram_bot.middlewares.langfuse_middleware.get_client",
+                return_value=mock_lf,
+            ),
+            patch("telegram_bot.middlewares.langfuse_middleware.propagate_attributes") as mock_prop,
+            patch(
+                "telegram_bot.middlewares.langfuse_middleware.make_session_id",
+                return_value="session-123",
+            ) as mock_make_session,
+        ):
+            await middleware(handler, event, data)
+
+        mock_make_session.assert_called_once_with("chat", 42)
+        mock_prop.assert_called_once_with(
+            session_id="session-123",
+            user_id="42",
+            tags=["telegram", "message"],
+        )

--- a/tests/unit/test_telegram_formatting.py
+++ b/tests/unit/test_telegram_formatting.py
@@ -1,0 +1,150 @@
+"""Unit tests for telegram_formatting Langfuse output recording."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from telegram_bot.services.telegram_formatting import (
+    _record_langfuse_response_output,
+    send_html_messages,
+)
+
+
+class TestRecordLangfuseResponseOutput:
+    def test_no_op_when_client_is_none(self):
+        with patch("telegram_bot.services.telegram_formatting.get_client", return_value=None):
+            # Should not raise
+            _record_langfuse_response_output("answer", 2)
+
+    def test_uses_update_current_trace_when_present(self):
+        mock_lf = MagicMock()
+        mock_lf.update_current_trace = MagicMock()
+        mock_lf.update_current_span = MagicMock()
+
+        with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
+            _record_langfuse_response_output("hello world", 1)
+
+        mock_lf.update_current_trace.assert_called_once_with(
+            output={"response_preview": "hello world", "chunks_count": 1}
+        )
+        mock_lf.update_current_span.assert_not_called()
+
+    def test_falls_back_to_update_current_span(self):
+        mock_lf = MagicMock()
+        del mock_lf.update_current_trace
+        mock_lf.update_current_span = MagicMock()
+
+        with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
+            _record_langfuse_response_output("fallback", 3)
+
+        mock_lf.update_current_span.assert_called_once_with(
+            output={"response_preview": "fallback", "chunks_count": 3}
+        )
+
+    def test_no_op_when_both_methods_missing(self):
+        mock_lf = MagicMock()
+        del mock_lf.update_current_trace
+        del mock_lf.update_current_span
+
+        with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
+            _record_langfuse_response_output("answer", 1)
+
+    def test_trace_failure_falls_back_to_span(self):
+        mock_lf = MagicMock()
+        mock_lf.update_current_trace = MagicMock(side_effect=RuntimeError("trace error"))
+        mock_lf.update_current_span = MagicMock()
+
+        with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
+            _record_langfuse_response_output("answer", 1)
+
+        mock_lf.update_current_trace.assert_called_once()
+        mock_lf.update_current_span.assert_called_once_with(
+            output={"response_preview": "answer", "chunks_count": 1}
+        )
+
+    def test_span_failure_is_silent(self):
+        mock_lf = MagicMock()
+        mock_lf.update_current_trace = MagicMock(side_effect=RuntimeError("trace error"))
+        mock_lf.update_current_span = MagicMock(side_effect=RuntimeError("span error"))
+
+        with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
+            # Should not raise
+            _record_langfuse_response_output("answer", 1)
+
+    def test_preview_truncated_to_800_chars(self):
+        mock_lf = MagicMock()
+        mock_lf.update_current_trace = MagicMock()
+
+        long_text = "x" * 2000
+        with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
+            _record_langfuse_response_output(long_text, 1)
+
+        call_args = mock_lf.update_current_trace.call_args.kwargs
+        assert len(call_args["output"]["response_preview"]) == 800
+        assert call_args["output"]["chunks_count"] == 1
+
+    def test_none_text_handled(self):
+        mock_lf = MagicMock()
+        mock_lf.update_current_trace = MagicMock()
+
+        with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
+            _record_langfuse_response_output(None, 1)
+
+        call_args = mock_lf.update_current_trace.call_args.kwargs
+        assert call_args["output"]["response_preview"] == ""
+        assert call_args["output"]["chunks_count"] == 1
+
+
+class TestSendHtmlMessagesLangfuse:
+    async def test_records_output_after_successful_send(self):
+        message = MagicMock()
+        message.answer = AsyncMock()
+
+        with patch(
+            "telegram_bot.services.telegram_formatting._record_langfuse_response_output"
+        ) as mock_record:
+            result = await send_html_messages(message, "Hello")
+
+        assert result is True
+        mock_record.assert_called_once_with("Hello", 1)
+
+    async def test_records_output_for_multi_chunk(self):
+        message = MagicMock()
+        message.answer = AsyncMock()
+        long_text = "A" * 5000
+
+        with patch(
+            "telegram_bot.services.telegram_formatting._record_langfuse_response_output"
+        ) as mock_record:
+            result = await send_html_messages(message, long_text)
+
+        assert result is True
+        # Should be called with the number of chunks > 1
+        call_args = mock_record.call_args
+        assert call_args[0][0] == long_text
+        assert call_args[0][1] > 1
+
+    async def test_no_record_when_no_messages(self):
+        message = MagicMock()
+
+        with patch(
+            "telegram_bot.services.telegram_formatting._record_langfuse_response_output"
+        ) as mock_record:
+            result = await send_html_messages(message, "")
+
+        assert result is False
+        mock_record.assert_not_called()
+
+    async def test_langfuse_failure_does_not_break_sending(self):
+        message = MagicMock()
+        message.answer = AsyncMock()
+
+        with patch(
+            "telegram_bot.services.telegram_formatting._record_langfuse_response_output",
+            side_effect=RuntimeError("langfuse down"),
+        ) as mock_record:
+            # Should not raise
+            result = await send_html_messages(message, "Hello")
+
+        assert result is True
+        mock_record.assert_called_once()


### PR DESCRIPTION
## Summary
Fixes #1363: root `telegram-message` traces have `input:null` and `output:null`, making the user query and final response invisible at the trace level.

## Changes
- `telegram_bot/middlewares/langfuse_middleware.py`:
  - Added `_extract_event_input(event, action_type)` helper that builds a safe, concise input dict from `Message` (text/caption preview + content_type) and `CallbackQuery` (callback data).
  - `LangfuseContextMiddleware` now passes `input=...` into `start_as_current_observation` so the root trace is no longer empty.
- `telegram_bot/services/telegram_formatting.py`:
  - Added `_record_langfuse_response_output(answer_text, chunks_count)` helper.
  - Uses SDK-native `update_current_trace` when present, falls back to `update_current_span`, and is a no-op when the client or method is missing.
  - `send_html_messages` calls the recorder after a successful send, wrapped in `try/except` so Langfuse failures never break Telegram delivery.
- Tests:
  - `tests/unit/test_langfuse_context_middleware.py` — covers input extraction for messages, captions, callbacks, truncation, and middleware integration.
  - `tests/unit/test_telegram_formatting.py` — covers trace/span fallback, no-op paths, failure resilience, and integration with `send_html_messages`.

## Verification
- `uv run pytest tests/unit/test_langfuse_context_middleware.py tests/unit/test_telegram_formatting.py -q` — 23 passed
- `make check` — passed