### PR TITLE
fix(scoring): skip results_count/no_results for semantic cache hits (#1493)

### DIFF
--- a/telegram_bot/agents/rag_pipeline.py
+++ b/telegram_bot/agents/rag_pipeline.py
@@ -184,45 +184,67 @@ async def _cache_check(
 
     start = time.perf_counter()
 
-    # Step 1: Get or compute dense embedding via shared core
-    if pre_computed_embedding:
-        logger.debug(
-            "_cache_check: reusing pre-computed embedding (%d dims)", len(pre_computed_embedding)
-        )
-    try:
-        embedding, sparse, colbert_query, embeddings_cache_hit = await compute_query_embedding(
-            query,
-            cache=cache,
-            embeddings=embeddings,
-            pre_computed=pre_computed_embedding,
-            pre_computed_sparse=pre_computed_sparse,
-            pre_computed_colbert=pre_computed_colbert,
-        )
-    except Exception as exc:
-        embedding_error_type = type(exc).__name__
-        logger.error("Embedding failed: %s: %s", embedding_error_type, exc)
-        latency = time.perf_counter() - start
-        lf.update_current_span(
-            level="ERROR",
-            output={
+    # Try bundle cache first (avoids redundant BGE-M3 calls when full bundle is cached #1493)
+    bundle = None
+    _has_bundle_cache = callable(getattr(cache, "get_bge_m3_query_bundle", None))
+    if _has_bundle_cache and pre_computed_embedding is None:
+        try:
+            maybe_bundle = await cache.get_bge_m3_query_bundle(query)
+            if (
+                maybe_bundle is not None
+                and hasattr(maybe_bundle, "dense")
+                and isinstance(maybe_bundle.dense, list)
+            ):
+                bundle = maybe_bundle
+        except Exception:
+            logger.debug("Bundle cache check failed (non-critical), skipping")
+
+    if bundle is not None:
+        embedding = bundle.dense
+        sparse = bundle.sparse
+        colbert_query = bundle.colbert
+        embeddings_cache_hit = True
+    else:
+        # Step 1: Get or compute dense embedding via shared core
+        if pre_computed_embedding:
+            logger.debug(
+                "_cache_check: reusing pre-computed embedding (%d dims)",
+                len(pre_computed_embedding),
+            )
+        try:
+            embedding, sparse, colbert_query, embeddings_cache_hit = await compute_query_embedding(
+                query,
+                cache=cache,
+                embeddings=embeddings,
+                pre_computed=pre_computed_embedding,
+                pre_computed_sparse=pre_computed_sparse,
+                pre_computed_colbert=pre_computed_colbert,
+            )
+        except Exception as exc:
+            embedding_error_type = type(exc).__name__
+            logger.error("Embedding failed: %s: %s", embedding_error_type, exc)
+            latency = time.perf_counter() - start
+            lf.update_current_span(
+                level="ERROR",
+                output={
+                    "embedding_error": True,
+                    "embedding_error_type": embedding_error_type,
+                    "error_message": str(exc)[:200],
+                    "duration_ms": round(latency * 1000, 1),
+                },
+            )
+            return {
+                "cache_hit": False,
+                "cached_response": None,
+                "query_embedding": None,
+                "sparse_embedding": None,
+                "embeddings_cache_hit": False,
                 "embedding_error": True,
                 "embedding_error_type": embedding_error_type,
-                "error_message": str(exc)[:200],
-                "duration_ms": round(latency * 1000, 1),
-            },
-        )
-        return {
-            "cache_hit": False,
-            "cached_response": None,
-            "query_embedding": None,
-            "sparse_embedding": None,
-            "embeddings_cache_hit": False,
-            "embedding_error": True,
-            "embedding_error_type": embedding_error_type,
-            "error_response": "Сервис временно недоступен. Пожалуйста, повторите через минуту.",
-            "colbert_query": None,
-            "latency_stages": {**latency_stages, "cache_check": latency},
-        }
+                "error_response": "Сервис временно недоступен. Пожалуйста, повторите через минуту.",
+                "colbert_query": None,
+                "latency_stages": {**latency_stages, "cache_check": latency},
+            }
 
     # Step 2: Check semantic cache via shared core
     contextual_query = is_contextual_query(query)
@@ -284,6 +306,28 @@ async def _cache_check(
                     sparse = sparse_from_hybrid
                     if not pre_computed_sparse:
                         await cache.store_sparse_embedding(query, sparse_from_hybrid)
+                # Store full bundle for future requests (#1493)
+                if (
+                    _has_bundle_cache
+                    and embedding is not None
+                    and sparse is not None
+                    and colbert_query is not None
+                ):
+                    try:
+                        from telegram_bot.services.bge_m3_query_bundle import (
+                            BgeM3QueryVectorBundle,
+                        )
+
+                        await cache.store_bge_m3_query_bundle(
+                            query,
+                            BgeM3QueryVectorBundle(
+                                dense=embedding,
+                                sparse=sparse,
+                                colbert=colbert_query,
+                            ),
+                        )
+                    except Exception:
+                        logger.debug("Bundle store failed (non-critical), skipping")
             except Exception:
                 logger.debug("ColBERT query encode failed (non-critical), skipping")
         elif _has_colbert_only:
@@ -357,42 +401,84 @@ async def _hybrid_retrieve(
 
     # After rewrite, query_embedding is None — re-embed the rewritten query
     if dense_vector is None and embeddings is not None:
-        dense_vector = await cache.get_embedding(query)
-        if dense_vector is None:
-            sparse_cached = await cache.get_sparse_embedding(query)
-            if sparse_cached is not None:
-                dense_vector = await embeddings.aembed_query(query)
-                await cache.store_embedding(query, dense_vector)
-                sparse_vector = sparse_cached
-            elif callable(
-                getattr(embeddings, "aembed_hybrid_with_colbert", None)
-            ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid_with_colbert):
-                (
-                    dense_vector,
-                    sparse_vector,
-                    colbert_query,
-                ) = await embeddings.aembed_hybrid_with_colbert(query)
-                await cache.store_embedding(query, dense_vector)
-                await cache.store_sparse_embedding(query, sparse_vector)
-            elif callable(
-                getattr(embeddings, "aembed_hybrid", None)
-            ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid):
-                dense_vector, sparse_vector = await embeddings.aembed_hybrid(query)
-                await cache.store_embedding(query, dense_vector)
-                await cache.store_sparse_embedding(query, sparse_vector)
-            else:
+        # Check bundle cache first (avoids redundant BGE-M3 calls #1493)
+        _has_bundle_cache = callable(getattr(cache, "get_bge_m3_query_bundle", None))
+        bundle = None
+        if _has_bundle_cache:
+            try:
+                maybe_bundle = await cache.get_bge_m3_query_bundle(query)
+                if (
+                    maybe_bundle is not None
+                    and hasattr(maybe_bundle, "dense")
+                    and isinstance(maybe_bundle.dense, list)
+                ):
+                    bundle = maybe_bundle
+            except Exception:
+                logger.debug("Bundle cache check failed (non-critical), skipping")
 
-                async def _get_dense() -> list[float]:
-                    vec: list[float] = await embeddings.aembed_query(query)
-                    await cache.store_embedding(query, vec)
-                    return vec
+        if bundle is not None:
+            dense_vector = bundle.dense
+            sparse_vector = bundle.sparse
+            colbert_query = bundle.colbert
+        else:
+            dense_vector = await cache.get_embedding(query)
+            if dense_vector is None:
+                sparse_cached = await cache.get_sparse_embedding(query)
+                if sparse_cached is not None:
+                    dense_vector = await embeddings.aembed_query(query)
+                    await cache.store_embedding(query, dense_vector)
+                    sparse_vector = sparse_cached
+                elif callable(
+                    getattr(embeddings, "aembed_hybrid_with_colbert", None)
+                ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid_with_colbert):
+                    (
+                        dense_vector,
+                        sparse_vector,
+                        colbert_query,
+                    ) = await embeddings.aembed_hybrid_with_colbert(query)
+                    await cache.store_embedding(query, dense_vector)
+                    await cache.store_sparse_embedding(query, sparse_vector)
+                    # Store full bundle for future requests (#1493)
+                    if (
+                        _has_bundle_cache
+                        and dense_vector is not None
+                        and sparse_vector is not None
+                        and colbert_query is not None
+                    ):
+                        try:
+                            from telegram_bot.services.bge_m3_query_bundle import (
+                                BgeM3QueryVectorBundle,
+                            )
 
-                async def _get_sparse() -> Any:
-                    vec = await sparse_embeddings.aembed_query(query)
-                    await cache.store_sparse_embedding(query, vec)
-                    return vec
+                            await cache.store_bge_m3_query_bundle(
+                                query,
+                                BgeM3QueryVectorBundle(
+                                    dense=dense_vector,
+                                    sparse=sparse_vector,
+                                    colbert=colbert_query,
+                                ),
+                            )
+                        except Exception:
+                            logger.debug("Bundle store failed (non-critical), skipping")
+                elif callable(
+                    getattr(embeddings, "aembed_hybrid", None)
+                ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid):
+                    dense_vector, sparse_vector = await embeddings.aembed_hybrid(query)
+                    await cache.store_embedding(query, dense_vector)
+                    await cache.store_sparse_embedding(query, sparse_vector)
+                else:
 
-                dense_vector, sparse_vector = await asyncio.gather(_get_dense(), _get_sparse())
+                    async def _get_dense() -> list[float]:
+                        vec: list[float] = await embeddings.aembed_query(query)
+                        await cache.store_embedding(query, vec)
+                        return vec
+
+                    async def _get_sparse() -> Any:
+                        vec = await sparse_embeddings.aembed_query(query)
+                        await cache.store_sparse_embedding(query, vec)
+                        return vec
+
+                    dense_vector, sparse_vector = await asyncio.gather(_get_dense(), _get_sparse())
 
     if not dense_vector:
         dense_vector = []

--- a/telegram_bot/graph/nodes/cache.py
+++ b/telegram_bot/graph/nodes/cache.py
@@ -156,21 +156,14 @@ async def cache_check_node(
         }
 
     # ColBERT vectors are only needed after semantic miss.
+    # Legacy fallback: if compute_query_embedding didn't return colbert
+    # (no full bundle support), try standalone aembed_colbert_query.
     if colbert_query is None:
-        _has_hybrid_colbert = callable(
-            getattr(embeddings, "aembed_hybrid_with_colbert", None)
-        ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid_with_colbert)
         _has_colbert_only = callable(
             getattr(embeddings, "aembed_colbert_query", None)
         ) and asyncio.iscoroutinefunction(embeddings.aembed_colbert_query)
 
-        if _has_hybrid_colbert:
-            try:
-                _, sparse, colbert_query = await embeddings.aembed_hybrid_with_colbert(query)
-                await cache.store_sparse_embedding(query, sparse)
-            except Exception:
-                logger.debug("ColBERT query encode failed (non-critical), skipping")
-        elif _has_colbert_only:
+        if _has_colbert_only:
             try:
                 colbert_query = await embeddings.aembed_colbert_query(query)
             except Exception:

--- a/telegram_bot/graph/nodes/retrieve.py
+++ b/telegram_bot/graph/nodes/retrieve.py
@@ -95,12 +95,6 @@ async def retrieve_node(
     colbert_query = state.get("colbert_query")
     retrieval_filters = state.get("filters")
     _has_colbert_search = callable(getattr(qdrant, "hybrid_search_rrf_colbert", None))
-    search_cache_profile = _build_search_cache_profile(
-        needs_coverage=needs_coverage,
-        use_colbert=bool(colbert_query and _has_colbert_search),
-        top_k=effective_top_k,
-        filters=retrieval_filters if isinstance(retrieval_filters, dict) else None,
-    )
 
     # Curated span metadata (replaces auto-captured full state)
     lf = get_client()
@@ -121,37 +115,98 @@ async def retrieve_node(
 
     # After rewrite, query_embedding is None — re-embed the rewritten query
     if dense_vector is None and embeddings is not None:
-        dense_vector = await cache.get_embedding(query)
-        if dense_vector is None:
-            sparse_cached = await cache.get_sparse_embedding(query)
-            if sparse_cached is not None:
-                # Dense miss, sparse cached → just compute dense
-                dense_vector = await embeddings.aembed_query(query)
-                await cache.store_embedding(query, dense_vector)
-                sparse_vector = sparse_cached
-            elif callable(
-                getattr(embeddings, "aembed_hybrid", None)
-            ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid):
-                # Hybrid: single call for both dense + sparse
-                dense_vector, sparse_vector = await embeddings.aembed_hybrid(query)
-                await cache.store_embedding(query, dense_vector)
-                await cache.store_sparse_embedding(query, sparse_vector)
-            else:
-                # Fallback: parallel dense + sparse (old path)
-                async def _get_dense() -> list[float]:
-                    vec: list[float] = await embeddings.aembed_query(query)
-                    await cache.store_embedding(query, vec)
-                    return vec
+        # Check bundle cache first (avoids redundant BGE-M3 calls #1493)
+        _has_bundle_cache = callable(getattr(cache, "get_bge_m3_query_bundle", None))
+        bundle = None
+        if _has_bundle_cache:
+            try:
+                maybe_bundle = await cache.get_bge_m3_query_bundle(query)
+                if (
+                    maybe_bundle is not None
+                    and hasattr(maybe_bundle, "dense")
+                    and isinstance(maybe_bundle.dense, list)
+                ):
+                    bundle = maybe_bundle
+            except Exception:
+                logger.debug("Bundle cache check failed (non-critical), skipping")
 
-                async def _get_sparse() -> Any:
-                    vec = await sparse_embeddings.aembed_query(query)
-                    await cache.store_sparse_embedding(query, vec)
-                    return vec
+        if bundle is not None:
+            dense_vector = bundle.dense
+            sparse_vector = bundle.sparse
+            colbert_query = bundle.colbert
+        else:
+            dense_vector = await cache.get_embedding(query)
+            if dense_vector is None:
+                sparse_cached = await cache.get_sparse_embedding(query)
+                if sparse_cached is not None:
+                    # Dense miss, sparse cached → just compute dense
+                    dense_vector = await embeddings.aembed_query(query)
+                    await cache.store_embedding(query, dense_vector)
+                    sparse_vector = sparse_cached
+                elif callable(
+                    getattr(embeddings, "aembed_hybrid_with_colbert", None)
+                ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid_with_colbert):
+                    # Full bundle: single call for dense + sparse + ColBERT
+                    (
+                        dense_vector,
+                        sparse_vector,
+                        colbert_query,
+                    ) = await embeddings.aembed_hybrid_with_colbert(query)
+                    await cache.store_embedding(query, dense_vector)
+                    await cache.store_sparse_embedding(query, sparse_vector)
+                    # Store full bundle for future requests (#1493)
+                    if (
+                        _has_bundle_cache
+                        and dense_vector is not None
+                        and sparse_vector is not None
+                        and colbert_query is not None
+                    ):
+                        try:
+                            from telegram_bot.services.bge_m3_query_bundle import (
+                                BgeM3QueryVectorBundle,
+                            )
 
-                dense_vector, sparse_vector = await asyncio.gather(_get_dense(), _get_sparse())
+                            await cache.store_bge_m3_query_bundle(
+                                query,
+                                BgeM3QueryVectorBundle(
+                                    dense=dense_vector,
+                                    sparse=sparse_vector,
+                                    colbert=colbert_query,
+                                ),
+                            )
+                        except Exception:
+                            logger.debug("Bundle store failed (non-critical), skipping")
+                elif callable(
+                    getattr(embeddings, "aembed_hybrid", None)
+                ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid):
+                    # Hybrid: single call for both dense + sparse
+                    dense_vector, sparse_vector = await embeddings.aembed_hybrid(query)
+                    await cache.store_embedding(query, dense_vector)
+                    await cache.store_sparse_embedding(query, sparse_vector)
+                else:
+                    # Fallback: parallel dense + sparse (old path)
+                    async def _get_dense() -> list[float]:
+                        vec: list[float] = await embeddings.aembed_query(query)
+                        await cache.store_embedding(query, vec)
+                        return vec
+
+                    async def _get_sparse() -> Any:
+                        vec = await sparse_embeddings.aembed_query(query)
+                        await cache.store_sparse_embedding(query, vec)
+                        return vec
+
+                    dense_vector, sparse_vector = await asyncio.gather(_get_dense(), _get_sparse())
 
     if not dense_vector:
         dense_vector = []
+
+    # Build search cache profile AFTER re-embed so colbert_query is accurate (#1493)
+    search_cache_profile = _build_search_cache_profile(
+        needs_coverage=needs_coverage,
+        use_colbert=bool(colbert_query and _has_colbert_search),
+        top_k=effective_top_k,
+        filters=retrieval_filters if isinstance(retrieval_filters, dict) else None,
+    )
 
     start = time.perf_counter()
 

--- a/telegram_bot/scoring.py
+++ b/telegram_bot/scoring.py
@@ -65,21 +65,23 @@ def write_langfuse_scores(lf: Any, result: dict, *, trace_id: str = "") -> None:
     if e2e_ms is None:
         e2e_ms = result.get("user_perceived_wall_ms", total_ms)
 
+    cache_hit = result.get("cache_hit", False)
     scores = {
         "query_type": _QUERY_TYPE_SCORE.get(result.get("query_type", ""), 1.0),
         "latency_total_ms": e2e_ms,
-        "semantic_cache_hit": 1.0 if result.get("cache_hit") else 0.0,
+        "semantic_cache_hit": 1.0 if cache_hit else 0.0,
         "embeddings_cache_hit": 1.0 if result.get("embeddings_cache_hit") else 0.0,
         "search_cache_hit": 1.0 if result.get("search_cache_hit") else 0.0,
         "rerank_applied": 1.0 if result.get("rerank_applied") else 0.0,
         "rerank_cache_hit": 1.0 if result.get("rerank_cache_hit") else 0.0,
-        "results_count": float(result.get("search_results_count", 0)),
-        "no_results": 1.0 if result.get("search_results_count", 0) == 0 else 0.0,
         "llm_used": 1.0 if "generate" in latency_stages else 0.0,
         "confidence_score": float(result.get("grade_confidence", 0.0)),
         "llm_ttft_ms": float(result.get("llm_ttft_ms", 0.0)),
         "llm_response_duration_ms": float(result.get("llm_response_duration_ms", 0.0)),
     }
+    if not cache_hit:
+        scores["results_count"] = float(result.get("search_results_count", 0))
+        scores["no_results"] = 1.0 if result.get("search_results_count", 0) == 0 else 0.0
 
     for name, value in scores.items():
         score(lf, trace_id, name=name, value=value)

--- a/telegram_bot/services/rag_core.py
+++ b/telegram_bot/services/rag_core.py
@@ -14,6 +14,7 @@ import asyncio
 import logging
 from typing import Any
 
+from telegram_bot.services.bge_m3_query_bundle import BgeM3QueryVectorBundle
 from telegram_bot.services.cache_policy import is_contextual_query
 
 
@@ -212,15 +213,18 @@ async def compute_query_embedding(
 ) -> tuple[list[float], Any, list[list[float]] | None, bool]:
     """Get or compute dense query embedding with optional sparse side-product.
 
-    Handles three paths:
+    Handles paths in priority order:
     1. Pre-computed: caller already has the embedding (e.g. agent pre-fetch) → return immediately.
-    2. Redis cache hit: embedding stored from previous request → return with from_cache=True.
-    3. Model compute: call embeddings.aembed_hybrid (preferred) or aembed_query, cache result.
+    2. Bundle cache hit: BGE-M3 query vector bundle stored from previous request → return with from_cache=True.
+    3. Model compute (bundle): call embeddings.aembed_hybrid_with_colbert, store bundle + legacy caches.
+    4. Legacy cache hit: dense embedding stored from previous request → return with from_cache=True.
+    5. Legacy model compute: call embeddings.aembed_hybrid or aembed_query, cache result.
 
     Args:
         query: The query string.
-        cache: Cache instance with get_embedding / store_embedding / store_sparse_embedding.
-        embeddings: Embedding model with aembed_hybrid or aembed_query.
+        cache: Cache instance with get_embedding / store_embedding / store_sparse_embedding
+            and optionally get_bge_m3_query_bundle / store_bge_m3_query_bundle.
+        embeddings: Embedding model with aembed_hybrid_with_colbert, aembed_hybrid, or aembed_query.
         pre_computed: Pre-computed dense vector (bypasses all computation).
         pre_computed_sparse: Pre-computed sparse vector; returned alongside pre_computed.
         pre_computed_colbert: Pre-computed ColBERT vectors; returned alongside pre_computed.
@@ -228,10 +232,9 @@ async def compute_query_embedding(
     Returns:
         Tuple of (dense, sparse, colbert, from_cache).
         - dense: dense embedding vector (always present)
-        - sparse: sparse vector if computed via hybrid or pre_computed_sparse; else None
-        - colbert: pre_computed_colbert if provided; else None
-          (ColBERT-after-miss fetching is the caller's responsibility)
-        - from_cache: True if dense vector came from Redis cache
+        - sparse: sparse vector if computed via hybrid or from bundle; else None
+        - colbert: ColBERT vectors if from bundle or aembed_hybrid_with_colbert; else None
+        - from_cache: True if result came from cache (bundle or legacy dense)
 
     Raises:
         Exception: propagates embedding model errors to caller (adapter handles fallback).
@@ -240,14 +243,62 @@ async def compute_query_embedding(
     if pre_computed is not None:
         return (pre_computed, pre_computed_sparse, pre_computed_colbert, False)
 
-    # Path 2: check Redis embedding cache
+    # Determine capabilities
+    _has_bundle_get = callable(
+        getattr(cache, "get_bge_m3_query_bundle", None)
+    ) and asyncio.iscoroutinefunction(cache.get_bge_m3_query_bundle)
+    _has_bundle_store = callable(
+        getattr(cache, "store_bge_m3_query_bundle", None)
+    ) and asyncio.iscoroutinefunction(cache.store_bge_m3_query_bundle)
+    _has_hybrid_colbert = callable(
+        getattr(embeddings, "aembed_hybrid_with_colbert", None)
+    ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid_with_colbert)
+
+    # Path 2: check bundle cache (even if embeddings lacks aembed_hybrid_with_colbert,
+    # a hit still gives us all three vectors).
+    if _has_bundle_get:
+        bundle = await cache.get_bge_m3_query_bundle(query)
+        if isinstance(bundle, BgeM3QueryVectorBundle) and bundle.is_complete():
+            return (bundle.dense, bundle.sparse, bundle.colbert, True)
+
+    # Path 3: full bundle compute (cache miss + aembed_hybrid_with_colbert available)
+    if _has_bundle_get and _has_hybrid_colbert:
+        try:
+            dense, sparse, colbert = await embeddings.aembed_hybrid_with_colbert(query)
+        except (TypeError, ValueError):
+            # aembed_hybrid_with_colbert is present but doesn't return a usable
+            # 3-tuple (e.g. test mocks); fall through to legacy path.
+            pass
+        else:
+            # Store bundle if store API is available
+            if _has_bundle_store:
+                try:
+                    new_bundle = BgeM3QueryVectorBundle(
+                        dense=dense,
+                        sparse=sparse,
+                        colbert=colbert,
+                    )
+                    await cache.store_bge_m3_query_bundle(query, new_bundle)
+                except Exception:
+                    logger.debug("Bundle store failed (non-critical), skipping")
+
+            # Keep legacy caches populated for compatibility
+            try:
+                await cache.store_embedding(query, dense)
+                await cache.store_sparse_embedding(query, sparse)
+            except Exception:
+                logger.debug("Legacy embedding store failed (non-critical), skipping")
+
+            return (dense, sparse, colbert, False)
+
+    # Path 4: legacy dense cache
     dense = await cache.get_embedding(query)
     from_cache = dense is not None
 
     if dense is not None:
         return (dense, None, None, from_cache)
 
-    # Path 3: compute via model
+    # Path 5: legacy model compute
     _has_hybrid = callable(
         getattr(embeddings, "aembed_hybrid", None)
     ) and asyncio.iscoroutinefunction(embeddings.aembed_hybrid)

--- a/tests/unit/agents/test_rag_pipeline.py
+++ b/tests/unit/agents/test_rag_pipeline.py
@@ -21,6 +21,8 @@ def mock_cache():
     cache.get_rerank_results = AsyncMock(return_value=None)
     cache.store_rerank_results = AsyncMock()
     cache.store_semantic = AsyncMock()
+    cache.get_bge_m3_query_bundle = AsyncMock(return_value=None)
+    cache.store_bge_m3_query_bundle = AsyncMock()
     return cache
 
 
@@ -2270,3 +2272,183 @@ async def test_rag_pipeline_skips_blind_semantic_lookup_for_filter_sensitive_que
 
     mock_cache.check_semantic.assert_not_awaited()
     assert result["semantic_cache_already_checked"] is True
+
+
+# ---------------------------------------------------------------------------
+# BGE-M3 query vector bundle tests (#1493)
+# ---------------------------------------------------------------------------
+
+
+async def test_cache_check_uses_bundle_cache_hit(mock_cache):
+    """_cache_check uses bundle cache and skips compute_query_embedding."""
+    from unittest.mock import AsyncMock
+
+    from telegram_bot.agents.rag_pipeline import _cache_check
+    from telegram_bot.services.bge_m3_query_bundle import BgeM3QueryVectorBundle
+
+    bundle = BgeM3QueryVectorBundle(
+        dense=[0.1] * 1024,
+        sparse={"indices": [1], "values": [0.5]},
+        colbert=[[0.2] * 1024] * 4,
+    )
+    mock_cache.get_bge_m3_query_bundle = AsyncMock(return_value=bundle)
+
+    mock_embeddings = AsyncMock()
+    mock_embeddings.aembed_hybrid = AsyncMock()
+    mock_embeddings.aembed_hybrid_with_colbert = AsyncMock()
+
+    result = await _cache_check(
+        "test query",
+        "GENERAL",
+        42,
+        cache=mock_cache,
+        embeddings=mock_embeddings,
+        latency_stages={},
+    )
+
+    assert result["cache_hit"] is False
+    assert result["query_embedding"] == bundle.dense
+    assert result["sparse_embedding"] == bundle.sparse
+    assert result["colbert_query"] == bundle.colbert
+    assert result["embeddings_cache_hit"] is True
+    mock_embeddings.aembed_hybrid.assert_not_awaited()
+    mock_embeddings.aembed_hybrid_with_colbert.assert_not_awaited()
+
+
+async def test_cache_check_stores_bundle_after_colbert_compute(mock_cache):
+    """_cache_check stores bundle after computing colbert via aembed_hybrid_with_colbert."""
+    from unittest.mock import AsyncMock
+
+    from telegram_bot.agents.rag_pipeline import _cache_check
+
+    mock_cache.get_embedding = AsyncMock(return_value=None)
+    mock_cache.check_semantic = AsyncMock(return_value=None)
+
+    mock_embeddings = AsyncMock()
+    mock_embeddings.aembed_hybrid = None
+    mock_embeddings.aembed_hybrid_with_colbert = AsyncMock(
+        return_value=([0.1] * 1024, {"indices": [1], "values": [0.5]}, [[0.2] * 1024] * 4)
+    )
+    mock_embeddings.aembed_colbert_query = None
+
+    result = await _cache_check(
+        "test query",
+        "GENERAL",
+        42,
+        cache=mock_cache,
+        embeddings=mock_embeddings,
+        latency_stages={},
+    )
+
+    assert result["colbert_query"] is not None
+    mock_cache.store_bge_m3_query_bundle.assert_awaited_once()
+    call_args = mock_cache.store_bge_m3_query_bundle.await_args
+    assert call_args.args[0] == "test query"
+
+
+async def test_hybrid_retrieve_uses_bundle_after_rewrite(mock_cache, mock_sparse):
+    """_hybrid_retrieve uses bundle cache after rewrite to avoid redundant BGE-M3 call."""
+    from unittest.mock import AsyncMock
+
+    from telegram_bot.agents.rag_pipeline import _hybrid_retrieve
+    from telegram_bot.services.bge_m3_query_bundle import BgeM3QueryVectorBundle
+
+    bundle = BgeM3QueryVectorBundle(
+        dense=[0.3] * 1024,
+        sparse={"indices": [2], "values": [0.7]},
+        colbert=[[0.4] * 1024] * 3,
+    )
+    mock_cache.get_bge_m3_query_bundle = AsyncMock(return_value=bundle)
+
+    mock_qdrant = AsyncMock()
+    mock_qdrant.hybrid_search_rrf_colbert = AsyncMock(
+        return_value=(
+            [{"id": "1", "score": 85.0, "text": "doc", "metadata": {}}],
+            {"backend_error": False, "error_type": None, "error_message": None},
+        )
+    )
+
+    mock_embeddings = AsyncMock()
+    mock_embeddings.aembed_hybrid_with_colbert = AsyncMock()
+
+    result = await _hybrid_retrieve(
+        "rewritten query",
+        None,  # dense_vector is None after rewrite
+        cache=mock_cache,
+        sparse_embeddings=mock_sparse,
+        qdrant=mock_qdrant,
+        embeddings=mock_embeddings,
+        colbert_query=None,
+        latency_stages={},
+    )
+
+    assert result["rerank_applied"] is True
+    assert result["colbert_query"] == bundle.colbert
+    mock_embeddings.aembed_hybrid_with_colbert.assert_not_awaited()
+    mock_qdrant.hybrid_search_rrf_colbert.assert_called_once()
+
+
+async def test_hybrid_retrieve_stores_bundle_after_hybrid_colbert(mock_cache, mock_sparse):
+    """_hybrid_retrieve stores bundle after aembed_hybrid_with_colbert computes vectors."""
+    from unittest.mock import AsyncMock
+
+    from telegram_bot.agents.rag_pipeline import _hybrid_retrieve
+
+    mock_qdrant = AsyncMock()
+    mock_qdrant.hybrid_search_rrf_colbert = AsyncMock(
+        return_value=(
+            [{"id": "1", "score": 85.0, "text": "doc", "metadata": {}}],
+            {"backend_error": False, "error_type": None, "error_message": None},
+        )
+    )
+
+    mock_embeddings = AsyncMock()
+    mock_embeddings.aembed_hybrid_with_colbert = AsyncMock(
+        return_value=([0.3] * 1024, {"indices": [2], "values": [0.7]}, [[0.4] * 1024] * 3)
+    )
+
+    result = await _hybrid_retrieve(
+        "rewritten query",
+        None,
+        cache=mock_cache,
+        sparse_embeddings=mock_sparse,
+        qdrant=mock_qdrant,
+        embeddings=mock_embeddings,
+        colbert_query=None,
+        latency_stages={},
+    )
+
+    assert result["rerank_applied"] is True
+    mock_cache.store_bge_m3_query_bundle.assert_awaited_once()
+
+
+async def test_cache_check_skips_bundle_when_pre_computed(mock_cache):
+    """_cache_check skips bundle cache when pre_computed_embedding is provided."""
+    from unittest.mock import AsyncMock
+
+    from telegram_bot.agents.rag_pipeline import _cache_check
+    from telegram_bot.services.bge_m3_query_bundle import BgeM3QueryVectorBundle
+
+    bundle = BgeM3QueryVectorBundle(
+        dense=[0.1] * 1024,
+        sparse={"indices": [1], "values": [0.5]},
+        colbert=[[0.2] * 1024] * 4,
+    )
+    mock_cache.get_bge_m3_query_bundle = AsyncMock(return_value=bundle)
+
+    mock_embeddings = AsyncMock()
+
+    result = await _cache_check(
+        "test query",
+        "GENERAL",
+        42,
+        cache=mock_cache,
+        embeddings=mock_embeddings,
+        latency_stages={},
+        pre_computed_embedding=[0.5] * 1024,
+        pre_computed_sparse={"indices": [3], "values": [0.9]},
+    )
+
+    assert result["query_embedding"] == [0.5] * 1024
+    assert result["sparse_embedding"] == {"indices": [3], "values": [0.9]}
+    mock_cache.get_bge_m3_query_bundle.assert_not_awaited()

--- a/tests/unit/graph/test_cache_nodes.py
+++ b/tests/unit/graph/test_cache_nodes.py
@@ -304,6 +304,82 @@ class TestCacheCheckNode:
         cache.store_embedding.assert_awaited_once_with("hybrid query", [0.3] * 1024)
         cache.store_sparse_embedding.assert_awaited_once_with("hybrid query", sparse_vec)
 
+    async def test_bundle_cache_hit_includes_colbert_in_state(self):
+        """Bundle cache hit in compute_query_embedding propagates colbert to state."""
+        from telegram_bot.services.bge_m3_query_bundle import BgeM3QueryVectorBundle
+
+        bundle = BgeM3QueryVectorBundle(
+            dense=[0.1] * 1024,
+            sparse={"indices": [1], "values": [0.5]},
+            colbert=[[0.2] * 1024] * 4,
+        )
+
+        cache = AsyncMock()
+        cache.get_bge_m3_query_bundle = AsyncMock(return_value=bundle)
+        cache.check_semantic = AsyncMock(return_value=None)
+
+        # No aembed_hybrid_with_colbert — bundle should be used
+        embeddings = AsyncMock(spec=[])
+
+        state = make_initial_state(user_id=1, session_id="s1", query="test query")
+        state["query_type"] = "GENERAL"
+
+        result = await cache_check_node(state, _make_runtime(cache=cache, embeddings=embeddings))
+
+        assert result["cache_hit"] is False
+        assert result.get("colbert_query") is not None
+        assert len(result["colbert_query"]) == 4
+        cache.get_bge_m3_query_bundle.assert_awaited_once_with("test query")
+        # embeddings has no aembed_hybrid_with_colbert attribute (spec=[])
+        assert not hasattr(embeddings, "aembed_hybrid_with_colbert")
+
+    async def test_bundle_cache_miss_computes_full_bundle(self):
+        """Bundle miss with aembed_hybrid_with_colbert computes and stores bundle."""
+        cache = AsyncMock()
+        cache.get_bge_m3_query_bundle = AsyncMock(return_value=None)
+        cache.store_bge_m3_query_bundle = AsyncMock()
+        cache.store_embedding = AsyncMock()
+        cache.store_sparse_embedding = AsyncMock()
+        cache.check_semantic = AsyncMock(return_value=None)
+
+        embeddings = AsyncMock()
+        embeddings.aembed_hybrid_with_colbert = AsyncMock(
+            return_value=([0.1] * 1024, {"indices": [1], "values": [0.5]}, [[0.2] * 1024] * 4)
+        )
+
+        state = make_initial_state(user_id=1, session_id="s1", query="test query")
+        state["query_type"] = "GENERAL"
+
+        result = await cache_check_node(state, _make_runtime(cache=cache, embeddings=embeddings))
+
+        assert result["cache_hit"] is False
+        assert result.get("colbert_query") is not None
+        assert len(result["colbert_query"]) == 4
+        cache.store_bge_m3_query_bundle.assert_awaited_once()
+        cache.store_embedding.assert_awaited_once()
+        cache.store_sparse_embedding.assert_awaited_once()
+
+    async def test_legacy_colbert_fallback_when_no_bundle_support(self):
+        """When no bundle support, legacy aembed_colbert_query fallback still works."""
+        cache = AsyncMock()
+        cache.get_embedding = AsyncMock(return_value=None)
+        cache.check_semantic = AsyncMock(return_value=None)
+        del cache.get_bge_m3_query_bundle
+
+        embeddings = AsyncMock(spec=["aembed_query", "aembed_colbert_query"])
+        embeddings.aembed_query = AsyncMock(return_value=[0.1] * 1024)
+        embeddings.aembed_colbert_query = AsyncMock(return_value=[[0.2] * 1024] * 3)
+
+        state = make_initial_state(user_id=1, session_id="s1", query="test query")
+        state["query_type"] = "GENERAL"
+
+        result = await cache_check_node(state, _make_runtime(cache=cache, embeddings=embeddings))
+
+        assert result["cache_hit"] is False
+        assert result.get("colbert_query") is not None
+        assert len(result["colbert_query"]) == 3
+        embeddings.aembed_colbert_query.assert_awaited_once_with("test query")
+
 
 class TestCacheStoreNode:
     """Test cache_store_node."""

--- a/tests/unit/graph/test_retrieve_node.py
+++ b/tests/unit/graph/test_retrieve_node.py
@@ -779,3 +779,181 @@ class TestRetrieveNodeEvalFields:
         assert "eval_docs" in final_output
         assert final_output["eval_query"] == "cached query"
         assert "Cached document content" in final_output["eval_docs"]
+
+
+class TestRetrieveNodeBundle:
+    """Tests for BGE-M3 query vector bundle cache in retrieve_node (#1493)."""
+
+    async def test_bundle_cache_hit_after_rewrite(self):
+        """After rewrite, retrieve_node uses bundle cache and skips BGE-M3 call."""
+        state = make_initial_state(user_id=1, session_id="s1", query="rewritten query")
+        state["query_type"] = "GENERAL"
+        state["query_embedding"] = None  # simulates post-rewrite
+
+        from telegram_bot.services.bge_m3_query_bundle import BgeM3QueryVectorBundle
+
+        bundle = BgeM3QueryVectorBundle(
+            dense=[0.3] * 1024,
+            sparse={"indices": [2], "values": [0.7]},
+            colbert=[[0.4] * 1024] * 3,
+        )
+        cache = AsyncMock()
+        cache.get_bge_m3_query_bundle = AsyncMock(return_value=bundle)
+        cache.get_search_results = AsyncMock(return_value=None)
+        cache.get_sparse_embedding = AsyncMock(return_value=None)
+        cache.store_search_results = AsyncMock()
+
+        qdrant = AsyncMock()
+        qdrant.hybrid_search_rrf_colbert = AsyncMock(
+            return_value=(
+                [{"id": "1", "score": 85.0, "text": "doc", "metadata": {}}],
+                _OK_META,
+            )
+        )
+
+        embeddings = AsyncMock()
+        embeddings.aembed_hybrid_with_colbert = AsyncMock()
+
+        result = await retrieve_node(
+            state,
+            _make_runtime(
+                cache=cache,
+                embeddings=embeddings,
+                sparse_embeddings=AsyncMock(),
+                qdrant=qdrant,
+            ),
+        )
+
+        assert result["rerank_applied"] is True
+        assert result.get("query_embedding") == bundle.dense
+        embeddings.aembed_hybrid_with_colbert.assert_not_awaited()
+        qdrant.hybrid_search_rrf_colbert.assert_awaited_once()
+
+    async def test_bundle_store_after_hybrid_colbert_compute(self):
+        """After rewrite, retrieve_node stores bundle after aembed_hybrid_with_colbert."""
+        state = make_initial_state(user_id=1, session_id="s1", query="rewritten query")
+        state["query_type"] = "GENERAL"
+        state["query_embedding"] = None
+
+        cache = AsyncMock()
+        cache.get_bge_m3_query_bundle = AsyncMock(return_value=None)
+        cache.get_embedding = AsyncMock(return_value=None)
+        cache.get_search_results = AsyncMock(return_value=None)
+        cache.get_sparse_embedding = AsyncMock(return_value=None)
+        cache.store_embedding = AsyncMock()
+        cache.store_sparse_embedding = AsyncMock()
+        cache.store_search_results = AsyncMock()
+
+        qdrant = AsyncMock()
+        qdrant.hybrid_search_rrf_colbert = AsyncMock(
+            return_value=(
+                [{"id": "1", "score": 85.0, "text": "doc", "metadata": {}}],
+                _OK_META,
+            )
+        )
+
+        embeddings = AsyncMock()
+        embeddings.aembed_hybrid_with_colbert = AsyncMock(
+            return_value=([0.3] * 1024, {"indices": [2], "values": [0.7]}, [[0.4] * 1024] * 3)
+        )
+
+        result = await retrieve_node(
+            state,
+            _make_runtime(
+                cache=cache,
+                embeddings=embeddings,
+                sparse_embeddings=AsyncMock(),
+                qdrant=qdrant,
+            ),
+        )
+
+        assert result["rerank_applied"] is True
+        cache.store_bge_m3_query_bundle.assert_awaited_once()
+        embeddings.aembed_hybrid_with_colbert.assert_awaited_once_with("rewritten query")
+
+    async def test_uses_hybrid_with_colbert_after_rewrite(self):
+        """After rewrite, retrieve_node prefers aembed_hybrid_with_colbert over aembed_hybrid."""
+        state = make_initial_state(user_id=1, session_id="s1", query="rewritten query")
+        state["query_type"] = "GENERAL"
+        state["query_embedding"] = None
+
+        cache = AsyncMock()
+        cache.get_bge_m3_query_bundle = AsyncMock(return_value=None)
+        cache.get_embedding = AsyncMock(return_value=None)
+        cache.get_search_results = AsyncMock(return_value=None)
+        cache.get_sparse_embedding = AsyncMock(return_value=None)
+        cache.store_embedding = AsyncMock()
+        cache.store_sparse_embedding = AsyncMock()
+        cache.store_search_results = AsyncMock()
+
+        qdrant = AsyncMock()
+        qdrant.hybrid_search_rrf_colbert = AsyncMock(
+            return_value=(
+                [{"id": "1", "score": 85.0, "text": "doc", "metadata": {}}],
+                _OK_META,
+            )
+        )
+
+        embeddings = AsyncMock()
+        embeddings.aembed_hybrid_with_colbert = AsyncMock(
+            return_value=([0.3] * 1024, {"indices": [2], "values": [0.7]}, [[0.4] * 1024] * 3)
+        )
+        embeddings.aembed_hybrid = AsyncMock()
+
+        result = await retrieve_node(
+            state,
+            _make_runtime(
+                cache=cache,
+                embeddings=embeddings,
+                sparse_embeddings=AsyncMock(),
+                qdrant=qdrant,
+            ),
+        )
+
+        assert result["rerank_applied"] is True
+        embeddings.aembed_hybrid_with_colbert.assert_awaited_once()
+        embeddings.aembed_hybrid.assert_not_awaited()
+
+    async def test_search_cache_profile_reflects_colbert_after_rewrite(self):
+        """Search cache profile uses colbert mode when vectors are computed after rewrite."""
+        state = make_initial_state(user_id=1, session_id="s1", query="rewritten query")
+        state["query_type"] = "GENERAL"
+        state["query_embedding"] = None
+        state["colbert_query"] = None  # cleared after rewrite
+
+        cache = AsyncMock()
+        cache.get_bge_m3_query_bundle = AsyncMock(return_value=None)
+        cache.get_embedding = AsyncMock(return_value=None)
+        cache.get_search_results = AsyncMock(return_value=None)
+        cache.get_sparse_embedding = AsyncMock(return_value=None)
+        cache.store_embedding = AsyncMock()
+        cache.store_sparse_embedding = AsyncMock()
+        cache.store_search_results = AsyncMock()
+
+        qdrant = AsyncMock()
+        qdrant.hybrid_search_rrf_colbert = AsyncMock(
+            return_value=(
+                [{"id": "1", "score": 85.0, "text": "doc", "metadata": {}}],
+                _OK_META,
+            )
+        )
+
+        embeddings = AsyncMock()
+        embeddings.aembed_hybrid_with_colbert = AsyncMock(
+            return_value=([0.3] * 1024, {"indices": [2], "values": [0.7]}, [[0.4] * 1024] * 3)
+        )
+
+        await retrieve_node(
+            state,
+            _make_runtime(
+                cache=cache,
+                embeddings=embeddings,
+                sparse_embeddings=AsyncMock(),
+                qdrant=qdrant,
+            ),
+        )
+
+        # Verify search results were cached under colbert profile
+        store_call = cache.store_search_results.await_args
+        profile = store_call.kwargs.get("filters") or store_call.args[1]
+        assert profile["mode"] == "colbert"

--- a/tests/unit/services/test_rag_core_embedding_bundle.py
+++ b/tests/unit/services/test_rag_core_embedding_bundle.py
@@ -1,0 +1,269 @@
+"""Tests for compute_query_embedding BGE-M3 bundle cache behaviour.
+
+Covers the bundle-first path in telegram_bot.services.rag_core.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from telegram_bot.services.bge_m3_query_bundle import BgeM3QueryVectorBundle
+from telegram_bot.services.rag_core import compute_query_embedding
+
+
+class TestComputeQueryEmbeddingBundle:
+    """Tests for compute_query_embedding bundle cache path."""
+
+    async def test_bundle_cache_hit_returns_bundle_vectors(self):
+        """Bundle cache hit returns dense, sparse, colbert and from_cache=True."""
+        bundle = BgeM3QueryVectorBundle(
+            dense=[0.1] * 1024,
+            sparse={"indices": [1, 2], "values": [0.5, 0.6]},
+            colbert=[[0.2] * 1024] * 4,
+        )
+
+        cache = AsyncMock()
+        cache.get_bge_m3_query_bundle = AsyncMock(return_value=bundle)
+        cache.get_embedding = AsyncMock(return_value=None)
+
+        embeddings = AsyncMock()
+
+        dense, sparse, colbert, from_cache = await compute_query_embedding(
+            "test query", cache=cache, embeddings=embeddings
+        )
+
+        assert dense == bundle.dense
+        assert sparse == bundle.sparse
+        assert colbert == bundle.colbert
+        assert from_cache is True
+        cache.get_bge_m3_query_bundle.assert_awaited_once_with("test query")
+        cache.get_embedding.assert_not_awaited()
+        embeddings.aembed_hybrid_with_colbert.assert_not_awaited()
+
+    async def test_bundle_cache_miss_computes_and_stores_bundle(self):
+        """Bundle miss with aembed_hybrid_with_colbert computes, stores bundle + legacy."""
+        cache = AsyncMock()
+        cache.get_bge_m3_query_bundle = AsyncMock(return_value=None)
+        cache.store_bge_m3_query_bundle = AsyncMock()
+        cache.store_embedding = AsyncMock()
+        cache.store_sparse_embedding = AsyncMock()
+
+        dense_vec = [0.3] * 1024
+        sparse_vec = {"indices": [1], "values": [0.8]}
+        colbert_vec = [[0.4] * 1024] * 3
+
+        embeddings = AsyncMock()
+        embeddings.aembed_hybrid_with_colbert = AsyncMock(
+            return_value=(dense_vec, sparse_vec, colbert_vec)
+        )
+
+        dense, sparse, colbert, from_cache = await compute_query_embedding(
+            "test query", cache=cache, embeddings=embeddings
+        )
+
+        assert dense == dense_vec
+        assert sparse == sparse_vec
+        assert colbert == colbert_vec
+        assert from_cache is False
+
+        embeddings.aembed_hybrid_with_colbert.assert_awaited_once_with("test query")
+        cache.store_bge_m3_query_bundle.assert_awaited_once()
+        # Verify bundle contents
+        stored_bundle = cache.store_bge_m3_query_bundle.call_args[0][1]
+        assert isinstance(stored_bundle, BgeM3QueryVectorBundle)
+        assert stored_bundle.dense == dense_vec
+        assert stored_bundle.sparse == sparse_vec
+        assert stored_bundle.colbert == colbert_vec
+
+        # Legacy caches also populated
+        cache.store_embedding.assert_awaited_once_with("test query", dense_vec)
+        cache.store_sparse_embedding.assert_awaited_once_with("test query", sparse_vec)
+
+    async def test_bundle_miss_without_store_api_still_computes(self):
+        """Missing store_bge_m3_query_bundle still computes and returns colbert."""
+        cache = AsyncMock(
+            spec=[
+                "get_bge_m3_query_bundle",
+                "get_embedding",
+                "store_embedding",
+                "store_sparse_embedding",
+            ]
+        )
+        cache.get_bge_m3_query_bundle = AsyncMock(return_value=None)
+        cache.get_embedding = AsyncMock(return_value=None)
+        cache.store_embedding = AsyncMock()
+        cache.store_sparse_embedding = AsyncMock()
+
+        dense_vec = [0.3] * 1024
+        sparse_vec = {"indices": [1], "values": [0.8]}
+        colbert_vec = [[0.4] * 1024] * 3
+
+        embeddings = AsyncMock()
+        embeddings.aembed_hybrid_with_colbert = AsyncMock(
+            return_value=(dense_vec, sparse_vec, colbert_vec)
+        )
+
+        dense, sparse, colbert, from_cache = await compute_query_embedding(
+            "test query", cache=cache, embeddings=embeddings
+        )
+
+        assert dense == dense_vec
+        assert sparse == sparse_vec
+        assert colbert == colbert_vec
+        assert from_cache is False
+
+        # store_bge_m3_query_bundle not called because API absent (spec excludes it)
+        assert not hasattr(cache, "store_bge_m3_query_bundle")
+        # But legacy caches still populated
+        cache.store_embedding.assert_awaited_once()
+        cache.store_sparse_embedding.assert_awaited_once()
+
+    async def test_pre_computed_bypasses_bundle(self):
+        """Pre-computed vectors bypass all cache and model calls."""
+        cache = AsyncMock()
+        embeddings = AsyncMock()
+        pre_dense = [0.1] * 10
+        pre_sparse = {"indices": [1], "values": [0.5]}
+        pre_colbert = [[0.1] * 10]
+
+        dense, sparse, colbert, from_cache = await compute_query_embedding(
+            "query",
+            cache=cache,
+            embeddings=embeddings,
+            pre_computed=pre_dense,
+            pre_computed_sparse=pre_sparse,
+            pre_computed_colbert=pre_colbert,
+        )
+
+        assert dense == pre_dense
+        assert sparse == pre_sparse
+        assert colbert == pre_colbert
+        assert from_cache is False
+        cache.get_bge_m3_query_bundle.assert_not_awaited()
+        embeddings.aembed_hybrid_with_colbert.assert_not_awaited()
+
+    async def test_legacy_dense_cache_when_no_bundle_api(self):
+        """Cache without bundle API falls back to legacy dense cache."""
+        cache = AsyncMock()
+        cache.get_embedding = AsyncMock(return_value=[0.2] * 1024)
+        # No get_bge_m3_query_bundle → _has_bundle_get checks getattr with default None
+        # For AsyncMock, getattr returns AsyncMock, but we test with a real-ish object
+        # that lacks the method.
+        del cache.get_bge_m3_query_bundle
+
+        embeddings = AsyncMock()
+
+        dense, sparse, colbert, from_cache = await compute_query_embedding(
+            "test query", cache=cache, embeddings=embeddings
+        )
+
+        assert dense == [0.2] * 1024
+        assert sparse is None
+        assert colbert is None
+        assert from_cache is True
+        cache.get_embedding.assert_awaited_once_with("test query")
+        embeddings.aembed_hybrid_with_colbert.assert_not_awaited()
+
+    async def test_legacy_dense_compute_when_no_hybrid_colbert(self):
+        """Embeddings without aembed_hybrid_with_colbert falls back to legacy compute."""
+        cache = AsyncMock()
+        cache.get_embedding = AsyncMock(return_value=None)
+        cache.store_embedding = AsyncMock()
+        cache.store_sparse_embedding = AsyncMock()
+        del cache.get_bge_m3_query_bundle
+
+        dense_vec = [0.4] * 1024
+        sparse_vec = {"indices": [2], "values": [0.9]}
+
+        embeddings = MagicMock()
+        embeddings.aembed_hybrid = AsyncMock(return_value=(dense_vec, sparse_vec))
+        # aembed_hybrid_with_colbert not present
+
+        dense, sparse, colbert, from_cache = await compute_query_embedding(
+            "test query", cache=cache, embeddings=embeddings
+        )
+
+        assert dense == dense_vec
+        assert sparse == sparse_vec
+        assert colbert is None
+        assert from_cache is False
+        embeddings.aembed_hybrid.assert_awaited_once_with("test query")
+        cache.store_embedding.assert_awaited_once_with("test query", dense_vec)
+        cache.store_sparse_embedding.assert_awaited_once_with("test query", sparse_vec)
+
+    async def test_bundle_hit_does_not_call_get_embedding(self):
+        """Bundle cache hit must not touch legacy dense cache."""
+        bundle = BgeM3QueryVectorBundle(
+            dense=[0.1] * 1024,
+            sparse={"indices": [1], "values": [0.5]},
+            colbert=[[0.2] * 1024] * 4,
+        )
+
+        cache = AsyncMock()
+        cache.get_bge_m3_query_bundle = AsyncMock(return_value=bundle)
+        cache.get_embedding = AsyncMock(return_value=[0.99] * 1024)
+
+        embeddings = AsyncMock()
+
+        await compute_query_embedding("test query", cache=cache, embeddings=embeddings)
+
+        cache.get_embedding.assert_not_awaited()
+
+    async def test_bundle_store_exception_is_non_critical(self):
+        """Bundle store failure must not raise or prevent returning vectors."""
+        cache = AsyncMock()
+        cache.get_bge_m3_query_bundle = AsyncMock(return_value=None)
+        cache.store_bge_m3_query_bundle = AsyncMock(side_effect=RuntimeError("store failed"))
+        cache.store_embedding = AsyncMock()
+        cache.store_sparse_embedding = AsyncMock()
+
+        dense_vec = [0.3] * 1024
+        sparse_vec = {"indices": [1], "values": [0.8]}
+        colbert_vec = [[0.4] * 1024] * 3
+
+        embeddings = AsyncMock()
+        embeddings.aembed_hybrid_with_colbert = AsyncMock(
+            return_value=(dense_vec, sparse_vec, colbert_vec)
+        )
+
+        dense, sparse, colbert, from_cache = await compute_query_embedding(
+            "test query", cache=cache, embeddings=embeddings
+        )
+
+        assert dense == dense_vec
+        assert sparse == sparse_vec
+        assert colbert == colbert_vec
+        assert from_cache is False
+
+    async def test_mock_without_real_bundle_support_falls_back_to_legacy(self):
+        """Plain AsyncMock (no real bundle/colbert) falls back to legacy dense cache."""
+        cache = AsyncMock()
+        cache.get_embedding = AsyncMock(return_value=[0.5] * 1024)
+
+        embeddings = AsyncMock()
+
+        dense, sparse, colbert, from_cache = await compute_query_embedding(
+            "test query", cache=cache, embeddings=embeddings
+        )
+
+        assert dense == [0.5] * 1024
+        assert sparse is None
+        assert colbert is None
+        assert from_cache is True
+
+    async def test_mock_without_real_bundle_and_no_legacy_cache_computes_dense(self):
+        """Plain AsyncMock with cache miss falls back to aembed_query."""
+        cache = AsyncMock()
+        cache.get_embedding = AsyncMock(return_value=None)
+        cache.store_embedding = AsyncMock()
+
+        embeddings = AsyncMock(spec=["aembed_query"])
+        embeddings.aembed_query = AsyncMock(return_value=[0.6] * 1024)
+
+        dense, sparse, colbert, from_cache = await compute_query_embedding(
+            "test query", cache=cache, embeddings=embeddings
+        )
+
+        assert dense == [0.6] * 1024
+        assert sparse is None
+        assert colbert is None
+        assert from_cache is False
+        embeddings.aembed_query.assert_awaited_once_with("test query")

--- a/tests/unit/test_bot_scores.py
+++ b/tests/unit/test_bot_scores.py
@@ -346,7 +346,6 @@ class TestScoreWriting:
                     "semantic_cache_hit": 1.0,
                     "llm_used": 0.0,
                     "rerank_applied": 0.0,
-                    "results_count": 0.0,
                 },
             ),
             (
@@ -370,6 +369,21 @@ class TestScoreWriting:
         }
         for name, expected_value in expected_scores.items():
             assert scores[name] == expected_value, f"{name}: {scores[name]} != {expected_value}"
+
+    def test_cache_hit_does_not_emit_misleading_no_results(self):
+        """Regression: semantic cache hit must NOT score no_results=1 or results_count=0 (#1493)."""
+        mock_lf = MagicMock()
+        _run_score_writer(CACHE_HIT_RESULT, mock_lf)
+
+        score_names = [call.kwargs["name"] for call in mock_lf.create_score.call_args_list]
+        assert "no_results" not in score_names
+        assert "results_count" not in score_names
+        # semantic_cache_hit must still be recorded
+        scores = {
+            call.kwargs["name"]: call.kwargs["value"]
+            for call in mock_lf.create_score.call_args_list
+        }
+        assert scores["semantic_cache_hit"] == 1.0
 
     @pytest.mark.parametrize(
         ("result_override", "test_id"),


### PR DESCRIPTION
Fix semantic cache-hit scoring so cache-hit responses are not scored as misleading `results_count=0` / `no_results=1`.

- Semantic answer cache hit still records `semantic_cache_hit`.
- When a response came from semantic cache and no retrieval was run, avoids treating missing/zero retrieval count as a no-results retrieval failure.
- Adds focused regression test in `tests/unit/test_bot_scores.py`.