### PR TITLE
fix(filters): make pre-agent FilterExtractor city-alias aware (#1607)

### DIFF
--- a/telegram_bot/services/filter_extractor.py
+++ b/telegram_bot/services/filter_extractor.py
@@ -3,7 +3,11 @@
 import re
 from typing import Any
 
-from telegram_bot.constants.apartment_constants import APARTMENT_CITY_NAMES
+from telegram_bot.constants.apartment_constants import (
+    APARTMENT_CITY_ALIASES,
+    APARTMENT_CITY_ALIASES_SORTED,
+    APARTMENT_CITY_NAMES,
+)
 from telegram_bot.services.base_filter_extractor import BaseFilterExtractor
 
 
@@ -156,9 +160,26 @@ class FilterExtractor(BaseFilterExtractor):
         return None
 
     def _extract_city(self, query: str) -> str | None:
-        """Extract city name."""
+        """Extract city name, normalizing RU morphological forms and EN aliases.
+
+        Aliases are matched longest-first (``APARTMENT_CITY_ALIASES_SORTED``)
+        so phrases like "святом власе" / "sunny beach" resolve to the same
+        canonical city as their full form. Without alias-aware matching the
+        pre-agent semantic-cache filter signature could omit ``city`` for
+        morphologically inflected queries and let cache reuse cross
+        locations (#1607).
+        """
+        query_lower = query.lower()
+
+        # Aliases first (longest match wins)
+        for alias in APARTMENT_CITY_ALIASES_SORTED:
+            if alias in query_lower:
+                return APARTMENT_CITY_ALIASES[alias]
+
+        # Canonical name fallback (covers cities without alias entries:
+        # Несебр, Бургас, Варна, София, Поморие, Созополь).
         for city in APARTMENT_CITY_NAMES:
-            if city.lower() in query.lower():
+            if city.lower() in query_lower:
                 return city
 
         return None

--- a/tests/unit/services/test_filter_extractor.py
+++ b/tests/unit/services/test_filter_extractor.py
@@ -149,6 +149,29 @@ class TestFilterExtractorCity:
         assert _ext.extract_filters(query)["city"] == city
 
     @pytest.mark.parametrize(
+        ("query", "city"),
+        [
+            # Russian morphological forms — were lost from cache signatures (#1607)
+            ("квартира в Святом Власе", "Свети Влас"),
+            ("квартира в святом власе", "Свети Влас"),
+            ("дом на свети власе", "Свети Влас"),
+            ("апартаменты на солнечном берегу", "Солнечный берег"),
+            ("квартира на солнечного берега", "Солнечный берег"),
+            # English aliases
+            ("apartment in sunny beach", "Солнечный берег"),
+            ("villa in elenite", "Элените"),
+            ("санни бич студия", "Солнечный берег"),
+        ],
+    )
+    def test_city_alias_resolves_to_canonical_name(self, query: str, city: str) -> None:
+        """City aliases (RU morphological forms + EN) must resolve to canonical
+        names so semantic-cache filter signatures stay stable across phrasings.
+
+        Regression for #1607.
+        """
+        assert _ext.extract_filters(query)["city"] == city
+
+    @pytest.mark.parametrize(
         "query",
         ["двукомнатная квартира до 50000", "квартира в Пловдив"],
     )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #1607.

`FilterExtractor._extract_city` (used by the pre-agent semantic-cache filter signature path at `telegram_bot/bot.py:778-780`, `2994-3016`) iterated only canonical city names from `APARTMENT_CITY_NAMES`. RU morphological forms and EN aliases were missed, so a query like *"квартира в Святом Власе"* produced a signature with no `city` field — and a filter-sensitive cache could reuse a *Свети Влас* answer for a *Солнечный берег* query (or vice versa).

`ApartmentFilterExtractor` already has alias-aware extraction via `APARTMENT_CITY_ALIASES_SORTED`. This PR moves the same pattern into `FilterExtractor`.

## Changes

- `telegram_bot/services/filter_extractor.py::_extract_city` — match `APARTMENT_CITY_ALIASES_SORTED` first (longest-first, like the apartment extractor), then fall back to canonical names for cities without alias entries (Несебр, Бургас, Варна, София, Поморие, Созополь).
- `tests/unit/services/test_filter_extractor.py::test_city_alias_resolves_to_canonical_name` — parametrized regression covering 8 phrasings: RU morphology (`Святом Власе`, `солнечном берегу`, ...) and EN (`sunny beach`, `elenite`, `санни бич`).

## Validation

- TDD: 7/8 alias parametrizations fail before the fix, all 8 pass after.
- `uv run pytest tests/unit/services/test_filter_extractor.py tests/unit/services/test_apartment_filter_extractor.py` → 165/165 pass.
- `uv run ruff check` → clean.