### PR TITLE
refactor(miniapp): own Redis lifecycle via FastAPI lifespan + Depends (#1645)

### DIFF
--- a/mini_app/api.py
+++ b/mini_app/api.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import json
 import os
 import uuid as _uuid_lib
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
 from mini_app.expert_start import StartExpertRequest, StartExpertResponse
@@ -15,7 +17,47 @@ from mini_app.phone import PhoneRequest, submit_phone
 from telegram_bot.services.content_loader import load_mini_app_config
 
 
-app = FastAPI(title="FortNoks Mini App API", version="0.1.0")
+_DEEPLINK_TTL = 300  # seconds
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """Open the Redis client on startup and close it on shutdown.
+
+    The Mini App backend uses Redis for short-lived deeplink payloads
+    (``miniapp:q:<uuid>``) and pub/sub notifications to the bot. Owning
+    the connection lifecycle here (instead of a module-level lazy
+    global) ensures graceful close on process shutdown and matches the
+    FastAPI-native pattern (#1645).
+    """
+    import redis.asyncio as aioredis
+
+    redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379")
+    client = aioredis.from_url(redis_url, decode_responses=True)
+    app.state.redis = client
+    try:
+        yield
+    finally:
+        # ``aioredis`` clients expose ``aclose`` in modern versions; fall back to
+        # ``close`` for older releases. Either way, the connection pool drains.
+        close = getattr(client, "aclose", None) or getattr(client, "close", None)
+        if close is not None:
+            result = close()
+            if hasattr(result, "__await__"):
+                await result
+
+
+async def get_redis(request: Request) -> Any:
+    """FastAPI dependency that returns the app-scoped Redis client.
+
+    Handlers receive the connection via ``Depends(get_redis)`` so the
+    lifecycle stays owned by ``lifespan`` instead of leaking into module
+    globals.
+    """
+    return request.app.state.redis
+
+
+app = FastAPI(title="FortNoks Mini App API", version="0.1.0", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,
@@ -23,21 +65,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-_redis_client: Any = None
-
-_DEEPLINK_TTL = 300  # seconds
-
-
-async def _get_redis() -> Any:
-    """Lazy-init Redis client from REDIS_URL env var."""
-    global _redis_client
-    if _redis_client is None:
-        import redis.asyncio as aioredis
-
-        redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379")
-        _redis_client = aioredis.from_url(redis_url, decode_responses=True)
-    return _redis_client
 
 
 @app.get("/api/config")
@@ -47,7 +74,10 @@ async def get_config() -> dict:
 
 
 @app.post("/api/start-expert")
-async def start_expert(request: StartExpertRequest) -> StartExpertResponse:
+async def start_expert(
+    request: StartExpertRequest,
+    redis: Any = Depends(get_redis),
+) -> StartExpertResponse:
     """Store deep-link payload in Redis and return start_link for openTelegramLink."""
     from fastapi import HTTPException
 
@@ -66,7 +96,6 @@ async def start_expert(request: StartExpertRequest) -> StartExpertResponse:
             "query_id": request.query_id,
         }
     )
-    redis = await _get_redis()
     await redis.set(f"miniapp:q:{uid}", payload, ex=_DEEPLINK_TTL)
 
     bot_username = os.environ.get("BOT_USERNAME", "")

