### PR TITLE
docs: add project and operational docs indexes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,11 @@
 - `services/`: supporting local service containers and helper APIs.
 - `k8s/`, `compose*.yml`, `DOCKER.md`: deploy and environment orchestration.
 
+## Documentation Entry Points
+- For project-wide docs navigation and fast doc search, start from [`docs/README.md`](docs/README.md).
+- For traces, cache, vector search, Compose/runtime, and service-health investigations, start from [`docs/runbooks/README.md`](docs/runbooks/README.md).
+- Use these indexes before ad hoc log/code searching; keep `AGENTS.md` as a gateway, not a duplicated operations manual.
+
 ## Runtime And Compose Contract
 - Treat `compose*.yml`, `docker/**`, `services/**`, `mini_app/**`, `src/api/**`, `src/voice/**`, and ingestion runtime paths as runtime-impacting surfaces.
 - For those changes, validate effective Compose config and service set, not only Python tests.

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,8 @@ Project documentation index for humans and agents. Use this page to understand t
 - [`GDRIVE_INGESTION.md`](GDRIVE_INGESTION.md) — Google Drive sync runbook.
 - [`QDRANT_STACK.md`](QDRANT_STACK.md) — Vector collections, schema, and operations.
 - [`ALERTING.md`](ALERTING.md) — Loki/Alertmanager setup.
+- [`INFRA_ISSUES_REPORT_1113_1126.md`](INFRA_ISSUES_REPORT_1113_1126.md) — Infrastructure issues report.
+- [`TROUBLESHOOTING_CACHE.md`](TROUBLESHOOTING_CACHE.md) — Cache troubleshooting guide.
 - [`runbooks/`](runbooks/) — Incident-specific runbooks.
 
 ## Quality & Evaluation

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,66 +1,87 @@
 # Documentation Index
 
-This is a concise map of the major documentation areas in this repository.
+Project documentation index for humans and agents. Use this page to understand the system, find subsystem docs, and search the doc tree quickly.
 
-## Reviewer Entry Points
+## Understand the Project Fast
 
-Start here if you are reviewing the project for hiring, portfolio, or collaboration:
-
-- [`README.md`](../README.md) — Project overview, architecture diagram, quick start, and reviewer path.
-- [`docs/portfolio/resume-case-study.md`](portfolio/resume-case-study.md) — Resume-ready case study with feature cards and honest limitations.
-- [`docs/review/PROJECT_GUIDE.md`](review/PROJECT_GUIDE.md) — Folder map and subsystem ownership.
-- [`docs/review/ACCESS_FOR_REVIEWERS.md`](review/ACCESS_FOR_REVIEWERS.md) — Safe commands and boundaries.
-- [`docs/review/GITHUB_REPO_SETUP.md`](review/GITHUB_REPO_SETUP.md) — Repository metadata and hygiene checklist.
+- [`../README.md`](../README.md) — System overview, architecture diagram, quick start, and reviewer path.
+- [`review/PROJECT_GUIDE.md`](review/PROJECT_GUIDE.md) — Folder map and subsystem ownership.
+- [`LOCAL-DEVELOPMENT.md`](LOCAL-DEVELOPMENT.md) — Local setup, day-to-day workflow, and validation ladder.
+- [`../DOCKER.md`](../DOCKER.md) — Docker Compose profiles, service map, ports, env, and runtime truth.
+- [`runbooks/README.md`](runbooks/README.md) — Operational investigations: traces, cache, vector search, Compose/runtime, and service health.
+- [`engineering/test-writing-guide.md`](engineering/test-writing-guide.md) — Test-writing rules and local-fast vs heavy-tier split.
+- [`engineering/sdk-registry.md`](engineering/sdk-registry.md) — SDK/framework lookup order and canonical versions.
+- [`engineering/issue-triage.md`](engineering/issue-triage.md) — Issue classification and routing playbook.
+- [`adr/`](adr/) — Architecture decision records.
+- [`audits/`](audits/) — Dated investigation artifacts and evidence.
 
 ## Architecture & Design
 
