### PR TITLE
fix(asyncio): migrate src/ from get_event_loop to running_loop/to_thread (#1639)

### DIFF
--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -116,7 +116,7 @@ class RAGPipeline:
 
         if isinstance(self.search_engine, (HybridRRFSearchEngine, HybridRRFColBERTSearchEngine)):
             # Pass query string directly for hybrid search (async handled inside)
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             search_results = await loop.run_in_executor(
                 None,
                 lambda: self.search_engine.search(
@@ -127,7 +127,7 @@ class RAGPipeline:
             )
         else:
             # For other engines, generate dense embedding (async)
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             ctx = contextvars.copy_context()
             query_embedding = await loop.run_in_executor(
                 None, lambda: ctx.run(self._encode_query, query)

--- a/src/ingestion/cocoindex_flow.py
+++ b/src/ingestion/cocoindex_flow.py
@@ -113,19 +113,24 @@ class VoyageEmbedFunction:
         async def _embed():
             return await self.service.embed_documents(texts)
 
-        # Run async in sync context
+        # Run async in sync context. asyncio.get_event_loop() is deprecated
+        # in 3.12+ and raises RuntimeError without a running loop in 3.14;
+        # use get_running_loop()/asyncio.run() per #1639 / Context7 cpython.
         try:
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                # If we're in an async context, create a new task
-                import concurrent.futures
-
-                with concurrent.futures.ThreadPoolExecutor() as pool:
-                    future = pool.submit(asyncio.run, _embed())
-                    embeddings = future.result()
-            else:
-                embeddings = loop.run_until_complete(_embed())
+            loop = asyncio.get_running_loop()
         except RuntimeError:
+            loop = None
+        if loop is not None and loop.is_running():
+            # Called from inside an active event loop (e.g. CocoIndex executor
+            # invokes us during async flow execution). Drop to a worker thread
+            # so we can spin up a fresh loop via asyncio.run without re-entering.
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor() as pool:
+                future = pool.submit(asyncio.run, _embed())
+                embeddings = future.result()
+        else:
+            # Called from purely sync context — own the loop for this call.
             embeddings = asyncio.run(_embed())
 
         return [np.array(emb, dtype=np.float32) for emb in embeddings]

--- a/src/ingestion/indexer.py
+++ b/src/ingestion/indexer.py
@@ -378,15 +378,13 @@ class DocumentIndexer:
 
         # Run embedding in threadpool to avoid blocking
         encode_start = time.time()
-        output = await asyncio.get_event_loop().run_in_executor(
-            None,
-            lambda: self.embedding_model.encode(
-                texts,
-                batch_size=self.settings.batch_size_embeddings,
-                return_dense=True,
-                return_sparse=True,
-                return_colbert_vecs=True,
-            ),
+        output = await asyncio.to_thread(
+            self.embedding_model.encode,
+            texts,
+            batch_size=self.settings.batch_size_embeddings,
+            return_dense=True,
+            return_sparse=True,
+            return_colbert_vecs=True,
         )
         encode_time = time.time() - encode_start
         logger.debug(f"BGE-M3 encode completed in {encode_time:.2f}s")

--- a/tests/contract/test_no_get_event_loop.py
+++ b/tests/contract/test_no_get_event_loop.py
@@ -1,0 +1,121 @@
+"""Contract test: production code must not use deprecated `asyncio.get_event_loop()`.
+
+`asyncio.get_event_loop()` is deprecated in Python 3.12+ and will raise
+RuntimeError when no loop is running starting Python 3.14
+(see Python whatsnew/3.14 / asyncio-eventloop docs).
+
+Preferred replacements (verified via Context7 /python/cpython):
+- Inside `async def`: use `asyncio.get_running_loop()`.
+- Move blocking sync work off the loop: use `asyncio.to_thread(...)`.
+- Sync-async bridge with multiple awaits: use `asyncio.Runner()` (3.11+).
+
+This test scans production paths (src/, scripts/, telegram_bot/, mini_app/,
+services/) for `asyncio.get_event_loop(` calls and reports every offender,
+EXCEPT a small allowlist of legacy LangChain sync-bridge wrappers tracked
+under #1639 follow-up. The allowlist must shrink, never grow.
+
+Refs #1639.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+SCAN_DIRS = [
+    REPO_ROOT / "src",
+    REPO_ROOT / "scripts",
+    REPO_ROOT / "telegram_bot",
+    REPO_ROOT / "mini_app",
+    REPO_ROOT / "services",
+]
+
+# Frozen allowlist: legacy sync-bridge wrappers around long-lived
+# httpx.AsyncClient. Removing or rewriting them requires deciding
+# whether to drop sync support or build a tested sync-async boundary
+# that does not break shared async resources. Tracked under #1639.
+ALLOWLIST: dict[str, set[int]] = {
+    "telegram_bot/integrations/embeddings.py": {59, 62, 179, 182},
+}
+
+
+def _iter_python_files(directories: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for d in directories:
+        if not d.exists():
+            continue
+        files.extend(p for p in d.rglob("*.py") if "/.venv/" not in str(p))
+    return files
+
+
+def _find_get_event_loop_calls(
+    source: str, file_path: Path
+) -> list[tuple[Path, int]]:
+    try:
+        tree = ast.parse(source, filename=str(file_path))
+    except SyntaxError:
+        return []
+    offenders: list[tuple[Path, int]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == "get_event_loop":
+            offenders.append((file_path, node.lineno))
+    return offenders
+
+
+def test_no_unallowlisted_get_event_loop_calls() -> None:
+    """Production code may not introduce new `asyncio.get_event_loop()` callsites.
+
+    Existing callsites listed in ALLOWLIST are tolerated until #1639
+    follow-up resolves the LangChain sync-bridge question. Anything outside
+    the allowlist must be migrated to get_running_loop / to_thread / Runner.
+    """
+    new_offenders: list[tuple[Path, int]] = []
+    stale_allowlist: list[tuple[str, int]] = []
+
+    for py_file in _iter_python_files(SCAN_DIRS):
+        rel = str(py_file.relative_to(REPO_ROOT))
+        offenders = _find_get_event_loop_calls(py_file.read_text(), py_file)
+        allowed_lines = ALLOWLIST.get(rel, set())
+        for path, lineno in offenders:
+            if lineno not in allowed_lines:
+                new_offenders.append((path, lineno))
+
+    # Detect stale entries: allowlist points to a line that no longer
+    # has a `get_event_loop` call. Forces the allowlist to shrink as
+    # callsites are migrated.
+    for rel, allowed_lines in ALLOWLIST.items():
+        py_file = REPO_ROOT / rel
+        if not py_file.exists():
+            for lineno in allowed_lines:
+                stale_allowlist.append((rel, lineno))
+            continue
+        actual = {ln for _, ln in _find_get_event_loop_calls(py_file.read_text(), py_file)}
+        for lineno in allowed_lines:
+            if lineno not in actual:
+                stale_allowlist.append((rel, lineno))
+
+    msgs: list[str] = []
+    if new_offenders:
+        msgs.append(
+            "New asyncio.get_event_loop() calls outside the allowlist (#1639):\n"
+            + "\n".join(
+                f"  {p.relative_to(REPO_ROOT)}:{lineno}" for p, lineno in new_offenders
+            )
+            + "\nReplace with asyncio.get_running_loop() (in async),"
+            " asyncio.to_thread(...) (blocking sync work),"
+            " or asyncio.Runner() (sync-async bridge)."
+        )
+    if stale_allowlist:
+        msgs.append(
+            "Stale ALLOWLIST entries — remove from the dict in this test (#1639):\n"
+            + "\n".join(f"  {rel}:{lineno}" for rel, lineno in stale_allowlist)
+        )
+
+    if msgs:
+        raise AssertionError("\n\n".join(msgs))

--- a/tests/contract/test_no_get_event_loop.py
+++ b/tests/contract/test_no_get_event_loop.py
@@ -68,6 +68,27 @@ def _find_get_event_loop_calls(
     return offenders
 
 
+def _format_new_offenders_message(new_offenders: list[tuple[Path, int]]) -> str:
+    offender_lines = "\n".join(
+        f"  {p.relative_to(REPO_ROOT)}:{lineno}" for p, lineno in new_offenders
+    )
+    return (
+        "New asyncio.get_event_loop() calls outside the allowlist (#1639):\n"
+        + offender_lines
+        + "\nReplace with asyncio.get_running_loop() (in async),"
+        " asyncio.to_thread(...) (blocking sync work),"
+        " or asyncio.Runner() (sync-async bridge)."
+    )
+
+
+def _format_stale_allowlist_message(stale_allowlist: list[tuple[str, int]]) -> str:
+    stale_lines = "\n".join(f"  {rel}:{lineno}" for rel, lineno in stale_allowlist)
+    return (
+        "Stale ALLOWLIST entries — remove from the dict in this test (#1639):\n"
+        + stale_lines
+    )
+
+
 def test_no_unallowlisted_get_event_loop_calls() -> None:
     """Production code may not introduce new `asyncio.get_event_loop()` callsites.
 
@@ -102,20 +123,35 @@ def test_no_unallowlisted_get_event_loop_calls() -> None:
 
     msgs: list[str] = []
     if new_offenders:
-        msgs.append(
-            "New asyncio.get_event_loop() calls outside the allowlist (#1639):\n"
-            + "\n".join(
-                f"  {p.relative_to(REPO_ROOT)}:{lineno}" for p, lineno in new_offenders
-            )
-            + "\nReplace with asyncio.get_running_loop() (in async),"
-            " asyncio.to_thread(...) (blocking sync work),"
-            " or asyncio.Runner() (sync-async bridge)."
-        )
+        msgs.append(_format_new_offenders_message(new_offenders))
     if stale_allowlist:
-        msgs.append(
-            "Stale ALLOWLIST entries — remove from the dict in this test (#1639):\n"
-            + "\n".join(f"  {rel}:{lineno}" for rel, lineno in stale_allowlist)
-        )
+        msgs.append(_format_stale_allowlist_message(stale_allowlist))
 
     if msgs:
         raise AssertionError("\n\n".join(msgs))
+
+
+def test_new_offenders_message_formats_all_paths() -> None:
+    msg = _format_new_offenders_message(
+        [
+            (REPO_ROOT / "src/core/pipeline.py", 119),
+            (REPO_ROOT / "src/ingestion/indexer.py", 381),
+        ]
+    )
+
+    assert "src/core/pipeline.py:119" in msg
+    assert "src/ingestion/indexer.py:381" in msg
+    assert "asyncio.to_thread" in msg
+    assert "asyncio.Runner" in msg
+
+
+def test_stale_allowlist_message_formats_all_entries() -> None:
+    msg = _format_stale_allowlist_message(
+        [
+            ("telegram_bot/integrations/embeddings.py", 59),
+            ("telegram_bot/integrations/embeddings.py", 62),
+        ]
+    )
+
+    assert "telegram_bot/integrations/embeddings.py:59" in msg
+    assert "telegram_bot/integrations/embeddings.py:62" in msg


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Closes #1639 (partial — `src/` only, embeddings sync wrappers deferred via allowlist)

`asyncio.get_event_loop()` is deprecated since Python 3.12 and starting 3.14 raises `RuntimeError` when no loop is running. Verified via Context7 [`/python/cpython`](https://github.com/python/cpython/blob/main/Doc/library/asyncio-eventloop.rst): SDK-native replacements are `asyncio.get_running_loop()` inside coroutines, `asyncio.to_thread(...)` for blocking sync work, and `asyncio.Runner()` for sync-async bridges with multiple awaits.

## Changes (3 production files in `src/`)

| File | Before | After | Rationale |
|---|---|---|---|
| `src/core/pipeline.py:119,130` | `loop = asyncio.get_event_loop()` | `loop = asyncio.get_running_loop()` | Both inside `async def`; the running loop is guaranteed. |
| `src/ingestion/indexer.py:381` | `await asyncio.get_event_loop().run_in_executor(None, lambda: encode(...))` | `await asyncio.to_thread(self.embedding_model.encode, ...)` | Same semantics (default executor, thread pool), simpler and SDK-native. |
| `src/ingestion/cocoindex_flow.py:118` | `loop = asyncio.get_event_loop(); if loop.is_running(): ... else: loop.run_until_complete(...)` | `try: loop = asyncio.get_running_loop() except RuntimeError: loop = None; if loop and loop.is_running(): asyncio.run-in-thread ...; else: asyncio.run(...)` | Sync-async bridge for CocoIndex `__call__`; behavior preserved. |

## TDD contract (obra/superpowers RED-GREEN-REFACTOR)

`tests/contract/test_no_get_event_loop.py` — AST scanner over `src/`, `scripts/`, `telegram_bot/`, `mini_app/`, `services/`. Forbids new `asyncio.get_event_loop()` calls outside a frozen `ALLOWLIST` and detects stale `ALLOWLIST` entries (so the list can only shrink, never grow).

- **RED**: 4 offenders flagged (`src/core/pipeline.py:119,130`, `src/ingestion/cocoindex_flow.py:118`, `src/ingestion/indexer.py:381`).
- **GREEN**: contract test passes after migration; only the 4 deferred sites in `telegram_bot/integrations/embeddings.py` remain in the allowlist.

## Allowlist — explicit deferral of LangChain sync wrappers

`telegram_bot/integrations/embeddings.py` lines 59, 62, 179, 182 are sync `embed_documents` / `embed_query` methods on `BGEM3Embeddings(Embeddings)` and `BGEM3HybridEmbeddings(Embeddings)` — LangChain ABC interface methods used as a sync API around a long-lived `BGEM3Client` holding an `httpx.AsyncClient`.

Per the issue's Forbidden list:

> No per-call `asyncio.run()` around a long-lived `httpx.AsyncClient` without a regression test proving it is safe.

So a naïve replacement with `asyncio.run(...)` per call would create a new loop each invocation and break the shared async client. The proper fix requires deciding between:

1. Removing sync wrappers entirely (after auditing every LangChain caller — `BGEM3Embeddings(Embeddings)` may be invoked by `langchain_core` from sync vectorstore code paths).
2. Building a tested `asyncio.Runner`-based sync boundary that owns the loop lifecycle and reuses the same `httpx.AsyncClient` across calls.

Both are bigger than this PR. Listed in the contract test's `ALLOWLIST` with a TODO link to #1639 follow-up. The contract test will fail loudly if anyone introduces *new* `get_event_loop` callsites.

## Verification

```
$ uv run pytest tests/contract/test_no_get_event_loop.py -q --override-ini="addopts="
1 passed in 0.54s

$ uv run pytest tests/unit/test_indexer.py tests/unit/test_cocoindex_flow.py tests/unit/core/test_pipeline.py -q --override-ini="addopts="
61 passed in 4.04s

$ uv run pytest tests/unit/ingestion/ tests/unit/core/ -q --override-ini="addopts="
247 passed, 16 skipped in 13.19s

$ uv run ruff check src/core/pipeline.py src/ingestion/cocoindex_flow.py src/ingestion/indexer.py tests/contract/test_no_get_event_loop.py
All checks passed!

$ uv run mypy src/core/pipeline.py src/ingestion/cocoindex_flow.py src/ingestion/indexer.py
Success: no issues found in 3 source files
```

## Forbidden checks (per #1639)

- ✅ No broad event-loop helper abstraction.
- ✅ No per-call `asyncio.run()` around long-lived `httpx.AsyncClient`. The 4 embeddings.py sites are explicitly allowlisted, not migrated to `asyncio.run`.
- ✅ Regression: 247 ingestion+core unit tests pass unchanged.

## Side-findings during verification

None — all pre-existing tests pass, and `asyncio.to_thread` argument forwarding preserved the previous `lambda`-to-callable contract for `embedding_model.encode(...)`.

## Methodology

Followed [obra/superpowers TDD](https://github.com/obra/superpowers/blob/main/skills/test-driven-development/SKILL.md) with explicit Context7 SDK lookup for cpython asyncio guidance:

1. Resolve library ID → `/python/cpython`.
2. Query Context7 for `get_event_loop` deprecation + `to_thread` / `Runner` migration patterns.
3. RED contract test fails with all 4 src/ offenders listed.
4. Apply minimal SDK-native fixes per file.
5. GREEN contract + 247 unit tests pass; ruff + mypy clean.