### PR TITLE
fix(observability): add Langfuse as_type to BGE, Qdrant and grade-documents spans (#1364 #1366)

### DIFF
--- a/src/voice/observability.py
+++ b/src/voice/observability.py
@@ -6,7 +6,7 @@ import logging
 from contextlib import suppress
 from typing import Any, cast
 
-from telegram_bot.observability import get_client, propagate_attributes
+from telegram_bot.observability import get_client, observe, propagate_attributes
 
 
 logger = logging.getLogger(__name__)
@@ -41,6 +41,7 @@ def build_voice_trace_metadata(
     return metadata
 
 
+@observe(name="voice-session", capture_input=False, capture_output=False)
 def update_voice_trace(
     *,
     call_id: str,

--- a/telegram_bot/agents/rag_pipeline.py
+++ b/telegram_bot/agents/rag_pipeline.py
@@ -598,7 +598,7 @@ async def _hybrid_retrieve(
 # ---------------------------------------------------------------------------
 
 
-@observe(name="grade-documents")
+@observe(name="grade-documents", as_type="evaluator")
 async def _grade_documents(
     documents: list[dict[str, Any]],
     prev_confidence: float,

--- a/telegram_bot/services/bge_m3_client.py
+++ b/telegram_bot/services/bge_m3_client.py
@@ -104,7 +104,9 @@ class BGEM3Client:
             )
         return self._client
 
-    @observe(name="bge-m3-encode-dense", capture_input=False, capture_output=False)
+    @observe(
+        name="bge-m3-encode-dense", as_type="embedding", capture_input=False, capture_output=False
+    )
     @bge_retry
     async def encode_dense(self, texts: list[str]) -> DenseResult:
         """Encode texts to dense vectors via /encode/dense."""
@@ -141,7 +143,9 @@ class BGEM3Client:
         )
         return DenseResult(vectors=all_vecs, processing_time=processing_time)
 
-    @observe(name="bge-m3-encode-sparse", capture_input=False, capture_output=False)
+    @observe(
+        name="bge-m3-encode-sparse", as_type="embedding", capture_input=False, capture_output=False
+    )
     @bge_retry
     async def encode_sparse(self, texts: list[str]) -> SparseResult:
         """Encode texts to sparse vectors via /encode/sparse."""
@@ -174,7 +178,9 @@ class BGEM3Client:
         )
         return SparseResult(weights=all_weights, processing_time=processing_time)
 
-    @observe(name="bge-m3-encode-hybrid", capture_input=False, capture_output=False)
+    @observe(
+        name="bge-m3-encode-hybrid", as_type="embedding", capture_input=False, capture_output=False
+    )
     @bge_retry
     async def encode_hybrid(self, texts: list[str]) -> HybridResult:
         """Encode texts to dense + sparse via /encode/hybrid (single call)."""
@@ -212,7 +218,7 @@ class BGEM3Client:
         )
         return result
 
-    @observe(name="bge-m3-rerank", capture_input=False, capture_output=False)
+    @observe(name="bge-m3-rerank", as_type="embedding", capture_input=False, capture_output=False)
     @bge_retry
     async def rerank(self, query: str, documents: list[str], top_k: int = 5) -> RerankResult:
         """Rerank documents via ColBERT MaxSim /rerank endpoint."""
@@ -253,7 +259,9 @@ class BGEM3Client:
         )
         return result
 
-    @observe(name="bge-m3-encode-colbert", capture_input=False, capture_output=False)
+    @observe(
+        name="bge-m3-encode-colbert", as_type="embedding", capture_input=False, capture_output=False
+    )
     @bge_retry
     async def encode_colbert(self, texts: list[str]) -> ColbertResult:
         """Encode texts to ColBERT multivectors via /encode/colbert."""

--- a/telegram_bot/services/qdrant.py
+++ b/telegram_bot/services/qdrant.py
@@ -370,7 +370,12 @@ class QdrantService:
         msg = str(exc).lower()
         return "not existing vector name" in msg or "requires specified vector name" in msg
 
-    @observe(name="qdrant-hybrid-search-rrf", capture_input=False, capture_output=False)
+    @observe(
+        name="qdrant-hybrid-search-rrf",
+        as_type="retriever",
+        capture_input=False,
+        capture_output=False,
+    )
     async def hybrid_search_rrf(
         self,
         dense_vector: list[float],
@@ -538,7 +543,12 @@ class QdrantService:
                 }
             return []
 
-    @observe(name="qdrant-hybrid-search-rrf-colbert", capture_input=False, capture_output=False)
+    @observe(
+        name="qdrant-hybrid-search-rrf-colbert",
+        as_type="retriever",
+        capture_input=False,
+        capture_output=False,
+    )
     async def hybrid_search_rrf_colbert(
         self,
         dense_vector: list[float],
@@ -778,7 +788,12 @@ class QdrantService:
             )
             return fallback
 
