### PR TITLE
refactor(kommo): own bearer + refresh-on-401 via httpx.Auth flow (#1646)

### DIFF
--- a/telegram_bot/services/kommo_client.py
+++ b/telegram_bot/services/kommo_client.py
@@ -1,12 +1,17 @@
 """Async Kommo CRM API adapter (#413).
 
-First-party httpx adapter with OAuth2 auto-refresh.
+First-party httpx adapter with OAuth2 auto-refresh delegated to a custom
+``httpx.Auth`` flow (#1646). Bearer header injection and refresh-on-401
+live in :class:`KommoOAuthAuth`, exactly as documented for multi-request
+auth flows in the upstream HTTPX advanced authentication docs.
 Pattern: BGEM3Client (same project).
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any, cast
 
 import httpx
@@ -34,6 +39,50 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class KommoOAuthAuth(httpx.Auth):
+    """Bearer-token auth flow for Kommo with refresh-on-401 (#1646).
+
+    The flow:
+
+    1. Fetch the current token via ``token_store.get_valid_token()``,
+       attach ``Authorization: Bearer ...`` and yield the request.
+    2. If the response is 401, ask the token store for a fresh token via
+       ``force_refresh()`` and yield the request a second time with the
+       new bearer.
+    3. If ``force_refresh()`` raises ``RuntimeError`` (e.g. seeded
+       long-lived tokens that have no refresh_token), terminate the flow
+       without re-yielding so the original 401 response surfaces to the
+       caller as a normal :class:`httpx.HTTPStatusError`.
+
+    Concurrent calls share an :class:`asyncio.Lock` so multiple in-flight
+    requests trigger at most one refresh.
+    """
+
+    def __init__(self, *, token_store: KommoTokenStoreProtocol) -> None:
+        self._token_store = token_store
+        self._lock = asyncio.Lock()
+
+    async def async_auth_flow(
+        self, request: httpx.Request
+    ) -> AsyncGenerator[httpx.Request, httpx.Response]:
+        token = await self._token_store.get_valid_token()
+        request.headers["Authorization"] = f"Bearer {token}"
+        response = yield request
+
+        if response.status_code != 401:
+            return
+
+        try:
+            async with self._lock:
+                token = await self._token_store.force_refresh()
+        except RuntimeError:
+            # No refresh_token (seeded long-lived) — surface the original 401.
+            return
+
+        request.headers["Authorization"] = f"Bearer {token}"
+        yield request
+
+
 class KommoClient:
     """Async Kommo CRM API adapter with auto-refresh OAuth2."""
 
@@ -46,31 +95,20 @@ class KommoClient:
             timeout=httpx.Timeout(30.0, connect=10.0),
             limits=httpx.Limits(max_keepalive_connections=5, max_connections=10),
             headers={"Content-Type": "application/json"},
+            auth=KommoOAuthAuth(token_store=token_store),
         )
 
     @kommo_retry
     async def _request(self, method: str, path: str, **kwargs: Any) -> dict:
-        """Execute request with auto-refresh on 401."""
-        token = await self._token_store.get_valid_token()
-        extra_headers = kwargs.pop("headers", None) or {}
-        headers = {"Authorization": f"Bearer {token}", **extra_headers}
-
-        response = await self._client.request(method, path, headers=headers, **kwargs)
-
-        if response.status_code == 401:
-            try:
-                token = await self._token_store.force_refresh()
-            except RuntimeError:
-                # Seeded long-lived tokens have no refresh_token — re-raise as HTTP error.
-                response.raise_for_status()
-                return {}  # unreachable, raise_for_status always throws on 401
-            headers["Authorization"] = f"Bearer {token}"
-            response = await self._client.request(method, path, headers=headers, **kwargs)
+        """Execute a request; bearer + refresh handled by ``KommoOAuthAuth``."""
+        response = await self._client.request(method, path, **kwargs)
 
         if response.status_code == 204:
             return {}
 
-        # Raises for 429/5xx so tenacity can retry.
+        # Raises for 401 (after the auth flow has already retried), 429, 5xx so
+        # tenacity retries transient cases and a seeded-token 401 surfaces
+        # as the canonical HTTPStatusError.
         response.raise_for_status()
 
         # Kommo can return empty body on some successful endpoints.

--- a/telegram_bot/services/kommo_client.py
+++ b/telegram_bot/services/kommo_client.py
@@ -54,8 +54,9 @@ class KommoOAuthAuth(httpx.Auth):
        without re-yielding so the original 401 response surfaces to the
        caller as a normal :class:`httpx.HTTPStatusError`.
 
-    Concurrent calls share an :class:`asyncio.Lock` so multiple in-flight
-    requests trigger at most one refresh.
+    Concurrent calls re-check the current token inside an :class:`asyncio.Lock`
+    so multiple in-flight 401s caused by the same stale bearer trigger at most
+    one refresh.
     """
 
     def __init__(self, *, token_store: KommoTokenStoreProtocol) -> None:
@@ -74,7 +75,11 @@ class KommoOAuthAuth(httpx.Auth):
 
         try:
             async with self._lock:
-                token = await self._token_store.force_refresh()
+                current_token = await self._token_store.get_valid_token()
+                if current_token != token:
+                    token = current_token
+                else:
+                    token = await self._token_store.force_refresh()
         except RuntimeError:
             # No refresh_token (seeded long-lived) — surface the original 401.
             return

--- a/tests/unit/services/test_kommo_client.py
+++ b/tests/unit/services/test_kommo_client.py
@@ -522,6 +522,36 @@ class TestKommoOAuthAuthFlow:
 
         mock_token_store.force_refresh.assert_awaited_once()
 
+    async def test_async_auth_flow_deduplicates_concurrent_401_refreshes(
+        self, mock_token_store
+    ) -> None:
+        import httpx
+
+        from telegram_bot.services.kommo_client import KommoOAuthAuth
+
+        mock_token_store.get_valid_token.side_effect = [
+            "stale-token",
+            "stale-token",
+            "stale-token",
+            "refreshed-token",
+        ]
+        mock_token_store.force_refresh.return_value = "refreshed-token"
+        auth = KommoOAuthAuth(token_store=mock_token_store)
+        first_request = httpx.Request("GET", "https://test-co.kommo.com/api/v4/leads/1")
+        second_request = httpx.Request("GET", "https://test-co.kommo.com/api/v4/leads/2")
+
+        first_flow = auth.async_auth_flow(first_request)
+        second_flow = auth.async_auth_flow(second_request)
+        await first_flow.__anext__()
+        await second_flow.__anext__()
+
+        first_retry = await first_flow.asend(httpx.Response(401, request=first_request))
+        second_retry = await second_flow.asend(httpx.Response(401, request=second_request))
+
+        assert first_retry.headers["Authorization"] == "Bearer refreshed-token"
+        assert second_retry.headers["Authorization"] == "Bearer refreshed-token"
+        mock_token_store.force_refresh.assert_awaited_once()
+
     async def test_async_auth_flow_swallows_runtime_error_from_refresh(
         self, mock_token_store
     ) -> None:

--- a/tests/unit/services/test_kommo_client.py
+++ b/tests/unit/services/test_kommo_client.py
@@ -442,3 +442,148 @@ async def test_upsert_contact_no_update_when_names_already_filled(kommo_client) 
 
     assert not captured
     assert result.id == 99
+
+
+
+# -----------------------------------------------------------------------------
+# httpx.Auth flow contract (#1646)
+# -----------------------------------------------------------------------------
+
+
+class TestKommoOAuthAuthFlow:
+    """KommoClient delegates OAuth bearer/refresh to a httpx.Auth subclass (#1646).
+
+    Context7 baseline (/encode/httpx) recommends overriding ``async_auth_flow``
+    on a subclass of ``httpx.Auth`` for multi-request authentication, including
+    refresh-on-401. Coordinating concurrent refresh with ``asyncio.Lock`` is the
+    documented pattern.
+    """
+
+    def test_kommo_oauth_auth_class_is_subclass_of_httpx_auth(self) -> None:
+        import httpx
+
+        from telegram_bot.services.kommo_client import KommoOAuthAuth
+
+        assert issubclass(KommoOAuthAuth, httpx.Auth)
+
+    def test_kommo_client_attaches_oauth_auth_to_async_client(
+        self, mock_token_store
+    ) -> None:
+        """The shared httpx.AsyncClient must be constructed with KommoOAuthAuth."""
+        from telegram_bot.services.kommo_client import KommoClient, KommoOAuthAuth
+
+        client = KommoClient(subdomain="test-co", token_store=mock_token_store)
+        # httpx exposes the auth on the AsyncClient as ``client.auth``.
+        assert isinstance(client._client.auth, KommoOAuthAuth)
+
+    async def test_async_auth_flow_sets_bearer_then_yields(
+        self, mock_token_store
+    ) -> None:
+        import httpx
+
+        from telegram_bot.services.kommo_client import KommoOAuthAuth
+
+        auth = KommoOAuthAuth(token_store=mock_token_store)
+        request = httpx.Request("GET", "https://test-co.kommo.com/api/v4/leads/1")
+
+        flow = auth.async_auth_flow(request)
+        first = await flow.__anext__()
+        assert first is request
+        assert first.headers["Authorization"] == "Bearer test-token"
+        # Simulate 200: flow completes after the first yield.
+        ok = httpx.Response(200, request=request)
+        with pytest.raises(StopAsyncIteration):
+            await flow.asend(ok)
+        mock_token_store.get_valid_token.assert_awaited_once()
+        mock_token_store.force_refresh.assert_not_called()
+
+    async def test_async_auth_flow_refreshes_and_yields_again_on_401(
+        self, mock_token_store
+    ) -> None:
+        import httpx
+
+        from telegram_bot.services.kommo_client import KommoOAuthAuth
+
+        auth = KommoOAuthAuth(token_store=mock_token_store)
+        request = httpx.Request("GET", "https://test-co.kommo.com/api/v4/leads/1")
+
+        flow = auth.async_auth_flow(request)
+        first = await flow.__anext__()
+        assert first.headers["Authorization"] == "Bearer test-token"
+
+        unauthorized = httpx.Response(401, request=request)
+        retry = await flow.asend(unauthorized)
+        # Same Request object re-yielded with refreshed bearer.
+        assert retry.headers["Authorization"] == "Bearer refreshed-token"
+        # Flow ends after retry response.
+        ok = httpx.Response(200, request=retry)
+        with pytest.raises(StopAsyncIteration):
+            await flow.asend(ok)
+
+        mock_token_store.force_refresh.assert_awaited_once()
+
+    async def test_async_auth_flow_swallows_runtime_error_from_refresh(
+        self, mock_token_store
+    ) -> None:
+        """Seeded long-lived tokens raise RuntimeError on force_refresh.
+
+        The auth flow must NOT propagate this RuntimeError out — httpx will
+        otherwise wrap it as a generic auth failure. Returning lets the original
+        401 response surface to the caller, where ``response.raise_for_status()``
+        produces the canonical ``httpx.HTTPStatusError``.
+        """
+        import httpx
+
+        from telegram_bot.services.kommo_client import KommoOAuthAuth
+
+        mock_token_store.force_refresh = AsyncMock(
+            side_effect=RuntimeError("No refresh_token available for Kommo.")
+        )
+        auth = KommoOAuthAuth(token_store=mock_token_store)
+        request = httpx.Request("GET", "https://test-co.kommo.com/api/v4/leads/1")
+
+        flow = auth.async_auth_flow(request)
+        await flow.__anext__()
+        unauthorized = httpx.Response(401, request=request)
+        # Flow must terminate without re-yielding when refresh is impossible.
+        with pytest.raises(StopAsyncIteration):
+            await flow.asend(unauthorized)
+
+
+class TestKommoClientRequestNoLongerHandles401:
+    """AST: ``KommoClient._request`` no longer carries the manual 401 branch (#1646).
+
+    Forbids regressing to the pre-#1646 manual ``if response.status_code == 401:``
+    refresh-and-retry block that duplicated httpx.Auth's responsibility.
+    """
+
+    def test_request_body_does_not_check_401_status_code(self) -> None:
+        import ast
+        import inspect
+        import textwrap
+
+        from telegram_bot.services import kommo_client as mod
+
+        source = textwrap.dedent(inspect.getsource(mod.KommoClient._request))
+        tree = ast.parse(source)
+
+        bad: list[int] = []
+        for node in ast.walk(tree):
+            # Look for `response.status_code == 401` comparisons in the body.
+            if not isinstance(node, ast.Compare):
+                continue
+            left = node.left
+            if not (
+                isinstance(left, ast.Attribute)
+                and left.attr == "status_code"
+            ):
+                continue
+            for cmp in node.comparators:
+                if isinstance(cmp, ast.Constant) and cmp.value == 401:
+                    bad.append(node.lineno)
+
+        assert not bad, (
+            "KommoClient._request must not check 401 inline; that is the "
+            "responsibility of KommoOAuthAuth.async_auth_flow (#1646). "
+            f"Offending lines: {bad}"
+        )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Closes #1646

Replaces `KommoClient._request`'s manual bearer-injection + 401-retry block with the SDK-native HTTPX pattern: a custom `httpx.Auth` subclass overriding `async_auth_flow`.

```python
class KommoOAuthAuth(httpx.Auth):
    async def async_auth_flow(self, request):
        token = await self._token_store.get_valid_token()
        request.headers["Authorization"] = f"Bearer {token}"
        response = yield request
        if response.status_code != 401:
            return
        try:
            async with self._lock:
                token = await self._token_store.force_refresh()
        except RuntimeError:
            return  # seeded long-lived tokens — surface 401 as-is
        request.headers["Authorization"] = f"Bearer {token}"
        yield request

self._client = httpx.AsyncClient(..., auth=KommoOAuthAuth(token_store=token_store))
```

SDK baseline verified through Context7 `/encode/httpx` Authentication docs (multi-request flow + `asyncio.Lock` for shared token state).

`_request` is now a single line: `await self._client.request(...)`. `raise_for_status()` still surfaces 401/429/5xx to `tenacity` so transient retry behaviour is preserved, and a seeded-token 401 lands as `httpx.HTTPStatusError` exactly as before.

## TDD (obra/superpowers RED-GREEN-REFACTOR)

6 new tests, RED before implementation, all GREEN after:
- `KommoOAuthAuth` subclasses `httpx.Auth`.
- `KommoClient._client.auth` is a `KommoOAuthAuth` instance.
- `async_auth_flow` yields with `Bearer test-token` on first call.
- 401 response triggers `force_refresh` and a second yield with `Bearer refreshed-token`.
- `RuntimeError` from `force_refresh` terminates the flow (no propagation).
- AST scan: `KommoClient._request` body contains no `status_code == 401` comparison.

43 existing tests across 5 files (`test_kommo_client.py`, `test_kommo_client_error_paths.py`, `test_kommo_client_lead_operations_edges.py`, `test_kommo_client_lead_score_sync.py`, `test_kommo_client_smart_upsert.py`) pass unchanged — behaviour on 401 happy and error paths is byte-equivalent.

## Verification

```bash
$ uv run pytest tests/unit/services/test_kommo_client*.py -q
49 passed in 3.04s

$ uv run ruff check telegram_bot/services/kommo_client.py tests/unit/services/test_kommo_client.py
All checks passed!

$ uv run mypy telegram_bot/services/kommo_client.py
Success: no issues found in 1 source file
```

## Forbidden / out-of-scope

- No third-party Kommo SDK.
- No custom HTTP client wrapper around HTTPX.
- Token storage layer untouched.
- `@kommo_retry` (tenacity) preserved for transport/transient errors.

## Side-findings

None.