### PR TITLE
fix: make hadolint docker_image hook execute hadolint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,11 +106,10 @@ repos:
     hooks:
       - id: hadolint
         name: Hadolint Dockerfile linter
-        entry: hadolint/hadolint:v2.12.0
+        entry: hadolint/hadolint:v2.12.0 hadolint --failure-threshold error
         language: docker_image
         files: Dockerfile.*|.*Dockerfile
         pass_filenames: true
-        args: ["--failure-threshold", "error"]
 
   # =============================================================================
   # PRE-PUSH HOOKS (Run before git push)


### PR DESCRIPTION
## Summary
- fix local hadolint pre-commit hook to execute hadolint explicitly via docker_image entry
- move --failure-threshold option into entry so file paths are passed after options
- keep scope minimal: only .pre-commit-config.yaml

Fixes #1350