-    @observe(name="qdrant-batch-search-rrf", capture_input=False, capture_output=False)
+    @observe(
+        name="qdrant-batch-search-rrf",
+        as_type="retriever",
+        capture_input=False,
+        capture_output=False,
+    )
     async def batch_search_rrf(
         self,
         queries: list[dict],
@@ -898,7 +913,12 @@ class QdrantService:
             )
             return []
 
-    @observe(name="qdrant-search-score-boosting", capture_input=False, capture_output=False)
+    @observe(
+        name="qdrant-search-score-boosting",
+        as_type="retriever",
+        capture_input=False,
+        capture_output=False,
+    )
     async def search_with_score_boosting(
         self,
         dense_vector: list[float],
@@ -1032,7 +1052,9 @@ class QdrantService:
             )
             return fallback_results
 
-    @observe(name="qdrant-mmr-rerank", capture_input=False, capture_output=False)
+    @observe(
+        name="qdrant-mmr-rerank", as_type="retriever", capture_input=False, capture_output=False
+    )
     def mmr_rerank(
         self,
         points: list[dict],

--- a/tests/contract/test_span_coverage_contract.py
+++ b/tests/contract/test_span_coverage_contract.py
@@ -47,6 +47,8 @@ SENSITIVE_SPANS = [
     "client-direct-pipeline",
     # Classify
     "classify-query",
+    # Graph node (sensitive)
+    "node-rewrite",
     # Cache (all 12)
     "cache-semantic-check",
     "cache-semantic-store",
@@ -143,7 +145,6 @@ LIGHT_SPANS = [
     "node-classify",
     "node-grade",
     "node-rerank",
-    "node-rewrite",
     "node-guard",
     "crm-get-deal",
     "crm-create-lead",

--- a/tests/contract/test_span_coverage_contract.py
+++ b/tests/contract/test_span_coverage_contract.py
@@ -165,7 +165,7 @@ def collect_observe_decorators(
     directories: list[Path],
     exclude_dirs: list[str] | None = None,
 ) -> dict[str, dict]:
-    """Return dict: span_name -> {capture_input, capture_output, file, line}."""
+    """Return dict: span_name -> {as_type, capture_input, capture_output, file, line}."""
     results: dict[str, dict] = {}
     exclude = set(exclude_dirs or [])
     for directory in directories:
@@ -192,9 +192,11 @@ def collect_observe_decorators(
                 if not isinstance(name_node, ast.Constant):
                     continue
                 span_name = name_node.value
+                at = kwargs.get("as_type")
                 ci = kwargs.get("capture_input")
                 co = kwargs.get("capture_output")
                 results[span_name] = {
+                    "as_type": getattr(at, "value", None) if at else None,
                     "capture_input": getattr(ci, "value", None) if ci else None,
                     "capture_output": getattr(co, "value", None) if co else None,
                     "file": str(py_file),
@@ -277,4 +279,65 @@ def test_sensitive_spans_match_yaml_contract(sensitive_spans: list[str]) -> None
         f"SENSITIVE_SPANS drift between test and YAML contract.\n"
         f"Only in Python constant: {sorted(only_python)}\n"
         f"Only in YAML contract: {sorted(only_yaml)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# as_type contract checks (#1364)
+# ---------------------------------------------------------------------------
+
+EMBEDDING_SPANS = [
+    "bge-m3-encode-dense",
+    "bge-m3-encode-sparse",
+    "bge-m3-encode-hybrid",
+    "bge-m3-rerank",
+    "bge-m3-encode-colbert",
+]
+
+RETRIEVER_SPANS = [
+    "qdrant-hybrid-search-rrf",
+    "qdrant-hybrid-search-rrf-colbert",
+    "qdrant-batch-search-rrf",
+    "qdrant-search-score-boosting",
+    "qdrant-mmr-rerank",
+]
+
+EVALUATOR_SPANS = [
+    "grade-documents",
+]
+
+
+@pytest.mark.parametrize("span_name", EMBEDDING_SPANS)
+def test_embedding_spans_have_as_type_embedding(
+    observed_spans: dict[str, dict], span_name: str
+) -> None:
+    assert span_name in observed_spans, f"Span '{span_name}' not found"
+    info = observed_spans[span_name]
+    assert info["as_type"] == "embedding", (
+        f"Span '{span_name}' at {info['file']}:{info['line']} "
+        f"must have as_type='embedding' (got {info['as_type']!r})"
+    )
+
+
+@pytest.mark.parametrize("span_name", RETRIEVER_SPANS)
+def test_retriever_spans_have_as_type_retriever(
+    observed_spans: dict[str, dict], span_name: str
+) -> None:
+    assert span_name in observed_spans, f"Span '{span_name}' not found"
+    info = observed_spans[span_name]
+    assert info["as_type"] == "retriever", (
+        f"Span '{span_name}' at {info['file']}:{info['line']} "
+        f"must have as_type='retriever' (got {info['as_type']!r})"
+    )
+
+
+@pytest.mark.parametrize("span_name", EVALUATOR_SPANS)
+def test_evaluator_spans_have_as_type_evaluator(
+    observed_spans: dict[str, dict], span_name: str
+) -> None:
+    assert span_name in observed_spans, f"Span '{span_name}' not found"
+    info = observed_spans[span_name]
+    assert info["as_type"] == "evaluator", (
+        f"Span '{span_name}' at {info['file']}:{info['line']} "
+        f"must have as_type='evaluator' (got {info['as_type']!r})"
     )

--- a/tests/observability/trace_contract.yaml
+++ b/tests/observability/trace_contract.yaml
@@ -227,13 +227,14 @@ spans:
 # Spans that must set capture_input=False, capture_output=False in production.
 # These spans handle PII, raw embeddings, or security-sensitive payloads.
 sensitive_spans:
-  # graph_nodes (excluding node-guard, node-classify, node-grade, node-rerank, node-rewrite)
+  # graph_nodes (excluding node-guard, node-classify, node-grade, node-rerank)
   - transcribe
   - classify-query
   - node-cache-check
   - node-cache-store
   - node-retrieve
   - node-generate
+  - node-rewrite
   - node-respond
   - node-summarize
   # agent_pipeline

--- a/tests/unit/test_observability_span_metadata.py
+++ b/tests/unit/test_observability_span_metadata.py
@@ -1,0 +1,179 @@
+"""Static tests for observability span metadata.
+
+AST-based tests for @observe decorator metadata (as_type, capture_input, capture_output)
+on BGE-M3, Qdrant, and RAG pipeline spans. No runtime SDK calls or network I/O.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _collect_observe_decorators(file_path: Path) -> dict[str, dict]:
+    """Return dict: span_name -> {as_type, capture_input, capture_output, line}."""
+    results: dict[str, dict] = {}
+    tree = ast.parse(file_path.read_text())
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+            continue
+        for decorator in node.decorator_list:
+            if not isinstance(decorator, ast.Call):
+                continue
+            func = decorator.func
+            is_observe = (isinstance(func, ast.Attribute) and func.attr == "observe") or (
+                isinstance(func, ast.Name) and func.id == "observe"
+            )
+            if not is_observe:
+                continue
+            kwargs = {kw.arg: kw.value for kw in decorator.keywords}
+            name_node = kwargs.get("name")
+            if not isinstance(name_node, ast.Constant):
+                continue
+            span_name = name_node.value
+            at = kwargs.get("as_type")
+            ci = kwargs.get("capture_input")
+            co = kwargs.get("capture_output")
+            results[span_name] = {
+                "as_type": getattr(at, "value", None) if at else None,
+                "capture_input": getattr(ci, "value", None) if ci else None,
+                "capture_output": getattr(co, "value", None) if co else None,
+                "line": node.lineno,
+            }
+    return results
+
+
+class TestBGEM3SpanMetadata:
+    """BGE-M3 client spans must be typed as embedding with capture disabled."""
+
+    @pytest.fixture(scope="class")
+    def bge_spans(self):
+        path = REPO_ROOT / "telegram_bot" / "services" / "bge_m3_client.py"
+        return _collect_observe_decorators(path)
+
+    @pytest.mark.parametrize(
+        "span_name",
+        [
+            "bge-m3-encode-dense",
+            "bge-m3-encode-sparse",
+            "bge-m3-encode-hybrid",
+            "bge-m3-rerank",
+            "bge-m3-encode-colbert",
+        ],
+    )
+    def test_bge_span_has_embedding_type_and_capture_disabled(self, bge_spans, span_name):
+        assert span_name in bge_spans, f"Span '{span_name}' not found"
+        info = bge_spans[span_name]
+        assert info["as_type"] == "embedding", (
+            f"Span '{span_name}' must have as_type='embedding' (got {info['as_type']!r})"
+        )
+        assert info["capture_input"] is False, (
+            f"Span '{span_name}' must have capture_input=False (got {info['capture_input']!r})"
+        )
+        assert info["capture_output"] is False, (
+            f"Span '{span_name}' must have capture_output=False (got {info['capture_output']!r})"
+        )
+
+
+class TestQdrantSpanMetadata:
+    """Qdrant retrieval spans must be typed as retriever with capture disabled."""
+
+    @pytest.fixture(scope="class")
+    def qdrant_spans(self):
+        path = REPO_ROOT / "telegram_bot" / "services" / "qdrant.py"
+        return _collect_observe_decorators(path)
+
+    @pytest.mark.parametrize(
+        "span_name",
+        [
+            "qdrant-hybrid-search-rrf",
+            "qdrant-hybrid-search-rrf-colbert",
+            "qdrant-batch-search-rrf",
+            "qdrant-search-score-boosting",
+            "qdrant-mmr-rerank",
+        ],
+    )
+    def test_qdrant_retrieval_span_has_retriever_type_and_capture_disabled(
+        self, qdrant_spans, span_name
+    ):
+        assert span_name in qdrant_spans, f"Span '{span_name}' not found"
+        info = qdrant_spans[span_name]
+        assert info["as_type"] == "retriever", (
+            f"Span '{span_name}' must have as_type='retriever' (got {info['as_type']!r})"
+        )
+        assert info["capture_input"] is False, (
+            f"Span '{span_name}' must have capture_input=False (got {info['capture_input']!r})"
+        )
+        assert info["capture_output"] is False, (
+            f"Span '{span_name}' must have capture_output=False (got {info['capture_output']!r})"
+        )
+
+
+class TestRAGPipelineSpanMetadata:
+    """RAG pipeline spans must have correct as_type and capture flags."""
+
+    @pytest.fixture(scope="class")
+    def rag_spans(self):
+        path = REPO_ROOT / "telegram_bot" / "agents" / "rag_pipeline.py"
+        return _collect_observe_decorators(path)
+
+    def test_grade_documents_has_evaluator_type(self, rag_spans):
+        assert "grade-documents" in rag_spans, "Span 'grade-documents' not found"
+        info = rag_spans["grade-documents"]
+        assert info["as_type"] == "evaluator", (
+            f"Span 'grade-documents' must have as_type='evaluator' (got {info['as_type']!r})"
+        )
+
+    def test_grade_documents_is_light_span(self, rag_spans):
+        """grade-documents is a light span: must NOT have capture_input=False."""
+        info = rag_spans["grade-documents"]
+        assert info["capture_input"] is not False, (
+            "grade-documents should not have capture_input=False (light span)"
+        )
+
+
+class TestBGEServiceWarmup:
+    """BGE-M3 API service must not create Langfuse traces during warmup."""
+
+    def test_app_py_has_no_observe_decorators(self):
+        """services/bge-m3-api/app.py uses raw model calls and must not import @observe."""
+        path = REPO_ROOT / "services" / "bge-m3-api" / "app.py"
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                continue
+            for decorator in node.decorator_list:
+                if not isinstance(decorator, ast.Call):
+                    continue
+                func = decorator.func
+                is_observe = (isinstance(func, ast.Attribute) and func.attr == "observe") or (
+                    isinstance(func, ast.Name) and func.id == "observe"
+                )
+                if is_observe:
+                    pytest.fail(f"app.py must not use @observe decorators (line {node.lineno})")
+
+    def test_warmup_encode_result_discarded(self):
+        """Lifespan warmup must call model.encode() as a bare expression (result discarded)."""
+        path = REPO_ROOT / "services" / "bge-m3-api" / "app.py"
+        tree = ast.parse(path.read_text())
+        lifespan_node = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == "lifespan":
+                lifespan_node = node
+                break
+        assert lifespan_node is not None, "lifespan function not found in app.py"
+
+        found_bare_encode = False
+        for child in ast.walk(lifespan_node):
+            if isinstance(child, ast.Expr) and isinstance(child.value, ast.Call):
+                call = child.value
+                func = call.func
+                if isinstance(func, ast.Attribute) and func.attr == "encode":
+                    found_bare_encode = True
+                    break
+        assert found_bare_encode, (
+            "lifespan warmup must call model.encode() as a bare expression (discarded)"
+        )


### PR DESCRIPTION
## Summary
Fixes #1364 and #1366 by adding correct `as_type` metadata to Langfuse spans and verifying warmup does not create orphan traces.

## Changes
- BGE-M3 encode/rerank spans: `as_type="embedding"` with `capture_input=False, capture_output=False`.
- Qdrant retrieval spans (hybrid RRF, ColBERT, batch RRF, score boosting, MMR): `as_type="retriever"` with capture disabled.
- `grade-documents` span: `as_type="evaluator"`.
- `voice-session` now has an AST-detectable `@observe` decorator while preserving capture disabled.
- `node-rewrite` is classified as sensitive to match its production `capture_input=False` decorator.
- Added/extended AST contract tests for span metadata and trace contract drift.
- Verified `services/bge-m3-api/app.py` startup warmup uses raw `model.encode()` without Langfuse decorators.

## Verification
- `uv run pytest tests/unit/test_observability_span_metadata.py tests/unit/test_bge_m3_rerank.py -q` — passed
- `uv run pytest tests/contract/test_span_coverage_contract.py tests/contract/test_trace_families_contract.py -q` — 141 passed
- `make check` — passed
