### PR TITLE
fix: isolate BGE-M3 batch encode item failures

### DIFF
--- a/services/bge-m3-api/app.py
+++ b/services/bge-m3-api/app.py
@@ -230,7 +230,7 @@ async def encode_dense(request: EncodeRequest):
         valid_indices, invalid_indices, error_messages = _validate_texts(request.texts)
         partial_failures = [
             PartialFailure(index=idx, error=msg)
-            for idx, msg in zip(invalid_indices, error_messages)
+            for idx, msg in zip(invalid_indices, error_messages, strict=True)
         ]
         if invalid_indices:
             encode_partial_failures_total.labels(encode_type="dense").inc(len(invalid_indices))
@@ -263,7 +263,7 @@ async def encode_dense(request: EncodeRequest):
         for i in valid_indices:
             dense_vecs[i] = next(valid_iter)
         for i in invalid_indices:
-            dense_vecs[i] = dense_sentinel
+            dense_vecs[i] = dense_sentinel.copy()
 
         return DenseResponse(
             dense_vecs=dense_vecs,
@@ -296,7 +296,7 @@ async def encode_sparse(request: EncodeRequest):
         valid_indices, invalid_indices, error_messages = _validate_texts(request.texts)
         partial_failures = [
             PartialFailure(index=idx, error=msg)
-            for idx, msg in zip(invalid_indices, error_messages)
+            for idx, msg in zip(invalid_indices, error_messages, strict=True)
         ]
         if invalid_indices:
             encode_partial_failures_total.labels(encode_type="sparse").inc(len(invalid_indices))
@@ -337,7 +337,7 @@ async def encode_sparse(request: EncodeRequest):
         for i in valid_indices:
             lexical_weights[i] = next(valid_iter)
         for i in invalid_indices:
-            lexical_weights[i] = sparse_sentinel
+            lexical_weights[i] = sparse_sentinel.copy()
 
         return SparseResponse(
             lexical_weights=lexical_weights,
@@ -370,7 +370,7 @@ async def encode_colbert(request: EncodeRequest):
         valid_indices, invalid_indices, error_messages = _validate_texts(request.texts)
         partial_failures = [
             PartialFailure(index=idx, error=msg)
-            for idx, msg in zip(invalid_indices, error_messages)
+            for idx, msg in zip(invalid_indices, error_messages, strict=True)
         ]
         if invalid_indices:
             encode_partial_failures_total.labels(encode_type="colbert").inc(len(invalid_indices))
@@ -403,7 +403,7 @@ async def encode_colbert(request: EncodeRequest):
         for i in valid_indices:
             colbert_vecs[i] = next(valid_iter)
         for i in invalid_indices:
-            colbert_vecs[i] = colbert_sentinel
+            colbert_vecs[i] = [row[:] for row in colbert_sentinel]
 
         return ColbertResponse(
             colbert_vecs=colbert_vecs,
@@ -437,7 +437,7 @@ async def encode_hybrid(request: EncodeRequest):
         valid_indices, invalid_indices, error_messages = _validate_texts(request.texts)
         partial_failures = [
             PartialFailure(index=idx, error=msg)
-            for idx, msg in zip(invalid_indices, error_messages)
+            for idx, msg in zip(invalid_indices, error_messages, strict=True)
         ]
         if invalid_indices:
             encode_partial_failures_total.labels(encode_type="hybrid").inc(len(invalid_indices))
@@ -491,9 +491,9 @@ async def encode_hybrid(request: EncodeRequest):
             lexical_weights[i] = next(sparse_iter)
             colbert_vecs[i] = next(colbert_iter)
         for i in invalid_indices:
-            dense_vecs[i] = dense_sentinel
-            lexical_weights[i] = sparse_sentinel
-            colbert_vecs[i] = colbert_sentinel
+            dense_vecs[i] = dense_sentinel.copy()
+            lexical_weights[i] = sparse_sentinel.copy()
+            colbert_vecs[i] = [row[:] for row in colbert_sentinel]
 
         return HybridResponse(
             dense_vecs=dense_vecs,

--- a/services/bge-m3-api/app.py
+++ b/services/bge-m3-api/app.py
@@ -28,6 +28,11 @@ encode_requests_total = Counter(
 )
 encode_duration = Histogram("bge_encode_seconds", "Encoding duration", ["encode_type"])
 encode_batch_size = Histogram("bge_encode_batch_size", "Batch size per request")
+encode_partial_failures_total = Counter(
+    "bge_encode_partial_failures_total",
+    "Items that failed validation in batch",
+    ["encode_type"],
+)
 model_loaded = Gauge("bge_model_loaded", "Model loaded status (1=loaded, 0=not loaded)")
 
 # Global model instance
@@ -88,9 +93,15 @@ class EncodeRequest(BaseModel):
     batch_size: int = Field(settings.BATCH_SIZE, description="Batch size for processing")
 
 
+class PartialFailure(BaseModel):
+    index: int
+    error: str
+
+
 class DenseResponse(BaseModel):
     dense_vecs: list[list[float]] = Field(..., description="Dense embeddings (1024-dim)")
     processing_time: float
+    partial_failures: list[PartialFailure] = Field(default_factory=list)
 
 
 class SparseResponse(BaseModel):
@@ -98,11 +109,13 @@ class SparseResponse(BaseModel):
         ..., description="Sparse vectors (indices + values)"
     )
     processing_time: float
+    partial_failures: list[PartialFailure] = Field(default_factory=list)
 
 
 class ColbertResponse(BaseModel):
     colbert_vecs: list[list[list[float]]] = Field(..., description="ColBERT multivectors")
     processing_time: float
+    partial_failures: list[PartialFailure] = Field(default_factory=list)
 
 
 class HybridResponse(BaseModel):
@@ -110,6 +123,7 @@ class HybridResponse(BaseModel):
     lexical_weights: list[dict[str, Any]]
     colbert_vecs: list[list[list[float]]]
     processing_time: float
+    partial_failures: list[PartialFailure] = Field(default_factory=list)
 
 
 class RerankResult(BaseModel):
@@ -143,6 +157,25 @@ class RerankResponse(BaseModel):
 
     results: list[RerankResult] = Field(..., description="Ranked results")
     processing_time: float
+
+
+def _validate_texts(texts: list[str]) -> tuple[list[int], list[int], list[str]]:
+    """Validate batch texts and separate valid from invalid indices.
+
+    Returns:
+        (valid_indices, invalid_indices, error_messages)
+    """
+    valid_indices = []
+    invalid_indices = []
+    error_messages = []
+    for i, text in enumerate(texts):
+        if not text or not text.strip():
+            invalid_indices.append(i)
+            error_messages.append("empty or whitespace-only string")
+            logger.warning("Item %d failed validation: empty or whitespace-only string", i)
+        else:
+            valid_indices.append(i)
+    return valid_indices, invalid_indices, error_messages
 
 
 def compute_maxsim_scores(query_vecs: np.ndarray, doc_vecs_list: list[np.ndarray]) -> list[float]:
@@ -194,23 +227,48 @@ async def encode_dense(request: EncodeRequest):
     encode_batch_size.observe(len(request.texts))
 
     try:
+        valid_indices, invalid_indices, error_messages = _validate_texts(request.texts)
+        partial_failures = [
+            PartialFailure(index=idx, error=msg)
+            for idx, msg in zip(invalid_indices, error_messages)
+        ]
+        if invalid_indices:
+            encode_partial_failures_total.labels(encode_type="dense").inc(len(invalid_indices))
+
         model = get_model()
         start_time = time.time()
 
-        embeddings = model.encode(
-            request.texts,
-            batch_size=request.batch_size,
-            max_length=request.max_length,
-            return_dense=True,
-            return_sparse=False,
-            return_colbert_vecs=False,
-        )
+        # Encode only valid texts
+        if valid_indices:
+            valid_texts = [request.texts[i] for i in valid_indices]
+            embeddings = model.encode(
+                valid_texts,
+                batch_size=request.batch_size,
+                max_length=request.max_length,
+                return_dense=True,
+                return_sparse=False,
+                return_colbert_vecs=False,
+            )
+            valid_vecs = embeddings["dense_vecs"].tolist()
+        else:
+            valid_vecs = []
 
         processing_time = time.time() - start_time
         encode_duration.labels(encode_type="dense").observe(processing_time)
 
+        # Reconstruct full-cardinality response
+        dense_sentinel = [0.0] * 1024
+        dense_vecs = [None] * len(request.texts)
+        valid_iter = iter(valid_vecs)
+        for i in valid_indices:
+            dense_vecs[i] = next(valid_iter)
+        for i in invalid_indices:
+            dense_vecs[i] = dense_sentinel
+
         return DenseResponse(
-            dense_vecs=embeddings["dense_vecs"].tolist(), processing_time=processing_time
+            dense_vecs=dense_vecs,
+            processing_time=processing_time,
+            partial_failures=partial_failures,
         )
 
     except Exception as e:
@@ -235,32 +293,57 @@ async def encode_sparse(request: EncodeRequest):
     encode_batch_size.observe(len(request.texts))
 
     try:
+        valid_indices, invalid_indices, error_messages = _validate_texts(request.texts)
+        partial_failures = [
+            PartialFailure(index=idx, error=msg)
+            for idx, msg in zip(invalid_indices, error_messages)
+        ]
+        if invalid_indices:
+            encode_partial_failures_total.labels(encode_type="sparse").inc(len(invalid_indices))
+
         model = get_model()
         start_time = time.time()
 
-        embeddings = model.encode(
-            request.texts,
-            batch_size=request.batch_size,
-            max_length=request.max_length,
-            return_dense=False,
-            return_sparse=True,
-            return_colbert_vecs=False,
-        )
+        # Encode only valid texts
+        if valid_indices:
+            valid_texts = [request.texts[i] for i in valid_indices]
+            embeddings = model.encode(
+                valid_texts,
+                batch_size=request.batch_size,
+                max_length=request.max_length,
+                return_dense=False,
+                return_sparse=True,
+                return_colbert_vecs=False,
+            )
+            # Convert sparse vectors to Qdrant format
+            valid_weights = []
+            for row in embeddings["lexical_weights"]:
+                indices = []
+                values = []
+                for idx, val in row.items():
+                    indices.append(int(idx))
+                    values.append(float(val))
+                valid_weights.append({"indices": indices, "values": values})
+        else:
+            valid_weights = []
 
         processing_time = time.time() - start_time
         encode_duration.labels(encode_type="sparse").observe(processing_time)
 
-        # Convert sparse vectors to Qdrant format
-        lexical_weights = []
-        for row in embeddings["lexical_weights"]:
-            indices = []
-            values = []
-            for idx, val in row.items():
-                indices.append(int(idx))
-                values.append(float(val))
-            lexical_weights.append({"indices": indices, "values": values})
+        # Reconstruct full-cardinality response
+        sparse_sentinel = {"indices": [], "values": []}
+        lexical_weights = [None] * len(request.texts)
+        valid_iter = iter(valid_weights)
+        for i in valid_indices:
+            lexical_weights[i] = next(valid_iter)
+        for i in invalid_indices:
+            lexical_weights[i] = sparse_sentinel
 
-        return SparseResponse(lexical_weights=lexical_weights, processing_time=processing_time)
+        return SparseResponse(
+            lexical_weights=lexical_weights,
+            processing_time=processing_time,
+            partial_failures=partial_failures,
+        )
 
     except Exception as e:
         logger.error(f"Sparse encoding error: {e!s}")
@@ -284,25 +367,49 @@ async def encode_colbert(request: EncodeRequest):
     encode_batch_size.observe(len(request.texts))
 
     try:
+        valid_indices, invalid_indices, error_messages = _validate_texts(request.texts)
+        partial_failures = [
+            PartialFailure(index=idx, error=msg)
+            for idx, msg in zip(invalid_indices, error_messages)
+        ]
+        if invalid_indices:
+            encode_partial_failures_total.labels(encode_type="colbert").inc(len(invalid_indices))
+
         model = get_model()
         start_time = time.time()
 
-        embeddings = model.encode(
-            request.texts,
-            batch_size=request.batch_size,
-            max_length=request.max_length,
-            return_dense=False,
-            return_sparse=False,
-            return_colbert_vecs=True,
-        )
+        # Encode only valid texts
+        if valid_indices:
+            valid_texts = [request.texts[i] for i in valid_indices]
+            embeddings = model.encode(
+                valid_texts,
+                batch_size=request.batch_size,
+                max_length=request.max_length,
+                return_dense=False,
+                return_sparse=False,
+                return_colbert_vecs=True,
+            )
+            valid_vecs = [vec.tolist() for vec in embeddings["colbert_vecs"]]
+        else:
+            valid_vecs = []
 
         processing_time = time.time() - start_time
         encode_duration.labels(encode_type="colbert").observe(processing_time)
 
-        # Convert to nested lists
-        colbert_vecs = [vec.tolist() for vec in embeddings["colbert_vecs"]]
+        # Reconstruct full-cardinality response
+        colbert_sentinel = [[0.0] * 1024]
+        colbert_vecs = [None] * len(request.texts)
+        valid_iter = iter(valid_vecs)
+        for i in valid_indices:
+            colbert_vecs[i] = next(valid_iter)
+        for i in invalid_indices:
+            colbert_vecs[i] = colbert_sentinel
 
-        return ColbertResponse(colbert_vecs=colbert_vecs, processing_time=processing_time)
+        return ColbertResponse(
+            colbert_vecs=colbert_vecs,
+            processing_time=processing_time,
+            partial_failures=partial_failures,
+        )
 
     except Exception as e:
         logger.error(f"ColBERT encoding error: {e!s}")
@@ -327,39 +434,73 @@ async def encode_hybrid(request: EncodeRequest):
     encode_batch_size.observe(len(request.texts))
 
     try:
+        valid_indices, invalid_indices, error_messages = _validate_texts(request.texts)
+        partial_failures = [
+            PartialFailure(index=idx, error=msg)
+            for idx, msg in zip(invalid_indices, error_messages)
+        ]
+        if invalid_indices:
+            encode_partial_failures_total.labels(encode_type="hybrid").inc(len(invalid_indices))
+
         model = get_model()
         start_time = time.time()
 
-        embeddings = model.encode(
-            request.texts,
-            batch_size=request.batch_size,
-            max_length=request.max_length,
-            return_dense=True,
-            return_sparse=True,
-            return_colbert_vecs=True,
-        )
+        # Encode only valid texts
+        if valid_indices:
+            valid_texts = [request.texts[i] for i in valid_indices]
+            embeddings = model.encode(
+                valid_texts,
+                batch_size=request.batch_size,
+                max_length=request.max_length,
+                return_dense=True,
+                return_sparse=True,
+                return_colbert_vecs=True,
+            )
+            valid_dense = embeddings["dense_vecs"].tolist()
+            valid_sparse = []
+            for row in embeddings["lexical_weights"]:
+                indices = []
+                values = []
+                for idx, val in row.items():
+                    indices.append(int(idx))
+                    values.append(float(val))
+                valid_sparse.append({"indices": indices, "values": values})
+            valid_colbert = [vec.tolist() for vec in embeddings["colbert_vecs"]]
+        else:
+            valid_dense = []
+            valid_sparse = []
+            valid_colbert = []
 
         processing_time = time.time() - start_time
         encode_duration.labels(encode_type="hybrid").observe(processing_time)
 
-        # Convert sparse vectors
-        lexical_weights = []
-        for row in embeddings["lexical_weights"]:
-            indices = []
-            values = []
-            for idx, val in row.items():
-                indices.append(int(idx))
-                values.append(float(val))
-            lexical_weights.append({"indices": indices, "values": values})
+        # Reconstruct full-cardinality responses
+        dense_sentinel = [0.0] * 1024
+        sparse_sentinel = {"indices": [], "values": []}
+        colbert_sentinel = [[0.0] * 1024]
 
-        # Convert colbert vectors
-        colbert_vecs = [vec.tolist() for vec in embeddings["colbert_vecs"]]
+        dense_vecs = [None] * len(request.texts)
+        lexical_weights = [None] * len(request.texts)
+        colbert_vecs = [None] * len(request.texts)
+
+        dense_iter = iter(valid_dense)
+        sparse_iter = iter(valid_sparse)
+        colbert_iter = iter(valid_colbert)
+        for i in valid_indices:
+            dense_vecs[i] = next(dense_iter)
+            lexical_weights[i] = next(sparse_iter)
+            colbert_vecs[i] = next(colbert_iter)
+        for i in invalid_indices:
+            dense_vecs[i] = dense_sentinel
+            lexical_weights[i] = sparse_sentinel
+            colbert_vecs[i] = colbert_sentinel
 
         return HybridResponse(
-            dense_vecs=embeddings["dense_vecs"].tolist(),
+            dense_vecs=dense_vecs,
             lexical_weights=lexical_weights,
             colbert_vecs=colbert_vecs,
             processing_time=processing_time,
+            partial_failures=partial_failures,
         )
 
     except Exception as e:

--- a/tests/unit/test_bge_m3_endpoints.py
+++ b/tests/unit/test_bge_m3_endpoints.py
@@ -176,6 +176,101 @@ class TestConfigDefaults:
         assert _cfg.settings.RERANK_MAX_LENGTH == 512
 
 
+class TestPartialFailureIsolation:
+    """Tests for per-item validation and partial failure isolation in batch encode."""
+
+    async def test_dense_batch_with_empty_string_returns_partial_failure(self, client):
+        """POST /encode/dense with ['hello', '', 'world'] returns 200 with partial_failures."""
+        resp = await client.post("/encode/dense", json={"texts": ["hello", "", "world"]})
+        assert resp.status_code == 200
+        data = resp.json()
+        # Response cardinality matches input cardinality
+        assert len(data["dense_vecs"]) == 3
+        # partial_failures reports index 1
+        assert "partial_failures" in data
+        assert len(data["partial_failures"]) == 1
+        assert data["partial_failures"][0]["index"] == 1
+        assert "error" in data["partial_failures"][0]
+        # Valid items have non-zero vectors
+        assert any(v != 0.0 for v in data["dense_vecs"][0])
+        assert any(v != 0.0 for v in data["dense_vecs"][2])
+        # Invalid item has zero-vector sentinel
+        assert all(v == 0.0 for v in data["dense_vecs"][1])
+        assert len(data["dense_vecs"][1]) == 1024
+
+    async def test_sparse_batch_with_empty_string(self, client):
+        """POST /encode/sparse with ['hello', '', 'world'] returns sentinel for empty."""
+        resp = await client.post("/encode/sparse", json={"texts": ["hello", "", "world"]})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["lexical_weights"]) == 3
+        assert "partial_failures" in data
+        assert len(data["partial_failures"]) == 1
+        assert data["partial_failures"][0]["index"] == 1
+        # Invalid item has empty indices/values
+        assert data["lexical_weights"][1]["indices"] == []
+        assert data["lexical_weights"][1]["values"] == []
+        # Valid items have non-empty weights
+        assert len(data["lexical_weights"][0]["indices"]) > 0
+        assert len(data["lexical_weights"][2]["indices"]) > 0
+
+    async def test_colbert_batch_with_empty_string(self, client):
+        """POST /encode/colbert with ['hello', '', 'world'] returns sentinel for empty."""
+        resp = await client.post("/encode/colbert", json={"texts": ["hello", "", "world"]})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["colbert_vecs"]) == 3
+        assert "partial_failures" in data
+        assert len(data["partial_failures"]) == 1
+        assert data["partial_failures"][0]["index"] == 1
+        # Invalid item: single zero-vector token [[0.0]*1024]
+        assert len(data["colbert_vecs"][1]) == 1
+        assert all(v == 0.0 for v in data["colbert_vecs"][1][0])
+        assert len(data["colbert_vecs"][1][0]) == 1024
+        # Valid items have multi-token vectors
+        assert len(data["colbert_vecs"][0]) > 0
+        assert len(data["colbert_vecs"][2]) > 0
+
+    async def test_hybrid_batch_with_empty_string(self, client):
+        """POST /encode/hybrid with ['hello', '', 'world'] returns sentinels for all types."""
+        resp = await client.post("/encode/hybrid", json={"texts": ["hello", "", "world"]})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "partial_failures" in data
+        assert len(data["partial_failures"]) == 1
+        assert data["partial_failures"][0]["index"] == 1
+        # Dense sentinel
+        assert len(data["dense_vecs"]) == 3
+        assert all(v == 0.0 for v in data["dense_vecs"][1])
+        # Sparse sentinel
+        assert len(data["lexical_weights"]) == 3
+        assert data["lexical_weights"][1]["indices"] == []
+        assert data["lexical_weights"][1]["values"] == []
+        # ColBERT sentinel
+        assert len(data["colbert_vecs"]) == 3
+        assert len(data["colbert_vecs"][1]) == 1
+        assert all(v == 0.0 for v in data["colbert_vecs"][1][0])
+
+    async def test_all_valid_items_no_partial_failures(self, client):
+        """A fully-valid batch returns empty partial_failures (backward compatible)."""
+        resp = await client.post("/encode/dense", json={"texts": ["hello", "world"]})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["partial_failures"] == []
+        assert len(data["dense_vecs"]) == 2
+
+    async def test_model_exception_still_returns_500(self, client, bge_app):
+        """Infrastructure/model errors still produce HTTP 500."""
+        fake_model = bge_app["fake_model"]
+        original_side_effect = fake_model.encode.side_effect
+        fake_model.encode.side_effect = RuntimeError("GPU OOM")
+        try:
+            resp = await client.post("/encode/dense", json={"texts": ["hello", "world"]})
+            assert resp.status_code == 500
+        finally:
+            fake_model.encode.side_effect = original_side_effect
+
+
 class TestWarmup:
     async def test_warmup_skips_colbert(self, bge_app):
         """Lifespan warmup avoids ColBERT to keep startup memory bounded."""

--- a/tests/unit/test_bge_m3_endpoints.py
+++ b/tests/unit/test_bge_m3_endpoints.py
@@ -259,6 +259,17 @@ class TestPartialFailureIsolation:
         assert data["partial_failures"] == []
         assert len(data["dense_vecs"]) == 2
 
+    async def test_dense_all_items_invalid_returns_all_sentinels(self, client):
+        """When ALL items fail validation, response is all sentinels with no model call."""
+        resp = await client.post("/encode/dense", json={"texts": ["", "   "]})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["dense_vecs"]) == 2
+        assert len(data["partial_failures"]) == 2
+        # Both are zero sentinels
+        assert all(v == 0.0 for v in data["dense_vecs"][0])
+        assert all(v == 0.0 for v in data["dense_vecs"][1])
+
     async def test_model_exception_still_returns_500(self, client, bge_app):
         """Infrastructure/model errors still produce HTTP 500."""
         fake_model = bge_app["fake_model"]


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #1643. Adds per-item validation and partial failure isolation to all BGE-M3 batch encode endpoints (`/encode/dense`, `/encode/sparse`, `/encode/colbert`, `/encode/hybrid`).

