### PR TITLE
fix: add Langfuse coverage to cross-encoder reranker (#1367)

### DIFF
--- a/src/retrieval/reranker.py
+++ b/src/retrieval/reranker.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
+from telegram_bot.observability import get_client, observe
+
 
 if TYPE_CHECKING:
     from sentence_transformers import CrossEncoder
@@ -62,6 +64,12 @@ def get_cross_encoder(model_name: str = "cross-encoder/ms-marco-MiniLM-L-6-v2") 
     return cast("CrossEncoder", _cross_encoder)
 
 
+@observe(
+    name="cross-encoder-rerank",
+    as_type="retriever",
+    capture_input=False,
+    capture_output=False,
+)
 def rerank_results(
     query: str,
     results: list[dict[str, Any]],
@@ -108,6 +116,17 @@ def rerank_results(
         reranked.extend(results[top_k:])
 
         logger.info(f"Reranked top {top_k} results with cross-encoder")
+
+        lf = get_client()
+        if lf is not None:
+            lf.update_current_span(
+                metadata={
+                    "model": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+                    "results_count": len(reranked),
+                    "top_k": top_k,
+                }
+            )
+
         return reranked
 
     except Exception as e:

--- a/tests/contract/test_span_coverage_contract.py
+++ b/tests/contract/test_span_coverage_contract.py
@@ -87,6 +87,7 @@ SENSITIVE_SPANS = [
     "detect-response-style",
     "get-prompt",
     "kommo-token-refresh",
+    "cross-encoder-rerank",
     "apartments-hybrid-search",
     "apartments-scroll",
     "apartment-filter-parse",
@@ -296,6 +297,7 @@ EMBEDDING_SPANS = [
 ]
 
 RETRIEVER_SPANS = [
+    "cross-encoder-rerank",
     "qdrant-hybrid-search-rrf",
     "qdrant-hybrid-search-rrf-colbert",
     "qdrant-batch-search-rrf",

--- a/tests/observability/trace_contract.yaml
+++ b/tests/observability/trace_contract.yaml
@@ -133,6 +133,7 @@ spans:
     - detect-response-style
     - get-prompt
     - kommo-token-refresh
+    - cross-encoder-rerank
     - colbert-rerank
     - session-summary-check
     - lead-score-upsert
@@ -292,6 +293,7 @@ sensitive_spans:
   - detect-response-style
   - get-prompt
   - kommo-token-refresh
+  - cross-encoder-rerank
   - apartments-hybrid-search
   - apartments-scroll
   - apartment-filter-parse


### PR DESCRIPTION
## Summary
- Add `@observe(name='cross-encoder-rerank', as_type='retriever', capture_input=False, capture_output=False)` to `src/retrieval/reranker.py::rerank_results`
- Add safe `get_client().update_current_span` metadata updates for model name and result counts
- Register span in trace_contract.yaml under services and sensitive_spans
- Add to SENSITIVE_SPANS and RETRIEVER_SPANS in test_span_coverage_contract.py

## Verification
- Reranker unit tests: 14 passed
- Contract tests: 143 passed
- Ruff lint: passed
- Mypy: timed out (pre-existing env issue with Python 3.14)