### PR TITLE
ci: keep PR workflow to static checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,21 +72,7 @@ jobs:
           EOF
           /tmp/gitleaks detect --source . --no-git --config /tmp/gitleaks.toml --verbose
 
-      - name: Set up Python for tests
-        run: uv python install 3.12
-
-      - name: Install dev dependencies
-        run: UV_PROJECT_ENVIRONMENT=.venv-py312 uv sync --python 3.12 --frozen
-
-      - name: Unit tests (core)
-        run: UV_PROJECT_ENVIRONMENT=.venv-py312 make test-unit
-
-      - name: Unit tests (optional extras)
-        run: |
-          UV_PROJECT_ENVIRONMENT=.venv-py312 uv sync --extra voice --extra ingest --extra eval --all-groups
-          UV_PROJECT_ENVIRONMENT=.venv-py312 uv run pytest tests/unit/ -n auto --dist=worksteal -x -q --timeout=30 -m "requires_extras and not legacy_api"
-
       - name: Security scan (bandit + vulture)
         run: |
-          UV_PROJECT_ENVIRONMENT=.venv-py312 uv run bandit -r src/ telegram_bot/ -c pyproject.toml
-          UV_PROJECT_ENVIRONMENT=.venv-py312 uv run vulture src/ telegram_bot/ --min-confidence 80 --exclude "*site-packages*,*dist-info*,__pycache__,.pytest_cache,.ruff_cache,.mypy_cache,*.egg-info,.venv*"
+          uv run --python 3.14 bandit -r src/ telegram_bot/ -c pyproject.toml
+          uv run --python 3.14 vulture src/ telegram_bot/ --min-confidence 80 --exclude "*site-packages*,*dist-info*,__pycache__,.pytest_cache,.ruff_cache,.mypy_cache,*.egg-info,.venv*"

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -194,7 +194,7 @@ make test-bot-health
 ## Source Of Truth
 
 - `main` in Git is the official deployment source of truth.
-- Standard flow: work locally, push to `dev` or a feature branch, open a PR to `main`, and merge the PR.
+- Standard flow: work locally, push to a feature branch, open a PR to `dev`, and merge `dev` to `main` for deployment snapshots.
 
 
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ make test-unit   # Unit tests (parallel via pytest-xdist)
 make test-full   # Full suite: parallel-safe tiers first, live/stateful tiers after
 ```
 
-Local verification is the release authority for this repo. Run focused checks for the touched area before merging to `dev` or deploying. CI is intentionally lightweight: it is a guardrail for fast checks, not the authoritative full-suite signal.
+Local verification is the release authority for this repo. Run focused checks for the touched area before merging to `dev` or deploying. CI is intentionally lightweight: it runs static/lint guardrails, not pytest suites or the authoritative full-suite signal.
 
 ## Honest Scope
 

--- a/docs/engineering/repo-hygiene-runbook.md
+++ b/docs/engineering/repo-hygiene-runbook.md
@@ -82,11 +82,12 @@ uv run python scripts/pr_queue_audit.py --base dev
 Buckets in priority order:
 
 1. **conflicts**          — needs rebase / merge resolution.
-2. **ci-failing**         — author must fix.
-3. **ci-pending**         — wait or re-run.
+2. **ci-failing**         — static CI guardrail failed; author must fix.
+3. **ci-pending**         — static CI guardrail is still running; wait or re-run.
 4. **changes-requested**  — reviewer asked for changes; ping author.
-5. **review-needed**      — CI green, no approval; assign reviewer.
-6. **ready**              — green and approved; merge it.
+5. **review-needed**      — static CI green, no approval; assign reviewer.
+6. **ready**              — static CI green and approved; confirm local test
+                            evidence before merge.
 7. **draft**              — author still working.
 8. **stale**              — flag is independent; surfaced for any PR older
                             than `--stale-days` (default 14).

--- a/docs/review/GITHUB_REPO_SETUP.md
+++ b/docs/review/GITHUB_REPO_SETUP.md
@@ -52,7 +52,7 @@ For **this** repository:
 - stable snapshot branch: `main` (lags behind `dev`).
 - protect both branches.
 - require PRs against `dev` for changes.
-- require fast CI checks before merge.
+- require fast static CI checks before merge.
 - disallow force pushes to protected branches.
 - create a review snapshot tag such as `portfolio-review-2026-05`.
 
@@ -61,17 +61,17 @@ is `dev`, every doc that mentions merging should say `dev`, not `main`.
 
 ## CI Expectations
 
-Minimum useful checks:
+CI is intentionally limited to fast static guardrails:
 
 - lint and format
 - type checking
-- focused unit tests
 - Compose config validation for runtime-sensitive changes
 - secret scanning friendly repository layout
 
-For this repository, local verification remains stronger than CI. README should
-say that CI is a guardrail and local `make check` plus focused tests are the
-primary evidence for code changes.
+Do not put pytest suites in pull-request CI. For this repository, local
+verification remains stronger than CI. README should say that CI is a static
+guardrail and local `make check` plus focused tests are the primary evidence
+for code changes.
 
 ## Security And Sanitization
 

--- a/scripts/pr_queue_audit.py
+++ b/scripts/pr_queue_audit.py
@@ -8,12 +8,13 @@ close. Designed for the weekly governance runbook (issue #1719).
 Buckets
 -------
 
-- ``ready``               : Mergeable, CI green, has at least one approval
-                            (or repo policy waives review). Merge candidate.
-- ``ci-failing``           : CI status is FAILURE / ERROR / CANCELLED.
-- ``ci-pending``           : CI not yet completed.
+- ``ready``               : Mergeable, static CI green, has at least one
+                            approval (or repo policy waives review). Confirm
+                            local test evidence before merge.
+- ``ci-failing``           : Static CI status is FAILURE / ERROR / CANCELLED.
+- ``ci-pending``           : Static CI not yet completed.
 - ``conflicts``            : ``mergeable`` reports CONFLICTING.
-- ``review-needed``        : CI green, no approvals yet.
+- ``review-needed``        : Static CI green, no approvals yet.
 - ``changes-requested``    : Reviewer asked for changes; awaits author.
 - ``draft``                : Marked as draft.
 - ``stale``                : Open longer than ``--stale-days`` (default 14).
@@ -45,7 +46,7 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
+import subprocess  # nosec B404
 import sys
 from collections.abc import Iterable
 from dataclasses import dataclass, field


### PR DESCRIPTION
## Summary
- remove pytest/unit-test execution from pull-request CI
- keep PR CI to static guardrails: Ruff, mypy, Compose config, Hadolint, Gitleaks, Bandit, Vulture
- document that local verification is the release authority and pytest suites stay local; nightly-heavy remains the separate scheduled/self-hosted heavy test lane
- align PR target wording on `dev` and clarify PR queue readiness wording

## Verification
- pre-commit during commit: Ruff, YAML, Bandit, Gitleaks passed
- `rg -n "uv run pytest|make test-unit|Unit tests|Set up Python for tests|UV_PROJECT_ENVIRONMENT|requires_extras" .github/workflows/ci.yml || true` produced no matches
- `uv run --python 3.14 ruff check scripts/pr_queue_audit.py`
- `uv run --python 3.14 bandit -r scripts/pr_queue_audit.py -c pyproject.toml`
- `uv run --python 3.14 bandit --version`
- `uv run --python 3.14 vulture --version`
- `python3 -m py_compile scripts/pr_queue_audit.py`
- `git diff --check`

Closes part of #1730.