### PR TITLE
test: narrow broad exception suppression that masked real failures (#1601)

### DIFF
--- a/tests/smoke/test_smoke_quantization.py
+++ b/tests/smoke/test_smoke_quantization.py
@@ -86,7 +86,14 @@ class TestSmokeQuantization:
         overlap = len(ids_with & ids_without) / max(len(ids_with), 1)
         assert overlap >= 0.6, f"Overlap {overlap:.0%} < 60%"
 
-    @pytest.mark.xfail(reason="Flaky timing comparison — depends on system load", strict=False)
+    @pytest.mark.skip(
+        reason=(
+            "Quantization latency comparison is timing-flaky on shared CI runners "
+            "and produced no actionable signal under xfail(strict=False). "
+            "Re-enable as a strict benchmark with a baseline + tolerance once a "
+            "dedicated benchmark host is available — see #1601 follow-up."
+        )
+    )
     async def test_quantization_latency_comparison(self, voyage_service, qdrant_service):
         """Measure latency with/without quantization (5 runs each, compare p95)."""
         embedding = await voyage_service.embed_query("апартаменты с бассейном")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -155,18 +155,16 @@ def isolate_otel_langfuse(monkeypatch):
         # symbol is provided by a sibling package, not the package itself).
         # Anything else (TypeError, ValueError, etc.) is a real isolation
         # bug we want to surface.
-        try:
+        with contextlib.suppress(ModuleNotFoundError, ImportError, AttributeError):
             p.start()
-        except (ModuleNotFoundError, ImportError, AttributeError):
-            pass
 
     yield
 
     for p in patches:
-        try:
+        # RuntimeError is raised by mock.patch when the start failed
+        # earlier and stop has no original to restore. AttributeError
+        # mirrors the start-time guard above.
+        with contextlib.suppress(
+            ModuleNotFoundError, ImportError, AttributeError, RuntimeError
+        ):
             p.stop()
-        except (ModuleNotFoundError, ImportError, AttributeError, RuntimeError):
-            # RuntimeError is raised by mock.patch when the start failed
-            # earlier and stop has no original to restore. AttributeError
-            # mirrors the start-time guard above.
-            pass

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,6 +1,5 @@
 """Unit test specific fixtures for isolation."""
 
-import contextlib
 import importlib.util
 import sys
 from unittest.mock import MagicMock, patch
@@ -149,11 +148,25 @@ def isolate_otel_langfuse(monkeypatch):
     ]
 
     for p in patches:
-        with contextlib.suppress(Exception):
+        # #1601: narrow suppression — only swallow expected optional-import
+        # failures (the patched module/class is intentionally missing in some
+        # envs) and lazy-attribute resolution misses (telegram_bot.services
+        # raises AttributeError from its lazy import handler when the target
+        # symbol is provided by a sibling package, not the package itself).
+        # Anything else (TypeError, ValueError, etc.) is a real isolation
+        # bug we want to surface.
+        try:
             p.start()
+        except (ModuleNotFoundError, ImportError, AttributeError):
+            pass
 
     yield
 
     for p in patches:
-        with contextlib.suppress(Exception):
+        try:
             p.stop()
+        except (ModuleNotFoundError, ImportError, AttributeError, RuntimeError):
+            # RuntimeError is raised by mock.patch when the start failed
+            # earlier and stop has no original to restore. AttributeError
+            # mirrors the start-time guard above.
+            pass

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,6 @@
 """Unit test specific fixtures for isolation."""
 
+import contextlib
 import importlib.util
 import sys
 from unittest.mock import MagicMock, patch
@@ -164,7 +165,5 @@ def isolate_otel_langfuse(monkeypatch):
         # RuntimeError is raised by mock.patch when the start failed
         # earlier and stop has no original to restore. AttributeError
         # mirrors the start-time guard above.
-        with contextlib.suppress(
-            ModuleNotFoundError, ImportError, AttributeError, RuntimeError
-        ):
+        with contextlib.suppress(ModuleNotFoundError, ImportError, AttributeError, RuntimeError):
             p.stop()

