### PR TITLE
fix: FakeMessage lacks chat attribute causing streaming TTFT fallback (#1379)

### DIFF
--- a/scripts/validate_traces.py
+++ b/scripts/validate_traces.py
@@ -125,6 +125,17 @@ class FakeSentMessage:
         pass
 
 
+class FakeChat:
+    """Minimal aiogram Chat stand-in for streaming validation.
+
+    Provides a stable chat.id so graph nodes that read message.chat.id
+    do not fall back to non-streaming mode.
+    """
+
+    def __init__(self, chat_id: int = 0) -> None:
+        self.id: int = chat_id
+
+
 class FakeMessage:
     """Minimal aiogram Message stand-in for streaming validation.
 
@@ -135,6 +146,7 @@ class FakeMessage:
     def __init__(self) -> None:
         self.t_answer_called: float | None = None
         self.sent: FakeSentMessage | None = None
+        self.chat = FakeChat(chat_id=0)
 
     async def answer(self, text: str, **kwargs: Any) -> FakeSentMessage:
         self.t_answer_called = time.monotonic()

--- a/tests/unit/test_validate_traces.py
+++ b/tests/unit/test_validate_traces.py
@@ -1,0 +1,33 @@
+"""Unit tests for FakeMessage and FakeChat in validate_traces."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.validate_traces import FakeChat, FakeMessage
+
+
+def test_fake_chat_has_stable_id() -> None:
+    chat = FakeChat(chat_id=42)
+    assert chat.id == 42
+
+
+def test_fake_message_has_chat_attribute() -> None:
+    msg = FakeMessage()
+    assert hasattr(msg, "chat")
+    assert msg.chat.id == 0
+
+
+def test_fake_message_chat_id_customizable() -> None:
+    msg = FakeMessage()
+    msg.chat = FakeChat(chat_id=99)
+    assert msg.chat.id == 99
+
+
+@pytest.mark.asyncio
+async def test_fake_message_answer_returns_sent_message() -> None:
+    msg = FakeMessage()
+    sent = await msg.answer("hello")
+    assert sent is not None
+    assert msg.t_answer_called is not None
+    assert msg.sent is sent


### PR DESCRIPTION
## Summary
Fixes #1379.

`scripts/validate_traces.py::FakeMessage` lacked a `chat` attribute. During streaming TTFT validation, `telegram_bot/graph/nodes/generate.py::_generate_streaming` accesses `message.chat.id`, which raised `AttributeError` and caused fallback to non-streaming mode. This meant TTFT was not being measured.

## Changes
- Added minimal `FakeChat` class with stable `id` attribute.
- Wired `FakeMessage.chat = FakeChat(chat_id=0)`.
- Added focused unit tests in `tests/unit/test_validate_traces.py` covering:
  - `FakeChat` stable ID
  - `FakeMessage.chat` attribute existence
  - `FakeMessage.chat.id` accessibility
  - `FakeMessage.answer()` behavior

## Verification
- `make check` passes
- `pytest tests/unit/test_validate_traces.py` passes
- Smoke test confirms `FakeMessage.chat.id` is accessible