### PR TITLE
fix(observability): instrument Mini App FastAPI with Langfuse traces (#1658) [Draft, blocked by #1595]

### DIFF
--- a/mini_app/api.py
+++ b/mini_app/api.py
@@ -1,4 +1,17 @@
-"""Mini App FastAPI backend."""
+"""Mini App FastAPI backend.
+
+Langfuse observability (#1658):
+    Endpoints ``/api/start-expert`` and ``/api/phone`` are wrapped with
+    ``@observe`` so the Mini App entry → Telegram dialog → CRM funnel can be
+    reconstructed in Langfuse Sessions UI. ``propagate_attributes`` attaches
+    a deterministic ``session_id="miniapp-{user_id}"`` so the subsequent
+    ``/start q_<uuid>`` Telegram trace links into the same session.
+
+WARNING (blocked-by #1595): until Telegram initData validation lands,
+``user_id`` is taken from the request body and may be forged. The Draft PR
+opening this work documents the dependency; do not treat the resulting
+``user_id`` attribute as authenticated.
+"""
 
 from __future__ import annotations
 
@@ -12,6 +25,11 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from mini_app.expert_start import StartExpertRequest, StartExpertResponse
 from mini_app.phone import PhoneRequest, submit_phone
+from telegram_bot.observability import (
+    get_client,
+    observe,
+    propagate_attributes,
+)
 from telegram_bot.services.content_loader import load_mini_app_config
 
 
@@ -40,56 +58,108 @@ async def _get_redis() -> Any:
     return _redis_client
 
 
+def _miniapp_session_id(user_id: int) -> str:
+    """Deterministic session id linking the Mini App entry to the Telegram dialog."""
+    return f"miniapp-{user_id}"
+
+
+def _safe_start_expert_input(req: StartExpertRequest) -> dict[str, Any]:
+    """Curated, PII-free input payload for the start-expert span."""
+    return {
+        "content_type": "miniapp",
+        "endpoint": "start-expert",
+        "expert_id": req.expert_id,
+        "message_present": req.message is not None and bool(req.message.strip()),
+        "message_len": len(req.message) if req.message else 0,
+        "query_id_present": req.query_id is not None,
+    }
+
+
+def _safe_phone_input(req: PhoneRequest) -> dict[str, Any]:
+    """Curated, PII-free input payload for the submit-phone span."""
+    return {
+        "content_type": "miniapp",
+        "endpoint": "submit-phone",
+        "source": req.source,
+        "phone_present": bool(req.phone),
+        "phone_len": len(req.phone) if req.phone else 0,
+        "name_present": req.name is not None and bool(req.name.strip()),
+    }
+
+
 @app.get("/api/config")
 async def get_config() -> dict:
     """Return Mini App UI config: questions + experts."""
     return load_mini_app_config()
 
 
-@app.post("/api/start-expert")
+@observe(name="miniapp-start-expert", capture_input=False, capture_output=False)
 async def start_expert(request: StartExpertRequest) -> StartExpertResponse:
     """Store deep-link payload in Redis and return start_link for openTelegramLink."""
     from fastapi import HTTPException
 
-    config = load_mini_app_config()
-    experts = config.get("experts", [])
-    expert = next((e for e in experts if e["id"] == request.expert_id), None)
-    if expert is None:
-        raise HTTPException(status_code=404, detail="Expert not found")
+    with propagate_attributes(
+        session_id=_miniapp_session_id(request.user_id),
+        user_id=str(request.user_id),
+        metadata={"source": "miniapp"},
+        tags=["miniapp", "start-expert", request.expert_id],
+    ):
+        config = load_mini_app_config()
+        experts = config.get("experts", [])
+        expert = next((e for e in experts if e["id"] == request.expert_id), None)
+        if expert is None:
+            raise HTTPException(status_code=404, detail="Expert not found")
 
-    uid = str(_uuid_lib.uuid4())
-    payload = json.dumps(
-        {
-            "expert_id": request.expert_id,
-            "message": request.message,
-            "user_id": request.user_id,
-            "query_id": request.query_id,
-        }
-    )
-    redis = await _get_redis()
-    await redis.set(f"miniapp:q:{uid}", payload, ex=_DEEPLINK_TTL)
-
-    bot_username = os.environ.get("BOT_USERNAME", "")
-    if not bot_username:
-        raise HTTPException(status_code=500, detail="BOT_USERNAME not configured")
-    start_link = f"https://t.me/{bot_username}?start=q_{uid}"
-
-    # Notify bot via Redis pub/sub — bot calls answerWebAppQuery + creates topic + RAG
-    await redis.publish(
-        "miniapp:start",
-        json.dumps(
+        uid = str(_uuid_lib.uuid4())
+        payload = json.dumps(
             {
-                "uuid": uid,
+                "expert_id": request.expert_id,
+                "message": request.message,
                 "user_id": request.user_id,
                 "query_id": request.query_id,
             }
-        ),
-    )
+        )
+        redis = await _get_redis()
+        await redis.set(f"miniapp:q:{uid}", payload, ex=_DEEPLINK_TTL)
 
-    return StartExpertResponse(
-        start_link=start_link,
-        expert_name=expert["name"],
-    )
+        bot_username = os.environ.get("BOT_USERNAME", "")
+        if not bot_username:
+            raise HTTPException(status_code=500, detail="BOT_USERNAME not configured")
+        start_link = f"https://t.me/{bot_username}?start=q_{uid}"
+
+        # Notify bot via Redis pub/sub — bot calls answerWebAppQuery + creates topic + RAG
+        await redis.publish(
+            "miniapp:start",
+            json.dumps(
+                {
+                    "uuid": uid,
+                    "user_id": request.user_id,
+                    "query_id": request.query_id,
+                }
+            ),
+        )
+
+        lf = get_client()
+        if lf is not None:
+            lf.update_current_span(
+                input=_safe_start_expert_input(request),
+                output={
+                    "delivery_status": "sent",
+                    "deeplink_emitted": True,
+                    "expert_name_resolved": True,
+                },
+                metadata={"source": "miniapp", "endpoint": "start-expert"},
+            )
+
+        return StartExpertResponse(
+            start_link=start_link,
+            expert_name=expert["name"],
+        )
+
+
+# Bind decorated callable to FastAPI route after definition so the @observe
+# wrapper participates in the request lifecycle.
+app.post("/api/start-expert")(start_expert)
 
 
 @app.post("/api/log")
@@ -102,10 +172,32 @@ async def remote_log(request: dict) -> dict:
     return {"status": "ok"}
 
 
-@app.post("/api/phone")
+@observe(name="miniapp-submit-phone", capture_input=False, capture_output=False)
 async def phone(request: PhoneRequest) -> dict:
     """Collect phone and create CRM lead."""
-    return await submit_phone(request)
+    with propagate_attributes(
+        session_id=_miniapp_session_id(request.user_id),
+        user_id=str(request.user_id),
+        metadata={"source": "miniapp"},
+        tags=["miniapp", "submit-phone", request.source],
+    ):
+        result = await submit_phone(request)
+
+        lf = get_client()
+        if lf is not None:
+            lf.update_current_span(
+                input=_safe_phone_input(request),
+                output={
+                    "delivery_status": "sent" if result.get("lead_id") else "degraded",
+                    "lead_created": result.get("lead_id") is not None,
+                },
+                metadata={"source": "miniapp", "endpoint": "submit-phone"},
+            )
+
+        return result
+
+
+app.post("/api/phone")(phone)
 
 
 @app.get("/health")

--- a/mini_app/phone.py
+++ b/mini_app/phone.py
@@ -1,4 +1,10 @@
-"""Mini App phone collection -> Kommo CRM lead."""
+"""Mini App phone collection -> Kommo CRM lead.
+
+Langfuse observability (#1658):
+    ``submit_phone`` is wrapped with ``@observe`` so the Kommo upsert+lead pair
+    appears as a span; failures are surfaced as ``level="ERROR"`` updates on
+    the active span before the graceful response is returned.
+"""
 
 from __future__ import annotations
 
@@ -6,6 +12,8 @@ import logging
 import re
 
 from pydantic import BaseModel, field_validator
+
+from telegram_bot.observability import get_client, observe
 
 
 logger = logging.getLogger(__name__)
@@ -36,8 +44,13 @@ def get_kommo_client():
     return KommoClient()
 
 
+@observe(
+    name="miniapp-kommo-create-lead",
+    capture_input=False,
+    capture_output=False,
+)
 async def submit_phone(request: PhoneRequest) -> dict:
-    """Submit phone to CRM."""
+    """Submit phone to CRM, marking the active span ERROR on Kommo failure."""
     try:
         client = get_kommo_client()
         contact = await client.upsert_contact(
@@ -49,6 +62,20 @@ async def submit_phone(request: PhoneRequest) -> dict:
             contact_id=contact["id"],
         )
         return {"success": True, "lead_id": lead["id"]}
-    except Exception:
+    except Exception as exc:
         logger.exception("CRM submission failed")
+        # Surface the failure on the active Langfuse span before returning the
+        # graceful response. Without this update the Kommo error is invisible
+        # in Sessions UI (#1658 evidence).
+        lf = get_client()
+        if lf is not None:
+            lf.update_current_span(
+                level="ERROR",
+                status_message=f"Kommo submission failed: {exc!s}",
+                metadata={
+                    "source": "miniapp",
+                    "endpoint": "submit-phone",
+                    "error_type": type(exc).__name__,
+                },
+            )
         return {"success": True, "lead_id": None}  # Graceful degradation

--- a/tests/unit/mini_app/test_observability.py
+++ b/tests/unit/mini_app/test_observability.py
@@ -1,0 +1,292 @@
+"""Langfuse observability coverage for Mini App FastAPI endpoints (#1658).
+
+These tests mirror the canonical pattern from
+``tests/unit/api/test_rag_api_runtime.py`` (PII-safe ``update_current_span`` +
+``propagate_attributes`` with ``session_id``/``user_id``/``tags``) and assert
+that ``mini_app/api.py`` and ``mini_app/phone.py`` instrument every public
+mutation endpoint with Langfuse spans.
+
+Forbidden by the issue's contract:
+- raw request payloads in span input/output (only curated dicts);
+- prometheus metrics (none added here);
+- ``langfuse_trace_id`` plumbing on the Mini App API surface (see #1253).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+pytest.importorskip("fastapi")
+
+from contextlib import nullcontext
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import ASGITransport, AsyncClient
+
+from mini_app.api import app, start_expert
+from mini_app.phone import PhoneRequest, submit_phone
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_langfuse_observed(func) -> bool:
+    """Return True when ``func`` carries a Langfuse @observe decorator marker.
+
+    Langfuse v4 exposes ``__langfuse_observed__`` and/or ``__wrapped__`` on the
+    decorated callable; we accept either signal as evidence of instrumentation.
+    """
+    return (
+        getattr(func, "__langfuse_observed__", False)
+        or hasattr(func, "__wrapped__")
+        or getattr(func, "__qualname__", "").startswith("observe")
+    )
+
+
+# ---------------------------------------------------------------------------
+# /api/start-expert
+# ---------------------------------------------------------------------------
+
+
+def test_start_expert_endpoint_is_observed():
+    """``start_expert`` must be wrapped by Langfuse @observe (#1658)."""
+    assert _is_langfuse_observed(start_expert), (
+        "mini_app.api.start_expert must carry @observe; got bare callable"
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_expert_propagates_session_attributes():
+    """``/api/start-expert`` must call propagate_attributes(session_id, user_id, tags)."""
+    fake_redis = AsyncMock()
+    fake_redis.set = AsyncMock(return_value=True)
+    fake_redis.publish = AsyncMock(return_value=1)
+
+    lf = MagicMock()
+    lf.update_current_span = MagicMock()
+
+    with (
+        patch("mini_app.api._get_redis", AsyncMock(return_value=fake_redis)),
+        patch.dict("os.environ", {"BOT_USERNAME": "testbot"}),
+        patch("mini_app.api.propagate_attributes", return_value=nullcontext()) as mock_propagate,
+        patch("mini_app.api.get_client", return_value=lf),
+        patch(
+            "mini_app.api.load_mini_app_config",
+            return_value={"experts": [{"id": "consultant", "name": "Консультант"}]},
+        ),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/api/start-expert",
+                json={
+                    "user_id": 123,
+                    "expert_id": "consultant",
+                    "message": "Подбери квартиру в Софии",
+                    "query_id": "qid-1",
+                },
+            )
+
+    assert resp.status_code == 200, resp.text
+    mock_propagate.assert_called_once()
+    kwargs = mock_propagate.call_args.kwargs
+    assert kwargs["session_id"] == "miniapp-123"
+    assert kwargs["user_id"] == "123"
+    tags = kwargs["tags"]
+    assert "miniapp" in tags
+    assert "start-expert" in tags
+    assert "consultant" in tags
+
+
+@pytest.mark.asyncio
+async def test_start_expert_updates_current_span_with_safe_payload():
+    """``/api/start-expert`` must report a curated, PII-free span payload."""
+    fake_redis = AsyncMock()
+    fake_redis.set = AsyncMock(return_value=True)
+    fake_redis.publish = AsyncMock(return_value=1)
+
+    lf = MagicMock()
+    lf.update_current_span = MagicMock()
+
+    raw_message = "Подбери квартиру в Софии"
+
+    with (
+        patch("mini_app.api._get_redis", AsyncMock(return_value=fake_redis)),
+        patch.dict("os.environ", {"BOT_USERNAME": "testbot"}),
+        patch("mini_app.api.propagate_attributes", return_value=nullcontext()),
+        patch("mini_app.api.get_client", return_value=lf),
+        patch(
+            "mini_app.api.load_mini_app_config",
+            return_value={"experts": [{"id": "consultant", "name": "Консультант"}]},
+        ),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            await client.post(
+                "/api/start-expert",
+                json={
+                    "user_id": 123,
+                    "expert_id": "consultant",
+                    "message": raw_message,
+                    "query_id": "qid-1",
+                },
+            )
+
+    lf.update_current_span.assert_called_once()
+    kwargs = lf.update_current_span.call_args.kwargs
+    input_payload = kwargs["input"]
+    assert isinstance(input_payload, dict)
+    assert input_payload["content_type"] == "miniapp"
+    assert input_payload["expert_id"] == "consultant"
+    # Raw user message MUST NOT appear in span input.
+    assert raw_message not in str(input_payload), (
+        f"Raw message leaked into span input: {input_payload!r}"
+    )
+    output_payload = kwargs.get("output", {})
+    assert isinstance(output_payload, dict)
+    # Raw uuid not asserted — but at minimum a deeplink_emitted-style flag must exist.
+    assert output_payload.get("delivery_status") in {"sent", "ok"}
+
+
+# ---------------------------------------------------------------------------
+# /api/phone
+# ---------------------------------------------------------------------------
+
+
+def test_phone_endpoint_is_observed():
+    """``mini_app.api.phone`` (and underlying ``submit_phone``) must be observed."""
+    # ``phone`` endpoint delegates to submit_phone — instrument the worker.
+    assert _is_langfuse_observed(submit_phone), (
+        "mini_app.phone.submit_phone must carry @observe; got bare callable"
+    )
+
+
+@pytest.mark.asyncio
+async def test_phone_propagates_session_attributes():
+    """``/api/phone`` must propagate session_id/user_id/tags for the funnel."""
+    mock_kommo = MagicMock()
+    mock_kommo.upsert_contact = AsyncMock(return_value={"id": 1})
+    mock_kommo.create_lead = AsyncMock(return_value={"id": 2})
+
+    lf = MagicMock()
+    lf.update_current_span = MagicMock()
+
+    with (
+        patch("mini_app.phone.get_kommo_client", return_value=mock_kommo),
+        patch("mini_app.api.propagate_attributes", return_value=nullcontext()) as mock_propagate,
+        patch("mini_app.api.get_client", return_value=lf),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/api/phone",
+                json={
+                    "phone": "+359888123456",
+                    "source": "viewing_consultant",
+                    "user_id": 456,
+                },
+            )
+
+    assert resp.status_code == 200, resp.text
+    mock_propagate.assert_called_once()
+    kwargs = mock_propagate.call_args.kwargs
+    assert kwargs["session_id"] == "miniapp-456"
+    assert kwargs["user_id"] == "456"
+    tags = kwargs["tags"]
+    assert "miniapp" in tags
+    assert "submit-phone" in tags
+    assert "viewing_consultant" in tags
+
+
+@pytest.mark.asyncio
+async def test_phone_excludes_pii_from_span_payload():
+    """Span payload for /api/phone must NOT contain raw phone or name."""
+    mock_kommo = MagicMock()
+    mock_kommo.upsert_contact = AsyncMock(return_value={"id": 1})
+    mock_kommo.create_lead = AsyncMock(return_value={"id": 2})
+
+    lf = MagicMock()
+    lf.update_current_span = MagicMock()
+
+    raw_phone = "+359888123456"
+    raw_name = "Ivan Petrov"
+
+    with (
+        patch("mini_app.phone.get_kommo_client", return_value=mock_kommo),
+        patch("mini_app.api.propagate_attributes", return_value=nullcontext()),
+        patch("mini_app.api.get_client", return_value=lf),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            await client.post(
+                "/api/phone",
+                json={
+                    "phone": raw_phone,
+                    "source": "viewing_consultant",
+                    "user_id": 456,
+                    "name": raw_name,
+                },
+            )
+
+    lf.update_current_span.assert_called_once()
+    kwargs = lf.update_current_span.call_args.kwargs
+    payload_repr = repr(kwargs.get("input", {})) + repr(kwargs.get("output", {}))
+    assert raw_phone not in payload_repr, f"Raw phone leaked into span: {payload_repr}"
+    assert raw_name not in payload_repr, f"Raw name leaked into span: {payload_repr}"
+    input_payload = kwargs["input"]
+    assert input_payload["content_type"] == "miniapp"
+    assert input_payload["source"] == "viewing_consultant"
+    assert input_payload["phone_present"] is True
+    assert input_payload["name_present"] is True
+
+
+# ---------------------------------------------------------------------------
+# submit_phone error path (Kommo failure)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_submit_phone_marks_span_error_on_kommo_failure():
+    """Kommo failure inside submit_phone must mark the active span ERROR
+    BEFORE returning the graceful response."""
+    lf = MagicMock()
+    lf.update_current_span = MagicMock()
+
+    with (
+        patch("mini_app.phone.get_kommo_client", side_effect=RuntimeError("Kommo down")),
+        patch("mini_app.phone.get_client", return_value=lf),
+    ):
+        result = await submit_phone(
+            PhoneRequest(phone="+359888123456", source="viewing_consultant", user_id=456)
+        )
+
+    # graceful contract preserved
+    assert result == {"success": True, "lead_id": None}
+    # but the error must surface in the span
+    lf.update_current_span.assert_called()
+    found_error = False
+    for call in lf.update_current_span.call_args_list:
+        if call.kwargs.get("level") == "ERROR":
+            found_error = True
+            assert (
+                "Kommo" in (call.kwargs.get("status_message") or "")
+                or "down" in (call.kwargs.get("status_message") or "").lower()
+            )
+    assert found_error, (
+        f"No ERROR-level span update after Kommo failure; "
+        f"calls={lf.update_current_span.call_args_list}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_phone_works_when_langfuse_client_is_none():
+    """Graceful degradation: get_client() == None must NOT break submit_phone."""
+    mock_kommo = MagicMock()
+    mock_kommo.upsert_contact = AsyncMock(return_value={"id": 1})
+    mock_kommo.create_lead = AsyncMock(return_value={"id": 7})
+
+    with (
+        patch("mini_app.phone.get_kommo_client", return_value=mock_kommo),
+        patch("mini_app.phone.get_client", return_value=None),
+    ):
+        result = await submit_phone(PhoneRequest(phone="+359888123456", source="test", user_id=1))
+    assert result == {"success": True, "lead_id": 7}


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Closes #1658 (Draft — blocked by #1595)

Adds Langfuse `@observe` instrumentation to `mini_app/api.py` and `mini_app/phone.py` so the Mini App entry → Telegram dialog → CRM funnel reconstructs in Langfuse Sessions UI.

### What changed

- `mini_app/api.py`
  - `@observe(name="miniapp-start-expert", capture_input=False, capture_output=False)` on `start_expert`.
  - `@observe(name="miniapp-submit-phone", capture_input=False, capture_output=False)` on `phone`.
  - Both endpoints wrap their body in `propagate_attributes(session_id="miniapp-{user_id}", user_id=str(user_id), metadata={"source": "miniapp"}, tags=["miniapp", <endpoint>, <expert_id|source>])` and call `get_client().update_current_span(input=..., output=..., metadata=...)` with curated, PII-free payloads.
  - `app.post("/api/start-expert")(start_expert)` / `app.post("/api/phone")(phone)` to keep the `@observe` wrapper participating in the request lifecycle (decorator-friendly route binding).
- `mini_app/phone.py`
  - `@observe(name="miniapp-kommo-create-lead", capture_input=False, capture_output=False)` on `submit_phone`.
  - On Kommo failure: `lf.update_current_span(level="ERROR", status_message=...)` **before** the graceful `{"success": True, "lead_id": None}` return — preserves the existing graceful contract while making the failure visible in Sessions UI.
- `tests/unit/mini_app/test_observability.py` — **new**, 8 cases:
  1. `start_expert` carries Langfuse `@observe`.
  2. `start_expert` propagates `session_id="miniapp-{user_id}"`, `user_id`, tags `["miniapp", "start-expert", <expert_id>]`.
  3. `start_expert` curated span input has no raw `message`.
  4. `submit_phone` carries `@observe`.
  5. `phone` propagates `session_id`, tags `["miniapp", "submit-phone", <source>]`.
  6. PII exclusion: raw `phone`/`name` never appear in span input/output; only `phone_present`, `phone_len`, `name_present`, `source`, `content_type`.
  7. Kommo failure → `level="ERROR"` span update before graceful return.
  8. Graceful degradation when `get_client()` returns `None`.

### SDK validation (Context7 + installed langfuse 4.6.1)

- `Langfuse.update_current_span(name=, input=, output=, metadata=, version=, level=, status_message=)` — confirmed via `inspect.signature` on the 4.6.1 wheel locally; Context7 SDK doc lookup (`/langfuse/langfuse-python`) corroborated the canonical pattern of `propagate_attributes` + `update_current_span` inside an `@observe`-decorated function.
- `observe(func=None, *, name, as_type, capture_input, capture_output, transform_to_string)` — `capture_output` parameter present, matches the existing repo pattern in `src/api/main.py:156`.

### Test run (local, in `.venv`)

```
$ pytest tests/unit/mini_app/test_observability.py -q
........  [100%]
8 passed in 2.89s

$ pytest tests/unit/mini_app -q
.......................................  [100%]
39 passed in 3.37s
```

No regressions in the rest of `tests/unit/mini_app/`.

### ⚠️ Why Draft — blocked by #1595

Per the issue's audit comment (validated against Langfuse Python SDK v3/v4 docs by the original author): until #1595 lands, `request.user_id` is taken **unvalidated** from the request body, which means a forged `user_id` would become a forged `propagate_attributes(user_id=...)` and pollute Langfuse Sessions UI with un-attributable identities. **Do not merge this PR before #1595.**

When #1595 is merged, the only follow-up here is to source `user_id` from the validated initData (≤ 5 lines) and remove the Draft flag.

### Side-finding (NOT addressed in this PR)

Running `pytest tests/unit/api/test_rag_api_runtime.py` with real `fastapi` installed surfaces 2 pre-existing failures on `response.content` for `JSONResponse` — the test was written against an in-file `_FakeJSONResponse` shim with a `.content` attribute, but real FastAPI's `JSONResponse` uses `.body`. Unrelated to #1658; should be filed as a separate issue under the testing-stabilization track (epic #1515).

### What's NOT in this PR (per issue's "Forbidden" section)

- ❌ no raw `request` payloads in span input/output
- ❌ no new prometheus metrics
- ❌ no Mini App frontend SDK changes
- ❌ no `langfuse_trace_id` plumbing on the Mini App API surface (separate concern: #1253)

### Verification (from the issue)

```bash
uv run pytest tests/unit/mini_app -q
uv run pytest tests/unit/test_langfuse_context_middleware.py -q
```

Manual (post-#1595): `make local-up`, hit `/api/start-expert` and `/api/phone` from the dev Mini App, confirm a single Langfuse session contains both endpoints + the subsequent Telegram `/start q_…` trace.

### Related

- #1659, #1660, #1661, #1662 — same `@observe` pattern; the next PR in this burn-down can re-use the curated payload + propagate shape introduced here.
- #1595 — **hard blocker** for merge.
- #1253 — `langfuse_trace_id` plumbing (out of scope).
- #1515 — testing-audit epic (where the `JSONResponse.content` side-finding belongs).