### PR TITLE
docs(runbooks): update Langfuse and LiteLLM runbooks

### DIFF
--- a/docs/runbooks/LANGFUSE_TRACING_GAPS.md
+++ b/docs/runbooks/LANGFUSE_TRACING_GAPS.md
@@ -1,5 +1,9 @@
 # Runbook: Langfuse Tracing Gaps
 
+- **Owner:** Observability / On-call
+- **Last verified:** 2026-05-07
+- **Verification command:** `make validate-traces-fast`
+
 Use this runbook when traces are missing from Langfuse or observability is broken.
 
 ## Symptoms
@@ -8,6 +12,7 @@ Use this runbook when traces are missing from Langfuse or observability is broke
 - Incomplete traces (missing spans)
 - `make validate-traces-fast` failing
 - Missing scores in Langfuse
+- Traces show `LLM failed: Connection error` despite healthy Langfuse ingestion
 
 ## Diagnosis
 
@@ -20,11 +25,13 @@ curl -s ${LANGFUSE_HOST}/api/public/health | jq
 # Should return {"status": "ok"}
 ```
 
-### 2. Verify Environment Variables
+### 2. Verify Environment Variables (Presence Only)
 
 ```bash
-# Check Langfuse config
-grep -E "LANGFUSE|LITELLM" .env
+# Check that required variables are present (do not print values)
+for v in LANGFUSE_PUBLIC_KEY LANGFUSE_SECRET_KEY LANGFUSE_HOST; do
+  grep -q "^${v}=" .env && echo "${v}: present" || echo "${v}: MISSING"
+done
 
 # Required:
 # LANGFUSE_PUBLIC_KEY
@@ -32,7 +39,29 @@ grep -E "LANGFUSE|LITELLM" .env
 # LANGFUSE_HOST (should be full URL, not just hostname)
 ```
 
-### 3. Check Observability Module
+### 3. Latest Trace API Fast Path
+
+```bash
+# List the most recent trace of each family
+langfuse api traces list --limit 20 --order-by timestamp.desc
+
+# Get a specific trace with inline observations and scores
+langfuse api traces get <trace-id> --fields core,io,scores,observations,metrics --json
+```
+
+### 4. Trace Interpretation Matrix
+
+| Trace Name | Expected Structure | Common Gaps |
+|---|---|---|
+| `telegram-message` | Deeply structured (25–35 obs, depth 8, 30+ scores) | Missing when bot observability client fails to initialize or middleware is skipped |
+| `litellm-acompletion` | Flat (1 GENERATION, depth 0, 0 scores) | **Proxy-generated**, not app-instrumented; inherently flat and lacks session context. See [LiteLLM Failure Runbook](LITEllm_FAILURE.md) |
+| `rag-api-query` | Structured SPANs + GENERATION | Often missing if RAG API is not called or `@observe` decorator is bypassed |
+| `voice-session` | Structured (capture disabled) | Missing when voice/LiveKit is off by default or voice agent did not start |
+| `ingestion-cli-run` | Structured (capture disabled) | Becomes stale when unified ingestion CLI has not run recently; check `make ingest-unified-status` |
+
+**Key distinction:** `litellm-acompletion` traces are created by the LiteLLM proxy's built-in Langfuse callback (`success_callback: ["langfuse"]`), not by the application's `@observe` decorators. They will never contain child spans, scores, or session attribution.
+
+### 5. Check Observability Module
 
 ```python
 # Test Langfuse client
@@ -43,7 +72,7 @@ print(f"Langfuse initialized: {lf is not None}")
 print(f"Current trace: {lf.get_current_trace_id()}")
 ```
 
-### 4. Run Trace Validation
+### 6. Run Trace Validation
 
 ```bash
 make validate-traces-fast
@@ -62,10 +91,10 @@ This checks that required trace families exist:
 
 **Fix:**
 1. Get new keys from Langfuse dashboard
-2. Update `.env`:
+2. Update `.env` with the new keys (do not commit the file):
    ```
-   LANGFUSE_PUBLIC_KEY=pk_live_xxx
-   LANGFUSE_SECRET_KEY=sk_live_xxx
+   LANGFUSE_PUBLIC_KEY=<your-public-key>
+   LANGFUSE_SECRET_KEY=<your-secret-key>
    ```
 3. Restart bot
 
