### PR TITLE
feat(observability): wrap background jobs (lead-score-sync, hot-lead, nurturing) in @observe (#1663)

### DIFF
--- a/telegram_bot/services/hot_lead_notifier.py
+++ b/telegram_bot/services/hot_lead_notifier.py
@@ -69,10 +69,7 @@ class HotLeadNotifier:
                     lf.update_current_span(output={"notified": False})
                     return False
 
-            text = (
-                f"Hot lead detected: lead_id={lead_id}, "
-                f"score={score}, session_id={session_id}"
-            )
+            text = f"Hot lead detected: lead_id={lead_id}, score={score}, session_id={session_id}"
             for manager_id in self._manager_ids:
                 await self._bot.send_message(chat_id=manager_id, text=text)
             lf.update_current_span(output={"notified": True})

--- a/telegram_bot/services/hot_lead_notifier.py
+++ b/telegram_bot/services/hot_lead_notifier.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from telegram_bot.observability import get_client, observe
+
 
 logger = logging.getLogger(__name__)
 
@@ -24,11 +26,19 @@ class HotLeadNotifier:
         self._manager_ids = manager_ids
         self._dedupe_ttl_sec = dedupe_ttl_sec
 
+    @observe(name="job-hot-lead-notify", capture_input=False, capture_output=False)
     async def notify_if_hot(self, payload: dict[str, Any]) -> bool:
         """Send notification to managers if lead is new (not deduped).
 
         Returns True if notification was sent, False if deduped or invalid.
+
+        Wrapped in ``@observe`` (#1663) so each notification attempt emits a
+        named Langfuse span. Curated ``update_current_span`` calls record only
+        ``{lead_id, score, threshold}`` as input and ``{notified}`` as output;
+        full payload dicts (which may carry phone/email/session_id metadata)
+        are intentionally NOT captured.
         """
+        lf = get_client()
         lead_id = payload.get("lead_id")
         session_id = payload.get("session_id")
         raw_score = payload.get("score", 0)
@@ -37,17 +47,36 @@ class HotLeadNotifier:
         except (TypeError, ValueError):
             logger.warning("Invalid hot lead score %r; defaulting to 0", raw_score)
             score = 0
-        if not lead_id or not session_id:
-            return False
 
-        redis = getattr(self._cache, "redis", None)
-        if redis is not None:
-            key = f"hot-lead:{session_id}:{lead_id}"
-            fresh = await redis.set(key, "1", ex=self._dedupe_ttl_sec, nx=True)
-            if not fresh:
+        lf.update_current_span(
+            input={
+                "lead_id": lead_id,
+                "score": score,
+                "threshold": payload.get("threshold"),
+            }
+        )
+
+        try:
+            if not lead_id or not session_id:
+                lf.update_current_span(output={"notified": False})
                 return False
 
-        text = f"Hot lead detected: lead_id={lead_id}, score={score}, session_id={session_id}"
-        for manager_id in self._manager_ids:
-            await self._bot.send_message(chat_id=manager_id, text=text)
-        return True
+            redis = getattr(self._cache, "redis", None)
+            if redis is not None:
+                key = f"hot-lead:{session_id}:{lead_id}"
+                fresh = await redis.set(key, "1", ex=self._dedupe_ttl_sec, nx=True)
+                if not fresh:
+                    lf.update_current_span(output={"notified": False})
+                    return False
+
+            text = (
+                f"Hot lead detected: lead_id={lead_id}, "
+                f"score={score}, session_id={session_id}"
+            )
+            for manager_id in self._manager_ids:
+                await self._bot.send_message(chat_id=manager_id, text=text)
+            lf.update_current_span(output={"notified": True})
+            return True
+        except Exception as exc:
+            lf.update_current_span(level="ERROR", status_message=str(exc)[:200])
+            raise

--- a/telegram_bot/services/hot_lead_notifier.py
+++ b/telegram_bot/services/hot_lead_notifier.py
@@ -15,6 +15,12 @@ from telegram_bot.observability import get_client, observe
 logger = logging.getLogger(__name__)
 
 
+def _update_current_span(lf: Any, **kwargs: Any) -> None:
+    """Update the current Langfuse span when tracing is available."""
+    if lf is not None:
+        lf.update_current_span(**kwargs)
+
+
 class HotLeadNotifier:
     """Fan-out hot-lead alerts to configured manager Telegram IDs."""
 
@@ -48,17 +54,18 @@ class HotLeadNotifier:
             logger.warning("Invalid hot lead score %r; defaulting to 0", raw_score)
             score = 0
 
-        lf.update_current_span(
+        _update_current_span(
+            lf,
             input={
                 "lead_id": lead_id,
                 "score": score,
                 "threshold": payload.get("threshold"),
-            }
+            },
         )
 
         try:
             if not lead_id or not session_id:
-                lf.update_current_span(output={"notified": False})
+                _update_current_span(lf, output={"notified": False})
                 return False
 
             redis = getattr(self._cache, "redis", None)
@@ -66,14 +73,14 @@ class HotLeadNotifier:
                 key = f"hot-lead:{session_id}:{lead_id}"
                 fresh = await redis.set(key, "1", ex=self._dedupe_ttl_sec, nx=True)
                 if not fresh:
-                    lf.update_current_span(output={"notified": False})
+                    _update_current_span(lf, output={"notified": False})
                     return False
 
             text = f"Hot lead detected: lead_id={lead_id}, score={score}, session_id={session_id}"
             for manager_id in self._manager_ids:
                 await self._bot.send_message(chat_id=manager_id, text=text)
-            lf.update_current_span(output={"notified": True})
+            _update_current_span(lf, output={"notified": True})
             return True
         except Exception as exc:
-            lf.update_current_span(level="ERROR", status_message=str(exc)[:200])
+            _update_current_span(lf, level="ERROR", status_message=str(exc)[:200])
             raise

--- a/telegram_bot/services/lead_score_sync.py
+++ b/telegram_bot/services/lead_score_sync.py
@@ -12,6 +12,12 @@ from telegram_bot.services.kommo_models import LeadScoreSyncPayload
 logger = logging.getLogger(__name__)
 
 
+def _update_current_span(lf: Any, **kwargs: Any) -> None:
+    """Update the current Langfuse span when tracing is available."""
+    if lf is not None:
+        lf.update_current_span(**kwargs)
+
+
 @observe(name="job-lead-score-sync", capture_input=False, capture_output=False)
 async def sync_pending_lead_scores(
     *,
@@ -31,10 +37,10 @@ async def sync_pending_lead_scores(
     try:
         with propagate_attributes(tags=["job", "lead-scoring"]):
             if scoring_store is None or kommo_client is None:
-                lf.update_current_span(output={"processed": 0, "failed": 0, "skipped": 0})
+                _update_current_span(lf, output={"processed": 0, "failed": 0, "skipped": 0})
                 return {"synced": 0, "failed": 0, "skipped": 0}
             if score_field_id <= 0 or band_field_id <= 0:
-                lf.update_current_span(output={"processed": 0, "failed": 0, "skipped": 0})
+                _update_current_span(lf, output={"processed": 0, "failed": 0, "skipped": 0})
                 return {"synced": 0, "failed": 0, "skipped": 0}
 
             pending = await scoring_store.list_pending_sync(limit=limit)
@@ -67,10 +73,10 @@ async def sync_pending_lead_scores(
                     await scoring_store.mark_failed(lead_id=rec.lead_id, error="kommo_error")
                     failed += 1
 
-            lf.update_current_span(
-                output={"processed": synced, "failed": failed, "skipped": skipped}
+            _update_current_span(
+                lf, output={"processed": synced, "failed": failed, "skipped": skipped}
             )
             return {"synced": synced, "failed": failed, "skipped": skipped}
     except Exception as exc:
-        lf.update_current_span(level="ERROR", status_message=str(exc)[:200])
+        _update_current_span(lf, level="ERROR", status_message=str(exc)[:200])
         raise

--- a/telegram_bot/services/lead_score_sync.py
+++ b/telegram_bot/services/lead_score_sync.py
@@ -31,14 +31,10 @@ async def sync_pending_lead_scores(
     try:
         with propagate_attributes(tags=["job", "lead-scoring"]):
             if scoring_store is None or kommo_client is None:
-                lf.update_current_span(
-                    output={"processed": 0, "failed": 0, "skipped": 0}
-                )
+                lf.update_current_span(output={"processed": 0, "failed": 0, "skipped": 0})
                 return {"synced": 0, "failed": 0, "skipped": 0}
             if score_field_id <= 0 or band_field_id <= 0:
-                lf.update_current_span(
-                    output={"processed": 0, "failed": 0, "skipped": 0}
-                )
+                lf.update_current_span(output={"processed": 0, "failed": 0, "skipped": 0})
                 return {"synced": 0, "failed": 0, "skipped": 0}
 
             pending = await scoring_store.list_pending_sync(limit=limit)
@@ -51,8 +47,7 @@ async def sync_pending_lead_scores(
                     skipped += 1
                     continue
                 key = (
-                    f"lead-score:{rec.lead_id}:{rec.session_id}:"
-                    f"{rec.score_value}:{rec.score_band}"
+                    f"lead-score:{rec.lead_id}:{rec.session_id}:{rec.score_value}:{rec.score_band}"
                 )
                 payload = LeadScoreSyncPayload.from_record(
                     rec,
@@ -69,9 +64,7 @@ async def sync_pending_lead_scores(
                     synced += 1
                 except Exception:
                     logger.exception("CRM score sync failed for lead %s", rec.lead_id)
-                    await scoring_store.mark_failed(
-                        lead_id=rec.lead_id, error="kommo_error"
-                    )
+                    await scoring_store.mark_failed(lead_id=rec.lead_id, error="kommo_error")
                     failed += 1
 
             lf.update_current_span(

--- a/telegram_bot/services/lead_score_sync.py
+++ b/telegram_bot/services/lead_score_sync.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from telegram_bot.observability import get_client, observe, propagate_attributes
 from telegram_bot.services.kommo_models import LeadScoreSyncPayload
 
 
 logger = logging.getLogger(__name__)
 
 
+@observe(name="job-lead-score-sync", capture_input=False, capture_output=False)
 async def sync_pending_lead_scores(
     *,
     scoring_store: Any,
@@ -19,38 +21,63 @@ async def sync_pending_lead_scores(
     band_field_id: int,
     limit: int = 20,
 ) -> dict[str, int]:
-    """Sync pending lead scores to Kommo and return counters."""
-    if scoring_store is None or kommo_client is None:
-        return {"synced": 0, "failed": 0, "skipped": 0}
-    if score_field_id <= 0 or band_field_id <= 0:
-        return {"synced": 0, "failed": 0, "skipped": 0}
+    """Sync pending lead scores to Kommo and return counters.
 
-    pending = await scoring_store.list_pending_sync(limit=limit)
-    synced = 0
-    failed = 0
-    skipped = 0
+    Wrapped in ``@observe`` so the background job emits a named Langfuse span
+    (#1663). Curated ``update_current_span(output=...)`` records aggregate
+    counters only (no per-record payloads, no PII).
+    """
+    lf = get_client()
+    try:
+        with propagate_attributes(tags=["job", "lead-scoring"]):
+            if scoring_store is None or kommo_client is None:
+                lf.update_current_span(
+                    output={"processed": 0, "failed": 0, "skipped": 0}
+                )
+                return {"synced": 0, "failed": 0, "skipped": 0}
+            if score_field_id <= 0 or band_field_id <= 0:
+                lf.update_current_span(
+                    output={"processed": 0, "failed": 0, "skipped": 0}
+                )
+                return {"synced": 0, "failed": 0, "skipped": 0}
 
-    for rec in pending:
-        if rec.kommo_lead_id is None:
-            skipped += 1
-            continue
-        key = f"lead-score:{rec.lead_id}:{rec.session_id}:{rec.score_value}:{rec.score_band}"
-        payload = LeadScoreSyncPayload.from_record(
-            rec,
-            score_field_id=score_field_id,
-            band_field_id=band_field_id,
-        ).to_kommo_payload()
-        try:
-            await kommo_client.update_lead_score(
-                lead_id=rec.kommo_lead_id,
-                payload=payload,
-                idempotency_key=key,
+            pending = await scoring_store.list_pending_sync(limit=limit)
+            synced = 0
+            failed = 0
+            skipped = 0
+
+            for rec in pending:
+                if rec.kommo_lead_id is None:
+                    skipped += 1
+                    continue
+                key = (
+                    f"lead-score:{rec.lead_id}:{rec.session_id}:"
+                    f"{rec.score_value}:{rec.score_band}"
+                )
+                payload = LeadScoreSyncPayload.from_record(
+                    rec,
+                    score_field_id=score_field_id,
+                    band_field_id=band_field_id,
+                ).to_kommo_payload()
+                try:
+                    await kommo_client.update_lead_score(
+                        lead_id=rec.kommo_lead_id,
+                        payload=payload,
+                        idempotency_key=key,
+                    )
+                    await scoring_store.mark_synced(lead_id=rec.lead_id)
+                    synced += 1
+                except Exception:
+                    logger.exception("CRM score sync failed for lead %s", rec.lead_id)
+                    await scoring_store.mark_failed(
+                        lead_id=rec.lead_id, error="kommo_error"
+                    )
+                    failed += 1
+
+            lf.update_current_span(
+                output={"processed": synced, "failed": failed, "skipped": skipped}
             )
-            await scoring_store.mark_synced(lead_id=rec.lead_id)
-            synced += 1
-        except Exception:
-            logger.exception("CRM score sync failed for lead %s", rec.lead_id)
-            await scoring_store.mark_failed(lead_id=rec.lead_id, error="kommo_error")
-            failed += 1
-
-    return {"synced": synced, "failed": failed, "skipped": skipped}
+            return {"synced": synced, "failed": failed, "skipped": skipped}
+    except Exception as exc:
+        lf.update_current_span(level="ERROR", status_message=str(exc)[:200])
+        raise

--- a/telegram_bot/services/nurturing_scheduler.py
+++ b/telegram_bot/services/nurturing_scheduler.py
@@ -18,7 +18,7 @@ from typing import Any
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
-from telegram_bot.observability import observe
+from telegram_bot.observability import get_client, observe, propagate_attributes
 
 
 logger = logging.getLogger(__name__)
@@ -96,24 +96,44 @@ class NurturingScheduler:
         except Exception:
             logger.exception("Nurturing batch failed")
 
+    @observe(name="job-nurturing-dispatch", capture_input=False, capture_output=False)
     async def run_nurturing_dispatch(self) -> None:
-        """Dispatch pending nurturing messages (called by scheduler)."""
-        try:
-            batch = getattr(self._config, "nurturing_dispatch_batch", 20)
-            count = await self._nurturing.dispatch_pending(batch_size=batch)
-            logger.info("Nurturing dispatch completed: %d messages sent", count)
-        except Exception:
-            logger.exception("Nurturing dispatch failed")
+        """Dispatch pending nurturing messages (called by scheduler).
 
+        Wrapped in ``@observe`` (#1663) so the job emits a named Langfuse span
+        tagged ``job/nurturing``. On failure, records ``level='ERROR'`` and
+        re-raises so APScheduler can mark the run as failed.
+        """
+        lf = get_client()
+        try:
+            with propagate_attributes(tags=["job", "nurturing"]):
+                batch = getattr(self._config, "nurturing_dispatch_batch", 20)
+                count = await self._nurturing.dispatch_pending(batch_size=batch)
+                logger.info("Nurturing dispatch completed: %d messages sent", count)
+        except Exception as exc:
+            logger.exception("Nurturing dispatch failed")
+            lf.update_current_span(level="ERROR", status_message=str(exc)[:200])
+            raise
+
+    @observe(name="job-funnel-rollup", capture_input=False, capture_output=False)
     async def run_funnel_rollup(self) -> None:
-        """Compute and persist daily funnel metrics (called by scheduler)."""
+        """Compute and persist daily funnel metrics (called by scheduler).
+
+        Wrapped in ``@observe`` (#1663) so the job emits a named Langfuse span
+        tagged ``job/analytics``. On failure, records ``level='ERROR'`` and
+        re-raises so APScheduler can mark the run as failed.
+        """
         import datetime as dt
 
+        lf = get_client()
         try:
-            today = dt.date.today()
-            snapshots = await self._analytics.build_daily_snapshot(metric_date=today)
-            if snapshots:
-                await self._analytics.persist_snapshots(snapshots=snapshots)
-            logger.info("Funnel rollup completed: %d stages", len(snapshots))
-        except Exception:
+            with propagate_attributes(tags=["job", "analytics"]):
+                today = dt.date.today()
+                snapshots = await self._analytics.build_daily_snapshot(metric_date=today)
+                if snapshots:
+                    await self._analytics.persist_snapshots(snapshots=snapshots)
+                logger.info("Funnel rollup completed: %d stages", len(snapshots))
+        except Exception as exc:
             logger.exception("Funnel rollup failed")
+            lf.update_current_span(level="ERROR", status_message=str(exc)[:200])
+            raise

--- a/telegram_bot/services/nurturing_scheduler.py
+++ b/telegram_bot/services/nurturing_scheduler.py
@@ -24,6 +24,12 @@ from telegram_bot.observability import get_client, observe, propagate_attributes
 logger = logging.getLogger(__name__)
 
 
+def _update_current_span(lf: Any, **kwargs: Any) -> None:
+    """Update the current Langfuse span when tracing is available."""
+    if lf is not None:
+        lf.update_current_span(**kwargs)
+
+
 class NurturingScheduler:
     """Manage scheduled nurturing batches and funnel analytics rollups."""
 
@@ -112,7 +118,7 @@ class NurturingScheduler:
                 logger.info("Nurturing dispatch completed: %d messages sent", count)
         except Exception as exc:
             logger.exception("Nurturing dispatch failed")
-            lf.update_current_span(level="ERROR", status_message=str(exc)[:200])
+            _update_current_span(lf, level="ERROR", status_message=str(exc)[:200])
             raise
 
     @observe(name="job-funnel-rollup", capture_input=False, capture_output=False)
@@ -135,5 +141,5 @@ class NurturingScheduler:
                 logger.info("Funnel rollup completed: %d stages", len(snapshots))
         except Exception as exc:
             logger.exception("Funnel rollup failed")
-            lf.update_current_span(level="ERROR", status_message=str(exc)[:200])
+            _update_current_span(lf, level="ERROR", status_message=str(exc)[:200])
             raise

--- a/tests/unit/services/test_hot_lead_notifier.py
+++ b/tests/unit/services/test_hot_lead_notifier.py
@@ -62,7 +62,6 @@ async def test_notifier_handles_non_numeric_score_without_crashing():
     assert "score=0" in bot.send_message.await_args.kwargs["text"]
 
 
-
 import pytest
 
 
@@ -137,12 +136,30 @@ class TestHotLeadNotifierObserveInstrumentation:
 
         sync_calls = [c for c in captured if c.get("name") == "job-hot-lead-notify"]
         assert len(sync_calls) == 1, (
-            f"Expected exactly one @observe(name='job-hot-lead-notify', ...). "
-            f"Captured: {captured}"
+            f"Expected exactly one @observe(name='job-hot-lead-notify', ...). Captured: {captured}"
         )
         kwargs = sync_calls[0]
         assert kwargs.get("capture_input") is False
         assert kwargs.get("capture_output") is False
+
+    async def test_notify_works_when_langfuse_client_unavailable(self, monkeypatch):
+        """Hot-lead notification must not require an initialized Langfuse client."""
+        self._disable_observe(monkeypatch)
+
+        from telegram_bot.services import hot_lead_notifier as hln_mod
+        from telegram_bot.services.hot_lead_notifier import HotLeadNotifier
+
+        monkeypatch.setattr(hln_mod, "get_client", lambda: None)
+
+        cache = AsyncMock()
+        cache.redis = None
+        bot = AsyncMock()
+        notifier = HotLeadNotifier(bot=bot, cache=cache, manager_ids=[1], dedupe_ttl_sec=60)
+
+        result = await notifier.notify_if_hot({"lead_id": 1, "score": 90, "session_id": "s1"})
+
+        assert result is True
+        bot.send_message.assert_awaited_once()
 
     async def test_input_payload_is_curated_lead_score_threshold_only(self, monkeypatch):
         """Span input must record curated keys (lead_id, score, threshold) only."""
@@ -155,9 +172,7 @@ class TestHotLeadNotifierObserveInstrumentation:
         cache.redis = AsyncMock()
         cache.redis.set = AsyncMock(return_value=True)
         bot = AsyncMock()
-        notifier = HotLeadNotifier(
-            bot=bot, cache=cache, manager_ids=[1], dedupe_ttl_sec=60
-        )
+        notifier = HotLeadNotifier(bot=bot, cache=cache, manager_ids=[1], dedupe_ttl_sec=60)
 
         # Payload includes a "secret" PII-like field that MUST NOT leak into spans.
         await notifier.notify_if_hot(
@@ -171,8 +186,7 @@ class TestHotLeadNotifierObserveInstrumentation:
         )
 
         input_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
-            if "input" in c.kwargs
+            c.kwargs for c in mock_lf.update_current_span.call_args_list if "input" in c.kwargs
         ]
         assert len(input_calls) >= 1, "update_current_span(input=...) was never called"
         captured_input = input_calls[0]["input"]
@@ -198,17 +212,14 @@ class TestHotLeadNotifierObserveInstrumentation:
         cache.redis = AsyncMock()
         cache.redis.set = AsyncMock(return_value=True)
         bot = AsyncMock()
-        notifier = HotLeadNotifier(
-            bot=bot, cache=cache, manager_ids=[1], dedupe_ttl_sec=60
-        )
+        notifier = HotLeadNotifier(bot=bot, cache=cache, manager_ids=[1], dedupe_ttl_sec=60)
 
         result = await notifier.notify_if_hot(
             {"lead_id": 1, "score": 90, "session_id": "s1", "threshold": 70}
         )
 
         output_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
-            if "output" in c.kwargs
+            c.kwargs for c in mock_lf.update_current_span.call_args_list if "output" in c.kwargs
         ]
         assert len(output_calls) >= 1, "update_current_span(output=...) was never called"
         captured_output = output_calls[-1]["output"]
@@ -227,9 +238,7 @@ class TestHotLeadNotifierObserveInstrumentation:
         cache.redis = AsyncMock()
         cache.redis.set = AsyncMock(return_value=False)  # deduped
         bot = AsyncMock()
-        notifier = HotLeadNotifier(
-            bot=bot, cache=cache, manager_ids=[1], dedupe_ttl_sec=60
-        )
+        notifier = HotLeadNotifier(bot=bot, cache=cache, manager_ids=[1], dedupe_ttl_sec=60)
 
         result = await notifier.notify_if_hot(
             {"lead_id": 1, "score": 90, "session_id": "s1", "threshold": 70}
@@ -237,8 +246,7 @@ class TestHotLeadNotifierObserveInstrumentation:
 
         assert result is False
         output_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
-            if "output" in c.kwargs
+            c.kwargs for c in mock_lf.update_current_span.call_args_list if "output" in c.kwargs
         ]
         assert len(output_calls) >= 1
         assert output_calls[-1]["output"].get("notified") is False
@@ -255,9 +263,7 @@ class TestHotLeadNotifierObserveInstrumentation:
         cache.redis.set = AsyncMock(return_value=True)
         bot = AsyncMock()
         bot.send_message = AsyncMock(side_effect=RuntimeError("Telegram down"))
-        notifier = HotLeadNotifier(
-            bot=bot, cache=cache, manager_ids=[1], dedupe_ttl_sec=60
-        )
+        notifier = HotLeadNotifier(bot=bot, cache=cache, manager_ids=[1], dedupe_ttl_sec=60)
 
         with pytest.raises(RuntimeError, match="Telegram down"):
             await notifier.notify_if_hot(
@@ -265,7 +271,8 @@ class TestHotLeadNotifierObserveInstrumentation:
             )
 
         error_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            c.kwargs
+            for c in mock_lf.update_current_span.call_args_list
             if c.kwargs.get("level") == "ERROR"
         ]
         assert len(error_calls) >= 1, (

--- a/tests/unit/services/test_hot_lead_notifier.py
+++ b/tests/unit/services/test_hot_lead_notifier.py
@@ -60,3 +60,217 @@ async def test_notifier_handles_non_numeric_score_without_crashing():
     assert result is True
     bot.send_message.assert_awaited_once()
     assert "score=0" in bot.send_message.await_args.kwargs["text"]
+
+
+
+import pytest
+
+
+class TestHotLeadNotifierObserveInstrumentation:
+    """Tests for @observe instrumentation on HotLeadNotifier.notify_if_hot (#1663).
+
+    Contract: notify_if_hot must be wrapped with @observe so each notification
+    attempt produces a named Langfuse span. Curated update_current_span calls
+    record only {lead_id, score, threshold} as input and {notified} as output.
+    Full payload dicts (which may contain phone/email/session metadata) MUST
+    NOT be captured.
+    """
+
+    @staticmethod
+    def _patched_lf(monkeypatch: pytest.MonkeyPatch):
+        from unittest.mock import MagicMock
+
+        from telegram_bot.services import hot_lead_notifier as hln_mod
+
+        mock_lf = MagicMock()
+        monkeypatch.setattr(hln_mod, "get_client", lambda: mock_lf)
+        return mock_lf
+
+    @staticmethod
+    def _disable_observe(monkeypatch: pytest.MonkeyPatch) -> None:
+        import importlib
+        import sys
+
+        from telegram_bot import observability as observability_mod
+
+        def fake_observe(**_kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        monkeypatch.setattr(observability_mod, "observe", fake_observe)
+        sys.modules.pop("telegram_bot.services.hot_lead_notifier", None)
+        importlib.import_module("telegram_bot.services.hot_lead_notifier")
+
+    def test_module_imports_observe_and_get_client(self):
+        """Module wires the Langfuse decorator + client accessor (#1663 contract)."""
+        from telegram_bot.services import hot_lead_notifier as hln_mod
+
+        assert hasattr(hln_mod, "observe"), (
+            "telegram_bot.services.hot_lead_notifier must import `observe`"
+        )
+        assert hasattr(hln_mod, "get_client"), (
+            "telegram_bot.services.hot_lead_notifier must import `get_client`"
+        )
+
+    def test_observe_decorator_applied_with_correct_kwargs(self, monkeypatch):
+        """@observe must be applied with the trace-coverage audit's exact kwargs."""
+        import importlib
+        import sys
+
+        from telegram_bot import observability as observability_mod
+
+        captured: list[dict[str, object]] = []
+
+        def recording_observe(**kwargs):
+            captured.append(kwargs)
+
+            def decorator(func):
+                return func
+
+            return decorator
+
+        monkeypatch.setattr(observability_mod, "observe", recording_observe)
+        sys.modules.pop("telegram_bot.services.hot_lead_notifier", None)
+        importlib.import_module("telegram_bot.services.hot_lead_notifier")
+
+        sync_calls = [c for c in captured if c.get("name") == "job-hot-lead-notify"]
+        assert len(sync_calls) == 1, (
+            f"Expected exactly one @observe(name='job-hot-lead-notify', ...). "
+            f"Captured: {captured}"
+        )
+        kwargs = sync_calls[0]
+        assert kwargs.get("capture_input") is False
+        assert kwargs.get("capture_output") is False
+
+    async def test_input_payload_is_curated_lead_score_threshold_only(self, monkeypatch):
+        """Span input must record curated keys (lead_id, score, threshold) only."""
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.hot_lead_notifier import HotLeadNotifier
+
+        cache = AsyncMock()
+        cache.redis = AsyncMock()
+        cache.redis.set = AsyncMock(return_value=True)
+        bot = AsyncMock()
+        notifier = HotLeadNotifier(
+            bot=bot, cache=cache, manager_ids=[1], dedupe_ttl_sec=60
+        )
+
+        # Payload includes a "secret" PII-like field that MUST NOT leak into spans.
+        await notifier.notify_if_hot(
+            {
+                "lead_id": 77,
+                "score": 88,
+                "session_id": "chat-abc",
+                "threshold": 70,
+                "phone": "+380501112233",
+            }
+        )
+
+        input_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if "input" in c.kwargs
+        ]
+        assert len(input_calls) >= 1, "update_current_span(input=...) was never called"
+        captured_input = input_calls[0]["input"]
+        assert isinstance(captured_input, dict)
+        assert captured_input.get("lead_id") == 77
+        assert captured_input.get("score") == 88
+        assert captured_input.get("threshold") == 70
+        # PII must NOT appear in span input.
+        assert "phone" not in captured_input
+        assert "+380501112233" not in str(captured_input)
+        # session_id is acceptable elsewhere but must not be captured here per audit
+        # (curated keys are exactly: lead_id, score, threshold).
+        assert set(captured_input.keys()) <= {"lead_id", "score", "threshold"}
+
+    async def test_output_payload_records_notified_bool(self, monkeypatch):
+        """Span output must record {'notified': bool}."""
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.hot_lead_notifier import HotLeadNotifier
+
+        cache = AsyncMock()
+        cache.redis = AsyncMock()
+        cache.redis.set = AsyncMock(return_value=True)
+        bot = AsyncMock()
+        notifier = HotLeadNotifier(
+            bot=bot, cache=cache, manager_ids=[1], dedupe_ttl_sec=60
+        )
+
+        result = await notifier.notify_if_hot(
+            {"lead_id": 1, "score": 90, "session_id": "s1", "threshold": 70}
+        )
+
+        output_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if "output" in c.kwargs
+        ]
+        assert len(output_calls) >= 1, "update_current_span(output=...) was never called"
+        captured_output = output_calls[-1]["output"]
+        assert isinstance(captured_output, dict)
+        assert captured_output.get("notified") is True
+        assert result is True
+
+    async def test_output_records_notified_false_when_deduped(self, monkeypatch):
+        """When deduped, span output must record notified=False."""
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.hot_lead_notifier import HotLeadNotifier
+
+        cache = AsyncMock()
+        cache.redis = AsyncMock()
+        cache.redis.set = AsyncMock(return_value=False)  # deduped
+        bot = AsyncMock()
+        notifier = HotLeadNotifier(
+            bot=bot, cache=cache, manager_ids=[1], dedupe_ttl_sec=60
+        )
+
+        result = await notifier.notify_if_hot(
+            {"lead_id": 1, "score": 90, "session_id": "s1", "threshold": 70}
+        )
+
+        assert result is False
+        output_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if "output" in c.kwargs
+        ]
+        assert len(output_calls) >= 1
+        assert output_calls[-1]["output"].get("notified") is False
+
+    async def test_exception_path_records_error_level_and_reraises(self, monkeypatch):
+        """On exception, update_current_span(level='ERROR', ...) and re-raise."""
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.hot_lead_notifier import HotLeadNotifier
+
+        cache = AsyncMock()
+        cache.redis = AsyncMock()
+        cache.redis.set = AsyncMock(return_value=True)
+        bot = AsyncMock()
+        bot.send_message = AsyncMock(side_effect=RuntimeError("Telegram down"))
+        notifier = HotLeadNotifier(
+            bot=bot, cache=cache, manager_ids=[1], dedupe_ttl_sec=60
+        )
+
+        with pytest.raises(RuntimeError, match="Telegram down"):
+            await notifier.notify_if_hot(
+                {"lead_id": 1, "score": 90, "session_id": "s1", "threshold": 70}
+            )
+
+        error_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if c.kwargs.get("level") == "ERROR"
+        ]
+        assert len(error_calls) >= 1, (
+            "Failure path must call update_current_span(level='ERROR', ...)"
+        )
+        status = error_calls[0].get("status_message", "")
+        assert "Telegram down" in status
+        assert len(status) <= 220

--- a/tests/unit/services/test_lead_score_sync.py
+++ b/tests/unit/services/test_lead_score_sync.py
@@ -101,3 +101,223 @@ async def test_sync_pending_lead_scores_marks_failed_on_kommo_error() -> None:
     assert result == {"synced": 0, "failed": 1, "skipped": 0}
     scoring_store.mark_failed.assert_awaited_once_with(lead_id=42, error="kommo_error")
     scoring_store.mark_synced.assert_not_called()
+
+
+
+class TestLeadScoreSyncObserveInstrumentation:
+    """Tests for @observe instrumentation on sync_pending_lead_scores (#1663).
+
+    Contract: sync_pending_lead_scores must be wrapped with @observe so the
+    background job emits a named Langfuse span instead of running untraced.
+    Curated update_current_span(output=...) records aggregate counters and
+    NEVER captures full per-record payloads (no PII, no kommo internals).
+    """
+
+    @staticmethod
+    def _patched_lf(monkeypatch: pytest.MonkeyPatch):
+        """Replace get_client used by the lead_score_sync module with a recording mock."""
+        from unittest.mock import MagicMock
+
+        from telegram_bot.services import lead_score_sync as lss_mod
+
+        mock_lf = MagicMock()
+        monkeypatch.setattr(lss_mod, "get_client", lambda: mock_lf)
+        return mock_lf
+
+    @staticmethod
+    def _disable_observe_and_propagate(monkeypatch: pytest.MonkeyPatch) -> None:
+        """Replace @observe + propagate_attributes at module-import time with no-ops.
+
+        This lets behavior assertions run without the real Langfuse SDK.
+        """
+        import contextlib
+        import importlib
+        import sys
+
+        from telegram_bot import observability as observability_mod
+
+        def fake_observe(**_kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        @contextlib.contextmanager
+        def fake_propagate(**_kwargs):
+            yield
+
+        monkeypatch.setattr(observability_mod, "observe", fake_observe)
+        monkeypatch.setattr(observability_mod, "propagate_attributes", fake_propagate)
+        sys.modules.pop("telegram_bot.services.lead_score_sync", None)
+        importlib.import_module("telegram_bot.services.lead_score_sync")
+
+    def test_module_imports_observe_get_client_and_propagate_attributes(self):
+        """Module wires the Langfuse decorator + helpers (#1663 contract)."""
+        from telegram_bot.services import lead_score_sync as lss_mod
+
+        assert hasattr(lss_mod, "observe"), (
+            "telegram_bot.services.lead_score_sync must import `observe` "
+            "from telegram_bot.observability for the @observe decorator on "
+            "sync_pending_lead_scores"
+        )
+        assert hasattr(lss_mod, "get_client"), (
+            "telegram_bot.services.lead_score_sync must import `get_client` "
+            "for curated update_current_span calls"
+        )
+        assert hasattr(lss_mod, "propagate_attributes"), (
+            "telegram_bot.services.lead_score_sync must import `propagate_attributes` "
+            "for tags=['job', 'lead-scoring']"
+        )
+
+    def test_observe_decorator_applied_with_correct_kwargs(self, monkeypatch):
+        """@observe must be applied with the trace-coverage audit's exact kwargs."""
+        import importlib
+        import sys
+
+        from telegram_bot import observability as observability_mod
+
+        captured: list[dict[str, object]] = []
+
+        def recording_observe(**kwargs):
+            captured.append(kwargs)
+
+            def decorator(func):
+                return func
+
+            return decorator
+
+        monkeypatch.setattr(observability_mod, "observe", recording_observe)
+        sys.modules.pop("telegram_bot.services.lead_score_sync", None)
+        importlib.import_module("telegram_bot.services.lead_score_sync")
+
+        sync_calls = [c for c in captured if c.get("name") == "job-lead-score-sync"]
+        assert len(sync_calls) == 1, (
+            f"Expected exactly one @observe(name='job-lead-score-sync', ...). "
+            f"Captured: {captured}"
+        )
+        kwargs = sync_calls[0]
+        assert kwargs.get("capture_input") is False
+        assert kwargs.get("capture_output") is False
+
+    @pytest.mark.asyncio
+    async def test_propagate_attributes_called_with_lead_scoring_tags(self, monkeypatch):
+        """propagate_attributes must be called with tags=['job', 'lead-scoring']."""
+        import contextlib
+        import importlib
+        import sys
+
+        from telegram_bot import observability as observability_mod
+
+        recorded_kwargs: list[dict[str, object]] = []
+
+        @contextlib.contextmanager
+        def recording_propagate(**kwargs):
+            recorded_kwargs.append(kwargs)
+            yield
+
+        def fake_observe(**_kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        monkeypatch.setattr(observability_mod, "observe", fake_observe)
+        monkeypatch.setattr(observability_mod, "propagate_attributes", recording_propagate)
+        sys.modules.pop("telegram_bot.services.lead_score_sync", None)
+        importlib.import_module("telegram_bot.services.lead_score_sync")
+
+        self._patched_lf(monkeypatch)
+        from telegram_bot.services.lead_score_sync import sync_pending_lead_scores
+
+        await sync_pending_lead_scores(
+            scoring_store=None,
+            kommo_client=None,
+            score_field_id=1,
+            band_field_id=2,
+        )
+
+        assert any(
+            kw.get("tags") == ["job", "lead-scoring"] for kw in recorded_kwargs
+        ), (
+            "propagate_attributes(tags=['job', 'lead-scoring']) was never called. "
+            f"Recorded: {recorded_kwargs}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_output_records_processed_failed_skipped_counts(self, monkeypatch):
+        """Span output must record processed/failed/skipped after the batch."""
+        self._disable_observe_and_propagate(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.lead_score_sync import sync_pending_lead_scores
+
+        scoring_store = AsyncMock()
+        kommo_client = AsyncMock()
+        scoring_store.list_pending_sync.return_value = [
+            SimpleNamespace(
+                lead_id=1,
+                session_id="s1",
+                score_value=10,
+                score_band="cold",
+                kommo_lead_id=901,
+            ),
+            SimpleNamespace(
+                lead_id=2,
+                session_id="s2",
+                score_value=80,
+                score_band="hot",
+                kommo_lead_id=None,
+            ),
+        ]
+
+        await sync_pending_lead_scores(
+            scoring_store=scoring_store,
+            kommo_client=kommo_client,
+            score_field_id=1001,
+            band_field_id=1002,
+        )
+
+        output_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if "output" in c.kwargs
+        ]
+        assert len(output_calls) >= 1, "update_current_span(output=...) was never called"
+        captured_output = output_calls[-1]["output"]
+        assert isinstance(captured_output, dict)
+        assert "processed" in captured_output
+        assert "failed" in captured_output
+        assert "skipped" in captured_output
+        assert captured_output["processed"] == 1
+        assert captured_output["failed"] == 0
+        assert captured_output["skipped"] == 1
+
+    @pytest.mark.asyncio
+    async def test_exception_path_records_error_level_and_reraises(self, monkeypatch):
+        """On exception, update_current_span(level='ERROR', ...) and re-raise."""
+        self._disable_observe_and_propagate(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.lead_score_sync import sync_pending_lead_scores
+
+        scoring_store = AsyncMock()
+        scoring_store.list_pending_sync.side_effect = RuntimeError("DB exploded")
+        kommo_client = AsyncMock()
+
+        with pytest.raises(RuntimeError, match="DB exploded"):
+            await sync_pending_lead_scores(
+                scoring_store=scoring_store,
+                kommo_client=kommo_client,
+                score_field_id=1,
+                band_field_id=2,
+            )
+
+        error_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if c.kwargs.get("level") == "ERROR"
+        ]
+        assert len(error_calls) >= 1, (
+            "Failure path must call update_current_span(level='ERROR', ...)"
+        )
+        status = error_calls[0].get("status_message", "")
+        assert "DB exploded" in status
+        assert len(status) <= 220, "status_message must be truncated to ~200 chars"

--- a/tests/unit/services/test_lead_score_sync.py
+++ b/tests/unit/services/test_lead_score_sync.py
@@ -103,7 +103,6 @@ async def test_sync_pending_lead_scores_marks_failed_on_kommo_error() -> None:
     scoring_store.mark_synced.assert_not_called()
 
 
-
 class TestLeadScoreSyncObserveInstrumentation:
     """Tests for @observe instrumentation on sync_pending_lead_scores (#1663).
 
@@ -192,8 +191,7 @@ class TestLeadScoreSyncObserveInstrumentation:
 
         sync_calls = [c for c in captured if c.get("name") == "job-lead-score-sync"]
         assert len(sync_calls) == 1, (
-            f"Expected exactly one @observe(name='job-lead-score-sync', ...). "
-            f"Captured: {captured}"
+            f"Expected exactly one @observe(name='job-lead-score-sync', ...). Captured: {captured}"
         )
         kwargs = sync_calls[0]
         assert kwargs.get("capture_input") is False
@@ -236,12 +234,29 @@ class TestLeadScoreSyncObserveInstrumentation:
             band_field_id=2,
         )
 
-        assert any(
-            kw.get("tags") == ["job", "lead-scoring"] for kw in recorded_kwargs
-        ), (
+        assert any(kw.get("tags") == ["job", "lead-scoring"] for kw in recorded_kwargs), (
             "propagate_attributes(tags=['job', 'lead-scoring']) was never called. "
             f"Recorded: {recorded_kwargs}"
         )
+
+    @pytest.mark.asyncio
+    async def test_sync_works_when_langfuse_client_unavailable(self, monkeypatch):
+        """Lead-score sync must degrade gracefully when tracing is unavailable."""
+        self._disable_observe_and_propagate(monkeypatch)
+
+        from telegram_bot.services import lead_score_sync as lss_mod
+        from telegram_bot.services.lead_score_sync import sync_pending_lead_scores
+
+        monkeypatch.setattr(lss_mod, "get_client", lambda: None)
+
+        result = await sync_pending_lead_scores(
+            scoring_store=None,
+            kommo_client=None,
+            score_field_id=1,
+            band_field_id=2,
+        )
+
+        assert result == {"synced": 0, "failed": 0, "skipped": 0}
 
     @pytest.mark.asyncio
     async def test_output_records_processed_failed_skipped_counts(self, monkeypatch):
@@ -278,8 +293,7 @@ class TestLeadScoreSyncObserveInstrumentation:
         )
 
         output_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
-            if "output" in c.kwargs
+            c.kwargs for c in mock_lf.update_current_span.call_args_list if "output" in c.kwargs
         ]
         assert len(output_calls) >= 1, "update_current_span(output=...) was never called"
         captured_output = output_calls[-1]["output"]
@@ -312,7 +326,8 @@ class TestLeadScoreSyncObserveInstrumentation:
             )
 
         error_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            c.kwargs
+            for c in mock_lf.update_current_span.call_args_list
             if c.kwargs.get("level") == "ERROR"
         ]
         assert len(error_calls) >= 1, (

--- a/tests/unit/services/test_nurturing_scheduler.py
+++ b/tests/unit/services/test_nurturing_scheduler.py
@@ -64,7 +64,6 @@ async def test_scheduler_uses_funnel_rollup_cron_from_config(fake_services):
     await scheduler.stop()
 
 
-
 class TestNurturingSchedulerObserveInstrumentation:
     """Tests for @observe instrumentation on NurturingScheduler jobs (#1663).
 
@@ -119,9 +118,7 @@ class TestNurturingSchedulerObserveInstrumentation:
             "for tags=['job', 'nurturing'] / ['job', 'analytics']"
         )
 
-    def test_dispatch_and_rollup_observe_decorators_applied_with_correct_kwargs(
-        self, monkeypatch
-    ):
+    def test_dispatch_and_rollup_observe_decorators_applied_with_correct_kwargs(self, monkeypatch):
         """@observe must be applied with the exact issue-spec kwargs to both jobs."""
         import contextlib
         import importlib
@@ -199,9 +196,9 @@ class TestNurturingSchedulerObserveInstrumentation:
         scheduler = NurturingScheduler(**fake_services)
         await scheduler.run_nurturing_dispatch()
 
-        assert any(
-            kw.get("tags") == ["job", "nurturing"] for kw in recorded_kwargs
-        ), f"Expected tags=['job', 'nurturing']. Recorded: {recorded_kwargs}"
+        assert any(kw.get("tags") == ["job", "nurturing"] for kw in recorded_kwargs), (
+            f"Expected tags=['job', 'nurturing']. Recorded: {recorded_kwargs}"
+        )
 
     @pytest.mark.asyncio
     async def test_rollup_propagates_analytics_tags(self, monkeypatch, fake_services):
@@ -237,14 +234,31 @@ class TestNurturingSchedulerObserveInstrumentation:
         scheduler = NurturingScheduler(**fake_services)
         await scheduler.run_funnel_rollup()
 
-        assert any(
-            kw.get("tags") == ["job", "analytics"] for kw in recorded_kwargs
-        ), f"Expected tags=['job', 'analytics']. Recorded: {recorded_kwargs}"
+        assert any(kw.get("tags") == ["job", "analytics"] for kw in recorded_kwargs), (
+            f"Expected tags=['job', 'analytics']. Recorded: {recorded_kwargs}"
+        )
 
     @pytest.mark.asyncio
-    async def test_dispatch_exception_records_error_and_reraises(
+    async def test_dispatch_error_preserves_original_exception_when_langfuse_unavailable(
         self, monkeypatch, fake_services
     ):
+        """Missing Langfuse client must not mask the job failure."""
+        self._disable_observe_and_propagate(monkeypatch)
+
+        from telegram_bot.services import nurturing_scheduler as ns_mod
+        from telegram_bot.services.nurturing_scheduler import NurturingScheduler
+
+        monkeypatch.setattr(ns_mod, "get_client", lambda: None)
+        fake_services["nurturing_service"].dispatch_pending = AsyncMock(
+            side_effect=RuntimeError("Dispatch boom")
+        )
+        scheduler = NurturingScheduler(**fake_services)
+
+        with pytest.raises(RuntimeError, match="Dispatch boom"):
+            await scheduler.run_nurturing_dispatch()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_exception_records_error_and_reraises(self, monkeypatch, fake_services):
         """Dispatch must record ERROR level and re-raise so APScheduler logs failure."""
         self._disable_observe_and_propagate(monkeypatch)
         mock_lf = self._patched_lf(monkeypatch)
@@ -260,7 +274,8 @@ class TestNurturingSchedulerObserveInstrumentation:
             await scheduler.run_nurturing_dispatch()
 
         error_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            c.kwargs
+            for c in mock_lf.update_current_span.call_args_list
             if c.kwargs.get("level") == "ERROR"
         ]
         assert len(error_calls) >= 1
@@ -268,9 +283,7 @@ class TestNurturingSchedulerObserveInstrumentation:
         assert len(error_calls[0].get("status_message", "")) <= 220
 
     @pytest.mark.asyncio
-    async def test_rollup_exception_records_error_and_reraises(
-        self, monkeypatch, fake_services
-    ):
+    async def test_rollup_exception_records_error_and_reraises(self, monkeypatch, fake_services):
         """Rollup must record ERROR level and re-raise so APScheduler logs failure."""
         self._disable_observe_and_propagate(monkeypatch)
         mock_lf = self._patched_lf(monkeypatch)
@@ -286,7 +299,8 @@ class TestNurturingSchedulerObserveInstrumentation:
             await scheduler.run_funnel_rollup()
 
         error_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            c.kwargs
+            for c in mock_lf.update_current_span.call_args_list
             if c.kwargs.get("level") == "ERROR"
         ]
         assert len(error_calls) >= 1

--- a/tests/unit/services/test_nurturing_scheduler.py
+++ b/tests/unit/services/test_nurturing_scheduler.py
@@ -62,3 +62,232 @@ async def test_scheduler_uses_funnel_rollup_cron_from_config(fake_services):
     assert "minute='7'" in str(job.trigger)
 
     await scheduler.stop()
+
+
+
+class TestNurturingSchedulerObserveInstrumentation:
+    """Tests for @observe instrumentation on NurturingScheduler jobs (#1663).
+
+    Contract: run_nurturing_dispatch and run_funnel_rollup must be wrapped with
+    @observe, propagate tags=['job', '<area>'], and on exception emit
+    update_current_span(level='ERROR', ...) before re-raising so APScheduler
+    can record the failure.
+    """
+
+    @staticmethod
+    def _patched_lf(monkeypatch: pytest.MonkeyPatch):
+        from telegram_bot.services import nurturing_scheduler as ns_mod
+
+        mock_lf = MagicMock()
+        monkeypatch.setattr(ns_mod, "get_client", lambda: mock_lf)
+        return mock_lf
+
+    @staticmethod
+    def _disable_observe_and_propagate(monkeypatch: pytest.MonkeyPatch) -> None:
+        import contextlib
+        import importlib
+        import sys
+
+        from telegram_bot import observability as observability_mod
+
+        def fake_observe(**_kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        @contextlib.contextmanager
+        def fake_propagate(**_kwargs):
+            yield
+
+        monkeypatch.setattr(observability_mod, "observe", fake_observe)
+        monkeypatch.setattr(observability_mod, "propagate_attributes", fake_propagate)
+        sys.modules.pop("telegram_bot.services.nurturing_scheduler", None)
+        importlib.import_module("telegram_bot.services.nurturing_scheduler")
+
+    def test_module_imports_observe_get_client_and_propagate_attributes(self):
+        """Module wires the Langfuse decorator + helpers (#1663 contract)."""
+        from telegram_bot.services import nurturing_scheduler as ns_mod
+
+        assert hasattr(ns_mod, "observe")
+        assert hasattr(ns_mod, "get_client"), (
+            "telegram_bot.services.nurturing_scheduler must import `get_client` "
+            "for curated update_current_span(level='ERROR', ...) calls"
+        )
+        assert hasattr(ns_mod, "propagate_attributes"), (
+            "telegram_bot.services.nurturing_scheduler must import `propagate_attributes` "
+            "for tags=['job', 'nurturing'] / ['job', 'analytics']"
+        )
+
+    def test_dispatch_and_rollup_observe_decorators_applied_with_correct_kwargs(
+        self, monkeypatch
+    ):
+        """@observe must be applied with the exact issue-spec kwargs to both jobs."""
+        import contextlib
+        import importlib
+        import sys
+
+        from telegram_bot import observability as observability_mod
+
+        captured: list[dict[str, object]] = []
+
+        def recording_observe(**kwargs):
+            captured.append(kwargs)
+
+            def decorator(func):
+                return func
+
+            return decorator
+
+        @contextlib.contextmanager
+        def fake_propagate(**_kwargs):
+            yield
+
+        monkeypatch.setattr(observability_mod, "observe", recording_observe)
+        monkeypatch.setattr(observability_mod, "propagate_attributes", fake_propagate)
+        sys.modules.pop("telegram_bot.services.nurturing_scheduler", None)
+        importlib.import_module("telegram_bot.services.nurturing_scheduler")
+
+        dispatch_calls = [c for c in captured if c.get("name") == "job-nurturing-dispatch"]
+        assert len(dispatch_calls) == 1, (
+            f"Expected one @observe(name='job-nurturing-dispatch', ...). Captured: {captured}"
+        )
+        assert dispatch_calls[0].get("capture_input") is False
+        assert dispatch_calls[0].get("capture_output") is False
+
+        rollup_calls = [c for c in captured if c.get("name") == "job-funnel-rollup"]
+        assert len(rollup_calls) == 1, (
+            f"Expected one @observe(name='job-funnel-rollup', ...). Captured: {captured}"
+        )
+        assert rollup_calls[0].get("capture_input") is False
+        assert rollup_calls[0].get("capture_output") is False
+
+        # Ensure the existing nurturing-scheduler-tick decorator is preserved.
+        tick_calls = [c for c in captured if c.get("name") == "nurturing-scheduler-tick"]
+        assert len(tick_calls) == 1, "Existing run_nurturing_batch @observe must be preserved"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_propagates_nurturing_tags(self, monkeypatch, fake_services):
+        """run_nurturing_dispatch must call propagate_attributes(tags=['job', 'nurturing'])."""
+        import contextlib
+        import importlib
+        import sys
+
+        from telegram_bot import observability as observability_mod
+
+        recorded_kwargs: list[dict[str, object]] = []
+
+        @contextlib.contextmanager
+        def recording_propagate(**kwargs):
+            recorded_kwargs.append(kwargs)
+            yield
+
+        def fake_observe(**_kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        monkeypatch.setattr(observability_mod, "observe", fake_observe)
+        monkeypatch.setattr(observability_mod, "propagate_attributes", recording_propagate)
+        sys.modules.pop("telegram_bot.services.nurturing_scheduler", None)
+        importlib.import_module("telegram_bot.services.nurturing_scheduler")
+
+        self._patched_lf(monkeypatch)
+        from telegram_bot.services.nurturing_scheduler import NurturingScheduler
+
+        scheduler = NurturingScheduler(**fake_services)
+        await scheduler.run_nurturing_dispatch()
+
+        assert any(
+            kw.get("tags") == ["job", "nurturing"] for kw in recorded_kwargs
+        ), f"Expected tags=['job', 'nurturing']. Recorded: {recorded_kwargs}"
+
+    @pytest.mark.asyncio
+    async def test_rollup_propagates_analytics_tags(self, monkeypatch, fake_services):
+        """run_funnel_rollup must call propagate_attributes(tags=['job', 'analytics'])."""
+        import contextlib
+        import importlib
+        import sys
+
+        from telegram_bot import observability as observability_mod
+
+        recorded_kwargs: list[dict[str, object]] = []
+
+        @contextlib.contextmanager
+        def recording_propagate(**kwargs):
+            recorded_kwargs.append(kwargs)
+            yield
+
+        def fake_observe(**_kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        monkeypatch.setattr(observability_mod, "observe", fake_observe)
+        monkeypatch.setattr(observability_mod, "propagate_attributes", recording_propagate)
+        sys.modules.pop("telegram_bot.services.nurturing_scheduler", None)
+        importlib.import_module("telegram_bot.services.nurturing_scheduler")
+
+        self._patched_lf(monkeypatch)
+        from telegram_bot.services.nurturing_scheduler import NurturingScheduler
+
+        fake_services["analytics_service"].build_daily_snapshot = AsyncMock(return_value=[])
+        scheduler = NurturingScheduler(**fake_services)
+        await scheduler.run_funnel_rollup()
+
+        assert any(
+            kw.get("tags") == ["job", "analytics"] for kw in recorded_kwargs
+        ), f"Expected tags=['job', 'analytics']. Recorded: {recorded_kwargs}"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_exception_records_error_and_reraises(
+        self, monkeypatch, fake_services
+    ):
+        """Dispatch must record ERROR level and re-raise so APScheduler logs failure."""
+        self._disable_observe_and_propagate(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.nurturing_scheduler import NurturingScheduler
+
+        fake_services["nurturing_service"].dispatch_pending = AsyncMock(
+            side_effect=RuntimeError("Dispatch boom")
+        )
+        scheduler = NurturingScheduler(**fake_services)
+
+        with pytest.raises(RuntimeError, match="Dispatch boom"):
+            await scheduler.run_nurturing_dispatch()
+
+        error_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if c.kwargs.get("level") == "ERROR"
+        ]
+        assert len(error_calls) >= 1
+        assert "Dispatch boom" in error_calls[0].get("status_message", "")
+        assert len(error_calls[0].get("status_message", "")) <= 220
+
+    @pytest.mark.asyncio
+    async def test_rollup_exception_records_error_and_reraises(
+        self, monkeypatch, fake_services
+    ):
+        """Rollup must record ERROR level and re-raise so APScheduler logs failure."""
+        self._disable_observe_and_propagate(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.nurturing_scheduler import NurturingScheduler
+
+        fake_services["analytics_service"].build_daily_snapshot = AsyncMock(
+            side_effect=RuntimeError("Rollup boom")
+        )
+        scheduler = NurturingScheduler(**fake_services)
+
+        with pytest.raises(RuntimeError, match="Rollup boom"):
+            await scheduler.run_funnel_rollup()
+
+        error_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if c.kwargs.get("level") == "ERROR"
+        ]
+        assert len(error_calls) >= 1
+        assert "Rollup boom" in error_calls[0].get("status_message", "")


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Closes #1663.

## Summary

Wraps the four background-job entry points called out by the 2026-05-19
Langfuse trace-coverage audit with `@observe(name="job-<name>", capture_input=False, capture_output=False)`,
so periodic / on-demand jobs emit named spans instead of running untraced.
Operators can now aggregate per-job latency in the Langfuse Sessions UI
and filter ops dashboards on `tags=["job", "<area>"]`.

The pattern is the one already accepted on
`NurturingScheduler.run_nurturing_batch` (`@observe(name="nurturing-scheduler-tick")`)
and on the HyDE generator from #1661 / PR #1673.

## Changes (4 functions × 3 files)

| Function | Span name | propagate_attributes(tags=…) | Curated span fields |
|---|---|---|---|
| `services/lead_score_sync.py::sync_pending_lead_scores` | `job-lead-score-sync` | `["job", "lead-scoring"]` | `output={processed, failed, skipped}` |
| `services/hot_lead_notifier.py::HotLeadNotifier.notify_if_hot` | `job-hot-lead-notify` | — | `input={lead_id, score, threshold}`, `output={notified}` |
| `services/nurturing_scheduler.py::NurturingScheduler.run_nurturing_dispatch` | `job-nurturing-dispatch` | `["job", "nurturing"]` | tags-only |
| `services/nurturing_scheduler.py::NurturingScheduler.run_funnel_rollup` | `job-funnel-rollup` | `["job", "analytics"]` | tags-only |

On exception, every wrapped job calls
`update_current_span(level="ERROR", status_message=str(exc)[:200])` and
re-raises so APScheduler can record the run as failed (per the issue's
Implementation Plan step 5). The pre-existing
`run_nurturing_batch` swallow-and-log behaviour is preserved unchanged.

## Validation

- `uv run pytest tests/unit/services/test_lead_score_sync.py tests/unit/services/test_hot_lead_notifier.py tests/unit/services/test_nurturing_scheduler.py -q` → **29 passed**
- 17 new tests across `TestLeadScoreSyncObserveInstrumentation`, `TestHotLeadNotifierObserveInstrumentation`, `TestNurturingSchedulerObserveInstrumentation` covering:
  - decorator configuration (exact `name=` / `capture_input=False` / `capture_output=False`)
  - curated input/output payloads (lead_id/score/threshold for hot-lead; processed/failed/skipped for lead-score-sync; notified bool for hot-lead in both fan-out and dedupe paths)
  - `propagate_attributes(tags=[...])` wiring
  - error path: `update_current_span(level='ERROR', status_message=...)` + re-raise
  - module imports `observe` / `get_client` / `propagate_attributes`
- Wider sweep: `uv run pytest tests/unit/services/ -q` → **999 passed**
- `uv run pytest tests/unit/test_bot_hot_lead.py tests/smoke/test_manager_flow.py tests/unit/services/test_funnel_lead_scoring.py` → **12 passed** (downstream callers)
- `uv run ruff check` on all 6 touched files → clean
- `uv run mypy telegram_bot/services/{lead_score_sync,hot_lead_notifier,nurturing_scheduler}.py` → no issues found

Tests follow the `monkeypatch` + `importlib.reload` pattern from
`tests/unit/test_hyde.py::TestHyDEObserveInstrumentation::test_observe_decorator_applied_with_correct_kwargs`,
so behaviour assertions run with a no-op `@observe` decorator and a
recording `get_client()` mock — no live Langfuse SDK needed.

## Forbidden checks (from issue #1663)

- ❌ **No new metrics/alerting** — alerts tracked separately in #1416. This PR only adds spans.
- ❌ **No coalesce / max_instances / misfire_grace_time changes** — APScheduler config in `NurturingScheduler.__init__` is byte-for-byte identical.
- ❌ **No APScheduler v3 → v4 refactor** — orthogonal to #1654; the `@observe` decorators work the same with both task-based and scheduler-based execution.
- ❌ **No PII in span input** — full `payload` dicts are intentionally NOT passed to `update_current_span`. The `notify_if_hot` curated key set is explicitly limited to `{lead_id, score, threshold}` and the test `test_input_payload_is_curated_lead_score_threshold_only` asserts the captured input keys are a subset of that allow-list, that `phone` and `+380501112233` from the payload do NOT appear, and that `session_id` is excluded too.

## Related

- #1661 / PR #1673 — same pattern applied to HyDE (reference).
- #1416 — alerting on job failure (out of scope for this PR).
- #1654 — APScheduler v3 → v4 migration (orthogonal).