--- a/tests/unit/mini_app/test_api_lifespan.py
+++ b/tests/unit/mini_app/test_api_lifespan.py
@@ -1,0 +1,139 @@
+"""Tests for mini_app.api lifespan + Redis dependency wiring (#1645).
+
+The previous implementation kept a module-level lazy ``_redis_client``
+global and an ``_get_redis()`` factory called from each request handler.
+That bypasses FastAPI's native lifecycle and never closes the Redis
+connection on app shutdown.
+
+This contract pins the new shape (Context7 /websites/fastapi):
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        app.state.redis = aioredis.from_url(...)
+        try:
+            yield
+        finally:
+            await app.state.redis.aclose()
+
+    app = FastAPI(lifespan=lifespan)
+
+    async def get_redis(request: Request) -> Any:
+        return request.app.state.redis
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def test_module_no_longer_exposes_module_level_redis_global() -> None:
+    """``_redis_client`` module global must be removed (#1645)."""
+    from mini_app import api as mod
+
+    assert not hasattr(mod, "_redis_client"), (
+        "mini_app.api._redis_client global must be removed; "
+        "Redis lifecycle is now owned by lifespan + app.state.redis"
+    )
+
+
+def test_module_no_longer_exposes_lazy_get_redis_factory() -> None:
+    """The lazy ``_get_redis()`` global factory is replaced by ``get_redis(request)``."""
+    from mini_app import api as mod
+
+    assert not hasattr(mod, "_get_redis"), (
+        "mini_app.api._get_redis lazy-init global must be removed; "
+        "use FastAPI Depends(get_redis) instead"
+    )
+
+
+def test_module_exposes_lifespan_and_get_redis_dependency() -> None:
+    """``lifespan`` and ``get_redis`` must be importable from mini_app.api."""
+    from mini_app import api as mod
+
+    assert hasattr(mod, "lifespan"), "mini_app.api.lifespan async context manager required"
+    assert hasattr(mod, "get_redis"), "mini_app.api.get_redis(request) dependency required"
+
+
+def test_app_uses_lifespan_for_lifecycle() -> None:
+    """FastAPI app must be constructed with the lifespan context manager."""
+    from mini_app import api as mod
+
+    # FastAPI stores the lifespan on ``app.router.lifespan_context``.
+    lifespan_ctx = getattr(mod.app.router, "lifespan_context", None)
+    assert lifespan_ctx is not None, "FastAPI(lifespan=...) wiring missing"
+
+
+async def test_lifespan_opens_and_closes_redis() -> None:
+    """Entering lifespan must construct Redis; exit must close it exactly once."""
+    from mini_app import api as mod
+
+    fake_client = MagicMock()
+    fake_client.aclose = AsyncMock()
+
+    with patch("redis.asyncio.from_url", return_value=fake_client) as mock_factory:
+        async with mod.lifespan(mod.app):
+            assert mod.app.state.redis is fake_client
+            mock_factory.assert_called_once()
+
+        # Lifespan exit closes the client exactly once.
+        fake_client.aclose.assert_awaited_once()
+
+
+async def test_get_redis_returns_app_state_redis() -> None:
+    """``get_redis(request)`` must return ``request.app.state.redis``."""
+    from mini_app import api as mod
+
+    sentinel_redis = MagicMock(name="redis-client")
+    fake_request = SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(redis=sentinel_redis))
+    )
+
+    result = await mod.get_redis(fake_request)
+    assert result is sentinel_redis
+
+
+def test_start_expert_handler_uses_depends_get_redis() -> None:
+    """AST contract: ``start_expert`` consumes Redis via ``Depends(get_redis)``.
+
+    Forbids regressing to the lazy module-level ``await _get_redis()`` lookup
+    that owned the connection lifecycle implicitly.
+    """
+    from mini_app import api as mod
+
+    source = textwrap.dedent(inspect.getsource(mod.start_expert))
+    tree = ast.parse(source)
+
+    func_def = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+        and node.name == "start_expert"
+    )
+
+    # Search default values + annotations for a Depends(get_redis) call.
+    uses_depends_get_redis = False
+    for default in list(func_def.args.defaults) + list(func_def.args.kw_defaults):
+        if default is None:
+            continue
+        if isinstance(default, ast.Call):
+            func = default.func
+            name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", "")
+            if name == "Depends":
+                # Confirm the dependency target is get_redis.
+                target = ast.unparse(default.args[0]) if default.args else ""
+                if "get_redis" in target:
+                    uses_depends_get_redis = True
+
+    # Defensively forbid the legacy lazy lookup inside the body.
+    body_source = ast.unparse(func_def)
+    assert "_get_redis(" not in body_source, (
+        "start_expert must not call legacy _get_redis(); use Depends(get_redis)"
+    )
+    assert uses_depends_get_redis, (
+        "start_expert must declare a Redis parameter via Depends(get_redis) "
+        "for FastAPI-native dependency injection (#1645)"
+    )

