### PR TITLE
test(integration): drop stale LightRAG health check (#1632)

### DIFF
--- a/tests/integration/test_docker_services.py
+++ b/tests/integration/test_docker_services.py
@@ -85,19 +85,6 @@ async def test_bge_m3_health():
 
 
 @pytest.mark.asyncio
-async def test_lightrag_health():
-    """Test LightRAG service health."""
-    if not _check_tcp("localhost", 9621):
-        pytest.skip("LightRAG not running on localhost:9621")
-
-    import aiohttp
-
-    async with aiohttp.ClientSession() as session:
-        async with session.get("http://localhost:9621/health") as resp:
-            assert resp.status == 200
-
-
-@pytest.mark.asyncio
 async def test_docling_health():
     """Test Docling document parsing service health."""
     if not _check_tcp("localhost", 5001):


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #1632.

`tests/integration/test_docker_services.py::test_lightrag_health` checks `http://localhost:9621/health`, but LightRAG is no longer defined as a Compose service. The probe is permanently skipped and misleads readers about the runtime contract.

## Change

Remove `test_lightrag_health`. Other service health probes (postgres/redis/qdrant/bge-m3/docling) untouched.

## Validation

- `uv run pytest tests/integration/test_docker_services.py --collect-only` → 5 tests collected, lightrag gone.
- `uv run ruff check` → clean.