### PR TITLE
perf(#1501): defer sparse/ColBERT pre-agent vector generation until semantic MISS

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -3173,6 +3173,7 @@ class PropertyBot:
                         self._cache, self._embeddings, user_text, dense, rag_result_store
                     )
                     topic_hint = get_query_topic_hint(user_text)
+                    grounding_mode_value = rag_result_store.get("grounding_mode", "normal")
                     rag_result_store["state_contract"] = _build_pre_agent_state_contract(
                         rag_result_store=rag_result_store,
                         query_type=query_type,
@@ -3182,7 +3183,7 @@ class PropertyBot:
                         if isinstance(rag_result_store.get("cache_key_sparse"), dict)
                         else None,
                         colbert_query=rag_result_store.get("cache_key_colbert"),
-                        grounding_mode="normal",
+                        grounding_mode=grounding_mode_value,
                         filters=extracted_filters or None,
                     )
                 except Exception:

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -164,6 +164,105 @@ def _build_pre_agent_state_contract(
     )
 
 
+def _has_async_method(obj: Any, name: str) -> bool:
+    method = getattr(obj, name, None)
+    return callable(method) and asyncio.iscoroutinefunction(method)
+
+
+async def _get_or_compute_pre_agent_dense(
+    cache: Any,
+    embeddings: Any,
+    query: str,
+    result_store: dict[str, Any],
+) -> list[float] | None:
+    """Compute or retrieve cached dense embedding for semantic cache lookup.
+
+    Uses ``aembed_dense_query`` when available, otherwise falls back to
+    ``aembed_query``. Records ``pre_agent_embed_ms`` and optionally
+    ``bge_model_processing_ms``.
+    """
+    dense: list[float] | None = await cache.get_embedding(query)
+    if dense is not None:
+        return dense
+
+    embed_start = time.perf_counter()
+    dense = None
+
+    if _has_async_method(embeddings, "aembed_dense_query"):
+        try:
+            result: Any = await embeddings.aembed_dense_query(query)
+            if isinstance(result, tuple) and len(result) == 2:
+                dense = result[0]
+                processing_s = result[1]
+                if isinstance(processing_s, (int, float)):
+                    result_store["bge_model_processing_ms"] = float(processing_s) * 1000
+            else:
+                dense = result
+        except Exception:
+            logger.warning("aembed_dense_query failed, falling back", exc_info=True)
+            dense = None
+
+    if dense is None and _has_async_method(embeddings, "aembed_query"):
+        dense = await embeddings.aembed_query(query)
+
+    if dense is not None:
+        await cache.store_embedding(query, dense)
+
+    result_store["pre_agent_embed_ms"] = (time.perf_counter() - embed_start) * 1000
+    return dense
+
+
+async def _prepare_pre_agent_retrieval_vectors(
+    cache: Any,
+    embeddings: Any,
+    query: str,
+    dense: list[float] | None,
+    result_store: dict[str, Any],
+) -> None:
+    """Prepare sparse and ColBERT vectors after semantic cache MISS.
+
+    Reads cached sparse, falls back to ``aembed_hybrid_with_colbert`` or
+    ``aembed_hybrid``, and then standalone ``aembed_colbert_query`` when
+    needed. Stashes ``cache_key_embedding``, ``cache_key_sparse``,
+    ``cache_key_colbert``, and ``pre_agent_retrieval_vector_ms``.
+    """
+    prep_start = time.perf_counter()
+
+    sparse = await cache.get_sparse_embedding(query)
+    colbert = None
+
+    if sparse is None:
+        if _has_async_method(embeddings, "aembed_hybrid_with_colbert"):
+            try:
+                _, sparse, colbert = await embeddings.aembed_hybrid_with_colbert(query)
+                if sparse is not None:
+                    await cache.store_sparse_embedding(query, sparse)
+            except Exception:
+                logger.debug("Pre-agent hybrid ColBERT encode failed, skipping", exc_info=True)
+                sparse = None
+                colbert = None
+        elif _has_async_method(embeddings, "aembed_hybrid"):
+            try:
+                _, sparse = await embeddings.aembed_hybrid(query)
+                if sparse is not None:
+                    await cache.store_sparse_embedding(query, sparse)
+            except Exception:
+                logger.debug("Pre-agent hybrid encode failed, skipping", exc_info=True)
+                sparse = None
+
+    if colbert is None and _has_async_method(embeddings, "aembed_colbert_query"):
+        try:
+            colbert = await embeddings.aembed_colbert_query(query)
+        except Exception:
+            logger.debug("Pre-agent ColBERT encode failed, skipping", exc_info=True)
+            colbert = None
+
+    result_store["cache_key_embedding"] = dense
+    result_store["cache_key_sparse"] = sparse
+    result_store["cache_key_colbert"] = colbert
+    result_store["pre_agent_retrieval_vector_ms"] = (time.perf_counter() - prep_start) * 1000
+
+
 async def _stream_agent_to_draft(
     agent: Any,
     payload: dict[str, Any],
@@ -2880,59 +2979,16 @@ class PropertyBot:
             if query_type in CACHEABLE_QUERY_TYPES:
                 extracted_filters: dict[str, Any] = {}
                 try:
-                    embed_start = time.perf_counter()
-                    embedding = await self._cache.get_embedding(user_text)
-                    sparse = await self._cache.get_sparse_embedding(user_text)
-                    colbert = None
-                    if embedding is None:
-                        _has_hybrid_colbert = callable(
-                            getattr(self._embeddings, "aembed_hybrid_with_colbert", None)
-                        ) and asyncio.iscoroutinefunction(
-                            self._embeddings.aembed_hybrid_with_colbert
-                        )
-                        _has_hybrid = callable(
-                            getattr(self._embeddings, "aembed_hybrid", None)
-                        ) and asyncio.iscoroutinefunction(self._embeddings.aembed_hybrid)
-                        if _has_hybrid_colbert:
-                            (
-                                embedding,
-                                sparse,
-                                colbert,
-                            ) = await self._embeddings.aembed_hybrid_with_colbert(user_text)
-                            await self._cache.store_embedding(user_text, embedding)
-                            await self._cache.store_sparse_embedding(user_text, sparse)
-                            rag_result_store["cache_key_colbert"] = colbert
-                        elif _has_hybrid:
-                            embedding, sparse = await self._embeddings.aembed_hybrid(user_text)
-                            await self._cache.store_embedding(user_text, embedding)
-                            await self._cache.store_sparse_embedding(user_text, sparse)
-                        else:
-                            embedding = await self._embeddings.aembed_query(user_text)
-                            await self._cache.store_embedding(user_text, embedding)
-                    else:
-                        # Embedding cached but sparse may have expired (#637)
-                        if sparse is None:
-                            _has_hybrid_colbert = callable(
-                                getattr(self._embeddings, "aembed_hybrid_with_colbert", None)
-                            ) and asyncio.iscoroutinefunction(
-                                self._embeddings.aembed_hybrid_with_colbert
-                            )
-                            _has_hybrid = callable(
-                                getattr(self._embeddings, "aembed_hybrid", None)
-                            ) and asyncio.iscoroutinefunction(self._embeddings.aembed_hybrid)
-                            if _has_hybrid_colbert:
-                                (
-                                    _,
-                                    sparse,
-                                    colbert,
-                                ) = await self._embeddings.aembed_hybrid_with_colbert(user_text)
-                                await self._cache.store_sparse_embedding(user_text, sparse)
-                            elif _has_hybrid:
-                                _, sparse = await self._embeddings.aembed_hybrid(user_text)
-                                await self._cache.store_sparse_embedding(user_text, sparse)
-                    rag_result_store["pre_agent_embed_ms"] = (
-                        time.perf_counter() - embed_start
-                    ) * 1000
+                    # 1. Dense embedding for semantic lookup only (#1501)
+                    dense = await _get_or_compute_pre_agent_dense(
+                        self._cache, self._embeddings, user_text, rag_result_store
+                    )
+                    # In production embeddings always expose aembed_query; this
+                    # guards the theoretical edge case where dense is unavailable.
+                    if dense is None:
+                        raise RuntimeError("Pre-agent dense embedding unavailable")
+
+                    # 2. Topic hint, grounding mode, filters, contextual query
                     topic_hint_label = get_query_topic_hint(user_text)
                     topic_hint = topic_hint_label.value if topic_hint_label is not None else None
                     grounding_mode = get_grounding_mode(
@@ -2987,7 +3043,7 @@ class PropertyBot:
                                 check_start = time.perf_counter()
                                 cached = await self._cache.check_semantic(
                                     query=user_text,
-                                    vector=embedding,
+                                    vector=dense,
                                     query_type=query_type,
                                     cache_scope="rag",
                                     agent_role=role,
@@ -3019,7 +3075,7 @@ class PropertyBot:
                             check_start = time.perf_counter()
                             cached = await self._cache.check_semantic(
                                 query=user_text,
-                                vector=embedding,
+                                vector=dense,
                                 query_type=query_type,
                                 cache_scope="rag",
                                 agent_role=role,
@@ -3037,9 +3093,8 @@ class PropertyBot:
                         logger.info("Pre-agent cache HIT (type=%s): %.60s", query_type, user_text)
                         rag_result_store["cache_hit"] = True
                         rag_result_store["query_type"] = query_type
-                        rag_result_store["cache_key_embedding"] = embedding
-                        rag_result_store["cache_key_sparse"] = sparse
-                        # Write Langfuse scores and trace metadata
+                        rag_result_store["cache_key_embedding"] = dense
+                        # Do NOT prepare sparse/ColBERT on HIT (#1501)
                         lf = get_client()
                         pre_agent_ms = (time.perf_counter() - pre_agent_start) * 1000
                         rag_result_store["pre_agent_ms"] = pre_agent_ms
@@ -3111,55 +3166,22 @@ class PropertyBot:
                         if root_trace_metadata is not None:
                             root_trace_metadata.update(cache_trace_metadata)
                         return cached
-                    # MISS: stash all embeddings so rag_pipeline can skip recomputation (#571)
+                    # MISS: prepare retrieval vectors, then build state contract (#1501)
                     logger.debug("Pre-agent cache MISS (type=%s): %.60s", query_type, user_text)
-                    rag_result_store["cache_key_embedding"] = embedding
-                    rag_result_store["cache_key_sparse"] = sparse
                     rag_result_store["query_type"] = query_type
-                    # Prefer the hybrid endpoint so BGE-M3 can return all query
-                    # representations from one request when supported.
-                    if colbert is None:
-                        _has_hybrid_colbert = callable(
-                            getattr(self._embeddings, "aembed_hybrid_with_colbert", None)
-                        ) and asyncio.iscoroutinefunction(
-                            self._embeddings.aembed_hybrid_with_colbert
-                        )
-                        _has_colbert_only = callable(
-                            getattr(self._embeddings, "aembed_colbert_query", None)
-                        ) and asyncio.iscoroutinefunction(self._embeddings.aembed_colbert_query)
-                        # Use the one-pass hybrid endpoint only when it can still
-                        # fill in missing query representations. If dense+sparse
-                        # are already cached, prefer standalone ColBERT to avoid
-                        # recomputing embeddings we already have.
-                        if _has_hybrid_colbert and (embedding is None or sparse is None):
-                            try:
-                                (
-                                    _,
-                                    sparse_from_hybrid,
-                                    colbert,
-                                ) = await self._embeddings.aembed_hybrid_with_colbert(user_text)
-                                if sparse is None and sparse_from_hybrid is not None:
-                                    sparse = sparse_from_hybrid
-                                    await self._cache.store_sparse_embedding(
-                                        user_text, sparse_from_hybrid
-                                    )
-                                    rag_result_store["cache_key_sparse"] = sparse_from_hybrid
-                            except Exception:
-                                logger.debug("Pre-agent hybrid ColBERT encode failed, skipping")
-                        elif _has_colbert_only:
-                            try:
-                                colbert = await self._embeddings.aembed_colbert_query(user_text)
-                            except Exception:
-                                logger.debug("Pre-agent ColBERT encode failed, skipping")
-                    rag_result_store["cache_key_colbert"] = colbert
+                    await _prepare_pre_agent_retrieval_vectors(
+                        self._cache, self._embeddings, user_text, dense, rag_result_store
+                    )
                     topic_hint = get_query_topic_hint(user_text)
                     rag_result_store["state_contract"] = _build_pre_agent_state_contract(
                         rag_result_store=rag_result_store,
                         query_type=query_type,
                         topic_hint=topic_hint.value if topic_hint is not None else None,
-                        dense_vector=embedding,
-                        sparse_vector=sparse if isinstance(sparse, dict) else None,
-                        colbert_query=colbert,
+                        dense_vector=dense,
+                        sparse_vector=rag_result_store.get("cache_key_sparse")
+                        if isinstance(rag_result_store.get("cache_key_sparse"), dict)
+                        else None,
+                        colbert_query=rag_result_store.get("cache_key_colbert"),
                         grounding_mode="normal",
                         filters=extracted_filters or None,
                     )

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -4969,6 +4969,52 @@ class TestPreAgentCacheCheck:
 
         assert stashed_store.get("cache_key_colbert") is None
 
+    async def test_pre_agent_cache_miss_strict_grounding_preserved_in_state_contract(
+        self, mock_config
+    ):
+        """On cache MISS with strict grounding, state_contract preserves grounding_mode (#1501)."""
+        bot, _ = _create_bot(mock_config)
+
+        dense = [0.5] * 10
+        sparse = {"indices": [1], "values": [0.7]}
+
+        bot._embeddings.aembed_dense_query = None  # unavailable
+        bot._embeddings.aembed_query = AsyncMock(return_value=dense)
+        bot._embeddings.aembed_hybrid_with_colbert = None  # unavailable
+        bot._embeddings.aembed_hybrid = AsyncMock(return_value=(dense, sparse))
+        bot._embeddings.aembed_colbert_query = None  # unavailable
+        bot._cache.get_embedding = AsyncMock(return_value=None)
+        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
+        bot._cache.store_embedding = AsyncMock()
+        bot._cache.store_sparse_embedding = AsyncMock()
+        bot._cache.check_semantic = AsyncMock(return_value=None)
+
+        stashed_store: dict = {}
+
+        async def _capture_invoke(*args, **kwargs):
+            stashed_store.update(kwargs["config"]["configurable"]["rag_result_store"])
+            return _mock_agent_result()
+
+        mock_agent = AsyncMock()
+        mock_agent.ainvoke = _capture_invoke
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+            patch("telegram_bot.bot.classify_query", return_value="FAQ"),
+        ):
+            message = _make_text_message("Какие документы нужны для ВНЖ?")
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        assert stashed_store.get("grounding_mode") == "strict"
+        contract = stashed_store.get("state_contract")
+        assert contract is not None
+        assert contract["grounding_mode"] == "strict"
+
 
 def _make_cc_callback_query(data: str, user_id: int = 12345):
     """Create a mock CallbackQuery for clearcache tests."""

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -4207,14 +4207,17 @@ class TestPreAgentCacheCheck:
         mock_agent.ainvoke.assert_called_once()
 
     async def test_pre_agent_uses_hybrid_when_available(self, mock_config):
-        """When aembed_hybrid exists, pre-agent path stashes dense+sparse only."""
+        """MISS: dense first, semantic check, then hybrid for sparse (#1501)."""
         bot, _ = _create_bot(mock_config)
 
         dense = [0.5] * 10
         sparse = {"indices": [1], "values": [0.7]}
 
+        bot._embeddings.aembed_dense_query = None  # unavailable
+        bot._embeddings.aembed_query = AsyncMock(return_value=dense)
         bot._embeddings.aembed_hybrid = AsyncMock(return_value=(dense, sparse))
-        bot._embeddings.aembed_query = AsyncMock()  # should NOT be called
+        bot._embeddings.aembed_hybrid_with_colbert = None  # unavailable
+        bot._embeddings.aembed_colbert_query = None  # unavailable
         bot._cache.get_embedding = AsyncMock(return_value=None)
         bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
         bot._cache.store_embedding = AsyncMock()
@@ -4222,11 +4225,8 @@ class TestPreAgentCacheCheck:
         bot._cache.check_semantic = AsyncMock(return_value=None)
 
         stashed_store: dict = {}
-        invoke_count = 0
 
         async def _capture_invoke(*args, **kwargs):
-            nonlocal invoke_count
-            invoke_count += 1
             stashed_store.update(kwargs["config"]["configurable"]["rag_result_store"])
             return _mock_agent_result()
 
@@ -4245,29 +4245,30 @@ class TestPreAgentCacheCheck:
                 mock_cas.typing.return_value = _make_typing_cm()
                 await bot.handle_query(message)
 
-        # aembed_hybrid must be called; aembed_query must NOT be called
+        # dense computed first, then hybrid called after semantic MISS
+        bot._embeddings.aembed_query.assert_awaited_once()
         bot._embeddings.aembed_hybrid.assert_awaited_once()
-        bot._embeddings.aembed_query.assert_not_called()
-        # sparse must be stored in cache
         bot._cache.store_sparse_embedding.assert_awaited_once()
-        # dense+sparse are stashed; ColBERT is deferred to post-semantic miss paths
         assert stashed_store.get("cache_key_embedding") == dense
         assert stashed_store.get("cache_key_sparse") == sparse
         assert stashed_store.get("cache_key_colbert") is None
+        assert stashed_store.get("state_contract") is not None
 
     async def test_pre_agent_uses_hybrid_with_colbert_and_stashes_all_three(self, mock_config):
-        """When aembed_hybrid_with_colbert exists, pre-agent stashes dense+sparse+colbert."""
+        """MISS: dense first, then hybrid_with_colbert for sparse+colbert (#1501)."""
         bot, _ = _create_bot(mock_config)
 
         dense = [0.5] * 10
         sparse = {"indices": [1], "values": [0.7]}
         colbert = [[0.2] * 10, [0.3] * 10]
 
+        bot._embeddings.aembed_dense_query = None  # unavailable
+        bot._embeddings.aembed_query = AsyncMock(return_value=dense)
         bot._embeddings.aembed_hybrid_with_colbert = AsyncMock(
             return_value=(dense, sparse, colbert)
         )
-        bot._embeddings.aembed_hybrid = AsyncMock()  # should NOT be called
-        bot._embeddings.aembed_query = AsyncMock()  # should NOT be called
+        bot._embeddings.aembed_hybrid = None  # unavailable
+        bot._embeddings.aembed_colbert_query = None  # unavailable
         bot._cache.get_embedding = AsyncMock(return_value=None)
         bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
         bot._cache.store_embedding = AsyncMock()
@@ -4295,25 +4296,26 @@ class TestPreAgentCacheCheck:
                 mock_cas.typing.return_value = _make_typing_cm()
                 await bot.handle_query(message)
 
-        # aembed_hybrid_with_colbert called; hybrid and query NOT called
+        # dense computed first, then hybrid_with_colbert after semantic MISS
+        bot._embeddings.aembed_query.assert_awaited_once()
         bot._embeddings.aembed_hybrid_with_colbert.assert_awaited_once()
-        bot._embeddings.aembed_hybrid.assert_not_called()
-        bot._embeddings.aembed_query.assert_not_called()
-        # All three vectors stashed
         assert stashed_store.get("cache_key_embedding") == dense
         assert stashed_store.get("cache_key_sparse") == sparse
         assert stashed_store.get("cache_key_colbert") == colbert
+        assert stashed_store.get("state_contract") is not None
 
     async def test_pre_agent_hybrid_colbert_fallback_to_hybrid_when_no_colbert(self, mock_config):
-        """When aembed_hybrid_with_colbert is absent, falls back to aembed_hybrid (no colbert)."""
+        """MISS: dense first, then aembed_hybrid fallback when hybrid_colbert absent."""
         bot, _ = _create_bot(mock_config)
 
         dense = [0.5] * 10
         sparse = {"indices": [1], "values": [0.7]}
 
-        bot._embeddings.aembed_hybrid_with_colbert = None  # not available
+        bot._embeddings.aembed_dense_query = None  # unavailable
+        bot._embeddings.aembed_query = AsyncMock(return_value=dense)
+        bot._embeddings.aembed_hybrid_with_colbert = None  # unavailable
         bot._embeddings.aembed_hybrid = AsyncMock(return_value=(dense, sparse))
-        bot._embeddings.aembed_query = AsyncMock()
+        bot._embeddings.aembed_colbert_query = None  # unavailable
         bot._cache.get_embedding = AsyncMock(return_value=None)
         bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
         bot._cache.store_embedding = AsyncMock()
@@ -4341,11 +4343,13 @@ class TestPreAgentCacheCheck:
                 mock_cas.typing.return_value = _make_typing_cm()
                 await bot.handle_query(message)
 
-        # aembed_hybrid called; colbert NOT stashed
+        # dense computed first, then hybrid fallback after semantic MISS
+        bot._embeddings.aembed_query.assert_awaited_once()
         bot._embeddings.aembed_hybrid.assert_awaited_once()
         assert stashed_store.get("cache_key_embedding") == dense
         assert stashed_store.get("cache_key_sparse") == sparse
         assert stashed_store.get("cache_key_colbert") is None
+        assert stashed_store.get("state_contract") is not None
 
     async def test_pre_agent_fallback_to_aembed_query_when_no_hybrid(self, mock_config):
         """Fallback to aembed_query when aembed_hybrid is not available."""
@@ -4390,13 +4394,16 @@ class TestPreAgentCacheCheck:
         assert stashed_store.get("cache_key_colbert") is None
 
     async def test_pre_agent_hybrid_stash_on_cache_hit(self, mock_config):
-        """On cache HIT with hybrid embeddings, sparse is stored and agent is skipped."""
+        """On cache HIT, only dense is computed; no sparse/ColBERT prep (#1501)."""
         bot, _ = _create_bot(mock_config)
 
         dense = [0.5] * 10
-        sparse = {"indices": [2], "values": [0.8]}
 
-        bot._embeddings.aembed_hybrid = AsyncMock(return_value=(dense, sparse))
+        bot._embeddings.aembed_dense_query = None  # unavailable
+        bot._embeddings.aembed_query = AsyncMock(return_value=dense)
+        bot._embeddings.aembed_hybrid = AsyncMock()  # should NOT be called
+        bot._embeddings.aembed_hybrid_with_colbert = None  # unavailable
+        bot._embeddings.aembed_colbert_query = None  # unavailable
         bot._cache.get_embedding = AsyncMock(return_value=None)
         bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
         bot._cache.store_embedding = AsyncMock()
@@ -4420,9 +4427,11 @@ class TestPreAgentCacheCheck:
                 mock_cas.typing.return_value = _make_typing_cm()
                 await bot.handle_query(message)
 
-        # On cache HIT, agent is NOT called but sparse must still be stored
+        # On cache HIT, agent is NOT called and no retrieval-vector prep happens
         mock_agent.ainvoke.assert_not_called()
-        bot._cache.store_sparse_embedding.assert_awaited_once()
+        bot._embeddings.aembed_query.assert_awaited_once()
+        bot._embeddings.aembed_hybrid.assert_not_called()
+        bot._cache.store_sparse_embedding.assert_not_awaited()
 
     async def test_pre_agent_hybrid_colbert_error_proceeds_to_agent(self, mock_config):
         """aembed_hybrid_with_colbert error is swallowed; agent.ainvoke still called (#633)."""
@@ -4458,17 +4467,16 @@ class TestPreAgentCacheCheck:
         mock_agent.ainvoke.assert_called_once()
 
     async def test_pre_agent_cache_hit_stashes_colbert_on_hybrid_colbert_path(self, mock_config):
-        """On cache HIT via hybrid_with_colbert, colbert is stashed and agent is skipped (#633)."""
+        """On cache HIT, only dense is computed; no hybrid_with_colbert call (#1501)."""
         bot, _ = _create_bot(mock_config)
 
         dense = [0.5] * 10
-        sparse = {"indices": [2], "values": [0.8]}
-        colbert = [[0.3] * 10, [0.4] * 10]
 
-        bot._embeddings.aembed_hybrid_with_colbert = AsyncMock(
-            return_value=(dense, sparse, colbert)
-        )
-        bot._embeddings.aembed_hybrid = AsyncMock()  # should NOT be called
+        bot._embeddings.aembed_dense_query = None  # unavailable
+        bot._embeddings.aembed_query = AsyncMock(return_value=dense)
+        bot._embeddings.aembed_hybrid_with_colbert = AsyncMock()  # should NOT be called
+        bot._embeddings.aembed_hybrid = None  # unavailable
+        bot._embeddings.aembed_colbert_query = None  # unavailable
         bot._cache.get_embedding = AsyncMock(return_value=None)
         bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
         bot._cache.store_embedding = AsyncMock()
@@ -4492,11 +4500,140 @@ class TestPreAgentCacheCheck:
                 mock_cas.typing.return_value = _make_typing_cm()
                 await bot.handle_query(message)
 
-        # On cache HIT, agent is NOT called
+        # On cache HIT, agent is NOT called and no retrieval-vector prep happens
         mock_agent.ainvoke.assert_not_called()
-        # hybrid_with_colbert was used, not hybrid
-        bot._embeddings.aembed_hybrid_with_colbert.assert_awaited_once()
+        bot._embeddings.aembed_query.assert_awaited_once()
+        bot._embeddings.aembed_hybrid_with_colbert.assert_not_called()
+        bot._cache.store_sparse_embedding.assert_not_awaited()
+
+    async def test_pre_agent_cache_hit_dense_missing_no_sparse_colbert(self, mock_config):
+        """HIT when dense missing: dense-only compute, no sparse/ColBERT prep (#1501)."""
+        bot, _ = _create_bot(mock_config)
+
+        dense = [0.5] * 10
+
+        bot._embeddings.aembed_dense_query = AsyncMock(return_value=(dense, 0.05))
+        bot._embeddings.aembed_query = AsyncMock()  # should NOT be called
+        bot._embeddings.aembed_hybrid_with_colbert = AsyncMock()  # should NOT be called
+        bot._embeddings.aembed_hybrid = AsyncMock()  # should NOT be called
+        bot._embeddings.aembed_colbert_query = AsyncMock()  # should NOT be called
+        bot._cache.get_embedding = AsyncMock(return_value=None)
+        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
+        bot._cache.store_embedding = AsyncMock()
+        bot._cache.store_sparse_embedding = AsyncMock()
+        bot._cache.check_semantic = AsyncMock(return_value="Cached answer")
+
+        mock_agent = AsyncMock()
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+            patch("telegram_bot.bot.classify_query", return_value="FAQ"),
+        ):
+            message = _make_text_message("как оформить покупку")
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        mock_agent.ainvoke.assert_not_called()
+        bot._embeddings.aembed_dense_query.assert_awaited_once()
+        bot._embeddings.aembed_query.assert_not_called()
+        bot._embeddings.aembed_hybrid_with_colbert.assert_not_called()
+        bot._embeddings.aembed_colbert_query.assert_not_called()
+        bot._cache.store_sparse_embedding.assert_not_awaited()
+
+    async def test_pre_agent_ttl_desync_hit_no_sparse_heal(self, mock_config):
+        """TTL-desync HIT: dense cached, sparse missing, but no healing on HIT (#1501)."""
+        bot, _ = _create_bot(mock_config)
+
+        cached_dense = [0.5] * 10
+
+        bot._embeddings.aembed_dense_query = None  # unavailable
+        bot._embeddings.aembed_query = AsyncMock()  # should NOT be called
+        bot._embeddings.aembed_hybrid_with_colbert = AsyncMock()  # should NOT be called
+        bot._embeddings.aembed_hybrid = AsyncMock()  # should NOT be called
+        bot._embeddings.aembed_colbert_query = AsyncMock()  # should NOT be called
+        bot._cache.get_embedding = AsyncMock(return_value=cached_dense)
+        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
+        bot._cache.store_embedding = AsyncMock()
+        bot._cache.store_sparse_embedding = AsyncMock()
+        bot._cache.check_semantic = AsyncMock(return_value="Cached answer")
+
+        mock_agent = AsyncMock()
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+            patch("telegram_bot.bot.classify_query", return_value="FAQ"),
+        ):
+            message = _make_text_message("квартиры у моря")
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        mock_agent.ainvoke.assert_not_called()
+        bot._embeddings.aembed_query.assert_not_called()
+        bot._embeddings.aembed_hybrid_with_colbert.assert_not_called()
         bot._embeddings.aembed_hybrid.assert_not_called()
+        bot._cache.store_sparse_embedding.assert_not_awaited()
+
+    async def test_pre_agent_miss_dense_then_sparse_colbert(self, mock_config):
+        """MISS: dense lookup first, semantic MISS, then sparse/ColBERT, then state_contract (#1501)."""
+        bot, _ = _create_bot(mock_config)
+
+        dense = [0.5] * 10
+        sparse = {"indices": [1], "values": [0.7]}
+        colbert = [[0.2] * 10]
+
+        bot._embeddings.aembed_dense_query = None  # unavailable
+        bot._embeddings.aembed_query = AsyncMock(return_value=dense)
+        bot._embeddings.aembed_hybrid_with_colbert = AsyncMock(
+            return_value=(dense, sparse, colbert)
+        )
+        bot._embeddings.aembed_hybrid = None  # unavailable
+        bot._embeddings.aembed_colbert_query = None  # unavailable
+        bot._cache.get_embedding = AsyncMock(return_value=None)
+        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
+        bot._cache.store_embedding = AsyncMock()
+        bot._cache.store_sparse_embedding = AsyncMock()
+        bot._cache.check_semantic = AsyncMock(return_value=None)
+
+        stashed_store: dict = {}
+
+        async def _capture_invoke(*args, **kwargs):
+            stashed_store.update(kwargs["config"]["configurable"]["rag_result_store"])
+            return _mock_agent_result()
+
+        mock_agent = AsyncMock()
+        mock_agent.ainvoke = _capture_invoke
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+            patch("telegram_bot.bot.classify_query", return_value="FAQ"),
+        ):
+            message = _make_text_message("документы для ВНЖ")
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                await bot.handle_query(message)
+
+        # Sequence: dense first, then hybrid_with_colbert after MISS
+        bot._embeddings.aembed_query.assert_awaited_once()
+        bot._embeddings.aembed_hybrid_with_colbert.assert_awaited_once()
+        assert stashed_store.get("cache_key_embedding") == dense
+        assert stashed_store.get("cache_key_sparse") == sparse
+        assert stashed_store.get("cache_key_colbert") == colbert
+        contract = stashed_store.get("state_contract")
+        assert contract is not None
+        assert contract["dense_vector"] == dense
+        assert contract["sparse_vector"] == sparse
+        assert contract["colbert_query"] == colbert
 
     async def test_pre_agent_cache_hit_respects_role_isolation(self, mock_config):
         """Cache check passes correct agent_role to check_semantic (#563)."""
