### PR TITLE
fix(1380): make validate-traces-fast runnable natively from host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -916,6 +916,18 @@ qdrant-backup: ## Create Qdrant collection snapshots (all collections)
 
 .PHONY: validate-traces validate-traces-fast
 
+# Local host overrides for native trace validation (issue #1380).
+# These default to localhost ports so validate-traces-fast works from the Docker host.
+# Callers can override per-variable: make validate-traces-fast QDRANT_URL=http://custom:6333
+VALIDATE_TRACES_QDRANT_URL ?= http://localhost:6333
+VALIDATE_TRACES_BGE_M3_URL ?= http://localhost:8000
+VALIDATE_TRACES_REDIS_URL ?= redis://localhost:6379
+VALIDATE_TRACES_REDIS_PASSWORD ?= dev_redis_pass
+VALIDATE_TRACES_LLM_BASE_URL ?= http://localhost:4000
+VALIDATE_TRACES_LANGFUSE_HOST ?= http://localhost:3001
+VALIDATE_TRACES_LANGFUSE_PUBLIC_KEY ?= pk-lf-dev
+VALIDATE_TRACES_LANGFUSE_SECRET_KEY ?= sk-lf-dev
+
 validate-traces: ## Full rebuild + trace validation + report
 	@echo "$(BLUE)Full rebuild + validation...$(NC)"
 	$(LOCAL_COMPOSE_CMD) build --no-cache bot litellm bge-m3
@@ -926,6 +938,14 @@ validate-traces: ## Full rebuild + trace validation + report
 validate-traces-fast: ## No rebuild; trace validation fails if required trace families are missing
 	@echo "$(BLUE)Fast validation (no rebuild)...$(NC)"
 	$(LOCAL_COMPOSE_CMD) --profile bot --profile ml up -d --wait
+	QDRANT_URL="$(VALIDATE_TRACES_QDRANT_URL)" \
+	BGE_M3_URL="$(VALIDATE_TRACES_BGE_M3_URL)" \
+	REDIS_URL="$(VALIDATE_TRACES_REDIS_URL)" \
+	REDIS_PASSWORD="$(VALIDATE_TRACES_REDIS_PASSWORD)" \
+	LLM_BASE_URL="$(VALIDATE_TRACES_LLM_BASE_URL)" \
+	LANGFUSE_HOST="$(VALIDATE_TRACES_LANGFUSE_HOST)" \
+	LANGFUSE_PUBLIC_KEY="$(VALIDATE_TRACES_LANGFUSE_PUBLIC_KEY)" \
+	LANGFUSE_SECRET_KEY="$(VALIDATE_TRACES_LANGFUSE_SECRET_KEY)" \
 	uv run python scripts/validate_traces.py --report
 	@echo "$(GREEN)Validation complete — see docs/reports/$(NC)"
 

--- a/Makefile
+++ b/Makefile
@@ -916,17 +916,8 @@ qdrant-backup: ## Create Qdrant collection snapshots (all collections)
 
 .PHONY: validate-traces validate-traces-fast
 
-# Local host overrides for native trace validation (issue #1380).
-# These default to localhost ports so validate-traces-fast works from the Docker host.
-# Callers can override per-variable: make validate-traces-fast QDRANT_URL=http://custom:6333
-VALIDATE_TRACES_QDRANT_URL ?= http://localhost:6333
-VALIDATE_TRACES_BGE_M3_URL ?= http://localhost:8000
-VALIDATE_TRACES_REDIS_URL ?= redis://localhost:6379
-VALIDATE_TRACES_REDIS_PASSWORD ?= dev_redis_pass
-VALIDATE_TRACES_LLM_BASE_URL ?= http://localhost:4000
-VALIDATE_TRACES_LANGFUSE_HOST ?= http://localhost:3001
-VALIDATE_TRACES_LANGFUSE_PUBLIC_KEY ?= pk-lf-dev
-VALIDATE_TRACES_LANGFUSE_SECRET_KEY ?= sk-lf-dev
+# Local host defaults for native trace validation (issue #1380).
+# Callers can override per-variable: make validate-traces-fast QDRANT_URL=http://custom:6333 REDIS_URL=redis://:x@custom:6379
 
 validate-traces: ## Full rebuild + trace validation + report
 	@echo "$(BLUE)Full rebuild + validation...$(NC)"
