### PR TITLE
fix(e2e): deterministic product-meaningful assertions in no-judge Telethon E2E

### DIFF
--- a/scripts/e2e/claude_judge.py
+++ b/scripts/e2e/claude_judge.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from dataclasses import dataclass
 
 from openai import AsyncOpenAI
@@ -254,6 +255,19 @@ class PassthroughJudge:
         return any(marker in lowered for marker in bad_markers)
 
     @staticmethod
+    def _has_numeric_price_with_currency(response: str) -> bool:
+        """Check if response contains a numeric price token together with a currency marker.
+
+        Requires at least one digit adjacent to ``евро`` or ``€``, so
+        currency-only text like ``"Все цены указаны в евро"`` is rejected.
+        """
+        lowered = response.lower()
+        # "70 000 евро", "70000€", "70к евро", "€70000", "евро 70 000"
+        return bool(re.search(r"(?:евро|€)\s*\d", lowered)) or bool(
+            re.search(r"\d[\d\s]*(?:k|к)?\s*(?:евро|€)", lowered)
+        )
+
+    @staticmethod
     def _check_filter_evidence(response: str, filters) -> dict[str, bool]:
         lowered = response.lower()
         checks: dict[str, bool] = {}
@@ -265,8 +279,7 @@ class PassthroughJudge:
                 short in lowered
                 or f"{short}к" in lowered
                 or f"{short} {price_str[-3:]}" in lowered
-                or "евро" in lowered
-                or "€" in lowered
+                or PassthroughJudge._has_numeric_price_with_currency(response)
             )
 
         if filters.price_min is not None:
@@ -276,8 +289,7 @@ class PassthroughJudge:
                 short in lowered
                 or f"{short}к" in lowered
                 or f"{short} {price_str[-3:]}" in lowered
-                or "евро" in lowered
-                or "€" in lowered
+                or PassthroughJudge._has_numeric_price_with_currency(response)
             )
 
         if filters.city is not None:

