### PR TITLE
fix(contextualize): surface batch failures via asyncio.TaskGroup (#1656)

### DIFF
--- a/src/contextualization/base.py
+++ b/src/contextualization/base.py
@@ -136,13 +136,9 @@ class ContextualizeProvider(ABC):
         async def _process(index: int, chunk: str) -> None:
             async with sem:
                 try:
-                    results[index] = await self.contextualize_single(
-                        chunk, f"chunk_{index}", query
-                    )
+                    results[index] = await self.contextualize_single(chunk, f"chunk_{index}", query)
                 except Exception as exc:
-                    logger.warning(
-                        "contextualize_batch chunk %d failed: %s", index, exc
-                    )
+                    logger.warning("contextualize_batch chunk %d failed: %s", index, exc)
                     results[index] = ContextualizedChunk(
                         original_text=chunk,
                         contextual_summary="",

--- a/src/contextualization/base.py
+++ b/src/contextualization/base.py
@@ -1,10 +1,14 @@
 """Base class for contextualization providers."""
 
 import asyncio
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -98,7 +102,14 @@ class ContextualizeProvider(ABC):
         *,
         max_concurrency: int = 5,
     ) -> list[ContextualizedChunk]:
-        """Contextualize chunks in parallel using asyncio.gather with semaphore.
+        """Contextualize chunks in parallel using asyncio.TaskGroup.
+
+        Per-chunk failures are caught inside each worker so the TaskGroup
+        stays alive and produces a fallback ``ContextualizedChunk`` with
+        ``context_method="none"`` and an empty ``contextual_summary`` at
+        the failed index. Output cardinality and order match the input
+        list (#1656). Callers can filter on ``context_method`` to detect
+        which chunks were skipped.
 
         Args:
             chunks: List of text chunks to contextualize
@@ -106,19 +117,46 @@ class ContextualizeProvider(ABC):
             max_concurrency: Maximum simultaneous API calls (default: 5)
 
         Returns:
-            List of contextualized chunks preserving input order
+            List of contextualized chunks preserving input order. Failed
+            chunks are represented as fallback records, never dropped.
         """
         sem = asyncio.Semaphore(max_concurrency)
+        # Pre-allocate so each task can write to its index slot — preserves
+        # order without sorting after the fact.
+        results: list[ContextualizedChunk] = [
+            ContextualizedChunk(
+                original_text="",
+                contextual_summary="",
+                article_number="",
+                context_method="none",
+            )
+            for _ in chunks
+        ]
 
-        async def _process_with_semaphore(index: int, chunk: str) -> ContextualizedChunk:
+        async def _process(index: int, chunk: str) -> None:
             async with sem:
-                return await self.contextualize_single(chunk, f"chunk_{index}", query)
+                try:
+                    results[index] = await self.contextualize_single(
+                        chunk, f"chunk_{index}", query
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "contextualize_batch chunk %d failed: %s", index, exc
+                    )
+                    results[index] = ContextualizedChunk(
+                        original_text=chunk,
+                        contextual_summary="",
+                        article_number=f"chunk_{index}",
+                        context_method="none",
+                    )
 
-        results = await asyncio.gather(
-            *[_process_with_semaphore(i, chunk) for i, chunk in enumerate(chunks)],
-            return_exceptions=True,
-        )
-        return [r for r in results if isinstance(r, ContextualizedChunk)]
+        if not chunks:
+            return []
+        async with asyncio.TaskGroup() as tg:
+            for i, chunk in enumerate(chunks):
+                tg.create_task(_process(i, chunk))
+
+        return results
 
     @staticmethod
     def get_system_prompt() -> str:

--- a/tests/unit/test_contextualization_batch.py
+++ b/tests/unit/test_contextualization_batch.py
@@ -204,3 +204,117 @@ class TestClaudeContextualizerBatch:
         claude_ctx.contextualize_single = _mock_single  # type: ignore[method-assign]
         await claude_ctx.contextualize_batch([f"c{i}" for i in range(10)], max_concurrency=2)
         assert peak <= 2
+
+
+
+# ---------------------------------------------------------------------------
+# Failure surfacing (#1656) — TaskGroup contract
+# ---------------------------------------------------------------------------
+
+
+class TestContextualizeBatchFailureSurfacing:
+    """contextualize_batch must NOT silently drop failed chunks (#1656).
+
+    Previous behavior used asyncio.gather(..., return_exceptions=True) and
+    filtered exceptions out, dropping the chunks entirely. New contract:
+    failures surface as fallback ContextualizedChunk records with
+    context_method='none' at the correct index, preserving cardinality
+    and order.
+
+    SDK baseline: asyncio.TaskGroup (PEP 654, Python 3.11+) is the
+    structured-concurrency primitive. Per-task try/except inside the
+    TaskGroup body keeps the group alive while recording per-chunk
+    failure outcomes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_failed_chunks_produce_fallback_record_at_correct_index(self) -> None:
+        class _FlakyContextualizer(ContextualizeProvider):
+            async def contextualize(self, chunks, query=None, context_window=3):
+                return []
+
+            async def contextualize_single(self, text, article_number, query=None):
+                if "fail" in text:
+                    raise RuntimeError(f"boom: {text}")
+                return ContextualizedChunk(
+                    original_text=text,
+                    contextual_summary=f"ok: {text}",
+                    article_number=article_number,
+                    context_method="test",
+                )
+
+        chunks = ["ok-0", "fail-1", "ok-2", "fail-3", "ok-4"]
+        results = await _FlakyContextualizer().contextualize_batch(chunks)
+
+        # No silent drops: cardinality preserved.
+        assert len(results) == len(chunks)
+        # Order preserved by index.
+        assert [r.original_text for r in results] == chunks
+        # Failed slots carry context_method='none'; succeeded slots keep 'test'.
+        methods = [r.context_method for r in results]
+        assert methods == ["test", "none", "test", "none", "test"]
+        # Failed slots have empty summary so downstream filtering is clear.
+        assert results[1].contextual_summary == ""
+        assert results[3].contextual_summary == ""
+
+    @pytest.mark.asyncio
+    async def test_all_failed_returns_fallbacks_not_empty_list(self) -> None:
+        class _AlwaysFails(ContextualizeProvider):
+            async def contextualize(self, chunks, query=None, context_window=3):
+                return []
+
+            async def contextualize_single(self, text, article_number, query=None):
+                raise RuntimeError("always")
+
+        results = await _AlwaysFails().contextualize_batch(["a", "b"])
+        assert len(results) == 2
+        assert all(r.context_method == "none" for r in results)
+        # Article numbers still indexed for traceability.
+        assert results[0].article_number == "chunk_0"
+        assert results[1].article_number == "chunk_1"
+
+    def test_base_module_uses_task_group_not_silent_gather(self) -> None:
+        """AST contract: contextualize_batch uses TaskGroup; no return_exceptions=True."""
+        import ast
+        import inspect
+        import textwrap
+
+        from src.contextualization import base as mod
+
+        source = textwrap.dedent(
+            inspect.getsource(mod.ContextualizeProvider.contextualize_batch)
+        )
+        tree = ast.parse(source)
+
+        uses_task_group = False
+        uses_silent_gather = False
+
+        for node in ast.walk(tree):
+            # asyncio.TaskGroup() — accept attribute or name reference.
+            if isinstance(node, ast.Call):
+                func = node.func
+                if isinstance(func, ast.Attribute) and func.attr == "TaskGroup":
+                    uses_task_group = True
+                if isinstance(func, ast.Name) and func.id == "TaskGroup":
+                    uses_task_group = True
+                # asyncio.gather(..., return_exceptions=True) — forbidden silent drop.
+                if (
+                    isinstance(func, ast.Attribute)
+                    and func.attr == "gather"
+                ) or (isinstance(func, ast.Name) and func.id == "gather"):
+                    for kw in node.keywords:
+                        if (
+                            kw.arg == "return_exceptions"
+                            and isinstance(kw.value, ast.Constant)
+                            and kw.value.value is True
+                        ):
+                            uses_silent_gather = True
+
+        assert uses_task_group, (
+            "contextualize_batch must use asyncio.TaskGroup for structured "
+            "concurrency (#1656)"
+        )
+        assert not uses_silent_gather, (
+            "contextualize_batch must not call asyncio.gather(..., "
+            "return_exceptions=True) — failures must be surfaced explicitly"
+        )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Closes #1656

`ContextualizeProvider.contextualize_batch` used `asyncio.gather(return_exceptions=True)` and silently filtered exceptions out of the result list. Failed chunks vanished — the caller had no way to know which inputs were skipped, breaking downstream index alignment.

## SDK baseline

Python stdlib (PEP 654):

- `asyncio.TaskGroup` is the structured-concurrency primitive (Python 3.11+).
- Per-task `try/except` inside the TaskGroup body keeps the group alive while recording per-chunk outcomes; the alternative — letting an exception propagate — would cancel siblings, which is the wrong policy here.

## Changes (single production file: `src/contextualization/base.py`)

- `contextualize_batch` now opens an `asyncio.TaskGroup` and pre-allocates the results list. Each worker writes to its own index slot, so input order is preserved without sorting and cardinality always matches.
- Per-chunk failures are caught inside the worker, logged via stdlib `logging.warning`, and recorded as a fallback `ContextualizedChunk` with `context_method="none"` (mirroring the existing failure shape used by `OpenAIContextualizer.contextualize`). Callers filter by `context_method` to detect skipped chunks.
- Empty input short-circuits to `[]` to avoid opening an empty TaskGroup.

## TDD contract (obra/superpowers RED-GREEN-REFACTOR)

New `TestContextualizeBatchFailureSurfacing` class — 3 tests, RED before implementation, all GREEN after:

| Test | Asserts |
|---|---|
| `test_failed_chunks_produce_fallback_record_at_correct_index` | Mixed success/failure on `["ok-0","fail-1","ok-2","fail-3","ok-4"]`: cardinality preserved (5/5), order preserved, failed indices carry `context_method="none"` with empty summary, succeeded indices keep `"test"`. |
| `test_all_failed_returns_fallbacks_not_empty_list` | All-fail input returns full-length list with each fallback indexed correctly (`chunk_0`, `chunk_1`). Confirms no silent drop. |
| `test_base_module_uses_task_group_not_silent_gather` | AST scan of `contextualize_batch` body: `asyncio.TaskGroup` IS used; `asyncio.gather(..., return_exceptions=True)` is NOT used. |

Existing tests untouched: `order_preserved`, `semaphore_limits_concurrency`, `all_chunks_processed`, etc. — 8 passing tests in `TestContextualizeBatch` and 3 in `TestClaudeContextualizerBatch`. All still pass.

## Verification

```
$ uv run pytest tests/unit/test_contextualization_batch.py tests/unit/contextualization/ -q --override-ini="addopts="
148 passed in 4.24s

$ uv run ruff check src/contextualization/base.py tests/unit/test_contextualization_batch.py
All checks passed!

$ uv run mypy src/contextualization/base.py
Success: no issues found in 1 source file
```

## Forbidden checks (per #1656)

- ✅ No silent exception filtering — failures are explicit fallback records.
- ✅ No unstructured list of `create_task` without `TaskGroup`.
- ✅ Provider hierarchy untouched.

## Failure-policy decision

Per the issue: "Decide and document the failure policy: raise after recording failure metadata, or return explicit per-chunk fallback records."

Chose **per-chunk fallback** (`context_method="none"`) over **raise** because:

1. Existing `OpenAIContextualizer.contextualize` already uses the same fallback shape internally; downstream code is shaped around filtering on `context_method`.
2. Indexing into the chunk list survives — caller can still pair input-N with output-N.
3. Logging via `logging.warning` makes failures visible without halting the entire batch.
4. Callers that want strict semantics can filter `[r for r in results if r.context_method != "none"]` and decide what to do.

## Side-findings during verification

None.

## Methodology

Followed [obra/superpowers TDD](https://github.com/obra/superpowers/blob/main/skills/test-driven-development/SKILL.md) and stdlib SDK-first guidance:

1. Identified `asyncio.TaskGroup` as the canonical structured-concurrency primitive in Python 3.11+ (issue cites it explicitly).
2. RED: 3 contract tests fail (silent drop, no TaskGroup).
3. GREEN: minimal TaskGroup migration; 3 RED tests + 145 pre-existing tests pass.