### PR TITLE
feat(observability): wrap QueryAnalyzer.analyze in @observe (#1659)

### DIFF
--- a/telegram_bot/services/query_analyzer.py
+++ b/telegram_bot/services/query_analyzer.py
@@ -126,12 +126,13 @@ class QueryAnalyzer:
             Dict with 'filters' and 'semantic_query'
         """
         lf = get_client()
-        lf.update_current_span(
-            input={
-                "query_preview": query[:120],
-                "model": self.model,
-            }
-        )
+        if lf is not None:
+            lf.update_current_span(
+                input={
+                    "query_preview": query[:120],
+                    "model": self.model,
+                }
+            )
         try:
             system_prompt = get_prompt("query-analysis", fallback=SYSTEM_PROMPT)
             result = await self._instructor_client.chat.completions.create(
@@ -150,24 +151,27 @@ class QueryAnalyzer:
             filters = result.filters
             semantic_query = result.semantic_query or query
 
-            lf.update_current_span(
-                output={
-                    "filter_keys": sorted(filters.keys()),
-                    "filter_count": len(filters),
-                    "semantic_query_len": len(semantic_query),
-                }
-            )
+            if lf is not None:
+                lf.update_current_span(
+                    output={
+                        "filter_keys": sorted(filters.keys()),
+                        "filter_count": len(filters),
+                        "semantic_query_len": len(semantic_query),
+                    }
+                )
 
             logger.info("QueryAnalyzer: filters=%s, semantic_query=%s", filters, semantic_query)
             return {"filters": filters, "semantic_query": semantic_query}
 
         except (openai.APIConnectionError, openai.RateLimitError, openai.APITimeoutError) as e:
             logger.error("QueryAnalyzer API error: %s", e)
-            lf.update_current_span(level="ERROR", status_message=str(e)[:200])
+            if lf is not None:
+                lf.update_current_span(level="ERROR", status_message=str(e)[:200])
             return {"filters": {}, "semantic_query": query}
         except Exception as e:
             logger.error("QueryAnalyzer error: %s", e, exc_info=True)
-            lf.update_current_span(level="ERROR", status_message=str(e)[:200])
+            if lf is not None:
+                lf.update_current_span(level="ERROR", status_message=str(e)[:200])
             return {"filters": {}, "semantic_query": query}
 
     async def close(self):

--- a/telegram_bot/services/query_analyzer.py
+++ b/telegram_bot/services/query_analyzer.py
@@ -13,6 +13,7 @@ from langfuse.openai import AsyncOpenAI
 from pydantic import BaseModel, Field
 
 from telegram_bot.integrations.prompt_manager import get_prompt
+from telegram_bot.observability import get_client, observe
 
 
 logger = logging.getLogger(__name__)
@@ -83,8 +84,40 @@ class QueryAnalyzer:
             )
             self._instructor_client = instructor.from_openai(self.client)
 
+    @observe(
+        name="query-analyzer",
+        capture_input=False,
+        capture_output=False,
+    )
     async def analyze(self, query: str) -> dict[str, Any]:
         """Analyze query and extract filters + semantic query.
+
+        Wrapped in ``@observe`` (#1659) so the auto-traced generation
+        produced by ``langfuse.openai`` (preserved through
+        ``instructor.from_openai`` — the underlying client's
+        ``chat.completions.create`` retains the wrapt langfuse marker, see
+        the preflight test ``TestQueryAnalyzerInstructorLangfuseCompat``)
+        becomes a child of a named ``query-analyzer`` span instead of an
+        orphan top-level trace when the analyzer is invoked outside a
+        request-scoped trace.
+
+        Per the audit comment on #1659 the wrapper is a *plain span*, not
+        ``as_type="generation"``: ``langfuse.openai`` already emits a
+        generation observation for each ``chat.completions.create`` call
+        and an outer generation would produce duplicate observations.
+
+        Curated ``update_current_span`` payloads avoid leaking the full
+        query or the full LLM response into Langfuse:
+
+        * input: ``{"query_preview": query[:120], "model": self.model}``
+        * output: ``{"filter_keys": sorted(filters.keys()),
+          "filter_count": len(filters),
+          "semantic_query_len": len(semantic_query)}``
+          — schema-level metadata only; no filter *values*, no semantic
+          query *content*.
+        * on exception: ``level="ERROR"`` with ``status_message`` truncated
+          to 200 chars; existing fallback contract preserved (returns
+          ``{"filters": {}, "semantic_query": query}``).
 
         Args:
             query: User query text
@@ -92,6 +125,13 @@ class QueryAnalyzer:
         Returns:
             Dict with 'filters' and 'semantic_query'
         """
+        lf = get_client()
+        lf.update_current_span(
+            input={
+                "query_preview": query[:120],
+                "model": self.model,
+            }
+        )
         try:
             system_prompt = get_prompt("query-analysis", fallback=SYSTEM_PROMPT)
             result = await self._instructor_client.chat.completions.create(
@@ -110,14 +150,24 @@ class QueryAnalyzer:
             filters = result.filters
             semantic_query = result.semantic_query or query
 
+            lf.update_current_span(
+                output={
+                    "filter_keys": sorted(filters.keys()),
+                    "filter_count": len(filters),
+                    "semantic_query_len": len(semantic_query),
+                }
+            )
+
             logger.info("QueryAnalyzer: filters=%s, semantic_query=%s", filters, semantic_query)
             return {"filters": filters, "semantic_query": semantic_query}
 
         except (openai.APIConnectionError, openai.RateLimitError, openai.APITimeoutError) as e:
             logger.error("QueryAnalyzer API error: %s", e)
+            lf.update_current_span(level="ERROR", status_message=str(e)[:200])
             return {"filters": {}, "semantic_query": query}
         except Exception as e:
             logger.error("QueryAnalyzer error: %s", e, exc_info=True)
+            lf.update_current_span(level="ERROR", status_message=str(e)[:200])
             return {"filters": {}, "semantic_query": query}
 
     async def close(self):

--- a/tests/unit/services/test_query_analyzer.py
+++ b/tests/unit/services/test_query_analyzer.py
@@ -8,6 +8,9 @@ import pytest
 from telegram_bot.services.query_analyzer import QueryAnalysisResult, QueryAnalyzer
 
 
+pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
+
+
 # =============================================================================
 # TestQueryAnalyzerInit
 # =============================================================================
@@ -362,3 +365,408 @@ class TestQueryAnalyzerFlow:
         result2 = await analyzer.analyze("query2")
         assert result2["filters"] == {"city": "Бургас"}
         assert result2["semantic_query"] == "квартира"
+
+
+
+# =============================================================================
+# TestQueryAnalyzerInstructorLangfuseCompat (#1659 STEP 0 PREFLIGHT)
+# =============================================================================
+
+
+class TestQueryAnalyzerInstructorLangfuseCompat:
+    """Preflight: confirm `instructor.from_openai(langfuse.openai.AsyncOpenAI(...))`
+    preserves langfuse auto-tracing on the underlying client.
+
+    Rationale (audit comment on #1659): if instructor patched
+    ``chat.completions.create`` at the wrong layer it would strip the
+    ``langfuse.openai`` wrap, and then a plain ``@observe`` wrapper around
+    ``QueryAnalyzer.analyze`` would NOT contain a nested generation
+    observation — we'd need ``with langfuse.start_as_current_observation
+    (as_type='generation', ...)`` instead.
+
+    What this test asserts: the AsyncInstructor instance retains a reference
+    to the original langfuse-wrapped client (``ic.client is c``) and that
+    client's ``chat.completions.create`` still carries the langfuse wrapt
+    marker (``_self_wrapper.__module__`` starts with ``"langfuse.openai"``).
+    instructor's ``AsyncInstructor.create`` ultimately delegates to
+    ``self.client.chat.completions.create`` via ``self.create_fn`` so the
+    langfuse generation is created at call time. Pass ⇒ simple ``@observe``
+    is the correct implementation strategy for #1659.
+    """
+
+    def test_chat_completions_create_remains_langfuse_wrapped(self):
+        """instructor must not strip the langfuse trace wrap on the client."""
+        import instructor
+        from langfuse.openai import AsyncOpenAI
+
+        c = AsyncOpenAI(api_key="x", base_url="http://x")
+        ic = instructor.from_openai(c)
+
+        # instructor stores the original client as ic.client
+        assert ic.client is c, (
+            "instructor.from_openai must retain the original langfuse-wrapped "
+            "client; otherwise the langfuse trace wrap is lost"
+        )
+
+        underlying_create = ic.client.chat.completions.create
+        # langfuse uses wrapt to monkey-patch the OpenAI SDK call site, leaving
+        # a BoundFunctionWrapper whose `_self_wrapper` points back at langfuse.
+        assert hasattr(underlying_create, "__wrapped__"), (
+            "Expected `__wrapped__` marker from wrapt on langfuse.openai's "
+            "patched chat.completions.create"
+        )
+        wrapper = getattr(underlying_create, "_self_wrapper", None)
+        assert wrapper is not None, (
+            "Expected wrapt `_self_wrapper` attribute on langfuse-patched create"
+        )
+        wrapper_module = getattr(wrapper, "__module__", "") or ""
+        assert wrapper_module.startswith("langfuse.openai"), (
+            f"langfuse trace wrap stripped after instructor.from_openai — "
+            f"_self_wrapper module is {wrapper_module!r}; "
+            f"#1659 implementation must switch to "
+            f"`with langfuse.start_as_current_observation(as_type='generation', "
+            f"name='query-analyzer-llm', model=self.model) as gen: ...`"
+        )
+
+
+# =============================================================================
+# TestQueryAnalyzerObserveInstrumentation (#1659)
+# =============================================================================
+
+
+class TestQueryAnalyzerObserveInstrumentation:
+    """Tests for @observe instrumentation on QueryAnalyzer.analyze (#1659).
+
+    Contract: ``analyze`` (line ~86) must be wrapped with::
+
+        @observe(name="query-analyzer",
+                 capture_input=False, capture_output=False)
+
+    so the auto-traced generation produced by ``langfuse.openai.AsyncOpenAI``
+    (preserved through ``instructor.from_openai``, see preflight test)
+    becomes a child of a named ``query-analyzer`` span instead of an orphan
+    top-level trace when the analyzer is invoked outside a request-scoped
+    trace.
+
+    CRITICAL: the wrapper MUST NOT use ``as_type="generation"`` —
+    ``langfuse.openai`` already creates a generation observation for each
+    ``chat.completions.create()`` call (preflight verifies the wrap
+    survives), and an outer generation would produce duplicate observations.
+    Plain span > nested generation is the intended structure.
+
+    Curated ``update_current_span`` payloads avoid leaking the full query
+    or full LLM response into Langfuse. On exception the span is recorded
+    at ``level="ERROR"`` with a truncated ``status_message``; the existing
+    fallback contract (``return {"filters": {}, "semantic_query": query}``)
+    is preserved verbatim.
+    """
+
+    @staticmethod
+    def _patched_lf(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+        """Replace get_client used by the query_analyzer module with a recording mock."""
+        from telegram_bot.services import query_analyzer as qa_mod
+
+        mock_lf = MagicMock()
+        monkeypatch.setattr(qa_mod, "get_client", lambda: mock_lf)
+        return mock_lf
+
+    @staticmethod
+    def _disable_observe(monkeypatch: pytest.MonkeyPatch) -> None:
+        """Replace the @observe decorator with a no-op and reload the module.
+
+        Uses ``monkeypatch.delitem(sys.modules, ...)`` so that after the test
+        the original module object is restored — otherwise the reload would
+        leave a fresh ``QueryAnalyzer`` class in ``sys.modules`` and other
+        tests would see drift between the lazy-imported package attribute
+        and any test-file-level binding (pattern from #1660 TDD).
+        """
+        import importlib
+        import sys
+
+        from telegram_bot import observability as observability_mod
+
+        def fake_observe(**_kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        monkeypatch.setattr(observability_mod, "observe", fake_observe)
+        monkeypatch.delitem(sys.modules, "telegram_bot.services.query_analyzer", raising=False)
+        importlib.import_module("telegram_bot.services.query_analyzer")
+
+    @staticmethod
+    def _record_observe_calls(
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> list[dict[str, object]]:
+        """Replace @observe with a recorder and reload the module.
+
+        Same ``monkeypatch.delitem`` strategy as ``_disable_observe`` — the
+        original module is restored on test teardown.
+        """
+        import importlib
+        import sys
+
+        from telegram_bot import observability as observability_mod
+
+        captured_calls: list[dict[str, object]] = []
+
+        def recording_observe(**kwargs):
+            captured_calls.append(kwargs)
+
+            def decorator(func):
+                return func
+
+            return decorator
+
+        monkeypatch.setattr(observability_mod, "observe", recording_observe)
+        monkeypatch.delitem(sys.modules, "telegram_bot.services.query_analyzer", raising=False)
+        importlib.import_module("telegram_bot.services.query_analyzer")
+        return captured_calls
+
+    # ------------------------------------------------------------------
+    # Module-level wiring
+    # ------------------------------------------------------------------
+
+    def test_module_imports_observe_and_get_client(self):
+        """Module wires the Langfuse decorator + client accessor (#1659 contract)."""
+        from telegram_bot.services import query_analyzer as qa_mod
+
+        assert hasattr(qa_mod, "observe"), (
+            "telegram_bot.services.query_analyzer must import `observe` from "
+            "telegram_bot.observability for the @observe decorator on "
+            "QueryAnalyzer.analyze"
+        )
+        assert hasattr(qa_mod, "get_client"), (
+            "telegram_bot.services.query_analyzer must import `get_client` "
+            "from telegram_bot.observability for curated update_current_span calls"
+        )
+
+    # ------------------------------------------------------------------
+    # Decorator kwargs
+    # ------------------------------------------------------------------
+
+    def test_observe_decorator_applied_with_correct_kwargs(self, monkeypatch):
+        """``analyze`` is decorated with the audit's exact kwargs.
+
+        CRITICAL: ``as_type`` MUST NOT be present — preflight confirmed
+        ``langfuse.openai`` wrap survives ``instructor.from_openai`` (the
+        underlying client's chat.completions.create still carries
+        ``_self_wrapper.__module__ == "langfuse.openai"``), so the wrapper
+        is a plain span and the nested generation is owned by langfuse.openai.
+        """
+        captured = self._record_observe_calls(monkeypatch)
+
+        matches = [c for c in captured if c.get("name") == "query-analyzer"]
+        assert len(matches) == 1, (
+            "Expected exactly one @observe(name='query-analyzer', ...) on "
+            f"QueryAnalyzer.analyze; observed names: {[c.get('name') for c in captured]}"
+        )
+        kwargs = matches[0]
+        assert kwargs.get("capture_input") is False, (
+            "capture_input must be False (issue #1659 explicit kwarg)"
+        )
+        assert kwargs.get("capture_output") is False, (
+            "capture_output must be False (issue #1659 explicit kwarg)"
+        )
+        assert "as_type" not in kwargs, (
+            "Wrapper must NOT use as_type='generation' — langfuse.openai "
+            "already creates a generation for each chat.completions.create "
+            "(verified by preflight); wrapping the public method as another "
+            "generation would produce duplicates."
+        )
+
+    # ------------------------------------------------------------------
+    # Behavior: input payload (curated)
+    # ------------------------------------------------------------------
+
+    async def test_input_payload_is_curated_query_preview_and_model(self, monkeypatch):
+        """``analyze`` records {query_preview (<=120), model} only — no full query."""
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.query_analyzer import (
+            QueryAnalysisResult,
+            QueryAnalyzer,
+        )
+
+        long_query = (
+            "Ищу 2-комнатную квартиру в Несебре с видом на море до 100000 "
+            "евро, желательно с мебелью, на средних этажах в новостройке "
+            "недалеко от пляжа и инфраструктуры — точно длиннее 120 символов"
+        )
+        assert len(long_query) > 120
+
+        analyzer = QueryAnalyzer(
+            api_key="test-api-key", base_url="http://localhost:8000", model="gpt-4o-mini"
+        )
+        analyzer._instructor_client = AsyncMock()
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
+            return_value=QueryAnalysisResult(filters={}, semantic_query="quartira")
+        )
+
+        await analyzer.analyze(long_query)
+
+        input_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if "input" in c.kwargs
+        ]
+        assert input_calls, (
+            "update_current_span(input=...) was never called on QueryAnalyzer.analyze"
+        )
+        captured_input = input_calls[0]["input"]
+        assert isinstance(captured_input, dict)
+        assert "query_preview" in captured_input
+        assert isinstance(captured_input["query_preview"], str)
+        assert len(captured_input["query_preview"]) <= 120
+        assert captured_input.get("model") == "gpt-4o-mini"
+
+        # Forbidden: full query MUST NOT appear in span input.
+        assert long_query not in str(captured_input)
+
+    # ------------------------------------------------------------------
+    # Behavior: output payload (curated)
+    # ------------------------------------------------------------------
+
+    async def test_output_payload_records_curated_qaresult_summary(self, monkeypatch):
+        """``analyze`` records curated summary of QueryAnalysisResult — no full payload.
+
+        ``QueryAnalysisResult`` has two fields: ``filters`` (dict[str, Any])
+        and ``semantic_query`` (str). To avoid leaking user query content
+        and filter values (which can include city names, exact prices, etc.)
+        the curated output captures schema-level metadata only:
+        - ``filter_keys``: sorted list of filter dimension names (bounded
+          schema enum: price, rooms, city, area, ...). No values.
+        - ``filter_count``: number of filters extracted.
+        - ``semantic_query_len``: length of the semantic query string. No
+          content.
+        """
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.query_analyzer import (
+            QueryAnalysisResult,
+            QueryAnalyzer,
+        )
+
+        analyzer = QueryAnalyzer(
+            api_key="test-api-key", base_url="http://localhost:8000", model="gpt-4o-mini"
+        )
+        secret_city = "СекретныйГородКоторыйНеДолженПопастьВspan"
+        secret_semantic = "очень-чувствительный-семантический-запрос-пользователя"
+        analyzer._instructor_client = AsyncMock()
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
+            return_value=QueryAnalysisResult(
+                filters={
+                    "price": {"lt": 100000},
+                    "city": secret_city,
+                    "rooms": 2,
+                },
+                semantic_query=secret_semantic,
+            )
+        )
+
+        result = await analyzer.analyze("any query")
+        # Behavior unchanged: caller still receives full filters + semantic_query
+        assert result["filters"]["city"] == secret_city
+        assert result["semantic_query"] == secret_semantic
+
+        output_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if "output" in c.kwargs
+        ]
+        assert output_calls, (
+            "update_current_span(output=...) was never called on QueryAnalyzer.analyze"
+        )
+        captured_output = output_calls[-1]["output"]
+        assert isinstance(captured_output, dict)
+        assert captured_output.get("filter_count") == 3
+        assert captured_output.get("filter_keys") == sorted(["price", "city", "rooms"])
+        assert captured_output.get("semantic_query_len") == len(secret_semantic)
+
+        # Forbidden: full LLM response payload MUST NOT appear in span output.
+        captured_str = str(captured_output)
+        assert secret_city not in captured_str, (
+            "Full filter values (e.g. city name) must not be captured to span output"
+        )
+        assert secret_semantic not in captured_str, (
+            "Full semantic_query content must not be captured to span output"
+        )
+
+    # ------------------------------------------------------------------
+    # Behavior: exception path
+    # ------------------------------------------------------------------
+
+    async def test_exception_path_records_error_level_and_returns_fallback(self, monkeypatch):
+        """On internal failure: span level=ERROR + truncated status_message.
+
+        Existing fallback contract is preserved: analyze swallows the
+        exception and returns ``{"filters": {}, "semantic_query": query}``.
+        The ERROR span is recorded before the fallback is returned.
+        """
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.query_analyzer import QueryAnalyzer
+
+        analyzer = QueryAnalyzer(
+            api_key="test-api-key", base_url="http://localhost:8000", model="gpt-4o-mini"
+        )
+        analyzer._instructor_client = AsyncMock()
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
+            side_effect=RuntimeError("Instructor exploded mid-analyze")
+        )
+
+        original_query = "квартира в Бургасе"
+        result = await analyzer.analyze(original_query)
+
+        # Existing fallback contract preserved
+        assert result == {"filters": {}, "semantic_query": original_query}
+
+        error_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if c.kwargs.get("level") == "ERROR"
+        ]
+        assert error_calls, (
+            "Failure path must call update_current_span(level='ERROR', ...) on "
+            "QueryAnalyzer.analyze (#1659 plan)"
+        )
+        status = error_calls[0].get("status_message", "")
+        assert "Instructor exploded mid-analyze" in status
+        assert len(status) <= 220
+
+    async def test_exception_path_for_openai_api_errors_records_error_level(self, monkeypatch):
+        """OpenAI-specific errors (timeout/connection/rate-limit) also record ERROR.
+
+        Existing code has separate `except (APIConnectionError, RateLimitError,
+        APITimeoutError)` and generic `except Exception` branches; both must
+        record ERROR before returning the fallback.
+        """
+        self._disable_observe(monkeypatch)
+        mock_lf = self._patched_lf(monkeypatch)
+
+        from telegram_bot.services.query_analyzer import QueryAnalyzer
+
+        analyzer = QueryAnalyzer(
+            api_key="test-api-key", base_url="http://localhost:8000", model="gpt-4o-mini"
+        )
+        analyzer._instructor_client = AsyncMock()
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
+            side_effect=openai.APITimeoutError(request=MagicMock())
+        )
+
+        original_query = "студия на первой линии"
+        result = await analyzer.analyze(original_query)
+
+        assert result == {"filters": {}, "semantic_query": original_query}
+
+        error_calls = [
+            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            if c.kwargs.get("level") == "ERROR"
+        ]
+        assert error_calls, (
+            "OpenAI APITimeoutError branch must also record level='ERROR' on the span"
+        )
+        status = error_calls[0].get("status_message", "")
+        assert isinstance(status, str)
+        assert len(status) <= 220

