### PR TITLE
fix: local redis auth drift diagnostics and credential redaction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,7 @@ MKL_NUM_THREADS=4
 # =============================================================================
 POSTGRES_PASSWORD=postgres  # Change in production!
 REDIS_PASSWORD=dev_redis_pass  # Change in production!
+# If you change REDIS_PASSWORD locally, run: make local-redis-recreate
 # Optional native-run override. When unset, the bot derives:
 # REDIS_URL=redis://:${REDIS_PASSWORD}@localhost:6379
 REDIS_MAXMEMORY=512mb  # dev: 512mb, VPS: 256mb (default in compose.yml)

--- a/Makefile
+++ b/Makefile
@@ -500,7 +500,7 @@ qa: all-checks test ## Full quality assurance
 # Local Development (compose.yml + compose.dev.yml via COMPOSE_FILE env)
 # =============================================================================
 
-.PHONY: local-up local-up-ingest local-down local-logs local-ps local-build run-bot bot
+.PHONY: local-up local-up-ingest local-down local-logs local-ps local-build local-redis-recreate run-bot bot
 LOCAL_SERVICES := redis qdrant bge-m3 litellm
 LOCAL_INGEST_SERVICES := docling
 LOCAL_ALL_SERVICES := $(LOCAL_SERVICES) $(LOCAL_INGEST_SERVICES)
@@ -532,6 +532,11 @@ local-ps:  ## Show local Docker status
 
 local-build:  ## Rebuild local Docker services
 	$(LOCAL_COMPOSE_CMD) build bge-m3 docling
+
+local-redis-recreate:  ## Recreate local Redis container after REDIS_PASSWORD/.env changes
+	@echo "$(BLUE)Recreating local Redis container with current .env values...$(NC)"
+	$(LOCAL_COMPOSE_CMD) up -d --no-deps --force-recreate redis
+	@echo "$(GREEN)✓ Local Redis recreated. Next: make test-bot-health$(NC)"
 
 # =============================================================================
 # Deployment

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -70,6 +70,13 @@ Bot preflight:
 make test-bot-health
 ```
 
+If `make test-bot-health` reports Redis auth failure after editing `.env`:
+
+```bash
+make local-redis-recreate
+make test-bot-health
+```
+
 `make test-bot-health` is a local helper for the published native bot prerequisites:
 - Redis via the same `BotConfig` + `redis.from_url(...)` path used by native startup
 - Qdrant via `BotConfig.get_collection_name()` + `qdrant-client`
@@ -140,6 +147,13 @@ make local-ps
 make local-down
 ```
 
+If you changed `.env` `REDIS_PASSWORD`, recreate local Redis before retrying bot health:
+
+```bash
+make local-redis-recreate
+make test-bot-health
+```
+
 `make bot` is the operator-facing command for this local loop; `make run-bot` remains the lower-level/native target.
 
 For ingestion workflows that require docling:
@@ -155,3 +169,4 @@ make local-down
 - `docker-bot-up` fails immediately: missing required env variables in `.env`.
 - Slow first startup: BGE-M3 and Docling warm up and cache models.
 - Ingestion status empty: verify `GDRIVE_SYNC_DIR` and collection bootstrap.
+- Redis auth error (`WRONGPASS` / `NOAUTH`) after changing `.env` `REDIS_PASSWORD`: run `make local-redis-recreate`, then `make test-bot-health`.

--- a/docs/runbooks/REDIS_CACHE_DEGRADATION.md
+++ b/docs/runbooks/REDIS_CACHE_DEGRADATION.md
@@ -73,6 +73,7 @@ Check for:
 |---|---|---|
 | `redis-cli ping` from **inside** the container fails | Service failure | Restart container, check disk/memory on host |
 | `redis-cli ping` works, but bot logs show `Connection refused` | App bug | Verify `REDIS_URL` in bot env; check password encoding |
