### PR TITLE
observability(search_engines): add @observe spans for direct embedding calls (#1367)

### DIFF
--- a/src/retrieval/search_engines.py
+++ b/src/retrieval/search_engines.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Union
 
+from langfuse import observe
 from qdrant_client import QdrantClient, models
 
 from src.config import AcornMode, QuantizationMode, SearchEngine, Settings
@@ -268,6 +269,18 @@ class HybridRRFSearchEngine(BaseSearchEngine):
         super().__init__(settings)
         self.embedding_model = get_bge_m3_model(use_fp16=True)
 
+    @observe(
+        name="search-engine-encode-hybrid",
+        as_type="embedding",
+        capture_input=False,
+        capture_output=False,
+    )
+    def _encode_query(self, query: str) -> Any:
+        """Generate embeddings for hybrid RRF search."""
+        return self.embedding_model.encode(
+            query, return_dense=True, return_sparse=True, return_colbert_vecs=False
+        )
+
     def search(
         self,
         query_embedding: str | list[float],
@@ -356,9 +369,7 @@ class HybridRRFSearchEngine(BaseSearchEngine):
         import logging
 
         # Generate all embeddings for query
-        query_embeddings = self.embedding_model.encode(
-            query, return_dense=True, return_sparse=True, return_colbert_vecs=False
-        )
+        query_embeddings = self._encode_query(query)
 
         # Convert to Python/Qdrant types
         dense_vector = convert_to_python_types(query_embeddings["dense_vecs"])
@@ -449,6 +460,18 @@ class HybridRRFColBERTSearchEngine(BaseSearchEngine):
         super().__init__(settings)
         self.embedding_model = get_bge_m3_model(use_fp16=True)
 
+    @observe(
+        name="search-engine-encode-hybrid-colbert",
+        as_type="embedding",
+        capture_input=False,
+        capture_output=False,
+    )
+    def _encode_query(self, query: str) -> Any:
+        """Generate embeddings for hybrid RRF + ColBERT search."""
+        return self.embedding_model.encode(
+            query, return_dense=True, return_sparse=True, return_colbert_vecs=True
+        )
+
     def search(
         self,
         query_embedding: str | list[float],
@@ -529,9 +552,7 @@ class HybridRRFColBERTSearchEngine(BaseSearchEngine):
         import logging
 
         # Generate all embeddings for query (dense + sparse + colbert)
-        query_embeddings = self.embedding_model.encode(
-            query, return_dense=True, return_sparse=True, return_colbert_vecs=True
-        )
+        query_embeddings = self._encode_query(query)
 
         # Convert to Python/Qdrant types
         dense_vector = convert_to_python_types(query_embeddings["dense_vecs"])
@@ -630,6 +651,18 @@ class DBSFColBERTSearchEngine(BaseSearchEngine):
         super().__init__(settings)
         self.embedding_model = get_bge_m3_model(use_fp16=True)
 
+    @observe(
+        name="search-engine-encode-dbsf-colbert",
+        as_type="embedding",
+        capture_input=False,
+        capture_output=False,
+    )
+    def _encode_query(self, query: str) -> Any:
+        """Generate embeddings for DBSF + ColBERT search."""
+        return self.embedding_model.encode(
+            query, return_dense=True, return_sparse=True, return_colbert_vecs=True
+        )
+
     def search(
         self,
         query_embedding: str | list[float],
@@ -706,9 +739,7 @@ class DBSFColBERTSearchEngine(BaseSearchEngine):
         import logging
 
         # Generate all embeddings
-        query_embeddings = self.embedding_model.encode(
-            query, return_dense=True, return_sparse=True, return_colbert_vecs=True
-        )
+        query_embeddings = self._encode_query(query)
 
         dense_vector = convert_to_python_types(query_embeddings["dense_vecs"])
         sparse_vector = lexical_weights_to_sparse(query_embeddings["lexical_weights"])

--- a/tests/contract/test_span_coverage_contract.py
+++ b/tests/contract/test_span_coverage_contract.py
@@ -68,6 +68,10 @@ SENSITIVE_SPANS = [
     "bge-m3-encode-hybrid",
     "bge-m3-rerank",
     "bge-m3-encode-colbert",
+    # Search engines (all 3)
+    "search-engine-encode-hybrid",
+    "search-engine-encode-hybrid-colbert",
+    "search-engine-encode-dbsf-colbert",
     # Qdrant (all 8)
     "qdrant-ensure-collection",
     "qdrant-apply-strict-mode",
@@ -301,6 +305,9 @@ EMBEDDING_SPANS = [
     "bge-m3-encode-hybrid",
     "bge-m3-rerank",
     "bge-m3-encode-colbert",
+    "search-engine-encode-hybrid",
+    "search-engine-encode-hybrid-colbert",
+    "search-engine-encode-dbsf-colbert",
 ]
 
 RETRIEVER_SPANS = [

--- a/tests/observability/trace_contract.yaml
+++ b/tests/observability/trace_contract.yaml
@@ -104,6 +104,11 @@ spans:
     - bge-m3-colbert-query-embed
     - bge-m3-hybrid-embed-batch
 
+  search_engines:
+    - search-engine-encode-hybrid
+    - search-engine-encode-hybrid-colbert
+    - search-engine-encode-dbsf-colbert
+
   qdrant:
     - qdrant-ensure-collection
     - qdrant-apply-strict-mode
@@ -279,6 +284,10 @@ sensitive_spans:
   - bge-m3-encode-hybrid
   - bge-m3-rerank
   - bge-m3-encode-colbert
+  # search_engines (raw vectors)
+  - search-engine-encode-hybrid
+  - search-engine-encode-hybrid-colbert
+  - search-engine-encode-dbsf-colbert
   # qdrant (raw search payloads + lifecycle)
   - qdrant-ensure-collection
   - qdrant-apply-strict-mode


### PR DESCRIPTION
## Summary

Add Langfuse `@observe` coverage to the three direct `self.embedding_model.encode(...)` calls in `src/retrieval/search_engines.py`:

- `HybridRRFSearchEngine._encode_query` → `search-engine-encode-hybrid`
- `HybridRRFColBERTSearchEngine._encode_query` → `search-engine-encode-hybrid-colbert`
- `DBSFColBERTSearchEngine._encode_query` → `search-engine-encode-dbsf-colbert`

## Changes

- Extract encode calls into private `_encode_query` wrapper methods decorated with `@observe(name=..., as_type='embedding', capture_input=False, capture_output=False)`.
- Update `tests/observability/trace_contract.yaml` to document the new spans in `spans.search_engines` and `sensitive_spans`.
- Update `tests/contract/test_span_coverage_contract.py` to include the new spans in `SENSITIVE_SPANS` and `EMBEDDING_SPANS`.

## Verification

- `pytest tests/contract/test_trace_families_contract.py` — 8 passed
- `pytest tests/contract/test_span_coverage_contract.py` — 147 passed
- `pytest tests/unit/test_search_engines.py` — 33 passed
- `ruff check` — clean
- `mypy src/retrieval/search_engines.py` — clean

## Non-goals

- Does not touch `src/core/pipeline.py` or `src/ingestion/indexer.py` (later slices).
- Does not change search ranking, vector generation arguments, Qdrant calls, or thresholds.