### PR TITLE
fix: stabilize mini-app-frontend under hardened compose security

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -201,3 +201,4 @@ make validate-traces-fast
 - Local and profile workflows use the canonical local compose set: `compose.yml:compose.dev.yml`.
 - Docker runtime for images that import `telegram_bot.observability` (and therefore `langfuse`) uses Python 3.13. Local native development may still use the repo's `uv` environment (Python 3.11+).
 - The `voice` profile (LiveKit, SIP, voice agent) is intentionally not part of the current local bring-up. Bring it up separately only when explicitly needed.
+- `mini-app-frontend` runs nginx as `101:101` with `cap_drop: [ALL]` and `cap_add: [NET_BIND_SERVICE]`; nginx runtime PID/temp paths are kept under `/tmp` to avoid privileged `chown` startup paths.

--- a/compose.yml
+++ b/compose.yml
@@ -384,6 +384,8 @@ services:
       dockerfile: Dockerfile
     restart: unless-stopped
     read_only: false
+    user: "101:101"
+    cap_add: ["NET_BIND_SERVICE"]
     logging: *default-logging
     depends_on:
       mini-app-api:

--- a/mini_app/frontend/Dockerfile
+++ b/mini_app/frontend/Dockerfile
@@ -18,11 +18,13 @@ RUN npm run build
 # ====== RUNTIME STAGE ======
 FROM nginx:1.29-alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de AS runtime
 
-# Remove default nginx config
-RUN rm /etc/nginx/conf.d/default.conf
-
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/app.conf
+COPY nginx.conf /etc/nginx/nginx.conf
+
+RUN mkdir -p /tmp/nginx/client_temp /tmp/nginx/proxy_temp /tmp/nginx/fastcgi_temp /tmp/nginx/uwsgi_temp /tmp/nginx/scgi_temp \
+    && chown -R 101:101 /tmp/nginx
+
+USER 101:101
 
 EXPOSE 80
 

--- a/mini_app/frontend/README.md
+++ b/mini_app/frontend/README.md
@@ -19,6 +19,8 @@ Renders the expert-selection UI, deep-link flow, and phone-capture form inside T
 - **Compose project**: `dev` (see [`../../DOCKER.md`](../../DOCKER.md) for contract details)
 - **Local port**: `8091` (host) mapped from container port `80`
 - **Health**: `GET http://localhost:8091/health` (nginx internal)
+- **Runtime security**: runs as `uid:gid 101:101` with `cap_drop: [ALL]` and only `cap_add: [NET_BIND_SERVICE]`
+- **Writable runtime paths**: nginx PID and temp/cache paths are rooted under `/tmp/nginx*`
 
 ## Local Development
 

