### PR TITLE
feat(observability): wrap HyDEGenerator.generate_hypothetical_document in @observe (#1661)

### DIFF
--- a/telegram_bot/services/query_preprocessor.py
+++ b/telegram_bot/services/query_preprocessor.py
@@ -17,6 +17,13 @@ from telegram_bot.observability import get_client, observe
 
 logger = logging.getLogger(__name__)
 
+
+def _update_current_span(lf: Any, **kwargs: Any) -> None:
+    """Update the current Langfuse span when tracing is available."""
+    if lf is not None:
+        lf.update_current_span(**kwargs)
+
+
 _SHORT_FINANCE_QUERY_EXPANSIONS: dict[str, str] = {
     "рассрочки": "какие варианты рассрочки при покупке квартиры",
     "рассрочка": "какие варианты рассрочки при покупке квартиры",
@@ -94,11 +101,12 @@ class HyDEGenerator:
             Hypothetical document text for embedding
         """
         lf = get_client()
-        lf.update_current_span(
+        _update_current_span(
+            lf,
             input={
                 "query_preview": query[:120],
                 "model": self.model,
-            }
+            },
         )
 
         try:
@@ -117,11 +125,12 @@ class HyDEGenerator:
             hypothetical_doc = response.choices[0].message.content or query
             logger.info("HyDE generated doc for '%s': %s...", query, hypothetical_doc[:100])
 
-            lf.update_current_span(
+            _update_current_span(
+                lf,
                 output={
                     "document_preview": hypothetical_doc[:200],
                     "tokens_estimated": len(hypothetical_doc.split()),
-                }
+                },
             )
             return hypothetical_doc
 
@@ -131,14 +140,16 @@ class HyDEGenerator:
             openai.APITimeoutError,
         ) as e:
             logger.error("HyDE generation API error: %s", e)
-            lf.update_current_span(
+            _update_current_span(
+                lf,
                 level="ERROR",
                 status_message=f"HyDE API error: {str(e)[:200]}",
             )
             return query
         except Exception as e:
             logger.error("HyDE generation failed: %s", e)
-            lf.update_current_span(
+            _update_current_span(
+                lf,
                 level="ERROR",
                 status_message=str(e)[:200],
             )

--- a/telegram_bot/services/query_preprocessor.py
+++ b/telegram_bot/services/query_preprocessor.py
@@ -12,6 +12,7 @@ import openai
 from langfuse.openai import AsyncOpenAI
 
 from telegram_bot.integrations.prompt_manager import get_prompt
+from telegram_bot.observability import get_client, observe
 
 
 logger = logging.getLogger(__name__)
@@ -77,8 +78,14 @@ class HyDEGenerator:
             timeout=30.0,
         )
 
+    @observe(name="hyde-generate-document", capture_input=False, capture_output=False)
     async def generate_hypothetical_document(self, query: str) -> str:
         """Generate a hypothetical document that would answer the query.
+
+        Wrapped in ``@observe`` so the auto-traced generation produced by
+        ``langfuse.openai`` becomes a child of a named span (#1661). Curated
+        ``update_current_span`` payloads avoid leaking full prompts/documents
+        into Langfuse.
 
         Args:
             query: User query (typically short, < 5 words)
@@ -86,6 +93,14 @@ class HyDEGenerator:
         Returns:
             Hypothetical document text for embedding
         """
+        lf = get_client()
+        lf.update_current_span(
+            input={
+                "query_preview": query[:120],
+                "model": self.model,
+            }
+        )
+
         try:
             system_prompt = get_prompt("hyde", fallback=self.HYDE_SYSTEM_PROMPT)
             response = await self.client.chat.completions.create(
@@ -101,6 +116,13 @@ class HyDEGenerator:
 
             hypothetical_doc = response.choices[0].message.content or query
             logger.info("HyDE generated doc for '%s': %s...", query, hypothetical_doc[:100])
+
+            lf.update_current_span(
+                output={
+                    "document_preview": hypothetical_doc[:200],
+                    "tokens_estimated": len(hypothetical_doc.split()),
+                }
+            )
             return hypothetical_doc
 
         except (
@@ -109,9 +131,17 @@ class HyDEGenerator:
             openai.APITimeoutError,
         ) as e:
             logger.error("HyDE generation API error: %s", e)
+            lf.update_current_span(
+                level="ERROR",
+                status_message=f"HyDE API error: {str(e)[:200]}",
+            )
             return query
         except Exception as e:
             logger.error("HyDE generation failed: %s", e)
+            lf.update_current_span(
+                level="ERROR",
+                status_message=str(e)[:200],
+            )
             return query
 
     async def close(self):

--- a/tests/unit/test_hyde.py
+++ b/tests/unit/test_hyde.py
@@ -322,6 +322,25 @@ class TestHyDEObserveInstrumentation:
             "Full generated document must not appear in span output"
         )
 
+    async def test_generate_works_when_langfuse_client_unavailable(self, monkeypatch):
+        """HyDE generation must not require an initialized Langfuse client."""
+        self._disable_observe(monkeypatch)
+
+        from telegram_bot.services import query_preprocessor as qp_mod
+        from telegram_bot.services.query_preprocessor import HyDEGenerator
+
+        monkeypatch.setattr(qp_mod, "get_client", lambda: None)
+
+        hyde = HyDEGenerator()
+        hyde.client = AsyncMock()
+        hyde.client.chat.completions.create = AsyncMock(
+            return_value=_mock_completion("Уютная квартира рядом с морем.")
+        )
+
+        result = await hyde.generate_hypothetical_document("квартира у моря")
+
+        assert result == "Уютная квартира рядом с морем."
+
     async def test_exception_path_records_error_level(self, monkeypatch):
         """On exception, update_current_span must be called with level='ERROR'."""
         self._disable_observe(monkeypatch)

--- a/tests/unit/test_hyde.py
+++ b/tests/unit/test_hyde.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import openai
+import pytest
 
 from telegram_bot.services.query_preprocessor import HyDEGenerator, QueryPreprocessor
 
@@ -180,6 +181,183 @@ class TestHyDEGenerator:
 
         # Should fallback to query when content is None
         assert result == "квартира"
+
+
+class TestHyDEObserveInstrumentation:
+    """Tests for @observe instrumentation on HyDEGenerator (#1661).
+
+    Contract: generate_hypothetical_document must be wrapped with @observe so
+    nested generation observations created by langfuse.openai are parented
+    under a named span instead of becoming orphan traces. Curated input/output
+    payloads are written via update_current_span; full prompts and full
+    documents must NOT appear in span fields.
+    """
+
+    @staticmethod
+    def _patched_lf(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+        """Replace get_client used by HyDE module with a recording mock."""
+        from telegram_bot.services import query_preprocessor as qp_mod
+
+        mock_lf = MagicMock()
+        monkeypatch.setattr(qp_mod, "get_client", lambda: mock_lf)
+        return mock_lf
+
+    @staticmethod
+    def _disable_observe(monkeypatch: pytest.MonkeyPatch) -> None:
+        """Replace the @observe decorator at module-import time with a no-op.
+
+        This lets behavior assertions (input/output/error) run without the real
+        Langfuse SDK trying to start an OTEL span.
+        """
+        import importlib
+        import sys
+
+        from telegram_bot import observability as observability_mod
+
+        def fake_observe(**_kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        monkeypatch.setattr(observability_mod, "observe", fake_observe)
+        # Reload query_preprocessor so it picks up the no-op decorator.
+        sys.modules.pop("telegram_bot.services.query_preprocessor", None)
+        importlib.import_module("telegram_bot.services.query_preprocessor")
+
+    def test_module_imports_observe_and_get_client(self):
+        """Module wires the Langfuse decorator + client accessor (#1661 contract)."""
+        from telegram_bot.services import query_preprocessor as qp_mod
+
+        assert hasattr(qp_mod, "observe"), (
+            "telegram_bot.services.query_preprocessor must import `observe` "
+            "from telegram_bot.observability for the @observe decorator on "
+            "HyDEGenerator.generate_hypothetical_document"
+        )
+        assert hasattr(qp_mod, "get_client"), (
+            "telegram_bot.services.query_preprocessor must import `get_client` "
+            "from telegram_bot.observability for curated update_current_span calls"
+        )
+
+    def test_observe_decorator_applied_with_correct_kwargs(self, monkeypatch):
+        """@observe must be applied with the trace-coverage audit's exact kwargs."""
+        import importlib
+        import sys
+
+        from telegram_bot import observability as observability_mod
+
+        captured: dict[str, object] = {}
+
+        def recording_observe(**kwargs):
+            captured.update(kwargs)
+
+            def decorator(func):
+                return func
+
+            return decorator
+
+        monkeypatch.setattr(observability_mod, "observe", recording_observe)
+        sys.modules.pop("telegram_bot.services.query_preprocessor", None)
+        importlib.import_module("telegram_bot.services.query_preprocessor")
+
+        assert captured.get("name") == "hyde-generate-document"
+        assert captured.get("capture_input") is False
+        assert captured.get("capture_output") is False
+
+    async def test_input_payload_is_curated_preview_only(self, monkeypatch):
+        """Span input must be a curated dict (no full query, no full prompt)."""
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        # Re-import to bind the no-op observe applied above.
+        from telegram_bot.services.query_preprocessor import HyDEGenerator
+
+        hyde = HyDEGenerator(model="test-model")
+        hyde.client = AsyncMock()
+        hyde.client.chat.completions.create = AsyncMock(
+            return_value=_mock_completion("ok")
+        )
+
+        long_query = "квартира у моря " * 20  # > 120 chars
+
+        await hyde.generate_hypothetical_document(long_query)
+
+        input_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if "input" in c.kwargs
+        ]
+        assert len(input_calls) >= 1, "update_current_span(input=...) was never called"
+        captured_input = input_calls[0]["input"]
+        assert isinstance(captured_input, dict)
+        assert captured_input.get("model") == "test-model"
+        preview = captured_input.get("query_preview", "")
+        assert len(preview) <= 120
+        assert long_query not in str(captured_input), (
+            "Full query must not appear in span input"
+        )
+        assert HyDEGenerator.HYDE_SYSTEM_PROMPT not in str(captured_input), (
+            "System prompt must not be captured in span input"
+        )
+
+    async def test_output_payload_is_curated_preview_only(self, monkeypatch):
+        """Span output must record preview + token-estimate, not full document."""
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.query_preprocessor import HyDEGenerator
+
+        long_doc = "Подробное описание объекта недвижимости. " * 30
+        hyde = HyDEGenerator()
+        hyde.client = AsyncMock()
+        hyde.client.chat.completions.create = AsyncMock(
+            return_value=_mock_completion(long_doc)
+        )
+
+        await hyde.generate_hypothetical_document("квартира у моря")
+
+        output_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if "output" in c.kwargs
+        ]
+        assert len(output_calls) >= 1, "update_current_span(output=...) was never called"
+        captured_output = output_calls[-1]["output"]
+        assert isinstance(captured_output, dict)
+        preview = captured_output.get("document_preview", "")
+        assert len(preview) <= 200
+        assert "tokens_estimated" in captured_output
+        assert isinstance(captured_output["tokens_estimated"], int)
+        assert long_doc not in str(captured_output), (
+            "Full generated document must not appear in span output"
+        )
+
+    async def test_exception_path_records_error_level(self, monkeypatch):
+        """On exception, update_current_span must be called with level='ERROR'."""
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.query_preprocessor import HyDEGenerator
+
+        hyde = HyDEGenerator()
+        hyde.client = AsyncMock()
+        hyde.client.chat.completions.create = AsyncMock(
+            side_effect=RuntimeError("LLM exploded")
+        )
+
+        result = await hyde.generate_hypothetical_document("квартира у моря")
+
+        # Fallback semantics preserved (issue forbids changing fallback path).
+        assert result == "квартира у моря"
+
+        error_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if c.kwargs.get("level") == "ERROR"
+        ]
+        assert len(error_calls) >= 1, (
+            "Failure path must call update_current_span(level='ERROR', ...)"
+        )
+        status = error_calls[0].get("status_message", "")
+        assert "LLM exploded" in status
+        assert len(status) <= 220, "status_message must be truncated to ~200 chars"
 
 
 class TestHyDEIntegration:

--- a/tests/unit/test_hyde.py
+++ b/tests/unit/test_hyde.py
@@ -274,17 +274,14 @@ class TestHyDEObserveInstrumentation:
 
         hyde = HyDEGenerator(model="test-model")
         hyde.client = AsyncMock()
-        hyde.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion("ok")
-        )
+        hyde.client.chat.completions.create = AsyncMock(return_value=_mock_completion("ok"))
 
         long_query = "квартира у моря " * 20  # > 120 chars
 
         await hyde.generate_hypothetical_document(long_query)
 
         input_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
-            if "input" in c.kwargs
+            c.kwargs for c in mock_lf.update_current_span.call_args_list if "input" in c.kwargs
         ]
         assert len(input_calls) >= 1, "update_current_span(input=...) was never called"
         captured_input = input_calls[0]["input"]
