### PR TITLE
fix(observability): add model/collection metadata to embedding, retrieval, and cache spans (#1365)

### DIFF
--- a/src/models/contextualized_embedding.py
+++ b/src/models/contextualized_embedding.py
@@ -162,6 +162,7 @@ class ContextualizedEmbeddingService:
                 "total_chunks": total_chunks,
                 "output_dimension": self._output_dimension,
             },
+            metadata={"model": self.MODEL_NAME},
         )
 
         if not document_chunks:
@@ -197,6 +198,7 @@ class ContextualizedEmbeddingService:
                 "embeddings_count": len(all_embeddings),
                 "dimensions": self._output_dimension,
             },
+            metadata={"model": self.MODEL_NAME},
         )
 
         logger.info(
@@ -238,6 +240,7 @@ class ContextualizedEmbeddingService:
         get_client().update_current_generation(
             model=self.MODEL_NAME,
             input={"query": query[:200], "output_dimension": self._output_dimension},
+            metadata={"model": self.MODEL_NAME},
         )
 
         # Wrap query in expected format: [[query]]
@@ -257,6 +260,7 @@ class ContextualizedEmbeddingService:
         get_client().update_current_generation(
             usage_details={"input": total_tokens},
             output={"dimensions": len(embedding)},
+            metadata={"model": self.MODEL_NAME},
         )
 
         return embedding
@@ -296,6 +300,7 @@ class ContextualizedEmbeddingService:
                 "queries_count": len(queries),
                 "output_dimension": self._output_dimension,
             },
+            metadata={"model": self.MODEL_NAME},
         )
 
         # Wrap each query in its own list: [["q1"], ["q2"], ...]
@@ -323,6 +328,7 @@ class ContextualizedEmbeddingService:
                 "embeddings_count": len(embeddings),
                 "dimensions": self._output_dimension,
             },
+            metadata={"model": self.MODEL_NAME},
         )
 
         logger.info(f"Embedded {len(queries)} queries with {self.MODEL_NAME}")

--- a/telegram_bot/integrations/cache.py
+++ b/telegram_bot/integrations/cache.py
@@ -537,19 +537,25 @@ class CacheLayerManager:
     async def get_embedding(self, text: str, model: str = "bge-m3") -> list[float] | None:
         """Get cached dense embedding via RedisVL EmbeddingsCache."""
         lf = get_client()
-        lf.update_current_span(input={"model": model, "text_length": len(text)})
+        lf.update_current_span(
+            input={"model": model, "text_length": len(text)},
+            metadata={"model": model},
+        )
         if self.embed_cache is None:
-            lf.update_current_span(output={"hit": False, "embed_cache_enabled": False})
+            lf.update_current_span(
+                output={"hit": False, "embed_cache_enabled": False},
+                metadata={"model": model},
+            )
             return None
         try:
             normalized = _normalize_query_for_cache(text)
             result = await self.embed_cache.aget(content=normalized, model_name=model)
             if result is not None:
                 self._metrics["embeddings"]["hits"] += 1
-                lf.update_current_span(output={"hit": True})
+                lf.update_current_span(output={"hit": True}, metadata={"model": model})
                 return list(result["embedding"])
             self._metrics["embeddings"]["misses"] += 1
-            lf.update_current_span(output={"hit": False})
+            lf.update_current_span(output={"hit": False}, metadata={"model": model})
             return None
         except Exception as e:
             logger.error("EmbeddingsCache get error: %s: %s", type(e).__name__, e)
@@ -558,6 +564,7 @@ class CacheLayerManager:
                 level="ERROR",
                 status_message=f"EmbeddingsCache get error: {type(e).__name__}",
                 output={"hit": False, "error": type(e).__name__},
+                metadata={"model": model},
             )
             return None
 
@@ -568,10 +575,14 @@ class CacheLayerManager:
         """Store dense embedding via RedisVL EmbeddingsCache."""
         lf = get_client()
         lf.update_current_span(
-            input={"model": model, "text_length": len(text), "embedding_dim": len(embedding)}
+            input={"model": model, "text_length": len(text), "embedding_dim": len(embedding)},
+            metadata={"model": model},
         )
         if self.embed_cache is None:
