### PR TITLE
chore(observability): 9 issue drafts for Langfuse trace coverage audit

### DIFF
--- a/.github/issue-drafts/2026-05-19-langfuse-trace-coverage/01-miniapp-api.md
+++ b/.github/issue-drafts/2026-05-19-langfuse-trace-coverage/01-miniapp-api.md
@@ -1,0 +1,56 @@
+# observability: Mini App FastAPI has zero Langfuse trace coverage
+
+## Source
+
+2026-05-19 Langfuse trace-coverage audit (`.github/issue-drafts/2026-05-19-langfuse-trace-coverage/`).
+
+## Problem
+
+`mini_app/` is a **separate FastAPI service** that handles conversion-funnel traffic from Telegram Mini App: `/api/start-expert`, `/api/phone`, `/api/log`, `/api/config`. It has **no** `@observe`, no `propagate_attributes`, no `get_client()` calls. Leads created via Mini App and the Kommo write inside `submit_phone()` are **invisible in Langfuse**, and there is no `session_id` linking the Mini App entry to the subsequent `/start q_<expert>` Telegram dialog.
+
+This breaks two things:
+
+1. The full funnel `Mini App → /start q_… → Telegram dialog → CRM` cannot be reconstructed in Langfuse Sessions UI.
+2. Failures of the Kommo upsert+create-lead pair inside `mini_app/phone.py:submit_phone` are visible only as logs, not as a span with `level=ERROR`.
+
+## Evidence
+
+- `mini_app/api.py:43-110` — endpoints `get_config`, `start_expert`, `remote_log`, `phone` — no Langfuse instrumentation.
+- `mini_app/phone.py:39` — `async def submit_phone(...)` performs Kommo `upsert_contact` + `create_lead` with no parent span.
+- `mini_app/expert_start.py` — payload assembly for deeplink, no `propagate_attributes(session_id=..., user_id=...)`.
+- `telegram_bot/observability.py` already exports `observe`, `get_client`, `propagate_attributes` for reuse.
+
+## SDK Baseline
+
+- Langfuse Python v3: `@observe(name=..., capture_input=False, capture_output=False)` for endpoints + `update_current_span(input={...})` for curated payloads (avoid leaking phone numbers / payloads).
+- `propagate_attributes(session_id=f"miniapp-{user_id}", user_id=str(user_id), tags=["miniapp", ...])` to attach session/user context.
+- Established pattern in repo: `src/api/main.py:156` (`@observe(name="rag-api-query", capture_input=False, capture_output=False)`).
+
+## Implementation Plan
+
+1. Add `@observe(name="miniapp-start-expert", capture_input=False, capture_output=False)` on `mini_app/api.py:start_expert` with `propagate_attributes(session_id=f"miniapp-{user_id}", user_id=str(user_id), tags=["miniapp", "start-expert", expert_id])`.
+2. Add `@observe(name="miniapp-submit-phone", capture_input=False, capture_output=False)` on `mini_app/api.py:phone` with the same propagate scope.
+3. Add `@observe(name="miniapp-kommo-create-lead", capture_input=False, capture_output=False)` on `mini_app/phone.py:submit_phone`; on Kommo failure call `get_client().update_current_span(level="ERROR", status_message=...)`.
+4. Use the same `session_id` format (`miniapp-{tg_user_id}`) when the Telegram bot subsequently handles `/start q_<expert>` so the funnel groups in Langfuse Sessions UI.
+5. Ensure PII (`phone`, `name`) is excluded from span input/output via curated dicts; rely on the SDK-level `mask` from `telegram_bot/observability.py`.
+
+## Forbidden
+
+- No raw `request` payloads in span input/output.
+- No `langfuse_trace_id` plumbing on the Mini App API surface yet (separate concern; see #1253).
+- No new prometheus metrics in this PR.
+- No changes to the Mini App frontend SDK.
+
+## Verification
+
+```bash
+uv run pytest tests/unit/mini_app -q
+uv run pytest tests/unit/test_langfuse_context_middleware.py -q
+```
+
+Manual: run `make local-up`, hit `/api/start-expert` and `/api/phone` from the dev Mini App, confirm a single Langfuse session contains both endpoints + the subsequent Telegram `/start q_…` trace.
+
+## Related
+
+- #1253 — trace context propagation between graphs (broader, separate).
+- #1543 — contextualize batch + ColBERT span gaps (orthogonal).

--- a/.github/issue-drafts/2026-05-19-langfuse-trace-coverage/02-hyde-generate-hypothetical-document.md
+++ b/.github/issue-drafts/2026-05-19-langfuse-trace-coverage/02-hyde-generate-hypothetical-document.md
@@ -1,0 +1,46 @@
+# observability: HyDEGenerator.generate_hypothetical_document produces orphan generations
+
+## Source
+
+2026-05-19 Langfuse trace-coverage audit (`.github/issue-drafts/2026-05-19-langfuse-trace-coverage/`).
+
+## Problem
+
+`HyDEGenerator` uses `langfuse.openai.AsyncOpenAI`, so each completion call **is** auto-traced as a generation. But the public method `generate_hypothetical_document` is **not** wrapped in `@observe`. When this is invoked outside an active span (e.g., from a code path that has not yet entered the Telegram middleware root span — direct evaluation runners, tests, future API surfaces), the generation becomes an orphan trace with no parent and no `session_id`/`user_id`.
+
+The Langfuse v3 docs explicitly recommend grouping related generations under an `@observe`-decorated parent (see *Group Multiple OpenAI Calls into a Single Trace*). This is a single-file fix, ~5 lines.
+
+## Evidence
+
+- `telegram_bot/services/query_preprocessor.py:37-119` — `class HyDEGenerator` and `async def generate_hypothetical_document(self, query: str) -> str` at line 80; no `@observe`.
+- The class is constructed via `langfuse.openai.AsyncOpenAI` (auto-trace ON), so `chat.completions.create` becomes `litellm-acompletion` generation — orphan when no parent.
+
+## SDK Baseline
+
+- Langfuse Python v3: `@observe(name="hyde-generate-document", capture_input=False, capture_output=False)` + curated `update_current_span(input={"query_preview": query[:120]})`.
+- Established pattern: `telegram_bot/services/query_analyzer.py` — same shape (instructor over Langfuse-wrapped client). See companion issue 03 for parallel fix there.
+
+## Implementation Plan
+
+1. Add `@observe(name="hyde-generate-document", capture_input=False, capture_output=False)` on `HyDEGenerator.generate_hypothetical_document`.
+2. Inside the method, before the LLM call, set curated input via `get_client().update_current_span(input={"query_preview": query[:120], "model": self._model})`.
+3. After the call, set curated output: `update_current_span(output={"document_preview": doc[:200], "tokens_estimated": len(doc.split())})`.
+4. On exception path, set `level="ERROR"`, `status_message=str(exc)[:200]`.
+
+## Forbidden
+
+- Do not strip the `langfuse.openai` wrapping; keep auto-trace on.
+- Do not log full generated document to span output (truncated only).
+- Do not change the prompt-fetching path (`get_prompt("hyde", ...)`); this issue is purely instrumentation.
+- No prompt-to-generation linking in this PR (separate issue, see draft 09).
+
+## Verification
+
+```bash
+uv run pytest tests/unit/services/test_query_preprocessor.py -q
+uv run pytest tests/unit -k "hyde" -q
+```
+
+## Related
+
+- #1652 — research issue on whether HyDE should be replaced with a LangChain-native primitive (orthogonal; this issue improves observability without touching the implementation).

--- a/.github/issue-drafts/2026-05-19-langfuse-trace-coverage/03-query-analyzer-analyze.md
+++ b/.github/issue-drafts/2026-05-19-langfuse-trace-coverage/03-query-analyzer-analyze.md
@@ -1,0 +1,46 @@
+# observability: QueryAnalyzer.analyze produces orphan generations
+
+## Source
+
+2026-05-19 Langfuse trace-coverage audit (`.github/issue-drafts/2026-05-19-langfuse-trace-coverage/`).
+
+## Problem
+
+`QueryAnalyzer` wraps an `instructor.from_openai(langfuse.openai.AsyncOpenAI)` client. The structured-output completion call **is** auto-traced as a generation, but the public `analyze()` method is **not** wrapped in `@observe`. When invoked from a code path without an active span (eval runner, batch script, test), the generation becomes orphan and loses the `session_id` / `user_id` / pipeline-step context.
+
+This is a single-file fix, ~8 lines.
+
+## Evidence
+
+- `telegram_bot/services/query_analyzer.py:65` — `class QueryAnalyzer`.
+- `telegram_bot/services/query_analyzer.py:86` — `async def analyze(self, query: str) -> dict[str, Any]`; no `@observe`.
+- `telegram_bot/services/query_analyzer.py:97` — `await self._instructor_client.chat.completions.create(...)` — auto-traced generation.
+
+## SDK Baseline
+
+- Langfuse Python v3: `@observe(name="query-analyzer", capture_input=False, capture_output=False)` + `update_current_span(input={...}, output={...})` with curated payloads.
+- Established pattern: `telegram_bot/services/apartment_filter_extractor.py:53` (`@observe(name="apartment-filter-parse", ...)`).
+
+## Implementation Plan
+
+1. Add `@observe(name="query-analyzer", capture_input=False, capture_output=False)` on `QueryAnalyzer.analyze`.
+2. Before the LLM call: `get_client().update_current_span(input={"query_preview": query[:120], "model": self._model})`.
+3. After parsing the structured output: `update_current_span(output={"intent": result.intent, "language": result.language, "confidence": result.confidence})` (use the actual fields from `QueryAnalysisResult`).
+4. On exception: `update_current_span(level="ERROR", status_message=str(exc)[:200])`.
+
+## Forbidden
+
+- Do not log the full LLM response payload to span output.
+- Do not introduce a new wrapper layer; keep `instructor` + `langfuse.openai` as is.
+- No changes to `QueryAnalysisResult` schema in this PR.
+
+## Verification
+
+```bash
+uv run pytest tests/unit/services/test_query_analyzer.py -q
+```
+
+## Related
+
+- Sibling: HyDEGenerator instrumentation (draft 02).
+- Sibling: `apartment_filter_extractor` already follows this pattern; reuse the shape.

--- a/.github/issue-drafts/2026-05-19-langfuse-trace-coverage/04-llm-service-public-methods.md
+++ b/.github/issue-drafts/2026-05-19-langfuse-trace-coverage/04-llm-service-public-methods.md
@@ -1,0 +1,49 @@
+# observability: LLMService public methods produce orphan generations
+
+## Source
+
+2026-05-19 Langfuse trace-coverage audit (`.github/issue-drafts/2026-05-19-langfuse-trace-coverage/`).
+
+## Problem
+
+`telegram_bot/services/llm.py:LLMService` uses `langfuse.openai.AsyncOpenAI` as its underlying client. Each `chat.completions.create` call is auto-traced as a generation. But all three public async methods — `generate_answer`, `stream_answer`, `generate` — are **not** wrapped in `@observe`. When `LLMService` is used outside a request-scoped trace (background tasks, fallback paths, scripts), generations show up as top-level orphans without `session_id`/`user_id`/pipeline-step grouping.
+
+This is a single-file fix; three method-level decorators.
+
+## Evidence
+
+- `telegram_bot/services/llm.py:61` — `class LLMService`.
+- `telegram_bot/services/llm.py:97` — `async def generate_answer(...)`; no `@observe`.
+- `telegram_bot/services/llm.py:213` — `async def stream_answer(...)`; no `@observe`.
+- `telegram_bot/services/llm.py:366` — `async def generate(...)`; no `@observe`.
+- `telegram_bot/services/llm.py:14` — `from langfuse.openai import AsyncOpenAI` (auto-trace path is correct, just not parented).
+
+## SDK Baseline
+
+- Langfuse Python v3: per-method `@observe(name="llm-service-<method>", capture_input=False, capture_output=False)`.
+- For `stream_answer`, mark as a coroutine that yields chunks; capture only summary metadata in `update_current_span(output=...)` after the stream is fully drained, not chunk-by-chunk.
+- Established pattern: `telegram_bot/services/ai_advisor_service.py:264` (`@observe(name="advisor-llm-call", capture_input=False, capture_output=False)`).
+
+## Implementation Plan
+
+1. Decorate `generate_answer` with `@observe(name="llm-service-generate-answer", capture_input=False, capture_output=False)`. Inside, set `update_current_span(input={"prompt_preview": prompt[:120], "model": self.model, "with_confidence": with_confidence})` and `update_current_span(output={"response_len": len(response_text)})` after the call.
+2. Decorate `stream_answer` with `@observe(name="llm-service-stream-answer", capture_input=False, capture_output=False)`. Track chunks count and final length in a local accumulator, then `update_current_span(output={"chunks": n, "total_len": len(full)})` after the generator finishes.
+3. Decorate `generate` with `@observe(name="llm-service-generate", capture_input=False, capture_output=False)`. Same shape as `generate_answer` but simpler: prompt preview in, response length out.
+4. On exception in any of the three: `update_current_span(level="ERROR", status_message=str(exc)[:200])` then re-raise.
+
+## Forbidden
+
+- Do not capture full prompt or full response in span input/output (truncated previews only).
+- Do not switch off `langfuse.openai` auto-trace; nested generation under our @observe span is the intended structure.
+- Do not change `ConfidenceResponse` schema or `instructor` integration.
+- Do not introduce a new metrics path; this PR is observability-only.
+
+## Verification
+
+```bash
+uv run pytest tests/unit/services/test_llm.py tests/unit/test_llm_service.py -q
+```
+
+## Related
+
+- Sibling drafts: 02 (HyDE), 03 (QueryAnalyzer), 05 (SessionSummaryWorker._generate_summary) — same orphan-generation pattern.

--- a/.github/issue-drafts/2026-05-19-langfuse-trace-coverage/05-session-summary-worker-generate-summary.md
+++ b/.github/issue-drafts/2026-05-19-langfuse-trace-coverage/05-session-summary-worker-generate-summary.md
@@ -1,0 +1,51 @@
+# observability: SessionSummaryWorker._generate_summary not wrapped in @observe
+
+## Source
+
+2026-05-19 Langfuse trace-coverage audit (`.github/issue-drafts/2026-05-19-langfuse-trace-coverage/`).
+
+## Problem
+
+`SessionSummaryWorker._check_idle_sessions` is decorated with `@observe(name="session-summary-check")`, but the LLM call site `_generate_summary` is **not** wrapped. The actual completion call at line 156 is auto-traced via `langfuse.openai`, but it sits as a flat child of `session-summary-check` without:
+
+- a dedicated span name to filter/aggregate on;
+- per-summary input/output metadata (history length, summary length, model);
+- an explicit `level=ERROR` path on LLM failure.
+
+Today an LLM failure during summary generation appears as a generic `litellm-acompletion` error; you cannot distinguish it from a generation failure in the request-scoped path.
+
+## Evidence
+
+- `telegram_bot/services/session_summary_worker.py:90` — `@observe(name="session-summary-check")` on `_check_idle_sessions`.
+- `telegram_bot/services/session_summary_worker.py:152` — `async def _generate_summary(self, history: list[dict[str, str]]) -> str`; no `@observe`.
+- `telegram_bot/services/session_summary_worker.py:156` — `await self._llm.chat.completions.create(...)`.
+
+## SDK Baseline
+
+- Langfuse Python v3: `@observe(name="session-summary-llm", capture_input=False, capture_output=False)` for the LLM-call wrapper.
+- Established pattern: `telegram_bot/services/nurturing_service.py:174` — `@observe(name="nurturing-llm-generate", capture_input=False, capture_output=False)` on the LLM-call wrapper inside an outer scheduler span.
+
+## Implementation Plan
+
+1. Decorate `_generate_summary` with `@observe(name="session-summary-llm", capture_input=False, capture_output=False)`.
+2. Set `update_current_span(input={"history_turns": len(history), "model": self._model})` before the call.
+3. Set `update_current_span(output={"summary_len": len(summary), "summary_preview": summary[:120]})` after the call.
+4. On LLM failure: `update_current_span(level="ERROR", status_message=str(exc)[:200])`, then re-raise.
+
+## Forbidden
+
+- Do not capture full conversation history in span input.
+- Do not capture full summary text in span output.
+- Do not change the placeholder fallback behavior tracked separately in #1599 / #1608.
+- No retry or job-scheduling changes in this PR.
+
+## Verification
+
+```bash
+uv run pytest tests/unit/services/test_session_summary_worker.py -q
+```
+
+## Related
+
+- #1599, #1608 — placeholder source / cap/perf for session summary worker (orthogonal, do not change in this PR).
+- #1654 — APScheduler migration for periodic loops (orthogonal, separate PR).

--- a/.github/issue-drafts/2026-05-19-langfuse-trace-coverage/06-background-jobs-spans.md
+++ b/.github/issue-drafts/2026-05-19-langfuse-trace-coverage/06-background-jobs-spans.md
@@ -1,0 +1,52 @@
+# observability: lead-scoring / hot-lead / nurturing-scheduler background jobs missing @observe
+
+## Source
+
+2026-05-19 Langfuse trace-coverage audit (`.github/issue-drafts/2026-05-19-langfuse-trace-coverage/`).
+
+## Problem
+
+Several periodic / on-demand background jobs run with **no Langfuse span**, so a hung or failing job is visible only via logs. Without a span, you cannot:
+
+- aggregate per-job latency in Langfuse Sessions UI;
+- attach a `tags=["job", "<name>"]` filter for ops dashboards;
+- record `level=ERROR` with a structured `status_message` for failure attribution.
+
+`NurturingScheduler.run_nurturing_batch` already has `@observe(name="nurturing-scheduler-tick")`, so the pattern is established and accepted. This issue extends the same pattern to the remaining jobs.
+
+## Evidence
+
+- `telegram_bot/services/lead_score_sync.py:14` — `async def sync_pending_lead_scores(...)`; no `@observe`.
+- `telegram_bot/services/hot_lead_notifier.py:27` — `async def notify_if_hot(self, payload)`; no `@observe`.
+- `telegram_bot/services/nurturing_scheduler.py:99` — `async def run_nurturing_dispatch(self)`; no `@observe`.
+- `telegram_bot/services/nurturing_scheduler.py:108` — `async def run_funnel_rollup(self)`; no `@observe`.
+- Companion (already done): `telegram_bot/services/nurturing_scheduler.py:90` — `@observe(name="nurturing-scheduler-tick")` on `run_nurturing_batch`.
+
+## SDK Baseline
+
+- Langfuse Python v3: `@observe(name="job-<name>", capture_input=False, capture_output=False)` paired with `propagate_attributes(tags=["job", "<area>"])` inside the body so every nested generation gets the job tag.
+- Established pattern: `telegram_bot/services/nurturing_scheduler.py:90`.
+
+## Implementation Plan
+
+1. Add `@observe(name="job-lead-score-sync", capture_input=False, capture_output=False)` on `sync_pending_lead_scores`. Inside, `propagate_attributes(tags=["job", "lead-scoring"])`. Set `update_current_span(output={"processed": n, "failed": k, "skipped": s})` after the batch.
+2. Add `@observe(name="job-hot-lead-notify", capture_input=False, capture_output=False)` on `HotLeadNotifier.notify_if_hot`. Set `update_current_span(input={"lead_id": lead_id, "score": score, "threshold": threshold})` and `output={"notified": bool_value}`.
+3. Add `@observe(name="job-nurturing-dispatch", capture_input=False, capture_output=False)` on `run_nurturing_dispatch` with `propagate_attributes(tags=["job", "nurturing"])`.
+4. Add `@observe(name="job-funnel-rollup", capture_input=False, capture_output=False)` on `run_funnel_rollup` with `propagate_attributes(tags=["job", "analytics"])`.
+5. On exception in any: `update_current_span(level="ERROR", status_message=str(exc)[:200])` then re-raise so APScheduler can record the failure.
+
+## Forbidden
+
+- No new metrics or alerting in this PR; just spans (alerts are tracked in #1416).
+- No coalesce/concurrency changes; only instrumentation.
+- Do not capture full `payload` dicts in `update_current_span(input=...)` — keep curated keys only (lead_id, score, threshold). PII (phone/email) must not appear in span input.
+
+## Verification
+
+```bash
+uv run pytest tests/unit/services/test_lead_score_sync.py tests/unit/services/test_hot_lead_notifier.py tests/unit/services/test_nurturing_scheduler.py -q
+```
+
+## Related
+
+- #1654 — APScheduler migration (orthogonal). This PR can land before or after #1654; the `@observe` decorators work the same with both task-based and scheduler-based execution.

--- a/.github/issue-drafts/2026-05-19-langfuse-trace-coverage/07-crm-callbacks-remaining-handlers.md
+++ b/.github/issue-drafts/2026-05-19-langfuse-trace-coverage/07-crm-callbacks-remaining-handlers.md
@@ -1,0 +1,66 @@
+# observability: complete @observe coverage on CRM aiogram callback handlers
+
+## Source
+
+2026-05-19 Langfuse trace-coverage audit (`.github/issue-drafts/2026-05-19-langfuse-trace-coverage/`).
+
+## Problem
+
+`LangfuseContextMiddleware` creates a root span per Telegram callback, and the highest-traffic CRM callbacks (`on_task_complete`, `on_note_text_received`) have nested `@observe` decorators. But several **write-side** callback handlers run inside the root span as a flat collection of statements — calling Kommo, mutating FSM state, posting messages — with no nested span. As a result the trace timeline shows one span and a fan of un-named `kommo-*` children, making it hard to read flow at a glance.
+
+This is the standard symptom of partial @observe rollout; this issue closes the gap on the remaining callbacks.
+
+## Evidence
+
+- `telegram_bot/handlers/crm_callbacks.py:37` — `async def on_lead_note(...)`; no `@observe`.
+- `telegram_bot/handlers/crm_callbacks.py:57` — `async def on_lead_task(...)`; no `@observe`.
+- `telegram_bot/handlers/crm_callbacks.py:100` — `async def on_task_postpone(...)`; no `@observe`.
+- `telegram_bot/handlers/crm_callbacks.py:125` — `async def on_contact_note(...)`; no `@observe`.
+- `telegram_bot/handlers/crm_callbacks.py:175` — `async def on_task_text_received(...)`; no `@observe`.
+- `telegram_bot/handlers/crm_callbacks.py:212` — `async def on_task_edit(...)`; no `@observe`.
+- `telegram_bot/handlers/crm_callbacks.py:230` — `async def on_edit_field_chosen(...)`; no `@observe`.
+- `telegram_bot/handlers/crm_callbacks.py:247` — `async def on_edit_task_text_received(...)`; no `@observe`.
+- `telegram_bot/handlers/crm_callbacks.py:275` — `async def on_edit_task_date_received(...)`; no `@observe`.
+- Companions already done: `crm_callbacks.py:77` (`crm-quick-complete`), `crm_callbacks.py:145` (`crm-quick-note`).
+
+## SDK Baseline
+
+- Langfuse Python v3: `@observe(name="crm-<action>", capture_input=False, capture_output=False)` per write-handler.
+- Curated `update_current_span(input={"deal_id": ..., "action": ...})`; **never** raw `callback.data` or full FSM state.
+- Established pattern: `crm_callbacks.py:77` and `crm_callbacks.py:145`.
+
+## Implementation Plan
+
+For each handler listed under Evidence, apply:
+
+1. Decorator: `@observe(name="crm-<short-action-name>", capture_input=False, capture_output=False)`. Suggested names:
+   - `on_lead_note` → `crm-lead-note-prompt`
+   - `on_lead_task` → `crm-lead-task-prompt`
+   - `on_task_postpone` → `crm-task-postpone`
+   - `on_contact_note` → `crm-contact-note-prompt`
+   - `on_task_text_received` → `crm-task-create`
+   - `on_task_edit` → `crm-task-edit-prompt`
+   - `on_edit_field_chosen` → `crm-task-edit-field`
+   - `on_edit_task_text_received` → `crm-task-edit-text`
+   - `on_edit_task_date_received` → `crm-task-edit-date`
+2. Curated `update_current_span(input={...})` with stable keys (e.g., `deal_id`, `task_id`, `field`, `action`).
+3. On user-facing failure (Kommo error caught and shown to user): `update_current_span(level="ERROR", status_message=str(exc)[:200])`.
+4. On no-op / cancelled paths: `update_current_span(output={"action": "cancelled"})` so the span carries the decision.
+
+## Forbidden
+
+- No raw `callback.data` or `state.get_data()` content in span input/output.
+- No PII (phone/email/full name) in span fields.
+- No changes to FSM state semantics.
+- No move of these callbacks to a different module.
+
+## Verification
+
+```bash
+uv run pytest tests/unit/handlers/test_crm_callbacks.py -q
+```
+
+## Related
+
+- #1655 — Kommo Pydantic custom-field models (orthogonal).
+- Sibling draft 09 — link Langfuse Prompts to generations (does not touch callbacks).

--- a/.github/issue-drafts/2026-05-19-langfuse-trace-coverage/08-generation-actual-model-name.md
+++ b/.github/issue-drafts/2026-05-19-langfuse-trace-coverage/08-generation-actual-model-name.md
@@ -1,0 +1,61 @@
+# observability: generation observations record requested model, not LiteLLM-routed actual model
+
+## Source
+
+2026-05-19 Langfuse trace-coverage audit (`.github/issue-drafts/2026-05-19-langfuse-trace-coverage/`).
+
+## Problem
+
+Several LLM-call wrappers correctly mark the span and pass `name=` to `chat.completions.create`, but they do not call `update_current_generation(model=response.model)` after the call. When LiteLLM routes the request to a different backend than what was requested (e.g., requested `gpt-oss-120b`, actually served by `cerebras/gpt-oss-120b`), the generation observation in Langfuse keeps the requested name. This:
+
+- breaks per-provider cost attribution in Langfuse Usage UI;
+- hides router fallback events from latency/cost dashboards;
+- makes A/B comparison between providers invisible.
+
+`telegram_bot/graph/nodes/rewrite.py` already does this correctly (`update_current_generation(model=rewrite_actual_model)` after the call). This issue propagates the same pattern to other LLM-call wrappers.
+
+## Evidence
+
+- ✅ Already correct: `telegram_bot/graph/nodes/rewrite.py` reads `response.model` and writes it to the generation.
+- ❌ Missing: `telegram_bot/services/ai_advisor_service.py:264` (`@observe(name="advisor-llm-call")`) — does not call `update_current_generation(model=...)`.
+- ❌ Missing: `telegram_bot/services/handoff_summary.py` — `generate_handoff_summary` LLM call.
+- ❌ Missing: `telegram_bot/services/nurturing_service.py:174` (`@observe(name="nurturing-llm-generate")`) — message-generation LLM call.
+- ❌ Missing: `telegram_bot/services/session_summary.py` — `generate_summary` LLM call.
+- ❌ Missing: `telegram_bot/services/query_analyzer.py:97` — instructor call (after fix in companion draft 03).
+
+## SDK Baseline
+
+- Langfuse Python v3: after the LLM call returns, call `get_client().update_current_generation(model=response.model, usage_details={"input": ..., "output": ...})` to attach the actual served model and usage breakdown.
+- Established pattern: `telegram_bot/graph/nodes/rewrite.py` (rewrite node).
+
+## Implementation Plan
+
+1. In each wrapper listed under Evidence, capture `response = await client.chat.completions.create(...)` (do not discard) and immediately call:
+   ```python
+   from telegram_bot.observability import get_client
+   actual_model = getattr(response, "model", None)
+   if actual_model:
+       get_client().update_current_generation(model=actual_model)
+   ```
+2. Where `response.usage` is available (non-streaming), also pass `usage_details={"input": response.usage.prompt_tokens, "output": response.usage.completion_tokens, "total": response.usage.total_tokens}` so Usage UI is correct.
+3. For streaming paths (`LLMService.stream_answer`), capture `chunk.model` from the first chunk that exposes it (varies by provider) and call `update_current_generation` once. Do not call it per chunk.
+4. Keep this fix scoped to instrumentation; no changes to retry, fallback, or routing logic.
+
+## Forbidden
+
+- No new dependency on LiteLLM internals; rely on standard OpenAI response shape (`response.model`, `response.usage.*`).
+- No mutation of caller-visible response object.
+- No log spam — write `update_current_generation` once per call site.
+
+## Verification
+
+```bash
+uv run pytest tests/unit/services -k "advisor or handoff_summary or nurturing or session_summary or query_analyzer" -q
+```
+
+Manual: send a Telegram query that hits each path; confirm in Langfuse UI that the generation `model` field equals what LiteLLM actually served (visible in LiteLLM logs as `successful_call_model_name`).
+
+## Related
+
+- #1648 — observability stack consolidation (orthogonal).
+- Sibling drafts 02-05 — orphan-generation @observe wrappers; this issue should land **after** those, since it modifies the same call sites.

--- a/.github/issue-drafts/2026-05-19-langfuse-trace-coverage/09-langfuse-prompts-link-to-generation.md
+++ b/.github/issue-drafts/2026-05-19-langfuse-trace-coverage/09-langfuse-prompts-link-to-generation.md
@@ -1,0 +1,66 @@
+# observability: link Langfuse Prompts to generations via update_current_generation(prompt=...)
+
+## Source
+
+2026-05-19 Langfuse trace-coverage audit (`.github/issue-drafts/2026-05-19-langfuse-trace-coverage/`).
+
+## Problem
+
+`telegram_bot/services/prompt_manager.get_prompt(name=, fallback=)` is used across nodes and services to fetch managed prompts from Langfuse. However, the fetched `Prompt` object is **never** passed into `update_current_generation(prompt=...)`. As a result:
+
+- Langfuse UI shows generations without a "Prompt" link, breaking the **Prompt → Traces** drill-down used to evaluate prompt versions.
+- A/B-experimentation and prompt rollback workflows lose their telemetry hook.
+- Cost/latency comparison "by prompt version" is impossible.
+
+## Evidence
+
+- `grep -rn "update_current_generation(prompt=" telegram_bot/ src/` returns **zero matches**.
+- All call sites currently look like: `prompt = get_prompt("...")`, build messages, call LLM — but the `prompt` object is discarded after `compile()` / `messages` extraction.
+- Hot call sites that should link prompts:
+  - `telegram_bot/services/generate_response.py` (`get_prompt("response_generation", ...)`)
+  - `telegram_bot/services/query_preprocessor.py` (`get_prompt("hyde", ...)`)
+  - `telegram_bot/services/query_analyzer.py` (`get_prompt("query_analysis", ...)`)
+  - `telegram_bot/services/nurturing_service.py` (`get_prompt("nurturing", ...)`)
+  - `telegram_bot/services/session_summary.py` (`get_prompt("session_summary", ...)`)
+  - `telegram_bot/services/ai_advisor_service.py` (`get_prompt("advisor", ...)`)
+  - `telegram_bot/services/handoff_summary.py` (`get_prompt("handoff_summary", ...)`)
+  - `src/contextualization/{claude,groq,openai}.py` (`get_prompt("contextualize", ...)`)
+
+## SDK Baseline
+
+- Langfuse Python v3 docs: `update_current_generation(prompt=prompt_obj)` accepts the `Prompt` object returned by `langfuse.get_prompt(...)`. This binds the generation observation to a versioned prompt in Langfuse Prompt Management.
+- Pattern (from Langfuse cookbook): inside an `@observe`-decorated function, after fetching the prompt and before/after the LLM call, call `get_client().update_current_generation(prompt=prompt_obj)`.
+
+## Implementation Plan
+
+1. Audit `prompt_manager.get_prompt(...)` callers. Where the function does not already return the raw `Prompt` object, **expose it** alongside the compiled messages without changing existing call sites' message-list contract.
+2. At each call site listed under Evidence, after the LLM call (inside the same `@observe` span), call:
+   ```python
+   from telegram_bot.observability import get_client
+   if prompt_obj is not None:
+       get_client().update_current_generation(prompt=prompt_obj)
+   ```
+3. For services where multiple prompts may be used in one trace (e.g., `query_analyzer` + `generate_response` chained), each call site links its own prompt — Langfuse handles the per-generation binding.
+4. For fallback paths where `prompt_obj` is `None` (Langfuse unavailable, fallback string used), skip the link silently — no errors.
+5. Add a unit test that mocks the Langfuse client and asserts `update_current_generation` was called with `prompt=<Prompt>` at least once per LLM-call wrapper.
+
+## Forbidden
+
+- Do not change the public signature of `get_prompt` in a breaking way; expand its return shape only if it stays backwards-compatible (e.g., add an optional `return_prompt_obj=False` flag, or return a tuple in a new `get_prompt_with_obj` function).
+- Do not link a fallback string as if it were a managed prompt — only link real `Prompt` objects from Langfuse.
+- No prompt-store migration in this PR.
+- No changes to prompt template content or variables.
+
+## Verification
+
+```bash
+uv run pytest tests/unit/services/test_prompt_manager.py -q
+uv run pytest tests/unit/services -k "generate_response or query_preprocessor or query_analyzer or nurturing or session_summary or advisor or handoff" -q
+uv run pytest tests/unit/contextualization -q
+```
+
+Manual: in Langfuse UI, open any production trace; the generation observation should show a "Prompt" link to a versioned prompt in Prompt Management.
+
+## Related
+
+- This issue depends on draft 02 (HyDE @observe), 03 (QueryAnalyzer @observe), 04 (LLMService @observe), 05 (SessionSummaryWorker @observe), and 08 (actual model name) — all of those should land first so that there is an active span/generation to update.

--- a/.github/issue-drafts/2026-05-19-langfuse-trace-coverage/README.md
+++ b/.github/issue-drafts/2026-05-19-langfuse-trace-coverage/README.md
@@ -1,0 +1,38 @@
+# Langfuse trace coverage audit — 2026-05-19
+
+Source: full audit of Langfuse instrumentation across the monorepo against
+Langfuse Python SDK v3 docs (`@observe`, `propagate_attributes`,
+`start_as_current_observation`, `langfuse.openai`, `langfuse.langchain.CallbackHandler`,
+prompt-to-generation linking, masking).
+
+Every file in this directory is a **ready-to-paste body for a separate GitHub issue**.
+Drafts are scoped so each maps to one focused PR.
+
+## Out of scope (already tracked)
+
+- #1543 — contextualize batch loop and ColBERT span gaps.
+- #1367 — closed; covered the original 7 zero-coverage modules.
+- #1253 — trace context propagation between RAG pipeline and SDK agent graphs.
+- #1416 — full self-hosted observability stack (Alloy/Loki/Grafana/Bugsink/Uptime Kuma).
+- #1369 — closed; duplicate detect-agent-intent / WARNING level fixes.
+
+## Drafts
+
+| # | File | Priority | One-liner |
+|---|------|----------|-----------|
+| 01 | `01-miniapp-api.md` | P0 | Mini App FastAPI has zero Langfuse spans; conversion funnel invisible. |
+| 02 | `02-hyde-generate-hypothetical-document.md` | P0 | `HyDEGenerator.generate_hypothetical_document` produces orphan generation. |
+| 03 | `03-query-analyzer-analyze.md` | P0 | `QueryAnalyzer.analyze` produces orphan generation. |
+| 04 | `04-llm-service-public-methods.md` | P0 | `LLMService.{generate_answer, stream_answer, generate}` produce orphan generations. |
+| 05 | `05-session-summary-worker-generate-summary.md` | P0 | `SessionSummaryWorker._generate_summary` not wrapped in @observe. |
+| 06 | `06-background-jobs-spans.md` | P1 | Lead-scoring sync, hot-lead notifier, and 2 nurturing-scheduler jobs are invisible. |
+| 07 | `07-crm-callbacks-remaining-handlers.md` | P1 | Several aiogram CRM callback handlers run inside root span without nested @observe. |
+| 08 | `08-generation-actual-model-name.md` | P1 | Generation observations record requested model, not LiteLLM-routed actual `response.model`. |
+| 09 | `09-langfuse-prompts-link-to-generation.md` | P2 | `update_current_generation(prompt=...)` not used; breaks Prompt → Trace linking. |
+
+## How to use
+
+1. Open each file in this folder.
+2. Copy the body into a new GitHub issue.
+3. Apply labels matching existing observability issues: `domain:observability`, priority (`P0-now` / `P1-next` / `P2-backlog`), and `lane:plan-needed` if planning is required.
+4. Close this docs PR after issues are filed; drafts can be deleted from the branch on merge.


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

This PR adds **9 issue drafts** to `.github/issue-drafts/2026-05-19-langfuse-trace-coverage/`, one markdown file per separate GitHub issue, written in the project's house style (matches #1656/#1655/#1654/#1653 — "Source / Problem / Evidence / SDK Baseline / Implementation Plan / Forbidden / Verification / Related").

Each draft maps to **one focused PR**. They are intentionally split for granularity: small, mergeable, low-risk per-file fixes.

## Audit method

- Sources: Langfuse Python SDK v3 docs (via Context7 `/langfuse/langfuse-docs`), repo grep for `@observe` / `from langfuse` / `get_client` / `propagate_attributes` / `langfuse.openai`.
- Cross-checked against existing observability issues to avoid duplicates.
- Out of scope (already tracked): #1543 (contextualize batch + ColBERT), #1367 (closed; original 7 modules), #1253 (cross-graph trace propagation), #1416 (full self-hosted obs stack), #1369 (closed).

## Drafts

| # | File | Priority | One-liner |
|---|------|----------|-----------|
| 01 | `01-miniapp-api.md` | **P0** | Mini App FastAPI has zero Langfuse spans; conversion funnel invisible. |
| 02 | `02-hyde-generate-hypothetical-document.md` | **P0** | `HyDEGenerator.generate_hypothetical_document` produces orphan generation. |
| 03 | `03-query-analyzer-analyze.md` | **P0** | `QueryAnalyzer.analyze` produces orphan generation. |
| 04 | `04-llm-service-public-methods.md` | **P0** | `LLMService.{generate_answer, stream_answer, generate}` produce orphan generations. |
| 05 | `05-session-summary-worker-generate-summary.md` | **P0** | `SessionSummaryWorker._generate_summary` not wrapped in @observe. |
| 06 | `06-background-jobs-spans.md` | P1 | Lead-scoring sync, hot-lead notifier, 2 nurturing-scheduler jobs invisible. |
| 07 | `07-crm-callbacks-remaining-handlers.md` | P1 | 9 aiogram CRM callback handlers run inside root span without nested @observe. |
| 08 | `08-generation-actual-model-name.md` | P1 | Generation observations record requested model, not LiteLLM-routed actual `response.model`. |
| 09 | `09-langfuse-prompts-link-to-generation.md` | P2 | `update_current_generation(prompt=...)` not used; breaks Prompt → Trace linking. |

## How to use this PR

1. Open each `.md` file in this branch on GitHub.
2. Copy the body into a new GitHub issue (one issue per file).
3. Apply existing observability labels: `domain:observability`, priority (`P0-now` / `P1-next` / `P2-backlog`), and `lane:plan-needed` if planning is required.
4. Close this docs PR after issues are filed; the drafts can stay in `.github/issue-drafts/` as an audit record, or be deleted from the branch on merge.

## Tested

- No code changes; docs-only. CI lint/test will pass without surprises.
- Each draft references real file:line locations and existing companion patterns in the repo (verified via grep).

## What was NOT done

- No `@observe` decorators were added to source code in this PR. Each draft is a separate PR's worth of work and should land in its own branch with its own tests.
- No issue was filed automatically (no `create_issue` tool available in this session); the drafts are designed for manual paste-create, mirroring the existing #1656/#1655/#1654 migration pattern.