### PR TITLE
refactor: use Qdrant RrfQuery for remaining custom RRF paths

### DIFF
--- a/src/evaluation/search_engines.py
+++ b/src/evaluation/search_engines.py
@@ -133,6 +133,8 @@ class HybridSearchEngine(SearchEngine):
     Note: ColBERT multi-vector matching is disabled for now.
     """
 
+    rrf_k: int = 60
+
     def __init__(self, collection_name: str, embedding_model):
         super().__init__(collection_name)
         self.embedding_model = embedding_model
@@ -163,7 +165,7 @@ class HybridSearchEngine(SearchEngine):
         response = self.client.query_points(
             collection_name=self.collection_name,
             prefetch=prefetch,
-            query=models.FusionQuery(fusion=models.Fusion.RRF),
+            query=models.RrfQuery(rrf=models.Rrf(k=self.rrf_k)),
             limit=top_k,
             with_payload=True,
         )
@@ -269,6 +271,8 @@ class HybridRRFColBERTSearchEngine(SearchEngine):
     - ColBERT: https://qdrant.tech/documentation/concepts/hybrid-queries/
     """
 
+    rrf_k: int = 60
+
     def __init__(self, collection_name: str, embedding_model):
         super().__init__(collection_name)
         self.embedding_model = embedding_model
@@ -306,7 +310,7 @@ class HybridRRFColBERTSearchEngine(SearchEngine):
                 models.Prefetch(query=dense_vector, using="dense", limit=self.stage1_limit),
                 models.Prefetch(query=sparse_vector, using="sparse", limit=self.stage1_limit),
             ],
-            query=models.FusionQuery(fusion=models.Fusion.RRF),
+            query=models.RrfQuery(rrf=models.Rrf(k=self.rrf_k)),
         )
 
         response = self.client.query_points(

--- a/telegram_bot/services/apartments_service.py
+++ b/telegram_bot/services/apartments_service.py
@@ -89,6 +89,7 @@ class ApartmentsService:
         colbert_query: list[list[float]] | None = None,
         filters: dict | None = None,
         top_k: int = 10,
+        rrf_k: int = 60,
     ) -> list[dict]:
         """Hybrid search on apartments collection with apartment-specific filters."""
         lf = get_client()
@@ -99,6 +100,7 @@ class ApartmentsService:
             sparse_vector=sparse_vector,
             filters=filters,
             top_k=top_k,
+            rrf_k=rrf_k,
         )
         return results
 
@@ -110,6 +112,7 @@ class ApartmentsService:
         sparse_vector: dict | None,
         filters: dict | None,
         top_k: int = 10,
