### PR TITLE
observability(ingestion): add Langfuse span to DocumentIndexer._embed_texts() (#1367)

### DIFF
--- a/src/ingestion/indexer.py
+++ b/src/ingestion/indexer.py
@@ -7,6 +7,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Any
 
+from langfuse import observe
 from qdrant_client import QdrantClient
 from qdrant_client.models import (
     Distance,
@@ -356,6 +357,12 @@ class DocumentIndexer:
             logger.error(f"✗ Batch failed after {batch_time:.2f}s: {type(e).__name__}: {e}")
             print(f"  ✗ Failed to index batch: {e}")
 
+    @observe(
+        name="ingestion-indexer-embed-texts",
+        as_type="embedding",
+        capture_input=False,
+        capture_output=False,
+    )
     async def _embed_texts(self, texts: list[str]) -> list[dict]:
         """
         Generate embeddings for texts using BGE-M3.

--- a/tests/contract/test_span_coverage_contract.py
+++ b/tests/contract/test_span_coverage_contract.py
@@ -136,13 +136,14 @@ SENSITIVE_SPANS = [
     # Entry points
     "voice-session",
     "rag-api-query",
-    # Ingestion (all 6)
+    # Ingestion (all 7)
     "ingestion-cli-run",
     "ingestion-cli-preflight",
     "ingestion-flow-run-once",
     "ingestion-flow-watch",
     "ingestion-qdrant-delete-file",
     "ingestion-qdrant-upsert-chunks",
+    "ingestion-indexer-embed-texts",
     # Contextualization (raw text chunks and queries)
     "claude-contextualize",
     "claude-contextualize-sync",
@@ -308,6 +309,7 @@ EMBEDDING_SPANS = [
     "search-engine-encode-hybrid",
     "search-engine-encode-hybrid-colbert",
     "search-engine-encode-dbsf-colbert",
+    "ingestion-indexer-embed-texts",
 ]
 
 RETRIEVER_SPANS = [

--- a/tests/observability/trace_contract.yaml
+++ b/tests/observability/trace_contract.yaml
@@ -229,6 +229,7 @@ spans:
     - ingestion-flow-watch
     - ingestion-qdrant-delete-file
     - ingestion-qdrant-upsert-chunks
+    - ingestion-indexer-embed-texts
 
   contextualization:
     - claude-contextualize
@@ -362,6 +363,7 @@ sensitive_spans:
   - ingestion-flow-watch
   - ingestion-qdrant-delete-file
   - ingestion-qdrant-upsert-chunks
+  - ingestion-indexer-embed-texts
   # contextualization (raw text chunks and queries)
   - claude-contextualize
   - claude-contextualize-sync

--- a/tests/unit/test_indexer.py
+++ b/tests/unit/test_indexer.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from src.ingestion.chunker import Chunk
 from src.ingestion.indexer import DocumentIndexer, IndexStats
 
@@ -429,6 +431,36 @@ class TestIndexBatch:
 
         captured = capsys.readouterr()
         assert "Failed to index batch" in captured.out
+
+
+class TestEmbedTextsObservability:
+    """Test _embed_texts observability decorator."""
+
+    def test_embed_texts_has_observe_decorator(self):
+        """Test that _embed_texts has @observe with correct config."""
+        import ast
+        from pathlib import Path
+
+        source = Path("src/ingestion/indexer.py").read_text()
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name == "_embed_texts"
+            ):
+                decorators = node.decorator_list
+                assert len(decorators) >= 1
+                observe_call = decorators[0]
+                assert isinstance(observe_call, ast.Call)
+                assert isinstance(observe_call.func, ast.Name)
+                assert observe_call.func.id == "observe"
+                kwargs = {kw.arg: kw.value for kw in observe_call.keywords}
+                assert kwargs["name"].value == "ingestion-indexer-embed-texts"
+                assert kwargs["as_type"].value == "embedding"
+                assert kwargs["capture_input"].value is False
+                assert kwargs["capture_output"].value is False
+                return
+        pytest.fail("_embed_texts not found or missing @observe decorator")
 
 
 class TestEmbedTexts:


### PR DESCRIPTION
## Summary
Add Langfuse trace coverage for ingestion `DocumentIndexer._embed_texts()` BGE-M3 embedding generation.

## Changes
- Wrap `_embed_texts()` with `@observe(name="ingestion-indexer-embed-texts", as_type="embedding", capture_input=False, capture_output=False)`
- Add span to `SENSITIVE_SPANS` and `EMBEDDING_SPANS` contract lists
- Add span to `trace_contract.yaml` ingestion and `sensitive_spans` sections
- Add focused AST-based unit test for decorator configuration

## Verification
- `uv run pytest tests/unit/test_indexer.py -q` — 18 passed
- `uv run pytest tests/contract/test_span_coverage_contract.py -q` — 149 passed
- `uv run ruff check src/ingestion/indexer.py tests/unit/test_indexer.py tests/contract/test_span_coverage_contract.py` — passed
- `git diff --check` — passed

## Acceptance
- Ingestion embedding generation has a named `as_type="embedding"` span
- Raw chunk text and embedding payloads are not captured
- Threadpool behavior and returned embedding shape are unchanged
- Trace contract files include the new span