### PR TITLE
docs(runbooks): quick-access table, canonical links, and LiteLLM routing verification

### DIFF
--- a/docs/runbooks/LANGFUSE_TRACING_GAPS.md
+++ b/docs/runbooks/LANGFUSE_TRACING_GAPS.md
@@ -14,6 +14,15 @@ Use this runbook when traces are missing from Langfuse or observability is broke
 - Missing scores in Langfuse
 - Traces show `LLM failed: Connection error` despite healthy Langfuse ingestion
 
+## Quick Validation Focus
+
+When traces appear missing, validate **app pipeline coverage** first:
+
+- Required trace families: **`rag-api-query`**, **`voice-session`**, **`ingestion-cli-run`**
+- Expected LiteLLM callback noise: **`litellm-acompletion`** (flat, proxy-generated, no session context)
+
+If the three required families are present and fresh, flat `litellm-acompletion` traces do **not** indicate a defect.
+
 ## Diagnosis
 
 ### 1. Check Langfuse Connectivity
@@ -189,3 +198,9 @@ docker compose restart bot
 - Monitor Langfuse ingestion rate
 - Alert on trace family gaps
 - Distinguish proxy-generated `litellm-acompletion` traces from app-instrumented `telegram-message` traces when triaging gaps
+
+## See Also
+
+- [Docker Services Reference](../../DOCKER.md)
+- [Local Development Guide](../LOCAL-DEVELOPMENT.md)
+- [LiteLLM Failure Runbook](LITEllm_FAILURE.md)

--- a/docs/runbooks/LITEllm_FAILURE.md
+++ b/docs/runbooks/LITEllm_FAILURE.md
@@ -17,6 +17,34 @@ Use this runbook when LiteLLM provider has outages or LLM calls are failing.
 
 ## Diagnosis
 
+### Verify Current Primary / Fallback Routing (read-only)
+
+Before restarting or editing config, confirm the active routing from the repo config files:
+
+```bash
+# Primary model for the gpt-4o-mini group (read-only)
+grep -A8 'model_name: gpt-4o-mini' docker/litellm/config.yaml
+
+# Fallback chain
+grep -A5 'fallbacks:' docker/litellm/config.yaml
+
+# Kubernetes equivalent
+grep -A8 'model_name: gpt-4o-mini' k8s/base/configmaps/litellm-config.yaml
+grep -A5 'fallbacks:' k8s/base/configmaps/litellm-config.yaml
+```
+
+Expected state (do **not** change without product decision):
+
+| Alias | Maps to | Role |
+|---|---|---|
+| `gpt-4o-mini` | `cerebras/zai-glm-4.7` (GLM 4.7) | **Primary** — low TTFT, reasoning disabled |
+| `gpt-4o-mini-cerebras-oss` | `cerebras/gpt-oss-120b` | Fallback 1 — reasoning, slower TTFT |
+| `gpt-4o-mini-fallback` | `groq/llama-3.1-70b-versatile` | Fallback 2 — fast, free tier |
+| `gpt-4o-mini-openai` | `openai/gpt-4o-mini` | Fallback 3 — reliable |
+
+- **Do not switch the primary back to a 120B model.** The `gpt-oss-120b` alias is reserved for benchmarking and fallback.
+- The bot sends requests to alias `gpt-4o-mini` (see `telegram_bot/graph/config.py`). `telegram_bot/config.py` sets a native default of `zai-glm-4.7` when running without the proxy.
+
 ### 1. Check LiteLLM Container State
 
 ```bash
@@ -160,14 +188,16 @@ If using multiple providers:
 
 ### Configure Fallback Models
 
-In `compose.yml` or `.env`:
+> **Caution:** Do not switch the primary model back to a 120B model (e.g., `cerebras/gpt-oss-120b`). GLM 4.7 (`cerebras/zai-glm-4.7`) remains the primary for low TTFT. Changing the primary requires a product decision.
+
+The canonical routing is defined in `docker/litellm/config.yaml` (Docker) and `k8s/base/configmaps/litellm-config.yaml` (K8s). Verify before editing:
 
 ```bash
-LITELLM_MODEL=azure/gpt-4o-mini
-LITELLM_FALLBACK_MODELS=gpt-4o,gpt-4o-mini
+grep -A8 'model_name: gpt-4o-mini' docker/litellm/config.yaml
+grep -A5 'fallbacks:' docker/litellm/config.yaml
 ```
 
-Then restart LiteLLM:
+If you must adjust fallback ordering, edit the config file and restart:
 
 ```bash
 docker compose restart litellm
@@ -186,3 +216,9 @@ When LLM fallback occurs:
 - Set up alerts for LLM timeout rates
 - Regular health checks: `curl -s ${LLM_BASE_URL}/health`
 - Watch for `OOMKilled` in container state after deploys or traffic spikes
