### PR TITLE
docs: add task-oriented indexes for fast agent/human orientation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,8 +62,10 @@
 - `k8s/`, `compose*.yml`, `DOCKER.md`: deploy and environment orchestration.
 
 ## Documentation Entry Points
-- For project-wide docs navigation and fast doc search, start from [`docs/README.md`](docs/README.md).
-- For traces, cache, vector search, Compose/runtime, and service-health investigations, start from [`docs/runbooks/README.md`](docs/runbooks/README.md).
+- **Project-wide docs navigation** and fast doc search: start from [`docs/README.md`](docs/README.md).
+- **Goal/task-oriented fast lookup** (e.g. "изучи последние трейсы", "сломался Qdrant/Redis/LiteLLM", "понять Docker services"): start from [`docs/indexes/`](docs/indexes/).
+- **Operational investigations and runbooks** (traces, cache, vector search, Compose/runtime, service health): start from [`docs/runbooks/README.md`](docs/runbooks/README.md).
+- **Detailed folder ownership** and local checks: start from the nearest folder `README.md`.
 - Use these indexes before ad hoc log/code searching; keep `AGENTS.md` as a gateway, not a duplicated operations manual.
 
 ## Runtime And Compose Contract

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,14 @@
 
 Project documentation index for humans and agents. Use this page to understand the system, find subsystem docs, and search the doc tree quickly.
 
+## Task-Oriented Indexes
+
+For fast orientation by goal rather than by subsystem, see [`indexes/`](indexes/):
+
+- [`indexes/fast-search.md`](indexes/fast-search.md) — "I need to find docs about X"
+- [`indexes/runtime-services.md`](indexes/runtime-services.md) — Docker, ingestion, mini app, bot, voice
+- [`indexes/observability-and-storage.md`](indexes/observability-and-storage.md) — Langfuse, Qdrant, Redis, LiteLLM, Postgres
+
 ## Understand the Project Fast
 
 - [`../README.md`](../README.md) — System overview, architecture diagram, quick start, and reviewer path.

--- a/docs/indexes/README.md
+++ b/docs/indexes/README.md
@@ -1,0 +1,24 @@
+# Documentation Indexes
+
+Task-oriented entrypoints for fast agent and human orientation. Use these pages when you know what you want to do, not when you want to read everything.
+
+For the full documentation map, see [`../README.md`](../README.md). For operational incident response, see [`../runbooks/README.md`](../runbooks/README.md).
+
+## Index Pages
+
+| Page | Use When |
+|---|---|
+| [`fast-search.md`](fast-search.md) | You need to grep the doc tree by topic or find the right canonical doc quickly. |
+| [`runtime-services.md`](runtime-services.md) | You need to understand Docker services, the ingestion pipeline, the mini app, or the Telegram bot flow. |
+| [`observability-and-storage.md`](observability-and-storage.md) | You need to study Langfuse traces, inspect Qdrant, or debug Redis/cache behavior. |
+
+## Canonical Doc Owners
+
+| Fact | Canonical Doc |
+|---|---|
+| Docker Compose files, profiles, services, ports, env | [`../../DOCKER.md`](../../DOCKER.md) |
+| Local developer flow and validation ladder | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md) |
+| Repo overview and top-level entrypoints | [`../../README.md`](../../README.md) |
+| Operational incident/runbook navigation | [`../runbooks/README.md`](../runbooks/README.md) |
+| Test-writing rules | [`../engineering/test-writing-guide.md`](../engineering/test-writing-guide.md) |
+| SDK/framework lookup order | [`../engineering/sdk-registry.md`](../engineering/sdk-registry.md) |

