### PR TITLE
fix: stabilize local test gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Unit tests (optional extras)
         run: |
           UV_PROJECT_ENVIRONMENT=.venv-py312 uv sync --extra voice --extra ingest --extra eval --all-groups
-          UV_PROJECT_ENVIRONMENT=.venv-py312 uv run pytest tests/unit/ -n auto --dist=worksteal -x -q --timeout=30 -m "requires_extras"
+          UV_PROJECT_ENVIRONMENT=.venv-py312 uv run pytest tests/unit/ -n auto --dist=worksteal -x -q --timeout=30 -m "requires_extras and not legacy_api"
 
       - name: Security scan (bandit + vulture)
         run: |

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ test-unit: ## Run core unit tests locally in parallel (fast default gate)
 
 test-unit-loadscope: ## Run unit tests with loadscope (faster fixture reuse locally)
 	@echo "$(BLUE)Running unit tests (loadscope)...$(NC)"
-	PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/unit/ -n auto --dist=loadscope -q --timeout=30 -m "not legacy_api"
+	PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/unit/ $(PYTEST_REQUIRES_EXTRAS_IGNORE) -n auto --dist=loadscope -q --timeout=30 -m "not legacy_api and not requires_extras and not slow"
 	@echo "$(GREEN)✓ Unit tests (loadscope) complete$(NC)"
 
 test-unit-full: ## Run all unit tests including optional-dep tests (nightly/main)

--- a/tests/unit/test_docker_static_validation.py
+++ b/tests/unit/test_docker_static_validation.py
@@ -44,14 +44,26 @@ def _docker_available() -> bool:
     return shutil.which("docker") is not None
 
 
+def _run_docker_command(args: list[str]) -> subprocess.CompletedProcess[str]:
+    if not _docker_available():
+        pytest.skip("Docker not available")
+    try:
+        return subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        pytest.skip("Docker not available")
+
+
 @pytest.mark.parametrize("dockerfile", DOCKERFILES)
 def test_dockerfile_exists(dockerfile: str) -> None:
     assert Path(dockerfile).is_file(), f"{dockerfile} not found"
 
 
-@pytest.mark.skipif(not _docker_available(), reason="Docker not available")
 def test_compose_dev_config_renders() -> None:
-    result = subprocess.run(
+    result = _run_docker_command(
         [
             "docker",
             "compose",
@@ -64,15 +76,12 @@ def test_compose_dev_config_renders() -> None:
             "config",
             "--quiet",
         ],
-        capture_output=True,
-        text=True,
     )
     assert result.returncode == 0, f"Compose dev config failed:\n{result.stderr}"
 
 
-@pytest.mark.skipif(not _docker_available(), reason="Docker not available")
 def test_compose_vps_config_renders() -> None:
-    result = subprocess.run(
+    result = _run_docker_command(
         [
             "docker",
             "compose",
@@ -85,16 +94,13 @@ def test_compose_vps_config_renders() -> None:
             "config",
             "--quiet",
         ],
-        capture_output=True,
-        text=True,
     )
     assert result.returncode == 0, f"Compose VPS config failed:\n{result.stderr}"
 
 
-@pytest.mark.skipif(not _docker_available(), reason="Docker not available")
 def test_compose_dev_config_renders_with_full_profile() -> None:
     """Profile-gated services must not fail merely because required env vars are unset (#1341)."""
-    result = subprocess.run(
+    result = _run_docker_command(
         [
             "docker",
             "compose",
@@ -109,8 +115,6 @@ def test_compose_dev_config_renders_with_full_profile() -> None:
             "config",
             "--quiet",
         ],
-        capture_output=True,
-        text=True,
     )
     assert result.returncode == 0, (
         f"Compose dev config with --profile full failed:\n{result.stderr}"

--- a/tests/unit/test_validate_trace_runtime.py
+++ b/tests/unit/test_validate_trace_runtime.py
@@ -14,6 +14,7 @@ def test_guard_blocks_ci_fallback_with_existing_postgres_volume(
     tmp_path: Path, monkeypatch, capsys
 ) -> None:
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
     env_file = tmp_path / "tests/fixtures/compose.ci.env"
     _write(
         env_file,
@@ -31,6 +32,7 @@ def test_guard_blocks_ci_fallback_with_existing_postgres_volume(
 
 def test_guard_allows_ci_fallback_when_volume_missing(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
     env_file = tmp_path / "tests/fixtures/compose.ci.env"
     _write(
         env_file,
@@ -43,8 +45,24 @@ def test_guard_allows_ci_fallback_when_volume_missing(tmp_path: Path, monkeypatc
     assert exit_code == 0
 
 
+def test_guard_allows_when_postgres_password_env_override(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("POSTGRES_PASSWORD", "override-password")
+    env_file = tmp_path / "tests/fixtures/compose.ci.env"
+    _write(
+        env_file,
+        "COMPOSE_PROJECT_NAME=dev\nPOSTGRES_PASSWORD=test-postgres-password\n",
+    )
+    monkeypatch.setattr(runtime_guard, "_volume_exists", lambda _: True)
+
+    exit_code = runtime_guard.main(["--env-file", str(env_file)])
+
+    assert exit_code == 0
+
+
 def test_guard_allows_when_dotenv_exists_even_if_volume_exists(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
     _write(tmp_path / ".env", "POSTGRES_PASSWORD=postgres\n")
     env_file = tmp_path / "tests/fixtures/compose.ci.env"
     _write(
@@ -62,6 +80,7 @@ def test_guard_allows_ci_fallback_with_default_password_and_existing_volume(
     tmp_path: Path, monkeypatch
 ) -> None:
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
     env_file = tmp_path / "tests/fixtures/compose.ci.env"
     _write(
         env_file,


### PR DESCRIPTION
## Summary

- `tests/unit/test_docker_static_validation.py`: move Docker CLI availability handling into a runtime helper so xdist workers skip cleanly when `docker` is unavailable, instead of raising `FileNotFoundError`.
- `tests/unit/test_validate_trace_runtime.py`: isolate `POSTGRES_PASSWORD` in guard tests and add a positive env override test.
- `Makefile`: align `test-unit-loadscope` selection with `test-unit` while keeping `--dist=loadscope`.
- `.github/workflows/ci.yml`: exclude `legacy_api` from optional extras CI lane.

## Verification

```bash
uv run pytest tests/unit/test_validate_trace_runtime.py -q
# 5 passed

uv run pytest tests/unit/test_docker_static_validation.py::test_compose_dev_config_renders tests/unit/test_docker_static_validation.py::test_compose_vps_config_renders tests/unit/test_docker_static_validation.py::test_compose_dev_config_renders_with_full_profile -q
# 3 skipped (Docker not available)

uv run ruff check tests/unit/test_docker_static_validation.py tests/unit/test_validate_trace_runtime.py
# All checks passed!

make -n test-unit-loadscope
# Selection aligned with test-unit

git diff --check
# No whitespace issues
```

## Follow-up

#1511 tracks the remaining scheduler policy cleanup.