### PR TITLE
feat(#1493): Cache BGE-M3 query vectors as one Redis bundle in pipeline and retrieve

### DIFF
--- a/telegram_bot/agents/rag_pipeline.py
+++ b/telegram_bot/agents/rag_pipeline.py
@@ -184,45 +184,67 @@ async def _cache_check(
 
     start = time.perf_counter()
 
-    # Step 1: Get or compute dense embedding via shared core
-    if pre_computed_embedding:
-        logger.debug(
-            "_cache_check: reusing pre-computed embedding (%d dims)", len(pre_computed_embedding)
-        )
-    try:
-        embedding, sparse, colbert_query, embeddings_cache_hit = await compute_query_embedding(
-            query,
-            cache=cache,
-            embeddings=embeddings,
-            pre_computed=pre_computed_embedding,
-            pre_computed_sparse=pre_computed_sparse,
-            pre_computed_colbert=pre_computed_colbert,
-        )
-    except Exception as exc:
-        embedding_error_type = type(exc).__name__
-        logger.error("Embedding failed: %s: %s", embedding_error_type, exc)
-        latency = time.perf_counter() - start
-        lf.update_current_span(
-            level="ERROR",
-            output={
+    # Try bundle cache first (avoids redundant BGE-M3 calls when full bundle is cached #1493)
+    bundle = None
+    _has_bundle_cache = callable(getattr(cache, "get_bge_m3_query_bundle", None))
+    if _has_bundle_cache and pre_computed_embedding is None:
+        try:
+            maybe_bundle = await cache.get_bge_m3_query_bundle(query)
+            if (
+                maybe_bundle is not None
+                and hasattr(maybe_bundle, "dense")
+                and isinstance(maybe_bundle.dense, list)
+            ):
+                bundle = maybe_bundle
+        except Exception:
+            logger.debug("Bundle cache check failed (non-critical), skipping")
+
+    if bundle is not None:
+        embedding = bundle.dense
+        sparse = bundle.sparse
+        colbert_query = bundle.colbert
+        embeddings_cache_hit = True
+    else:
+        # Step 1: Get or compute dense embedding via shared core
+        if pre_computed_embedding:
+            logger.debug(
+                "_cache_check: reusing pre-computed embedding (%d dims)",
+                len(pre_computed_embedding),
+            )
+        try:
+            embedding, sparse, colbert_query, embeddings_cache_hit = await compute_query_embedding(
+                query,
+                cache=cache,
+                embeddings=embeddings,
+                pre_computed=pre_computed_embedding,
+                pre_computed_sparse=pre_computed_sparse,
+                pre_computed_colbert=pre_computed_colbert,
+            )
+        except Exception as exc:
+            embedding_error_type = type(exc).__name__
+            logger.error("Embedding failed: %s: %s", embedding_error_type, exc)
+            latency = time.perf_counter() - start
+            lf.update_current_span(
+                level="ERROR",
+                output={
+                    "embedding_error": True,
+                    "embedding_error_type": embedding_error_type,
+                    "error_message": str(exc)[:200],
+                    "duration_ms": round(latency * 1000, 1),
+                },
+            )
+            return {
+                "cache_hit": False,
+                "cached_response": None,
+                "query_embedding": None,
+                "sparse_embedding": None,
+                "embeddings_cache_hit": False,
                 "embedding_error": True,
                 "embedding_error_type": embedding_error_type,
-                "error_message": str(exc)[:200],
-                "duration_ms": round(latency * 1000, 1),
-            },
-        )
-        return {
-            "cache_hit": False,
-            "cached_response": None,
-            "query_embedding": None,
-            "sparse_embedding": None,
-            "embeddings_cache_hit": False,
-            "embedding_error": True,
-            "embedding_error_type": embedding_error_type,
-            "error_response": "Сервис временно недоступен. Пожалуйста, повторите через минуту.",
-            "colbert_query": None,
-            "latency_stages": {**latency_stages, "cache_check": latency},
-        }
+                "error_response": "Сервис временно недоступен. Пожалуйста, повторите через минуту.",
+                "colbert_query": None,
+                "latency_stages": {**latency_stages, "cache_check": latency},
+            }
 
     # Step 2: Check semantic cache via shared core
     contextual_query = is_contextual_query(query)
@@ -284,6 +306,28 @@ async def _cache_check(
                     sparse = sparse_from_hybrid
                     if not pre_computed_sparse:
                         await cache.store_sparse_embedding(query, sparse_from_hybrid)
+                # Store full bundle for future requests (#1493)
+                if (
+                    _has_bundle_cache
+                    and embedding is not None
+                    and sparse is not None
+                    and colbert_query is not None
+                ):
+                    try:
+                        from telegram_bot.services.bge_m3_query_bundle import (
+                            BgeM3QueryVectorBundle,
+                        )
+
+                        await cache.store_bge_m3_query_bundle(
+                            query,
+                            BgeM3QueryVectorBundle(
+                                dense=embedding,
+                                sparse=sparse,
+                                colbert=colbert_query,
+                            ),
+                        )
+                    except Exception:
+                        logger.debug("Bundle store failed (non-critical), skipping")
             except Exception:
                 logger.debug("ColBERT query encode failed (non-critical), skipping")
         elif _has_colbert_only:
@@ -357,42 +401,84 @@ async def _hybrid_retrieve(
 
     # After rewrite, query_embedding is None — re-embed the rewritten query
     if dense_vector is None and embeddings is not None:
-        dense_vector = await cache.get_embedding(query)
-        if dense_vector is None:
-            sparse_cached = await cache.get_sparse_embedding(query)
-            if sparse_cached is not None:
-                dense_vector = await embeddings.aembed_query(query)
-                await cache.store_embedding(query, dense_vector)
-                sparse_vector = sparse_cached
-            elif callable(
-                getattr(embeddings, "aembed_hybrid_with_colbert", None)
-            ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid_with_colbert):
-                (
-                    dense_vector,
-                    sparse_vector,
-                    colbert_query,
-                ) = await embeddings.aembed_hybrid_with_colbert(query)
-                await cache.store_embedding(query, dense_vector)
-                await cache.store_sparse_embedding(query, sparse_vector)
-            elif callable(
-                getattr(embeddings, "aembed_hybrid", None)
-            ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid):
-                dense_vector, sparse_vector = await embeddings.aembed_hybrid(query)
-                await cache.store_embedding(query, dense_vector)
-                await cache.store_sparse_embedding(query, sparse_vector)
-            else:
+        # Check bundle cache first (avoids redundant BGE-M3 calls #1493)
+        _has_bundle_cache = callable(getattr(cache, "get_bge_m3_query_bundle", None))
+        bundle = None
+        if _has_bundle_cache:
+            try:
+                maybe_bundle = await cache.get_bge_m3_query_bundle(query)
+                if (
+                    maybe_bundle is not None
+                    and hasattr(maybe_bundle, "dense")
+                    and isinstance(maybe_bundle.dense, list)
+                ):
+                    bundle = maybe_bundle
+            except Exception:
+                logger.debug("Bundle cache check failed (non-critical), skipping")
 
-                async def _get_dense() -> list[float]:
-                    vec: list[float] = await embeddings.aembed_query(query)
-                    await cache.store_embedding(query, vec)
-                    return vec
+        if bundle is not None:
+            dense_vector = bundle.dense
+            sparse_vector = bundle.sparse
+            colbert_query = bundle.colbert
+        else:
+            dense_vector = await cache.get_embedding(query)
+            if dense_vector is None:
+                sparse_cached = await cache.get_sparse_embedding(query)
+                if sparse_cached is not None:
+                    dense_vector = await embeddings.aembed_query(query)
+                    await cache.store_embedding(query, dense_vector)
+                    sparse_vector = sparse_cached
+                elif callable(
+                    getattr(embeddings, "aembed_hybrid_with_colbert", None)
+                ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid_with_colbert):
+                    (
+                        dense_vector,
+                        sparse_vector,
+                        colbert_query,
+                    ) = await embeddings.aembed_hybrid_with_colbert(query)
+                    await cache.store_embedding(query, dense_vector)
+                    await cache.store_sparse_embedding(query, sparse_vector)
+                    # Store full bundle for future requests (#1493)
+                    if (
+                        _has_bundle_cache
+                        and dense_vector is not None
+                        and sparse_vector is not None
+                        and colbert_query is not None
+                    ):
+                        try:
+                            from telegram_bot.services.bge_m3_query_bundle import (
+                                BgeM3QueryVectorBundle,
+                            )
 
-                async def _get_sparse() -> Any:
-                    vec = await sparse_embeddings.aembed_query(query)
-                    await cache.store_sparse_embedding(query, vec)
-                    return vec
+                            await cache.store_bge_m3_query_bundle(
+                                query,
+                                BgeM3QueryVectorBundle(
+                                    dense=dense_vector,
+                                    sparse=sparse_vector,
+                                    colbert=colbert_query,
+                                ),
+                            )
+                        except Exception:
+                            logger.debug("Bundle store failed (non-critical), skipping")
+                elif callable(
+                    getattr(embeddings, "aembed_hybrid", None)
+                ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid):
+                    dense_vector, sparse_vector = await embeddings.aembed_hybrid(query)
+                    await cache.store_embedding(query, dense_vector)
+                    await cache.store_sparse_embedding(query, sparse_vector)
+                else:
 
-                dense_vector, sparse_vector = await asyncio.gather(_get_dense(), _get_sparse())
+                    async def _get_dense() -> list[float]:
+                        vec: list[float] = await embeddings.aembed_query(query)
+                        await cache.store_embedding(query, vec)
+                        return vec
+
+                    async def _get_sparse() -> Any:
+                        vec = await sparse_embeddings.aembed_query(query)
+                        await cache.store_sparse_embedding(query, vec)
+                        return vec
+
+                    dense_vector, sparse_vector = await asyncio.gather(_get_dense(), _get_sparse())
 
     if not dense_vector:
         dense_vector = []

--- a/telegram_bot/graph/nodes/retrieve.py
+++ b/telegram_bot/graph/nodes/retrieve.py
@@ -95,12 +95,6 @@ async def retrieve_node(
     colbert_query = state.get("colbert_query")
     retrieval_filters = state.get("filters")
     _has_colbert_search = callable(getattr(qdrant, "hybrid_search_rrf_colbert", None))
-    search_cache_profile = _build_search_cache_profile(
-        needs_coverage=needs_coverage,
-        use_colbert=bool(colbert_query and _has_colbert_search),
-        top_k=effective_top_k,
-        filters=retrieval_filters if isinstance(retrieval_filters, dict) else None,
-    )
 
     # Curated span metadata (replaces auto-captured full state)
     lf = get_client()
@@ -121,37 +115,98 @@ async def retrieve_node(
 
     # After rewrite, query_embedding is None — re-embed the rewritten query
     if dense_vector is None and embeddings is not None:
-        dense_vector = await cache.get_embedding(query)
-        if dense_vector is None:
-            sparse_cached = await cache.get_sparse_embedding(query)
-            if sparse_cached is not None:
-                # Dense miss, sparse cached → just compute dense
-                dense_vector = await embeddings.aembed_query(query)
-                await cache.store_embedding(query, dense_vector)
-                sparse_vector = sparse_cached
-            elif callable(
-                getattr(embeddings, "aembed_hybrid", None)
-            ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid):
-                # Hybrid: single call for both dense + sparse
-                dense_vector, sparse_vector = await embeddings.aembed_hybrid(query)
-                await cache.store_embedding(query, dense_vector)
-                await cache.store_sparse_embedding(query, sparse_vector)
-            else:
-                # Fallback: parallel dense + sparse (old path)
-                async def _get_dense() -> list[float]:
-                    vec: list[float] = await embeddings.aembed_query(query)
-                    await cache.store_embedding(query, vec)
-                    return vec
+        # Check bundle cache first (avoids redundant BGE-M3 calls #1493)
+        _has_bundle_cache = callable(getattr(cache, "get_bge_m3_query_bundle", None))
+        bundle = None
+        if _has_bundle_cache:
+            try:
+                maybe_bundle = await cache.get_bge_m3_query_bundle(query)
+                if (
+                    maybe_bundle is not None
+                    and hasattr(maybe_bundle, "dense")
+                    and isinstance(maybe_bundle.dense, list)
+                ):
+                    bundle = maybe_bundle
+            except Exception:
+                logger.debug("Bundle cache check failed (non-critical), skipping")
 
-                async def _get_sparse() -> Any:
-                    vec = await sparse_embeddings.aembed_query(query)
-                    await cache.store_sparse_embedding(query, vec)
-                    return vec
+        if bundle is not None:
+            dense_vector = bundle.dense
+            sparse_vector = bundle.sparse
+            colbert_query = bundle.colbert
+        else:
+            dense_vector = await cache.get_embedding(query)
+            if dense_vector is None:
+                sparse_cached = await cache.get_sparse_embedding(query)
+                if sparse_cached is not None:
+                    # Dense miss, sparse cached → just compute dense
+                    dense_vector = await embeddings.aembed_query(query)
+                    await cache.store_embedding(query, dense_vector)
+                    sparse_vector = sparse_cached
+                elif callable(
+                    getattr(embeddings, "aembed_hybrid_with_colbert", None)
+                ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid_with_colbert):
+                    # Full bundle: single call for dense + sparse + ColBERT
+                    (
+                        dense_vector,
+                        sparse_vector,
+                        colbert_query,
+                    ) = await embeddings.aembed_hybrid_with_colbert(query)
+                    await cache.store_embedding(query, dense_vector)
+                    await cache.store_sparse_embedding(query, sparse_vector)
+                    # Store full bundle for future requests (#1493)
+                    if (
+                        _has_bundle_cache
+                        and dense_vector is not None
+                        and sparse_vector is not None
+                        and colbert_query is not None
+                    ):
+                        try:
+                            from telegram_bot.services.bge_m3_query_bundle import (
+                                BgeM3QueryVectorBundle,
+                            )
 
-                dense_vector, sparse_vector = await asyncio.gather(_get_dense(), _get_sparse())
+                            await cache.store_bge_m3_query_bundle(
+                                query,
+                                BgeM3QueryVectorBundle(
+                                    dense=dense_vector,
+                                    sparse=sparse_vector,
+                                    colbert=colbert_query,
+                                ),
+                            )
+                        except Exception:
+                            logger.debug("Bundle store failed (non-critical), skipping")
+                elif callable(
+                    getattr(embeddings, "aembed_hybrid", None)
+                ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid):
+                    # Hybrid: single call for both dense + sparse
+                    dense_vector, sparse_vector = await embeddings.aembed_hybrid(query)
+                    await cache.store_embedding(query, dense_vector)
+                    await cache.store_sparse_embedding(query, sparse_vector)
+                else:
+                    # Fallback: parallel dense + sparse (old path)
+                    async def _get_dense() -> list[float]:
+                        vec: list[float] = await embeddings.aembed_query(query)
+                        await cache.store_embedding(query, vec)
+                        return vec
+
+                    async def _get_sparse() -> Any:
+                        vec = await sparse_embeddings.aembed_query(query)
+                        await cache.store_sparse_embedding(query, vec)
+                        return vec
+
+                    dense_vector, sparse_vector = await asyncio.gather(_get_dense(), _get_sparse())
 
     if not dense_vector:
         dense_vector = []
+
+    # Build search cache profile AFTER re-embed so colbert_query is accurate (#1493)
+    search_cache_profile = _build_search_cache_profile(
+        needs_coverage=needs_coverage,
+        use_colbert=bool(colbert_query and _has_colbert_search),
+        top_k=effective_top_k,
+        filters=retrieval_filters if isinstance(retrieval_filters, dict) else None,
+    )
 
     start = time.perf_counter()
 

--- a/tests/unit/agents/test_rag_pipeline.py
+++ b/tests/unit/agents/test_rag_pipeline.py
@@ -21,6 +21,8 @@ def mock_cache():
     cache.get_rerank_results = AsyncMock(return_value=None)
     cache.store_rerank_results = AsyncMock()
     cache.store_semantic = AsyncMock()
+    cache.get_bge_m3_query_bundle = AsyncMock(return_value=None)
+    cache.store_bge_m3_query_bundle = AsyncMock()
     return cache
 
 
@@ -2270,3 +2272,183 @@ async def test_rag_pipeline_skips_blind_semantic_lookup_for_filter_sensitive_que
 
     mock_cache.check_semantic.assert_not_awaited()
     assert result["semantic_cache_already_checked"] is True
+
+
+# ---------------------------------------------------------------------------
+# BGE-M3 query vector bundle tests (#1493)
+# ---------------------------------------------------------------------------
+
+
+async def test_cache_check_uses_bundle_cache_hit(mock_cache):
+    """_cache_check uses bundle cache and skips compute_query_embedding."""
+    from unittest.mock import AsyncMock
+
+    from telegram_bot.agents.rag_pipeline import _cache_check
+    from telegram_bot.services.bge_m3_query_bundle import BgeM3QueryVectorBundle
+
+    bundle = BgeM3QueryVectorBundle(
+        dense=[0.1] * 1024,
+        sparse={"indices": [1], "values": [0.5]},
+        colbert=[[0.2] * 1024] * 4,
+    )
+    mock_cache.get_bge_m3_query_bundle = AsyncMock(return_value=bundle)
+
+    mock_embeddings = AsyncMock()
+    mock_embeddings.aembed_hybrid = AsyncMock()
+    mock_embeddings.aembed_hybrid_with_colbert = AsyncMock()
+
+    result = await _cache_check(
+        "test query",
+        "GENERAL",
+        42,
+        cache=mock_cache,
+        embeddings=mock_embeddings,
+        latency_stages={},
+    )
+
+    assert result["cache_hit"] is False
+    assert result["query_embedding"] == bundle.dense
+    assert result["sparse_embedding"] == bundle.sparse
+    assert result["colbert_query"] == bundle.colbert
+    assert result["embeddings_cache_hit"] is True
+    mock_embeddings.aembed_hybrid.assert_not_awaited()
+    mock_embeddings.aembed_hybrid_with_colbert.assert_not_awaited()
+
+
+async def test_cache_check_stores_bundle_after_colbert_compute(mock_cache):
+    """_cache_check stores bundle after computing colbert via aembed_hybrid_with_colbert."""
+    from unittest.mock import AsyncMock
+
+    from telegram_bot.agents.rag_pipeline import _cache_check
+
+    mock_cache.get_embedding = AsyncMock(return_value=None)
+    mock_cache.check_semantic = AsyncMock(return_value=None)
+
+    mock_embeddings = AsyncMock()
+    mock_embeddings.aembed_hybrid = None
+    mock_embeddings.aembed_hybrid_with_colbert = AsyncMock(
+        return_value=([0.1] * 1024, {"indices": [1], "values": [0.5]}, [[0.2] * 1024] * 4)
+    )
+    mock_embeddings.aembed_colbert_query = None
+
+    result = await _cache_check(
+        "test query",
+        "GENERAL",
+        42,
+        cache=mock_cache,
+        embeddings=mock_embeddings,
+        latency_stages={},
+    )
+
+    assert result["colbert_query"] is not None
+    mock_cache.store_bge_m3_query_bundle.assert_awaited_once()
+    call_args = mock_cache.store_bge_m3_query_bundle.await_args
+    assert call_args.args[0] == "test query"
+
+
+async def test_hybrid_retrieve_uses_bundle_after_rewrite(mock_cache, mock_sparse):
+    """_hybrid_retrieve uses bundle cache after rewrite to avoid redundant BGE-M3 call."""
+    from unittest.mock import AsyncMock
+
+    from telegram_bot.agents.rag_pipeline import _hybrid_retrieve
+    from telegram_bot.services.bge_m3_query_bundle import BgeM3QueryVectorBundle
+
+    bundle = BgeM3QueryVectorBundle(
+        dense=[0.3] * 1024,
+        sparse={"indices": [2], "values": [0.7]},
+        colbert=[[0.4] * 1024] * 3,
+    )
+    mock_cache.get_bge_m3_query_bundle = AsyncMock(return_value=bundle)
+
+    mock_qdrant = AsyncMock()
+    mock_qdrant.hybrid_search_rrf_colbert = AsyncMock(
+        return_value=(
+            [{"id": "1", "score": 85.0, "text": "doc", "metadata": {}}],
+            {"backend_error": False, "error_type": None, "error_message": None},
+        )
+    )
+
+    mock_embeddings = AsyncMock()
+    mock_embeddings.aembed_hybrid_with_colbert = AsyncMock()
+
+    result = await _hybrid_retrieve(
+        "rewritten query",
+        None,  # dense_vector is None after rewrite
+        cache=mock_cache,
+        sparse_embeddings=mock_sparse,
+        qdrant=mock_qdrant,
+        embeddings=mock_embeddings,
+        colbert_query=None,
+        latency_stages={},
+    )
+
+    assert result["rerank_applied"] is True
+    assert result["colbert_query"] == bundle.colbert
+    mock_embeddings.aembed_hybrid_with_colbert.assert_not_awaited()
+    mock_qdrant.hybrid_search_rrf_colbert.assert_called_once()
+
+
+async def test_hybrid_retrieve_stores_bundle_after_hybrid_colbert(mock_cache, mock_sparse):
+    """_hybrid_retrieve stores bundle after aembed_hybrid_with_colbert computes vectors."""
+    from unittest.mock import AsyncMock
+
+    from telegram_bot.agents.rag_pipeline import _hybrid_retrieve
+
+    mock_qdrant = AsyncMock()
+    mock_qdrant.hybrid_search_rrf_colbert = AsyncMock(
+        return_value=(
+            [{"id": "1", "score": 85.0, "text": "doc", "metadata": {}}],
+            {"backend_error": False, "error_type": None, "error_message": None},
+        )
+    )
+
+    mock_embeddings = AsyncMock()
+    mock_embeddings.aembed_hybrid_with_colbert = AsyncMock(
+        return_value=([0.3] * 1024, {"indices": [2], "values": [0.7]}, [[0.4] * 1024] * 3)
+    )
+
+    result = await _hybrid_retrieve(
+        "rewritten query",
+        None,
+        cache=mock_cache,
+        sparse_embeddings=mock_sparse,
+        qdrant=mock_qdrant,
+        embeddings=mock_embeddings,
+        colbert_query=None,
+        latency_stages={},
+    )
+
+    assert result["rerank_applied"] is True
+    mock_cache.store_bge_m3_query_bundle.assert_awaited_once()
+
+
+async def test_cache_check_skips_bundle_when_pre_computed(mock_cache):
+    """_cache_check skips bundle cache when pre_computed_embedding is provided."""
+    from unittest.mock import AsyncMock
+
+    from telegram_bot.agents.rag_pipeline import _cache_check
+    from telegram_bot.services.bge_m3_query_bundle import BgeM3QueryVectorBundle
+
+    bundle = BgeM3QueryVectorBundle(
+        dense=[0.1] * 1024,
+        sparse={"indices": [1], "values": [0.5]},
+        colbert=[[0.2] * 1024] * 4,
+    )
+    mock_cache.get_bge_m3_query_bundle = AsyncMock(return_value=bundle)
+
+    mock_embeddings = AsyncMock()
+
+    result = await _cache_check(
+        "test query",
+        "GENERAL",
+        42,
+        cache=mock_cache,
+        embeddings=mock_embeddings,
+        latency_stages={},
+        pre_computed_embedding=[0.5] * 1024,
+        pre_computed_sparse={"indices": [3], "values": [0.9]},
+    )
+
+    assert result["query_embedding"] == [0.5] * 1024
+    assert result["sparse_embedding"] == {"indices": [3], "values": [0.9]}
+    mock_cache.get_bge_m3_query_bundle.assert_not_awaited()

--- a/tests/unit/graph/test_retrieve_node.py
+++ b/tests/unit/graph/test_retrieve_node.py
@@ -779,3 +779,181 @@ class TestRetrieveNodeEvalFields:
         assert "eval_docs" in final_output
         assert final_output["eval_query"] == "cached query"
         assert "Cached document content" in final_output["eval_docs"]
+
+
+class TestRetrieveNodeBundle:
+    """Tests for BGE-M3 query vector bundle cache in retrieve_node (#1493)."""
+
+    async def test_bundle_cache_hit_after_rewrite(self):
+        """After rewrite, retrieve_node uses bundle cache and skips BGE-M3 call."""
+        state = make_initial_state(user_id=1, session_id="s1", query="rewritten query")
+        state["query_type"] = "GENERAL"
+        state["query_embedding"] = None  # simulates post-rewrite
+
+        from telegram_bot.services.bge_m3_query_bundle import BgeM3QueryVectorBundle
+
+        bundle = BgeM3QueryVectorBundle(
+            dense=[0.3] * 1024,
+            sparse={"indices": [2], "values": [0.7]},
+            colbert=[[0.4] * 1024] * 3,
+        )
+        cache = AsyncMock()
+        cache.get_bge_m3_query_bundle = AsyncMock(return_value=bundle)
+        cache.get_search_results = AsyncMock(return_value=None)
+        cache.get_sparse_embedding = AsyncMock(return_value=None)
+        cache.store_search_results = AsyncMock()
+
+        qdrant = AsyncMock()
+        qdrant.hybrid_search_rrf_colbert = AsyncMock(
+            return_value=(
+                [{"id": "1", "score": 85.0, "text": "doc", "metadata": {}}],
+                _OK_META,
+            )
+        )
+
+        embeddings = AsyncMock()
+        embeddings.aembed_hybrid_with_colbert = AsyncMock()
+
+        result = await retrieve_node(
+            state,
+            _make_runtime(
+                cache=cache,
+                embeddings=embeddings,
+                sparse_embeddings=AsyncMock(),
+                qdrant=qdrant,
+            ),
+        )
+
+        assert result["rerank_applied"] is True
+        assert result.get("query_embedding") == bundle.dense
+        embeddings.aembed_hybrid_with_colbert.assert_not_awaited()
+        qdrant.hybrid_search_rrf_colbert.assert_awaited_once()
+
+    async def test_bundle_store_after_hybrid_colbert_compute(self):
+        """After rewrite, retrieve_node stores bundle after aembed_hybrid_with_colbert."""
+        state = make_initial_state(user_id=1, session_id="s1", query="rewritten query")
+        state["query_type"] = "GENERAL"
+        state["query_embedding"] = None
+
+        cache = AsyncMock()
+        cache.get_bge_m3_query_bundle = AsyncMock(return_value=None)
+        cache.get_embedding = AsyncMock(return_value=None)
+        cache.get_search_results = AsyncMock(return_value=None)
+        cache.get_sparse_embedding = AsyncMock(return_value=None)
+        cache.store_embedding = AsyncMock()
+        cache.store_sparse_embedding = AsyncMock()
+        cache.store_search_results = AsyncMock()
+
+        qdrant = AsyncMock()
+        qdrant.hybrid_search_rrf_colbert = AsyncMock(
+            return_value=(
+                [{"id": "1", "score": 85.0, "text": "doc", "metadata": {}}],
+                _OK_META,
+            )
+        )
+
+        embeddings = AsyncMock()
+        embeddings.aembed_hybrid_with_colbert = AsyncMock(
+            return_value=([0.3] * 1024, {"indices": [2], "values": [0.7]}, [[0.4] * 1024] * 3)
+        )
+
+        result = await retrieve_node(
+            state,
+            _make_runtime(
+                cache=cache,
+                embeddings=embeddings,
+                sparse_embeddings=AsyncMock(),
+                qdrant=qdrant,
+            ),
+        )
+
+        assert result["rerank_applied"] is True
+        cache.store_bge_m3_query_bundle.assert_awaited_once()
+        embeddings.aembed_hybrid_with_colbert.assert_awaited_once_with("rewritten query")
+
+    async def test_uses_hybrid_with_colbert_after_rewrite(self):
+        """After rewrite, retrieve_node prefers aembed_hybrid_with_colbert over aembed_hybrid."""
+        state = make_initial_state(user_id=1, session_id="s1", query="rewritten query")
+        state["query_type"] = "GENERAL"
+        state["query_embedding"] = None
+
+        cache = AsyncMock()
+        cache.get_bge_m3_query_bundle = AsyncMock(return_value=None)
+        cache.get_embedding = AsyncMock(return_value=None)
+        cache.get_search_results = AsyncMock(return_value=None)
+        cache.get_sparse_embedding = AsyncMock(return_value=None)
+        cache.store_embedding = AsyncMock()
+        cache.store_sparse_embedding = AsyncMock()
+        cache.store_search_results = AsyncMock()
+
+        qdrant = AsyncMock()
+        qdrant.hybrid_search_rrf_colbert = AsyncMock(
+            return_value=(
+                [{"id": "1", "score": 85.0, "text": "doc", "metadata": {}}],
+                _OK_META,
+            )
+        )
+
+        embeddings = AsyncMock()
+        embeddings.aembed_hybrid_with_colbert = AsyncMock(
+            return_value=([0.3] * 1024, {"indices": [2], "values": [0.7]}, [[0.4] * 1024] * 3)
+        )
+        embeddings.aembed_hybrid = AsyncMock()
+
+        result = await retrieve_node(
+            state,
+            _make_runtime(
+                cache=cache,
+                embeddings=embeddings,
+                sparse_embeddings=AsyncMock(),
+                qdrant=qdrant,
+            ),
+        )
+
+        assert result["rerank_applied"] is True
+        embeddings.aembed_hybrid_with_colbert.assert_awaited_once()
+        embeddings.aembed_hybrid.assert_not_awaited()
+
+    async def test_search_cache_profile_reflects_colbert_after_rewrite(self):
+        """Search cache profile uses colbert mode when vectors are computed after rewrite."""
+        state = make_initial_state(user_id=1, session_id="s1", query="rewritten query")
+        state["query_type"] = "GENERAL"
+        state["query_embedding"] = None
+        state["colbert_query"] = None  # cleared after rewrite
+
+        cache = AsyncMock()
+        cache.get_bge_m3_query_bundle = AsyncMock(return_value=None)
+        cache.get_embedding = AsyncMock(return_value=None)
+        cache.get_search_results = AsyncMock(return_value=None)
+        cache.get_sparse_embedding = AsyncMock(return_value=None)
+        cache.store_embedding = AsyncMock()
+        cache.store_sparse_embedding = AsyncMock()
+        cache.store_search_results = AsyncMock()
+
+        qdrant = AsyncMock()
+        qdrant.hybrid_search_rrf_colbert = AsyncMock(
+            return_value=(
+                [{"id": "1", "score": 85.0, "text": "doc", "metadata": {}}],
+                _OK_META,
+            )
+        )
+
+        embeddings = AsyncMock()
+        embeddings.aembed_hybrid_with_colbert = AsyncMock(
+            return_value=([0.3] * 1024, {"indices": [2], "values": [0.7]}, [[0.4] * 1024] * 3)
+        )
+
+        await retrieve_node(
+            state,
+            _make_runtime(
+                cache=cache,
+                embeddings=embeddings,
+                sparse_embeddings=AsyncMock(),
+                qdrant=qdrant,
+            ),
+        )
+
+        # Verify search results were cached under colbert profile
+        store_call = cache.store_search_results.await_args
+        profile = store_call.kwargs.get("filters") or store_call.args[1]
+        assert profile["mode"] == "colbert"


### PR DESCRIPTION
## Summary
- Add bundle-aware cache-check behavior to `rag_pipeline.py` `_cache_check` and `_hybrid_retrieve`.
- Add `aembed_hybrid_with_colbert` support and bundle cache to `retrieve.py` rewrite/re-embed path.
- Ensure Qdrant receives dense+sparse+ColBERT when the adapter supports it.
- Store complete BGE-M3 bundles after computing vectors to avoid redundant BGE-M3 calls on subsequent requests.

## Changes
- `telegram_bot/agents/rag_pipeline.py`: bundle check/store in `_cache_check` and `_hybrid_retrieve`
- `telegram_bot/graph/nodes/retrieve.py`: bundle check/store, `aembed_hybrid_with_colbert` path, move `search_cache_profile` after re-embed
- `tests/unit/agents/test_rag_pipeline.py`: bundle hit, bundle store, pre-computed skip tests
- `tests/unit/graph/test_retrieve_node.py`: bundle hit, bundle store, hybrid_with_colbert preference, search cache profile tests

## Verification
- `uv run pytest tests/unit/agents/test_rag_pipeline.py -k "cache_check or colbert or rewrite or reembed or hybrid_retrieve" tests/unit/graph/test_retrieve_node.py -q` → 66 passed