### PR TITLE
observability: reconcile trace-family contract with telegram-message traces

### DIFF
--- a/docs/runbooks/LANGFUSE_TRACING_GAPS.md
+++ b/docs/runbooks/LANGFUSE_TRACING_GAPS.md
@@ -21,10 +21,13 @@ Expected local behavior after #1446: one warning from `telegram_bot.observabilit
 
 When traces appear missing, validate **app pipeline coverage** first:
 
-- Required trace families: **`rag-api-query`**, **`voice-session`**, **`ingestion-cli-run`**
+- Required direct trace families: **`rag-api-query`**, **`voice-session`**, **`ingestion-cli-run`**
+- Required Telegram families under `telegram-message` observations: **`telegram-rag-query`**, **`telegram-rag-supervisor`**
+- Required sanitized root fields on `telegram-message.input`: **`content_type`**, **`query_preview`**, **`query_hash`**, **`query_len`**, **`route`**
+- Forbidden raw root fields on `telegram-message.input`: **`user`**, **`chat`**, **`message`**, **`event_from_user`**, **`event_chat`**, **`raw_update`**
 - Expected LiteLLM callback noise: **`litellm-acompletion`** (flat, proxy-generated, no session context)
 
-If the three required families are present and fresh, flat `litellm-acompletion` traces do **not** indicate a defect.
+If direct families and nested Telegram families are present and root input is sanitized, flat `litellm-acompletion` traces do **not** indicate a defect.
 
 ## Diagnosis
 
@@ -76,13 +79,13 @@ langfuse api scores list --trace-id <trace-id> --json
 langfuse api observations list --trace-id <trace-id> --fields core,basic,io,metadata,usage,metrics --json
 ```
 
-**Validation focus:** When triaging gaps, check first for missing or stale `rag-api-query`, `voice-session`, and `ingestion-cli-run`. Proxy-generated `litellm-acompletion` traces are expected flat noise and should not be treated as missing app instrumentation.
+**Validation focus:** Check missing/stale `rag-api-query`, `voice-session`, `ingestion-cli-run`, then inspect recent `telegram-message` traces for nested `telegram-rag-query`/`telegram-rag-supervisor` observations plus sanitized root fields. Proxy-generated `litellm-acompletion` traces are expected flat noise and should not be treated as app coverage.
 
 ### 4. Trace Interpretation Matrix
 
 | Trace Name | Expected Structure | Common Gaps |
 |---|---|---|
-| `telegram-message` | Deeply structured (25–35 obs, depth 8, 30+ scores) | Missing when bot observability client fails to initialize or middleware is skipped |
+| `telegram-message` | Deeply structured (25–35 obs, depth 8, 30+ scores) with sanitized root input (`content_type`, `query_preview`, `query_hash`, `query_len`, `route`) | Missing when bot observability client fails to initialize or middleware is skipped; contract fails if raw `user/chat/message` payloads appear |
 | `litellm-acompletion` | Flat (1 GENERATION, depth 0, 0 scores) | **Proxy-generated**, not app-instrumented; inherently flat and lacks session context. See [LiteLLM Failure Runbook](LITEllm_FAILURE.md) |
 | `rag-api-query` | Structured SPANs + GENERATION | Often missing if RAG API is not called or `@observe` decorator is bypassed |
 | `core-pipeline-query-embedding` | SPAN (`as_type="embedding"`, capture disabled) | Missing or orphaned when the embedding call runs inside `run_in_executor` without preserving `contextvars` |
@@ -109,10 +112,12 @@ print(f"Current trace: {lf.get_current_trace_id()}")
 make validate-traces-fast
 ```
 
-This checks that required trace families exist and are not stale. Validation should focus on missing or outdated:
+This checks required direct families plus Telegram nested-family/root-context contract. Validation should focus on missing or outdated:
 - `rag-api-query`
 - `voice-session`
 - `ingestion-cli-run`
