### PR TITLE
fix: eval tests validate runtime code, not local copies

### DIFF
--- a/src/evaluation/run_ab_test.py
+++ b/src/evaluation/run_ab_test.py
@@ -21,9 +21,6 @@ from datetime import datetime
 
 import numpy as np
 
-from src.evaluation.evaluator import SearchEvaluator
-from src.evaluation.search_engines import create_search_engine
-
 
 def run_ab_test(
     queries_file: str,
@@ -54,6 +51,9 @@ def run_ab_test(
     if not queries:
         print("⚠️  No queries found. Aborting A/B test.")
         return {"baseline": {}, "hybrid": {}, "dbsf_colbert": {}, "comparisons": {}, "reports": {}}
+
+    from src.evaluation.evaluator import SearchEvaluator
+    from src.evaluation.search_engines import create_search_engine
 
     print()
 

--- a/src/evaluation/run_ab_test.py
+++ b/src/evaluation/run_ab_test.py
@@ -19,6 +19,8 @@ import json
 import time
 from datetime import datetime
 
+import numpy as np
+
 from src.evaluation.evaluator import SearchEvaluator
 from src.evaluation.search_engines import create_search_engine
 
@@ -261,20 +263,6 @@ def run_ab_test(
     # Save comparison (convert numpy types to Python types for JSON)
     comparison_report_file = f"{output_dir}/comparison_report_{timestamp}.json"
 
-    def convert_numpy(obj):
-        """Convert numpy types to Python types for JSON serialization."""
-        import numpy as np
-
-        if isinstance(obj, np.bool_):
-            return bool(obj)
-        if isinstance(obj, (np.integer, np.floating)):
-            return float(obj)
-        if isinstance(obj, dict):
-            return {k: convert_numpy(v) for k, v in obj.items()}
-        if isinstance(obj, list):
-            return [convert_numpy(item) for item in obj]
-        return obj
-
     comparison_hybrid_clean = convert_numpy(comparison_hybrid)
     comparison_dbsf_clean = convert_numpy(comparison_dbsf)
     comparison_hybrid_dbsf_clean = convert_numpy(comparison_hybrid_dbsf)
@@ -393,6 +381,39 @@ def print_comparison(comparison: dict):
             print("   ⚠️  NOT SIGNIFICANT (p ≥ 0.05)")
 
 
+def convert_numpy(obj):
+    """Convert numpy types to Python types for JSON serialization."""
+    if isinstance(obj, np.bool_):
+        return bool(obj)
+    if isinstance(obj, (np.integer, np.floating)):
+        return float(obj)
+    if isinstance(obj, dict):
+        return {k: convert_numpy(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [convert_numpy(item) for item in obj]
+    return obj
+
+
+def determine_conclusion(dbsf_vs_baseline: float, dbsf_vs_hybrid: float) -> str:
+    """Determine overall winner conclusion for A/B test report.
+
+    Args:
+        dbsf_vs_baseline: Relative improvement percentage of DBSF+ColBERT over baseline (Recall@10).
+        dbsf_vs_hybrid: Relative improvement percentage of DBSF+ColBERT over hybrid (Recall@10).
+
+    Returns:
+        Conclusion string: one of 'SIGNIFICANTLY OUTPERFORMS', 'MODERATELY OUTPERFORMS',
+        'SLIGHTLY OUTPERFORMS', or 'BASELINE STILL PERFORMS BEST'.
+    """
+    if dbsf_vs_baseline > 10 and dbsf_vs_hybrid > 5:
+        return "SIGNIFICANTLY OUTPERFORMS"
+    if dbsf_vs_baseline > 5:
+        return "MODERATELY OUTPERFORMS"
+    if dbsf_vs_baseline > 0:
+        return "SLIGHTLY OUTPERFORMS"
+    return "BASELINE STILL PERFORMS BEST"
+
+
 def generate_markdown_report(filename: str, data: dict):
     """Generate human-readable markdown report for 3-way comparison."""
     baseline = data["baseline_eval"]["metrics"]
@@ -509,11 +530,13 @@ def generate_markdown_report(filename: str, data: dict):
     dbsf_vs_baseline = comp_dbsf["improvements"]["recall@10"]["relative_improvement_pct"]
     dbsf_vs_hybrid = comp_hybrid_dbsf["improvements"]["recall@10"]["relative_improvement_pct"]
 
-    if dbsf_vs_baseline > 10 and dbsf_vs_hybrid > 5:
+    conclusion_label = determine_conclusion(dbsf_vs_baseline, dbsf_vs_hybrid)
+
+    if conclusion_label == "SIGNIFICANTLY OUTPERFORMS":
         conclusion = "✅ **DBSF+ColBERT SIGNIFICANTLY OUTPERFORMS BOTH BASELINE AND HYBRID**"
-    elif dbsf_vs_baseline > 5:
+    elif conclusion_label == "MODERATELY OUTPERFORMS":
         conclusion = "✅ **DBSF+ColBERT MODERATELY OUTPERFORMS BASELINE**"
-    elif dbsf_vs_baseline > 0:
+    elif conclusion_label == "SLIGHTLY OUTPERFORMS":
         conclusion = "⚠️ **DBSF+ColBERT SLIGHTLY OUTPERFORMS BASELINE**"
     else:
         conclusion = "❌ **BASELINE STILL PERFORMS BEST - INVESTIGATE DBSF+ColBERT IMPLEMENTATION**"

--- a/tests/unit/evaluation/test_evaluate_with_ragas.py
+++ b/tests/unit/evaluation/test_evaluate_with_ragas.py
@@ -1,16 +1,38 @@
 """
-Unit tests for src/evaluation/evaluate_with_ragas.py
+Unit tests for src/evaluation/ragas_evaluation.py
 
-Tests RAGAS evaluation functionality with mocked dependencies.
+Tests RAGAS evaluation helpers and threshold constants.
 """
 
 from __future__ import annotations
 
 import json
+import sys
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+# Mock heavy dependencies before importing the module under test
+_mock_modules = {
+    "datasets": MagicMock(),
+    "openai": MagicMock(),
+    "ragas": MagicMock(),
+    "ragas.dataset_schema": MagicMock(),
+    "ragas.llms": MagicMock(),
+    "ragas.metrics": MagicMock(),
+    "ragas.metrics.collections": MagicMock(),
+}
+
+with patch.dict(sys.modules, _mock_modules):
+    from src.evaluation.ragas_evaluation import (
+        ANSWER_RELEVANCY_THRESHOLD,
+        CONTEXT_PRECISION_THRESHOLD,
+        CONTEXT_RECALL_THRESHOLD,
+        FAITHFULNESS_THRESHOLD,
+        _metric_mean,
+    )
 
 
 # Mock modules using class-scope fixture to avoid test pollution
@@ -30,7 +52,7 @@ def mock_evaluation_imports():
     mock_ragas_metrics = MagicMock()
     mock_search_engines = MagicMock()
 
-    # Setup mock classes — use instances, NOT the MagicMock class itself.
+    # Setup mock classes -- use instances, NOT the MagicMock class itself.
     # Assigning `MagicMock` (the class) then setting `.return_value` on it
     # overwrites the class-level property descriptor and permanently corrupts
     # MagicMock for all subsequent tests in the process.
@@ -172,29 +194,28 @@ class TestEvaluateWithRagas:
                 raise ValueError(f"Unknown engine: {engine_name}")
 
     def test_ragas_score_calculation(self):
-        """Test RAGAS score is average of all metrics."""
+        """Test RAGAS score is average of all metrics using _metric_mean."""
+        # _metric_mean accepts a dict-like object and extracts values by key
         mock_result = {
-            "faithfulness": 0.8,
-            "context_relevancy": 0.7,
-            "answer_relevancy": 0.9,
-            "context_recall": 0.6,
+            "faithfulness": [0.8, 0.9, 0.7],
+            "context_relevancy": [0.7, 0.8, 0.6],
+            "answer_relevancy": [0.9, 0.85, 0.95],
+            "context_recall": [0.6, 0.7, 0.5],
         }
 
-        expected_score = (0.8 + 0.7 + 0.9 + 0.6) / 4
-        calculated_score = (
-            sum(
-                [
-                    mock_result["faithfulness"],
-                    mock_result["context_relevancy"],
-                    mock_result["answer_relevancy"],
-                    mock_result["context_recall"],
-                ]
-            )
-            / 4
-        )
+        faith_mean = _metric_mean(mock_result, "faithfulness")
+        ctx_rel_mean = _metric_mean(mock_result, "context_relevancy")
+        ans_rel_mean = _metric_mean(mock_result, "answer_relevancy")
+        ctx_rec_mean = _metric_mean(mock_result, "context_recall")
 
-        assert abs(calculated_score - expected_score) < 0.001
-        assert calculated_score == 0.75
+        assert faith_mean == pytest.approx(0.8)
+        assert ctx_rel_mean == pytest.approx(0.7)
+        assert ans_rel_mean == pytest.approx(0.9)
+        assert ctx_rec_mean == pytest.approx(0.6)
+
+        # Overall RAGAS score is the average of metric means
+        ragas_score = (faith_mean + ctx_rel_mean + ans_rel_mean + ctx_rec_mean) / 4
+        assert ragas_score == pytest.approx(0.75)
 
     def test_context_extraction_from_results(self):
         """Test contexts are extracted from top 5 results."""
@@ -366,30 +387,34 @@ class TestMetricsExtraction:
     """Tests for metrics extraction from RAGAS results."""
 
     def test_metrics_extraction(self):
-        """Test metrics are extracted and converted to float."""
-        ragas_result = {
-            "faithfulness": 0.85,
-            "context_relevancy": 0.78,
-            "answer_relevancy": 0.92,
-            "context_recall": 0.80,
+        """Test metrics are extracted using _metric_mean."""
+        # _metric_mean works with dict-like objects supporting __getitem__
+        mock_result = {
+            "faithfulness": [0.85],
+            "context_relevancy": [0.78],
+            "answer_relevancy": [0.92],
+            "context_recall": [0.80],
         }
 
-        metrics = {
-            "faithfulness": float(ragas_result["faithfulness"]),
-            "context_relevancy": float(ragas_result["context_relevancy"]),
-            "answer_relevancy": float(ragas_result["answer_relevancy"]),
-            "context_recall": float(ragas_result["context_recall"]),
-        }
+        faith = _metric_mean(mock_result, "faithfulness")
+        ctx_rel = _metric_mean(mock_result, "context_relevancy")
+        ans_rel = _metric_mean(mock_result, "answer_relevancy")
+        ctx_rec = _metric_mean(mock_result, "context_recall")
 
-        assert all(isinstance(v, float) for v in metrics.values())
-        assert metrics["faithfulness"] == 0.85
+        assert isinstance(faith, float)
+        assert faith == pytest.approx(0.85)
+        assert ctx_rel == pytest.approx(0.78)
+        assert ans_rel == pytest.approx(0.92)
+        assert ctx_rec == pytest.approx(0.80)
 
     def test_ragas_score_average(self):
-        """Test RAGAS score is calculated as average."""
-        metrics = [0.8, 0.7, 0.9, 0.6]
-        ragas_score = sum(metrics) / len(metrics)
+        """Test RAGAS score is calculated as average using _metric_mean."""
+        mock_result = {
+            "metric_a": [0.8, 0.7, 0.9, 0.6],
+        }
 
-        assert ragas_score == 0.75
+        mean_val = _metric_mean(mock_result, "metric_a")
+        assert mean_val == pytest.approx(0.75)
 
 
 class TestEnvironmentChecks:
@@ -410,6 +435,21 @@ class TestEnvironmentChecks:
 
             api_key = os.getenv("OPENAI_API_KEY")
             assert api_key == "sk-test123"
+
+    def test_threshold_constants(self):
+        """Test that threshold constants have expected values."""
+        assert FAITHFULNESS_THRESHOLD == 0.80
+        assert CONTEXT_PRECISION_THRESHOLD == 0.80
+        assert CONTEXT_RECALL_THRESHOLD == 0.90
+        assert ANSWER_RELEVANCY_THRESHOLD == 0.80
+
+    def test_metric_above_threshold(self):
+        """Test metric comparison against imported thresholds."""
+        faithfulness_score = 0.85
+        assert faithfulness_score >= FAITHFULNESS_THRESHOLD
+
+        context_recall_score = 0.88
+        assert context_recall_score < CONTEXT_RECALL_THRESHOLD
 
 
 class TestResultsFormat:
@@ -433,6 +473,9 @@ class TestResultsFormat:
         assert "metrics" in result
         assert "num_queries" in result
         assert "ragas_score" in result["metrics"]
+        # Verify metrics exceed thresholds
+        assert result["metrics"]["faithfulness"] >= FAITHFULNESS_THRESHOLD
+        assert result["metrics"]["answer_relevancy"] >= ANSWER_RELEVANCY_THRESHOLD
 
     def test_saved_results_format(self, tmp_path):
         """Test saved results file format."""

--- a/tests/unit/evaluation/test_run_ab_test.py
+++ b/tests/unit/evaluation/test_run_ab_test.py
@@ -1,9 +1,5 @@
 # tests/unit/evaluation/test_run_ab_test.py
-"""Tests for src/evaluation/run_ab_test.py.
-
-Note: The run_ab_test.py module has relative imports that make it difficult to test
-in isolation. These tests focus on the testable parts and skip module-level imports.
-"""
+"""Tests for src/evaluation/run_ab_test.py helper functions."""
 
 import json
 import os
@@ -12,30 +8,16 @@ import tempfile
 import numpy as np
 import pytest
 
+from src.evaluation.run_ab_test import convert_numpy, determine_conclusion, print_metrics
+
 
 class TestConvertNumpy:
-    """Tests for convert_numpy helper function.
-
-    Note: This function is defined inside run_ab_test function,
-    so we test the logic pattern here with a local implementation.
-    """
-
-    def _convert_numpy(self, obj):
-        """Local implementation of convert_numpy for testing."""
-        if isinstance(obj, np.bool_):
-            return bool(obj)
-        if isinstance(obj, (np.integer, np.floating)):
-            return float(obj)
-        if isinstance(obj, dict):
-            return {k: self._convert_numpy(v) for k, v in obj.items()}
-        if isinstance(obj, list):
-            return [self._convert_numpy(item) for item in obj]
-        return obj
+    """Tests for convert_numpy helper function."""
 
     def test_convert_numpy_bool(self):
         """Test numpy bool to Python bool conversion."""
         val = np.bool_(True)
-        result = self._convert_numpy(val)
+        result = convert_numpy(val)
 
         assert result is True
         assert isinstance(result, bool)
@@ -43,7 +25,7 @@ class TestConvertNumpy:
     def test_convert_numpy_int(self):
         """Test numpy int to Python float conversion."""
         val = np.int64(42)
-        result = self._convert_numpy(val)
+        result = convert_numpy(val)
 
         assert result == 42.0
         assert isinstance(result, float)
@@ -51,7 +33,7 @@ class TestConvertNumpy:
     def test_convert_numpy_float(self):
         """Test numpy float to Python float conversion."""
         val = np.float32(3.14)
-        result = self._convert_numpy(val)
+        result = convert_numpy(val)
 
         assert result == pytest.approx(3.14, rel=1e-5)
         assert isinstance(result, float)
@@ -63,7 +45,7 @@ class TestConvertNumpy:
             "int_val": np.int32(10),
             "float_val": np.float64(2.5),
         }
-        result = self._convert_numpy(data)
+        result = convert_numpy(data)
 
         assert result["bool_val"] is False
         assert isinstance(result["int_val"], float)
@@ -72,7 +54,7 @@ class TestConvertNumpy:
     def test_convert_list_with_numpy(self):
         """Test conversion of list with numpy types."""
         data = [np.bool_(True), np.int64(5), np.float32(1.5)]
-        result = self._convert_numpy(data)
+        result = convert_numpy(data)
 
         assert result[0] is True
         assert isinstance(result[1], float)
@@ -81,7 +63,7 @@ class TestConvertNumpy:
     def test_convert_python_types_unchanged(self):
         """Test that Python types are unchanged."""
         data = {"string": "text", "int": 42, "float": 3.14, "bool": True}
-        result = self._convert_numpy(data)
+        result = convert_numpy(data)
 
         assert result == data
 
@@ -92,7 +74,7 @@ class TestConvertNumpy:
                 "inner": [np.int64(1), np.float32(2.0)],
             }
         }
-        result = self._convert_numpy(data)
+        result = convert_numpy(data)
 
         assert result["outer"]["inner"] == [1.0, 2.0]
 
@@ -100,20 +82,7 @@ class TestConvertNumpy:
 class TestPrintMetricsStandalone:
     """Standalone tests for print_metrics output format."""
 
-    def _print_metrics(self, metrics: dict):
-        """Local implementation matching the expected output format."""
-        output = []
-        output.append(f"   Recall@1:  {metrics.get('recall@1', 0):.4f}")
-        output.append(f"   Recall@3:  {metrics.get('recall@3', 0):.4f}")
-        output.append(f"   Recall@5:  {metrics.get('recall@5', 0):.4f}")
-        output.append(f"   Recall@10: {metrics.get('recall@10', 0):.4f}")
-        output.append(f"   MRR:       {metrics.get('mrr', 0):.4f}")
-        output.append(f"   NDCG@10:   {metrics.get('ndcg@10', 0):.4f}")
-        failure_rate = metrics.get("failure_rate", 0)
-        output.append(f"   Failure:   {failure_rate:.4f} ({failure_rate * 100:.1f}%)")
-        return "\n".join(output)
-
-    def test_print_metrics_basic(self):
+    def test_print_metrics_basic(self, capsys):
         """Test print_metrics outputs correct format."""
         metrics = {
             "recall@1": 0.9123,
@@ -125,23 +94,25 @@ class TestPrintMetricsStandalone:
             "failure_rate": 0.0234,
         }
 
-        output = self._print_metrics(metrics)
+        print_metrics(metrics)
+        captured = capsys.readouterr()
 
-        assert "Recall@1:  0.9123" in output
-        assert "Recall@3:  0.9456" in output
-        assert "Recall@10: 0.9890" in output
-        assert "MRR:       0.8765" in output
-        assert "NDCG@10:   0.8543" in output
-        assert "Failure:   0.0234" in output
+        assert "Recall@1:  0.9123" in captured.out
+        assert "Recall@3:  0.9456" in captured.out
+        assert "Recall@10: 0.9890" in captured.out
+        assert "MRR:       0.8765" in captured.out
+        assert "NDCG@10:   0.8543" in captured.out
+        assert "Failure:   0.0234" in captured.out
 
-    def test_print_metrics_missing_values(self):
+    def test_print_metrics_missing_values(self, capsys):
         """Test print_metrics handles missing values."""
         metrics = {}
 
-        output = self._print_metrics(metrics)
+        print_metrics(metrics)
+        captured = capsys.readouterr()
 
-        assert "Recall@1:  0.0000" in output
-        assert "MRR:       0.0000" in output
+        assert "Recall@1:  0.0000" in captured.out
+        assert "MRR:       0.0000" in captured.out
 
 
 class TestMarkdownReportGeneration:
@@ -205,14 +176,7 @@ class TestMarkdownReportGeneration:
         dbsf_vs_baseline = 18.75  # > 10%
         dbsf_vs_hybrid = 8.0  # > 5%
 
-        if dbsf_vs_baseline > 10 and dbsf_vs_hybrid > 5:
-            conclusion = "SIGNIFICANTLY OUTPERFORMS"
-        elif dbsf_vs_baseline > 5:
-            conclusion = "MODERATELY OUTPERFORMS"
-        elif dbsf_vs_baseline > 0:
-            conclusion = "SLIGHTLY OUTPERFORMS"
-        else:
-            conclusion = "BASELINE STILL PERFORMS BEST"
+        conclusion = determine_conclusion(dbsf_vs_baseline, dbsf_vs_hybrid)
 
         assert conclusion == "SIGNIFICANTLY OUTPERFORMS"
 
@@ -221,14 +185,7 @@ class TestMarkdownReportGeneration:
         dbsf_vs_baseline = 7.5  # > 5% but <= 10%
         dbsf_vs_hybrid = 3.0  # <= 5%
 
-        if dbsf_vs_baseline > 10 and dbsf_vs_hybrid > 5:
-            conclusion = "SIGNIFICANTLY OUTPERFORMS"
-        elif dbsf_vs_baseline > 5:
-            conclusion = "MODERATELY OUTPERFORMS"
-        elif dbsf_vs_baseline > 0:
-            conclusion = "SLIGHTLY OUTPERFORMS"
-        else:
-            conclusion = "BASELINE STILL PERFORMS BEST"
+        conclusion = determine_conclusion(dbsf_vs_baseline, dbsf_vs_hybrid)
 
         assert conclusion == "MODERATELY OUTPERFORMS"
 


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Fixes #1625. Evaluation unit tests were asserting local re-implementations of helper functions instead of importing from the actual runtime modules, allowing production code to drift undetected.

## Changes

### Runtime refactoring (`src/evaluation/run_ab_test.py`)
- Extracted `convert_numpy()` from a nested function inside `run_ab_test()` to a module-level function
- Added `import numpy as np` at module top level (was a local import)
- Created `determine_conclusion(dbsf_vs_baseline, dbsf_vs_hybrid) -> str` as a module-level function
- Updated `generate_markdown_report()` to call `determine_conclusion()` instead of inline logic

### Test rewrite (`tests/unit/evaluation/test_run_ab_test.py`)
- Removed local `_convert_numpy` and `_print_metrics` re-implementations
- Imports and tests `convert_numpy`, `print_metrics`, `determine_conclusion` directly from runtime
- Uses `capsys` fixture for `print_metrics` output assertions

### Test rewrite (`tests/unit/evaluation/test_evaluate_with_ragas.py`)
- Fixed docstring to reference `ragas_evaluation.py` (was incorrectly pointing to `evaluate_with_ragas.py`)
- Imports `_metric_mean` and threshold constants from `src.evaluation.ragas_evaluation`
- Rewrote metric tests to call `_metric_mean` directly
- Added threshold constant tests using imported values

## Verification

- Ruff lint: all checks pass
- Targeted tests: 44/44 pass
- Full evaluation suite: 193 pass, 1 skipped (expected, requires eval extra)
- No regressions detected