### PR TITLE
docs: fix broken .claude/rules/ links and add docs-check tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@
 	lock update update-pkg reinstall setup-hooks \
 	qdrant-backup \
 	git-hygiene git-hygiene-fix repo-cleanup repo-cleanup-force \
-	test-contract
+	test-contract \
+	docs-check
 
 # Configurable container names & thresholds
 REDIS_CONTAINER ?= dev_redis_1
@@ -476,6 +477,11 @@ docs-build: ## Build documentation
 	@echo "$(BLUE)Building documentation...$(NC)"
 	uv run mkdocs build
 	@echo "$(GREEN)✓ Documentation built in site/$(NC)"
+
+docs-check: ## Check Markdown relative links for broken targets
+	@echo "$(BLUE)Checking documentation links...$(NC)"
+	python3 scripts/check_markdown_links.py
+	@echo "$(GREEN)✓ Documentation links OK$(NC)"
 
 # =============================================================================
 # QUICK COMMANDS

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -202,4 +202,4 @@ All queries are traced in Langfuse with:
 ## Related Documentation
 
 - [Pipeline Overview](PIPELINE_OVERVIEW.md)
-- [Observability](../.claude/rules/features/telegram-bot.md#observability)
+- [Bot Architecture](BOT_ARCHITECTURE.md)

--- a/docs/BOT_INTERNAL_STRUCTURE.md
+++ b/docs/BOT_INTERNAL_STRUCTURE.md
@@ -173,6 +173,6 @@ grep -n "dp.message_handlers" telegram_bot/bot.py
 
 ## Related Documentation
 
-- [Telegram Bot Feature Doc](../.claude/rules/features/telegram-bot.md)
+- [Bot Architecture](BOT_ARCHITECTURE.md)
 - [Client Pipeline](CLIENT_PIPELINE.md)
 - [Pipeline Overview](PIPELINE_OVERVIEW.md)

--- a/docs/HITL.md
+++ b/docs/HITL.md
@@ -134,6 +134,6 @@ HITL is enabled by default for all CRM write tools. No configuration required.
 
 ## Related Documentation
 
-- [CRM Integration](.claude/rules/features/telegram-bot.md#crm-integration)
+- [HITL CRM Flow](HITL_CRM_FLOW.md)
 - [LangGraph Interrupt](https://langchain-ai.github.io/langgraph/concepts/human_in_the_loop/#interrupt)
 - Bot source: `telegram_bot/agents/hitl.py`

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -168,18 +168,18 @@ rag/
 |-------|------|
 | Local development setup | [LOCAL-DEVELOPMENT.md](LOCAL-DEVELOPMENT.md) |
 | Pipeline architecture | [PIPELINE_OVERVIEW.md](PIPELINE_OVERVIEW.md) |
-| Troubleshooting | [.claude/rules/troubleshooting.md](../.claude/rules/troubleshooting.md) |
-| Feature documentation | [.claude/rules/features/telegram-bot.md](../.claude/rules/features/telegram-bot.md) |
+| Troubleshooting | [runbooks/README.md](runbooks/README.md) |
+| Feature documentation | [BOT_ARCHITECTURE.md](BOT_ARCHITECTURE.md) |
 
 ## Next Steps
 
 1. Read [LOCAL-DEVELOPMENT.md](LOCAL-DEVELOPMENT.md) for detailed setup
 2. Review [PIPELINE_OVERVIEW.md](PIPELINE_OVERVIEW.md) to understand the architecture
-3. Check `.claude/rules/features/telegram-bot.md` for bot internals
+3. Check [BOT_ARCHITECTURE.md](BOT_ARCHITECTURE.md) for bot internals
 4. Explore `tests/` to understand testing patterns
 
 ## Getting Help
 
 - **Issues**: Create a GitHub issue for bugs or feature requests
-- **Internal docs**: See `.claude/rules/` for development guidelines
-- **Troubleshooting**: See `.claude/rules/troubleshooting.md` for common issues
+- **Internal docs**: See [docs/engineering/](engineering/) for development guidelines
+- **Troubleshooting**: See [runbooks/README.md](runbooks/README.md) for common issues

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Check Markdown relative links and exit nonzero on missing targets.
+
+Checks at least README.md, DOCKER.md, AGENTS.md, all docs/**/*.md,
+and folder README.md files. Skips external URLs, anchors-only links,
+mailto links, and generated/cache/vendor directories.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+# Directories to skip
+SKIP_DIRS = {
+    ".git",
+    ".venv",
+    "venv",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    "node_modules",
+    ".terraform",
+    "vendor",
+    "generated",
+    "cache",
+    "dist",
+    "build",
+    "site",
+    ".claude",
+}
+
+# Markdown link regex: [text](url)
+LINK_RE = re.compile(r"\[([^\]]*)\]\(([^)]+)\)")
+
+
+def should_skip_dir(path: Path) -> bool:
+    return any(part in SKIP_DIRS for part in path.parts)
+
+
+def is_skipped_link(url: str) -> bool:
+    """Skip external URLs, anchors-only, mailto, and empty links."""
+    if not url:
+        return True
+    if url.startswith(("http://", "https://", "ftp://", "mailto:")):
+        return True
+    return bool(url.startswith("#"))
+
+
+def resolve_link(source_file: Path, url: str) -> Path:
+    """Resolve a relative URL against its source file, stripping any fragment."""
+    # Strip fragment
+    if "#" in url:
+        url = url.split("#", 1)[0]
+    # Strip query string (rare in md but possible)
+    if "?" in url:
+        url = url.split("?", 1)[0]
+    if not url:
+        return source_file
+    target = source_file.parent / url
+    return target.resolve()
+
+
+def collect_markdown_files(root: Path) -> list[Path]:
+    """Collect markdown files to check."""
+    files = set()
+
+    # Always include these root files if they exist
+    for name in ("README.md", "DOCKER.md", "AGENTS.md"):
+        p = root / name
+        if p.exists():
+            files.add(p.resolve())
+
+    # All docs/**/*.md
+    for p in (root / "docs").rglob("*.md"):
+        if not should_skip_dir(p):
+            files.add(p.resolve())
+
+    # Folder README.md files
+    for p in root.rglob("README.md"):
+        if not should_skip_dir(p):
+            files.add(p.resolve())
+
+    return sorted(files)
+
+
+INLINE_CODE_RE = re.compile(r"`[^`]+`")
+
+
+def strip_inline_code(line: str) -> str:
+    """Remove inline code spans so links inside backticks are not matched."""
+    return INLINE_CODE_RE.sub("", line)
+
+
+def check_links(root: Path) -> list[tuple[Path, int, str, Path]]:
+    """Return list of (source_file, line_number, url, missing_target)."""
+    broken = []
+    md_files = collect_markdown_files(root)
+
+    for md_file in md_files:
+        text = md_file.read_text(encoding="utf-8")
+        in_fenced_code = False
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            stripped = line.strip()
+            # Toggle fenced code block state
+            if stripped.startswith("```"):
+                in_fenced_code = not in_fenced_code
+                continue
+            if in_fenced_code:
+                continue
+            # Remove inline code before matching links
+            clean_line = strip_inline_code(line)
+            for match in LINK_RE.finditer(clean_line):
+                url = match.group(2).strip()
+                if is_skipped_link(url):
+                    continue
+                target = resolve_link(md_file, url)
+                if not target.exists():
+                    broken.append((md_file, line_no, url, target))
+
+    return broken
+
+
+def main() -> int:
+    root = Path.cwd()
+    broken = check_links(root)
+
+    if not broken:
+        print("All relative Markdown links OK.")
+        return 0
+
+    print(f"Broken links found: {len(broken)}")
+    for source, line_no, url, target in broken:
+        rel_source = source.relative_to(root)
+        try:
+            rel_target = target.relative_to(root)
+        except ValueError:
+            rel_target = target
+        print(f"  {rel_source}:{line_no} -> '{url}' (missing: {rel_target})")
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -43,5 +43,5 @@ curl http://localhost:8080/health
 
 ## See Also
 
-- [`../telegram_bot/graph/`](../telegram_bot/graph/) — LangGraph pipeline implementation
-- [`../telegram_bot/services/`](../telegram_bot/services/) — Services reused by the API lifespan
+- [`../../telegram_bot/graph/`](../../telegram_bot/graph/) — LangGraph pipeline implementation
+- [`../../telegram_bot/services/`](../../telegram_bot/services/) — Services reused by the API lifespan


### PR DESCRIPTION
## Summary

- Replace broken `.claude/rules/` relative links in `docs/HITL.md`, `docs/API_REFERENCE.md`, `docs/BOT_INTERNAL_STRUCTURE.md`, `docs/ONBOARDING.md` with current in-repo docs.
- Add `scripts/check_markdown_links.py`, a small Python 3 script that checks Markdown relative links and exits nonzero on missing targets.
- Add `make docs-check` target that runs the script.

## Verification

- `python3 scripts/check_markdown_links.py` — catches remaining pre-existing broken links in `src/api/README.md` (outside this PR scope).
- `make docs-check` — same, exits nonzero as designed.
- `rg -n "\.claude/" README.md DOCKER.md AGENTS.md docs` — no live broken `.claude/rules/` links remain in reserved docs.

Related: #1396