+- `telegram-rag-query` and `telegram-rag-supervisor` under `telegram-message` observations
+- sanitized `telegram-message.input` fields (`content_type`, `query_preview`, `query_hash`, `query_len`, `route`)
 
 If these are present and fresh, flat `litellm-acompletion` traces are expected proxy-generated noise and do not indicate a defect.
 

--- a/logs/review-request-1455-trace-contract.md
+++ b/logs/review-request-1455-trace-contract.md
@@ -1,0 +1,38 @@
+# Review Request: W-1455 Trace Contract
+
+POLICY_ACK docs_lookup=forbidden local_only=true
+
+## Scope Reviewed
+- `scripts/validate_traces.py`
+- `tests/unit/test_validate_traces_coverage_gate.py`
+- `tests/contract/test_trace_families_contract.py`
+- `docs/runbooks/LANGFUSE_TRACING_GAPS.md`
+
+## Requirements Checklist
+- [x] Coverage gate supports observation-level families under `telegram-message` root.
+- [x] Root sanitized context contract enforced (`content_type`, `query_preview`, `query_hash`, `query_len`, `route`).
+- [x] Raw Telegram objects are treated as contract violations.
+- [x] Cache-hit path tolerated without forcing retrieve/generate spans.
+- [x] Duplicate `detect-agent-intent` and WARNING observations are counted.
+- [x] `litellm-acompletion` does not count as app coverage.
+- [x] Existing non-Telegram direct families preserved (`rag-api-query`, `voice-session`, `ingestion-cli-run`).
+
+## Diff Review Notes
+- `check_required_trace_coverage()` now merges direct-family checks with nested observation checks from recent `telegram-message` traces.
+- Added explicit contract telemetry fields in coverage output for debugging (`root_context_missing`, `root_context_pii_violations`, observation counters).
+- Gate remains deterministic and backwards-compatible for direct-family-only callers via explicit empty overrides.
+- Contract scan test now includes `services/` to match existing contract entries (`bge-m3-service-*`, `user-base-service-*`).
+
+## Risk Review
+- Main behavioral change: missing sanitized Telegram root context now fails `required_trace_families_present` via synthetic requirement `telegram-message-root-context`.
+- No runtime behavior changes in bot/graph code; only validation/reporting contract.
+- No secret/raw payloads added to logs or docs.
+
+## Verification Evidence
+- `uv run pytest tests/unit/test_validate_traces_coverage_gate.py -q`
+- `uv run pytest tests/unit/test_validate_aggregates.py -q`
+- `uv run pytest tests/contract/test_trace_families_contract.py tests/contract/test_span_coverage_contract.py -q`
+- `make check`
+
+## Review Decision
+- **clean** (no unresolved blockers in scope)

--- a/scripts/validate_traces.py
+++ b/scripts/validate_traces.py
@@ -16,10 +16,11 @@ import asyncio
 import json
 import logging
 import os
-import subprocess
+import subprocess  # nosec B404
 import sys
 import time
 import uuid
+from collections import Counter
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -84,6 +85,24 @@ TRACKED_NODE_NAMES = [
 ]
 _TRACKED_NODE_SET = frozenset(TRACKED_NODE_NAMES)
 REQUIRED_TRACE_NAMES = ["rag-api-query", "voice-session", "ingestion-cli-run"]
