### PR TITLE
fix(observability): trace pre-agent cache decisions

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -2962,27 +2962,77 @@ class PropertyBot:
                                 filters=extracted_filters
                             )
                             rag_result_store["semantic_cache_filter_signature"] = filter_signature
+                    cache_obs_input = {
+                        "query_len": len(user_text),
+                        "query_type": query_type,
+                        "cache_scope": "rag",
+                        "agent_role": role,
+                        "filter_sensitive": filter_signal.is_filter_sensitive,
+                        "has_filter_signature": filter_signature is not None,
+                        "contextual_query": contextual_query,
+                    }
                     cached = None
-                    if contextual_query or (
-                        filter_signal.is_filter_sensitive and filter_signature is None
-                    ):
-                        rag_result_store["semantic_cache_already_checked"] = True
-                    else:
-                        check_start = time.perf_counter()
-                        cached = await self._cache.check_semantic(
-                            query=user_text,
-                            vector=embedding,
-                            query_type=query_type,
-                            cache_scope="rag",
-                            agent_role=role,
-                            grounding_mode=grounding_mode if grounding_mode == "strict" else None,
-                            require_safe_reuse=grounding_mode == "strict",
-                            filter_signature=filter_signature,
+                    try:
+                        with get_client().start_as_current_observation(
+                            as_type="span",
+                            name="cache-check",
+                            input=cache_obs_input,
+                        ) as cache_obs:
+                            if contextual_query or (
+                                filter_signal.is_filter_sensitive and filter_signature is None
+                            ):
+                                rag_result_store["semantic_cache_already_checked"] = True
+                                cache_obs.update(output={"cache_hit": False, "skipped": True})
+                            else:
+                                check_start = time.perf_counter()
+                                cached = await self._cache.check_semantic(
+                                    query=user_text,
+                                    vector=embedding,
+                                    query_type=query_type,
+                                    cache_scope="rag",
+                                    agent_role=role,
+                                    grounding_mode=grounding_mode
+                                    if grounding_mode == "strict"
+                                    else None,
+                                    require_safe_reuse=grounding_mode == "strict",
+                                    filter_signature=filter_signature,
+                                )
+                                rag_result_store["pre_agent_cache_check_ms"] = (
+                                    time.perf_counter() - check_start
+                                ) * 1000
+                                rag_result_store["semantic_cache_already_checked"] = True
+                                if cached:
+                                    cache_obs.update(output={"cache_hit": True})
+                                else:
+                                    cache_obs.update(output={"cache_hit": False})
+                    except Exception:
+                        logger.warning(
+                            "cache-check observation failed, proceeding without it",
+                            exc_info=True,
                         )
-                        rag_result_store["pre_agent_cache_check_ms"] = (
-                            time.perf_counter() - check_start
-                        ) * 1000
-                        rag_result_store["semantic_cache_already_checked"] = True
+                        cached = None
+                        if contextual_query or (
+                            filter_signal.is_filter_sensitive and filter_signature is None
+                        ):
+                            rag_result_store["semantic_cache_already_checked"] = True
+                        else:
+                            check_start = time.perf_counter()
+                            cached = await self._cache.check_semantic(
+                                query=user_text,
+                                vector=embedding,
+                                query_type=query_type,
+                                cache_scope="rag",
+                                agent_role=role,
+                                grounding_mode=grounding_mode
+                                if grounding_mode == "strict"
+                                else None,
+                                require_safe_reuse=grounding_mode == "strict",
+                                filter_signature=filter_signature,
+                            )
+                            rag_result_store["pre_agent_cache_check_ms"] = (
+                                time.perf_counter() - check_start
+                            ) * 1000
+                            rag_result_store["semantic_cache_already_checked"] = True
                     if cached:
                         logger.info("Pre-agent cache HIT (type=%s): %.60s", query_type, user_text)
                         rag_result_store["cache_hit"] = True

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -14,7 +14,7 @@ import pytest
 # Skip entire module if aiogram not installed
 pytest.importorskip("aiogram", reason="aiogram not installed")
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 from telegram_bot.bot import PropertyBot, make_session_id
 from telegram_bot.config import BotConfig
@@ -3049,6 +3049,54 @@ class TestClientDirectPipeline:
         mock_factory.assert_called_once()
         mock_agent.ainvoke.assert_awaited_once()
         mock_rag.assert_not_called()
+
+
+class TestHandleQuerySDKAgent:
+    """Test SDK agent query path pre-agent cache observations."""
+
+    def _setup_pre_agent_cache_miss(self, bot):
+        bot._cache.get_embedding = AsyncMock(return_value=None)
+        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
+        bot._embeddings.aembed_query = AsyncMock(return_value=[0.1] * 10)
+        bot._cache.store_embedding = AsyncMock()
+        bot._cache.check_semantic = AsyncMock(return_value=None)
+        bot._cache.store_semantic = AsyncMock()
+
+    async def test_pre_agent_cache_miss_emits_cache_check_observation(self, mock_config):
+        bot, _ = _create_bot(mock_config)
+        self._setup_pre_agent_cache_miss(bot)
+
+        observation = MagicMock()
+        observation.__enter__.return_value = observation
+        observation.__exit__.return_value = None
+        mock_lf = MagicMock()
+        mock_lf.get_current_trace_id.return_value = "trace-pre-agent-miss"
+        mock_lf.start_as_current_observation.return_value = observation
+
+        mock_agent = AsyncMock()
+        mock_agent.ainvoke = AsyncMock(return_value=_mock_agent_result())
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.get_client", return_value=mock_lf),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+            patch("telegram_bot.bot.classify_query", return_value="FAQ"),
+        ):
+            message = _make_text_message("2-комн в Солнечный берег до 120к")
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        mock_lf.start_as_current_observation.assert_any_call(
+            as_type="span",
+            name="cache-check",
+            input=ANY,
+        )
+        assert any(
+            call.kwargs.get("output", {}).get("cache_hit") is False
+            for call in observation.update.call_args_list
+        )
 
 
 class TestStreamingCoordination:


### PR DESCRIPTION
## Summary
- Adds a real SDK `cache-check` observation span around the pre-agent semantic cache decision in `telegram_bot/bot.py`.
- The span records sanitized decision metadata (query length, type, filter signals, contextual status) without raw user text, IDs, or secrets.
- On miss, the span output records `cache_hit: false`.
- Best-effort: if Langfuse client retrieval or observation creation raises, Telegram handling continues without failing the user flow.
- Adds `TestHandleQuerySDKAgent::test_pre_agent_cache_miss_emits_cache_check_observation` to verify the observation is emitted on pre-agent cache miss.

## Verification
- `uv run pytest tests/unit/test_bot_handlers.py::TestHandleQuerySDKAgent::test_pre_agent_cache_miss_emits_cache_check_observation -q` passes
- `uv run pytest tests/unit/test_bot_handlers.py -q` passes (193 passed)
- `uv run pytest tests/unit/e2e/test_langfuse_trace_validator.py -q` passes (9 passed)