--- a/tests/unit/ingestion/test_cocoindex_init.py
+++ b/tests/unit/ingestion/test_cocoindex_init.py
@@ -1,7 +1,6 @@
 # tests/unit/ingestion/test_cocoindex_init.py
 """Tests for CocoIndex initialization."""
 
-import contextlib
 from unittest.mock import patch
 
 import pytest
@@ -49,8 +48,17 @@ class TestCocoIndexInit:
             collection_name="test_collection",
         )
 
-        with contextlib.suppress(Exception):
+        # #1601: narrow suppression — only swallow expected post-init failures
+        # caused by partially-mocked cocoindex flow construction. Anything else
+        # (e.g. AssertionError) is a real bug we want surfaced.
+        try:
             build_flow(config)
+        except (TypeError, AttributeError, RuntimeError, ValueError) as exc:
+            # build_flow reached cocoindex.init and only then tripped on the
+            # next mocked-out symbol — that is exactly what this unit asserts.
+            assert mock_init.called, (
+                f"cocoindex.init was not invoked before build_flow raised: {exc!r}"
+            )
 
         # Verify init was called
         assert mock_init.called


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Closes #1601

Three masking patterns identified by the 2026-05-19 audit, all narrowed in this PR.

### 1. `tests/unit/conftest.py` — `isolate_otel_langfuse` autouse fixture

**Before:** `contextlib.suppress(Exception)` around every `p.start()` and `p.stop()`. Any unexpected patch failure (`TypeError`, `ValueError`, …) silently leaked real telemetry/network code into unit tests.

**After:** narrow to `(ModuleNotFoundError, ImportError, AttributeError)` on start, plus `RuntimeError` on stop. Each guard has a comment explaining why it's expected:
- `ModuleNotFoundError`/`ImportError` — patched module is intentionally missing in some envs.
- `AttributeError` — `telegram_bot.services.__init__` raises from its lazy-import `__getattr__` when a sibling-provided symbol is being patched (verified by re-running the affected test set).
- `RuntimeError` (stop only) — `mock.patch` raises this when the start silently failed and there is no original to restore.

Anything else now propagates and fails the test.

### 2. `tests/unit/ingestion/test_cocoindex_init.py::test_build_flow_calls_init_with_settings`

**Before:** `with contextlib.suppress(Exception): build_flow(config)` followed by `assert mock_init.called`. A real failure inside `build_flow` (after `cocoindex.init`) could be masked.

**After:** narrow to `(TypeError, AttributeError, RuntimeError, ValueError)` and add an inline `assert mock_init.called` *inside* the except branch — making the unit's actual contract (init invoked with the correct settings) explicit. `AssertionError` and other unexpected exceptions now propagate.

### 3. `tests/smoke/test_smoke_quantization.py::test_quantization_latency_comparison`

**Before:** `@pytest.mark.xfail(reason="Flaky timing comparison — depends on system load", strict=False)`. XPASS produced no signal; the failure stayed expected indefinitely.

**After:** `@pytest.mark.skip` with a reason that points at #1601 follow-up: re-enable as a strict benchmark with a baseline + tolerance once a dedicated benchmark host is available. `xfail(strict=False)` on a flaky timing comparison is exactly the no-signal pattern the issue calls out.

### Tests

```
$ pytest tests/unit/services/test_query_analyzer.py tests/unit/observability/ tests/unit/mini_app/ -q
..............................................................   [100%]
206 passed in 4.87s
```

`tests/unit/ingestion/test_cocoindex_init.py` is gated by `pytest.importorskip("cocoindex")` and remains skipped without the ingest extra installed; the narrowed exception list still covers the same partial-mock failure modes when the extra is present.

### Stylistic follow-up

Initial ruff run flagged `SIM105` on the new try/except/pass block. Last commit converts to `contextlib.suppress(...)` with the same narrow exception tuple — behaviour unchanged, lint clean.

### Out of scope

- Audit-level review of every other broad `except Exception` in the test tree (epic #1515 territory).
- Replacing the cocoindex partial-mock with a fully-mocked `build_flow` happy path — would require a deeper refactor of `src.ingestion.unified.flow` test scaffolding; tracked separately if it becomes painful.

Refs #1601 #1515.