### PR TITLE
docs: project docs order audit and maintenance guide

### DIFF
--- a/docs/audits/2026-05-07-project-docs-order-audit.md
+++ b/docs/audits/2026-05-07-project-docs-order-audit.md
@@ -1,0 +1,214 @@
+# Project Documentation Order Audit — 2026-05-07
+
+**Scope:** `docs/`, root `README.md`, `DOCKER.md`, `AGENTS.md`, folder `README.md` files, and `AGENTS.override.md` files.
+**Method:** Read current files, exact `rg` searches, relative-link existence checks. No code, Compose, or runtime changes.
+**Related:** #1396
+
+---
+
+## 1. Executive Summary
+
+The docs tree is well-organized at the top level (`docs/README.md`, `docs/runbooks/README.md`, `docs/engineering/`), but **three stale-doc risk areas** and **two duplicate-truth risks** create drift. Several broken links point to a retired `.claude/rules/` path. Folder READMEs are generally healthy, but a few lack fast-search recipes. No automated link checker is in place.
+
+**Risk level:** MEDIUM. The core entrypoints (`docs/README.md`, `docs/runbooks/README.md`, `DOCKER.md`, `docs/LOCAL-DEVELOPMENT.md`) are current, but duplication increases the cost of every env/compose change.
+
+---
+
+## 2. Methodology
+
+Commands run during this audit (representative sample):
+
+```bash
+rg -n -i "source of truth|canonical|compose project name|worktree-named" docs/ README.md DOCKER.md
+rg -n "make docker-up|make local-up|make check|make test-unit|make test-bot-health" docs/ README.md DOCKER.md
+rg -n "\.claude/" docs/ README.md
+find . -maxdepth 3 -name 'AGENTS.override.md' -o -name 'README.md' | sort
+rg -n "TROUBLESHOOTING_CACHE|CACHE_DEGRADATION|REDIS_CACHE_DEGRADATION" docs/ README.md
+rg -n "BOT_ARCHITECTURE|BOT_INTERNAL_STRUCTURE|PROJECT_STACK|PIPELINE_OVERVIEW" docs/ README.md
+```
+
+All claims below are backed by current file contents or command output.
+
+---
+
+## 3. Stale-Doc Risk Areas
+
+### 3.1 Onboarding / Local-Development / README overlap
+
+Five documents describe the same local setup steps (env copy, `make docker-up`, `make test-bot-health`, validation ladder):
+
+- `README.md` (root) — lines 184–199, 279–280
+- `docs/LOCAL-DEVELOPMENT.md` — lines 11–82, 127–128
+- `docs/ONBOARDING.md` — lines 28–72, 176–178
+- `docs/ONBOARDING_CHECKLIST.md` — lines 28–71, 87–93
+- `DOCKER.md` — lines 35–62, 136–154
+
+**Impact:** When a make target, env variable, or port changes, up to five files may need edits. The probability of at least one staying stale is high.
+
+**Mitigation in place:** `DOCKER.md` and `docs/LOCAL-DEVELOPMENT.md` already declare themselves canonical. The risk is that the other three files still duplicate the instructions instead of linking.
+
+### 3.2 Cache documentation triplicate
+
+Three docs cover cache tiers, thresholds, and degradation:
+
+- `docs/TROUBLESHOOTING_CACHE.md` — 188 lines; focused on debug recipes
+- `docs/CACHE_DEGRADATION.md` — 93 lines; focused on tier definitions and degradation modes
+- `docs/runbooks/REDIS_CACHE_DEGRADATION.md` — runbook format; focused on operator response
+
+**Impact:** Threshold values and version prefixes (`v5`, `v8`) appear in multiple files. A bump in `integrations/cache.py` may not propagate to all three.
+
+### 3.3 Architecture docs without clear boundaries
+
+Four docs describe system architecture:
+
+- `docs/PROJECT_STACK.md` — high-level subsystem map
+- `docs/BOT_ARCHITECTURE.md` — bot layer architecture
+- `docs/BOT_INTERNAL_STRUCTURE.md` — bot internal components
+- `docs/PIPELINE_OVERVIEW.md` — ingestion, query, and voice runtime flows
+
+They cross-reference each other (e.g., `BOT_INTERNAL_STRUCTURE.md:178` → `PIPELINE_OVERVIEW.md`), but there is no explicit boundary rule telling authors which doc owns which kind of change.
+
+---
+
+## 4. Duplicate Source-of-Truth Risks
+
+### 4.1 ADRS.md vs docs/adr/
+
+`docs/ADRS.md` contains six ADRs with titles and dates that differ from the canonical files in `docs/adr/`:
+
+| ADRS.md entry | docs/adr/ file | Match? |
+|---|---|---|
+| ADR-001: TypedDict for Graph State | `0001-colbert-reranking.md` | **No** |
+| ADR-002: RRF Fusion over Semantic Search Only | `0002-bge-m3-embeddings.md` | **No** |
+| ADR-003: RedisVL for Semantic Cache | `0003-langgraph-voice-text-split.md` | **No** |
+| ADR-004: Interrupt-based HITL Pattern | `0004-redisvl-semantic-cache.md` | **No** |
+| ADR-005: BGE-M3 for All Embeddings | `0005-hybrid-search-rrf.md` | **No** |
+| ADR-006: LiteLLM for LLM Abstraction | `0006-kommo-crm.md` | **No** |
+
+**Impact:** `docs/adr/` is the canonical directory (file names are stable, referenced from plans), but `ADRS.md` presents itself as an authoritative list. A reader may trust the summary and never open the canonical files.
+
+### 4.2 Developer guide vs add-new-node guide
+
+- `docs/DEVELOPER_GUIDE.md` — 243 lines; includes LangGraph node creation, state contract, registration
+- `docs/ADD_NEW_RAG_NODE.md` — dedicated guide for the same task
+
+Both describe creating a node in `telegram_bot/graph/nodes/`, registering it in `build_graph()`, and updating state. The dedicated guide is more detailed, but `DEVELOPER_GUIDE.md` does not redirect to it.
+
+---
+
+## 5. Missing Quick-Search Paths
+
+### 5.1 No consolidated cross-cutting search recipes in `docs/engineering/`
+
+`docs/runbooks/README.md` provides `rg` recipes for traces, Redis, and Qdrant, but there is no equivalent in `docs/engineering/` for cross-cutting code searches (e.g., "find all LiteLLM provider keys", "find all collection name references").
+
+### 5.2 Some folder READMEs lack fast-search sections
+
+Healthy examples (`services/README.md`, `telegram_bot/README.md`, `mini_app/README.md`) include focused checks and `rg` recipes. Others (`src/README.md`, `tests/README.md`, `scripts/README.md`) are minimal indexes without search helpers.
+
+### 5.3 No automated link checker
+
+Broken relative links were found manually:
+
+| File | Broken link | Target missing |
+|---|---|---|
+| `docs/HITL.md:137` | `.claude/rules/features/telegram-bot.md` | yes |
+| `docs/API_REFERENCE.md:205` | `.claude/rules/features/telegram-bot.md` | yes |
+| `docs/BOT_INTERNAL_STRUCTURE.md:176` | `.claude/rules/features/telegram-bot.md` | yes |
+| `docs/ONBOARDING.md:171–172` | `.claude/rules/troubleshooting.md` | yes |
+| `docs/ONBOARDING.md:178` | `.claude/rules/features/telegram-bot.md` | yes |
+
+A CI-level markdown link checker (or a `make docs-check` target) would catch these before merge.
+
+---
+
+## 6. Docs Lookup Order
+
+Agents and workers should use this lookup order when answering questions or updating documentation:
+
+1. **Project indexes first** — `docs/README.md`, `docs/runbooks/README.md`, nearest folder `README.md`
+2. **Nearest README / `AGENTS.override.md` second** — local subsystem rules and boundaries
+3. **Current code / config third** — the running source of truth for ports, env vars, service names, routes
+4. **Official docs / Context7 fourth** — for SDK/framework version-sensitive behavior
+5. **Broad web / Exa only as fallback** — when the above four layers do not answer the question
+
+`AGENTS.md` should stay a **gateway**, not a duplicated operations manual. Navigation and detailed guidance belong in the indexes (`docs/README.md`, `docs/runbooks/README.md`) and folder READMEs.
+
+---
+
+## 7. Recommended Follow-Up Waves
+
+### Wave 1 — Onboarding / env deduplication (small, safe)
+
+- Make `docs/LOCAL-DEVELOPMENT.md` the single canonical local-setup doc.
+- Convert `docs/ONBOARDING.md` and `docs/ONBOARDING_CHECKLIST.md` into **redirect/checklist-only** pages that link to `LOCAL-DEVELOPMENT.md` and `DOCKER.md`.
+- Remove duplicate `make` command matrices from `README.md` and link to `DOCKER.md`.
+
+### Wave 2 — Cache docs consolidation (medium)
+
+- Merge tier definitions and thresholds into **one canonical doc** (prefer `docs/runbooks/REDIS_CACHE_DEGRADATION.md` because it already links to source files).
+- Convert `docs/TROUBLESHOOTING_CACHE.md` and `docs/CACHE_DEGRADATION.md` into runbook appendices or archive them.
+
+### Wave 3 — ADR reconciliation (small)
+
+- Either:
+  - **Option A:** Make `docs/ADRS.md` a lightweight index that links to `docs/adr/000*.md` and nothing more.
+  - **Option B:** Archive `docs/ADRS.md` and update `docs/README.md` to point directly to `docs/adr/`.
+
+### Wave 4 — Architecture doc boundaries (medium, needs design)
+
+- Add a one-paragraph "Ownership" header to each of the four architecture docs defining what kind of change belongs there.
+- Example rule: `PROJECT_STACK.md` owns subsystem boundaries; `PIPELINE_OVERVIEW.md` owns runtime flow; `BOT_ARCHITECTURE.md` owns Telegram-layer design; `BOT_INTERNAL_STRUCTURE.md` owns file-level component map.
+
+### Wave 5 — Broken-link cleanup and automation (small)
+
+- Fix the five broken `.claude/rules/` links listed in §5.3.
+- Evaluate adding a `make docs-check` target (e.g., `markdown-link-check` or a lightweight Python script) to CI.
+
+### Wave 6 — Folder README search recipes (small, incremental)
+
+- Add a "Fast Search" or `rg` recipe section to `src/README.md`, `tests/README.md`, and `scripts/README.md`, following the pattern in `services/README.md`.
+
+---
+
+## 8. Appendix: Files Inspected
+
+```
+README.md
+AGENTS.md
+DOCKER.md
+docs/README.md
+docs/LOCAL-DEVELOPMENT.md
+docs/ONBOARDING.md
+docs/ONBOARDING_CHECKLIST.md
+docs/PROJECT_STACK.md
+docs/BOT_ARCHITECTURE.md
+docs/BOT_INTERNAL_STRUCTURE.md
+docs/PIPELINE_OVERVIEW.md
+docs/TROUBLESHOOTING_CACHE.md
+docs/CACHE_DEGRADATION.md
+docs/runbooks/README.md
+docs/runbooks/REDIS_CACHE_DEGRADATION.md
+docs/ADRS.md
+docs/adr/0001-colbert-reranking.md
+docs/adr/0002-bge-m3-embeddings.md
+docs/adr/0003-langgraph-voice-text-split.md
+docs/adr/0004-redisvl-semantic-cache.md
+docs/adr/0005-hybrid-search-rrf.md
+docs/adr/0006-kommo-crm.md
+docs/DEVELOPER_GUIDE.md
+docs/ADD_NEW_RAG_NODE.md
+docs/API_REFERENCE.md
+docs/HITL.md
+docs/engineering/sdk-registry.md
+docs/engineering/test-writing-guide.md
+docs/engineering/issue-triage.md
+telegram_bot/AGENTS.override.md
+telegram_bot/README.md
+services/README.md
+mini_app/README.md
+src/ingestion/unified/AGENTS.override.md
+src/README.md
+tests/README.md
+scripts/README.md
+```

