### PR TITLE
refactor: use OpenAI structured outputs for evaluation query generation

### DIFF
--- a/src/evaluation/generate_test_queries.py
+++ b/src/evaluation/generate_test_queries.py
@@ -10,7 +10,6 @@ Creates 3 types of queries for each article:
 import asyncio
 import json
 import os
-from dataclasses import dataclass
 
 import instructor
 from openai import AsyncOpenAI
@@ -30,16 +29,6 @@ class GeneratedQueries(BaseModel):
         description="Semantic query describing the essence of the article in own words"
     )
     paraphrased: str = Field(description="Paraphrased question about the article content")
-
-
-@dataclass
-class LLMConfig:
-    """Configuration for the LLM client used in evaluation."""
-
-    api_url: str
-    api_key: str
-    model: str
-    max_tokens: int
 
 
 # Load settings
@@ -207,19 +196,31 @@ async def generate_all_queries(
         AsyncOpenAI(base_url=resolved_base_url, api_key=resolved_api_key)
     )
 
+    semaphore = asyncio.Semaphore(max_concurrent)
     all_queries: list[dict] = []
     completed = 0
 
-    # Process articles sequentially (respecting max_concurrent via semaphore if needed)
-    for article_num, text in article_texts.items():
-        try:
-            queries = await generate_queries_for_article(client, model, article_num, text)
-            all_queries.extend(queries)
-            completed += 1
-            print(f"[{completed}/{len(article_texts)}] Article {article_num}: 3 queries generated")
-        except Exception as e:
-            completed += 1
-            print(f"[{completed}/{len(article_texts)}] Article {article_num}: ERROR: {e}")
+    async def _process_article(article_num: str, text: str) -> list[dict]:
+        nonlocal completed
+        async with semaphore:
+            try:
+                queries = await generate_queries_for_article(client, model, article_num, text)
+                completed += 1
+                print(
+                    f"[{completed}/{len(article_texts)}] Article {article_num}: 3 queries generated"
+                )
+                return queries
+            except Exception as e:
+                completed += 1
+                print(f"[{completed}/{len(article_texts)}] Article {article_num}: ERROR: {e}")
+                return []
+
+    results = await asyncio.gather(
+        *(_process_article(article_num, text) for article_num, text in article_texts.items())
+    )
+
+    for queries in results:
+        all_queries.extend(queries)
 
     print(f"\nGenerated {len(all_queries)} queries total")
 

--- a/src/evaluation/generate_test_queries.py
+++ b/src/evaluation/generate_test_queries.py
@@ -9,32 +9,47 @@ Creates 3 types of queries for each article:
 
 import asyncio
 import json
-from typing import Protocol, cast
+import os
+from dataclasses import dataclass
 
+import instructor
+from openai import AsyncOpenAI
+from pydantic import BaseModel, Field
 from qdrant_client import QdrantClient, models
 
 from src.config import Settings
 
 
-class ContextualRetrievalGroqAsyncProtocol(Protocol):
+class GeneratedQueries(BaseModel):
+    """Structured output model for LLM-generated test queries."""
+
+    direct: str = Field(
+        description="Direct query mentioning the article number or its key legal concept"
+    )
+    semantic: str = Field(
+        description="Semantic query describing the essence of the article in own words"
+    )
+    paraphrased: str = Field(description="Paraphrased question about the article content")
+
+
+@dataclass
+class LLMConfig:
+    """Configuration for the LLM client used in evaluation."""
+
     api_url: str
     api_key: str
     model: str
     max_tokens: int
-
-    def print_stats(self) -> None: ...
-
-
-class ContextualRetrievalGroqAsyncFactoryProtocol(Protocol):
-    def __call__(
-        self, *, model: str, max_concurrent: int
-    ) -> ContextualRetrievalGroqAsyncProtocol: ...
 
 
 # Load settings
 _settings = Settings()
 QDRANT_URL = _settings.qdrant_url
 QDRANT_API_KEY = _settings.qdrant_api_key or ""
+
+# LLM configuration from environment
+LLM_BASE_URL = os.environ.get("LLM_BASE_URL", "https://openrouter.ai/api/v1")
+LLM_API_KEY = os.environ.get("LLM_API_KEY", "")
 
 
 def _make_client() -> QdrantClient:
@@ -92,10 +107,16 @@ def fetch_article_texts(collection_name: str, article_numbers: list[str]) -> dic
 
 
 async def generate_queries_for_article(
-    llm: ContextualRetrievalGroqAsyncProtocol, article_num: str, article_text: str
+    client: instructor.AsyncInstructor, model: str, article_num: str, article_text: str
 ) -> list[dict]:
     """
     Generate 3 types of queries for a single article.
+
+    Args:
+        client: Instructor-patched AsyncOpenAI client
+        model: Model name to use
+        article_num: Article number string
+        article_text: Full text of the article
 
     Returns:
         List of query objects with type and expected_article
@@ -122,68 +143,45 @@ async def generate_queries_for_article(
 ВАЖНО:
 - Запросы должны быть короткими (5-15 слов)
 - Каждый запрос должен логически вести к этой статье
-- Используй естественный язык, как будто спрашивает обычный человек
+- Используй естественный язык, как будто спрашивает обычный человек"""
 
-ОТВЕТ в формате JSON:
-{{
-  "direct": "...",
-  "semantic": "...",
-  "paraphrased": "..."
-}}"""
-
-    # Call LLM using aiohttp directly
-    import aiohttp
-
-    async with (
-        aiohttp.ClientSession() as session,
-        session.post(
-            llm.api_url,
-            headers={"Authorization": f"Bearer {llm.api_key}", "Content-Type": "application/json"},
-            json={
-                "model": llm.model,
-                "messages": [{"role": "user", "content": prompt}],
-                "temperature": 0.7,
-                "max_tokens": llm.max_tokens,
-            },
-        ) as resp,
-    ):
-        response = await resp.json()
-
-    # Parse JSON response
-    content = response["choices"][0]["message"]["content"]
-
-    # Extract JSON from response (in case there's extra text)
-    start_idx = content.find("{")
-    end_idx = content.rfind("}") + 1
-    json_str = content[start_idx:end_idx]
-
-    queries_dict = json.loads(json_str)
+    result = await client.chat.completions.create(
+        model=model,
+        response_model=GeneratedQueries,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.7,
+        max_retries=2,
+    )
 
     # Create query objects
     return [
         {
-            "query": queries_dict["direct"],
+            "query": result.direct,
             "type": "direct",
-            "expected_article": article_num,  # Already a string
+            "expected_article": article_num,
             "difficulty": "easy",
         },
         {
-            "query": queries_dict["semantic"],
+            "query": result.semantic,
             "type": "semantic",
-            "expected_article": article_num,  # Already a string
+            "expected_article": article_num,
             "difficulty": "medium",
         },
         {
-            "query": queries_dict["paraphrased"],
+            "query": result.paraphrased,
             "type": "paraphrased",
-            "expected_article": article_num,  # Already a string
+            "expected_article": article_num,
             "difficulty": "hard",
         },
     ]
 
 
 async def generate_all_queries(
-    article_texts: dict[str, str], model: str = "openai/gpt-oss-120b", max_concurrent: int = 5
+    article_texts: dict[str, str],
+    model: str = "openai/gpt-oss-120b",
+    max_concurrent: int = 5,
+    base_url: str | None = None,
+    api_key: str | None = None,
 ) -> list[dict]:
     """
     Generate queries for all articles asynchronously.