Previously, a single invalid input (empty string, whitespace-only) in a batch could cause the entire request to fail with HTTP 500. Now, invalid items are identified upfront, only valid items are sent to the model, and responses maintain exact input cardinality with sentinel values at failed positions.

## Changes

### `services/bge-m3-api/app.py`
- Added `PartialFailure` Pydantic model and `partial_failures` field to all response models
- Added `_validate_texts()` helper separating valid/invalid indices
- Added `encode_partial_failures_total` Prometheus counter for observability
- Refactored all 4 encode endpoints: validate first, encode valid-only, reconstruct full-cardinality output with sentinels for invalid items
- True model/infrastructure errors still raise HTTP 500

### `tests/unit/test_bge_m3_endpoints.py`
- 7 new tests in `TestPartialFailureIsolation` class covering:
  - One bad item among good items (all 4 endpoints)
  - Fully valid batch returns empty `partial_failures` (backward compat)
  - All items invalid returns all sentinels without model call
  - Model exceptions still return 500

## Sentinel values
- Dense: `[0.0] * 1024`
- Sparse: `{"indices": [], "values": []}`
- ColBERT: `[[0.0] * 1024]` (single zero-vector token)

## Verification
```
47 passed in 3.20s (40 existing + 7 new)
ruff check: All checks passed
ruff format: All files formatted
```

## Acceptance Criteria
- [x] Batch response cardinality remains equal to input cardinality
- [x] Tests cover one bad item among good items
- [x] Observability records partial failures (Prometheus counter)