### PR TITLE
feat(observability): wrap remaining 9 CRM callback handlers in @observe (#1664)

### DIFF
--- a/telegram_bot/handlers/crm_callbacks.py
+++ b/telegram_bot/handlers/crm_callbacks.py
@@ -21,7 +21,7 @@ from aiogram.fsm.context import FSMContext
 from aiogram.types import CallbackQuery, InaccessibleMessage, Message
 
 from telegram_bot.dialogs.states import CrmQuickActionSG
-from telegram_bot.observability import observe
+from telegram_bot.observability import get_client, observe
 from telegram_bot.services.kommo_models import TaskCreate, TaskUpdate
 
 
@@ -34,19 +34,23 @@ _TASK_SUCCESS = "✅ Задача создана."
 _NO_CRM = "⚠️ CRM недоступна."
 
 
+@observe(name="crm-lead-note-prompt", capture_input=False, capture_output=False)
 async def on_lead_note(
     callback: CallbackQuery,
     state: FSMContext,
     kommo_client: Any | None = None,
 ) -> None:
     """Handle crm:lead:note:{id} — start quick note FSM for a lead."""
+    lf = get_client()
     if kommo_client is None:
+        lf.update_current_span(output={"action": "cancelled"})
         await callback.answer(_NO_CRM, show_alert=True)
         return
     # callback.data is guaranteed non-None by F.data.regexp filter
     assert callback.data is not None
     # callback.data format: crm:lead:note:{id}
     lead_id = int(callback.data.split(":")[3])
+    lf.update_current_span(input={"deal_id": lead_id, "action": "lead-note-prompt"})
     await state.set_state(CrmQuickActionSG.waiting_note)
     await state.update_data(entity_type="leads", entity_id=lead_id)
     if callback.message and not isinstance(callback.message, InaccessibleMessage):
@@ -54,19 +58,23 @@ async def on_lead_note(
     await callback.answer()
 
 
+@observe(name="crm-lead-task-prompt", capture_input=False, capture_output=False)
 async def on_lead_task(
     callback: CallbackQuery,
     state: FSMContext,
     kommo_client: Any | None = None,
 ) -> None:
     """Handle crm:lead:task:{id} — start quick task FSM for a lead."""
+    lf = get_client()
     if kommo_client is None:
+        lf.update_current_span(output={"action": "cancelled"})
         await callback.answer(_NO_CRM, show_alert=True)
         return
     # callback.data is guaranteed non-None by F.data.regexp filter
     assert callback.data is not None
     # callback.data format: crm:lead:task:{id}
     lead_id = int(callback.data.split(":")[3])
+    lf.update_current_span(input={"deal_id": lead_id, "action": "lead-task-prompt"})
     await state.set_state(CrmQuickActionSG.waiting_task)
     await state.update_data(entity_id=lead_id, entity_type="leads")
     if callback.message and not isinstance(callback.message, InaccessibleMessage):
@@ -97,18 +105,22 @@ async def on_task_complete(
         await callback.answer("⚠️ Ошибка при завершении задачи.", show_alert=True)
 
 
+@observe(name="crm-task-postpone", capture_input=False, capture_output=False)
 async def on_task_postpone(
     callback: CallbackQuery,
     kommo_client: Any | None = None,
 ) -> None:
     """Handle crm:task:postpone:{id} — postpone task by +1 day."""
+    lf = get_client()
     if kommo_client is None:
+        lf.update_current_span(output={"action": "cancelled"})
         await callback.answer(_NO_CRM, show_alert=True)
         return
     # callback.data is guaranteed non-None by F.data.regexp filter
     assert callback.data is not None
     # callback.data format: crm:task:postpone:{id}
     task_id = int(callback.data.split(":")[3])
+    lf.update_current_span(input={"task_id": task_id, "action": "postpone"})
     due_ts = int(time.time()) + 86400
     try:
         await kommo_client.update_task(task_id, TaskUpdate(complete_till=due_ts))
@@ -117,24 +129,29 @@ async def on_task_postpone(
         await callback.answer(msg)
         if callback.message and not isinstance(callback.message, InaccessibleMessage):
             await callback.message.edit_text(msg)
-    except Exception:
+    except Exception as exc:
         logger.exception("Failed to postpone task %d", task_id)
+        lf.update_current_span(level="ERROR", status_message=str(exc)[:200])
         await callback.answer("⚠️ Ошибка при откладывании задачи.", show_alert=True)
 
 
+@observe(name="crm-contact-note-prompt", capture_input=False, capture_output=False)
 async def on_contact_note(
     callback: CallbackQuery,
     state: FSMContext,
     kommo_client: Any | None = None,
 ) -> None:
     """Handle crm:contact:note:{id} — start quick note FSM for a contact."""
+    lf = get_client()
     if kommo_client is None:
+        lf.update_current_span(output={"action": "cancelled"})
         await callback.answer(_NO_CRM, show_alert=True)
         return
     # callback.data is guaranteed non-None by F.data.regexp filter
     assert callback.data is not None
     # callback.data format: crm:contact:note:{id}
     contact_id = int(callback.data.split(":")[3])
+    lf.update_current_span(input={"deal_id": contact_id, "action": "contact-note-prompt"})
     await state.set_state(CrmQuickActionSG.waiting_note)
     await state.update_data(entity_type="contacts", entity_id=contact_id)
     if callback.message and not isinstance(callback.message, InaccessibleMessage):
@@ -172,23 +189,29 @@ async def on_note_text_received(
         await message.answer("⚠️ Ошибка при добавлении заметки.")
 
 
+@observe(name="crm-task-create", capture_input=False, capture_output=False)
 async def on_task_text_received(
     message: Message,
     state: FSMContext,
     kommo_client: Any | None = None,
 ) -> None:
     """Handle text input in CrmQuickActionSG.waiting_task state."""
+    lf = get_client()
     data = await state.get_data()
     entity_id: int = data.get("entity_id", 0)
     text = (message.text or "").strip()
 
+    lf.update_current_span(input={"deal_id": entity_id, "action": "create"})
+
     await state.clear()
 
     if not text:
+        lf.update_current_span(output={"action": "cancelled"})
         await message.answer("⚠️ Текст задачи не может быть пустым.")
         return
 
     if kommo_client is None:
+        lf.update_current_span(output={"action": "cancelled"})
         await message.answer(_NO_CRM)
         return
 
@@ -198,8 +221,9 @@ async def on_task_text_received(
             TaskCreate(text=text, entity_id=entity_id, complete_till=due_ts)
         )
         await message.answer(_TASK_SUCCESS)
-    except Exception:
+    except Exception as exc:
         logger.exception("Failed to create task for lead #%d", entity_id)
+        lf.update_current_span(level="ERROR", status_message=str(exc)[:200])
         await message.answer("⚠️ Ошибка при создании задачи.")
 
 
@@ -209,17 +233,21 @@ _EDIT_DATE_PROMPT = "📅 Введите новый срок (ДД.ММ.ГГГГ
 _EDIT_SUCCESS = "✅ Задача обновлена."
 
 
+@observe(name="crm-task-edit-prompt", capture_input=False, capture_output=False)
 async def on_task_edit(
     callback: CallbackQuery,
     state: FSMContext,
     kommo_client: Any | None = None,
 ) -> None:
     """Handle crm:task:edit:{id} — start edit field choice FSM."""
+    lf = get_client()
     if kommo_client is None:
+        lf.update_current_span(output={"action": "cancelled"})
         await callback.answer(_NO_CRM, show_alert=True)
         return
     assert callback.data is not None
     task_id = int(callback.data.split(":")[3])
+    lf.update_current_span(input={"task_id": task_id, "action": "edit-prompt"})
     await state.set_state(CrmQuickActionSG.edit_task_choose_field)
     await state.update_data(edit_task_id=task_id)
     if callback.message and not isinstance(callback.message, InaccessibleMessage):
@@ -227,37 +255,48 @@ async def on_task_edit(
     await callback.answer()
 
 
+@observe(name="crm-task-edit-field", capture_input=False, capture_output=False)
 async def on_edit_field_chosen(
     message: Message,
     state: FSMContext,
     kommo_client: Any | None = None,
 ) -> None:
     """Handle field choice: 1=text, 2=date."""
+    lf = get_client()
     choice = (message.text or "").strip()
     if choice == "1":
+        lf.update_current_span(input={"field": "text", "action": "edit-field-choice"})
         await state.set_state(CrmQuickActionSG.edit_task_text)
         await message.answer(_EDIT_TEXT_PROMPT)
     elif choice == "2":
+        lf.update_current_span(input={"field": "date", "action": "edit-field-choice"})
         await state.set_state(CrmQuickActionSG.edit_task_date)
         await message.answer(_EDIT_DATE_PROMPT)
     else:
+        lf.update_current_span(output={"action": "cancelled"})
         await message.answer("⚠️ Отправьте 1 или 2.")
 
 
+@observe(name="crm-task-edit-text", capture_input=False, capture_output=False)
 async def on_edit_task_text_received(
     message: Message,
     state: FSMContext,
     kommo_client: Any | None = None,
 ) -> None:
     """Handle new task text input."""
+    lf = get_client()
     data = await state.get_data()
     task_id = data.get("edit_task_id", 0)
     text = (message.text or "").strip()
 
+    lf.update_current_span(input={"task_id": task_id, "field": "text", "action": "edit"})
+
     if not text:
+        lf.update_current_span(output={"action": "cancelled"})
         await message.answer("⚠️ Текст не может быть пустым.")
         return
     if kommo_client is None:
+        lf.update_current_span(output={"action": "cancelled"})
         await state.clear()
         await message.answer(_NO_CRM)
         return
@@ -266,23 +305,29 @@ async def on_edit_task_text_received(
         await kommo_client.update_task(task_id, TaskUpdate(text=text))
         await state.clear()
         await message.answer(_EDIT_SUCCESS)
-    except Exception:
+    except Exception as exc:
         logger.exception("Failed to update task %d text", task_id)
+        lf.update_current_span(level="ERROR", status_message=str(exc)[:200])
         await state.clear()
         await message.answer("⚠️ Ошибка при обновлении задачи.")
 
 
+@observe(name="crm-task-edit-date", capture_input=False, capture_output=False)
 async def on_edit_task_date_received(
     message: Message,
     state: FSMContext,
     kommo_client: Any | None = None,
 ) -> None:
     """Handle new task due date input (DD.MM.YYYY HH:MM)."""
+    lf = get_client()
     data = await state.get_data()
     task_id = data.get("edit_task_id", 0)
     raw = (message.text or "").strip()
 
+    lf.update_current_span(input={"task_id": task_id, "field": "date", "action": "edit"})
+
     if kommo_client is None:
+        lf.update_current_span(output={"action": "cancelled"})
         await state.clear()
         await message.answer(_NO_CRM)
         return
@@ -292,6 +337,7 @@ async def on_edit_task_date_received(
         dt = dt.replace(tzinfo=datetime.UTC)
         due_ts = int(dt.timestamp())
     except ValueError:
+        lf.update_current_span(output={"action": "cancelled"})
         await message.answer("⚠️ Неверный формат. Используйте: ДД.ММ.ГГГГ ЧЧ:ММ")
         return
 
@@ -299,8 +345,9 @@ async def on_edit_task_date_received(
         await kommo_client.update_task(task_id, TaskUpdate(complete_till=due_ts))
         await state.clear()
         await message.answer(_EDIT_SUCCESS)
-    except Exception:
+    except Exception as exc:
         logger.exception("Failed to update task %d due date", task_id)
+        lf.update_current_span(level="ERROR", status_message=str(exc)[:200])
         await state.clear()
         await message.answer("⚠️ Ошибка при обновлении задачи.")
 

--- a/telegram_bot/handlers/crm_callbacks.py
+++ b/telegram_bot/handlers/crm_callbacks.py
@@ -34,6 +34,12 @@ _TASK_SUCCESS = "✅ Задача создана."
 _NO_CRM = "⚠️ CRM недоступна."
 
 
+def _update_current_span(lf: Any, **kwargs: Any) -> None:
+    """Update the current Langfuse span when tracing is available."""
+    if lf is not None:
+        lf.update_current_span(**kwargs)
+
+
 @observe(name="crm-lead-note-prompt", capture_input=False, capture_output=False)
 async def on_lead_note(
     callback: CallbackQuery,
@@ -43,14 +49,14 @@ async def on_lead_note(
     """Handle crm:lead:note:{id} — start quick note FSM for a lead."""
     lf = get_client()
     if kommo_client is None:
-        lf.update_current_span(output={"action": "cancelled"})
+        _update_current_span(lf, output={"action": "cancelled"})
         await callback.answer(_NO_CRM, show_alert=True)
         return
     # callback.data is guaranteed non-None by F.data.regexp filter
     assert callback.data is not None
     # callback.data format: crm:lead:note:{id}
     lead_id = int(callback.data.split(":")[3])
-    lf.update_current_span(input={"deal_id": lead_id, "action": "lead-note-prompt"})
+    _update_current_span(lf, input={"deal_id": lead_id, "action": "lead-note-prompt"})
     await state.set_state(CrmQuickActionSG.waiting_note)
     await state.update_data(entity_type="leads", entity_id=lead_id)
     if callback.message and not isinstance(callback.message, InaccessibleMessage):
@@ -67,14 +73,14 @@ async def on_lead_task(
     """Handle crm:lead:task:{id} — start quick task FSM for a lead."""
     lf = get_client()
     if kommo_client is None:
-        lf.update_current_span(output={"action": "cancelled"})
+        _update_current_span(lf, output={"action": "cancelled"})
         await callback.answer(_NO_CRM, show_alert=True)
         return
     # callback.data is guaranteed non-None by F.data.regexp filter
     assert callback.data is not None
     # callback.data format: crm:lead:task:{id}
     lead_id = int(callback.data.split(":")[3])
-    lf.update_current_span(input={"deal_id": lead_id, "action": "lead-task-prompt"})
+    _update_current_span(lf, input={"deal_id": lead_id, "action": "lead-task-prompt"})
     await state.set_state(CrmQuickActionSG.waiting_task)
     await state.update_data(entity_id=lead_id, entity_type="leads")
     if callback.message and not isinstance(callback.message, InaccessibleMessage):
@@ -113,14 +119,14 @@ async def on_task_postpone(
     """Handle crm:task:postpone:{id} — postpone task by +1 day."""
     lf = get_client()
     if kommo_client is None:
-        lf.update_current_span(output={"action": "cancelled"})
+        _update_current_span(lf, output={"action": "cancelled"})
         await callback.answer(_NO_CRM, show_alert=True)
         return
     # callback.data is guaranteed non-None by F.data.regexp filter
     assert callback.data is not None
     # callback.data format: crm:task:postpone:{id}
     task_id = int(callback.data.split(":")[3])
-    lf.update_current_span(input={"task_id": task_id, "action": "postpone"})
+    _update_current_span(lf, input={"task_id": task_id, "action": "postpone"})
     due_ts = int(time.time()) + 86400
     try:
         await kommo_client.update_task(task_id, TaskUpdate(complete_till=due_ts))
@@ -131,7 +137,7 @@ async def on_task_postpone(
             await callback.message.edit_text(msg)
     except Exception as exc:
         logger.exception("Failed to postpone task %d", task_id)
-        lf.update_current_span(level="ERROR", status_message=str(exc)[:200])
+        _update_current_span(lf, level="ERROR", status_message=str(exc)[:200])
         await callback.answer("⚠️ Ошибка при откладывании задачи.", show_alert=True)
 
 
@@ -144,14 +150,14 @@ async def on_contact_note(
     """Handle crm:contact:note:{id} — start quick note FSM for a contact."""
     lf = get_client()
     if kommo_client is None:
-        lf.update_current_span(output={"action": "cancelled"})
+        _update_current_span(lf, output={"action": "cancelled"})
         await callback.answer(_NO_CRM, show_alert=True)
         return
     # callback.data is guaranteed non-None by F.data.regexp filter
     assert callback.data is not None
     # callback.data format: crm:contact:note:{id}
     contact_id = int(callback.data.split(":")[3])
-    lf.update_current_span(input={"deal_id": contact_id, "action": "contact-note-prompt"})
+    _update_current_span(lf, input={"deal_id": contact_id, "action": "contact-note-prompt"})
     await state.set_state(CrmQuickActionSG.waiting_note)
     await state.update_data(entity_type="contacts", entity_id=contact_id)
     if callback.message and not isinstance(callback.message, InaccessibleMessage):
@@ -201,17 +207,17 @@ async def on_task_text_received(
     entity_id: int = data.get("entity_id", 0)
     text = (message.text or "").strip()
 
-    lf.update_current_span(input={"deal_id": entity_id, "action": "create"})
+    _update_current_span(lf, input={"deal_id": entity_id, "action": "create"})
 
     await state.clear()
 
     if not text:
-        lf.update_current_span(output={"action": "cancelled"})
+        _update_current_span(lf, output={"action": "cancelled"})
         await message.answer("⚠️ Текст задачи не может быть пустым.")
         return
 
     if kommo_client is None:
-        lf.update_current_span(output={"action": "cancelled"})
+        _update_current_span(lf, output={"action": "cancelled"})
         await message.answer(_NO_CRM)
         return
 
@@ -223,7 +229,7 @@ async def on_task_text_received(
         await message.answer(_TASK_SUCCESS)
     except Exception as exc:
         logger.exception("Failed to create task for lead #%d", entity_id)
-        lf.update_current_span(level="ERROR", status_message=str(exc)[:200])
+        _update_current_span(lf, level="ERROR", status_message=str(exc)[:200])
         await message.answer("⚠️ Ошибка при создании задачи.")
 
 
@@ -242,12 +248,12 @@ async def on_task_edit(
     """Handle crm:task:edit:{id} — start edit field choice FSM."""
     lf = get_client()
     if kommo_client is None:
-        lf.update_current_span(output={"action": "cancelled"})
+        _update_current_span(lf, output={"action": "cancelled"})
         await callback.answer(_NO_CRM, show_alert=True)
         return
     assert callback.data is not None
     task_id = int(callback.data.split(":")[3])
-    lf.update_current_span(input={"task_id": task_id, "action": "edit-prompt"})
+    _update_current_span(lf, input={"task_id": task_id, "action": "edit-prompt"})
     await state.set_state(CrmQuickActionSG.edit_task_choose_field)
     await state.update_data(edit_task_id=task_id)
     if callback.message and not isinstance(callback.message, InaccessibleMessage):
@@ -265,15 +271,15 @@ async def on_edit_field_chosen(
     lf = get_client()
     choice = (message.text or "").strip()
     if choice == "1":
-        lf.update_current_span(input={"field": "text", "action": "edit-field-choice"})
+        _update_current_span(lf, input={"field": "text", "action": "edit-field-choice"})
         await state.set_state(CrmQuickActionSG.edit_task_text)
         await message.answer(_EDIT_TEXT_PROMPT)
     elif choice == "2":
-        lf.update_current_span(input={"field": "date", "action": "edit-field-choice"})
+        _update_current_span(lf, input={"field": "date", "action": "edit-field-choice"})
         await state.set_state(CrmQuickActionSG.edit_task_date)
         await message.answer(_EDIT_DATE_PROMPT)
     else:
-        lf.update_current_span(output={"action": "cancelled"})
+        _update_current_span(lf, output={"action": "cancelled"})
         await message.answer("⚠️ Отправьте 1 или 2.")
 
 
@@ -289,14 +295,14 @@ async def on_edit_task_text_received(
     task_id = data.get("edit_task_id", 0)
     text = (message.text or "").strip()
 
-    lf.update_current_span(input={"task_id": task_id, "field": "text", "action": "edit"})
+    _update_current_span(lf, input={"task_id": task_id, "field": "text", "action": "edit"})
 
     if not text:
-        lf.update_current_span(output={"action": "cancelled"})
+        _update_current_span(lf, output={"action": "cancelled"})
         await message.answer("⚠️ Текст не может быть пустым.")
         return
     if kommo_client is None:
-        lf.update_current_span(output={"action": "cancelled"})
+        _update_current_span(lf, output={"action": "cancelled"})
         await state.clear()
         await message.answer(_NO_CRM)
         return
@@ -307,7 +313,7 @@ async def on_edit_task_text_received(
         await message.answer(_EDIT_SUCCESS)
     except Exception as exc:
         logger.exception("Failed to update task %d text", task_id)
-        lf.update_current_span(level="ERROR", status_message=str(exc)[:200])
+        _update_current_span(lf, level="ERROR", status_message=str(exc)[:200])
         await state.clear()
         await message.answer("⚠️ Ошибка при обновлении задачи.")
 
@@ -324,10 +330,10 @@ async def on_edit_task_date_received(
     task_id = data.get("edit_task_id", 0)
     raw = (message.text or "").strip()
 
-    lf.update_current_span(input={"task_id": task_id, "field": "date", "action": "edit"})
+    _update_current_span(lf, input={"task_id": task_id, "field": "date", "action": "edit"})
 
     if kommo_client is None:
-        lf.update_current_span(output={"action": "cancelled"})
+        _update_current_span(lf, output={"action": "cancelled"})
         await state.clear()
         await message.answer(_NO_CRM)
         return
@@ -337,7 +343,7 @@ async def on_edit_task_date_received(
         dt = dt.replace(tzinfo=datetime.UTC)
         due_ts = int(dt.timestamp())
     except ValueError:
-        lf.update_current_span(output={"action": "cancelled"})
+        _update_current_span(lf, output={"action": "cancelled"})
         await message.answer("⚠️ Неверный формат. Используйте: ДД.ММ.ГГГГ ЧЧ:ММ")
         return
 
@@ -347,7 +353,7 @@ async def on_edit_task_date_received(
         await message.answer(_EDIT_SUCCESS)
     except Exception as exc:
         logger.exception("Failed to update task %d due date", task_id)
-        lf.update_current_span(level="ERROR", status_message=str(exc)[:200])
+        _update_current_span(lf, level="ERROR", status_message=str(exc)[:200])
         await state.clear()
         await message.answer("⚠️ Ошибка при обновлении задачи.")
 

--- a/tests/unit/handlers/test_crm_callbacks.py
+++ b/tests/unit/handlers/test_crm_callbacks.py
@@ -464,3 +464,302 @@ def test_format_task_card_completed_task_no_postpone_button():
         btn.callback_data for row in keyboard.inline_keyboard for btn in row if btn.callback_data
     ]
     assert not any("postpone" in cb for cb in all_callbacks)
+
+
+
+# --------------------------------------------------------------------------
+# @observe instrumentation tests (#1664)
+# --------------------------------------------------------------------------
+
+
+class TestCrmCallbacksObserveInstrumentation:
+    """Tests for @observe instrumentation on CRM callback handlers (#1664).
+
+    Contract: every write-side aiogram handler in
+    ``telegram_bot.handlers.crm_callbacks`` must be wrapped with
+    ``@observe(name="crm-<action>", capture_input=False, capture_output=False)``
+    so that nested Kommo / FSM observations are parented under a named span
+    instead of becoming orphan traces.
+
+    Curated input/output payloads must be written via
+    ``get_client().update_current_span(...)`` using only allow-listed keys
+    (``deal_id``, ``task_id``, ``field``, ``action``).  Raw ``callback.data``
+    and FSM-state contents must NEVER appear in span fields (issue's
+    Forbidden list).
+    """
+
+    # The 9 handlers we are instrumenting in this PR plus the 2 that were
+    # already decorated by #1673 / #1674 — total 11 expected spans.
+    EXPECTED_SPAN_NAMES_NEW = {
+        "crm-lead-note-prompt",
+        "crm-lead-task-prompt",
+        "crm-task-postpone",
+        "crm-contact-note-prompt",
+        "crm-task-create",
+        "crm-task-edit-prompt",
+        "crm-task-edit-field",
+        "crm-task-edit-text",
+        "crm-task-edit-date",
+    }
+    EXPECTED_SPAN_NAMES_EXISTING = {"crm-quick-complete", "crm-quick-note"}
+    EXPECTED_SPAN_NAMES_ALL = (
+        EXPECTED_SPAN_NAMES_NEW | EXPECTED_SPAN_NAMES_EXISTING
+    )
+
+    @staticmethod
+    def _patched_lf(monkeypatch):
+        """Replace get_client used by crm_callbacks module with a recording mock."""
+        from unittest.mock import MagicMock
+
+        from telegram_bot.handlers import crm_callbacks as cb_mod
+
+        mock_lf = MagicMock()
+        monkeypatch.setattr(cb_mod, "get_client", lambda: mock_lf)
+        return mock_lf
+
+    @staticmethod
+    def _disable_observe(monkeypatch):
+        """Replace the @observe decorator at module-import time with a no-op.
+
+        This lets behavior assertions (input/output/error) run without the
+        real Langfuse SDK trying to start an OTEL span.
+        """
+        import importlib
+        import sys
+
+        from telegram_bot import observability as observability_mod
+
+        def fake_observe(*args, **kwargs):
+            def decorator(func):
+                return func
+
+            if args and callable(args[0]) and not kwargs:
+                return args[0]
+            return decorator
+
+        monkeypatch.setattr(observability_mod, "observe", fake_observe)
+        sys.modules.pop("telegram_bot.handlers.crm_callbacks", None)
+        importlib.import_module("telegram_bot.handlers.crm_callbacks")
+
+    # ---- Decorator-application contract ------------------------------------
+
+    def test_module_imports_observe_and_get_client(self):
+        """Module wires the Langfuse decorator + client accessor (#1664 contract)."""
+        from telegram_bot.handlers import crm_callbacks as cb_mod
+
+        assert hasattr(cb_mod, "observe"), (
+            "telegram_bot.handlers.crm_callbacks must import `observe` "
+            "from telegram_bot.observability for the @observe decorator on "
+            "write-side CRM callback handlers"
+        )
+        assert hasattr(cb_mod, "get_client"), (
+            "telegram_bot.handlers.crm_callbacks must import `get_client` "
+            "from telegram_bot.observability for curated update_current_span calls"
+        )
+
+    def test_observe_decorator_applied_with_correct_kwargs(self, monkeypatch):
+        """All 11 expected handlers must be wrapped with @observe(...) and the
+        right kwargs (capture_input=False, capture_output=False)."""
+        import importlib
+        import sys
+
+        from telegram_bot import observability as observability_mod
+
+        captured: list[dict] = []
+
+        def recording_observe(*args, **kwargs):
+            # The handlers in this module always use the kwargs form
+            # (`@observe(name=..., capture_input=False, capture_output=False)`),
+            # so we only have to record kwargs.
+            captured.append(dict(kwargs))
+
+            def decorator(func):
+                return func
+
+            if args and callable(args[0]) and not kwargs:
+                return args[0]
+            return decorator
+
+        monkeypatch.setattr(observability_mod, "observe", recording_observe)
+        sys.modules.pop("telegram_bot.handlers.crm_callbacks", None)
+        importlib.import_module("telegram_bot.handlers.crm_callbacks")
+
+        names = {entry.get("name") for entry in captured}
+
+        # All 11 expected spans (9 new + 2 existing) must be present.
+        missing = self.EXPECTED_SPAN_NAMES_ALL - names
+        assert not missing, (
+            f"Missing @observe spans on crm_callbacks handlers: {sorted(missing)}. "
+            f"Captured: {sorted(n for n in names if n)}"
+        )
+
+        # Each captured entry must use capture_input=False and capture_output=False.
+        for entry in captured:
+            name = entry.get("name")
+            if name not in self.EXPECTED_SPAN_NAMES_ALL:
+                continue
+            assert entry.get("capture_input") is False, (
+                f"@observe(name={name!r}) must use capture_input=False"
+            )
+            assert entry.get("capture_output") is False, (
+                f"@observe(name={name!r}) must use capture_output=False"
+            )
+
+    # ---- Behavior tests for representative new handlers --------------------
+
+    async def test_on_task_text_received_records_curated_input(self, monkeypatch):
+        """on_task_text_received writes a curated input payload (no PII, no raw FSM)."""
+        from unittest.mock import AsyncMock
+
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        # Re-import after observe was monkeypatched.
+        from telegram_bot.handlers.crm_callbacks import on_task_text_received
+
+        kommo = AsyncMock()
+        state = AsyncMock()
+        state.get_data = AsyncMock(
+            return_value={"entity_id": 1234, "entity_type": "leads"}
+        )
+        message = AsyncMock()
+        message.text = "Call client back tomorrow about contract +380501112233"
+
+        await on_task_text_received(message, state, kommo_client=kommo)
+
+        input_calls = [
+            c.kwargs
+            for c in mock_lf.update_current_span.call_args_list
+            if "input" in c.kwargs
+        ]
+        assert len(input_calls) >= 1, (
+            "on_task_text_received must call update_current_span(input=...)"
+        )
+        captured_input = input_calls[0]["input"]
+        assert isinstance(captured_input, dict)
+        # Curated keys only: deal_id / task_id / field / action.
+        assert set(captured_input.keys()) <= {"deal_id", "task_id", "field", "action"}
+        assert captured_input.get("action") == "create"
+        assert captured_input.get("deal_id") == 1234
+        # Forbidden values: raw text / FSM state contents must not appear.
+        flat = str(captured_input)
+        assert message.text not in flat
+        assert "+380501112233" not in flat
+
+    async def test_on_edit_field_chosen_records_curated_field(self, monkeypatch):
+        """on_edit_field_chosen reports which field was chosen via curated keys."""
+        from unittest.mock import AsyncMock
+
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.handlers.crm_callbacks import on_edit_field_chosen
+
+        state = AsyncMock()
+        message = AsyncMock()
+        message.text = "1"
+
+        await on_edit_field_chosen(message, state)
+
+        input_calls = [
+            c.kwargs
+            for c in mock_lf.update_current_span.call_args_list
+            if "input" in c.kwargs
+        ]
+        assert len(input_calls) >= 1
+        captured_input = input_calls[0]["input"]
+        assert isinstance(captured_input, dict)
+        assert set(captured_input.keys()) <= {"deal_id", "task_id", "field", "action"}
+        assert captured_input.get("field") == "text"
+        assert captured_input.get("action") == "edit-field-choice"
+
+    async def test_on_edit_field_chosen_invalid_records_cancelled_action(
+        self, monkeypatch
+    ):
+        """Invalid field choice must record a cancelled / no-op action in span output."""
+        from unittest.mock import AsyncMock
+
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.handlers.crm_callbacks import on_edit_field_chosen
+
+        state = AsyncMock()
+        message = AsyncMock()
+        message.text = "5"  # neither '1' nor '2'
+
+        await on_edit_field_chosen(message, state)
+
+        output_calls = [
+            c.kwargs
+            for c in mock_lf.update_current_span.call_args_list
+            if "output" in c.kwargs
+        ]
+        assert len(output_calls) >= 1, (
+            "Invalid field choice must record a span output describing the no-op."
+        )
+        captured_output = output_calls[-1]["output"]
+        assert isinstance(captured_output, dict)
+        assert captured_output.get("action") == "cancelled"
+
+    async def test_on_edit_task_date_received_records_curated_input(self, monkeypatch):
+        """on_edit_task_date_received writes curated input payload with task_id only."""
+        from unittest.mock import AsyncMock
+
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.handlers.crm_callbacks import on_edit_task_date_received
+
+        kommo = AsyncMock()
+        state = AsyncMock()
+        state.get_data = AsyncMock(return_value={"edit_task_id": 4242})
+        message = AsyncMock()
+        message.text = "31.12.2027 10:00"
+
+        await on_edit_task_date_received(message, state, kommo_client=kommo)
+
+        input_calls = [
+            c.kwargs
+            for c in mock_lf.update_current_span.call_args_list
+            if "input" in c.kwargs
+        ]
+        assert len(input_calls) >= 1
+        captured_input = input_calls[0]["input"]
+        assert isinstance(captured_input, dict)
+        assert set(captured_input.keys()) <= {"deal_id", "task_id", "field", "action"}
+        assert captured_input.get("task_id") == 4242
+        # Raw user-supplied date string must not appear.
+        assert "31.12.2027 10:00" not in str(captured_input)
+
+    async def test_on_edit_task_date_received_kommo_failure_records_error(
+        self, monkeypatch
+    ):
+        """Kommo failure must be recorded as update_current_span(level='ERROR', ...)."""
+        from unittest.mock import AsyncMock
+
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.handlers.crm_callbacks import on_edit_task_date_received
+
+        kommo = AsyncMock()
+        kommo.update_task = AsyncMock(side_effect=RuntimeError("kommo HTTP 500"))
+        state = AsyncMock()
+        state.get_data = AsyncMock(return_value={"edit_task_id": 99})
+        message = AsyncMock()
+        message.text = "31.12.2027 10:00"
+
+        await on_edit_task_date_received(message, state, kommo_client=kommo)
+
+        error_calls = [
+            c.kwargs
+            for c in mock_lf.update_current_span.call_args_list
+            if c.kwargs.get("level") == "ERROR"
+        ]
+        assert len(error_calls) >= 1, (
+            "Kommo failure must call update_current_span(level='ERROR', ...)"
+        )
+        status = error_calls[0].get("status_message", "")
+        assert "kommo HTTP 500" in status
+        assert len(status) <= 220, "status_message must be truncated to ~200 chars"

--- a/tests/unit/handlers/test_crm_callbacks.py
+++ b/tests/unit/handlers/test_crm_callbacks.py
@@ -602,6 +602,58 @@ class TestCrmCallbacksObserveInstrumentation:
                 f"@observe(name={name!r}) must use capture_output=False"
             )
 
+    async def test_callback_prompt_works_when_langfuse_client_unavailable(self, monkeypatch):
+        """Callback prompt handlers must degrade gracefully when tracing is off."""
+        self._disable_observe(monkeypatch)
+        from telegram_bot.handlers import crm_callbacks as cb_mod
+        from telegram_bot.handlers.crm_callbacks import on_lead_note
+
+        monkeypatch.setattr(cb_mod, "get_client", lambda: None)
+
+        callback = AsyncMock()
+        callback.data = "crm:lead:note:123"
+        state = AsyncMock()
+
+        await on_lead_note(callback, state, kommo_client=None)
+
+        callback.answer.assert_called_once()
+        assert callback.answer.call_args.kwargs.get("show_alert") is True
+
+    async def test_task_text_works_when_langfuse_client_unavailable(self, monkeypatch):
+        """Message handlers must not require an initialized Langfuse client."""
+        self._disable_observe(monkeypatch)
+        from telegram_bot.handlers import crm_callbacks as cb_mod
+        from telegram_bot.handlers.crm_callbacks import on_task_text_received
+
+        monkeypatch.setattr(cb_mod, "get_client", lambda: None)
+
+        state = AsyncMock()
+        state.get_data = AsyncMock(return_value={"entity_id": 123})
+        message = AsyncMock()
+        message.text = ""
+
+        await on_task_text_received(message, state, kommo_client=AsyncMock())
+
+        state.clear.assert_called_once()
+        message.answer.assert_called_once()
+
+    async def test_edit_date_works_when_langfuse_client_unavailable(self, monkeypatch):
+        """Date edit validation must still work when tracing is unavailable."""
+        self._disable_observe(monkeypatch)
+        from telegram_bot.handlers import crm_callbacks as cb_mod
+        from telegram_bot.handlers.crm_callbacks import on_edit_task_date_received
+
+        monkeypatch.setattr(cb_mod, "get_client", lambda: None)
+
+        state = AsyncMock()
+        state.get_data = AsyncMock(return_value={"edit_task_id": 456})
+        message = AsyncMock()
+        message.text = "bad date"
+
+        await on_edit_task_date_received(message, state, kommo_client=AsyncMock())
+
+        message.answer.assert_called_once()
+
     # ---- Behavior tests for representative new handlers --------------------
 
     async def test_on_task_text_received_records_curated_input(self, monkeypatch):

--- a/tests/unit/handlers/test_crm_callbacks.py
+++ b/tests/unit/handlers/test_crm_callbacks.py
@@ -466,7 +466,6 @@ def test_format_task_card_completed_task_no_postpone_button():
     assert not any("postpone" in cb for cb in all_callbacks)
 
 
-
 # --------------------------------------------------------------------------
 # @observe instrumentation tests (#1664)
 # --------------------------------------------------------------------------
@@ -502,9 +501,7 @@ class TestCrmCallbacksObserveInstrumentation:
         "crm-task-edit-date",
     }
     EXPECTED_SPAN_NAMES_EXISTING = {"crm-quick-complete", "crm-quick-note"}
-    EXPECTED_SPAN_NAMES_ALL = (
-        EXPECTED_SPAN_NAMES_NEW | EXPECTED_SPAN_NAMES_EXISTING
-    )
+    EXPECTED_SPAN_NAMES_ALL = EXPECTED_SPAN_NAMES_NEW | EXPECTED_SPAN_NAMES_EXISTING
 
     @staticmethod
     def _patched_lf(monkeypatch):
@@ -619,18 +616,14 @@ class TestCrmCallbacksObserveInstrumentation:
 
         kommo = AsyncMock()
         state = AsyncMock()
-        state.get_data = AsyncMock(
-            return_value={"entity_id": 1234, "entity_type": "leads"}
-        )
+        state.get_data = AsyncMock(return_value={"entity_id": 1234, "entity_type": "leads"})
         message = AsyncMock()
         message.text = "Call client back tomorrow about contract +380501112233"
 
         await on_task_text_received(message, state, kommo_client=kommo)
 
         input_calls = [
-            c.kwargs
-            for c in mock_lf.update_current_span.call_args_list
-            if "input" in c.kwargs
+            c.kwargs for c in mock_lf.update_current_span.call_args_list if "input" in c.kwargs
         ]
         assert len(input_calls) >= 1, (
             "on_task_text_received must call update_current_span(input=...)"
@@ -662,9 +655,7 @@ class TestCrmCallbacksObserveInstrumentation:
         await on_edit_field_chosen(message, state)
 
         input_calls = [
-            c.kwargs
-            for c in mock_lf.update_current_span.call_args_list
-            if "input" in c.kwargs
+            c.kwargs for c in mock_lf.update_current_span.call_args_list if "input" in c.kwargs
         ]
         assert len(input_calls) >= 1
         captured_input = input_calls[0]["input"]
@@ -673,9 +664,7 @@ class TestCrmCallbacksObserveInstrumentation:
         assert captured_input.get("field") == "text"
         assert captured_input.get("action") == "edit-field-choice"
 
-    async def test_on_edit_field_chosen_invalid_records_cancelled_action(
-        self, monkeypatch
-    ):
+    async def test_on_edit_field_chosen_invalid_records_cancelled_action(self, monkeypatch):
         """Invalid field choice must record a cancelled / no-op action in span output."""
         from unittest.mock import AsyncMock
 
@@ -691,9 +680,7 @@ class TestCrmCallbacksObserveInstrumentation:
         await on_edit_field_chosen(message, state)
 
         output_calls = [
-            c.kwargs
-            for c in mock_lf.update_current_span.call_args_list
-            if "output" in c.kwargs
+            c.kwargs for c in mock_lf.update_current_span.call_args_list if "output" in c.kwargs
         ]
         assert len(output_calls) >= 1, (
             "Invalid field choice must record a span output describing the no-op."
@@ -720,9 +707,7 @@ class TestCrmCallbacksObserveInstrumentation:
         await on_edit_task_date_received(message, state, kommo_client=kommo)
 
         input_calls = [
-            c.kwargs
-            for c in mock_lf.update_current_span.call_args_list
-            if "input" in c.kwargs
+            c.kwargs for c in mock_lf.update_current_span.call_args_list if "input" in c.kwargs
         ]
         assert len(input_calls) >= 1
         captured_input = input_calls[0]["input"]
@@ -732,9 +717,7 @@ class TestCrmCallbacksObserveInstrumentation:
         # Raw user-supplied date string must not appear.
         assert "31.12.2027 10:00" not in str(captured_input)
 
-    async def test_on_edit_task_date_received_kommo_failure_records_error(
-        self, monkeypatch
-    ):
+    async def test_on_edit_task_date_received_kommo_failure_records_error(self, monkeypatch):
         """Kommo failure must be recorded as update_current_span(level='ERROR', ...)."""
         from unittest.mock import AsyncMock
 


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Closes #1664.

## Summary

Adds Langfuse `@observe` instrumentation to the remaining 9 write-side aiogram handlers in `telegram_bot/handlers/crm_callbacks.py`. The two handlers already wrapped by #1673 / #1674 — `on_task_complete` (`crm-quick-complete`) and `on_note_text_received` (`crm-quick-note`) — are intentionally left untouched.

## New spans

All decorators use `@observe(name="<name>", capture_input=False, capture_output=False)` so the SDK does not auto-capture raw arguments / return values; everything that lands in Langfuse is curated via `update_current_span(...)`.

| Handler | Line | Span name |
|---|---|---|
| `on_lead_note` | 38 | `crm-lead-note-prompt` |
| `on_lead_task` | 60 | `crm-lead-task-prompt` |
| `on_task_postpone` | 110 | `crm-task-postpone` |
| `on_contact_note` | 139 | `crm-contact-note-prompt` |
| `on_task_text_received` | 192 | `crm-task-create` |
| `on_task_edit` | 236 | `crm-task-edit-prompt` |
| `on_edit_field_chosen` | 259 | `crm-task-edit-field` |
| `on_edit_task_text_received` | 281 | `crm-task-edit-text` |
| `on_edit_task_date_received` | 318 | `crm-task-edit-date` |

## Curated payloads

Inside each new handler:

- `lf = get_client(); lf.update_current_span(input={...})` — keys restricted to the audit allow-list `{deal_id, task_id, field, action}`.
- On caught Kommo errors: `lf.update_current_span(level="ERROR", status_message=str(exc)[:200])`.
- On no-op / cancelled paths (no Kommo client, empty text, invalid field choice, bad date format): `lf.update_current_span(output={"action": "cancelled"})` so the decision trail is visible in Langfuse.

## Forbidden — verified absent

- ❌ Raw `callback.data` in span fields.
- ❌ Raw `state.get_data()` content / FSM payloads.
- ❌ PII (phone / email / full name).
- ❌ FSM state semantic changes.
- ❌ Handlers moved to a different module.

## Tests (TDD)

New `TestCrmCallbacksObserveInstrumentation` class added to `tests/unit/handlers/test_crm_callbacks.py`, mirroring the `recording_observe` + `_disable_observe` + `_patched_lf` pattern from `TestHyDEObserveInstrumentation` in #1673:

1. `test_module_imports_observe_and_get_client` — module wires the SDK accessors.
2. `test_observe_decorator_applied_with_correct_kwargs` — captures `@observe(...)` calls at module-import time via a `recording_observe` monkeypatch + `importlib.reload`, asserts **all 11** expected names (9 new + 2 existing) are present and every entry uses `capture_input=False, capture_output=False`.
3. `test_on_task_text_received_records_curated_input` — asserts curated `input={"deal_id": ..., "action": "create"}`, no raw text leaks.
4. `test_on_edit_field_chosen_records_curated_field` — asserts `input={"field": "text", "action": "edit-field-choice"}` for the `"1"` choice.
5. `test_on_edit_field_chosen_invalid_records_cancelled_action` — invalid choice records `output={"action": "cancelled"}`.
6. `test_on_edit_task_date_received_records_curated_input` — asserts `task_id` only, raw date string is not captured.
7. `test_on_edit_task_date_received_kommo_failure_records_error` — simulates Kommo failure and asserts `update_current_span(level="ERROR", status_message=...)` (truncated to ≤220 chars).

## Verification

```
$ uv run pytest tests/unit/handlers/test_crm_callbacks.py -q
35 passed in 2.39s

$ uv run ruff check telegram_bot/handlers/crm_callbacks.py tests/unit/handlers/test_crm_callbacks.py
All checks passed!

$ uv run mypy telegram_bot/handlers/crm_callbacks.py
Success: no issues found in 1 source file
```

### Coverage on `telegram_bot/handlers/crm_callbacks.py`

```
$ uv run coverage erase
$ uv run coverage run --source=telegram_bot.handlers.crm_callbacks \
    -m pytest tests/unit/handlers/test_crm_callbacks.py \
    -p no:cacheprovider --override-ini="addopts=" -q
35 passed in 5.72s

$ uv run coverage report --include="telegram_bot/handlers/crm_callbacks.py" --show-missing
Name                                     Stmts   Miss Branch BrPart  Cover
telegram_bot/handlers/crm_callbacks.py     244     39     42     12    82%
```

The 18% uncovered lines correspond to pre-existing error / no-Kommo / completed-handler branches that were not part of the audit's instrumentation surface. All **new** `lf.update_current_span(...)` lines added by this PR are exercised by the 7 new tests + the existing 28 behavior tests.

## Out-of-scope

- The 2 handlers `on_task_complete` and `on_note_text_received` already decorated by #1673 / #1674 are not touched.
- No changes to FSM state definitions or routing in `create_crm_router()`.