--- a/scripts/e2e/claude_judge.py
+++ b/scripts/e2e/claude_judge.py
@@ -263,8 +263,8 @@ class PassthroughJudge:
         """
         lowered = response.lower()
         # "70 000 евро", "70000€", "70к евро", "€70000", "евро 70 000"
-        return bool(re.search(r"(?:евро|€)\s*\d", lowered)) or bool(
-            re.search(r"\d[\d\s]*(?:k|к)?\s*(?:евро|€)", lowered)
+        return bool(re.search(r"(?:евро\b|€)\s*\d", lowered)) or bool(
+            re.search(r"\d[\d\s]*(?:k|к)?\s*(?:евро\b|€)", lowered)
         )
 
     @staticmethod

--- a/scripts/e2e/claude_judge.py
+++ b/scripts/e2e/claude_judge.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from openai import AsyncOpenAI
 
 from .config import E2EConfig
-from .test_scenarios import TestScenario
+from .test_scenarios import TestGroup, TestScenario
 
 
 logger = logging.getLogger(__name__)
@@ -86,6 +86,7 @@ class JudgeResult:
     total_score: float
     passed: bool
     summary: str
+    check_details: dict | None = None
 
     @classmethod
     def from_dict(cls, data: dict) -> JudgeResult:
@@ -99,6 +100,7 @@ class JudgeResult:
             total_score=data["total_score"],
             passed=data["pass"],
             summary=data["summary"],
+            check_details=data.get("check_details"),
         )
 
 
@@ -230,35 +232,156 @@ def build_judge(config: E2EConfig) -> LiteLLMJudge | ClaudeJudge:
 
 
 class PassthroughJudge:
-    """Simple judge that passes any non-empty bot response (no LLM needed)."""
+    """Deterministic judge with product-meaningful checks (no LLM needed)."""
 
     def __init__(self, config: E2EConfig):
         self.config = config
+
+    @staticmethod
+    def _contains_any_keyword(response: str, keywords: list[str]) -> bool:
+        lowered = response.lower()
+        return any(keyword.lower() in lowered for keyword in keywords)
+
+    @staticmethod
+    def _generic_fallback_detected(response: str) -> bool:
+        lowered = response.lower()
+        bad_markers = [
+            "не нашел информацию",
+            "попробуйте переформулировать",
+            "не удалось найти",
+            "сервис временно недоступен",
+        ]
+        return any(marker in lowered for marker in bad_markers)
+
+    @staticmethod
+    def _check_filter_evidence(response: str, filters) -> dict[str, bool]:
+        lowered = response.lower()
+        checks: dict[str, bool] = {}
+
+        if filters.price_max is not None:
+            price_str = str(filters.price_max)
+            short = price_str[:-3] if len(price_str) > 3 else price_str
+            checks["price_max"] = (
+                short in lowered
+                or f"{short}к" in lowered
+                or f"{short} {price_str[-3:]}" in lowered
+                or "евро" in lowered
+                or "€" in lowered
+            )
+
+        if filters.price_min is not None:
+            price_str = str(filters.price_min)
+            short = price_str[:-3] if len(price_str) > 3 else price_str
+            checks["price_min"] = (
+                short in lowered
+                or f"{short}к" in lowered
+                or f"{short} {price_str[-3:]}" in lowered
+                or "евро" in lowered
+                or "€" in lowered
+            )
+
+        if filters.city is not None:
+            checks["city"] = filters.city.lower()[:6] in lowered
+
+        if filters.rooms is not None:
+            room_str = str(filters.rooms)
+            checks["rooms"] = (
+                room_str in lowered
+                or (filters.rooms == 2 and "двух" in lowered)
+                or (filters.rooms == 3 and "трех" in lowered)
+                or f"{room_str}-ком" in lowered
+            )
+
+        if filters.distance_to_sea_max is not None:
+            checks["distance_to_sea_max"] = (
+                str(filters.distance_to_sea_max) in lowered
+                or "м" in lowered
+                or "мор" in lowered
+                or "пляж" in lowered
+            )
+
+        return checks
 
     async def evaluate(
         self,
         scenario: TestScenario,
         bot_response: str,
     ) -> JudgeResult:
-        """Pass if bot returned a non-empty response."""
-        if bot_response and bot_response.strip():
+        """Evaluate bot response with deterministic product checks."""
+        if not bot_response or not bot_response.strip():
             return JudgeResult(
-                relevance=CriterionScore(8, "Response received"),
-                completeness=CriterionScore(8, "Response received"),
-                filter_accuracy=CriterionScore(8, "Response received"),
-                tone_format=CriterionScore(8, "Response received"),
-                no_hallucination=CriterionScore(8, "Response received"),
-                total_score=8.0,
-                passed=True,
-                summary="Bot responded (no-judge mode)",
+                relevance=CriterionScore(0, "Empty response"),
+                completeness=CriterionScore(0, "Empty response"),
+                filter_accuracy=CriterionScore(0, "Empty response"),
+                tone_format=CriterionScore(0, "Empty response"),
+                no_hallucination=CriterionScore(0, "Empty response"),
+                total_score=0.0,
+                passed=False,
+                summary="Bot returned empty response",
+                check_details={"presence": False},
             )
+
+        check_details: dict = {"presence": True}
+        failed_checks: list[str] = []
+
+        # 1. Expected keywords
+        if scenario.expected_keywords:
+            has_keywords = self._contains_any_keyword(bot_response, scenario.expected_keywords)
+            check_details["expected_keywords"] = has_keywords
+            if not has_keywords:
+                failed_checks.append(f"Missing expected keywords: {scenario.expected_keywords}")
+        else:
+            check_details["expected_keywords"] = None
+
+        # 2. Generic fallback rejection for RAG/property scenarios
+        is_rag_property = scenario.group in {
+            TestGroup.PRICE_FILTERS,
+            TestGroup.ROOM_FILTERS,
+            TestGroup.LOCATION_FILTERS,
+            TestGroup.SEARCH,
+            TestGroup.IMMIGRATION,
+            TestGroup.VOICE_TRANSCRIPTION,
+        }
+        if is_rag_property and scenario.id not in {"7.1", "8.3"}:
+            fallback = self._generic_fallback_detected(bot_response)
+            check_details["generic_fallback"] = fallback
+            if fallback:
+                failed_checks.append("Generic fallback detected")
+        else:
+            check_details["generic_fallback"] = None
+
+        # 3. Expected filter evidence
+        if scenario.expected_filters is not None:
+            evidence = self._check_filter_evidence(bot_response, scenario.expected_filters)
+            check_details["filter_evidence"] = evidence
+            missing = [k for k, v in evidence.items() if not v]
+            if missing:
+                failed_checks.append(f"Missing filter evidence for: {missing}")
+        else:
+            check_details["filter_evidence"] = None
+
+        passed = not failed_checks
+
+        if passed:
+            summary = "Bot responded with meaningful content (no-judge mode)"
+            if check_details.get("expected_keywords") is True:
+                summary += " | keywords matched"
+            if check_details.get("filter_evidence"):
+                summary += f" | filters: {check_details['filter_evidence']}"
+        else:
+            summary = "; ".join(failed_checks)
+
+        score = 8.0 if passed else 2.0
+        reason = summary if passed else "Deterministic check failed"
+
         return JudgeResult(
-            relevance=CriterionScore(0, "Empty response"),
-            completeness=CriterionScore(0, "Empty response"),
-            filter_accuracy=CriterionScore(0, "Empty response"),
-            tone_format=CriterionScore(0, "Empty response"),
-            no_hallucination=CriterionScore(0, "Empty response"),
-            total_score=0.0,
-            passed=False,
-            summary="Bot returned empty response",
+            relevance=CriterionScore(int(score), reason),
+            completeness=CriterionScore(int(score), reason),
+            filter_accuracy=CriterionScore(int(score), reason),
+            tone_format=CriterionScore(int(score), reason),
+            no_hallucination=CriterionScore(int(score), reason),
+            total_score=score,
+            passed=passed,
+            summary=summary,
+            check_details=check_details,
         )

--- a/scripts/e2e/report_generator.py
+++ b/scripts/e2e/report_generator.py
@@ -244,6 +244,10 @@ HTML_TEMPLATE = """<!DOCTYPE html>
                     <div class="response">{{ result.bot_response[:500] }}{% if result.bot_response|length > 500 %}...{% endif %}</div>
                     <div class="label-tag">Judge Summary:</div>
                     <div class="response">{{ result.judge_result.summary }}</div>
