### PR TITLE
feat(observability): wrap LLMService.{generate_answer,stream_answer,generate} in @observe (#1660)

### DIFF
--- a/telegram_bot/services/llm.py
+++ b/telegram_bot/services/llm.py
@@ -23,6 +23,12 @@ logger = logging.getLogger(__name__)
 LOW_CONFIDENCE_THRESHOLD = 0.3
 
 
+def _update_current_span(lf: Any, **kwargs: Any) -> None:
+    """Update the current Langfuse span when tracing is available."""
+    if lf is not None:
+        lf.update_current_span(**kwargs)
+
+
 class ConfidenceResponse(BaseModel):
     """Pydantic model for LLM confidence extraction via Instructor.
 
@@ -125,12 +131,13 @@ class LLMService:
         prompt or full response into Langfuse.
         """
         lf = get_client()
-        lf.update_current_span(
+        _update_current_span(
+            lf,
             input={
                 "prompt_preview": question[:120],
                 "model": self.model,
                 "with_confidence": with_confidence,
-            }
+            },
         )
         try:
             context = self._format_context(context_chunks)
@@ -177,7 +184,7 @@ class LLMService:
                     max_tokens=self.model_max_tokens,
                     name="generate-answer",  # type: ignore[call-overload]  # langfuse kwarg
                 )