-            lf.update_current_span(output={"stored": False, "embed_cache_enabled": False})
+            lf.update_current_span(
+                output={"stored": False, "embed_cache_enabled": False},
+                metadata={"model": model},
+            )
             return
         try:
             normalized = _normalize_query_for_cache(text)
@@ -582,13 +593,14 @@ class CacheLayerManager:
                 embedding=embedding,
                 ttl=ttl,
             )
-            lf.update_current_span(output={"stored": True})
+            lf.update_current_span(output={"stored": True}, metadata={"model": model})
         except Exception as e:
             logger.error("EmbeddingsCache store error: %s: %s", type(e).__name__, e)
             lf.update_current_span(
                 level="ERROR",
                 status_message=f"EmbeddingsCache store error: {type(e).__name__}",
                 output={"stored": False, "error": type(e).__name__},
+                metadata={"model": model},
             )
 
     # ========== Convenience: Sparse Embeddings ==========
@@ -599,11 +611,17 @@ class CacheLayerManager:
     ) -> dict[str, Any] | None:
         """Get cached sparse embedding."""
         lf = get_client()
-        lf.update_current_span(input={"model": model, "text_length": len(text)})
+        lf.update_current_span(
+            input={"model": model, "text_length": len(text)},
+            metadata={"model": model},
+        )
         result = await self.get_exact(
             "sparse", _hash(f"{model}:{_normalize_query_for_cache(text)}")
         )
-        lf.update_current_span(output={"hit": result is not None})
+        lf.update_current_span(
+            output={"hit": result is not None},
+            metadata={"model": model},
+        )
         return result
 
     @observe(name="cache-sparse-store", capture_input=False, capture_output=False)
@@ -617,12 +635,13 @@ class CacheLayerManager:
                 "model": model,
                 "text_length": len(text),
                 "sparse_indices_count": len(sparse_vector.get("indices", [])),
-            }
+            },
+            metadata={"model": model},
         )
         await self.store_exact(
             "sparse", _hash(f"{model}:{_normalize_query_for_cache(text)}"), sparse_vector
         )
-        lf.update_current_span(output={"stored": True})
+        lf.update_current_span(output={"stored": True}, metadata={"model": model})
 
     # ========== Convenience: Search Results ==========
 

--- a/telegram_bot/services/bge_m3_client.py
+++ b/telegram_bot/services/bge_m3_client.py
@@ -23,6 +23,7 @@ from telegram_bot.services._retry import bge_retry
 DEFAULT_TIMEOUT = httpx.Timeout(connect=5.0, read=30.0, write=5.0, pool=5.0)
 DEFAULT_BATCH_SIZE = 32
 DEFAULT_MAX_LENGTH = 512
+BGE_M3_MODEL_NAME = "BAAI/bge-m3"
 
 
 @dataclass
@@ -116,10 +117,14 @@ class BGEM3Client:
                 "texts_count": len(texts),
                 "batch_size": self.batch_size,
                 "max_length": self.max_length,
-            }
+            },
+            metadata={"model": BGE_M3_MODEL_NAME},
         )
         if not texts:
-            lf.update_current_span(output={"vectors_count": 0, "vector_dim": 0})
+            lf.update_current_span(
+                output={"vectors_count": 0, "vector_dim": 0},
+                metadata={"model": BGE_M3_MODEL_NAME},
+            )
             return DenseResult(vectors=[])
         client = self._get_client()
         all_vecs: list[list[float]] = []
@@ -139,7 +144,8 @@ class BGEM3Client:
                 "vectors_count": len(all_vecs),
                 "vector_dim": len(all_vecs[0]) if all_vecs else 0,
                 "processing_time": processing_time,
-            }
+            },
+            metadata={"model": BGE_M3_MODEL_NAME},
         )
         return DenseResult(vectors=all_vecs, processing_time=processing_time)
 
@@ -155,10 +161,14 @@ class BGEM3Client:
                 "texts_count": len(texts),
                 "batch_size": self.batch_size,
                 "max_length": self.max_length,
