### PR TITLE
fix(smoke): add redis_url fixture + use HumanMessage dot notation (#1766)

### DIFF
--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -13,6 +13,20 @@ from telegram_bot.services.qdrant import QdrantService
 
 
 @pytest.fixture(scope="module")
+def redis_url() -> str:
+    """Redis URL for smoke tests, with REDIS_PASSWORD injected if not embedded.
+
+    Mirrors `scripts/validate_traces.py::_build_redis_url` so smoke tests work
+    against Compose dev defaults (auth-required Redis) without per-test plumbing.
+    """
+    base = os.getenv("REDIS_URL", "redis://localhost:6379")
+    password = os.getenv("REDIS_PASSWORD", "")
+    if password and "@" not in base:
+        base = base.replace("redis://", f"redis://:{password}@", 1)
+    return base
+
+
+@pytest.fixture(scope="module")
 def require_live_services(request):
     """Skip if live services not available. Checks BOTH Qdrant AND Redis."""
     qdrant_url = os.getenv("QDRANT_URL", "http://localhost:6333")

--- a/tests/smoke/test_langgraph_smoke.py
+++ b/tests/smoke/test_langgraph_smoke.py
@@ -46,7 +46,7 @@ async def test_initial_state_has_required_keys():
     assert required.issubset(state.keys())
     assert state["user_id"] == 123
     assert state["session_id"] == "smoke-abc-20260209"
-    assert state["messages"][0]["content"] == "test"
+    assert state["messages"][0].content == "test"
 
 
 @pytest.mark.smoke

--- a/tests/smoke/test_smoke_fixtures.py
+++ b/tests/smoke/test_smoke_fixtures.py
@@ -1,0 +1,72 @@
+# tests/smoke/test_smoke_fixtures.py
+"""Regression locks for tests/smoke/conftest.py contracts (#1766).
+
+These run without live services: they verify the fixture contract itself
+and the SDK-native message access pattern, so the smoke tier does not
+silently regress to fixture-not-found errors or HumanMessage subscript bugs.
+"""
+
+import pytest
+
+
+@pytest.mark.smoke
+def test_redis_url_fixture_is_provided(redis_url: str) -> None:
+    """Smoke conftest must expose a `redis_url` fixture.
+
+    Regression for #1766: `require_live_services` and `cache_service`
+    consume `redis_url` via `request.getfixturevalue("redis_url")`. Before
+    the fix, no `redis_url` fixture existed anywhere in the test tree, so
+    smoke runs errored at fixture resolution.
+    """
+    assert isinstance(redis_url, str)
+    assert redis_url.startswith(("redis://", "rediss://"))
+
+
+@pytest.mark.smoke
+def test_redis_url_fixture_injects_password(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`redis_url` mirrors `_build_redis_url`: injects REDIS_PASSWORD if not embedded."""
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+    monkeypatch.setenv("REDIS_PASSWORD", "topsecret")
+
+    # Reimport / recompute by calling the fixture function directly.
+    from tests.smoke.conftest import redis_url as redis_url_fixture
+
+    # Module-scoped pytest fixtures are wrapped; reach the underlying function.
+    func = getattr(redis_url_fixture, "__wrapped__", redis_url_fixture)
+    url = func() if callable(func) else None
+    assert url == "redis://:topsecret@localhost:6379", url
+
+
+@pytest.mark.smoke
+def test_redis_url_fixture_preserves_explicit_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`redis_url` does not double-inject credentials when URL already has @."""
+    monkeypatch.setenv("REDIS_URL", "redis://:already@host:6379")
+    monkeypatch.setenv("REDIS_PASSWORD", "ignored")
+
+    from tests.smoke.conftest import redis_url as redis_url_fixture
+
+    func = getattr(redis_url_fixture, "__wrapped__", redis_url_fixture)
+    url = func() if callable(func) else None
+    assert url == "redis://:already@host:6379", url
+
+
+@pytest.mark.smoke
+def test_initial_state_message_uses_dot_notation() -> None:
+    """`state["messages"][0]` is a HumanMessage; access content via attribute (#1766).
+
+    LangChain SDK contract (per langgraph graph-api docs): when state uses
+    `add_messages`, messages are deserialized to BaseMessage objects and
+    must be read with dot notation, not dict subscript.
+    """
+    from langchain_core.messages import HumanMessage
+
+    from telegram_bot.graph.state import make_initial_state
+
+    state = make_initial_state(user_id=1, session_id="s", query="hello")
+    assert isinstance(state["messages"][0], HumanMessage)
+    assert state["messages"][0].content == "hello"
+
+    # Subscript must remain unsupported — protect against accidental
+    # reintroduction of dict-style access in tests.
+    with pytest.raises(TypeError):
+        _ = state["messages"][0]["content"]  # type: ignore[index]


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Closes #1766 (P0 smoke failures section).

## Problem

`make test-smoke` errored with two distinct P0 failures:

1. **Missing `redis_url` fixture.** `tests/smoke/conftest.py` calls `request.getfixturevalue("redis_url")` in both `require_live_services` and `cache_service`, but no `redis_url` fixture was defined anywhere in the test tree. Every smoke run failed at fixture resolution before any service check ran.
2. **HumanMessage subscript bug.** `tests/smoke/test_langgraph_smoke.py::test_initial_state_has_required_keys` asserted `state["messages"][0]["content"] == "test"`, but `make_initial_state` returns `HumanMessage(content=...)` (a Pydantic v2 `BaseModel` — not subscriptable). The assertion raised `TypeError`.

## Fix

- **`tests/smoke/conftest.py`** — add module-scoped `redis_url` fixture mirroring `scripts/validate_traces.py::_build_redis_url`: injects `REDIS_PASSWORD` only when the URL has no embedded credentials. Module scope matches the consumers (`require_live_services`, `cache_service` are also module-scoped).
- **`tests/smoke/test_langgraph_smoke.py`** — read `HumanMessage.content` via dot notation, per the LangGraph graph-api SDK contract that `add_messages` always deserializes to `BaseMessage` objects (Context7-confirmed).
- **`tests/smoke/test_smoke_fixtures.py`** *(new)* — regression locks. Three fixture-contract assertions (default URL, `REDIS_PASSWORD` injection, explicit-creds preservation) plus a dot-vs-subscript lock on `HumanMessage`. Runs without live services.

## Verification

- `uvx ruff check` and `uvx ruff format --check` clean across the three touched files.
- Standalone exec of the fixture function (loaded via `importlib` to bypass heavy bot imports) returns the expected three branches:
  - default → `redis://localhost:6379`
  - `REDIS_PASSWORD` set → `redis://:topsecret@localhost:6379`
  - URL already has `@` → preserved unchanged
- `HumanMessage(content="x").content == "x"`; subscript still raises `TypeError` (lock holds).

## Out of scope

Other items from #1766 ship as follow-ups so this PR stays scoped to the P0 unblock:
- Tighten broad `ignore::DeprecationWarning` filters
- Nightly coverage gate enforcement
- Smoke-readiness docs (.env, Redis auth, Qdrant seed data)