-                lf.update_current_span(output={"response_len": len(response_model.answer)})
+                _update_current_span(lf, output={"response_len": len(response_model.answer)})
                 return ConfidenceResult(
                     answer=response_model.answer,
                     confidence=response_model.confidence,
@@ -195,12 +202,12 @@ class LLMService:
 
             message = response.choices[0].message
             response_text = message.content or ""
-            lf.update_current_span(output={"response_len": len(response_text)})
+            _update_current_span(lf, output={"response_len": len(response_text)})
             return response_text
 
         except (openai.APITimeoutError, openai.APIConnectionError) as e:
             logger.error(f"LLM API timeout/connection: {e}")
-            lf.update_current_span(level="ERROR", status_message=str(e)[:200])
+            _update_current_span(lf, level="ERROR", status_message=str(e)[:200])
             fallback = self._get_fallback_answer(question, context_chunks)
             if with_confidence:
                 return ConfidenceResult(
@@ -209,7 +216,7 @@ class LLMService:
             return fallback
         except openai.RateLimitError as e:
             logger.error(f"LLM API rate limit: {e}")
-            lf.update_current_span(level="ERROR", status_message=str(e)[:200])
+            _update_current_span(lf, level="ERROR", status_message=str(e)[:200])
             fallback = self._get_fallback_answer(question, context_chunks)
             if with_confidence:
                 return ConfidenceResult(
@@ -218,7 +225,7 @@ class LLMService:
             return fallback
         except Exception as e:
             logger.error(f"LLM generation failed: {e}", exc_info=True)
-            lf.update_current_span(level="ERROR", status_message=str(e)[:200])
+            _update_current_span(lf, level="ERROR", status_message=str(e)[:200])
             fallback = self._get_fallback_answer(question, context_chunks)
             if with_confidence:
                 return ConfidenceResult(
@@ -273,11 +280,12 @@ class LLMService:
         ``langfuse.openai`` own that on the inner generation.
         """
         lf = get_client()
-        lf.update_current_span(
+        _update_current_span(
+            lf,
             input={
                 "prompt_preview": question[:120],
                 "model": self.model,
-            }
+            },
         )
         chunks_count = 0
         total_len = 0
@@ -327,15 +335,15 @@ class LLMService:
                     total_len += len(delta.content)
                     yield delta.content
 
-            lf.update_current_span(output={"chunks": chunks_count, "total_len": total_len})
+            _update_current_span(lf, output={"chunks": chunks_count, "total_len": total_len})
 
         except (openai.RateLimitError, openai.APITimeoutError, openai.APIConnectionError) as e:
             logger.error(f"LLM streaming error: {e}")
-            lf.update_current_span(level="ERROR", status_message=str(e)[:200])
+            _update_current_span(lf, level="ERROR", status_message=str(e)[:200])
             yield self._get_fallback_answer(question, context_chunks)
         except Exception as e:
             logger.error(f"LLM streaming failed: {e}", exc_info=True)
-            lf.update_current_span(level="ERROR", status_message=str(e)[:200])
+            _update_current_span(lf, level="ERROR", status_message=str(e)[:200])
             yield self._get_fallback_answer(question, context_chunks)
 
     def _format_context(self, chunks: list[dict[str, Any]]) -> str:
@@ -449,11 +457,12 @@ class LLMService:
         contract).
         """
         lf = get_client()
-        lf.update_current_span(
+        _update_current_span(
+            lf,
             input={
                 "prompt_preview": prompt[:120],
                 "model": self.model,
-            }
+            },
         )
         try:
             response = await self.client.chat.completions.create(
@@ -464,11 +473,11 @@ class LLMService:
                 name="generate-simple",  # type: ignore[call-overload]  # langfuse kwarg
             )
             response_text = response.choices[0].message.content or ""
-            lf.update_current_span(output={"response_len": len(response_text)})
+            _update_current_span(lf, output={"response_len": len(response_text)})
             return response_text
         except Exception as e:
             logger.error(f"LLM generate failed: {e}")
-            lf.update_current_span(level="ERROR", status_message=str(e)[:200])
+            _update_current_span(lf, level="ERROR", status_message=str(e)[:200])
             raise
 
     async def close(self):

--- a/telegram_bot/services/llm.py
+++ b/telegram_bot/services/llm.py
@@ -177,9 +177,7 @@ class LLMService:
                     max_tokens=self.model_max_tokens,
                     name="generate-answer",  # type: ignore[call-overload]  # langfuse kwarg
                 )
-                lf.update_current_span(
-                    output={"response_len": len(response_model.answer)}
-                )
+                lf.update_current_span(output={"response_len": len(response_model.answer)})
                 return ConfidenceResult(
                     answer=response_model.answer,
                     confidence=response_model.confidence,
@@ -329,9 +327,7 @@ class LLMService:
                     total_len += len(delta.content)
                     yield delta.content
 
-            lf.update_current_span(
-                output={"chunks": chunks_count, "total_len": total_len}
-            )
+            lf.update_current_span(output={"chunks": chunks_count, "total_len": total_len})
 
         except (openai.RateLimitError, openai.APITimeoutError, openai.APIConnectionError) as e:
             logger.error(f"LLM streaming error: {e}")

--- a/telegram_bot/services/llm.py
+++ b/telegram_bot/services/llm.py
@@ -14,6 +14,8 @@ import openai
 from langfuse.openai import AsyncOpenAI
 from pydantic import BaseModel, Field, field_validator
 
+from telegram_bot.observability import get_client, observe
+
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +96,11 @@ class LLMService:
             )
             self._instructor_client = instructor.from_openai(self.client)
 
+    @observe(
+        name="llm-service-generate-answer",
+        capture_input=False,
+        capture_output=False,
+    )
     async def generate_answer(
         self,
         question: str,
@@ -101,7 +108,30 @@ class LLMService:
         system_prompt: str | None = None,
         with_confidence: bool = False,
     ) -> str | ConfidenceResult:
-        """Generate answer based on question and retrieved context."""
+        """Generate answer based on question and retrieved context.
+
+        Wrapped in ``@observe`` (#1660) so the auto-traced generation produced
+        by ``langfuse.openai`` becomes a child of a named ``llm-service-
+        generate-answer`` span instead of an orphan top-level trace when
+        invoked outside a request-scoped trace (background tasks, scripts,
+        fallback paths).
+
+        Per the audit correction on #1660 the wrapper is a *plain span*, not
+        ``as_type="generation"``: ``langfuse.openai.AsyncOpenAI`` already
+        emits a generation observation for each ``chat.completions.create``
+        call and an outer generation would produce duplicate observations.
+
+        Curated ``update_current_span`` payloads avoid leaking the full
+        prompt or full response into Langfuse.
+        """
+        lf = get_client()
+        lf.update_current_span(
+            input={
+                "prompt_preview": question[:120],
+                "model": self.model,
+                "with_confidence": with_confidence,
+            }
+        )
         try:
             context = self._format_context(context_chunks)
 
@@ -147,6 +177,9 @@ class LLMService:
                     max_tokens=self.model_max_tokens,
                     name="generate-answer",  # type: ignore[call-overload]  # langfuse kwarg
                 )
+                lf.update_current_span(
+                    output={"response_len": len(response_model.answer)}
+                )
                 return ConfidenceResult(
                     answer=response_model.answer,
                     confidence=response_model.confidence,
@@ -163,10 +196,13 @@ class LLMService:
             )
 
             message = response.choices[0].message
-            return message.content or ""
+            response_text = message.content or ""
+            lf.update_current_span(output={"response_len": len(response_text)})
+            return response_text
 
         except (openai.APITimeoutError, openai.APIConnectionError) as e:
             logger.error(f"LLM API timeout/connection: {e}")
+            lf.update_current_span(level="ERROR", status_message=str(e)[:200])
             fallback = self._get_fallback_answer(question, context_chunks)
             if with_confidence:
                 return ConfidenceResult(
@@ -175,6 +211,7 @@ class LLMService:
             return fallback
         except openai.RateLimitError as e:
             logger.error(f"LLM API rate limit: {e}")
+            lf.update_current_span(level="ERROR", status_message=str(e)[:200])
             fallback = self._get_fallback_answer(question, context_chunks)
             if with_confidence:
                 return ConfidenceResult(
@@ -183,6 +220,7 @@ class LLMService:
             return fallback
         except Exception as e:
             logger.error(f"LLM generation failed: {e}", exc_info=True)
+            lf.update_current_span(level="ERROR", status_message=str(e)[:200])
             fallback = self._get_fallback_answer(question, context_chunks)
             if with_confidence:
                 return ConfidenceResult(
@@ -210,13 +248,41 @@ class LLMService:
             "Если контекст не содержит релевантной информации, установи confidence < 0.5."
         )
 
+    @observe(
+        name="llm-service-stream-answer",
+        capture_input=False,
+        capture_output=False,
+    )
     async def stream_answer(
         self,
         question: str,
         context_chunks: list[dict[str, Any]],
         system_prompt: str | None = None,
     ) -> AsyncGenerator[str]:
-        """Stream answer generation token by token."""
+        """Stream answer generation token by token.
+
+        Wrapped in ``@observe`` (#1660) as a *plain span* — NOT
+        ``as_type="generation"``. Per the audit on #1660: ``langfuse.openai``
+        already creates a generation observation for the underlying
+        ``chat.completions.create()`` call (with ``stream_options.include_usage``
+        the final chunk carries ``usage``, attached to that nested generation
+        automatically). Wrapping the method itself as a generation would
+        produce duplicate generation observations for one LLM call.
+
+        After the stream finishes the wrapper records summary metadata via
+        ``update_current_span(output={"chunks": ..., "total_len": ...})``.
+        Token usage is intentionally NOT recorded here — let
+        ``langfuse.openai`` own that on the inner generation.
+        """
+        lf = get_client()
+        lf.update_current_span(
+            input={
+                "prompt_preview": question[:120],
+                "model": self.model,
+            }
+        )
+        chunks_count = 0
+        total_len = 0
         try:
             context = self._format_context(context_chunks)
 
@@ -259,13 +325,21 @@ class LLMService:
                     continue
                 delta = chunk.choices[0].delta
                 if delta.content:
+                    chunks_count += 1
+                    total_len += len(delta.content)
                     yield delta.content
+
+            lf.update_current_span(
+                output={"chunks": chunks_count, "total_len": total_len}
+            )
 
         except (openai.RateLimitError, openai.APITimeoutError, openai.APIConnectionError) as e:
             logger.error(f"LLM streaming error: {e}")
+            lf.update_current_span(level="ERROR", status_message=str(e)[:200])
             yield self._get_fallback_answer(question, context_chunks)
         except Exception as e:
             logger.error(f"LLM streaming failed: {e}", exc_info=True)
+            lf.update_current_span(level="ERROR", status_message=str(e)[:200])
             yield self._get_fallback_answer(question, context_chunks)
 
     def _format_context(self, chunks: list[dict[str, Any]]) -> str:
@@ -363,8 +437,28 @@ class LLMService:
 
         return response
 
+    @observe(
+        name="llm-service-generate",
+        capture_input=False,
+        capture_output=False,
+    )
     async def generate(self, prompt: str, max_tokens: int = 200) -> str:
-        """Simple text generation for internal use (CESC, preference extraction)."""
+        """Simple text generation for internal use (CESC, preference extraction).
+
+        Wrapped in ``@observe`` (#1660) as a plain span; ``langfuse.openai``
+        owns the nested generation. Curated ``update_current_span`` payloads
+        avoid leaking the full prompt/response into Langfuse. On failure the
+        span is recorded at ``level="ERROR"`` with a truncated
+        ``status_message`` and the exception is re-raised (existing
+        contract).
+        """
+        lf = get_client()
+        lf.update_current_span(
+            input={
+                "prompt_preview": prompt[:120],
+                "model": self.model,
+            }
+        )
         try:
             response = await self.client.chat.completions.create(
                 model=self.model,
@@ -373,9 +467,12 @@ class LLMService:
                 max_tokens=max_tokens,
                 name="generate-simple",  # type: ignore[call-overload]  # langfuse kwarg
             )
-            return response.choices[0].message.content or ""
+            response_text = response.choices[0].message.content or ""
+            lf.update_current_span(output={"response_len": len(response_text)})
+            return response_text
         except Exception as e:
             logger.error(f"LLM generate failed: {e}")
+            lf.update_current_span(level="ERROR", status_message=str(e)[:200])
             raise
 
     async def close(self):

--- a/tests/unit/services/test_llm.py
+++ b/tests/unit/services/test_llm.py
@@ -110,6 +110,23 @@ class TestLLMServiceGenerateAnswer:
 
         assert result == "Generated answer text"
 
+    async def test_generate_answer_works_when_langfuse_client_unavailable(
+        self, sample_chunks, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Tracing must degrade gracefully when get_client() returns None."""
+        from telegram_bot.services import llm as llm_mod
+
+        monkeypatch.setattr(llm_mod, "get_client", lambda: None)
+        service = LLMService(api_key="test-key")
+        service.client = AsyncMock()
+        service.client.chat.completions.create = AsyncMock(
+            return_value=_mock_completion("Generated answer text")
+        )
+
+        result = await service.generate_answer("What apartments?", sample_chunks)
+
+        assert result == "Generated answer text"
+
     async def test_configured_max_tokens_used_for_answer_confidence_and_stream(self, sample_chunks):
         """LLM answer paths use the configured generation token budget."""
         service = LLMService(api_key="test-key", max_tokens=1234)
@@ -227,6 +244,27 @@ class TestLLMServiceStreamAnswer:
             chunks.append(chunk)
 
         assert chunks == ["Hello", " World"]
+
+    async def test_stream_answer_works_when_langfuse_client_unavailable(
+        self, sample_chunks, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Streaming must not require an initialized Langfuse client."""
+        from telegram_bot.services import llm as llm_mod
+
+        monkeypatch.setattr(llm_mod, "get_client", lambda: None)
+        service = LLMService(api_key="test-key")
+
+        chunk = MagicMock(usage=None, choices=[MagicMock(delta=MagicMock(content="Hello"))])
+
+        async def mock_stream():
+            yield chunk
+
+        service.client = AsyncMock()
+        service.client.chat.completions.create = AsyncMock(return_value=mock_stream())
+
+        chunks = [part async for part in service.stream_answer("Question?", sample_chunks)]
+
+        assert chunks == ["Hello"]
 
     async def test_stream_answer_skips_usage_chunks(self, sample_chunks):
         """Test that usage chunks are skipped."""
@@ -500,6 +538,23 @@ class TestLLMServiceGenerate:
 
     async def test_generate_returns_content(self):
         """Test successful generation."""
+        service = LLMService(api_key="test-key")
+        service.client = AsyncMock()
+        service.client.chat.completions.create = AsyncMock(
+            return_value=_mock_completion("Generated text")
+        )
+
+        result = await service.generate("Test prompt")
+
+        assert result == "Generated text"
+
+    async def test_generate_works_when_langfuse_client_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Simple generation must not require an initialized Langfuse client."""
+        from telegram_bot.services import llm as llm_mod
+
+        monkeypatch.setattr(llm_mod, "get_client", lambda: None)
         service = LLMService(api_key="test-key")
         service.client = AsyncMock()
         service.client.chat.completions.create = AsyncMock(

--- a/tests/unit/services/test_llm.py
+++ b/tests/unit/services/test_llm.py
@@ -595,7 +595,6 @@ class TestLLMServiceClose:
         await service.close()
 
 
-
 class TestLLMServiceObserveInstrumentation:
     """Tests for @observe instrumentation on LLMService public methods (#1660).
 
@@ -763,8 +762,7 @@ class TestLLMServiceObserveInstrumentation:
         assert kwargs.get("capture_input") is False
         assert kwargs.get("capture_output") is False
         assert "as_type" not in kwargs, (
-            "generate wrapper must NOT use as_type='generation' (audit "
-            "correction on #1660)."
+            "generate wrapper must NOT use as_type='generation' (audit correction on #1660)."
         )
 
     # ------------------------------------------------------------------
@@ -783,9 +781,7 @@ class TestLLMServiceObserveInstrumentation:
 
         service = LLMService(api_key="test-key", model="gpt-4o-mini")
         service.client = AsyncMock()
-        service.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion("ok")
-        )
+        service.client.chat.completions.create = AsyncMock(return_value=_mock_completion("ok"))
 
         long_question = (
             "Это очень длинный вопрос про недвижимость в Болгарии, "
@@ -797,12 +793,9 @@ class TestLLMServiceObserveInstrumentation:
         await service.generate_answer(long_question, [{"text": "ctx"}])
 
         input_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
-            if "input" in c.kwargs
+            c.kwargs for c in mock_lf.update_current_span.call_args_list if "input" in c.kwargs
         ]
-        assert input_calls, (
-            "update_current_span(input=...) was never called on generate_answer"
-        )
+        assert input_calls, "update_current_span(input=...) was never called on generate_answer"
         captured_input = input_calls[0]["input"]
         assert isinstance(captured_input, dict)
         assert "prompt_preview" in captured_input
@@ -836,12 +829,9 @@ class TestLLMServiceObserveInstrumentation:
         assert result == long_response  # behavior unchanged
 
         output_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
-            if "output" in c.kwargs
+            c.kwargs for c in mock_lf.update_current_span.call_args_list if "output" in c.kwargs
         ]
-        assert output_calls, (
-            "update_current_span(output=...) was never called on generate_answer"
-        )
+        assert output_calls, "update_current_span(output=...) was never called on generate_answer"
         captured_output = output_calls[-1]["output"]
         assert isinstance(captured_output, dict)
         assert captured_output.get("response_len") == len(long_response)
@@ -874,7 +864,8 @@ class TestLLMServiceObserveInstrumentation:
         assert "Сервис генерации ответов временно недоступен" in result
 
         error_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            c.kwargs
+            for c in mock_lf.update_current_span.call_args_list
             if c.kwargs.get("level") == "ERROR"
         ]
         assert error_calls, (
@@ -918,12 +909,9 @@ class TestLLMServiceObserveInstrumentation:
         assert chunks == ["A", "B"]
 
         input_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
-            if "input" in c.kwargs
+            c.kwargs for c in mock_lf.update_current_span.call_args_list if "input" in c.kwargs
         ]
-        assert input_calls, (
-            "update_current_span(input=...) was never called on stream_answer"
-        )
+        assert input_calls, "update_current_span(input=...) was never called on stream_answer"
         captured_input = input_calls[0]["input"]
         assert isinstance(captured_input, dict)
         assert "prompt_preview" in captured_input
@@ -942,8 +930,7 @@ class TestLLMServiceObserveInstrumentation:
 
         contents = ["Hel", "lo ", "World!"]
         body_chunks = [
-            MagicMock(usage=None, choices=[MagicMock(delta=MagicMock(content=c))])
-            for c in contents
+            MagicMock(usage=None, choices=[MagicMock(delta=MagicMock(content=c))]) for c in contents
         ]
         usage_tail = MagicMock(usage=MagicMock(total_tokens=42), choices=[])
 
@@ -961,8 +948,7 @@ class TestLLMServiceObserveInstrumentation:
         assert full == "Hello World!"
 
         output_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
-            if "output" in c.kwargs
+            c.kwargs for c in mock_lf.update_current_span.call_args_list if "output" in c.kwargs
         ]
         assert output_calls, (
             "update_current_span(output=...) was never called on stream_answer "
@@ -993,14 +979,14 @@ class TestLLMServiceObserveInstrumentation:
         )
 
         chunks = [
-            c async for c in service.stream_answer(
-                "q", [{"text": "ctx", "metadata": {"title": "X"}}]
-            )
+            c
+            async for c in service.stream_answer("q", [{"text": "ctx", "metadata": {"title": "X"}}])
         ]
         assert chunks, "stream_answer must still yield a fallback chunk on error"
 
         error_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            c.kwargs
+            for c in mock_lf.update_current_span.call_args_list
             if c.kwargs.get("level") == "ERROR"
         ]
         assert error_calls, (
@@ -1064,19 +1050,14 @@ class TestLLMServiceObserveInstrumentation:
 
         service = LLMService(api_key="test-key", model="gpt-4o-mini")
         service.client = AsyncMock()
-        service.client.chat.completions.create = AsyncMock(
-            return_value=_mock_completion("ok")
-        )
+        service.client.chat.completions.create = AsyncMock(return_value=_mock_completion("ok"))
 
         await service.generate(long_prompt)
 
         input_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
-            if "input" in c.kwargs
+            c.kwargs for c in mock_lf.update_current_span.call_args_list if "input" in c.kwargs
         ]
-        assert input_calls, (
-            "update_current_span(input=...) was never called on generate"
-        )
+        assert input_calls, "update_current_span(input=...) was never called on generate"
         captured_input = input_calls[0]["input"]
         assert isinstance(captured_input, dict)
         assert "prompt_preview" in captured_input
@@ -1104,12 +1085,9 @@ class TestLLMServiceObserveInstrumentation:
         assert result == long_response  # behavior unchanged
 
         output_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
-            if "output" in c.kwargs
+            c.kwargs for c in mock_lf.update_current_span.call_args_list if "output" in c.kwargs
         ]