--- a/tests/unit/mini_app/test_api_lifespan.py
+++ b/tests/unit/mini_app/test_api_lifespan.py
@@ -29,6 +29,11 @@ import textwrap
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+
+pytest.importorskip("fastapi")
+
 
 def test_module_no_longer_exposes_module_level_redis_global() -> None:
     """``_redis_client`` module global must be removed (#1645)."""
@@ -88,9 +93,7 @@ async def test_get_redis_returns_app_state_redis() -> None:
     from mini_app import api as mod
 
     sentinel_redis = MagicMock(name="redis-client")
-    fake_request = SimpleNamespace(
-        app=SimpleNamespace(state=SimpleNamespace(redis=sentinel_redis))
-    )
+    fake_request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(redis=sentinel_redis)))
 
     result = await mod.get_redis(fake_request)
     assert result is sentinel_redis
@@ -110,8 +113,7 @@ def test_start_expert_handler_uses_depends_get_redis() -> None:
     func_def = next(
         node
         for node in ast.walk(tree)
-        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
-        and node.name == "start_expert"
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == "start_expert"
     )
 
     # Search default values + annotations for a Depends(get_redis) call.

--- a/tests/unit/mini_app/test_chat.py
+++ b/tests/unit/mini_app/test_chat.py
@@ -10,7 +10,17 @@ pytest.importorskip("fastapi")
 
 from httpx import ASGITransport, AsyncClient
 
-from mini_app.api import app
+from mini_app.api import app, get_redis
+
+
+def _override_redis(mock_redis: AsyncMock) -> None:
+    """Install ``mock_redis`` as the FastAPI Depends(get_redis) override."""
+    app.dependency_overrides[get_redis] = lambda: mock_redis
+
+
+def _clear_redis_override() -> None:
+    """Remove the dependency override after the test."""
+    app.dependency_overrides.pop(get_redis, None)
 
 
 @pytest.mark.asyncio
@@ -26,8 +36,9 @@ async def test_health_endpoint():
 async def test_start_expert_not_found():
     """Unknown expert_id should return 404."""
     mock_redis = AsyncMock()
-    with patch("mini_app.api.load_mini_app_config", return_value={"experts": []}):
-        with patch("mini_app.api._get_redis", new=AsyncMock(return_value=mock_redis)):
+    _override_redis(mock_redis)
+    try:
+        with patch("mini_app.api.load_mini_app_config", return_value={"experts": []}):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
@@ -35,6 +46,8 @@ async def test_start_expert_not_found():
                     "/api/start-expert",
                     json={"user_id": 123, "expert_id": "nonexistent"},
                 )
+    finally:
+        _clear_redis_override()
     assert resp.status_code == 404
 
 
@@ -43,8 +56,9 @@ async def test_start_expert_returns_start_link():
     """Valid expert should return start_link for deep linking."""
     mock_redis = AsyncMock()
     experts = [{"id": "consultant", "name": "Консультант", "emoji": "👷"}]
-    with patch("mini_app.api.load_mini_app_config", return_value={"experts": experts}):
-        with patch("mini_app.api._get_redis", new=AsyncMock(return_value=mock_redis)):
+    _override_redis(mock_redis)
+    try:
+        with patch("mini_app.api.load_mini_app_config", return_value={"experts": experts}):
             with patch.dict(os.environ, {"BOT_USERNAME": "testbot"}):
                 async with AsyncClient(
                     transport=ASGITransport(app=app), base_url="http://test"
@@ -57,6 +71,8 @@ async def test_start_expert_returns_start_link():
                             "message": "Подбери квартиру",
                         },
                     )
+    finally:
+        _clear_redis_override()
     assert resp.status_code == 200
     data = resp.json()
     assert "start_link" in data
@@ -71,8 +87,9 @@ async def test_start_expert_stores_payload_in_redis():
     """API should store payload in Redis with TTL 300s."""
     mock_redis = AsyncMock()
     experts = [{"id": "consultant", "name": "Консультант", "emoji": "👷"}]