@@ -938,14 +929,14 @@ validate-traces: ## Full rebuild + trace validation + report
 validate-traces-fast: ## No rebuild; trace validation fails if required trace families are missing
 	@echo "$(BLUE)Fast validation (no rebuild)...$(NC)"
 	$(LOCAL_COMPOSE_CMD) --profile bot --profile ml up -d --wait
-	QDRANT_URL="$(VALIDATE_TRACES_QDRANT_URL)" \
-	BGE_M3_URL="$(VALIDATE_TRACES_BGE_M3_URL)" \
-	REDIS_URL="$(VALIDATE_TRACES_REDIS_URL)" \
-	REDIS_PASSWORD="$(VALIDATE_TRACES_REDIS_PASSWORD)" \
-	LLM_BASE_URL="$(VALIDATE_TRACES_LLM_BASE_URL)" \
-	LANGFUSE_HOST="$(VALIDATE_TRACES_LANGFUSE_HOST)" \
-	LANGFUSE_PUBLIC_KEY="$(VALIDATE_TRACES_LANGFUSE_PUBLIC_KEY)" \
-	LANGFUSE_SECRET_KEY="$(VALIDATE_TRACES_LANGFUSE_SECRET_KEY)" \
+	QDRANT_URL="$(or $(QDRANT_URL),http://localhost:6333)" \
+	BGE_M3_URL="$(or $(BGE_M3_URL),http://localhost:8000)" \
+	REDIS_URL="$(or $(REDIS_URL),redis://localhost:6379)" \
+	REDIS_PASSWORD="$(or $(REDIS_PASSWORD),dev_redis_pass)" \
+	LLM_BASE_URL="$(or $(LLM_BASE_URL),http://localhost:4000)" \
+	LANGFUSE_HOST="$(or $(LANGFUSE_HOST),http://localhost:3001)" \
+	LANGFUSE_PUBLIC_KEY="$(or $(LANGFUSE_PUBLIC_KEY),pk-lf-dev)" \
+	LANGFUSE_SECRET_KEY="$(or $(LANGFUSE_SECRET_KEY),sk-lf-dev)" \
 	uv run python scripts/validate_traces.py --report
 	@echo "$(GREEN)Validation complete — see docs/reports/$(NC)"
 

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -94,6 +94,8 @@ Trace coverage gate:
 make validate-traces-fast
 ```
 
+This target runs natively on the host and automatically points to local Docker service endpoints (`localhost:6333`, `localhost:8000`, `localhost:4000`, etc.). You can override individual endpoints if needed: `make validate-traces-fast QDRANT_URL=http://custom:6333`.
+
 If Langfuse CLI returns `401` or points to wrong host, run with explicit host:
 
 ```bash


### PR DESCRIPTION
Fixes #1380.

## Problem
`make validate-traces-fast` runs `scripts/validate_traces.py` natively on the Docker host, but `GraphConfig.from_env()` defaults to Docker-internal hostnames (`http://qdrant:6333`, `http://bge-m3:8000`, etc.) that do not resolve from the host.

## Fix
Add Makefile-level `?=` env overrides for the `validate-traces-fast` target:

- `QDRANT_URL` → `http://localhost:6333`
- `BGE_M3_URL` → `http://localhost:8000`
- `REDIS_URL` → `redis://localhost:6379` (password injected via `REDIS_PASSWORD`)
- `LLM_BASE_URL` → `http://localhost:4000`
- `LANGFUSE_HOST` → `http://localhost:3001`
- `LANGFUSE_PUBLIC_KEY` → `pk-lf-dev`
- `LANGFUSE_SECRET_KEY` → `sk-lf-dev`

Callers can override per-variable, e.g. `make validate-traces-fast QDRANT_URL=http://custom:6333`.

## Verification
- `make -n validate-traces-fast` confirms env vars are injected
- `make check` passes
- `timeout 60 make validate-traces-fast` gets past the original Qdrant hostname failure

## Docs
Updated `docs/LOCAL-DEVELOPMENT.md` to note the native-host behavior.