@@ -4666,16 +4803,18 @@ class TestPreAgentCacheCheck:
         sparse = {"indices": [1], "values": [0.7]}
         colbert_result = [[0.2] * 10]
 
-        bot._cache.get_embedding = AsyncMock(return_value=None)
-        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
-        bot._cache.store_embedding = AsyncMock()
-        bot._cache.store_sparse_embedding = AsyncMock()
-        bot._cache.check_semantic = AsyncMock(return_value=None)
+        bot._embeddings.aembed_dense_query = None  # unavailable
+        bot._embeddings.aembed_query = AsyncMock(return_value=dense)
         bot._embeddings.aembed_hybrid_with_colbert = AsyncMock(
             return_value=(dense, sparse, colbert_result)
         )
         bot._embeddings.aembed_hybrid = AsyncMock(return_value=(dense, sparse))
         bot._embeddings.aembed_colbert_query = AsyncMock(return_value=[[0.9] * 10])
+        bot._cache.get_embedding = AsyncMock(return_value=None)
+        bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
+        bot._cache.store_embedding = AsyncMock()
+        bot._cache.store_sparse_embedding = AsyncMock()
+        bot._cache.check_semantic = AsyncMock(return_value=None)
 
         stashed_store: dict = {}
 
@@ -4698,6 +4837,8 @@ class TestPreAgentCacheCheck:
                 mock_cas.typing.return_value = _make_typing_cm()
                 await bot.handle_query(message)
 