--- a/docs/engineering/docs-maintenance.md
+++ b/docs/engineering/docs-maintenance.md
@@ -1,0 +1,216 @@
+# Documentation Maintenance Guide
+
+**Scope:** How agents and workers should create, update, and review documentation after code, config, or runtime changes.
+**Related:** #1396
+
+---
+
+## 1. Purpose
+
+Docs are part of the production surface. Stale docs waste agent time, mislead reviewers, and increase the blast radius of every config change. This guide defines the minimum maintenance contract for the repo.
+
+---
+
+## 2. Docs Lookup Order
+
+When answering questions or writing documentation, use this order. Do not skip layers without a reason.
+
+| Priority | Layer | Examples |
+|---|---|---|
+| 1 | **Project indexes** | `docs/README.md`, `docs/runbooks/README.md`, nearest folder `README.md` |
+| 2 | **Nearest README / `AGENTS.override.md`** | `telegram_bot/README.md`, `src/ingestion/unified/AGENTS.override.md` |
+| 3 | **Current code / config** | `compose.yml`, `Makefile`, `pyproject.toml`, service entrypoints |
+| 4 | **Official docs / Context7** | SDK/framework docs for version-sensitive behavior |
+| 5 | **Broad web / Exa** | Only when layers 1–4 do not answer the question |
+
+**Rule:** `AGENTS.md` stays a **gateway** — it points to indexes and rules, but it does not duplicate long operations manuals. Navigation and detailed guidance belong in `docs/README.md`, `docs/runbooks/README.md`, and folder READMEs.
+
+---
+
+## 3. Canonical Owners (One Source of Truth per Fact)
+
+| Fact | Canonical Doc | Do Not Duplicate In |
+|---|---|---|
+| Docker Compose files, profiles, services, ports, env, local project name | `DOCKER.md` | Folder READMEs, `ONBOARDING.md`, root `README.md` |
+| Local developer flow, commands, validation ladder | `docs/LOCAL-DEVELOPMENT.md` | `ONBOARDING_CHECKLIST.md`, root `README.md` |
+| Repo overview, primary entrypoints, high-level architecture | `README.md` (root) | `docs/PROJECT_STACK.md` (keep boundary: root = elevator pitch; `PROJECT_STACK` = subsystem map) |
+| Folder ownership, entrypoints, boundaries, local checks | Nearest `README.md` | Parent READMEs, `AGENTS.md` |
+| Test-writing rules | `docs/engineering/test-writing-guide.md` | `DEVELOPER_GUIDE.md` |
+| Runtime/Compose contract tests | `tests/unit/test_docker_static_validation.py` + Compose fixtures | Markdown prose only |
+| SDK/framework lookup order and versions | `docs/engineering/sdk-registry.md` | `AGENTS.md`, folder READMEs |
+| Issue triage workflow | `docs/engineering/issue-triage.md` | `AGENTS.md` (gateway only) |
+| Operational runbooks | `docs/runbooks/*.md` | `docs/TROUBLESHOOTING_*.md` (redirect or archive) |
+
+Folder READMEs are **indexes**, not second sources of truth. They may summarize and link to canonical docs; they must not duplicate long Compose/env/deploy rules.
+
+---
+
+## 4. Impact Gate (When Must Docs Be Updated?)
+
+Before finishing any task that changes code, config, tests, runtime behavior, public commands, service boundaries, API routes, Docker/Compose files, env vars, dependencies, or user-visible workflow, ask:
+
+1. **Did this task change a documented command, port, env var, profile, service name, route, entrypoint, runtime version, test command, dependency, or owner boundary?**
+2. **Which canonical doc owns that fact?**
+3. **Is that doc inside the current `RESERVED_FILES`?**
+
+**Disposition:**
+
+- **Impacted + reserved** → Update docs in this PR.
+- **Impacted + not reserved** → Do not edit outside reservation. Report a `new_bugs` entry with evidence and `recommended_disposition: new_or_existing_issue`.
+- **Not impacted** → Add command evidence or a finding: `Docs impact check: no documented contract changed`.
+
+Do not finish code/config/runtime work without either updating docs or explicitly reporting why no docs update is needed.
+
+---
+
+## 5. Agent / Worker Update Rules
+
+### 5.1 Before Editing Docs
+
+Inspect the code/config that owns the fact:
+
+- **Docker/runtime docs:** `compose.yml`, `compose.dev.yml`, `compose.vps.yml`, `Makefile`, Dockerfiles, healthchecks, `tests/fixtures/compose.ci.env`.
+- **Service docs:** Service entrypoint, Dockerfile, compose service name, tests.
+- **API docs:** Code route definitions, Dockerfile `EXPOSE`, compose ports/healthcheck, README entrypoints.
+- **SDK/framework docs:** If behavior is version-sensitive, use Context7/official-docs summary; if missing and tools are available, refresh docs before writing.
+
+Do not preserve stale text just because it was already documented. **Code/config wins** unless the task is explicitly to change the contract.
+
+### 5.2 README Index Contract
+
+Every maintained folder README should be concise and scannable:
+
+- Purpose (one paragraph)
+- Entrypoints / important files
+- Runtime services or dependencies when relevant
+- Owner boundaries / invariants
+- Focused checks (commands)
+- **See also** links to canonical docs
+
+Use **relative links**. Never write absolute local paths such as `/home/user/...`.
+
+### 5.3 Docker Docs Contract
+
+- `DOCKER.md` owns service/profile/project-name/env/port truth.
+- `docs/LOCAL-DEVELOPMENT.md` owns the day-to-day local sequence.
+- Folder READMEs should link to `DOCKER.md`, not duplicate profile matrices.
+- Canonical local Compose project is `dev`; do not document worktree-named Docker projects.
+- LiveKit/voice stays separate/off by default unless the task explicitly re-enables it.
+
+When updating Docker docs, validate at least one relevant command or explain why skipped:
+
+```bash
+COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml --compatibility config --services
+make check
+```
+
+### 5.4 Audit and Plan Docs
+
+- Audits go in `docs/audits/` with a `YYYY-MM-DD-` prefix.
+- Plans go in `docs/plans/` or `docs/superpowers/plans/`.
+- Both are **dated evidence**, not timeless source of truth. They may be archived when follow-up is complete.
+- Do not let audit findings silently replace canonical policy docs.
+
+---
+
+## 6. Review Traps
+
+Block or fix docs that contain any of the following:
+
+| Trap | Example | Fix |
+|---|---|---|
+| **Contradicted boundaries** | A package README says "no dependency on X" while imports prove otherwise | Update README or code; do not leave the contradiction |
+| **Stale ports / healthcheck paths / service names / profile names / Python versions** | Doc says `localhost:3000` but compose maps `3001` | Edit canonical doc; link from others |
+| **Absolute local links** | `/home/user/projects/rag-fresh/...` | Replace with relative repo paths |
+| **Raw secrets / tokens / DSNs / chat IDs / phone numbers / private URLs** | Pasted `.env` line with `TELEGRAM_BOT_TOKEN=123:abc` | Redact to `<redacted>` or describe the variable name |
+| **Instructions to use VPS/deploy/live services for local-only tasks** | "Run on production Langfuse to test" | Restrict to local Docker endpoints |
+| **Duplicate source-of-truth tables** | Folder README repeats the full Compose profile matrix from `DOCKER.md` | Replace with a link to `DOCKER.md` |
+| **Marketing prose in READMEs** | "Revolutionary AI-powered platform" | Replace with purpose, entrypoints, boundaries, checks |
+| **Broken relative links** | Link to `.claude/rules/features/telegram-bot.md` which no longer exists | Fix or remove the link |
+
+---
+
+## 7. Verification for Doc Changes
+
+Run these checks before claiming a docs task is complete:
+
+```bash
+# 1. No trailing whitespace or conflict markers
+git diff --check
+
+# 2. Changed files are only the intended docs
+git diff --name-only
+
+# 3. Markdown relative-link existence check (example for this repo)
+# Python one-liner: scan for relative links and assert the path exists
+python3 -c "
+import re, sys
+from pathlib import Path
+files = Path('docs').rglob('*.md')
+files = list(files) + [Path('README.md'), Path('DOCKER.md'), Path('AGENTS.md')]
+bad = []
+for f in files:
+    text = f.read_text()
+    for m in re.finditer(r'\]\(([^)]+)\)', text):
+        link = m.group(1)
+        if link.startswith('http') or link.startswith('#'):
+            continue
+        target = (f.parent / link).resolve()
+        if not target.exists():
+            bad.append((f, link))
+if bad:
+    for f, link in bad:
+        print(f'BROKEN: {f} -> {link}')
+    sys.exit(1)
+print('All relative links OK')
+"
+```
+
+If `make check` is required by the worker prompt, run it. If the task is docs-only and no code/runtime behavior changed, record:
+
+```json
+{
+  "cmd": "make check",
+  "exit": 0,
+  "status": "skipped",
+  "required": false,
+  "summary": "docs-only; no code/runtime behavior changed"
+}
+```
+
+---
+
+## 8. Fast Doc Search Recipes
+
+Add or preserve these recipes in folder READMEs and runbook indexes:
+
+```bash
+# Cross-cutting code search by topic
+rg -n "Langfuse|trace|score|observation" docs/runbooks docs/audits telegram_bot src scripts
+rg -n "Redis|cache|semantic cache|redis-cli" docs/runbooks telegram_bot src tests
+rg -n "Qdrant|collection|vector|ColBERT|hybrid" docs/runbooks src telegram_bot tests
+rg -n "LiteLLM|proxy|master_key|provider" docs/ README.md compose*.yml
+
+# Find all folder READMEs and AGENTS overrides
+find . -maxdepth 3 \( -name 'README.md' -o -name 'AGENTS.override.md' \) | sort
+
+# Find duplicate source-of-truth phrases
+rg -n -i "source of truth|canonical" docs/ README.md DOCKER.md AGENTS.md
+```
+
+---
+
+## 9. Summary Checklist for Workers
+
+Before finishing any PR that touches docs:
+
+- [ ] I inspected the code/config that owns the fact before editing docs.
+- [ ] I updated the canonical doc, not a duplicate.
+- [ ] I did not duplicate Compose/env/test rules in folder READMEs.
+- [ ] I used relative links, not absolute paths.
+- [ ] I redacted any secrets, tokens, or DSNs.
+- [ ] I ran `git diff --check`.
+- [ ] I ran a relative-link existence check or recorded why it was skipped.
+- [ ] If the task changed runtime behavior, I validated the relevant command or recorded why skipped.
+- [ ] If the task is docs-only, I recorded `make check` as skipped with reason `docs-only; no code/runtime behavior changed`.
+- [ ] I did not edit `AGENTS.md` to duplicate navigation that belongs in `docs/README.md` or `docs/runbooks/README.md`.


