### PR TITLE
docs(env): clarify database URL config requires explicit env values (#1522)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,6 +91,9 @@ DOCLING_URL=http://localhost:5001
 # Unified Google Drive ingestion (required for ingestion service / VPS deploys)
 GDRIVE_SYNC_DIR=/absolute/path/to/drive-sync
 GDRIVE_COLLECTION_NAME=gdrive_documents_bge
+# Database URL format: postgresql://user:pass@host:5432/dbname
+# This example matches the compose.dev.yml POSTGRES_PASSWORD default (postgres).
+# Source code requires explicit configuration — no hardcoded fallback.
 INGESTION_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/cocoindex
 
 # =============================================================================
@@ -203,6 +206,8 @@ LIVEKIT_API_SECRET=secret
 LIFECELL_SIP_USER=
 LIFECELL_SIP_PASS=
 RAG_API_URL=http://rag-api:8080
+# Database URL format: postgresql://user:pass@host:5432/dbname
+# Requires explicit configuration — no hardcoded fallback in source.
 DATABASE_URL=postgresql://postgres:postgres@postgres:5432/postgres
 
 # =============================================================================
@@ -238,6 +243,7 @@ MANAGER_HOT_LEAD_THRESHOLD=60
 MANAGER_HOT_LEAD_DEDUPE_SEC=3600
 
 # Real Estate Database
+# Requires explicit configuration — no hardcoded fallback in source.
 REALESTATE_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/realestate
 
 # ── Handoff (Forum Topics) ──────────────────────────────────────


### PR DESCRIPTION
## Summary
- #1522 requested removal of hardcoded `postgres:postgres` defaults from 3 source files
- Source code fix was already applied in prior audit commit (bd74d3b4): all 3 files now use empty string defaults
- Verification: `rg 'postgres:postgres' src/` returns no matches
- Added inline comments to `.env.example` clarifying that `INGESTION_DATABASE_URL`, `DATABASE_URL`, and `REALESTATE_DATABASE_URL` require explicit configuration (no hardcoded fallback in source)

## Verification
```
rg 'postgres:postgres' src/                    # no matches (clean)
uv run pytest tests/unit/ingestion/test_unified_config.py -v -x    # 5 passed
uv run pytest tests/unit/ingestion/test_qdrant_hybrid_target.py -v -x  # 1 skipped (cocoindex)
uv run pytest tests/unit/graph/test_config.py -v -x   # 28 passed
uv run pytest tests/unit/test_compose_runtime_contract.py -v -x    # 7 passed
uv run pytest tests/unit/test_docker_static_validation.py -v -x    # 30 passed
```

## Files changed
- `.env.example`: Added clarifying comments on database URL config lines

Closes #1522