-- [`docs/PROJECT_STACK.md`](PROJECT_STACK.md) — System architecture and subsystem map.
-- [`docs/BOT_ARCHITECTURE.md`](BOT_ARCHITECTURE.md) — Bot layer architecture.
-- [`docs/BOT_INTERNAL_STRUCTURE.md`](BOT_INTERNAL_STRUCTURE.md) — Bot internal component structure.
-- [`docs/PIPELINE_OVERVIEW.md`](PIPELINE_OVERVIEW.md) — Ingestion, query, and voice runtime flows.
-- [`docs/ADD_NEW_RAG_NODE.md`](ADD_NEW_RAG_NODE.md) — Guide for adding a new RAG graph node.
-- [`docs/PIPELINE_ROUTING.md`](PIPELINE_ROUTING.md) — Query routing and state machine design.
-- [`docs/CONTEXTUALIZED_EMBEDDINGS.md`](CONTEXTUALIZED_EMBEDDINGS.md) — Embedding strategy and contextualization.
-- [`docs/RAG_API.md`](RAG_API.md) — FastAPI RAG API contract.
-- [`docs/API_REFERENCE.md`](API_REFERENCE.md) — API reference.
+- [`PROJECT_STACK.md`](PROJECT_STACK.md) — System architecture and subsystem map.
+- [`BOT_ARCHITECTURE.md`](BOT_ARCHITECTURE.md) — Bot layer architecture.
+- [`BOT_INTERNAL_STRUCTURE.md`](BOT_INTERNAL_STRUCTURE.md) — Bot internal component structure.
+- [`PIPELINE_OVERVIEW.md`](PIPELINE_OVERVIEW.md) — Ingestion, query, and voice runtime flows.
+- [`PIPELINE_ROUTING.md`](PIPELINE_ROUTING.md) — Query routing and state machine design.
+- [`CONTEXTUALIZED_EMBEDDINGS.md`](CONTEXTUALIZED_EMBEDDINGS.md) — Embedding strategy and contextualization.
+- [`RAG_API.md`](RAG_API.md) — FastAPI RAG API contract.
+- [`API_REFERENCE.md`](API_REFERENCE.md) — API reference.
+- [`ADD_NEW_RAG_NODE.md`](ADD_NEW_RAG_NODE.md) — Guide for adding a new RAG graph node.
 
 ## Operations & Runbooks
 
-- [`DOCKER.md`](../DOCKER.md) — Docker Compose profiles, service map, env requirements.
-- [`docs/LOCAL-DEVELOPMENT.md`](LOCAL-DEVELOPMENT.md) — Local setup and validation guide.
-- [`docs/ONBOARDING.md`](ONBOARDING.md) — Onboarding guide.
-- [`docs/ONBOARDING_CHECKLIST.md`](ONBOARDING_CHECKLIST.md) — Onboarding checklist.
+- [`../DOCKER.md`](../DOCKER.md) — Docker Compose profiles, service map, env requirements.
+- [`LOCAL-DEVELOPMENT.md`](LOCAL-DEVELOPMENT.md) — Local setup and validation guide.
+- [`ONBOARDING.md`](ONBOARDING.md) — Onboarding guide.
+- [`ONBOARDING_CHECKLIST.md`](ONBOARDING_CHECKLIST.md) — Onboarding checklist.
 - [`services/README.md`](../services/README.md) — Local service containers (BGE-M3, Docling, user-base).
 - [`docker/README.md`](../docker/README.md) — Helper runtime assets (configs, scripts, monitoring rules).
 - [`k8s/README.md`](../k8s/README.md) — Partial k3s manifests, overlays, and deploy commands.
-- [`docs/INGESTION.md`](INGESTION.md) — Unified ingestion guide and troubleshooting.
-- [`docs/GDRIVE_INGESTION.md`](GDRIVE_INGESTION.md) — Google Drive sync runbook.
-- [`docs/QDRANT_STACK.md`](QDRANT_STACK.md) — Vector collections, schema, and operations.
-- [`docs/ALERTING.md`](ALERTING.md) — Loki/Alertmanager setup.
-- [`docs/INFRA_ISSUES_REPORT_1113_1126.md`](INFRA_ISSUES_REPORT_1113_1126.md) — Infrastructure issues report.
-- [`docs/TROUBLESHOOTING_CACHE.md`](TROUBLESHOOTING_CACHE.md) — Cache troubleshooting guide.
-- [`docs/runbooks/`](runbooks/) — Incident-specific runbooks.
+- [`INGESTION.md`](INGESTION.md) — Unified ingestion guide and troubleshooting.
+- [`GDRIVE_INGESTION.md`](GDRIVE_INGESTION.md) — Google Drive sync runbook.
+- [`QDRANT_STACK.md`](QDRANT_STACK.md) — Vector collections, schema, and operations.
+- [`ALERTING.md`](ALERTING.md) — Loki/Alertmanager setup.
+- [`runbooks/`](runbooks/) — Incident-specific runbooks.
 
 ## Quality & Evaluation
 
