### PR TITLE
test(e2e): preflight qdrant data for trace gate (#1488)

### DIFF
--- a/scripts/e2e/config.py
+++ b/scripts/e2e/config.py
@@ -55,6 +55,29 @@ class E2EConfig:
         default_factory=lambda: os.getenv("E2E_COLLECTION_NAME", "gdrive_documents_bge")
     )
 
+    # Qdrant preflight configuration
+    qdrant_url: str = field(
+        default_factory=lambda: os.getenv("QDRANT_URL", "http://localhost:6333")
+    )
+    qdrant_doc_collection: str = field(
+        default_factory=lambda: os.getenv("E2E_QDRANT_DOC_COLLECTION", "gdrive_documents_bge")
+    )
+    qdrant_apartment_collection: str = field(
+        default_factory=lambda: os.getenv("E2E_QDRANT_APARTMENT_COLLECTION", "apartments")
+    )
+    qdrant_min_doc_points: int = field(
+        default_factory=lambda: int(os.getenv("E2E_QDRANT_MIN_DOC_POINTS", "1"))
+    )
+    qdrant_min_apartment_points: int = field(
+        default_factory=lambda: int(os.getenv("E2E_QDRANT_MIN_APARTMENT_POINTS", "1"))
+    )
+    qdrant_doc_vectors: str = field(
+        default_factory=lambda: os.getenv("E2E_QDRANT_DOC_VECTORS", "dense,colbert")
+    )
+    qdrant_apartment_vectors: str = field(
+        default_factory=lambda: os.getenv("E2E_QDRANT_APARTMENT_VECTORS", "dense,colbert")
+    )
+
     # Reports
     reports_dir: str = "reports"
 

