### PR TITLE
feat(telegram): voice RAG root trace I/O via safe payloads (#1307)

### DIFF
--- a/telegram_bot/middlewares/langfuse_middleware.py
+++ b/telegram_bot/middlewares/langfuse_middleware.py
@@ -10,6 +10,7 @@ from aiogram import BaseMiddleware
 from aiogram.types import CallbackQuery, Message, TelegramObject
 
 from telegram_bot.observability import get_client, propagate_attributes
+from telegram_bot.observability_payloads import build_safe_input_payload
 from telegram_bot.tracing_context import classify_action, make_session_id
 
 
@@ -19,22 +20,28 @@ logger = logging.getLogger(__name__)
 def _extract_event_input(event: TelegramObject, action_type: str) -> dict[str, Any]:
     """Build a safe, concise input dict from a Telegram event.
 
-    PII masking is delegated to the Langfuse SDK mask layer; this helper only
-    extracts coarse action/text metadata so the root trace is not empty.
+    Uses ``build_safe_input_payload`` so no raw message text reaches the
+    Langfuse root trace.
     """
     if isinstance(event, Message):
         text = event.text or event.caption or ""
-        return {
-            "action": action_type,
-            "content_type": event.content_type,
-            "text_preview": text[:500] if text else "",
-        }
+        return build_safe_input_payload(
+            content_type=str(getattr(event, "content_type", "unknown")),
+            text=text,
+            action=action_type,
+        )
     if isinstance(event, CallbackQuery):
-        return {
-            "action": action_type,
-            "callback_data": (event.data or "")[:200],
-        }
-    return {"action": action_type}
+        return build_safe_input_payload(
+            content_type="callback",
+            text=event.data or "",
+            action=action_type,
+            extra={"callback_data": event.data or ""},
+        )
+    return build_safe_input_payload(
+        content_type="unknown",
+        text="",
+        action=action_type,
+    )
 
 
 class LangfuseContextMiddleware(BaseMiddleware):
@@ -61,10 +68,14 @@ class LangfuseContextMiddleware(BaseMiddleware):
         session_id = make_session_id("chat", chat_id)
         action_type = classify_action(event, data)
 
+        observation_name = (
+            "telegram-rag-voice" if action_type == "rag-voice" else f"telegram-{action_type}"
+        )
+
         with (
             lf.start_as_current_observation(
                 as_type="span",
-                name=f"telegram-{action_type}",
+                name=observation_name,
                 input=_extract_event_input(event, action_type),
             ),
             propagate_attributes(

--- a/telegram_bot/services/telegram_formatting.py
+++ b/telegram_bot/services/telegram_formatting.py
@@ -7,6 +7,7 @@ import logging
 from typing import Any
 
 from telegram_bot.observability import get_client
+from telegram_bot.observability_payloads import build_safe_output_payload
 
 
 logger = logging.getLogger(__name__)
@@ -147,7 +148,7 @@ def build_html_messages(
 def _record_langfuse_response_output(answer_text: str, chunks_count: int) -> None:
     """Best-effort update of the current Langfuse trace/span output after a send.
 
-    Uses ``update_current_trace`` when present, falls back to ``update_current_span``,
+    Uses ``set_current_trace_io`` when present, falls back to ``update_current_span``,
     and is a no-op when the client or method is missing so Telegram sending never
     breaks because of observability.
     """
@@ -155,19 +156,16 @@ def _record_langfuse_response_output(answer_text: str, chunks_count: int) -> Non
     if lf is None:
         return
 
-    output = {
-        "response_preview": (answer_text or "")[:800],
-        "chunks_count": chunks_count,
-    }
+    output = build_safe_output_payload(answer_text, chunks_count)
 
-    update_trace = getattr(lf, "update_current_trace", None)
-    if callable(update_trace):
+    set_trace_io = getattr(lf, "set_current_trace_io", None)
+    if callable(set_trace_io):
         try:
-            update_trace(output=output)
+            set_trace_io(output=output)
             return
         except Exception:
             logger.debug(
-                "update_current_trace failed, falling back to update_current_span", exc_info=True
+                "set_current_trace_io failed, falling back to update_current_span", exc_info=True
             )
 
     update_span = getattr(lf, "update_current_span", None)

--- a/telegram_bot/tracing_context.py
+++ b/telegram_bot/tracing_context.py
@@ -31,6 +31,8 @@ def classify_action(event: Any, _data: dict[str, Any] | None = None) -> str:
             return f"callback-{cb_data.split(':')[0]}"
         return "callback"
     if isinstance(event, Message):
+        if getattr(event, "content_type", None) == "voice":
+            return "rag-voice"
         text = event.text or ""
         if text.startswith("/"):
             cmd = text.split()[0].split("@")[0].lstrip("/")

--- a/tests/unit/middlewares/test_langfuse_middleware.py
+++ b/tests/unit/middlewares/test_langfuse_middleware.py
@@ -70,15 +70,17 @@ async def test_creates_span_when_langfuse_enabled(middleware, handler, message_e
 
     assert result == "ok"
     handler.assert_awaited_once()
-    mock_lf.start_as_current_observation.assert_called_once_with(
-        as_type="span",
-        name="telegram-cmd-start",
-        input={
-            "action": "cmd-start",
-            "content_type": "text",
-            "text_preview": "/start",
-        },
-    )
+    mock_lf.start_as_current_observation.assert_called_once()
+    call_kwargs = mock_lf.start_as_current_observation.call_args.kwargs
+    assert call_kwargs["as_type"] == "span"
+    assert call_kwargs["name"] == "telegram-cmd-start"
+    input_payload = call_kwargs["input"]
+    assert input_payload["action"] == "cmd-start"
+    assert input_payload["content_type"] == "text"
+    assert "query_preview" in input_payload
+    assert "query_hash" in input_payload
+    assert input_payload["query_len"] == 6
+    assert "text_preview" not in input_payload
     mock_propagate.assert_called_once()
     call_kwargs = mock_propagate.call_args[1]
     assert call_kwargs["user_id"] == "42"
@@ -120,11 +122,15 @@ async def test_callback_action_type(middleware, handler, event_data):
     ):
         await middleware(handler, cb, event_data)
 
-    mock_lf.start_as_current_observation.assert_called_once_with(
-        as_type="span",
-        name="telegram-callback-fav",
-        input={
-            "action": "callback-fav",
-            "callback_data": "fav:add:123",
-        },
-    )
+    mock_lf.start_as_current_observation.assert_called_once()
+    call_kwargs = mock_lf.start_as_current_observation.call_args.kwargs
+    assert call_kwargs["as_type"] == "span"
+    assert call_kwargs["name"] == "telegram-callback-fav"
+    input_payload = call_kwargs["input"]
+    assert input_payload["action"] == "callback-fav"
+    assert input_payload["content_type"] == "callback"
+    assert "query_preview" in input_payload
+    assert "query_hash" in input_payload
+    assert input_payload["query_len"] == 11
+    assert "callback_data" in input_payload
+    assert "text_preview" not in input_payload

--- a/tests/unit/observability/test_tracing_context.py
+++ b/tests/unit/observability/test_tracing_context.py
@@ -76,5 +76,21 @@ class TestClassifyAction:
         msg.text = "Привет!"
         assert classify_action(msg) == "message"
 
+    def test_message_voice(self):
+        from aiogram.types import Message
+
+        msg = MagicMock(spec=Message)
+        msg.text = None
+        msg.content_type = "voice"
+        assert classify_action(msg) == "rag-voice"
+
+    def test_message_photo(self):
+        from aiogram.types import Message
+
+        msg = MagicMock(spec=Message)
+        msg.text = None
+        msg.content_type = "photo"
+        assert classify_action(msg) == "message"
+
     def test_unknown_event(self):
         assert classify_action(MagicMock()) == "update"

--- a/tests/unit/test_langfuse_context_middleware.py
+++ b/tests/unit/test_langfuse_context_middleware.py
@@ -24,11 +24,13 @@ class TestExtractEventInput:
         msg.caption = None
         msg.content_type = "text"
         result = _extract_event_input(msg, "message")
-        assert result == {
-            "action": "message",
-            "content_type": "text",
-            "text_preview": "Hello world",
-        }
+        assert result["action"] == "message"
+        assert result["content_type"] == "text"
+        assert "query_preview" in result
+        assert "query_hash" in result
+        assert result["query_len"] == 11
+        assert "text_preview" not in result
+        assert "text" not in result
 
     def test_message_caption_fallback(self):
         msg = MagicMock(spec=Message)
@@ -36,11 +38,10 @@ class TestExtractEventInput:
         msg.caption = "Photo caption"
         msg.content_type = "photo"
         result = _extract_event_input(msg, "message")
-        assert result == {
-            "action": "message",
-            "content_type": "photo",
-            "text_preview": "Photo caption",
-        }
+        assert result["action"] == "message"
+        assert result["content_type"] == "photo"
+        assert "query_preview" in result
+        assert result["query_len"] == 13
 
     def test_message_empty_text(self):
         msg = MagicMock(spec=Message)
@@ -48,11 +49,9 @@ class TestExtractEventInput:
         msg.caption = None
         msg.content_type = "contact"
         result = _extract_event_input(msg, "message")
-        assert result == {
-            "action": "message",
-            "content_type": "contact",
-            "text_preview": "",
-        }
+        assert result["action"] == "message"
+        assert result["content_type"] == "contact"
+        assert result["query_len"] == 0
 
     def test_message_text_truncated(self):
         msg = MagicMock(spec=Message)
@@ -60,28 +59,39 @@ class TestExtractEventInput:
         msg.caption = None
         msg.content_type = "text"
         result = _extract_event_input(msg, "cmd-start")
-        assert result["text_preview"] == "x" * 500
+        assert result["query_len"] == 1000
         assert result["action"] == "cmd-start"
+
+    def test_message_voice(self):
+        msg = MagicMock(spec=Message)
+        msg.text = None
+        msg.caption = None
+        msg.content_type = "voice"
+        result = _extract_event_input(msg, "rag-voice")
+        assert result["action"] == "rag-voice"
+        assert result["content_type"] == "voice"
+        assert result["query_len"] == 0
 
     def test_callback_query(self):
         cb = MagicMock(spec=CallbackQuery)
         cb.data = "menu:search"
         result = _extract_event_input(cb, "callback-menu")
-        assert result == {
-            "action": "callback-menu",
-            "callback_data": "menu:search",
-        }
+        assert result["action"] == "callback-menu"
+        assert result["content_type"] == "callback"
+        assert "query_preview" in result
+        assert result["query_len"] == 11
 
     def test_callback_query_long_data(self):
         cb = MagicMock(spec=CallbackQuery)
         cb.data = "x" * 300
         result = _extract_event_input(cb, "callback")
-        assert result["callback_data"] == "x" * 200
+        assert result["query_len"] == 300
 
     def test_unknown_event(self):
         event = MagicMock()
         result = _extract_event_input(event, "update")
-        assert result == {"action": "update"}
+        assert result["action"] == "update"
+        assert result["content_type"] == "unknown"
 
 
 class TestLangfuseContextMiddleware:
@@ -126,11 +136,41 @@ class TestLangfuseContextMiddleware:
         call_kwargs = mock_lf.start_as_current_observation.call_args.kwargs
         assert call_kwargs["as_type"] == "span"
         assert call_kwargs["name"] == "telegram-message"
-        assert call_kwargs["input"] == {
-            "action": "message",
-            "content_type": "text",
-            "text_preview": "user query",
-        }
+        input_payload = call_kwargs["input"]
+        assert input_payload["action"] == "message"
+        assert input_payload["content_type"] == "text"
+        assert "query_preview" in input_payload
+        assert "text_preview" not in input_payload
+        mock_prop.assert_called_once()
+        handler.assert_called_once_with(msg, data)
+
+    async def test_voice_observation_started(self, middleware: LangfuseContextMiddleware):
+        handler = AsyncMock(return_value="handler_result")
+        msg = MagicMock(spec=Message)
+        msg.text = None
+        msg.caption = None
+        msg.content_type = "voice"
+        data = {"event_from_user": MagicMock(id=123), "event_chat": MagicMock(id=456)}
+
+        mock_lf = MagicMock()
+        mock_obs_ctx = MagicMock()
+        mock_lf.start_as_current_observation.return_value = mock_obs_ctx
+
+        with (
+            patch(
+                "telegram_bot.middlewares.langfuse_middleware.get_client",
+                return_value=mock_lf,
+            ),
+            patch("telegram_bot.middlewares.langfuse_middleware.propagate_attributes") as mock_prop,
+        ):
+            result = await middleware(handler, msg, data)
+
+        assert result == "handler_result"
+        call_kwargs = mock_lf.start_as_current_observation.call_args.kwargs
+        assert call_kwargs["name"] == "telegram-rag-voice"
+        input_payload = call_kwargs["input"]
+        assert input_payload["action"] == "rag-voice"
+        assert input_payload["content_type"] == "voice"
         mock_prop.assert_called_once()
         handler.assert_called_once_with(msg, data)
 
@@ -158,10 +198,11 @@ class TestLangfuseContextMiddleware:
         assert result == "handler_result"
         call_kwargs = mock_lf.start_as_current_observation.call_args.kwargs
         assert call_kwargs["name"] == "telegram-callback-filter"
-        assert call_kwargs["input"] == {
-            "action": "callback-filter",
-            "callback_data": "filter:apply",
-        }
+        input_payload = call_kwargs["input"]
+        assert input_payload["action"] == "callback-filter"
+        assert input_payload["content_type"] == "callback"
+        assert "query_preview" in input_payload
+        assert "text_preview" not in input_payload
         mock_prop.assert_called_once()
 
     async def test_uses_user_id_when_chat_missing(self, middleware: LangfuseContextMiddleware):

--- a/tests/unit/test_telegram_formatting.py
+++ b/tests/unit/test_telegram_formatting.py
@@ -16,83 +16,110 @@ class TestRecordLangfuseResponseOutput:
             # Should not raise
             _record_langfuse_response_output("answer", 2)
 
-    def test_uses_update_current_trace_when_present(self):
+    def test_builds_safe_output_payload(self):
         mock_lf = MagicMock()
-        mock_lf.update_current_trace = MagicMock()
+        mock_lf.set_current_trace_io = MagicMock()
+
+        with (
+            patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf),
+            patch(
+                "telegram_bot.services.telegram_formatting.build_safe_output_payload",
+                return_value={"mock": "payload"},
+            ) as mock_build,
+        ):
+            _record_langfuse_response_output("hello", 2)
+
+        mock_build.assert_called_once_with("hello", 2)
+        mock_lf.set_current_trace_io.assert_called_once_with(output={"mock": "payload"})
+
+    def test_uses_set_current_trace_io_when_present(self):
+        mock_lf = MagicMock()
+        mock_lf.set_current_trace_io = MagicMock()
         mock_lf.update_current_span = MagicMock()
 
         with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
             _record_langfuse_response_output("hello world", 1)
 
-        mock_lf.update_current_trace.assert_called_once_with(
-            output={"response_preview": "hello world", "chunks_count": 1}
-        )
+        mock_lf.set_current_trace_io.assert_called_once()
         mock_lf.update_current_span.assert_not_called()
+        call_kwargs = mock_lf.set_current_trace_io.call_args.kwargs
+        assert "output" in call_kwargs
+        output = call_kwargs["output"]
+        assert "answer_preview" in output
+        assert "answer_hash" in output
+        assert output["chunks_count"] == 1
+        assert output["delivery_status"] == "sent"
 
     def test_falls_back_to_update_current_span(self):
         mock_lf = MagicMock()
-        del mock_lf.update_current_trace
+        del mock_lf.set_current_trace_io
         mock_lf.update_current_span = MagicMock()
 
         with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
             _record_langfuse_response_output("fallback", 3)
 
-        mock_lf.update_current_span.assert_called_once_with(
-            output={"response_preview": "fallback", "chunks_count": 3}
-        )
+        mock_lf.update_current_span.assert_called_once()
+        call_kwargs = mock_lf.update_current_span.call_args.kwargs
+        assert "output" in call_kwargs
+        output = call_kwargs["output"]
+        assert "answer_preview" in output
+        assert output["chunks_count"] == 3
 
     def test_no_op_when_both_methods_missing(self):
         mock_lf = MagicMock()
-        del mock_lf.update_current_trace
+        del mock_lf.set_current_trace_io
         del mock_lf.update_current_span
 
         with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
             _record_langfuse_response_output("answer", 1)
 
-    def test_trace_failure_falls_back_to_span(self):
+    def test_trace_io_failure_falls_back_to_span(self):
         mock_lf = MagicMock()
-        mock_lf.update_current_trace = MagicMock(side_effect=RuntimeError("trace error"))
+        mock_lf.set_current_trace_io = MagicMock(side_effect=RuntimeError("trace io error"))
         mock_lf.update_current_span = MagicMock()
 
         with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
             _record_langfuse_response_output("answer", 1)
 
-        mock_lf.update_current_trace.assert_called_once()
-        mock_lf.update_current_span.assert_called_once_with(
-            output={"response_preview": "answer", "chunks_count": 1}
-        )
+        mock_lf.set_current_trace_io.assert_called_once()
+        mock_lf.update_current_span.assert_called_once()
 
     def test_span_failure_is_silent(self):
         mock_lf = MagicMock()
-        mock_lf.update_current_trace = MagicMock(side_effect=RuntimeError("trace error"))
+        mock_lf.set_current_trace_io = MagicMock(side_effect=RuntimeError("trace io error"))
         mock_lf.update_current_span = MagicMock(side_effect=RuntimeError("span error"))
 
         with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
             # Should not raise
             _record_langfuse_response_output("answer", 1)
 
-    def test_preview_truncated_to_800_chars(self):
+    def test_preview_truncated_to_safe_limit(self):
         mock_lf = MagicMock()
-        mock_lf.update_current_trace = MagicMock()
+        mock_lf.set_current_trace_io = MagicMock()
 
         long_text = "x" * 2000
         with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
             _record_langfuse_response_output(long_text, 1)
 
-        call_args = mock_lf.update_current_trace.call_args.kwargs
-        assert len(call_args["output"]["response_preview"]) == 800
-        assert call_args["output"]["chunks_count"] == 1
+        call_args = mock_lf.set_current_trace_io.call_args.kwargs
+        output = call_args["output"]
+        # _preview limit is 240 chars; redactor may append a short suffix
+        assert len(output["answer_preview"]) <= 260
+        assert output["answer_len"] == 2000
+        assert output["chunks_count"] == 1
 
     def test_none_text_handled(self):
         mock_lf = MagicMock()
-        mock_lf.update_current_trace = MagicMock()
+        mock_lf.set_current_trace_io = MagicMock()
 
         with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
             _record_langfuse_response_output(None, 1)
 
-        call_args = mock_lf.update_current_trace.call_args.kwargs
-        assert call_args["output"]["response_preview"] == ""
-        assert call_args["output"]["chunks_count"] == 1
+        call_args = mock_lf.set_current_trace_io.call_args.kwargs
+        output = call_args["output"]
+        assert output["answer_preview"] == ""
+        assert output["answer_len"] == 0
+        assert output["chunks_count"] == 1
 
 
 class TestSendHtmlMessagesLangfuse:


### PR DESCRIPTION
## Summary
- Classify voice Message content type as \"voice\" and action/root kind as \"rag-voice\" in `tracing_context`.
- Middleware root trace input uses `build_safe_input_payload`; no raw message text reaches Langfuse root input.
- Voice root observation named `telegram-rag-voice`.
- Telegram delivery/output uses `build_safe_output_payload`.
- Prefer `set_current_trace_io(output=...)`; fallback to `update_current_span`.
- Remove `update_current_trace` usage/preservation.

## Verification
- Focused unit tests pass for all 3 changed modules.