### PR TITLE
Fix mini-app frontend nginx temp paths on tmpfs runtime

### DIFF
--- a/logs/review-fix-pr-1457-static-validation.md
+++ b/logs/review-fix-pr-1457-static-validation.md
@@ -1,0 +1,21 @@
+# Review Fix Log — PR #1457 Static Validation
+
+## Scope
+- Fixed merge blocker in `tests/unit/test_docker_static_validation.py`.
+- No production files changed.
+
+## Blocker
+- Static validation tests still asserted legacy nginx temp paths under `/tmp/nginx/*`.
+- Static validation tests still implied Dockerfile should pre-create `/tmp/nginx/*` temp dirs.
+
+## Changes
+- Updated Dockerfile runtime contract assertion to forbid legacy `/tmp/nginx` pre-create pattern.
+- Updated nginx temp path assertions to require direct `/tmp/client_temp` and `/tmp/proxy_temp`.
+
+## Verification
+- `uv run pytest tests/unit/test_docker_static_validation.py -q` → `19 passed, 3 skipped`.
+- `uv run pytest tests/unit/mini_app/test_frontend_runtime_contract.py tests/unit/test_docker_static_validation.py -q` → `24 passed, 3 skipped`.
+- `git diff --check` → clean.
+
+## Notes
+- Warnings about Python 3.14/langfuse are pre-existing and unrelated to this static contract fix.

--- a/logs/review-request-1452-mini-frontend-nginx.md
+++ b/logs/review-request-1452-mini-frontend-nginx.md
@@ -1,0 +1,30 @@
+# Local Review — Issue #1452 mini-app frontend nginx runtime health
+
+## Scope reviewed
+- mini_app/frontend/nginx.conf
+- mini_app/frontend/Dockerfile
+- mini_app/frontend/README.md
+- tests/unit/mini_app/test_frontend_runtime_contract.py
+
+## Requirements checklist
+- `mini-app-frontend` must start with current Compose/runtime filesystem settings: **PASS**
+- Healthcheck `GET /health` unchanged and still valid: **PASS**
+- Compose contract consistency preserved for local/dev and VPS: **PASS** (no Compose changes)
+- Regression coverage added for nginx temp path runtime contract: **PASS**
+
+## Key risk checks
+- SPA routing, `/api/` proxy, listen `80`, `/health` endpoint unchanged.
+- Security posture unchanged (`user 101:101`, capability handling untouched in compose).
+- Removed build-time `/tmp/nginx/*` scaffolding that is hidden by runtime `tmpfs /tmp`; switched nginx temp dirs to direct `/tmp/*` paths writable at runtime.
+
+## Verification evidence
+- `uv run pytest tests/unit/mini_app/test_frontend_runtime_contract.py -q` (red then green cycle completed)
+- `uv run pytest tests/unit/mini_app/test_frontend_runtime_contract.py tests/unit/test_compose_config.py tests/unit/test_compose.py -q`
+- `COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml --compatibility config --services`
+- `make check`
+- Optional: `COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml --compatibility config mini-app-frontend`
+
+## Review outcome
+- Decision: **clean**
+- Blockers: **none**
+- Follow-ups: **none required**

--- a/mini_app/frontend/Dockerfile
+++ b/mini_app/frontend/Dockerfile
@@ -21,9 +21,6 @@ FROM nginx:1.29-alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e591939
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/nginx.conf
 
-RUN mkdir -p /tmp/nginx/client_temp /tmp/nginx/proxy_temp /tmp/nginx/fastcgi_temp /tmp/nginx/uwsgi_temp /tmp/nginx/scgi_temp \
-    && chown -R 101:101 /tmp/nginx
-
 USER 101:101
 
 EXPOSE 80

--- a/mini_app/frontend/README.md
+++ b/mini_app/frontend/README.md
@@ -20,7 +20,7 @@ Renders the expert-selection UI, deep-link flow, and phone-capture form inside T
 - **Local port**: `8091` (host) mapped from container port `80`
 - **Health**: `GET http://localhost:8091/health` (nginx internal)
 - **Runtime security**: runs as `uid:gid 101:101` with `cap_drop: [ALL]` and only `cap_add: [NET_BIND_SERVICE]`
