### PR TITLE
fix(e2e): replace naive datetime.utcnow() with datetime.now(UTC) (#1640)

### DIFF
--- a/scripts/e2e/runner.py
+++ b/scripts/e2e/runner.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import sys
 import time
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from rich.console import Console
@@ -57,7 +57,7 @@ async def run_single_test(
 
     try:
         # Record start time for trace validation
-        test_started_at = datetime.utcnow()
+        test_started_at = datetime.now(UTC)
 
         # Determine scenario kind for trace validation
         delivery = getattr(scenario, "delivery", "text")

--- a/tests/contract/test_no_naive_utcnow.py
+++ b/tests/contract/test_no_naive_utcnow.py
@@ -1,0 +1,83 @@
+"""Contract test: production code must not use naive `datetime.utcnow()`.
+
+`datetime.utcnow()` returns a naive datetime (no tzinfo). It is deprecated
+in Python 3.12+ and silently mixes with timezone-aware datetimes returned
+by SDKs such as Langfuse, leading to drift or `TypeError` at compare time.
+
+Replacement is `datetime.now(UTC)` (or `datetime.now(timezone.utc)`).
+
+This test scans production code paths via AST and reports every offending
+call site. Test code (`tests/`) is intentionally excluded — historical
+fixtures may still construct naive datetimes for compatibility checks.
+
+Refs #1640.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# Production code paths that must not contain naive UTC constructors.
+SCAN_DIRS = [
+    REPO_ROOT / "scripts",
+    REPO_ROOT / "src",
+    REPO_ROOT / "telegram_bot",
+    REPO_ROOT / "mini_app",
+    REPO_ROOT / "services",
+]
+
+# Forbidden datetime constructors (all return naive datetimes).
+FORBIDDEN_ATTRS = {"utcnow", "utcfromtimestamp"}
+
+
+def _iter_python_files(directories: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for d in directories:
+        if not d.exists():
+            continue
+        files.extend(p for p in d.rglob("*.py") if "/.venv/" not in str(p))
+    return files
+
+
+def _find_naive_utc_calls(source: str, file_path: Path) -> list[tuple[Path, int, str]]:
+    """Return [(file, lineno, full-call-name)] for every forbidden call in source."""
+    try:
+        tree = ast.parse(source, filename=str(file_path))
+    except SyntaxError:
+        return []
+
+    offenders: list[tuple[Path, int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # Match `datetime.utcnow(...)` and `datetime.utcfromtimestamp(...)`
+        # whether `datetime` is the class or the module is irrelevant —
+        # both yield naive datetimes and are forbidden.
+        if isinstance(func, ast.Attribute) and func.attr in FORBIDDEN_ATTRS:
+            target = ast.unparse(func)
+            offenders.append((file_path, node.lineno, target))
+    return offenders
+
+
+def test_no_naive_utcnow_in_production_code() -> None:
+    """No production module may call datetime.utcnow() / utcfromtimestamp()."""
+    offenders: list[tuple[Path, int, str]] = []
+    for py_file in _iter_python_files(SCAN_DIRS):
+        offenders.extend(_find_naive_utc_calls(py_file.read_text(), py_file))
+
+    if offenders:
+        rel = [
+            f"  {p.relative_to(REPO_ROOT)}:{lineno} -> {name}()"
+            for p, lineno, name in offenders
+        ]
+        msg = (
+            "Naive UTC datetime constructors found in production code "
+            "(see #1640). Replace with `datetime.now(UTC)`:\n"
+            + "\n".join(rel)
+        )
+        raise AssertionError(msg)


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Closes #1640.

## Summary

`datetime.utcnow()` returns a **naive** datetime (no `tzinfo`). It is deprecated in Python 3.12+ and silently mixes with timezone-aware datetimes returned by SDKs such as Langfuse, leading to drift or `TypeError` at compare time. The repo's only remaining offender was `scripts/e2e/runner.py:60`.

This PR fixes that one site and adds an AST-based regression guard so the issue cannot regress silently.

## TDD cycle (per [obra/superpowers](https://github.com/obra/superpowers/blob/main/skills/test-driven-development/SKILL.md))

1. **RED** — wrote `tests/contract/test_no_naive_utcnow.py` first. Initial run failed with the expected message:
   ```
   AssertionError: Naive UTC datetime constructors found in production code (see #1640).
   Replace with `datetime.now(UTC)`:
     scripts/e2e/runner.py:60 -> datetime.utcnow()
   ```
2. **GREEN** — minimal one-line fix in `scripts/e2e/runner.py`: import `UTC`, change `datetime.utcnow()` → `datetime.now(UTC)`.
3. **Verify GREEN** — `pytest tests/contract/test_no_naive_utcnow.py -q` → `1 passed in 0.52s`.
4. **REFACTOR** — N/A, change is already minimal.

## Changes

### `scripts/e2e/runner.py`

```diff
-from datetime import datetime
+from datetime import UTC, datetime
 ...
-        test_started_at = datetime.utcnow()
+        test_started_at = datetime.now(UTC)
```

Downstream `scripts/e2e/langfuse_trace_validator.wait_for_trace` does `started_at - timedelta(seconds=5)`, which works identically for aware and naive datetimes; the timestamp is then passed to the Langfuse SDK, which serializes to ISO with a timezone offset. This is **more** correct than naive `utcnow()` (which serialized without offset, requiring the server to assume UTC).

### `tests/contract/test_no_naive_utcnow.py` (new)

AST-based contract test. Scans `scripts/`, `src/`, `telegram_bot/`, `mini_app/`, `services/` for `datetime.utcnow()` and `datetime.utcfromtimestamp()` calls and lists every offender. `tests/` is intentionally excluded — historical fixtures may legitimately construct naive datetimes for compatibility checks. The test follows the same shape as the existing `tests/contract/` suite.

## Validation

```bash
$ uv run pytest tests/contract/test_no_naive_utcnow.py -q --override-ini="addopts="
.                                                                        [100%]
1 passed in 0.52s

$ uv run ruff check scripts/e2e/runner.py tests/contract/test_no_naive_utcnow.py
All checks passed!

$ uv run mypy scripts/e2e/runner.py
# 0 new errors. Pre-existing errors in unchanged files documented below.
```

## Forbidden checks (#1640) — all honored

- ✅ No local timezone conversions; only `datetime.now(UTC)`.
- ✅ No mixed naive/aware comparisons introduced.
- ✅ No unrelated evaluation refactor in this PR.

## Side-findings (not fixed in this PR — surface for triage)

While running mypy on the touched module, I noticed pre-existing type errors in adjacent E2E files. These are **out of scope** for #1640 and untouched by this PR, but worth tracking:

1. **`scripts/e2e/claude_judge.py:218`** — 5 `union-attr` errors. Code accesses `.text` on `block` whose union type from the Anthropic SDK includes `CodeExecutionToolResultBlock`, `BashCodeExecutionToolResultBlock`, `TextEditorCodeExecutionToolResultBlock`, `ToolSearchToolResultBlock`, `ContainerUploadBlock` — none of which have a `.text` attribute. Likely needs an `isinstance(block, TextBlock)` narrow before access.
2. **`scripts/e2e/langfuse_trace_validator.py:221`** — `Returning Any from function declared to return "str | None"`. Cast or `# type: ignore[no-any-return]` would suffice.
3. **`scripts/e2e/langfuse_trace_validator.py:267,271`** — `Incompatible types in assignment (expression has type "Collection[str]", variable has type "str | list[str]")` and same for `list[str] | None`. The `set()` operations need either a different annotation or a `list(...)` conversion at the assignment site.

If desired, I can open a follow-up issue to track these.

## Notes for reviewers

- Issue body listed several other files as candidate offenders (`src/evaluation/ragas_evaluation.py`, `tests/baseline/collector.py`, etc.). Current `grep` shows zero `datetime.utcnow(` occurrences in any of them — the migration was already partially done in earlier PRs. The contract test will catch any regression across the full surface.
- The contract test runs in ~0.5s and uses only the standard library (`ast`, `pathlib`), so it's safe to add to the default suite.