### PR TITLE
feat(observability): link Langfuse Prompts to generations (#1666)

### DIFF
--- a/telegram_bot/integrations/prompt_manager.py
+++ b/telegram_bot/integrations/prompt_manager.py
@@ -59,7 +59,35 @@ def get_prompt_with_config(
         Tuple of (compiled_prompt_text, config_dict).
         Returns empty dict for config when using fallback.
     """
-    return _fetch_prompt_core(name, fallback=fallback, cache_ttl=cache_ttl, variables=variables)
+    text, config, _ = _fetch_prompt_core(
+        name, fallback=fallback, cache_ttl=cache_ttl, variables=variables
+    )
+    return text, config
+
+
+def get_prompt_with_object(
+    name: str,
+    *,
+    fallback: str,
+    cache_ttl: int = DEFAULT_CACHE_TTL,
+    variables: dict[str, str] | None = None,
+) -> tuple[str, Any | None]:
+    """Return ``(compiled_prompt_string, raw_prompt_object_or_None)``.
+
+    The raw Prompt object is ``None`` when Langfuse is unavailable or the
+    prompt was loaded from the fallback. Callers can pass it as
+    ``langfuse_prompt=<prompt_obj>`` to ``chat.completions.create(...)`` on a
+    ``langfuse.openai`` client, or as ``prompt=<prompt_obj>`` to
+    ``langfuse.update_current_generation(...)`` for non-OpenAI providers.
+
+    Only managed Langfuse Prompt objects are linkable — fallback strings are
+    intentionally returned with ``None`` so callers can guard with
+    ``if prompt_obj is not None``.
+    """
+    text, _, prompt_obj = _fetch_prompt_core(
+        name, fallback=fallback, cache_ttl=cache_ttl, variables=variables
+    )
+    return text, prompt_obj
 
 
 @observe(name="get-prompt", capture_input=False, capture_output=False)
@@ -81,7 +109,9 @@ def get_prompt(
     Returns:
         Compiled prompt string from Langfuse, or the fallback.
     """
-    text, _ = _fetch_prompt_core(name, fallback=fallback, cache_ttl=cache_ttl, variables=variables)
+    text, _, _ = _fetch_prompt_core(
+        name, fallback=fallback, cache_ttl=cache_ttl, variables=variables
+    )
     return text
 
 
@@ -91,17 +121,22 @@ def _fetch_prompt_core(
     fallback: str,
     cache_ttl: int,
     variables: dict[str, str] | None = None,
-) -> tuple[str, dict[str, Any]]:
-    """Core prompt fetcher returning (text, config) tuple."""
+) -> tuple[str, dict[str, Any], Any | None]:
+    """Core prompt fetcher returning ``(text, config, prompt_obj_or_None)``.
+
+    ``prompt_obj`` is the raw Langfuse Prompt object (with ``.compile()``,
+    ``.version``, ``.config`` attributes) when fetched successfully; ``None``
+    otherwise (Langfuse unavailable, missing prompt, transient failure).
+    """
     vars_ = variables or {}
 
-    def _fallback_result() -> tuple[str, dict[str, Any]]:
+    def _fallback_result() -> tuple[str, dict[str, Any], Any | None]:
         _update_prompt_span_output(client, name=name, source="fallback")
-        return _apply_fallback_vars(fallback, vars_), {}
+        return _apply_fallback_vars(fallback, vars_), {}, None
 
     client = get_client()
     if client is None:
-        return _apply_fallback_vars(fallback, vars_), {}
+        return _apply_fallback_vars(fallback, vars_), {}, None
 
     if _is_temporarily_missing(name) or _is_transient_failure(name):
         return _fallback_result()
@@ -122,8 +157,8 @@ def _fetch_prompt_core(
             prompt_version=getattr(prompt, "version", None),
         )
         if vars_:
-            return str(prompt.compile(**vars_)), config
-        return str(prompt.compile()), config
+            return str(prompt.compile(**vars_)), config, prompt
+        return str(prompt.compile()), config, prompt
     except Exception as e:
         if _is_prompt_not_found(e):
             _missing_prompts_until[name] = time.monotonic() + cache_ttl

--- a/telegram_bot/services/apartment_llm_extractor.py
+++ b/telegram_bot/services/apartment_llm_extractor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import warnings
 from typing import Any, cast
@@ -9,8 +10,8 @@ from typing import Any, cast
 import instructor
 from openai import AsyncOpenAI
 
-from telegram_bot.integrations.prompt_manager import get_prompt
-from telegram_bot.observability import observe
+from telegram_bot.integrations.prompt_manager import get_prompt, get_prompt_with_object
+from telegram_bot.observability import get_client, observe
 from telegram_bot.services.apartment_models import (
     ApartmentSearchFilters,
     HardFilters,
@@ -52,6 +53,23 @@ def _get_system_prompt() -> str:
     Falls back to EXTRACTION_SYSTEM_PROMPT when Langfuse is unavailable.
     """
     return get_prompt(
+        "apartment-extraction-system-prompt",
+        fallback=EXTRACTION_SYSTEM_PROMPT,
+    )
+
+
+def _get_system_prompt_with_object() -> tuple[str, Any | None]:
+    """Fetch system prompt + raw Langfuse Prompt object for #1666 linking.
+
+    Returns the same compiled string as ``_get_system_prompt`` plus the raw
+    Langfuse Prompt object (``None`` if Langfuse is unavailable / fallback
+    was used). Callers can pass the object to
+    ``langfuse.update_current_generation(prompt=...)`` to link the generation
+    observation to a Prompt Management entry. Only managed Langfuse Prompt
+    objects are linkable — fallback strings are intentionally returned with
+    ``None`` so callers can guard with ``if prompt_obj is not None``.
+    """
+    return get_prompt_with_object(
         "apartment-extraction-system-prompt",
         fallback=EXTRACTION_SYSTEM_PROMPT,
     )
@@ -113,8 +131,19 @@ class ApartmentLlmExtractor:
                 context = f"\nУже извлечено regex: {filled}\nДоизвлеки остальное."
 
         source = "hybrid" if partial_filters else "llm"
+
+        # Fetch the prompt + raw Prompt object so we can link the generation
+        # observation to Prompt Management (#1666). The underlying client is
+        # plain `openai.AsyncOpenAI` (not `langfuse.openai`) so the
+        # `langfuse_prompt=` kwarg path is not available; we use the
+        # `update_current_generation(prompt=...)` secondary path instead.
+        system_prompt, prompt_obj = _get_system_prompt_with_object()
+        if prompt_obj is not None:
+            with contextlib.suppress(Exception):
+                get_client().update_current_generation(prompt=prompt_obj)
+
         messages = [
-            {"role": "system", "content": _get_system_prompt() + context},
+            {"role": "system", "content": system_prompt + context},
             {"role": "user", "content": query},
         ]
 

--- a/telegram_bot/services/generate_response.py
+++ b/telegram_bot/services/generate_response.py
@@ -286,6 +286,20 @@ def _extract_usage_details(usage: Any | None) -> dict[str, int] | None:
     return details or None
 
 
+def _update_current_span(lf_client: Any | None, **kwargs: Any) -> None:
+    """Update the current Langfuse span when tracing is available."""
+    if lf_client is not None:
+        with contextlib.suppress(Exception):
+            lf_client.update_current_span(**kwargs)
+
+
+def _update_current_generation(lf_client: Any | None, **kwargs: Any) -> None:
+    """Update the current Langfuse generation when tracing is available."""
+    if lf_client is not None:
+        with contextlib.suppress(Exception):
+            lf_client.update_current_generation(**kwargs)
+
+
 def _select_recent_history(
     messages: list[Any], max_messages: int = _MAX_HISTORY_MESSAGES
 ) -> list[Any]:
@@ -338,7 +352,7 @@ async def _chat_create_with_optional_name(
         # Plain client created via GraphConfig.create_llm(auto_trace=False).
         # Skip both Langfuse-specific kwargs to avoid a needless TypeError →
         # retry round-trip on every call. Generation linking for these clients
-        # happens via lf_client.update_current_generation(prompt=...) in caller.
+        # happens via _update_current_generation(lf_client, prompt=...) in caller.
         kwargs.pop("langfuse_prompt", None)
         return await create_fn(**kwargs)
     try:
@@ -443,8 +457,8 @@ async def _generate_streaming(
                     stream_only_ttft_ms = (first_token_at - t_stream_start) * 1000
                     if lf_client is not None:
                         with contextlib.suppress(Exception):
-                            lf_client.update_current_generation(
-                                completion_start_time=datetime.now(UTC)
+                            _update_current_generation(
+                                lf_client, completion_start_time=datetime.now(UTC)
                             )
                 accumulated += text
                 now = time.monotonic()
@@ -598,7 +612,8 @@ async def generate_response(
         context = format_context(docs, effective_max_context_docs)
 
     # Curated span metadata
-    lf_client.update_current_span(
+    _update_current_span(
+        lf_client,
         input={
             "query_preview": effective_query[:120],
             "query_len": len(effective_query),
@@ -608,7 +623,7 @@ async def generate_response(
             "grounding_mode": grounding_mode,
             "needs_coverage": needs_coverage,
             "coverage_reason": coverage_reason,
-        }
+        },
     )
 
     if should_safe_fallback(
@@ -622,7 +637,8 @@ async def generate_response(
         PipelineMetrics.get().record("generate", elapsed * 1000)
         answer = build_safe_fallback_response(docs)
         current_latency = latency_stages or {}
-        lf_client.update_current_span(
+        _update_current_span(
+            lf_client,
             output={
                 "response_length": len(answer),
                 "llm_provider_model": "safe_fallback",
@@ -633,7 +649,7 @@ async def generate_response(
                 "needs_coverage": needs_coverage,
                 "coverage_mode": "exhaustive_list" if needs_coverage else "default",
                 "coverage_reason": coverage_reason,
-            }
+            },
         )
         return _ensure_generation_signal_defaults(
             {
@@ -960,7 +976,8 @@ async def generate_response(
                 )
     except Exception as e:
         logger.exception("generate_response: LLM call failed, using fallback")
-        lf_client.update_current_span(
+        _update_current_span(
+            lf_client,
             level="ERROR",
             status_message=f"LLM failed: {str(e)[:200]}",
         )
@@ -986,7 +1003,7 @@ async def generate_response(
             # (auto_trace=False) where the kwarg is stripped by the helper.
             generation_payload["prompt"] = prompt_obj
         with contextlib.suppress(Exception):
-            lf_client.update_current_generation(**generation_payload)
+            _update_current_generation(lf_client, **generation_payload)
 
     # Build eval context for managed evaluators (#386)
     retrieved_ctx = retrieved_context or []
@@ -1033,7 +1050,7 @@ async def generate_response(
                 "completion_tokens": getattr(usage, "completion_tokens", None),
                 "total_tokens": getattr(usage, "total_tokens", None),
             }
-    lf_client.update_current_span(output=span_output)
+    _update_current_span(lf_client, output=span_output)
 
     # --- Latency breakdown (#147) ---
     streaming_was_enabled = bool(message is not None and config.streaming_enabled)
@@ -1061,7 +1078,8 @@ async def generate_response(
             _drift_warn_threshold = 500
         if llm_ttft_drift_ms > _drift_warn_threshold:
             with contextlib.suppress(Exception):
-                lf_client.update_current_span(
+                _update_current_span(
+                    lf_client,
                     level="WARNING",
                     status_message=(
                         f"TTFT drift detected: {llm_ttft_drift_ms:.1f}ms "

--- a/telegram_bot/services/generate_response.py
+++ b/telegram_bot/services/generate_response.py
@@ -12,7 +12,11 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any
 
-from telegram_bot.integrations.prompt_manager import get_prompt, get_prompt_with_config
+from telegram_bot.integrations.prompt_manager import (
+    get_prompt,
+    get_prompt_with_config,
+    get_prompt_with_object,
+)
 from telegram_bot.integrations.prompt_templates import (
     build_system_prompt_with_manager,
     get_token_limit,
@@ -132,6 +136,19 @@ def _build_system_prompt_with_config(domain: str) -> tuple[str, dict[str, Any]]:
     return get_prompt_with_config(
         "generate", fallback=_GENERATE_FALLBACK, variables={"domain": domain}
     )
+
+
+def _get_linkable_prompt_object(name: str, fallback: str, variables: dict[str, str]) -> Any | None:
+    """Return the raw Langfuse Prompt object (or None) for #1666 generation linking.
+
+    Companion to ``get_prompt_with_config``: fetches the same prompt and returns
+    only the raw object suitable for ``langfuse_prompt=`` linking. Langfuse's
+    SDK internal cache (cache_ttl_seconds) deduplicates the underlying network
+    call, so this is effectively free when called immediately after
+    ``get_prompt_with_config`` for the same name.
+    """
+    _, prompt_obj = get_prompt_with_object(name, fallback=fallback, variables=variables)
+    return prompt_obj
 
 
 def _format_context(documents: list[dict[str, Any]], max_docs: int = _MAX_CONTEXT_DOCS) -> str:
@@ -298,6 +315,12 @@ def _is_unsupported_name_kwarg(exc: TypeError) -> bool:
     return "unexpected keyword argument" in message and "'name'" in message
 
 
+def _is_unsupported_langfuse_prompt_kwarg(exc: TypeError) -> bool:
+    """Return True if client rejected Langfuse-specific `langfuse_prompt` kwarg."""
+    message = str(exc)
+    return "unexpected keyword argument" in message and "'langfuse_prompt'" in message
+
+
 async def _chat_create_with_optional_name(
     llm: Any,
     *,
@@ -306,21 +329,35 @@ async def _chat_create_with_optional_name(
 ) -> Any:
     """Call chat.completions.create with Langfuse `name` when supported.
 
-    Some clients (plain OpenAI SDK) reject `name` as an unexpected kwarg.
-    Langfuse-wrapped clients accept it and use it for generation naming.
+    Some clients (plain OpenAI SDK) reject `name` and `langfuse_prompt` as
+    unexpected kwargs. Langfuse-wrapped clients accept them and use them for
+    generation naming and Prompt Management linking (#1666) respectively.
     """
     create_fn = llm.chat.completions.create
     if getattr(llm, "_langfuse_auto_trace", True) is False:
         # Plain client created via GraphConfig.create_llm(auto_trace=False).
-        # Skip the Langfuse ``name`` kwarg entirely to avoid a needless
-        # TypeError → retry round-trip on every call.
+        # Skip both Langfuse-specific kwargs to avoid a needless TypeError →
+        # retry round-trip on every call. Generation linking for these clients
+        # happens via lf_client.update_current_generation(prompt=...) in caller.
+        kwargs.pop("langfuse_prompt", None)
         return await create_fn(**kwargs)
     try:
         return await create_fn(name=observation_name, **kwargs)
     except TypeError as exc:
+        if _is_unsupported_langfuse_prompt_kwarg(exc):
+            logger.debug("LLM client does not support `langfuse_prompt`; retrying without it")
+            kwargs.pop("langfuse_prompt", None)
+            try:
+                return await create_fn(name=observation_name, **kwargs)
+            except TypeError as exc2:
+                if not _is_unsupported_name_kwarg(exc2):
+                    raise
+                logger.debug("LLM client does not support `name`; retrying without it")
+                return await create_fn(**kwargs)
         if not _is_unsupported_name_kwarg(exc):
             raise
         logger.debug("LLM client does not support `name`; retrying without it")
+        kwargs.pop("langfuse_prompt", None)
         return await create_fn(**kwargs)
 
 
@@ -333,6 +370,7 @@ async def _generate_streaming(
     lf_client: Any | None = None,
     temperature: float = 0.7,
     sanitize_response: Callable[[str], str] | None = None,
+    langfuse_prompt: Any | None = None,
 ) -> tuple[str, str, float, float | None, float | None, dict[str, int] | None, Any]:
     """Stream LLM response to Telegram via native sendMessageDraft (Bot API 9.5).
 
@@ -353,16 +391,23 @@ async def _generate_streaming(
 
     t_request_start = time.monotonic()
 
+    stream_create_kwargs: dict[str, Any] = {
+        "model": config.llm_model,
+        "messages": llm_messages,
+        "temperature": temperature,
+        "max_tokens": effective_max_tokens,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        **config.get_reasoning_kwargs(),
+    }
+    if langfuse_prompt is not None:
+        # Link the streamed generation to its Langfuse Prompt entry (#1666).
+        stream_create_kwargs["langfuse_prompt"] = langfuse_prompt
+
     stream = await _chat_create_with_optional_name(
         llm,
         observation_name="generate-answer",
-        model=config.llm_model,
-        messages=llm_messages,
-        temperature=temperature,
-        max_tokens=effective_max_tokens,
-        stream=True,
-        stream_options={"include_usage": True},
-        **config.get_reasoning_kwargs(),
+        **stream_create_kwargs,
     )
 
     t_stream_start = time.monotonic()
@@ -630,9 +675,15 @@ async def generate_response(
 
     prompt_config: dict[str, Any] = {}
     prompt_name = "generate"
+    prompt_obj: Any | None = None
     use_style = False
     if needs_coverage:
         system_prompt, prompt_config = get_prompt_with_config(
+            "generate_exhaustive_list",
+            fallback=_EXHAUSTIVE_GENERATE_FALLBACK,
+            variables={"domain": config.domain},
+        )
+        prompt_obj = _get_linkable_prompt_object(
             "generate_exhaustive_list",
             fallback=_EXHAUSTIVE_GENERATE_FALLBACK,
             variables={"domain": config.domain},
@@ -660,8 +711,14 @@ async def generate_response(
         style_budget = style_token_limit(style_info.style, style_info.difficulty)
         system_prompt = style_system_prompt
         max_tokens = min(style_budget, legacy_max_tokens)
+        # Style-mode prompts are built from internal templates, not Langfuse
+        # Prompt Management — there is no linkable Prompt object.
+        prompt_obj = None
     else:
         system_prompt, prompt_config = _build_system_prompt_with_config(config.domain)
+        prompt_obj = _get_linkable_prompt_object(
+            "generate", fallback=_GENERATE_FALLBACK, variables={"domain": config.domain}
+        )
         # Langfuse prompt config overrides: temperature, max_tokens editable in UI
         if "max_tokens" in prompt_config:
             max_tokens = min(int(prompt_config["max_tokens"]), legacy_max_tokens)
@@ -721,6 +778,9 @@ async def generate_response(
                         text,
                         sources_enabled=sources_enabled,
                     )
+                if "langfuse_prompt" in params and prompt_obj is not None:
+                    # Link streamed generation to Langfuse Prompt entry (#1666).
+                    stream_kwargs["langfuse_prompt"] = prompt_obj
                 stream_result = await generate_streaming(
                     llm,
                     config,
@@ -770,14 +830,19 @@ async def generate_response(
                     )
                     sent_msg = getattr(stream_exc, "sent_msg", None)
                     t_llm_start = time.monotonic()
+                    create_kwargs: dict[str, Any] = {
+                        "model": config.llm_model,
+                        "messages": llm_messages,
+                        "temperature": effective_temperature,
+                        "max_tokens": max_tokens,
+                        **config.get_reasoning_kwargs(),
+                    }
+                    if prompt_obj is not None:
+                        create_kwargs["langfuse_prompt"] = prompt_obj
                     response_obj = await _chat_create_with_optional_name(
                         llm,
                         observation_name="generate-answer",
-                        model=config.llm_model,
-                        messages=llm_messages,
-                        temperature=effective_temperature,
-                        max_tokens=max_tokens,
-                        **config.get_reasoning_kwargs(),
+                        **create_kwargs,
                     )
                     t_llm_end = time.monotonic()
                     answer = response_obj.choices[0].message.content or ""
@@ -835,14 +900,19 @@ async def generate_response(
                     # Recovery path succeeded below; keep normal-success span level.
                     # Degraded mode is tracked via llm_stream_recovery=True.
                     t_llm_start = time.monotonic()
+                    create_kwargs = {
+                        "model": config.llm_model,
+                        "messages": llm_messages,
+                        "temperature": effective_temperature,
+                        "max_tokens": max_tokens,
+                        **config.get_reasoning_kwargs(),
+                    }
+                    if prompt_obj is not None:
+                        create_kwargs["langfuse_prompt"] = prompt_obj
                     response_obj = await _chat_create_with_optional_name(
                         llm,
                         observation_name="generate-answer",
-                        model=config.llm_model,
-                        messages=llm_messages,
-                        temperature=effective_temperature,
-                        max_tokens=max_tokens,
-                        **config.get_reasoning_kwargs(),
+                        **create_kwargs,
                     )
                     t_llm_end = time.monotonic()
                     answer = response_obj.choices[0].message.content or ""
@@ -861,14 +931,20 @@ async def generate_response(
         else:
             # Non-streaming path
             t_llm_start = time.monotonic()
+            create_kwargs = {
+                "model": config.llm_model,
+                "messages": llm_messages,
+                "temperature": effective_temperature,
+                "max_tokens": max_tokens,
+                **config.get_reasoning_kwargs(),
+            }
+            if prompt_obj is not None:
+                # Link the generation observation to its Langfuse Prompt entry (#1666).
+                create_kwargs["langfuse_prompt"] = prompt_obj
             response_obj = await _chat_create_with_optional_name(
                 llm,
                 observation_name="generate-answer",
-                model=config.llm_model,
-                messages=llm_messages,
-                temperature=effective_temperature,
-                max_tokens=max_tokens,
-                **config.get_reasoning_kwargs(),
+                **create_kwargs,
             )
             t_llm_end = time.monotonic()
             answer = response_obj.choices[0].message.content or ""
@@ -903,6 +979,12 @@ async def generate_response(
             generation_payload["usage_details"] = usage_details
         elif completion_tokens is not None:
             generation_payload["usage_details"] = {"output": int(completion_tokens)}
+        if prompt_obj is not None:
+            # Link the generation observation to its Langfuse Prompt entry (#1666).
+            # Belt-and-braces: redundant with the langfuse_prompt= kwarg above for
+            # langfuse.openai-wrapped clients, but required for plain OpenAI clients
+            # (auto_trace=False) where the kwarg is stripped by the helper.
+            generation_payload["prompt"] = prompt_obj
         with contextlib.suppress(Exception):
             lf_client.update_current_generation(**generation_payload)
 

--- a/telegram_bot/services/query_analyzer.py
+++ b/telegram_bot/services/query_analyzer.py
@@ -12,8 +12,8 @@ import openai
 from langfuse.openai import AsyncOpenAI
 from pydantic import BaseModel, Field
 
-from telegram_bot.observability import get_client, observe
 from telegram_bot.integrations.prompt_manager import get_prompt_with_object
+from telegram_bot.observability import get_client, observe
 
 
 logger = logging.getLogger(__name__)

--- a/telegram_bot/services/query_analyzer.py
+++ b/telegram_bot/services/query_analyzer.py
@@ -12,8 +12,8 @@ import openai
 from langfuse.openai import AsyncOpenAI
 from pydantic import BaseModel, Field
 
-from telegram_bot.integrations.prompt_manager import get_prompt
 from telegram_bot.observability import get_client, observe
+from telegram_bot.integrations.prompt_manager import get_prompt_with_object
 
 
 logger = logging.getLogger(__name__)
@@ -134,18 +134,28 @@ class QueryAnalyzer:
                 }
             )
         try:
-            system_prompt = get_prompt("query-analysis", fallback=SYSTEM_PROMPT)
-            result = await self._instructor_client.chat.completions.create(
-                model=self.model,
-                messages=[
+            system_prompt, prompt_obj = get_prompt_with_object(
+                "query-analysis", fallback=SYSTEM_PROMPT
+            )
+            create_kwargs: dict[str, Any] = {
+                "model": self.model,
+                "messages": [
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": f"Запрос пользователя: {query}"},
                 ],
-                response_model=QueryAnalysisResult,
-                max_retries=2,
-                temperature=0.0,
-                max_tokens=1000,
-                name="query-analysis",  # type: ignore[call-overload]  # langfuse kwarg
+                "response_model": QueryAnalysisResult,
+                "max_retries": 2,
+                "temperature": 0.0,
+                "max_tokens": 1000,
+                "name": "query-analysis",  # langfuse kwarg
+            }
+            if prompt_obj is not None:
+                # Link generation observation to its Langfuse Prompt entry (#1666).
+                # Instructor preserves the langfuse.openai wrap, so the kwarg is
+                # forwarded to the underlying create() call (verified in #1681 preflight).
+                create_kwargs["langfuse_prompt"] = prompt_obj
+            result = await self._instructor_client.chat.completions.create(  # type: ignore[call-overload]
+                **create_kwargs,
             )
 
             filters = result.filters

--- a/telegram_bot/services/query_preprocessor.py
+++ b/telegram_bot/services/query_preprocessor.py
@@ -11,8 +11,8 @@ from typing import Any
 import openai
 from langfuse.openai import AsyncOpenAI
 
-from telegram_bot.integrations.prompt_manager import get_prompt
 from telegram_bot.observability import get_client, observe
+from telegram_bot.integrations.prompt_manager import get_prompt_with_object
 
 
 logger = logging.getLogger(__name__)
@@ -110,16 +110,24 @@ class HyDEGenerator:
         )
 
         try:
-            system_prompt = get_prompt("hyde", fallback=self.HYDE_SYSTEM_PROMPT)
-            response = await self.client.chat.completions.create(
-                model=self.model,
-                messages=[
+            system_prompt, prompt_obj = get_prompt_with_object(
+                "hyde", fallback=self.HYDE_SYSTEM_PROMPT
+            )
+            create_kwargs: dict[str, Any] = {
+                "model": self.model,
+                "messages": [
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": query},
                 ],
-                temperature=0.7,
-                max_tokens=200,
-                name="hyde-generate",  # type: ignore[call-overload]  # langfuse kwarg
+                "temperature": 0.7,
+                "max_tokens": 200,
+                "name": "hyde-generate",  # langfuse kwarg
+            }
+            if prompt_obj is not None:
+                # Link generation observation to its Langfuse Prompt entry (#1666).
+                create_kwargs["langfuse_prompt"] = prompt_obj
+            response = await self.client.chat.completions.create(  # type: ignore[call-overload]
+                **create_kwargs,
             )
 
             hypothetical_doc = response.choices[0].message.content or query

--- a/telegram_bot/services/query_preprocessor.py
+++ b/telegram_bot/services/query_preprocessor.py
@@ -11,8 +11,8 @@ from typing import Any
 import openai
 from langfuse.openai import AsyncOpenAI
 
-from telegram_bot.observability import get_client, observe
 from telegram_bot.integrations.prompt_manager import get_prompt_with_object
+from telegram_bot.observability import get_client, observe
 
 
 logger = logging.getLogger(__name__)

--- a/tests/unit/integrations/test_prompt_manager.py
+++ b/tests/unit/integrations/test_prompt_manager.py
@@ -306,3 +306,110 @@ class TestResetClient:
         _transient_failures_until["some-prompt"] = 9999999999.0
         _reset_client()
         assert "some-prompt" not in _transient_failures_until
+
+
+
+# ---------------------------------------------------------------------------
+# get_prompt_with_object — exposes raw Langfuse Prompt object alongside text
+# (#1666: Link Prompt Management entries to LLM generations)
+# ---------------------------------------------------------------------------
+
+
+from telegram_bot.integrations.prompt_manager import get_prompt_with_object
+
+
+class TestGetPromptWithObject:
+    """Tests for get_prompt_with_object — returns (compiled_text, raw_prompt_or_None)."""
+
+    def test_returns_prompt_object_when_langfuse_succeeds(self):
+        """When Langfuse is available and prompt is found, returns the raw Prompt object."""
+        mock_prompt = MagicMock()
+        mock_prompt.compile.return_value = "Langfuse prompt text"
+        mock_prompt.version = 5
+        mock_client = MagicMock()
+        mock_client.get_prompt.return_value = mock_prompt
+
+        with patch("telegram_bot.integrations.prompt_manager.get_client", return_value=mock_client):
+            text, prompt_obj = get_prompt_with_object("my-prompt", fallback="fallback")
+
+        assert text == "Langfuse prompt text"
+        assert prompt_obj is mock_prompt
+        mock_client.get_prompt.assert_called_once_with(
+            "my-prompt", cache_ttl_seconds=DEFAULT_CACHE_TTL
+        )
+
+    def test_returns_none_object_when_langfuse_client_unavailable(self):
+        """When Langfuse client is None (disabled), returns fallback string with None object."""
+        with patch("telegram_bot.integrations.prompt_manager.get_client", return_value=None):
+            text, prompt_obj = get_prompt_with_object("my-prompt", fallback="fallback text")
+
+        assert text == "fallback text"
+        assert prompt_obj is None
+
+    def test_returns_none_object_when_prompt_not_found(self):
+        """When Langfuse returns 404, returns fallback string with None object."""
+        mock_client = MagicMock()
+        mock_client.get_prompt.side_effect = Exception(
+            "status_code: 404, body: {'message': \"Prompt not found: 'my-prompt'\"}"
+        )
+
+        with patch("telegram_bot.integrations.prompt_manager.get_client", return_value=mock_client):
+            text, prompt_obj = get_prompt_with_object("my-prompt", fallback="fallback text")
+
+        assert text == "fallback text"
+        assert prompt_obj is None
+
+    def test_returns_none_object_on_transient_failure(self):
+        """When Langfuse raises a transient error, returns fallback with None object."""
+        mock_client = MagicMock()
+        mock_client.get_prompt.side_effect = Exception("[Errno 111] Connection refused")
+
+        with patch("telegram_bot.integrations.prompt_manager.get_client", return_value=mock_client):
+            text, prompt_obj = get_prompt_with_object("my-prompt", fallback="fallback")
+
+        assert text == "fallback"
+        assert prompt_obj is None
+
+    def test_compiles_with_variables_and_returns_prompt_object(self):
+        """Variables are passed to prompt.compile and the raw object is still returned."""
+        mock_prompt = MagicMock()
+        mock_prompt.compile.return_value = "Ассистент по недвижимость"
+        mock_client = MagicMock()
+        mock_client.get_prompt.return_value = mock_prompt
+
+        with patch("telegram_bot.integrations.prompt_manager.get_client", return_value=mock_client):
+            text, prompt_obj = get_prompt_with_object(
+                "generate",
+                fallback="Ассистент по {{domain}}",
+                variables={"domain": "недвижимость"},
+            )
+
+        assert text == "Ассистент по недвижимость"
+        assert prompt_obj is mock_prompt
+        mock_prompt.compile.assert_called_once_with(domain="недвижимость")
+
+    def test_fallback_with_variables_returns_compiled_fallback_and_none(self):
+        """When falling back, fallback {{var}} placeholders are still substituted."""
+        with patch("telegram_bot.integrations.prompt_manager.get_client", return_value=None):
+            text, prompt_obj = get_prompt_with_object(
+                "generate",
+                fallback="Hello {{name}}",
+                variables={"name": "World"},
+            )
+
+        assert text == "Hello World"
+        assert prompt_obj is None
+
+    def test_does_not_break_existing_get_prompt_contract(self):
+        """get_prompt() still returns a plain string — no breaking change."""
+        mock_prompt = MagicMock()
+        mock_prompt.compile.return_value = "compiled"
+        mock_client = MagicMock()
+        mock_client.get_prompt.return_value = mock_prompt
+
+        with patch("telegram_bot.integrations.prompt_manager.get_client", return_value=mock_client):
+            result = get_prompt("my-prompt", fallback="fallback")
+
+        # Must still be a plain string, not a tuple — backwards-compat guard.
+        assert isinstance(result, str)
+        assert result == "compiled"

--- a/tests/unit/integrations/test_prompt_manager.py
+++ b/tests/unit/integrations/test_prompt_manager.py
@@ -308,7 +308,6 @@ class TestResetClient:
         assert "some-prompt" not in _transient_failures_until
 
 
-
 # ---------------------------------------------------------------------------
 # get_prompt_with_object — exposes raw Langfuse Prompt object alongside text
 # (#1666: Link Prompt Management entries to LLM generations)

--- a/tests/unit/services/test_apartment_llm_extractor.py
+++ b/tests/unit/services/test_apartment_llm_extractor.py
@@ -175,3 +175,137 @@ class TestGetSystemPrompt:
     def test_system_prompt_forbids_null_view_tags(self) -> None:
         assert "view_tags=[]" in EXTRACTION_SYSTEM_PROMPT
         assert "Никогда не возвращай null для массивов" in EXTRACTION_SYSTEM_PROMPT
+
+
+
+class TestApartmentExtractorPromptLinking:
+    """Tests for #1666 — Langfuse Prompt → generation linking on extract().
+
+    Contract: ``ApartmentLlmExtractor.extract`` is decorated with @observe;
+    the underlying client is plain ``openai.AsyncOpenAI`` (not
+    ``langfuse.openai``), so the SECONDARY prompt-linking path applies:
+    fetch the raw Langfuse Prompt object via ``get_prompt_with_object`` and
+    pass it to ``langfuse.update_current_generation(prompt=...)`` inside
+    the @observe-wrapped method.
+
+    Forbidden by #1666:
+    - Do not link a fallback string as a managed prompt (guard with
+      ``if prompt_obj is not None``).
+    - Do not break existing ``_get_system_prompt`` callers.
+    """
+
+    @pytest.fixture
+    def mock_extractor(self) -> ApartmentLlmExtractor:
+        from openai import AsyncOpenAI
+
+        client = AsyncOpenAI(api_key="test-key", base_url="http://test:4000")
+        return ApartmentLlmExtractor(client, model="test-model")
+
+    @pytest.fixture
+    def mock_llm_result_simple(self) -> ApartmentSearchFilters:
+        return ApartmentSearchFilters(
+            hard=HardFilters(city="Солнечный берег", rooms=2),
+            soft=SoftPreferences(),
+            meta=ExtractionMeta(source="llm", confidence="HIGH"),
+        )
+
+    async def test_extract_calls_update_current_generation_with_managed_prompt(
+        self, mock_extractor: ApartmentLlmExtractor, mock_llm_result_simple: ApartmentSearchFilters
+    ) -> None:
+        """When Langfuse Prompt object is available, link it to the generation."""
+        # Mock a managed Langfuse Prompt object (sentinel — not None).
+        managed_prompt = object()  # placeholder for langfuse.model.Prompt instance
+        mock_extractor._client.chat.completions.create = AsyncMock(  # type: ignore[method-assign]
+            return_value=mock_llm_result_simple
+        )
+
+        with (
+            patch(
+                "telegram_bot.services.apartment_llm_extractor.get_prompt_with_object",
+                return_value=("compiled prompt text", managed_prompt),
+            ),
+            patch(
+                "telegram_bot.services.apartment_llm_extractor.get_client",
+            ) as mock_get_client,
+        ):
+            mock_lf = mock_get_client.return_value
+            await mock_extractor.extract("двушка у моря")
+
+            # Assert generation was linked to the managed prompt object.
+            mock_lf.update_current_generation.assert_called_once_with(prompt=managed_prompt)
+
+    async def test_extract_skips_linking_when_fallback_returned(
+        self, mock_extractor: ApartmentLlmExtractor, mock_llm_result_simple: ApartmentSearchFilters
+    ) -> None:
+        """Fallback strings (Langfuse unavailable) MUST NOT be linked as managed prompts."""
+        mock_extractor._client.chat.completions.create = AsyncMock(  # type: ignore[method-assign]
+            return_value=mock_llm_result_simple
+        )
+
+        with (
+            patch(
+                "telegram_bot.services.apartment_llm_extractor.get_prompt_with_object",
+                return_value=(EXTRACTION_SYSTEM_PROMPT, None),  # prompt_obj is None
+            ),
+            patch(
+                "telegram_bot.services.apartment_llm_extractor.get_client",
+            ) as mock_get_client,
+        ):
+            mock_lf = mock_get_client.return_value
+            await mock_extractor.extract("двушка у моря")
+
+            # CRITICAL: must NOT call update_current_generation with prompt=None.
+            mock_lf.update_current_generation.assert_not_called()
+
+    async def test_extract_uses_compiled_text_from_with_object(
+        self, mock_extractor: ApartmentLlmExtractor, mock_llm_result_simple: ApartmentSearchFilters
+    ) -> None:
+        """The compiled string from get_prompt_with_object must reach the LLM call."""
+        mock_extractor._client.chat.completions.create = AsyncMock(  # type: ignore[method-assign]
+            return_value=mock_llm_result_simple
+        )
+        sentinel_prompt_text = "SENTINEL_COMPILED_PROMPT_TEXT_FROM_LANGFUSE"
+
+        with (
+            patch(
+                "telegram_bot.services.apartment_llm_extractor.get_prompt_with_object",
+                return_value=(sentinel_prompt_text, object()),
+            ),
+            patch(
+                "telegram_bot.services.apartment_llm_extractor.get_client",
+            ),
+        ):
+            await mock_extractor.extract("двушка у моря")
+
+            call_kwargs = mock_extractor._client.chat.completions.create.call_args.kwargs
+            messages = call_kwargs["messages"]
+            assert messages[0]["role"] == "system"
+            assert sentinel_prompt_text in messages[0]["content"]
+
+    async def test_extract_swallows_update_current_generation_failure(
+        self, mock_extractor: ApartmentLlmExtractor, mock_llm_result_simple: ApartmentSearchFilters
+    ) -> None:
+        """Linking failures must NOT break the extraction flow.
+
+        Forbidden semantics: a transient Langfuse error during prompt linking
+        must not propagate and crash the apartment search hot path.
+        """
+        mock_extractor._client.chat.completions.create = AsyncMock(  # type: ignore[method-assign]
+            return_value=mock_llm_result_simple
+        )
+
+        with (
+            patch(
+                "telegram_bot.services.apartment_llm_extractor.get_prompt_with_object",
+                return_value=("compiled", object()),
+            ),
+            patch(
+                "telegram_bot.services.apartment_llm_extractor.get_client",
+            ) as mock_get_client,
+        ):
+            mock_lf = mock_get_client.return_value
+            mock_lf.update_current_generation.side_effect = RuntimeError("Langfuse exploded")
+
+            # Should not raise — the contextlib.suppress(Exception) guard handles it.
+            result = await mock_extractor.extract("двушка у моря")
+            assert result.hard.city == "Солнечный берег"

--- a/tests/unit/services/test_apartment_llm_extractor.py
+++ b/tests/unit/services/test_apartment_llm_extractor.py
@@ -177,7 +177,6 @@ class TestGetSystemPrompt:
         assert "Никогда не возвращай null для массивов" in EXTRACTION_SYSTEM_PROMPT
 
 
-
 class TestApartmentExtractorPromptLinking:
     """Tests for #1666 — Langfuse Prompt → generation linking on extract().
 

--- a/tests/unit/services/test_generate_response.py
+++ b/tests/unit/services/test_generate_response.py
@@ -1150,7 +1150,6 @@ async def test_streaming_uses_send_message_draft() -> None:
     assert "Часть 1 Часть 2" in str(call_kwargs)
 
 
-
 # ---------------------------------------------------------------------------
 # #1666 — link Langfuse Prompts to generations via langfuse_prompt= kwarg
 # ---------------------------------------------------------------------------
@@ -1241,9 +1240,7 @@ async def test_generate_response_links_prompt_via_update_current_generation() ->
         )
 
     update_calls = [
-        c
-        for c in lf.update_current_generation.call_args_list
-        if "prompt" in (c.kwargs or {})
+        c for c in lf.update_current_generation.call_args_list if "prompt" in (c.kwargs or {})
     ]
     assert update_calls, "Expected update_current_generation(prompt=...) for #1666 linking"
     assert update_calls[0].kwargs["prompt"] is fake_prompt

--- a/tests/unit/services/test_generate_response.py
+++ b/tests/unit/services/test_generate_response.py
@@ -1266,3 +1266,24 @@ async def test_generate_response_does_not_link_prompt_via_update_when_object_is_
 
     for call in lf.update_current_generation.call_args_list:
         assert "prompt" not in (call.kwargs or {})
+
+
+@pytest.mark.asyncio
+async def test_generate_response_works_when_langfuse_client_unavailable() -> None:
+    """Prompt linking must degrade gracefully when Langfuse client is unavailable."""
+    config, client = _make_non_streaming_config(answer="Ответ без tracing")
+
+    with patch(
+        "telegram_bot.services.generate_response.get_prompt_with_object",
+        return_value=("Hardcoded fallback", None),
+    ):
+        result = await generate_response(
+            query="Тест",
+            documents=[{"text": "Doc", "score": 0.8, "metadata": {}}],
+            config=config,
+            get_lf_client=lambda: None,
+            raw_messages=[{"role": "user", "content": "Тест"}],
+        )
+
+    assert result["response"] == "Ответ без tracing"
+    client.chat.completions.create.assert_awaited_once()

--- a/tests/unit/services/test_generate_response.py
+++ b/tests/unit/services/test_generate_response.py
@@ -1148,3 +1148,124 @@ async def test_streaming_uses_send_message_draft() -> None:
     message.answer.assert_called_once()
     call_kwargs = message.answer.call_args
     assert "Часть 1 Часть 2" in str(call_kwargs)
+
+
+
+# ---------------------------------------------------------------------------
+# #1666 — link Langfuse Prompts to generations via langfuse_prompt= kwarg
+# ---------------------------------------------------------------------------
+
+
+class _FakePrompt:
+    """Stand-in for a Langfuse-managed Prompt object."""
+
+    def __init__(self, text: str = "Compiled system prompt", version: int = 7):
+        self.compiled_text = text
+        self.version = version
+        self.config: dict[str, Any] = {}
+
+    def compile(self, **_kwargs: Any) -> str:
+        return self.compiled_text
+
+
+@pytest.mark.asyncio
+async def test_generate_response_forwards_langfuse_prompt_kwarg_when_prompt_object_available() -> (
+    None
+):
+    """The raw Langfuse Prompt object must be forwarded as ``langfuse_prompt=`` (#1666)."""
+    config, client = _make_non_streaming_config(answer="Ответ модели")
+    lf = MagicMock()
+    fake_prompt = _FakePrompt(text="Ассистент по недвижимость")
+
+    with patch(
+        "telegram_bot.services.generate_response.get_prompt_with_object",
+        return_value=("Ассистент по недвижимость", fake_prompt),
+    ):
+        await generate_response(
+            query="Что есть в Несебре?",
+            documents=[{"text": "Doc", "score": 0.9, "metadata": {"city": "Несебр"}}],
+            config=config,
+            lf_client=lf,
+            raw_messages=[{"role": "user", "content": "Что есть в Несебре?"}],
+        )
+
+    client.chat.completions.create.assert_awaited_once()
+    call_kwargs = client.chat.completions.create.await_args.kwargs
+    assert call_kwargs.get("langfuse_prompt") is fake_prompt
+
+
+@pytest.mark.asyncio
+async def test_generate_response_does_not_forward_langfuse_prompt_when_object_is_none() -> None:
+    """No ``langfuse_prompt`` must be sent when prompt fell back to a hardcoded string (#1666)."""
+    config, client = _make_non_streaming_config(answer="Ответ")
+    lf = MagicMock()
+
+    with patch(
+        "telegram_bot.services.generate_response.get_prompt_with_object",
+        return_value=("Hardcoded fallback prompt", None),
+    ):
+        await generate_response(
+            query="Тест",
+            documents=[{"text": "Doc", "score": 0.8, "metadata": {}}],
+            config=config,
+            lf_client=lf,
+            raw_messages=[{"role": "user", "content": "Тест"}],
+        )
+
+    client.chat.completions.create.assert_awaited_once()
+    call_kwargs = client.chat.completions.create.await_args.kwargs
+    assert "langfuse_prompt" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_generate_response_links_prompt_via_update_current_generation() -> None:
+    """When a Prompt object is available, ``update_current_generation`` is called with it (#1666).
+
+    Belt-and-braces backup for plain OpenAI clients (auto_trace=False) where the
+    helper strips the ``langfuse_prompt=`` kwarg.
+    """
+    config, _ = _make_non_streaming_config(answer="Ответ")
+    lf = MagicMock()
+    fake_prompt = _FakePrompt()
+
+    with patch(
+        "telegram_bot.services.generate_response.get_prompt_with_object",
+        return_value=("Compiled", fake_prompt),
+    ):
+        await generate_response(
+            query="Тест",
+            documents=[{"text": "Doc", "score": 0.8, "metadata": {}}],
+            config=config,
+            lf_client=lf,
+            raw_messages=[{"role": "user", "content": "Тест"}],
+        )
+
+    update_calls = [
+        c
+        for c in lf.update_current_generation.call_args_list
+        if "prompt" in (c.kwargs or {})
+    ]
+    assert update_calls, "Expected update_current_generation(prompt=...) for #1666 linking"
+    assert update_calls[0].kwargs["prompt"] is fake_prompt
+
+
+@pytest.mark.asyncio
+async def test_generate_response_does_not_link_prompt_via_update_when_object_is_none() -> None:
+    """When prompt fell back to hardcoded string, no ``prompt=`` kwarg is sent (#1666)."""
+    config, _ = _make_non_streaming_config(answer="Ответ")
+    lf = MagicMock()
+
+    with patch(
+        "telegram_bot.services.generate_response.get_prompt_with_object",
+        return_value=("Hardcoded fallback", None),
+    ):
+        await generate_response(
+            query="Тест",
+            documents=[{"text": "Doc", "score": 0.8, "metadata": {}}],
+            config=config,
+            lf_client=lf,
+            raw_messages=[{"role": "user", "content": "Тест"}],
+        )
+
+    for call in lf.update_current_generation.call_args_list:
+        assert "prompt" not in (call.kwargs or {})


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #1666 — Link Langfuse Prompts to their generation observations so the **Prompt → Traces** drill-down works in Langfuse UI.

Two paths used per the audit correction on #1666:
- **PRIMARY** — `langfuse_prompt=prompt_obj` kwarg in `chat.completions.create(...)` for `langfuse.openai` clients (4 sites)
- **SECONDARY** — `update_current_generation(prompt=prompt_obj)` for plain `openai.AsyncOpenAI` clients behind `instructor` (1 site)

## Changes

### `telegram_bot/integrations/prompt_manager.py`
- New backwards-compatible `get_prompt_with_object(name, fallback)` returning `(compiled_text, prompt_obj_or_None)`.
- `get_prompt(...)` signature unchanged.
- Internally `_fetch_prompt_core` now returns a 3-tuple `(text, config, prompt_obj)`.

### Primary path (4 langfuse.openai sites)
- `services/generate_response.py` — `_chat_create_with_optional_name` forwards `langfuse_prompt=`; graceful TypeError fallback for plain clients.
- `services/query_analyzer.py` — `instructor.from_openai(langfuse.openai.AsyncOpenAI)` preserves the wrap (preflight in PR #1681); `langfuse_prompt=` forwarded.
- `services/query_preprocessor.py` (HyDE) — same pattern.

### Secondary path (1 instructor + plain AsyncOpenAI site)
- `services/apartment_llm_extractor.py` — `update_current_generation(prompt=...)` inside the existing `@observe`-wrapped `extract` method, wrapped in `contextlib.suppress(Exception)` so transient Langfuse errors don't break the apartment search hot path.

## Out of scope (documented)

- `ai_advisor_service.py` — uses `get_prompt()` but threading `prompt_obj` into `_call_llm` needs a signature change. Unused import removed; deferred to follow-up.
- `src/contextualization/{claude,groq,openai}.py`, `nurturing_service.py`, `session_summary.py`, `handoff_summary.py` — issue body listed them but **none use `get_prompt()`** per current grep.
- `agent.py` (LangChain `create_agent`) — different architecture; prompt linking via LangChain `CallbackHandler` is a separate concern.

## Validation

```bash
uv run pytest tests/unit/integrations/test_prompt_manager.py \
              tests/unit/services/test_apartment_llm_extractor.py \
              tests/unit/services/test_query_analyzer.py \
              tests/unit/services/test_generate_response.py \
              tests/unit/test_hyde.py \
              tests/unit/services/test_ai_advisor_service.py \
              -q --override-ini='addopts='
# → 175 passed in 3.97s

uv run ruff check <touched files>
# → All checks passed!

uv run mypy <touched modules>
# → Success: no issues found in 6 source files
```

## Coverage

Measured via `coverage run` directly (pre-existing `pytest --cov` conftest blocker):

| File | Coverage |
|------|----------|
| `prompt_manager.py` | **96%** |
| `apartment_llm_extractor.py` | **98%** |
| `query_analyzer.py` | **95%** |
| `ai_advisor_service.py` | **92%** |
| `query_preprocessor.py` | **84%** |
| `generate_response.py` | **76%** |
| **TOTAL** | **83%** |

## Forbidden checks (#1666)

- ✅ `get_prompt(name, fallback)` signature unchanged
- ✅ Fallback strings NOT linked as managed prompts (`None` guard)
- ✅ No prompt-store migration
- ✅ No prompt template/variable changes

Closes #1666.