### PR TITLE
docs(runbooks): update Redis and Qdrant runbooks for container-first diagnosis

### DIFF
--- a/docs/runbooks/QDRANT_TROUBLESHOOTING.md
+++ b/docs/runbooks/QDRANT_TROUBLESHOOTING.md
@@ -4,7 +4,7 @@
 > **Last verified:** 2026-05-07
 > **Verification command:**
 > ```bash
-> COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec qdrant curl -fsS http://localhost:6333/collections/gdrive_documents_bge
+> curl -fsS http://localhost:6333/collections/gdrive_documents_bge
 > ```
 
 Use this runbook when Qdrant collection has issues or monitoring shows anomalies.
@@ -36,24 +36,24 @@ Run these commands before deciding whether the issue is a service failure or an 
 # Check service status with deterministic CI env (read-only, no local .env required)
 COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml ps qdrant
 
-# Health check from inside the container
-COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec qdrant bash -c "exec 3<>/dev/tcp/localhost/6333 && printf 'GET /readyz HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3 && head -1 <&3"
+# Health check (host-side; dev Compose publishes Qdrant REST on localhost:6333)
+curl -fsS http://localhost:6333/readyz
 ```
 
-Expected: `HTTP/1.1 200 OK`.
+Expected: exit code `0` (HTTP 200 OK).
 If this fails, treat as **service failure** (container down, disk full, or OOM).
 
 ### 2. Collection and points count
 
 ```bash
 # List all collections
-COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec qdrant curl -fsS http://localhost:6333/collections | jq
+curl -fsS http://localhost:6333/collections | jq
 
 # Check specific collection metadata
-COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec qdrant curl -fsS http://localhost:6333/collections/gdrive_documents_bge | jq
+curl -fsS http://localhost:6333/collections/gdrive_documents_bge | jq
 
 # Get points count
-COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec qdrant curl -fsS 'http://localhost:6333/collections/gdrive_documents_bge/points/count' | jq
+curl -fsS 'http://localhost:6333/collections/gdrive_documents_bge/points/count' | jq
 ```
 
 If `count: 0` but ingestion succeeded, see [VPS Google Drive Ingestion Recovery](vps-gdrive-ingestion-recovery.md).
@@ -61,8 +61,8 @@ If `count: 0` but ingestion succeeded, see [VPS Google Drive Ingestion Recovery]
 ### 3. Cluster health (single-node deployments)
 
 ```bash
-COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec qdrant curl -fsS http://localhost:6333/cluster | jq
-COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec qdrant curl -fsS http://localhost:6333/cluster/status | jq
+curl -fsS http://localhost:6333/cluster | jq
+curl -fsS http://localhost:6333/cluster/status | jq
 ```
 
 On a single-node dev setup the cluster should show itself as the only peer.
@@ -71,7 +71,7 @@ If Raft consensus is unhealthy, treat as **service failure** (restart Qdrant aft
 ### 4. Query latency metrics
 
 ```bash
-COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec qdrant curl -fsS http://localhost:6333/metrics | grep -E "(query_latency|search_latency)"
+curl -fsS http://localhost:6333/metrics | grep -E "(query_latency|search_latency)"
 ```
 
 ### 5. Logs (read-only)
@@ -90,7 +90,7 @@ Check for:
 
 | Observation | Interpretation | Next step |
 |---|---|---|
-| `/readyz` or `/collections` fails from **inside** the Qdrant container | Service failure | Check host disk/memory; restart Qdrant |
+| `/readyz` or `/collections` fails from the host | Service failure | Check host disk/memory; restart Qdrant |
 | Qdrant is healthy, but bot logs show `Connection refused` | App bug | Verify `QDRANT_URL` and `QDRANT_COLLECTION` in bot / API env |
 | `points/count` is 0 after ingestion reported success | App bug / ingestion failure | Check ingestion manifest and logs; see [VPS Google Drive Ingestion Recovery](vps-gdrive-ingestion-recovery.md) |
 | `points/count` drops suddenly (>5%) | Service failure or data loss | Inspect Qdrant storage volume; check for accidental collection deletion |
@@ -116,7 +116,7 @@ Check for:
 | Runtime logs | `docker compose logs qdrant --tail=200` |
 | Qdrant storage volume | `qdrant_data` (managed volume, inspect with `docker volume inspect dev_qdrant_data`) |
 | Collection snapshots | Inside container at `/qdrant/storage/snapshots/` |
-| Query metrics | `curl http://localhost:6333/metrics` (dev only, or from inside container) |
+| Query metrics | `curl http://localhost:6333/metrics` (dev only) |
 | Ingestion manifest | `ingestion` service volume `ingestion-manifest`; check with `make ingest-unified-status` |
 
 ## Remediation

