### PR TITLE
fix(telegram): /clear exits active aiogram-dialog stack and clears FSM (#1454)

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -1344,10 +1344,46 @@ class PropertyBot:
         )
 
     @observe(name="cmd-clear", capture_input=False, capture_output=False)
-    async def cmd_clear(self, message: Message):
-        """Handle /clear command - clear conversation history."""
+    async def cmd_clear(
+        self,
+        message: Message,
+        state: FSMContext | None = None,
+        dialog_manager: Any = None,
+    ):
+        """Handle /clear command - clear conversation history and exit any active dialog state.
+
+        Closes any active aiogram-dialog stack (e.g. DemoSG apartment-search) and
+        resets the FSM state so subsequent free-text questions are routed back to
+        the supervisor / RAG path. See #1454.
+        """
         assert message.from_user is not None
         user_id = message.from_user.id
+        # #1454: drop any active aiogram-dialog stack BEFORE clearing FSM, so
+        # the dialog framework can clean up its own state correctly. Without
+        # this the user remained in DemoSG.search after /clear and the next
+        # free-text message was handled by demo-search instead of telegram-rag.
+        dialog_reset_failed = False
+        if dialog_manager is not None:
+            try:
+                if getattr(dialog_manager, "has_context", lambda: False)():
+                    await dialog_manager.reset_stack(remove_keyboard=False)
+            except Exception:
+                logger.warning(
+                    "Failed to reset aiogram-dialog stack during /clear for user_id=%s",
+                    user_id,
+                    exc_info=True,
+                )
+                dialog_reset_failed = True
+        if state is not None:
+            try:
+                await state.clear()
+            except Exception:
+                logger.warning(
+                    "Failed to clear FSM state during /clear for user_id=%s",
+                    user_id,
+                    exc_info=True,
+                )
+                dialog_reset_failed = True
         checkpointer_cleared = True
         history_cleared = True
         text_thread_id = _supervisor_thread_id(message.chat.id)
@@ -1386,8 +1422,13 @@ class PropertyBot:
                 )
                 history_cleared = False
 
-        if checkpointer_cleared and history_cleared:
+        if checkpointer_cleared and history_cleared and not dialog_reset_failed:
             await message.answer("✅ История диалога очищена.")