@@ -96,7 +125,18 @@ result = await graph.ainvoke(state)
 write_langfuse_scores(lf, result, trace_id=trace_id)
 ```
 
+### Flat `litellm-acompletion` Traces Everywhere
+
+**Cause:** LiteLLM proxy is logging every LLM call as a standalone trace via its native Langfuse callback. This is expected behavior, but it produces flat traces with no pipeline context.
+
+**Fix (informational):**
+- Do not chase missing spans inside `litellm-acompletion` — it will never have them.
+- If you need structured LLM spans, look for `generate-answer` or `service-generate-response` inside `telegram-message` traces instead.
+- If the noise is excessive, consider disabling the LiteLLM callback in `docker/litellm/config.yaml` and relying on app-native `@observe` decorators alone (requires product decision).
+
 ## Remediation
+
+> **Caution:** Mutating commands below. Run only after confirming the diagnosis above.
 
 ### Restart Observability
 
@@ -115,10 +155,17 @@ redis-cli DEL langfuse:prompt_cache
 
 ### Enable Debug Logging
 
+Add to `.env` (do not commit):
+
 ```bash
-# Add to .env
 LOG_LEVEL=DEBUG
 LOG_observability=DEBUG
+```
+
+Then restart the bot:
+
+```bash
+docker compose restart bot
 ```
 
 ## Prevention
@@ -126,3 +173,4 @@ LOG_observability=DEBUG
 - Regular `make validate-traces-fast` runs
 - Monitor Langfuse ingestion rate
 - Alert on trace family gaps
+- Distinguish proxy-generated `litellm-acompletion` traces from app-instrumented `telegram-message` traces when triaging gaps

--- a/docs/runbooks/LITEllm_FAILURE.md
+++ b/docs/runbooks/LITEllm_FAILURE.md
@@ -1,5 +1,9 @@
 # Runbook: LiteLLM Failure and Fallback Behavior
 
+- **Owner:** LLM Proxy / On-call
+- **Last verified:** 2026-05-07
+- **Verification command:** `curl -s http://localhost:4000/health`
+
 Use this runbook when LiteLLM provider has outages or LLM calls are failing.
 
 ## Symptoms
@@ -8,16 +12,18 @@ Use this runbook when LiteLLM provider has outages or LLM calls are failing.
 - `Model not found` (404) errors
 - Extremely high latency on all LLM calls
 - No responses from bot despite successful retrieval
+- Traces show `LLM failed: Connection error` while Langfuse ingestion appears healthy
+- LiteLLM container exits with code `137` (`OOMKilled`)
 
 ## Diagnosis
 
-### 1. Check LiteLLM Logs
+### 1. Check LiteLLM Container State
 
 ```bash
 # Check if LiteLLM container is running
 docker compose ps litellm
 
-# View LiteLLM logs
+# View bounded LiteLLM logs
 docker compose logs litellm --tail=100
 ```
 
@@ -25,17 +31,17 @@ docker compose logs litellm --tail=100
 
 ```bash
 # Health check
-curl http://localhost:4000/health
+curl -s http://localhost:4000/health | jq
 
 # Or your configured LiteLLM URL
-curl ${LITELLM_URL}/health
+curl -s ${LITELLM_URL}/health | jq
 ```
 
 ### 3. Check Model Availability
 
 ```bash
 # List available models via LiteLLM proxy
-curl http://localhost:4000/v1/models
+curl -s http://localhost:4000/v1/models | jq
 ```
 
 ### 4. Check Bot Logs for LLM Errors
@@ -43,6 +49,52 @@ curl http://localhost:4000/v1/models
 ```bash
 docker compose logs bot 2>&1 | grep -i "llm\|openai\|timeout" | tail -50
 ```
