### PR TITLE
fix(#1404): update LiteLLM fallback comments and add token-limit guard tests

### DIFF
--- a/docker/litellm/config.yaml
+++ b/docker/litellm/config.yaml
@@ -6,7 +6,7 @@ model_list:
   # Primary: Cerebras GLM 4.7 (reasoning disabled for low TTFT)
   # ALIAS: "gpt-4o-mini" is an internal alias — it does NOT call OpenAI.
   # The bot sends requests to "gpt-4o-mini" which LiteLLM routes to Cerebras.
-  # See fallbacks below for the actual OpenAI fallback (gpt-4o-mini-openai).
+  # See router_settings.fallbacks for the actual OpenAI fallback (gpt-4o-mini-openai).
   - model_name: gpt-4o-mini
     litellm_params:
       model: cerebras/zai-glm-4.7

--- a/k8s/base/configmaps/litellm-config.yaml
+++ b/k8s/base/configmaps/litellm-config.yaml
@@ -8,7 +8,7 @@ data:
       # Primary: Cerebras GLM 4.7 (reasoning disabled for low TTFT)
       # ALIAS: "gpt-4o-mini" is an internal alias — it does NOT call OpenAI.
       # The bot sends requests to "gpt-4o-mini" which LiteLLM routes to Cerebras.
-      # See fallbacks below for the actual OpenAI fallback (gpt-4o-mini-openai).
+      # See router_settings.fallbacks for the actual OpenAI fallback (gpt-4o-mini-openai).
       - model_name: gpt-4o-mini
         litellm_params:
           model: cerebras/zai-glm-4.7

--- a/tests/unit/test_litellm_config_sync.py
+++ b/tests/unit/test_litellm_config_sync.py
@@ -201,3 +201,53 @@ class TestLiteLLMConfigSync:
                 mismatches.append(f"  '{name}': docker uses {docker_key!r}, k8s uses {k8s_key!r}")
 
         assert not mismatches, "Token limit key name drift detected:\n" + "\n".join(mismatches)
+
+    def test_gpt_4o_mini_primary_is_cerebras_zai_glm_47(self):
+        """Guard: gpt-4o-mini must route to Cerebras zai-glm-4.7 as primary."""
+        docker = _load_docker_config()
+        k8s = _load_k8s_config()
+
+        for source, cfg in (("docker", docker), ("k8s", k8s)):
+            entries = [e for e in cfg["model_list"] if e["model_name"] == "gpt-4o-mini"]
+            assert len(entries) == 1, f"Expected exactly one gpt-4o-mini entry in {source}"
+            params = entries[0]["litellm_params"]
+            assert params.get("model") == "cerebras/zai-glm-4.7", (
+                f"{source}: gpt-4o-mini primary model must be cerebras/zai-glm-4.7, "
+                f"got {params.get('model')!r}"
+            )
+
+    def test_gpt_4o_mini_max_completion_tokens_is_512(self):
+        """Guard: gpt-4o-mini token limit must stay at 512."""
+        docker = _load_docker_config()
+        k8s = _load_k8s_config()
+
+        for source, cfg in (("docker", docker), ("k8s", k8s)):
+            entries = [e for e in cfg["model_list"] if e["model_name"] == "gpt-4o-mini"]
+            assert entries, f"No gpt-4o-mini entry in {source}"
+            params = entries[0]["litellm_params"]
+            limit = _normalize_token_limit(params)
+            assert limit == 512, (
+                f"{source}: gpt-4o-mini max_completion_tokens must be 512, got {limit}"
+            )
+
+    def test_gpt_oss_120b_entries_use_cerebras_model_and_1024_limit(self):
+        """Guard: gpt-oss-120b and fallback alias use cerebras/gpt-oss-120b with 1024 limit."""
+        docker = _load_docker_config()
+        k8s = _load_k8s_config()
+
+        expected = {
+            "gpt-oss-120b": "cerebras/gpt-oss-120b",
+            "gpt-4o-mini-cerebras-oss": "cerebras/gpt-oss-120b",
+        }
+
+        for source, cfg in (("docker", docker), ("k8s", k8s)):
+            for alias, provider_model in expected.items():
+                entries = [e for e in cfg["model_list"] if e["model_name"] == alias]
+                assert entries, f"No {alias} entry in {source}"
+                params = entries[0]["litellm_params"]
+                assert params.get("model") == provider_model, (
+                    f"{source}: {alias} provider model must be {provider_model!r}, "
+                    f"got {params.get('model')!r}"
+                )
+                limit = _normalize_token_limit(params)
+                assert limit == 1024, f"{source}: {alias} token limit must be 1024, got {limit}"


### PR DESCRIPTION
## Summary
- Refresh stale \"See fallbacks below\" comments to point to `router_settings.fallbacks` in both Docker and k8s LiteLLM configs.
- Add focused guard tests for provider token limits and primary mapping:
  - `gpt-4o-mini` -> `cerebras/zai-glm-4.7` with `max_completion_tokens == 512`
  - `gpt-oss-120b` and `gpt-4o-mini-cerebras-oss` -> `cerebras/gpt-oss-120b` with limit `1024`

Fixes #1404