+        elif dialog_reset_failed and checkpointer_cleared and history_cleared:
+            await message.answer(
+                "⚠️ История очищена, но не удалось сбросить состояние активного диалога. "
+                "Используйте /start, если бот продолжает отвечать в режиме поиска."
+            )
         else:
             await message.answer(
                 "⚠️ История очищена частично: локальный контекст сброшен, "

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -409,6 +409,75 @@ class TestCommandHandlers:
 
         bot._cache.clear_conversation.assert_awaited_once_with(12345)
 
+    async def test_cmd_clear_resets_active_dialog_stack(self, mock_config):
+        """#1454: /clear must reset any active aiogram-dialog stack so the next
+        free-text message is routed back to the supervisor / RAG path
+        (e.g. user is no longer stuck inside DemoSG.search)."""
+        bot, _ = _create_bot(mock_config)
+        bot._cache = MagicMock()
+        bot._cache.clear_conversation = AsyncMock()
+        message = _make_text_message()
+        dialog_manager = AsyncMock()
+        dialog_manager.has_context = MagicMock(return_value=True)
+        dialog_manager.reset_stack = AsyncMock()
+        state = AsyncMock()
+
+        await bot.cmd_clear(message, state=state, dialog_manager=dialog_manager)
+
+        dialog_manager.reset_stack.assert_awaited_once()
+        # remove_keyboard=False — keep the chat composer untouched after /clear
+        assert dialog_manager.reset_stack.await_args.kwargs.get("remove_keyboard") is False
+        state.clear.assert_awaited_once()
+        message.answer.assert_awaited_once()
+        assert "очищена" in message.answer.await_args.args[0].lower()
+
+    async def test_cmd_clear_clears_fsm_state_without_active_dialog(self, mock_config):
+        """#1454: when no aiogram-dialog stack is active, /clear still clears FSM."""
+        bot, _ = _create_bot(mock_config)
+        bot._cache = MagicMock()
+        bot._cache.clear_conversation = AsyncMock()
+        message = _make_text_message()
+        dialog_manager = AsyncMock()
+        dialog_manager.has_context = MagicMock(return_value=False)
+        dialog_manager.reset_stack = AsyncMock()
+        state = AsyncMock()
+
+        await bot.cmd_clear(message, state=state, dialog_manager=dialog_manager)
+
+        dialog_manager.reset_stack.assert_not_awaited()
+        state.clear.assert_awaited_once()
+
+    async def test_cmd_clear_handles_dialog_reset_failure_gracefully(self, mock_config):
+        """#1454: a failure inside reset_stack must NOT raise; it surfaces as a
+        partial-success message so the user knows to fall back to /start."""
+        bot, _ = _create_bot(mock_config)
+        bot._cache = MagicMock()
+        bot._cache.clear_conversation = AsyncMock()
+        message = _make_text_message()
+        dialog_manager = AsyncMock()
+        dialog_manager.has_context = MagicMock(return_value=True)
+        dialog_manager.reset_stack = AsyncMock(side_effect=RuntimeError("dialog stack corrupted"))
+        state = AsyncMock()
+
+        await bot.cmd_clear(message, state=state, dialog_manager=dialog_manager)
+
+        dialog_manager.reset_stack.assert_awaited_once()
+        message.answer.assert_awaited_once()
+        text = message.answer.await_args.args[0].lower()
+        assert "/start" in text or "состояния" in text or "диалога" in text
+
+    async def test_cmd_clear_works_without_state_or_manager(self, mock_config):
+        """Backward-compat: /clear must still work when state/dialog_manager are not injected."""
+        bot, _ = _create_bot(mock_config)
+        bot._cache = MagicMock()
+        bot._cache.clear_conversation = AsyncMock()
+        message = _make_text_message()
+
+        await bot.cmd_clear(message)
+
+        bot._cache.clear_conversation.assert_awaited_once_with(12345)
+        message.answer.assert_awaited_once()
+
     async def test_cmd_clear_falls_back_to_sync_delete_thread(self, mock_config):
         """Test /clear supports sync checkpointers exposing delete_thread only."""
 


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Closes #1454

`/clear` previously cleared conversation history (cache, checkpointers, Qdrant) but **did not exit the active aiogram-dialog stack or clear the FSM state**. After running `/clear` while inside `DemoSG.search`, the next free-text message was still routed to `demo-search` and returned apartment listings instead of the supervisor/RAG answer.

Reproduction (from issue, verified May 8, 2026 against `@home_bg_bot` on PR #1453 build):

1. Send `Подбери недорогую двухкомнатную квартиру в Свети Власе у моря`.
2. `/clear` → `✅ История диалога очищена.`
3. Send `Расскажи про недвижимость в Болгарии.`
4. **Bug:** bot replies `🔍 Ищу подходящие варианты...` + `Найдено N апартаментов...` (Langfuse traces tagged `demo-search`, `apartment-extraction-pipeline`). `/start` did reset the flow — confirming the fix scope.

## Fix

`telegram_bot/bot.py::PropertyBot.cmd_clear` now accepts `state: FSMContext | None` and `dialog_manager: Any | None` via aiogram dependency injection. Both default to `None` so existing tests / call sites continue to work.

Before clearing checkpointers and history, the handler:

1. Calls `dialog_manager.reset_stack(remove_keyboard=False)` if `has_context()` is `True`, dropping any open aiogram-dialog stack (DemoSG, CatalogSG, FunnelSG, etc.) without removing the chat composer.
2. Calls `state.clear()` to reset the FSM.
3. Catches exceptions from both — a corrupt dialog stack must not break `/clear`. Failures surface as a partial-success message pointing the user at `/start` as a fallback.

The downstream cache/checkpointer/history teardown is unchanged.

## Tests (4 new, all in `tests/unit/test_bot_handlers.py`)

```
tests/unit/test_bot_handlers.py::TestCommandHandlers
  test_cmd_clear_resets_active_dialog_stack             PASSED
  test_cmd_clear_clears_fsm_state_without_active_dialog PASSED
  test_cmd_clear_handles_dialog_reset_failure_gracefully PASSED
  test_cmd_clear_works_without_state_or_manager         PASSED  ← back-compat

15/15 cmd_clear tests pass.
201/201 tests/unit/test_bot_handlers.py pass — no regressions.
```

## Out of scope (intentionally)

- No new `/exit-demo` or sub-command — issue only asks that `/clear` either leaves demo apartment-search mode **or** exposes a separate exit. Reusing `/clear` keeps the surface area minimal and matches `/start` behaviour. Adding a dedicated `/exit-demo` UX command can be a follow-up.
- No `clear` button in dialogs — that's a UX-design call, separate ticket.
- No change to `/clearcache` (separate command, unaffected).

## Verification

```bash
uv run pytest tests/unit/test_bot_handlers.py -k cmd_clear -q
uv run pytest tests/unit/test_bot_handlers.py -q
```

Manual:
1. `make local-up`, run bot.
2. Trigger demo apartment search via `Подбери ...`.
3. Send `/clear`.
4. Send free-text `Расскажи про недвижимость в Болгарии.`.
5. Confirm Langfuse trace is tagged `agent,message,rag,telegram` (not `demo-search`).