-    with patch("mini_app.api.load_mini_app_config", return_value={"experts": experts}):
-        with patch("mini_app.api._get_redis", new=AsyncMock(return_value=mock_redis)):
+    _override_redis(mock_redis)
+    try:
+        with patch("mini_app.api.load_mini_app_config", return_value={"experts": experts}):
             with patch.dict(os.environ, {"BOT_USERNAME": "testbot"}):
                 async with AsyncClient(
                     transport=ASGITransport(app=app), base_url="http://test"
@@ -81,6 +98,8 @@ async def test_start_expert_stores_payload_in_redis():
                         "/api/start-expert",
                         json={"user_id": 123, "expert_id": "consultant", "message": "Тест"},
                     )
+    finally:
+        _clear_redis_override()
     assert resp.status_code == 200
     # Redis.set should have been called with TTL=300
     mock_redis.set.assert_called_once()
@@ -99,8 +118,9 @@ async def test_start_expert_fails_without_bot_username():
     """Missing BOT_USERNAME should return 500."""
     mock_redis = AsyncMock()
     experts = [{"id": "consultant", "name": "Консультант", "emoji": "👷"}]
-    with patch("mini_app.api.load_mini_app_config", return_value={"experts": experts}):
-        with patch("mini_app.api._get_redis", new=AsyncMock(return_value=mock_redis)):
+    _override_redis(mock_redis)
+    try:
+        with patch("mini_app.api.load_mini_app_config", return_value={"experts": experts}):
             with patch.dict(os.environ, {"BOT_USERNAME": ""}, clear=False):
                 async with AsyncClient(
                     transport=ASGITransport(app=app), base_url="http://test"
@@ -109,4 +129,6 @@ async def test_start_expert_fails_without_bot_username():
                         "/api/start-expert",
                         json={"user_id": 123, "expert_id": "consultant"},
                     )
+    finally:
+        _clear_redis_override()
     assert resp.status_code == 500


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Closes #1645

Replaces the module-level `_redis_client` global + `_get_redis()` lazy factory in `mini_app/api.py` with FastAPI's native lifecycle:

```python
@asynccontextmanager
async def lifespan(app: FastAPI):
    client = aioredis.from_url(...)
    app.state.redis = client
    try:
        yield
    finally:
        await client.aclose()

app = FastAPI(..., lifespan=lifespan)

async def get_redis(request: Request) -> Any:
    return request.app.state.redis
```

`/api/start-expert` now consumes Redis via `Depends(get_redis)`. SDK baseline verified through Context7 (`/websites/fastapi`).

## TDD (obra/superpowers RED-GREEN-REFACTOR)

7 new tests in `tests/unit/mini_app/test_api_lifespan.py`. RED before implementation, all GREEN after:
- `_redis_client` and `_get_redis` removed.
- `lifespan` + `get_redis` importable; `app.router.lifespan_context` non-None.
- Lifespan opens Redis on enter, closes exactly once on exit (mocks `redis.asyncio.from_url`).
- `get_redis(request)` returns `request.app.state.redis`.
- AST contract: `start_expert` declares `Depends(get_redis)`; legacy `_get_redis(` absent from body.

4 existing `/api/start-expert` tests in `test_chat.py` migrated from `patch("mini_app.api._get_redis", ...)` to FastAPI's `app.dependency_overrides[get_redis] = lambda: mock_redis`. Behaviour assertions unchanged.

## Verification

```bash
$ uv run pytest tests/unit/mini_app/ -q
38 passed in 2.96s

$ uv run ruff check mini_app/api.py tests/unit/mini_app/test_api_lifespan.py tests/unit/mini_app/test_chat.py
All checks passed!

$ uv run mypy mini_app/api.py
Success: no issues found in 1 source file
```

## Forbidden / out-of-scope

- No module-level lazy Redis global.
- No per-request Redis client creation.
- Mini App auth (#1595) and remote_log hardening (#1613) untouched — separate concerns.

## Side-findings

None — `mini_app/api.py` and the migrated tests lint+type-check clean. No pre-existing errors surfaced in adjacent files during verification.