### PR TITLE
docs: add ADR and audit indexes

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,16 @@
+# Architecture Decision Records
+
+This directory contains architecture decisions that are still useful for understanding core project tradeoffs.
+
+## Index
+
+- [0001 - ColBERT reranking](0001-colbert-reranking.md)
+- [0002 - BGE-M3 embeddings](0002-bge-m3-embeddings.md)
+- [0003 - LangGraph voice/text split](0003-langgraph-voice-text-split.md)
+- [0004 - RedisVL semantic cache](0004-redisvl-semantic-cache.md)
+- [0005 - Hybrid search with RRF](0005-hybrid-search-rrf.md)
+- [0006 - Kommo CRM](0006-kommo-crm.md)
+
+## When To Use
+
+Start here when changing retrieval architecture, embeddings, reranking, semantic cache behavior, CRM integration, or voice/Text LangGraph boundaries. Verify every ADR against current code before treating it as active implementation truth.

--- a/docs/archive/workflows/disabled/update-roadmap.yml
+++ b/docs/archive/workflows/disabled/update-roadmap.yml
@@ -106,4 +106,4 @@ jobs:
           echo "- **Completed:** ${{ steps.progress.outputs.done }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Progress:** ${{ steps.progress.outputs.percent }}%" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "🔗 [View ROADMAP.md](../../ROADMAP.md)" >> $GITHUB_STEP_SUMMARY
+          echo "🔗 ROADMAP.md is not present in the current repository snapshot." >> $GITHUB_STEP_SUMMARY

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -1,0 +1,16 @@
+# Audits
+
+This directory contains timestamped operational and documentation audits. Audit files are evidence snapshots: use them to understand what was observed at a point in time, then verify current behavior against live code, config, logs, or service state.
+
+## Recent Operational Audits
+
+- [2026-05-05 - Langfuse recent traces structure audit](2026-05-05-langfuse-recent-traces-structure-audit.md)
+- [2026-05-05 - Langfuse Telethon trace audit](2026-05-05-langfuse-telethon-trace-audit.md)
+- [2026-05-05 - Langfuse trace 8d79036a audit](2026-05-05-langfuse-trace-8d79036a-audit.md)
+- [2026-05-07 - Docker Langfuse health audit](2026-05-07-docker-langfuse-health-audit.md)
+- [2026-05-07 - Langfuse real env OTEL fix](2026-05-07-langfuse-real-env-otel-fix.md)
+- [2026-05-07 - Telegram bot logs audit](2026-05-07-telegram-bot-logs-audit.md)
+
+## When To Use
+
+Start here when investigating repeated runtime failures, trace anomalies, Docker/Langfuse health drift, or Telegram bot log incidents. For operational commands and live investigation flow, use [runbooks](../runbooks/README.md) first.

--- a/docs/plans/2026-03-19-catalog-reply-keyboard-navigation-design.md
+++ b/docs/plans/2026-03-19-catalog-reply-keyboard-navigation-design.md
@@ -167,7 +167,7 @@ This file is the primary place to absorb the old reply-keyboard behavior contrac
 
 ### `telegram_bot/keyboards/`
 
-Add a dedicated catalog keyboard module, either by extending [client_keyboard.py](/home/user/projects/rag-fresh/telegram_bot/keyboards/client_keyboard.py) or creating a sibling module.
+Add a dedicated catalog keyboard module, either by extending [client_keyboard.py](../../telegram_bot/keyboards/client_keyboard.py) or creating a sibling module.
 
 Required responsibilities:
 


### PR DESCRIPTION
## Summary
- add README indexes for docs/adr and docs/audits
- replace one absolute local docs link with a relative repo link
- remove a dead ROADMAP.md markdown link from an archived disabled workflow

## Verification
- git diff --check -- docs/adr/README.md docs/audits/README.md docs/plans/2026-03-19-catalog-reply-keyboard-navigation-design.md docs/archive/workflows/disabled/update-roadmap.yml
- scoped changed markdown link check
- pre-commit hooks during commit
- pre-push fast local sanity gate

Related: #1396