### PR TITLE
fix(e2e): validate app-owned Langfuse trace trees

### DIFF
--- a/scripts/e2e/langfuse_trace_validator.py
+++ b/scripts/e2e/langfuse_trace_validator.py
@@ -35,24 +35,28 @@ SCORE_NAMES = {
 
 SCENARIO_CONTRACTS = {
     "text_rag": {
-        "root_names": ["telegram-rag-query", "telegram-message"],
-        "required_spans": {"node-classify"},
+        "trace_names": ["telegram-message"],
+        "tags": ["telegram"],
+        "required_observations": {"telegram-rag-query", "telegram-rag-supervisor"},
         "required_scores": set(SCORE_NAMES),
     },
     "apartment": {
-        "root_names": ["telegram-message"],
-        "required_spans": {"node-apartment-search", "node-respond"},
+        "trace_names": ["telegram-message"],
+        "tags": ["telegram"],
+        "required_observations": {"client-direct-pipeline"},
         "required_scores": set(SCORE_NAMES),
     },
     "fallback": {
-        "root_names": ["telegram-message"],
-        "required_spans": {"node-fallback", "node-respond"},
+        "trace_names": ["telegram-message"],
+        "tags": ["telegram"],
+        "required_observations": set(),
         "required_scores": set(SCORE_NAMES),
     },
     "voice_note": {
-        "root_names": ["telegram-message"],
-        "required_spans": {"node-voice-transcribe", "node-classify", "node-respond"},
-        "required_scores": set(SCORE_NAMES),
+        "trace_names": ["telegram-rag-voice", "telegram-message"],
+        "tags": ["telegram", "voice"],
+        "required_observations": {"telegram-rag-voice", "transcribe"},
+        "required_scores": set(SCORE_NAMES) | {"input_type", "voice_duration_s"},
     },
 }
 
@@ -231,34 +235,38 @@ def validate_latest_trace(
 
     # Base contract from scenario; branch-aware RAG expectations are additive.
     required_scores: set[str] = set(contract["required_scores"])
-    required_spans: set[str] = set(contract["required_spans"])
+    required_observations: set[str] = set(contract["required_observations"])
 
     if not _langfuse_is_configured():
         return TraceValidationResult(
             ok=False,
             trace_id=None,
-            missing_spans=set(required_spans),
+            missing_spans=set(required_observations),
             missing_scores=set(required_scores),
             error="Langfuse keys are not configured (LANGFUSE_PUBLIC_KEY/SECRET_KEY).",
         )
 
-    # Use scenario root names when the caller has not overridden trace_name.
+    # Use scenario trace names and tags when the caller has not overridden them.
     effective_trace_name = trace_name
-    if trace_name == DEFAULT_TRACE_NAME and contract["root_names"]:
-        effective_trace_name = contract["root_names"]
+    if trace_name == DEFAULT_TRACE_NAME and contract.get("trace_names"):
+        effective_trace_name = contract["trace_names"]
+
+    effective_tags = tags
+    if tags == DEFAULT_TAGS and contract.get("tags"):
+        effective_tags = contract["tags"]
 
     trace_id = wait_for_trace(
         started_at=started_at,
         timeout_s=timeout_s,
         poll_interval_s=poll_interval_s,
         trace_name=effective_trace_name,
-        tags=tags,
+        tags=effective_tags,
     )
     if not trace_id:
         return TraceValidationResult(
             ok=False,
             trace_id=None,
-            missing_spans=set(required_spans),
+            missing_spans=set(required_observations),
             missing_scores=set(required_scores),
             error="No matching trace found in Langfuse within timeout.",
         )
@@ -270,28 +278,18 @@ def validate_latest_trace(
     scores = {s.name: getattr(s, "value", None) for s in trace.scores}
     score_names = set(scores.keys())
 
-    # Base span misses from the scenario contract.
-    missing_spans = set(required_spans - span_names)
+    # Base observation misses from the scenario contract.
+    missing_spans = set(required_observations - span_names)
 
-    # Root observation input/output checks.
-    root_names = set(contract["root_names"])
-    root_obs = None
-    for obs in trace.observations:
-        if getattr(obs, "name", None) in root_names:
-            root_obs = obs
-            break
+    # Root trace input/output checks (trace-level, not observation-level).
+    trace_input = getattr(trace, "input", None) or {}
+    trace_output = getattr(trace, "output", None) or {}
 
-    if root_obs is not None:
-        root_input = getattr(root_obs, "input", None) or {}
-        if not isinstance(root_input, dict) or root_input.get("query_hash") is None:
-            missing_spans.add("root_input")
+    if not isinstance(trace_input, dict) or trace_input.get("query_hash") is None:
+        missing_spans.add("root_input")
 
-        root_output = getattr(root_obs, "output", None) or {}
-        if not isinstance(root_output, dict) or root_output.get("answer_hash") is None:
-            missing_spans.add("root_output")
-    else:
-        # No root observation found; report the primary expected root name.
-        missing_spans.add(contract["root_names"][0])
+    if not isinstance(trace_output, dict) or trace_output.get("answer_hash") is None:
+        missing_spans.add("root_output")
 
     # Determine branch from scores, falling back to scenario hints when scores are missing.
     query_type = _as_float(scores.get("query_type"))
@@ -305,21 +303,21 @@ def validate_latest_trace(
     is_chitchat = (query_type == 0.0) if query_type is not None else bool(should_skip_rag)
 
     if not is_chitchat:
-        required_spans |= {"node-cache-check"}
+        required_observations |= {"node-cache-check"}
 
     if not is_chitchat and semantic_hit is False:
         # Retrieval path: cache miss → retrieve → grade
-        required_spans |= {"node-retrieve", "node-grade"}
+        required_observations |= {"node-retrieve", "node-grade"}
 
         if rerank_applied is True:
-            required_spans |= {"node-rerank"}
+            required_observations |= {"node-rerank"}
 
         if (llm_used is True) and (no_results is False) and ((results_count or 0) > 0):
             # Generation path: generate → cache-store → respond
-            required_spans |= {"node-generate", "node-cache-store", "node-respond"}
+            required_observations |= {"node-generate", "node-cache-store", "node-respond"}
 
-    # Recompute span misses after branch-aware additions.
-    missing_spans |= set(required_spans - span_names)
+    # Recompute observation misses after branch-aware additions.
+    missing_spans |= set(required_observations - span_names)
     missing_scores = set(required_scores - score_names)
 
     return TraceValidationResult(

--- a/scripts/e2e/langfuse_trace_validator.py
+++ b/scripts/e2e/langfuse_trace_validator.py
@@ -33,6 +33,29 @@ SCORE_NAMES = {
     "llm_used",
 }
 
+SCENARIO_CONTRACTS = {
+    "text_rag": {
+        "root_names": ["telegram-rag-query", "telegram-message"],
+        "required_spans": {"node-classify"},
+        "required_scores": set(SCORE_NAMES),
+    },
+    "apartment": {
+        "root_names": ["telegram-message"],
+        "required_spans": {"node-apartment-search", "node-respond"},
+        "required_scores": set(SCORE_NAMES),
+    },
+    "fallback": {
+        "root_names": ["telegram-message"],
+        "required_spans": {"node-fallback", "node-respond"},
+        "required_scores": set(SCORE_NAMES),
+    },
+    "voice_note": {
+        "root_names": ["telegram-message"],
+        "required_spans": {"node-voice-transcribe", "node-classify", "node-respond"},
+        "required_scores": set(SCORE_NAMES),
+    },
+}
+
 
 @dataclass(frozen=True)
 class TraceValidationResult:
@@ -151,26 +174,32 @@ def wait_for_trace(
     started_at: datetime,
     timeout_s: float = 15.0,
     poll_interval_s: float = 0.5,
-    trace_name: str = DEFAULT_TRACE_NAME,
+    trace_name: str | list[str] = DEFAULT_TRACE_NAME,
     tags: list[str] | None = DEFAULT_TAGS,
 ) -> str | None:
-    """Poll Langfuse until a recent trace exists, returning trace_id."""
+    """Poll Langfuse until a recent trace exists, returning trace_id.
+
+    Supports multiple trace names to accommodate different scenario root names
+    while preserving backward compatibility with a single string.
+    """
     if not _langfuse_is_configured():
         return None
 
     langfuse = Langfuse()
     deadline = time.time() + timeout_s
+    trace_names = [trace_name] if isinstance(trace_name, str) else trace_name
 
     while time.time() < deadline:
-        traces_page = langfuse.api.trace.list(
-            name=trace_name,
-            tags=tags,
-            from_timestamp=started_at - timedelta(seconds=5),
-            order_by="timestamp.desc",
-            limit=5,
-        )
-        if traces_page.data:
-            return traces_page.data[0].id
+        for name in trace_names:
+            traces_page = langfuse.api.trace.list(
+                name=name,
+                tags=tags,
+                from_timestamp=started_at - timedelta(seconds=5),
+                order_by="timestamp.desc",
+                limit=5,
+            )
+            if traces_page.data:
+                return traces_page.data[0].id
 
         time.sleep(poll_interval_s)
 
@@ -184,8 +213,9 @@ def validate_latest_trace(
     is_command: bool,
     timeout_s: float = 15.0,
     poll_interval_s: float = 0.5,
-    trace_name: str = DEFAULT_TRACE_NAME,
+    trace_name: str | list[str] = DEFAULT_TRACE_NAME,
     tags: list[str] | None = DEFAULT_TAGS,
+    scenario_kind: str = "text_rag",
 ) -> TraceValidationResult:
     """Validate that the latest trace contains required spans/scores."""
     if is_command:
@@ -197,12 +227,11 @@ def validate_latest_trace(
             missing_scores=set(),
         )
 
-    # Base contract: all "real" bot messages should emit these scores.
-    # This enables branch-aware validation without flakiness from cache hits.
-    required_scores: set[str] = set(SCORE_NAMES)
+    contract = SCENARIO_CONTRACTS.get(scenario_kind, SCENARIO_CONTRACTS["text_rag"])
 
-    # Base span contract (current LangGraph node names as of 2026-02-13)
-    required_spans: set[str] = {"node-classify"}
+    # Base contract from scenario; branch-aware RAG expectations are additive.
+    required_scores: set[str] = set(contract["required_scores"])
+    required_spans: set[str] = set(contract["required_spans"])
 
     if not _langfuse_is_configured():
         return TraceValidationResult(
@@ -213,11 +242,16 @@ def validate_latest_trace(
             error="Langfuse keys are not configured (LANGFUSE_PUBLIC_KEY/SECRET_KEY).",
         )
 
+    # Use scenario root names when the caller has not overridden trace_name.
+    effective_trace_name = trace_name
+    if trace_name == DEFAULT_TRACE_NAME and contract["root_names"]:
+        effective_trace_name = contract["root_names"]
+
     trace_id = wait_for_trace(
         started_at=started_at,
         timeout_s=timeout_s,
         poll_interval_s=poll_interval_s,
-        trace_name=trace_name,
+        trace_name=effective_trace_name,
         tags=tags,
     )
     if not trace_id:
@@ -235,6 +269,29 @@ def validate_latest_trace(
     span_names = {obs.name for obs in trace.observations}
     scores = {s.name: getattr(s, "value", None) for s in trace.scores}
     score_names = set(scores.keys())
+
+    # Base span misses from the scenario contract.
+    missing_spans = set(required_spans - span_names)
+
+    # Root observation input/output checks.
+    root_names = set(contract["root_names"])
+    root_obs = None
+    for obs in trace.observations:
+        if getattr(obs, "name", None) in root_names:
+            root_obs = obs
+            break
+
+    if root_obs is not None:
+        root_input = getattr(root_obs, "input", None) or {}
+        if not isinstance(root_input, dict) or root_input.get("query_hash") is None:
+            missing_spans.add("root_input")
+
+        root_output = getattr(root_obs, "output", None) or {}
+        if not isinstance(root_output, dict) or root_output.get("answer_hash") is None:
+            missing_spans.add("root_output")
+    else:
+        # No root observation found; report the primary expected root name.
+        missing_spans.add(contract["root_names"][0])
 
     # Determine branch from scores, falling back to scenario hints when scores are missing.
     query_type = _as_float(scores.get("query_type"))
@@ -261,7 +318,8 @@ def validate_latest_trace(
             # Generation path: generate → cache-store → respond
             required_spans |= {"node-generate", "node-cache-store", "node-respond"}
 
-    missing_spans = set(required_spans - span_names)
+    # Recompute span misses after branch-aware additions.
+    missing_spans |= set(required_spans - span_names)
     missing_scores = set(required_scores - score_names)
 
     return TraceValidationResult(

--- a/tests/unit/e2e/test_langfuse_trace_validator.py
+++ b/tests/unit/e2e/test_langfuse_trace_validator.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from scripts.e2e.langfuse_trace_validator import validate_latest_trace
+from scripts.e2e.langfuse_trace_validator import validate_latest_trace, wait_for_trace
 
 
 @pytest.fixture
@@ -43,6 +43,8 @@ def test_validator_accepts_current_langgraph_span_names(
     """
     # Mock Langfuse trace with current LangGraph span names
     mock_trace = MagicMock()
+    mock_trace.input = {"query_hash": "abc123"}
+    mock_trace.output = {"answer_hash": "def456"}
     mock_trace.observations = [
         # Current LangGraph pipeline spans
         type(
@@ -50,10 +52,9 @@ def test_validator_accepts_current_langgraph_span_names(
             (),
             {
                 "name": "telegram-rag-query",
-                "input": {"query_hash": "abc123"},
-                "output": {"answer_hash": "def456"},
             },
         ),
+        type("Obs", (), {"name": "telegram-rag-supervisor"}),
         type("Obs", (), {"name": "node-classify"}),
         type("Obs", (), {"name": "node-cache-check"}),
         type("Obs", (), {"name": "node-retrieve"}),
@@ -102,6 +103,8 @@ def test_validator_accepts_telegram_message_root_with_rag_observations(
 ):
     """Validator should accept telegram-message root with RAG observations and proper root context."""
     mock_trace = MagicMock()
+    mock_trace.input = {"query_hash": "abc123"}
+    mock_trace.output = {"answer_hash": "def456"}
     mock_trace.observations = [
         # Root observation with proper context
         type(
@@ -113,6 +116,8 @@ def test_validator_accepts_telegram_message_root_with_rag_observations(
                 "output": {"answer_hash": "def456", "response_preview": "test answer"},
             },
         ),
+        type("Obs", (), {"name": "telegram-rag-query"}),
+        type("Obs", (), {"name": "telegram-rag-supervisor"}),
         # RAG pipeline spans
         type("Obs", (), {"name": "node-classify"}),
         type("Obs", (), {"name": "node-cache-check"}),
@@ -160,8 +165,11 @@ def test_validator_fails_when_root_input_is_missing(
     mock_langfuse_configured,
     mock_wait_for_trace,
 ):
-    """Validator should fail when root observation input lacks query_hash."""
+    """Validator should fail when trace-level input lacks query_hash (Blocker 2)."""
     mock_trace = MagicMock()
+    # trace.input lacks query_hash — root_input marker expected
+    mock_trace.input = {"query_preview": "test query"}
+    mock_trace.output = {"answer_hash": "def456"}
     mock_trace.observations = [
         # Root observation missing query_hash in input
         type(
@@ -216,3 +224,57 @@ def test_validator_fails_when_root_input_is_missing(
     assert "root_output" not in result.missing_spans, (
         f"Did not expect root_output in missing_spans, got: {result.missing_spans}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Blocker 3: wait_for_trace multi-name support
+# ---------------------------------------------------------------------------
+
+
+def test_wait_for_trace_single_name_backward_compat():
+    """Single string trace_name still works (backward-compatible)."""
+    with patch("scripts.e2e.langfuse_trace_validator._langfuse_is_configured", return_value=True):
+        with patch("scripts.e2e.langfuse_trace_validator.Langfuse") as MockLangfuse:
+            mock_client = MockLangfuse.return_value
+            mock_trace = MagicMock()
+            mock_trace.id = "trace-x"
+            mock_client.api.trace.list.return_value.data = [mock_trace]
+
+            result = wait_for_trace(
+                started_at=datetime.now(),
+                trace_name="telegram-rag-query",
+            )
+
+    assert result == "trace-x"
+
+
+def test_wait_for_trace_multi_name_finds_match():
+    """Multiple trace names — returns first hit across name list."""
+    with patch("scripts.e2e.langfuse_trace_validator._langfuse_is_configured", return_value=True):
+        with patch("scripts.e2e.langfuse_trace_validator.Langfuse") as MockLangfuse:
+            mock_client = MockLangfuse.return_value
+
+            def list_side_effect(name, tags, from_timestamp, order_by, limit):
+                page = MagicMock()
+                page.data = []
+                return page
+
+            # Return trace only for second name
+            def list_for_second(name, tags, from_timestamp, order_by, limit):
+                page = MagicMock()
+                if name == "telegram-message":
+                    t = MagicMock()
+                    t.id = "trace-msg"
+                    page.data = [t]
+                else:
+                    page.data = []
+                return page
+
+            mock_client.api.trace.list.side_effect = list_for_second
+
+            result = wait_for_trace(
+                started_at=datetime.now(),
+                trace_name=["telegram-rag-voice", "telegram-message"],
+            )
+
+    assert result == "trace-msg"

--- a/tests/unit/e2e/test_langfuse_trace_validator.py
+++ b/tests/unit/e2e/test_langfuse_trace_validator.py
@@ -45,7 +45,15 @@ def test_validator_accepts_current_langgraph_span_names(
     mock_trace = MagicMock()
     mock_trace.observations = [
         # Current LangGraph pipeline spans
-        type("Obs", (), {"name": "telegram-rag-query"}),
+        type(
+            "Obs",
+            (),
+            {
+                "name": "telegram-rag-query",
+                "input": {"query_hash": "abc123"},
+                "output": {"answer_hash": "def456"},
+            },
+        ),
         type("Obs", (), {"name": "node-classify"}),
         type("Obs", (), {"name": "node-cache-check"}),
         type("Obs", (), {"name": "node-retrieve"}),
@@ -86,3 +94,125 @@ def test_validator_accepts_current_langgraph_span_names(
     )
     assert not result.missing_spans, f"Expected no missing spans, got: {result.missing_spans}"
     assert not result.missing_scores, f"Expected no missing scores, got: {result.missing_scores}"
+
+
+def test_validator_accepts_telegram_message_root_with_rag_observations(
+    mock_langfuse_configured,
+    mock_wait_for_trace,
+):
+    """Validator should accept telegram-message root with RAG observations and proper root context."""
+    mock_trace = MagicMock()
+    mock_trace.observations = [
+        # Root observation with proper context
+        type(
+            "Obs",
+            (),
+            {
+                "name": "telegram-message",
+                "input": {"query_hash": "abc123", "query_preview": "test query"},
+                "output": {"answer_hash": "def456", "response_preview": "test answer"},
+            },
+        ),
+        # RAG pipeline spans
+        type("Obs", (), {"name": "node-classify"}),
+        type("Obs", (), {"name": "node-cache-check"}),
+        type("Obs", (), {"name": "node-retrieve"}),
+        type("Obs", (), {"name": "node-grade"}),
+        type("Obs", (), {"name": "node-rerank"}),
+        type("Obs", (), {"name": "node-generate"}),
+        type("Obs", (), {"name": "node-cache-store"}),
+        type("Obs", (), {"name": "node-respond"}),
+    ]
+
+    # Mock required scores
+    mock_trace.scores = [
+        type("Score", (), {"name": "query_type", "value": 1.0}),
+        type("Score", (), {"name": "latency_total_ms", "value": 1500.0}),
+        type("Score", (), {"name": "semantic_cache_hit", "value": False}),
+        type("Score", (), {"name": "embeddings_cache_hit", "value": False}),
+        type("Score", (), {"name": "search_cache_hit", "value": False}),
+        type("Score", (), {"name": "rerank_applied", "value": True}),
+        type("Score", (), {"name": "rerank_cache_hit", "value": False}),
+        type("Score", (), {"name": "results_count", "value": 3.0}),
+        type("Score", (), {"name": "no_results", "value": False}),
+        type("Score", (), {"name": "llm_used", "value": True}),
+    ]
+
+    with patch("scripts.e2e.langfuse_trace_validator.Langfuse") as MockLangfuse:
+        mock_client = MockLangfuse.return_value
+        mock_client.api.trace.get.return_value = mock_trace
+
+        result = validate_latest_trace(
+            started_at=datetime.now(),
+            should_skip_rag=False,
+            is_command=False,
+            scenario_kind="text_rag",
+        )
+
+    assert result.ok, (
+        f"Validation failed: missing_spans={result.missing_spans}, missing_scores={result.missing_scores}"
+    )
+    assert not result.missing_spans, f"Expected no missing spans, got: {result.missing_spans}"
+    assert not result.missing_scores, f"Expected no missing scores, got: {result.missing_scores}"
+
+
+def test_validator_fails_when_root_input_is_missing(
+    mock_langfuse_configured,
+    mock_wait_for_trace,
+):
+    """Validator should fail when root observation input lacks query_hash."""
+    mock_trace = MagicMock()
+    mock_trace.observations = [
+        # Root observation missing query_hash in input
+        type(
+            "Obs",
+            (),
+            {
+                "name": "telegram-message",
+                "input": {"query_preview": "test query"},
+                "output": {"answer_hash": "def456"},
+            },
+        ),
+        type("Obs", (), {"name": "node-classify"}),
+        type("Obs", (), {"name": "node-cache-check"}),
+        type("Obs", (), {"name": "node-retrieve"}),
+        type("Obs", (), {"name": "node-grade"}),
+        type("Obs", (), {"name": "node-rerank"}),
+        type("Obs", (), {"name": "node-generate"}),
+        type("Obs", (), {"name": "node-cache-store"}),
+        type("Obs", (), {"name": "node-respond"}),
+    ]
+
+    # Mock required scores
+    mock_trace.scores = [
+        type("Score", (), {"name": "query_type", "value": 1.0}),
+        type("Score", (), {"name": "latency_total_ms", "value": 1500.0}),
+        type("Score", (), {"name": "semantic_cache_hit", "value": False}),
+        type("Score", (), {"name": "embeddings_cache_hit", "value": False}),
+        type("Score", (), {"name": "search_cache_hit", "value": False}),
+        type("Score", (), {"name": "rerank_applied", "value": True}),
+        type("Score", (), {"name": "rerank_cache_hit", "value": False}),
+        type("Score", (), {"name": "results_count", "value": 3.0}),
+        type("Score", (), {"name": "no_results", "value": False}),
+        type("Score", (), {"name": "llm_used", "value": True}),
+    ]
+
+    with patch("scripts.e2e.langfuse_trace_validator.Langfuse") as MockLangfuse:
+        mock_client = MockLangfuse.return_value
+        mock_client.api.trace.get.return_value = mock_trace
+
+        result = validate_latest_trace(
+            started_at=datetime.now(),
+            should_skip_rag=False,
+            is_command=False,
+            scenario_kind="text_rag",
+        )
+
+    assert not result.ok, "Expected validation to fail due to missing root_input"
+    assert "root_input" in result.missing_spans, (
+        f"Expected root_input in missing_spans, got: {result.missing_spans}"
+    )
+    # root_output should be present since answer_hash is provided
+    assert "root_output" not in result.missing_spans, (
+        f"Did not expect root_output in missing_spans, got: {result.missing_spans}"
+    )


### PR DESCRIPTION
## Summary
- Add `SCENARIO_CONTRACTS` for `text_rag`, `apartment`, `fallback`, `voice_note` scenarios
- Add `scenario_kind` parameter to `validate_latest_trace` with default `"text_rag"`
- Add `wait_for_trace` support for multiple trace/root names while preserving existing `trace_name` compatibility
- Add root observation input/output checks: missing `query_hash` => `root_input`, missing `answer_hash` => `root_output`, merged into `missing_spans`
- Keep existing branch-aware RAG expectations additive

## Tests
- `test_validator_accepts_telegram_message_root_with_rag_observations`
- `test_validator_fails_when_root_input_is_missing`