### PR TITLE
build(make): truth-up test-all-fast help (#1635)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,8 +225,8 @@ test-fast: ## Run unit tests in parallel (xdist, loadscope)
 	PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/unit/ -n auto -q --timeout=30 -m "not legacy_api"
 	@echo "$(GREEN)✓ Parallel tests complete$(NC)"
 
-test-all-fast: ## Run ALL test suites in parallel (unit + integration + smoke)
-	@echo "$(BLUE)Running all tests in parallel...$(NC)"
+test-all-fast: ## Run unit tests + critical graph-path integration tests in parallel (no smoke; smoke needs live services via 'make test-smoke')
+	@echo "$(BLUE)Running unit + critical graph-path integration tests in parallel...$(NC)"
 	PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/unit/ tests/integration/test_graph_paths.py -n auto -q --timeout=30 -m "not legacy_api"
 	@echo "$(GREEN)✓ All fast tests complete$(NC)"
 


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #1635.

`make test-all-fast` advertised "unit + integration + smoke" in its `##` help, but the actual command runs only `tests/unit/` + `tests/integration/test_graph_paths.py`. Smoke tests require live services and are exposed separately via `make test-smoke`.

## Decision

Align the help with what runs, rather than expanding the command. Folding `tests/smoke/` into a "fast deterministic" target would break the fast/deterministic promise (smoke needs Docker stack up).

## Validation

- `grep -A3 "^test-all-fast" Makefile` confirms the new help and unchanged command.
- No new test runs added; coverage of the target is unchanged.