### PR TITLE
fix: tighten CRM empty task assertion (#1626)

### DIFF
--- a/tests/unit/dialogs/test_crm_tasks.py
+++ b/tests/unit/dialogs/test_crm_tasks.py
@@ -211,7 +211,7 @@ def test_render_tasks_text_empty():
     from telegram_bot.dialogs.crm_tasks import render_tasks_text
 
     result = render_tasks_text([])
-    assert "нет" in result.lower() or "пуст" in result.lower() or len(result) > 0
+    assert "нет" in result.lower() or "пуст" in result.lower()
 
 
 def test_render_tasks_text_single_task():


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Fixes #1626 - removes the always-true `len(result) > 0` fallback from the `test_render_tasks_text_empty` assertion.

## Changes

- Removed `or len(result) > 0` from the assertion in `test_render_tasks_text_empty`
- The test now properly verifies that `render_tasks_text([])` returns a message containing "нет" or "пуст", matching the actual implementation (`"Задач нет."`)

## Before

```python
assert "нет" in result.lower() or "пуст" in result.lower() or len(result) > 0
```

Any non-empty string would pass this assertion, defeating its purpose.

## After

```python
assert "нет" in result.lower() or "пуст" in result.lower()
```

Only messages containing the expected empty-state keywords pass.

## Verification

- `pytest tests/unit/dialogs/test_crm_tasks.py::test_render_tasks_text_empty -v` passes successfully.