### PR DESCRIPTION
## Summary

This PR adds two documentation governance files:

1. **`docs/audits/2026-05-07-project-docs-order-audit.md`** — A concise audit of the current docs tree that identifies:
   - Stale-doc risk areas (onboarding/env overlap, cache docs triplicate, architecture doc boundary drift)
   - Duplicate source-of-truth risks (`ADRS.md` vs `docs/adr/`, `DEVELOPER_GUIDE.md` vs `ADD_NEW_RAG_NODE.md`)
   - Broken relative links (retired `.claude/rules/` paths)
   - Missing quick-search paths and automated link checking
   - Six recommended follow-up waves, ordered by size and safety

2. **`docs/engineering/docs-maintenance.md`** — A maintenance playbook defining:
   - Canonical doc owners (one source of truth per fact)
   - Impact gate: when must docs be updated after code/config/runtime changes
   - Agent/worker update rules (inspect code before editing docs, no duplication in folder READMEs)
   - Review traps (stale ports, absolute links, raw secrets, marketing prose)
   - Verification recipes (whitespace checks, relative-link existence checks)
   - Fast doc search `rg` recipes

## Docs Lookup Order

Both files explicitly document the lookup order:
1. Project indexes (`docs/README.md`, `docs/runbooks/README.md`, folder `README.md`)
2. Nearest README / `AGENTS.override.md`
3. Current code / config
4. Official docs / Context7
5. Broad web / Exa fallback

And reiterate that `AGENTS.md` stays a gateway, not a duplicated operations manual.

## Verification

- `git diff --check` passed
- Relative-link existence check passed for both new files
- Redaction gate passed (no secrets, tokens, or DSNs)
- `make check` skipped with reason: docs-only; no code/runtime behavior changed

Related: #1396