--- a/tests/unit/services/test_query_analyzer.py
+++ b/tests/unit/services/test_query_analyzer.py
@@ -367,7 +367,6 @@ class TestQueryAnalyzerFlow:
         assert result2["semantic_query"] == "квартира"
 
 
-
 # =============================================================================
 # TestQueryAnalyzerInstructorLangfuseCompat (#1659 STEP 0 PREFLIGHT)
 # =============================================================================
@@ -608,8 +607,7 @@ class TestQueryAnalyzerObserveInstrumentation:
         await analyzer.analyze(long_query)
 
         input_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
-            if "input" in c.kwargs
+            c.kwargs for c in mock_lf.update_current_span.call_args_list if "input" in c.kwargs
         ]
         assert input_calls, (
             "update_current_span(input=...) was never called on QueryAnalyzer.analyze"
@@ -672,8 +670,7 @@ class TestQueryAnalyzerObserveInstrumentation:
         assert result["semantic_query"] == secret_semantic
 
         output_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
-            if "output" in c.kwargs
+            c.kwargs for c in mock_lf.update_current_span.call_args_list if "output" in c.kwargs
         ]
         assert output_calls, (
             "update_current_span(output=...) was never called on QueryAnalyzer.analyze"
@@ -692,6 +689,30 @@ class TestQueryAnalyzerObserveInstrumentation:
         assert secret_semantic not in captured_str, (
             "Full semantic_query content must not be captured to span output"
         )
+
+    async def test_analyze_works_when_langfuse_client_is_none(self, monkeypatch):
+        """Tracing must degrade gracefully when Langfuse is unavailable."""
+        self._disable_observe(monkeypatch)
+
+        from telegram_bot.services import query_analyzer as qa_mod
+        from telegram_bot.services.query_analyzer import (
+            QueryAnalysisResult,
+            QueryAnalyzer,
+        )
+
+        monkeypatch.setattr(qa_mod, "get_client", lambda: None)
+
+        analyzer = QueryAnalyzer(
+            api_key="test-api-key", base_url="http://localhost:8000", model="gpt-4o-mini"
+        )
+        analyzer._instructor_client = AsyncMock()
+        analyzer._instructor_client.chat.completions.create = AsyncMock(
+            return_value=QueryAnalysisResult(filters={"city": "Бургас"}, semantic_query="квартира")
+        )
+
+        result = await analyzer.analyze("квартира в Бургасе")
+
+        assert result == {"filters": {"city": "Бургас"}, "semantic_query": "квартира"}
 
     # ------------------------------------------------------------------
     # Behavior: exception path
@@ -724,7 +745,8 @@ class TestQueryAnalyzerObserveInstrumentation:
         assert result == {"filters": {}, "semantic_query": original_query}
 
         error_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            c.kwargs
+            for c in mock_lf.update_current_span.call_args_list
             if c.kwargs.get("level") == "ERROR"
         ]
         assert error_calls, (
@@ -761,7 +783,8 @@ class TestQueryAnalyzerObserveInstrumentation:
         assert result == {"filters": {}, "semantic_query": original_query}
 
         error_calls = [
-            c.kwargs for c in mock_lf.update_current_span.call_args_list
+            c.kwargs
+            for c in mock_lf.update_current_span.call_args_list
             if c.kwargs.get("level") == "ERROR"
         ]
         assert error_calls, (


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Wraps `QueryAnalyzer.analyze` (telegram_bot/services/query_analyzer.py:86) with `@observe(name="query-analyzer", capture_input=False, capture_output=False)` so the auto-traced generation produced by `langfuse.openai.AsyncOpenAI` becomes a child of a named span instead of an orphan top-level trace when the analyzer is invoked outside a request-scoped trace (background tasks, scripts, fallback paths).

Closes #1659.

## STEP 0 Preflight outcome — instructor preserves langfuse wrap ✅

Per the audit comment on #1659, before adding `@observe` we needed to verify whether `instructor.from_openai(langfuse.openai.AsyncOpenAI(...))` strips the langfuse auto-trace.

Added `TestQueryAnalyzerInstructorLangfuseCompat::test_chat_completions_create_remains_langfuse_wrapped` which constructs the chain and inspects the resulting `AsyncInstructor`. Findings:

- `ic.client is original_langfuse_client` → **True**. instructor stores a direct reference to the langfuse-wrapped client (no rebind).
- `ic.client.chat.completions.create.__wrapped__` → present (wrapt marker survives).
- `ic.client.chat.completions.create._self_wrapper.__module__` → **`"langfuse.openai"`** (langfuse-emitted wrapper survives).
- `AsyncInstructor.create` ultimately delegates to `self.client.chat.completions.create` via `self.create_fn`, so the langfuse generation observation is created at call time.

**Conclusion:** simple `@observe` decorator is the correct strategy. No need for `langfuse.start_as_current_observation(as_type="generation", ...)`. Implementation branch taken: **simple `@observe`** (matches the pattern already established by #1673/#1674/#1678/#1679).

## Changes

`telegram_bot/services/query_analyzer.py`
- Imports `observe` and `get_client` from `telegram_bot.observability`.
- `analyze` is decorated with `@observe(name="query-analyzer", capture_input=False, capture_output=False)`.
- Wrapper is a **plain span**, not `as_type="generation"`: `langfuse.openai` already emits a generation per `chat.completions.create` (preflight confirmed wrap survives instructor); an outer generation would duplicate observations.
- Curated `update_current_span` payloads (Forbidden-section compliant):
  - input: `{"query_preview": query[:120], "model": self.model}`
  - output: `{"filter_keys": sorted(filters.keys()), "filter_count": <int>, "semantic_query_len": <int>}` — schema-level metadata only; **no filter values** (city names, prices) and **no semantic query content** leak to the span. `QueryAnalysisResult` has only two fields (`filters` dict, `semantic_query` str), so the curated payload summarizes both without exposing user-derived text.
  - on exception: `level="ERROR"` with `status_message` truncated to 200 chars.
- **Existing fallback contract preserved verbatim**: both `(APIConnectionError, RateLimitError, APITimeoutError)` and generic `Exception` branches return `{"filters": {}, "semantic_query": query}`. The ERROR span is recorded before the fallback is returned.

`tests/unit/services/test_query_analyzer.py`
- New `TestQueryAnalyzerInstructorLangfuseCompat` class — 1 preflight test (asserts `_self_wrapper.__module__.startswith("langfuse.openai")`).
- New `TestQueryAnalyzerObserveInstrumentation` class — 6 tests:
  - `test_module_imports_observe_and_get_client`
  - `test_observe_decorator_applied_with_correct_kwargs` (asserts `name`, `capture_input=False`, `capture_output=False`, **and absence of `as_type`**)
  - `test_input_payload_is_curated_query_preview_and_model` (asserts ≤120 char preview, model, no full query leak)
  - `test_output_payload_records_curated_qaresult_summary` (uses sentinel filter-value & semantic-query strings to verify they do NOT appear in span output)
  - `test_exception_path_records_error_level_and_returns_fallback` (generic `Exception` branch — verifies ERROR span + fallback dict semantics preserved)
  - `test_exception_path_for_openai_api_errors_records_error_level` (OpenAI `APITimeoutError` branch)
- Test pattern follows #1679 (LLMService): `monkeypatch.setattr(observability_mod, "observe", ...)` + `monkeypatch.delitem(sys.modules, ...)` + `importlib.import_module(...)`. The `delitem` ensures the original module object is restored on test teardown so identity-checks elsewhere don't drift.

## Validation

```bash
$ uv run pytest tests/unit/services/test_query_analyzer.py -q --override-ini="addopts="
...................................                                      [100%]
35 passed in 3.42s

$ uv run pytest tests/unit/services/ -q --override-ini="addopts="
983 passed, 9 warnings in 6.43s

$ uv run ruff check telegram_bot/services/query_analyzer.py tests/unit/services/test_query_analyzer.py
All checks passed!

$ uv run mypy telegram_bot/services/query_analyzer.py
Success: no issues found in 1 source file
```

## Coverage

```bash
$ uv run coverage erase
$ uv run coverage run -m pytest tests/unit/services/test_query_analyzer.py -p no:cacheprovider --override-ini="addopts=" -q
35 passed in 7.34s

$ uv run coverage report --include="telegram_bot/services/query_analyzer.py" --show-missing
Name                                      Stmts   Miss Branch BrPart  Cover   Missing
-------------------------------------------------------------------------------------
telegram_bot/services/query_analyzer.py      45      0      0      0   100%
-------------------------------------------------------------------------------------
TOTAL                                        45      0      0      0   100%
```

**100% line coverage** on the touched file (45 statements, 0 missed).

Note on the coverage workaround: `--source=telegram_bot.services.query_analyzer` is blocked by a pre-existing conftest issue (`tests/unit/conftest.py:97` autouse `mock_get_client` patches `telegram_bot.bot.get_client` which fails to resolve under coverage's source detection — same blocker reported in #1679). Plain `coverage run -m pytest` + `--include` filter works and is the same workaround used by #1679. `pytest --cov` is also blocked by the same issue.

## Forbidden checks ✅

- ❌ → ✅ Full query NOT captured to span input (asserted by `test_input_payload_is_curated_query_preview_and_model` with a >120-char query).
- ❌ → ✅ Full LLM response payload NOT captured to span output (asserted by `test_output_payload_records_curated_qaresult_summary` with sentinel city name and sentinel semantic_query).
- ❌ → ✅ No new wrapper layer introduced — `instructor` + `langfuse.openai` chain unchanged.
- ❌ → ✅ `QueryAnalysisResult` schema unchanged (still `filters: dict[str, Any]` and `semantic_query: str`).
- ❌ → ✅ No issues created — only this PR.