### PR TITLE
fix(e2e): harden Telethon readiness gate and redact auth output

### DIFF
--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -27,7 +27,8 @@ Minimum env for Telegram E2E (Telethon userbot):
 - `TELEGRAM_API_ID` (from [my.telegram.org](https://my.telegram.org))
 - `TELEGRAM_API_HASH` (from [my.telegram.org](https://my.telegram.org))
 - `E2E_BOT_USERNAME` (defaults to `@test_nika_homes_bot`)
-- a pre-created Telethon session file (e.g., `e2e_tester.session`)
+- an authorized Telethon session file (e.g., `e2e_tester.session`)
+- if the session is present but unauthorized, refresh it with `uv run python scripts/e2e/auth.py --phone <PHONE>`
 
 The canonical local Compose project name is `dev`. `COMPOSE_PROJECT_NAME=dev` is set in `tests/fixtures/compose.ci.env`, which `make` targets use as a fallback when `.env` is absent. Do not create worktree-named Docker projects.
 

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -135,10 +135,12 @@ Use the `local-*` shortcuts (they now run a minimal subset from `compose.yml:com
 ```bash
 make local-up
 make test-bot-health
-make run-bot
+make bot
 make local-ps
 make local-down
 ```
+
+`make bot` is the operator-facing command for this local loop; `make run-bot` remains the lower-level/native target.
 
 For ingestion workflows that require docling:
 

--- a/docs/audits/2026-05-08-telethon-readiness-gate.md
+++ b/docs/audits/2026-05-08-telethon-readiness-gate.md
@@ -1,0 +1,73 @@
+# 2026-05-08 Telethon Readiness Gate
+
+## Scope
+
+Issue: #1443
+Blocking context: #1307
+Surface: `scripts/e2e/*` Telethon local runtime loop
+
+This audit validates whether local Telethon E2E entrypoints are ready for a bounded connect/send/receive check without exposing sensitive credentials.
+
+## Redacted Prerequisite Check
+
+- `.env` present: `true`
+- `TELEGRAM_API_ID` present: `true`
+- `TELEGRAM_API_HASH` present: `true`
+- `E2E_BOT_USERNAME` present: `true`
+- `e2e_tester.session` present: `true`
+
+## Commands Executed
+
+```bash
+uv run ruff check scripts/e2e/auth.py scripts/e2e/telegram_client.py scripts/e2e/config.py scripts/e2e/runner.py
+uv run python scripts/e2e/runner.py --scenario 1.1 --no-judge
+uv run python - <<'PY'
+import asyncio
+from telethon import TelegramClient
+from scripts.e2e.config import E2EConfig
+
+async def main():
+    c = E2EConfig()
+    client = TelegramClient(c.telegram_session, c.telegram_api_id, c.telegram_api_hash)
+    await client.connect()
+    try:
+        print(f"connected={True}")
+        print(f"authorized={await client.is_user_authorized()}")
+    finally:
+        await client.disconnect()
+
+asyncio.run(main())
+PY
+```
+
+## Findings
+
+1. Repo-owned redaction leaks were present before the run:
+   - `scripts/e2e/auth.py` printed API ID, phone, and authenticated account identity.
+   - `scripts/e2e/telegram_client.py` logged account username/phone on connect.
+   - `scripts/e2e/runner.py` printed configured bot username.
+2. Local session authorization check result: `connected=true`, `authorized=false`.
+3. `runner.py --scenario 1.1 --no-judge` now fails fast with a clear non-interactive blocker message when the session is unauthorized.
+
+## Repo Fixes Applied
+
+- Sanitized `scripts/e2e/auth.py` output to avoid exposing API ID, phone, and account identity.
+- Updated `scripts/e2e/telegram_client.py` to use `connect()` + authorization gate, and to avoid identity logging.
+- Updated `scripts/e2e/runner.py` to avoid bot-username echo and to render a concise blocker error instead of traceback on runtime auth gate failure.
+- Updated `docs/LOCAL-DEVELOPMENT.md` with explicit requirement that Telethon session must be authorized.
+
+## Gate Result
+
+`blocked-on-local-credentials`
+
+Reason: local Telethon session file exists but is not authorized, so send/receive against the configured bot cannot proceed yet.
+
+## Next Step
+
+Re-authorize the local session via `scripts/e2e/auth.py`, then rerun:
+
+```bash
+uv run python scripts/e2e/runner.py --scenario 1.1 --no-judge
+```
+
+On successful connect/send/receive, resume #1307 runtime trace validation loop.

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -4,6 +4,7 @@ This directory contains timestamped operational and documentation audits. Audit 
 
 ## Recent Operational Audits
 
+- [2026-05-08 - Telethon readiness gate](2026-05-08-telethon-readiness-gate.md)
 - [2026-05-08 - Full docs actualization audit](2026-05-08-full-docs-actualization-audit.md)
 - [2026-05-08 - Telethon Langfuse runtime loop audit](2026-05-08-telethon-langfuse-runtime-loop.md)
 - [2026-05-08 - Docs index and gateway audit](2026-05-08-docs-index-gateway-audit.md)

--- a/scripts/e2e/auth.py
+++ b/scripts/e2e/auth.py
@@ -35,9 +35,8 @@ async def main(phone: str, code: str | None = None, password: str | None = None)
         print("Error: TELEGRAM_API_ID and TELEGRAM_API_HASH must be set in .env")
         sys.exit(1)
 
-    print(f"API ID: {API_ID}")
-    print(f"Phone: {phone}")
-    print(f"Session: {SESSION_NAME}.session")
+    print("Starting Telethon authentication flow...")
+    print(f"Session target: {SESSION_NAME}.session")
     print()
 
     client = TelegramClient(SESSION_NAME, API_ID, API_HASH)
@@ -50,7 +49,6 @@ async def main(phone: str, code: str | None = None, password: str | None = None)
             HASH_FILE.write_text(
                 json.dumps(
                     {
-                        "phone": phone,
                         "phone_code_hash": result.phone_code_hash,
                     }
                 )
@@ -58,7 +56,7 @@ async def main(phone: str, code: str | None = None, password: str | None = None)
             print("Code sent to your Telegram app!")
             print()
             print("Run again with the code:")
-            print(f"  python scripts/e2e/auth.py --phone {phone} --code <CODE>")
+            print("  python scripts/e2e/auth.py --phone <PHONE> --code <CODE>")
             await client.disconnect()
             return
 
@@ -78,17 +76,17 @@ async def main(phone: str, code: str | None = None, password: str | None = None)
             if not password:
                 print("2FA enabled! Run with --password:")
                 print(
-                    f"  python scripts/e2e/auth.py --phone {phone} --code {code} --password <PASSWORD>"
+                    "  python scripts/e2e/auth.py --phone <PHONE> --code <CODE> --password <PASSWORD>"
                 )
                 await client.disconnect()
                 return
             await client.sign_in(password=password)
             HASH_FILE.unlink()
 
-    me = await client.get_me()
+    authorized = await client.is_user_authorized()
     print()
-    print(f"Authenticated as: {me.first_name} (@{me.username})")
-    print(f"Session saved: {SESSION_NAME}.session")
+    print(f"Authenticated: {'yes' if authorized else 'no'}")
+    print("Session saved.")
     print()
     print("Run E2E tests: make e2e-test")
 

--- a/scripts/e2e/runner.py
+++ b/scripts/e2e/runner.py
@@ -262,15 +262,19 @@ def main():
     else:
         scenarios = SCENARIOS
 
-    console.print(f"\n[bold]Running {len(scenarios)} E2E tests against {config.bot_username}[/]\n")
+    console.print(f"\n[bold]Running {len(scenarios)} E2E tests against configured bot target[/]\n")
 
     # Check if trace validation is enabled
     validate_traces = is_validation_enabled()
 
     # Run tests
-    report = asyncio.run(
-        run_tests(config, scenarios, validate_traces=validate_traces, no_judge=args.no_judge)
-    )
+    try:
+        report = asyncio.run(
+            run_tests(config, scenarios, validate_traces=validate_traces, no_judge=args.no_judge)
+        )
+    except RuntimeError as exc:
+        console.print(f"[red]E2E runner blocked:[/] {exc}")
+        sys.exit(1)
 
     # Generate reports
     generator = ReportGenerator(config.reports_dir)

--- a/scripts/e2e/telegram_client.py
+++ b/scripts/e2e/telegram_client.py
@@ -39,9 +39,14 @@ class E2ETelegramClient:
             self.config.telegram_api_id,
             self.config.telegram_api_hash,
         )
-        await self._client.start()
-        me = await self._client.get_me()
-        logger.info(f"Connected as {me.username or me.phone}")
+        await self._client.connect()
+        authorized = await self._client.is_user_authorized()
+        if not authorized:
+            await self._client.disconnect()
+            raise RuntimeError(
+                "Telethon session is not authorized. Run scripts/e2e/auth.py to refresh e2e_tester.session."
+            )
+        logger.info("Connected to Telegram (authorized=True)")
 
     async def disconnect(self) -> None:
         """Disconnect from Telegram."""


### PR DESCRIPTION
## Summary
- sanitize `scripts/e2e/auth.py` to avoid printing API ID, phone, or account identity
- switch Telethon client startup to non-interactive `connect()` + explicit authorization gate
- make E2E runner return a concise blocker message instead of traceback for unauthorized local sessions
- document Telethon readiness gate result and authorized-session prerequisite in docs

## Verification
- `git diff --check`
- `uv run ruff check scripts/e2e/auth.py scripts/e2e/telegram_client.py scripts/e2e/config.py scripts/e2e/runner.py`
- `uv run python scripts/e2e/runner.py --scenario 1.1 --no-judge` (expected blocked result: unauthorized local session)
- `uv run python - <<'PY' ... is_user_authorized() ... PY` (redacted boolean evidence only)

## Issue
- Related to #1443
- Updates blocker context for #1307 (current state: `blocked-on-local-credentials`)
