### PR TITLE
fix(validator): accept cache-check as alias for node-cache-check in trace validation

### DIFF
--- a/scripts/e2e/langfuse_trace_validator.py
+++ b/scripts/e2e/langfuse_trace_validator.py
@@ -33,6 +33,12 @@ SCORE_NAMES = {
     "llm_used",
 }
 
+# Observation alias groups: canonical name -> set of acceptable aliases.
+# Any alias present in the trace satisfies the requirement for the canonical name.
+OBSERVATION_ALIAS_GROUPS = {
+    "node-cache-check": {"node-cache-check", "cache-check"},
+}
+
 SCENARIO_CONTRACTS = {
     "text_rag": {
         "trace_names": ["telegram-message"],
@@ -173,6 +179,23 @@ def _as_float(value: object) -> float | None:
     return None
 
 
+def _resolve_missing_observations(
+    required_observations: set[str], span_names: set[str]
+) -> set[str]:
+    """Return required observations not satisfied by any present span name.
+
+    Supports alias groups: if a required observation has aliases defined in
+    :data:`OBSERVATION_ALIAS_GROUPS`, any alias present in ``span_names``
+    satisfies the requirement for the canonical name.
+    """
+    missing: set[str] = set()
+    for req in required_observations:
+        aliases = OBSERVATION_ALIAS_GROUPS.get(req, {req})
+        if not (aliases & span_names):
+            missing.add(req)
+    return missing
+
+
 def wait_for_trace(
     *,
     started_at: datetime,
@@ -279,7 +302,7 @@ def validate_latest_trace(
     score_names = set(scores.keys())
 
     # Base observation misses from the scenario contract.
-    missing_spans = set(required_observations - span_names)
+    missing_spans = _resolve_missing_observations(required_observations, span_names)
 
     # Root trace input/output checks (trace-level, not observation-level).
     trace_input = getattr(trace, "input", None) or {}
@@ -317,7 +340,7 @@ def validate_latest_trace(
             required_observations |= {"node-generate", "node-cache-store", "node-respond"}
 
     # Recompute observation misses after branch-aware additions.
-    missing_spans |= set(required_observations - span_names)
+    missing_spans |= _resolve_missing_observations(required_observations, span_names)
     missing_scores = set(required_scores - score_names)
 
     return TraceValidationResult(

--- a/tests/unit/e2e/test_langfuse_trace_validator.py
+++ b/tests/unit/e2e/test_langfuse_trace_validator.py
@@ -278,3 +278,117 @@ def test_wait_for_trace_multi_name_finds_match():
             )
 
     assert result == "trace-msg"
+
+
+# ---------------------------------------------------------------------------
+# Alias group: node-cache-check / cache-check
+# ---------------------------------------------------------------------------
+
+
+def _sanitized_observed_trace(*, include_cache_check_alias: bool = False):
+    """Build a mock trace shaped like sanitized local audit observations.
+
+    Based on artifact evidence (root_input keys present, observed cache names,
+    required score names present). No raw payload values.
+
+    Scores are chosen so only the ``node-cache-check`` branch requirement is
+    triggered, keeping the alias-group test focused.
+    """
+    mock_trace = MagicMock()
+    mock_trace.input = {
+        "action": "message",
+        "content_type": "text",
+        "query_hash": "abc123",
+        "query_len": 24,
+        "query_preview": "test query",
+    }
+    mock_trace.output = {"answer_hash": "def456"}
+
+    observations = [
+        type("Obs", (), {"name": "telegram-message"}),
+        type("Obs", (), {"name": "telegram-rag-query"}),
+        type("Obs", (), {"name": "telegram-rag-supervisor"}),
+        type("Obs", (), {"name": "client-direct-pipeline"}),
+        type("Obs", (), {"name": "classify-query"}),
+        type("Obs", (), {"name": "cache-semantic-check"}),
+        type("Obs", (), {"name": "cache-exact-get"}),
+        type("Obs", (), {"name": "cache-search-get"}),
+        type("Obs", (), {"name": "cache-embedding-get"}),
+        type("Obs", (), {"name": "grade-documents"}),
+        type("Obs", (), {"name": "hybrid-retrieve"}),
+        type("Obs", (), {"name": "service-generate-response"}),
+        type("Obs", (), {"name": "history-save"}),
+    ]
+
+    if include_cache_check_alias:
+        observations.append(type("Obs", (), {"name": "cache-check"}))
+
+    # Observations are unordered; shuffle alias into middle of list.
+    mock_trace.observations = observations
+
+    # Scores configured so ``semantic_cache_hit=True`` short-circuits the
+    # retrieval/generation branch requirements, leaving only
+    # ``node-cache-check`` as the branch-required observation.
+    mock_trace.scores = [
+        type("Score", (), {"name": "query_type", "value": 1.0}),
+        type("Score", (), {"name": "latency_total_ms", "value": 1500.0}),
+        type("Score", (), {"name": "semantic_cache_hit", "value": True}),
+        type("Score", (), {"name": "embeddings_cache_hit", "value": False}),
+        type("Score", (), {"name": "search_cache_hit", "value": False}),
+        type("Score", (), {"name": "rerank_applied", "value": False}),
+        type("Score", (), {"name": "rerank_cache_hit", "value": False}),
+        type("Score", (), {"name": "results_count", "value": 0.0}),
+        type("Score", (), {"name": "no_results", "value": True}),
+        type("Score", (), {"name": "llm_used", "value": False}),
+    ]
+    return mock_trace
+
+
+def test_validator_fails_when_cache_check_alias_group_unsatisfied(
+    mock_langfuse_configured,
+    mock_wait_for_trace,
+):
+    """Without node-cache-check or cache-check, validation must fail (strict)."""
+    mock_trace = _sanitized_observed_trace(include_cache_check_alias=False)
+
+    with patch("scripts.e2e.langfuse_trace_validator.Langfuse") as MockLangfuse:
+        mock_client = MockLangfuse.return_value
+        mock_client.api.trace.get.return_value = mock_trace
+
+        result = validate_latest_trace(
+            started_at=datetime.now(),
+            should_skip_rag=False,
+            is_command=False,
+            scenario_kind="text_rag",
+        )
+
+    assert not result.ok, "Expected validation to fail without cache-check alias"
+    assert "node-cache-check" in result.missing_spans, (
+        f"Expected node-cache-check in missing_spans, got: {result.missing_spans}"
+    )
+
+
+def test_validator_passes_with_cache_check_alias(
+    mock_langfuse_configured,
+    mock_wait_for_trace,
+):
+    """cache-check satisfies the node-cache-check requirement via alias group."""
+    mock_trace = _sanitized_observed_trace(include_cache_check_alias=True)
+
+    with patch("scripts.e2e.langfuse_trace_validator.Langfuse") as MockLangfuse:
+        mock_client = MockLangfuse.return_value
+        mock_client.api.trace.get.return_value = mock_trace
+
+        result = validate_latest_trace(
+            started_at=datetime.now(),
+            should_skip_rag=False,
+            is_command=False,
+            scenario_kind="text_rag",
+        )
+
+    assert result.ok, (
+        f"Validation failed: missing_spans={result.missing_spans}, missing_scores={result.missing_scores}"
+    )
+    assert "node-cache-check" not in result.missing_spans, (
+        f"Did not expect node-cache-check in missing_spans, got: {result.missing_spans}"
+    )


### PR DESCRIPTION
## Summary
- Add alias group mechanism to trace validator for product-equivalent observation names
- `node-cache-check` ↔ `cache-check` alias allows traces with pipeline-level `cache-check` spans to satisfy the graph-node `node-cache-check` requirement
- Scores remain strict (no aliasing), per SDK baseline

## Details
- New `OBSERVATION_ALIAS_GROUPS` dict maps canonical names to acceptable aliases
- `_resolve_missing_observations()` function replaces direct set subtraction at two call sites
- Two focused unit tests validate alias-group behavior (both pass and fail cases)
- All 14 existing tests continue to pass

## Files
- `scripts/e2e/langfuse_trace_validator.py` — alias group mechanism
- `tests/unit/e2e/test_langfuse_trace_validator.py` — alias group tests