--- a/docs/indexes/fast-search.md
+++ b/docs/indexes/fast-search.md
@@ -1,0 +1,122 @@
+# Fast Doc Search
+
+Quick search patterns and task-oriented lookups. Use these commands from the repo root to find the right canonical doc without browsing the tree manually.
+
+## By Request Type
+
+### "Study recent Langfuse traces"
+
+Start with the runbook, then search related code:
+
+```bash
+# Runbook
+cat docs/runbooks/LANGFUSE_TRACING_GAPS.md
+
+# Trace spans and scoring in source
+rg -n "Langfuse|trace|observation|score" telegram_bot/graph/ telegram_bot/services/ src/api/ src/evaluation/
+```
+
+See also: [`observability-and-storage.md`](observability-and-storage.md#langfuse-traces)
+
+### "Inspect Qdrant issues"
+
+```bash
+# Runbook
+cat docs/runbooks/QDRANT_TROUBLESHOOTING.md
+
+# Stack reference
+cat docs/QDRANT_STACK.md
+
+# Collection policy and runtime integration
+rg -n "Qdrant|collection|vector" telegram_bot/services/ src/ingestion/unified/ src/config/
+```
+
+See also: [`observability-and-storage.md`](observability-and-storage.md#qdrant)
+
+### "Inspect Redis/cache issues"
+
+```bash
+# Runbook
+cat docs/runbooks/REDIS_CACHE_DEGRADATION.md
+
+# Cache architecture and thresholds
+cat docs/TROUBLESHOOTING_CACHE.md
+
+# Redis integration and cache tiers
+rg -n "Redis|cache|redis-cli" telegram_bot/integrations/ telegram_bot/services/ src/
+```
+
+See also: [`observability-and-storage.md`](observability-and-storage.md#redis-and-cache)
+
+### "Understand Docker services"
+
+```bash
+# Canonical source of truth
+cat DOCKER.md
+
+# Service containers index
+cat services/README.md
+
+# Compose validation
+make verify-compose-images
+```
+
+See also: [`runtime-services.md`](runtime-services.md#docker-services)
+
+### "Understand ingestion"
+
+```bash
+# Runbook and guide
+cat docs/INGESTION.md
+cat docs/GDRIVE_INGESTION.md
+
+# Pipeline code
+rg -n "ingestion|cocoindex|docling" src/ingestion/unified/
+
+# CLI help
+uv run python -m src.ingestion.unified.cli --help
+```
+
+See also: [`runtime-services.md`](runtime-services.md#ingestion)
+
+### "Understand mini app"
+
+```bash
+# Mini app index
+cat mini_app/README.md
+
+# Backend entrypoint and tests
+rg -n "mini_app" mini_app/ tests/unit/mini_app/
+```
+
+See also: [`runtime-services.md`](runtime-services.md#mini-app)
+
+### "Understand Telegram bot flow"
+
+```bash
+# Bot index
+cat telegram_bot/README.md
+
+# LangGraph pipeline
+rg -n "build_graph|State|node" telegram_bot/graph/
+
+# Bot handlers and services
+rg -n "handler|middleware|pipeline" telegram_bot/handlers/ telegram_bot/services/
+```
+
+See also: [`runtime-services.md`](runtime-services.md#telegram-bot)
+
+## General Search Commands
+
+Search the doc tree from the repo root:
+
+```bash
+# Find all docs mentioning a keyword
+rg -n "Langfuse|LiteLLM|Redis|Qdrant|Compose|ingestion|voice|mini app|Telegram|RAG" docs/ README.md DOCKER.md AGENTS.md
+
+# List all README indexes
+find . -maxdepth 3 -name README.md | sort
+
+# List runbooks
+find docs/runbooks -maxdepth 1 -name '*.md' | sort
+```

--- a/docs/indexes/observability-and-storage.md
+++ b/docs/indexes/observability-and-storage.md
@@ -1,0 +1,133 @@
+# Observability and Storage Index
+
+Quick orientation for Langfuse traces, Qdrant, and Redis/cache investigations. Links to runbooks and canonical docs instead of duplicating operational procedures.
+
+## Langfuse Traces
+
+Use this path when traces are missing, gaps appear, or you need to validate scoring.
+
+### Start Here
+
+- **Runbook**: [`../runbooks/LANGFUSE_TRACING_GAPS.md`](../runbooks/LANGFUSE_TRACING_GAPS.md)
+- **Quality scoring**: [`../RAG_QUALITY_SCORES.md`](../RAG_QUALITY_SCORES.md)
+
+### Common Investigations
+
+| Question | Where to Look |
+|---|---|
+| Are traces being exported? | `telegram_bot/integrations/langfuse_client.py` and middleware trace root |
+| What spans are emitted? | Search for `span=` or `trace=` in `telegram_bot/graph/`, `telegram_bot/services/`, `src/api/` |
+| Is scoring configured? | `src/evaluation/` and `telegram_bot/services/scoring.py` |
+| Trace validation command | `make validate-traces-fast` |
+
+### Fast Search
+
+```bash
+# Langfuse spans and scoring in bot and API
+rg -n "langfuse|trace|span|score|observation" telegram_bot/ src/api/ src/evaluation/
+
+# Ingestion trace contract
+rg -n "ingestion-cli|ingestion-flow|ingestion-qdrant" src/ingestion/unified/
+```
+
+## Qdrant
+
+Use this path for collection health, vector search issues, schema drift, or missing points.
+
+### Start Here
+
+- **Runbook**: [`../runbooks/QDRANT_TROUBLESHOOTING.md`](../runbooks/QDRANT_TROUBLESHOOTING.md)
+- **Stack reference**: [`../QDRANT_STACK.md`](../QDRANT_STACK.md)
+
+### Common Investigations
+
+| Question | Where to Look |
+|---|---|
+| Which collections exist? | `curl -fsS http://localhost:6333/collections` |
+| Is the runtime collection healthy? | `curl -fsS http://localhost:6333/collections/gdrive_documents_bge` |
+| Did bootstrap create the right schema? | `uv run python -m src.ingestion.unified.cli schema-check --require-colbert` |
+| Is ColBERT coverage sufficient? | `uv run python -m src.ingestion.unified.cli coverage-check --min-ratio 0.995` |
+| Are points actually present? | `curl -fsS http://localhost:6333/collections/gdrive_documents_bge | python3 -m json.tool` |
+
+### Collections Overview
+
+| Collection | Purpose | Owner |
+|---|---|---|
+| `gdrive_documents_bge` | Default document chunks (dense + sparse + ColBERT) | Unified ingestion |
+| `gdrive_documents_bge_active` | Alias for blue/green cutover | Bot startup (`QdrantService._ensure_alias`) |
+| `apartments` | Apartment listings (top-level payload) | `scripts/apartments/setup_collection.py` |
+| `conversation_history` | User session history vectors | `telegram_bot/services/history_service.py` |
+
+### Fast Search
+
+```bash
+# Qdrant runtime integration
+rg -n "qdrant|collection|vector|hybrid|rrf|colbert" telegram_bot/services/ src/ingestion/unified/ src/retrieval/
+
+# Collection policy
+rg -n "resolve_collection_name|quantization" src/config/
+```
+
+## Redis and Cache
+
+Use this path for cache degradation, eviction, latency, or semantic cache misses.
+
+### Start Here
+
+- **Runbook**: [`../runbooks/REDIS_CACHE_DEGRADATION.md`](../runbooks/REDIS_CACHE_DEGRADATION.md)
+- **Cache architecture**: [`../TROUBLESHOOTING_CACHE.md`](../TROUBLESHOOTING_CACHE.md)
+
+### Common Investigations
+
+| Question | Where to Look |
+|---|---|
+| Is Redis reachable? | `redis-cli -p 6379 -a "$REDIS_PASSWORD" ping` |
+| Are cache keys present? | `KEYS sem:v5:*` in `redis-cli` |
+| Which tier is missing? | `cache.get_metrics()` in bot logs or `telegram_bot/integrations/cache.py` |
+| Why is everything a miss? | Check `grade_confidence` threshold uses RRF scale, not cosine similarity |
+| Cache version stale after model change? | Bump `CACHE_VERSION` or `SEMANTIC_CACHE_VERSION` in `integrations/cache.py` |
+
+### Cache Tiers
+
+| Tier | Type | TTL | Purpose |
+|---|---|---|---|
+| Semantic | RedisVL SemanticCache | Query-dependent | LLM response caching |
+| Embeddings | RedisVL EmbeddingsCache | 7 days | Dense embedding cache |
+| Sparse | Redis exact | 7 days | Sparse embedding cache |
+| Search | Redis exact | 2 hours | Search results cache |
+| Rerank | Redis exact | 2 hours | Reranked results cache |
+
+### Fast Search
+
+```bash
+# Cache implementation
+rg -n "CacheLayerManager|SemanticCache|EmbeddingsCache" telegram_bot/integrations/cache.py
+
+# Cache usage in pipelines
+rg -n "cache|semantic|embeddings" telegram_bot/pipelines/ telegram_bot/services/
+
+# Redis integration beyond cache
+rg -n "redis|Redis" telegram_bot/integrations/ telegram_bot/services/
+```
+
+## LiteLLM Proxy
+
+Use this path for LLM connection failures or proxy errors.
+
+- **Runbook**: [`../runbooks/LITEllm_FAILURE.md`](../runbooks/LITEllm_FAILURE.md)
+- **Compose service**: `litellm` (profile `bot` and `voice`)
+- **Local URL**: http://localhost:4000
+
+Quick check:
+
+```bash
+curl -fsS http://localhost:4000/health
+```
+
+## Postgres
+
+Use this path for WAL recovery or replication issues.
+
+- **Runbook**: [`../runbooks/POSTGRESQL_WAL_RECOVERY.md`](../runbooks/POSTGRESQL_WAL_RECOVERY.md)
+- **Compose service**: `postgres` (default/unprofiled)
+- **Used by**: Lead scoring, graph checkpoints, unified ingestion state, user data

--- a/docs/indexes/runtime-services.md
+++ b/docs/indexes/runtime-services.md
@@ -1,0 +1,135 @@
+# Runtime Services Index
+
+Quick orientation for Docker services, ingestion, the mini app, and the Telegram bot. Links to canonical docs instead of duplicating service tables or env rules.
+
+## Docker Services
+
+The canonical source of truth for Compose files, profiles, service names, ports, and env is [`../../DOCKER.md`](../../DOCKER.md). This section provides orientation only.
+
+### Compose Profiles
+
+| Profile | When You Need It |
+|---|---|
+| (default, no profile) | Core services: Postgres, Redis, Qdrant, BGE-M3, Docling, user-base, mini-app |
+| `bot` | Telegram bot + LiteLLM proxy |
+| `ingest` | Unified ingestion service |
+| `ml` | Langfuse + ClickHouse + MinIO |
+| `obs` | Loki + Promtail + Alertmanager |
+| `voice` | LiveKit + SIP + voice agent (off by default) |
+
+Common commands:
+
+```bash
+make docker-up          # default/unprofiled services
+make docker-bot-up      # bot profile
+make docker-ingest-up   # ingestion profile
+make docker-ml-up       # observability profile
+make docker-ps          # list running containers
+```
+
+### Local Service Containers
+
+For per-service build, healthcheck, and test details, see [`../../services/README.md`](../../services/README.md).
+
+| Service | Local URL | Purpose |
+|---|---|---|
+| `bge-m3` | http://localhost:8000 | Dense + sparse + ColBERT embeddings |
+| `docling` | http://localhost:5001 | PDF/DOCX → markdown parsing |
+| `user-base` | http://localhost:8003 | Russian dense embeddings |
+
+## Ingestion
+
+The unified ingestion pipeline is the primary document ingestion path.
+
+- **Package**: `src/ingestion/unified/`
+- **CLI**: `uv run python -m src.ingestion.unified.cli`
+- **Canonical docs**: [`../INGESTION.md`](../INGESTION.md), [`../GDRIVE_INGESTION.md`](../GDRIVE_INGESTION.md)
+
+Quick commands:
+
+```bash
+make ingest-unified-preflight   # validate deps and env
+make ingest-unified-bootstrap   # create/validate collection schema
+make ingest-unified             # one-shot run
+make ingest-unified-status      # state/DLQ status
+make ingest-unified-logs        # container logs
+```
+
+Key concepts:
+- Reads from `GDRIVE_SYNC_DIR`
+- Uses Docling for parsing, BGE-M3 for embeddings
+- Writes to Qdrant; tracks state in PostgreSQL
+- Supports incremental updates and resume
+
+See also: [`../QDRANT_STACK.md`](../QDRANT_STACK.md) for collection schema and bootstrap details.
+
+## Mini App
+
+Telegram Mini App backend (FastAPI) and frontend (React + Vite).
+
+- **Backend entrypoint**: `mini_app/api.py`
+- **Service name**: `mini-app-api`
+- **Local port**: `8090`
+- **Canonical doc**: [`../../mini_app/README.md`](../../mini_app/README.md)
+
+Quick start:
+
+```bash
+COMPOSE_FILE=compose.yml:compose.dev.yml docker compose up -d mini-app-api
+curl -fsS http://localhost:8090/health
+```
+
+API surface:
+- `GET /api/config` — UI questions + experts list
+- `POST /api/start-expert` — Store deep-link payload
+- `POST /api/phone` — Collect phone and create CRM lead
+- `GET /health` — Service health
+
+## Telegram Bot
+
+Telegram transport layer and RAG orchestration.
+
+- **Entrypoint**: `telegram_bot/main.py`
+- **Bot class**: `telegram_bot/bot.py`
+- **LangGraph pipeline**: `telegram_bot/graph/graph.py`
+- **Canonical doc**: [`../../telegram_bot/README.md`](../../telegram_bot/README.md)
+
+Key flows:
+1. **Message/voice** → handlers (`telegram_bot/handlers/`)
+2. **Query classification** → pipeline selection
+3. **Cache check** → Redis semantic cache
+4. **Retrieval** → hybrid search in Qdrant (dense + sparse + optional ColBERT rerank)
+5. **Generation** → LiteLLM proxy
+6. **Response** → Telegram message with citations
+
+Subsystems:
+- `telegram_bot/graph/` — LangGraph nodes, edges, and state
+- `telegram_bot/services/` — Qdrant queries, cache, apartment search, CRM tools
+- `telegram_bot/agents/` — Agent SDK RAG functions
+- `telegram_bot/dialogs/` — Funnel UI and filter extraction
+- `telegram_bot/middlewares/` — Throttling, i18n, error handling
+
+Quick commands:
+
+```bash
+make run-bot           # native bot run (fast iteration)
+make docker-bot-up     # bot in Docker
+make test-bot-health   # local prerequisite check
+python -m telegram_bot.preflight   # startup health check
+```
+
+## Voice Agent
+
+LiveKit-powered voice path. Deferred by default.
+
+- **Entrypoint**: `src/voice/agent.py`
+- **RAG API**: `src/api/main:app`
+- **Compose profile**: `voice` (intentionally off by default)
+
+To start:
+
+```bash
+make docker-voice-up
+```
+
+See [`../../src/voice/`](../../src/voice/) for implementation details.


### PR DESCRIPTION
## Summary

Add `docs/indexes/` section with task-oriented entrypoints for fast agent and human orientation.

## Changes

- `docs/indexes/README.md` — index page for the indexes section
- `docs/indexes/fast-search.md` — grep patterns and quick lookups by request type
- `docs/indexes/runtime-services.md` — Docker services, ingestion, mini app, Telegram bot, voice
- `docs/indexes/observability-and-storage.md` — Langfuse traces, Qdrant, Redis/cache, LiteLLM, Postgres
- `docs/README.md` — add "Task-Oriented Indexes" section linking to the new pages

## Design

- All links are relative.
- Canonical docs (DOCKER.md, runbooks, subsystem READMEs) are linked instead of duplicated.
- No runtime code, Compose files, or runbooks were modified.

## Verification

- `git diff --check` passed
- Relative markdown link existence check passed for all new files
- `rg` keyword coverage confirmed for all requested topics

Related: #1396