+| Bot preflight shows `invalid username-password pair` / `WRONGPASS` / `NOAUTH` after local `.env` edit | Local auth drift | Run `make local-redis-recreate`, then `make test-bot-health` |
 | Redis memory is near limit and `evicted_keys` is rising | Service failure / capacity | Scale `maxmemory` or reduce TTL; see Remediation |
 | Cache hit rate is 0% but Redis is healthy and has keys | App bug | Check semantic cache threshold, query_type mapping, or `CACHE_VERSION` drift in `telegram_bot/integrations/cache.py` |
 | High latency **with** cache hits | App bug | Profile embedding or rerank tiers; latency may be upstream of Redis |
@@ -115,6 +116,19 @@ Check for:
 3. Verify network connectivity from the bot container:
    ```bash
    COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec bot redis-cli -h redis -a test-redis-password ping
+   ```
+
+### Local `REDIS_PASSWORD` Drift After `.env` Change
+
+When local bot preflight reports auth failures (`invalid username-password pair`, `WRONGPASS`, `NOAUTH`), your running Redis container may still use the previous password.
+
+1. Recreate local Redis with current `.env` values:
+   ```bash
+   make local-redis-recreate
+   ```
+2. Re-run local bot health:
+   ```bash
+   make test-bot-health
    ```
 
 ### Cache Corruption or Version Drift

--- a/scripts/test_bot_health.sh
+++ b/scripts/test_bot_health.sh
@@ -34,7 +34,7 @@ AUTH_TOKENS = (
 )
 
 def redact_redis_credentials(text: str) -> str:
-    return re.sub(r"(redis://)([^@\s]+)@", r"\1***@", text)
+    return re.sub(r"(rediss?://)([^@\s]+)@", r"\1***@", text)
 
 config = BotConfig()
 client = redis.from_url(config.redis_url, decode_responses=True)

--- a/scripts/test_bot_health.sh
+++ b/scripts/test_bot_health.sh
@@ -24,12 +24,33 @@ fi
 uv run --no-sync python - <<'PY' || fail "Redis is unreachable or auth failed for native bot startup"
 from telegram_bot.config import BotConfig
 import redis
+import re
+
+AUTH_TOKENS = (
+    "invalid username-password pair",
+    "wrongpass",
+    "authentication required",
+    "noauth",
+)
+
+def redact_redis_credentials(text: str) -> str:
+    return re.sub(r"(redis://)([^@\s]+)@", r"\1***@", text)
 
 config = BotConfig()
 client = redis.from_url(config.redis_url, decode_responses=True)
 try:
     if client.ping() is not True:
         raise RuntimeError("unexpected Redis ping response")
+except Exception as exc:
+    message = redact_redis_credentials(str(exc))
+    lowered = message.lower()
+    if any(token in lowered for token in AUTH_TOKENS):
+        raise RuntimeError(
+            "Redis auth failed for native bot startup. "
+            ".env REDIS_PASSWORD likely differs from running Redis container password. "
+            "Run `make local-redis-recreate` and retry `make test-bot-health`."
+        ) from None
+    raise RuntimeError(f"Redis check failed: {message}") from None
 finally:
     client.close()
 PY

--- a/telegram_bot/integrations/cache.py
+++ b/telegram_bot/integrations/cache.py
@@ -50,7 +50,7 @@ DEFAULT_TTLS: dict[str, int] = {
 }
 
 _METRIC_TIERS = ("semantic", "embeddings", "sparse", "search", "rerank")
-_REDIS_URL_CREDENTIALS_RE = re.compile(r"(redis://)([^@\s]+)@")
+_REDIS_URL_CREDENTIALS_RE = re.compile(r"(rediss?://)([^@\s]+)@")
 
 
 def _hash(data: str) -> str:

--- a/telegram_bot/integrations/cache.py
+++ b/telegram_bot/integrations/cache.py
@@ -50,6 +50,7 @@ DEFAULT_TTLS: dict[str, int] = {
 }
 
 _METRIC_TIERS = ("semantic", "embeddings", "sparse", "search", "rerank")
+_REDIS_URL_CREDENTIALS_RE = re.compile(r"(redis://)([^@\s]+)@")
 
 
 def _hash(data: str) -> str:
