### PR TITLE
chore: 3 audit follow-up issue drafts + create_issues.sh

### DIFF
--- a/.github/issue-drafts/2026-05-19-audit-newgaps/01-langgraph-send-parallel-fanout.md
+++ b/.github/issue-drafts/2026-05-19-audit-newgaps/01-langgraph-send-parallel-fanout.md
@@ -1,0 +1,90 @@
+# refactor: use LangGraph `Send` for parallel fan-out in HyDE / multi-language / multi-query paths
+
+## Source
+
+2026-05-19 cross-domain SDK audit (`.github/issue-drafts/2026-05-19-langfuse-trace-coverage/AUDIT_REPORT.md`, Finding 4).
+
+## Problem
+
+LangGraph 1.x exposes `Send` (from `langgraph.types`) — the SDK-native primitive for parallel fan-out in conditional edges. It dispatches one source node to multiple downstream node invocations with different inputs (the canonical "map" pattern in graph-based pipelines).
+
+Repo grep:
+
+```bash
+$ grep -rn "from langgraph\.types import Send\|Send(" telegram_bot/ src/
+# (no matches)
+```
+
+Several paths today are **sequential** where parallel fan-out would improve latency and recall:
+
+1. **HyDE multi-document expansion** — `telegram_bot/services/query_preprocessor.py:HyDEGenerator.generate_hypothetical_document` produces a single hypothetical document per query. Variants like multi-perspective HyDE (different system prompts per worker) need parallel calls. Today this would require `asyncio.gather` outside the graph; with `Send`, it stays inside the graph and inherits checkpointer / Langfuse parent context naturally.
+2. **Multi-language query expansion** — apartment search supports Russian/English/Bulgarian. If the system ever does parallel queries in each language and merges via RRF, `Send` is the SDK-native shape.
+3. **Pre-agent classification + retrieval** — currently classify → cache_check → retrieve runs serially. Independent steps (e.g. classify intent + extract apartment filters) could fan-out from `START`.
+
+## Evidence — what's in the repo today
+
+- `telegram_bot/graph/graph.py` builds a sequential `StateGraph` with `add_node` + `add_edge` / `add_conditional_edges`. No fan-out.
+- `telegram_bot/services/query_preprocessor.py:HyDEGenerator.generate_hypothetical_document` — single LLM call.
+- `telegram_bot/agents/rag_pipeline.py` — sequential retrieval / grade / rerank pipeline.
+
+## Context7 SDK baseline — `/langchain-ai/langgraph`
+
+```python
+from langgraph.types import Send
+from langgraph.graph import StateGraph
+
+def fan_out(state):
+    # Returns list of Send commands; LangGraph runs targets concurrently.
+    return [
+        Send("worker_node", {"query": q})
+        for q in state["queries"]
+    ]
+
+workflow.add_conditional_edges("classify", fan_out, ["worker_node"])
+```
+
+`Send` carries:
+- target node name (must be in graph);
+- partial state for that invocation (each worker sees its own `state["query"]`);
+- the workers' state updates merge back via the state reducer (e.g. `Annotated[list, add_messages]` or custom reducer).
+
+## Implementation plan
+
+This is a **scoping issue**, not a single PR. Required steps:
+
+1. **Survey** — list every place in `telegram_bot/graph/`, `telegram_bot/agents/`, `telegram_bot/services/` where the bot does sequential work that's structurally a map-then-merge.
+2. **Pick one pilot** — recommend HyDE multi-document. Reasons: small surface, clear quality win (multi-perspective recall), doesn't change UX.
+3. **Define merge reducer** — for HyDE, the reducer collects N hypothetical docs into a list, then dense+sparse retrieval consumes the list as a single batched embedding call.
+4. **Span model** — `Send` workers automatically get nested under the parent span when wrapped in an `@observe`-decorated graph node. Verify against `_validation_comments/04-1661-hyde.md` recommendations.
+5. **Pilot PR** — implement HyDE fan-out behind a config flag (`HYDE_FANOUT_DOCS=3`).
+6. **Evaluation** — measure NDCG@10 / Recall@10 vs single-doc HyDE on the gold set.
+
+## Forbidden
+
+- No external `asyncio.gather` in graph code where `Send` would express the same pattern (loses checkpointer context and Langfuse parent span).
+- No new graph framework beyond LangGraph 1.x.
+- No change to current sequential paths until the pilot ships and proves the pattern works.
+
+## SDK / Local Baseline
+
+- LangGraph: `1.0.x` per repo's pin (`telegram_bot/pyproject.toml`).
+- `Send` is part of `langgraph.types` since LangGraph 0.2.x; stable in 1.x.
+
+## Verification
+
+```bash
+uv run pytest tests/unit/services/test_query_preprocessor.py -q
+uv run pytest tests/unit/graph -q
+# Add a focused test that asserts the graph topology contains a Send-based fan-out
+# under HYDE_FANOUT_DOCS > 1.
+```
+
+## Related
+
+- #1538 — broader SDK-vs-custom audit. This is one concrete next item.
+- #1535 — voice path migration to `create_agent`. Orthogonal.
+- #1652 — research issue for LangChain-native HyDE replacement. Cross-link: if a LangChain HyDE primitive exists in pinned versions, prefer that over `Send`-based fan-out.
+
+## Priority
+
+**P3-backlog** — quality and latency improvement, not a bug.