-        assert output_calls, (
-            "update_current_span(output=...) was never called on generate"
-        )
+        assert output_calls, "update_current_span(output=...) was never called on generate"
         captured_output = output_calls[-1]["output"]
         assert isinstance(captured_output, dict)
         assert captured_output.get("response_len") == len(long_response)
@@ -1140,7 +1118,8 @@ class TestLLMServiceObserveInstrumentation:
             await service.generate("prompt")
 
         error_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            c.kwargs
+            for c in mock_lf.update_current_span.call_args_list
             if c.kwargs.get("level") == "ERROR"
         ]
         assert error_calls, (

--- a/tests/unit/services/test_llm.py
+++ b/tests/unit/services/test_llm.py
@@ -593,3 +593,560 @@ class TestLLMServiceClose:
 
         # Should not raise
         await service.close()
+
+
+
+class TestLLMServiceObserveInstrumentation:
+    """Tests for @observe instrumentation on LLMService public methods (#1660).
+
+    Contract: ``generate_answer`` (line ~97), ``stream_answer`` (line ~213) and
+    ``generate`` (line ~366) must each be wrapped with::
+
+        @observe(name="llm-service-<method>",
+                 capture_input=False, capture_output=False)
+
+    so the auto-traced generation produced by ``langfuse.openai.AsyncOpenAI``
+    becomes a child of a named span instead of an orphan top-level trace.
+
+    CRITICAL (audit correction on #1660): the wrapper must NOT use
+    ``as_type="generation"``. ``langfuse.openai`` already creates a generation
+    observation for each ``chat.completions.create()`` call — making the
+    wrapper itself a generation would produce duplicate generation
+    observations for one LLM call. Plain span > nested generation is the
+    intended structure.
+
+    Curated ``update_current_span`` payloads avoid leaking full prompt/full
+    response into Langfuse. On LLM exception the span is recorded at
+    ``level="ERROR"`` with a truncated ``status_message``; ``generate``
+    re-raises while ``generate_answer``/``stream_answer`` already swallow API
+    errors and yield/return a fallback (existing public contract preserved).
+    """
+
+    @staticmethod
+    def _patched_lf(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+        """Replace get_client used by the llm module with a recording mock."""
+        from telegram_bot.services import llm as llm_mod
+
+        mock_lf = MagicMock()
+        monkeypatch.setattr(llm_mod, "get_client", lambda: mock_lf)
+        return mock_lf
+
+    @staticmethod
+    def _disable_observe(monkeypatch: pytest.MonkeyPatch) -> None:
+        """Replace the @observe decorator at module-import time with a no-op.
+
+        Uses ``monkeypatch.delitem(sys.modules, ...)`` so that after the test
+        the ORIGINAL module object is restored — otherwise the reload would
+        leave a fresh ``LLMService`` class in ``sys.modules`` and downstream
+        tests that assert ``services.LLMService is LLMService`` (identity)
+        would fail due to drift between the lazy-imported package attribute
+        and the test-file-level binding.
+        """
+        import importlib
+        import sys
+
+        from telegram_bot import observability as observability_mod
+
+        def fake_observe(**_kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        monkeypatch.setattr(observability_mod, "observe", fake_observe)
+        monkeypatch.delitem(sys.modules, "telegram_bot.services.llm", raising=False)
+        importlib.import_module("telegram_bot.services.llm")
+
+    @staticmethod
+    def _record_observe_calls(
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> list[dict[str, object]]:
+        """Replace @observe with a recorder and reload the llm module.
+
+        Same ``monkeypatch.delitem`` strategy as ``_disable_observe`` — the
+        original module is restored on test teardown.
+        """
+        import importlib
+        import sys
+
+        from telegram_bot import observability as observability_mod
+
+        captured_calls: list[dict[str, object]] = []
+
+        def recording_observe(**kwargs):
+            captured_calls.append(kwargs)
+
+            def decorator(func):
+                return func
+
+            return decorator
+
+        monkeypatch.setattr(observability_mod, "observe", recording_observe)
+        monkeypatch.delitem(sys.modules, "telegram_bot.services.llm", raising=False)
+        importlib.import_module("telegram_bot.services.llm")
+        return captured_calls
+
+    # ------------------------------------------------------------------
+    # Module-level wiring
+    # ------------------------------------------------------------------
+
+    def test_module_imports_observe_and_get_client(self):
+        """Module wires the Langfuse decorator + client accessor (#1660 contract)."""
+        from telegram_bot.services import llm as llm_mod
+
+        assert hasattr(llm_mod, "observe"), (
+            "telegram_bot.services.llm must import `observe` from "
+            "telegram_bot.observability for the @observe decorator on "
+            "LLMService.{generate_answer,stream_answer,generate}"
+        )
+        assert hasattr(llm_mod, "get_client"), (
+            "telegram_bot.services.llm must import `get_client` from "
+            "telegram_bot.observability for curated update_current_span calls"
+        )
+
+    # ------------------------------------------------------------------
+    # Decorator kwargs (one test per method)
+    # ------------------------------------------------------------------
+
+    def test_generate_answer_decorator_kwargs(self, monkeypatch):
+        """``generate_answer`` is decorated with the audit's exact kwargs.
+
+        CRITICAL: ``as_type="generation"`` MUST NOT be present (audit
+        correction on #1660). The class uses ``langfuse.openai.AsyncOpenAI``
+        which already creates a generation for each call — the wrapper is a
+        plain span, langfuse.openai owns the nested generation.
+        """
+        captured = self._record_observe_calls(monkeypatch)
+
+        matches = [c for c in captured if c.get("name") == "llm-service-generate-answer"]
+        assert len(matches) == 1, (
+            "Expected exactly one @observe(name='llm-service-generate-answer', ...) "
+            f"on LLMService.generate_answer; observed names: {[c.get('name') for c in captured]}"
+        )
+        kwargs = matches[0]
+        assert kwargs.get("capture_input") is False
+        assert kwargs.get("capture_output") is False
+        assert "as_type" not in kwargs, (
+            "Wrapper must NOT use as_type='generation' (audit correction on #1660): "
+            "langfuse.openai already creates a generation for each chat.completions.create; "
+            "wrapping the public method as another generation would produce duplicates."
+        )
+
+    def test_stream_answer_decorator_kwargs(self, monkeypatch):
+        """``stream_answer`` is a plain span — NO as_type=generation (audit)."""
+        captured = self._record_observe_calls(monkeypatch)
+
+        matches = [c for c in captured if c.get("name") == "llm-service-stream-answer"]
+        assert len(matches) == 1, (
+            "Expected exactly one @observe(name='llm-service-stream-answer', ...) "
+            f"on LLMService.stream_answer; observed names: {[c.get('name') for c in captured]}"
+        )
+        kwargs = matches[0]
+        assert kwargs.get("capture_input") is False
+        assert kwargs.get("capture_output") is False
+        assert "as_type" not in kwargs, (
+            "stream_answer wrapper must NOT use as_type='generation' (audit "
+            "correction on #1660): langfuse.openai handles the streaming "
+            "generation; wrapper stays a plain span."
+        )
+
+    def test_generate_decorator_kwargs(self, monkeypatch):
+        """``generate`` is decorated as a plain span — NO as_type=generation."""
+        captured = self._record_observe_calls(monkeypatch)
+
+        matches = [c for c in captured if c.get("name") == "llm-service-generate"]
+        assert len(matches) == 1, (
+            "Expected exactly one @observe(name='llm-service-generate', ...) "
+            f"on LLMService.generate; observed names: {[c.get('name') for c in captured]}"
+        )
+        kwargs = matches[0]
+        assert kwargs.get("capture_input") is False
+        assert kwargs.get("capture_output") is False
+        assert "as_type" not in kwargs, (
+            "generate wrapper must NOT use as_type='generation' (audit "
+            "correction on #1660)."
+        )
+
+    # ------------------------------------------------------------------
+    # Behavior: generate_answer
+    # ------------------------------------------------------------------
+
+    async def test_generate_answer_curated_input_no_full_prompt(self, monkeypatch):
+        """``generate_answer`` records prompt_preview/model/with_confidence only.
+
+        Full prompt MUST NOT appear in span input (#1660 Forbidden section).
+        """
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.llm import LLMService
+
+        service = LLMService(api_key="test-key", model="gpt-4o-mini")
+        service.client = AsyncMock()
+        service.client.chat.completions.create = AsyncMock(
+            return_value=_mock_completion("ok")
+        )
+
+        long_question = (
+            "Это очень длинный вопрос про недвижимость в Болгарии, "
+            "который точно длиннее ста двадцати символов и должен быть "
+            "усечён в превью при записи в Langfuse span input."
+        )
+        assert len(long_question) > 120
+
+        await service.generate_answer(long_question, [{"text": "ctx"}])
+
+        input_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if "input" in c.kwargs
+        ]
+        assert input_calls, (
+            "update_current_span(input=...) was never called on generate_answer"
+        )
+        captured_input = input_calls[0]["input"]
+        assert isinstance(captured_input, dict)
+        assert "prompt_preview" in captured_input
+        assert isinstance(captured_input["prompt_preview"], str)
+        assert len(captured_input["prompt_preview"]) <= 120
+        assert captured_input.get("model") == "gpt-4o-mini"
+        assert "with_confidence" in captured_input
+        assert captured_input["with_confidence"] is False
+
+        # Forbidden: full question MUST NOT appear in span input.
+        assert long_question not in str(captured_input)
+
+    async def test_generate_answer_curated_output_response_len(self, monkeypatch):
+        """``generate_answer`` records response_len after LLM (#1660 plan)."""
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.llm import LLMService
+
+        long_response = (
+            "Подобрал три варианта 2BR у моря в Несебре от 65к EUR. "
+            "Все с видом на море и инфраструктурой в шаговой доступности."
+        )
+        service = LLMService(api_key="test-key")
+        service.client = AsyncMock()
+        service.client.chat.completions.create = AsyncMock(
+            return_value=_mock_completion(long_response)
+        )
+
+        result = await service.generate_answer("вопрос", [{"text": "ctx"}])
+        assert result == long_response  # behavior unchanged
+
+        output_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if "output" in c.kwargs
+        ]
+        assert output_calls, (
+            "update_current_span(output=...) was never called on generate_answer"
+        )
+        captured_output = output_calls[-1]["output"]
+        assert isinstance(captured_output, dict)
+        assert captured_output.get("response_len") == len(long_response)
+        # Forbidden: full response text MUST NOT appear in span output.
+        assert long_response not in str(captured_output)
+
+    async def test_generate_answer_error_path_records_error_level(self, monkeypatch):
+        """Per audit: on internal failure, span level=ERROR with truncated msg.
+
+        ``generate_answer`` already swallows OpenAI errors and returns a
+        fallback string, so the public method does NOT re-raise. The error
+        path must still be recorded on the span (#1660 plan step 4).
+        """
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.llm import LLMService
+
+        service = LLMService(api_key="test-key")
+        service.client = AsyncMock()
+        service.client.chat.completions.create = AsyncMock(
+            side_effect=RuntimeError("LLM exploded mid-generate-answer")
+        )
+
+        result = await service.generate_answer(
+            "q",
+            [{"text": "ctx", "metadata": {"title": "X"}}],
+        )
+        assert isinstance(result, str)
+        assert "Сервис генерации ответов временно недоступен" in result
+
+        error_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if c.kwargs.get("level") == "ERROR"
+        ]
+        assert error_calls, (
+            "Failure path must call update_current_span(level='ERROR', ...) "
+            "on LLMService.generate_answer (#1660 plan step 4)"
+        )
+        status = error_calls[0].get("status_message", "")
+        assert "LLM exploded mid-generate-answer" in status
+        assert len(status) <= 220
+
+    # ------------------------------------------------------------------
+    # Behavior: stream_answer
+    # ------------------------------------------------------------------
+
+    async def test_stream_answer_curated_input_no_full_prompt(self, monkeypatch):
+        """``stream_answer`` records prompt_preview/model only — no full prompt."""
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.llm import LLMService
+
+        long_question = (
+            "Это очень-очень-очень длинный вопрос на стрим, который "
+            "превышает сто двадцать символов и должен быть аккуратно "
+            "усечён до prompt_preview ровно в 120 символов или меньше."
+        )
+        assert len(long_question) > 120
+
+        chunk1 = MagicMock(usage=None, choices=[MagicMock(delta=MagicMock(content="A"))])
+        chunk2 = MagicMock(usage=None, choices=[MagicMock(delta=MagicMock(content="B"))])
+
+        async def stream():
+            for c in [chunk1, chunk2]:
+                yield c
+
+        service = LLMService(api_key="test-key", model="gpt-4o-mini")
+        service.client = AsyncMock()
+        service.client.chat.completions.create = AsyncMock(return_value=stream())
+
+        chunks = [c async for c in service.stream_answer(long_question, [{"text": "ctx"}])]
+        assert chunks == ["A", "B"]
+
+        input_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if "input" in c.kwargs
+        ]
+        assert input_calls, (
+            "update_current_span(input=...) was never called on stream_answer"
+        )
+        captured_input = input_calls[0]["input"]
+        assert isinstance(captured_input, dict)
+        assert "prompt_preview" in captured_input
+        assert isinstance(captured_input["prompt_preview"], str)
+        assert len(captured_input["prompt_preview"]) <= 120
+        assert captured_input.get("model") == "gpt-4o-mini"
+        # Forbidden: full question MUST NOT appear in span input.
+        assert long_question not in str(captured_input)
+
+    async def test_stream_answer_curated_output_chunks_and_total_len(self, monkeypatch):
+        """``stream_answer`` records {chunks, total_len} after generator drains."""
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.llm import LLMService
+
+        contents = ["Hel", "lo ", "World!"]
+        body_chunks = [
+            MagicMock(usage=None, choices=[MagicMock(delta=MagicMock(content=c))])
+            for c in contents
+        ]
+        usage_tail = MagicMock(usage=MagicMock(total_tokens=42), choices=[])
+
+        async def stream():
+            for c in [*body_chunks, usage_tail]:
+                yield c
+
+        service = LLMService(api_key="test-key")
+        service.client = AsyncMock()
+        service.client.chat.completions.create = AsyncMock(return_value=stream())
+
+        full = ""
+        async for c in service.stream_answer("q", [{"text": "ctx"}]):
+            full += c
+        assert full == "Hello World!"
+
+        output_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if "output" in c.kwargs
+        ]
+        assert output_calls, (
+            "update_current_span(output=...) was never called on stream_answer "
+            "after the generator finished"
+        )
+        captured_output = output_calls[-1]["output"]
+        assert isinstance(captured_output, dict)
+        assert captured_output.get("chunks") == 3, (
+            f"Expected chunks=3 (body chunks only, usage chunk skipped), "
+            f"got {captured_output.get('chunks')}"
+        )
+        assert captured_output.get("total_len") == len(full)
+
+        # Forbidden: full response text MUST NOT appear in span output.
+        assert full not in str(captured_output)
+
+    async def test_stream_answer_error_path_records_error_level(self, monkeypatch):
+        """On stream failure, span level=ERROR + status_message; fallback yields."""
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.llm import LLMService
+
+        service = LLMService(api_key="test-key")
+        service.client = AsyncMock()
+        service.client.chat.completions.create = AsyncMock(
+            side_effect=RuntimeError("LLM exploded mid-stream-answer")
+        )
+
+        chunks = [
+            c async for c in service.stream_answer(
+                "q", [{"text": "ctx", "metadata": {"title": "X"}}]
+            )
+        ]
+        assert chunks, "stream_answer must still yield a fallback chunk on error"
+
+        error_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if c.kwargs.get("level") == "ERROR"
+        ]
+        assert error_calls, (
+            "Failure path must call update_current_span(level='ERROR', ...) "
+            "on LLMService.stream_answer (#1660 plan step 4)"
+        )
+        status = error_calls[0].get("status_message", "")
+        assert "LLM exploded mid-stream-answer" in status
+        assert len(status) <= 220
+
+    async def test_stream_options_include_usage_preserved(self, monkeypatch):
+        """Sanity guard: ``stream_options={"include_usage": True}`` not regressed.
+
+        The audit on #1660 explicitly notes the existing call already passes
+        ``stream_options={"include_usage": True}`` (line ~245-252 of llm.py
+        on dev) and that it MUST be preserved so langfuse.openai can read
+        token usage from the final chunk and attach it to the nested
+        generation observation.
+        """
+        self._disable_observe(monkeypatch)
+        self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.llm import LLMService
+
+        async def empty_stream():
+            return
+            yield  # pragma: no cover
+
+        service = LLMService(api_key="test-key")
+        service.client = AsyncMock()
+        service.client.chat.completions.create = AsyncMock(return_value=empty_stream())
+
+        async for _ in service.stream_answer("q", [{"text": "ctx"}]):
+            pass
+
+        kwargs = service.client.chat.completions.create.call_args.kwargs
+        assert kwargs.get("stream") is True
+        assert kwargs.get("stream_options") == {"include_usage": True}, (
+            "stream_options={'include_usage': True} must be preserved "
+            "(audit on #1660: required for langfuse.openai to capture token "
+            "usage from the final streaming chunk)"
+        )
+
+    # ------------------------------------------------------------------
+    # Behavior: generate
+    # ------------------------------------------------------------------
+
+    async def test_generate_curated_input_no_full_prompt(self, monkeypatch):
+        """``generate`` records prompt_preview/model only — no full prompt."""
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.llm import LLMService
+
+        long_prompt = (
+            "Очень длинный системный промт для CESC, который содержит "
+            "более ста двадцати символов и должен попасть в span только "
+            "в виде prompt_preview, никогда полностью."
+        )
+        assert len(long_prompt) > 120
+
+        service = LLMService(api_key="test-key", model="gpt-4o-mini")
+        service.client = AsyncMock()
+        service.client.chat.completions.create = AsyncMock(
+            return_value=_mock_completion("ok")
+        )
+
+        await service.generate(long_prompt)
+
+        input_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if "input" in c.kwargs
+        ]
+        assert input_calls, (
+            "update_current_span(input=...) was never called on generate"
+        )
+        captured_input = input_calls[0]["input"]
+        assert isinstance(captured_input, dict)
+        assert "prompt_preview" in captured_input
+        assert isinstance(captured_input["prompt_preview"], str)
+        assert len(captured_input["prompt_preview"]) <= 120
+        assert captured_input.get("model") == "gpt-4o-mini"
+        # Forbidden: full prompt MUST NOT appear in span input.
+        assert long_prompt not in str(captured_input)
+
+    async def test_generate_curated_output_response_len(self, monkeypatch):
+        """``generate`` records response_len after LLM (#1660 plan)."""
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.llm import LLMService
+
+        long_response = "Сгенерированный длинный ответ для CESC извлечения предпочтений клиента."
+        service = LLMService(api_key="test-key")
+        service.client = AsyncMock()
+        service.client.chat.completions.create = AsyncMock(
+            return_value=_mock_completion(long_response)
+        )
+
+        result = await service.generate("prompt")
+        assert result == long_response  # behavior unchanged
+
+        output_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if "output" in c.kwargs
+        ]
+        assert output_calls, (
+            "update_current_span(output=...) was never called on generate"
+        )
+        captured_output = output_calls[-1]["output"]
+        assert isinstance(captured_output, dict)
+        assert captured_output.get("response_len") == len(long_response)
+        # Forbidden: full response text MUST NOT appear in span output.
+        assert long_response not in str(captured_output)
+
+    async def test_generate_error_path_records_error_level_and_reraises(self, monkeypatch):
+        """``generate`` records ERROR span and RE-RAISES (existing contract).
+
+        Unlike ``generate_answer``/``stream_answer`` which swallow API errors
+        and emit a fallback string, ``generate`` re-raises (verified by the
+        existing ``test_generate_raises_on_error`` test in this file). The
+        @observe wrapper must record the error span before the exception
+        propagates.
+        """
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.llm import LLMService
+
+        service = LLMService(api_key="test-key")
+        service.client = AsyncMock()
+        service.client.chat.completions.create = AsyncMock(
+            side_effect=RuntimeError("LLM exploded mid-generate")
+        )
+
+        with pytest.raises(RuntimeError, match="LLM exploded mid-generate"):
+            await service.generate("prompt")
+
+        error_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if c.kwargs.get("level") == "ERROR"
+        ]
+        assert error_calls, (
+            "Failure path must call update_current_span(level='ERROR', ...) "
+            "on LLMService.generate (#1660 plan step 4)"
+        )
+        status = error_calls[0].get("status_message", "")
+        assert "LLM exploded mid-generate" in status
+        assert len(status) <= 220


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Closes #1660.

