### PR TITLE
docs(e2e): add core Langfuse trace gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -574,7 +574,7 @@ deploy-vps-local:  ## Fallback/manual deploy: sync local workspace to VPS via rs
 # E2E TESTING
 # =============================================================================
 
-.PHONY: e2e-install e2e-generate-data e2e-index-data e2e-test e2e-test-traces e2e-test-group e2e-telegram-test e2e-setup
+.PHONY: e2e-install e2e-generate-data e2e-index-data e2e-test e2e-test-traces e2e-test-traces-core e2e-test-group e2e-telegram-test e2e-setup
 
 e2e-install: ## Install E2E testing dependencies
 	@echo "$(BLUE)Installing E2E dependencies...$(NC)"
@@ -605,6 +605,11 @@ e2e-test-traces: ## Run E2E tests + validate Langfuse traces
 	@echo "$(BLUE)Running E2E tests with Langfuse trace validation...$(NC)"
 	E2E_VALIDATE_LANGFUSE=1 uv run python scripts/e2e/runner.py
 	@echo "$(GREEN)✓ E2E tests with trace validation complete$(NC)"
+
+e2e-test-traces-core: ## Run required #1307 Telethon scenarios with Langfuse validation
+	@echo "$(BLUE)Running #1307 core Telethon trace scenarios...$(NC)"
+	E2E_VALIDATE_LANGFUSE=1 uv run python scripts/e2e/runner.py --no-judge --scenario 0.1 --scenario 6.3 --scenario 7.1 --scenario 8.1
+	@echo "$(GREEN)✓ #1307 core trace scenarios complete$(NC)"
 
 e2e-test-group: ## Run specific test group (usage: make e2e-test-group GROUP=filters)
 	uv run python scripts/e2e/runner.py --group $(GROUP)

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -38,6 +38,11 @@ E2E judge routing defaults:
 - direct Anthropic judge is opt-in only: `E2E_JUDGE_PROVIDER=anthropic-direct` + `ANTHROPIC_API_KEY`
 - for transport-only Telethon checks without LLM judge: run `uv run python scripts/e2e/runner.py --no-judge`
 
+Voice-note fixture for E2E:
+- `E2E_VOICE_NOTE_PATH` — path to a local `.ogg` or `.oga` voice-note fixture
+- keep a short, non-sensitive query recording in an ignored local path such as `tmp/e2e/` (e.g., *"найди квартиру у моря до 120 тысяч"*)
+- do not commit personal voice recordings to the repo
+
 The canonical local Compose project name is `dev`. `COMPOSE_PROJECT_NAME=dev` is set in `tests/fixtures/compose.ci.env`, which `make` targets use as a fallback when `.env` is absent. Do not create worktree-named Docker projects.
 
 Secret model by compose file:
@@ -172,7 +177,20 @@ make local-ps
 make local-down
 ```
 
-## 8. Common Issues
+## 8. E2E Core Trace Gate (#1307)
+
+Required core Telethon trace scenarios with Langfuse validation:
+
+```bash
+make local-up
+make docker-ml-up
+make bot
+make e2e-test-traces-core
+```
+
+Keep `make bot` running in another terminal while the E2E command executes. Use `make run-bot` only when you do not need the tee'd `logs/bot-run.log` evidence.
+
+## 9. Common Issues
 
 - `docker-bot-up` fails immediately: missing required env variables in `.env`.
 - Slow first startup: BGE-M3 and Docling warm up and cache models.

--- a/tests/README.md
+++ b/tests/README.md
@@ -97,7 +97,10 @@ make test-nightly            # chaos + smoke + slow unit
 ```bash
 make e2e-test                # pytest E2E suite (live services)
 make e2e-telegram-test       # Telegram userbot runner
+make e2e-test-traces-core    # required #1307 core Telethon trace gate
 ```
+
+The `e2e-test-traces-core` target runs the required #1307 Telethon scenarios with Langfuse validation (`E2E_VALIDATE_LANGFUSE=1`). Ensure the bot is running locally (`make bot`) before executing this gate.
 
 ### RAG evaluation
 ```bash