-            }
+            },
+            metadata={"model": BGE_M3_MODEL_NAME},
         )
         if not texts:
-            lf.update_current_span(output={"weights_count": 0})
+            lf.update_current_span(
+                output={"weights_count": 0},
+                metadata={"model": BGE_M3_MODEL_NAME},
+            )
             return SparseResult(weights=[])
         client = self._get_client()
         all_weights: list[dict[str, Any]] = []
@@ -174,7 +184,8 @@ class BGEM3Client:
             all_weights.extend(data["lexical_weights"])
             processing_time = data.get("processing_time")
         lf.update_current_span(
-            output={"weights_count": len(all_weights), "processing_time": processing_time}
+            output={"weights_count": len(all_weights), "processing_time": processing_time},
+            metadata={"model": BGE_M3_MODEL_NAME},
         )
         return SparseResult(weights=all_weights, processing_time=processing_time)
 
@@ -189,10 +200,14 @@ class BGEM3Client:
             input={
                 "texts_count": len(texts),
                 "max_length": self.max_length,
-            }
+            },
+            metadata={"model": BGE_M3_MODEL_NAME},
         )
         if not texts:
-            lf.update_current_span(output={"dense_count": 0, "sparse_count": 0, "colbert_count": 0})
+            lf.update_current_span(
+                output={"dense_count": 0, "sparse_count": 0, "colbert_count": 0},
+                metadata={"model": BGE_M3_MODEL_NAME},
+            )
             return HybridResult(dense_vecs=[], lexical_weights=[])
         client = self._get_client()
         resp = await client.post(
@@ -214,7 +229,8 @@ class BGEM3Client:
                 "sparse_count": len(result.lexical_weights),
                 "colbert_count": len(result.colbert_vecs or []),
                 "processing_time": result.processing_time,
-            }
+            },
+            metadata={"model": BGE_M3_MODEL_NAME},
         )
         return result
 
@@ -229,10 +245,14 @@ class BGEM3Client:
                 "documents_count": len(documents),
                 "top_k": top_k,
                 "max_length": self.max_length,
-            }
+            },
+            metadata={"model": BGE_M3_MODEL_NAME},
         )
         if not documents:
-            lf.update_current_span(output={"results_count": 0, "top_score": None})
+            lf.update_current_span(
+                output={"results_count": 0, "top_score": None},
+                metadata={"model": BGE_M3_MODEL_NAME},
+            )
             return RerankResult()
         client = self._get_client()
         resp = await client.post(
@@ -255,7 +275,8 @@ class BGEM3Client:
                 "results_count": len(result.results),
                 "top_score": result.results[0]["score"] if result.results else None,
                 "processing_time": result.processing_time,
-            }
+            },
+            metadata={"model": BGE_M3_MODEL_NAME},
         )
         return result
 
@@ -270,10 +291,14 @@ class BGEM3Client:
             input={
                 "texts_count": len(texts),
                 "max_length": self.max_length,
-            }
+            },
+            metadata={"model": BGE_M3_MODEL_NAME},
         )
         if not texts:
-            lf.update_current_span(output={"colbert_count": 0, "colbert_vector_count": 0})
+            lf.update_current_span(
+                output={"colbert_count": 0, "colbert_vector_count": 0},
+                metadata={"model": BGE_M3_MODEL_NAME},
+            )
             return ColbertResult(colbert_vecs=[])
         client = self._get_client()
         resp = await client.post(
@@ -291,7 +316,8 @@ class BGEM3Client:
                 "colbert_count": len(result.colbert_vecs),
                 "colbert_vector_count": len(result.colbert_vecs[0]) if result.colbert_vecs else 0,
                 "processing_time": result.processing_time,
-            }
+            },
+            metadata={"model": BGE_M3_MODEL_NAME},
         )
         return result
 

--- a/telegram_bot/services/qdrant.py
+++ b/telegram_bot/services/qdrant.py
@@ -430,7 +430,11 @@ class QdrantService:
                 "has_filters": bool(filters),
                 "group_by": group_by,
                 "rrf_k": rrf_k,