## Summary

Wraps `LLMService.{generate_answer, stream_answer, generate}` (in `telegram_bot/services/llm.py`) with `@observe(name="llm-service-<method>", capture_input=False, capture_output=False)` so the auto-traced generation produced by `langfuse.openai.AsyncOpenAI` becomes a child of a named span instead of an orphan top-level trace when the service is invoked outside a request-scoped trace (background tasks, fallback paths, scripts).

## ⚠️ Audit correction (overrides the initial validation comment on #1660)

- The wrapper is a **plain span**, not `@observe(as_type="generation")`. The class uses `langfuse.openai.AsyncOpenAI` which already creates a generation observation for each `chat.completions.create()` call. Wrapping the public method itself as another generation would produce **duplicate** generation observations for one LLM call. Final structure:
  ```
  span: llm-service-stream-answer
    └── generation: chat.completions.create   ← owned by langfuse.openai
  ```
- For `stream_answer` the existing `stream_options={"include_usage": True}` (line ~245-252 on dev) is preserved verbatim. A `test_stream_options_include_usage_preserved` regression-guard test pins this. Token usage attribution stays on the inner generation, owned by `langfuse.openai`; the outer span records only `{chunks, total_len}` summary after the generator drains.

## Curated `update_current_span` payloads

- `input`: `prompt_preview` (≤120 chars) + `model`. `generate_answer` adds `with_confidence`.
- `output`: `response_len` for non-streaming methods; `{chunks, total_len}` for `stream_answer` after the generator finishes.
- on exception: `level="ERROR"` + `status_message=str(exc)[:200]`.
  - `generate` re-raises (existing public contract — preserved).
  - `generate_answer` / `stream_answer` already swallow OpenAI errors and return/yield a fallback string. The ERROR span is recorded before the fallback is emitted.