-- [`docs/RAG_QUALITY_SCORES.md`](RAG_QUALITY_SCORES.md) — Scoring taxonomy and trace expectations.
-- [`docs/DEVELOPER_GUIDE.md`](DEVELOPER_GUIDE.md) — Development conventions and test guidance.
-- [`docs/ADRS.md`](ADRS.md) — Architecture decision records.
+- [`RAG_QUALITY_SCORES.md`](RAG_QUALITY_SCORES.md) — Scoring taxonomy and trace expectations.
+- [`DEVELOPER_GUIDE.md`](DEVELOPER_GUIDE.md) — Development conventions and test guidance.
+- [`ADRS.md`](ADRS.md) — Architecture decision records.
 
 ## Migration & SDK
 
-- [`docs/SDK_MIGRATION_AUDIT_2026-03-13.md`](SDK_MIGRATION_AUDIT_2026-03-13.md) — Canonical SDK keeper stack.
-- [`docs/SDK_MIGRATION_ROADMAP_2026-03-13.md`](SDK_MIGRATION_ROADMAP_2026-03-13.md) — Post-audit execution order.
-- [`docs/SDK_CANONICAL_REMEDIATION_REPORT_2026-03-15.md`](SDK_CANONICAL_REMEDIATION_REPORT_2026-03-15.md) — SDK canonical remediation report.
+- [`SDK_MIGRATION_AUDIT_2026-03-13.md`](SDK_MIGRATION_AUDIT_2026-03-13.md) — Canonical SDK keeper stack.
+- [`SDK_MIGRATION_ROADMAP_2026-03-13.md`](SDK_MIGRATION_ROADMAP_2026-03-13.md) — Post-audit execution order.
+- [`SDK_CANONICAL_REMEDIATION_REPORT_2026-03-15.md`](SDK_CANONICAL_REMEDIATION_REPORT_2026-03-15.md) — SDK canonical remediation report.
 
 ## Engineering Notes
 
-- [`docs/ERROR_RESPONSES.md`](ERROR_RESPONSES.md) — Error response taxonomy.
-- [`docs/HITL.md`](HITL.md) — Human-in-the-loop design.
-- [`docs/HITL_CRM_FLOW.md`](HITL_CRM_FLOW.md) — CRM-specific HITL flow.
-- [`docs/CACHE_DEGRADATION.md`](CACHE_DEGRADATION.md) — Cache failure modes.
-- [`docs/CLIENT_PIPELINE.md`](CLIENT_PIPELINE.md) — Client pipeline details.
+- [`ERROR_RESPONSES.md`](ERROR_RESPONSES.md) — Error response taxonomy.
+- [`HITL.md`](HITL.md) — Human-in-the-loop design.
+- [`HITL_CRM_FLOW.md`](HITL_CRM_FLOW.md) — CRM-specific HITL flow.
+- [`CACHE_DEGRADATION.md`](CACHE_DEGRADATION.md) — Cache failure modes.
+- [`CLIENT_PIPELINE.md`](CLIENT_PIPELINE.md) — Client pipeline details.
 
 ## Archive
 
