### PR TITLE
Fix PollingLockBusy diagnostics and traceback logging

### DIFF
--- a/telegram_bot/integrations/polling_lock.py
+++ b/telegram_bot/integrations/polling_lock.py
@@ -34,13 +34,47 @@ class RedisPollingLock:
             return await result
         return result
 
+    async def _call_redis(self, method_name: str, *args: Any, **kwargs: Any) -> Any:
+        method = getattr(self.redis, method_name, None)
+        if method is None:
+            return None
+        result = method(*args, **kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+    async def _read_busy_diagnostics(self) -> dict[str, Any]:
+        diagnostics: dict[str, Any] = {"key": self.key}
+
+        owner = await self._call_redis("get", self.key)
+        if owner is not None:
+            if isinstance(owner, bytes):
+                owner = owner.decode("utf-8", errors="replace")
+            diagnostics["owner"] = owner
+
+        pttl = await self._call_redis("pttl", self.key)
+        if pttl is not None:
+            diagnostics["pttl_ms"] = pttl
+        else:
+            ttl = await self._call_redis("ttl", self.key)
+            if ttl is not None:
+                diagnostics["ttl_sec"] = ttl
+
+        return diagnostics
+
     async def acquire(self, owner: str) -> None:
         self._lock = await self._create_backend_lock()
         created = await self._call("acquire", token=owner)
         if not created:
             self._lock = None
+            diagnostics = await self._read_busy_diagnostics()
             raise PollingLockBusy(
-                f"Polling lock {self.key!r} is already held; stop the other bot instance first"
+                "Polling lock busy"
+                f" key={diagnostics.get('key')!r}"
+                f" owner={diagnostics.get('owner')!r}"
+                f" pttl_ms={diagnostics.get('pttl_ms')!r}"
+                f" ttl_sec={diagnostics.get('ttl_sec')!r};"
+                " stop the other bot instance first"
             )
 
     async def refresh(self) -> None:

--- a/telegram_bot/main.py
+++ b/telegram_bot/main.py
@@ -78,7 +78,10 @@ async def main():
 
     try:
         await _start_with_retry()
-    except (TelegramUnauthorizedError, TelegramConflictError, PollingLockBusy):
+    except PollingLockBusy:
+        logger.exception("Polling lock is busy; another bot instance is active")
+        raise
+    except (TelegramUnauthorizedError, TelegramConflictError):
         logger.error("Fatal Telegram error — check bot token or stop other instances")
         raise
     except KeyboardInterrupt:

--- a/tests/unit/integrations/test_polling_lock.py
+++ b/tests/unit/integrations/test_polling_lock.py
@@ -11,10 +11,15 @@ async def test_acquire_raises_when_lock_already_exists() -> None:
     backend_lock.acquire = AsyncMock(return_value=False)
     redis = MagicMock()
     redis.lock.return_value = backend_lock
+    redis.get = AsyncMock(return_value=b"host:456")
+    redis.pttl = AsyncMock(return_value=42000)
     lock = RedisPollingLock(redis=redis, key="bot:polling", ttl_sec=90)
 
-    with pytest.raises(PollingLockBusy):
+    with pytest.raises(PollingLockBusy, match="owner='host:456'") as exc:
         await lock.acquire(owner="host:123")
+
+    assert "key='bot:polling'" in str(exc.value)
+    assert "pttl_ms=42000" in str(exc.value)
 
     redis.lock.assert_called_once_with(
         "bot:polling",
@@ -23,6 +28,25 @@ async def test_acquire_raises_when_lock_already_exists() -> None:
         thread_local=False,
     )
     backend_lock.acquire.assert_awaited_once_with(token="host:123")
+    redis.get.assert_awaited_once_with("bot:polling")
+    redis.pttl.assert_awaited_once_with("bot:polling")
+
+
+@pytest.mark.asyncio
+async def test_acquire_uses_ttl_when_pttl_unavailable() -> None:
+    backend_lock = MagicMock()
+    backend_lock.acquire = AsyncMock(return_value=False)
+    redis = MagicMock()
+    redis.lock.return_value = backend_lock
+    redis.get = AsyncMock(return_value="host:999")
+    redis.pttl = AsyncMock(return_value=None)
+    redis.ttl = AsyncMock(return_value=77)
+    lock = RedisPollingLock(redis=redis, key="bot:polling", ttl_sec=90)
+
+    with pytest.raises(PollingLockBusy, match="ttl_sec=77"):
+        await lock.acquire(owner="host:123")
+
+    redis.ttl.assert_awaited_once_with("bot:polling")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -233,6 +233,7 @@ class TestMainFunction:
         mock_config_instance.telegram_token = "test-token"
         mock_config_instance.llm_api_key = "test-api-key"
         mock_bot_config.return_value = mock_config_instance
+        mock_logger = MagicMock()
 
         with (
             patch.dict(
@@ -247,8 +248,10 @@ class TestMainFunction:
         ):
             from telegram_bot import main as main_module
 
-            with pytest.raises(PollingLockBusy, match="lock busy"):
-                await main_module.main()
+            with patch.object(main_module.logging, "getLogger", return_value=mock_logger):
+                with pytest.raises(PollingLockBusy, match="lock busy"):
+                    await main_module.main()
 
             mock_property_bot_instance.start.assert_awaited_once()
             mock_property_bot_instance.stop.assert_awaited_once()
+            mock_logger.exception.assert_called_once()


### PR DESCRIPTION
## Summary
Fixes startup diagnostics for `PollingLockBusy` so operators can see actionable lock state without unsafe lock stealing.

Fixes #1409

### Changed files
- `telegram_bot/integrations/polling_lock.py`
  - Added safe busy-lock diagnostics collection from Redis (`get`, `pttl`, fallback `ttl`).
  - `PollingLockBusy` message now includes lock key, owner token value (if available), and TTL/PTTL fields.
  - No force-acquire/lock takeover behavior added.
- `telegram_bot/main.py`
  - Handle `PollingLockBusy` separately and log via `logger.exception(...)` to preserve traceback.
- `tests/unit/integrations/test_polling_lock.py`
  - Added assertions for owner/key/PTTL diagnostics.
  - Added fallback TTL-path test when PTTL is unavailable.
- `tests/unit/test_main.py`
  - Added assertion that `logger.exception` is called when startup fails with `PollingLockBusy`.

### Docs impact
- checked: true
- impacted: false
- proposals: []

### Command evidence
- `uv run pytest tests/unit/integrations/test_polling_lock.py tests/unit/test_main.py -q` (passed)
- `make check` (passed)
