### PR TITLE
fix: observability trace anomalies for detect-agent-intent and generate-response

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -2712,9 +2712,10 @@ class PropertyBot:
             None if the pipeline signals needs_agent=True (caller falls through to sdk_agent).
         """
         # Apartment fast path: intent check → regex filters → hybrid search → generate (#629)
-        from .pipelines.client import detect_agent_intent, run_client_pipeline
+        from .pipelines.client import infer_agent_intent, run_client_pipeline
 
-        agent_intent = detect_agent_intent(user_text)
+        # Pre-agent branch selection should not emit an extra detect-agent-intent span.
+        agent_intent = infer_agent_intent(user_text)
         if agent_intent == "apartment":
             apt_answer = await self._handle_apartment_fast_path(
                 user_text=user_text,

--- a/telegram_bot/pipelines/client.py
+++ b/telegram_bot/pipelines/client.py
@@ -59,9 +59,20 @@ def detect_agent_intent(user_text: str) -> str:
     Returns:
         Intent string: "mortgage" | "handoff" | "daily_summary" | "apartment" | "".
     """
-    text = user_text.lower()
+    intent = infer_agent_intent(user_text)
     lf = get_client()
     lf.update_current_span(input={"query_length": len(user_text)})
+    lf.update_current_span(output={"intent": intent or "none"})
+    return intent
+
+
+def infer_agent_intent(user_text: str) -> str:
+    """Pure intent classifier without tracing side-effects.
+
+    Used by pre-agent branching code paths that must not emit an additional
+    ``detect-agent-intent`` span outside ``client-direct-pipeline``.
+    """
+    text = user_text.lower()
     if any(kw in text for kw in ("ипотек", "кредит", "рассрочк")):
         intent = "mortgage"
     elif any(kw in text for kw in ("менеджер", "позвон", "связаться")):
@@ -85,7 +96,6 @@ def detect_agent_intent(user_text: str) -> str:
         intent = "apartment"
     else:
         intent = ""
-    lf.update_current_span(output={"intent": intent or "none"})
     return intent
 
 

--- a/telegram_bot/services/generate_response.py
+++ b/telegram_bot/services/generate_response.py
@@ -826,10 +826,8 @@ async def generate_response(
                     response_sent = delivered
                 else:
                     logger.warning("Streaming failed, falling back to non-streaming", exc_info=True)
-                    lf_client.update_current_span(
-                        level="WARNING",
-                        status_message="Streaming failed, using non-streaming fallback",
-                    )
+                    # Recovery path succeeded below; keep normal-success span level.
+                    # Degraded mode is tracked via llm_stream_recovery=True.
                     t_llm_start = time.monotonic()
                     response_obj = await _chat_create_with_optional_name(
                         llm,

--- a/tests/unit/services/test_generate_response.py
+++ b/tests/unit/services/test_generate_response.py
@@ -927,6 +927,49 @@ async def test_stream_failure_raises_and_triggers_fallback() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stream_recovery_success_does_not_set_warning_level() -> None:
+    """Successful stream recovery should record degradation metadata, not WARNING level."""
+    config, client = _make_non_streaming_config(answer="Нестриминговый fallback")
+    config.streaming_enabled = True
+    fallback_response = MagicMock()
+    fallback_response.choices = [MagicMock()]
+    fallback_response.choices[0].message.content = "Нестриминговый fallback"
+    fallback_response.model = "gpt-4o-mini"
+    fallback_response.usage = None
+    client.chat.completions.create = AsyncMock(
+        side_effect=[RuntimeError("LLM сервис недоступен"), fallback_response]
+    )
+    config.create_llm.return_value = client
+
+    lf = MagicMock()
+    bot = AsyncMock()
+    bot.send_message_draft = AsyncMock(return_value=True)
+    sent_msg = AsyncMock()
+    sent_msg.chat = MagicMock(id=1)
+    sent_msg.message_id = 2
+    message = AsyncMock()
+    message.chat = MagicMock(id=1)
+    message.bot = bot
+    message.answer = AsyncMock(return_value=sent_msg)
+
+    result = await generate_response(
+        query="Тест ошибки стрима",
+        documents=[{"text": "Контекст", "score": 0.8, "metadata": {}}],
+        config=config,
+        lf_client=lf,
+        message=message,
+        raw_messages=[{"role": "user", "content": "Тест ошибки стрима"}],
+    )
+
+    warning_calls = [
+        c for c in lf.update_current_span.call_args_list if c.kwargs.get("level") == "WARNING"
+    ]
+    assert result["response"] == "Нестриминговый fallback"
+    assert result["llm_stream_recovery"] is True
+    assert warning_calls == []
+
+
+@pytest.mark.asyncio
 async def test_partial_stream_recovery_edits_existing_message_instead_of_sending_duplicate() -> (
     None
 ):

--- a/tests/unit/test_bot_handlers_query.py
+++ b/tests/unit/test_bot_handlers_query.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -142,3 +143,37 @@ class TestHandleVoiceRecursionLimit:
             "recursion" in record.message.lower() or "limit" in record.message.lower()
             for record in caplog.records
         ), "Expected log mention of recursion limit"
+
+
+class TestClientDirectIntentPrecheck:
+    """Regression tests for client-direct pre-agent intent detection (#1369)."""
+
+    async def test_pre_agent_intent_check_does_not_call_traced_detector(self, mock_config):
+        """PropertyBot precheck must avoid creating extra detect-agent-intent spans."""
+        bot = _create_bot(mock_config)
+        message = MagicMock()
+
+        with (
+            patch(
+                "telegram_bot.pipelines.client.detect_agent_intent",
+                side_effect=AssertionError(
+                    "traced detect_agent_intent must not run in bot precheck"
+                ),
+            ),
+            patch(
+                "telegram_bot.pipelines.client.run_client_pipeline",
+                AsyncMock(return_value=SimpleNamespace(needs_agent=False, answer="ok")),
+            ) as mock_run_pipeline,
+        ):
+            result = await bot._handle_client_direct_pipeline(
+                message=message,
+                user_text="какие документы нужны",
+                user_id=123,
+                session_id="s1",
+                role="client",
+                query_type="GENERAL",
+                rag_result_store={},
+            )
+
+        assert result == "ok"
+        assert mock_run_pipeline.await_count == 1


### PR DESCRIPTION
## Summary
- avoid duplicate `detect-agent-intent` spans by using an untraced pre-agent intent helper in `PropertyBot`
- keep traced `detect_agent_intent` inside `client-direct-pipeline` for canonical pipeline observability
- prevent successful streaming recovery in `service-generate-response` from setting span level `WARNING`; recovery remains visible via `llm_stream_recovery`
- add focused regression tests for both issues

## Validation
- `uv run pytest tests/unit/pipelines/test_client_pipeline.py tests/unit/services/test_generate_response.py tests/unit/test_bot_handlers_query.py -q`
- `uv run pytest tests/contract/test_error_contract.py tests/contract/test_span_coverage_contract.py -q` (shows unrelated baseline failure in `telegram_bot/graph/nodes/transcribe.py` allowlist)
- `make check`
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit` skipped/aborted: user-forbidden broad/system-heavy run

Fixes #1369