+
+### 5. OOM / Exit 137 Diagnosis
+
+If the LiteLLM container is restarting or missing:
+
+```bash
+# Inspect exit status and OOM flag
+docker inspect <litellm-container> --format '
+  Name={{.Name}}
+  OOMKilled={{.State.OOMKilled}}
+  ExitCode={{.State.ExitCode}}
+  Status={{.State.Status}}
+'
+
+# Bounded recent logs around the crash
+docker compose logs litellm --tail=200 | grep -i "killed\|oom\|memory\|137"
+```
+
+**Interpretation:**
+- `OOMKilled=true` or `ExitCode=137` → LiteLLM was killed by the kernel due to memory exhaustion.
+- `Status=restarting` with `OOMKilled=false` → Likely a configuration or upstream provider error; inspect logs for `ZodError`, `P1000`, or connection refused messages.
+- If health endpoint returns `200` but models list is empty → LiteLLM is alive but cannot reach upstream providers.
+
+### 6. Verify Environment Variables (Presence Only)
+
+```bash
+# Check that required variables are present (do not print values)
+for v in LLM_BASE_URL LITELLM_URL LITELLM_MASTER_KEY; do
+  grep -q "^${v}=" .env && echo "${v}: present" || echo "${v}: MISSING"
+done
+
+# Should be:
+# LLM_BASE_URL=http://litellm:4000
+# Not pointing directly to an upstream provider
+```
+
+### 7. Distinguish Langfuse Healthy vs LLM Unhealthy
+
+Langfuse ingestion can be **fully healthy** while traces show `LLM failed: Connection error`.
+
+**Why:** Langfuse traces capture the *attempt* to call the LLM. If LiteLLM or the upstream provider is unreachable, the trace still ingests, but the LLM span records a connection failure. The ingestion pipeline itself is independent of the LLM proxy's availability.
+
+**Fast path to confirm:**
+1. Check Langfuse health: `curl -s ${LANGFUSE_HOST}/api/public/health` → expect `{"status": "ok"}`
+2. Check LiteLLM health: `curl -s http://localhost:4000/health` → expect `true` or a healthy body
+3. If Langfuse is OK but LiteLLM health fails → root cause is LiteLLM or upstream provider, not Langfuse
 
 ## Common Error Patterns
 
@@ -52,8 +104,9 @@ docker compose logs bot 2>&1 | grep -i "llm\|openai\|timeout" | tail -50
 
 **Fix:**
 ```bash
-# Check LITELLM configuration
-grep -E "LLM_BASE_URL|LITELLM" .env
+# Check LITELLM configuration (presence only)
+grep -q "^LLM_BASE_URL=" .env && echo "LLM_BASE_URL: present" || echo "LLM_BASE_URL: MISSING"
+grep -q "^LITELLM" .env && echo "LITELLM vars: present" || echo "LITELLM vars: MISSING"
 
 # Should be:
 # LLM_BASE_URL=http://litellm:4000
@@ -79,17 +132,27 @@ The bot has graceful degradation for LLM failures:
 
 ## Remediation
 
+> **Caution:** Mutating commands below. Run only after confirming the diagnosis above.
+
 ### Restart LiteLLM
 
 ```bash
 docker compose restart litellm
 ```
 
+### Increase LiteLLM Memory Limit
+
+If OOM is confirmed, raise the memory limit in `compose.yml` or `compose.override.yml` and recreate:
+
+```bash
+docker compose up -d --force-recreate litellm
+```
+
 ### Switch LLM Provider
 
 If using multiple providers:
 
-1. Update `LLM_BASE_URL` to new provider
+1. Update `LLM_BASE_URL` to new provider in `.env` (do not commit)
 2. Restart bot:
    ```bash
    docker compose restart bot
@@ -104,6 +167,12 @@ LITELLM_MODEL=azure/gpt-4o-mini
 LITELLM_FALLBACK_MODELS=gpt-4o,gpt-4o-mini
 ```
 
+Then restart LiteLLM:
+
+```bash
+docker compose restart litellm
+```
+
 ## Impact on RAG Quality
 
 When LLM fallback occurs:
@@ -115,4 +184,5 @@ When LLM fallback occurs:
 
 - Monitor LiteLLM uptime
 - Set up alerts for LLM timeout rates
-- Regular health checks: `curl ${LLM_BASE_URL}/health`
+- Regular health checks: `curl -s ${LLM_BASE_URL}/health`
+- Watch for `OOMKilled` in container state after deploys or traffic spikes


### PR DESCRIPTION
## Summary

Update Langfuse and LiteLLM runbooks so operators can quickly diagnose latest traces and LLM connectivity/OOM failures.

### Changes

- Add Owner / Last verified / Verification command metadata to both runbooks.
- Replace unsafe `.env` grep with presence-only checks that do not print secret values.
- Add latest Langfuse trace API fast path and trace interpretation matrix.
- Explain `telegram-message`, `litellm-acompletion`, missing `rag-api-query` / `voice-session`, stale `ingestion-cli-run`.
- In LiteLLM runbook, add OOM/exit 137 diagnosis using `docker ps`, `docker inspect`, `curl :4000/health`, bounded logs.
- Explain that Langfuse ingestion can be healthy while traces show `LLM failed: Connection error` caused by LiteLLM/provider.
- Keep mutating commands in Remediation only, with caution.
- Use relative links only.

### Verification

- `rg` confirms all required topics are present in both files.
- `rg` confirms no unsafe `.env` dumping commands remain.
- `git diff --check` passes with no whitespace errors.