+                    {% if result.judge_result.check_details is not none %}
+                    <div class="label-tag">Deterministic Checks:</div>
+                    <div class="response">{{ result.judge_result.check_details | tojson }}</div>
+                    {% endif %}
                     {% if result.observability_ok is not none %}
                     <div class="label-tag">Langfuse Trace:</div>
                     <div class="response">
@@ -318,6 +322,7 @@ class ReportGenerator:
                         "tone_format": asdict(r.judge_result.tone_format),
                         "no_hallucination": asdict(r.judge_result.no_hallucination),
                         "summary": r.judge_result.summary,
+                        "check_details": r.judge_result.check_details,
                     },
                     "error": r.error,
                 }

--- a/tests/unit/e2e/test_passthrough_judge.py
+++ b/tests/unit/e2e/test_passthrough_judge.py
@@ -281,3 +281,20 @@ def test_price_evidence_euro_in_euro_word_alone_fails() -> None:
     evidence = result.check_details["filter_evidence"]
     assert evidence is not None
     assert evidence["price_max"] is False
+
+
+def test_price_evidence_fails_digits_before_longer_euro_word() -> None:
+    """Numeric text followed by longer word beginning with евро must NOT satisfy price_max."""
+    judge = PassthroughJudge(E2EConfig())
+    result = asyncio.run(
+        judge.evaluate(
+            _price_filter_scenario(),
+            "Есть 70000 европейских вариантов.",
+        )
+    )
+
+    assert result.passed is False
+    assert result.check_details is not None
+    evidence = result.check_details["filter_evidence"]
+    assert evidence is not None
+    assert evidence["price_max"] is False

--- a/tests/unit/e2e/test_passthrough_judge.py
+++ b/tests/unit/e2e/test_passthrough_judge.py
@@ -9,26 +9,153 @@ from scripts.e2e.claude_judge import PassthroughJudge
 from scripts.e2e.config import E2EConfig
 
 
-def _scenario() -> scenarios.TestScenario:
+def _chitchat_scenario() -> scenarios.TestScenario:
     return scenarios.TestScenario(
-        id="x",
-        name="sample",
-        query="query",
+        id="2.4",
+        name="How are you",
+        query="Как дела?",
         group=scenarios.TestGroup.CHITCHAT,
+        should_skip_rag=True,
     )
 
 
-def test_passthrough_judge_passes_non_empty_short_response() -> None:
+def _immigration_scenario() -> scenarios.TestScenario:
+    return scenarios.TestScenario(
+        id="0.1",
+        name="Digital Nomad visa basics",
+        query="Какие требования для визы Digital Nomad в Болгарии?",
+        group=scenarios.TestGroup.IMMIGRATION,
+        expected_keywords=["digital", "nomad", "виза", "болгар"],
+    )
+
+
+def _search_scenario() -> scenarios.TestScenario:
+    return scenarios.TestScenario(
+        id="6.3",
+        name="Complex query",
+        query="2-комн в Солнечный берег до 120к с видом на море",
+        group=scenarios.TestGroup.SEARCH,
+        expected_filters=scenarios.ExpectedFilters(
+            rooms=2, city="Солнечный берег", price_max=120000
+        ),
+        expected_keywords=["Солнечн", "мор"],
+    )
+
+
+def _price_filter_scenario() -> scenarios.TestScenario:
+    return scenarios.TestScenario(
+        id="3.1",
+        name="Price max",
+        query="квартиры до 80000 евро",
+        group=scenarios.TestGroup.PRICE_FILTERS,
+        expected_filters=scenarios.ExpectedFilters(price_max=80000),
+    )
+
+
+def test_passthrough_judge_chitchat_passes_with_response_presence() -> None:
     judge = PassthroughJudge(E2EConfig())
