### PR TITLE
docs: tighten subsystem READMEs with canonical doc and AGENTS.override links

### DIFF
--- a/mini_app/README.md
+++ b/mini_app/README.md
@@ -56,5 +56,7 @@ Do not change the exposed port (`8090`), healthcheck path, or API response shape
 
 ## See Also
 
-- [`frontend/README.md`](frontend/README.md) — Frontend build, dev server, and test details.
-- [`../DOCKER.md`](../DOCKER.md) — Compose operations and service map.
+- [`frontend/README.md`](frontend/README.md) — Frontend build, dev server, and test details
+- [`../DOCKER.md`](../DOCKER.md) — Compose operations and service map
+- [`../docs/LOCAL-DEVELOPMENT.md`](../docs/LOCAL-DEVELOPMENT.md) — Local setup and validation ladder
+- [`../docs/runbooks/README.md`](../docs/runbooks/README.md) — Operational troubleshooting

--- a/services/README.md
+++ b/services/README.md
@@ -58,5 +58,6 @@ Do not modify the application code in these directories without also verifying t
 
 ## See Also
 
-- [`../DOCKER.md`](../DOCKER.md) — Compose profiles, env requirements, and service map.
-- [`../docs/LOCAL-DEVELOPMENT.md`](../docs/LOCAL-DEVELOPMENT.md) — Local setup and validation flow.
+- [`../DOCKER.md`](../DOCKER.md) — Compose profiles, env requirements, and service map
+- [`../docs/LOCAL-DEVELOPMENT.md`](../docs/LOCAL-DEVELOPMENT.md) — Local setup and validation flow
+- [`../docs/runbooks/README.md`](../docs/runbooks/README.md) — Operational troubleshooting

--- a/src/README.md
+++ b/src/README.md
@@ -61,3 +61,5 @@ pytest src/retrieval/ src/ingestion/unified/ src/api/
 
 - [`../telegram_bot/README.md`](../telegram_bot/README.md) — Telegram transport layer
 - [`../DOCKER.md`](../DOCKER.md) — Docker orchestration and service dependencies
+- [`../docs/LOCAL-DEVELOPMENT.md`](../docs/LOCAL-DEVELOPMENT.md) — Local setup and validation ladder
+- [`../docs/runbooks/README.md`](../docs/runbooks/README.md) — Operational troubleshooting

--- a/src/ingestion/README.md
+++ b/src/ingestion/README.md
@@ -61,6 +61,11 @@ make check
 
 ## See Also
 
+- [`./unified/AGENTS.override.md`](./unified/AGENTS.override.md) — Ingestion-specific scope rules and validation
 - [`./unified/README.md`](./unified/README.md) — Detailed unified pipeline docs
 - [`../retrieval/`](../retrieval/) — Search engines that consume ingested data
+- [`../../DOCKER.md`](../../DOCKER.md) — Docker orchestration and service dependencies
+- [`../../docs/LOCAL-DEVELOPMENT.md`](../../docs/LOCAL-DEVELOPMENT.md) — Local setup and validation ladder
+- [`../../docs/runbooks/README.md`](../../docs/runbooks/README.md) — Operational troubleshooting
+- [`../../docs/INGESTION.md`](../../docs/INGESTION.md) — Unified ingestion guide and troubleshooting
 - [`../../docs/engineering/test-writing-guide.md`](../../docs/engineering/test-writing-guide.md) — Test conventions

--- a/src/retrieval/README.md
+++ b/src/retrieval/README.md
@@ -61,3 +61,6 @@ python -m src.evaluation.run_ab_test --help
 
 - [`../ingestion/`](../ingestion/) — Chunk production and payload contract
 - [`../../telegram_bot/services/qdrant.py`](../../telegram_bot/services/qdrant.py) — Async Qdrant service used by the bot
+- [`../../DOCKER.md`](../../DOCKER.md) — Docker orchestration and service dependencies
+- [`../../docs/LOCAL-DEVELOPMENT.md`](../../docs/LOCAL-DEVELOPMENT.md) — Local setup and validation ladder
+- [`../../docs/runbooks/README.md`](../../docs/runbooks/README.md) — Operational troubleshooting

--- a/src/voice/README.md
+++ b/src/voice/README.md
@@ -46,3 +46,5 @@ make check
 
 - [`../api/`](../api/) — RAG API that the voice agent consumes
 - [`../../DOCKER.md`](../../DOCKER.md) — Docker profiles and service orchestration
+- [`../../docs/LOCAL-DEVELOPMENT.md`](../../docs/LOCAL-DEVELOPMENT.md) — Local setup and validation ladder
+- [`../../docs/runbooks/README.md`](../../docs/runbooks/README.md) — Operational troubleshooting

--- a/telegram_bot/README.md
+++ b/telegram_bot/README.md
@@ -58,6 +58,9 @@ python -m telegram_bot.preflight
 
 ## See Also
 
+- [`AGENTS.override.md`](AGENTS.override.md) — Bot-specific scope rules and validation
 - [`../DOCKER.md`](../DOCKER.md) — Docker bring-up and service dependencies
+- [`../docs/LOCAL-DEVELOPMENT.md`](../docs/LOCAL-DEVELOPMENT.md) — Local setup and validation ladder
+- [`../docs/runbooks/README.md`](../docs/runbooks/README.md) — Operational troubleshooting
 - [`../src/retrieval/`](../src/retrieval/) — Search engine implementations
 - [`../src/ingestion/`](../src/ingestion/) — Document ingestion pipeline

--- a/telegram_bot/services/README.md
+++ b/telegram_bot/services/README.md
@@ -47,5 +47,9 @@ make check
 
 ## See Also
 
+- [`../AGENTS.override.md`](../AGENTS.override.md) — Bot-specific scope rules and validation
+- [`../../DOCKER.md`](../../DOCKER.md) — Docker bring-up and service dependencies
+- [`../../docs/LOCAL-DEVELOPMENT.md`](../../docs/LOCAL-DEVELOPMENT.md) — Local setup and validation ladder
+- [`../../docs/runbooks/README.md`](../../docs/runbooks/README.md) — Operational troubleshooting
 - [`../middlewares/`](../middlewares/) — Error handling, throttling, Langfuse trace root
 - [`../../src/retrieval/`](../../src/retrieval/) — Search engine implementations


### PR DESCRIPTION
## Summary

Tightens subsystem README files so an agent can quickly understand where code lives before editing. No runtime or code changes.

## Changes

Adds relative links to canonical docs and nearest `AGENTS.override.md` files in all reserved subsystem READMEs:

- `telegram_bot/README.md`
- `telegram_bot/services/README.md`
- `src/README.md`
- `src/retrieval/README.md`
- `src/ingestion/README.md`
- `src/voice/README.md`
- `mini_app/README.md`
- `services/README.md`

### Added links

- `AGENTS.override.md` — bot and ingestion scope rules
- `DOCKER.md` — Docker bring-up and service dependencies
- `docs/LOCAL-DEVELOPMENT.md` — local setup and validation ladder
- `docs/runbooks/README.md` — operational troubleshooting
- `docs/INGESTION.md` — unified ingestion guide

## Verification

- `git diff --check` — clean
- Relative markdown link existence check — all links resolve
- `git status --porcelain` — only reserved READMEs modified

Related: #1396