### PR TITLE
fix(mini-app): surface CRM failures instead of fake-success (#1596)

### DIFF
--- a/mini_app/api.py
+++ b/mini_app/api.py
@@ -132,9 +132,20 @@ async def remote_log(request: dict) -> dict:
 
 
 @app.post("/api/phone")
-async def phone(request: PhoneRequest) -> dict:
-    """Collect phone and create CRM lead."""
-    return await submit_phone(request)
+async def phone(request: PhoneRequest) -> Any:
+    """Collect phone and create CRM lead.
+
+    Returns the same JSON shape as :func:`submit_phone`. On CRM failure
+    (``success=False``) the response is wrapped in a ``502 Bad Gateway``
+    so the frontend can distinguish a captured lead from a dropped one
+    (#1596). Pydantic validation failures continue to surface as ``422``.
+    """
+    from fastapi.responses import JSONResponse
+
+    result = await submit_phone(request)
+    if not result.get("success"):
+        return JSONResponse(status_code=502, content=result)
+    return result
 
 
 @app.get("/health")

--- a/mini_app/phone.py
+++ b/mini_app/phone.py
@@ -37,7 +37,19 @@ def get_kommo_client():
 
 
 async def submit_phone(request: PhoneRequest) -> dict:
-    """Submit phone to CRM."""
+    """Submit phone to CRM.
+
+    Returns
+    -------
+    dict
+        ``{"success": True, "lead_id": <int>}`` on success.
+        ``{"success": False, "lead_id": None, "error": "crm_submission_failed"}``
+        on any CRM failure. Returning ``success: True`` for a swallowed
+        exception (#1596) made it impossible for clients to distinguish a
+        real captured lead from a dropped one. The error code is stable so
+        the frontend can show a retry/contact-support state without parsing
+        free-form text.
+    """
     try:
         client = get_kommo_client()
         contact = await client.upsert_contact(
@@ -51,4 +63,8 @@ async def submit_phone(request: PhoneRequest) -> dict:
         return {"success": True, "lead_id": lead["id"]}
     except Exception:
         logger.exception("CRM submission failed")
-        return {"success": True, "lead_id": None}  # Graceful degradation
+        return {
+            "success": False,
+            "lead_id": None,
+            "error": "crm_submission_failed",
+        }

--- a/tests/unit/mini_app/test_phone.py
+++ b/tests/unit/mini_app/test_phone.py
@@ -44,10 +44,38 @@ async def test_submit_phone_invalid():
 
 
 @pytest.mark.asyncio
-async def test_submit_phone_crm_failure_graceful():
+async def test_submit_phone_crm_failure_returns_error_payload():
+    """CRM failures must surface as success=False so clients can react.
+    Previously every exception was swallowed into success=True, leaving
+    the UI unable to distinguish a real lead from a dropped one (#1596).
+    """
     with patch("mini_app.phone.get_kommo_client", side_effect=Exception("CRM down")):
         result = await submit_phone(PhoneRequest(phone="+359888123456", source="test", user_id=123))
-    assert result == {"success": True, "lead_id": None}
+    assert result["success"] is False
+    assert result["lead_id"] is None
+    assert result.get("error") == "crm_submission_failed"
+
+
+@pytest.mark.asyncio
+async def test_phone_endpoint_returns_502_on_crm_failure():
+    """The /api/phone endpoint must return a non-2xx status (502 Bad Gateway)
+    when the CRM submission fails so the frontend can show a retry/error
+    UI instead of treating the lead as captured (#1596)."""
+    with patch("mini_app.phone.get_kommo_client", side_effect=Exception("CRM down")):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/api/phone",
+                json={
+                    "phone": "+359888123456",
+                    "source": "viewing_consultant",
+                    "user_id": 123,
+                },
+            )
+    assert resp.status_code == 502
+    body = resp.json()
+    assert body["success"] is False
+    assert body["lead_id"] is None
+    assert body.get("error") == "crm_submission_failed"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #1596.

`submit_phone()` caught every exception, logged it, and returned `{"success": True, "lead_id": None}`. The Mini App frontend therefore treated dropped leads as captured — every CRM outage silently lost contact requests.

## Changes

**`mini_app/phone.py`**
- `submit_phone()` now returns `{"success": False, "lead_id": None, "error": "crm_submission_failed"}` on any exception. Stable error code so the frontend can render retry / contact-support UI without parsing free-form text.

**`mini_app/api.py`**
- `/api/phone` returns `502 Bad Gateway` when `success` is `False` (CRM unreachable), preserving `422` for Pydantic validation failures. Frontend can now distinguish:
  - `200` — lead captured
  - `422` — fix the input
  - `502` — retry / contact support

**Tests**
- `test_submit_phone_crm_failure_returns_error_payload` replaces the old `_graceful` test that pinned the bug.
- `test_phone_endpoint_returns_502_on_crm_failure` covers the HTTP contract.

## Validation

- TDD: both new regression tests fail before the fix, pass after.
- `uv run pytest tests/unit/mini_app/` → 39/39 pass.
- `uv run ruff check` → clean.
- `tests/smoke/test_mini_app_api.py` already accepts `200 or 422` for validation; unchanged behavior under the new contract.

## Out of scope

- Auth on Mini App mutation endpoints is tracked separately in #1595.
- Phone normalization via `phonenumbers` is tracked separately in #1614.