## Forbidden compliance (#1660)

- ✅ Full prompt is never captured in span input (only `prompt_preview` truncated to 120 chars).
- ✅ Full response text is never captured in span output (only `response_len` / `{chunks, total_len}`).
- ✅ `langfuse.openai` auto-trace stays on; nested generation under our span is the intended structure.
- ✅ `ConfidenceResponse` schema and `instructor` integration for `with_confidence=True` are unchanged.
- ✅ No new metrics path introduced.

## TDD

Added `TestLLMServiceObserveInstrumentation` (14 tests) — first run was 14 RED, then 14 GREEN after implementation:

- `test_module_imports_observe_and_get_client`
- `test_generate_answer_decorator_kwargs` — asserts `name`, `capture_input=False`, `capture_output=False`, **AND `as_type` not in kwargs** (audit guard).
- `test_stream_answer_decorator_kwargs` — same shape; NO `as_type`.
- `test_generate_decorator_kwargs` — same shape; NO `as_type`.
- `test_generate_answer_curated_input_no_full_prompt` — full question NOT in span input; only ≤120-char preview + `model` + `with_confidence`.
- `test_generate_answer_curated_output_response_len` — `response_len` recorded; full response NOT in span output.
- `test_generate_answer_error_path_records_error_level` — `level="ERROR"` + `status_message` truncated; existing fallback contract preserved.
- `test_stream_answer_curated_input_no_full_prompt`
- `test_stream_answer_curated_output_chunks_and_total_len` — `{chunks, total_len}` recorded after generator drains; usage chunk skipped.
- `test_stream_answer_error_path_records_error_level`
- `test_stream_options_include_usage_preserved` — sanity guard against regression of `stream_options={"include_usage": True}`.
- `test_generate_curated_input_no_full_prompt`
- `test_generate_curated_output_response_len`
- `test_generate_error_path_records_error_level_and_reraises` — re-raise contract preserved.