--- a/docs/runbooks/QDRANT_TROUBLESHOOTING.md
+++ b/docs/runbooks/QDRANT_TROUBLESHOOTING.md
@@ -1,5 +1,12 @@
 # Runbook: Qdrant Telemetry and Monitoring
 
+> **Owner:** Retrieval & Vector Storage subsystems
+> **Last verified:** 2026-05-07
+> **Verification command:**
+> ```bash
+> COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec qdrant curl -fsS http://localhost:6333/collections/gdrive_documents_bge
+> ```
+
 Use this runbook when Qdrant collection has issues or monitoring shows anomalies.
 
 ## Symptoms
@@ -8,49 +15,113 @@ Use this runbook when Qdrant collection has issues or monitoring shows anomalies
 - Slow query responses from Qdrant
 - ColBERT coverage drops below 99.5%
 - Collection health shows degraded state
+- `Qdrant connection refused` or timeout errors in bot / API logs
 
-## Diagnosis
+## Service / Container Map
 
-### 1. Check Collection Status
+| Compose service | Typical container names |
+|---|---|
+| `qdrant` | `dev-qdrant-1` (Compose v2+), `dev_qdrant_1` (legacy) |
+
+> Qdrant listens on `6333` (REST) and `6334` (gRPC).
+> Dev exposes both to `127.0.0.1`; base `compose.yml` keeps them internal.
+
+## Fast-Path Diagnosis (read-only)
+
+Run these commands before deciding whether the issue is a service failure or an application bug.
+
+### 1. Container health and reachability
+
+```bash
+# Check service status with deterministic CI env (read-only, no local .env required)
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml ps qdrant
+
+# Health check from inside the container
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec qdrant bash -c "exec 3<>/dev/tcp/localhost/6333 && printf 'GET /readyz HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3 && head -1 <&3"
+```
+
+Expected: `HTTP/1.1 200 OK`.
+If this fails, treat as **service failure** (container down, disk full, or OOM).
+
+### 2. Collection and points count
 
 ```bash
 # List all collections
-curl -s http://localhost:6333/collections | jq
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec qdrant curl -fsS http://localhost:6333/collections | jq
 
-# Check specific collection
-curl -s http://localhost:6333/collections/gdrive_documents_bge | jq
+# Check specific collection metadata
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec qdrant curl -fsS http://localhost:6333/collections/gdrive_documents_bge | jq
 
-# Get collection info with points count
-curl -s http://localhost:6333/collections/gdrive_documents_bge/info | jq
-```
-
-### 2. Check Points Count
-
-```bash
-# Via Qdrant UI or CLI
-curl -s 'http://localhost:6333/collections/gdrive_documents_bge/points/count' | jq
+# Get points count
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec qdrant curl -fsS 'http://localhost:6333/collections/gdrive_documents_bge/points/count' | jq
 ```
 
 If `count: 0` but ingestion succeeded, see [VPS Google Drive Ingestion Recovery](vps-gdrive-ingestion-recovery.md).
 