+
+## See Also
+
+- [Langfuse Tracing Gaps](LANGFUSE_TRACING_GAPS.md)
+- [Docker Services Reference](../../DOCKER.md)
+- [Local Development Guide](../LOCAL-DEVELOPMENT.md)

--- a/docs/runbooks/QDRANT_TROUBLESHOOTING.md
+++ b/docs/runbooks/QDRANT_TROUBLESHOOTING.md
@@ -23,8 +23,8 @@ Use this runbook when Qdrant collection has issues or monitoring shows anomalies
 |---|---|
 | `qdrant` | `dev-qdrant-1` (Compose v2+), `dev_qdrant_1` (legacy) |
 
-> Qdrant listens on `6333` (REST) and `6334` (gRPC).
-> Dev exposes both to `127.0.0.1`; base `compose.yml` keeps them internal.
+> For service endpoints, ports, and Compose profiles, see the canonical [`DOCKER.md`](../../DOCKER.md).
+> For local development commands and the validation ladder, see [`docs/LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md).
 
 ## Fast-Path Diagnosis (read-only)
 
@@ -201,3 +201,5 @@ If Qdrant logs show storage or memory errors:
 
 - [Redis Cache Degradation](REDIS_CACHE_DEGRADATION.md)
 - [VPS Google Drive Ingestion Recovery](vps-gdrive-ingestion-recovery.md)
+- [Docker Services Reference](../../DOCKER.md)
+- [Local Development Guide](../LOCAL-DEVELOPMENT.md)

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -2,6 +2,16 @@
 
 Operator entrypoint for container/service investigations and incident response. If a Docker service breaks, start here before ad hoc log searching.
 
+## Quick Access
+
+| Operator request | First command / doc |
+|---|---|
+| Recent Langfuse traces (`изучи последние трейсы`) | `make validate-traces-fast` → [`LANGFUSE_TRACING_GAPS.md`](LANGFUSE_TRACING_GAPS.md) |
+| Qdrant health / query / index issues (`изучи последние qdrant запросы`) | `curl -fsS http://localhost:6333/readyz` → [`QDRANT_TROUBLESHOOTING.md`](QDRANT_TROUBLESHOOTING.md) |
+| Redis / cache degradation (`сломался redis`) | `COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec redis redis-cli -a test-redis-password ping` → [`REDIS_CACHE_DEGRADATION.md`](REDIS_CACHE_DEGRADATION.md) |
+| LiteLLM / provider failure (`сломался litellm`) | `curl -s http://localhost:4000/health` → [`LITEllm_FAILURE.md`](LITEllm_FAILURE.md) |
+| Compose service health | `make docker-ps` → [`DOCKER.md`](../../DOCKER.md) |
+
 ## Start Here
 
 | Symptom / Request | Runbook |

--- a/docs/runbooks/REDIS_CACHE_DEGRADATION.md
+++ b/docs/runbooks/REDIS_CACHE_DEGRADATION.md
@@ -52,8 +52,8 @@ COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env
 ```
 
 Look for:
-- `used_memory_human` — near the 300M limit in `compose.yml` indicates memory pressure
-- `maxmemory` — should match `256mb` (base) or `512mb` (dev override)
+- `used_memory_human` — compare against the `redis` service `deploy.resources.limits.memory` in [`compose.yml`](../../compose.yml)
+- `maxmemory` — verify against the `redis` service definition in [`compose.yml`](../../compose.yml) and dev overrides in [`compose.dev.yml`](../../compose.dev.yml); canonical values are in [`DOCKER.md`](../../DOCKER.md)
 - `evicted_keys` > 0 — confirms aggressive eviction due to memory pressure
 
 ### 3. Logs (read-only)
@@ -172,3 +172,5 @@ The system degrades gracefully — users still get responses, just without cache
 
 - [Qdrant Troubleshooting](QDRANT_TROUBLESHOOTING.md)
 - [VPS Google Drive Ingestion Recovery](vps-gdrive-ingestion-recovery.md)
+- [Docker Services Reference](../../DOCKER.md)
+- [Local Development Guide](../LOCAL-DEVELOPMENT.md)


### PR DESCRIPTION
Related: #1396

## Summary

- Adds a compact "request -> first commands/docs" quick-access table to `docs/runbooks/README.md` covering Langfuse traces, Qdrant health, Redis degradation, LiteLLM failures, and Compose service health.
- Strengthens the Langfuse runbook with a top-level validation focus box that distinguishes required trace families (`rag-api-query`, `voice-session`, `ingestion-cli-run`) from expected `litellm-acompletion` proxy noise.
- Links Qdrant and Redis runbooks back to canonical `DOCKER.md` and `docs/LOCAL-DEVELOPMENT.md` instead of duplicating Compose env/port details.
- Documents read-only verification of the current primary/fallback model routing in the LiteLLM runbook, explicitly stating that GLM 4.7 (`cerebras/zai-glm-4.7`) remains primary and must not be switched back to a 120B model.