The `_disable_observe` / `_record_observe_calls` test helpers use `monkeypatch.delitem(sys.modules, ...)` so the original `telegram_bot.services.llm` module is restored on test teardown — this avoids cross-test pollution that would otherwise break `test_llm_service.py::test_services_package_no_longer_exports_llmservice` (which compares `services.LLMService is LLMService` identity).

## Verification

- `uv run pytest tests/unit/services/test_llm.py …` → 52 passed (38 baseline + 14 new).
- `uv run pytest tests/unit/services -q` → **990 passed**, no regressions.
- `uv run ruff check telegram_bot/services/llm.py tests/unit/services/test_llm.py` → clean.
- `uv run mypy telegram_bot/services/llm.py` → `Success: no issues found in 1 source file`.

## Coverage

```
$ uv run coverage run -m pytest tests/unit/services/test_llm.py -p no:cacheprovider --override-ini="addopts=" -q
$ uv run coverage report --include="telegram_bot/services/llm.py" --show-missing
Name                           Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------
telegram_bot/services/llm.py     192     33     62      4    79%   208, 213-220, 226, 289->299, 325, 402-438
```

- Baseline (dev): **77%**.
- This PR: **79%** (+2pp).
- All new lines (the 3 decorators, curated `update_current_span` calls, response-length tracking, ERROR span recording, streaming accumulators) are covered by the new TDD tests.
- The 33 missed lines are **pre-existing untested code**: `get_low_confidence_response` (lines 402-438) and the `with_confidence=True` exception fallback branches in `generate_answer` (lines 208, 213-220, 226). These were never tested before this PR and are out of scope for #1660.
- Note on `--source=...`: the `coverage run --source=telegram_bot.services.llm …` invocation suggested in the task comment is blocked by a pre-existing conftest issue — `tests/unit/conftest.py:97` autouses `patch("telegram_bot.bot.get_client", …)` and under coverage's source-attribute detection the parent `telegram_bot.bot` attribute is not yet bound on the package, raising `AttributeError`. Fell back to plain `coverage run` + `--include` filter, which produces the same effective measurement for the file under test.

## Reference pattern

Follows the same shape as #1673 (HyDE / #1661) and #1674 (SessionSummary / #1662), with the `as_type=generation` correction noted on the issue.