-- [`docs/archive/`](archive/) — Historical documentation and retired CI workflows that are preserved for context but are not active runtime or CI configuration.
+- [`archive/`](archive/) — Historical documentation and retired CI workflows preserved for context.
+
+## Fast Doc Search
+
+Search the doc tree from the repo root:
+
+```bash
+rg -n "Langfuse|LiteLLM|Redis|Qdrant|Compose|ingestion|voice|mini app|Telegram|RAG" docs README.md DOCKER.md AGENTS.md
+find docs -maxdepth 3 -name README.md -o -path 'docs/runbooks/*.md'
+```
+
+## Where Docs Live
+
+| Path | Purpose |
+|---|---|
+| `docs/runbooks/` | Operational troubleshooting and incident response |
+| `docs/engineering/` | Engineering process, standards, and workflow guides |
+| `docs/audits/` | Dated evidence and investigation artifacts; not entrypoints |
+| `docs/plans/` and `docs/superpowers/plans/` | Implementation plans and design specs |
+| `docs/review/` and `docs/portfolio/` | Reviewer and portfolio entry points |
+| Folder `README.md` files | Local subsystem indexes (e.g., `services/`, `k8s/`, `docker/`) |

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,49 @@
+# Operational Runbooks Index
+
+Operator entrypoint for container/service investigations and incident response. If a Docker service breaks, start here before ad hoc log searching.
+
+## Start Here
+
+| Symptom / Request | Runbook |
+|---|---|
+| Langfuse traces missing, gaps, or drift | [`LANGFUSE_TRACING_GAPS.md`](LANGFUSE_TRACING_GAPS.md) |
+| LiteLLM / LLM connection failures or proxy errors | [`LITEllm_FAILURE.md`](LITEllm_FAILURE.md) |
+| Redis cache degradation, eviction, or latency | [`REDIS_CACHE_DEGRADATION.md`](REDIS_CACHE_DEGRADATION.md) |
+| Qdrant health, collection, or vector search issues | [`QDRANT_TROUBLESHOOTING.md`](QDRANT_TROUBLESHOOTING.md) |
+| Postgres WAL recovery or replication issues | [`POSTGRESQL_WAL_RECOVERY.md`](POSTGRESQL_WAL_RECOVERY.md) |
+| VPS / Google Drive ingestion recovery | [`vps-gdrive-ingestion-recovery.md`](vps-gdrive-ingestion-recovery.md) |
+
+## Container / Service Map
+
+| Service (Compose name) | Common container names | Runbook |
+|---|---|---|
+| `qdrant` | `dev-qdrant-1`, `dev_qdrant_1` | [`QDRANT_TROUBLESHOOTING.md`](QDRANT_TROUBLESHOOTING.md) |
+| `redis` (app cache) and cache Redis containers | `dev-redis-1`, `dev_redis_1` | [`REDIS_CACHE_DEGRADATION.md`](REDIS_CACHE_DEGRADATION.md) |
+| `langfuse`, `langfuse-worker`, ClickHouse, MinIO, Langfuse Postgres/Redis | `dev-langfuse-1`, `dev-langfuse-worker-1`, `dev-clickhouse-1`, `dev-minio-1` | [`LANGFUSE_TRACING_GAPS.md`](LANGFUSE_TRACING_GAPS.md) |
+| `litellm` | `dev-litellm-1`, `dev_litellm_1` | [`LITEllm_FAILURE.md`](LITEllm_FAILURE.md) |
+| `postgres` | `dev-postgres-1`, `dev_postgres_1` | [`POSTGRESQL_WAL_RECOVERY.md`](POSTGRESQL_WAL_RECOVERY.md) |
+| Ingestion-related services | `dev-ingestion-1`, `dev-docling-1`, `dev-bge-m3-1` | [`vps-gdrive-ingestion-recovery.md`](vps-gdrive-ingestion-recovery.md) |
+
+> **Note:** Container names may differ between Compose versions (`dev-qdrant-1` vs `dev_qdrant_1`). Prefer `docker compose ps` and service names in docs.
+
+## Fast Search Commands
+
+Search runbooks and source areas by topic:
+
+```bash
+# Langfuse / traces / observability
+rg -n "Langfuse|trace|score|observation" docs/runbooks docs/audits telegram_bot src scripts
+
+# Redis / cache
+rg -n "Redis|cache|semantic cache|redis-cli" docs/runbooks telegram_bot src tests
+
+# Qdrant / vectors
+rg -n "Qdrant|collection|vector|ColBERT|hybrid" docs/runbooks src telegram_bot tests
+```
+
+## Safety Notes
+
+- Use Docker Compose native env handling (`--env-file`, `-f`, `COMPOSE_DISABLE_ENV_FILE=1`).
+- Do not print `.env` values in logs or runbooks.
+- Prefer read-only checks before restarts, clears, or destructive operations.
+- Container names may use hyphens or underscores depending on the Compose version and project name.


### PR DESCRIPTION
## Summary
- Reshapes `docs/README.md` into the project-wide documentation index for quick understanding and fast docs search.
- Creates `docs/runbooks/README.md` as the operator entrypoint for container/service investigations.
- Adds a concise `Documentation Entry Points` gateway section to `AGENTS.md` without duplicating operational tables.

## Verification
- Local markdown link existence check passed for all three files.
- `git diff --check` passed with no whitespace errors.
- No secrets or `.env` values present in changed docs.