--- a/tests/unit/test_makefile_contract.py
+++ b/tests/unit/test_makefile_contract.py
@@ -175,3 +175,65 @@ def test_validate_traces_fast_runs_postgres_auth_preflight() -> None:
         "validate-traces-fast must run scripts/validate_trace_runtime.py preflight "
         "before docker compose up to avoid silent Postgres auth mismatch loops."
     )
+
+
+# --- #1307 core trace gate contract tests ---
+
+
+def test_e2e_test_traces_core_is_phony() -> None:
+    text = _makefile_text()
+    phony_blocks = re.findall(r"^\.PHONY:.*(?:\\\n.*)*", text, re.MULTILINE)
+    assert phony_blocks, ".PHONY declaration not found in Makefile"
+    combined = " ".join(phony_blocks)
+    assert "e2e-test-traces-core" in combined, "e2e-test-traces-core must be declared in .PHONY"
+
+
+def test_e2e_test_traces_core_target_exists() -> None:
+    text = _makefile_text()
+    assert re.search(r"^e2e-test-traces-core:", text, re.MULTILINE), (
+        "e2e-test-traces-core target must exist in Makefile"
+    )
+
+
+def test_e2e_test_traces_core_uses_langfuse_validation() -> None:
+    text = _makefile_text()
+    block_match = re.search(
+        r"^e2e-test-traces-core:.*?(?=^[A-Za-z0-9_.-]+:|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert block_match, "e2e-test-traces-core target not found in Makefile"
+    block = block_match.group(0)
+    assert "E2E_VALIDATE_LANGFUSE=1" in block, (
+        "e2e-test-traces-core must set E2E_VALIDATE_LANGFUSE=1"
+    )
+
+
+def test_e2e_test_traces_core_uses_no_judge() -> None:
+    text = _makefile_text()
+    block_match = re.search(
+        r"^e2e-test-traces-core:.*?(?=^[A-Za-z0-9_.-]+:|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert block_match, "e2e-test-traces-core target not found in Makefile"
+    block = block_match.group(0)
+    assert "--no-judge" in block, (
+        "e2e-test-traces-core must use --no-judge to skip LLM judge during core trace gate"
+    )
+
+
+def test_e2e_test_traces_core_includes_required_scenarios() -> None:
+    text = _makefile_text()
+    block_match = re.search(
+        r"^e2e-test-traces-core:.*?(?=^[A-Za-z0-9_.-]+:|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert block_match, "e2e-test-traces-core target not found in Makefile"
+    block = block_match.group(0)
+    required = ("0.1", "6.3", "7.1", "8.1")
+    missing = [s for s in required if f"--scenario {s}" not in block]
+    assert not missing, (
+        f"e2e-test-traces-core must include all required #1307 scenarios; missing: {missing}"
+    )


### PR DESCRIPTION
## Summary

Task 7 of #1307 Langfuse product-critical tracing plan.

### Changes
- Add `e2e-test-traces-core` Makefile target that runs the required core Telethon scenarios (0.1, 6.3, 7.1, 8.1) with Langfuse validation (`E2E_VALIDATE_LANGFUSE=1`, `--no-judge`).
- Document `E2E_VOICE_NOTE_PATH` fixture requirement in `docs/LOCAL-DEVELOPMENT.md`.
- Document the core command sequence (`make local-up`, `make docker-ml-up`, `make bot`, `make e2e-test-traces-core`).
- Add E2E trace gate note in `tests/README.md`.
- Update `tests/unit/test_makefile_contract.py` to enforce the new target contract.

### Checks run
- `flock`-locked `pytest tests/unit/test_makefile_contract.py` — 18 passed.
- `make check` — lint + type-check passed.
- `git diff --check` — clean.

### Notes
- No live Telethon run was performed in this task.