### PR TITLE
refactor(api): remove dead reranker variable in RAG API lifespan (#1642)

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -56,11 +56,14 @@ async def lifespan(app: FastAPI):
         timeout=30,
     )
 
-    reranker = None
+    # Reranking is performed server-side by Qdrant via the ColBERT vector;
+    # there is no per-process Python reranker to construct. We log the
+    # configured path here so misconfiguration is visible at startup.
     if cfg.rerank_provider == "colbert":
         logger.info("Reranking via server-side Qdrant ColBERT path")
     elif cfg.rerank_provider != "none":
         logger.warning("Unknown RERANK_PROVIDER=%s, reranking disabled", cfg.rerank_provider)
+
     llm = cfg.create_llm()
 
     graph = build_graph(
@@ -68,7 +71,7 @@ async def lifespan(app: FastAPI):
         embeddings=embeddings,
         sparse_embeddings=sparse_embeddings,
         qdrant=qdrant,
-        reranker=reranker,
+        reranker=None,
         llm=llm,
         message=None,
     )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Closes #1642

Removes the dead `reranker = None` initialization in the RAG API lifespan. The variable was never assigned to a real reranker instance — both the `colbert` and unknown-provider branches only logged. Reranking via ColBERT is performed server-side by Qdrant (#569 / `hybrid_search_rrf_colbert`); there is no per-process Python reranker to construct at the API layer.

## Changes (single file: `src/api/main.py`)

- Remove the dead `reranker = None` line.
- Pass `reranker=None` literal directly into `build_graph()`.
- Keep both startup log lines (`colbert` info, unknown `warning`) — they are the only observable signal that `RERANK_PROVIDER` is wired correctly.
- Add a brief comment explaining why the reranker arg stays `None` at the API layer.

## Tests — pure refactor, no new tests needed

All 11 existing tests in `tests/unit/api/test_rag_api_runtime.py` pass unchanged because they already pin the contract this PR preserves:

- `test_lifespan_respects_rerank_provider_none` — `mock_build_graph.call_args.kwargs["reranker"] is None`.
- `test_lifespan_keeps_colbert_runtime_server_side` — same assertion.
- `test_lifespan_unknown_rerank_provider_logs_and_closes_embeddings` — `mock_warning.assert_called_once()`.

So the dead-variable removal is fully covered: byte-for-byte identical behavior.

## Verification

```
$ uv run pytest tests/unit/api/test_rag_api_runtime.py -q --override-ini="addopts="
11 passed in 2.67s
$ uv run ruff check src/api/main.py
All checks passed!
$ uv run mypy src/api/main.py
Success: no issues found in 1 source file
```

## Forbidden checks (per #1642)

- ✅ No change to retrieval/rerank behavior — `build_graph` still receives `reranker=None` for every provider value.
- ✅ No new local reranker abstraction.

## Side-findings during verification

None (`src/api/main.py` was clean under ruff and mypy before and after).

## Methodology note

Followed [obra/superpowers TDD methodology](https://github.com/obra/superpowers/blob/main/skills/test-driven-development/SKILL.md):
- Baseline GREEN (11/11 tests pass).
- Refactor.
- Re-verify GREEN (11/11 tests pass).

This is a pure refactor case where the existing test suite serves as the safety net per the REFACTOR phase of the RED-GREEN-REFACTOR cycle.