### PR TITLE
refactor(graph): use init_chat_model for SummarizationNode (#1653)

### DIFF
--- a/telegram_bot/graph/graph.py
+++ b/telegram_bot/graph/graph.py
@@ -279,17 +279,20 @@ def build_graph(
 
 
 def _create_summarize_model(config: Any) -> Any:
-    """Create a LangChain ChatOpenAI for SummarizationNode via LiteLLM proxy.
+    """Create a LangChain chat model for SummarizationNode via LiteLLM proxy.
 
-    Tracing is handled by @observe on pipeline nodes and LiteLLM proxy logging.
-    CallbackHandler removed: broken context propagation in async LangGraph (#157).
+    Uses LangChain's SDK-native ``init_chat_model`` (LangChain 1.x) instead of
+    direct ChatOpenAI construction so the abstraction stays provider-neutral
+    (#1653). Tracing is handled by @observe on pipeline nodes and LiteLLM
+    proxy logging. CallbackHandler removed: broken context propagation in
+    async LangGraph (#157).
     """
-    from langchain_openai import ChatOpenAI
-    from pydantic import SecretStr
+    from langchain.chat_models import init_chat_model
 
-    return ChatOpenAI(
+    return init_chat_model(
         model=config.llm_model,
-        api_key=SecretStr(config.llm_api_key or "no-key"),
+        model_provider="openai",
+        api_key=config.llm_api_key or "no-key",
         base_url=config.llm_base_url,
     )
 

--- a/tests/unit/graph/test_config.py
+++ b/tests/unit/graph/test_config.py
@@ -290,3 +290,76 @@ class TestGraphConfig:
             f"skip_rerank_threshold={config.skip_rerank_threshold} must be > "
             f"single-query top-1 RRF={single_query_top1_rrf:.5f}"
         )
+
+
+
+class TestCreateSummarizeModel:
+    """Contract: _create_summarize_model must use SDK-native init_chat_model (#1653).
+
+    LangChain 1.x exposes `langchain.chat_models.init_chat_model` as the
+    provider-neutral way to construct a chat model. Direct ChatOpenAI
+    instantiation skips the abstraction and complicates provider switching.
+    Verified via Context7 /websites/langchain_oss_python_langchain.
+    """
+
+    def test_uses_init_chat_model_with_openai_provider(self):
+        """_create_summarize_model must call init_chat_model with model_provider='openai'."""
+        from unittest.mock import patch
+
+        from telegram_bot.graph.graph import _create_summarize_model
+
+        cfg = MagicMock()
+        cfg.llm_model = "gpt-4o-mini"
+        cfg.llm_api_key = "sk-test"
+        cfg.llm_base_url = "http://litellm:4000"
+
+        sentinel = MagicMock(name="ChatModel")
+        with patch("langchain.chat_models.init_chat_model", return_value=sentinel) as mock_icm:
+            result = _create_summarize_model(cfg)
+
+        assert result is sentinel
+        mock_icm.assert_called_once()
+        kwargs = mock_icm.call_args.kwargs
+        assert kwargs.get("model") == "gpt-4o-mini"
+        assert kwargs.get("model_provider") == "openai"
+        assert kwargs.get("api_key") == "sk-test"
+        assert kwargs.get("base_url") == "http://litellm:4000"
+
+    def test_falls_back_to_no_key_placeholder_when_api_key_missing(self):
+        """Empty api_key must fall back to 'no-key' placeholder for LiteLLM proxy."""
+        from unittest.mock import patch
+
+        from telegram_bot.graph.graph import _create_summarize_model
+
+        cfg = MagicMock()
+        cfg.llm_model = "gpt-4o-mini"
+        cfg.llm_api_key = None
+        cfg.llm_base_url = "http://litellm:4000"
+
+        with patch("langchain.chat_models.init_chat_model") as mock_icm:
+            _create_summarize_model(cfg)
+
+        kwargs = mock_icm.call_args.kwargs
+        assert kwargs.get("api_key") == "no-key"
+
+    def test_does_not_construct_chat_openai_directly(self):
+        """Module must not import or instantiate ChatOpenAI in _create_summarize_model."""
+        import ast
+        import inspect
+
+        from telegram_bot.graph import graph as mod
+
+        source = inspect.getsource(mod._create_summarize_model)
+        tree = ast.parse(source)
+
+        bad: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                func = node.func
+                if isinstance(func, ast.Name) and func.id == "ChatOpenAI":
+                    bad.append(f"line {node.lineno}: ChatOpenAI(...)")
+
+        assert not bad, (
+            "_create_summarize_model must use init_chat_model, not ChatOpenAI: "
+            + "; ".join(bad)
+        )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Closes #1653

Replaces direct `langchain_openai.ChatOpenAI` instantiation in `_create_summarize_model` with the LangChain 1.x SDK-native `init_chat_model` factory. This keeps the chat-model construction provider-neutral and removes the manual `SecretStr` wrap that was needed only for the typed `ChatOpenAI(api_key=...)` field.

## SDK baseline (verified via Context7 `/websites/langchain_oss_python_langchain`)

```python
model = init_chat_model(
    model="MODEL_NAME",
    model_provider="openai",
    base_url="BASE_URL",
    api_key="YOUR_API_KEY",
)
```

This is the documented LangChain 1.x shape for any OpenAI-compatible provider behind a proxy (Together AI, vLLM, LiteLLM). `init_chat_model` also handles `api_key` forwarding without requiring `SecretStr` at the call site.

## Changes (single function: `telegram_bot/graph/graph.py::_create_summarize_model`)

```diff
 def _create_summarize_model(config: Any) -> Any:
-    from langchain_openai import ChatOpenAI
-    from pydantic import SecretStr
-    return ChatOpenAI(
-        model=config.llm_model,
-        api_key=SecretStr(config.llm_api_key or "no-key"),
-        base_url=config.llm_base_url,
-    )
+    from langchain.chat_models import init_chat_model
+    return init_chat_model(
+        model=config.llm_model,
+        model_provider="openai",
+        api_key=config.llm_api_key or "no-key",
+        base_url=config.llm_base_url,
+    )
```

LiteLLM proxy settings continue to flow through `base_url` + `api_key`. Tracing remains driven by `@observe` on pipeline nodes and LiteLLM proxy logs.

## TDD contract (obra/superpowers RED-GREEN-REFACTOR)

New `TestCreateSummarizeModel` class in `tests/unit/graph/test_config.py` — 3 tests, all RED before the swap, all GREEN after:

| Test | Asserts |
|---|---|
| `test_uses_init_chat_model_with_openai_provider` | `init_chat_model` called once with `model`, `model_provider="openai"`, `api_key`, `base_url`. |
| `test_falls_back_to_no_key_placeholder_when_api_key_missing` | `llm_api_key=None` produces `api_key="no-key"`. |
| `test_does_not_construct_chat_openai_directly` | AST scan: no `ChatOpenAI(...)` call inside `_create_summarize_model`. |

## Verification

```
$ uv run pytest tests/unit/graph/ -q --override-ini="addopts="
449 passed in 5.30s

$ uv run ruff check telegram_bot/graph/graph.py tests/unit/graph/test_config.py
All checks passed!

$ uv run mypy telegram_bot/graph/graph.py
Success: no issues found in 1 source file
```

## Forbidden checks (per #1653)

- ✅ No custom provider resolver.
- ✅ SummarizationNode behavior unchanged — model object is used identically by `langmem.short_term.SummarizationNode`.
- ✅ `max_tokens_before_summary` trigger not modified (separate concern, tracked elsewhere).

## Side-findings during verification

None — `langchain.chat_models.init_chat_model` is already an indirect dependency of the project's pinned `langchain` 1.x stack; no new dependency added.

## Methodology

Followed [obra/superpowers TDD](https://github.com/obra/superpowers/blob/main/skills/test-driven-development/SKILL.md) and Context7 SDK lookup:

1. Resolve library ID → `/websites/langchain_oss_python_langchain` (1622 snippets).
2. Confirmed `init_chat_model(model, model_provider, base_url, api_key)` shape.
3. RED: 3 contract tests fail (still calling `ChatOpenAI`).
4. GREEN: minimal swap; 3 RED tests + 446 pre-existing graph tests pass.