### PR TITLE
fix(extraction): regex-first hybrid merge so numeric filters survive LLM (#1609)

### DIFF
--- a/telegram_bot/services/apartment_extraction_pipeline.py
+++ b/telegram_bot/services/apartment_extraction_pipeline.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from telegram_bot.observability import observe
 from telegram_bot.services.apartment_filter_extractor import ApartmentFilterExtractor
+from telegram_bot.services.apartment_llm_extractor import merge_extraction_results
 from telegram_bot.services.apartment_models import (
     ApartmentSearchFilters,
     ExtractionMeta,
@@ -42,24 +43,42 @@ class ApartmentExtractionPipeline:
 
     @observe(name="apartment-extraction-pipeline", capture_input=False, capture_output=False)
     async def extract(self, query: str) -> ApartmentSearchFilters:
-        """Main entry point: cache → LLM (primary) → regex (fallback)."""
-        # 1. Check cache
+        """Hybrid extraction: cache → regex (deterministic numeric) → LLM (gap fill) → merge.
+
+        Regex runs first so deterministic numeric filters (rooms, price, area,
+        floor) are never lost even if the LLM mis-extracts them. The regex
+        ``HardFilters`` are forwarded to the LLM as ``partial_filters`` so the
+        LLM only fills gaps. The two results are merged with
+        :func:`merge_extraction_results` (regex wins for numeric, LLM keeps
+        soft preferences and fills missing fields). See issue #1609.
+        """
+        # 1. Cache
         cached = await self._cache_get(query)
         if cached:
             return cached
 
-        # 2. LLM primary
+        # 2. Regex first — deterministic, cheap. Serves as both the numeric
+        #    floor for hybrid merging AND the offline fallback if LLM fails.
+        parsed = self._regex.parse(query)
+        regex_result = self._parsed_to_search_filters(parsed)
+
+        # 3. LLM gap-fill. Pass regex hard filters as partial_filters so the
+        #    LLM does not re-extract what regex already found. Merge results
+        #    so regex numeric values win.
         if self._llm is not None:
             try:
-                result = await self._llm.extract(query=query)
-                await self._cache_set(query, result)
-                return result
+                llm_result = await self._llm.extract(
+                    query=query,
+                    partial_filters=regex_result.hard,
+                )
+                merged = merge_extraction_results(regex_result, llm_result)
+                await self._cache_set(query, merged)
+                return merged
             except Exception:
                 logger.warning("LLM extraction failed, falling back to regex", exc_info=True)
 
-        # 3. Regex fallback
-        parsed = self._regex.parse(query)
-        return self._parsed_to_search_filters(parsed)
+        # 4. Regex-only fallback (no LLM configured or LLM failed).
+        return regex_result
 
     def _parsed_to_search_filters(self, parsed: object) -> ApartmentSearchFilters:
         """Convert legacy ApartmentQueryParseResult to ApartmentSearchFilters."""

--- a/tests/unit/services/test_apartment_extraction_pipeline.py
+++ b/tests/unit/services/test_apartment_extraction_pipeline.py
@@ -68,8 +68,8 @@ class TestPipelineHighConfidence:
 
 
 class TestPipelineMediumConfidence:
-    async def test_llm_called_without_partial_filters(self) -> None:
-        """LLM-first: no partial_filters — LLM extracts from scratch."""
+    async def test_llm_called_with_regex_partial_filters(self) -> None:
+        """Hybrid: regex hard filters are forwarded to LLM as partial_filters (#1609)."""
         regex = _make_regex_extractor("MEDIUM")
         llm_result = _make_filters("HIGH", "llm")
         llm = AsyncMock()
@@ -81,8 +81,12 @@ class TestPipelineMediumConfidence:
         llm.extract.assert_called_once()
         call_kwargs = llm.extract.call_args
         partial = call_kwargs.kwargs.get("partial_filters")
-        assert partial is None
-        assert result.meta.source == "llm"
+        assert partial is not None
+        # Regex extracted city + rooms; both are forwarded.
+        assert partial.city == "Солнечный берег"
+        assert partial.rooms == 2
+        # After merge, source becomes "hybrid" (regex + llm).
+        assert result.meta.source == "hybrid"
 
     async def test_medium_without_llm_returns_regex(self) -> None:
         regex = _make_regex_extractor("MEDIUM")
@@ -95,6 +99,8 @@ class TestPipelineMediumConfidence:
 
 class TestPipelineLowConfidence:
     async def test_low_calls_full_llm_extraction(self) -> None:
+        """Even at LOW regex confidence, regex hard filters are forwarded as
+        partial_filters (#1609); the LLM still does the bulk of extraction."""
         regex = _make_regex_extractor("LOW")
         llm_result = _make_filters("HIGH", "llm")
         llm = AsyncMock()
@@ -105,13 +111,14 @@ class TestPipelineLowConfidence:
         result = await pipeline.extract("хочу квартиру у моря")
 
         llm.extract.assert_called_once()
-        # No partial_filters for LOW confidence
         call_kwargs = llm.extract.call_args
         partial = call_kwargs.kwargs.get("partial_filters") or (
             call_kwargs.args[1] if len(call_kwargs.args) > 1 else None
         )
-        assert partial is None
-        assert result.meta.source == "llm"
+        assert partial is not None
+        # Whatever regex extracted (rooms=2, city) is forwarded.
+        assert partial.rooms == 2
+        assert result.meta.source == "hybrid"
 
     async def test_low_without_llm_returns_regex(self) -> None:
         regex = _make_regex_extractor("LOW")
@@ -195,3 +202,55 @@ class TestExtractionPipelineObservability:
             "ApartmentExtractionPipeline.extract must be decorated with "
             "@observe(name='apartment-extraction-pipeline')"
         )
+
+
+
+class TestRegexWinsForNumeric:
+    """Regression for #1609: numeric fields extracted by regex must win over LLM.
+
+    Before the fix the pipeline returned the LLM result untouched whenever
+    LLM extraction succeeded, so a bad/partial LLM response could silently
+    drop deterministic numeric filters that regex had already extracted.
+    The pipeline must run regex first, pass hard filters to the LLM as
+    partial_filters, and merge results via merge_extraction_results
+    (regex wins for numeric, LLM fills gaps).
+    """
+
+    async def test_pipeline_passes_regex_hard_filters_to_llm(self) -> None:
+        regex = _make_regex_extractor("HIGH")
+        llm_result = _make_filters("HIGH", "llm")
+        llm = AsyncMock()
+        llm.extract = AsyncMock(return_value=llm_result)
+
+        pipeline = ApartmentExtractionPipeline(regex_extractor=regex, llm_extractor=llm)
+        await pipeline.extract("двушка солнечный берег")
+
+        llm.extract.assert_called_once()
+        kwargs = llm.extract.call_args.kwargs
+        partial = kwargs.get("partial_filters")
+        assert partial is not None, (
+            "Pipeline must forward regex-extracted HardFilters as partial_filters"
+        )
+        assert partial.rooms == 2
+        assert partial.city == "Солнечный берег"
+
+    async def test_regex_numeric_wins_when_llm_misextracts(self) -> None:
+        regex = _make_regex_extractor("HIGH")  # rooms=2
+
+        # Simulate LLM mis-extracting rooms=5 + dropping city. Both must
+        # be overridden by the regex result via merge_extraction_results.
+        bad_llm_result = ApartmentSearchFilters(
+            hard=HardFilters(rooms=5, city=None),
+            soft=SoftPreferences(),
+            meta=ExtractionMeta(source="llm", confidence="HIGH"),
+        )
+        llm = AsyncMock()
+        llm.extract = AsyncMock(return_value=bad_llm_result)
+
+        pipeline = ApartmentExtractionPipeline(regex_extractor=regex, llm_extractor=llm)
+        result = await pipeline.extract("двушка солнечный берег")
+
+        # Regex wins for both fields it filled; meta.source becomes "hybrid".
+        assert result.hard.rooms == 2
+        assert result.hard.city == "Солнечный берег"
+        assert result.meta.source == "hybrid"


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #1609.

`ApartmentExtractionPipeline` had a `merge_extraction_results()` helper where regex numeric fields win over LLM, but the success path returned the LLM result untouched. A partial or wrong LLM response could silently drop deterministic numeric filters (rooms, price, area, floor) that regex had already extracted.

## Changes

**`telegram_bot/services/apartment_extraction_pipeline.py`**

1. Run regex first on every uncached query.
2. Forward regex `HardFilters` to the LLM as `partial_filters=...` so the LLM only fills gaps.
3. Merge results via `merge_extraction_results()` — regex wins for numeric; LLM keeps soft preferences and fills missing fields.
4. `meta.source` becomes `"hybrid"` on the merged path.
5. LLM exception path falls back to regex-only as before.

**Tests**

- New `TestRegexWinsForNumeric` covers the regression: a bad LLM extract (`rooms=5, city=None`) is overridden by regex (`rooms=2, city=Солнечный берег`); merged `meta.source == "hybrid"`.
- Updated `TestPipelineMediumConfidence` / `TestPipelineLowConfidence` to assert the new contract — regex hard filters are forwarded to the LLM as `partial_filters`, and merged result is `hybrid`.

## Validation

- TDD: new regression tests fail before the fix, pass after.
- `uv run pytest tests/unit/services/test_apartment_extraction_pipeline.py tests/unit/services/test_apartment_llm_extractor.py tests/unit/services/test_apartment_filter_extractor.py tests/unit/services/test_apartment_extraction_e2e.py tests/unit/handlers/test_demo_e2e.py` → 186 passed.
- `uv run ruff check` → clean.
- `tests/contract/test_span_coverage_contract.py::test_all_observed_spans_accounted_for` is a pre-existing failure on `dev` (unrelated to this change; verified by stash + rerun).

## Out of scope

- Cache key shape unchanged — merged hybrid results are still cached under the same prefix.
- `ApartmentLlmExtractor.extract` already accepted `partial_filters`; no change needed there.