+REQUIRED_TELEGRAM_OBSERVATION_FAMILIES = ["telegram-rag-query", "telegram-rag-supervisor"]
+TELEGRAM_ROOT_TRACE_NAME = "telegram-message"
+TELEGRAM_ROOT_CONTEXT_REQUIREMENT = "telegram-message-root-context"
+TELEGRAM_ROOT_CONTEXT_REQUIRED_FIELDS = (
+    "content_type",
+    "query_preview",
+    "query_hash",
+    "query_len",
+    "route",
+)
+TELEGRAM_ROOT_CONTEXT_FORBIDDEN_FIELDS = (
+    "user",
+    "chat",
+    "message",
+    "event_from_user",
+    "event_chat",
+    "raw_update",
+)
 
 GO_NO_GO_THRESHOLDS_PATH = (
     Path(__file__).resolve().parent.parent / "tests" / "baseline" / "thresholds.yaml"
@@ -233,7 +252,7 @@ def check_worktree_clean(strict: bool = False) -> None:
     Args:
         strict: If True, exit on dirty worktree. If False, log warning only.
     """
-    result = subprocess.run(
+    result = subprocess.run(  # nosec B603 B607
         ["git", "status", "--porcelain", "--untracked-files=normal"],
         capture_output=True,
         text=True,
@@ -268,7 +287,7 @@ def detect_runner_mode(collection: str) -> str:
 
 def get_git_sha() -> str:
     """Get current git commit SHA."""
-    result = subprocess.run(
+    result = subprocess.run(  # nosec B603 B607
         ["git", "rev-parse", "HEAD"],
         capture_output=True,
         text=True,
@@ -781,16 +800,41 @@ def check_orphan_traces(results: list[TraceResult]) -> float:
 def check_required_trace_coverage(
     *,
     required_trace_names: list[str] | None = None,
+    required_observation_names: list[str] | None = None,
     lookback_hours: int = 24,
-) -> dict[str, list[str]]:
-    """Check that required trace families exist in Langfuse within lookback window."""
-    required = required_trace_names or REQUIRED_TRACE_NAMES
+) -> dict[str, Any]:
+    """Check required trace coverage in Langfuse within lookback window.
+
+    Coverage combines:
+    1) Direct trace-family names for non-Telegram roots.
+    2) Required observation families nested under telegram-message root traces.
+    3) Sanitized root input contract for telegram-message traces.
+    """
+    required_direct = REQUIRED_TRACE_NAMES if required_trace_names is None else required_trace_names
+    required_nested = (
+        REQUIRED_TELEGRAM_OBSERVATION_FAMILIES
+        if required_observation_names is None
+        else required_observation_names
+    )
+    required = [*required_direct, *required_nested]
+    include_root_context_contract = bool(required_nested)
+    if include_root_context_contract:
+        required.append(TELEGRAM_ROOT_CONTEXT_REQUIREMENT)
     from_timestamp = datetime.now(UTC) - timedelta(hours=lookback_hours)
     lf = Langfuse()
     present: list[str] = []
     missing: list[str] = []
+    nested_present: set[str] = set()
+    root_context_missing: dict[str, list[str]] = {}
+    root_context_pii_violations: dict[str, list[str]] = {}
+    observation_counts: Counter[str] = Counter()
+    warning_observation_count = 0
+    cache_hit_without_retrieve_generation = 0
+    non_cache_without_retrieve_generation = 0
+    root_traces_checked = 0
+    root_traces_with_required_families = 0
 
-    for trace_name in required:
+    for trace_name in required_direct:
         try:
             traces_page = lf.api.trace.list(
                 name=trace_name,
@@ -806,16 +850,129 @@ def check_required_trace_coverage(
             logger.warning("Failed to check required trace '%s': %s", trace_name, exc)
             missing.append(trace_name)
 
+    root_trace_refs: list[Any] = []
+    if required_nested:
+        try:
+            root_page = lf.api.trace.list(
+                name=TELEGRAM_ROOT_TRACE_NAME,
+                from_timestamp=from_timestamp,
+                order_by="timestamp.desc",
+                limit=50,
+            )
+            root_trace_refs = list(getattr(root_page, "data", None) or [])
+        except Exception as exc:
+            logger.warning(
+                "Failed to list '%s' root traces for nested coverage: %s",
+                TELEGRAM_ROOT_TRACE_NAME,
+                exc,
+            )
+
+    for trace_ref in root_trace_refs:
+        trace_id = getattr(trace_ref, "id", None)
+        if not trace_id:
+            continue
+        try:
+            trace = lf.api.trace.get(trace_id)
+        except Exception as exc:
+            logger.warning("Failed to fetch root trace '%s': %s", trace_id, exc)
+            continue
+
+        root_traces_checked += 1
+        observations = list(getattr(trace, "observations", None) or [])
+        observation_names: list[str] = []
+
+        for obs in observations:
+            obs_name = getattr(obs, "name", None)
+            if not obs_name:
+                continue
+            observation_names.append(obs_name)
+            observation_counts[obs_name] += 1
+            level = getattr(obs, "level", None)
+            if isinstance(level, str) and level.upper() == "WARNING":
+                warning_observation_count += 1
+
+        observation_name_set = set(observation_names)
+        trace_has_required_nested = False
+        for required_name in required_nested:
+            if required_name in observation_name_set:
+                nested_present.add(required_name)
+                trace_has_required_nested = True
+
+        if not trace_has_required_nested:
+            continue
+
+        root_traces_with_required_families += 1
+
+        trace_input = getattr(trace, "input", None)
+        trace_input = trace_input if isinstance(trace_input, dict) else {}
+
+        missing_fields = [
+            field
+            for field in TELEGRAM_ROOT_CONTEXT_REQUIRED_FIELDS
+            if field not in trace_input or trace_input.get(field) is None
+        ]
+        if missing_fields:
+            root_context_missing[trace_id] = sorted(missing_fields)
+
+        pii_fields = sorted(
+            key for key in trace_input if key in TELEGRAM_ROOT_CONTEXT_FORBIDDEN_FIELDS
+        )
+        if pii_fields:
+            root_context_pii_violations[trace_id] = pii_fields
+
+        route = str(trace_input.get("route", "")).lower()
+        is_cache_hit = route in {"cache_hit", "semantic_cache_hit", "search_cache_hit"}
+        has_retrieve_or_generate = bool(
+            {
+                "node-retrieve",
+                "node-generate",
+                "retrieve",
+                "generate",
+                "rag-pipeline",
+            }
+            & observation_name_set
+        )
+
+        if is_cache_hit and not has_retrieve_or_generate:
+            cache_hit_without_retrieve_generation += 1
+        elif not is_cache_hit and not has_retrieve_or_generate:
+            non_cache_without_retrieve_generation += 1
+
+    for required_name in required_nested:
+        if required_name in nested_present:
+            present.append(required_name)
+        else:
+            missing.append(required_name)
+
+    if include_root_context_contract:
+        has_root_contract_failures = bool(root_context_missing or root_context_pii_violations)
+        if root_traces_with_required_families > 0 and not has_root_contract_failures:
+            present.append(TELEGRAM_ROOT_CONTEXT_REQUIREMENT)
+        else:
+            missing.append(TELEGRAM_ROOT_CONTEXT_REQUIREMENT)
+
     lf.flush()
     logger.info("Required trace coverage: present=%s missing=%s", present, missing)
-    return {"required": required, "present": present, "missing": missing}
+    return {
+        "required": required,
+        "present": present,
+        "missing": missing,
+        "observation_counts": dict(sorted(observation_counts.items())),
+        "warning_observation_count": warning_observation_count,
+        "root_context_missing": root_context_missing,
+        "root_context_pii_violations": root_context_pii_violations,
+        "cache_hit_without_retrieve_generation": cache_hit_without_retrieve_generation,
+        "non_cache_without_retrieve_generation": non_cache_without_retrieve_generation,
+        "root_traces_checked": root_traces_checked,
+        "root_traces_with_required_families": root_traces_with_required_families,
+    }
 
 
 def evaluate_go_no_go(
     aggregates: dict[str, Any],
     results: list[TraceResult],
     orphan_rate: float = 0.0,
-    required_trace_coverage: dict[str, list[str]] | None = None,
+    required_trace_coverage: dict[str, Any] | None = None,
     thresholds: dict[str, Any] | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Evaluate Go/No-Go criteria for Gate 1.
@@ -1437,8 +1594,8 @@ async def run_validation(args: argparse.Namespace) -> None:
         lf_client = get_langfuse_client()
         if lf_client:
             lf_client.flush()
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("Skipping final Langfuse flush: %s", exc)
     await asyncio.sleep(5)  # extra wait for async flush
 
     # Enrich results from Langfuse API (scores + node spans) before aggregates

--- a/tests/contract/test_trace_families_contract.py
+++ b/tests/contract/test_trace_families_contract.py
@@ -21,6 +21,7 @@ CONTRACT_PATH = Path(__file__).resolve().parent.parent / "observability" / "trac
 _SCAN_DIRS = [
     Path(__file__).resolve().parent.parent.parent / "telegram_bot",
     Path(__file__).resolve().parent.parent.parent / "src",
+    Path(__file__).resolve().parent.parent.parent / "services",
 ]
 # Exclude non-production code from the undocumented-spans check
 _EXCLUDE_PATTERNS = ["src/evaluation", ".venv/"]

--- a/tests/unit/test_validate_traces_coverage_gate.py
+++ b/tests/unit/test_validate_traces_coverage_gate.py
@@ -6,10 +6,23 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from scripts.validate_traces import (
+    REQUIRED_TELEGRAM_OBSERVATION_FAMILIES,
     REQUIRED_TRACE_NAMES,
+    TELEGRAM_ROOT_CONTEXT_REQUIREMENT,
     check_required_trace_coverage,
     evaluate_go_no_go,
 )
+
+
+def _trace(trace_id: str, *, name: str = "telegram-message", input_data: dict | None = None):
+    return SimpleNamespace(id=trace_id, name=name, input=input_data or {}, observations=[])
+
+
+def _obs(name: str, *, level: str | None = None):
+    obs = SimpleNamespace(name=name)
+    if level is not None:
+        obs.level = level
+    return obs
 
 
 def test_check_required_trace_coverage_marks_missing_trace_families() -> None:
@@ -18,13 +31,125 @@ def test_check_required_trace_coverage_marks_missing_trace_families() -> None:
         SimpleNamespace(data=[SimpleNamespace(id="trace-api")]),
         SimpleNamespace(data=[]),
         SimpleNamespace(data=[]),
+        SimpleNamespace(data=[]),
+    ]
+
+    with patch("scripts.validate_traces.Langfuse", return_value=mock_lf):
+        coverage = check_required_trace_coverage(required_observation_names=[])
+
+    assert coverage["present"] == ["rag-api-query"]
+    assert set(coverage["missing"]) == {"voice-session", "ingestion-cli-run"}
+
+
+def test_check_required_trace_coverage_accepts_telegram_observations_under_root() -> None:
+    mock_lf = MagicMock()
+    mock_lf.api.trace.list.side_effect = [
+        # Direct family checks
+        SimpleNamespace(data=[SimpleNamespace(id="trace-api")]),
+        SimpleNamespace(data=[SimpleNamespace(id="trace-voice")]),
+        SimpleNamespace(data=[SimpleNamespace(id="trace-ingest")]),
+        # Telegram root traces in lookback window
+        SimpleNamespace(data=[SimpleNamespace(id="root-1"), SimpleNamespace(id="root-2")]),
+    ]
+
+    root_1 = _trace(
+        "root-1",
+        input_data={
+            "content_type": "text",
+            "query_preview": "какие есть варианты внж?",
+            "query_hash": "a1b2c3d4",
+            "query_len": 24,
+            "route": "rag_query",
+        },
+    )
+    root_1.observations = [
+        _obs("telegram-rag-query"),
+        _obs("telegram-rag-supervisor"),
+        _obs("detect-agent-intent"),
+        _obs("detect-agent-intent"),
+        _obs("node-cache-check", level="WARNING"),
+        _obs("node-retrieve"),
+        _obs("node-generate"),
+    ]
+
+    root_2 = _trace(
+        "root-2",
+        input_data={
+            "content_type": "text",
+            "query_preview": "повтори прошлый ответ",
+            "query_hash": "e5f6a7b8",
+            "query_len": 21,
+            "route": "cache_hit",
+        },
+    )
+    root_2.observations = [
+        _obs("telegram-rag-query"),
+        _obs("node-cache-check"),
+    ]
+
+    mock_lf.api.trace.get.side_effect = [root_1, root_2]
+
+    with patch("scripts.validate_traces.Langfuse", return_value=mock_lf):
+        coverage = check_required_trace_coverage()
+
+    expected_present = set(REQUIRED_TRACE_NAMES) | set(REQUIRED_TELEGRAM_OBSERVATION_FAMILIES)
+    assert expected_present.issubset(set(coverage["present"]))
+    assert TELEGRAM_ROOT_CONTEXT_REQUIREMENT in coverage["present"]
+    assert TELEGRAM_ROOT_CONTEXT_REQUIREMENT not in coverage["missing"]
+    assert coverage["warning_observation_count"] == 1
+    assert coverage["observation_counts"]["detect-agent-intent"] == 2
+    assert coverage["root_context_missing"] == {}
+    assert coverage["root_context_pii_violations"] == {}
+    assert coverage["cache_hit_without_retrieve_generation"] == 1
+
+
+def test_check_required_trace_coverage_fails_when_root_context_is_unsanitized() -> None:
+    mock_lf = MagicMock()
+    mock_lf.api.trace.list.side_effect = [
+        SimpleNamespace(data=[]),
+    ]
+
+    bad_root = _trace(
+        "bad-root",
+        input_data={
+            "content_type": "text",
+            "query_preview": "сырой вопрос",
+            "query_len": 11,
+            "route": "rag_query",
+            "user": {"id": 123},
+            "message": {"text": "raw"},
+        },
+    )
+    bad_root.observations = [_obs("telegram-rag-query")]
+    mock_lf.api.trace.get.return_value = bad_root
+    mock_lf.api.trace.list.side_effect = [SimpleNamespace(data=[SimpleNamespace(id="bad-root")])]
+
+    with patch("scripts.validate_traces.Langfuse", return_value=mock_lf):
+        coverage = check_required_trace_coverage(
+            required_trace_names=[],
+            required_observation_names=["telegram-rag-query"],
+        )
+
+    assert "telegram-rag-query" in coverage["present"]
+    assert TELEGRAM_ROOT_CONTEXT_REQUIREMENT in coverage["missing"]
+    assert coverage["root_context_missing"] == {"bad-root": ["query_hash"]}
+    assert coverage["root_context_pii_violations"] == {"bad-root": ["message", "user"]}
+
+
+def test_check_required_trace_coverage_litellm_proxy_traces_do_not_count_as_app_coverage() -> None:
+    mock_lf = MagicMock()
+    mock_lf.api.trace.list.side_effect = [
+        SimpleNamespace(data=[]),
+        SimpleNamespace(data=[]),
+        SimpleNamespace(data=[]),
+        SimpleNamespace(data=[]),
     ]
 
     with patch("scripts.validate_traces.Langfuse", return_value=mock_lf):
         coverage = check_required_trace_coverage()
 
-    assert coverage["present"] == ["rag-api-query"]
-    assert set(coverage["missing"]) == {"voice-session", "ingestion-cli-run"}
+    assert "telegram-rag-query" in coverage["missing"]
+    assert "telegram-rag-supervisor" in coverage["missing"]
 
 
 def test_evaluate_go_no_go_fails_when_required_trace_family_missing() -> None:


### PR DESCRIPTION
## Summary
- extend trace coverage gate to validate telegram observation families under recent `telegram-message` roots
- enforce sanitized telegram root input contract (required safe fields, forbidden raw telegram payload keys)
- count duplicate `detect-agent-intent` and WARNING observations in coverage telemetry
- treat cache-hit routes as valid without forcing retrieve/generate spans
- ensure contract scan includes `services/` spans used by trace contract
- document updated validation focus in Langfuse tracing gaps runbook

## Validation
- uv run pytest tests/unit/test_validate_traces_coverage_gate.py -q
- uv run pytest tests/unit/test_validate_aggregates.py -q
- uv run pytest tests/contract/test_trace_families_contract.py tests/contract/test_span_coverage_contract.py -q
- make check

Fixes #1455
