### PR TITLE
chore(deps): make voyageai optional before Python 3.14 migration (#1773)

### DIFF
--- a/docs/engineering/sdk-registry.md
+++ b/docs/engineering/sdk-registry.md
@@ -358,17 +358,22 @@ paths: "telegram_bot/**,src/**,mini_app/**,pyproject.toml"
   - Keep model choice and retry policy local to contextualization path
 
 ## voyageai
+- **status:** **OPTIONAL EXTRA** (#1773). Not used by the default bot/retrieval runtime (BGE-M3 + Qdrant). Install via `uv sync --extra voyage`.
 - **triggers:** rerank, embedding, voyage, ColBERT, contextualized embedding
 - **context7_id:** /voyage-ai/voyageai-python
 - **как_у_нас:**
-  - `telegram_bot/services/voyage.py` — reranking service
-  - `src/models/contextualized_embedding.py` — contextualized late-interaction embeddings
+  - `telegram_bot/services/voyage.py` — reranking service (legacy/optional)
+  - `src/models/contextualized_embedding.py` — contextualized late-interaction embeddings (`USE_CONTEXTUALIZED_EMBEDDINGS=true` only)
+  - `src/ingestion/unified/qdrant_writer.py` — optional dense provider when `use_local_embeddings=False`
+  - `src/ingestion/gdrive_indexer.py` — legacy GDrive ingestion (deprecated)
 - **паттерны:**
   - `voyageai.Client()` для sync, lazy import (тяжёлые deps: pandas, scipy)
   - Rerank: `client.rerank(query, documents, model="rerank-2")`
+  - Lazy import ОБЯЗАТЕЛЬНО (#1773): `import voyageai` / `from telegram_bot.services import VoyageService` only inside the function/method that needs it.
 - **gotchas:**
   - Тяжёлый import (pandas, scipy.stats) — lazy import ОБЯЗАТЕЛЬНО
-  - НЕ импортировать на top-level в модулях бота (замедляет старт)
+  - НЕ импортировать на top-level в модулях бота (замедляет старт + ломает Python 3.14 base test collection из-за Pydantic V1 моделей)
+  - Voyage-зависимые тесты помечены `pytest.importorskip("voyageai") + @pytest.mark.requires_extras` и пропускаются в core tier.
 
 ## anthropic
 - **triggers:** Claude, Anthropic, contextualization, claude judge

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,9 @@ dependencies = [
     "requests",
     "qdrant-client>=1.17.1",  # Vector database client (v1.17+ for weighted RRF, relevance feedback)
     "langfuse>=4.0.0,<5.0",  # Native v4 observability migration
-    # Voyage AI Integration (2026-01-21)
-    "voyageai>=0.3.0",        # Voyage AI embeddings and reranking
+    # Voyage AI is OPTIONAL (#1773): not used by default bot/retrieval runtime.
+    # Install via `uv sync --extra voyage` only for legacy GDrive ingestion or
+    # contextualized-embedding paths.
     "tenacity>=8.2.0",        # Retry logic with exponential backoff
     "redis>=7.1.0",
     "redisvl>=0.16.0",
@@ -102,9 +103,17 @@ eval = [
     "pandas>=2.0.0",
 ]
 
+# Voyage AI (#1773) — optional. Not used by the default BGE-M3 + Qdrant
+# runtime. Required only for legacy GDrive ingestion, contextualized
+# embeddings, or the optional Voyage path in
+# `src/ingestion/unified/qdrant_writer.py` (`use_local_embeddings=False`).
+voyage = [
+    "voyageai>=0.3.0",
+]
+
 # All optional dependencies
 all = [
-    "contextual-rag[docs,voice,eval,ingest,ml-local]",
+    "contextual-rag[docs,voice,eval,ingest,ml-local,voyage]",
 ]
 
 # =============================================================================

--- a/src/ingestion/gdrive_indexer.py
+++ b/src/ingestion/gdrive_indexer.py
@@ -28,7 +28,6 @@ from qdrant_client.models import (
 )
 
 from src.ingestion.chunker import Chunk
-from telegram_bot.services import VoyageService
 
 
 warnings.warn(
@@ -98,7 +97,11 @@ class GDriveIndexer:
         else:
             self.client = QdrantClient(url=self.qdrant_url, timeout=120)
 
-        # Voyage AI for dense embeddings
+        # Voyage AI for dense embeddings.
+        # Lazy import (#1773): voyageai is an optional extra and must not
+        # be imported by the default ingestion path.
+        from telegram_bot.services import VoyageService
+
         self.voyage_service = VoyageService(
             api_key=self.voyage_api_key,
             model_docs=voyage_model,

--- a/src/ingestion/unified/qdrant_writer.py
+++ b/src/ingestion/unified/qdrant_writer.py
@@ -19,7 +19,6 @@ from qdrant_client.models import (
 
 from src.ingestion.unified.observability import observe, try_update_ingestion_trace
 from src.retrieval.topic_classifier import classify_chunk_topic, classify_doc_type
-from telegram_bot.services import VoyageService
 
 
 logger = logging.getLogger(__name__)
@@ -98,6 +97,10 @@ class QdrantHybridWriter:
         else:
             if not voyage_api_key:
                 raise ValueError("voyage_api_key is required when use_local_embeddings=False")
+            # Lazy import (#1773): voyageai is an optional extra and must not
+            # be imported by the default ingestion path.
+            from telegram_bot.services import VoyageService
+
             self.voyage = VoyageService(
                 api_key=voyage_api_key,
                 model_docs=voyage_model,

--- a/src/models/contextualized_embedding.py
+++ b/src/models/contextualized_embedding.py
@@ -20,18 +20,33 @@ import logging
 from dataclasses import dataclass
 from typing import Literal
 
-import voyageai
 from langfuse import get_client, observe
 from tenacity import (
     before_sleep_log,
     retry,
-    retry_if_exception_type,
+    retry_if_exception,
     stop_after_attempt,
     wait_random_exponential,
 )
 
 
 logger = logging.getLogger(__name__)
+
+
+# Voyage AI is loaded lazily (#1773): the package is an optional extra and
+# must not be imported at module load time. We retry on transient Voyage SDK
+# errors by exception class name so the retry decorators do not need
+# `voyageai.error.*` imports.
+_VOYAGE_RETRYABLE_ERRORS = frozenset({"RateLimitError", "ServiceUnavailableError", "Timeout"})
+
+
+def _is_voyage_retryable(exc: BaseException) -> bool:
+    """Return True for transient Voyage SDK errors, by exception class name."""
+    name = type(exc).__name__
+    if name not in _VOYAGE_RETRYABLE_ERRORS:
+        return False
+    module = type(exc).__module__ or ""
+    return module.startswith("voyageai")
 
 
 @dataclass
@@ -103,6 +118,11 @@ class ContextualizedEmbeddingService:
                 f"Invalid output_dimension {output_dimension}. Supported: {self.SUPPORTED_DIMS}"
             )
 
+        # Lazy import (#1773): voyageai is an optional extra. Importing here
+        # keeps `import src.models.contextualized_embedding` cheap and lets
+        # default runtime ignore the dependency.
+        import voyageai
+
         self._client = voyageai.Client(api_key=api_key)
         self._output_dimension = output_dimension
         self._output_dtype = output_dtype
@@ -119,13 +139,7 @@ class ContextualizedEmbeddingService:
 
     @observe(name="voyage-contextualized-embed-documents", as_type="generation")
     @retry(
-        retry=retry_if_exception_type(
-            (
-                voyageai.error.RateLimitError,
-                voyageai.error.ServiceUnavailableError,
-                voyageai.error.Timeout,
-            )
-        ),
+        retry=retry_if_exception(_is_voyage_retryable),
         wait=wait_random_exponential(multiplier=1, max=60),
         stop=stop_after_attempt(6),
         before_sleep=before_sleep_log(logger, logging.WARNING),
@@ -214,13 +228,7 @@ class ContextualizedEmbeddingService:
 
     @observe(name="voyage-contextualized-embed-query", as_type="generation")
     @retry(
-        retry=retry_if_exception_type(
-            (
-                voyageai.error.RateLimitError,
-                voyageai.error.ServiceUnavailableError,
-                voyageai.error.Timeout,
-            )
-        ),
+        retry=retry_if_exception(_is_voyage_retryable),
         wait=wait_random_exponential(multiplier=1, max=60),
         stop=stop_after_attempt(6),
         before_sleep=before_sleep_log(logger, logging.WARNING),
@@ -267,13 +275,7 @@ class ContextualizedEmbeddingService:
 
     @observe(name="voyage-contextualized-embed-queries", as_type="generation")
     @retry(
-        retry=retry_if_exception_type(
-            (
-                voyageai.error.RateLimitError,
-                voyageai.error.ServiceUnavailableError,
-                voyageai.error.Timeout,
-            )
-        ),
+        retry=retry_if_exception(_is_voyage_retryable),
         wait=wait_random_exponential(multiplier=1, max=60),
         stop=stop_after_attempt(6),
         before_sleep=before_sleep_log(logger, logging.WARNING),

--- a/telegram_bot/pyproject.toml
+++ b/telegram_bot/pyproject.toml
@@ -12,7 +12,8 @@ dependencies = [
     "grpcio>=1.60.0",
     "redis>=5.0.0",
     "redisvl>=0.3.0",
-    "voyageai>=0.3.0",
+    # Voyage AI is OPTIONAL (#1773): not used by default bot/retrieval runtime.
+    # Install via `uv sync --extra voyage` only for legacy ingestion paths.
     "tenacity>=8.2.0",
     "cachetools>=5.3.0",
     "python-dotenv>=1.0.0",
@@ -34,6 +35,14 @@ dependencies = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["telegram_bot"]
+
+[project.optional-dependencies]
+# Voyage AI (#1773) — optional. Only required for legacy GDrive ingestion,
+# contextualized-embedding paths, or `qdrant_writer` with
+# `use_local_embeddings=False`. Default bot/retrieval runtime does not use it.
+voyage = [
+    "voyageai>=0.3.0",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/telegram_bot/requirements.txt
+++ b/telegram_bot/requirements.txt
@@ -11,8 +11,8 @@ qdrant-client>=1.14.0
 redis>=5.0.0
 redisvl>=0.3.0
 
-# Voyage AI (embeddings, reranking)
-voyageai>=0.3.0
+# Voyage AI is OPTIONAL (#1773); install via `uv sync --extra voyage`.
+# Not used by the default BGE-M3 + Qdrant runtime.
 tenacity>=8.2.0
 
 # FastEmbed for sparse vectors (BM42)

--- a/telegram_bot/uv.lock
+++ b/telegram_bot/uv.lock
@@ -2067,6 +2067,10 @@ dependencies = [
     { name = "redis" },
     { name = "redisvl" },
     { name = "tenacity" },
+]
+
+[package.optional-dependencies]
+voyage = [
     { name = "voyageai" },
 ]
 
@@ -2097,8 +2101,9 @@ requires-dist = [
     { name = "redis", specifier = ">=5.0.0" },
     { name = "redisvl", specifier = ">=0.3.0" },
     { name = "tenacity", specifier = ">=8.2.0" },
-    { name = "voyageai", specifier = ">=0.3.0" },
+    { name = "voyageai", marker = "extra == 'voyage'", specifier = ">=0.3.0" },
 ]
+provides-extras = ["voyage"]
 
 [[package]]
 name = "redis"

--- a/tests/integration/test_contextualized_pipeline.py
+++ b/tests/integration/test_contextualized_pipeline.py
@@ -7,8 +7,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.unit.helpers.voyage import skip_if_voyageai_unusable
 
-pytest.importorskip("voyageai", reason="voyageai not installed (#1773 voyage extra)")
+
+skip_if_voyageai_unusable()
 pytestmark = pytest.mark.requires_extras
 
 

--- a/tests/integration/test_contextualized_pipeline.py
+++ b/tests/integration/test_contextualized_pipeline.py
@@ -8,6 +8,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+pytest.importorskip("voyageai", reason="voyageai not installed (#1773 voyage extra)")
+pytestmark = pytest.mark.requires_extras
+
+
 class TestContextualizedEmbeddingService:
     """Tests for ContextualizedEmbeddingService initialization and configuration."""
 

--- a/tests/unit/helpers/voyage.py
+++ b/tests/unit/helpers/voyage.py
@@ -1,0 +1,19 @@
+"""Test helpers for optional Voyage AI dependencies."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def skip_if_voyageai_unusable() -> None:
+    """Skip tests when the optional voyageai extra cannot be imported.
+
+    Under Python 3.14 the currently pinned voyageai package can raise a
+    Pydantic V1 ``ValueError`` during import, not just ``ImportError``.
+    """
+    try:
+        importlib.import_module("voyageai")
+    except Exception as exc:
+        pytest.skip(f"voyageai optional extra unusable: {exc!r}", allow_module_level=True)

--- a/tests/unit/models/test_contextualized_pipeline.py
+++ b/tests/unit/models/test_contextualized_pipeline.py
@@ -7,8 +7,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.unit.helpers.voyage import skip_if_voyageai_unusable
 
-pytest.importorskip("voyageai", reason="voyageai not installed (#1773 voyage extra)")
+
+skip_if_voyageai_unusable()
 pytestmark = pytest.mark.requires_extras
 
 

--- a/tests/unit/models/test_contextualized_pipeline.py
+++ b/tests/unit/models/test_contextualized_pipeline.py
@@ -8,6 +8,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+pytest.importorskip("voyageai", reason="voyageai not installed (#1773 voyage extra)")
+pytestmark = pytest.mark.requires_extras
+
+
 class TestContextualizedEmbeddingService:
     """Tests for ContextualizedEmbeddingService initialization and configuration."""
 

--- a/tests/unit/services/test_voyage_observability.py
+++ b/tests/unit/services/test_voyage_observability.py
@@ -4,8 +4,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.unit.helpers.voyage import skip_if_voyageai_unusable
 
-pytest.importorskip("voyageai", reason="voyageai not installed (#1773 voyage extra)")
+
+skip_if_voyageai_unusable()
 pytestmark = pytest.mark.requires_extras
 
 

--- a/tests/unit/services/test_voyage_observability.py
+++ b/tests/unit/services/test_voyage_observability.py
@@ -5,6 +5,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+pytest.importorskip("voyageai", reason="voyageai not installed (#1773 voyage extra)")
+pytestmark = pytest.mark.requires_extras
+
+
 class TestVoyageServiceObservability:
     """Test VoyageService has @observe decorators."""
 

--- a/tests/unit/test_contextualized_embeddings.py
+++ b/tests/unit/test_contextualized_embeddings.py
@@ -14,8 +14,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.unit.helpers.voyage import skip_if_voyageai_unusable
 
-pytest.importorskip("voyageai", reason="voyageai not installed (#1773 voyage extra)")
+
+skip_if_voyageai_unusable()
 pytestmark = pytest.mark.requires_extras
 
 import voyageai

--- a/tests/unit/test_contextualized_embeddings.py
+++ b/tests/unit/test_contextualized_embeddings.py
@@ -13,6 +13,11 @@ import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+pytest.importorskip("voyageai", reason="voyageai not installed (#1773 voyage extra)")
+pytestmark = pytest.mark.requires_extras
+
 import voyageai
 
 

--- a/tests/unit/test_voyage_optional_imports.py
+++ b/tests/unit/test_voyage_optional_imports.py
@@ -1,0 +1,152 @@
+# tests/unit/test_voyage_optional_imports.py
+"""Regression locks: voyageai must remain optional (#1773).
+
+These tests prove that the default bot/retrieval/ingestion runtime does NOT
+import `voyageai` at module load time. Voyage is an optional extra; importing
+it eagerly under Python 3.14 breaks base test collection (`voyageai` ships
+Pydantic V1 models incompatible with 3.14 — see issue body).
+
+The protection works in two layers:
+  1. Source-level: AST scan for top-level `import voyageai` / `from voyageai`
+     in every default-runtime module that consumes Voyage. This catches the
+     regression even when `voyageai` happens to be installed in CI.
+  2. Runtime-level: import the module in a sandboxed `sys.modules` and assert
+     `voyageai` did not get pulled in transitively.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# Modules that must NOT import voyageai at module load time. Each is on the
+# default runtime/ingestion path; voyage usage inside them must be lazy.
+DEFAULT_RUNTIME_VOYAGE_CONSUMERS = [
+    "src.ingestion.unified.qdrant_writer",
+    "src.ingestion.gdrive_indexer",
+    "src.ingestion.cocoindex_flow",
+    "src.models.contextualized_embedding",
+]
+
+
+def _module_path(dotted: str) -> Path:
+    parts = dotted.split(".")
+    candidate = REPO_ROOT.joinpath(*parts).with_suffix(".py")
+    if candidate.exists():
+        return candidate
+    pkg = REPO_ROOT.joinpath(*parts) / "__init__.py"
+    if pkg.exists():
+        return pkg
+    raise FileNotFoundError(f"cannot locate source for {dotted}")
+
+
+def _toplevel_imports(source: str) -> set[str]:
+    """Return the set of fully-qualified module names imported at module top
+    level (i.e. ignoring imports nested inside functions, methods, or
+    conditional `if/else` blocks at deeper scope)."""
+    tree = ast.parse(source)
+    found: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                found.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            found.add(node.module.split(".")[0])
+    return found
+
+
+def _toplevel_voyage_symbols(source: str) -> list[str]:
+    """Return top-level imports that pull voyageai directly or transitively.
+
+    Catches both `import voyageai` and `from telegram_bot.services import
+    VoyageService`-style transitive triggers (the lazy `__getattr__` in
+    `telegram_bot/services/__init__.py` resolves at the from-import site,
+    so the import is *not* deferred from the consumer's perspective).
+    """
+    tree = ast.parse(source)
+    bad: list[str] = []
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.split(".")[0] == "voyageai":
+                    bad.append(f"import {alias.name}")
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            names = {a.name for a in node.names}
+            if module.split(".")[0] == "voyageai":
+                bad.append(f"from {module} import {sorted(names)}")
+            if module == "telegram_bot.services" and "VoyageService" in names:
+                bad.append("from telegram_bot.services import VoyageService")
+            if module == "telegram_bot.services.voyage":
+                bad.append(f"from {module} import {sorted(names)}")
+    return bad
+
+
+@pytest.mark.parametrize("dotted", DEFAULT_RUNTIME_VOYAGE_CONSUMERS)
+def test_module_has_no_toplevel_voyage_import(dotted: str) -> None:
+    """Static lock: no top-level Voyage import in default-runtime consumers.
+
+    Regression for #1773: if a future change reintroduces a top-level
+    `import voyageai`, `from voyageai import ...`, or
+    `from telegram_bot.services import VoyageService` in any of these
+    modules, base test collection breaks under Python 3.14 even though the
+    runtime path itself never needs Voyage.
+    """
+    src_path = _module_path(dotted)
+    bad = _toplevel_voyage_symbols(src_path.read_text(encoding="utf-8"))
+    assert not bad, (
+        f"{dotted} has top-level Voyage imports {bad} at {src_path}; "
+        "Voyage is an optional extra (#1773). Move the import inside the "
+        "function/method that actually instantiates a Voyage client."
+    )
+
+
+def test_default_bot_runtime_imports_skip_voyageai() -> None:
+    """Runtime lock: importing telegram_bot does not pull in voyageai.
+
+    `telegram_bot/services/__init__.py` already uses lazy `__getattr__`, so
+    `import telegram_bot.services` should not trigger voyageai. Make that
+    contract explicit via a regression test.
+    """
+    sys.modules.pop("voyageai", None)
+    importlib.import_module("telegram_bot.services")
+    assert "voyageai" not in sys.modules, (
+        "Importing telegram_bot.services pulled in voyageai. Voyage is "
+        "optional (#1773); access VoyageService only via attribute lookup "
+        "from a callsite that needs it."
+    )
+
+
+def test_voyage_extra_declared_in_root_pyproject() -> None:
+    """Root pyproject must expose `voyage` as an optional extra (not base)."""
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    # voyageai must not appear in the [project] dependencies block.
+    deps_block = pyproject.split("[project.optional-dependencies]", 1)[0]
+    assert "voyageai" not in deps_block, (
+        "voyageai is back in base [project.dependencies] (#1773 regression)."
+    )
+    # And it must appear in the [project.optional-dependencies] section
+    # under a `voyage` extra.
+    optional_block = pyproject.split("[project.optional-dependencies]", 1)[1]
+    assert "voyage = [" in optional_block, "voyage extra missing from pyproject.toml"
+    assert "voyageai" in optional_block
+
+
+def test_voyage_extra_declared_in_telegram_bot_pyproject() -> None:
+    """telegram_bot pyproject must expose voyage as an optional extra."""
+    pyproject = (REPO_ROOT / "telegram_bot" / "pyproject.toml").read_text(encoding="utf-8")
+    deps_block = pyproject.split("[project.optional-dependencies]", 1)[0]
+    assert "voyageai" not in deps_block, (
+        "voyageai is back in telegram_bot base dependencies (#1773 regression)."
+    )
+    optional_block = pyproject.split("[project.optional-dependencies]", 1)[1]
+    assert "voyage = [" in optional_block
+    assert "voyageai" in optional_block

--- a/tests/unit/test_voyage_service.py
+++ b/tests/unit/test_voyage_service.py
@@ -5,6 +5,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+pytest.importorskip("voyageai", reason="voyageai not installed (#1773 voyage extra)")
+pytestmark = pytest.mark.requires_extras
+
+
 class TestVoyageServiceUnit:
     """Unit tests for VoyageService (no API calls)."""
 

--- a/tests/unit/test_voyage_service.py
+++ b/tests/unit/test_voyage_service.py
@@ -4,8 +4,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.unit.helpers.voyage import skip_if_voyageai_unusable
 
-pytest.importorskip("voyageai", reason="voyageai not installed (#1773 voyage extra)")
+
+skip_if_voyageai_unusable()
 pytestmark = pytest.mark.requires_extras
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -886,7 +886,6 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
     { name = "uvloop" },
-    { name = "voyageai" },
 ]
 
 [package.optional-dependencies]
@@ -920,6 +919,7 @@ all = [
     { name = "torchvision", version = "0.26.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
     { name = "transformers" },
     { name = "uvicorn" },
+    { name = "voyageai" },
 ]
 docling = [
     { name = "docling-serve", extra = ["ui"] },
@@ -968,6 +968,9 @@ voice = [
     { name = "opentelemetry-sdk" },
     { name = "uvicorn" },
 ]
+voyage = [
+    { name = "voyageai" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1000,7 +1003,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "cachetools", specifier = ">=5.0.0" },
     { name = "cocoindex", marker = "extra == 'ingest'", specifier = ">=0.3.28" },
-    { name = "contextual-rag", extras = ["docs", "voice", "eval", "ingest", "ml-local"], marker = "extra == 'all'" },
+    { name = "contextual-rag", extras = ["docs", "voice", "eval", "ingest", "ml-local", "voyage"], marker = "extra == 'all'" },
     { name = "datasets", marker = "extra == 'eval'", specifier = ">=3.0.0" },
     { name = "docling", marker = "extra == 'ingest'", specifier = ">=2.70.0" },
     { name = "docling-core", marker = "extra == 'ingest'", specifier = ">=2.61.0" },
@@ -1051,9 +1054,9 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'mini-app'", specifier = ">=0.30.0" },
     { name = "uvicorn", marker = "extra == 'voice'", specifier = ">=0.30.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "voyageai", specifier = ">=0.3.0" },
+    { name = "voyageai", marker = "extra == 'voyage'", specifier = ">=0.3.0" },
 ]
-provides-extras = ["ml-local", "docs", "mini-app", "voice", "docling", "ingest", "eval", "all"]
+provides-extras = ["ml-local", "docs", "mini-app", "voice", "docling", "ingest", "eval", "voyage", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Closes #1773.

## Problem

`voyageai` lived in the base dependency set of both `pyproject.toml` and `telegram_bot/pyproject.toml`, but the default bot/retrieval runtime does not use it (BGE-M3 + Qdrant + ColBERT). Under Python 3.14, importing `voyageai` triggers Pydantic V1 model errors that break base test collection:

```
ValueError: On field "content" the following field constraints are set but not enforced: min_items
```

The affected import chain at default `make test-unit`:

```
tests/unit/ingestion/test_gdrive_flow.py
-> src/ingestion/gdrive_flow.py
-> src/ingestion/gdrive_indexer.py
-> from telegram_bot.services import VoyageService    (TOP-LEVEL — triggers __getattr__)
-> telegram_bot/services/voyage.py
-> import voyageai                                     (TOP-LEVEL, Python 3.14 break)
```

## Fix — option 1 from the issue: optionalize first, delete later

### Dependency split
- Root `pyproject.toml`: remove `voyageai>=0.3.0` from `[project.dependencies]`, add `voyage = ["voyageai>=0.3.0"]` under `[project.optional-dependencies]`, add `voyage` to the `all` aggregate extra.
- `telegram_bot/pyproject.toml`: same split (new `[project.optional-dependencies].voyage`).
- `telegram_bot/requirements.txt`: removed voyageai with a pointer to `--extra voyage`.
- Both `uv.lock` and `telegram_bot/uv.lock` regenerated to mark voyageai `marker = "extra == 'voyage'"`.

### Lazy imports — Voyage stays usable for legacy/optional paths but is no longer eagerly imported by default-runtime modules
- `src/ingestion/unified/qdrant_writer.py` — `from telegram_bot.services import VoyageService` moved into the `use_local_embeddings=False` branch where it's actually used.
- `src/ingestion/gdrive_indexer.py` (deprecated module) — same import moved inside `__init__`.
- `src/models/contextualized_embedding.py` — top-level `import voyageai` dropped; lazy-imported inside `__init__`. The three `retry_if_exception_type((voyageai.error.RateLimitError, ...))` decorators are replaced with `retry_if_exception(_is_voyage_retryable)`, where the predicate matches by exception class name + module prefix (`voyageai.*`) so the decorator never needs to load `voyageai`.
- `src/ingestion/cocoindex_flow.py` was already lazy.

### Test guards
Mark voyage-using tests so they skip cleanly without the extra:
- `tests/unit/test_voyage_service.py`
- `tests/unit/services/test_voyage_observability.py`
- `tests/unit/test_contextualized_embeddings.py`
- `tests/unit/models/test_contextualized_pipeline.py`
- `tests/integration/test_contextualized_pipeline.py`

Each gets:

```python
pytest.importorskip("voyageai", reason="voyageai not installed (#1773 voyage extra)")
pytestmark = pytest.mark.requires_extras
```

### Regression locks (new)
`tests/unit/test_voyage_optional_imports.py` — 7 tests:
- AST scan rejects top-level `import voyageai`, `from voyageai import ...`, **and** `from telegram_bot.services import VoyageService` in: `src.ingestion.unified.qdrant_writer`, `src.ingestion.gdrive_indexer`, `src.ingestion.cocoindex_flow`, `src.models.contextualized_embedding`.
- Runtime: `import telegram_bot.services` does NOT add `voyageai` to `sys.modules`.
- pyproject contract: voyageai is absent from base deps and present under the `voyage` extra in both root and `telegram_bot/`.

### Docs
`docs/engineering/sdk-registry.md` — voyage section now documents `status: OPTIONAL EXTRA`, the four consumer paths, the lazy-import rule, and the Python 3.14 / requires_extras gotcha.

## TDD evidence

Stashing the production fixes (`pyproject`, lazy-import edits, contextualized_embedding decorator rewrite) and running the new regression suite makes **5/7 tests fail** as expected:

- `qdrant_writer` and `gdrive_indexer` transitive `from telegram_bot.services import VoyageService` are caught
- `contextualized_embedding` top-level `import voyageai` is caught
- both pyproject contract checks fail

After restoring the fixes: **7/7 GREEN**.

## Verification

```
uvx ruff check <touched files>             -> All checks passed
uvx ruff format --check <touched files>    -> formatted
.venv/bin/python -m pytest tests/unit/test_voyage_optional_imports.py
                                            -> 7 passed in 0.14s
uv lock           # root        -> voyageai now under marker = "extra == 'voyage'"
uv lock           # telegram_bot/
```

## Acceptance criteria (from #1773)

- [x] Base install/test environment can run without `voyageai` installed.
- [x] Default bot/retrieval startup does not import `voyageai` (regression test: `test_default_bot_runtime_imports_skip_voyageai`).
- [x] Default ingestion path with `USE_LOCAL_DENSE_EMBEDDINGS=true` does not import `voyageai`.
- [x] Voyage-specific tests are excluded from default `make test-unit` unless extras installed.
- [x] Optional Voyage tier still has targeted tests under `requires_extras`.
- [x] `uv.lock` and `telegram_bot/uv.lock` reflect the dependency split.
- [x] `docs/engineering/sdk-registry.md` describes Voyage as optional/legacy.

## Out of scope

- Full deletion of Voyage code paths (issue calls for reconsidering in follow-up after optional-path usage is confirmed dead).
- Switching default ingestion away from local BGE-M3 (already the default per Compose).