### PR TITLE
feat(hygiene): lane-aware git/pr/issue audit tooling (#1718 + parents)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 	ingest-unified-preflight ingest-unified-bootstrap ingest-unified ingest-unified-watch ingest-unified-status ingest-unified-reprocess ingest-unified-logs \
 	lock update update-pkg reinstall setup-hooks \
 	qdrant-backup \
-	git-hygiene git-hygiene-fix repo-cleanup repo-cleanup-force \
+	git-hygiene git-hygiene-fix pr-hygiene issue-hygiene repo-cleanup repo-cleanup-force \
 	docker-clean docker-clean-aggressive
 	test-contract \
 	docs-check \
@@ -1135,6 +1135,16 @@ git-hygiene: ## Git hygiene report (merged branches, stale worktrees, transient 
 git-hygiene-fix: ## Git hygiene safe cleanup preview (dry-run)
 	@echo "$(BLUE)Running git hygiene cleanup (dry-run)...$(NC)"
 	uv run python scripts/git_hygiene.py --fix --dry-run || true
+	@echo ""
+
+pr-hygiene: ## PR queue triage report (open PRs, blocked reasons, SLA)
+	@echo "$(BLUE)Running PR queue triage...$(NC)"
+	uv run python scripts/pr_queue_audit.py || true
+	@echo ""
+
+issue-hygiene: ## Issue queue hygiene report (no-label / no-assignee / no-lane / stale)
+	@echo "$(BLUE)Running issue queue hygiene audit...$(NC)"
+	uv run python scripts/issue_queue_audit.py || true
 	@echo ""
 
 repo-cleanup: ## Full repo cleanup: branches, worktrees, stashes (dry-run)

--- a/docs/engineering/repo-hygiene-runbook.md
+++ b/docs/engineering/repo-hygiene-runbook.md
@@ -1,0 +1,177 @@
+# Weekly Repo Hygiene Runbook
+
+> Operator playbook for keeping local git state, the open PR queue, and the
+> issue backlog manageable. Spec: [#1717](https://github.com/yastman/rag/issues/1717).
+
+## TL;DR (5-minute Monday check)
+
+```bash
+make git-hygiene          # local branches + worktrees + transient files
+make pr-hygiene           # open PR queue triage
+make issue-hygiene        # open issue queue hygiene
+```
+
+Each command exits non-zero whenever something is actionable, so they're CI-
+friendly and can be wired into a weekly Slack/email digest.
+
+## What each tool covers
+
+| Tool                              | Covers                                | Issue   |
+| --------------------------------- | ------------------------------------- | ------- |
+| `scripts/git_hygiene.py`          | branches, worktrees, transient files  | #1718   |
+| `scripts/pr_queue_audit.py`       | open PR queue, blocked reasons, SLA   | #1719   |
+| `scripts/issue_queue_audit.py`    | open issue labels, lanes, assignees   | #1720   |
+
+All three accept `--json` for programmatic consumption and human-readable
+output by default.
+
+## Safety guarantees
+
+The cleanup tooling is designed so a tired operator running `make ... -fix`
+on Monday morning cannot lose work:
+
+- **Never deletes the current branch.** Classified as `protected`.
+- **Never deletes long-lived branches** (`dev`, `main`, `master`, `develop`).
+- **Never deletes a branch checked out in a worktree** (would fail anyway,
+  but we block it explicitly with a clear reason).
+- **Never deletes a branch with uncommitted changes in its worktree.**
+- **Never deletes a branch ahead of upstream or with upstream `[gone]`** in
+  the default `--fix` mode. Those are surfaced under `requires-human` so the
+  operator can decide.
+- **Default to non-destructive checks.** `--fix` requires an explicit flag;
+  `--dry-run` previews any deletion.
+
+The `--include-requires-human` opt-in flag will additionally delete branches
+in the requires-human lane, but still refuses dirty worktrees.
+
+## 1. Git hygiene
+
+```bash
+make git-hygiene                              # report
+make git-hygiene-fix                          # dry-run cleanup of safe lane
+uv run python scripts/git_hygiene.py --fix    # apply cleanup
+uv run python scripts/git_hygiene.py --json   # machine-readable
+```
+
+Lanes you'll see in the output:
+
+| Lane               | Action                                                |
+| ------------------ | ----------------------------------------------------- |
+| `safe-to-delete`   | `--fix` removes them. Safe by construction.           |
+| `protected`        | Informational; never touched.                         |
+| `requires-human`   | Decide per branch. Common reasons:                    |
+|                    | • upstream gone (remote branch was deleted)           |
+|                    | • ahead of upstream (un-pushed commits)               |
+|                    | • not merged into base                                |
+|                    | • checked out at a worktree                           |
+|                    | • uncommitted changes in worktree                     |
+
+Worktrees show up under `requires-human` whenever they are detached, in
+`/tmp`, or dirty. None of those are auto-removed; the operator decides
+whether to commit, stash, or `git worktree remove --force` after backup.
+
+## 2. PR queue triage
+
+```bash
+make pr-hygiene                                       # report
+uv run python scripts/pr_queue_audit.py --json
+uv run python scripts/pr_queue_audit.py --bucket conflicts
+uv run python scripts/pr_queue_audit.py --base dev
+```
+
+Buckets in priority order:
+
+1. **conflicts**          — needs rebase / merge resolution.
+2. **ci-failing**         — author must fix.
+3. **ci-pending**         — wait or re-run.
+4. **changes-requested**  — reviewer asked for changes; ping author.
+5. **review-needed**      — CI green, no approval; assign reviewer.
+6. **ready**              — green and approved; merge it.
+7. **draft**              — author still working.
+8. **stale**              — flag is independent; surfaced for any PR older
+                            than `--stale-days` (default 14).
+9. **unknown**            — gh fields missing; investigate.
+
+### Triage SLA
+
+The runbook recommends:
+
+- **conflicts / ci-failing / changes-requested**: ping author within 2
+  business days.
+- **review-needed > 3 days**: assign a reviewer.
+- **ready**: merge same-day if author confirms.
+- **stale > 30 days**: close with a note, asking author to reopen with
+  rebase if still relevant.
+
+### Ownership rule
+
+Pick the smallest unit:
+
+- The author owns `conflicts`, `ci-failing`, `changes-requested`.
+- The reviewer pool owns `review-needed`.
+- The merger (CODEOWNER or release manager) owns `ready`.
+
+## 3. Issue queue hygiene
+
+```bash
+make issue-hygiene
+uv run python scripts/issue_queue_audit.py --json
+uv run python scripts/issue_queue_audit.py --bucket no-lane
+uv run python scripts/issue_queue_audit.py --bucket no-assignee
+```
+
+Buckets:
+
+| Bucket         | Action                                                         |
+| -------------- | -------------------------------------------------------------- |
+| `no-labels`    | Add at least one functional label (bug/refactor/docs/...).     |
+| `no-assignee`  | Pick an owner or surface in standup.                           |
+| `no-lane`      | Add `lane:quick-win` / `lane:plan-needed` / `lane:architecture-heavy`. |
+| `stale`        | Older than `--stale-days` (default 60). Confirm or close.     |
+| `triaged`      | Already has labels + assignee + lane. No action.              |
+
+### Splitting issues
+
+A single issue should:
+
+1. Belong to **one** lane label.
+2. Be small enough that a single PR can close it.
+
+If the body needs a checklist longer than 5 items, **split** it into a parent
+issue + 1 child issue per lane (the pattern used for #1717 → #1718 / #1719 /
+#1720).
+
+### Lane labels
+
+| Lane                        | When to pick                                              |
+| --------------------------- | --------------------------------------------------------- |
+| `lane:quick-win`            | Narrow, established change. One PR. Concrete verification. |
+| `lane:plan-needed`          | Multi-file or runtime-impacting. Route via `@writing-plans`. |
+| `lane:architecture-heavy`   | Structurally ambiguous. Spec → review → plan → execute.   |
+
+These match the existing decision model in
+`docs/engineering/issue-triage.md`.
+
+## Weekly schedule (suggested)
+
+| Day        | Action                                       |
+| ---------- | -------------------------------------------- |
+| Mon AM     | Run all three reports; post a short summary. |
+| Mon-Wed    | Address `conflicts` / `ci-failing` PRs.      |
+| Tue        | Add labels/lanes to fresh issues.            |
+| Thu        | Triage `review-needed` PRs.                  |
+| Fri        | Run `git-hygiene-fix --dry-run`, then apply. |
+
+## Non-goals
+
+- The runbook does not auto-close stale items; closure is a human decision.
+- It does not change branch protection rules.
+- It does not enforce a merge order; it surfaces signals.
+
+## Related
+
+- [#1717](https://github.com/yastman/rag/issues/1717) — parent spec
+- [#1718](https://github.com/yastman/rag/issues/1718) — git/worktree safety (this runbook §1)
+- [#1719](https://github.com/yastman/rag/issues/1719) — PR queue triage (this runbook §2)
+- [#1720](https://github.com/yastman/rag/issues/1720) — issue queue hygiene (this runbook §3)
+- [`docs/engineering/issue-triage.md`](issue-triage.md) — decision model & lanes

--- a/scripts/git_hygiene.py
+++ b/scripts/git_hygiene.py
@@ -350,11 +350,7 @@ def collect_branches(
     worktrees: list[WorktreeInfo],
 ) -> list[BranchInfo]:
     """Collect per-branch metadata required for classification."""
-    fmt = (
-        "%(refname:short)\t"
-        "%(upstream:short)\t"
-        "%(upstream:track)"
-    )
+    fmt = "%(refname:short)\t%(upstream:short)\t%(upstream:track)"
     raw = _run(
         ["git", "for-each-ref", f"--format={fmt}", "refs/heads/"],
         check=False,
@@ -689,11 +685,7 @@ def main() -> None:
             print("No safe-to-delete branches.")
 
         if args.include_requires_human:
-            elig = [
-                b
-                for b in report.requires_human
-                if not b.worktree_dirty and not b.is_current
-            ]
+            elig = [b for b in report.requires_human if not b.worktree_dirty and not b.is_current]
             if elig:
                 if not args.json:
                     label = "dry-run" if args.dry_run else "cleanup"

--- a/scripts/git_hygiene.py
+++ b/scripts/git_hygiene.py
@@ -1,160 +1,464 @@
 #!/usr/bin/env python3
-"""Git hygiene report and cleanup tool.
+"""Git hygiene report and safe cleanup tool.
 
-Scans the repository for:
-- Branches merged to origin/main
-- Branches without upstream tracking
-- Detached or /tmp worktrees
-- Untracked transient files (coverage.json, test_output*, *.log)
+Classifies every local branch and worktree into one of three lanes:
+
+- ``safe-to-delete``   : merged into the configured base branch, has upstream,
+                         is not the current branch, and is not attached to a
+                         dirty or ``/tmp`` worktree.
+- ``protected``        : current branch, configured base branch, or one of the
+                         well-known long-lived branches (``main``, ``master``,
+                         ``develop``).
+- ``requires-human``   : everything else — unmerged, upstream-gone, ahead of
+                         upstream, no upstream tracking, or attached to a
+                         dirty/transient worktree. These are surfaced in the
+                         report but are NOT deleted by ``--fix`` unless the
+                         operator explicitly opts in via
+                         ``--include-requires-human``.
+
+Worktrees are also classified:
+
+- ``safe``         : on disk under the repository, attached to a known branch,
+                     and clean.
+- ``requires-human``: detached HEAD, located under ``/tmp``, or contains
+                      uncommitted changes.
 
 Usage:
-    python scripts/git_hygiene.py          # Human-readable report
-    python scripts/git_hygiene.py --json   # JSON output
-    python scripts/git_hygiene.py --fix    # Auto-cleanup merged branches
-    python scripts/git_hygiene.py --fix --dry-run  # Preview cleanup
+    python scripts/git_hygiene.py                    # Human-readable report
+    python scripts/git_hygiene.py --json             # Machine-readable
+    python scripts/git_hygiene.py --fix --dry-run    # Preview safe deletions
+    python scripts/git_hygiene.py --fix              # Apply safe deletions
+
+Exit code is non-zero whenever the report contains anything actionable
+(safe-to-delete, requires-human, dirty worktrees, transient files), so it can
+be wired into CI or weekly hygiene checks.
 """
 
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
 import subprocess
 import sys
 from dataclasses import dataclass, field
+from typing import Literal
 
 
 DEFAULT_BASE_BRANCH = "dev"
+PROTECTED_NAMES: frozenset[str] = frozenset({"main", "master", "develop"})
+
 base_branch = os.environ.get("REPO_BASE_BRANCH", DEFAULT_BASE_BRANCH)
+
+BranchCategory = Literal["safe-to-delete", "protected", "requires-human"]
+WorktreeCategory = Literal["safe", "requires-human"]
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BranchInfo:
+    """Per-branch hygiene metadata and classification."""
+
+    name: str
+    category: BranchCategory = "requires-human"
+    reasons: list[str] = field(default_factory=list)
+    upstream: str | None = None
+    upstream_gone: bool = False
+    ahead: int = 0
+    behind: int = 0
+    merged_into_base: bool = False
+    worktree_path: str | None = None
+    worktree_dirty: bool = False
+    is_current: bool = False
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "category": self.category,
+            "reasons": list(self.reasons),
+            "upstream": self.upstream,
+            "upstream_gone": self.upstream_gone,
+            "ahead": self.ahead,
+            "behind": self.behind,
+            "merged_into_base": self.merged_into_base,
+            "worktree_path": self.worktree_path,
+            "worktree_dirty": self.worktree_dirty,
+            "is_current": self.is_current,
+        }
+
+
+@dataclass
+class WorktreeInfo:
+    """Per-worktree hygiene metadata and classification."""
+
+    path: str
+    branch: str | None = None
+    detached: bool = False
+    bare: bool = False
+    in_tmp: bool = False
+    dirty: bool = False
+    is_main: bool = False
+
+    @property
+    def reasons(self) -> list[str]:
+        out: list[str] = []
+        if self.bare:
+            out.append("bare")
+        if self.detached:
+            out.append("detached HEAD")
+        if self.in_tmp:
+            out.append("in /tmp")
+        if self.dirty:
+            out.append("uncommitted changes")
+        return out
+
+    @property
+    def category(self) -> WorktreeCategory:
+        return "safe" if not self.reasons else "requires-human"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "path": self.path,
+            "branch": self.branch,
+            "category": self.category,
+            "reasons": self.reasons,
+            "detached": self.detached,
+            "bare": self.bare,
+            "in_tmp": self.in_tmp,
+            "dirty": self.dirty,
+            "is_main": self.is_main,
+        }
 
 
 @dataclass
 class HygieneReport:
     """Aggregated hygiene findings."""
 
-    merged_branches: list[str] = field(default_factory=list)
-    no_upstream_branches: list[str] = field(default_factory=list)
-    stale_worktrees: list[dict[str, str]] = field(default_factory=list)
+    branches: list[BranchInfo] = field(default_factory=list)
+    worktrees: list[WorktreeInfo] = field(default_factory=list)
     transient_files: list[str] = field(default_factory=list)
+
+    # ----- New, lane-aware accessors -----
+
+    def branches_in_category(self, category: BranchCategory) -> list[BranchInfo]:
+        return [b for b in self.branches if b.category == category]
+
+    @property
+    def safe_to_delete(self) -> list[BranchInfo]:
+        return self.branches_in_category("safe-to-delete")
+
+    @property
+    def protected(self) -> list[BranchInfo]:
+        return self.branches_in_category("protected")
+
+    @property
+    def requires_human(self) -> list[BranchInfo]:
+        return self.branches_in_category("requires-human")
+
+    @property
+    def stale_worktrees_info(self) -> list[WorktreeInfo]:
+        return [w for w in self.worktrees if w.category != "safe"]
+
+    # ----- Backward-compatible accessors (kept for existing JSON consumers) -----
+
+    @property
+    def merged_branches(self) -> list[str]:
+        """Branches eligible for safe automatic deletion."""
+        return [b.name for b in self.safe_to_delete]
+
+    @property
+    def no_upstream_branches(self) -> list[str]:
+        """Branches surfaced under ``requires-human`` for missing upstream."""
+        return [b.name for b in self.requires_human if "no upstream" in b.reasons]
+
+    @property
+    def stale_worktrees(self) -> list[dict[str, str]]:
+        """Backward-compat shape: list of ``{path, reason}`` dicts."""
+        out: list[dict[str, str]] = []
+        for w in self.stale_worktrees_info:
+            out.append({"path": w.path, "reason": ", ".join(w.reasons) or "unknown"})
+        return out
+
+    # ----- Aggregate counters -----
 
     @property
     def total_issues(self) -> int:
+        # Protected branches are always present and not actionable, so they
+        # don't contribute to the count.
         return (
-            len(self.merged_branches)
-            + len(self.no_upstream_branches)
-            + len(self.stale_worktrees)
+            len(self.safe_to_delete)
+            + len(self.requires_human)
+            + len(self.stale_worktrees_info)
             + len(self.transient_files)
         )
 
     def to_dict(self) -> dict[str, object]:
         return {
+            # Backward-compat top-level keys
             "merged_branches": self.merged_branches,
             "no_upstream_branches": self.no_upstream_branches,
             "stale_worktrees": self.stale_worktrees,
             "transient_files": self.transient_files,
             "total_issues": self.total_issues,
+            # New lane-aware view
+            "classification": {
+                "safe_to_delete": [b.to_dict() for b in self.safe_to_delete],
+                "protected": [b.to_dict() for b in self.protected],
+                "requires_human": [b.to_dict() for b in self.requires_human],
+                "worktrees": [w.to_dict() for w in self.worktrees],
+            },
         }
 
 
-def _run(cmd: list[str], *, check: bool = True) -> str:
+# ---------------------------------------------------------------------------
+# Git helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(cmd: list[str], *, check: bool = True, cwd: str | None = None) -> str:
     """Run a git command and return stripped stdout."""
     result = subprocess.run(
         cmd,
         capture_output=True,
         text=True,
         check=check,
+        cwd=cwd,
     )
     return result.stdout.strip()
 
 
-def find_merged_branches() -> list[str]:
-    """Find local branches already merged into the configured base branch."""
-    # Fetch latest remote state silently
+def _current_branch() -> str | None:
+    name = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"], check=False)
+    if not name or name == "HEAD":
+        return None
+    return name
+
+
+def _is_merged_into_base(branch: str, base: str) -> bool:
+    """Return True if ``branch`` tip is reachable from ``origin/base``.
+
+    Falls back to local ``base`` if the remote ref does not exist.
+    """
+    for ref in (f"origin/{base}", base):
+        result = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", branch, ref],
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return True
+        # returncode 1 == not an ancestor; >1 means ref doesn't exist, try fallback
+        if result.returncode == 1:
+            return False
+    return False
+
+
+def _worktree_is_dirty(path: str) -> bool:
+    """Return True if the worktree at ``path`` has uncommitted changes.
+
+    Uses ``git status --porcelain`` against the given worktree path. Any
+    non-empty output (modified, staged, untracked) counts as dirty.
+    """
+    result = subprocess.run(
+        ["git", "-C", path, "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        # Treat unreachable worktree as suspicious -> dirty for safety.
+        return True
+    return bool(result.stdout.strip())
+
+
+def fetch_remote_state() -> None:
+    """Best-effort fetch with prune so upstream-gone is detectable."""
     subprocess.run(
         ["git", "fetch", "--prune"],
         capture_output=True,
         check=False,
     )
-    raw = _run(
-        [
-            "git",
-            "branch",
-            "--merged",
-            f"origin/{base_branch}",
-            "--format=%(refname:short)",
-        ]
-    )
+
+
+# ---------------------------------------------------------------------------
+# Worktree discovery
+# ---------------------------------------------------------------------------
+
+
+def collect_worktrees() -> list[WorktreeInfo]:
+    """Parse ``git worktree list --porcelain`` and check dirty state for each."""
+    raw = _run(["git", "worktree", "list", "--porcelain"], check=False)
+    worktrees: list[WorktreeInfo] = []
     if not raw:
-        return []
-    protected = {base_branch, "main", "master", "develop"}
-    return [b for b in raw.splitlines() if b.strip() not in protected]
+        return worktrees
 
+    current: dict[str, object] = {}
 
-def find_no_upstream_branches() -> list[str]:
-    """Find local branches with no upstream tracking branch."""
-    raw = _run(
-        [
-            "git",
-            "for-each-ref",
-            "--format=%(refname:short) %(upstream)",
-            "refs/heads/",
-        ]
-    )
-    if not raw:
-        return []
-    result: list[str] = []
-    for line in raw.splitlines():
-        parts = line.split(maxsplit=1)
-        branch = parts[0]
-        upstream = parts[1] if len(parts) > 1 else ""
-        if not upstream:
-            result.append(branch)
-    return result
+    def finalize(entry: dict[str, object]) -> None:
+        if not entry:
+            return
+        path = str(entry.get("path", ""))
+        if not path:
+            return
+        wt = WorktreeInfo(
+            path=path,
+            branch=entry.get("branch"),  # type: ignore[arg-type]
+            detached=bool(entry.get("detached", False)),
+            bare=bool(entry.get("bare", False)),
+            in_tmp=path.startswith("/tmp"),
+            is_main=bool(entry.get("is_main", False)),
+        )
+        # Bare worktrees are not real working trees; skip dirty probe.
+        if not wt.bare:
+            wt.dirty = _worktree_is_dirty(path)
+        worktrees.append(wt)
 
-
-def find_stale_worktrees() -> list[dict[str, str]]:
-    """Find worktrees that are detached or reside in /tmp."""
-    raw = _run(["git", "worktree", "list", "--porcelain"])
-    if not raw:
-        return []
-
-    stale: list[dict[str, str]] = []
-    current: dict[str, str] = {}
-
+    is_first = True
     for line in raw.splitlines():
         if line.startswith("worktree "):
-            current = {"path": line.split(" ", 1)[1]}
+            finalize(current)
+            current = {"path": line.split(" ", 1)[1], "is_main": is_first}
+            is_first = False
+        elif line.startswith("branch "):
+            ref = line.split(" ", 1)[1]
+            current["branch"] = ref.removeprefix("refs/heads/")
         elif line == "detached":
-            current["reason"] = "detached HEAD"
+            current["detached"] = True
         elif line == "bare":
-            current["reason"] = "bare"
+            current["bare"] = True
         elif line == "":
-            if current:
-                path = current.get("path", "")
-                if current.get("reason") or path.startswith("/tmp"):
-                    if path.startswith("/tmp") and "reason" not in current:
-                        current["reason"] = "in /tmp"
-                    stale.append(current)
+            finalize(current)
             current = {}
+    finalize(current)
+    return worktrees
 
-    # Handle last entry
-    if current:
-        path = current.get("path", "")
-        if current.get("reason") or path.startswith("/tmp"):
-            if path.startswith("/tmp") and "reason" not in current:
-                current["reason"] = "in /tmp"
-            stale.append(current)
 
-    return stale
+# ---------------------------------------------------------------------------
+# Branch discovery & classification
+# ---------------------------------------------------------------------------
+
+
+def collect_branches(
+    *,
+    base: str,
+    current: str | None,
+    worktrees: list[WorktreeInfo],
+) -> list[BranchInfo]:
+    """Collect per-branch metadata required for classification."""
+    fmt = (
+        "%(refname:short)\t"
+        "%(upstream:short)\t"
+        "%(upstream:track)"
+    )
+    raw = _run(
+        ["git", "for-each-ref", f"--format={fmt}", "refs/heads/"],
+        check=False,
+    )
+    if not raw:
+        return []
+
+    wt_by_branch: dict[str, WorktreeInfo] = {}
+    for wt in worktrees:
+        if wt.branch:
+            wt_by_branch[wt.branch] = wt
+
+    branches: list[BranchInfo] = []
+    for line in raw.splitlines():
+        parts = line.split("\t")
+        if not parts or not parts[0]:
+            continue
+        name = parts[0]
+        upstream = parts[1] if len(parts) > 1 and parts[1] else None
+        track = parts[2] if len(parts) > 2 else ""
+
+        info = BranchInfo(
+            name=name,
+            upstream=upstream,
+            is_current=(name == current),
+        )
+
+        # Parse upstream tracking ([gone], [ahead 1], [ahead 1, behind 2])
+        if track == "[gone]":
+            info.upstream_gone = True
+        elif track:
+            inside = track.strip("[]")
+            for token in (t.strip() for t in inside.split(",")):
+                if token.startswith("ahead "):
+                    with contextlib.suppress(ValueError, IndexError):
+                        info.ahead = int(token.split()[1])
+                elif token.startswith("behind "):
+                    with contextlib.suppress(ValueError, IndexError):
+                        info.behind = int(token.split()[1])
+
+        info.merged_into_base = _is_merged_into_base(name, base)
+
+        wt = wt_by_branch.get(name)
+        if wt is not None:
+            info.worktree_path = wt.path
+            info.worktree_dirty = wt.dirty
+
+        branches.append(info)
+
+    return branches
+
+
+def classify_branch(info: BranchInfo, *, base: str) -> BranchInfo:
+    """Set ``info.category`` and ``info.reasons`` based on collected metadata."""
+    reasons: list[str] = []
+
+    # Protected branches are not deletable regardless of state.
+    if info.is_current or info.name == base or info.name in PROTECTED_NAMES:
+        info.category = "protected"
+        if info.is_current:
+            reasons.append("current branch")
+        elif info.name == base:
+            reasons.append(f"base branch ({base})")
+        else:
+            reasons.append("long-lived branch")
+        info.reasons = reasons
+        return info
+
+    # Anything below this point is deletable in principle, so collect risk
+    # signals and decide between safe-to-delete and requires-human.
+    if info.upstream is None:
+        reasons.append("no upstream")
+    if info.upstream_gone:
+        reasons.append("upstream gone")
+    if info.ahead > 0:
+        reasons.append(f"{info.ahead} commit(s) ahead of upstream")
+    if not info.merged_into_base:
+        reasons.append(f"not merged into {base}")
+    if info.worktree_path:
+        reasons.append(f"checked out at {info.worktree_path}")
+        if info.worktree_dirty:
+            reasons.append("uncommitted changes in worktree")
+
+    if not reasons:
+        info.category = "safe-to-delete"
+        info.reasons = [f"merged into {base}", "upstream tracking present", "no live worktree"]
+    else:
+        info.category = "requires-human"
+        info.reasons = reasons
+
+    return info
+
+
+def classify_branches(branches: list[BranchInfo], *, base: str) -> list[BranchInfo]:
+    return [classify_branch(b, base=base) for b in branches]
+
+
+# ---------------------------------------------------------------------------
+# Transient files (unchanged)
+# ---------------------------------------------------------------------------
 
 
 def find_transient_files() -> list[str]:
-    """Find untracked transient files (coverage, test output, logs).
-
-    Uses ``git ls-files --others --exclude-standard`` so that tracked files
-    and files matched by ``.gitignore`` are excluded.  This also avoids
-    expensive filesystem walks through ``.venv/`` or ``node_modules/``.
-    """
+    """Find untracked transient files (coverage, test output, logs)."""
     raw = _run(
         [
             "git",
@@ -171,12 +475,73 @@ def find_transient_files() -> list[str]:
     return sorted(raw.splitlines()) if raw else []
 
 
+# ---------------------------------------------------------------------------
+# Backward-compat helpers (kept so external callers/tests stay green)
+# ---------------------------------------------------------------------------
+
+
+def find_merged_branches() -> list[str]:
+    """Backward-compat: list of branch names eligible for safe deletion."""
+    fetch_remote_state()
+    current = _current_branch()
+    worktrees = collect_worktrees()
+    branches = classify_branches(
+        collect_branches(base=base_branch, current=current, worktrees=worktrees),
+        base=base_branch,
+    )
+    return [b.name for b in branches if b.category == "safe-to-delete"]
+
+
+def find_no_upstream_branches() -> list[str]:
+    """Backward-compat: branches without upstream tracking."""
+    raw = _run(
+        [
+            "git",
+            "for-each-ref",
+            "--format=%(refname:short) %(upstream)",
+            "refs/heads/",
+        ],
+        check=False,
+    )
+    if not raw:
+        return []
+    out: list[str] = []
+    for line in raw.splitlines():
+        parts = line.split(maxsplit=1)
+        branch = parts[0]
+        upstream = parts[1] if len(parts) > 1 else ""
+        if not upstream:
+            out.append(branch)
+    return out
+
+
+def find_stale_worktrees() -> list[dict[str, str]]:
+    """Backward-compat: dicts of ``{path, reason}`` for any non-safe worktree."""
+    worktrees = collect_worktrees()
+    out: list[dict[str, str]] = []
+    for wt in worktrees:
+        if wt.category != "safe":
+            out.append({"path": wt.path, "reason": ", ".join(wt.reasons) or "unknown"})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Report assembly
+# ---------------------------------------------------------------------------
+
+
 def build_report() -> HygieneReport:
-    """Build a complete hygiene report."""
+    """Assemble a complete hygiene report."""
+    fetch_remote_state()
+    current = _current_branch()
+    worktrees = collect_worktrees()
+    branches = classify_branches(
+        collect_branches(base=base_branch, current=current, worktrees=worktrees),
+        base=base_branch,
+    )
     return HygieneReport(
-        merged_branches=find_merged_branches(),
-        no_upstream_branches=find_no_upstream_branches(),
-        stale_worktrees=find_stale_worktrees(),
+        branches=branches,
+        worktrees=worktrees,
         transient_files=find_transient_files(),
     )
 
@@ -184,32 +549,35 @@ def build_report() -> HygieneReport:
 def print_human_report(report: HygieneReport) -> None:
     """Print a human-readable summary."""
     print("=== Git Hygiene Report ===\n")
+    print(f"Base branch: {base_branch}\n")
 
-    # Merged branches
-    print(f"Merged branches ({len(report.merged_branches)}):")
-    if report.merged_branches:
-        for b in report.merged_branches:
-            print(f"  - {b}")
+    safe = report.safe_to_delete
+    print(f"Safe to delete ({len(safe)}):")
+    if safe:
+        for b in safe:
+            print(f"  - {b.name}")
     else:
         print("  (none)")
 
-    # No upstream
-    print(f"\nBranches without upstream ({len(report.no_upstream_branches)}):")
-    if report.no_upstream_branches:
-        for b in report.no_upstream_branches:
-            print(f"  - {b}")
+    rh = report.requires_human
+    print(f"\nRequires human review ({len(rh)}):")
+    if rh:
+        for b in rh:
+            wt = f" [worktree: {b.worktree_path}]" if b.worktree_path else ""
+            print(f"  - {b.name}{wt}")
+            for reason in b.reasons:
+                print(f"      • {reason}")
     else:
         print("  (none)")
 
-    # Stale worktrees
-    print(f"\nStale worktrees ({len(report.stale_worktrees)}):")
-    if report.stale_worktrees:
-        for wt in report.stale_worktrees:
-            print(f"  - {wt['path']} ({wt.get('reason', 'unknown')})")
+    stale = report.stale_worktrees_info
+    print(f"\nStale / dirty worktrees ({len(stale)}):")
+    if stale:
+        for wt in stale:
+            print(f"  - {wt.path}  ({', '.join(wt.reasons)})")
     else:
         print("  (none)")
 
-    # Transient files
     print(f"\nTransient files ({len(report.transient_files)}):")
     if report.transient_files:
         for f in report.transient_files:
@@ -217,75 +585,123 @@ def print_human_report(report: HygieneReport) -> None:
     else:
         print("  (none)")
 
-    print(f"\nTotal issues: {report.total_issues}")
+    print(f"\nProtected branches: {len(report.protected)}")
+    for b in report.protected:
+        print(f"  - {b.name}  ({', '.join(b.reasons)})")
+
+    print(f"\nTotal actionable issues: {report.total_issues}")
 
 
-def fix_merged_branches(
-    branches: list[str], *, dry_run: bool = False, quiet: bool = False
+# ---------------------------------------------------------------------------
+# Cleanup actions
+# ---------------------------------------------------------------------------
+
+
+def fix_safe_branches(
+    branches: list[BranchInfo], *, dry_run: bool = False, quiet: bool = False
 ) -> list[str]:
-    """Delete branches merged to the configured base branch."""
+    """Delete branches that are safely mergeable into base."""
     deleted: list[str] = []
     for branch in branches:
         if dry_run:
             if not quiet:
-                print(f"  [dry-run] would delete: {branch}")
-            deleted.append(branch)
-        else:
-            result = subprocess.run(
-                ["git", "branch", "-d", branch],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            if result.returncode == 0:
-                if not quiet:
-                    print(f"  deleted: {branch}")
-                deleted.append(branch)
-            elif not quiet:
-                print(f"  FAILED to delete {branch}: {result.stderr.strip()}")
+                print(f"  [dry-run] would delete: {branch.name}")
+            deleted.append(branch.name)
+            continue
+        result = subprocess.run(
+            ["git", "branch", "-d", branch.name],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            if not quiet:
+                print(f"  deleted: {branch.name}")
+            deleted.append(branch.name)
+        elif not quiet:
+            print(f"  FAILED to delete {branch.name}: {result.stderr.strip()}")
     return deleted
+
+
+# Backward-compat shim: existing tests/code may call ``fix_merged_branches``.
+def fix_merged_branches(
+    branches: list[str], *, dry_run: bool = False, quiet: bool = False
+) -> list[str]:
+    """Backward-compatible shim accepting plain branch names."""
+    return fix_safe_branches(
+        [BranchInfo(name=b, category="safe-to-delete") for b in branches],
+        dry_run=dry_run,
+        quiet=quiet,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Git hygiene report and cleanup tool",
+        description="Git hygiene report and safe cleanup tool",
     )
-    parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Output report as JSON",
-    )
+    parser.add_argument("--json", action="store_true", help="Output report as JSON")
     parser.add_argument(
         "--fix",
         action="store_true",
-        help="Auto-cleanup merged branches (conservative: only merged to origin/base branch)",
+        help="Auto-cleanup safe-to-delete branches (merged + clean worktree + has upstream).",
     )
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Preview cleanup actions without executing (use with --fix)",
+        help="Preview cleanup actions without executing (use with --fix).",
+    )
+    parser.add_argument(
+        "--include-requires-human",
+        action="store_true",
+        help=(
+            "Also delete branches in the 'requires-human' lane. "
+            "Refuses to delete a branch attached to a dirty worktree even with this flag."
+        ),
     )
     args = parser.parse_args()
 
     if args.dry_run and not args.fix:
         parser.error("--dry-run requires --fix")
+    if args.include_requires_human and not args.fix:
+        parser.error("--include-requires-human requires --fix")
 
     report = build_report()
 
     if args.fix:
         if not args.json:
             print("=== Git Hygiene Cleanup ===\n")
-        if report.merged_branches:
+
+        if report.safe_to_delete:
             if not args.json:
                 label = "dry-run" if args.dry_run else "cleanup"
-                print(f"Merged branches ({label}):")
-            fix_merged_branches(
-                report.merged_branches,
+                print(f"Safe-to-delete branches ({label}):")
+            fix_safe_branches(
+                report.safe_to_delete,
                 dry_run=args.dry_run,
                 quiet=args.json,
             )
         elif not args.json:
-            print("No merged branches to clean up.")
+            print("No safe-to-delete branches.")
+
+        if args.include_requires_human:
+            elig = [
+                b
+                for b in report.requires_human
+                if not b.worktree_dirty and not b.is_current
+            ]
+            if elig:
+                if not args.json:
+                    label = "dry-run" if args.dry_run else "cleanup"
+                    print(f"\nRequires-human branches ({label}, opt-in):")
+                fix_safe_branches(elig, dry_run=args.dry_run, quiet=args.json)
+            elif not args.json:
+                print("\nNo eligible requires-human branches (all blocked by safety guard).")
+
         if not args.json:
             print()
 

--- a/scripts/issue_queue_audit.py
+++ b/scripts/issue_queue_audit.py
@@ -67,7 +67,7 @@ class IssueStatus:
 
     @property
     def is_triaged(self) -> bool:
-        return bool(self.labels and self.assignees and self.lane)
+        return self.flags == ["triaged"]
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -243,9 +243,7 @@ def print_human_report(issues: list[IssueStatus], counts: dict[str, int]) -> Non
     else:
         for issue in actionable:
             flags_str = ",".join(issue.flags)
-            print(
-                f"  #{issue.number:>5} ({issue.age_days}d) [{flags_str}]  {issue.title}"
-            )
+            print(f"  #{issue.number:>5} ({issue.age_days}d) [{flags_str}]  {issue.title}")
             assignees = ", ".join(f"@{a}" for a in issue.assignees) or "—"
             lane = issue.lane or "—"
             print(f"         lane={lane}  assignees={assignees}")

--- a/scripts/issue_queue_audit.py
+++ b/scripts/issue_queue_audit.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Open issue queue hygiene report.
+
+Reads open issues via ``gh issue list --json ...`` and classifies each into
+hygiene buckets so an operator can decide what to label, assign, split, or
+close. Designed for the weekly governance runbook (issue #1720).
+
+Lane labels respected
+---------------------
+- ``lane:quick-win``           : narrow, low-risk; pick up first
+- ``lane:plan-needed``         : multi-file or runtime-impacting
+- ``lane:architecture-heavy``  : ambiguous structure, needs spec
+- (none)                        : missing-lane warning surfaced separately
+
+Hygiene buckets
+---------------
+- ``no-labels``         : Issue has no labels at all.
+- ``no-assignee``       : Issue is not assigned to anyone.
+- ``no-lane``           : Has labels but no ``lane:*`` label.
+- ``stale``             : Open longer than ``--stale-days`` (default 60).
+- ``triaged``           : Has at least one label, an assignee, and a lane.
+
+A single issue may show up in multiple buckets; the JSON output exposes the
+full set of flags per issue.
+
+CLI
+---
+
+    python scripts/issue_queue_audit.py
+    python scripts/issue_queue_audit.py --json
+    python scripts/issue_queue_audit.py --bucket no-lane
+    python scripts/issue_queue_audit.py --stale-days 30
+
+Exit code is 0 only when there are no issues missing labels, assignees, or a
+lane, and no stale issues; otherwise 1.
+
+Requirements: ``gh`` CLI authenticated to the target repository.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+
+IssueBucket = Literal["no-labels", "no-assignee", "no-lane", "stale", "triaged"]
+LANE_PREFIX = "lane:"
+
+
+@dataclass
+class IssueStatus:
+    """Hygiene-classification record for a single open issue."""
+
+    number: int
+    title: str
+    url: str
+    age_days: int
+    labels: list[str] = field(default_factory=list)
+    assignees: list[str] = field(default_factory=list)
+    lane: str = ""  # "" when no lane:* label
+    flags: list[IssueBucket] = field(default_factory=list)
+
+    @property
+    def is_triaged(self) -> bool:
+        return bool(self.labels and self.assignees and self.lane)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "number": self.number,
+            "title": self.title,
+            "url": self.url,
+            "age_days": self.age_days,
+            "labels": list(self.labels),
+            "assignees": list(self.assignees),
+            "lane": self.lane,
+            "flags": list(self.flags),
+            "is_triaged": self.is_triaged,
+        }
+
+
+GH_FIELDS: tuple[str, ...] = (
+    "number",
+    "title",
+    "url",
+    "labels",
+    "assignees",
+    "createdAt",
+    "updatedAt",
+)
+
+
+def fetch_open_issues(
+    *,
+    limit: int = 500,
+    runner=subprocess.run,
+) -> list[dict[str, Any]]:
+    """Invoke ``gh issue list`` and return parsed JSON."""
+    cmd = [
+        "gh",
+        "issue",
+        "list",
+        "--state",
+        "open",
+        "--limit",
+        str(limit),
+        "--json",
+        ",".join(GH_FIELDS),
+    ]
+    result = runner(cmd, capture_output=True, text=True, check=False)
+    if getattr(result, "returncode", 1) != 0:
+        raise RuntimeError(
+            f"gh issue list failed (exit {result.returncode}): {getattr(result, 'stderr', '')!r}"
+        )
+    raw = (result.stdout or "").strip()
+    if not raw:
+        return []
+    parsed = json.loads(raw)
+    if not isinstance(parsed, list):
+        raise RuntimeError("gh returned non-list JSON; cannot triage")
+    return parsed
+
+
+def _parse_age_days(created_at: str, *, now: datetime | None = None) -> int:
+    if not created_at:
+        return 0
+    try:
+        # Python 3.11+ ``fromisoformat`` parses the trailing ``Z`` natively.
+        dt = datetime.fromisoformat(created_at)
+    except ValueError:
+        return 0
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    reference = now or datetime.now(UTC)
+    return max(0, (reference - dt).days)
+
+
+def classify_issue(
+    raw: dict[str, Any],
+    *,
+    stale_days: int = 60,
+    now: datetime | None = None,
+) -> IssueStatus:
+    """Classify a single ``gh issue list`` entry."""
+    number = int(raw.get("number", 0))
+    title = str(raw.get("title", "") or "")
+    url = str(raw.get("url", "") or "")
+
+    label_names: list[str] = []
+    for label in raw.get("labels") or []:
+        if isinstance(label, dict) and label.get("name"):
+            label_names.append(str(label["name"]))
+
+    assignee_logins: list[str] = []
+    for assignee in raw.get("assignees") or []:
+        if isinstance(assignee, dict) and assignee.get("login"):
+            assignee_logins.append(str(assignee["login"]))
+
+    lane = next((lbl for lbl in label_names if lbl.startswith(LANE_PREFIX)), "")
+    age_days = _parse_age_days(raw.get("createdAt", ""), now=now)
+
+    flags: list[IssueBucket] = []
+    if not label_names:
+        flags.append("no-labels")
+    if not assignee_logins:
+        flags.append("no-assignee")
+    if label_names and not lane:
+        flags.append("no-lane")
+    if age_days >= stale_days:
+        flags.append("stale")
+    if not flags:
+        flags.append("triaged")
+
+    return IssueStatus(
+        number=number,
+        title=title,
+        url=url,
+        age_days=age_days,
+        labels=label_names,
+        assignees=assignee_logins,
+        lane=lane,
+        flags=flags,
+    )
+
+
+def summarise(issues: list[IssueStatus]) -> dict[str, int]:
+    """Return per-bucket counts plus a per-lane breakdown."""
+    counts = dict.fromkeys(("no-labels", "no-assignee", "no-lane", "stale", "triaged"), 0)
+    counts["total"] = len(issues)
+    lanes: dict[str, int] = {}
+    for issue in issues:
+        for flag in issue.flags:
+            counts[flag] = counts.get(flag, 0) + 1
+        lanes[issue.lane or "(none)"] = lanes.get(issue.lane or "(none)", 0) + 1
+    counts.update({f"lane::{k}": v for k, v in lanes.items()})
+    return counts
+
+
+def filter_bucket(issues: list[IssueStatus], bucket: IssueBucket | None) -> list[IssueStatus]:
+    if bucket is None:
+        return issues
+    return [i for i in issues if bucket in i.flags]
+
+
+def print_human_report(issues: list[IssueStatus], counts: dict[str, int]) -> None:
+    print("=== Issue Queue Hygiene ===")
+    print(f"Total open issues: {counts.get('total', 0)}")
+    print(
+        f"  no-labels:   {counts.get('no-labels', 0)}\n"
+        f"  no-assignee: {counts.get('no-assignee', 0)}\n"
+        f"  no-lane:     {counts.get('no-lane', 0)}\n"
+        f"  stale:       {counts.get('stale', 0)}\n"
+        f"  triaged:     {counts.get('triaged', 0)}\n"
+    )
+
+    print("Lane breakdown:")
+    lane_keys = sorted([k for k in counts if k.startswith("lane::")])
+    if not lane_keys:
+        print("  (none)")
+    else:
+        for key in lane_keys:
+            lane_name = key.removeprefix("lane::")
+            print(f"  {lane_name:30}  {counts[key]}")
+    print()
+
+    if not issues:
+        print("(no issues to display)")
+        return
+
+    print("Issues requiring action:")
+    actionable = [
+        i
+        for i in issues
+        if any(f in {"no-labels", "no-assignee", "no-lane", "stale"} for f in i.flags)
+    ]
+    actionable.sort(key=lambda i: i.age_days, reverse=True)
+    if not actionable:
+        print("  (none)")
+    else:
+        for issue in actionable:
+            flags_str = ",".join(issue.flags)
+            print(
+                f"  #{issue.number:>5} ({issue.age_days}d) [{flags_str}]  {issue.title}"
+            )
+            assignees = ", ".join(f"@{a}" for a in issue.assignees) or "—"
+            lane = issue.lane or "—"
+            print(f"         lane={lane}  assignees={assignees}")
+            print(f"         {issue.url}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_report(
+    raw_issues: list[dict[str, Any]],
+    *,
+    stale_days: int = 60,
+    now: datetime | None = None,
+) -> list[IssueStatus]:
+    return [classify_issue(item, stale_days=stale_days, now=now) for item in raw_issues]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Open issue queue hygiene report")
+    parser.add_argument(
+        "--stale-days",
+        type=int,
+        default=60,
+        help="Age threshold in days that flags an issue as stale (default: 60).",
+    )
+    parser.add_argument(
+        "--bucket",
+        choices=("no-labels", "no-assignee", "no-lane", "stale", "triaged"),
+        default=None,
+        help="Show only issues with the given hygiene flag.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=500,
+        help="Max issues requested from gh (default: 500).",
+    )
+    parser.add_argument("--json", action="store_true", help="JSON output")
+    args = parser.parse_args(argv)
+
+    raw = fetch_open_issues(limit=args.limit)
+    classified = build_report(raw, stale_days=args.stale_days)
+    classified = filter_bucket(classified, args.bucket)
+    counts = summarise(classified)
+
+    if args.json:
+        payload = {
+            "summary": counts,
+            "stale_days": args.stale_days,
+            "bucket_filter": args.bucket,
+            "items": [i.to_dict() for i in classified],
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        print_human_report(classified, counts)
+
+    actionable = (
+        counts.get("no-labels", 0)
+        + counts.get("no-assignee", 0)
+        + counts.get("no-lane", 0)
+        + counts.get("stale", 0)
+    )
+    return 0 if actionable == 0 else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - thin CLI shim
+    sys.exit(main())

--- a/scripts/pr_queue_audit.py
+++ b/scripts/pr_queue_audit.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""Open PR queue triage report.
+
+Reads open pull requests via ``gh pr list --json ...`` and classifies each
+into actionable buckets so an operator can decide what to merge / nudge /
+close. Designed for the weekly governance runbook (issue #1719).
+
+Buckets
+-------
+
+- ``ready``               : Mergeable, CI green, has at least one approval
+                            (or repo policy waives review). Merge candidate.
+- ``ci-failing``           : CI status is FAILURE / ERROR / CANCELLED.
+- ``ci-pending``           : CI not yet completed.
+- ``conflicts``            : ``mergeable`` reports CONFLICTING.
+- ``review-needed``        : CI green, no approvals yet.
+- ``changes-requested``    : Reviewer asked for changes; awaits author.
+- ``draft``                : Marked as draft.
+- ``stale``                : Open longer than ``--stale-days`` (default 14).
+- ``unknown``              : Could not determine state (gh field missing).
+
+A PR can land in only one bucket. Order of precedence:
+
+    draft > conflicts > ci-failing > ci-pending > changes-requested
+        > review-needed > ready > unknown
+
+``stale`` is reported as a separate flag in addition to the primary bucket so
+that long-lived but otherwise-ready PRs still surface.
+
+CLI
+---
+
+    python scripts/pr_queue_audit.py                     # human report
+    python scripts/pr_queue_audit.py --json              # machine-readable
+    python scripts/pr_queue_audit.py --base dev          # filter by base
+    python scripts/pr_queue_audit.py --stale-days 7
+    python scripts/pr_queue_audit.py --bucket conflicts  # one bucket only
+
+Exit code is 0 on a clean queue, 1 otherwise.
+
+Requirements: ``gh`` CLI authenticated to the target repository.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+
+PRBucket = Literal[
+    "ready",
+    "ci-failing",
+    "ci-pending",
+    "conflicts",
+    "review-needed",
+    "changes-requested",
+    "draft",
+    "stale",
+    "unknown",
+]
+
+# Order: most actionable first; used for sorted reports and for triage SLA.
+PRIORITY_ORDER: tuple[PRBucket, ...] = (
+    "conflicts",
+    "ci-failing",
+    "ci-pending",
+    "changes-requested",
+    "review-needed",
+    "ready",
+    "draft",
+    "stale",
+    "unknown",
+)
+
+
+GH_FIELDS: tuple[str, ...] = (
+    "number",
+    "title",
+    "url",
+    "isDraft",
+    "mergeable",
+    "mergeStateStatus",
+    "baseRefName",
+    "headRefName",
+    "createdAt",
+    "updatedAt",
+    "author",
+    "labels",
+    "reviewDecision",
+    "statusCheckRollup",
+)
+
+
+@dataclass
+class PRStatus:
+    """Triage classification of a single open pull request."""
+
+    number: int
+    title: str
+    url: str
+    base: str
+    head: str
+    bucket: PRBucket
+    age_days: int
+    is_stale: bool = False
+    blocked_reason: str = ""
+    author: str = ""
+    labels: list[str] = field(default_factory=list)
+    review_decision: str = ""
+    ci_state: str = ""
+    is_draft: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "number": self.number,
+            "title": self.title,
+            "url": self.url,
+            "base": self.base,
+            "head": self.head,
+            "bucket": self.bucket,
+            "age_days": self.age_days,
+            "is_stale": self.is_stale,
+            "blocked_reason": self.blocked_reason,
+            "author": self.author,
+            "labels": list(self.labels),
+            "review_decision": self.review_decision,
+            "ci_state": self.ci_state,
+            "is_draft": self.is_draft,
+        }
+
+
+# ---------------------------------------------------------------------------
+# gh CLI invocation
+# ---------------------------------------------------------------------------
+
+
+def fetch_open_prs(
+    *,
+    base: str | None = None,
+    limit: int = 200,
+    runner=subprocess.run,
+) -> list[dict[str, Any]]:
+    """Invoke ``gh pr list`` and return the parsed JSON list."""
+    cmd: list[str] = [
+        "gh",
+        "pr",
+        "list",
+        "--state",
+        "open",
+        "--limit",
+        str(limit),
+        "--json",
+        ",".join(GH_FIELDS),
+    ]
+    if base:
+        cmd.extend(["--base", base])
+
+    result = runner(cmd, capture_output=True, text=True, check=False)
+    if getattr(result, "returncode", 1) != 0:
+        raise RuntimeError(
+            f"gh pr list failed (exit {result.returncode}): {getattr(result, 'stderr', '')!r}"
+        )
+    raw = (result.stdout or "").strip()
+    if not raw:
+        return []
+    parsed = json.loads(raw)
+    if not isinstance(parsed, list):
+        raise RuntimeError("gh returned non-list JSON; cannot triage")
+    return parsed
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def _ci_state(rollup: Iterable[Any] | None) -> str:
+    """Reduce ``statusCheckRollup`` to a single state string.
+
+    GitHub returns a list of check runs; we surface the worst-case state.
+    """
+    if not rollup:
+        return ""
+    severity = {
+        "FAILURE": 5,
+        "ERROR": 5,
+        "CANCELLED": 4,
+        "TIMED_OUT": 4,
+        "ACTION_REQUIRED": 4,
+        "PENDING": 3,
+        "IN_PROGRESS": 3,
+        "QUEUED": 3,
+        "SUCCESS": 2,
+        "NEUTRAL": 1,
+        "SKIPPED": 1,
+    }
+    worst_state = ""
+    worst_score = -1
+    for check in rollup:
+        if not isinstance(check, dict):
+            continue
+        # Both ``conclusion`` (CheckRun) and ``state`` (StatusContext) appear.
+        state = check.get("conclusion") or check.get("state") or ""
+        if not state:
+            continue
+        score = severity.get(state, 0)
+        if score > worst_score:
+            worst_score = score
+            worst_state = state
+    return worst_state
+
+
+def _parse_age_days(created_at: str, *, now: datetime | None = None) -> int:
+    if not created_at:
+        return 0
+    try:
+        # Python 3.11+ ``fromisoformat`` parses the trailing ``Z`` natively.
+        dt = datetime.fromisoformat(created_at)
+    except ValueError:
+        return 0
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    reference = now or datetime.now(UTC)
+    return max(0, (reference - dt).days)
+
+
+def classify_pr(
+    raw: dict[str, Any],
+    *,
+    stale_days: int = 14,
+    now: datetime | None = None,
+) -> PRStatus:
+    """Convert a single ``gh pr list`` entry into a ``PRStatus``."""
+    number = int(raw.get("number", 0))
+    title = str(raw.get("title", "") or "")
+    url = str(raw.get("url", "") or "")
+    base = str(raw.get("baseRefName", "") or "")
+    head = str(raw.get("headRefName", "") or "")
+    is_draft = bool(raw.get("isDraft", False))
+
+    author_block = raw.get("author") or {}
+    author = author_block.get("login", "") if isinstance(author_block, dict) else ""
+
+    label_names: list[str] = []
+    for label in raw.get("labels") or []:
+        if isinstance(label, dict) and label.get("name"):
+            label_names.append(str(label["name"]))
+
+    review_decision = str(raw.get("reviewDecision") or "")
+    mergeable = str(raw.get("mergeable") or "").upper()
+    merge_state = str(raw.get("mergeStateStatus") or "").upper()
+    ci_state = _ci_state(raw.get("statusCheckRollup"))
+
+    age_days = _parse_age_days(raw.get("createdAt", ""), now=now)
+    is_stale = age_days >= stale_days
+
+    bucket: PRBucket = "unknown"
+    blocked_reason = ""
+
+    if is_draft:
+        bucket = "draft"
+        blocked_reason = "marked as draft"
+    elif mergeable == "CONFLICTING" or merge_state == "DIRTY":
+        bucket = "conflicts"
+        blocked_reason = "merge conflicts"
+    elif ci_state in {"FAILURE", "ERROR", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED"}:
+        bucket = "ci-failing"
+        blocked_reason = f"CI {ci_state.lower()}"
+    elif ci_state in {"PENDING", "IN_PROGRESS", "QUEUED"}:
+        bucket = "ci-pending"
+        blocked_reason = "CI in progress"
+    elif review_decision == "CHANGES_REQUESTED":
+        bucket = "changes-requested"
+        blocked_reason = "reviewer requested changes"
+    elif review_decision == "APPROVED":
+        bucket = "ready"
+        blocked_reason = ""
+    elif review_decision == "REVIEW_REQUIRED":
+        bucket = "review-needed"
+        blocked_reason = "no approval yet"
+    elif review_decision == "":
+        # No review policy -> ready if everything else is fine
+        bucket = "ready" if ci_state in {"SUCCESS", ""} else "review-needed"
+    else:
+        bucket = "unknown"
+        blocked_reason = f"unrecognised reviewDecision={review_decision!r}"
+
+    return PRStatus(
+        number=number,
+        title=title,
+        url=url,
+        base=base,
+        head=head,
+        bucket=bucket,
+        age_days=age_days,
+        is_stale=is_stale,
+        blocked_reason=blocked_reason,
+        author=author,
+        labels=label_names,
+        review_decision=review_decision,
+        ci_state=ci_state,
+        is_draft=is_draft,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def summarise(prs: list[PRStatus]) -> dict[str, int]:
+    """Return per-bucket counts plus the stale-flag count."""
+    counts: dict[str, int] = dict.fromkeys(PRIORITY_ORDER, 0)
+    counts["stale_flagged"] = 0
+    for pr in prs:
+        counts[pr.bucket] = counts.get(pr.bucket, 0) + 1
+        if pr.is_stale:
+            counts["stale_flagged"] += 1
+    return counts
+
+
+def print_human_report(prs: list[PRStatus], counts: dict[str, int]) -> None:
+    """Print a grouped human-readable report."""
+    total = sum(counts[b] for b in PRIORITY_ORDER)
+    print("=== PR Queue Triage ===")
+    print(f"Total open PRs: {total}")
+    print(f"Stale (flagged): {counts['stale_flagged']}\n")
+
+    by_bucket: dict[str, list[PRStatus]] = {b: [] for b in PRIORITY_ORDER}
+    for pr in prs:
+        by_bucket[pr.bucket].append(pr)
+
+    for bucket in PRIORITY_ORDER:
+        items = by_bucket[bucket]
+        if not items:
+            continue
+        items.sort(key=lambda p: p.age_days, reverse=True)
+        print(f"[{bucket}] ({len(items)}):")
+        for pr in items:
+            stale_flag = " [STALE]" if pr.is_stale else ""
+            reason = f"  -- {pr.blocked_reason}" if pr.blocked_reason else ""
+            print(f"  #{pr.number:>5} ({pr.age_days}d){stale_flag}  {pr.title}")
+            print(f"         base={pr.base} head={pr.head} author=@{pr.author}{reason}")
+            print(f"         {pr.url}")
+        print()
+
+
+def filter_bucket(prs: list[PRStatus], bucket: PRBucket | None) -> list[PRStatus]:
+    if bucket is None:
+        return prs
+    return [pr for pr in prs if pr.bucket == bucket]
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_report(
+    raw_prs: list[dict[str, Any]],
+    *,
+    stale_days: int = 14,
+    now: datetime | None = None,
+) -> list[PRStatus]:
+    return [classify_pr(item, stale_days=stale_days, now=now) for item in raw_prs]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Open PR queue triage report")
+    parser.add_argument(
+        "--base",
+        default=None,
+        help="Filter PRs by base branch (e.g. dev, main).",
+    )
+    parser.add_argument(
+        "--stale-days",
+        type=int,
+        default=14,
+        help="Age threshold in days that flags a PR as stale (default: 14).",
+    )
+    parser.add_argument(
+        "--bucket",
+        choices=list(PRIORITY_ORDER),
+        default=None,
+        help="Show only PRs in the given bucket.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=200,
+        help="Max PRs requested from gh (default: 200).",
+    )
+    parser.add_argument("--json", action="store_true", help="JSON output")
+    args = parser.parse_args(argv)
+
+    raw_prs = fetch_open_prs(base=args.base, limit=args.limit)
+    classified = build_report(raw_prs, stale_days=args.stale_days)
+    classified = filter_bucket(classified, args.bucket)
+    counts = summarise(classified)
+
+    if args.json:
+        payload = {
+            "summary": counts,
+            "stale_days": args.stale_days,
+            "base_filter": args.base,
+            "bucket_filter": args.bucket,
+            "items": [pr.to_dict() for pr in classified],
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        print_human_report(classified, counts)
+
+    actionable_buckets = {"conflicts", "ci-failing", "changes-requested", "review-needed", "ready"}
+    actionable = sum(counts[b] for b in actionable_buckets) + counts["stale_flagged"]
+    return 0 if actionable == 0 else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - thin CLI shim
+    sys.exit(main())

--- a/tests/unit/scripts/test_git_hygiene.py
+++ b/tests/unit/scripts/test_git_hygiene.py
@@ -1,24 +1,366 @@
+"""Unit tests for ``scripts/git_hygiene.py``.
+
+Two test surfaces:
+
+1. **Static guards** — assertions over the source text so the file always
+   keeps the conventions encoded by the wider repo (``dev`` as base branch,
+   protected long-lived names).
+2. **Behavioural** — exercise the classification and reporting logic by
+   constructing ``BranchInfo`` / ``WorktreeInfo`` records directly (no live
+   git invocation), so #1718 safety guarantees are pinned by tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
 from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "git_hygiene.py"
+
+
+def _load_module():
+    """Import ``scripts/git_hygiene.py`` as a standalone module."""
+    spec = importlib.util.spec_from_file_location("git_hygiene_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def gh():
+    return _load_module()
+
+
+# ---------------------------------------------------------------------------
+# Static guards (kept for backward compatibility with #1718 audit checklist)
+# ---------------------------------------------------------------------------
 
 
 def test_git_hygiene_uses_dev_default_branch() -> None:
-    text = Path("scripts/git_hygiene.py").read_text(encoding="utf-8")
+    text = SCRIPT_PATH.read_text(encoding="utf-8")
     assert 'DEFAULT_BASE_BRANCH = "dev"' in text
 
 
-def test_git_hygiene_protects_configured_base_branch() -> None:
-    text = Path("scripts/git_hygiene.py").read_text(encoding="utf-8")
-    assert 'protected = {base_branch, "main", "master", "develop"}' in text
+def test_git_hygiene_protects_long_lived_branches() -> None:
+    text = SCRIPT_PATH.read_text(encoding="utf-8")
+    # Set membership; new code uses ``PROTECTED_NAMES`` frozenset.
+    assert '"main"' in text
+    assert '"master"' in text
+    assert '"develop"' in text
 
 
 def test_repo_cleanup_uses_dev_default_branch() -> None:
-    text = Path("scripts/repo_cleanup.sh").read_text(encoding="utf-8")
-    assert (
-        'MAIN_BRANCH="${MAIN_BRANCH:-dev}"' in text or 'MAIN_BRANCH="${MAIN_BRANCH:-dev}"' in text
-    )
+    text = (REPO_ROOT / "scripts" / "repo_cleanup.sh").read_text(encoding="utf-8")
+    assert 'MAIN_BRANCH="${MAIN_BRANCH:-dev}"' in text
 
 
 def test_repo_cleanup_filters_base_branch_by_exact_match() -> None:
-    text = Path("scripts/repo_cleanup.sh").read_text(encoding="utf-8")
+    text = (REPO_ROOT / "scripts" / "repo_cleanup.sh").read_text(encoding="utf-8")
     assert 'grep -v "$MAIN_BRANCH"' not in text
     assert '[ "$branch" = "$MAIN_BRANCH" ] && continue' in text
+
+
+# ---------------------------------------------------------------------------
+# Branch classification
+# ---------------------------------------------------------------------------
+
+
+def _branch(gh, name: str, **overrides):
+    info = gh.BranchInfo(name=name)
+    for key, value in overrides.items():
+        setattr(info, key, value)
+    return info
+
+
+def test_classify_current_branch_is_protected(gh) -> None:
+    info = _branch(gh, "feature/x", is_current=True, merged_into_base=True)
+    out = gh.classify_branch(info, base="dev")
+    assert out.category == "protected"
+    assert "current branch" in out.reasons
+
+
+def test_classify_base_branch_is_protected(gh) -> None:
+    info = _branch(gh, "dev", merged_into_base=True)
+    out = gh.classify_branch(info, base="dev")
+    assert out.category == "protected"
+    assert any("base branch" in r for r in out.reasons)
+
+
+@pytest.mark.parametrize("name", ["main", "master", "develop"])
+def test_classify_long_lived_branch_is_protected(gh, name: str) -> None:
+    out = gh.classify_branch(_branch(gh, name), base="dev")
+    assert out.category == "protected"
+
+
+def test_classify_merged_with_upstream_is_safe_to_delete(gh) -> None:
+    info = _branch(
+        gh,
+        "feature/done",
+        upstream="origin/feature/done",
+        merged_into_base=True,
+    )
+    out = gh.classify_branch(info, base="dev")
+    assert out.category == "safe-to-delete"
+    assert any("merged into dev" in r for r in out.reasons)
+
+
+def test_classify_no_upstream_is_requires_human(gh) -> None:
+    info = _branch(
+        gh,
+        "feature/local-only",
+        upstream=None,
+        merged_into_base=True,
+    )
+    out = gh.classify_branch(info, base="dev")
+    assert out.category == "requires-human"
+    assert "no upstream" in out.reasons
+
+
+def test_classify_upstream_gone_is_requires_human(gh) -> None:
+    info = _branch(
+        gh,
+        "feature/orphan",
+        upstream="origin/feature/orphan",
+        upstream_gone=True,
+        merged_into_base=True,
+    )
+    out = gh.classify_branch(info, base="dev")
+    assert out.category == "requires-human"
+    assert "upstream gone" in out.reasons
+
+
+def test_classify_ahead_of_upstream_is_requires_human(gh) -> None:
+    info = _branch(
+        gh,
+        "feature/wip",
+        upstream="origin/feature/wip",
+        ahead=3,
+        merged_into_base=True,
+    )
+    out = gh.classify_branch(info, base="dev")
+    assert out.category == "requires-human"
+    assert any("3 commit(s) ahead" in r for r in out.reasons)
+
+
+def test_classify_unmerged_is_requires_human(gh) -> None:
+    info = _branch(
+        gh,
+        "feature/wip",
+        upstream="origin/feature/wip",
+        merged_into_base=False,
+    )
+    out = gh.classify_branch(info, base="dev")
+    assert out.category == "requires-human"
+    assert any("not merged into dev" in r for r in out.reasons)
+
+
+def test_classify_dirty_worktree_blocks_safe_deletion(gh) -> None:
+    """Even merged + upstream-tracked branch is requires-human if its worktree is dirty."""
+    info = _branch(
+        gh,
+        "feature/done-but-dirty",
+        upstream="origin/feature/done-but-dirty",
+        merged_into_base=True,
+        worktree_path="/tmp/wt",
+        worktree_dirty=True,
+    )
+    out = gh.classify_branch(info, base="dev")
+    assert out.category == "requires-human"
+    assert any("uncommitted changes in worktree" in r for r in out.reasons)
+
+
+def test_classify_clean_worktree_attached_branch_is_requires_human(gh) -> None:
+    """Branch is checked out in a worktree -> ``git branch -d`` would fail; surface it."""
+    info = _branch(
+        gh,
+        "feature/checked-out",
+        upstream="origin/feature/checked-out",
+        merged_into_base=True,
+        worktree_path="/projects/sandbox/wt",
+        worktree_dirty=False,
+    )
+    out = gh.classify_branch(info, base="dev")
+    assert out.category == "requires-human"
+    assert any("checked out at" in r for r in out.reasons)
+
+
+# ---------------------------------------------------------------------------
+# Worktree classification
+# ---------------------------------------------------------------------------
+
+
+def test_worktree_clean_repo_is_safe(gh) -> None:
+    wt = gh.WorktreeInfo(path="/projects/sandbox/rag", branch="dev")
+    assert wt.category == "safe"
+    assert wt.reasons == []
+
+
+def test_worktree_in_tmp_is_requires_human(gh) -> None:
+    wt = gh.WorktreeInfo(path="/tmp/scratch", branch="feature/x", in_tmp=True)
+    assert wt.category == "requires-human"
+    assert "in /tmp" in wt.reasons
+
+
+def test_worktree_detached_is_requires_human(gh) -> None:
+    wt = gh.WorktreeInfo(path="/srv/wt", detached=True)
+    assert wt.category == "requires-human"
+    assert "detached HEAD" in wt.reasons
+
+
+def test_worktree_dirty_is_requires_human(gh) -> None:
+    wt = gh.WorktreeInfo(path="/srv/wt", branch="feature/x", dirty=True)
+    assert wt.category == "requires-human"
+    assert "uncommitted changes" in wt.reasons
+
+
+# ---------------------------------------------------------------------------
+# Report contracts
+# ---------------------------------------------------------------------------
+
+
+def test_report_total_issues_excludes_protected(gh) -> None:
+    branches = [
+        gh.BranchInfo(name="dev", category="protected", reasons=["base branch (dev)"]),
+        gh.BranchInfo(name="feature/done", category="safe-to-delete"),
+        gh.BranchInfo(name="feature/wip", category="requires-human", reasons=["x"]),
+    ]
+    worktrees = [
+        gh.WorktreeInfo(path="/srv/clean"),
+        gh.WorktreeInfo(path="/tmp/scratch", in_tmp=True),
+    ]
+    report = gh.HygieneReport(branches=branches, worktrees=worktrees, transient_files=["a.log"])
+
+    assert report.total_issues == 4  # 1 safe + 1 requires-human + 1 stale wt + 1 transient
+
+
+def test_report_backward_compat_keys(gh) -> None:
+    branches = [
+        gh.BranchInfo(name="feature/done", category="safe-to-delete"),
+        gh.BranchInfo(
+            name="feature/local",
+            category="requires-human",
+            reasons=["no upstream"],
+        ),
+    ]
+    worktrees = [gh.WorktreeInfo(path="/tmp/old", in_tmp=True)]
+    report = gh.HygieneReport(branches=branches, worktrees=worktrees)
+
+    assert report.merged_branches == ["feature/done"]
+    assert report.no_upstream_branches == ["feature/local"]
+    assert report.stale_worktrees == [{"path": "/tmp/old", "reason": "in /tmp"}]
+
+
+def test_report_to_dict_contains_classification_view(gh) -> None:
+    report = gh.HygieneReport(
+        branches=[gh.BranchInfo(name="feature/done", category="safe-to-delete")],
+    )
+    payload = report.to_dict()
+    # Round-trip JSON to make sure it is serialisable.
+    encoded = json.loads(json.dumps(payload))
+    assert "classification" in encoded
+    assert encoded["classification"]["safe_to_delete"][0]["name"] == "feature/done"
+    # Backward-compat top-level keys remain in place.
+    assert "merged_branches" in encoded
+    assert "no_upstream_branches" in encoded
+
+
+# ---------------------------------------------------------------------------
+# Cleanup safety
+# ---------------------------------------------------------------------------
+
+
+def test_fix_safe_branches_dry_run_does_not_invoke_git(monkeypatch, gh) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(*args, **kwargs):  # pragma: no cover - guard
+        calls.append(list(args[0]))
+        raise AssertionError("subprocess.run must not be invoked in dry-run")
+
+    monkeypatch.setattr(gh.subprocess, "run", fake_run)
+
+    deleted = gh.fix_safe_branches(
+        [gh.BranchInfo(name="feature/x", category="safe-to-delete")],
+        dry_run=True,
+        quiet=True,
+    )
+    assert deleted == ["feature/x"]
+    assert calls == []
+
+
+def test_fix_safe_branches_invokes_git_branch_d(monkeypatch, gh) -> None:
+    seen: list[list[str]] = []
+
+    class _Result:
+        returncode = 0
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        seen.append(list(cmd))
+        return _Result()
+
+    monkeypatch.setattr(gh.subprocess, "run", fake_run)
+
+    deleted = gh.fix_safe_branches(
+        [gh.BranchInfo(name="feature/done", category="safe-to-delete")],
+        dry_run=False,
+        quiet=True,
+    )
+    assert deleted == ["feature/done"]
+    assert seen == [["git", "branch", "-d", "feature/done"]]
+
+
+def test_fix_merged_branches_backward_compat_shim(monkeypatch, gh) -> None:
+    """Existing callers passing list[str] still work."""
+    seen: list[list[str]] = []
+
+    class _Result:
+        returncode = 0
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        seen.append(list(cmd))
+        return _Result()
+
+    monkeypatch.setattr(gh.subprocess, "run", fake_run)
+    deleted = gh.fix_merged_branches(["feature/done"], dry_run=False, quiet=True)
+    assert deleted == ["feature/done"]
+    assert seen == [["git", "branch", "-d", "feature/done"]]
+
+
+# ---------------------------------------------------------------------------
+# CLI argparse safety
+# ---------------------------------------------------------------------------
+
+
+def test_cli_dry_run_requires_fix(gh, capsys) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        old_argv = sys.argv
+        sys.argv = ["git_hygiene.py", "--dry-run"]
+        try:
+            gh.main()
+        finally:
+            sys.argv = old_argv
+    assert exc_info.value.code != 0
+    err = capsys.readouterr().err
+    assert "--dry-run requires --fix" in err
+
+
+def test_cli_include_requires_human_requires_fix(gh, capsys) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        old_argv = sys.argv
+        sys.argv = ["git_hygiene.py", "--include-requires-human"]
+        try:
+            gh.main()
+        finally:
+            sys.argv = old_argv
+    assert exc_info.value.code != 0
+    err = capsys.readouterr().err
+    assert "--include-requires-human requires --fix" in err

--- a/tests/unit/scripts/test_issue_queue_audit.py
+++ b/tests/unit/scripts/test_issue_queue_audit.py
@@ -1,0 +1,207 @@
+"""Unit tests for ``scripts/issue_queue_audit.py``."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "issue_queue_audit.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("issue_queue_audit_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def iq():
+    return _load_module()
+
+
+NOW = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+
+
+def _issue(
+    *,
+    number: int = 1,
+    title: str = "test issue",
+    days_old: int = 1,
+    labels: list[str] | None = None,
+    assignees: list[str] | None = None,
+) -> dict:
+    created = (NOW - timedelta(days=days_old)).isoformat().replace("+00:00", "Z")
+    return {
+        "number": number,
+        "title": title,
+        "url": f"https://example.test/issue/{number}",
+        "labels": [{"name": n} for n in (labels or [])],
+        "assignees": [{"login": login} for login in (assignees or [])],
+        "createdAt": created,
+        "updatedAt": created,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-flag classification
+# ---------------------------------------------------------------------------
+
+
+def test_issue_with_no_labels_no_assignee(iq) -> None:
+    out = iq.classify_issue(_issue(), now=NOW)
+    assert "no-labels" in out.flags
+    assert "no-assignee" in out.flags
+    assert "no-lane" not in out.flags  # gated on having any labels
+    assert out.is_triaged is False
+
+
+def test_issue_with_labels_but_no_lane(iq) -> None:
+    out = iq.classify_issue(_issue(labels=["bug"], assignees=["alice"]), now=NOW)
+    assert "no-lane" in out.flags
+    assert "no-labels" not in out.flags
+    assert "no-assignee" not in out.flags
+
+
+def test_fully_triaged_issue(iq) -> None:
+    out = iq.classify_issue(
+        _issue(labels=["bug", "lane:quick-win"], assignees=["alice"]),
+        now=NOW,
+    )
+    assert out.flags == ["triaged"]
+    assert out.is_triaged is True
+    assert out.lane == "lane:quick-win"
+
+
+def test_stale_flag_added_when_old(iq) -> None:
+    out = iq.classify_issue(
+        _issue(days_old=120, labels=["bug", "lane:plan-needed"], assignees=["bob"]),
+        stale_days=60,
+        now=NOW,
+    )
+    assert "stale" in out.flags
+    assert out.is_triaged is False  # any flag means not fully triaged
+
+
+def test_lane_picks_first_lane_label(iq) -> None:
+    out = iq.classify_issue(
+        _issue(labels=["bug", "lane:quick-win", "lane:plan-needed"], assignees=["alice"]),
+        now=NOW,
+    )
+    assert out.lane == "lane:quick-win"
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def test_summarise_counts_buckets_and_lanes(iq) -> None:
+    raw = [
+        _issue(number=1),  # no-labels + no-assignee
+        _issue(number=2, labels=["bug"]),  # no-lane + no-assignee
+        _issue(number=3, labels=["bug", "lane:quick-win"], assignees=["alice"]),
+        _issue(
+            number=4,
+            labels=["bug", "lane:plan-needed"],
+            assignees=["bob"],
+            days_old=120,
+        ),
+    ]
+    classified = iq.build_report(raw, stale_days=60, now=NOW)
+    counts = iq.summarise(classified)
+
+    assert counts["total"] == 4
+    assert counts["no-labels"] == 1
+    assert counts["no-assignee"] == 2
+    assert counts["no-lane"] == 1
+    assert counts["stale"] == 1
+    assert counts["triaged"] == 1
+    assert counts["lane::lane:quick-win"] == 1
+    assert counts["lane::lane:plan-needed"] == 1
+    assert counts["lane::(none)"] == 2
+
+
+def test_filter_bucket_returns_only_matches(iq) -> None:
+    raw = [
+        _issue(number=1),
+        _issue(number=2, labels=["bug", "lane:quick-win"], assignees=["a"]),
+    ]
+    classified = iq.build_report(raw, now=NOW)
+    only_no_labels = iq.filter_bucket(classified, "no-labels")
+    assert [i.number for i in only_no_labels] == [1]
+
+
+# ---------------------------------------------------------------------------
+# fetch_open_issues uses gh CLI through the runner
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_open_issues_invokes_gh(iq) -> None:
+    captured: dict[str, list[str]] = {}
+
+    class _Result:
+        returncode = 0
+        stdout = "[]"
+        stderr = ""
+
+    def fake_runner(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        return _Result()
+
+    iq.fetch_open_issues(limit=10, runner=fake_runner)
+    assert captured["cmd"][:3] == ["gh", "issue", "list"]
+    assert "--state" in captured["cmd"]
+    assert "open" in captured["cmd"]
+    assert "10" in captured["cmd"]
+
+
+def test_fetch_open_issues_raises_on_failure(iq) -> None:
+    class _Result:
+        returncode = 1
+        stdout = ""
+        stderr = "auth error"
+
+    def fake_runner(cmd, **kwargs):
+        return _Result()
+
+    with pytest.raises(RuntimeError, match="gh issue list failed"):
+        iq.fetch_open_issues(runner=fake_runner)
+
+
+def test_fetch_open_issues_raises_on_non_list_json(iq) -> None:
+    class _Result:
+        returncode = 0
+        stdout = '{"oops": true}'
+        stderr = ""
+
+    def fake_runner(cmd, **kwargs):
+        return _Result()
+
+    with pytest.raises(RuntimeError, match="non-list JSON"):
+        iq.fetch_open_issues(runner=fake_runner)
+
+
+def test_fetch_open_issues_returns_parsed_list(iq) -> None:
+    payload = [_issue(number=99)]
+
+    class _Result:
+        returncode = 0
+        stdout = json.dumps(payload)
+        stderr = ""
+
+    def fake_runner(cmd, **kwargs):
+        return _Result()
+
+    out = iq.fetch_open_issues(runner=fake_runner)
+    assert len(out) == 1
+    assert out[0]["number"] == 99

--- a/tests/unit/scripts/test_pr_queue_audit.py
+++ b/tests/unit/scripts/test_pr_queue_audit.py
@@ -1,0 +1,266 @@
+"""Unit tests for ``scripts/pr_queue_audit.py``.
+
+Exercise the classification logic through ``classify_pr`` with synthetic
+``gh pr list --json`` payloads. ``fetch_open_prs`` is exercised through a
+fake subprocess runner so we do not require a real ``gh`` installation.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "pr_queue_audit.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("pr_queue_audit_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def pq():
+    return _load_module()
+
+
+# Reference "now" used across age computations so tests are deterministic.
+NOW = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+
+
+def _pr(
+    *,
+    number: int = 1,
+    title: str = "test pr",
+    base: str = "dev",
+    head: str = "feature/x",
+    is_draft: bool = False,
+    mergeable: str = "MERGEABLE",
+    merge_state: str = "CLEAN",
+    rollup_state: str = "SUCCESS",
+    review_decision: str = "APPROVED",
+    days_old: int = 1,
+    author: str = "alice",
+    labels: list[str] | None = None,
+) -> dict:
+    created = (NOW - timedelta(days=days_old)).isoformat().replace("+00:00", "Z")
+    return {
+        "number": number,
+        "title": title,
+        "url": f"https://example.test/pr/{number}",
+        "isDraft": is_draft,
+        "mergeable": mergeable,
+        "mergeStateStatus": merge_state,
+        "baseRefName": base,
+        "headRefName": head,
+        "createdAt": created,
+        "updatedAt": created,
+        "author": {"login": author},
+        "labels": [{"name": n} for n in (labels or [])],
+        "reviewDecision": review_decision,
+        "statusCheckRollup": [{"conclusion": rollup_state}],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Bucket classification
+# ---------------------------------------------------------------------------
+
+
+def test_ready_pr(pq) -> None:
+    out = pq.classify_pr(_pr(), now=NOW)
+    assert out.bucket == "ready"
+    assert out.blocked_reason == ""
+
+
+def test_draft_pr_takes_precedence_over_other_signals(pq) -> None:
+    out = pq.classify_pr(
+        _pr(is_draft=True, mergeable="CONFLICTING", rollup_state="FAILURE"),
+        now=NOW,
+    )
+    assert out.bucket == "draft"
+    assert out.is_draft is True
+
+
+def test_conflict_pr(pq) -> None:
+    out = pq.classify_pr(_pr(mergeable="CONFLICTING"), now=NOW)
+    assert out.bucket == "conflicts"
+    assert "merge conflicts" in out.blocked_reason
+
+
+def test_dirty_merge_state_is_conflict(pq) -> None:
+    out = pq.classify_pr(_pr(mergeable="UNKNOWN", merge_state="DIRTY"), now=NOW)
+    assert out.bucket == "conflicts"
+
+
+def test_ci_failing_pr(pq) -> None:
+    out = pq.classify_pr(_pr(rollup_state="FAILURE"), now=NOW)
+    assert out.bucket == "ci-failing"
+    assert "CI failure" in out.blocked_reason
+
+
+def test_ci_pending_pr(pq) -> None:
+    out = pq.classify_pr(_pr(rollup_state="IN_PROGRESS"), now=NOW)
+    assert out.bucket == "ci-pending"
+
+
+def test_changes_requested_pr(pq) -> None:
+    out = pq.classify_pr(_pr(review_decision="CHANGES_REQUESTED"), now=NOW)
+    assert out.bucket == "changes-requested"
+
+
+def test_review_required_pr(pq) -> None:
+    out = pq.classify_pr(_pr(review_decision="REVIEW_REQUIRED"), now=NOW)
+    assert out.bucket == "review-needed"
+
+
+def test_no_review_policy_pr_with_green_ci(pq) -> None:
+    out = pq.classify_pr(_pr(review_decision=""), now=NOW)
+    assert out.bucket == "ready"
+
+
+def test_no_review_policy_with_no_ci_data(pq) -> None:
+    raw = _pr(review_decision="")
+    raw["statusCheckRollup"] = []
+    out = pq.classify_pr(raw, now=NOW)
+    assert out.bucket == "ready"
+
+
+# ---------------------------------------------------------------------------
+# Stale flag
+# ---------------------------------------------------------------------------
+
+
+def test_stale_flag_set_for_old_prs(pq) -> None:
+    out = pq.classify_pr(_pr(days_old=20), stale_days=14, now=NOW)
+    assert out.is_stale is True
+    assert out.age_days == 20
+
+
+def test_stale_flag_off_for_fresh_prs(pq) -> None:
+    out = pq.classify_pr(_pr(days_old=2), stale_days=14, now=NOW)
+    assert out.is_stale is False
+
+
+# ---------------------------------------------------------------------------
+# Severity reduction over rollup
+# ---------------------------------------------------------------------------
+
+
+def test_ci_state_picks_worst_check_first(pq) -> None:
+    raw = _pr()
+    raw["statusCheckRollup"] = [
+        {"conclusion": "SUCCESS"},
+        {"state": "FAILURE"},
+        {"conclusion": "PENDING"},
+    ]
+    out = pq.classify_pr(raw, now=NOW)
+    assert out.ci_state == "FAILURE"
+    assert out.bucket == "ci-failing"
+
+
+# ---------------------------------------------------------------------------
+# Aggregate: summarise + filter
+# ---------------------------------------------------------------------------
+
+
+def test_summarise_counts_per_bucket(pq) -> None:
+    raw = [
+        _pr(number=1, mergeable="CONFLICTING"),
+        _pr(number=2, rollup_state="FAILURE"),
+        _pr(number=3, review_decision="APPROVED"),
+        _pr(number=4, days_old=30),  # stale + ready
+    ]
+    classified = pq.build_report(raw, stale_days=14, now=NOW)
+    counts = pq.summarise(classified)
+
+    assert counts["conflicts"] == 1
+    assert counts["ci-failing"] == 1
+    assert counts["ready"] == 2
+    assert counts["stale_flagged"] == 1
+
+
+def test_filter_bucket_returns_only_match(pq) -> None:
+    raw = [
+        _pr(number=1, mergeable="CONFLICTING"),
+        _pr(number=2),
+    ]
+    classified = pq.build_report(raw, now=NOW)
+    only_conflicts = pq.filter_bucket(classified, "conflicts")
+    assert [p.number for p in only_conflicts] == [1]
+
+
+# ---------------------------------------------------------------------------
+# fetch_open_prs uses gh CLI through the runner
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_open_prs_invokes_gh_with_correct_args(pq) -> None:
+    captured: dict[str, list[str]] = {}
+
+    class _Result:
+        returncode = 0
+        stdout = "[]"
+        stderr = ""
+
+    def fake_runner(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        return _Result()
+
+    pq.fetch_open_prs(base="dev", limit=50, runner=fake_runner)
+    assert captured["cmd"][:3] == ["gh", "pr", "list"]
+    assert "--state" in captured["cmd"]
+    assert "--base" in captured["cmd"]
+    assert "dev" in captured["cmd"]
+
+
+def test_fetch_open_prs_raises_on_gh_failure(pq) -> None:
+    class _Result:
+        returncode = 1
+        stdout = ""
+        stderr = "auth error"
+
+    def fake_runner(cmd, **kwargs):
+        return _Result()
+
+    with pytest.raises(RuntimeError, match="gh pr list failed"):
+        pq.fetch_open_prs(runner=fake_runner)
+
+
+def test_fetch_open_prs_raises_on_non_list_json(pq) -> None:
+    class _Result:
+        returncode = 0
+        stdout = '{"oops": true}'
+        stderr = ""
+
+    def fake_runner(cmd, **kwargs):
+        return _Result()
+
+    with pytest.raises(RuntimeError, match="non-list JSON"):
+        pq.fetch_open_prs(runner=fake_runner)
+
+
+def test_fetch_open_prs_returns_parsed_list(pq) -> None:
+    payload = [_pr(number=42)]
+
+    class _Result:
+        returncode = 0
+        stdout = json.dumps(payload)
+        stderr = ""
+
+    def fake_runner(cmd, **kwargs):
+        return _Result()
+
+    out = pq.fetch_open_prs(runner=fake_runner)
+    assert len(out) == 1
+    assert out[0]["number"] == 42


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Closes #1718, partially addresses #1717 / #1719 / #1720.

## What ships

| File | Purpose | Issue |
|---|---|---|
| `scripts/git_hygiene.py` | 3-tier branch + worktree classification | #1718 |
| `scripts/pr_queue_audit.py` | Open PR queue triage via `gh pr list --json` | #1719 |
| `scripts/issue_queue_audit.py` | Open issue hygiene via `gh issue list --json` | #1720 |
| `docs/engineering/repo-hygiene-runbook.md` | Weekly operator runbook | #1717 |
| `Makefile` | `pr-hygiene` + `issue-hygiene` targets | #1717 |
| `tests/unit/scripts/test_*.py` | 58 unit tests across all three scripts | — |

## #1718 — git/worktree safety (the headline)

Replaces the previous binary `merged / no-upstream` classification with
the three-lane model required by the #1717 spec:

| Lane | Definition | Action |
|---|---|---|
| `safe-to-delete` | Merged into base + has upstream + no live worktree | `--fix` deletes |
| `protected` | Current branch / base branch / main/master/develop | Always informational |
| `requires-human` | Unmerged · upstream gone · ahead of upstream · no upstream · checked out at worktree · dirty worktree | Surfaced, never auto-deleted by default |

Worktrees get the same treatment: detached / `/tmp` / dirty are
`requires-human`, clean ones are `safe`.

### Safety guarantees (pinned by tests)

- Never deletes the **current branch**.
- Never deletes a branch checked out at a **worktree**.
- Never deletes a branch with **uncommitted changes** in its worktree.
- Never deletes a branch **ahead of upstream** or with `upstream [gone]`
  in the default `--fix` mode.
- `--fix` requires explicit invocation; `--dry-run` previews any
  deletion; `--include-requires-human` is opt-in and still refuses
  dirty worktrees.

### JSON backward-compatibility

Existing top-level keys are preserved (`merged_branches`,
`no_upstream_branches`, `stale_worktrees`, `transient_files`,
`total_issues`). The lane-aware view is added under
`classification.{safe_to_delete,protected,requires_human,worktrees}`.

## #1719 — PR queue triage

`gh pr list --json` → priority-ordered buckets:

```
conflicts > ci-failing > ci-pending > changes-requested
  > review-needed > ready > draft > unknown
```

`stale` (>14d default) is a separate flag, surfaced for any PR
regardless of its primary bucket. Each PR gets a structured
`blocked_reason` and `age_days`.

CLI mirrors `git_hygiene.py`: human report + `--json` + `--bucket`
+ `--base` + `--stale-days` + `--limit`. Exit code is 0 on a fully
clean queue, 1 otherwise — wire-friendly for a Monday CI digest.

## #1720 — issue queue hygiene

`gh issue list --json` → flag set per issue: `no-labels`, `no-assignee`,
`no-lane` (has labels but no `lane:*` label), `stale`, `triaged`.
Aggregate counts include a per-lane breakdown so the queue mix is
visible at a glance.

CLI: `--json`, `--bucket`, `--stale-days`, `--limit`. Exit code 0 only
when all four hygiene flags are zero.

## #1717 — runbook

`docs/engineering/repo-hygiene-runbook.md` ties everything together:
5-minute Monday check, what each tool covers, safety guarantees, lane
definitions, triage SLA, ownership rule (author / reviewer / merger),
and a suggested weekly schedule.

## Verification

- `ruff check` is clean for all three scripts and the three test files.
- `pytest tests/unit/scripts/test_git_hygiene.py`: 28 passed in the
  sandbox (Python 3.9). The PR/issue tests require Python 3.11+ for
  `datetime.UTC`, which is the project's pinned floor
  (`requires-python = ">=3.11"`) — they will run in CI.
- The hygiene script was exercised against the working tree during
  development and correctly tagged the current dirty worktree as
  `requires-human` while keeping `dev` and the current branch in
  `protected`.

## Out of scope

- No branch deletions performed in this PR.
- No CI workflow changes (you can opt into running these reports in CI
  by adding `make pr-hygiene` to a scheduled workflow).
- No branch protection policy changes.