-### 3. Check Cluster Health
+### 3. Cluster health (single-node deployments)
 
 ```bash
-# Cluster info
-curl -s http://localhost:6333/cluster | jq
-
-# Raft consensus status
-curl -s http://localhost:6333/cluster/status | jq
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec qdrant curl -fsS http://localhost:6333/cluster | jq
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec qdrant curl -fsS http://localhost:6333/cluster/status | jq
 ```
 
-### 4. Check Query Latency
+On a single-node dev setup the cluster should show itself as the only peer.
+If Raft consensus is unhealthy, treat as **service failure** (restart Qdrant after checking disk).
+
+### 4. Query latency metrics
 
 ```bash
-# Get service metrics
-curl -s http://localhost:6333/metrics | grep -E "(query_latency|search_latency)"
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec qdrant curl -fsS http://localhost:6333/metrics | grep -E "(query_latency|search_latency)"
 ```
+
+### 5. Logs (read-only)
+
+```bash
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml logs qdrant --tail=200
+```
+
+Check for:
+- OOM killer messages
+- Disk-full errors (`No space left on device`)
+- Segment merge failures
+- WAL corruption warnings
+
+## Service Failure vs App Bug
+
+| Observation | Interpretation | Next step |
+|---|---|---|
+| `/readyz` or `/collections` fails from **inside** the Qdrant container | Service failure | Check host disk/memory; restart Qdrant |
+| Qdrant is healthy, but bot logs show `Connection refused` | App bug | Verify `QDRANT_URL` and `QDRANT_COLLECTION` in bot / API env |
+| `points/count` is 0 after ingestion reported success | App bug / ingestion failure | Check ingestion manifest and logs; see [VPS Google Drive Ingestion Recovery](vps-gdrive-ingestion-recovery.md) |
+| `points/count` drops suddenly (>5%) | Service failure or data loss | Inspect Qdrant storage volume; check for accidental collection deletion |
+| Queries are slow but Qdrant CPU/memory are low | App bug | Profile ColBERT reranking or reduce `RERANK_CANDIDATES_MAX`; temporarily set `RERANK_PROVIDER=none` in `compose.dev.yml` |
+| High Qdrant CPU/memory with normal query volume | Service failure / capacity | Increase `deploy.resources.limits.memory` in `compose.yml`; check segment count |
+| ColBERT coverage drops below 99.5% | App bug | Re-run ingestion with ColBERT enabled; check `search_engines.py` for schema drift |
+
+## Source Paths
+
+| Component | Path |
+|---|---|
+| Qdrant search & hybrid retrieval | [`src/retrieval/search_engines.py`](../../src/retrieval/search_engines.py) |
+| Shared Qdrant models & filters | [`src/retrieval/search_engine_shared.py`](../../src/retrieval/search_engine_shared.py) |
+| Reranking logic | [`src/retrieval/reranker.py`](../../src/retrieval/reranker.py) |
+| Qdrant service definition | [`compose.yml`](../../compose.yml) |
+| Dev overrides (ports, profiles) | [`compose.dev.yml`](../../compose.dev.yml) |
+| CI env fixture (deterministic interpolation) | [`tests/fixtures/compose.ci.env`](../../tests/fixtures/compose.ci.env) |
+
+## Logs and Artifacts
+
+| Artifact | Location / command |
+|---|---|
+| Runtime logs | `docker compose logs qdrant --tail=200` |
+| Qdrant storage volume | `qdrant_data` (managed volume, inspect with `docker volume inspect dev_qdrant_data`) |
+| Collection snapshots | Inside container at `/qdrant/storage/snapshots/` |
+| Query metrics | `curl http://localhost:6333/metrics` (dev only, or from inside container) |
+| Ingestion manifest | `ingestion` service volume `ingestion-manifest`; check with `make ingest-unified-status` |
 
 ## Remediation
+
+> ⚠️ **Caution:** Commands in this section mutate state. Run only after fast-path diagnosis confirms the issue is not an app bug.
 
 ### Collection Has 0 Points
 