--- a/mini_app/frontend/nginx.conf
+++ b/mini_app/frontend/nginx.conf
@@ -1,31 +1,56 @@
-server {
-    listen 80;
-    server_name _;
+worker_processes auto;
+pid /tmp/nginx.pid;
+error_log /dev/stderr warn;
 
-    root /usr/share/nginx/html;
-    index index.html;
+events {
+    worker_connections 1024;
+}
 
-    # SPA fallback: all routes served from index.html
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
 
-    # Proxy /api/* to FastAPI backend
-    location /api/ {
-        proxy_pass http://mini-app-api:8090;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        # SSE support
-        proxy_buffering off;
-        proxy_cache off;
-        proxy_read_timeout 300s;
-    }
+    access_log /dev/stdout;
+    sendfile on;
+    keepalive_timeout 65;
 
-    # Health check endpoint
-    location /health {
-        return 200 "ok";
-        add_header Content-Type text/plain;
+    # Keep all nginx writable runtime artifacts under /tmp
+    # so the service works with dropped filesystem capabilities.
+    client_body_temp_path /tmp/nginx/client_temp;
+    proxy_temp_path /tmp/nginx/proxy_temp;
+    fastcgi_temp_path /tmp/nginx/fastcgi_temp;
+    uwsgi_temp_path /tmp/nginx/uwsgi_temp;
+    scgi_temp_path /tmp/nginx/scgi_temp;
+
+    server {
+        listen 80;
+        server_name _;
+
+        root /usr/share/nginx/html;
+        index index.html;
+
+        # SPA fallback: all routes served from index.html
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+
+        # Proxy /api/* to FastAPI backend
+        location /api/ {
+            proxy_pass http://mini-app-api:8090;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            # SSE support
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 300s;
+        }
+
+        # Health check endpoint
+        location /health {
+            return 200 "ok";
+            add_header Content-Type text/plain;
+        }
     }
 }

--- a/tests/unit/test_compose_config.py
+++ b/tests/unit/test_compose_config.py
@@ -285,6 +285,23 @@ class TestMiniAppFrontendHealthcheck:
         assert self._EXPECTED_PROBE in content
 
 
+class TestMiniAppFrontendSecurityContract:
+    """Frontend nginx must stay compatible with hardened capability settings (#1431)."""
+
+    def test_compose_runs_frontend_as_nginx_uid_gid(self, vps: dict) -> None:
+        svc = vps["services"]["mini-app-frontend"]
+        assert svc.get("user") == "101:101", (
+            "mini-app-frontend must run as nginx user to avoid root chown/setuid startup paths"
+        )
+
+    def test_compose_frontend_drops_all_and_readds_only_bind_capability(self, vps: dict) -> None:
+        svc = vps["services"]["mini-app-frontend"]
+        assert "ALL" in svc.get("cap_drop", []), "mini-app-frontend must keep cap_drop: [ALL]"
+        assert svc.get("cap_add") == ["NET_BIND_SERVICE"], (
+            "mini-app-frontend must only add NET_BIND_SERVICE to bind port 80 as non-root"
+        )
+
+
 class TestHandoffComposeContract:
     """Bot compose env must expose the production handoff contract."""
 

--- a/tests/unit/test_docker_static_validation.py
+++ b/tests/unit/test_docker_static_validation.py
@@ -36,6 +36,8 @@ _LANGFUSE_RUNTIME_DOCKERFILES = [
 ]
 
 COMPOSE_CI_ENV = Path("tests/fixtures/compose.ci.env")
+MINI_APP_FRONTEND_DOCKERFILE = Path("mini_app/frontend/Dockerfile")
+MINI_APP_FRONTEND_NGINX_CONF = Path("mini_app/frontend/nginx.conf")
 
 
 def _docker_available() -> bool:
@@ -143,3 +145,23 @@ def test_langfuse_dockerfile_uses_python313(dockerfile: str) -> None:
     assert "python3.13" in text or "python:3.13" in text, (
         f"{dockerfile} must use Python 3.13 runtime for langfuse SDK compatibility"
     )
+
+
+def test_mini_app_frontend_dockerfile_runs_as_unprivileged_nginx_user() -> None:
+    text = MINI_APP_FRONTEND_DOCKERFILE.read_text()
+    assert "USER 101:101" in text, (
+        "mini_app/frontend/Dockerfile must run nginx as uid/gid 101 to avoid root-only startup paths"
+    )
+    assert "COPY nginx.conf /etc/nginx/nginx.conf" in text, (
+        "mini_app/frontend/Dockerfile must install the hardened main nginx.conf"
+    )
+    assert "/tmp/nginx/client_temp" in text, (
+        "mini_app/frontend/Dockerfile must pre-create /tmp/nginx temp directories for nginx startup"
+    )
+
+
+def test_mini_app_frontend_nginx_runtime_paths_use_tmp() -> None:
+    text = MINI_APP_FRONTEND_NGINX_CONF.read_text()
+    assert "pid /tmp/nginx.pid;" in text
+    assert "client_body_temp_path /tmp/nginx/client_temp;" in text
+    assert "proxy_temp_path /tmp/nginx/proxy_temp;" in text


### PR DESCRIPTION
## Summary
- run `mini-app-frontend` as `101:101` and add only `NET_BIND_SERVICE` while preserving `cap_drop: [ALL]`
- replace frontend nginx config with hardened main config (`pid` + temp paths under `/tmp`) to avoid privileged startup paths
- pre-create `/tmp/nginx/*` dirs in image and add regression checks for compose/dockerfile/nginx contract

## Tests
- `uv run pytest tests/unit/test_compose_config.py tests/unit/test_docker_static_validation.py -q`
- `COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml --profile bot --profile ml config --quiet`
- `COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml build mini-app-frontend`
- `make check`

## Targeted Docker evidence
- `docker run --user 101:101 --cap-drop ALL --cap-add NET_BIND_SERVICE ... dev_mini-app-frontend:latest` serves `/health` and logs contain no `chown("/var/cache/nginx/client_temp" ... Operation not permitted)`

Closes #1431
