### PR TITLE
fix: suppress PollingLockBusy traceback in console startup

### DIFF
--- a/telegram_bot/main.py
+++ b/telegram_bot/main.py
@@ -78,9 +78,9 @@ async def main():
 
     try:
         await _start_with_retry()
-    except PollingLockBusy:
-        logger.exception("Polling lock is busy; another bot instance is active")
-        raise
+    except PollingLockBusy as exc:
+        logger.error("Polling lock is busy; another bot instance is active: %s", exc)
+        raise SystemExit(2) from None
     except (TelegramUnauthorizedError, TelegramConflictError):
         logger.error("Fatal Telegram error — check bot token or stop other instances")
         raise

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -210,12 +210,16 @@ class TestMainFunction:
             mock_property_bot_instance.start.assert_awaited_once()
             mock_property_bot_instance.stop.assert_awaited_once()
 
-    async def test_main_propagates_polling_lock_busy(self):
-        """Polling lock conflicts should fail fast without retry."""
+    async def test_main_handles_polling_lock_busy_without_traceback(self):
+        """Polling lock conflicts should exit non-zero with concise operator log."""
         from telegram_bot.integrations.polling_lock import PollingLockBusy
 
         mock_property_bot_instance = AsyncMock()
-        mock_property_bot_instance.start = AsyncMock(side_effect=PollingLockBusy("lock busy"))
+        lock_error = PollingLockBusy(
+            "Polling lock busy key='telegram-bot:polling' owner='host:456' pttl_ms=52000 ttl_sec=None;"
+            " stop the other bot instance first"
+        )
+        mock_property_bot_instance.start = AsyncMock(side_effect=lock_error)
         mock_property_bot = MagicMock(return_value=mock_property_bot_instance)
         mock_bot_config = MagicMock()
         mock_setup_logging = MagicMock()
@@ -249,9 +253,12 @@ class TestMainFunction:
             from telegram_bot import main as main_module
 
             with patch.object(main_module.logging, "getLogger", return_value=mock_logger):
-                with pytest.raises(PollingLockBusy, match="lock busy"):
+                with pytest.raises(SystemExit, match="2"):
                     await main_module.main()
 
             mock_property_bot_instance.start.assert_awaited_once()
             mock_property_bot_instance.stop.assert_awaited_once()
-            mock_logger.exception.assert_called_once()
+            mock_logger.error.assert_called_once_with(
+                "Polling lock is busy; another bot instance is active: %s", lock_error
+            )
+            mock_logger.exception.assert_not_called()


### PR DESCRIPTION
## Summary
- catch `PollingLockBusy` in `telegram_bot.main.main()` and exit with `SystemExit(2) from None`
- log a concise operator-facing error message instead of emitting full traceback for expected lock contention
- keep startup control flow intact (`finally` still awaits `bot.stop()`)
- update unit test to assert non-zero exit and concise error logging for lock contention

## Validation
- `uv run pytest tests/unit/test_main.py tests/unit/test_logging_config.py -q`
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit` (executed earlier in this session; failed due unrelated suite instability/xdist timeout in `tests/unit/agents/test_utility_tools.py::test_handoff_high_urgency`; per operator instruction this broad gate is now skipped and not retried)

Closes #1411
