### PR TITLE
fix(secrets): add env safety structural checks and safe placeholders (#1325)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,7 +72,7 @@ GROQ_API_KEY=
 OPENAI_API_KEY=
 
 # Anthropic Claude API (optional)
-ANTHROPIC_API_KEY=sk-ant-api03-your-key-here
+ANTHROPIC_API_KEY=<your-anthropic-key-here>
 
 # Qdrant Vector Database
 # Local development (Docker internal):
@@ -132,8 +132,8 @@ MAX_CONTEXT_TOKENS=8000
 # Containerized services use LANGFUSE_DOCKER_HOST and default to the Docker network alias.
 # On VPS without local Langfuse, set both LANGFUSE_HOST and LANGFUSE_DOCKER_HOST
 # to the same reachable value (for example https://cloud.langfuse.com).
-LANGFUSE_PUBLIC_KEY=pk-lf-dev
-LANGFUSE_SECRET_KEY=sk-lf-dev
+LANGFUSE_PUBLIC_KEY=<your-langfuse-public-key>
+LANGFUSE_SECRET_KEY=<your-langfuse-secret-key>
 LANGFUSE_HOST=http://localhost:3001
 LANGFUSE_DOCKER_HOST=http://langfuse:3000
 # Isolate traces by environment in Langfuse UI (prod/staging/dev). Optional.
@@ -188,7 +188,7 @@ E2E_BOT_USERNAME=@test_nika_homes_bot
 # =============================================================================
 # Create a separate bot for alerts via @BotFather (not the main bot!)
 # See docs/ALERTING.md for setup instructions
-TELEGRAM_ALERTING_BOT_TOKEN=your-alerting-bot-token
+TELEGRAM_ALERTING_BOT_TOKEN=<your-alerting-bot-token>
 # Chat ID for alerts (use @userinfobot to get your chat ID)
 # For groups: add bot to group and use negative chat ID
 TELEGRAM_ALERTING_CHAT_ID=-1001234567890

--- a/.env.local.example
+++ b/.env.local.example
@@ -3,9 +3,9 @@
 # Скопируйте в .env и заполните значения
 
 # === API Keys ===
-OPENAI_API_KEY=sk-your-openai-key
-ANTHROPIC_API_KEY=sk-ant-your-anthropic-key
-GROQ_API_KEY=gsk_your-groq-key
+OPENAI_API_KEY=<your-openai-key>
+ANTHROPIC_API_KEY=<your-anthropic-key>
+GROQ_API_KEY=<your-groq-key>
 
 # === Local Services (docker-compose.local.yml) ===
 QDRANT_URL=http://localhost:6333

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-dev install-all lint format type-check security test test-full test-cov clean all-checks \
+.PHONY: help install install-dev install-all lint format type-check security check-env-safety test test-full test-cov clean all-checks \
 	test-preflight test-smoke test-load-eviction \
 	smoke-fast smoke-zoo \
 	monitoring-up monitoring-down monitoring-logs monitoring-status monitoring-test-alert \
@@ -172,7 +172,12 @@ dead-code: ## Find dead code with Vulture (alias for security)
 	uv run vulture src/ telegram_bot/ --min-confidence 80 --exclude "*site-packages*,*dist-info*,__pycache__,.pytest_cache,.ruff_cache,.mypy_cache,*.egg-info,.venv*"
 	@echo "$(GREEN)✓ Dead code check complete$(NC)"
 
-all-checks: lint type-check security ## Run all code quality checks
+check-env-safety: ## Run env safety structural check (no real secrets in tracked files)
+	@echo "$(BLUE)Running env safety check...$(NC)"
+	@./scripts/check_env_safety.sh
+	@echo "$(GREEN)✓ Env safety check passed$(NC)"
+
+all-checks: lint type-check security check-env-safety ## Run all code quality checks
 	@echo "$(GREEN)✓✓✓ All checks passed! ✓✓✓$(NC)"
 
 # =============================================================================

--- a/scripts/check_env_safety.sh
+++ b/scripts/check_env_safety.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Safe structural check: verify no real .env files are tracked or present
+# in the working tree, and that .gitignore properly ignores them.
+#
+# Usage:
+#   ./scripts/check_env_safety.sh          # Check env safety
+#   ./scripts/check_env_safety.sh --ci     # Strict mode (fails on warnings)
+#
+# Related: scripts/validate_prod_env.sh (production env validation)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+STRICT_MODE=false
+if [ "${1:-}" = "--ci" ]; then
+  STRICT_MODE=true
+fi
+
+errors=0
+warnings=0
+
+# ── Check 1: .gitignore must ignore .env files ──────────────────────────────
+
+if ! grep -qE '^\.env\s*$' .gitignore 2>/dev/null; then
+  echo "FAIL: .env is not ignored in .gitignore" >&2
+  errors=$((errors + 1))
+else
+  echo "  OK: .env is ignored"
+fi
+
+if ! grep -qE '^\.env\.\*\s*$' .gitignore 2>/dev/null; then
+  echo "FAIL: .env.* is not ignored in .gitignore" >&2
+  errors=$((errors + 1))
+else
+  echo "  OK: .env.* is ignored"
+fi
+
+if ! grep -qE '^credentials\.json\s*$' .gitignore 2>/dev/null; then
+  echo "FAIL: credentials.json is not ignored in .gitignore" >&2
+  errors=$((errors + 1))
+else
+  echo "  OK: credentials.json is ignored"
+fi
+
+if ! grep -qE '^secrets\.ya?ml\s*$' .gitignore 2>/dev/null; then
+  echo "FAIL: secrets.yaml is not ignored in .gitignore" >&2
+  errors=$((errors + 1))
+else
+  echo "  OK: secrets.yaml is ignored"
+fi
+
+# ── Check 2: No non-example .env files tracked in git ───────────────────────
+
+tracked_envs=$(git ls-files | grep -E '^\.env' | grep -v '\.example$' || true)
+if [ -n "$tracked_envs" ]; then
+  echo "FAIL: Non-example .env files are tracked in git:" >&2
+  echo "$tracked_envs" | sed 's/^/  - /' >&2
+  errors=$((errors + 1))
+else
+  echo "  OK: no non-example .env files tracked"
+fi
+
+# ── Check 3: No non-example .env files in working tree ──────────────────────
+
+while IFS= read -r -d '' file; do
+  basename_file=$(basename "$file")
+  # Skip example/template files and common virtualenv paths
+  if [[ "$basename_file" == *.example ]]; then
+    continue
+  fi
+  echo "FAIL: Non-example env file detected in working tree: $file" >&2
+  echo "  Remove it or rename to .env.example if it's a template." >&2
+  errors=$((errors + 1))
+done < <(find . -maxdepth 2 -name ".env*" -type f \
+  -not -path "./.git/*" \
+  -not -path "./node_modules/*" \
+  -not -path "./.venv/*" \
+  -not -path "./venv/*" \
+  -print0)
+
+# ── Check 4: .env.example files should use obvious placeholders ─────────────
+# Warn about values that look like real API key prefixes (not empty or <...>)
+
+_real_key_prefixes='sk-ant-|sk-proj-|sk-|gsk_|csk-|pa-|pk-lf-|sk-lf-|Bearer '
+_placeholder_pattern='^\s*[A-Z_][A-Z0-9_]*=\s*(<.*>|\s*)$'
+
+for env_example in .env.example .env.local.example telegram_bot/.env.example k8s/secrets/.env.example; do
+  if [ ! -f "$env_example" ]; then
+    continue
+  fi
+
+  # Find lines with real-looking key prefixes that are NOT placeholder-style
+  bad_lines=$(grep -nE "^\s*[A-Z_][A-Z0-9_]*=\s*.*(${_real_key_prefixes})" "$env_example" | grep -vE "${_placeholder_pattern}" || true)
+  if [ -n "$bad_lines" ]; then
+    echo "WARN: $env_example contains values that resemble real API key prefixes:" >&2
+    echo "$bad_lines" | sed 's/^/  /' >&2
+    warnings=$((warnings + 1))
+  fi
+done
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+
+if [ "$warnings" -gt 0 ] && [ "$STRICT_MODE" = true ]; then
+  echo "" >&2
+  echo "Env safety check failed: $warnings warning(s) in strict mode." >&2
+  exit 1
+fi
+
+if [ "$errors" -gt 0 ]; then
+  echo "" >&2
+  echo "Env safety check failed with $errors error(s)." >&2
+  exit 1
+fi
+
+echo "Env safety check passed."

--- a/tests/unit/security/test_secret_hygiene.py
+++ b/tests/unit/security/test_secret_hygiene.py
@@ -110,3 +110,70 @@ def test_k8s_bot_redis_password_declared_before_redis_url():
         "REDIS_PASSWORD must be declared before REDIS_URL because Kubernetes "
         "expands $(REDIS_PASSWORD) only from previously defined env vars."
     )
