### PR TITLE
fix(rag): forward active Langfuse trace id from rag_search to rag_pipeline (#1253)

### DIFF
--- a/telegram_bot/agents/rag_tool.py
+++ b/telegram_bot/agents/rag_tool.py
@@ -157,26 +157,31 @@ async def rag_search(
                 result_store.get("semantic_cache_already_checked")
             )
 
+        trace_id = lf.get_current_trace_id() or ""
+
         invoke_start = time.perf_counter()
-        result = await rag_pipeline(
-            query,
-            user_id=ctx.telegram_user_id if ctx else 0,
-            session_id=ctx.session_id if ctx else "",
-            query_type=query_type,
-            original_query=ctx.original_query if ctx else "",
-            cache=ctx.cache if ctx else None,
-            embeddings=ctx.embeddings if ctx else None,
-            sparse_embeddings=ctx.sparse_embeddings if ctx else None,
-            qdrant=ctx.qdrant if ctx else None,
-            reranker=ctx.reranker if ctx else None,
-            llm=ctx.llm if ctx else None,
-            agent_role=ctx.role if ctx else None,
-            state_contract=state_contract,
-            pre_computed_embedding=pre_computed_embedding,
-            pre_computed_sparse=pre_computed_sparse,
-            pre_computed_colbert=pre_computed_colbert,
-            semantic_cache_already_checked=semantic_cache_already_checked,
-        )
+        pipeline_kwargs: dict[str, Any] = {
+            "user_id": ctx.telegram_user_id if ctx else 0,
+            "session_id": ctx.session_id if ctx else "",
+            "query_type": query_type,
+            "original_query": ctx.original_query if ctx else "",
+            "cache": ctx.cache if ctx else None,
+            "embeddings": ctx.embeddings if ctx else None,
+            "sparse_embeddings": ctx.sparse_embeddings if ctx else None,
+            "qdrant": ctx.qdrant if ctx else None,
+            "reranker": ctx.reranker if ctx else None,
+            "llm": ctx.llm if ctx else None,
+            "agent_role": ctx.role if ctx else None,
+            "state_contract": state_contract,
+            "pre_computed_embedding": pre_computed_embedding,
+            "pre_computed_sparse": pre_computed_sparse,
+            "pre_computed_colbert": pre_computed_colbert,
+            "semantic_cache_already_checked": semantic_cache_already_checked,
+        }
+        if trace_id:
+            pipeline_kwargs["langfuse_trace_id"] = trace_id
+
+        result = await rag_pipeline(query, **pipeline_kwargs)
         pipeline_wall_ms = (time.perf_counter() - invoke_start) * 1000
 
         # Streaming hook (#428): when streaming is restored for the agent text path

--- a/tests/unit/agents/test_rag_tool.py
+++ b/tests/unit/agents/test_rag_tool.py
@@ -486,3 +486,45 @@ async def test_rag_search_falls_back_to_query_when_no_original(bot_context):
     # Guard should use the tool query as fallback
     guard_state = mock_guard.call_args[0][0]
     assert guard_state["messages"][0]["content"] == "цены на квартиры"
+
+
+async def test_rag_search_forwards_active_trace_id_to_pipeline(bot_context):
+    """rag_search forwards active Langfuse trace id to rag_pipeline (#1253)."""
+    from telegram_bot.agents.rag_tool import rag_search
+
+    mock_lf = MagicMock()
+    mock_lf.get_current_trace_id = MagicMock(return_value="trace-active-123")
+
+    with (
+        patch(
+            "telegram_bot.agents.rag_tool.rag_pipeline",
+            new_callable=AsyncMock,
+            return_value=_pipeline_result(),
+        ) as mock_pipeline,
+        patch("telegram_bot.agents.rag_tool.get_client", return_value=mock_lf),
+    ):
+        await rag_search.ainvoke({"query": "test"}, config=_make_config(bot_context))
+
+    assert mock_pipeline.call_count == 1
+    assert mock_pipeline.call_args.kwargs.get("langfuse_trace_id") == "trace-active-123"
+
+
+async def test_rag_search_omits_langfuse_trace_id_when_no_active_trace(bot_context):
+    """rag_search omits langfuse_trace_id kwarg when no active trace (#1253)."""
+    from telegram_bot.agents.rag_tool import rag_search
+
+    mock_lf = MagicMock()
+    mock_lf.get_current_trace_id = MagicMock(return_value="")
+
+    with (
+        patch(
+            "telegram_bot.agents.rag_tool.rag_pipeline",
+            new_callable=AsyncMock,
+            return_value=_pipeline_result(),
+        ) as mock_pipeline,
+        patch("telegram_bot.agents.rag_tool.get_client", return_value=mock_lf),
+    ):
+        await rag_search.ainvoke({"query": "test"}, config=_make_config(bot_context))
+
+    assert mock_pipeline.call_count == 1
+    assert "langfuse_trace_id" not in mock_pipeline.call_args.kwargs


### PR DESCRIPTION
## Summary
Forward the active Langfuse trace id from `telegram_bot/agents/rag_tool.py::rag_search` into the `rag_pipeline(...)` call using the native `langfuse_trace_id` kwarg accepted by Langfuse `@observe` wrappers.

## Changes
- In `rag_search`, compute `trace_id = lf.get_current_trace_id() or \"\"` before the non-guard `rag_pipeline(...)` call.
- Pass `langfuse_trace_id=trace_id` to `rag_pipeline(...)` only when `trace_id` is non-empty.
- Keep fail-soft behavior: if `get_current_trace_id()` is missing/raises/returns falsy, RAG still works.
- Add focused tests:
  - active trace id is forwarded to `rag_pipeline`;
  - empty/no trace id does not break and omits the kwarg.

## Verification
- `uv run pytest tests/unit/agents/test_rag_tool.py -q` — 19 passed
- `git diff --check` — clean
- `uv run ruff check telegram_bot/agents/rag_tool.py tests/unit/agents/test_rag_tool.py` — passed