-- **Writable runtime paths**: nginx PID and temp/cache paths are rooted under `/tmp/nginx*`
+- **Writable runtime paths**: nginx PID and temp/cache paths are rooted directly under `/tmp/*`
 
 ## Local Development
 

--- a/mini_app/frontend/nginx.conf
+++ b/mini_app/frontend/nginx.conf
@@ -16,11 +16,11 @@ http {
 
     # Keep all nginx writable runtime artifacts under /tmp
     # so the service works with dropped filesystem capabilities.
-    client_body_temp_path /tmp/nginx/client_temp;
-    proxy_temp_path /tmp/nginx/proxy_temp;
-    fastcgi_temp_path /tmp/nginx/fastcgi_temp;
-    uwsgi_temp_path /tmp/nginx/uwsgi_temp;
-    scgi_temp_path /tmp/nginx/scgi_temp;
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path /tmp/proxy_temp;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
 
     server {
         listen 80;

--- a/tests/unit/mini_app/test_frontend_runtime_contract.py
+++ b/tests/unit/mini_app/test_frontend_runtime_contract.py
@@ -8,6 +8,7 @@ PACKAGE_JSON = ROOT / "mini_app/frontend/package.json"
 PACKAGE_LOCK = ROOT / "mini_app/frontend/package-lock.json"
 DOCKERFILE = ROOT / "mini_app/frontend/Dockerfile"
 DOCKERIGNORE = ROOT / "mini_app/frontend/.dockerignore"
+NGINX_CONF = ROOT / "mini_app/frontend/nginx.conf"
 NODE_FLOOR = "^20.19.0 || >=22.12.0"
 
 
@@ -40,3 +41,19 @@ def test_frontend_build_context_ignores_local_dependency_and_build_artifacts() -
     assert "node_modules/" in entries
     assert "dist/" in entries
     assert ".env" in entries
+
+
+def test_frontend_nginx_temp_paths_use_tmp_root_dirs() -> None:
+    text = NGINX_CONF.read_text(encoding="utf-8")
+    directives = (
+        "client_body_temp_path",
+        "proxy_temp_path",
+        "fastcgi_temp_path",
+        "uwsgi_temp_path",
+        "scgi_temp_path",
+    )
+    for directive in directives:
+        pattern = rf"{directive}\s+/tmp/[a-z_]+;"
+        assert re.search(pattern, text), (
+            f"{directive} must use a direct /tmp/<dir> path so nginx can create it on tmpfs"
+        )

--- a/tests/unit/test_docker_static_validation.py
+++ b/tests/unit/test_docker_static_validation.py
@@ -155,13 +155,13 @@ def test_mini_app_frontend_dockerfile_runs_as_unprivileged_nginx_user() -> None:
     assert "COPY nginx.conf /etc/nginx/nginx.conf" in text, (
         "mini_app/frontend/Dockerfile must install the hardened main nginx.conf"
     )
-    assert "/tmp/nginx/client_temp" in text, (
-        "mini_app/frontend/Dockerfile must pre-create /tmp/nginx temp directories for nginx startup"
+    assert "mkdir -p /tmp/nginx" not in text and "/tmp/nginx/client_temp" not in text, (
+        "mini_app/frontend/Dockerfile must not pre-create legacy /tmp/nginx temp directories"
     )
 
 
 def test_mini_app_frontend_nginx_runtime_paths_use_tmp() -> None:
     text = MINI_APP_FRONTEND_NGINX_CONF.read_text()
     assert "pid /tmp/nginx.pid;" in text
-    assert "client_body_temp_path /tmp/nginx/client_temp;" in text
-    assert "proxy_temp_path /tmp/nginx/proxy_temp;" in text
+    assert "client_body_temp_path /tmp/client_temp;" in text
+    assert "proxy_temp_path /tmp/proxy_temp;" in text


### PR DESCRIPTION
## Summary
- switch nginx temp directives from `/tmp/nginx/*` to direct `/tmp/*` directories
- remove ineffective build-time `/tmp/nginx` bootstrap from frontend Dockerfile
- add regression test for nginx temp-path runtime contract
- update frontend runtime path docs

## Verification
- uv run pytest tests/unit/mini_app/test_frontend_runtime_contract.py tests/unit/test_compose_config.py tests/unit/test_compose.py -q
- COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml --compatibility config --services
- make check

Fixes #1452