+        rrf_k: int = 60,
     ) -> tuple[list[dict], int]:
         """Search with apartment-specific filter (no metadata. prefix).
 
@@ -143,7 +146,7 @@ class ApartmentsService:
                 )
             )
 
-        rrf_query = models.FusionQuery(fusion=models.Fusion.RRF)
+        rrf_query = models.RrfQuery(rrf=models.Rrf(k=rrf_k))
 
         if colbert_query:
             # 3-stage: dense+sparse → RRF → ColBERT rescore

--- a/tests/unit/evaluation/test_search_engines_eval.py
+++ b/tests/unit/evaluation/test_search_engines_eval.py
@@ -371,11 +371,11 @@ class TestHybridSearchEngine:
         engine = HybridSearchEngine("test_collection", mock_model)
         engine.search("test query", top_k=5)
 
-        # Verify query_points was called with FusionQuery(RRF)
+        # Verify query_points was called with RrfQuery
         call_kwargs = mock_client.query_points.call_args[1]
         query = call_kwargs["query"]
-        assert isinstance(query, models.FusionQuery)
-        assert query.fusion == models.Fusion.RRF
+        assert isinstance(query, models.RrfQuery)
+        assert query.rrf.k == 60
 
     @patch("src.evaluation.search_engines.QdrantClient")
     @patch("src.evaluation.search_engines.Settings")
@@ -589,8 +589,8 @@ class TestHybridRRFColBERTSearchEngine:
         assert len(prefetch) == 1
         inner_prefetch = prefetch[0]
         assert isinstance(inner_prefetch, models.Prefetch)
-        assert isinstance(inner_prefetch.query, models.FusionQuery)
-        assert inner_prefetch.query.fusion == models.Fusion.RRF
+        assert isinstance(inner_prefetch.query, models.RrfQuery)
+        assert inner_prefetch.query.rrf.k == 60
 
 
 class TestCreateSearchEngine:

--- a/tests/unit/services/test_apartments_service.py
+++ b/tests/unit/services/test_apartments_service.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from qdrant_client import models
 
 from telegram_bot.services.apartments_service import (
     ApartmentsService,
@@ -311,3 +312,71 @@ class TestScrollWithFilters:
             exclude_ids=["a4"],
         )
         assert len(r3) == 1
+
+
+class TestSearchWithFiltersQueryShape:
+    """Test the query shape sent to Qdrant by search_with_filters."""
+
+    @pytest.fixture
+    def mock_qdrant(self) -> MagicMock:
+        q = MagicMock()
+        q.client = MagicMock()
+        q.collection_name = "apartments"
+        mock_response = SimpleNamespace(points=[])
+        q.client.query_points = AsyncMock(return_value=mock_response)
+        return q
+
+    async def test_rrf_query_without_colbert(self, mock_qdrant: MagicMock) -> None:
+        """query_points is called with models.RrfQuery when no colbert_query."""
+        svc = ApartmentsService(mock_qdrant)
+        await svc.search_with_filters(
+            dense_vector=[0.1, 0.2, 0.3],
+            colbert_query=None,
+            sparse_vector={"indices": [1, 2], "values": [0.5, 0.8]},
+            filters=None,
+            top_k=5,
+        )
+
+        call_kwargs = mock_qdrant.client.query_points.call_args.kwargs
+        query = call_kwargs["query"]
+        assert isinstance(query, models.RrfQuery)
+        assert query.rrf.k == 60
+
+    async def test_rrf_query_with_colbert(self, mock_qdrant: MagicMock) -> None:
+        """When colbert_query is provided, intermediate prefetch uses RrfQuery and outer uses colbert."""
+        svc = ApartmentsService(mock_qdrant)
+        await svc.search_with_filters(
+            dense_vector=[0.1, 0.2, 0.3],
+            colbert_query=[[0.1, 0.2], [0.3, 0.4]],
+            sparse_vector={"indices": [1, 2], "values": [0.5, 0.8]},
+            filters=None,
+            top_k=5,
+        )
+
+        call_kwargs = mock_qdrant.client.query_points.call_args.kwargs
+        # Outer query uses colbert vectors
+        assert call_kwargs["using"] == "colbert"
+        assert call_kwargs["query"] == [[0.1, 0.2], [0.3, 0.4]]
+        # Inner prefetch uses RrfQuery
+        prefetch_list = call_kwargs["prefetch"]
+        assert len(prefetch_list) == 1
+        rrf_prefetch = prefetch_list[0]
+        assert isinstance(rrf_prefetch.query, models.RrfQuery)
+        assert rrf_prefetch.query.rrf.k == 60
+
+    async def test_rrf_k_parameter_threaded_through(self, mock_qdrant: MagicMock) -> None:
+        """Pass rrf_k=42 and verify the Rrf object has k=42."""
+        svc = ApartmentsService(mock_qdrant)
+        await svc.search_with_filters(
+            dense_vector=[0.1, 0.2, 0.3],
+            colbert_query=None,
+            sparse_vector={"indices": [1, 2], "values": [0.5, 0.8]},
+            filters=None,
+            top_k=5,
+            rrf_k=42,
+        )
+
+        call_kwargs = mock_qdrant.client.query_points.call_args.kwargs
+        query = call_kwargs["query"]
+        assert isinstance(query, models.RrfQuery)
+        assert query.rrf.k == 42


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #1647

Replaces all remaining `FusionQuery(fusion=models.Fusion.RRF)` usage with Qdrant-native `RrfQuery(rrf=models.Rrf(k=rrf_k))`, exposing a tunable `rrf_k` parameter (default 60) consistently across production and evaluation search engines.

## Changes

| File | Change |
|------|--------|
| `telegram_bot/services/apartments_service.py` | Added `rrf_k: int = 60` to `search()` and `search_with_filters()` signatures; replaced FusionQuery with RrfQuery |
| `src/evaluation/search_engines.py` | Added `rrf_k: int = 60` class attribute to `HybridSearchEngine` and `HybridRRFColBERTSearchEngine`; replaced FusionQuery with RrfQuery |
| `tests/unit/evaluation/test_search_engines_eval.py` | Updated assertions from FusionQuery/Fusion.RRF to RrfQuery/rrf.k == 60 |
| `tests/unit/services/test_apartments_service.py` | Added 3 new regression tests verifying query shape (RrfQuery without ColBERT, with ColBERT, and rrf_k threading) |

## What was tested

- All 1331 unit tests pass (including 3 new regression tests)
- `ruff check` passes cleanly on all modified files
- No `FusionQuery(RRF)` remains in the refactored files

## Design notes

- DBSF fusion paths (`HybridDBSFColBERTSearchEngine`) are intentionally untouched since they use a different fusion strategy
- Named vector contracts (dense, bm42/sparse, colbert) are unchanged
- Evaluation engines expose `rrf_k` as a class attribute rather than a constructor parameter, consistent with their existing pattern