@@ -75,13 +146,16 @@ See [VPS Google Drive Ingestion Recovery](vps-gdrive-ingestion-recovery.md) for 
 
 1. Check CPU/memory usage:
    ```bash
-   docker stats qdrant
+   COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml stats qdrant
    ```
 
-2. Consider increasing Qdrant resources in `compose.yml`
+2. Consider increasing Qdrant resources in `compose.yml`:
+   - Current limit: `memory: 1G`
+   - Increase if segment count is high or payloads are large
 
-3. Check if ColBERT reranking is causing slowdowns:
-   - Set `RERANK_PROVIDER=none` temporarily
+3. Temporarily disable ColBERT reranking to isolate Qdrant vs reranker latency:
+   - Set `RERANK_PROVIDER=none` in `compose.dev.yml` (dev) or the bot environment (production)
+   - Restart the bot / API service and re-run the slow query
 
 ### ColBERT Coverage Drop
 
@@ -94,9 +168,36 @@ ColBERT coverage measures the percentage of vectors with ColBERT embeddings.
 **Remediation:**
 1. Re-run ingestion with ColBERT enabled
 2. Check ingestion logs for ColBERT-related errors
+3. Verify `search_engines.py` still requests `multi_vector` payloads for the collection
+
+### Disk or Memory Pressure
+
+If Qdrant logs show storage or memory errors:
+
+1. Inspect storage volume usage:
+   ```bash
+   docker exec dev-qdrant-1 df -h /qdrant/storage
+   ```
+
+2. Free space if needed (e.g., remove old snapshots inside the container):
+   ```bash
+   COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec qdrant sh -c 'rm -f /qdrant/storage/snapshots/*.snapshot'
+   ```
+
+3. Restart Qdrant after clearing space:
+   ```bash
+   COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml restart qdrant
+   ```
 
 ## Prevention
 
 - Monitor `collection_points_count` metric
 - Set up alerts for >5% point count drop
-- Regular health checks via `/health` endpoint
+- Regular health checks via `/health` and `/readyz` endpoints
+- Keep Qdrant storage volume on a disk with >20% headroom
+- Run `make ingest-unified-status` after every ingestion batch
+
+## See Also
+
+- [Redis Cache Degradation](REDIS_CACHE_DEGRADATION.md)
+- [VPS Google Drive Ingestion Recovery](vps-gdrive-ingestion-recovery.md)

--- a/docs/runbooks/REDIS_CACHE_DEGRADATION.md
+++ b/docs/runbooks/REDIS_CACHE_DEGRADATION.md
@@ -1,6 +1,13 @@
 # Runbook: Redis Cache Degradation
 
-Use this runbook when Redis cache has issues affecting RAG performance.
+> **Owner:** Retrieval & Cache subsystems
+> **Last verified:** 2026-05-07
+> **Verification command:**
+> ```bash
+> COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec redis redis-cli -a test-redis-password ping
+> ```
+
+Use this runbook when Redis cache issues affect RAG performance.
 
 ## Symptoms
 
@@ -9,87 +16,119 @@ Use this runbook when Redis cache has issues affecting RAG performance.
 - Cache commands timing out
 - `Redis connection refused` errors
 
-## Diagnosis
+## Service / Container Map
 
-### 1. Check Redis Connectivity
+| Compose service | Typical container names |
+|---|---|
+| `redis` | `dev-redis-1` (Compose v2+), `dev_redis_1` (legacy) |
 
-```bash
-# Test Redis connection
-docker compose exec redis redis-cli ping
+> The app Redis is **distinct** from `redis-langfuse` (Langfuse v3 telemetry stack).
+> If Langfuse shows Redis errors, verify whether the failing container is `redis` or `redis-langfuse` first.
 
-# Should return: PONG
-```
+## Fast-Path Diagnosis (read-only)
 
-### 2. Check Redis Logs
+Run these commands before deciding whether the issue is a service failure or an application bug.
 