-            }
+            },
+            metadata={
+                "collection": self._collection_name,
+                "quantization_mode": self._quantization_mode,
+            },
         )
         # Build prefetch queries
         prefetch = []
@@ -497,7 +501,11 @@ class QdrantService:
                         "results_count": len(results),
                         "top_score": results[0]["score"] if results else None,
                         "grouped": True,
-                    }
+                    },
+                    metadata={
+                        "collection": self._collection_name,
+                        "quantization_mode": self._quantization_mode,
+                    },
                 )
                 if return_meta:
                     return results, ok_meta
@@ -518,7 +526,11 @@ class QdrantService:
                     "results_count": len(results),
                     "top_score": results[0]["score"] if results else None,
                     "grouped": False,
-                }
+                },
+                metadata={
+                    "collection": self._collection_name,
+                    "quantization_mode": self._quantization_mode,
+                },
             )
             if return_meta:
                 return results, ok_meta
@@ -533,6 +545,10 @@ class QdrantService:
                     "results_count": 0,
                     "error": type(e).__name__,
                     "collection": self._collection_name,
+                },
+                metadata={
+                    "collection": self._collection_name,
+                    "quantization_mode": self._quantization_mode,
                 },
             )
             if return_meta:
@@ -595,7 +611,11 @@ class QdrantService:
                 "has_filters": bool(filters),
                 "colbert_tokens": len(colbert_query) if colbert_query else 0,
                 "rrf_k": rrf_k,
-            }
+            },
+            metadata={
+                "collection": self._collection_name,
+                "quantization_mode": self._quantization_mode,
+            },
         )
         if self._colbert_available is False:
             logger.debug(
@@ -618,7 +638,11 @@ class QdrantService:
                     "fallback_reason": "colbert_unavailable",
                     "results_count": len(fallback_results),
                     "top_score": fallback_results[0]["score"] if fallback_results else None,
-                }
+                },
+                metadata={
+                    "collection": self._collection_name,
+                    "quantization_mode": self._quantization_mode,
+                },
             )
             return fallback
 
@@ -642,7 +666,11 @@ class QdrantService:
                     "fallback_reason": "empty_colbert_query",
                     "results_count": len(fallback_results),
                     "top_score": fallback_results[0]["score"] if fallback_results else None,
-                }
+                },
+                metadata={
+                    "collection": self._collection_name,
+                    "quantization_mode": self._quantization_mode,
+                },
             )
             return fallback
 
@@ -730,7 +758,11 @@ class QdrantService:
                         "fallback_reason": "colbert_empty",
                         "results_count": len(fallback_results),
                         "top_score": fallback_results[0]["score"] if fallback_results else None,
-                    }
+                    },
+                    metadata={
+                        "collection": self._collection_name,
+                        "quantization_mode": self._quantization_mode,
+                    },
                 )
                 if fallback_results:
                     self._colbert_available = False
@@ -746,7 +778,11 @@ class QdrantService:
                     "fallback_reason": None,
                     "results_count": len(results),
                     "top_score": results[0]["score"] if results else None,
-                }
+                },
+                metadata={
+                    "collection": self._collection_name,
+                    "quantization_mode": self._quantization_mode,
+                },
             )
             if return_meta:
                 return results, ok_meta
@@ -767,6 +803,10 @@ class QdrantService:
             lf.update_current_span(
                 level="WARNING",
                 status_message=f"ColBERT search failed: {type(e).__name__}",
+                metadata={
+                    "collection": self._collection_name,
+                    "quantization_mode": self._quantization_mode,
+                },
             )
             fallback = await self.hybrid_search_rrf(
                 dense_vector=dense_vector,
@@ -784,7 +824,11 @@ class QdrantService:
                     "fallback_reason": f"colbert_error:{type(e).__name__}",
                     "results_count": len(fallback_results),
                     "top_score": fallback_results[0]["score"] if fallback_results else None,
-                }
+                },
+                metadata={
+                    "collection": self._collection_name,
+                    "quantization_mode": self._quantization_mode,
+                },
             )
             return fallback
 
