### PR TITLE
fix(observability): add Langfuse @observe coverage to contextualization providers (#1367 slice A)

### DIFF
--- a/src/contextualization/claude.py
+++ b/src/contextualization/claude.py
@@ -3,6 +3,7 @@
 from typing import Any, cast
 
 from anthropic import Anthropic, APIStatusError, AsyncAnthropic, RateLimitError
+from langfuse import observe
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_random_exponential
 
 from src.config import Settings
@@ -80,6 +81,7 @@ class ClaudeContextualizer(ContextualizeProvider):
                 )
         return results
 
+    @observe(name="claude-contextualize", capture_input=False, capture_output=False)
     @retry(
         retry=retry_if_exception_type((RateLimitError, APIStatusError)),
         wait=wait_random_exponential(multiplier=1, max=60),
@@ -134,6 +136,7 @@ class ClaudeContextualizer(ContextualizeProvider):
             context_method="claude",
         )
 
+    @observe(name="claude-contextualize-sync", capture_input=False, capture_output=False)
     @retry(
         retry=retry_if_exception_type((RateLimitError, APIStatusError)),
         wait=wait_random_exponential(multiplier=1, max=60),

--- a/src/contextualization/groq.py
+++ b/src/contextualization/groq.py
@@ -1,6 +1,7 @@
 """Groq-based contextualization provider (high-speed alternative)."""
 
 from groq import APIStatusError, AsyncGroq, Groq, RateLimitError
+from langfuse import observe
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_random_exponential
 
 from src.config import Settings
@@ -52,6 +53,7 @@ class GroqContextualizer(ContextualizeProvider):
                 )
         return results
 
+    @observe(name="groq-contextualize", capture_input=False, capture_output=False)
     @retry(
         retry=retry_if_exception_type((RateLimitError, APIStatusError)),
         wait=wait_random_exponential(multiplier=1, max=60),
@@ -89,6 +91,7 @@ class GroqContextualizer(ContextualizeProvider):
             context_method="groq",
         )
 
+    @observe(name="groq-contextualize-sync", capture_input=False, capture_output=False)
     @retry(
         retry=retry_if_exception_type((RateLimitError, APIStatusError)),
         wait=wait_random_exponential(multiplier=1, max=60),

--- a/src/contextualization/openai.py
+++ b/src/contextualization/openai.py
@@ -1,5 +1,6 @@
 """OpenAI-based contextualization provider."""
 
+from langfuse import observe
 from openai import APIStatusError, AsyncOpenAI, OpenAI, RateLimitError
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_random_exponential
 
@@ -51,6 +52,7 @@ class OpenAIContextualizer(ContextualizeProvider):
                 )
         return results
 
+    @observe(name="openai-contextualize", capture_input=False, capture_output=False)
     @retry(
         retry=retry_if_exception_type((RateLimitError, APIStatusError)),
         wait=wait_random_exponential(multiplier=1, max=60),
@@ -94,6 +96,7 @@ class OpenAIContextualizer(ContextualizeProvider):
             context_method="openai",
         )
 
+    @observe(name="openai-contextualize-sync", capture_input=False, capture_output=False)
     @retry(
         retry=retry_if_exception_type((RateLimitError, APIStatusError)),
         wait=wait_random_exponential(multiplier=1, max=60),

--- a/tests/contract/test_span_coverage_contract.py
+++ b/tests/contract/test_span_coverage_contract.py
@@ -138,6 +138,13 @@ SENSITIVE_SPANS = [
     "ingestion-flow-watch",
     "ingestion-qdrant-delete-file",
     "ingestion-qdrant-upsert-chunks",
+    # Contextualization (raw text chunks and queries)
+    "claude-contextualize",
+    "claude-contextualize-sync",
+    "openai-contextualize",
+    "openai-contextualize-sync",
+    "groq-contextualize",
+    "groq-contextualize-sync",
 ]
 
 # Light spans — use auto-capture (capture_input should NOT be explicitly set to False)

--- a/tests/observability/trace_contract.yaml
+++ b/tests/observability/trace_contract.yaml
@@ -224,6 +224,14 @@ spans:
     - ingestion-qdrant-delete-file
     - ingestion-qdrant-upsert-chunks
 
+  contextualization:
+    - claude-contextualize
+    - claude-contextualize-sync
+    - openai-contextualize
+    - openai-contextualize-sync
+    - groq-contextualize
+    - groq-contextualize-sync
+
 # Spans that must set capture_input=False, capture_output=False in production.
 # These spans handle PII, raw embeddings, or security-sensitive payloads.
 sensitive_spans:
@@ -343,6 +351,13 @@ sensitive_spans:
   - ingestion-flow-watch
   - ingestion-qdrant-delete-file
   - ingestion-qdrant-upsert-chunks
+  # contextualization (raw text chunks and queries)
+  - claude-contextualize
+  - claude-contextualize-sync
+  - openai-contextualize
+  - openai-contextualize-sync
+  - groq-contextualize
+  - groq-contextualize-sync
 
 scores:
   core_rag:


### PR DESCRIPTION
## Summary
Add Langfuse `@observe` coverage to contextualization providers with PII-safe capture flags.

## Changes
- Instrument `ClaudeContextualizer`, `OpenAIContextualizer`, and `GroqContextualizer` with `@observe(capture_input=False, capture_output=False)` on both async `contextualize_single` and sync `contextualize_sync` entry points.
- Add new span names to `trace_contract.yaml` and the span coverage contract test.

## Verification
- `tests/unit/contextualization/` — 134 passed
- `tests/contract/test_span_coverage_contract.py` + `tests/contract/test_trace_families_contract.py` — 147 passed
- `make check` — ruff passed; mypy timed out due to pre-existing Python 3.14 + langfuse compatibility issue (not related to these changes).

## Span names
- `claude-contextualize` / `claude-contextualize-sync`
- `openai-contextualize` / `openai-contextualize-sync`
- `groq-contextualize` / `groq-contextualize-sync`