+        # dense computed first, then hybrid_with_colbert after semantic MISS
+        bot._embeddings.aembed_query.assert_awaited_once()
         bot._embeddings.aembed_hybrid_with_colbert.assert_awaited_once()
         bot._embeddings.aembed_colbert_query.assert_not_awaited()
         assert stashed_store.get("cache_key_colbert") == colbert_result
@@ -4712,14 +4853,16 @@ class TestPreAgentCacheCheck:
         sparse = {"indices": [1], "values": [0.7]}
         colbert_result = [[0.2] * 10]
 
+        bot._embeddings.aembed_dense_query = None  # unavailable
+        bot._embeddings.aembed_query = AsyncMock(return_value=dense)
+        bot._embeddings.aembed_hybrid_with_colbert = None
+        bot._embeddings.aembed_hybrid = AsyncMock(return_value=(dense, sparse))
+        bot._embeddings.aembed_colbert_query = AsyncMock(return_value=colbert_result)
         bot._cache.get_embedding = AsyncMock(return_value=None)
         bot._cache.get_sparse_embedding = AsyncMock(return_value=None)
         bot._cache.store_embedding = AsyncMock()
         bot._cache.store_sparse_embedding = AsyncMock()
         bot._cache.check_semantic = AsyncMock(return_value=None)
