### PR TITLE
docs: repair markdown links and agent workflow docs

### DIFF
--- a/.kiro/steering/agent-workflow.md
+++ b/.kiro/steering/agent-workflow.md
@@ -1,0 +1,31 @@
+---
+inclusion: always
+---
+
+# Agent Workflow Steering
+
+Follow the repo-local agent workflow in `skills/superpowers/` before working on
+GitHub issues.
+
+Required references:
+
+- `skills/superpowers/README.md`
+- `skills/superpowers/issue-skill-map.md`
+- `AGENTS.md`
+- `docs/README.md`
+- `docs/engineering/test-writing-guide.md`
+- `docs/LOCAL-DEVELOPMENT.md`
+
+For GitHub issue tasks:
+
+1. Identify the issue number.
+2. Read `skills/superpowers/issue-skill-map.md` and load the required skills.
+3. Create isolated work in a dedicated branch/worktree or Kiro sandbox.
+4. Use test-first workflow for bug, feature, refactor, and behavior changes.
+5. Do not use production, secrets, SSH, cloud credentials, or live CRM writes
+   unless the issue explicitly approves it.
+6. Before opening a PR or claiming completion, include fresh verification
+   evidence and list skipped checks.
+
+When the issue lacks acceptance criteria, ask for clarification or add a short
+plan before implementation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ For fast orientation by goal rather than by subsystem, see [`indexes/`](indexes/
 - [`engineering/test-writing-guide.md`](engineering/test-writing-guide.md) — Test-writing rules and local-fast vs heavy-tier split.
 - [`engineering/sdk-registry.md`](engineering/sdk-registry.md) — SDK/framework lookup order and canonical versions.
 - [`engineering/issue-triage.md`](engineering/issue-triage.md) — Issue classification and routing playbook.
+- [`../skills/superpowers/`](../skills/superpowers/) — Repo-local agent skills, Kiro Web steering, and issue-to-skill map.
 - [`engineering/README.md`](engineering/README.md) — Engineering process index with active and historical notes.
 - [`adr/`](adr/) — Architecture decision records.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,9 +61,8 @@ For fast orientation by goal rather than by subsystem, see [`indexes/`](indexes/
 
 ## Migration & SDK
 
-- [`SDK_MIGRATION_AUDIT_2026-03-13.md`](SDK_MIGRATION_AUDIT_2026-03-13.md) — Canonical SDK keeper stack.
-- [`SDK_MIGRATION_ROADMAP_2026-03-13.md`](SDK_MIGRATION_ROADMAP_2026-03-13.md) — Post-audit execution order.
-- [`SDK_CANONICAL_REMEDIATION_REPORT_2026-03-15.md`](SDK_CANONICAL_REMEDIATION_REPORT_2026-03-15.md) — SDK canonical remediation report.
+- [`engineering/sdk-registry.md`](engineering/sdk-registry.md) — Canonical SDK/framework lookup order and keeper stack.
+- [`indexes/docker-sdk-map.md`](indexes/docker-sdk-map.md) — Docker image and SDK ownership map.
 
 ## Engineering Notes
 
@@ -72,10 +71,6 @@ For fast orientation by goal rather than by subsystem, see [`indexes/`](indexes/
 - [`HITL_CRM_FLOW.md`](HITL_CRM_FLOW.md) — CRM-specific HITL flow.
 - [`CACHE_DEGRADATION.md`](CACHE_DEGRADATION.md) — Cache failure modes.
 - [`CLIENT_PIPELINE.md`](CLIENT_PIPELINE.md) — Client pipeline details.
-
-## Archive
-
-- [`archive/`](archive/) — Historical documentation and retired CI workflows preserved for context.
 
 ## Fast Doc Search
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -26,7 +26,7 @@ Operator entrypoint for container/service investigations and incident response. 
 | Qdrant health, collection, or vector search issues | [`QDRANT_TROUBLESHOOTING.md`](QDRANT_TROUBLESHOOTING.md) |
 | Postgres WAL recovery or replication issues | [`POSTGRESQL_WAL_RECOVERY.md`](POSTGRESQL_WAL_RECOVERY.md) |
 | VPS / Google Drive ingestion recovery | [`vps-gdrive-ingestion-recovery.md`](vps-gdrive-ingestion-recovery.md) |
-| Weekly git/pr/issue hygiene workflow | [`GIT_PR_ISSUE_HYGIENE.md`](GIT_PR_ISSUE_HYGIENE.md) |
+| Weekly git/pr/issue hygiene workflow | [`GIT_PR_ISSUE_NATIVE.md`](GIT_PR_ISSUE_NATIVE.md) |
 
 ## Container / Service Map
 

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -23,6 +23,7 @@ SKIP_DIRS = {
     "node_modules",
     ".terraform",
     "vendor",
+    "tmp",
     "generated",
     "cache",
     "dist",

--- a/skills/superpowers/README.md
+++ b/skills/superpowers/README.md
@@ -1,0 +1,40 @@
+# Superpowers Agent Skills
+
+Repo-local operating guide for agentic issue execution. Use this folder when a
+GitHub issue is handed to Kiro Web, Codex, or another autonomous coding agent.
+
+## Kiro Web Entry Points
+
+Kiro Web can start from `app.kiro.dev`, from a GitHub issue comment containing
+`/kiro`, or from a GitHub issue labeled `kiro`. Kiro reads persistent workspace
+guidance from `.kiro/steering/` and also supports `AGENTS.md`.
+
+When sending an issue to Kiro, include:
+
+- the issue number and outcome;
+- acceptance criteria;
+- the skill list from [`issue-skill-map.md`](issue-skill-map.md);
+- verification commands expected before PR;
+- any safety gates such as no production, secrets, SSH, cloud, or live CRM
+  writes unless explicitly approved.
+
+## Core Skills
+
+- [`using-git-worktrees.md`](using-git-worktrees.md) - isolate each issue in a
+  dedicated worktree/branch and verify a clean baseline.
+- [`test-driven-development.md`](test-driven-development.md) - for features,
+  bug fixes, refactors, and behavior changes: RED, GREEN, REFACTOR.
+- [`writing-plans.md`](writing-plans.md) - for multi-step work: write a
+  task-by-task plan before code changes.
+- [`verification-before-completion.md`](verification-before-completion.md) -
+  no completion, PR, or close claim without fresh verification evidence.
+- [`subagent-driven-development.md`](subagent-driven-development.md) - for
+  independent slices that can be delegated safely.
+- [`executing-plans.md`](executing-plans.md) - for executing an approved plan
+  step by step in one session.
+
+## Issue Routing
+
+Use [`issue-skill-map.md`](issue-skill-map.md) as the current queue map. It
+maps each audited issue to the minimum skill set an agent should load before
+implementation.

--- a/skills/superpowers/executing-plans.md
+++ b/skills/superpowers/executing-plans.md
@@ -1,0 +1,15 @@
+# Skill: executing-plans
+
+Use when executing an approved plan in one session.
+
+Required workflow:
+
+1. Follow the plan task by task.
+2. Keep each step small and independently checkable.
+3. Run the plan's verification command after each task or slice.
+4. Stop on failed verification and fix before continuing.
+5. Report completed tasks, skipped checks, and remaining risks in the PR or
+   issue.
+
+Prefer this over ad hoc implementation when the issue has several steps but does
+not need parallel workers.

--- a/skills/superpowers/issue-skill-map.md
+++ b/skills/superpowers/issue-skill-map.md
@@ -1,0 +1,56 @@
+# Issue Skill Map
+
+Current mapping for the audited issue batch. Use this when deciding what to
+send to Kiro Web or another agent.
+
+## Universal Rule
+
+Every implementation issue starts with:
+
+- `using-git-worktrees`
+- `verification-before-completion`
+
+Add `test-driven-development` for behavior changes, bug fixes, refactors, and
+features. Add `writing-plans` when work is multi-step, architecture-heavy, or
+cross-module. Add `subagent-driven-development` only when slices are independent
+and file ownership can be reserved.
+
+## Kiro Web Handoff
+
+For Kiro Web, comment on the issue with `/kiro` or add the `kiro` label only
+after the issue has:
+
+- a clear outcome;
+- acceptance criteria;
+- the required skills from this map;
+- expected verification commands;
+- safety notes.
+
+Kiro will also read `.kiro/steering/agent-workflow.md`, which points back to
+this folder.
+
+## Per-Issue Map
+
+| Issue | Type | Required skills | Notes |
+|---|---|---|---|
+| #1727 | dev tooling / hooks | `using-git-worktrees`, `writing-plans`, `verification-before-completion` | Add tests/checks for hook behavior where possible; no `devex` label exists, use existing infra/tech-debt taxonomy. |
+| #1654 | bot refactor | `using-git-worktrees`, `writing-plans`, `test-driven-development`, `verification-before-completion` | APScheduler loop refactor; protect bot startup/shutdown behavior with tests. |
+| #1652 | research / design | `writing-plans`, `verification-before-completion` | Research first; no implementation until LangChain-native HyDE replacement is confirmed. |
+| #1650 | retrieval refactor | `using-git-worktrees`, `test-driven-development`, `verification-before-completion` | Batch request behavior must be covered with focused retrieval/client tests. |
+| #1649 | eval refactor | `using-git-worktrees`, `test-driven-development`, `verification-before-completion` | Structured output change needs regression tests for generated evaluation queries. |
+| #1648 | observability enhancement | `using-git-worktrees`, `writing-plans`, `test-driven-development`, `verification-before-completion` | Cross-cutting metrics/exporter work needs plan and focused observability checks. |
+| #1647 | retrieval architecture refactor | `using-git-worktrees`, `writing-plans`, `test-driven-development`, `verification-before-completion` | Architecture-heavy Qdrant/RRF path; plan before edits. |
+| #1643 | retrieval bug | `using-git-worktrees`, `test-driven-development`, `verification-before-completion` | Reproduce batch item failure isolation with a failing test first. |
+| #1637 | test bug | `using-git-worktrees`, `test-driven-development`, `verification-before-completion` | Test fixture leak; failing test or focused regression required. |
+| #1636 | test design / needs triage | `writing-plans`, `verification-before-completion` | Decide restore helper vs rewrite tests vs quarantine before implementation. |
+| #1635 | test infra | `using-git-worktrees`, `test-driven-development`, `verification-before-completion` | Validate advertised test target behavior. |
+| #1634 | test coverage | `using-git-worktrees`, `test-driven-development`, `verification-before-completion` | Add behavioral assertion for Redis eviction pressure. |
+| #1633 | test infra | `using-git-worktrees`, `test-driven-development`, `verification-before-completion` | Cover REDIS_URL unset behavior and target semantics. |
+| #1632 | test cleanup | `using-git-worktrees`, `verification-before-completion` | Remove stale health check; TDD optional if no behavior code changes. |
+| #1631 | retrieval tests | `using-git-worktrees`, `test-driven-development`, `verification-before-completion` | Prevent passing with empty Qdrant data. |
+| #1630 | cache/e2e bug | `using-git-worktrees`, `test-driven-development`, `verification-before-completion` | Reproduce skipped regression after live stack preflight. |
+| #1629 | ingestion e2e bug | `using-git-worktrees`, `test-driven-development`, `verification-before-completion` | Tighten assertions so error/no-op results fail. |
+| #1628 | bot test coverage | `using-git-worktrees`, `test-driven-development`, `verification-before-completion` | Exercise `PropertyBot.start` through BGE warmup path. |
+| #1627 | CRM live test safety | `using-git-worktrees`, `writing-plans`, `test-driven-development`, `verification-before-completion` | Requires explicit live-write gate and serial cleanup; no real CRM writes without approval. |
+| #1626 | CRM test bug | `using-git-worktrees`, `test-driven-development`, `verification-before-completion` | Add failing assertion for wrong non-empty CRM output. |
+| #1625 | eval test coverage | `using-git-worktrees`, `writing-plans`, `test-driven-development`, `verification-before-completion` | Move validation from local copies to runtime code. |

--- a/skills/superpowers/subagent-driven-development.md
+++ b/skills/superpowers/subagent-driven-development.md
@@ -1,0 +1,15 @@
+# Skill: subagent-driven-development
+
+Use when an approved plan has independent slices that can be delegated without
+overlapping files or responsibilities.
+
+Required workflow:
+
+- reserve disjoint files or subsystems for each worker;
+- give each worker the relevant issue number, skill list, safety boundaries,
+  expected tests, and report path;
+- verify every worker report before accepting it;
+- integrate only after focused checks pass.
+
+Do not use this for tightly coupled changes where one worker's next step depends
+on another worker's unfinished result.

--- a/skills/superpowers/test-driven-development.md
+++ b/skills/superpowers/test-driven-development.md
@@ -1,0 +1,15 @@
+# Skill: test-driven-development
+
+Use for features, bug fixes, refactors, and behavior changes.
+
+Required workflow:
+
+1. Write the smallest failing test for the target behavior.
+2. Run it and confirm the expected RED failure.
+3. Write the minimal implementation to pass.
+4. Run the focused test and confirm GREEN.
+5. Refactor only after tests are green.
+6. Expand tests only where risk or integration boundaries require it.
+
+If a test cannot be written, the agent must explain why in the PR and provide a
+manual or command-based verification alternative.

--- a/skills/superpowers/using-git-worktrees.md
+++ b/skills/superpowers/using-git-worktrees.md
@@ -1,0 +1,15 @@
+# Skill: using-git-worktrees
+
+Use when starting implementation for any issue.
+
+Required workflow:
+
+1. Create a dedicated git worktree/branch for the issue.
+2. Prefer `.worktrees/` when present; verify it is ignored before use.
+3. Run project setup if needed.
+4. Run a focused baseline verification command before changes.
+5. Record the worktree path, branch, baseline command, and result in the issue
+   or PR.
+
+Do not implement directly in the main working tree unless the issue is
+explicitly documentation-only and the operator approves skipping isolation.

--- a/skills/superpowers/verification-before-completion.md
+++ b/skills/superpowers/verification-before-completion.md
@@ -1,0 +1,15 @@
+# Skill: verification-before-completion
+
+Use before claiming an issue is complete, opening a PR, merging, or closing an
+issue.
+
+Required evidence:
+
+- focused tests for the changed behavior;
+- lint/type/build checks when the touched surface requires them;
+- command output summary with pass/fail/skipped checks;
+- explicit residual risks;
+- explanation for any skipped tests.
+
+Do not accept "should pass" or worker self-report as proof. The final PR or
+issue comment must include fresh verification evidence from the current run.

--- a/skills/superpowers/writing-plans.md
+++ b/skills/superpowers/writing-plans.md
@@ -1,0 +1,16 @@
+# Skill: writing-plans
+
+Use for multi-step implementation, cross-module changes, architecture-heavy
+work, or work that needs sequencing before edits.
+
+Plan requirements:
+
+- list exact files likely to change;
+- split work into small checkable tasks;
+- include a failing-test step before each behavior change;
+- include exact verification commands and expected results;
+- identify docs impact and safety gates;
+- commit or PR only after verification evidence is fresh.
+
+For Kiro Web autonomous tasks, put the plan or plan expectation in the issue
+before adding `/kiro` or the `kiro` label.

--- a/tests/unit/scripts/test_check_markdown_links.py
+++ b/tests/unit/scripts/test_check_markdown_links.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_markdown_links.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_markdown_links_under_test", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_collect_markdown_files_skips_temp_dependency_dirs(tmp_path) -> None:
+    checker = _load_module()
+    temp_readme = tmp_path / "tool" / "deps" / "tmp" / "package" / "README.md"
+    temp_readme.parent.mkdir(parents=True)
+    temp_readme.write_text("[missing](MISSING.md)\n", encoding="utf-8")
+
+    assert temp_readme.resolve() not in checker.collect_markdown_files(tmp_path)
+
+
+def test_current_repository_markdown_links_are_valid() -> None:
+    checker = _load_module()
+
+    assert checker.check_links(REPO_ROOT) == []


### PR DESCRIPTION
## Summary
- replace `docs/README.md` links to ignored SDK/archive artifacts with tracked SDK docs
- update runbook index to the native git/pr/issue hygiene runbook
- make markdown link checking ignore dependency `tmp/` folders and cover it with a focused unit test
- add repo-local Kiro/superpowers agent workflow docs that were left on the old ops branch

## Verification
- `uv run pytest tests/unit/scripts/test_check_markdown_links.py -q` => 2 passed
- `uv run python scripts/check_markdown_links.py` => All relative Markdown links OK
- `git diff --check origin/dev..HEAD`
- `rg -n "SDK_MIGRATION|SDK_CANONICAL|docs/reports|reports/2026|archive/" docs/README.md .kiro skills || true` => no matches

Part of #1730 cleanup.