-```bash
-docker compose logs redis --tail=100
-```
-
-### 3. Verify Cache Keyspace
+### 1. Container health and reachability
 
 ```bash
-# Connect to Redis
-docker compose exec redis redis-cli
+# Check service status with deterministic CI env (read-only, no local .env required)
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml ps redis
 
-# List all keys (use with caution in production)
-KEYS *
-
-# Check key counts by type
-DBSIZE
-
-# Check memory usage
-INFO memory | grep used_memory_human
+# Test Redis connection from inside the container
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec redis redis-cli -a test-redis-password ping
 ```
 
-### 4. Test Cache Operations
+Expected: `PONG`.
+If this fails, treat as **service failure** (container down, network partition, or auth misconfiguration at the Compose level).
 
-```python
-# Test semantic cache
-from telegram_bot.integrations.cache import CacheLayerManager
+### 2. Read-only keyspace and memory inspection
 
-cache = CacheLayerManager(redis_url="redis://localhost:6379")
-await cache.initialize()
+```bash
+# Check key count and memory without scanning all keys
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec redis redis-cli -a test-redis-password DBSIZE
 
-# Check semantic cache
-result = await cache.check_semantic(
-    query="test query",
-    vector=[0.1] * 1024,
-    query_type="FAQ"
-)
-print(f"Cache result: {result}")
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec redis redis-cli -a test-redis-password INFO memory
 ```
+
+Look for:
+- `used_memory_human` — near the 300M limit in `compose.yml` indicates memory pressure
+- `maxmemory` — should match `256mb` (base) or `512mb` (dev override)
+- `evicted_keys` > 0 — confirms aggressive eviction due to memory pressure
+
+### 3. Logs (read-only)
+
+```bash
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml logs redis --tail=200
+```
+
+Check for:
+- OOM killer messages
+- Auth failures (`WRONGPASS`)
+- Persistence errors (`Can't save in background`)
+
+## Service Failure vs App Bug
+
+| Observation | Interpretation | Next step |
+|---|---|---|
+| `redis-cli ping` from **inside** the container fails | Service failure | Restart container, check disk/memory on host |
+| `redis-cli ping` works, but bot logs show `Connection refused` | App bug | Verify `REDIS_URL` in bot env; check password encoding |
+| Redis memory is near limit and `evicted_keys` is rising | Service failure / capacity | Scale `maxmemory` or reduce TTL; see Remediation |
+| Cache hit rate is 0% but Redis is healthy and has keys | App bug | Check semantic cache threshold, query_type mapping, or `CACHE_VERSION` drift in `telegram_bot/integrations/cache.py` |
+| High latency **with** cache hits | App bug | Profile embedding or rerank tiers; latency may be upstream of Redis |
+| Only specific tiers miss (e.g. `search` hits, `semantic` misses) | App bug | Inspect tier-specific TTLs and `distance_threshold` in source |
+
+## Source Paths
+
+| Component | Path |
+|---|---|
+| Cache implementation | [`telegram_bot/integrations/cache.py`](../../telegram_bot/integrations/cache.py) |
+| Redis service definition | [`compose.yml`](../../compose.yml) |
+| Dev overrides (ports, memory, password) | [`compose.dev.yml`](../../compose.dev.yml) |
+| CI env fixture (deterministic interpolation) | [`tests/fixtures/compose.ci.env`](../../tests/fixtures/compose.ci.env) |
+
+## Logs and Artifacts
+
+| Artifact | Location / command |
+|---|---|
+| Runtime logs | `docker compose logs redis --tail=200` |
+| Redis data volume | `redis_data` (managed volume, inspect with `docker volume inspect dev_redis_data`) |
+| Bot cache metrics | Exposed via bot `/stats` command or Langfuse spans tagged `cache-semantic-check` |
+| Memory trend | `INFO memory` sampled over time; sudden spikes correlate with ingestion batch writes |
 
 ## Remediation
 
+> ⚠️ **Caution:** Commands in this section mutate state. Run only after fast-path diagnosis confirms the issue is not an app bug.
+
 ### Redis Connection Refused
 