+
+
+@pytest.mark.timeout(0)
+def test_no_non_example_env_files_tracked():
+    """Ensure no non-example .env files are tracked in git (#1325)."""
+    import subprocess
+    from pathlib import Path
+
+    project_root = Path(__file__).parent.parent.parent.parent
+    result = subprocess.run(
+        ["git", "ls-files"],
+        capture_output=True,
+        text=True,
+        cwd=project_root,
+    )
+    tracked_envs = [
+        line
+        for line in result.stdout.splitlines()
+        if Path(line).name.startswith(".env") and not line.endswith(".example")
+    ]
+    assert not tracked_envs, (
+        f"Real .env files must not be tracked in git: {tracked_envs}\n"
+        "Add them to .gitignore and remove from the index."
+    )
+
+
+@pytest.mark.timeout(0)
+def test_env_example_files_use_safe_placeholders():
+    """Ensure .env.example files do not contain real-looking API key prefixes (#1325)."""
+    import re
+    from pathlib import Path
+
+    project_root = Path(__file__).parent.parent.parent.parent
+    env_examples = [
+        project_root / ".env.example",
+        project_root / ".env.local.example",
+        project_root / "telegram_bot" / ".env.example",
+        project_root / "k8s" / "secrets" / ".env.example",
+    ]
+
+    # Common real API key prefixes that should not appear as example values
+    bad_prefixes = [
+        r"sk-ant-",
+        r"sk-proj-",
+        r"sk-",
+        r"gsk_",
+        r"csk-",
+        r"pa-",
+        r"pk-lf-",
+        r"sk-lf-",
+    ]
+    prefix_pattern = re.compile(r"^\s*[A-Z_][A-Z0-9_]*=\s*.*(" + "|".join(bad_prefixes) + r")")
+    # Allow placeholder-style values like <your-key> or empty values
+    placeholder_pattern = re.compile(r"^\s*[A-Z_][A-Z0-9_]*=\s*(<.*>|\s*)$")
+
+    errors = []
+    for env_file in env_examples:
+        if not env_file.exists():
+            continue
+        for lineno, line in enumerate(env_file.read_text().splitlines(), 1):
+            if prefix_pattern.search(line) and not placeholder_pattern.search(line):
+                errors.append(f"  {env_file.name}:{lineno}: {line.strip()}")
+
+    assert not errors, (
+        "Security violation: .env.example files contain values that resemble real API keys.\n"
+        "Use placeholder format like <your-key-here> or leave empty.\n" + "\n".join(errors)
+    )


### PR DESCRIPTION
## Summary

Restricted safe remediation for issue #1325: ensures local .env-style secrets are ignored and safe example/config/documentation patterns exist.

### Changes

- **New script**: scripts/check_env_safety.sh
  - Verifies .gitignore ignores .env, .env.*, credentials.json, secrets.yaml
  - Ensures no non-example .env files are tracked in git
  - Scans working tree for accidental .env files (excluding .env.*.example)
  - Warns about .env.example files containing real-looking API key prefixes

- **New tests** in tests/unit/security/test_secret_hygiene.py:
  - test_no_non_example_env_files_tracked
  - test_env_example_files_use_safe_placeholders

- **Updated .env.example** and **.env.local.example** to use <placeholder> format instead of real key prefixes

- **Updated Makefile**: added check-env-safety target and wired into all-checks

### Verification

- scripts/check_env_safety.sh passes locally and in --ci strict mode
- pytest focused tests: 131 passed (secret_hygiene, env_example, release_gate, docker_static, compose_langfuse)
- Pre-commit hooks (gitleaks, detect-private-key, bandit) all pass

Fixes #1325