### PR TITLE
fix(1501): propagate bge_model_processing_ms to client pipeline scores and metadata

### DIFF
--- a/telegram_bot/pipelines/client.py
+++ b/telegram_bot/pipelines/client.py
@@ -372,12 +372,15 @@ async def run_client_pipeline(
     pre_agent_ms = float(_store.get("pre_agent_ms", 0.0) or 0.0)
     pre_agent_embed_ms = _store.get("pre_agent_embed_ms")
     pre_agent_cache_check_ms = _store.get("pre_agent_cache_check_ms")
+    bge_model_processing_ms = _store.get("bge_model_processing_ms")
     if pre_agent_ms > 0:
         result["pre_agent_ms"] = pre_agent_ms
     if isinstance(pre_agent_embed_ms, Real):
         result["pre_agent_embed_ms"] = float(pre_agent_embed_ms)
     if isinstance(pre_agent_cache_check_ms, Real):
         result["pre_agent_cache_check_ms"] = float(pre_agent_cache_check_ms)
+    if isinstance(bge_model_processing_ms, Real) and not isinstance(bge_model_processing_ms, bool):
+        result["bge_model_processing_ms"] = float(bge_model_processing_ms)
 
     pipeline_result = await rag_pipeline(
         user_text,
@@ -529,6 +532,7 @@ async def run_client_pipeline(
         "environment": _safe_langfuse_env(config),
         "pipeline_wall_ms": wall_ms,
         "pre_agent_ms": pre_agent_ms,
+        "bge_model_processing_ms": result.get("bge_model_processing_ms"),
         "e2e_latency_ms": e2e_wall_ms,
     }
     _store.update(trace_metadata)

--- a/telegram_bot/scoring.py
+++ b/telegram_bot/scoring.py
@@ -7,6 +7,7 @@ All scores use create_score(trace_id=...) for explicit trace scoping (#435).
 
 from __future__ import annotations
 
+from numbers import Real
 from typing import Any
 
 
@@ -183,6 +184,14 @@ def write_langfuse_scores(lf: Any, result: dict, *, trace_id: str = "") -> None:
             trace_id,
             name="bge_embed_latency_ms",
             value=float(embed_latency_ms),
+        )
+    bge_model_processing_ms = result.get("bge_model_processing_ms")
+    if isinstance(bge_model_processing_ms, Real) and not isinstance(bge_model_processing_ms, bool):
+        score(
+            lf,
+            trace_id,
+            name="bge_model_processing_ms",
+            value=float(bge_model_processing_ms),
         )
 
     # --- Prompt injection defense (#226) ---

--- a/tests/unit/pipelines/test_client_pipeline.py
+++ b/tests/unit/pipelines/test_client_pipeline.py
@@ -626,6 +626,167 @@ class TestPipelineFullFlow:
         assert metadata["e2e_latency_ms"] >= metadata["pipeline_wall_ms"]
         assert rag_store["e2e_latency_ms"] >= rag_store["pipeline_wall_ms"]
 
+    async def test_pipeline_propagates_bge_model_processing_ms_to_scores(self):
+        """bge_model_processing_ms from rag_result_store reaches write_langfuse_scores input."""
+        msg = _make_message()
+        lf = _make_lf_client()
+        lf.get_current_trace_id.return_value = "trace-bge-123"
+
+        rag_result = {
+            "response": "",
+            "cache_hit": False,
+            "documents": [{"metadata": {"title": "Doc"}, "score": 0.9}],
+            "grade_confidence": 0.7,
+            "llm_call_count": 0,
+            "latency_stages": {},
+            "query_embedding": [0.1, 0.2],
+            "cache_key_embedding": [0.1, 0.2],
+        }
+        gen_result = {
+            "response": "Generated answer",
+            "response_sent": False,
+            "llm_call_count": 1,
+        }
+        rag_store = {"bge_model_processing_ms": 456.7}
+
+        with (
+            _patch_observability(lf),
+            _patch_rag_pipeline(rag_result),
+            _patch_generate_response(gen_result),
+            patch("telegram_bot.pipelines.client.write_langfuse_scores") as mock_write,
+            patch("telegram_bot.pipelines.client.score"),
+        ):
+            await run_client_pipeline(
+                user_text="Какие квартиры в центре?",
+                user_id=1,
+                session_id="s1",
+                message=msg,
+                cache=AsyncMock(),
+                embeddings=MagicMock(),
+                sparse_embeddings=MagicMock(),
+                qdrant=MagicMock(),
+                reranker=None,
+                llm=None,
+                config=_make_config(),
+                query_type="GENERAL",
+                rag_result_store=rag_store,
+            )
+
+        mock_write.assert_called_once()
+        result_passed = mock_write.call_args.args[1]
+        assert result_passed["bge_model_processing_ms"] == 456.7
+
+    async def test_pipeline_trace_metadata_includes_bge_model_processing_ms(self):
+        """bge_model_processing_ms is included in Langfuse trace metadata."""
+        msg = _make_message()
+        lf = _make_lf_client()
+
+        rag_result = {
+            "response": "",
+            "cache_hit": False,
+            "documents": [{"metadata": {"title": "Doc"}, "score": 0.9}],
+            "grade_confidence": 0.7,
+            "llm_call_count": 0,
+            "latency_stages": {},
+            "query_embedding": [0.1, 0.2],
+            "cache_key_embedding": [0.1, 0.2],
+        }
+        gen_result = {
+            "response": "Generated answer",
+            "response_sent": False,
+            "llm_call_count": 1,
+        }
+        rag_store = {"bge_model_processing_ms": 234.5}
+
+        with (
+            _patch_observability(lf),
+            _patch_rag_pipeline(rag_result),
+            _patch_generate_response(gen_result),
+            patch("telegram_bot.pipelines.client.write_langfuse_scores"),
+            patch("telegram_bot.pipelines.client.score"),
+        ):
+            await run_client_pipeline(
+                user_text="Какие квартиры в центре?",
+                user_id=1,
+                session_id="s1",
+                message=msg,
+                cache=AsyncMock(),
+                embeddings=MagicMock(),
+                sparse_embeddings=MagicMock(),
+                qdrant=MagicMock(),
+                reranker=None,
+                llm=None,
+                config=_make_config(),
+                query_type="GENERAL",
+                rag_result_store=rag_store,
+            )
+
+        trace_calls = lf.update_current_span.call_args_list
+        pipeline_call = next(
+            (c for c in trace_calls if c.kwargs.get("metadata", {}).get("pipeline_mode")),
+            None,
+        )
+        assert pipeline_call is not None
+        metadata = pipeline_call.kwargs["metadata"]
+        assert metadata["bge_model_processing_ms"] == 234.5
+        assert rag_store["bge_model_processing_ms"] == 234.5
+
+    async def test_pipeline_ignores_non_numeric_bge_model_processing_ms(self):
+        """Non-numeric bge_model_processing_ms must not pollute result or metadata."""
+        msg = _make_message()
+        lf = _make_lf_client()
+        lf.get_current_trace_id.return_value = "trace-bge-456"
+
+        rag_result = {
+            "response": "",
+            "cache_hit": False,
+            "documents": [{"metadata": {"title": "Doc"}, "score": 0.9}],
+            "grade_confidence": 0.7,
+            "llm_call_count": 0,
+            "latency_stages": {},
+            "query_embedding": [0.1, 0.2],
+            "cache_key_embedding": [0.1, 0.2],
+        }
+        gen_result = {
+            "response": "Generated answer",
+            "response_sent": False,
+            "llm_call_count": 1,
+        }
+        rag_store = {"bge_model_processing_ms": "not_a_number"}
+
+        with (
+            _patch_observability(lf),
+            _patch_rag_pipeline(rag_result),
+            _patch_generate_response(gen_result),
+            patch("telegram_bot.pipelines.client.write_langfuse_scores") as mock_write,
+            patch("telegram_bot.pipelines.client.score"),
+        ):
+            await run_client_pipeline(
+                user_text="Какие квартиры в центре?",
+                user_id=1,
+                session_id="s1",
+                message=msg,
+                cache=AsyncMock(),
+                embeddings=MagicMock(),
+                sparse_embeddings=MagicMock(),
+                qdrant=MagicMock(),
+                reranker=None,
+                llm=None,
+                config=_make_config(),
+                query_type="GENERAL",
+                rag_result_store=rag_store,
+            )
+
+        result_passed = mock_write.call_args.args[1]
+        assert "bge_model_processing_ms" not in result_passed
+        trace_calls = lf.update_current_span.call_args_list
+        pipeline_call = next(
+            (c for c in trace_calls if c.kwargs.get("metadata", {}).get("pipeline_mode")),
+            None,
+        )
+        assert pipeline_call is not None
+        assert pipeline_call.kwargs["metadata"].get("bge_model_processing_ms") is None
+
     async def test_pipeline_metadata_includes_route_topic_and_grounding_contract(self):
         """Client-direct trace metadata should expose route/topic/grounding fields early."""
         msg = _make_message()

--- a/tests/unit/test_bot_scores.py
+++ b/tests/unit/test_bot_scores.py
@@ -337,6 +337,23 @@ class TestScoreWriting:
         assert scores["answer_to_question_ratio"] == 2.4
         assert scores["response_style_applied"] == 1.0
 
+    def test_writes_bge_model_processing_latency_separately(self):
+        """BGE service processing time is a separate score from wrapper wall time."""
+        mock_lf = MagicMock()
+        result = {
+            **CACHE_HIT_RESULT,
+            "pre_agent_embed_ms": 321.5,
+            "bge_model_processing_ms": 123.0,
+        }
+        _run_score_writer(result, mock_lf)
+
+        scores = {
+            call.kwargs["name"]: call.kwargs["value"]
+            for call in mock_lf.create_score.call_args_list
+        }
+        assert scores["bge_embed_latency_ms"] == 321.5
+        assert scores["bge_model_processing_ms"] == 123.0
+
     @pytest.mark.parametrize(
         ("result_fixture", "expected_scores"),
         [


### PR DESCRIPTION
## Summary

Propagates the pre-agent BGE service processing latency `bge_model_processing_ms` from `rag_result_store` into the client-direct pipeline result and trace metadata, and writes it as a separate Langfuse score.

## Changes

- `telegram_bot/scoring.py`: writes `bge_model_processing_ms` as a separate numeric score when present in result.
- `telegram_bot/pipelines/client.py`: copies `bge_model_processing_ms` from `rag_result_store` into `result`, includes it in trace metadata, and stores it back into `rag_result_store`.
- `tests/unit/test_bot_scores.py`: verifies the new score is written separately from `bge_embed_latency_ms`.
- `tests/unit/pipelines/test_client_pipeline.py`: proves the value propagates to `write_langfuse_scores()` input and trace metadata.

## Backward Compatibility

- `bge_embed_latency_ms` behavior remains unchanged: prefers `pre_agent_embed_ms` when present, otherwise falls back to `latency_stages.cache_check * 1000`.

## Verification

- `uv run pytest tests/unit/test_bot_scores.py::TestScoreWriting -q` ✅
- `uv run pytest tests/unit/pipelines/test_client_pipeline.py -k "pre_agent or bge_model_processing" -q` ✅