### PR TITLE
fix: disable Langfuse auto-capture for telegram RAG sensitive spans

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -2469,7 +2469,7 @@ class PropertyBot:
         else:
             await callback.answer()
 
-    @observe(name="telegram-rag-query")
+    @observe(name="telegram-rag-query", capture_input=False, capture_output=False)
     async def handle_query(
         self,
         message: Message,
@@ -2748,7 +2748,7 @@ class PropertyBot:
             return None  # caller falls through to sdk_agent path
         return result.answer
 
-    @observe(name="telegram-rag-supervisor")
+    @observe(name="telegram-rag-supervisor", capture_input=False, capture_output=False)
     async def _handle_query_supervisor(
         self,
         message: Message,

--- a/tests/contract/test_span_coverage_contract.py
+++ b/tests/contract/test_span_coverage_contract.py
@@ -132,6 +132,8 @@ SENSITIVE_SPANS = [
     "cb-feedback",
     "cb-feedback-reason",
     "cb-clearcache",
+    "telegram-rag-query",
+    "telegram-rag-supervisor",
     # Dialog/handler spans with capture disabled
     "dialog-crm-create-note",
     "dialog-crm-create-contact",

--- a/tests/observability/trace_contract.yaml
+++ b/tests/observability/trace_contract.yaml
@@ -363,6 +363,8 @@ sensitive_spans:
   - cb-feedback
   - cb-feedback-reason
   - cb-clearcache
+  - telegram-rag-query
+  - telegram-rag-supervisor
   # dialog/handler spans with capture disabled
   - dialog-crm-create-note
   - dialog-crm-create-contact


### PR DESCRIPTION
## Summary
- disable Langfuse auto-capture on `telegram-rag-query` and `telegram-rag-supervisor` decorators
- add both span names to canonical sensitive span contracts in YAML and AST contract test list
- preserve existing explicit sanitized span updates (`update_current_span`) and trace hierarchy

## Verification
- `uv run pytest tests/contract/test_span_coverage_contract.py -q`
- `uv run pytest tests/unit/test_bot_handlers_query.py tests/unit/test_bot_scores.py -q`
- `make check`

Closes #1447
