### PR TITLE
feat(#1486): worktree runtime env contract for E2E trace gates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,6 +393,7 @@ LOCAL_COMPOSE_FILE := compose.yml:compose.dev.yml
 LOCAL_COMPOSE_CMD := COMPOSE_FILE=$(LOCAL_COMPOSE_FILE) $(COMPOSE_CMD) --env-file $$( [ -f .env ] && echo .env || echo tests/fixtures/compose.ci.env )
 # Runtime env for E2E trace gates: allow worktrees to point at the main checkout .env
 RAG_RUNTIME_ENV_FILE ?= $$( [ -f .env ] && echo .env || echo tests/fixtures/compose.ci.env )
+export RAG_RUNTIME_ENV_FILE
 
 .PHONY: docker-core-up docker-bot-up docker-obs-up docker-ai-up docker-ingest-up docker-voice-up docker-full-up docker-down docker-ps
 

--- a/Makefile
+++ b/Makefile
@@ -391,6 +391,8 @@ COMPOSE_CMD := docker compose --compatibility
 LOCAL_COMPOSE_FILE := compose.yml:compose.dev.yml
 # Local dev env fallback: use .env if present, otherwise safe CI fixture values
 LOCAL_COMPOSE_CMD := COMPOSE_FILE=$(LOCAL_COMPOSE_FILE) $(COMPOSE_CMD) --env-file $$( [ -f .env ] && echo .env || echo tests/fixtures/compose.ci.env )
+# Runtime env for E2E trace gates: allow worktrees to point at the main checkout .env
+RAG_RUNTIME_ENV_FILE ?= $$( [ -f .env ] && echo .env || echo tests/fixtures/compose.ci.env )
 
 .PHONY: docker-core-up docker-bot-up docker-obs-up docker-ai-up docker-ingest-up docker-voice-up docker-full-up docker-down docker-ps
 
@@ -598,17 +600,17 @@ e2e-test: ## Run pytest E2E suite (Docker/live services)
 
 e2e-telegram-test: ## Run Telegram userbot E2E runner (Telethon + judge)
 	@echo "$(BLUE)Running Telegram E2E runner...$(NC)"
-	uv run python scripts/e2e/runner.py
+	uv run --env-file "$$RAG_RUNTIME_ENV_FILE" python scripts/e2e/runner.py
 	@echo "$(GREEN)✓ Telegram E2E runner complete$(NC)"
 
 e2e-test-traces: ## Run E2E tests + validate Langfuse traces
 	@echo "$(BLUE)Running E2E tests with Langfuse trace validation...$(NC)"
-	E2E_VALIDATE_LANGFUSE=1 uv run python scripts/e2e/runner.py
+	E2E_VALIDATE_LANGFUSE=1 uv run --env-file "$$RAG_RUNTIME_ENV_FILE" python scripts/e2e/runner.py
 	@echo "$(GREEN)✓ E2E tests with trace validation complete$(NC)"
 
 e2e-test-traces-core: ## Run required #1307 Telethon scenarios with Langfuse validation
 	@echo "$(BLUE)Running #1307 core Telethon trace scenarios...$(NC)"
-	E2E_VALIDATE_LANGFUSE=1 uv run python scripts/e2e/runner.py --no-judge --scenario 0.1 --scenario 6.3 --scenario 7.1 --scenario 8.1
+	E2E_VALIDATE_LANGFUSE=1 uv run --env-file "$$RAG_RUNTIME_ENV_FILE" python scripts/e2e/runner.py --no-judge --scenario 0.1 --scenario 6.3 --scenario 7.1 --scenario 8.1
 	@echo "$(GREEN)✓ #1307 core trace scenarios complete$(NC)"
 
 e2e-test-group: ## Run specific test group (usage: make e2e-test-group GROUP=filters)

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -190,7 +190,16 @@ make e2e-test-traces-core
 
 Keep `make bot` running in another terminal while the E2E command executes. Use `make run-bot` only when you do not need the tee'd `logs/bot-run.log` evidence.
 
-## 9. Common Issues
+## 9. Runtime env in worktrees
+
+Swarm worktrees start from a fresh `origin/dev` checkout and do not contain the main checkout's `.env` or Telegram session files. To keep E2E trace gates reproducible without copying secrets into every worktree:
+
+- Compose commands must use `$(LOCAL_COMPOSE_CMD)` (or explicitly `docker compose --env-file tests/fixtures/compose.ci.env ...`) so services start with safe fallback values when `.env` is absent.
+- Telethon/E2E commands must use `uv run --env-file "$RAG_RUNTIME_ENV_FILE" ...` so runner credentials are loaded explicitly.
+- For swarm worktrees, set `RAG_RUNTIME_ENV_FILE=/home/user/projects/rag-fresh/.env` when local Telegram credentials live only in the main checkout.
+- Do not copy `.env`, Telegram sessions, or provider keys into worker worktrees.
+
+## 10. Common Issues
 
 - `docker-bot-up` fails immediately: missing required env variables in `.env`.
 - Slow first startup: BGE-M3 and Docling warm up and cache models.

--- a/tests/unit/test_makefile_contract.py
+++ b/tests/unit/test_makefile_contract.py
@@ -271,3 +271,32 @@ def test_langfuse_latest_trace_audit_runs_audit_script() -> None:
     assert "scripts/e2e/langfuse_latest_trace_audit.py" in block, (
         "langfuse-latest-trace-audit must invoke scripts/e2e/langfuse_latest_trace_audit.py"
     )
+
+
+# --- #1486 runtime env contract tests ---
+
+
+def test_e2e_trace_targets_use_runtime_env_file() -> None:
+    """E2E trace targets must load runtime env explicitly so worktrees without .env still work."""
+    text = _makefile_text()
+    for target in ("e2e-telegram-test", "e2e-test-traces", "e2e-test-traces-core"):
+        block_match = re.search(
+            rf"^{re.escape(target)}:.*?(?=^[A-Za-z0-9_.-]+:|\Z)",
+            text,
+            re.MULTILINE | re.DOTALL,
+        )
+        assert block_match, f"{target} target not found in Makefile"
+        block = block_match.group(0)
+        assert '--env-file "$$RAG_RUNTIME_ENV_FILE"' in block, (
+            f'{target} must use --env-file "$$RAG_RUNTIME_ENV_FILE" '
+            f"to load runtime credentials explicitly in worktrees"
+        )
+
+
+def test_runtime_env_file_has_safe_fallback() -> None:
+    """RAG_RUNTIME_ENV_FILE must exist and fall back to the safe CI fixture when .env is absent."""
+    text = _makefile_text()
+    assert "RAG_RUNTIME_ENV_FILE" in text, "RAG_RUNTIME_ENV_FILE not found in Makefile"
+    assert "tests/fixtures/compose.ci.env" in text, (
+        "Makefile must reference tests/fixtures/compose.ci.env as the safe fallback"
+    )

--- a/tests/unit/test_makefile_contract.py
+++ b/tests/unit/test_makefile_contract.py
@@ -294,9 +294,14 @@ def test_e2e_trace_targets_use_runtime_env_file() -> None:
 
 
 def test_runtime_env_file_has_safe_fallback() -> None:
-    """RAG_RUNTIME_ENV_FILE must exist and fall back to the safe CI fixture when .env is absent."""
+    """RAG_RUNTIME_ENV_FILE must have a safe CI-fallback *and* be exported so recipes
+    receive it even when the shell environment does not set it."""
     text = _makefile_text()
     assert "RAG_RUNTIME_ENV_FILE" in text, "RAG_RUNTIME_ENV_FILE not found in Makefile"
     assert "tests/fixtures/compose.ci.env" in text, (
         "Makefile must reference tests/fixtures/compose.ci.env as the safe fallback"
+    )
+    assert "export RAG_RUNTIME_ENV_FILE" in text, (
+        "Makefile must export RAG_RUNTIME_ENV_FILE so recipe shells "
+        "receive the Make-defined fallback even when the environment does not set it"
     )


### PR DESCRIPTION
## Summary
- Add `RAG_RUNTIME_ENV_FILE` with safe fallback to `tests/fixtures/compose.ci.env` so E2E trace gates can load runtime credentials explicitly.
- Update `e2e-telegram-test`, `e2e-test-traces`, and `e2e-test-traces-core` to use `uv run --env-file \"$$RAG_RUNTIME_ENV_FILE\" ...`.
- Add Makefile contract tests asserting the new behavior.
- Document worktree env use in `docs/LOCAL-DEVELOPMENT.md`.

## Verification
- `test_e2e_trace_targets_use_runtime_env_file` ✅
- `test_runtime_env_file_has_safe_fallback` ✅
- `test_makefile_contract.py` (all 27) ✅
- `test_local_compose_contract.py` ✅
- `test_env_example.py` ✅