### PR TITLE
test(ci): enforce tracked test files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Install dev dependencies
         run: UV_PROJECT_ENVIRONMENT=.venv-py312 uv sync --python 3.12 --frozen
 
+      - name: Verify test files are tracked
+        run: UV_PROJECT_ENVIRONMENT=.venv-py312 uv run python scripts/check_test_tracking.py
+
       - name: Unit tests (core)
         run: UV_PROJECT_ENVIRONMENT=.venv-py312 make test-unit
 

--- a/scripts/check_test_tracking.py
+++ b/scripts/check_test_tracking.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Fail if test files are present in working tree but not tracked by Git."""
+
+from __future__ import annotations
+
+import re
+import subprocess  # nosec B404
+from pathlib import Path
+
+
+TEST_FILENAME_RE = re.compile(
+    r"(^test_.*\.(py|sh)$)|(\.(test|spec)\.[cm]?[jt]sx?$)",
+    re.IGNORECASE,
+)
+
+
+def _repo_root() -> Path:
+    result = subprocess.run(  # nosec B603 B607 - fixed local git command, no shell.
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(result.stdout.strip())
+
+
+def _git_untracked(repo_root: Path) -> list[Path]:
+    result = subprocess.run(  # nosec B603 B607 - fixed local git command, no shell.
+        ["git", "ls-files", "--others", "--exclude-standard"],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=repo_root,
+    )
+    return [Path(line.strip()) for line in result.stdout.splitlines() if line.strip()]
+
+
+def _is_test_path(path: Path) -> bool:
+    parts = set(path.parts)
+    if "tests" in parts or "__tests__" in parts:
+        return True
+    return TEST_FILENAME_RE.search(path.name) is not None
+
+
+def _is_inside_nested_repo(path: Path, repo_root: Path) -> bool:
+    current = repo_root / path
+    for parent in current.parents:
+        if parent == repo_root:
+            break
+        if (parent / ".git").exists():
+            return True
+    return False
+
+
+def find_untracked_tests(repo_root: Path) -> list[Path]:
+    offenders: list[Path] = []
+    for path in _git_untracked(repo_root):
+        if not _is_test_path(path):
+            continue
+        if _is_inside_nested_repo(path, repo_root):
+            continue
+        offenders.append(path)
+    return sorted(offenders)
+
+
+def main() -> int:
+    root = _repo_root()
+    offenders = find_untracked_tests(root)
+    if not offenders:
+        print("OK: no untracked test files found")
+        return 0
+
+    print("Found untracked test files. Add or ignore them explicitly:")
+    for path in offenders:
+        print(f" - {path.as_posix()}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_check_test_tracking.py
+++ b/tests/unit/scripts/test_check_test_tracking.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from scripts import check_test_tracking
+
+
+def test_is_test_path_recognizes_tests_dir() -> None:
+    assert check_test_tracking._is_test_path(Path("tests/unit/test_x.py"))
+
+
+def test_is_test_path_recognizes_frontend_pattern() -> None:
+    assert check_test_tracking._is_test_path(Path("mini_app/frontend/src/main.test.tsx"))
+
+
+def test_is_test_path_ignores_non_tests() -> None:
+    assert not check_test_tracking._is_test_path(Path("src/services/runtime.py"))
+
+
+def test_is_inside_nested_repo_detects_embedded_git(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    (repo_root / "vendor" / "tool").mkdir(parents=True)
+    (repo_root / "vendor" / "tool" / ".git").mkdir()
+    candidate = Path("vendor/tool/tests/test_demo.py")
+    assert check_test_tracking._is_inside_nested_repo(candidate, repo_root)
+
+
+def test_find_untracked_tests_filters_nested_repo_and_non_tests(
+    monkeypatch: object, tmp_path: Path
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    (repo_root / "nested").mkdir()
+    (repo_root / "nested" / ".git").mkdir()
+
+    def fake_git_untracked(_: Path) -> list[Path]:
+        return [
+            Path("tests/unit/test_a.py"),
+            Path("docs/README.md"),
+            Path("nested/tests/test_b.py"),
+            Path("mini_app/frontend/src/__tests__/App.test.tsx"),
+        ]
+
+    monkeypatch.setattr(check_test_tracking, "_git_untracked", fake_git_untracked)
+    offenders = check_test_tracking.find_untracked_tests(repo_root)
+    assert offenders == [
+        Path("mini_app/frontend/src/__tests__/App.test.tsx"),
+        Path("tests/unit/test_a.py"),
+    ]


### PR DESCRIPTION
## Summary
- Adds a CI guard that fails when test files are present but untracked.
- Adds focused unit coverage for nested repository filtering.

Refs #1730.

## Verification
- uv run pytest tests/unit/scripts/test_check_test_tracking.py -v
- uv run python scripts/check_test_tracking.py