### PR TITLE
fix(docker): keep mini app nginx temp paths writable

### DIFF
--- a/mini_app/frontend/Dockerfile
+++ b/mini_app/frontend/Dockerfile
@@ -21,6 +21,19 @@ FROM nginx:1.29-alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e591939
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/nginx.conf
 
+RUN mkdir -p \
+    /tmp/client_temp \
+    /tmp/proxy_temp \
+    /tmp/fastcgi_temp \
+    /tmp/uwsgi_temp \
+    /tmp/scgi_temp \
+    && chown -R 101:101 \
+    /tmp/client_temp \
+    /tmp/proxy_temp \
+    /tmp/fastcgi_temp \
+    /tmp/uwsgi_temp \
+    /tmp/scgi_temp
+
 USER 101:101
 
 EXPOSE 80

--- a/tests/unit/mini_app/test_frontend_runtime_contract.py
+++ b/tests/unit/mini_app/test_frontend_runtime_contract.py
@@ -57,3 +57,19 @@ def test_frontend_nginx_temp_paths_use_tmp_root_dirs() -> None:
         assert re.search(pattern, text), (
             f"{directive} must use a direct /tmp/<dir> path so nginx can create it on tmpfs"
         )
+
+
+def test_frontend_nginx_temp_dirs_are_created_for_unprivileged_runtime() -> None:
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    nginx_conf = NGINX_CONF.read_text(encoding="utf-8")
+    for path in [
+        "/tmp/client_temp",
+        "/tmp/proxy_temp",
+        "/tmp/fastcgi_temp",
+        "/tmp/uwsgi_temp",
+        "/tmp/scgi_temp",
+    ]:
+        assert path in nginx_conf
+        assert path in dockerfile
+    assert "chown -R 101:101" in dockerfile
+    assert "USER 101:101" in dockerfile


### PR DESCRIPTION
## Summary
- Fixes #1487: mini-app frontend health pre-validation for `validate-traces-fast`.
- Ensures nginx temp directories under `/tmp` are created and owned by `101:101` in the Dockerfile before switching to unprivileged user.
- Adds contract test verifying temp paths exist in both `nginx.conf` and `Dockerfile`, and that `chown -R 101:101` and `USER 101:101` are present.