### PR TITLE
feat(observability): wire Langfuse traces into Mini App funnel (#1658)

### DIFF
--- a/mini_app/api.py
+++ b/mini_app/api.py
@@ -14,6 +14,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from mini_app.expert_start import StartExpertRequest, StartExpertResponse
 from mini_app.phone import PhoneRequest, submit_phone
+from telegram_bot.observability import get_client, observe, propagate_attributes
 from telegram_bot.services.content_loader import load_mini_app_config
 
 
@@ -73,52 +74,97 @@ async def get_config() -> dict:
     return load_mini_app_config()
 
 
+def _update_current_span(**kwargs: Any) -> None:
+    """Curated update_current_span; no-op when Langfuse client absent."""
+    lf = get_client()
+    if lf is not None:
+        lf.update_current_span(**kwargs)
+
+
 @app.post("/api/start-expert")
+@observe(name="miniapp-start-expert", capture_input=False, capture_output=False)
 async def start_expert(
     request: StartExpertRequest,
     redis: Any = Depends(get_redis),
 ) -> StartExpertResponse:
-    """Store deep-link payload in Redis and return start_link for openTelegramLink."""
+    """Store deep-link payload in Redis and return start_link for openTelegramLink.
+
+    Wrapped in ``@observe`` (#1658) so the Mini App entry point lands as a
+    named Langfuse span. ``propagate_attributes(session_id="miniapp-{user_id}")``
+    groups the Mini App and the subsequent Telegram ``/start q_<expert>``
+    trace into the same Langfuse Session, reconstructing the funnel
+    ``Mini App -> /start q_<expert> -> Telegram dialog -> CRM``.
+
+    PII safety: ``capture_input/output=False`` and the curated
+    ``update_current_span(input=...)`` records only ``expert_id`` plus
+    payload-shape booleans — never the message body or raw deep-link UUID.
+    """
     from fastapi import HTTPException
 
-    config = load_mini_app_config()
-    experts = config.get("experts", [])
-    expert = next((e for e in experts if e["id"] == request.expert_id), None)
-    if expert is None:
-        raise HTTPException(status_code=404, detail="Expert not found")
+    with propagate_attributes(
+        session_id=f"miniapp-{request.user_id}",
+        user_id=str(request.user_id),
+        tags=["miniapp", "start-expert", request.expert_id],
+        metadata={"surface": "miniapp"},
+    ):
+        _update_current_span(
+            input={
+                "expert_id": request.expert_id,
+                "has_message": request.message is not None,
+                "has_query_id": request.query_id is not None,
+            }
+        )
 
-    uid = str(_uuid_lib.uuid4())
-    payload = json.dumps(
-        {
-            "expert_id": request.expert_id,
-            "message": request.message,
-            "user_id": request.user_id,
-            "query_id": request.query_id,
-        }
-    )
-    await redis.set(f"miniapp:q:{uid}", payload, ex=_DEEPLINK_TTL)
+        config = load_mini_app_config()
+        experts = config.get("experts", [])
+        expert = next((e for e in experts if e["id"] == request.expert_id), None)
+        if expert is None:
+            _update_current_span(level="ERROR", status_message="expert_not_found")
+            raise HTTPException(status_code=404, detail="Expert not found")
 
-    bot_username = os.environ.get("BOT_USERNAME", "")
-    if not bot_username:
-        raise HTTPException(status_code=500, detail="BOT_USERNAME not configured")
-    start_link = f"https://t.me/{bot_username}?start=q_{uid}"
-
-    # Notify bot via Redis pub/sub — bot calls answerWebAppQuery + creates topic + RAG
-    await redis.publish(
-        "miniapp:start",
-        json.dumps(
+        uid = str(_uuid_lib.uuid4())
+        payload = json.dumps(
             {
-                "uuid": uid,
+                "expert_id": request.expert_id,
+                "message": request.message,
                 "user_id": request.user_id,
                 "query_id": request.query_id,
             }
-        ),
-    )
+        )
+        await redis.set(f"miniapp:q:{uid}", payload, ex=_DEEPLINK_TTL)
 
-    return StartExpertResponse(
-        start_link=start_link,
-        expert_name=expert["name"],
-    )
+        bot_username = os.environ.get("BOT_USERNAME", "")
+        if not bot_username:
+            _update_current_span(level="ERROR", status_message="bot_username_not_configured")
+            raise HTTPException(status_code=500, detail="BOT_USERNAME not configured")
+        start_link = f"https://t.me/{bot_username}?start=q_{uid}"
+
+        # Notify bot via Redis pub/sub — bot calls answerWebAppQuery + creates
+        # topic + RAG.
+        await redis.publish(
+            "miniapp:start",
+            json.dumps(
+                {
+                    "uuid": uid,
+                    "user_id": request.user_id,
+                    "query_id": request.query_id,
+                }
+            ),
+        )
+
+        # Curated success metadata — no raw UUID, no full URL.
+        _update_current_span(
+            output={
+                "expert_id": request.expert_id,
+                "expert_name": expert["name"],
+                "deeplink_published": True,
+            }
+        )
+
+        return StartExpertResponse(
+            start_link=start_link,
+            expert_name=expert["name"],
+        )
 
 
 @app.post("/api/log")
@@ -132,9 +178,23 @@ async def remote_log(request: dict) -> dict:
 
 
 @app.post("/api/phone")
+@observe(name="miniapp-submit-phone", capture_input=False, capture_output=False)
 async def phone(request: PhoneRequest) -> dict:
-    """Collect phone and create CRM lead."""
-    return await submit_phone(request)
+    """Collect phone and create CRM lead.
+
+    Wrapped in ``@observe`` (#1658) with the same ``miniapp-{user_id}`` session
+    grouping as ``start_expert`` so the funnel reconstructs in Langfuse
+    Sessions. PII (phone, name) never reaches the span: ``capture_input/output``
+    are off, and the inner ``submit_phone`` curates its own output.
+    """
+    with propagate_attributes(
+        session_id=f"miniapp-{request.user_id}",
+        user_id=str(request.user_id),
+        tags=["miniapp", "submit-phone", request.source],
+        metadata={"surface": "miniapp"},
+    ):
+        _update_current_span(input={"source": request.source, "has_name": request.name is not None})
+        return await submit_phone(request)
 
 
 @app.get("/health")

--- a/mini_app/phone.py
+++ b/mini_app/phone.py
@@ -7,6 +7,8 @@ import re
 
 from pydantic import BaseModel, field_validator
 
+from telegram_bot.observability import get_client, observe
+
 
 logger = logging.getLogger(__name__)
 
@@ -36,8 +38,17 @@ def get_kommo_client():
     return KommoClient()
 
 
+@observe(name="miniapp-kommo-create-lead", capture_input=False, capture_output=False)
 async def submit_phone(request: PhoneRequest) -> dict:
-    """Submit phone to CRM."""
+    """Submit phone to CRM.
+
+    Wrapped in ``@observe`` (#1658). On Kommo failure the surrounding span is
+    flipped to ``level="ERROR"`` with a bounded ``status_message`` so the
+    funnel break is visible in Langfuse, not just in logs. The success/failure
+    return contract is intentionally untouched here (#1596 / PR #1767 owns the
+    fake-success regression separately).
+    """
+    lf = get_client()
     try:
         client = get_kommo_client()
         contact = await client.upsert_contact(
@@ -48,7 +59,24 @@ async def submit_phone(request: PhoneRequest) -> dict:
             name=f"Mini App: {request.source}",
             contact_id=contact["id"],
         )
-        return {"success": True, "lead_id": lead["id"]}
-    except Exception:
+    except Exception as exc:
         logger.exception("CRM submission failed")
+        if lf is not None:
+            # Bounded status_message keeps Langfuse payload small and PII-free.
+            lf.update_current_span(
+                level="ERROR",
+                status_message=f"kommo_submission_failed: {type(exc).__name__}"[:200],
+                output={"crm_ok": False, "lead_created": False},
+            )
         return {"success": True, "lead_id": None}  # Graceful degradation
+
+    # Curated success output — no phone, no name, no raw Kommo IDs.
+    if lf is not None:
+        lf.update_current_span(
+            output={
+                "crm_ok": True,
+                "lead_created": lead.get("id") is not None,
+                "contact_resolved": contact.get("id") is not None,
+            }
+        )
+    return {"success": True, "lead_id": lead["id"]}

--- a/tests/unit/mini_app/test_langfuse_tracing.py
+++ b/tests/unit/mini_app/test_langfuse_tracing.py
@@ -1,0 +1,364 @@
+"""Mini App Langfuse trace coverage (#1658).
+
+Regression locks: every Mini App entry point that hits the bot/CRM funnel
+must emit a named, propagated, PII-safe Langfuse trace. Before #1658 the
+Mini App had zero trace coverage — leads created via Mini App and the
+Kommo upsert/create-lead pair were invisible in Langfuse, and the funnel
+`Mini App -> /start q_<expert> -> Telegram dialog -> CRM` could not be
+reconstructed in Langfuse Sessions UI.
+
+Contract enforced here:
+
+1. `mini_app.api.start_expert`, `mini_app.api.phone`, and
+   `mini_app.phone.submit_phone` are wrapped with `@observe` and reach
+   `propagate_attributes(session_id=f"miniapp-{user_id}", user_id=...)`.
+2. PII (phone, name, raw deeplink UUID, full message) is NOT captured —
+   `capture_input=False, capture_output=False` and curated payloads omit
+   the sensitive keys.
+3. CRM upsert/create-lead failures inside `submit_phone` raise the
+   surrounding span to `level="ERROR"` with a bounded `status_message`.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+pytest.importorskip("fastapi")
+
+from httpx import ASGITransport, AsyncClient
+
+import mini_app.api as api_mod
+import mini_app.phone as phone_mod
+from mini_app.api import app
+from mini_app.phone import PhoneRequest, submit_phone
+
+
+# ---------------------------------------------------------------------------
+# Helper: a fixture that records `propagate_attributes(...)` invocations
+# without breaking the surrounding `@observe`-decorated function.
+# ---------------------------------------------------------------------------
+
+
+def _make_propagate_recorder() -> tuple[MagicMock, MagicMock]:
+    """Return (mock_cm, mock_factory).
+
+    `mock_factory` records every kwargs it was called with and returns the
+    context manager `mock_cm`, which is a no-op `with`-statement target.
+    """
+    mock_cm = MagicMock()
+    mock_cm.__enter__ = MagicMock(return_value=None)
+    mock_cm.__exit__ = MagicMock(return_value=False)
+    mock_factory = MagicMock(return_value=mock_cm)
+    return mock_cm, mock_factory
+
+
+# ---------------------------------------------------------------------------
+# 1. @observe decorators are applied — static lock so a future revert can't
+#    silently drop tracing.
+# ---------------------------------------------------------------------------
+
+
+class TestMiniAppObserveCoverage:
+    """`@observe` must wrap every Mini App entry point on the funnel path."""
+
+    def test_start_expert_handler_is_observed(self):
+        # `@observe` (or its langfuse-disabled stub) wraps the coroutine and
+        # leaves `__wrapped__` accessible. We accept either marker, mirroring
+        # tests/unit/services/test_voyage_observability.py.
+        fn = api_mod.start_expert
+        assert hasattr(fn, "__wrapped__") or hasattr(fn, "_langfuse_observation"), (
+            "mini_app.api.start_expert must be wrapped with @observe (#1658)."
+        )
+
+    def test_phone_handler_is_observed(self):
+        fn = api_mod.phone
+        assert hasattr(fn, "__wrapped__") or hasattr(fn, "_langfuse_observation"), (
+            "mini_app.api.phone must be wrapped with @observe (#1658)."
+        )
+
+    def test_submit_phone_is_observed(self):
+        fn = phone_mod.submit_phone
+        assert hasattr(fn, "__wrapped__") or hasattr(fn, "_langfuse_observation"), (
+            "mini_app.phone.submit_phone must be wrapped with @observe (#1658)."
+        )
+
+    def test_observability_symbols_imported_in_api(self):
+        """`mini_app.api` must import `observe` and `propagate_attributes`.
+
+        Without these the `@observe` static lock above can be bypassed by
+        re-defining a local `observe` shim. Make the import explicit.
+        """
+        import mini_app.api as mod
+
+        assert hasattr(mod, "observe"), "mini_app.api must import `observe` (#1658)"
+        assert hasattr(mod, "propagate_attributes"), (
+            "mini_app.api must import `propagate_attributes` (#1658)"
+        )
+
+    def test_observability_symbols_imported_in_phone(self):
+        import mini_app.phone as mod
+
+        assert hasattr(mod, "observe"), "mini_app.phone must import `observe` (#1658)"
+        assert hasattr(mod, "get_client"), (
+            "mini_app.phone must import `get_client` for ERROR-level span updates (#1658)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. `propagate_attributes` is called with the funnel-grouping session_id
+#    `miniapp-{user_id}` and SDK-shaped tags / user_id.
+# ---------------------------------------------------------------------------
+
+
+class TestPropagateAttributesContract:
+    """Funnel must be reconstructable in Langfuse Sessions UI (#1658)."""
+
+    @pytest.mark.asyncio
+    async def test_start_expert_propagates_session_user_tags(self):
+        """`/api/start-expert` propagates session_id=miniapp-{user_id} + user_id + tags."""
+        mock_redis = MagicMock()
+        mock_redis.set = AsyncMock()
+        mock_redis.publish = AsyncMock()
+
+        async def _override_redis():
+            return mock_redis
+
+        # FastAPI dependency override avoids the real Redis connection.
+        app.dependency_overrides[api_mod.get_redis] = _override_redis
+
+        _, mock_propagate = _make_propagate_recorder()
+
+        try:
+            with (
+                patch.object(api_mod, "propagate_attributes", mock_propagate),
+                patch.dict("os.environ", {"BOT_USERNAME": "testbot"}, clear=False),
+            ):
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.post(
+                        "/api/start-expert",
+                        json={
+                            "user_id": 42,
+                            "expert_id": "consultant",
+                            "message": "ignored-secret-content",
+                            "query_id": "q-1",
+                        },
+                    )
+            # Body of the endpoint succeeded, so propagate_attributes was reached.
+            assert resp.status_code == 200, resp.text
+        finally:
+            app.dependency_overrides.pop(api_mod.get_redis, None)
+
+        assert mock_propagate.call_count >= 1, (
+            "start_expert must enter `propagate_attributes(...)` exactly once."
+        )
+        kwargs = mock_propagate.call_args.kwargs
+        assert kwargs.get("session_id") == "miniapp-42", (
+            "session_id must be `miniapp-{user_id}` so the Mini App and the "
+            "subsequent Telegram /start q_<expert> trace group together."
+        )
+        assert kwargs.get("user_id") == "42"
+        tags = kwargs.get("tags") or []
+        assert "miniapp" in tags
+        assert "start-expert" in tags
+        assert "consultant" in tags, "expert_id must appear as a tag for funnel filtering"
+
+    @pytest.mark.asyncio
+    async def test_phone_propagates_session_user_tags(self):
+        mock_kommo = MagicMock()
+        mock_kommo.upsert_contact = AsyncMock(return_value={"id": 1})
+        mock_kommo.create_lead = AsyncMock(return_value={"id": 2})
+
+        _, mock_propagate = _make_propagate_recorder()
+
+        with (
+            patch.object(api_mod, "propagate_attributes", mock_propagate),
+            patch("mini_app.phone.get_kommo_client", return_value=mock_kommo),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.post(
+                    "/api/phone",
+                    json={
+                        "phone": "+359888123456",
+                        "source": "viewing_consultant",
+                        "user_id": 7,
+                    },
+                )
+        assert resp.status_code == 200, resp.text
+        assert mock_propagate.call_count >= 1
+        kwargs = mock_propagate.call_args.kwargs
+        assert kwargs.get("session_id") == "miniapp-7"
+        assert kwargs.get("user_id") == "7"
+        tags = kwargs.get("tags") or []
+        assert "miniapp" in tags
+        assert "submit-phone" in tags
+        assert "viewing_consultant" in tags, "source must appear as a tag for funnel filtering"
+
+
+# ---------------------------------------------------------------------------
+# 3. Kommo failure inside submit_phone must surface as a Langfuse ERROR span.
+# ---------------------------------------------------------------------------
+
+
+class TestKommoFailureSpan:
+    """CRM outages must be visible in Langfuse, not just as logs (#1658)."""
+
+    @pytest.mark.asyncio
+    async def test_kommo_failure_marks_span_error(self):
+        mock_lf = MagicMock()
+        mock_lf.update_current_span = MagicMock()
+
+        with (
+            patch("mini_app.phone.get_client", return_value=mock_lf),
+            patch("mini_app.phone.get_kommo_client", side_effect=Exception("CRM down")),
+        ):
+            await submit_phone(
+                PhoneRequest(phone="+359888123456", source="viewing_consultant", user_id=99)
+            )
+
+        error_calls = [
+            c.kwargs
+            for c in mock_lf.update_current_span.call_args_list
+            if c.kwargs.get("level") == "ERROR"
+        ]
+        assert error_calls, (
+            "submit_phone must call `update_current_span(level='ERROR', ...)` on Kommo "
+            "failure so the funnel break is visible in Langfuse, not only in logs."
+        )
+        msg = error_calls[0].get("status_message") or ""
+        assert isinstance(msg, str)
+        assert msg, "status_message must be set"
+        assert len(msg) <= 200, (
+            "status_message must be bounded (<=200 chars) to avoid payload bloat in Langfuse."
+        )
+
+    @pytest.mark.asyncio
+    async def test_kommo_success_does_not_emit_error_span(self):
+        mock_kommo = MagicMock()
+        mock_kommo.upsert_contact = AsyncMock(return_value={"id": 1})
+        mock_kommo.create_lead = AsyncMock(return_value={"id": 2})
+
+        mock_lf = MagicMock()
+        mock_lf.update_current_span = MagicMock()
+
+        with (
+            patch("mini_app.phone.get_client", return_value=mock_lf),
+            patch("mini_app.phone.get_kommo_client", return_value=mock_kommo),
+        ):
+            await submit_phone(
+                PhoneRequest(phone="+359888123456", source="viewing_consultant", user_id=99)
+            )
+
+        error_calls = [
+            c.kwargs
+            for c in mock_lf.update_current_span.call_args_list
+            if c.kwargs.get("level") == "ERROR"
+        ]
+        assert not error_calls, "Kommo success must not emit ERROR-level span"
+
+    @pytest.mark.asyncio
+    async def test_no_phone_or_name_in_curated_output(self):
+        """Curated `update_current_span(output=...)` MUST NOT contain PII (#1658)."""
+        mock_kommo = MagicMock()
+        mock_kommo.upsert_contact = AsyncMock(return_value={"id": 1})
+        mock_kommo.create_lead = AsyncMock(return_value={"id": 2})
+
+        mock_lf = MagicMock()
+        mock_lf.update_current_span = MagicMock()
+
+        with (
+            patch("mini_app.phone.get_client", return_value=mock_lf),
+            patch("mini_app.phone.get_kommo_client", return_value=mock_kommo),
+        ):
+            await submit_phone(
+                PhoneRequest(
+                    phone="+359888123456",
+                    name="Иван",
+                    source="viewing_consultant",
+                    user_id=99,
+                )
+            )
+
+        for call in mock_lf.update_current_span.call_args_list:
+            payload = call.kwargs.get("output") or {}
+            serialized = repr(payload)
+            assert "+359888123456" not in serialized, (
+                "Curated output must NOT include the raw phone number"
+            )
+            assert "Иван" not in serialized, (
+                "Curated output must NOT include the user-provided name"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 4. Sanity: capture_input/output flags on @observe are False everywhere on
+#    the Mini App funnel path. AST-based check works whether or not Langfuse
+#    is installed in the test env, so the contract cannot drift silently.
+# ---------------------------------------------------------------------------
+
+
+class TestObserveCaptureFlags:
+    """`@observe(..., capture_input=False, capture_output=False)` per #1658."""
+
+    @staticmethod
+    def _observe_decorator_kwargs(module_path: str, func_name: str) -> dict[str, str]:
+        """Return the keyword arguments of the `@observe(...)` decorator.
+
+        Source-level inspection so the contract is enforced even when the
+        Langfuse SDK is absent and `@observe` is the no-op stub.
+        """
+        import ast
+        from pathlib import Path
+
+        source = Path(module_path).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        target: ast.AsyncFunctionDef | ast.FunctionDef | None = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef) and node.name == func_name:
+                target = node
+                break
+
+        assert target is not None, f"{func_name} not found in {module_path}"
+
+        for dec in target.decorator_list:
+            if not isinstance(dec, ast.Call):
+                continue
+            func = dec.func
+            if isinstance(func, ast.Name) and func.id == "observe":
+                return {kw.arg: ast.unparse(kw.value) for kw in dec.keywords if kw.arg}
+            if isinstance(func, ast.Attribute) and func.attr == "observe":
+                return {kw.arg: ast.unparse(kw.value) for kw in dec.keywords if kw.arg}
+
+        raise AssertionError(f"{func_name} has no @observe(...) decorator in {module_path}")
+
+    @pytest.mark.parametrize(
+        ("module", "func_name"),
+        [
+            ("mini_app/api.py", "start_expert"),
+            ("mini_app/api.py", "phone"),
+            ("mini_app/phone.py", "submit_phone"),
+        ],
+    )
+    def test_observe_does_not_capture_payloads(self, module: str, func_name: str) -> None:
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[3]
+        kwargs = self._observe_decorator_kwargs(str(repo_root / module), func_name)
+        assert kwargs.get("capture_input") == "False", (
+            f"{module}::{func_name} must use `@observe(..., capture_input=False)` (#1658). "
+            f"Found: {kwargs}"
+        )
+        assert kwargs.get("capture_output") == "False", (
+            f"{module}::{func_name} must use `@observe(..., capture_output=False)` (#1658). "
+            f"Found: {kwargs}"
+        )
+        assert "name" in kwargs and kwargs["name"].startswith("'miniapp-"), (
+            f"{module}::{func_name} must use a `miniapp-*` span name (#1658). Found: {kwargs}"
+        )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Closes #1658.

## Problem

`mini_app/` is a separate FastAPI service that handles conversion-funnel traffic from Telegram Mini App: `/api/start-expert`, `/api/phone`, `/api/log`, `/api/config`. Before this PR it had **zero** Langfuse instrumentation — no `@observe`, no `propagate_attributes`, no `get_client()` calls.

Two consequences from the issue body:

1. The full funnel `Mini App → /start q_<expert> → Telegram dialog → CRM` could not be reconstructed in Langfuse Sessions UI.
2. Failures of the Kommo upsert+create-lead pair inside `mini_app/phone.py:submit_phone` were visible only in logs, never as a span with `level=ERROR`.

## Fix

### `mini_app/api.py`
- `start_expert`: `@observe(name="miniapp-start-expert", capture_input=False, capture_output=False)`. Inside, opens `propagate_attributes(session_id=f"miniapp-{user_id}", user_id=str(user_id), tags=["miniapp", "start-expert", expert_id], metadata={"surface": "miniapp"})`. Curated `update_current_span(input=...)` records only `expert_id` plus payload-shape booleans (`has_message`, `has_query_id`); curated success output records `expert_name` and a `deeplink_published` flag — never the raw deep-link UUID or full URL. ERROR-level updates on `expert_not_found` and missing `BOT_USERNAME`.
- `phone`: same observe + propagate scope with `tags=["miniapp", "submit-phone", source]`. Shape-only curated input; CRM-side span is owned by the inner `submit_phone`.

### `mini_app/phone.py`
- `submit_phone`: `@observe(name="miniapp-kommo-create-lead", capture_input=False, capture_output=False)`. On Kommo failure: `get_client().update_current_span(level="ERROR", status_message=...)` with a bounded status message (`≤200 chars`). Curated success output records boolean flags only — never the phone, name, or raw Kommo IDs.
- The success/failure return contract is intentionally unchanged. The fake-success regression is owned separately by PR #1767 / issue #1596.

### Funnel grouping
`session_id=f"miniapp-{tg_user_id}"` is the contract. The Telegram bot's subsequent `/start q_<expert>` handler should use the same key so the Mini App span and the Telegram dialog group into one Langfuse Session.

## Tests (`tests/unit/mini_app/test_langfuse_tracing.py` — 13 tests)

1. **`TestMiniAppObserveCoverage`** (5 tests) — `@observe` is applied; `mini_app.api` imports `observe`/`propagate_attributes`; `mini_app.phone` imports `observe`/`get_client`.
2. **`TestPropagateAttributesContract`** (2 tests) — `/api/start-expert` and `/api/phone` enter `propagate_attributes(...)` with the funnel-grouping `session_id=miniapp-{user_id}` plus the expected `user_id`/tags. FastAPI `dependency_overrides` swaps Redis with a mock; no real service needed.
3. **`TestKommoFailureSpan`** (3 tests) — Kommo failure flips the span to `level="ERROR"` with bounded `status_message`; success does NOT emit an ERROR-level span; curated `update_current_span(output=...)` payloads contain neither the phone (`+359888123456`) nor the user-provided name (`Иван`).
4. **`TestObserveCaptureFlags`** (3 parametrized, AST-based) — for each of `start_expert`, `phone`, `submit_phone` the `@observe(...)` decorator must carry `capture_input=False`, `capture_output=False`, and a `miniapp-*` span name. AST inspection works whether Langfuse is installed in the test env or not.

## TDD verification

- **RED**: with original `mini_app/api.py` and `mini_app/phone.py` checked out from HEAD (`grep -c '@observe'` → `0 / 0`), all 13 tests fail.
- **GREEN**: with the fix applied, the full Mini App test suite passes — **51 passed in 0.49s** (13 new + 38 pre-existing). No regression to `test_phone.py`, `test_chat.py`, `test_start_expert.py`, etc.
- `uvx ruff check mini_app/api.py mini_app/phone.py tests/unit/mini_app/test_langfuse_tracing.py` → All checks passed.
- `uvx ruff format --check …` → All files formatted.

## Out of scope (per issue body)

- No raw `request` payloads in span input/output.
- No `langfuse_trace_id` plumbing on the Mini App API surface; that remains tracked by #1253.
- No new Prometheus metrics in this PR.
- No changes to the Mini App frontend SDK.