### PR TITLE
chore(renovate): restrict livekit/livekit-server to semver release tags (#1339)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,17 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "livekit/livekit-server: prefer semver release tags (v<major>.<minor>...) over commit-SHA-like tags so compose.yml clearly identifies the deployed release. See #1339.",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "livekit/livekit-server"
+      ],
+      "allowedVersions": "/^v[0-9]+\\.[0-9]+(?:\\.[0-9]+)?(?:-[a-zA-Z0-9.-]+)?$/"
+    }
   ]
 }


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Closes #1339

Adds a packageRule that restricts `livekit/livekit-server` updates to semver release tags only. Renovate previously proposed `v95a5e3c` (a commit-SHA-style tag mapping to v1.10.1) in PR #1320 — the digest was correct, but `compose.yml` no longer carried the readable release version, making it hard for human reviewers to know which LiveKit release was deployed.

### Change

`renovate.json`:

```jsonc
"packageRules": [
  {
    "description": "livekit/livekit-server: prefer semver release tags (v<major>.<minor>...) over commit-SHA-like tags so compose.yml clearly identifies the deployed release. See #1339.",
    "matchDatasources": ["docker"],
    "matchPackageNames": ["livekit/livekit-server"],
    "allowedVersions": "/^v[0-9]+\\.[0-9]+(?:\\.[0-9]+)?(?:-[a-zA-Z0-9.-]+)?$/"
  }
]
```

The regex matches `v1.10.1`, `v1.10`, `v1.10.1-rc.1`, etc., but rejects `v95a5e3c`. Renovate-config validation: JSON parses cleanly (`python -c "import json; json.load(open('renovate.json'))"` exits 0).

### Verification

After merge, the next Renovate run on `livekit/livekit-server` will only consider semver-shaped tags. No runtime/code change.