@@ -292,9 +289,7 @@ class TestHyDEObserveInstrumentation:
         assert captured_input.get("model") == "test-model"
         preview = captured_input.get("query_preview", "")
         assert len(preview) <= 120
-        assert long_query not in str(captured_input), (
-            "Full query must not appear in span input"
-        )
+        assert long_query not in str(captured_input), "Full query must not appear in span input"
         assert HyDEGenerator.HYDE_SYSTEM_PROMPT not in str(captured_input), (
             "System prompt must not be captured in span input"
         )
@@ -309,15 +304,12 @@ class TestHyDEObserveInstrumentation:
         long_doc = "Подробное описание объекта недвижимости. " * 30
         hyde = HyDEGenerator()
         hyde.client = AsyncMock()
-        hyde.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion(long_doc)
-        )
+        hyde.client.chat.completions.create = AsyncMock(return_value=_mock_completion(long_doc))
 
         await hyde.generate_hypothetical_document("квартира у моря")
 
         output_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
-            if "output" in c.kwargs
+            c.kwargs for c in mock_lf.update_current_span.call_args_list if "output" in c.kwargs
         ]
         assert len(output_calls) >= 1, "update_current_span(output=...) was never called"
         captured_output = output_calls[-1]["output"]
@@ -339,9 +331,7 @@ class TestHyDEObserveInstrumentation:
 
         hyde = HyDEGenerator()
         hyde.client = AsyncMock()