-    result = asyncio.run(judge.evaluate(_scenario(), "ok"))
+    result = asyncio.run(judge.evaluate(_chitchat_scenario(), "Привет! Как дела?"))
 
     assert result.passed is True
-    assert result.total_score == 8.0
+    assert result.check_details is not None
+    assert result.check_details["presence"] is True
+    assert result.check_details["expected_keywords"] is None
 
 
-def test_passthrough_judge_fails_whitespace_response() -> None:
+def test_passthrough_judge_fails_empty_response() -> None:
     judge = PassthroughJudge(E2EConfig())
-    result = asyncio.run(judge.evaluate(_scenario(), "   "))
+    result = asyncio.run(judge.evaluate(_chitchat_scenario(), ""))
 
     assert result.passed is False
-    assert result.total_score == 0.0
+    assert result.check_details is not None
+    assert result.check_details["presence"] is False
+
+
+def test_passthrough_judge_passes_with_expected_keywords() -> None:
+    judge = PassthroughJudge(E2EConfig())
+    result = asyncio.run(
+        judge.evaluate(
+            _immigration_scenario(),
+            "Для визы Digital Nomad в Болгарии нужны документы.",
+        )
+    )
+
+    assert result.passed is True
+    assert result.check_details is not None
+    assert result.check_details["expected_keywords"] is True
+
+
+def test_passthrough_judge_fails_missing_expected_keywords() -> None:
+    judge = PassthroughJudge(E2EConfig())
+    result = asyncio.run(
+        judge.evaluate(
+            _immigration_scenario(),
+            "Я не знаю, что сказать.",
+        )
+    )
+
+    assert result.passed is False
+    assert result.check_details is not None
+    assert result.check_details["expected_keywords"] is False
+
+
+def test_passthrough_judge_fails_generic_fallback_for_rag() -> None:
+    judge = PassthroughJudge(E2EConfig())
+    scenario = scenarios.TestScenario(
+        id="3.1",
+        name="Price max",
+        query="квартиры до 80000 евро",
+        group=scenarios.TestGroup.PRICE_FILTERS,
+        expected_filters=scenarios.ExpectedFilters(price_max=80000),
+    )
+    result = asyncio.run(
+        judge.evaluate(
+            scenario,
+            "К сожалению, не удалось найти подходящую информацию. "
+            "Попробуйте переформулировать запрос.",
+        )
+    )
+
+    assert result.passed is False
+    assert result.check_details is not None
+    assert result.check_details["generic_fallback"] is True
+
+
+def test_passthrough_judge_passes_without_fallback_for_rag() -> None:
+    judge = PassthroughJudge(E2EConfig())
+    result = asyncio.run(judge.evaluate(_price_filter_scenario(), "Нашел квартиру за 70 000 евро."))
+
+    assert result.passed is True
+    assert result.check_details is not None
+    assert result.check_details["generic_fallback"] is False
+
+
+def test_passthrough_judge_fails_missing_filter_evidence() -> None:
+    judge = PassthroughJudge(E2EConfig())
+    result = asyncio.run(judge.evaluate(_search_scenario(), "Есть хорошие варианты."))
+
+    assert result.passed is False
+    assert result.check_details is not None
+    evidence = result.check_details["filter_evidence"]
+    assert evidence is not None
+    assert evidence["rooms"] is False
+    assert evidence["city"] is False
+    assert evidence["price_max"] is False
+
+
+def test_passthrough_judge_passes_with_filter_evidence() -> None:
+    judge = PassthroughJudge(E2EConfig())
+    result = asyncio.run(
+        judge.evaluate(
+            _search_scenario(),
+            "2-комнатная в Солнечном береге за 120 000 евро с видом на море.",
+        )
+    )
+
+    assert result.passed is True
+    assert result.check_details is not None
+    evidence = result.check_details["filter_evidence"]
+    assert evidence is not None
+    assert evidence["rooms"] is True
+    assert evidence["city"] is True
+    assert evidence["price_max"] is True

