### PR TITLE
feat(e2e): support Telethon voice trace scenarios

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -178,6 +178,10 @@ TELEGRAM_API_ID=12345678
 TELEGRAM_API_HASH=your-api-hash-here
 E2E_BOT_USERNAME=@test_nika_homes_bot
 
+# Path to a local audio file used for voice-note E2E scenarios (8.1–8.3).
+# If unset or empty, voice scenarios will raise a clear RuntimeError.
+# E2E_VOICE_NOTE_PATH=tmp/e2e/voice_fixture.mp3
+
 # =============================================================================
 # ALERTING (Telegram notifications via Alertmanager)
 # =============================================================================

--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,7 @@ secrets.yaml
 
 # Temporary files
 tmp/
+tmp/e2e/
 temp/
 *.tmp
 tmp*.json

--- a/scripts/e2e/config.py
+++ b/scripts/e2e/config.py
@@ -58,6 +58,9 @@ class E2EConfig:
     # Reports
     reports_dir: str = "reports"
 
+    # Voice note fixture path for voice delivery scenarios
+    voice_note_path: str = field(default_factory=lambda: os.getenv("E2E_VOICE_NOTE_PATH", ""))
+
     # Observability validation (Langfuse)
     validate_langfuse: bool = field(
         default_factory=lambda: (

--- a/scripts/e2e/runner.py
+++ b/scripts/e2e/runner.py
@@ -59,11 +59,33 @@ async def run_single_test(
         # Record start time for trace validation
         test_started_at = datetime.utcnow()
 
+        # Determine scenario kind for trace validation
+        delivery = getattr(scenario, "delivery", "text")
+        group = getattr(scenario, "group", None)
+        if delivery == "voice":
+            scenario_kind = "voice_note"
+        elif group in {
+            TestGroup.PRICE_FILTERS,
+            TestGroup.ROOM_FILTERS,
+            TestGroup.LOCATION_FILTERS,
+            TestGroup.SEARCH,
+        }:
+            scenario_kind = "apartment"
+        elif group == TestGroup.EDGE_CASES:
+            scenario_kind = "fallback"
+        else:
+            scenario_kind = "text_rag"
+
         # Send message and get response
-        response = await client.send_and_wait(
-            query=scenario.query,
-            response_timeout=scenario.timeout,
-        )
+        if delivery == "voice":
+            response = await client.send_voice_and_wait(
+                response_timeout=scenario.timeout,
+            )
+        else:
+            response = await client.send_and_wait(
+                query=scenario.query,
+                response_timeout=scenario.timeout,
+            )
 
         # Validate Langfuse trace if enabled
         trace_validation = None
@@ -71,8 +93,9 @@ async def run_single_test(
             trace_validation = validate_latest_trace(
                 started_at=test_started_at,
                 should_skip_rag=bool(getattr(scenario, "should_skip_rag", False)),
-                is_command=bool(getattr(scenario, "group", None) == TestGroup.COMMANDS),
+                is_command=bool(group == TestGroup.COMMANDS),
                 timeout_s=20.0,
+                scenario_kind=scenario_kind,
             )
             if not trace_validation.ok:
                 logger.warning(f"Trace validation failed: {trace_validation}")
@@ -257,7 +280,8 @@ def main():
     parser.add_argument(
         "--scenario",
         type=str,
-        help="Run only specific scenario by ID (e.g., 3.1)",
+        action="append",
+        help="Run only specific scenario by ID (e.g., 3.1). Can be repeated.",
     )
     parser.add_argument(
         "--no-judge",
@@ -285,11 +309,13 @@ def main():
 
     # Select scenarios
     if args.scenario:
-        scenario = get_scenario_by_id(args.scenario)
-        if not scenario:
-            console.print(f"[red]Scenario {args.scenario} not found[/]")
-            sys.exit(1)
-        scenarios = [scenario]
+        scenarios = []
+        for sid in args.scenario:
+            scenario = get_scenario_by_id(sid)
+            if not scenario:
+                console.print(f"[red]Scenario {sid} not found[/]")
+                sys.exit(1)
+            scenarios.append(scenario)
     elif args.group:
         group = TestGroup(args.group)
         scenarios = get_scenarios_by_group(group)

--- a/scripts/e2e/telegram_client.py
+++ b/scripts/e2e/telegram_client.py
@@ -111,6 +111,77 @@ class E2ETelegramClient:
             raw_message=response,
         )
 
+    async def send_voice_and_wait(
+        self,
+        response_timeout: int | None = None,
+    ) -> BotResponse:
+        """Send voice note to bot and wait for response.
+
+        Args:
+            response_timeout: Response timeout in seconds (default from config)
+
+        Returns:
+            BotResponse with text and timing
+
+        Raises:
+            RuntimeError: If voice note path is not configured or file does not exist.
+            TimeoutError: If no response within timeout
+        """
+        if not self._client:
+            raise RuntimeError("Client not connected")
+
+        path = self.config.voice_note_path
+        if not path:
+            raise RuntimeError(
+                "E2E_VOICE_NOTE_PATH is not set. "
+                "Provide a local audio file path for voice-note scenarios."
+            )
+
+        from pathlib import Path as _Path
+
+        if not _Path(path).exists():
+            raise RuntimeError(
+                f"Voice note fixture not found: {path}. "
+                "Set E2E_VOICE_NOTE_PATH to an existing audio file."
+            )
+
+        effective_timeout = response_timeout or self.config.response_timeout
+
+        start_time = time.time()
+
+        async with self._client.conversation(
+            self.config.bot_username,
+            timeout=effective_timeout,
+        ) as conv:
+            await conv.send_file(path, voice_note=True)
+            logger.debug(f"Sent voice note: {path}")
+
+            # Wait for response (handles streaming - waits for final message)
+            response = await conv.get_response()
+
+            # For streaming bots, wait a bit more for edits to complete
+            await asyncio.sleep(1.0)
+
+            # Try to get the latest version of the message (after edits)
+            try:
+                final_response = await conv.get_edit(timeout=3)
+                response = final_response
+            except TimeoutError:
+                # No edits, use original response
+                pass
+
+        end_time = time.time()
+        response_time_ms = int((end_time - start_time) * 1000)
+
+        logger.debug(f"Response ({response_time_ms}ms): {response.text[:100]}...")
+
+        return BotResponse(
+            text=response.text or "",
+            message_id=response.id,
+            response_time_ms=response_time_ms,
+            raw_message=response,
+        )
+
     async def __aenter__(self):
         """Async context manager entry."""
         await self.connect()

--- a/scripts/e2e/test_scenarios.py
+++ b/scripts/e2e/test_scenarios.py
@@ -42,6 +42,7 @@ class TestScenario:
     expected_filters: ExpectedFilters | None = None
     should_skip_rag: bool = False  # For CHITCHAT tests
     timeout: int = 60
+    delivery: str = "text"  # "text" or "voice"
 
 
 # All 28 test scenarios
@@ -289,6 +290,7 @@ SCENARIOS: list[TestScenario] = [
         name="Voice transcription + property search",
         query="(voice) найди квартиру у моря до 120 тысяч",
         group=TestGroup.VOICE_TRANSCRIPTION,
+        delivery="voice",
         description="Voice message should transcribe and run property search flow.",
         expected_keywords=["квартир", "мор", "120"],
     ),
@@ -297,6 +299,7 @@ SCENARIOS: list[TestScenario] = [
         name="Voice transcription + CRM lookup",
         query="(voice) покажи мои сделки в crm",
         group=TestGroup.VOICE_TRANSCRIPTION,
+        delivery="voice",
         description="Voice message should transcribe and route to CRM tool path.",
         expected_keywords=["сделк", "crm", "ID"],
     ),
@@ -305,6 +308,7 @@ SCENARIOS: list[TestScenario] = [
         name="Voice transcription timeout handling",
         query="(voice) [simulate timeout]",
         group=TestGroup.VOICE_TRANSCRIPTION,
+        delivery="voice",
         description="Voice transcription timeout should return graceful fallback.",
         expected_keywords=["не удалось", "попробуйте", "голос"],
     ),

--- a/tests/unit/e2e/test_telegram_client_voice.py
+++ b/tests/unit/e2e/test_telegram_client_voice.py
@@ -1,0 +1,94 @@
+"""Unit tests for E2ETelegramClient voice-note delivery."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.e2e.config import E2EConfig
+from scripts.e2e.telegram_client import BotResponse, E2ETelegramClient
+
+
+class _Msg:
+    def __init__(self, text: str, message_id: int = 1) -> None:
+        self.text = text
+        self.id = message_id
+
+
+class _Conv:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def send_message(self, _query: str) -> None:
+        return None
+
+    async def send_file(self, _path: str, *, voice_note: bool = False) -> None:
+        self.last_path = _path
+        self.last_voice_note = voice_note
+
+    async def get_response(self):
+        return _Msg("ok")
+
+    async def get_edit(self, **_kwargs):
+        raise TimeoutError
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.last_username: str | None = None
+
+    def conversation(self, username: str, timeout: int):
+        self.last_username = username
+        return _Conv()
+
+
+def _cfg_with_voice(voice_path: str) -> E2EConfig:
+    with patch.dict(os.environ, {"E2E_VOICE_NOTE_PATH": voice_path}, clear=False):
+        return E2EConfig()
+
+
+@pytest.mark.asyncio
+async def test_send_voice_and_wait_uses_conversation_send_file(tmp_path: Path) -> None:
+    fixture = tmp_path / "voice.mp3"
+    fixture.write_text("fake audio")
+    cfg = _cfg_with_voice(str(fixture))
+
+    telethon_client = _FakeClient()
+    client = E2ETelegramClient(cfg)
+    client._client = telethon_client
+
+    result = await client.send_voice_and_wait()
+
+    assert isinstance(result, BotResponse)
+    assert result.text == "ok"
+
+
+@pytest.mark.asyncio
+async def test_send_voice_and_wait_raises_when_path_not_configured() -> None:
+    cfg = _cfg_with_voice("")
+    client = E2ETelegramClient(cfg)
+    client._client = _FakeClient()
+
+    with pytest.raises(RuntimeError, match="E2E_VOICE_NOTE_PATH is not set"):
+        await client.send_voice_and_wait()
+
+
+@pytest.mark.asyncio
+async def test_send_voice_and_wait_raises_when_fixture_missing() -> None:
+    cfg = _cfg_with_voice("/nonexistent/path/to/voice.mp3")
+    client = E2ETelegramClient(cfg)
+    client._client = _FakeClient()
+
+    with pytest.raises(RuntimeError, match="Voice note fixture not found"):
+        await client.send_voice_and_wait()
+
+
+def test_config_reads_e2e_voice_note_path() -> None:
+    cfg = _cfg_with_voice("/tmp/e2e/voice_fixture.mp3")
+    assert cfg.voice_note_path == "/tmp/e2e/voice_fixture.mp3"

--- a/tests/unit/e2e/test_telegram_client_voice.py
+++ b/tests/unit/e2e/test_telegram_client_voice.py
@@ -42,10 +42,13 @@ class _Conv:
 class _FakeClient:
     def __init__(self) -> None:
         self.last_username: str | None = None
+        self.last_conv: _Conv | None = None
 
     def conversation(self, username: str, timeout: int):
         self.last_username = username
-        return _Conv()
+        conv = _Conv()
+        self.last_conv = conv
+        return conv
 
 
 def _cfg_with_voice(voice_path: str) -> E2EConfig:
@@ -67,6 +70,11 @@ async def test_send_voice_and_wait_uses_conversation_send_file(tmp_path: Path) -
 
     assert isinstance(result, BotResponse)
     assert result.text == "ok"
+
+    conv = telethon_client.last_conv
+    assert conv is not None
+    assert conv.last_voice_note is True
+    assert conv.last_path == str(fixture)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/e2e/test_voice_transcription_scenarios.py
+++ b/tests/unit/e2e/test_voice_transcription_scenarios.py
@@ -12,3 +12,9 @@ def test_voice_transcription_scenarios_have_expected_ids():
     group_scenarios = scenarios.get_scenarios_by_group(scenarios.TestGroup.VOICE_TRANSCRIPTION)
     scenario_ids = {s.id for s in group_scenarios}
     assert scenario_ids == {"8.1", "8.2", "8.3"}
+
+
+def test_voice_transcription_scenarios_use_voice_delivery():
+    group_scenarios = scenarios.get_scenarios_by_group(scenarios.TestGroup.VOICE_TRANSCRIPTION)
+    for s in group_scenarios:
+        assert s.delivery == "voice", f"Scenario {s.id} should use voice delivery"


### PR DESCRIPTION
## Summary

- Task 5 of #1307 Langfuse product-critical tracing plan.
- Focused tests run under `/home/user/projects/rag-fresh/.signals/test-run.lock`.
- No live Telethon run was performed; this task is unit support only.

## Changes

1. Add `voice_note_path` to `E2EConfig`, reading `E2E_VOICE_NOTE_PATH` with a default empty string.
2. Add `.env.example` documentation for `E2E_VOICE_NOTE_PATH`.
3. Add `.gitignore` entry for local voice fixtures under `tmp/e2e/`.
4. Add `E2ETelegramClient.send_voice_and_wait(response_timeout=None)` using the existing `send_and_wait` response/edit timing pattern.
5. Add `delivery: str = "text"` to `TestScenario` and set `delivery="voice"` for scenarios `8.1`, `8.2`, and `8.3`.
6. Route voice delivery in `run_single_test`: voice scenarios call `send_voice_and_wait`; all others continue to call `send_and_wait`.
7. Pass the right validator scenario kind (`voice_note`, `apartment`, `fallback`, `text_rag`) to Langfuse trace validation.
8. Change CLI `--scenario` to `action="append"` and support one or more repeated scenario IDs.
9. Keep changes backwards-compatible for current tests and no-judge flows.