### PR TITLE
refactor(kommo): model custom_fields_values entries with Pydantic (#1655)

### DIFF
--- a/telegram_bot/handlers/phone_collector.py
+++ b/telegram_bot/handlers/phone_collector.py
@@ -23,7 +23,12 @@ from telegram_bot.keyboards.phone_keyboard import (
 )
 from telegram_bot.observability import observe
 from telegram_bot.services.content_loader import get_phone_config
-from telegram_bot.services.kommo_models import ContactCreate, LeadCreate, TaskCreate
+from telegram_bot.services.kommo_models import (
+    ContactCreate,
+    KommoCustomField,
+    LeadCreate,
+    TaskCreate,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -55,20 +60,27 @@ def _build_custom_fields(
     telegram_field_id: int = 0,
     telegram_username_field_id: int = 0,
 ) -> list[dict]:
-    """Build Kommo custom_fields_values for lead."""
-    fields: list[dict] = []
+    """Build Kommo ``custom_fields_values`` for a lead.
 
-    if service_field_id:
-        fields.append({"field_id": service_field_id, "values": [{"value": crm_title}]})
-    if source_field_id:
-        fields.append({"field_id": source_field_id, "values": [{"value": "Telegram-бот"}]})
-    if telegram_field_id and telegram_id:
-        fields.append({"field_id": telegram_field_id, "values": [{"value": str(telegram_id)}]})
-    if telegram_username_field_id and username:
-        fields.append(
-            {"field_id": telegram_username_field_id, "values": [{"value": f"@{username}"}]}
+    Each entry is constructed via :class:`KommoCustomField` so the API
+    payload shape is owned by Pydantic (#1655). ``KommoCustomField.build_simple``
+    skips fields whose CRM id is unset, matching the previous guard chain.
+    """
+    candidates: list[KommoCustomField | None] = [
+        KommoCustomField.build_simple(field_id=service_field_id, value=crm_title),
+        KommoCustomField.build_simple(field_id=source_field_id, value="Telegram-бот"),
+    ]
+    if telegram_id:
+        candidates.append(
+            KommoCustomField.build_simple(field_id=telegram_field_id, value=str(telegram_id))
         )
-    return fields
+    if username:
+        candidates.append(
+            KommoCustomField.build_simple(
+                field_id=telegram_username_field_id, value=f"@{username}"
+            )
+        )
+    return KommoCustomField.dump_list(candidates)
 
 
 def _build_note_text(

--- a/telegram_bot/handlers/phone_collector.py
+++ b/telegram_bot/handlers/phone_collector.py
@@ -76,9 +76,7 @@ def _build_custom_fields(
         )
     if username:
         candidates.append(
-            KommoCustomField.build_simple(
-                field_id=telegram_username_field_id, value=f"@{username}"
-            )
+            KommoCustomField.build_simple(field_id=telegram_username_field_id, value=f"@{username}")
         )
     return KommoCustomField.dump_list(candidates)
 

--- a/telegram_bot/services/kommo_models.py
+++ b/telegram_bot/services/kommo_models.py
@@ -71,9 +71,7 @@ class KommoCustomField(BaseModel):
         :class:`httpx.AsyncClient.post(json=...)` without further work.
         """
         return [
-            item.model_dump(by_alias=True, exclude_none=True)
-            for item in items
-            if item is not None
+            item.model_dump(by_alias=True, exclude_none=True) for item in items if item is not None
         ]
 
 

--- a/telegram_bot/services/kommo_models.py
+++ b/telegram_bot/services/kommo_models.py
@@ -12,6 +12,71 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field
 
 
+# --- Custom field building blocks (#1655) ---
+
+
+class KommoCustomFieldValue(BaseModel):
+    """One entry inside ``KommoCustomField.values`` (Kommo API v4).
+
+    Kommo's per-field value object is ``{"value": <scalar>, "enum_code"?: str}``.
+    Modelling it explicitly removes hand-built dicts at every emitter site.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    value: Any
+    enum_code: str | None = None
+
+
+class KommoCustomField(BaseModel):
+    """Single ``custom_fields_values`` entry on a Lead/Contact payload.
+
+    Serialised shape (``model_dump(by_alias=True, exclude_none=True)``):
+
+        {"field_id": 100, "values": [{"value": "..."}, ...]}
+
+    Use :meth:`build_simple` for the common single-string-value case and
+    :meth:`dump_list` to drop ``None`` placeholders that callers emit when
+    a field id is missing from configuration.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    field_id: int
+    values: list[KommoCustomFieldValue]
+
+    @classmethod
+    def build_simple(
+        cls, *, field_id: int | None, value: Any, enum_code: str | None = None
+    ) -> KommoCustomField | None:
+        """Return a single-value field, or ``None`` if ``field_id`` is falsy.
+
+        Mirrors the existing handler guard (``if service_field_id: ...``):
+        a ``None``/``0`` field id means the CRM has not configured this
+        custom field, so emit nothing instead of pointing at field 0.
+        """
+        if not field_id:
+            return None
+        return cls(
+            field_id=field_id,
+            values=[KommoCustomFieldValue(value=value, enum_code=enum_code)],
+        )
+
+    @staticmethod
+    def dump_list(items: list[KommoCustomField | None]) -> list[dict[str, Any]]:
+        """Serialise a list of fields, skipping ``None`` placeholders.
+
+        Returns the canonical Kommo API shape so emitters can pass the
+        result straight into ``LeadCreate.custom_fields_values`` or
+        :class:`httpx.AsyncClient.post(json=...)` without further work.
+        """
+        return [
+            item.model_dump(by_alias=True, exclude_none=True)
+            for item in items
+            if item is not None
+        ]
+
+
 # --- Request models (Create/Update) ---
 
 

--- a/tests/unit/services/test_kommo_models.py
+++ b/tests/unit/services/test_kommo_models.py
@@ -167,3 +167,171 @@ def test_contact_update_build_empty():
 
     fields = ContactUpdate.build_contact_fields()
     assert fields == []
+
+
+
+# -----------------------------------------------------------------------------
+# KommoCustomField (#1655) — typed builder for custom_fields_values payloads
+# -----------------------------------------------------------------------------
+
+
+class TestKommoCustomFieldValue:
+    """Pydantic model for a single Kommo custom field value entry."""
+
+    def test_string_value_serializes_to_value_dict(self) -> None:
+        from telegram_bot.services.kommo_models import KommoCustomFieldValue
+
+        v = KommoCustomFieldValue(value="Telegram-бот")
+        assert v.model_dump(exclude_none=True) == {"value": "Telegram-бот"}
+
+    def test_int_value_serializes_to_value_dict(self) -> None:
+        from telegram_bot.services.kommo_models import KommoCustomFieldValue
+
+        v = KommoCustomFieldValue(value=12345)
+        assert v.model_dump(exclude_none=True) == {"value": 12345}
+
+    def test_enum_code_when_present(self) -> None:
+        from telegram_bot.services.kommo_models import KommoCustomFieldValue
+
+        v = KommoCustomFieldValue(value="+380501234567", enum_code="WORK")
+        assert v.model_dump(exclude_none=True) == {
+            "value": "+380501234567",
+            "enum_code": "WORK",
+        }
+
+
+class TestKommoCustomField:
+    """Pydantic model for a Kommo custom_fields_values entry (field_id + values)."""
+
+    def test_serialized_payload_matches_kommo_api_shape(self) -> None:
+        from telegram_bot.services.kommo_models import (
+            KommoCustomField,
+            KommoCustomFieldValue,
+        )
+
+        f = KommoCustomField(
+            field_id=100,
+            values=[KommoCustomFieldValue(value="Осмотр объектов")],
+        )
+        assert f.model_dump(by_alias=True, exclude_none=True) == {
+            "field_id": 100,
+            "values": [{"value": "Осмотр объектов"}],
+        }
+
+    def test_field_id_zero_is_rejected_by_helper(self) -> None:
+        """build_simple skips construction when field_id is falsy.
+
+        The handler today guards with ``if service_field_id: ...`` and the
+        new helper should preserve that contract — emitting a field with
+        id=0 would target a non-existent CRM field.
+        """
+        from telegram_bot.services.kommo_models import KommoCustomField
+
+        # field_id=0 / None must produce an explicit None so callers can filter.
+        assert KommoCustomField.build_simple(field_id=0, value="x") is None
+        assert KommoCustomField.build_simple(field_id=None, value="x") is None
+
+    def test_build_simple_returns_payload_for_valid_field(self) -> None:
+        from telegram_bot.services.kommo_models import KommoCustomField
+
+        f = KommoCustomField.build_simple(field_id=200, value="Telegram-бот")
+        assert f is not None
+        assert f.model_dump(by_alias=True, exclude_none=True) == {
+            "field_id": 200,
+            "values": [{"value": "Telegram-бот"}],
+        }
+
+    def test_dump_list_filters_none_entries(self) -> None:
+        from telegram_bot.services.kommo_models import KommoCustomField
+
+        items = [
+            KommoCustomField.build_simple(field_id=100, value="A"),
+            None,  # represents a missing field — must be skipped
+            KommoCustomField.build_simple(field_id=0, value="B"),  # also None
+            KommoCustomField.build_simple(field_id=300, value="C"),
+        ]
+        payload = KommoCustomField.dump_list(items)
+        assert payload == [
+            {"field_id": 100, "values": [{"value": "A"}]},
+            {"field_id": 300, "values": [{"value": "C"}]},
+        ]
+
+
+class TestPhoneCollectorBuildsViaPydantic:
+    """phone_collector._build_custom_fields must construct entries via KommoCustomField (#1655).
+
+    The function still returns ``list[dict]`` for httpx posting, but each entry
+    must come from KommoCustomField.model_dump(by_alias=True, exclude_none=True)
+    rather than a hand-rolled dict literal. AST scan keeps the contract enforced
+    even if the helper signature changes.
+    """
+
+    def test_handler_returns_payload_byte_compatible_with_kommo_api(self) -> None:
+        from telegram_bot.handlers.phone_collector import _build_custom_fields
+
+        fields = _build_custom_fields(
+            "Осмотр объектов",
+            12345,
+            "ivan",
+            service_field_id=100,
+            source_field_id=200,
+            telegram_field_id=300,
+            telegram_username_field_id=400,
+        )
+
+        # Existing dict shape preserved — Kommo API contract unchanged.
+        assert {"field_id": 100, "values": [{"value": "Осмотр объектов"}]} in fields
+        assert {"field_id": 200, "values": [{"value": "Telegram-бот"}]} in fields
+        assert {"field_id": 300, "values": [{"value": "12345"}]} in fields
+        assert {"field_id": 400, "values": [{"value": "@ivan"}]} in fields
+
+    def test_handler_uses_kommo_custom_field_model(self) -> None:
+        """AST contract: phone_collector._build_custom_fields uses KommoCustomField.
+
+        Forbids regressing to hand-built ``{"field_id": ..., "values": [...]}``
+        dict literals. The function may still produce dicts via
+        ``KommoCustomField.dump_list(...)`` or ``model_dump(by_alias=True)``.
+        """
+        import ast
+        import inspect
+        import textwrap
+
+        from telegram_bot.handlers import phone_collector as mod
+
+        source = textwrap.dedent(inspect.getsource(mod._build_custom_fields))
+        tree = ast.parse(source)
+
+        uses_model = False
+        bad_literals: list[int] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                func = node.func
+                if (
+                    isinstance(func, ast.Attribute)
+                    and func.attr in {"build_simple", "dump_list", "model_dump"}
+                ) or (
+                    isinstance(func, ast.Name)
+                    and func.id in {"KommoCustomField", "KommoCustomFieldValue"}
+                ):
+                    uses_model = True
+            if isinstance(node, ast.Dict):
+                # A literal dict whose keys include 'field_id' AND 'values'
+                # is exactly the hand-built shape we want to remove.
+                key_strings = {
+                    k.value
+                    for k in node.keys
+                    if isinstance(k, ast.Constant) and isinstance(k.value, str)
+                }
+                if {"field_id", "values"}.issubset(key_strings):
+                    bad_literals.append(node.lineno)
+
+        assert uses_model, (
+            "phone_collector._build_custom_fields must build entries via "
+            "KommoCustomField (build_simple / dump_list / model_dump), "
+            "not raw dict literals (#1655)"
+        )
+        assert not bad_literals, (
+            "phone_collector._build_custom_fields contains hand-built "
+            "{field_id, values} dict literals on lines: "
+            + ", ".join(map(str, bad_literals))
+        )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Closes #1655

Replaces hand-rolled `{"field_id": ..., "values": [{"value": ...}]}` dict literals in `telegram_bot/handlers/phone_collector.py` with two new Pydantic v2 models in `telegram_bot/services/kommo_models.py`:

- **`KommoCustomFieldValue`** — single value entry (`value` + optional `enum_code`).
- **`KommoCustomField`** — `field_id` + `values` list, with two helpers:
  - `build_simple(field_id, value, enum_code=None)` → `KommoCustomField | None`. Returns `None` when `field_id` is falsy, preserving the existing emitter guard.
  - `dump_list(items)` → `list[dict]`. Drops `None` placeholders and serialises survivors via `model_dump(by_alias=True, exclude_none=True)`.

Output shape is byte-identical to the previous implementation, so the Kommo API contract is unchanged and the existing 28 `test_phone_collector.py` tests pass without modification.

## TDD (obra/superpowers RED-GREEN-REFACTOR)

8 new tests. RED before implementation, GREEN after:
- `TestKommoCustomFieldValue` (×3) — string/int/`enum_code` serialisation.
- `TestKommoCustomField` (×4) — exact Kommo API payload shape, `field_id=0`/`None` rejection, `dump_list` filtering.
- `TestPhoneCollectorBuildsViaPydantic` (×2) — handler returns byte-compat payload + AST scan forbids hand-built `{field_id, values}` dict literals from regressing.

## Verification

```bash
$ uv run pytest tests/unit/services/test_kommo_models.py \
                tests/unit/services/test_kommo_models_lead_create.py \
                tests/unit/handlers/test_phone_collector.py -q
68 passed in 2.86s

$ uv run ruff check telegram_bot/services/kommo_models.py \
                    telegram_bot/handlers/phone_collector.py \
                    tests/unit/services/test_kommo_models.py
All checks passed!

$ uv run mypy telegram_bot/services/kommo_models.py \
              telegram_bot/handlers/phone_collector.py
Success: no issues found in 2 source files
```

## Out of scope

Per issue body, also flagged: `mini_app/phone.py` and `scripts/kommo_seed.py`. Verified via grep — neither file currently emits the same `{field_id, values}` dict literal pattern, so no follow-up needed there.

Kommo API client (`KommoClient`), Lead/Contact schema and `LeadScoreSyncPayload` are untouched.

## Side-findings

None — all touched files lint clean, all touched tests pass.