### PR TITLE
test(codex): add unit tests for swarm session/log forensics and cleanup helpers (#1551)

### DIFF
--- a/.codex/scripts/cleanup_swarm_run.py
+++ b/.codex/scripts/cleanup_swarm_run.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Clean up swarm run artifacts after an accepted worker signal.
+
+Usage:
+    uv run python .codex/scripts/cleanup_swarm_run.py <worker-or-prefix>
+        [--worktree DIR] [--dry-run] [--archive-dir DIR]
+
+After the orchestrator accepts a worker's DONE signal, this script safely
+removes or archives:
+  - Large raw OpenCode TUI logs (logs/opencode-${PREFIX}*.log)
+  - Worker prompt copies (.codex/prompts/${PREFIX}*)
+  - Intermediate/tmp files from swarm runs
+  - Closes the worker tmux window (when applicable)
+
+It preserves:
+  - Accepted signal files (.signals/DONE-${PREFIX}*.json, .signals/launch-*, etc.)
+  - Compact artifacts produced by issue #1551 helpers
+  - The worktree itself
+
+Safety features:
+  - Dry-run mode (default prints what would be done)
+  - Requires explicit --execute flag for actual cleanup
+  - Never removes .signals/ directory content
+  - Archived files go to an archive directory, not deleted (default: .signals/archive/)
+
+Purpose (issue #1551): eliminate clutter and large log files from completed
+swarm runs while preserving all accepted artifacts and signals.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess  # nosec B404 — tmux window management, checked via shutil.which()
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+# Files/dirs to clean up (relative to worktree root)
+CLEANUP_PATTERNS = [
+    ("logs/", "opencode-${PREFIX}*.log"),
+    (".codex/prompts/", "${PREFIX}*"),
+]
+
+# Directories/files that are NEVER removed
+PROTECTED_PATHS = [
+    ".signals/",
+]
+
+# Minimum file size (bytes) for log cleanup consideration
+MIN_LOG_BYTES = 1024  # only clean logs > 1KB
+
+
+def _find_files(worktree: Path, pattern_dir: str, glob_pattern: str) -> list[Path]:
+    d = worktree / pattern_dir
+    if not d.is_dir():
+        return []
+    return sorted(d.glob(glob_pattern))
+
+
+def _plan_actions(worktree: Path, prefix: str) -> list[dict[str, Any]]:
+    """Build a list of planned cleanup actions without executing them."""
+    actions: list[dict[str, Any]] = []
+
+    for pattern_dir, glob_tmpl in CLEANUP_PATTERNS:
+        glob_pat = glob_tmpl.replace("${PREFIX}", prefix)
+        files = _find_files(worktree, pattern_dir, glob_pat)
+
+        for f in files:
+            resolved = str(f.resolve())
+            # Skip protected paths
+            if any(resolved.startswith(str((worktree / p).resolve())) for p in PROTECTED_PATHS):
+                continue
+
+            # Skip files that are too small to be worth cleaning
+            try:
+                size = f.stat().st_size
+            except OSError:
+                size = 0
+            if pattern_dir.startswith("logs") and size < MIN_LOG_BYTES:
+                continue
+
+            actions.append(
+                {
+                    "type": "archive",
+                    "path": resolved,
+                    "size_bytes": size,
+                    "reason": f"Cleanup pattern: {pattern_dir}{glob_pat}",
+                }
+            )
+
+    return actions
+
+
+def _execute_actions(actions: list[dict[str, Any]], archive_dir: Path) -> list[dict[str, Any]]:
+    """Execute cleanup actions, archiving files instead of deleting them."""
+    results: list[dict[str, Any]] = []
+    archive_dir.mkdir(parents=True, exist_ok=True)
+
+    for action in actions:
+        src = Path(action["path"])
+        if not src.exists():
+            results.append({**action, "status": "skipped", "reason": "file missing"})
+            continue
+
+        # Create a safe archive name with timestamp
+        ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        archive_name = f"{ts}_{src.name}"
+        dst = archive_dir / archive_name
+
+        try:
+            shutil.move(str(src), str(dst))
+            results.append({**action, "status": "archived", "archived_to": str(dst)})
+        except OSError as exc:
+            results.append({**action, "status": "error", "error": str(exc)})
+
+    return results
+
+
+def _close_tmux_window(worker_name: str, dry_run: bool = False) -> dict[str, Any]:
+    """Attempt to close the tmux window associated with a worker.
+
+    Uses the canonical `tmux kill-window` command. This is a best-effort
+    operation — workers may have already exited, or tmux may not be available.
+    """
+    if not shutil.which("tmux"):
+        return {"action": "close_tmux_window", "status": "skipped", "reason": "tmux not available"}
+
+    if dry_run:
+        # Try to find the window
+        try:
+            result = subprocess.run(  # nosec B603 B607 — hardcoded cmd, tmux checked via which()
+                ["tmux", "list-windows", "-F", "#{window_name}"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            windows = result.stdout.strip().split("\n")
+            matching = [w for w in windows if worker_name in w]
+            if matching:
+                return {
+                    "action": "close_tmux_window",
+                    "status": "would_close",
+                    "matching_windows": matching,
+                }
+            return {
+                "action": "close_tmux_window",
+                "status": "skipped",
+                "reason": "no matching tmux window found",
+            }
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            return {"action": "close_tmux_window", "status": "error", "error": str(exc)}
+    else:
+        # Actually close matching windows
+        try:
+            result = subprocess.run(  # nosec B603 B607 — hardcoded cmd
+                ["tmux", "list-windows", "-F", "#{window_name}"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            windows = result.stdout.strip().split("\n")
+            matching = [w for w in windows if worker_name in w]
+            closed = []
+            for w in matching:
+                subprocess.run(  # nosec B603 B607 — hardcoded cmd, window name from tmux
+                    ["tmux", "kill-window", "-t", w],
+                    capture_output=True,
+                    timeout=10,
+                )
+                closed.append(w)
+            return {
+                "action": "close_tmux_window",
+                "status": "closed" if closed else "none_found",
+                "closed_windows": closed,
+            }
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            return {"action": "close_tmux_window", "status": "error", "error": str(exc)}
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Swarm run cleaner — safely archive worker artifacts after accepted signal"
+    )
+    parser.add_argument("prefix", type=str, help="Worker name or run prefix")
+    parser.add_argument(
+        "--worktree",
+        "-w",
+        type=Path,
+        default=Path.cwd(),
+        help="Worktree root directory (default: cwd)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="Preview actions without executing (default)",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Actually perform cleanup (required for real cleanup)",
+    )
+    parser.add_argument(
+        "--archive-dir",
+        type=Path,
+        default=None,
+        help="Archive directory (default: .signals/archive/ in worktree)",
+    )
+    parser.add_argument(
+        "--no-tmux-close", action="store_true", help="Skip tmux window close attempt"
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=None,
+        help="Output action report JSON path (defaults to stdout)",
+    )
+    args = parser.parse_args()
+
+    wt = args.worktree.resolve()
+    prefix = args.prefix
+    archive_dir = args.archive_dir or wt / ".signals" / "archive"
+
+    # Check if this is an accepted run — look for a DONE signal with status "done"
+    done_files = _find_files(wt, ".signals", f"DONE-{prefix}*.json")
+    if done_files:
+        try:
+            with open(done_files[0], encoding="utf-8") as fh:
+                done_data = json.load(fh)
+        except (json.JSONDecodeError, OSError):
+            done_data = {}
+        signal_status = done_data.get("status", "unknown")
+        if signal_status != "done" and not args.execute:
+            print(
+                f"Warning: latest DONE signal status is '{signal_status}', not 'done'. "
+                f"Use --execute to force cleanup.",
+                file=sys.stderr,
+            )
+
+    actions = _plan_actions(wt, prefix)
+    results: list[dict[str, Any]] = []
+
+    if args.execute:
+        results = _execute_actions(actions, archive_dir)
+    else:
+        results = [
+            {
+                **a,
+                "status": "would_archive",
+                "archived_to": f"would be: {archive_dir / a['path'].split('/')[-1]}",
+            }
+            for a in actions
+        ]
+
+    # Tmux window close
+    tmux_result = None
+    if not args.no_tmux_close:
+        dry_run_tmux = not args.execute
+        tmux_result = _close_tmux_window(prefix, dry_run=dry_run_tmux)
+
+    report: dict[str, Any] = {
+        "format": "cleanup_report_v1",
+        "prefix": prefix,
+        "worktree": str(wt),
+        "archive_dir": str(archive_dir),
+        "dry_run": not args.execute,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "total_files_to_clean": len(actions),
+        "results": results,
+    }
+    if tmux_result:
+        report["tmux_window"] = tmux_result
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            json.dump(report, fh, indent=2, ensure_ascii=False)
+        print(f"Cleanup report written to {args.output}", file=sys.stderr)
+    else:
+        json.dump(report, sys.stdout, indent=2, ensure_ascii=False)
+        sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.codex/scripts/opencode_log_markers.py
+++ b/.codex/scripts/opencode_log_markers.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Strip ANSI, find byte-offset markers, and return bounded snippets from OpenCode logs.
+
+Usage:
+    uv run python .codex/scripts/opencode_log_markers.py <opencode-log> [options]
+
+Scans an OpenCode TUI (terminal UI) log file and:
+  - Strips ANSI escape sequences
+  - Locates important markers: DONE, FAILED, BLOCKED, swarm_notify_orchestrator,
+    validators, errors, exceptions, tracebacks
+  - For each marker, returns a bounded snippet (±N lines context) with byte
+    offsets and line numbers
+  - Supports output as compact JSON or human-readable text
+
+Purpose (issue #1551): prevents agents from ever tailing/rg-ing raw TUI logs
+which can dump huge ANSI-bloated chunks into context.  Instead, this tool
+produces deterministic, bounded marker summaries.
+
+Markers searched (case-sensitive):
+  - swarm_notify_orchestrator
+  - DONE JSON / "DONE"
+  - FAILED / BLOCKED
+  - error / Error / ERROR
+  - exception / traceback
+  - validator / acceptance / precheck
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+# Canonical markers to search for (regex, label)
+MARKER_PATTERNS: list[tuple[str, str]] = [
+    (r"swarm_notify_orchestrator", "orchestrator_wakeup"),
+    (r'"status"\s*:\s*"DONE"', "DONE_status"),
+    (r'"status"\s*:\s*"done"', "done_status"),
+    (r'"status"\s*:\s*"FAILED"', "FAILED_status"),
+    (r'"status"\s*:\s*"BLOCKED"', "BLOCKED_status"),
+    (r'"status"\s*:\s*"blocked"', "blocked_status"),
+    (r'"status"\s*:\s*"failed"', "failed_status"),
+    (
+        r"\bacceptance\b.*\bprecheck\b",
+        "acceptance_precheck",
+    ),
+    (
+        r"\bprecheck\b.*\bacceptance\b",
+        "acceptance_precheck",
+    ),
+    (r"\bvalidator\b", "validator"),
+    (r"\bTraceback \(most recent call last\)", "traceback"),
+    (r"\bException\b", "exception"),
+    (r"\bError\b", "error"),
+    (r"\bERROR\b", "ERROR"),
+    (r'"review_decision"\s*:\s*"blockers"', "review_blockers"),
+    (r'"review_decision"\s*:\s*"clean"', "review_clean"),
+    (r'"review_decision"\s*:\s*"escalate"', "review_escalate"),
+]
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
+ANSI_CSI_ESC = re.compile(r"\x1b\][^\x07]*\x07")  # OSC sequences (title, etc.)
+
+
+def strip_ansi(text: str) -> str:
+    """Strip ANSI escape sequences from *text*."""
+    return ANSI_CSI_ESC.sub("", ANSI_RE.sub("", text))
+
+
+def find_markers(lines: list[str], patterns: list[tuple[str, str]]) -> list[dict[str, Any]]:
+    """Search *lines* (after possible ANSI stripping) for each pattern.
+
+    Returns a list of marker dicts with line number, byte offset, matched text,
+    pattern label, and bounded snippet.
+    """
+    markers: list[dict[str, Any]] = []
+    for i, line in enumerate(lines, start=1):
+        for pat, label in patterns:
+            m = re.search(pat, line)
+            if m:
+                markers.append(
+                    {
+                        "line": i,
+                        "label": label,
+                        "pattern": pat,
+                        "matched_text": m.group(0),
+                        "full_line": line.rstrip(),
+                    }
+                )
+    return markers
+
+
+def extract_snippets(
+    lines: list[str], markers: list[dict[str, Any]], context: int = 5
+) -> list[dict[str, Any]]:
+    """For each marker, attach bounded context (±*context* lines)."""
+    snippets: list[dict[str, Any]] = []
+    for mk in markers:
+        ln = mk["line"]
+        start = max(0, ln - context - 1)
+        end = min(len(lines), ln + context)
+        snippets.append(
+            {
+                "marker": mk,
+                "context_before": lines[start : ln - 1],
+                "marker_line": lines[ln - 1].rstrip(),
+                "context_after": lines[ln:end],
+                "byte_offset_start": sum(len(s) for s in lines[:start])
+                if start < len(lines)
+                else 0,
+                "byte_offset_end": sum(len(s) for s in lines[:end])
+                if end <= len(lines)
+                else sum(len(s) for s in lines),
+            }
+        )
+    return snippets
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="OpenCode log marker scanner — strip ANSI, find markers, emit bounded snippets"
+    )
+    parser.add_argument("log_file", type=Path, help="OpenCode TUI log file path")
+    parser.add_argument(
+        "--context",
+        "-c",
+        type=int,
+        default=5,
+        help="Lines of context around each marker (default: 5)",
+    )
+    parser.add_argument(
+        "--no-strip",
+        action="store_true",
+        help="Skip ANSI stripping (useful if log is already clean)",
+    )
+    parser.add_argument(
+        "--output", "-o", type=Path, default=None, help="Output JSON path (defaults to stdout)"
+    )
+    parser.add_argument(
+        "--summary-only", action="store_true", help="Only emit marker counts, no snippets"
+    )
+    args = parser.parse_args()
+
+    log_path = args.log_file
+    if not log_path.exists():
+        print(f"Log file not found: {log_path}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        with open(log_path, encoding="utf-8") as fh:
+            raw_lines = fh.readlines()
+    except OSError as exc:
+        print(f"Error reading {log_path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    lines = raw_lines if args.no_strip else [strip_ansi(line) for line in raw_lines]
+
+    markers = find_markers(lines, MARKER_PATTERNS)
+    snippets = extract_snippets(lines, markers, context=args.context)
+
+    # Count by label
+    label_counts: dict[str, int] = {}
+    for mk in markers:
+        label_counts[mk["label"]] = label_counts.get(mk["label"], 0) + 1
+
+    result: dict[str, Any] = {
+        "format": "opencode_markers_v1",
+        "file": str(log_path.resolve()),
+        "total_lines": len(lines),
+        "total_bytes_raw": log_path.stat().st_size,
+        "stripped_ansi": not args.no_strip,
+        "context_window": args.context,
+        "total_markers_found": len(markers),
+        "marker_counts": label_counts,
+    }
+
+    if args.summary_only:
+        result["snippets"] = []
+    else:
+        result["snippets"] = snippets
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            json.dump(result, fh, indent=2, ensure_ascii=False)
+        print(f"Markers written to {args.output}", file=sys.stderr)
+    else:
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+        sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.codex/scripts/session_extract_spikes.py
+++ b/.codex/scripts/session_extract_spikes.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Extract bounded JSON-serialisable snippets around token spikes from a session profile.
+
+Usage:
+    uv run python .codex/scripts/session_extract_spikes.py profile.json [threshold]
+
+Reads a profile produced by session_log_profile.py, finds spike events whose
+absolute token delta exceeds *threshold* (default 5000), and emits compact
+snippets with bounded context and line references.  Purpose: give the
+orchestrator focused spike evidence instead of raw full-profile JSON or
+full-session transcripts.
+
+Note: The profile already contains spike_jumps_over_threshold; this script lets
+you re-filter at a different threshold without re-parsing the original JSONL.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _bounded_snippets(
+    timeline: list[dict[str, Any]], spike_lines: set[int], context: int = 3
+) -> list[dict[str, Any]]:
+    """Return bounded snippets around *spike_lines* with *context* entries each side."""
+    snippets: list[dict[str, Any]] = []
+    for idx, entry in enumerate(timeline):
+        line = entry.get("line", 0)
+        if line not in spike_lines:
+            continue
+        start = max(0, idx - context)
+        end = min(len(timeline), idx + context + 1)
+        snippets.append(
+            {
+                "spike_line": line,
+                "spike_delta": entry.get("delta"),
+                "spike_ts": entry.get("ts", ""),
+                "context_before": timeline[start:idx],
+                "spike_entry": entry,
+                "context_after": timeline[idx + 1 : end],
+            }
+        )
+    return snippets
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Extract bounded snippets around token spikes from a session profile"
+    )
+    parser.add_argument("profile", type=Path, help="Profile JSON from session_log_profile.py")
+    parser.add_argument(
+        "threshold",
+        type=int,
+        nargs="?",
+        default=5000,
+        help="Minimum absolute token delta to treat as a spike (default: 5000)",
+    )
+    parser.add_argument(
+        "--context",
+        "-c",
+        type=int,
+        default=3,
+        help="Number of timeline entries of context each side (default: 3)",
+    )
+    parser.add_argument(
+        "--output", "-o", type=Path, default=None, help="Output JSON path (defaults to stdout)"
+    )
+    args = parser.parse_args()
+
+    with open(args.profile, encoding="utf-8") as fh:
+        profile = json.load(fh)
+
+    timeline = profile.get("token_timeline", [])
+    if not timeline:
+        print("No token timeline in profile — nothing to extract.", file=sys.stderr)
+        sys.exit(1)
+
+    all_jumps = profile.get("largest_token_jumps", [])
+    spike_lines = {j["line"] for j in all_jumps if j["abs_delta"] > args.threshold}
+
+    snippets = _bounded_snippets(timeline, spike_lines, context=args.context)
+
+    result = {
+        "format": "spike_snippets_v1",
+        "threshold": args.threshold,
+        "context_window": args.context,
+        "total_spikes": len(spike_lines),
+        "snippets": snippets,
+    }
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            json.dump(result, fh, indent=2, ensure_ascii=False)
+        print(f"Snippets written to {args.output}", file=sys.stderr)
+    else:
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+        sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.codex/scripts/session_log_profile.py
+++ b/.codex/scripts/session_log_profile.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Parse a Codex rollout JSONL log and emit a compact session profile as JSON.
+
+Usage:
+    uv run python .codex/scripts/session_log_profile.py <codex-rollout.jsonl> [--output profile.json]
+
+Output: compact JSON with:
+  - Token timeline: per-event token counts with line/timestamp refs
+  - Largest token jumps: events where token delta exceeded thresholds
+  - Tool calls: count, output sizes, and suspicious patterns
+  - Suspicious commands: repeated polling, large output volumes
+  - Summary statistics
+
+Purpose (issue #1551): Codex/OpenCode orchestrator can consume this profile
+instead of reading raw JSONL transcripts, saving context and avoiding accidental
+large-dump incidents.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+MAX_OUTPUT_BYTES = 500_000  # flag any tool output exceeding this
+MAX_DELTA_TOKENS = 5_000  # flag token jumps exceeding this
+SUSPICIOUS_COMMAND_PATTERNS = (
+    "--print-logs",
+    "tail -f",
+    "cat ",
+    "rg ",
+    "grep ",
+    "find ",
+)
+
+
+@dataclass
+class _Event:
+    line: int
+    ts: str
+    role: str
+    token_count: int | None
+    delta: int | None
+    tool_name: str | None
+    tool_input_str: str | None
+    output_bytes: int | None
+    warnings: list[str] = field(default_factory=list)
+
+
+def _strip_ansi(text: str) -> str:
+    """Strip ANSI escape sequences from *text*."""
+    # minimal regex — full ANSI stripping is complex; this covers common ESC[ codes
+    import re
+
+    return re.sub(r"\x1b\[[0-9;]*[a-zA-Z]", "", text).rstrip()
+
+
+def _parse_jsonl(path: str | Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                records.append(json.loads(stripped))
+            except json.JSONDecodeError:
+                # corrupted line — skip but note in output
+                records.append({"_parse_error": True, "_raw": stripped[:200]})
+    return records
+
+
+def _token_from(rec: dict[str, Any]) -> int | None:
+    """Best-effort extract token count from a Codex JSONL record.
+
+    Codex records come from the Anthropic API streaming format.  Typical paths:
+
+    * message_start.message.usage.input_tokens → int
+    * message_delta.usage.output_tokens → int
+    * content_block_start / content_block_delta → may carry usage
+    * Defaults: check rec['usage'], rec.get('token_count'), etc.
+    """
+    # message_start in Anthropic streaming
+    ms = rec.get("message_start", {})
+    if isinstance(ms, dict):
+        msg = ms.get("message", {})
+        if isinstance(msg, dict):
+            usage = msg.get("usage", {})
+            if isinstance(usage, dict):
+                inp = usage.get("input_tokens")
+                if isinstance(inp, int):
+                    return inp
+
+    # message_delta
+    md = rec.get("message_delta", {})
+    if isinstance(md, dict):
+        usage = md.get("usage", {})
+        if isinstance(usage, dict):
+            out = usage.get("output_tokens")
+            if isinstance(out, int):
+                return out
+
+    # flat usage field (OpenAI-style records)
+    usage = rec.get("usage", {})
+    if isinstance(usage, dict):
+        tot = usage.get("total_tokens")
+        if isinstance(tot, int):
+            return tot
+
+    # heuristic: token_count key
+    tc = rec.get("token_count")
+    if isinstance(tc, int):
+        return tc
+
+    return None
+
+
+def _tool_info(rec: dict[str, Any]) -> tuple[str | None, int | None]:
+    """Return (tool_name, output_bytes) from a Codex JSONL record.
+
+    Codex tool-use records typically have 'content_block_start' or
+    'tool_result' keys with 'content' or 'output' sub-keys.
+    """
+    # Anthropic-style tool_use
+    cbs = rec.get("content_block_start", {})
+    if isinstance(cbs, dict):
+        cb = cbs.get("content_block", {})
+        if isinstance(cb, dict) and cb.get("type") == "tool_use":
+            return (cb.get("name"), None)
+
+    # tool result with content
+    tr = rec.get("tool_result", {})
+    if isinstance(tr, dict):
+        content = tr.get("content", "")
+        if isinstance(content, (str, list)):
+            if isinstance(content, list):
+                content = json.dumps(content)
+            return (None, len(content.encode("utf-8")))
+
+    # Generic tool output
+    output = rec.get("output")
+    if isinstance(output, str):
+        return (None, len(output.encode("utf-8")))
+
+    return (None, None)
+
+
+def _make_profile(records: list[dict[str, Any]]) -> dict[str, Any]:
+    events: list[_Event] = []
+    prev_tokens: int | None = None
+    tool_calls: list[dict[str, Any]] = []
+    suspicious: list[dict[str, Any]] = []
+
+    for idx, rec in enumerate(records, start=1):
+        if rec.get("_parse_error"):
+            events.append(
+                _Event(
+                    line=idx,
+                    ts="",
+                    role="parse_error",
+                    token_count=0,
+                    delta=0,
+                    tool_name=None,
+                    tool_input_str=None,
+                    output_bytes=None,
+                )
+            )
+            continue
+
+        ts = str(rec.get("timestamp", rec.get("ts", "")))
+        role = str(rec.get("role", rec.get("type", "")))
+
+        tc = _token_from(rec)
+        tool_name, out_bytes = _tool_info(rec)
+        warnings: list[str] = []
+
+        delta = None
+        if tc is not None and prev_tokens is not None:
+            delta = tc - prev_tokens
+
+        if tool_name is not None or out_bytes is not None:
+            tool_calls.append(
+                {
+                    "line": idx,
+                    "ts": ts,
+                    "tool_name": tool_name,
+                    "output_bytes": out_bytes,
+                }
+            )
+
+        # Suspicious command patterns
+        if tool_name:
+            inp_str = json.dumps(rec.get("input", rec.get("arguments", {})))
+            for pat in SUSPICIOUS_COMMAND_PATTERNS:
+                if pat.lower() in inp_str.lower():
+                    suspicious.append(
+                        {
+                            "line": idx,
+                            "ts": ts,
+                            "reason": f"Command pattern '{pat}' detected in tool input",
+                            "tool": tool_name,
+                        }
+                    )
+                    break
+
+        # Large output
+        if out_bytes and out_bytes > MAX_OUTPUT_BYTES:
+            warnings.append(f"Output exceeds {MAX_OUTPUT_BYTES} bytes ({out_bytes})")
+            suspicious.append(
+                {
+                    "line": idx,
+                    "ts": ts,
+                    "reason": f"Tool output size {out_bytes} > {MAX_OUTPUT_BYTES}",
+                    "tool": tool_name,
+                }
+            )
+
+        events.append(
+            _Event(
+                line=idx,
+                ts=ts,
+                role=role,
+                token_count=tc,
+                delta=delta,
+                tool_name=tool_name,
+                tool_input_str=None,
+                output_bytes=out_bytes,
+                warnings=warnings,
+            )
+        )
+        if tc is not None:
+            prev_tokens = tc
+
+    # Build token timeline
+    timeline: list[dict[str, Any]] = []
+    for e in events:
+        entry: dict[str, Any] = {"line": e.line, "ts": e.ts}
+        if e.token_count is not None:
+            entry["tokens"] = e.token_count
+        if e.delta is not None:
+            entry["delta"] = e.delta
+        if e.role:
+            entry["role"] = e.role
+        if e.warnings:
+            entry["warnings"] = e.warnings
+        if entry.get("tokens") is not None or entry.get("delta") is not None:
+            timeline.append(entry)
+
+    # Largest token jumps (absolute delta)
+    deltas = sorted(
+        [(e.line, abs(e.delta), e.delta, e.ts) for e in events if e.delta is not None],
+        key=lambda x: x[1],
+        reverse=True,
+    )
+    largest_jumps = [
+        {"line": line, "abs_delta": abs_d, "delta": d, "ts": ts}
+        for line, abs_d, d, ts in deltas[:20]
+    ]
+
+    # Jumps exceeding threshold
+    spike_jumps = [j for j in largest_jumps if j["abs_delta"] > MAX_DELTA_TOKENS]
+
+    # Summary
+    token_values = [tc for e in events if e.token_count is not None for tc in (e.token_count,)]
+    total_records = len(records)
+    total_tool_calls = len(tool_calls)
+    total_output_bytes = sum((tc.get("output_bytes") or 0) for tc in tool_calls)
+
+    return {
+        "format": "session_profile_v1",
+        "total_records": total_records,
+        "total_events_with_tokens": len(token_values),
+        "max_tokens": max(token_values) if token_values else 0,
+        "min_tokens": min(token_values) if token_values else 0,
+        "token_timeline": timeline,
+        "largest_token_jumps": largest_jumps,
+        "spike_jumps_over_threshold": spike_jumps,
+        "threshold_delta_tokens": MAX_DELTA_TOKENS,
+        "tool_calls_total": total_tool_calls,
+        "tool_output_bytes_total": total_output_bytes,
+        "tool_call_details": tool_calls,
+        "suspicious_commands": suspicious,
+    }
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Codex session log profiler — emit compact token/payload profile from JSONL"
+    )
+    parser.add_argument("input", type=Path, help="Codex rollout JSONL file")
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=None,
+        help="Output profile JSON path (defaults to stdout)",
+    )
+    args = parser.parse_args()
+
+    records = _parse_jsonl(args.input)
+    profile = _make_profile(records)
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            json.dump(profile, fh, indent=2, ensure_ascii=False)
+        print(f"Profile written to {args.output}", file=sys.stderr)
+    else:
+        json.dump(profile, sys.stdout, indent=2, ensure_ascii=False)
+        sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.codex/scripts/swarm_run_correlate.py
+++ b/.codex/scripts/swarm_run_correlate.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Build a compact run dossier from swarm worker metadata files.
+
+Usage:
+    uv run python .codex/scripts/swarm_run_correlate.py <worker-or-run-prefix>
+        [--worktree DIR] [--output dossier.json]
+
+Given a worker name or run prefix (e.g. "worker-1551-swarm-helpers"), this
+script scans a swarm worktree for:
+  - .signals/launch-${PREFIX}*.json
+  - .signals/secretary-${PREFIX}*.json
+  - .signals/wakeup-${PREFIX}*.json
+  - .signals/DONE-${PREFIX}*.json  (and other signal files)
+  - .codex/prompts/${PREFIX}* (worker prompt files)
+  - logs/opencode-${PREFIX}*.log   (just stat info, not raw content)
+
+and emits a compact JSON dossier with key metadata, timestamps, status, and
+file references.  The dossier is safe to read into orchestrator context without
+unbounded log scanning.
+
+Purpose (issue #1551): replace manual artifact correlation with a deterministic
+per-run dossier.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+def _find_files(worktree: Path, pattern_dir: str, glob_pattern: str) -> list[Path]:
+    d = worktree / pattern_dir
+    if not d.is_dir():
+        return []
+    files = sorted(d.glob(glob_pattern))
+    return list(files)
+
+
+def _stat_info(p: Path) -> dict[str, Any]:
+    try:
+        st = p.stat()
+        return {
+            "path": str(p),
+            "size_bytes": st.st_size,
+            "mtime": datetime.fromtimestamp(st.st_mtime, tz=UTC).isoformat(),
+        }
+    except OSError:
+        return {"path": str(p), "error": "stat failed"}
+
+
+def _load_json_safe(p: Path) -> dict[str, Any] | None:
+    try:
+        with open(p, encoding="utf-8") as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        return None
+    except (json.JSONDecodeError, OSError) as exc:
+        return {"_load_error": str(exc)}
+
+
+def _safe_read_head(p: Path, lines: int = 20) -> str:
+    """Read first *lines* lines of a text file safely."""
+    try:
+        with open(p, encoding="utf-8") as fh:
+            return "".join(fh.readline() for _ in range(lines))
+    except OSError as exc:
+        return f"[read error: {exc}]"
+
+
+def _extract_key_meta(data: dict[str, Any] | None, prefix: str) -> dict[str, Any]:
+    if data is None:
+        return {}
+    if isinstance(data.get("_load_error"), str):
+        return {"_load_error": data["_load_error"]}
+    # Pull key fields only — we want a compact dossier
+    keys = {
+        "launch": [
+            "worker",
+            "runner",
+            "agent",
+            "model",
+            "variant",
+            "started_at",
+            "prompt_sha256",
+            "issue",
+            "required_skills",
+            "prompt_file",
+            "worktree",
+            "route_check_confirmed",
+        ],
+        "wakeup": ["worker", "status", "tag", "sent_at", "signal_file"],
+        "signal": [
+            "status",
+            "issue",
+            "summary",
+            "review_decision",
+            "changed_files",
+            "findings",
+            "blockers_found",
+            "blockers_resolved",
+            "new_bugs",
+            "verification_budget",
+            "next_action",
+            "ts",
+        ],
+        "secretary": ["issue", "title", "route", "status", "summary", "ts", "brief"],
+    }
+    kset = keys.get(prefix, [])
+    if not kset:
+        return {}
+    return {k: data[k] for k in kset if k in data}
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Swarm run correlator — build compact run dossier from metadata files"
+    )
+    parser.add_argument("prefix", type=str, help="Worker name or run prefix")
+    parser.add_argument(
+        "--worktree",
+        "-w",
+        type=Path,
+        default=Path.cwd(),
+        help="Worktree root directory (default: cwd)",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=None,
+        help="Output dossier JSON path (defaults to stdout)",
+    )
+    parser.add_argument(
+        "--include-log-head",
+        action="store_true",
+        help="Include first 20 lines of the raw OpenCode log (off by default)",
+    )
+    args = parser.parse_args()
+
+    wt = args.worktree.resolve()
+    prefix = args.prefix
+
+    # Collect files
+    launch_files = _find_files(wt, ".signals", f"launch-{prefix}*.json")
+    wakeup_files = _find_files(wt, ".signals", f"wakeup-{prefix}*.json")
+    secretary_files = _find_files(wt, ".signals", f"secretary-{prefix}*.json")
+    done_files = _find_files(wt, ".signals", f"DONE-{prefix}*.json")
+    exit_files = _find_files(wt, ".signals", f"exit-{prefix}*.json")
+    all_signal_files = _find_files(wt, ".signals", "*.json")
+
+    prompt_files = _find_files(wt, ".codex/prompts", f"{prefix}*")
+
+    log_files = _find_files(wt, "logs", f"opencode-{prefix}*.log")
+
+    # Build dossier
+    dossier: dict[str, Any] = {
+        "format": "run_dossier_v1",
+        "prefix": prefix,
+        "worktree": str(wt),
+        "generated_at": datetime.now(UTC).isoformat(),
+    }
+
+    # Launch metadata
+    if launch_files:
+        launch_data = _load_json_safe(launch_files[0])
+        dossier["launch"] = _extract_key_meta(launch_data, "launch")
+        dossier["launch"]["_file"] = str(launch_files[0])
+    else:
+        dossier["launch"] = None
+
+    # Wakeup metadata
+    dossier["wakeups"] = []
+    for wf in wakeup_files:
+        wdata = _load_json_safe(wf)
+        meta = _extract_key_meta(wdata, "wakeup")
+        meta["_file"] = str(wf)
+        dossier["wakeups"].append(meta)
+
+    # DONE/exit signals
+    all_completion_files = done_files + exit_files
+    dossier["completion_signals"] = []
+    for cf in all_completion_files:
+        cdata = _load_json_safe(cf)
+        meta = _extract_key_meta(cdata, "signal")
+        meta["_file"] = str(cf)
+        dossier["completion_signals"].append(meta)
+
+    # Secretary briefs (may have been inline in launch or separate file)
+    dossier["secretary_briefs"] = []
+    for sf in secretary_files:
+        sdata = _load_json_safe(sf)
+        meta = _extract_key_meta(sdata, "secretary")
+        meta["_file"] = str(sf)
+        dossier["secretary_briefs"].append(meta)
+
+    # Prompt file info
+    dossier["prompt_files"] = []
+    for pf in prompt_files:
+        info = _stat_info(pf)
+        if args.include_log_head:
+            info["head_lines"] = _safe_read_head(pf, 20)
+        dossier["prompt_files"].append(info)
+
+    # Log file info (stat only, not content)
+    dossier["log_files"] = []
+    for lf in log_files:
+        info = _stat_info(lf)
+        if args.include_log_head:
+            info["head_lines"] = _safe_read_head(lf, 20)
+        dossier["log_files"].append(info)
+
+    # Summary stats
+    log_total_bytes = sum(
+        f.get("size_bytes", 0) for f in dossier["log_files"] if isinstance(f.get("size_bytes"), int)
+    )
+    dossier["summary"] = {
+        "launch_exists": bool(launch_files),
+        "wakeup_count": len(wakeup_files),
+        "completion_signal_count": len(all_completion_files),
+        "secretary_brief_count": len(secretary_files),
+        "prompt_file_count": len(prompt_files),
+        "log_file_count": len(log_files),
+        "log_total_bytes": log_total_bytes,
+        "signal_file_count": len(all_signal_files),
+    }
+
+    # Determine run status
+    latest_status = "unknown"
+    for meta in dossier["completion_signals"]:
+        if meta.get("status"):
+            latest_status = meta["status"]
+    if wakeup_files and not dossier["completion_signals"]:
+        for w in dossier["wakeups"]:
+            if w.get("status"):
+                latest_status = w["status"]
+    dossier["inferred_status"] = latest_status
+
+    # Output
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            json.dump(dossier, fh, indent=2, ensure_ascii=False)
+        print(f"Dossier written to {args.output}", file=sys.stderr)
+    else:
+        json.dump(dossier, sys.stdout, indent=2, ensure_ascii=False)
+        sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/codex/__init__.py
+++ b/tests/unit/codex/__init__.py
@@ -1,0 +1,1 @@
+# Unit tests for .codex/scripts/ swarm helpers (issue #1551)

--- a/tests/unit/codex/test_swarm_helpers.py
+++ b/tests/unit/codex/test_swarm_helpers.py
@@ -1,0 +1,765 @@
+"""Unit tests for .codex/scripts/ swarm session/log forensics and cleanup helpers.
+
+Covers all five helpers from issue #1551:
+  - session_log_profile.py
+  - session_extract_spikes.py
+  - swarm_run_correlate.py
+  - opencode_log_markers.py
+  - cleanup_swarm_run.py
+
+The tests are focused, local-fast, and do NOT require Docker, tmux, or real
+Codex/OpenCode sessions. They operate on synthetic fixtures.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+# Make .codex/scripts importable
+_SCRIPTS_DIR = Path(__file__).resolve().parents[3] / ".codex" / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmpdir() -> Path:
+    with tempfile.TemporaryDirectory() as td:
+        yield Path(td)
+
+
+@pytest.fixture
+def sample_jsonl(tmpdir: Path) -> Path:
+    """Create a minimal synthetic Codex JSONL log."""
+    records = [
+        {
+            "timestamp": "2026-05-14T10:00:00Z",
+            "type": "message_start",
+            "message_start": {"message": {"usage": {"input_tokens": 15000}}},
+        },
+        {
+            "timestamp": "2026-05-14T10:00:01Z",
+            "type": "content_block_start",
+            "content_block_start": {"content_block": {"type": "tool_use", "name": "bash"}},
+            "input": "cat large_file.txt",
+        },
+        {"timestamp": "2026-05-14T10:00:02Z", "type": "tool_result", "output": "x" * 600_000},
+        {
+            "timestamp": "2026-05-14T10:00:03Z",
+            "type": "message_delta",
+            "message_delta": {"usage": {"output_tokens": 25000}},
+        },
+        {
+            "timestamp": "2026-05-14T10:00:04Z",
+            "type": "message_delta",
+            "message_delta": {"usage": {"output_tokens": 25400}},
+        },
+    ]
+    p = tmpdir / "test_rollout.jsonl"
+    with open(p, "w", encoding="utf-8") as fh:
+        fh.writelines(json.dumps(rec) + "\n" for rec in records)
+    return p
+
+
+@pytest.fixture
+def sample_profile() -> dict[str, Any]:
+    """Return a minimal profile matching session_log_profile.py output shape."""
+    return {
+        "format": "session_profile_v1",
+        "total_records": 5,
+        "total_events_with_tokens": 3,
+        "max_tokens": 25400,
+        "min_tokens": 15000,
+        "token_timeline": [
+            {"line": 1, "ts": "2026-05-14T10:00:00Z", "tokens": 15000},
+            {"line": 4, "ts": "2026-05-14T10:00:03Z", "tokens": 25000, "delta": 10000},
+            {"line": 5, "ts": "2026-05-14T10:00:04Z", "tokens": 25400, "delta": 400},
+        ],
+        "largest_token_jumps": [
+            {"line": 4, "abs_delta": 10000, "delta": 10000, "ts": "2026-05-14T10:00:03Z"},
+            {"line": 5, "abs_delta": 400, "delta": 400, "ts": "2026-05-14T10:00:04Z"},
+        ],
+        "spike_jumps_over_threshold": [
+            {"line": 4, "abs_delta": 10000, "delta": 10000, "ts": "2026-05-14T10:00:03Z"},
+        ],
+        "threshold_delta_tokens": 5000,
+        "tool_calls_total": 2,
+        "tool_output_bytes_total": 600002,
+        "tool_call_details": [
+            {"line": 2, "ts": "2026-05-14T10:00:01Z", "tool_name": "bash", "output_bytes": None},
+            {"line": 3, "ts": "2026-05-14T10:00:02Z", "tool_name": None, "output_bytes": 600002},
+        ],
+        "suspicious_commands": [
+            {
+                "line": 2,
+                "ts": "2026-05-14T10:00:01Z",
+                "reason": "Command pattern 'cat ' detected in tool input",
+                "tool": "bash",
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def ansi_log_content() -> str:
+    """Synthetic OpenCode TUI log with ANSI codes and key markers."""
+    return (
+        "\x1b[32m[INFO]\x1b[0m Starting worker\n"
+        "Running validation checks...\n"
+        "\x1b[33m[WARN]\x1b[0m Precheck result: pass\n"
+        'Writing DONE JSON with status "DONE"\n'
+        "Running swarm_notify_orchestrator --signal done.json\n"
+        "\x1b[31m[ERROR]\x1b[0m Traceback (most recent call last):\n"
+        '  File "script.py", line 10, in foo\n'
+        "Exception: Something went wrong\n"
+        "validator acceptance precheck passed\n"
+        'Final: {"status": "done", "summary": "completed"}\n'
+    )
+
+
+@pytest.fixture
+def ansi_log_file(tmpdir: Path, ansi_log_content: str) -> Path:
+    p = tmpdir / "opencode-W-test.log"
+    with open(p, "w", encoding="utf-8") as fh:
+        fh.write(ansi_log_content)
+    return p
+
+
+@pytest.fixture
+def swarm_worktree(tmpdir: Path) -> Path:
+    """Create a minimal swarm worktree structure for correlation tests."""
+    wt = tmpdir / "swarm_wt"
+    signals_dir = wt / ".signals"
+    prompts_dir = wt / ".codex" / "prompts"
+    logs_dir = wt / "logs"
+    for d in (signals_dir, prompts_dir, logs_dir):
+        d.mkdir(parents=True, exist_ok=True)
+
+    # Launch file
+    launch_data = {
+        "worker": "worker-1551-swarm-helpers",
+        "runner": "opencode",
+        "agent": "pr-worker-deepseek",
+        "model": "opencode-go/deepseek-v4-pro",
+        "variant": "wave1-1551",
+        "started_at": "2026-05-14T15:22:26+00:00",
+        "prompt_sha256": "44e6ac3659b992c953ec40268c8ef48e0ecb63725c6741c38de6bb279b5734ae",
+        "required_skills": ["swarm-pr-finish"],
+        "prompt_file": "/tmp/.codex/prompts/worker-1551-swarm-helpers.md",
+        "worktree": str(wt),
+        "route_check_confirmed": "1",
+    }
+    with open(signals_dir / "launch-worker-1551-swarm-helpers.json", "w") as fh:
+        json.dump(launch_data, fh)
+
+    # DONE signal
+    done_data = {
+        "status": "done",
+        "issue": 1551,
+        "summary": "Implemented swarm helpers",
+        "review_decision": "not_reviewed",
+        "changed_files": [".codex/scripts/session_log_profile.py"],
+        "findings": [],
+        "blockers_found": [],
+        "blockers_resolved": [],
+        "new_bugs": [],
+        "verification_budget": "focused_only",
+        "runner": "opencode",
+        "worker": "worker-1551-swarm-helpers",
+        "ts": "2026-05-14T16:00:00+00:00",
+    }
+    with open(signals_dir / "DONE-worker-1551-swarm-helpers.json", "w") as fh:
+        json.dump(done_data, fh)
+
+    # Wakeup
+    wakeup_data = {
+        "worker": "worker-1551-swarm-helpers",
+        "status": "done",
+        "tag": "DONE",
+        "sent_at": "2026-05-14T16:01:00+00:00",
+        "signal_file": str(signals_dir / "DONE-worker-1551-swarm-helpers.json"),
+    }
+    with open(signals_dir / "wakeup-worker-1551-swarm-helpers.json", "w") as fh:
+        json.dump(wakeup_data, fh)
+
+    # Prompt file
+    with open(prompts_dir / "worker-1551-swarm-helpers.md", "w") as fh:
+        fh.write("# Worker prompt\nImplement issue 1551.\n")
+
+    # Log file (synthetic, >1 KB to pass cleanup min-size filter)
+    with open(logs_dir / "opencode-worker-1551-swarm-helpers.log", "w") as fh:
+        fh.write("line 1\n" * 300)
+
+    return wt
+
+
+# ---------------------------------------------------------------------------
+# session_log_profile tests
+# ---------------------------------------------------------------------------
+
+
+class TestSessionLogProfile:
+    """Tests for session_log_profile.py."""
+
+    def test_imports(self):
+        """Module imports cleanly."""
+        import session_log_profile as slp
+
+        assert hasattr(slp, "main")
+        assert hasattr(slp, "_parse_jsonl")
+        assert hasattr(slp, "_token_from")
+        assert hasattr(slp, "_make_profile")
+
+    def test_parse_jsonl_valid(self, sample_jsonl):
+        """Parses valid JSONL and returns records."""
+        import session_log_profile as slp
+
+        records = slp._parse_jsonl(sample_jsonl)
+        assert len(records) == 5
+        assert records[0]["timestamp"].startswith("2026")
+
+    def test_parse_jsonl_handles_corrupted_lines(self, tmpdir):
+        """Corrupted JSONL lines are captured as parse-error records."""
+        import session_log_profile as slp
+
+        bad = tmpdir / "bad.jsonl"
+        with open(bad, "w", encoding="utf-8") as fh:
+            fh.write('{"valid": true}\n')
+            fh.write("not json at all\n")
+            fh.write('{"also_valid": 1}\n')
+        records = slp._parse_jsonl(bad)
+        assert len(records) == 3
+        assert records[1].get("_parse_error") is True
+
+    def test_token_from_message_start(self):
+        """Extracts input_tokens from anthropic message_start."""
+        import session_log_profile as slp
+
+        rec = {"message_start": {"message": {"usage": {"input_tokens": 12345}}}}
+        assert slp._token_from(rec) == 12345
+
+    def test_token_from_message_delta(self):
+        """Extracts output_tokens from anthropic message_delta."""
+        import session_log_profile as slp
+
+        rec = {"message_delta": {"usage": {"output_tokens": 500}}}
+        assert slp._token_from(rec) == 500
+
+    def test_token_from_flat_usage(self):
+        """Extracts total_tokens from OpenAI-style usage."""
+        import session_log_profile as slp
+
+        rec = {"usage": {"total_tokens": 999}}
+        assert slp._token_from(rec) == 999
+
+    def test_token_from_token_count_key(self):
+        """Heuristic: token_count key."""
+        import session_log_profile as slp
+
+        rec = {"token_count": 42}
+        assert slp._token_from(rec) == 42
+
+    def test_token_from_unknown(self):
+        """Returns None for unrecognised records."""
+        import session_log_profile as slp
+
+        assert slp._token_from({}) is None
+        assert slp._token_from({"type": "ping"}) is None
+
+    def test_make_profile_structure(self, sample_jsonl):
+        """make_profile returns expected top-level keys."""
+        import session_log_profile as slp
+
+        records = slp._parse_jsonl(sample_jsonl)
+        profile = slp._make_profile(records)
+        assert profile["format"] == "session_profile_v1"
+        assert isinstance(profile["total_records"], int)
+        assert isinstance(profile["token_timeline"], list)
+        assert isinstance(profile["largest_token_jumps"], list)
+        assert isinstance(profile["spike_jumps_over_threshold"], list)
+        assert isinstance(profile["suspicious_commands"], list)
+
+    def test_make_profile_finds_spike(self, sample_jsonl):
+        """Large token delta is captured as a spike."""
+        import session_log_profile as slp
+
+        records = slp._parse_jsonl(sample_jsonl)
+        profile = slp._make_profile(records)
+        spikes = profile["spike_jumps_over_threshold"]
+        assert len(spikes) >= 1
+        assert spikes[0]["abs_delta"] > 5000
+
+    def test_make_profile_finds_suspicious_cat(self, sample_jsonl):
+        """'cat ' in tool input is flagged as suspicious."""
+        import session_log_profile as slp
+
+        records = slp._parse_jsonl(sample_jsonl)
+        profile = slp._make_profile(records)
+        suspicious = profile["suspicious_commands"]
+        assert any("cat " in s.get("reason", "") for s in suspicious)
+
+    def test_empty_jsonl(self, tmpdir):
+        """Empty JSONL produces empty but valid profile."""
+        import session_log_profile as slp
+
+        empty = tmpdir / "empty.jsonl"
+        empty.write_text("")
+        records = slp._parse_jsonl(empty)
+        profile = slp._make_profile(records)
+        assert profile["total_records"] == 0
+        assert profile["token_timeline"] == []
+
+
+# ---------------------------------------------------------------------------
+# session_extract_spikes tests
+# ---------------------------------------------------------------------------
+
+
+class TestSessionExtractSpikes:
+    """Tests for session_extract_spikes.py."""
+
+    def test_imports(self):
+        import session_extract_spikes as ses
+
+        assert hasattr(ses, "main")
+        assert hasattr(ses, "_bounded_snippets")
+
+    def test_bounded_snippets(self, sample_profile):
+        """Extracts snippets with correct context window."""
+        import session_extract_spikes as ses
+
+        timeline = sample_profile["token_timeline"]
+        spike_lines = {4}
+        snippets = ses._bounded_snippets(timeline, spike_lines, context=1)
+        assert len(snippets) == 1
+        snip = snippets[0]
+        assert snip["spike_line"] == 4
+        assert snip["spike_delta"] == 10000
+        assert snip["spike_entry"]["line"] == 4
+        # context=1 means 1 entry before and after
+        assert len(snip["context_before"]) <= 1
+        assert len(snip["context_after"]) <= 1
+
+    def test_bounded_snippets_empty(self):
+        """No spike lines returns empty list."""
+        import session_extract_spikes as ses
+
+        assert ses._bounded_snippets([], set()) == []
+
+    def test_bounded_snippets_no_match(self):
+        """Spike lines not in timeline returns empty."""
+        import session_extract_spikes as ses
+
+        timeline = [{"line": 1, "tokens": 100}]
+        assert ses._bounded_snippets(timeline, {99}, context=3) == []
+
+    def test_bounded_snippets_boundary(self):
+        """Snippets at timeline boundary don't crash."""
+        import session_extract_spikes as ses
+
+        timeline = [{"line": 1, "tokens": 100}]
+        snippets = ses._bounded_snippets(timeline, {1}, context=5)
+        assert len(snippets) == 1
+        assert len(snippets[0]["context_before"]) == 0
+        assert len(snippets[0]["context_after"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# swarm_run_correlate tests
+# ---------------------------------------------------------------------------
+
+
+class TestSwarmRunCorrelate:
+    """Tests for swarm_run_correlate.py."""
+
+    def test_imports(self):
+        import swarm_run_correlate as src
+
+        assert hasattr(src, "main")
+        assert hasattr(src, "_find_files")
+        assert hasattr(src, "_extract_key_meta")
+
+    def test_find_files_launch(self, swarm_worktree: Path):
+        """Finds launch files by prefix."""
+        import swarm_run_correlate as src
+
+        files = src._find_files(swarm_worktree, ".signals", "launch-*.json")
+        assert len(files) >= 1
+        assert any("launch-worker-1551" in f.name for f in files)
+
+    def test_find_files_nonexistent_dir(self):
+        """_find_files returns [] for nonexistent directories."""
+        import swarm_run_correlate as src
+
+        files = src._find_files(Path("/does/not/exist"), ".signals", "*.json")
+        assert files == []
+
+    def test_load_json_safe_valid(self, swarm_worktree: Path):
+        """_load_json_safe loads valid JSON."""
+        import swarm_run_correlate as src
+
+        launch_file = swarm_worktree / ".signals" / "launch-worker-1551-swarm-helpers.json"
+        data = src._load_json_safe(launch_file)
+        assert data is not None
+        assert data["worker"] == "worker-1551-swarm-helpers"
+        assert isinstance(data["prompt_sha256"], str)
+        assert data["prompt_sha256"]
+
+    def test_load_json_safe_invalid(self, tmpdir: Path):
+        """_load_json_safe returns error dict for broken JSON."""
+        import swarm_run_correlate as src
+
+        broken = tmpdir / "broken.json"
+        broken.write_text("{not valid")
+        data = src._load_json_safe(broken)
+        assert isinstance(data, dict)
+        assert "_load_error" in data
+
+    def test_load_json_safe_missing(self):
+        """_load_json_safe returns None for missing files."""
+        import swarm_run_correlate as src
+
+        assert src._load_json_safe(Path("/no/such/file.json")) is None
+
+    def test_extract_key_meta_launch(self):
+        """Extracts only relevant keys from launch data."""
+        import swarm_run_correlate as src
+
+        launch = {
+            "worker": "w1",
+            "runner": "opencode",
+            "agent": "a1",
+            "model": "m1",
+            "variant": "v1",
+            "started_at": "ts1",
+            "prompt_sha256": "abc",
+            "required_skills": ["s1"],
+            "prompt_file": "pf",
+            "worktree": "wt",
+            "route_check_confirmed": "1",
+            "extra_field": "should_not_appear",
+        }
+        meta = src._extract_key_meta(launch, "launch")
+        assert "extra_field" not in meta
+        assert meta["worker"] == "w1"
+        assert meta["prompt_sha256"] == "abc"
+
+    def test_extract_key_meta_error(self):
+        """_load_error dict is returned as-is."""
+        import swarm_run_correlate as src
+
+        meta = src._extract_key_meta({"_load_error": "bad"}, "launch")
+        assert meta == {"_load_error": "bad"}
+
+    def test_extract_key_meta_unknown_prefix(self):
+        """Unknown prefix returns empty dict."""
+        import swarm_run_correlate as src
+
+        assert src._extract_key_meta({"a": 1}, "unknown") == {}
+
+    def test_worker_dossier_launch_metadata(self, swarm_worktree: Path):
+        """Correlated dossier includes launch metadata with expected keys."""
+        import swarm_run_correlate as src
+
+        launch_files = src._find_files(
+            swarm_worktree, ".signals", "launch-worker-1551-swarm-helpers*.json"
+        )
+        assert launch_files
+        launch_data = src._load_json_safe(launch_files[0])
+        assert launch_data is not None
+        meta = src._extract_key_meta(launch_data, "launch")
+        assert meta.get("worker") == "worker-1551-swarm-helpers"
+        assert meta.get("prompt_sha256")
+
+
+# ---------------------------------------------------------------------------
+# opencode_log_markers tests
+# ---------------------------------------------------------------------------
+
+
+class TestOpenCodeLogMarkers:
+    """Tests for opencode_log_markers.py."""
+
+    def test_imports(self):
+        import opencode_log_markers as olm
+
+        assert hasattr(olm, "main")
+        assert hasattr(olm, "strip_ansi")
+        assert hasattr(olm, "find_markers")
+        assert hasattr(olm, "extract_snippets")
+
+    def test_strip_ansi_removes_color_codes(self):
+        """ANSI color codes are stripped from text."""
+        import opencode_log_markers as olm
+
+        colored = "\x1b[32mGreen text\x1b[0m normal"
+        clean = olm.strip_ansi(colored)
+        assert clean == "Green text normal"
+
+    def test_strip_ansi_no_ansi(self):
+        """Text without ANSI passes through unchanged."""
+        import opencode_log_markers as olm
+
+        assert olm.strip_ansi("plain text") == "plain text"
+
+    def test_strip_ansi_empty(self):
+        """Empty string survives stripping."""
+        import opencode_log_markers as olm
+
+        assert olm.strip_ansi("") == ""
+
+    def test_find_markers_orchestrator(self):
+        """Finds swarm_notify_orchestrator marker."""
+        import opencode_log_markers as olm
+
+        lines = ["Running swarm_notify_orchestrator --signal done.json"]
+        markers = olm.find_markers(lines, olm.MARKER_PATTERNS)
+        assert len(markers) >= 1
+        assert markers[0]["label"] == "orchestrator_wakeup"
+
+    def test_find_markers_done_status(self):
+        """Finds DONE status marker."""
+        import opencode_log_markers as olm
+
+        lines = ['{"status": "DONE", "worker": "w1"}']
+        markers = olm.find_markers(lines, olm.MARKER_PATTERNS)
+        assert len(markers) >= 1
+        assert markers[0]["label"] == "DONE_status"
+
+    def test_find_markers_traceback(self):
+        """Finds traceback marker."""
+        import opencode_log_markers as olm
+
+        lines = ["Traceback (most recent call last):", "  File 'x.py', line 1"]
+        markers = olm.find_markers(lines, olm.MARKER_PATTERNS)
+        assert len(markers) >= 1
+        assert markers[0]["label"] == "traceback"
+
+    def test_find_markers_multiple_patterns(self):
+        """Multiple patterns in one line all get captured."""
+        import opencode_log_markers as olm
+
+        lines = ["Error: Exception occurred and validator failed"]
+        markers = olm.find_markers(lines, olm.MARKER_PATTERNS)
+        labels = {m["label"] for m in markers}
+        assert "exception" in labels or "error" in labels
+
+    def test_find_markers_none(self):
+        """No markers returns empty list."""
+        import opencode_log_markers as olm
+
+        markers = olm.find_markers(["nothing interesting here"], olm.MARKER_PATTERNS)
+        assert markers == []
+
+    def test_extract_snippets_context(self):
+        """Snippets include correct context window."""
+        import opencode_log_markers as olm
+
+        lines = [f"line {i}" for i in range(20)]
+        markers = [
+            {
+                "line": 10,
+                "label": "test",
+                "pattern": "line 9",
+                "matched_text": "line 9",
+                "full_line": "line 9",
+            }
+        ]
+        snippets = olm.extract_snippets(lines, markers, context=3)
+        assert len(snippets) == 1
+        snip = snippets[0]
+        assert len(snip["context_before"]) == 3
+        assert len(snip["context_after"]) == 3
+        assert "line 9" in snip["marker_line"]
+
+    def test_extract_snippets_empty_markers(self):
+        """Empty markers returns empty snippets."""
+        import opencode_log_markers as olm
+
+        assert olm.extract_snippets(["a"], [], context=5) == []
+
+    def test_extract_snippets_boundary_start(self):
+        """Snippet at start returns fewer context_before lines."""
+        import opencode_log_markers as olm
+
+        lines = [f"line {i}" for i in range(5)]
+        markers = [
+            {
+                "line": 1,
+                "label": "start",
+                "pattern": "line 0",
+                "matched_text": "line 0",
+                "full_line": "line 0",
+            }
+        ]
+        snippets = olm.extract_snippets(lines, markers, context=5)
+        assert len(snippets[0]["context_before"]) == 0
+        assert len(snippets[0]["context_after"]) == 4
+
+    def test_markers_from_ansi_log(self, ansi_log_file):
+        """Integration: finds markers in an ANSI log file."""
+        import opencode_log_markers as olm
+
+        with open(ansi_log_file, encoding="utf-8") as fh:
+            raw_lines = fh.readlines()
+        clean_lines = [olm.strip_ansi(ln) for ln in raw_lines]
+        markers = olm.find_markers(clean_lines, olm.MARKER_PATTERNS)
+        assert len(markers) > 0
+
+    def test_markers_discover_done_and_orch(self, ansi_log_file):
+        """ANSI log contains DONE and orchestrator markers."""
+        import opencode_log_markers as olm
+
+        with open(ansi_log_file, encoding="utf-8") as fh:
+            raw_lines = fh.readlines()
+        clean_lines = [olm.strip_ansi(ln) for ln in raw_lines]
+        markers = olm.find_markers(clean_lines, olm.MARKER_PATTERNS)
+        labels = {m["label"] for m in markers}
+        assert "done_status" in labels
+        assert "orchestrator_wakeup" in labels
+
+
+# ---------------------------------------------------------------------------
+# cleanup_swarm_run tests
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupSwarmRun:
+    """Tests for cleanup_swarm_run.py."""
+
+    def test_imports(self):
+        import cleanup_swarm_run as csr
+
+        assert hasattr(csr, "main")
+        assert hasattr(csr, "_plan_actions")
+        assert hasattr(csr, "_execute_actions")
+
+    def test_plan_actions_finds_logs(self, swarm_worktree: Path):
+        """_plan_actions discovers log files for a worker prefix."""
+        import cleanup_swarm_run as csr
+
+        actions = csr._plan_actions(swarm_worktree, "worker-1551-swarm-helpers")
+        log_actions = [a for a in actions if "logs/" in a["path"]]
+        assert len(log_actions) >= 1
+
+    def test_plan_actions_finds_prompts(self, swarm_worktree: Path):
+        """_plan_actions discovers prompt files for a worker prefix."""
+        import cleanup_swarm_run as csr
+
+        actions = csr._plan_actions(swarm_worktree, "worker-1551-swarm-helpers")
+        prompt_actions = [a for a in actions if ".codex/prompts" in a["path"]]
+        assert len(prompt_actions) >= 1
+
+    def test_plan_actions_no_match(self, swarm_worktree: Path):
+        """_plan_actions returns [] for unmatched prefix."""
+        import cleanup_swarm_run as csr
+
+        actions = csr._plan_actions(swarm_worktree, "nonexistent-prefix")
+        assert actions == []
+
+    def test_execute_actions_archives_files(self, swarm_worktree: Path, tmpdir: Path):
+        """_execute_actions archives files to archive_dir."""
+        import cleanup_swarm_run as csr
+
+        actions = csr._plan_actions(swarm_worktree, "worker-1551-swarm-helpers")
+        archive_dir = tmpdir / "archive"
+        results = csr._execute_actions(actions, archive_dir)
+        archived = [r for r in results if r.get("status") == "archived"]
+        assert len(archived) >= 1
+        for r in archived:
+            dst = Path(r["archived_to"])
+            assert dst.exists()
+
+    def test_execute_actions_empty(self, tmpdir: Path):
+        """Empty actions returns empty results."""
+        import cleanup_swarm_run as csr
+
+        results = csr._execute_actions([], tmpdir / "archive")
+        assert results == []
+
+    def test_execute_actions_missing_file(self, tmpdir: Path):
+        """Missing files are skipped gracefully."""
+        import cleanup_swarm_run as csr
+
+        actions = [{"path": str(tmpdir / "nonexistent.log"), "size_bytes": 9999}]
+        results = csr._execute_actions(actions, tmpdir / "archive")
+        assert results[0]["status"] == "skipped"
+
+    def test_close_tmux_window_dry_run(self):
+        """_close_tmux_window in dry-run mode does not modify tmux."""
+        import shutil
+
+        import cleanup_swarm_run as csr
+
+        if not shutil.which("tmux"):
+            pytest.skip("tmux not available")
+        result = csr._close_tmux_window("no-such-worker-zzz", dry_run=True)
+        assert result["action"] == "close_tmux_window"
+
+    def test_close_tmux_window_no_tmux(self, monkeypatch: pytest.MonkeyPatch):
+        """When tmux is not available, close is skipped."""
+        import shutil as _shutil
+
+        import cleanup_swarm_run as csr
+
+        monkeypatch.setattr(_shutil, "which", lambda _x: None)
+        result = csr._close_tmux_window("worker-x", dry_run=True)
+        assert result["status"] == "skipped"
+        assert "tmux not available" in result["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Edge cases and regression
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Edge-case and regression tests across all helpers."""
+
+    def test_profile_with_no_tokens(self, tmpdir: Path):
+        """JSONL with no token-bearing records produces valid empty profile."""
+        import session_log_profile as slp
+
+        p = tmpdir / "no_tokens.jsonl"
+        with open(p, "w", encoding="utf-8") as fh:
+            fh.write('{"type": "ping"}\n{"type": "pong"}\n')
+        records = slp._parse_jsonl(p)
+        profile = slp._make_profile(records)
+        assert profile["token_timeline"] == []
+        assert profile["max_tokens"] == 0
+
+    def test_profile_unicode_record(self, tmpdir: Path):
+        """JSONL with unicode content is handled."""
+        import session_log_profile as slp
+
+        p = tmpdir / "unicode.jsonl"
+        with open(p, "w", encoding="utf-8") as fh:
+            fh.write('{"type": "message", "text": "Привет мир!"}\n')
+        records = slp._parse_jsonl(p)
+        assert len(records) == 1
+
+    def test_markers_strip_ansi_osc(self):
+        """ANSI OSC sequences (title setters) are stripped."""
+        import opencode_log_markers as olm
+
+        text = "\x1b]0;Terminal Title\x07Hello"
+        clean = olm.strip_ansi(text)
+        assert "\x1b]" not in clean
+        assert "Hello" in clean
+
+    def test_correlator_no_worktree_files(self, tmpdir: Path):
+        """Correlator handles a directory with no worker files."""
+        import swarm_run_correlate as src
+
+        files = src._find_files(tmpdir, ".signals", "launch-*.json")
+        assert files == []


### PR DESCRIPTION
## Summary
- Adds focused unit tests (54 cases, all passing) for the five deterministic swarm helpers from issue #1551
- Helpers cover: Codex JSONL profiling, spike extraction, run correlation, OpenCode log marker scanning, and artifact cleanup
- Scripts live in `.codex/scripts/` (gitignored, local-only worktree artifacts)
- Tests use synthetic fixtures — no Docker, tmux, or real sessions required

## Scope
- `tests/unit/codex/test_swarm_helpers.py` — 54 tests across 5 helper modules
- All tests pass locally (`uv run pytest`)
- No production, secrets, or external dependencies touched

## Issue
Closes #1551