@@ -192,6 +190,8 @@ async def generate_all_queries(
         article_texts: Dict mapping article_number (str) -> text
         model: LLM model to use
         max_concurrent: Max parallel requests
+        base_url: LLM API base URL (defaults to LLM_BASE_URL env var)
+        api_key: LLM API key (defaults to LLM_API_KEY env var)
 
     Returns:
         List of all generated queries
@@ -200,50 +200,28 @@ async def generate_all_queries(
     print(f"   Max concurrent: {max_concurrent}")
     print(f"   Total articles: {len(article_texts)}\n")
 
-    # Lazy import — legacy module not on sys.path by default
-    import importlib.util
-    import os
+    resolved_base_url = base_url or LLM_BASE_URL
+    resolved_api_key = api_key or LLM_API_KEY
 
-    _spec = importlib.util.spec_from_file_location(
-        "contextualize_groq_async",
-        os.path.join(
-            os.path.dirname(__file__), "..", "..", "legacy", "contextualize_groq_async.py"
-        ),
+    client = instructor.from_openai(
+        AsyncOpenAI(base_url=resolved_base_url, api_key=resolved_api_key)
     )
-    if _spec is None or _spec.loader is None:
-        raise ImportError("legacy/contextualize_groq_async.py not found")
-    _mod = importlib.util.module_from_spec(_spec)
-    _spec.loader.exec_module(_mod)
 
-    llm_factory = cast(
-        ContextualRetrievalGroqAsyncFactoryProtocol, _mod.ContextualRetrievalGroqAsync
-    )
-    llm = llm_factory(model=model, max_concurrent=max_concurrent)
-
-    all_queries = []
+    all_queries: list[dict] = []
     completed = 0
 
-    # Create async tasks
-    tasks = []
+    # Process articles sequentially (respecting max_concurrent via semaphore if needed)
     for article_num, text in article_texts.items():
-        task = generate_queries_for_article(llm, article_num, text)
-        tasks.append((article_num, task))
-
-    # Process with progress tracking
-    for article_num, task_coro in tasks:
         try:
-            queries = await task_coro
+            queries = await generate_queries_for_article(client, model, article_num, text)
             all_queries.extend(queries)
             completed += 1
-            print(f"[{completed}/{len(tasks)}] Article {article_num}: 3 queries generated")
+            print(f"[{completed}/{len(article_texts)}] Article {article_num}: 3 queries generated")
         except Exception as e:
-            print(f"[{completed}/{len(tasks)}] Article {article_num}: ERROR: {e}")
             completed += 1
+            print(f"[{completed}/{len(article_texts)}] Article {article_num}: ERROR: {e}")
 
     print(f"\nGenerated {len(all_queries)} queries total")
-
-    # Print stats
-    llm.print_stats()
 
     return all_queries
 
@@ -302,7 +280,7 @@ async def main():
     print("Step 3: Generate test queries with LLM")
     queries = await generate_all_queries(
         article_texts,
-        model="openai/gpt-oss-120b",  # 120B parameters, 100% accuracy
+        model="openai/gpt-oss-120b",
         max_concurrent=5,
     )
 

--- a/tests/unit/evaluation/test_generate_test_queries.py
+++ b/tests/unit/evaluation/test_generate_test_queries.py
@@ -125,61 +125,24 @@ class TestGenerateQueriesForArticle:
     """Tests for generate_queries_for_article function."""
 
     async def test_generate_queries_success(self, mock_imports):
-        """Test successful query generation for an article."""
-        # Mock LLM response
-        llm_response = {
-            "choices": [
-                {
-                    "message": {
-                        "content": json.dumps(
-                            {
-                                "direct": "статья 115",
-                                "semantic": "наказание за убийство",
-                                "paraphrased": "что грозит за лишение жизни",
-                            }
-                        )
-                    }
-                }
-            ]
-        }
+        """Test successful query generation for an article using instructor client."""
+        from src.evaluation.generate_test_queries import (
+            GeneratedQueries,
+            generate_queries_for_article,
+        )
 
-        mock_session = AsyncMock()
-        mock_response = AsyncMock()
-        mock_response.json = AsyncMock(return_value=llm_response)
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(
+            return_value=GeneratedQueries(
+                direct="статья 115",
+                semantic="наказание за убийство",
+                paraphrased="что грозит за лишение жизни",
+            )
+        )
 
-        # Create async context manager mocks
-        mock_context = AsyncMock()
-        mock_context.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_context.__aexit__ = AsyncMock(return_value=False)
-
-        mock_session.post.return_value = mock_context
-
-        # Simulate generate_queries_for_article logic
-        article_num = "115"
-
-        content = llm_response["choices"][0]["message"]["content"]
-        queries_dict = json.loads(content)
-
-        queries = [
-            {
-                "query": queries_dict["direct"],
-                "type": "direct",
-                "expected_article": article_num,
-                "difficulty": "easy",
-            },
-            {
-                "query": queries_dict["semantic"],
-                "type": "semantic",
-                "expected_article": article_num,
-                "difficulty": "medium",
-            },
-            {
-                "query": queries_dict["paraphrased"],
-                "type": "paraphrased",
-                "expected_article": article_num,
-                "difficulty": "hard",
-            },
-        ]
+        queries = await generate_queries_for_article(
+            mock_client, "openai/gpt-oss-120b", "115", "Article 115 text content"
+        )
 
         assert len(queries) == 3
         assert queries[0]["type"] == "direct"
@@ -202,25 +165,19 @@ class TestGenerateQueriesForArticle:
 
         assert text_preview == short_text
 
-    def test_json_extraction_from_response(self):
-        """Test JSON is correctly extracted from LLM response."""
-        content = """Here is the JSON response:
-{
-  "direct": "query 1",
-  "semantic": "query 2",
-  "paraphrased": "query 3"
-}
-Some additional text"""
+    def test_generated_queries_model_valid(self):
+        """Test GeneratedQueries Pydantic model validates correctly with valid input."""
+        from src.evaluation.generate_test_queries import GeneratedQueries
 
-        start_idx = content.find("{")
-        end_idx = content.rfind("}") + 1
-        json_str = content[start_idx:end_idx]
+        result = GeneratedQueries(
+            direct="статья 115",
+            semantic="наказание за убийство",
+            paraphrased="что грозит за лишение жизни",
+        )
 
-        queries_dict = json.loads(json_str)
-
-        assert queries_dict["direct"] == "query 1"
-        assert queries_dict["semantic"] == "query 2"
-        assert queries_dict["paraphrased"] == "query 3"
+        assert result.direct == "статья 115"
+        assert result.semantic == "наказание за убийство"
+        assert result.paraphrased == "что грозит за лишение жизни"
 
     def test_query_object_structure(self):
         """Test generated query objects have correct structure."""
@@ -257,37 +214,40 @@ class TestGenerateAllQueries:
     """Tests for generate_all_queries function."""
 
     async def test_generate_all_queries_success(self, mock_imports):
-        """Test generating queries for multiple articles."""
+        """Test generating queries for multiple articles with instructor client."""
+        from src.evaluation.generate_test_queries import (
+            GeneratedQueries,
+            generate_all_queries,
+        )
+
+        mock_instructor_client = MagicMock()
+        mock_instructor_client.chat.completions.create = AsyncMock(
+            return_value=GeneratedQueries(
+                direct="прямой запрос",
+                semantic="семантический запрос",
+                paraphrased="перефразированный запрос",
+            )
+        )
+
         article_texts = {
             "115": "Murder text",
             "121": "Injury text",
         }
 
-        # Simulate query generation
-        all_queries = []
-        for article_num in article_texts:
-            queries = [
-                {
-                    "query": f"direct {article_num}",
-                    "type": "direct",
-                    "expected_article": article_num,
-                },
-                {
-                    "query": f"semantic {article_num}",
-                    "type": "semantic",
-                    "expected_article": article_num,
-                },
-                {
-                    "query": f"paraphrased {article_num}",
-                    "type": "paraphrased",
-                    "expected_article": article_num,
-                },
-            ]
-            all_queries.extend(queries)
+        with patch("src.evaluation.generate_test_queries.instructor") as mock_instructor_mod:
+            mock_instructor_mod.from_openai.return_value = mock_instructor_client
 
-        assert len(all_queries) == 6  # 3 queries per article * 2 articles
-        assert all_queries[0]["expected_article"] == "115"
-        assert all_queries[3]["expected_article"] == "121"
+            result = await generate_all_queries(
+                article_texts,
+                model="openai/gpt-oss-120b",
+                max_concurrent=5,
+                base_url="http://test.api/v1",
+                api_key="test-key",
+            )
+
+        assert len(result) == 6  # 3 queries per article * 2 articles
+        assert result[0]["expected_article"] == "115"
+        assert result[3]["expected_article"] == "121"
 
     async def test_generate_queries_with_errors(self, mock_imports):
         """Test error handling during query generation."""
@@ -498,18 +458,21 @@ class TestLLMClientConfiguration:
         assert max_concurrent == 5
 
     def test_llm_request_structure(self):
-        """Test LLM request has correct structure."""
-        request = {
+        """Test instructor client is called with correct parameters."""
+        from src.evaluation.generate_test_queries import GeneratedQueries
+
+        # Verify expected call parameters for instructor
+        expected_kwargs = {
             "model": "openai/gpt-oss-120b",
-            "messages": [{"role": "user", "content": "Generate queries..."}],
+            "response_model": GeneratedQueries,
             "temperature": 0.7,
-            "max_tokens": 1024,
+            "max_retries": 2,
         }
 
-        assert request["model"] == "openai/gpt-oss-120b"
-        assert request["temperature"] == 0.7
-        assert len(request["messages"]) == 1
-        assert request["messages"][0]["role"] == "user"
+        assert expected_kwargs["model"] == "openai/gpt-oss-120b"
+        assert expected_kwargs["response_model"] is GeneratedQueries
+        assert expected_kwargs["temperature"] == 0.7
+        assert expected_kwargs["max_retries"] == 2
 
 
 class TestErrorHandling:
@@ -528,18 +491,174 @@ class TestErrorHandling:
 
             fetch_article_texts("test_collection", ["115"])
 
-    def test_invalid_json_response(self):
-        """Test handling invalid JSON in LLM response."""
-        invalid_content = "This is not valid JSON"
+    async def test_invalid_model_output_raises(self, mock_imports):
+        """Test that instructor raises when LLM returns invalid output."""
+        from src.evaluation.generate_test_queries import generate_queries_for_article
 
-        with pytest.raises(ValueError):
-            start_idx = invalid_content.find("{")
-            if start_idx == -1:
-                raise ValueError("No JSON found in response")
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=Exception("Instructor validation failed: max retries exceeded")
+        )
 
-    def test_missing_json_keys(self):
-        """Test handling missing keys in LLM JSON response."""
-        partial_json = {"direct": "query 1"}  # Missing semantic and paraphrased
+        with pytest.raises(Exception, match="Instructor validation failed"):
+            await generate_queries_for_article(
+                mock_client, "openai/gpt-oss-120b", "115", "Some article text"
+            )
 
-        with pytest.raises(KeyError):
-            _ = partial_json["semantic"]
+    def test_missing_model_fields_raise_validation_error(self):
+        """Test that missing fields in GeneratedQueries raise ValidationError."""
+        from pydantic import ValidationError
+
+        from src.evaluation.generate_test_queries import GeneratedQueries
+
+        with pytest.raises(ValidationError):
+            GeneratedQueries(direct="query 1")  # type: ignore[call-arg]
+
+
+class TestStructuredOutputParsing:
+    """Regression tests for the instructor-based structured output refactor."""
+
+    def test_generated_queries_model_valid(self):
+        """Test GeneratedQueries model with valid input succeeds."""
+        from src.evaluation.generate_test_queries import GeneratedQueries
+
+        result = GeneratedQueries(
+            direct="статья 115",
+            semantic="наказание за убийство",
+            paraphrased="что грозит за лишение жизни",
+        )
+
+        assert result.direct == "статья 115"
+        assert result.semantic == "наказание за убийство"
+        assert result.paraphrased == "что грозит за лишение жизни"
+
+    def test_generated_queries_model_missing_field(self):
+        """Test that missing fields raise ValidationError."""
+        from pydantic import ValidationError
+
+        from src.evaluation.generate_test_queries import GeneratedQueries
+
+        with pytest.raises(ValidationError):
+            GeneratedQueries(direct="query 1", semantic="query 2")  # type: ignore[call-arg]
+
+        with pytest.raises(ValidationError):
+            GeneratedQueries(direct="query 1")  # type: ignore[call-arg]
+
+        with pytest.raises(ValidationError):
+            GeneratedQueries()  # type: ignore[call-arg]
+
+    async def test_structured_parsing_returns_correct_shape(self, mock_imports):
+        """Test generate_queries_for_article returns list of 3 dicts with correct keys."""
+        from src.evaluation.generate_test_queries import (
+            GeneratedQueries,
+            generate_queries_for_article,
+        )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(
+            return_value=GeneratedQueries(
+                direct="статья 121",
+                semantic="тяжкие телесные повреждения",
+                paraphrased="что будет за нанесение тяжких травм",
+            )
+        )
+
+        result = await generate_queries_for_article(
+            mock_client, "openai/gpt-oss-120b", "121", "Article 121 about injuries..."
+        )
+
+        # Correct number of queries
+        assert len(result) == 3
+
+        # Each dict has required keys
+        required_keys = {"query", "type", "expected_article", "difficulty"}
+        for query_dict in result:
+            assert set(query_dict.keys()) == required_keys
+
+        # Type and difficulty mappings are correct
+        assert result[0]["type"] == "direct"
+        assert result[0]["difficulty"] == "easy"
+        assert result[1]["type"] == "semantic"
+        assert result[1]["difficulty"] == "medium"
+        assert result[2]["type"] == "paraphrased"
+        assert result[2]["difficulty"] == "hard"
+
+        # Expected article is set correctly
+        assert all(q["expected_article"] == "121" for q in result)
+
+        # Query content matches model output
+        assert result[0]["query"] == "статья 121"
+        assert result[1]["query"] == "тяжкие телесные повреждения"
+        assert result[2]["query"] == "что будет за нанесение тяжких травм"
+
+    async def test_invalid_model_output_raises(self, mock_imports):
+        """Test that exception from instructor propagates to caller."""
+        from src.evaluation.generate_test_queries import generate_queries_for_article
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=Exception("Max retries exceeded: validation failed")
+        )
+
+        with pytest.raises(Exception, match="Max retries exceeded"):
+            await generate_queries_for_article(
+                mock_client, "openai/gpt-oss-120b", "115", "Some article text"
+            )
+
+    async def test_generate_all_queries_creates_instructor_client(self, mock_imports):
+        """Test that generate_all_queries creates instructor client with correct params."""
+        from src.evaluation.generate_test_queries import (
+            GeneratedQueries,
+            generate_all_queries,
+        )
+
+        mock_instructor_client = MagicMock()
+        mock_instructor_client.chat.completions.create = AsyncMock(
+            return_value=GeneratedQueries(
+                direct="direct query",
+                semantic="semantic query",
+                paraphrased="paraphrased query",
+            )
+        )
+
+        with (
+            patch("src.evaluation.generate_test_queries.instructor") as mock_instructor_mod,
+            patch("src.evaluation.generate_test_queries.AsyncOpenAI") as mock_openai_cls,
+        ):
+            mock_instructor_mod.from_openai.return_value = mock_instructor_client
+            mock_openai_instance = MagicMock()
+            mock_openai_cls.return_value = mock_openai_instance
+
+            await generate_all_queries(
+                {"115": "Article text"},
+                model="openai/gpt-oss-120b",
+                base_url="http://custom.api/v1",
+                api_key="custom-key",
+            )
+
+            # Verify AsyncOpenAI was created with correct params
+            mock_openai_cls.assert_called_once_with(
+                base_url="http://custom.api/v1", api_key="custom-key"
+            )
+
+            # Verify instructor.from_openai was called with the AsyncOpenAI instance
+            mock_instructor_mod.from_openai.assert_called_once_with(mock_openai_instance)
+
+    def test_generated_queries_model_extra_fields_ignored(self):
+        """Test that extra fields do not break GeneratedQueries model."""
+        from src.evaluation.generate_test_queries import GeneratedQueries
+
+        # Pydantic v2 default ignores extra fields
+        result = GeneratedQueries.model_validate(
+            {
+                "direct": "query 1",
+                "semantic": "query 2",
+                "paraphrased": "query 3",
+                "extra_field": "ignored",
+            }
+        )
+
+        assert result.direct == "query 1"
+        assert result.semantic == "query 2"
+        assert result.paraphrased == "query 3"
+        assert not hasattr(result, "extra_field")

--- a/tests/unit/evaluation/test_generate_test_queries.py
+++ b/tests/unit/evaluation/test_generate_test_queries.py
@@ -165,20 +165,6 @@ class TestGenerateQueriesForArticle:
 
         assert text_preview == short_text
 
-    def test_generated_queries_model_valid(self):
-        """Test GeneratedQueries Pydantic model validates correctly with valid input."""
-        from src.evaluation.generate_test_queries import GeneratedQueries
-
-        result = GeneratedQueries(
-            direct="статья 115",
-            semantic="наказание за убийство",
-            paraphrased="что грозит за лишение жизни",
-        )
-
-        assert result.direct == "статья 115"
-        assert result.semantic == "наказание за убийство"
-        assert result.paraphrased == "что грозит за лишение жизни"
-
     def test_query_object_structure(self):
         """Test generated query objects have correct structure."""
         query_obj = {
@@ -250,30 +236,53 @@ class TestGenerateAllQueries:
         assert result[3]["expected_article"] == "121"
 
     async def test_generate_queries_with_errors(self, mock_imports):
-        """Test error handling during query generation."""
+        """Test error handling during query generation through real generate_all_queries."""
+        from src.evaluation.generate_test_queries import (
+            GeneratedQueries,
+            generate_all_queries,
+        )
+
+        call_count = 0
+
+        async def _create_side_effect(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            # Determine which article based on the prompt content
+            content = kwargs.get("messages", [{}])[0].get("content", "")
+            if "999" in content:
+                raise ValueError("LLM API error")
+            return GeneratedQueries(
+                direct="прямой запрос",
+                semantic="семантический запрос",
+                paraphrased="перефразированный запрос",
+            )
+
+        mock_instructor_client = MagicMock()
+        mock_instructor_client.chat.completions.create = AsyncMock(side_effect=_create_side_effect)
+
         article_texts = {
             "115": "Normal text",
             "999": "Error text",
             "121": "Normal text",
         }
 
-        all_queries = []
-        errors = []
+        with patch("src.evaluation.generate_test_queries.instructor") as mock_instructor_mod:
+            mock_instructor_mod.from_openai.return_value = mock_instructor_client
 
-        for article_num in article_texts:
-            try:
-                if article_num == "999":
-                    raise ValueError("LLM API error")
-                queries = [
-                    {"query": f"q {article_num}", "type": "direct", "expected_article": article_num}
-                ]
-                all_queries.extend(queries)
-            except ValueError as e:
-                errors.append(str(e))
+            result = await generate_all_queries(
+                article_texts,
+                model="openai/gpt-oss-120b",
+                max_concurrent=5,
+                base_url="http://test.api/v1",
+                api_key="test-key",
+            )
 
-        assert len(all_queries) == 2  # Only 115 and 121
-        assert len(errors) == 1
-        assert "LLM API error" in errors[0]
+        # Only articles 115 and 121 succeed (3 queries each)
+        assert len(result) == 6
+        expected_articles = {q["expected_article"] for q in result}
+        assert "115" in expected_articles
+        assert "121" in expected_articles
+        assert "999" not in expected_articles
 
 
 class TestSelectRepresentativeArticles:
@@ -490,20 +499,6 @@ class TestErrorHandling:
             from src.evaluation.generate_test_queries import fetch_article_texts
 
             fetch_article_texts("test_collection", ["115"])
-
-    async def test_invalid_model_output_raises(self, mock_imports):
-        """Test that instructor raises when LLM returns invalid output."""
-        from src.evaluation.generate_test_queries import generate_queries_for_article
-
-        mock_client = MagicMock()
-        mock_client.chat.completions.create = AsyncMock(
-            side_effect=Exception("Instructor validation failed: max retries exceeded")
-        )
-
-        with pytest.raises(Exception, match="Instructor validation failed"):
-            await generate_queries_for_article(
-                mock_client, "openai/gpt-oss-120b", "115", "Some article text"
-            )
 
     def test_missing_model_fields_raise_validation_error(self):
         """Test that missing fields in GeneratedQueries raise ValidationError."""


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #1649. Replaces brittle raw `aiohttp` + JSON substring parsing (`content.find("{")` / `rfind("}")`) in `src/evaluation/generate_test_queries.py` with OpenAI structured outputs via the `instructor` library and a Pydantic response model.

## Changes

- **Pydantic model:** Added `GeneratedQueries(BaseModel)` with `direct`, `semantic`, `paraphrased` fields for type-safe LLM output parsing
- **Instructor integration:** Replaced `aiohttp.ClientSession.post()` + manual JSON extraction with `instructor.from_openai(AsyncOpenAI(...))` and `client.chat.completions.create(response_model=GeneratedQueries, max_retries=2)`
- **Cleanup:** Removed legacy `ContextualRetrievalGroqAsyncProtocol` classes, dead `LLMConfig` dataclass, and `importlib`-based dynamic loading
- **Concurrency:** Implemented proper `asyncio.Semaphore` + `asyncio.gather` for the `max_concurrent` parameter
- **Environment config:** Added `LLM_BASE_URL` and `LLM_API_KEY` env var sourcing

## Tests

- Added `TestStructuredOutputParsing` class with 6 regression tests covering:
  - Valid model construction
  - Missing field validation errors
  - Correct output shape (3 dicts with required keys)
  - Error propagation from instructor
  - Instructor client creation with correct params
  - Extra fields handling
- Updated existing tests to mock instructor client instead of aiohttp sessions
- **Result:** 32 tests pass (`uv run pytest tests/unit/evaluation -q`)

## Scope

- Changes scoped to `src/evaluation/` only - no modifications to main bot runtime (`telegram_bot/`)
- No prompt or output schema rewrites beyond this tool

## Verification

```
uv run ruff check src/evaluation/generate_test_queries.py tests/unit/evaluation/test_generate_test_queries.py  # clean
uv run pytest tests/unit/evaluation -q  # 32 passed
```