--- a/.github/issue-drafts/2026-05-19-audit-newgaps/02-langgraph-streamwriter-custom-mode.md
+++ b/.github/issue-drafts/2026-05-19-audit-newgaps/02-langgraph-streamwriter-custom-mode.md
@@ -1,0 +1,99 @@
+# refactor: replace custom DraftStreamer with LangGraph `StreamWriter` + `stream_mode="custom"`
+
+## Source
+
+2026-05-19 cross-domain SDK audit (`.github/issue-drafts/2026-05-19-langfuse-trace-coverage/AUDIT_REPORT.md`, Finding 5).
+
+## Problem
+
+LangGraph 1.x exposes `stream_mode="custom"` plus `StreamWriter` (injected as a node parameter) as the SDK-native way to emit progress events from inside graph nodes — typing indicators, partial drafts, retrieval-progress dots, etc. — without polluting the main `values`/`updates` stream and without coupling streaming logic to Telegram-specific surfaces.
+
+Repo grep:
+
+```bash
+$ grep -rn "StreamWriter\|stream_writer\|stream_mode=\"custom\"" telegram_bot/ src/
+# (no matches)
+```
+
+Today the bot uses **two custom abstractions** for the same job:
+
+1. `telegram_bot/services/draft_streamer.py:DraftStreamer` — Telegram `sendMessageDraft` polling wrapper.
+2. `telegram_bot/bot.py:3689-3749 _stream_agent_to_draft` — custom adapter from `agent.astream` to `DraftStreamer`.
+
+Both are flagged in the SDK audit (#1538) as "custom code that has an SDK equivalent". This issue is the concrete proposal.
+
+## Evidence — what's in the repo today
+
+- `telegram_bot/services/draft_streamer.py` — 51 lines, custom polling.
+- `telegram_bot/bot.py:3689-3749` — adapter glue tied to aiogram message edits.
+- `tests/unit/test_draft_streamer*.py` — tests pinned to the custom abstraction.
+- Issue #1538 lists this exact migration as P2.
+- Issue #1541 lists `DraftStreamer` as never-instantiated dead code (this audit recommends re-verifying that claim per `audit-clarify-1541-formula-query-not-dead.md`).
+
+## Context7 SDK baseline — `/langchain-ai/langgraph`
+
+```python
+# 1) Producer side — emit custom events from inside any graph node
+from langgraph.config import get_stream_writer
+
+async def respond_node(state, runtime):
+    writer = get_stream_writer()
+    writer({"type": "thinking", "stage": "retrieve"})
+    docs = await retrieve(state["query"])
+    writer({"type": "draft", "text": "Searching apartments..."})
+    answer = await generate(docs, state["query"])
+    writer({"type": "draft", "text": answer})
+    return {"messages": [AIMessage(content=answer)]}
+
+# 2) Consumer side — Telegram bot subscribes to the custom mode
+async for event in graph.astream(input, config, stream_mode="custom"):
+    # event is the dict the producer wrote
+    await dispatch_to_telegram_draft(event)
+```
+
+`StreamMode = Literal["values", "updates", "checkpoints", "tasks", "debug", "messages", "custom"]`.
+
+The `"custom"` mode is independent of the main state stream, so producer events don't fight with the canonical state-update stream that the rest of the app already consumes.
+
+## Implementation plan
+
+1. **Producer** — replace direct calls to `DraftStreamer.write(...)` inside graph nodes with `get_stream_writer()(...)`. Producer emits structured events (`{"type": "thinking" | "draft" | "filter_extracted" | ...}`).
+2. **Consumer** — refactor `bot.py:_stream_agent_to_draft` into a thin adapter that:
+   - calls `graph.astream(input, config, stream_mode=["custom", "messages"])` (multi-mode);
+   - dispatches `"custom"` events to `aiogram` message edits;
+   - dispatches `"messages"` events for token-level streaming where needed.
+3. **Delete** `services/draft_streamer.py` once all producers/consumers are migrated.
+4. **Migrate tests** — assertions move from `DraftStreamer.write_called_with(...)` to `graph.astream(stream_mode="custom") yields {...}`.
+5. **Pin removed** — `_BACKGROUND_TASKS` set in `funnel.py:263` (#1541) and any other ad-hoc streaming glue.
+
+## Forbidden
+
+- No new custom streaming abstraction.
+- No coupling of `aiogram` editing logic into graph node code (graph nodes write to `StreamWriter`, the bot consumes; aiogram concerns stay in `bot.py`).
+- Land BEFORE or AFTER #1535 (voice path migration). Order does not matter; both paths can adopt `stream_mode="custom"` independently.
+
+## SDK / Local Baseline
+
+- LangGraph: `1.0.x` per repo's pin.
+- `StreamWriter` and `stream_mode="custom"` are stable in LangGraph 1.x.
+- `langgraph.config.get_stream_writer()` is the canonical accessor inside async nodes.
+
+## Verification
+
+```bash
+uv run pytest tests/unit/test_draft_streamer*.py -q   # adapt or remove
+uv run pytest tests/unit/graph -q
+uv run pytest tests/unit/test_bot_handlers.py -k "stream" -q
+```
+
+Manual: send a long query in dev. Confirm Telegram message edits show retrieval progress + final answer streamed exactly as before, but with no `DraftStreamer` import in the call chain.
+
+## Related
+
+- #1538 — broader SDK-vs-custom audit; this is one of the concrete migrations listed there as P2.
+- #1541 — dead-code cleanup includes `DraftStreamer`. After this PR lands, the cleanup is straightforward.
+- #1535 — voice path migration to `create_agent`. Orthogonal but synergistic.
+
+## Priority
+
+**P2-backlog** — moderate maintenance win, modest UX consistency win.

--- a/.github/issue-drafts/2026-05-19-audit-newgaps/03-instructor-streaming-partial.md
+++ b/.github/issue-drafts/2026-05-19-audit-newgaps/03-instructor-streaming-partial.md
@@ -1,0 +1,108 @@
+# research: evaluate `instructor.create_partial` for live filter / structured-output streaming
+
+## Source
+
+2026-05-19 cross-domain SDK audit (`.github/issue-drafts/2026-05-19-langfuse-trace-coverage/AUDIT_REPORT.md`, Finding 7).
+
+## Problem
+
+`instructor` 1.x ships `client.create_partial(response_model=..., stream=True)` and `client.create_iterable(response_model=..., stream=True)` for token-by-token streaming of structured Pydantic models. The repo uses `instructor` for structured extraction (apartment filters, query analysis, confidence scoring) but **only in non-streaming mode**.
+
+Repo grep:
+
+```bash
+$ grep -rn "create_partial\|create_iterable" telegram_bot/ src/
+# (no matches)
+```
+
+## Evidence — what's in the repo today
+
+- `telegram_bot/services/apartment_llm_extractor.py:121` — single non-streaming call.
+- `telegram_bot/services/query_analyzer.py:97` — single non-streaming call.
+- `telegram_bot/services/llm.py:140-141` — confidence path, single non-streaming call.
+
+The user-facing impact varies by surface:
+
+- **Telegram text path** — Telegram does not have token-level UX. `create_partial` is **not useful** here.
+- **Voice path** — STT → query understanding → response. If the voice agent surfaces "extracting filters: bedrooms=2…" while the LLM still streams, that's a perceived-latency win. **Useful here**.
+- **Future Mini App live UI** — if the Mini App grows a live chat surface, `create_partial` enables incremental rendering.
+
+## Context7 SDK baseline — `/567-labs/instructor`
+
+```python
+import instructor
+from pydantic import BaseModel
+
+class ApartmentFilters(BaseModel):
+    city: str | None
+    bedrooms: int | None
+    price_max: int | None
+
+# Existing client construction stays the same — preserves langfuse.openai auto-trace.
+client = instructor.from_openai(langfuse.openai.AsyncOpenAI(...))
+
+stream = client.create_partial(
+    response_model=ApartmentFilters,
+    stream=True,
+    messages=[...],
+)
+async for partial in stream:
+    # partial is ApartmentFilters with progressively-more-filled fields
+    if partial.city:
+        await voice_agent.say(f"Looking in {partial.city}...")
+    if partial.bedrooms:
+        await voice_agent.say(f"{partial.bedrooms}-bedroom...")
+```
+
+Or for multiple objects:
+
+```python
+stream = client.create_iterable(
+    response_model=Apartment,
+    messages=[...],
+)
+async for apt in stream:
+    await voice_agent.preview_apartment(apt)
+```
+
+## Implementation plan — RESEARCH ONLY
+
+This is a research issue; the outcome is one of:
+
+1. **Pilot in voice path** — a focused PR that streams apartment filter extraction in the voice agent and surfaces partials via TTS.
+2. **Defer** — document why streaming partials don't help current surfaces (e.g., latency budget already low, voice agent uses different framework).
+3. **Reject** — confirm `langfuse.openai` + `instructor.from_openai` + `create_partial` either does or does not preserve auto-trace in streaming mode.
+
+### Required research steps
+
+1. **Verify Langfuse trace shape** — `langfuse.openai` wraps `chat.completions.create`. Test that `instructor.create_partial(stream=True)` on top of a langfuse-wrapped client produces a single generation observation (not N orphan observations per chunk).
+2. **Latency profile** — measure first-partial-emitted latency vs total-completion latency for current voice queries. If < 200ms gap, the UX win is marginal.
+3. **Voice agent integration point** — identify where `apartment_llm_extractor` is called in voice path and whether the agent can accept incremental filter updates.
+
+## Forbidden
+
+- Do **not** switch to `instructor.from_provider("openai/gpt-...", async_client=True)` — that builds its own client and breaks the `langfuse.openai` auto-trace integration. The current `from_openai(langfuse.openai.AsyncOpenAI(...))` is the correct shape.
+- No new instructor-replacement abstraction.
+
+## SDK / Local Baseline
+
+- `instructor>=1.7.0` per `telegram_bot/pyproject.toml:10`.
+- `instructor.create_partial` is stable; `Partial[Model]` import lives at `instructor.dsl.partial`.
+
+## Verification
+
+```bash
+uv run pytest tests/unit/services/test_apartment_llm_extractor.py -q
+uv run pytest tests/unit/services/test_query_analyzer.py -q
+# Add: tests/unit/services/test_create_partial_langfuse_trace_shape.py
+```
+
+## Related
+
+- #1659 (`QueryAnalyzer` orphan generation) — orthogonal. Wraps a single non-streaming call.
+- #1660 (`LLMService` orphan generation) — orthogonal. The streaming paths in `LLMService` use OpenAI SDK streaming, not `instructor`.
+- `_validation_comments/02-1659-query-analyzer.md` — already flags the `instructor` + `langfuse.openai` compatibility risk that this issue would also need to validate.
+
+## Priority
+
+**P3-research** — outcome should be either a pilot issue or a documented decision in `docs/engineering/sdk-registry.md` saying why partial streaming is intentionally not used.

--- a/.github/issue-drafts/2026-05-19-audit-newgaps/README.md
+++ b/.github/issue-drafts/2026-05-19-audit-newgaps/README.md
@@ -1,0 +1,44 @@
+# Cross-domain SDK audit — new issue drafts (2026-05-19)
+
+Three SDK-native gaps surfaced during the 2026-05-19 audit (see context: closed PR #1657, full report
+in `.github/issue-drafts/2026-05-19-langfuse-trace-coverage/AUDIT_REPORT.md` if that branch is restored,
+or in the audit comments on #1538).
+
+## Files
+
+| File | Type | Priority | Title |
+|------|------|----------|-------|
+| `01-langgraph-send-parallel-fanout.md` | refactor | P3-backlog | LangGraph `Send` for parallel fan-out (HyDE multi-doc, multi-language) |
+| `02-langgraph-streamwriter-custom-mode.md` | refactor | P2-backlog | LangGraph `StreamWriter` + `stream_mode="custom"` replacing `DraftStreamer` |
+| `03-instructor-streaming-partial.md` | research | P3-backlog | Evaluate `instructor.create_partial` for voice-path live filter streaming |
+
+## How to file
+
+**Automated (recommended):**
+
+```bash
+GITHUB_TOKEN=ghp_xxx bash .github/issue-drafts/2026-05-19-audit-newgaps/create_issues.sh
+```
+
+Or with `gh` CLI:
+
+```bash
+bash .github/issue-drafts/2026-05-19-audit-newgaps/create_issues.sh --gh
+```
+
+The script reads each `*.md`, extracts the title from the first H1, and creates the issue with
+the labels listed in the script (matching repo convention from #1647–#1666).
+
+**Manual:** open new GitHub issues, copy the H1 as title, paste the rest as body, apply the labels
+from `create_issues.sh:FILES`.
+
+## Why drafts and not direct issue creation
+
+The provider gateway used by this repo's agent does not expose a `create_issue` tool — only
+`create_pull_request`. The script approach mirrors the pattern from PR #1657's `post_comments.sh`.
+
+## Cross-references
+
+- #1538 — broader SDK-vs-custom audit; these 3 issues are concrete next items extending it.
+- #1535 — voice path migration to `create_agent`. Issue 02 (StreamWriter) is synergistic.
+- #1652 — research issue for LangChain-native HyDE replacement. Issue 01 (Send) cross-links.

--- a/.github/issue-drafts/2026-05-19-audit-newgaps/create_issues.sh
+++ b/.github/issue-drafts/2026-05-19-audit-newgaps/create_issues.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Create 3 new GitHub issues from the audit-newgap markdown drafts.
+#
+# Each markdown file's first H1 (`# title`) becomes the issue title;
+# everything after the title becomes the issue body.
+#
+# Requires: GITHUB_TOKEN env var with `repo` scope, plus `curl` and `jq`.
+# Run from the repo root:
+#   GITHUB_TOKEN=ghp_xxx bash .github/issue-drafts/2026-05-19-audit-newgaps/create_issues.sh
+#
+# Or with gh CLI (no token plumbing needed if you're logged in):
+#   bash .github/issue-drafts/2026-05-19-audit-newgaps/create_issues.sh --gh
+
+set -euo pipefail
+
+OWNER="yastman"
+REPO="rag"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# File -> labels mapping. Labels follow the repo's convention seen in #1658-#1666
+# and #1647-#1656 (domain:observability / refactor / status:triaged / priority).
+declare -A FILES=(
+  ["01-langgraph-send-parallel-fanout.md"]="domain:observability,refactor,SDK-audit,P3-backlog,lane:plan-needed,status:triaged"
+  ["02-langgraph-streamwriter-custom-mode.md"]="domain:observability,refactor,SDK-audit,P2-backlog,lane:plan-needed,status:triaged"
+  ["03-instructor-streaming-partial.md"]="domain:observability,SDK-audit,P3-backlog,lane:plan-needed,status:triaged"
+)
+
+# Ordered keys (associative array iteration order isn't stable in bash)
+ORDERED_FILES=(
+  "01-langgraph-send-parallel-fanout.md"
+  "02-langgraph-streamwriter-custom-mode.md"
+  "03-instructor-streaming-partial.md"
+)
+
+USE_GH="false"
+if [[ "${1:-}" == "--gh" ]]; then
+  USE_GH="true"
+fi
+
+if [[ "$USE_GH" == "false" && -z "${GITHUB_TOKEN:-}" ]]; then
+  echo "ERROR: GITHUB_TOKEN is not set. Either:" >&2
+  echo "  - export GITHUB_TOKEN=ghp_xxx (with 'repo' scope), or" >&2
+  echo "  - re-run with --gh flag if you have 'gh' CLI installed and authenticated." >&2
+  exit 1
+fi
+
+create_issue() {
+  local file="$1"
+  local labels="$2"
+  local full_path="${DIR}/${file}"
+
+  if [[ ! -f "$full_path" ]]; then
+    echo "  SKIP: file not found: $full_path" >&2
+    return 0
+  fi
+
+  # Extract title from first H1 (strip leading "# " and any trailing whitespace).
+  local title
+  title=$(grep -m1 "^# " "$full_path" | sed -E 's/^# +//' | tr -d '\r' | sed -E 's/[[:space:]]+$//')
+
+  if [[ -z "$title" ]]; then
+    echo "  FAIL: no H1 found in $file" >&2
+    return 1
+  fi
+
+  # Body = everything AFTER the first H1 line.
+  local body
+  body=$(awk 'BEGIN{found=0} /^# /{if(!found){found=1; next}} {if(found) print}' "$full_path")
+
+  echo "==> Creating issue: $title"
+  echo "    File:   $file"
+  echo "    Labels: $labels"
+
+  if [[ "$USE_GH" == "true" ]]; then
+    # gh CLI accepts comma-separated --label values, but its convention is one --label per item.
+    local label_args=()
+    IFS=',' read -ra LABEL_ARR <<< "$labels"
+    for l in "${LABEL_ARR[@]}"; do
+      label_args+=(--label "$l")
+    done
+    gh issue create -R "${OWNER}/${REPO}" \
+      --title "$title" \
+      --body "$body" \
+      "${label_args[@]}" \
+      >/dev/null
+  else
+    # Build JSON payload via jq to handle newlines / special chars safely.
+    local labels_json
+    # Convert "a,b,c" -> ["a","b","c"]
+    labels_json=$(jq -nc --arg s "$labels" '$s | split(",")')
+    local payload
+    payload=$(jq -n \
+      --arg title "$title" \
+      --arg body "$body" \
+      --argjson labels "$labels_json" \
+      '{title: $title, body: $body, labels: $labels}')
+
+    local response_status
+    response_status=$(
+      curl -sS -o /tmp/create_issue_resp.json -w "%{http_code}" \
+        -X POST \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/repos/${OWNER}/${REPO}/issues" \
+        --data "$payload"
+    )
+    if [[ "$response_status" != "201" ]]; then
+      echo "    FAIL: HTTP ${response_status}" >&2
+      cat /tmp/create_issue_resp.json >&2
+      return 1
+    fi
+
+    local issue_num
+    issue_num=$(jq -r '.number' < /tmp/create_issue_resp.json)
+    local issue_url
+    issue_url=$(jq -r '.html_url' < /tmp/create_issue_resp.json)
+    echo "    OK: #${issue_num} — ${issue_url}"
+  fi
+}
+
+echo "==> Creating 3 audit follow-up issues from cross-domain SDK audit"
+echo ""
+
+for file in "${ORDERED_FILES[@]}"; do
+  create_issue "$file" "${FILES[$file]}"
+  echo ""
+done
+
+echo "==> Done. 3 new issues created."
+echo "   Cross-link them under #1538 (SDK-vs-custom audit) for traceability."


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Adds 3 ready-to-file issue drafts surfaced by the 2026-05-19 cross-domain SDK audit (closed PR #1657), plus `create_issues.sh` that creates them on GitHub in one prog.

## Drafts

| # | Priority | Title |
|---|----------|-------|
| 01 | P3-backlog | `refactor: use LangGraph Send for parallel fan-out in HyDE / multi-language / multi-query paths` |
| 02 | P2-backlog | `refactor: replace custom DraftStreamer with LangGraph StreamWriter + stream_mode=custom` |
| 03 | P3-backlog | `research: evaluate instructor.create_partial for live filter / structured-output streaming` |

Each markdown is a complete issue body in the repo's #1647–#1666 format (Source / Problem / Evidence / SDK Baseline / Implementation Plan / Forbidden / Verification / Related).

## How to file the issues

**With PAT:**
```bash
GITHUB_TOKEN=ghp_xxx bash .github/issue-drafts/2026-05-19-audit-newgaps/create_issues.sh
```

**With gh CLI:**
```bash
bash .github/issue-drafts/2026-05-19-audit-newgaps/create_issues.sh --gh
```

The script extracts the H1 as title, posts the rest as body, and applies labels per repo convention (`domain:observability`, `refactor` / `research`, `SDK-audit`, priority, `lane:plan-needed`, `status:triaged`).

## Why drafts and a script, not direct issue creation

The provider gateway used by this repo's agent does not expose a `create_issue` tool — only `create_pull_request`. Same workflow as PR #1657's `post_comments.sh`.

## Validation

- `bash -n create_issues.sh` — syntax OK
- Title extraction tested locally on each markdown:
  - `01-...` → `refactor: use LangGraph Send for parallel fan-out in HyDE / multi-language / multi-query paths`
  - `02-...` → `refactor: replace custom DraftStreamer with LangGraph StreamWriter + stream_mode="custom"`
  - `03-...` → `research: evaluate instructor.create_partial for live filter / structured-output streaming`

## Cross-references

- #1538 — broader SDK-vs-custom audit; these are concrete next items
- #1535 — voice path migration; #02 (StreamWriter) is synergistic
- #1652 — LangChain HyDE research; #01 (Send) cross-links

## Runtime impact

None — docs/scripts only.