@@ -832,7 +876,11 @@ class QdrantService:
                 "top_k": top_k,
                 "has_filters": bool(filters),
                 "rrf_k": rrf_k,
-            }
+            },
+            metadata={
+                "collection": self._collection_name,
+                "quantization_mode": self._quantization_mode,
+            },
         )
 
         query_filter = self._build_filter(filters)
@@ -900,7 +948,11 @@ class QdrantService:
                     "results_count": len(result),
                     "unique_points": len(seen),
                     "top_score": result[0]["score"] if result else None,
-                }
+                },
+                metadata={
+                    "collection": self._collection_name,
+                    "quantization_mode": self._quantization_mode,
+                },
             )
             return result
 
@@ -910,6 +962,10 @@ class QdrantService:
                 level="ERROR",
                 status_message=f"Batch search failed: {type(e).__name__}",
                 output={"results_count": 0, "error": type(e).__name__},
+                metadata={
+                    "collection": self._collection_name,
+                    "quantization_mode": self._quantization_mode,
+                },
             )
             return []
 
@@ -961,7 +1017,11 @@ class QdrantService:
                 "freshness_boost": freshness_boost,
                 "freshness_field": freshness_field,
                 "freshness_scale_days": freshness_scale_days,
-            }
+            },
+            metadata={
+                "collection": self._collection_name,
+                "quantization_mode": self._quantization_mode,
+            },
         )
 
         if not freshness_boost:
@@ -979,7 +1039,11 @@ class QdrantService:
                     "mode": "plain",
                     "results_count": len(plain_results),
                     "top_score": plain_results[0]["score"] if plain_results else None,
-                }
+                },
+                metadata={
+                    "collection": self._collection_name,
+                    "quantization_mode": self._quantization_mode,
+                },
             )
             return plain_results
 
@@ -1023,7 +1087,11 @@ class QdrantService:
                     "mode": "boosted",
                     "results_count": len(boosted_results),
                     "top_score": boosted_results[0]["score"] if boosted_results else None,
-                }
+                },
+                metadata={
+                    "collection": self._collection_name,
+                    "quantization_mode": self._quantization_mode,
+                },
             )
             return boosted_results
 
@@ -1032,6 +1100,10 @@ class QdrantService:
             lf.update_current_span(
                 level="WARNING",
                 status_message=f"Score boosting fallback: {type(e).__name__}",
+                metadata={
+                    "collection": self._collection_name,
+                    "quantization_mode": self._quantization_mode,
+                },
             )
             result = await self._client.query_points(
                 collection_name=self._collection_name,
@@ -1048,7 +1120,11 @@ class QdrantService:
                     "results_count": len(fallback_results),
                     "top_score": fallback_results[0]["score"] if fallback_results else None,
                     "fallback_error": type(e).__name__,
-                }
+                },
+                metadata={
+                    "collection": self._collection_name,
+                    "quantization_mode": self._quantization_mode,
+                },
             )
             return fallback_results
 
@@ -1085,11 +1161,21 @@ class QdrantService:
                 "embeddings_count": len(embeddings),
                 "top_k": top_k,
                 "lambda_mult": lambda_mult,
-            }
+            },
+            metadata={
+                "collection": self._collection_name,
+                "quantization_mode": self._quantization_mode,
+            },
         )
 
         if not points or len(points) <= top_k:
-            lf.update_current_span(output={"results_count": len(points), "rerank_applied": False})
+            lf.update_current_span(
+                output={"results_count": len(points), "rerank_applied": False},
+                metadata={
+                    "collection": self._collection_name,
+                    "quantization_mode": self._quantization_mode,
+                },
+            )
             return points
 
         embeddings_array = np.array(embeddings)
@@ -1141,7 +1227,13 @@ class QdrantService:
                 selected_embeddings.append(embeddings_array[best_idx])
 
         reranked = [points[i] for i in selected_indices]
-        lf.update_current_span(output={"results_count": len(reranked), "rerank_applied": True})
+        lf.update_current_span(
+            output={"results_count": len(reranked), "rerank_applied": True},
+            metadata={
+                "collection": self._collection_name,
+                "quantization_mode": self._quantization_mode,
+            },
+        )
         return reranked
 
     def _build_filter(self, filters: dict | None) -> models.Filter | None:

