### PR TITLE
perf: reduce pre-agent BGE latency in client-direct RAG traces (#1501)

### DIFF
--- a/telegram_bot/integrations/embeddings.py
+++ b/telegram_bot/integrations/embeddings.py
@@ -44,7 +44,7 @@ class BGEM3Embeddings(Embeddings):
             batch_size=batch_size,
         )
 
-    @observe(name="bge-m3-dense-embed")
+    @observe(name="bge-m3-dense-embed", capture_input=False, capture_output=False)
     async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
         if not texts:
             return []
@@ -81,12 +81,12 @@ class BGEM3SparseEmbeddings:
             max_length=max_length,
         )
 
-    @observe(name="bge-m3-sparse-embed")
+    @observe(name="bge-m3-sparse-embed", capture_input=False, capture_output=False)
     async def aembed_query(self, text: str) -> dict[str, Any]:
         result = await self._client.encode_sparse([text])
         return result.weights[0]
 
-    @observe(name="bge-m3-sparse-embed-batch")
+    @observe(name="bge-m3-sparse-embed-batch", capture_input=False, capture_output=False)
     async def aembed_documents(self, texts: list[str]) -> list[dict[str, Any]]:
         if not texts:
             return []
@@ -116,13 +116,19 @@ class BGEM3HybridEmbeddings(Embeddings):
             max_length=max_length,
         )
 
-    @observe(name="bge-m3-hybrid-embed")
+    @observe(name="bge-m3-dense-query-embed", capture_input=False, capture_output=False)
+    async def aembed_dense_query(self, text: str) -> tuple[list[float], float | None]:
+        """Embed query text via /encode/dense, returning (dense_vector, processing_time)."""
+        result = await self._client.encode_dense([text])
+        return result.vectors[0], result.processing_time
+
+    @observe(name="bge-m3-hybrid-embed", capture_input=False, capture_output=False)
     async def aembed_hybrid(self, text: str) -> tuple[list[float], dict[str, Any]]:
         """Embed text via /encode/hybrid, returning (dense, sparse)."""
         result = await self._client.encode_hybrid([text])
         return result.dense_vecs[0], result.lexical_weights[0]
 
-    @observe(name="bge-m3-hybrid-colbert-embed")
+    @observe(name="bge-m3-hybrid-colbert-embed", capture_input=False, capture_output=False)
     async def aembed_hybrid_with_colbert(
         self, text: str
     ) -> tuple[list[float], dict[str, Any], list[list[float]]]:
@@ -143,13 +149,13 @@ class BGEM3HybridEmbeddings(Embeddings):
 
         return dense, sparse, colbert
 
-    @observe(name="bge-m3-colbert-query-embed")
+    @observe(name="bge-m3-colbert-query-embed", capture_input=False, capture_output=False)
     async def aembed_colbert_query(self, text: str) -> list[list[float]]:
         """Embed text via /encode/colbert, returning query token vectors only."""
         result = await self._client.encode_colbert([text])
         return result.colbert_vecs[0]
 
-    @observe(name="bge-m3-hybrid-embed-batch")
+    @observe(name="bge-m3-hybrid-embed-batch", capture_input=False, capture_output=False)
     async def aembed_hybrid_batch(
         self, texts: list[str]
     ) -> tuple[list[list[float]], list[dict[str, Any]]]:

--- a/tests/unit/integrations/test_embeddings.py
+++ b/tests/unit/integrations/test_embeddings.py
@@ -208,6 +208,21 @@ class TestBGEM3HybridEmbeddings:
             result = await emb.aembed_query("test")
         assert result == [0.1, 0.2]
 
+    async def test_aembed_dense_query_uses_dense_endpoint_and_returns_processing_time(self):
+        from telegram_bot.services.bge_m3_client import BGEM3Client, DenseResult
+
+        mock_client = AsyncMock(spec=BGEM3Client)
+        mock_client.encode_dense = AsyncMock(
+            return_value=DenseResult(vectors=[[0.1] * 1024], processing_time=0.123)
+        )
+
+        emb = BGEM3HybridEmbeddings(client=mock_client)
+        dense, processing_time = await emb.aembed_dense_query("test query")
+
+        assert dense == [0.1] * 1024
+        assert processing_time == 0.123
+        mock_client.encode_dense.assert_awaited_once_with(["test query"])
+
     async def test_aembed_hybrid_with_colbert(self):
         """aembed_hybrid_with_colbert returns 3-tuple (dense, sparse, colbert)."""
         from telegram_bot.services.bge_m3_client import BGEM3Client, HybridResult

--- a/tests/unit/test_observability_span_metadata.py
+++ b/tests/unit/test_observability_span_metadata.py
@@ -229,6 +229,38 @@ class TestUserBaseServiceSpanMetadata:
         )
 
 
+class TestBGEIntegrationWrapperSpanMetadata:
+    """BGE integration wrapper spans must have capture disabled."""
+
+    @pytest.fixture(scope="class")
+    def integration_spans(self):
+        path = REPO_ROOT / "telegram_bot" / "integrations" / "embeddings.py"
+        return _collect_observe_decorators(path)
+
+    @pytest.mark.parametrize(
+        "span_name",
+        [
+            "bge-m3-dense-embed",
+            "bge-m3-dense-query-embed",
+            "bge-m3-sparse-embed",
+            "bge-m3-sparse-embed-batch",
+            "bge-m3-hybrid-embed",
+            "bge-m3-hybrid-colbert-embed",
+            "bge-m3-colbert-query-embed",
+            "bge-m3-hybrid-embed-batch",
+        ],
+    )
+    def test_integration_span_has_capture_disabled(self, integration_spans, span_name):
+        assert span_name in integration_spans, f"Span '{span_name}' not found"
+        info = integration_spans[span_name]
+        assert info["capture_input"] is False, (
+            f"Span '{span_name}' must have capture_input=False (got {info['capture_input']!r})"
+        )
+        assert info["capture_output"] is False, (
+            f"Span '{span_name}' must have capture_output=False (got {info['capture_output']!r})"
+        )
+
+
 class TestBGEM3SpanRuntimeMetadata:
     """Runtime tests for BGE-M3 span metadata."""
 


### PR DESCRIPTION
## Summary
- Add `aembed_dense_query` helper to `BGEM3HybridEmbeddings` to expose BGE service `processing_time` without changing legacy wrapper return types.
- Prevent Langfuse BGE wrapper spans from capturing raw vector payloads by setting `capture_input=False, capture_output=False` on all 8 BGE integration `@observe` decorators.
- Add AST-based `TestBGEIntegrationWrapperSpanMetadata` to assert capture flags for all wrapper spans.
- Add `test_aembed_dense_query_uses_dense_endpoint_and_returns_processing_time` to verify the new helper.

## Verification
- `uv run pytest tests/unit/test_observability_span_metadata.py::TestBGEIntegrationWrapperSpanMetadata -q` ✅ 8 passed
- `uv run pytest tests/unit/integrations/test_embeddings.py::TestBGEM3HybridEmbeddings::test_aembed_dense_query_uses_dense_endpoint_and_returns_processing_time -q` ✅ 1 passed
- Combined focused ladder ✅ 11 passed

## Changed files
- `telegram_bot/integrations/embeddings.py`
- `tests/unit/integrations/test_embeddings.py`
- `tests/unit/test_observability_span_metadata.py`