--- a/scripts/e2e/qdrant_preflight.py
+++ b/scripts/e2e/qdrant_preflight.py
@@ -1,0 +1,153 @@
+"""Qdrant preflight checks for E2E trace gate."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from qdrant_client import QdrantClient
+
+
+@dataclass(frozen=True)
+class CollectionRequirement:
+    """Requirement for a Qdrant collection."""
+
+    name: str
+    min_points: int
+    required_vectors: frozenset[str]
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    """Result of Qdrant preflight checks."""
+
+    ok: bool
+    message: str
+    checked: list[dict[str, object]]
+
+
+DEFAULT_REQUIREMENTS: tuple[CollectionRequirement, ...] = (
+    CollectionRequirement(
+        name=os.getenv("E2E_QDRANT_DOC_COLLECTION", "gdrive_documents_bge"),
+        min_points=int(os.getenv("E2E_QDRANT_MIN_DOC_POINTS", "1")),
+        required_vectors=frozenset(
+            v.strip()
+            for v in os.getenv("E2E_QDRANT_DOC_VECTORS", "dense,colbert").split(",")
+            if v.strip()
+        ),
+    ),
+    CollectionRequirement(
+        name=os.getenv("E2E_QDRANT_APARTMENT_COLLECTION", "apartments"),
+        min_points=int(os.getenv("E2E_QDRANT_MIN_APARTMENT_POINTS", "1")),
+        required_vectors=frozenset(
+            v.strip()
+            for v in os.getenv("E2E_QDRANT_APARTMENT_VECTORS", "dense,colbert").split(",")
+            if v.strip()
+        ),
+    ),
+)
+
+
+def _vector_names_from_info(info) -> list[str]:
+    """Extract vector names from collection info without exposing payload schemas."""
+    vectors = getattr(info.config.params, "vectors", None)
+    sparse_vectors = getattr(info.config.params, "sparse_vectors", None)
+    names: list[str] = []
+    if vectors is not None:
+        if isinstance(vectors, dict):
+            names.extend(vectors.keys())
+        elif hasattr(vectors, "vector_name"):
+            names.append(vectors.vector_name)
+    if sparse_vectors is not None and isinstance(sparse_vectors, dict):
+        names.extend(sparse_vectors.keys())
+    return names
+
+
+def run_qdrant_preflight(
+    qdrant_url: str | None = None,
+    requirements: tuple[CollectionRequirement, ...] | None = None,
+) -> PreflightResult:
+    """Run Qdrant preflight checks.
+
+    Args:
+        qdrant_url: Qdrant server URL. Defaults to QDRANT_URL env var or http://localhost:6333.
+        requirements: Collection requirements to validate. Defaults to DEFAULT_REQUIREMENTS.
+
+    Returns:
+        PreflightResult with ok status, sanitized message, and checked details.
+    """
+    url = qdrant_url or os.getenv("QDRANT_URL", "http://localhost:6333")
+    reqs = requirements if requirements is not None else DEFAULT_REQUIREMENTS
+
+    checked: list[dict[str, object]] = []
+    failures: list[str] = []
+
+    try:
+        client = QdrantClient(url=url)
+    except Exception as exc:
+        return PreflightResult(
+            ok=False,
+            message=f"Qdrant connection failed: {exc}",
+            checked=[],
+        )
+
+    for req in reqs:
+        item: dict[str, object] = {
+            "collection": req.name,
+            "exists": False,
+            "points_count": 0,
+            "vectors": [],
+        }
+
+        try:
+            exists = client.collection_exists(req.name)
+            item["exists"] = exists
+
+            if not exists:
+                failures.append(
+                    f"Collection '{req.name}' does not exist. "
+                    "Ensure the collection is created and indexed before running E2E traces."
+                )
+                checked.append(item)
+                continue
+
+            info = client.get_collection(req.name)
+            points_count = getattr(info, "points_count", 0)
+            item["points_count"] = points_count
+
+            vector_names = _vector_names_from_info(info)
+            item["vectors"] = vector_names
+
+            if points_count < req.min_points:
+                failures.append(
+                    f"Collection '{req.name}' has {points_count} points "
+                    f"(minimum required: {req.min_points}). "
+                    "Re-index data to meet the threshold."
+                )
+
+            missing_vectors = req.required_vectors - set(vector_names)
+            if missing_vectors:
+                failures.append(
+                    f"Collection '{req.name}' missing required vectors: {sorted(missing_vectors)}. "
+                    "Recreate the collection with the required vector configurations."
+                )
+        except Exception as exc:
+            failures.append(
+                f"Collection '{req.name}' check failed: {exc}. "
+                "Verify Qdrant is reachable and the collection schema is valid."
+            )
+
+        checked.append(item)
+
+    if failures:
+        return PreflightResult(
+            ok=False,
+            message="Qdrant preflight failed:\n- " + "\n- ".join(failures),
+            checked=checked,
+        )
+
+    return PreflightResult(
+        ok=True,
+        message="Qdrant preflight passed",
+        checked=checked,
+    )

--- a/scripts/e2e/runner.py
+++ b/scripts/e2e/runner.py
@@ -294,6 +294,11 @@ def main():
         choices=["litellm", "anthropic-direct"],
         help="Override E2E_JUDGE_PROVIDER for this run",
     )
+    parser.add_argument(
+        "--skip-qdrant-preflight",
+        action="store_true",
+        help="Skip Qdrant preflight check (for local debugging only)",
+    )
     args = parser.parse_args()
 
     # Load config
@@ -327,6 +332,36 @@ def main():
         f"{len(scenarios)} E2E tests against {config.bot_username} "
         f"(judge={config.judge_provider}, mode={'no-judge' if args.no_judge else 'llm'})[/]\n"
     )
+
+    # Qdrant preflight for RAG/apartment/voice scenarios
+    needs_qdrant = any(s.group not in {TestGroup.COMMANDS, TestGroup.CHITCHAT} for s in scenarios)
+    if needs_qdrant and not args.skip_qdrant_preflight:
+        from scripts.e2e.qdrant_preflight import CollectionRequirement, run_qdrant_preflight
+
+        requirements = (
+            CollectionRequirement(
+                name=config.qdrant_doc_collection,
+                min_points=config.qdrant_min_doc_points,
+                required_vectors=frozenset(
+                    v.strip() for v in config.qdrant_doc_vectors.split(",") if v.strip()
+                ),
+            ),
+            CollectionRequirement(
+                name=config.qdrant_apartment_collection,
+                min_points=config.qdrant_min_apartment_points,
+                required_vectors=frozenset(
+                    v.strip() for v in config.qdrant_apartment_vectors.split(",") if v.strip()
+                ),
+            ),
+        )
+        preflight = run_qdrant_preflight(qdrant_url=config.qdrant_url, requirements=requirements)
+        if not preflight.ok:
+            console.print("[red]Qdrant preflight failed:[/]")
+            for line in preflight.message.splitlines():
+                console.print(f"  {line}")
+            sys.exit(1)
+        console.print("[green]Qdrant preflight passed[/]")
+        console.print()
 
     # Check if trace validation is enabled
     validate_traces = is_validation_enabled()

--- a/tests/unit/e2e/test_qdrant_preflight.py
+++ b/tests/unit/e2e/test_qdrant_preflight.py
@@ -1,0 +1,257 @@
+"""Unit tests for Qdrant E2E preflight."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from scripts.e2e.qdrant_preflight import (
+    CollectionRequirement,
+    _vector_names_from_info,
+    run_qdrant_preflight,
+)
+
+
+def _make_info(points_count: int, vector_names: list[str], sparse_names: list[str] | None = None):
+    """Build a mock collection info object."""
+    info = MagicMock()
+    info.points_count = points_count
+    info.config.params.vectors = {name: MagicMock() for name in vector_names}
+    if sparse_names:
+        info.config.params.sparse_vectors = {name: MagicMock() for name in sparse_names}
+    else:
+        info.config.params.sparse_vectors = {}
+    return info
+
+
+class TestRunQdrantPreflight:
+    def test_missing_gdrive_documents_bge_fails_with_sanitized_remediation(self):
+        with patch("scripts.e2e.qdrant_preflight.QdrantClient") as MockClient:
+            mock_client = MockClient.return_value
+            mock_client.collection_exists.return_value = False
+
+            result = run_qdrant_preflight(
+                qdrant_url="http://localhost:6333",
+                requirements=(
+                    CollectionRequirement(
+                        name="gdrive_documents_bge",
+                        min_points=1,
+                        required_vectors=frozenset(["dense", "colbert"]),
+                    ),
+                ),
+            )
+
+        assert not result.ok
+        assert "gdrive_documents_bge" in result.message
+        assert "does not exist" in result.message
+        assert any(
+            item["collection"] == "gdrive_documents_bge" and item["exists"] is False
+            for item in result.checked
+        )
+
+    def test_below_minimum_count_fails(self):
+        with patch("scripts.e2e.qdrant_preflight.QdrantClient") as MockClient:
+            mock_client = MockClient.return_value
+            mock_client.collection_exists.return_value = True
+            mock_client.get_collection.return_value = _make_info(
+                points_count=0, vector_names=["dense", "colbert"]
+            )
+
+            result = run_qdrant_preflight(
+                qdrant_url="http://localhost:6333",
+                requirements=(
+                    CollectionRequirement(
+                        name="gdrive_documents_bge",
+                        min_points=1,
+                        required_vectors=frozenset(["dense", "colbert"]),
+                    ),
+                ),
+            )
+
+        assert not result.ok
+        assert "has 0 points" in result.message
+        assert "minimum required: 1" in result.message
+
+    def test_missing_dense_vector_fails(self):
+        with patch("scripts.e2e.qdrant_preflight.QdrantClient") as MockClient:
+            mock_client = MockClient.return_value
+            mock_client.collection_exists.return_value = True
+            mock_client.get_collection.return_value = _make_info(
+                points_count=5, vector_names=["colbert"]
+            )
+
+            result = run_qdrant_preflight(
+                qdrant_url="http://localhost:6333",
+                requirements=(
+                    CollectionRequirement(
+                        name="gdrive_documents_bge",
+                        min_points=1,
+                        required_vectors=frozenset(["dense", "colbert"]),
+                    ),
+                ),
+            )
+
+        assert not result.ok
+        assert "missing required vectors" in result.message
+        assert "dense" in result.message
+
+    def test_missing_colbert_vector_fails(self):
+        with patch("scripts.e2e.qdrant_preflight.QdrantClient") as MockClient:
+            mock_client = MockClient.return_value
+            mock_client.collection_exists.return_value = True
+            mock_client.get_collection.return_value = _make_info(
+                points_count=5, vector_names=["dense"]
+            )
+
+            result = run_qdrant_preflight(
+                qdrant_url="http://localhost:6333",
+                requirements=(
+                    CollectionRequirement(
+                        name="gdrive_documents_bge",
+                        min_points=1,
+                        required_vectors=frozenset(["dense", "colbert"]),
+                    ),
+                ),
+            )
+
+        assert not result.ok
+        assert "missing required vectors" in result.message
+        assert "colbert" in result.message
+
+    def test_apartments_below_minimum_count_fails(self):
+        with patch("scripts.e2e.qdrant_preflight.QdrantClient") as MockClient:
+            mock_client = MockClient.return_value
+            mock_client.collection_exists.return_value = True
+            mock_client.get_collection.return_value = _make_info(
+                points_count=0, vector_names=["dense", "colbert"]
+            )
+
+            result = run_qdrant_preflight(
+                qdrant_url="http://localhost:6333",
+                requirements=(
+                    CollectionRequirement(
+                        name="apartments",
+                        min_points=1,
+                        required_vectors=frozenset(["dense", "colbert"]),
+                    ),
+                ),
+            )
+
+        assert not result.ok
+        assert "apartments" in result.message
+        assert "has 0 points" in result.message
+
+    def test_no_payload_contents_printed(self):
+        with patch("scripts.e2e.qdrant_preflight.QdrantClient") as MockClient:
+            mock_client = MockClient.return_value
+            mock_client.collection_exists.return_value = True
+            info = _make_info(points_count=5, vector_names=["dense", "colbert"])
+            # Attach a payload schema that must NOT leak into output
+            info.config.params.payload_schema = {"secret_field": "secret_value"}
+            mock_client.get_collection.return_value = info
+
+            result = run_qdrant_preflight(
+                qdrant_url="http://localhost:6333",
+                requirements=(
+                    CollectionRequirement(
+                        name="gdrive_documents_bge",
+                        min_points=1,
+                        required_vectors=frozenset(["dense", "colbert"]),
+                    ),
+                ),
+            )
+
+        assert result.ok
+        assert "secret" not in result.message.lower()
+        assert "payload" not in result.message.lower()
+        for item in result.checked:
+            assert "payload" not in item
+            assert "secret" not in str(item).lower()
+
+    def test_passes_when_all_requirements_met(self):
+        with patch("scripts.e2e.qdrant_preflight.QdrantClient") as MockClient:
+            mock_client = MockClient.return_value
+            mock_client.collection_exists.return_value = True
+            mock_client.get_collection.return_value = _make_info(
+                points_count=10, vector_names=["dense", "colbert"]
+            )
+
+            result = run_qdrant_preflight(
+                qdrant_url="http://localhost:6333",
+                requirements=(
+                    CollectionRequirement(
+                        name="gdrive_documents_bge",
+                        min_points=1,
+                        required_vectors=frozenset(["dense", "colbert"]),
+                    ),
+                ),
+            )
+
+        assert result.ok
+        assert result.message == "Qdrant preflight passed"
+        assert result.checked[0]["points_count"] == 10
+        assert result.checked[0]["vectors"] == ["dense", "colbert"]
+
+    def test_multiple_requirements_partial_failure(self):
+        with patch("scripts.e2e.qdrant_preflight.QdrantClient") as MockClient:
+            mock_client = MockClient.return_value
+            mock_client.collection_exists.side_effect = [True, False]
+            mock_client.get_collection.return_value = _make_info(
+                points_count=10, vector_names=["dense", "colbert"]
+            )
+
+            result = run_qdrant_preflight(
+                qdrant_url="http://localhost:6333",
+                requirements=(
+                    CollectionRequirement(
+                        name="gdrive_documents_bge",
+                        min_points=1,
+                        required_vectors=frozenset(["dense", "colbert"]),
+                    ),
+                    CollectionRequirement(
+                        name="apartments",
+                        min_points=1,
+                        required_vectors=frozenset(["dense", "colbert"]),
+                    ),
+                ),
+            )
+
+        assert not result.ok
+        assert "apartments" in result.message
+        assert "does not exist" in result.message
+        assert len(result.checked) == 2
+
+    def test_connection_failure_returns_early(self):
+        with patch("scripts.e2e.qdrant_preflight.QdrantClient") as MockClient:
+            MockClient.side_effect = Exception("Connection refused")
+
+            result = run_qdrant_preflight(
+                qdrant_url="http://bad-host:6333",
+                requirements=(),
+            )
+
+        assert not result.ok
+        assert "Connection refused" in result.message
+        assert result.checked == []
+
+
+class TestVectorNamesFromInfo:
+    def test_extracts_named_vectors(self):
+        info = MagicMock()
+        info.config.params.vectors = {"dense": MagicMock(), "colbert": MagicMock()}
+        info.config.params.sparse_vectors = {"bm42": MagicMock()}
+        assert sorted(_vector_names_from_info(info)) == ["bm42", "colbert", "dense"]
+
+    def test_handles_single_vector_config(self):
+        class SingleVec:
+            vector_name = "default"
+
+        info = MagicMock()
+        info.config.params.vectors = SingleVec()
+        info.config.params.sparse_vectors = {}
+        assert _vector_names_from_info(info) == ["default"]
+
+    def test_handles_none_vectors(self):
+        info = MagicMock()
+        info.config.params.vectors = None
+        info.config.params.sparse_vectors = None
+        assert _vector_names_from_info(info) == []


### PR DESCRIPTION
## Summary
- Add `scripts/e2e/qdrant_preflight.py` with sanitized Qdrant collection/vector checks.
- Add config knobs to `scripts/e2e/config.py` for collection names, min points, and required vectors.
- Wire preflight into `scripts/e2e/runner.py` before Telegram sends for RAG/apartment/voice scenarios.
- Add `--skip-qdrant-preflight` for local debugging.
- Preserve `e2e-test-traces-core` Makefile target shape.
- Add focused unit tests proving sanitized failures for missing collections, low counts, and missing vectors.

## Verification
- `uv run pytest tests/unit/e2e/test_qdrant_preflight.py tests/unit/test_makefile_contract.py -q` ✅
- `uv run pytest tests/unit/e2e/test_langfuse_trace_validator.py -q` ✅

Closes #1488