### PR TITLE
fix(observability): tier trace family coverage gates

### DIFF
--- a/scripts/validate_traces.py
+++ b/scripts/validate_traces.py
@@ -108,6 +108,10 @@ GO_NO_GO_THRESHOLDS_PATH = (
     Path(__file__).resolve().parent.parent / "tests" / "baseline" / "thresholds.yaml"
 )
 
+TRACE_CONTRACT_PATH = (
+    Path(__file__).resolve().parent.parent / "tests" / "observability" / "trace_contract.yaml"
+)
+
 
 def _load_go_no_go_thresholds(
     custom: dict[str, Any] | None = None,
@@ -120,6 +124,25 @@ def _load_go_no_go_thresholds(
     if custom:
         defaults.update(custom)
     return defaults
+
+
+def load_trace_coverage_tiers() -> dict[str, list[str]]:
+    """Load coverage tiers from trace_contract.yaml.
+
+    Returns:
+        dict with keys: required_for_1307, required_when_exercised,
+        opportunistic_for_1307.  Falls back to empty lists if missing.
+    """
+    if not TRACE_CONTRACT_PATH.exists():
+        return {}
+    with open(TRACE_CONTRACT_PATH) as f:
+        contract = yaml.safe_load(f) or {}
+    tiers = contract.get("coverage_tiers", {})
+    return {
+        "required_for_1307": tiers.get("required_for_1307", []),
+        "required_when_exercised": tiers.get("required_when_exercised", []),
+        "opportunistic_for_1307": tiers.get("opportunistic_for_1307", []),
+    }
 
 
 class FakeSentMessage:
@@ -850,6 +873,27 @@ def check_required_trace_coverage(
             logger.warning("Failed to check required trace '%s': %s", trace_name, exc)
             missing.append(trace_name)
 
+    # Opportunistic families — tracked but non-blocking
+    tiers = load_trace_coverage_tiers()
+    opportunistic = [t for t in tiers.get("opportunistic_for_1307", []) if t not in required_direct]
+    opportunistic_present: list[str] = []
+    opportunistic_missing: list[str] = []
+    for trace_name in opportunistic:
+        try:
+            traces_page = lf.api.trace.list(
+                name=trace_name,
+                from_timestamp=from_timestamp,
+                order_by="timestamp.desc",
+                limit=1,
+            )
+            if getattr(traces_page, "data", None):
+                opportunistic_present.append(trace_name)
+            else:
+                opportunistic_missing.append(trace_name)
+        except Exception as exc:
+            logger.warning("Failed to check opportunistic trace '%s': %s", trace_name, exc)
+            opportunistic_missing.append(trace_name)
+
     root_trace_refs: list[Any] = []
     if required_nested:
         try:
@@ -957,6 +1001,8 @@ def check_required_trace_coverage(
         "required": required,
         "present": present,
         "missing": missing,
+        "opportunistic_present": opportunistic_present,
+        "opportunistic_missing": opportunistic_missing,
         "observation_counts": dict(sorted(observation_counts.items())),
         "warning_observation_count": warning_observation_count,
         "root_context_missing": root_context_missing,
@@ -1112,13 +1158,18 @@ def evaluate_go_no_go(
         }
     else:
         missing_families = required_trace_coverage.get("missing", [])
+        opportunistic_missing = required_trace_coverage.get("opportunistic_missing", [])
+        actual_parts: list[str] = []
+        if missing_families:
+            actual_parts.append(f"missing: {', '.join(sorted(missing_families))}")
+        if opportunistic_missing:
+            actual_parts.append(
+                f"opportunistic missing: {', '.join(sorted(opportunistic_missing))}"
+            )
+        actual = "; ".join(actual_parts) if actual_parts else "all present"
         criteria["required_trace_families_present"] = {
             "target": ", ".join(required_trace_coverage.get("required", REQUIRED_TRACE_NAMES)),
-            "actual": (
-                "all present"
-                if not missing_families
-                else f"missing: {', '.join(sorted(missing_families))}"
-            ),
+            "actual": actual,
             "passed": not missing_families,
             "skipped": False,
             "stddev": "\u2014",

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -37,3 +37,8 @@ def score_keys(trace_contract):
     for group in trace_contract["scores"].values():
         scores.extend(group)
     return scores
+
+
+@pytest.fixture(scope="session")
+def coverage_tiers(trace_contract):
+    return trace_contract.get("coverage_tiers", {})

--- a/tests/contract/test_trace_families_contract.py
+++ b/tests/contract/test_trace_families_contract.py
@@ -90,6 +90,7 @@ def test_contract_yaml_exists():
     assert "required_families" in data
     assert "spans" in data
     assert "scores" in data
+    assert "coverage_tiers" in data
 
 
 # ---------------------------------------------------------------------------
@@ -100,6 +101,22 @@ def test_contract_yaml_exists():
 def test_required_families_non_empty(required_families):
     assert required_families, "required_families must not be empty"
     assert len(required_families) >= 1
+
+
+# ---------------------------------------------------------------------------
+# b2) coverage_tiers entries are non-empty strings
+# ---------------------------------------------------------------------------
+
+
+def test_coverage_tiers_entries_are_non_empty_strings(coverage_tiers):
+    assert coverage_tiers, "coverage_tiers must exist and not be empty"
+    for tier_name, tier_list in coverage_tiers.items():
+        assert isinstance(tier_list, list), f"{tier_name} must be a list"
+        assert tier_list, f"{tier_name} must not be empty"
+        for entry in tier_list:
+            assert isinstance(entry, str) and entry.strip(), (
+                f"coverage_tiers.{tier_name} contains empty or non-string entry: {entry!r}"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/observability/trace_contract.yaml
+++ b/tests/observability/trace_contract.yaml
@@ -13,6 +13,18 @@ required_families:
   - voice-session
   - ingestion-cli-run
 
+coverage_tiers:
+  required_for_1307:
+    - telegram-message
+    - telegram-rag-query
+    - telegram-rag-supervisor
+    - telegram-rag-voice
+  required_when_exercised:
+    - rag-api-query
+    - ingestion-cli-run
+  opportunistic_for_1307:
+    - voice-session
+
 spans:
   graph_nodes:
     - node-guard

--- a/tests/unit/test_validate_traces_coverage_gate.py
+++ b/tests/unit/test_validate_traces_coverage_gate.py
@@ -122,7 +122,10 @@ def test_check_required_trace_coverage_fails_when_root_context_is_unsanitized() 
     )
     bad_root.observations = [_obs("telegram-rag-query")]
     mock_lf.api.trace.get.return_value = bad_root
-    mock_lf.api.trace.list.side_effect = [SimpleNamespace(data=[SimpleNamespace(id="bad-root")])]
+    mock_lf.api.trace.list.side_effect = [
+        SimpleNamespace(data=[]),  # opportunistic voice-session check
+        SimpleNamespace(data=[SimpleNamespace(id="bad-root")]),  # telegram root check
+    ]
 
     with patch("scripts.validate_traces.Langfuse", return_value=mock_lf):
         coverage = check_required_trace_coverage(
@@ -185,3 +188,23 @@ def test_evaluate_go_no_go_passes_when_required_trace_families_present() -> None
     gate = criteria["required_trace_families_present"]
     assert gate["passed"] is True
     assert gate["actual"] == "all present"
+
+
+def test_evaluate_go_no_go_treats_opportunistic_voice_session_as_nonblocking() -> None:
+    criteria = evaluate_go_no_go(
+        {"cold": {}, "cache_hit": {}},
+        [],
+        orphan_rate=0.0,
+        required_trace_coverage={
+            "required": ["rag-api-query", "ingestion-cli-run"],
+            "present": ["rag-api-query", "ingestion-cli-run"],
+            "missing": [],
+            "opportunistic_missing": ["voice-session"],
+            "opportunistic_present": [],
+        },
+    )
+
+    gate = criteria["required_trace_families_present"]
+    assert gate["passed"] is True
+    assert "voice-session" in gate["actual"]
+    assert "opportunistic" in gate["actual"].lower() or "missing" in gate["actual"].lower()


### PR DESCRIPTION
## Summary
- Adds tiered trace family coverage gate to distinguish required vs opportunistic families.
- Introduces `coverage_tiers` in `trace_contract.yaml` with `required_for_1307`, `required_when_exercised`, and `opportunistic_for_1307` tiers.
- Updates `validate_traces.py` to load coverage tiers, check opportunistic families non-blockingly, and report them separately in `evaluate_go_no_go`.
- Adds unit test ensuring opportunistic missing families (e.g. `voice-session`) do not fail the gate.
- Adds contract test ensuring `coverage_tiers` entries are non-empty strings.