### PR TITLE
feat(config): wire LLM_MAX_TOKENS / LLM_TEMPERATURE in GraphConfig.from_env (#1537)

### DIFF
--- a/telegram_bot/graph/config.py
+++ b/telegram_bot/graph/config.py
@@ -113,6 +113,8 @@ class GraphConfig:
                 "LLM_API_KEY", os.getenv("OPENAI_API_KEY", "")
             ),  # LLM_API_KEY preferred
             llm_model=os.getenv("LLM_MODEL", "gpt-4o-mini"),
+            llm_temperature=float(os.getenv("LLM_TEMPERATURE", "0.7")),
+            llm_max_tokens=int(os.getenv("LLM_MAX_TOKENS", "4096")),
             rewrite_model=os.getenv("REWRITE_MODEL", os.getenv("LLM_MODEL", "gpt-4o-mini")),
             rewrite_max_tokens=int(os.getenv("REWRITE_MAX_TOKENS", "64")),
             generate_max_tokens=int(os.getenv("GENERATE_MAX_TOKENS", "1024")),

--- a/tests/unit/graph/test_config.py
+++ b/tests/unit/graph/test_config.py
@@ -26,6 +26,32 @@ class TestGraphConfig:
             cfg = GraphConfig.from_env()
         assert cfg.rewrite_max_tokens == 128
 
+    def test_from_env_llm_max_tokens(self):
+        """Regression for #1537: LLM_MAX_TOKENS must drive llm_max_tokens.
+        Before the fix the field defaulted to 4096 with no env override path."""
+        from telegram_bot.graph.config import GraphConfig
+
+        env = {"LLM_MAX_TOKENS": "2048"}
+        with patch.dict(os.environ, env, clear=True):
+            cfg = GraphConfig.from_env()
+        assert cfg.llm_max_tokens == 2048
+
+    def test_from_env_llm_temperature(self):
+        from telegram_bot.graph.config import GraphConfig
+
+        env = {"LLM_TEMPERATURE": "0.2"}
+        with patch.dict(os.environ, env, clear=True):
+            cfg = GraphConfig.from_env()
+        assert cfg.llm_temperature == 0.2
+
+    def test_from_env_llm_max_tokens_default(self):
+        """When LLM_MAX_TOKENS is unset, the dataclass default (4096) is preserved."""
+        from telegram_bot.graph.config import GraphConfig
+
+        with patch.dict(os.environ, {}, clear=True):
+            cfg = GraphConfig.from_env()
+        assert cfg.llm_max_tokens == 4096
+
     def test_from_env_max_rewrite_attempts(self):
         from telegram_bot.graph.config import GraphConfig
 


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #1537.

The three call-site hardcodes of `max_tokens=4096` cited in the issue (`services/llm.py:145/159/247`) were already replaced with `self.model_max_tokens`. The remaining gap is that `GraphConfig.llm_max_tokens` had no env loader, so operators couldn't actually override it without code changes. Same gap for `llm_temperature`.

## Changes

- `telegram_bot/graph/config.py::GraphConfig.from_env()` now reads:
  - `LLM_MAX_TOKENS` → `llm_max_tokens` (default `4096` preserved)
  - `LLM_TEMPERATURE` → `llm_temperature` (default `0.7` preserved)

## Validation

- `uv run pytest tests/unit/graph/test_config.py` → 34/34 pass.
- New tests:
  - `test_from_env_llm_max_tokens` — `LLM_MAX_TOKENS=2048` ⇒ `llm_max_tokens == 2048`
  - `test_from_env_llm_max_tokens_default` — env empty ⇒ `4096` preserved
  - `test_from_env_llm_temperature` — `LLM_TEMPERATURE=0.2` ⇒ `0.2`
- `uv run ruff check` → clean.