### PR TITLE
feat(#1307): use safe observability payloads in RAG API and voice handler

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -19,6 +19,10 @@ from langgraph.errors import GraphRecursionError
 
 from src.api.schemas import QueryRequest, QueryResponse
 from telegram_bot.observability import observe
+from telegram_bot.observability_payloads import (
+    build_safe_input_payload,
+    build_safe_output_payload,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -203,9 +207,18 @@ async def _execute_query(req: QueryRequest) -> QueryResponse:
             elapsed_ms = (time.perf_counter() - start) * 1000
             lf = get_client()
             if lf is not None:
+                fallback_response = (
+                    "Запрос слишком сложный — достигнут лимит обработки. Попробуйте упростить его."
+                )
                 lf.update_current_span(
-                    input=req.query,
-                    output="recursion_limit_reached",
+                    input=build_safe_input_payload(
+                        content_type="api", text=req.query, route="rag-api-query"
+                    ),
+                    output=build_safe_output_payload(
+                        answer_text=fallback_response,
+                        chunks_count=1,
+                        fallback_reason="recursion_limit",
+                    ),
                     metadata={
                         "source": req.channel,
                         "query_type": "ERROR",
@@ -240,8 +253,14 @@ async def _execute_query(req: QueryRequest) -> QueryResponse:
         lf = get_client()
         if lf is not None:
             lf.update_current_span(
-                input=req.query,
-                output=result.get("response", ""),
+                input=build_safe_input_payload(
+                    content_type="api", text=req.query, route="rag-api-query"
+                ),
+                output=build_safe_output_payload(
+                    answer_text=result.get("response", ""),
+                    chunks_count=1,
+                    sources_count=result.get("search_results_count", 0),
+                ),
                 metadata={
                     "source": req.channel,
                     "query_type": result.get("query_type", ""),

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -55,6 +55,7 @@ from .observability import (
     observe,
     propagate_attributes,
 )
+from .observability_payloads import build_safe_input_payload, build_safe_output_payload
 from .scoring import (
     compute_checkpointer_overhead_proxy_ms,
     score,
@@ -3957,11 +3958,17 @@ class PropertyBot:
             tid = lf.get_current_trace_id() or ""
             try:
                 lf.update_current_span(
-                    input={
-                        "voice_duration_s": voice.duration,
-                        "stt_text": result.get("stt_text", ""),
-                    },
-                    output={"response": result.get("response", "")},
+                    input=build_safe_input_payload(
+                        content_type="voice",
+                        text=result.get("stt_text", ""),
+                        extra={"voice_duration_s": voice.duration},
+                    ),
+                    output=build_safe_output_payload(
+                        answer_text=result.get("response", ""),
+                        chunks_count=1,
+                        sources_count=result.get("sources_count")
+                        or result.get("search_results_count", 0),
+                    ),
                     metadata=_build_trace_metadata(result),
                 )
             except Exception:

--- a/tests/unit/api/test_rag_api_runtime.py
+++ b/tests/unit/api/test_rag_api_runtime.py
@@ -139,8 +139,23 @@ async def test_query_updates_current_observation_and_propagates_api_attributes()
     )
     lf.update_current_span.assert_called_once()
     call_kwargs = lf.update_current_span.call_args.kwargs
-    assert call_kwargs["input"] == "test"
-    assert call_kwargs["output"] == "ok"
+    # Safe input payload
+    input_payload = call_kwargs["input"]
+    assert isinstance(input_payload, dict)
+    assert input_payload["content_type"] == "api"
+    assert "query_preview" in input_payload
+    assert "query_hash" in input_payload
+    assert input_payload["query_len"] == 4
+    assert "test" not in input_payload  # raw text must not be present
+    # Safe output payload
+    output_payload = call_kwargs["output"]
+    assert isinstance(output_payload, dict)
+    assert "answer_preview" in output_payload
+    assert "answer_hash" in output_payload
+    assert output_payload["answer_len"] == 2
+    assert output_payload["chunks_count"] == 1
+    assert output_payload["delivery_status"] == "sent"
+    assert "ok" not in output_payload  # raw response must not be present
     assert call_kwargs["metadata"] == {"source": "voice", "query_type": "GENERAL"}
 
 
@@ -367,10 +382,20 @@ async def test_query_graph_recursion_error_preserves_trace_context() -> None:
         await query(QueryRequest(query="complex", user_id=42, session_id="sess-1"))
 
     call_kwargs = lf.update_current_span.call_args.kwargs
-    assert call_kwargs["input"] == "complex"
-    assert (
-        "recursion" in str(call_kwargs.get("output", "")).lower()
-        or "limit" in str(call_kwargs.get("output", "")).lower()
-    )
+    # Safe input payload
+    input_payload = call_kwargs["input"]
+    assert isinstance(input_payload, dict)
+    assert input_payload["content_type"] == "api"
+    assert "query_preview" in input_payload
+    assert "query_hash" in input_payload
+    assert input_payload["query_len"] == 7
+    assert "complex" not in input_payload  # raw text must not be present
+    # Safe output payload with fallback_reason
+    output_payload = call_kwargs["output"]
+    assert isinstance(output_payload, dict)
+    assert "answer_preview" in output_payload
+    assert "answer_hash" in output_payload
+    assert output_payload["fallback_reason"] == "recursion_limit"
+    assert output_payload["chunks_count"] == 1
     assert call_kwargs["metadata"]["source"] == "api"
     assert call_kwargs["metadata"]["query_type"] == "ERROR"

--- a/tests/unit/test_bot_scores.py
+++ b/tests/unit/test_bot_scores.py
@@ -553,6 +553,63 @@ class TestVoiceTraceMetadata:
         assert metadata["checkpointer_overhead_proxy_ms"] is not None
 
 
+class TestVoiceSafePayloads:
+    """Test that handle_voice uses PII-safe input/output payloads (#1307)."""
+
+    async def test_voice_input_payload_is_safe(self, mock_config):
+        """handle_voice must not include raw stt_text in update_current_span input."""
+        mock_lf = MagicMock()
+        mock_lf.update_current_span = MagicMock()
+        mock_lf.create_score = MagicMock()
+        mock_lf.get_current_trace_id = MagicMock(return_value="trace-abc-123")
+
+        voice_result = {
+            **FULL_PIPELINE_RESULT,
+            "stt_text": "тест запрос",
+            "stt_duration_ms": 250.0,
+            "voice_duration_s": 5.0,
+            "input_type": "voice",
+        }
+        await _run_handle_voice(mock_config, voice_result, mock_lf)
+
+        call_kwargs = mock_lf.update_current_span.call_args.kwargs
+        input_payload = call_kwargs["input"]
+        assert isinstance(input_payload, dict)
+        assert input_payload["content_type"] == "voice"
+        assert "query_preview" in input_payload
+        assert "query_hash" in input_payload
+        assert input_payload["query_len"] == len("тест запрос")
+        assert "stt_text" not in input_payload
+        assert "тест запрос" not in input_payload
+        assert input_payload["voice_duration_s"] == 5.0
+
+    async def test_voice_output_payload_is_safe(self, mock_config):
+        """handle_voice must not include raw response in update_current_span output."""
+        mock_lf = MagicMock()
+        mock_lf.update_current_span = MagicMock()
+        mock_lf.create_score = MagicMock()
+        mock_lf.get_current_trace_id = MagicMock(return_value="trace-abc-123")
+
+        voice_result = {
+            **FULL_PIPELINE_RESULT,
+            "stt_text": "тест",
+            "response": "Вот квартиры до 100000 евро...",
+            "input_type": "voice",
+        }
+        await _run_handle_voice(mock_config, voice_result, mock_lf)
+
+        call_kwargs = mock_lf.update_current_span.call_args.kwargs
+        output_payload = call_kwargs["output"]
+        assert isinstance(output_payload, dict)
+        assert "answer_preview" in output_payload
+        assert "answer_hash" in output_payload
+        assert output_payload["answer_len"] == len("Вот квартиры до 100000 евро...")
+        assert output_payload["chunks_count"] == 1
+        assert output_payload["delivery_status"] == "sent"
+        assert "response" not in output_payload
+        assert "Вот квартиры" not in output_payload
+
+
 VOICE_PIPELINE_RESULT = {
     **FULL_PIPELINE_RESULT,
     "stt_text": "тест голосовой запрос",


### PR DESCRIPTION
## Summary
- RAG API `update_current_span` input/output payloads now use `build_safe_input_payload` / `build_safe_output_payload` helpers from `telegram_bot.observability_payloads`.
- GraphRecursionError fallback uses `build_safe_output_payload(..., fallback_reason=\"recursion_limit\")`.
- Telegram `handle_voice` tracing payloads no longer include raw `stt_text` or raw response; uses safe builders while preserving existing scores and behavior.
- Adds focused unit tests for safe payload contracts.

## Verification
- `uv run pytest tests/unit/api/test_rag_api_runtime.py tests/unit/test_bot_scores.py -q` — 54 passed
- `git diff --check` — clean