### PR TITLE
test(crm): tighten empty-task assertion to canonical string (#1626)

### DIFF
--- a/tests/unit/dialogs/test_crm_tasks.py
+++ b/tests/unit/dialogs/test_crm_tasks.py
@@ -207,11 +207,13 @@ def test_task_type_id_from_key_unknown_raises():
 
 
 def test_render_tasks_text_empty():
-    """render_tasks_text returns empty indicator when no tasks."""
+    """render_tasks_text returns the canonical empty-state message when no tasks."""
     from telegram_bot.dialogs.crm_tasks import render_tasks_text
 
     result = render_tasks_text([])
-    assert "нет" in result.lower() or "пуст" in result.lower() or len(result) > 0
+    # Must be exactly the canonical empty-state string. The previous loose
+    # assertion (`len(result) > 0`) accepted any non-empty wrong output.
+    assert result == "Задач нет."
 
 
 def test_render_tasks_text_single_task():


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #1626.

`test_render_tasks_text_empty` accepted any non-empty result via `or len(result) > 0`, so an unrelated wrong message (e.g. `"Что-то пошло не так."`) would still pass. The implementation returns the canonical `"Задач нет."` string for empty task lists at `telegram_bot/dialogs/crm_tasks.py:155-156`.

## Change

Pin the assertion to the exact canonical string.

## Validation

- `uv run pytest tests/unit/dialogs/test_crm_tasks.py` → 24/24 pass.
- TDD sabotage: changing the impl return value to a different non-empty string makes the new assertion fail; restoring it makes it pass.
- `uv run ruff check` → clean.