@@ -65,6 +66,10 @@ def _normalize_query_for_cache(text: str) -> str:
     Applied ONLY to cache key generation, not to the query in the pipeline.
     """
     return re.sub(r"[^\w\s]+$", "", text.strip().lower()).strip()
+
+
+def _redact_redis_credentials(text: str) -> str:
+    return _REDIS_URL_CREDENTIALS_RE.sub(r"\1***@", text)
 
 
 def _create_semantic_cache(
@@ -184,9 +189,13 @@ class CacheLayerManager:
                 health_check_interval=30,
             )
             await self.redis.ping()  # type: ignore[misc]
-            logger.info("Redis connected: %s", self.redis_url)
+            logger.info("Redis connected: %s", _redact_redis_credentials(self.redis_url))
         except Exception as e:
-            logger.error("Redis connection failed: %s: %s", type(e).__name__, e)
+            logger.error(
+                "Redis connection failed: %s: %s",
+                type(e).__name__,
+                _redact_redis_credentials(str(e)),
+            )
             self.redis = None
             return
 

--- a/telegram_bot/preflight.py
+++ b/telegram_bot/preflight.py
@@ -4,6 +4,7 @@ import contextlib
 import inspect
 import logging
 import os
+import re
 from enum import StrEnum
 from urllib.parse import urlparse
 
@@ -26,6 +27,26 @@ _DEFAULT_COLBERT_COVERAGE_WARN_THRESHOLD = 0.995
 
 # BGE-M3 dense vector dimensionality (used when auto-creating missing collections)
 _BGEM3_DENSE_DIM = 1024
+_REDIS_AUTH_FAILURE_HINT = (
+    "Redis auth failed: .env REDIS_PASSWORD may not match the running Redis container password. "
+    "Run `make local-redis-recreate` and then `make test-bot-health`."
+)
+_REDIS_URL_CREDENTIALS_RE = re.compile(r"(redis://)([^@\s]+)@")
+_REDIS_AUTH_TOKENS = (
+    "invalid username-password pair",
+    "wrongpass",
+    "authentication required",
+    "noauth",
+)
+
+
+def _redact_redis_credentials(text: str) -> str:
+    return _REDIS_URL_CREDENTIALS_RE.sub(r"\1***@", text)
+
+
+def _is_redis_auth_failure(message: str) -> bool:
+    lowered = message.lower()
+    return any(token in lowered for token in _REDIS_AUTH_TOKENS)
 
 
 def _read_colbert_coverage_warn_threshold() -> float:
@@ -194,7 +215,7 @@ async def _check_redis_deep(redis_url: str) -> tuple[bool, dict[str, str]]:
         return True, details
 
     except Exception as exc:
-        details["error"] = str(exc)
+        details["error"] = _redact_redis_credentials(str(exc))
         return False, details
     finally:
         await r.aclose()
@@ -246,7 +267,7 @@ async def _verify_cache_synthetic(redis_url: str) -> tuple[bool, list[str]]:
                     continue
 
             except Exception as exc:
-                errors.append(f"{prefix} error: {exc}")
+                errors.append(f"{prefix} error: {_redact_redis_credentials(str(exc))}")
                 # Best-effort cleanup
                 with contextlib.suppress(Exception):
                     await r.delete(test_key)
@@ -306,6 +327,8 @@ async def _check_single_dep(
     if name == "redis":
         passed, details = await _check_redis_deep(config.redis_url)
         if not passed:
+            if _is_redis_auth_failure(details.get("error", "")):
+                logger.error("Preflight FAIL: %s", _REDIS_AUTH_FAILURE_HINT)
             logger.error("Preflight FAIL: Redis deep check — %s", details)
         return passed
 

--- a/telegram_bot/preflight.py
+++ b/telegram_bot/preflight.py
@@ -31,7 +31,7 @@ _REDIS_AUTH_FAILURE_HINT = (
     "Redis auth failed: .env REDIS_PASSWORD may not match the running Redis container password. "
     "Run `make local-redis-recreate` and then `make test-bot-health`."
 )
-_REDIS_URL_CREDENTIALS_RE = re.compile(r"(redis://)([^@\s]+)@")
+_REDIS_URL_CREDENTIALS_RE = re.compile(r"(rediss?://)([^@\s]+)@")
 _REDIS_AUTH_TOKENS = (
     "invalid username-password pair",
     "wrongpass",

--- a/tests/unit/integrations/test_cache_layers.py
+++ b/tests/unit/integrations/test_cache_layers.py
@@ -162,6 +162,22 @@ class TestCacheLayerManagerInitialize:
 
         assert mgr.redis is None
 
+    async def test_initialize_redacts_redis_credentials_in_logs(self, caplog):
+        mgr = CacheLayerManager(redis_url="redis://:supersecret@localhost:6379/0")
+        mock_redis = AsyncMock()
+        mock_redis.ping = AsyncMock(return_value=True)
+
+        with (
+            patch("telegram_bot.integrations.cache.redis.from_url", return_value=mock_redis),
+            patch("telegram_bot.integrations.cache._create_semantic_cache", return_value=None),
+            caplog.at_level("INFO", logger="telegram_bot.integrations.cache"),
+        ):
+            await mgr.initialize()
+
+        assert "Redis connected:" in caplog.text
+        assert "supersecret" not in caplog.text
+        assert "localhost:6379" in caplog.text
+
 
 class TestSemanticCache:
     """Test semantic cache check/store."""

--- a/tests/unit/integrations/test_cache_layers.py
+++ b/tests/unit/integrations/test_cache_layers.py
@@ -178,6 +178,22 @@ class TestCacheLayerManagerInitialize:
         assert "supersecret" not in caplog.text
         assert "localhost:6379" in caplog.text
 
+    async def test_initialize_redacts_redis_credentials_in_rediss_logs(self, caplog):
+        mgr = CacheLayerManager(redis_url="rediss://:supersecret@localhost:6379/0")
+        mock_redis = AsyncMock()
+        mock_redis.ping = AsyncMock(return_value=True)
+
+        with (
+            patch("telegram_bot.integrations.cache.redis.from_url", return_value=mock_redis),
+            patch("telegram_bot.integrations.cache._create_semantic_cache", return_value=None),
+            caplog.at_level("INFO", logger="telegram_bot.integrations.cache"),
+        ):
+            await mgr.initialize()
+
+        assert "Redis connected:" in caplog.text
+        assert "supersecret" not in caplog.text
+        assert "rediss://***@localhost:6379/0" in caplog.text
+
 
 class TestSemanticCache:
     """Test semantic cache check/store."""

--- a/tests/unit/scripts/test_bot_health_script.py
+++ b/tests/unit/scripts/test_bot_health_script.py
@@ -38,3 +38,8 @@ def test_bot_health_reports_redis_password_drift_remediation() -> None:
     text = SCRIPT.read_text(encoding="utf-8")
     assert "REDIS_PASSWORD" in text
     assert "make local-redis-recreate" in text
+
+
+def test_bot_health_redacts_redis_and_rediss_credentials() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert r"(rediss?://)([^@\s]+)@" in text

--- a/tests/unit/scripts/test_bot_health_script.py
+++ b/tests/unit/scripts/test_bot_health_script.py
@@ -32,3 +32,9 @@ def test_bot_health_reports_local_postgres_expectation() -> None:
     assert "REAL_ESTATE_DATABASE_URL" in text
     assert "localhost:5432" in text
     assert "optional" in text.lower()
+
+
+def test_bot_health_reports_redis_password_drift_remediation() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "REDIS_PASSWORD" in text
+    assert "make local-redis-recreate" in text

--- a/tests/unit/test_env_example.py
+++ b/tests/unit/test_env_example.py
@@ -25,6 +25,7 @@ def test_local_env_contract_uses_root_dotenv_as_canonical_file() -> None:
     local_dev = Path("docs/LOCAL-DEVELOPMENT.md").read_text(encoding="utf-8")
     docker_doc = Path("DOCKER.md").read_text(encoding="utf-8")
     makefile = Path("Makefile").read_text(encoding="utf-8")
+    env_example = Path(".env.example").read_text(encoding="utf-8")
     bot_config = Path("telegram_bot/config.py").read_text(encoding="utf-8")
 
     assert "cp .env.example .env" in readme
@@ -35,6 +36,9 @@ def test_local_env_contract_uses_root_dotenv_as_canonical_file() -> None:
     assert 'env_file=".env"' in bot_config
     assert "uv run --env-file .env python -m telegram_bot.main" in makefile
     assert "[ -f ./.env ] && . ./.env" in makefile
+    assert "local-redis-recreate" in makefile
+    assert "make local-redis-recreate" in env_example
+    assert "make local-redis-recreate" in local_dev
     assert ".env.local" not in bot_config
     assert ".env.local" not in makefile
     assert ".env -> .env.local symlink" not in makefile

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -158,6 +158,20 @@ class TestCheckRedisDeep:
         assert passed is False
         assert "error" in details
 
+    async def test_error_text_redacts_redis_password_from_uri(self):
+        mock_redis = AsyncMock()
+        mock_redis.ping = AsyncMock(
+            side_effect=RuntimeError("error for redis://:supersecret@localhost:6379")
+        )
+        mock_redis.aclose = AsyncMock()
+
+        with patch("telegram_bot.preflight.aioredis.from_url", return_value=mock_redis):
+            passed, details = await _check_redis_deep("redis://localhost")
+
+        assert passed is False
+        assert "supersecret" not in details["error"]
+        assert "redis://***@localhost:6379" in details["error"]
+
     async def test_noeviction_policy_warning(self):
         mock_redis = AsyncMock()
         mock_redis.ping = AsyncMock(return_value=True)
@@ -320,6 +334,30 @@ class TestCheckSingleDep:
 
         assert result is True
         mock_deep.assert_awaited_once_with(config.redis_url)
+
+    async def test_redis_auth_error_logs_password_drift_remediation(self, caplog):
+        import logging
+
+        config = _make_config(redis_url="redis://:verysecret@localhost:6379/0")
+        client = AsyncMock(spec=httpx.AsyncClient)
+
+        with (
+            patch(
+                "telegram_bot.preflight._check_redis_deep",
+                new_callable=AsyncMock,
+                return_value=(
+                    False,
+                    {"error": "invalid username-password pair or user is disabled."},
+                ),
+            ),
+            caplog.at_level(logging.ERROR),
+        ):
+            result = await _check_single_dep("redis", config, client)
+
+        assert result is False
+        assert "make local-redis-recreate" in caplog.text
+        assert "REDIS_PASSWORD" in caplog.text
+        assert "verysecret" not in caplog.text
 
     async def test_redis_cache_delegates_to_verify_cache(self):
         config = _make_config()

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -172,6 +172,20 @@ class TestCheckRedisDeep:
         assert "supersecret" not in details["error"]
         assert "redis://***@localhost:6379" in details["error"]
 
+    async def test_error_text_redacts_redis_password_from_rediss_uri(self):
+        mock_redis = AsyncMock()
+        mock_redis.ping = AsyncMock(
+            side_effect=RuntimeError("error for rediss://:supersecret@localhost:6379")
+        )
+        mock_redis.aclose = AsyncMock()
+
+        with patch("telegram_bot.preflight.aioredis.from_url", return_value=mock_redis):
+            passed, details = await _check_redis_deep("redis://localhost")
+
+        assert passed is False
+        assert "supersecret" not in details["error"]
+        assert "rediss://***@localhost:6379" in details["error"]
+
     async def test_noeviction_policy_warning(self):
         mock_redis = AsyncMock()
         mock_redis.ping = AsyncMock(return_value=True)


### PR DESCRIPTION
## Summary\n- clarify local Redis auth drift remediation by adding [0;34mRecreating local Redis container with current .env values...[0m 
COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility --env-file $( [ -f .env ] && echo .env || echo tests/fixtures/compose.ci.env ) up -d --no-deps --force-recreate redis
[0;32m✓ Local Redis recreated. Next: make test-bot-health[0m \n- redact Redis URL credentials in startup/cache diagnostics\n- cover auth drift and redaction behavior with unit tests and docs updates\n\n## Verification\n- uv run pytest tests/unit/test_preflight.py tests/unit/integrations/test_cache_layers.py tests/unit/scripts/test_bot_health_script.py tests/unit/test_env_example.py -q\n- make check\n\nFixes #1445