-        bot._embeddings.aembed_hybrid_with_colbert = None
-        bot._embeddings.aembed_hybrid = AsyncMock(return_value=(dense, sparse))
-        bot._embeddings.aembed_colbert_query = AsyncMock(return_value=colbert_result)
 
         stashed_store: dict = {}
 
@@ -4742,6 +4885,9 @@ class TestPreAgentCacheCheck:
                 mock_cas.typing.return_value = _make_typing_cm()
                 await bot.handle_query(message)
 
+        # dense computed first, then hybrid for sparse, then colbert_query for colbert
+        bot._embeddings.aembed_query.assert_awaited_once()
+        bot._embeddings.aembed_hybrid.assert_awaited_once()
         bot._embeddings.aembed_colbert_query.assert_awaited_once()
         assert stashed_store.get("cache_key_colbert") == colbert_result
 


### PR DESCRIPTION
## Summary
- Defer expensive sparse and ColBERT pre-agent query vector generation until after semantic cache MISS.
- Add `_has_async_method`, `_get_or_compute_pre_agent_dense`, and `_prepare_pre_agent_retrieval_vectors` helpers.
- On cache HIT: only compute/retrieve dense embedding; skip sparse/ColBERT preparation entirely.
- On cache MISS: compute dense for semantic lookup first, then prepare sparse/ColBERT and populate `state_contract`.
- Update tests to assert dense-only lookup on HIT and deferred sparse/ColBERT on MISS.

## Changes
- `telegram_bot/bot.py`: Add helper functions and restructure pre-agent cache check.
- `tests/unit/test_bot_handlers.py`: Update 4 existing tests and add 3 new regression tests.