### PR TITLE
perf(bot): bound text-path history saves and drain on shutdown (#1600)

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -13,7 +13,7 @@ import re
 import socket
 import time
 import uuid
-from collections.abc import Awaitable
+from collections.abc import Coroutine
 from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote, urlparse
 
@@ -787,7 +787,7 @@ class PropertyBot:
         self._register_handlers()
 
     def _spawn_history_save(
-        self, coro: Awaitable[None], *, user_id: int | str
+        self, coro: Coroutine[Any, Any, None], *, user_id: int | str
     ) -> asyncio.Task[None] | None:
         """Track and bound fan-out for fire-and-forget history persistence (#1600).
 
@@ -809,15 +809,18 @@ class PropertyBot:
             )
             lf = get_client()
             if lf is not None:
-                tid = lf.get_current_trace_id() or ""
-                if tid:
-                    lf.create_score(
-                        trace_id=tid,
-                        name="history_save_dropped",
-                        value=1,
-                        data_type="BOOLEAN",
-                        score_id=f"{tid}-history_save_dropped",
-                    )
+                try:
+                    tid = lf.get_current_trace_id() or ""
+                    if tid:
+                        lf.create_score(
+                            trace_id=tid,
+                            name="history_save_dropped",
+                            value=1,
+                            data_type="BOOLEAN",
+                            score_id=f"{tid}-history_save_dropped",
+                        )
+                except Exception:
+                    logger.warning("Failed to write history-save drop score", exc_info=True)
             # Close the unscheduled coroutine so we do not leak a "never awaited" warning.
             close = getattr(coro, "close", None)
             if callable(close):

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -13,6 +13,7 @@ import re
 import socket
 import time
 import uuid
+from collections.abc import Awaitable
 from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote, urlparse
 
@@ -762,6 +763,19 @@ class PropertyBot:
         self._polling_lock_task: asyncio.Task[None] | None = None
         self._polling_lock_owner: str | None = None
 
+        # Bounded fan-out for fire-and-forget history persistence (#1600).
+        # Without a bound the text path could accumulate unbounded background
+        # tasks under burst traffic / slow DB writes. Track every spawned save
+        # so shutdown can drain them; reject new saves with a Langfuse signal
+        # once the in-flight count reaches `_history_save_max_concurrency`.
+        self._history_save_tasks: set[asyncio.Task[None]] = set()
+        self._history_save_max_concurrency: int = int(
+            os.getenv("HISTORY_SAVE_MAX_CONCURRENCY", "32")
+        )
+        self._history_save_drain_timeout_s: float = float(
+            os.getenv("HISTORY_SAVE_DRAIN_TIMEOUT_S", "5.0")
+        )
+
         # Track initialization state
         self._cache_initialized = False
         self._pre_agent_filter_extractor: Any | None = None
@@ -771,6 +785,50 @@ class PropertyBot:
 
         # Register handlers
         self._register_handlers()
+
+    def _spawn_history_save(
+        self, coro: Awaitable[None], *, user_id: int | str
+    ) -> asyncio.Task[None] | None:
+        """Track and bound fan-out for fire-and-forget history persistence (#1600).
+
+        Without a bound the text path could accumulate unbounded background
+        tasks under burst traffic / slow DB writes. This helper:
+
+        * rejects the save and logs/scores ``history_save_dropped=1`` once the
+          in-flight count reaches ``_history_save_max_concurrency``;
+        * tracks every spawned task in ``_history_save_tasks`` so ``stop()``
+          can drain them with a bounded timeout.
+
+        Returns the spawned task on success, ``None`` if dropped.
+        """
+        if len(self._history_save_tasks) >= self._history_save_max_concurrency:
+            logger.warning(
+                "history-save fan-out at limit (%d in flight); dropping save for user_id=%s",
+                self._history_save_max_concurrency,
+                user_id,
+            )
+            lf = get_client()
+            if lf is not None:
+                tid = lf.get_current_trace_id() or ""
+                if tid:
+                    lf.create_score(
+                        trace_id=tid,
+                        name="history_save_dropped",
+                        value=1,
+                        data_type="BOOLEAN",
+                        score_id=f"{tid}-history_save_dropped",
+                    )
+            # Close the unscheduled coroutine so we do not leak a "never awaited" warning.
+            close = getattr(coro, "close", None)
+            if callable(close):
+                with contextlib.suppress(Exception):
+                    close()
+            return None
+
+        task = asyncio.create_task(coro, name=f"history-save-{user_id}")
+        self._history_save_tasks.add(task)
+        task.add_done_callback(self._history_save_tasks.discard)
+        return task
 
     def _get_pre_agent_filter_extractor(self) -> Any:
         """Lazily construct the deterministic extractor used on pre-agent semantic misses."""
@@ -3691,7 +3749,7 @@ class PropertyBot:
                     except Exception:
                         logger.warning("Failed to save history turn", exc_info=True)
 
-                asyncio.create_task(_bg_save_history(), name=f"history-save-{user_id}")  # noqa: RUF006
+                self._spawn_history_save(_bg_save_history(), user_id=user_id)
 
         return response_text
 
@@ -5212,6 +5270,28 @@ class PropertyBot:
     async def stop(self):
         """Stop bot and cleanup."""
         logger.info("Stopping bot...")
+        # Drain pending fire-and-forget history saves before tearing services down
+        # so in-flight DB writes are not lost on shutdown (#1600). Bounded by
+        # _history_save_drain_timeout_s so a stuck DB cannot block shutdown.
+        if self._history_save_tasks:
+            in_flight = list(self._history_save_tasks)
+            logger.info("Draining %d in-flight history-save tasks...", len(in_flight))
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*in_flight, return_exceptions=True),
+                    timeout=self._history_save_drain_timeout_s,
+                )
+            except TimeoutError:
+                logger.warning(
+                    "history-save drain timed out after %.1fs; cancelling %d task(s)",
+                    self._history_save_drain_timeout_s,
+                    sum(1 for t in in_flight if not t.done()),
+                )
+                for task in in_flight:
+                    if not task.done():
+                        task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await asyncio.gather(*in_flight, return_exceptions=True)
         if self._miniapp_subscriber_task is not None:
             self._miniapp_subscriber_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/tests/unit/test_bot_history_save_bound.py
+++ b/tests/unit/test_bot_history_save_bound.py
@@ -178,3 +178,30 @@ async def test_drop_when_langfuse_disabled_is_quiet():
 
     blocker.set()
     await asyncio.gather(*bot._history_save_tasks)
+
+
+async def test_drop_when_langfuse_score_write_fails_is_quiet():
+    """Langfuse failures on drop telemetry must not break the text path."""
+    bot = _make_bot(max_concurrency=1)
+    blocker = asyncio.Event()
+
+    async def slow_coro():
+        await blocker.wait()
+
+    bot._spawn_history_save(slow_coro(), user_id="a")
+
+    mock_lf = MagicMock()
+    mock_lf.get_current_trace_id.return_value = "trace-xyz"
+    mock_lf.create_score.side_effect = RuntimeError("langfuse unavailable")
+
+    with patch("telegram_bot.bot.get_client", return_value=mock_lf):
+
+        async def coro2():
+            await asyncio.sleep(0)
+
+        result = bot._spawn_history_save(coro2(), user_id="b")
+
+    assert result is None
+
+    blocker.set()
+    await asyncio.gather(*bot._history_save_tasks)

--- a/tests/unit/test_bot_history_save_bound.py
+++ b/tests/unit/test_bot_history_save_bound.py
@@ -1,0 +1,180 @@
+"""Tests for #1600: bounded fan-out for fire-and-forget history saves.
+
+The bot's text path used to call ``asyncio.create_task(...)`` for every
+``_bg_save_history`` invocation with no concurrency cap and no shutdown
+drain. This file pins the new contract on ``PropertyBot._spawn_history_save``:
+
+* tasks are tracked in ``_history_save_tasks`` and removed on completion
+  via ``add_done_callback``;
+* once the in-flight count hits ``_history_save_max_concurrency``, new
+  saves are dropped (coro is closed, no leak) and a Langfuse score
+  ``history_save_dropped=1`` is emitted;
+* ``stop()`` drains pending saves with a bounded timeout.
+
+Tests use a minimal ``PropertyBot`` shape via ``object.__new__`` to avoid
+the full constructor (which wires aiogram, Redis, Postgres, etc.) — only
+the subset relevant to the helper is initialised.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_bot(*, max_concurrency: int = 32, drain_timeout: float = 0.5) -> Any:
+    """Build a minimal PropertyBot with only the history-save fields."""
+    from telegram_bot.bot import PropertyBot
+
+    bot = object.__new__(PropertyBot)
+    bot._history_save_tasks = set()
+    bot._history_save_max_concurrency = max_concurrency
+    bot._history_save_drain_timeout_s = drain_timeout
+    bot._miniapp_subscriber_task = None
+    bot._polling_lock_task = None
+    bot._polling_lock = None
+    bot._polling_lock_owner = None
+    return bot
+
+
+async def test_spawn_tracks_task_and_removes_on_completion():
+    bot = _make_bot()
+
+    completed = asyncio.Event()
+
+    async def coro():
+        completed.set()
+
+    task = bot._spawn_history_save(coro(), user_id=42)
+    assert task is not None
+    assert task in bot._history_save_tasks
+
+    await asyncio.wait_for(completed.wait(), timeout=1.0)
+    await task
+
+    # Done-callback runs in the loop's next pass; yield once so it fires.
+    await asyncio.sleep(0)
+    assert task not in bot._history_save_tasks
+
+
+async def test_spawn_drops_save_at_concurrency_limit():
+    bot = _make_bot(max_concurrency=2)
+
+    blocker = asyncio.Event()
+
+    async def slow_coro():
+        await blocker.wait()
+
+    # Saturate the limit with two pending tasks.
+    t1 = bot._spawn_history_save(slow_coro(), user_id="a")
+    t2 = bot._spawn_history_save(slow_coro(), user_id="b")
+    assert t1 is not None and t2 is not None
+    assert len(bot._history_save_tasks) == 2
+
+    # Third save must be dropped — coro is closed, no leak.
+    closed = False
+
+    async def third_coro():
+        nonlocal closed
+        try:
+            await asyncio.sleep(10)
+        finally:
+            closed = True
+
+    third = third_coro()
+    result = bot._spawn_history_save(third, user_id="c")
+    assert result is None
+    assert len(bot._history_save_tasks) == 2
+
+    # The dropped coroutine must have been .close()'d so we don't leak.
+    # Verify by trying to send into it: it should raise.
+    with pytest.raises((StopIteration, RuntimeError)):
+        third.send(None)
+
+    blocker.set()
+    await asyncio.gather(t1, t2)
+
+
+async def test_drop_emits_langfuse_dropped_score():
+    bot = _make_bot(max_concurrency=1)
+
+    blocker = asyncio.Event()
+
+    async def slow_coro():
+        await blocker.wait()
+
+    bot._spawn_history_save(slow_coro(), user_id="a")
+
+    mock_lf = MagicMock()
+    mock_lf.get_current_trace_id.return_value = "trace-xyz"
+
+    with patch("telegram_bot.bot.get_client", return_value=mock_lf):
+
+        async def dropped_coro():
+            await asyncio.sleep(0)
+
+        result = bot._spawn_history_save(dropped_coro(), user_id="b")
+    assert result is None
+
+    mock_lf.create_score.assert_called_once()
+    call_kwargs = mock_lf.create_score.call_args.kwargs
+    assert call_kwargs["name"] == "history_save_dropped"
+    assert call_kwargs["value"] == 1
+    assert call_kwargs["data_type"] == "BOOLEAN"
+    assert call_kwargs["trace_id"] == "trace-xyz"
+
+    blocker.set()
+    await asyncio.gather(*bot._history_save_tasks)
+
+
+async def test_drop_without_active_trace_does_not_raise():
+    """Dropped saves must not crash when no Langfuse trace is active."""
+    bot = _make_bot(max_concurrency=1)
+    blocker = asyncio.Event()
+
+    async def slow_coro():
+        await blocker.wait()
+
+    bot._spawn_history_save(slow_coro(), user_id="a")
+
+    mock_lf = MagicMock()
+    mock_lf.get_current_trace_id.return_value = ""
+
+    with patch("telegram_bot.bot.get_client", return_value=mock_lf):
+
+        async def coro2():
+            await asyncio.sleep(0)
+
+        result = bot._spawn_history_save(coro2(), user_id="b")
+
+    assert result is None
+    mock_lf.create_score.assert_not_called()
+
+    blocker.set()
+    await asyncio.gather(*bot._history_save_tasks)
+
+
+async def test_drop_when_langfuse_disabled_is_quiet():
+    """No Langfuse client → no score emission, no exception."""
+    bot = _make_bot(max_concurrency=1)
+    blocker = asyncio.Event()
+
+    async def slow_coro():
+        await blocker.wait()
+
+    bot._spawn_history_save(slow_coro(), user_id="a")
+
+    with patch("telegram_bot.bot.get_client", return_value=None):
+
+        async def coro2():
+            await asyncio.sleep(0)
+
+        result = bot._spawn_history_save(coro2(), user_id="b")
+
+    assert result is None
+
+    blocker.set()
+    await asyncio.gather(*bot._history_save_tasks)


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Closes #1600.

## Problem

`PropertyBot` text path called `asyncio.create_task(_bg_save_history(), ...)` per response with no concurrency cap and no shutdown drain. Under burst traffic / slow DB writes the bot could accumulate unbounded background tasks, increasing memory pressure, hiding backlog/failure signals, and dropping in-flight writes on `stop()`.

## Fix

- `PropertyBot._spawn_history_save()` helper:
  - tracks every spawned task in `_history_save_tasks` and removes it on completion via `add_done_callback`;
  - rejects new saves once `len(...) >= HISTORY_SAVE_MAX_CONCURRENCY` (default 32) — coro is `.close()`'d so no "never awaited" warning;
  - emits Langfuse `history_save_dropped=1` score when an active trace exists, so backlog is observable.
- `stop()` drains pending saves with bounded `HISTORY_SAVE_DRAIN_TIMEOUT_S` (default 5s); cancels stragglers if the timeout elapses.
- Both knobs configurable via env.

## Tests

`tests/unit/test_bot_history_save_bound.py` covers the new helper:
- spawn tracks task / removes on completion;
- spawn drops at concurrency limit + closes coroutine (no leak);
- drop emits Langfuse `history_save_dropped` score;
- drop without active trace does not raise;
- drop without Langfuse client is quiet.

`uv run pytest tests/unit/test_bot_history_save_bound.py tests/unit/test_bot_handlers.py` — all green.
