### PR TITLE
fix(observability): set stable OTEL service identity for Langfuse traces (#1370)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -143,6 +143,10 @@ LANGFUSE_DOCKER_HOST=http://langfuse:3000
 # Prompt label to fetch from Langfuse (default: production). Optional.
 # LANGFUSE_PROMPT_LABEL=production
 
+# OpenTelemetry service identity for Langfuse/OTel traces.
+# Each service sets a default automatically in Compose; override only when needed.
+# OTEL_SERVICE_NAME=telegram-bot
+
 # Search & retrieval tuning
 # SEARCH_TOP_K=20                    # Qdrant hybrid search top-k (default 20)
 # RELEVANCE_THRESHOLD_RRF=0.005      # Min RRF score to keep a document (default 0.005)

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -100,6 +100,26 @@ Local `make` targets that use `$(LOCAL_COMPOSE_CMD)` automatically fall back to 
 - `LIVEKIT_API_KEY` / `LIVEKIT_API_SECRET` (dev defaults exist)
 - `ELEVENLABS_API_KEY` (if ElevenLabs is used)
 
+### OpenTelemetry Service Identity (`OTEL_SERVICE_NAME`)
+
+Each Langfuse-instrumented service sets a stable `OTEL_SERVICE_NAME` default in Compose so traces and observations are consistently attributed. The variable is optional — every service falls back to its default when `OTEL_SERVICE_NAME` is unset.
+
+| Service | Default `OTEL_SERVICE_NAME` |
+| --- | --- |
+| `bot` | `telegram-bot` |
+| `mini-app-api` | `mini-app-api` |
+| `ingestion` | `ingestion` |
+| `rag-api` | `rag-api` |
+
+The defaults are set in `compose.yml` and mirrored in `compose.dev.yml` for profile-gated local overrides. `telegram_bot/observability.py` also sets `telegram-bot` at runtime as a safety fallback for non-Docker execution. Kubernetes manifests under `k8s/` additionally hard-code the `telegram-bot` identity.
+
+To override, export `OTEL_SERVICE_NAME` in the shell or set it in `.env` before starting services:
+
+```bash
+export OTEL_SERVICE_NAME=custom-bot-name
+make docker-bot-up
+```
+
 ## Health Checks
 
 ```bash

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -59,6 +59,7 @@ services:
       COLBERT_TIMEOUT: "${COLBERT_TIMEOUT:-120}"
       LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-sk-lf-dev}
+      OTEL_SERVICE_NAME: "${OTEL_SERVICE_NAME:-telegram-bot}"
 
   # ML services — profile-gated on dev (VPS: always-on via compose.yml base)
   clickhouse:
@@ -116,6 +117,7 @@ services:
     environment:
       LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-sk-lf-dev}
+      OTEL_SERVICE_NAME: "${OTEL_SERVICE_NAME:-ingestion}"
 
   loki:
     ports:
@@ -127,6 +129,7 @@ services:
     environment:
       LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-sk-lf-dev}
+      OTEL_SERVICE_NAME: "${OTEL_SERVICE_NAME:-rag-api}"
 
   livekit-server:
     ports:
@@ -159,6 +162,7 @@ services:
     environment:
       LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-sk-lf-dev}
+      OTEL_SERVICE_NAME: "${OTEL_SERVICE_NAME:-mini-app-api}"
 
   mini-app-frontend:
     ports:

--- a/compose.yml
+++ b/compose.yml
@@ -269,6 +269,7 @@ services:
       LANGFUSE_FLUSH_AT: "${LANGFUSE_FLUSH_AT:-512}"
       LANGFUSE_FLUSH_INTERVAL: "${LANGFUSE_FLUSH_INTERVAL:-5.0}"
       LANGFUSE_PROMPT_LABEL: "${LANGFUSE_PROMPT_LABEL:-production}"
+      OTEL_SERVICE_NAME: "${OTEL_SERVICE_NAME:-telegram-bot}"
       # CRM — Kommo integration
       KOMMO_ENABLED: "${KOMMO_ENABLED:-false}"
       KOMMO_SUBDOMAIN: "${KOMMO_SUBDOMAIN:-}"
@@ -348,6 +349,7 @@ services:
       LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
       LANGFUSE_HOST: ${LANGFUSE_DOCKER_HOST:-http://langfuse:3000}
+      OTEL_SERVICE_NAME: "${OTEL_SERVICE_NAME:-mini-app-api}"
       REALESTATE_DATABASE_URL: "postgresql://postgres:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/realestate"
       KOMMO_ENABLED: "${KOMMO_ENABLED:-false}"
       KOMMO_SUBDOMAIN: "${KOMMO_SUBDOMAIN:-}"
@@ -415,6 +417,7 @@ services:
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-}
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY:-}
       - LANGFUSE_HOST=${LANGFUSE_DOCKER_HOST:-http://langfuse:3000}
+      - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-ingestion}
       - GDRIVE_SYNC_DIR=/data/drive-sync
       - INGESTION_DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/cocoindex
       - QDRANT_URL=http://qdrant:6333
@@ -762,6 +765,7 @@ services:
       LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
       LANGFUSE_HOST: ${LANGFUSE_DOCKER_HOST:-http://langfuse:3000}
+      OTEL_SERVICE_NAME: "${OTEL_SERVICE_NAME:-rag-api}"
     depends_on:
       redis:
         condition: service_healthy

--- a/k8s/base/bot/deployment.yaml
+++ b/k8s/base/bot/deployment.yaml
@@ -118,6 +118,8 @@ spec:
                 secretKeyRef:
                   name: api-keys
                   key: LANGFUSE_HOST
+            - name: OTEL_SERVICE_NAME
+              value: "telegram-bot"
             # CRM — Kommo
             - name: KOMMO_ENABLED
               value: "false"

--- a/telegram_bot/observability.py
+++ b/telegram_bot/observability.py
@@ -127,6 +127,12 @@ def _resolve_config_value(explicit: str | None, env_name: str) -> str | None:
     return normalized or None
 
 
+def _ensure_otel_service_name(default: str) -> None:
+    """Set OTEL_SERVICE_NAME to default when absent, preserving explicit config."""
+    if not os.environ.get("OTEL_SERVICE_NAME"):
+        os.environ["OTEL_SERVICE_NAME"] = default
+
+
 def _to_float(value: Any) -> float | None:
     if value is None:
         return None
@@ -419,6 +425,7 @@ def initialize_langfuse(
     if tracing_env:
         kwargs["environment"] = tracing_env
 
+    _ensure_otel_service_name("telegram-bot")
     try:
         kwargs["flush_at"] = int(os.environ.get("LANGFUSE_FLUSH_AT", "512"))
         kwargs["flush_interval"] = float(os.environ.get("LANGFUSE_FLUSH_INTERVAL", "5.0"))

--- a/tests/unit/test_compose_config.py
+++ b/tests/unit/test_compose_config.py
@@ -299,6 +299,56 @@ class TestHandoffComposeContract:
         assert "MANAGERS_GROUP_ID" in bot_env
 
 
+class TestOtelServiceNameDefaults:
+    """Services that emit Langfuse/OTel traces must have stable OTEL_SERVICE_NAME defaults (#1370)."""
+
+    _EXPECTED = {
+        "bot": "telegram-bot",
+        "mini-app-api": "mini-app-api",
+        "ingestion": "ingestion",
+        "rag-api": "rag-api",
+    }
+
+    def _get_env(self, svc: dict) -> dict:
+        env = svc.get("environment", {})
+        if isinstance(env, list):
+            result = {}
+            for item in env:
+                if isinstance(item, str) and "=" in item:
+                    key, val = item.split("=", 1)
+                    result[key] = val
+            return result
+        return env
+
+    @pytest.mark.parametrize("svc_name,expected", _EXPECTED.items())
+    def test_vps_service_has_otel_service_name_default(
+        self, vps: dict, svc_name: str, expected: str
+    ) -> None:
+        if svc_name not in vps["services"]:
+            pytest.skip(f"Service {svc_name} not present in vps compose")
+        svc = vps["services"][svc_name]
+        env = self._get_env(svc)
+        assert "OTEL_SERVICE_NAME" in env, f"vps:{svc_name} missing OTEL_SERVICE_NAME"
+        assert expected in env["OTEL_SERVICE_NAME"], (
+            f"vps:{svc_name} OTEL_SERVICE_NAME default should include {expected!r}; "
+            f"got {env['OTEL_SERVICE_NAME']!r}"
+        )
+
+    @pytest.mark.parametrize("svc_name,expected", _EXPECTED.items())
+    def test_dev_service_has_otel_service_name_default(
+        self, dev: dict, svc_name: str, expected: str
+    ) -> None:
+        if svc_name not in dev["services"]:
+            pytest.skip(f"Service {svc_name} not present in dev compose")
+        svc = dev["services"][svc_name]
+        env = self._get_env(svc)
+        assert "OTEL_SERVICE_NAME" in env, f"dev:{svc_name} missing OTEL_SERVICE_NAME"
+        assert expected in env["OTEL_SERVICE_NAME"], (
+            f"dev:{svc_name} OTEL_SERVICE_NAME default should include {expected!r}; "
+            f"got {env['OTEL_SERVICE_NAME']!r}"
+        )
+
+
 # =============================================================================
 # #1307 — Langfuse web memory contract
 # =============================================================================

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -824,3 +824,43 @@ class TestLangfuseImportFailure:
         """traced_pipeline should work when propagate_attributes is a fallback."""
         with observability_without_langfuse.traced_pipeline(session_id="s", user_id="u"):
             pass
+
+
+class TestOtelServiceName:
+    """Tests for OTEL_SERVICE_NAME handling (#1370)."""
+
+    def test_initialize_langfuse_sets_otel_service_name_when_absent(self, monkeypatch):
+        """When OTEL_SERVICE_NAME is unset, initialize_langfuse sets it to telegram-bot."""
+        import os
+
+        import telegram_bot.observability as observability
+
+        monkeypatch.delenv("OTEL_SERVICE_NAME", raising=False)
+        observability._reset_langfuse_client_for_tests()
+        fake_client = MagicMock()
+        with patch("telegram_bot.observability.Langfuse", return_value=fake_client):
+            observability.initialize_langfuse(
+                public_key="pk-test",
+                secret_key="sk-test",
+                force=True,
+            )
+
+        assert os.environ.get("OTEL_SERVICE_NAME") == "telegram-bot"
+
+    def test_initialize_langfuse_does_not_override_existing_otel_service_name(self, monkeypatch):
+        """When OTEL_SERVICE_NAME is already set, initialize_langfuse preserves it."""
+        import os
+
+        import telegram_bot.observability as observability
+
+        monkeypatch.setenv("OTEL_SERVICE_NAME", "custom-service")
+        observability._reset_langfuse_client_for_tests()
+        fake_client = MagicMock()
+        with patch("telegram_bot.observability.Langfuse", return_value=fake_client):
+            observability.initialize_langfuse(
+                public_key="pk-test",
+                secret_key="sk-test",
+                force=True,
+            )
+
+        assert os.environ.get("OTEL_SERVICE_NAME") == "custom-service"


### PR DESCRIPTION
## Summary
Fixes #1370: Langfuse traces show `service.name=unknown_service`.

- Adds `_ensure_otel_service_name()` helper in `telegram_bot/observability.py` to default `OTEL_SERVICE_NAME` to `telegram-bot` without overriding explicit user configuration.
- Adds `OTEL_SERVICE_NAME` defaults to Compose for Python services that emit Langfuse/OTel traces:
  - `bot` → `telegram-bot`
  - `mini-app-api` → `mini-app-api`
  - `ingestion` → `ingestion`
  - `rag-api` → `rag-api`
- Updates `.env.example` with `OTEL_SERVICE_NAME` documentation.
- Adds `OTEL_SERVICE_NAME` env var to the k8s bot deployment manifest.
- Adds unit tests for observability behavior and compose config defaults.