### PR TITLE
fix(contextualization): use langfuse.openai drop-in for auto-tracing (#1367)

### DIFF
--- a/docs/runbooks/LANGFUSE_TRACING_GAPS.md
+++ b/docs/runbooks/LANGFUSE_TRACING_GAPS.md
@@ -80,6 +80,7 @@ langfuse api observations list --trace-id <trace-id> --fields core,basic,io,meta
 | `rag-api-query` | Structured SPANs + GENERATION | Often missing if RAG API is not called or `@observe` decorator is bypassed |
 | `voice-session` | Structured (capture disabled) | Missing when voice/LiveKit is off by default or voice agent did not start |
 | `ingestion-cli-run` | Structured (capture disabled) | Becomes stale when unified ingestion CLI has not run recently; check `make ingest-unified-status` |
+| `openai-contextualize` | SPAN with nested GENERATION (auto-traced via `langfuse.openai` drop-in) | Missing if `OpenAIContextualizer` uses plain `openai` clients; inner completions would become orphan `litellm-acompletion` traces |
 
 **Key distinction:** `litellm-acompletion` traces are created by the LiteLLM proxy's built-in Langfuse callback (`success_callback: ["langfuse"]`), not by the application's `@observe` decorators. They will never contain child spans, scores, or session attribution.
 

--- a/src/contextualization/openai.py
+++ b/src/contextualization/openai.py
@@ -1,7 +1,8 @@
 """OpenAI-based contextualization provider."""
 
 from langfuse import observe
-from openai import APIStatusError, AsyncOpenAI, OpenAI, RateLimitError
+from langfuse.openai import AsyncOpenAI, OpenAI
+from openai import APIStatusError, RateLimitError
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_random_exponential
 
 from src.config import Settings

--- a/tests/unit/contextualization/test_openai.py
+++ b/tests/unit/contextualization/test_openai.py
@@ -80,6 +80,32 @@ class TestOpenAIContextualizerInit:
 
             assert contextualizer.sync_client == mock_client
 
+    def test_init_uses_langfuse_openai_drop_in(self):
+        """Test that contextualizer uses langfuse.openai clients for auto-tracing.
+
+        This prevents orphan litellm-acompletion traces by ensuring inner
+        completion calls are nested under the active @observe span.
+        """
+        import importlib
+
+        import src.contextualization.openai as ctx_mod
+
+        mock_settings = MagicMock()
+        mock_settings.openai_api_key = "test-key"
+
+        with (
+            patch("langfuse.openai.AsyncOpenAI") as mock_lf_async,
+            patch("langfuse.openai.OpenAI") as mock_lf_sync,
+        ):
+            mock_lf_async.return_value = MagicMock()
+            mock_lf_sync.return_value = MagicMock()
+
+            importlib.reload(ctx_mod)
+            ctx_mod.OpenAIContextualizer(settings=mock_settings)
+
+            mock_lf_async.assert_called_once_with(api_key="test-key")
+            mock_lf_sync.assert_called_once_with(api_key="test-key")
+
 
 class TestOpenAIContextualizerContextualize:
     """Tests for OpenAIContextualizer.contextualize method."""


### PR DESCRIPTION
## Summary

Switch `OpenAIContextualizer` from plain `openai` clients to `langfuse.openai` drop-ins so inner `chat.completions.create` calls are auto-traced as child GENERATION observations under the `openai-contextualize` `@observe` span.

## Changes

- Import `AsyncOpenAI`/`OpenAI` from `langfuse.openai` in `src/contextualization/openai.py`
- Keep `APIStatusError` and `RateLimitError` from `openai` for tenacity retry behavior
- Add focused test `test_init_uses_langfuse_openai_drop_in` verifying the import path via module reload
- Update `docs/runbooks/LANGFUSE_TRACING_GAPS.md` with `openai-contextualize` trace row

## Intentionally unchanged

- `GraphConfig.create_llm(auto_trace=False)` and `generate_response` still use plain OpenAI to avoid duplicate/orphan traces
- LiteLLM routing is untouched

## Verification

- `uv run pytest tests/unit/contextualization/test_openai.py -q` → 19 passed
- `uv run pytest tests/unit/test_langfuse_openai_trace_context.py -q` → 7 passed
- `uv run ruff check src/contextualization/openai.py tests/unit/contextualization/test_openai.py tests/unit/test_langfuse_openai_trace_context.py` → clean
- `git diff --check` → clean