### PR TITLE
ops: fix local docker dev stack - Langfuse secrets, Postgres auth, stale Python images

### DIFF
--- a/tests/fixtures/compose.ci.env
+++ b/tests/fixtures/compose.ci.env
@@ -1,14 +1,15 @@
 # Non-secret values for deterministic Docker Compose config rendering in tests.
 COMPOSE_PROJECT_NAME=dev
 CLICKHOUSE_PASSWORD=test-clickhouse-password
-ENCRYPTION_KEY=test-encryption-key
+ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000
 GDRIVE_SYNC_DIR=/tmp/rag-fresh-compose-ci-drive-sync
 LANGFUSE_REDIS_PASSWORD=test-langfuse-redis-password
 LITELLM_MASTER_KEY=test-litellm-master-key
 LLM_API_KEY=test-llm-api-key
+MANAGERS_GROUP_ID=-1001234567890
 MINIO_ROOT_PASSWORD=test-minio-password
-NEXTAUTH_SECRET=test-nextauth-secret
+NEXTAUTH_SECRET=test-nextauth-secret-placeholder-for-local-dev-ci-only
 POSTGRES_PASSWORD=test-postgres-password
 REDIS_PASSWORD=test-redis-password
-SALT=test-salt
+SALT=test-salt-placeholder-for-local-dev-ci-only
 TELEGRAM_BOT_TOKEN=test-telegram-bot-token


### PR DESCRIPTION
## Summary

Repairs the local Docker `dev` stack so Langfuse and Python app services start again after a WSL restart exposed three drifts.

## Changes

- `tests/fixtures/compose.ci.env`:
  - `ENCRYPTION_KEY`: 64 hex chars (Langfuse v3 Zod validation requires exactly 256 bits)
  - `SALT` / `NEXTAUTH_SECRET`: longer placeholders
  - `MANAGERS_GROUP_ID`: add missing bot fixture var

## Fixes Applied (runtime)

1. **Langfuse secret validation failure** — updated fixture to valid shapes; recreated `langfuse` and `langfuse-worker`. Both now healthy.
2. **Postgres password mismatch** — aligned existing `dev_postgres_data` password non-destructively via `ALTER USER`; verified TCP auth from Docker network.
3. **Stale Python 3.14 images** — rebuilt `bot`, `mini-app-api`, `rag-api` images. All now run Python 3.13.13.

## Verification

- `docker compose ps`: `langfuse`, `langfuse-worker`, `mini-app-api`, `rag-api` all healthy
- `curl http://127.0.0.1:3001/api/public/health` → 200
- `docker run --rm dev_bot python --version` → Python 3.13.13
- `make check` passed

## Notes

- `bot` requires a real `TELEGRAM_BOT_TOKEN` to fully start; with the fixture token it passes the original pydantic/langfuse crash and fails at Telegram token validation (expected for CI/test fixture).
- No destructive volume resets were needed.