### PR TITLE
test(load): drop class-level REDIS_URL skip; default in Makefile (#1633)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,7 @@ test-smoke: ## Run smoke tests (requires live services)
 
 test-load-eviction: ## Run Redis eviction tests
 	@echo "$(BLUE)Running Redis eviction tests...$(NC)"
+	REDIS_URL="$${REDIS_URL:-redis://localhost:6379}" \
 	uv run pytest tests/load/test_load_redis_eviction.py -v -s
 	@echo "$(GREEN)✓ Redis eviction tests complete$(NC)"
 

--- a/tests/load/test_load_redis_eviction.py
+++ b/tests/load/test_load_redis_eviction.py
@@ -42,9 +42,17 @@ def _redis_url_candidates() -> list[str]:
     return urls
 
 
-@pytest.mark.skipif(not os.getenv("REDIS_URL"), reason="REDIS_URL not set")
+@pytest.mark.load
 class TestLoadRedisEviction:
-    """Test Redis eviction behavior under load."""
+    """Test Redis eviction behavior under load.
+
+    Reachability is handled by the redis_client fixture below — it tries
+    a TCP probe and several auth fallbacks before skipping. The previous
+    class-level ``@pytest.mark.skipif(not os.getenv("REDIS_URL"), ...)``
+    caused ``make test-load-eviction`` to silently skip when the env var
+    was unset even though a Redis was listening on localhost:6379. See
+    issue #1633.
+    """
 
     @pytest.fixture
     async def redis_client(self):


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #1633.

`tests/load/test_load_redis_eviction.py::TestLoadRedisEviction` had a class-level `@pytest.mark.skipif(not os.getenv("REDIS_URL"), ...)`. Combined with `Makefile:test-load-eviction` not setting `REDIS_URL`, operators running the documented command got 4 silent skips even with Redis reachable on `localhost:6379`.

The `redis_client` fixture already does the right thing: TCP probe → multi-auth fallback (`REDIS_PASSWORD` / `dev_redis_pass` / plain) → fixture-level skip with the actual reason.

## Changes

- `tests/load/test_load_redis_eviction.py`: drop the class-level `skipif`; replace with `@pytest.mark.load` (already registered) and a docstring pointing at the issue.
- `Makefile`: `test-load-eviction` now defaults `REDIS_URL=redis://localhost:6379` so the documented command runs out of the box, while still allowing override.

## Validation

- `unset REDIS_URL; uv run pytest tests/load/test_load_redis_eviction.py` → tests collected (4), skipped at fixture level with `Redis not running on localhost:6379` instead of at class level. Before: collected 0 (class-skip).
- `uv run ruff check` → clean.