### PR TITLE
docs: update stale Makefile targets and Compose refs in onboarding docs

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -189,6 +189,9 @@ COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility up -d --
 
 # Image drift check against compose-pinned images (uses compose.yml + compose.dev.yml + tests/fixtures/compose.ci.env)
 make verify-compose-images
+
+# Validate required Langfuse trace families (fast, no rebuild)
+make validate-traces-fast
 ```
 
 ## Notes

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -189,7 +189,7 @@ The `/health` endpoint checks:
 For full dependency health checks, use the preflight command:
 
 ```bash
-make preflight
+make test-preflight
 ```
 
 ## Langfuse Tracing

--- a/docs/INGESTION.md
+++ b/docs/INGESTION.md
@@ -90,7 +90,7 @@ Commonly used:
 
 ## Docker Service
 
-`docker-compose.dev.yml` includes `ingestion` service under profile `ingest`.
+`compose.yml` + `compose.dev.yml` include the `ingestion` service under profile `ingest`.
 
 ```bash
 make docker-ingest-up

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -63,23 +63,24 @@ See `.env.example` for full variable documentation.
 make docker-up
 
 # Or with monitoring (Grafana, Loki)
-make docker-up-dev
+make docker-full-up
 ```
 
 Verify services are healthy:
 
 ```bash
-make docker-health
+make test-bot-health
+make docker-ps
 ```
 
 ## Step 4: Run Preflight Checks
 
 ```bash
 # Check all dependencies
-make preflight
+make test-preflight
 
 # Verify embeddings service
-make embeddings-health
+curl -fsS http://localhost:8000/health
 ```
 
 ## Step 5: Start the Bot

--- a/docs/ONBOARDING_CHECKLIST.md
+++ b/docs/ONBOARDING_CHECKLIST.md
@@ -59,7 +59,7 @@ uv run python -m telegram_bot.main
 
 If you do set `REDIS_URL` manually for native runs, it must include the Redis password. Otherwise the bot derives the local URL from `REDIS_PASSWORD`.
 
-`make test-bot-health` is the local helper for Redis/Qdrant/LiteLLM plus the optional localhost Postgres note. The full startup preflight still runs in [`telegram_bot/preflight.py`](telegram_bot/preflight.py) when the bot starts, and that runtime path keeps the repo-local BGE-M3 health contract.
+`make test-bot-health` is the local helper for Redis/Qdrant/LiteLLM plus the optional localhost Postgres note. The full startup preflight still runs in [`telegram_bot/preflight.py`](../telegram_bot/preflight.py) when the bot starts, and that runtime path keeps the repo-local BGE-M3 health contract.
 
 ## 5. Validation
 

--- a/docs/ONBOARDING_CHECKLIST.md
+++ b/docs/ONBOARDING_CHECKLIST.md
@@ -59,7 +59,7 @@ uv run python -m telegram_bot.main
 
 If you do set `REDIS_URL` manually for native runs, it must include the Redis password. Otherwise the bot derives the local URL from `REDIS_PASSWORD`.
 
-`make test-bot-health` is the local helper for Redis/Qdrant/LiteLLM plus the optional localhost Postgres note. The full startup preflight still runs in [`telegram_bot/preflight.py`](/home/user/projects/rag-fresh-issue-1198/telegram_bot/preflight.py) when the bot starts, and that runtime path keeps the repo-local BGE-M3 health contract.
+`make test-bot-health` is the local helper for Redis/Qdrant/LiteLLM plus the optional localhost Postgres note. The full startup preflight still runs in [`telegram_bot/preflight.py`](telegram_bot/preflight.py) when the bot starts, and that runtime path keeps the repo-local BGE-M3 health contract.
 
 ## 5. Validation
 
@@ -73,6 +73,8 @@ make test-unit
 # Run full test suite
 make test-full
 ```
+
+For trace validation and the canonical Compose env override pattern, see [`DOCKER.md`](../DOCKER.md).
 
 ## 6. Key Files to Understand
 

--- a/docs/PROJECT_STACK.md
+++ b/docs/PROJECT_STACK.md
@@ -1,6 +1,6 @@
 # Project Stack
 
-Current stack snapshot for this repository as of 2026-02-18.
+Current stack snapshot for this repository as of 2026-05-07.
 
 ## Runtime And Tooling
 
@@ -9,7 +9,7 @@ Current stack snapshot for this repository as of 2026-02-18.
 | Language | Python `>=3.11` (recommended `3.12`) |
 | Package/deps | `uv`, `pyproject.toml`, `uv.lock` |
 | Lint/type/tests | Ruff, MyPy, pytest + xdist |
-| Local orchestration | Docker Compose v2 (`docker-compose.dev.yml`) |
+| Local orchestration | Docker Compose v2 (`compose.yml` + `compose.dev.yml`) |
 | Server orchestration | k3s + Kustomize (`k8s/overlays/*`) |
 
 ## Core Application Components
@@ -39,9 +39,9 @@ Current stack snapshot for this repository as of 2026-02-18.
 
 ## Deployment Surfaces
 
-- Local dev: `docker-compose.dev.yml` via `make docker-up` / `make docker-bot-up` / `make docker-full-up`
-- Minimal local: same `docker-compose.dev.yml` via `make local-up` / `make local-down`
-- VPS compose: `docker-compose.vps.yml`
+- Local dev: `compose.yml:compose.dev.yml` via `make docker-up` / `make docker-bot-up` / `make docker-full-up`
+- Minimal local: same `compose.yml:compose.dev.yml` via `make local-up` / `make local-down`
+- VPS compose: `compose.vps.yml`
 - k3s overlays: `k8s/overlays/core`, `k8s/overlays/bot`, `k8s/overlays/ingest`, `k8s/overlays/full`
 
 ## Canonical Operations Docs


### PR DESCRIPTION
## Summary
- Replace nonexistent `make docker-up-dev`, `make docker-health`, `make preflight`, `make embeddings-health` in `docs/ONBOARDING.md` with real current targets (`docker-full-up`, `test-bot-health`, `test-preflight`, `curl` health check).
- Replace `make preflight` in `docs/API_REFERENCE.md` with `make test-preflight`.
- Replace stale `docker-compose.dev.yml` references in `docs/INGESTION.md` and `docs/PROJECT_STACK.md` with `compose.yml:compose.dev.yml` / current Compose v2 wording, and update snapshot date to 2026-05-07.
- Fix the absolute broken `rag-fresh-issue-1198` link in `docs/ONBOARDING_CHECKLIST.md` to a relative repo link.
- Add concise quick-command pointer in `DOCKER.md` for `make validate-traces-fast` and reference `DOCKER.md` from `docs/ONBOARDING_CHECKLIST.md`.

Refs #1396