--- a/tests/unit/integrations/test_cache_layers.py
+++ b/tests/unit/integrations/test_cache_layers.py
@@ -1153,3 +1153,69 @@ class TestRedisPoolConfig:
             call_kwargs = mock_redis.from_url.call_args[1]
             assert "max_connections" in call_kwargs
             assert call_kwargs["max_connections"] == 20
+
+
+class TestCacheSpanMetadata:
+    """Runtime tests for cache embedding span metadata (#1365)."""
+
+    @pytest.fixture
+    def mock_lf(self):
+        mock = MagicMock()
+        mock.update_current_span = MagicMock()
+        return mock
+
+    async def test_get_embedding_exposes_model_metadata(self, mock_lf):
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        mock_ec = AsyncMock()
+        mock_ec.aget = AsyncMock(return_value={"embedding": [0.1] * 1024})
+        mgr.embed_cache = mock_ec
+
+        with patch("telegram_bot.integrations.cache.get_client", return_value=mock_lf):
+            await mgr.get_embedding("тест", model="bge-m3")
+
+        metadata_calls = [
+            c for c in mock_lf.update_current_span.call_args_list if "metadata" in c.kwargs
+        ]
+        assert any(c.kwargs["metadata"].get("model") == "bge-m3" for c in metadata_calls)
+
+    async def test_store_embedding_exposes_model_metadata(self, mock_lf):
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        mock_ec = AsyncMock()
+        mock_ec.aset = AsyncMock()
+        mgr.embed_cache = mock_ec
+
+        with patch("telegram_bot.integrations.cache.get_client", return_value=mock_lf):
+            await mgr.store_embedding("тест", [0.2] * 1024, model="bge-m3")
+
+        metadata_calls = [
+            c for c in mock_lf.update_current_span.call_args_list if "metadata" in c.kwargs
+        ]
+        assert any(c.kwargs["metadata"].get("model") == "bge-m3" for c in metadata_calls)
+
+    async def test_get_sparse_embedding_exposes_model_metadata(self, mock_lf):
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        mgr.redis = AsyncMock()
+        mgr.redis.get = AsyncMock(return_value=None)
+
+        with patch("telegram_bot.integrations.cache.get_client", return_value=mock_lf):
+            await mgr.get_sparse_embedding("тест", model="bge_m3_sparse")
+
+        metadata_calls = [
+            c for c in mock_lf.update_current_span.call_args_list if "metadata" in c.kwargs
+        ]
+        assert any(c.kwargs["metadata"].get("model") == "bge_m3_sparse" for c in metadata_calls)
+
+    async def test_store_sparse_embedding_exposes_model_metadata(self, mock_lf):
+        mgr = CacheLayerManager(redis_url="redis://localhost:6379")
+        mgr.redis = AsyncMock()
+        mgr.redis.setex = AsyncMock()
+
+        with patch("telegram_bot.integrations.cache.get_client", return_value=mock_lf):
+            await mgr.store_sparse_embedding(
+                "тест", {"indices": [1], "values": [0.5]}, model="bge_m3_sparse"
+            )
+
+        metadata_calls = [
+            c for c in mock_lf.update_current_span.call_args_list if "metadata" in c.kwargs
+        ]
+        assert any(c.kwargs["metadata"].get("model") == "bge_m3_sparse" for c in metadata_calls)

--- a/tests/unit/test_observability_span_metadata.py
+++ b/tests/unit/test_observability_span_metadata.py
@@ -1,13 +1,19 @@
-"""Static tests for observability span metadata.
+"""Static and runtime tests for observability span metadata.
 
 AST-based tests for @observe decorator metadata (as_type, capture_input, capture_output)