-        hyde.client.chat.completions.create = AsyncMock(
-            side_effect=RuntimeError("LLM exploded")
-        )
+        hyde.client.chat.completions.create = AsyncMock(side_effect=RuntimeError("LLM exploded"))
 
         result = await hyde.generate_hypothetical_document("квартира у моря")
 
@@ -349,7 +339,8 @@ class TestHyDEObserveInstrumentation:
         assert result == "квартира у моря"
 
         error_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            c.kwargs
+            for c in mock_lf.update_current_span.call_args_list
             if c.kwargs.get("level") == "ERROR"
         ]
         assert len(error_calls) >= 1, (


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #1661 — HyDEGenerator.generate_hypothetical_document orphan generations.

Wraps the public method with `@observe(name="hyde-generate-document", capture_input=False, capture_output=False)` so the auto-traced generation from `langfuse.openai` becomes a child of a named span instead of an orphan when called outside the Telegram middleware root span.

## Changes

- `telegram_bot/services/query_preprocessor.py`:
  - Imported `observe`, `get_client` from `telegram_bot.observability`.
  - Decorated `generate_hypothetical_document` with `@observe`.
  - Added curated `update_current_span(input=...)` (query_preview ≤120 chars, model) and `update_current_span(output=...)` (document_preview ≤200 chars, tokens_estimated).
  - On exception: `update_current_span(level="ERROR", status_message=str(exc)[:200])`.
  - Fallback semantics preserved (return original query on API failure).

- `tests/unit/test_hyde.py`:
  - New `TestHyDEObserveInstrumentation` class with 5 TDD tests:
    1. Module imports `observe` and `get_client`.
    2. `@observe` is applied with the exact kwargs from the audit.
    3. Span input is curated (no full query, no system prompt).
    4. Span output is curated (no full document, includes `tokens_estimated`).
    5. Exception path records `level="ERROR"` with truncated status.

## Validation

```bash
uv run pytest tests/unit/test_hyde.py -q             # 35 passed
uv run pytest tests/unit/test_query_preprocessor.py \
              tests/unit/test_query_preprocessor_unit.py \
              tests/unit/test_hyde.py -q             # 108 passed
uv run ruff check telegram_bot/services/query_preprocessor.py tests/unit/test_hyde.py  # clean
uv run mypy telegram_bot/services/query_preprocessor.py  # clean
```

## Forbidden (per #1661)

- ✅ Did not strip `langfuse.openai` wrapping; kept auto-trace on.
- ✅ No full document logged to span output (truncated only).
- ✅ Did not change the prompt-fetching path (`get_prompt("hyde", ...)`).
- ✅ No prompt-to-generation linking in this PR (separate concern, #1666).

## Cross-references

- #1652 — research issue on LangChain-native HyDE replacement (orthogonal).
- #1666 — Langfuse Prompts to generations linking (depends on this PR).
- #1659 — sibling orphan-generation issue for `QueryAnalyzer` (next).

## Review notes

This is the first PR of the 9 Langfuse trace-coverage issues (#1658–#1666). Pattern (TDD-first, curated payloads, no PII leak) can be reused for siblings.