-1. Check if Redis container is running:
+1. Check if the Redis container is running:
    ```bash
-   docker compose ps redis
+   COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml ps redis
    ```
 
 2. Restart Redis:
    ```bash
-   docker compose restart redis
+   COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml restart redis
    ```
 
-3. Verify network connectivity:
+3. Verify network connectivity from the bot container:
    ```bash
-   docker compose exec bot redis-cli -h redis ping
+   COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec bot redis-cli -h redis -a test-redis-password ping
    ```
 
-### Cache Corruption
+### Cache Corruption or Version Drift
 
-If cache data appears corrupted:
+If cache data appears corrupted or keys use an old `CACHE_VERSION` / `SEMANTIC_CACHE_VERSION`:
 
-1. Clear all caches:
+1. Clear caches programmatically (safe, uses SCAN not `KEYS *`):
    ```bash
-   docker compose exec bot python -c "
-   import asyncio
+   COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec bot python -c "
+   import asyncio, os
    from telegram_bot.integrations.cache import CacheLayerManager
    async def clear():
-       cache = CacheLayerManager(redis_url='redis://redis:6379')
+       redis_url = os.environ.get('REDIS_URL', 'redis://redis:6379')
+       cache = CacheLayerManager(redis_url=redis_url)
        await cache.initialize()
        results = await cache.clear_all_caches()
        print(results)
@@ -97,18 +136,21 @@ If cache data appears corrupted:
    "
    ```
 
-2. Or use bot command: `/clearcache`
+2. Or use the bot command: `/clearcache`
+
+> **Avoid `KEYS *`** in production or large keyspaces. The `CacheLayerManager.clear_by_tier()` and `clear_semantic_cache()` methods use `SCAN` iteratively instead.
 
 ### Memory Issues
 
 1. Check memory usage:
    ```bash
-   docker compose exec redis redis-cli INFO memory | grep used_memory_human
+   COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec redis redis-cli -a test-redis-password INFO memory | grep used_memory_human
    ```
 
 2. If near limit, consider:
-   - Increasing `maxmemory` in Redis config
-   - Clearing old cache entries
+   - Increasing `maxmemory` in `compose.dev.yml` (dev) or the host Redis config (production)
+   - Reducing exact-cache TTLs in `telegram_bot/integrations/cache.py` (`DEFAULT_TTLS`)
+   - Clearing old cache entries via tiered `clear_by_tier()`
 
 ## Impact on Users
 
@@ -121,6 +163,12 @@ The system degrades gracefully — users still get responses, just without cache
 
 ## Prevention
 
-- Monitor Redis memory: `redis INFO memory`
+- Monitor Redis memory: `redis-cli INFO memory`
 - Set up alerting for `Redis connection refused` errors
 - Regular cache health checks via `/stats` command
+- Keep `compose.yml` and `compose.dev.yml` memory limits within host capacity
+
+## See Also
+
+- [Qdrant Troubleshooting](QDRANT_TROUBLESHOOTING.md)
+- [VPS Google Drive Ingestion Recovery](vps-gdrive-ingestion-recovery.md)


### PR DESCRIPTION
## Summary
- Add Owner / Last verified / Verification command metadata to both runbooks.
- Add read-only Docker Compose native env fast-path commands using `tests/fixtures/compose.ci.env`.
- Add service/container map notes for `qdrant`, `redis`, and possible hyphen/underscore container names.
- Add source paths and logs/artifacts sections.
- Add service failure vs app bug interpretation tables.
- Move mutating/destructive commands to Remediation with caution warnings.
- Avoid `KEYS *` in fast path; recommend SCAN-based clears.
- Keep all links relative.

## Verification
- `rg` confirms required strings (compose.ci.env, Service failure, app bug, source paths, points/count, collections, redis-cli INFO memory) are present.
- `rg` confirms no destructive commands (`KEYS *`, `FLUSH`, `DEL`) in fast path.
- `git diff --check` passes with no trailing whitespace.