--- a/tests/unit/e2e/test_passthrough_judge.py
+++ b/tests/unit/e2e/test_passthrough_judge.py
@@ -159,3 +159,125 @@ def test_passthrough_judge_passes_with_filter_evidence() -> None:
     assert evidence["rooms"] is True
     assert evidence["city"] is True
     assert evidence["price_max"] is True
+
+
+# ── price filter evidence: currency-only rejection ──────────────────────
+
+
+def test_price_evidence_fails_currency_only_text() -> None:
+    """Currency-only text like 'Все цены указаны в евро' must NOT satisfy price_max."""
+    judge = PassthroughJudge(E2EConfig())
+    result = asyncio.run(
+        judge.evaluate(
+            _price_filter_scenario(),
+            "Все цены указаны в евро.",
+        )
+    )
+
+    assert result.passed is False
+    assert result.check_details is not None
+    evidence = result.check_details["filter_evidence"]
+    assert evidence is not None
+    assert evidence["price_max"] is False
+
+
+def test_price_evidence_fails_euro_sign_only() -> None:
+    """Standalone € without a numeric price token must NOT satisfy price_max."""
+    judge = PassthroughJudge(E2EConfig())
+    result = asyncio.run(
+        judge.evaluate(
+            _price_filter_scenario(),
+            "Стоимость указана в €.",
+        )
+    )
+
+    assert result.passed is False
+    assert result.check_details is not None
+    evidence = result.check_details["filter_evidence"]
+    assert evidence is not None
+    assert evidence["price_max"] is False
+
+
+def test_price_evidence_passes_numeric_price_with_currency() -> None:
+    """Numeric price token together with currency passes price_max."""
+    judge = PassthroughJudge(E2EConfig())
+    result = asyncio.run(
+        judge.evaluate(
+            _price_filter_scenario(),
+            "Нашел квартиру за 70 000 евро с двумя спальнями.",
+        )
+    )
+
+    assert result.passed is True
+    assert result.check_details is not None
+    evidence = result.check_details["filter_evidence"]
+    assert evidence is not None
+    assert evidence["price_max"] is True
+
+
+def test_price_evidence_passes_numeric_price_with_euro_sign() -> None:
+    """Numeric price token with € passes price_max."""
+    judge = PassthroughJudge(E2EConfig())
+    result = asyncio.run(
+        judge.evaluate(
+            _price_filter_scenario(),
+            "Есть вариант за 65000€ в центре.",
+        )
+    )
+
+    assert result.passed is True
+    assert result.check_details is not None
+    evidence = result.check_details["filter_evidence"]
+    assert evidence is not None
+    assert evidence["price_max"] is True
+
+
+def test_price_evidence_passes_threshold_shorthand() -> None:
+    """Exact threshold shorthand (80к for 80000) passes without currency."""
+    judge = PassthroughJudge(E2EConfig())
+    result = asyncio.run(
+        judge.evaluate(
+            _price_filter_scenario(),
+            "Квартира за 80к в хорошем районе.",
+        )
+    )
+
+    assert result.passed is True
+    assert result.check_details is not None
+    evidence = result.check_details["filter_evidence"]
+    assert evidence is not None
+    assert evidence["price_max"] is True
+
+
+def test_price_evidence_fails_no_price_or_currency() -> None:
+    """Text with no price number and no currency must fail price_max."""
+    judge = PassthroughJudge(E2EConfig())
+    result = asyncio.run(
+        judge.evaluate(
+            _price_filter_scenario(),
+            "Есть хорошие варианты недвижимости.",
+        )
+    )
+
+    assert result.passed is False
+    assert result.check_details is not None
+    evidence = result.check_details["filter_evidence"]
+    assert evidence is not None
+    assert evidence["price_max"] is False
+
+
+def test_price_evidence_euro_in_euro_word_alone_fails() -> None:
+    """The substring 'евро' inside another word without a number must fail."""
+    judge = PassthroughJudge(E2EConfig())
+    result = asyncio.run(
+        judge.evaluate(
+            _price_filter_scenario(),
+            "Обсуждаем европейскую недвижимость.",
+        )
+    )
+
+    assert result.passed is False
+    assert result.check_details is not None
+    evidence = result.check_details["filter_evidence"]
+    assert evidence is not None
+    assert evidence["price_max"] is False


### PR DESCRIPTION
Closes #1489. Makes no-judge mode deterministic with product-level checks: expected keywords, generic fallback rejection for RAG/property scenarios, expected filter evidence, and looser chitchat behavior. Includes check details in reports.