-on BGE-M3, Qdrant, and RAG pipeline spans. No runtime SDK calls or network I/O.
+on BGE-M3, Qdrant, and RAG pipeline spans.
+
+Runtime tests verify model/collection metadata is passed to update_current_span.
 """
 
 import ast
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+from telegram_bot.services.bge_m3_client import BGE_M3_MODEL_NAME, BGEM3Client
+from telegram_bot.services.qdrant import QdrantService
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -177,3 +183,165 @@ class TestBGEServiceWarmup:
         assert found_bare_encode, (
             "lifespan warmup must call model.encode() as a bare expression (discarded)"
         )
+
+
+class TestBGEM3SpanRuntimeMetadata:
+    """Runtime tests for BGE-M3 span metadata."""
+
+    @pytest.fixture
+    def mock_lf(self):
+        mock = MagicMock()
+        mock.update_current_span = MagicMock()
+        return mock
+
+    @pytest.fixture
+    def bge_client(self):
+        client = BGEM3Client(base_url="http://test")
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json = MagicMock(
+            return_value={"dense_vecs": [[0.1] * 1024], "processing_time": 0.1}
+        )
+        client._client = AsyncMock()
+        client._client.is_closed = False
+        client._client.post = AsyncMock(return_value=mock_resp)
+        return client
+
+    async def test_encode_dense_exposes_model_metadata(self, mock_lf, bge_client):
+        with patch("telegram_bot.services.bge_m3_client.get_client", return_value=mock_lf):
+            await bge_client.encode_dense(["hello"])
+        metadata_calls = [
+            c for c in mock_lf.update_current_span.call_args_list if "metadata" in c.kwargs
+        ]
+        assert any(c.kwargs["metadata"].get("model") == BGE_M3_MODEL_NAME for c in metadata_calls)
+
+    async def test_encode_sparse_exposes_model_metadata(self, mock_lf, bge_client):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json = MagicMock(
+            return_value={"lexical_weights": [{"a": 0.1}], "processing_time": 0.1}
+        )
+        bge_client._client.post = AsyncMock(return_value=mock_resp)
+        with patch("telegram_bot.services.bge_m3_client.get_client", return_value=mock_lf):
+            await bge_client.encode_sparse(["hello"])
+        metadata_calls = [
+            c for c in mock_lf.update_current_span.call_args_list if "metadata" in c.kwargs
+        ]
+        assert any(c.kwargs["metadata"].get("model") == BGE_M3_MODEL_NAME for c in metadata_calls)
+
+    async def test_encode_hybrid_exposes_model_metadata(self, mock_lf, bge_client):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json = MagicMock(
+            return_value={
+                "dense_vecs": [[0.1] * 1024],
+                "lexical_weights": [{"a": 0.1}],
+                "processing_time": 0.1,
+            }
+        )
+        bge_client._client.post = AsyncMock(return_value=mock_resp)
+        with patch("telegram_bot.services.bge_m3_client.get_client", return_value=mock_lf):
+            await bge_client.encode_hybrid(["hello"])
+        metadata_calls = [
+            c for c in mock_lf.update_current_span.call_args_list if "metadata" in c.kwargs
+        ]
+        assert any(c.kwargs["metadata"].get("model") == BGE_M3_MODEL_NAME for c in metadata_calls)
+
+    async def test_rerank_exposes_model_metadata(self, mock_lf, bge_client):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json = MagicMock(
+            return_value={"results": [{"index": 0, "score": 0.9}], "processing_time": 0.1}
+        )
+        bge_client._client.post = AsyncMock(return_value=mock_resp)
+        with patch("telegram_bot.services.bge_m3_client.get_client", return_value=mock_lf):
+            await bge_client.rerank("query", ["doc1", "doc2"])
+        metadata_calls = [
+            c for c in mock_lf.update_current_span.call_args_list if "metadata" in c.kwargs
+        ]
+        assert any(c.kwargs["metadata"].get("model") == BGE_M3_MODEL_NAME for c in metadata_calls)
+
+    async def test_encode_colbert_exposes_model_metadata(self, mock_lf, bge_client):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json = MagicMock(
+            return_value={"colbert_vecs": [[[0.1] * 1024]], "processing_time": 0.1}
+        )
+        bge_client._client.post = AsyncMock(return_value=mock_resp)
+        with patch("telegram_bot.services.bge_m3_client.get_client", return_value=mock_lf):
+            await bge_client.encode_colbert(["hello"])
+        metadata_calls = [
+            c for c in mock_lf.update_current_span.call_args_list if "metadata" in c.kwargs
+        ]
+        assert any(c.kwargs["metadata"].get("model") == BGE_M3_MODEL_NAME for c in metadata_calls)
+
+
+class TestQdrantSpanRuntimeMetadata:
+    """Runtime tests for Qdrant retrieval span metadata."""
+
+    @pytest.fixture
+    def mock_lf(self):
+        mock = MagicMock()
+        mock.update_current_span = MagicMock()
+        return mock
+
+    @pytest.fixture
+    def qdrant_service(self):
+        with patch("telegram_bot.services.qdrant.AsyncQdrantClient"):
+            svc = QdrantService(
+                url="http://localhost:6333",
+                collection_name="test_collection",
+                quantization_mode="scalar",
+            )
+            svc._client = AsyncMock()
+            svc._collection_validated = True
+            return svc
+
+    def _assert_collection_metadata(self, mock_lf, collection_name, quantization_mode):
+        metadata_calls = [
+            c for c in mock_lf.update_current_span.call_args_list if "metadata" in c.kwargs
+        ]
+        assert any(
+            c.kwargs["metadata"].get("collection") == collection_name
+            and c.kwargs["metadata"].get("quantization_mode") == quantization_mode
+            for c in metadata_calls
+        )
+
+    async def test_hybrid_search_rrf_exposes_collection_metadata(self, mock_lf, qdrant_service):
+        qdrant_service._client.query_points = AsyncMock(return_value=MagicMock(points=[]))
+        with patch("telegram_bot.services.qdrant.get_client", return_value=mock_lf):
+            await qdrant_service.hybrid_search_rrf(dense_vector=[0.1] * 1024)
+        self._assert_collection_metadata(mock_lf, "test_collection_scalar", "scalar")
+
+    async def test_hybrid_search_rrf_colbert_exposes_collection_metadata(
+        self, mock_lf, qdrant_service
+    ):
+        qdrant_service._client.query_points = AsyncMock(return_value=MagicMock(points=[]))
+        with patch("telegram_bot.services.qdrant.get_client", return_value=mock_lf):
+            await qdrant_service.hybrid_search_rrf_colbert(
+                dense_vector=[0.1] * 1024,
+                colbert_query=[[0.1] * 1024],
+            )
+        self._assert_collection_metadata(mock_lf, "test_collection_scalar", "scalar")
+
+    async def test_batch_search_rrf_exposes_collection_metadata(self, mock_lf, qdrant_service):
+        qdrant_service._client.query_batch_points = AsyncMock(return_value=[])
+        with patch("telegram_bot.services.qdrant.get_client", return_value=mock_lf):
+            await qdrant_service.batch_search_rrf(queries=[{"dense_vector": [0.1] * 1024}])
+        self._assert_collection_metadata(mock_lf, "test_collection_scalar", "scalar")
+
+    async def test_search_with_score_boosting_exposes_collection_metadata(
+        self, mock_lf, qdrant_service
+    ):
+        qdrant_service._client.query_points = AsyncMock(return_value=MagicMock(points=[]))
+        with patch("telegram_bot.services.qdrant.get_client", return_value=mock_lf):
+            await qdrant_service.search_with_score_boosting(dense_vector=[0.1] * 1024)
+        self._assert_collection_metadata(mock_lf, "test_collection_scalar", "scalar")
+
+    def test_mmr_rerank_exposes_collection_metadata(self, mock_lf, qdrant_service):
+        with patch("telegram_bot.services.qdrant.get_client", return_value=mock_lf):
+            qdrant_service.mmr_rerank(
+                points=[{"id": "1", "score": 0.9, "text": "a", "metadata": {}}],
+                embeddings=[[0.1] * 1024],
+            )
+        self._assert_collection_metadata(mock_lf, "test_collection_scalar", "scalar")


### PR DESCRIPTION
Adds Langfuse span metadata (model, collection) to embedding, retrieval, and cache spans. Rebased onto current dev after #1374/#1375.