### PR TITLE
docs: define agent and swarm worker hygiene policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,6 +264,10 @@ docs/SDK_*_20*.md
 
 # Internal AI/orchestration tool directories
 docs/superpowers/
+!docs/superpowers/
+docs/superpowers/*
+!docs/superpowers/plans/
+!docs/superpowers/plans/*.md
 .planning/
 rag-small-to-big-research.md
 .gsd/

--- a/.gitignore
+++ b/.gitignore
@@ -267,6 +267,7 @@ docs/superpowers/
 !docs/superpowers/
 docs/superpowers/*
 !docs/superpowers/plans/
+docs/superpowers/plans/*
 !docs/superpowers/plans/*.md
 .planning/
 rag-small-to-big-research.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Prefer local/test environments. Do not access production, VPS, secrets, SSH,
 cloud credentials, or real CRM write paths unless explicitly required. Redact
 secrets in outputs.
 
-## Workspace And Swarm Hygiene
+## Workspace Hygiene
 
 Do not start non-trivial edits in a dirty checkout. Use an isolated git worktree
 for feature work or when unrelated local changes exist; see

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,15 @@ Prefer local/test environments. Do not access production, VPS, secrets, SSH,
 cloud credentials, or real CRM write paths unless explicitly required. Redact
 secrets in outputs.
 
+## Workspace And Swarm Hygiene
+
+Do not start non-trivial edits in a dirty checkout. Use an isolated git worktree
+for feature work or when unrelated local changes exist; see
+[`docs/engineering/repo-hygiene-runbook.md`](docs/engineering/repo-hygiene-runbook.md).
+
+Git hooks and push gates run lint/static guardrails only. Run tests explicitly as local validation; see
+[`docs/LOCAL-DEVELOPMENT.md`](docs/LOCAL-DEVELOPMENT.md).
+
 ## Validation
 
 Use [`docs/LOCAL-DEVELOPMENT.md`](docs/LOCAL-DEVELOPMENT.md) and the nearest

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -117,12 +117,22 @@ The authoritative startup preflight still lives in [`telegram_bot/preflight.py`]
 
 ## 4. Development Gates
 
+Git hooks and push gates are static guardrails only: lint, formatting, type
+checks, and repository policy checks. They should not run pytest suites. Run
+tests explicitly as local validation on the development machine.
+
 Local release gate:
 
 ```bash
 make check
 PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit
 make test-bot-health
+```
+
+PR-ready local gate:
+
+```bash
+make local-pr-ready
 ```
 
 Optional broader gates:

--- a/docs/engineering/repo-hygiene-runbook.md
+++ b/docs/engineering/repo-hygiene-runbook.md
@@ -14,6 +14,22 @@ make issue-hygiene        # open issue queue hygiene
 Each command exits non-zero whenever something is actionable, so they're CI-
 friendly and can be wired into a weekly Slack/email digest.
 
+## Before Starting New Work
+
+Do not start non-trivial edits in a dirty checkout. Start from a clean worktree
+or create a project-local `.worktrees/<branch>` checkout when unrelated local
+changes exist:
+
+```bash
+make git-hygiene
+git fetch origin
+git worktree add .worktrees/<branch> -b <branch> origin/dev
+```
+
+Use the new worktree for feature edits, verification, commits, and PR
+preparation. Leave unrelated dirty branches untouched until their owner or
+operator decides whether to keep, merge, or discard them.
+
 ## What each tool covers
 
 | Tool                              | Covers                                | Issue   |

--- a/docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md
+++ b/docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md
@@ -85,3 +85,21 @@ No external changes have been applied yet.
   - `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_launch_opencode_worker.py tests/test_validate_worker_prompt.py tests/test_validate_worker_signal.py tests/test_swarm_plan_contract.py tests/test_swarm_launch_contract.py tests/test_worker_contract.py tests/test_swarm_acceptance_contract.py tests/test_opencode_agent_contract.py tests/test_swarm_superpowers_dry_run.py -q`
 - Result: individual task checks passed; full external swarm subset `18 passed`.
 - Notes: `swarm-launch` now documents preflight gates; worker contracts and OpenCode agents now constrain branch/worktree/push behavior; acceptance now verifies `changed_files`/`reserved_files`/Superpowers evidence and disposition; signal validator accepts namespaced Superpowers arrays; dry-run test does not launch tmux/OpenCode.
+
+### 2026-05-20 Task 11 Review Fixes: push defaults and multiline Superpowers
+
+- Files changed:
+  - `/home/user/.config/opencode/agents/pr-worker.md`
+  - `/home/user/.config/opencode/agents/pr-review-fix.md`
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/scripts/validate_worker_prompt.py`
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/scripts/validate_worker_signal.py`
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_validate_worker_prompt.py`
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_validate_worker_signal.py`
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_opencode_agent_contract.py`
+- Backup paths: none
+- Verification commands:
+  - `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_validate_worker_prompt.py tests/test_validate_worker_signal.py -q`
+  - `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_opencode_agent_contract.py -q`
+  - `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_launch_opencode_worker.py tests/test_validate_worker_prompt.py tests/test_validate_worker_signal.py tests/test_swarm_plan_contract.py tests/test_swarm_launch_contract.py tests/test_worker_contract.py tests/test_swarm_acceptance_contract.py tests/test_opencode_agent_contract.py tests/test_swarm_superpowers_dry_run.py -q`
+- Result: `8 passed`; `3 passed`; full external swarm subset `21 passed`.
+- Notes: removed default push/PR language from worker agents, changed legacy signal validation so code-producing workers may finish locally without push by default, and expanded prompt validation to catch forbidden Superpowers in multiline/bullet `Required Superpowers` blocks.

--- a/docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md
+++ b/docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md
@@ -43,3 +43,15 @@ No external changes have been applied yet.
   - `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_launch_opencode_worker.py -q`
 - Result: `4 passed`
 - Notes: launcher now accepts `superpowers:<slug>` / `superpowers/<slug>`, searches OpenCode plugin and Codex Superpowers paths, rejects worker-forbidden Superpowers, and bundles namespaced skills under filesystem-safe names.
+
+### 2026-05-20 Task 4: prompt validator Superpowers policy
+
+- Files changed:
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/scripts/validate_worker_prompt.py`
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_validate_worker_prompt.py`
+- Backup paths: none
+- Verification commands:
+  - `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_validate_worker_prompt.py -q`
+  - `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_launch_opencode_worker.py tests/test_validate_worker_prompt.py -q`
+- Result: `4 passed`; `8 passed`
+- Notes: validator now requires Superpowers policy and finish-report fields for code-changing workers, rejects forbidden worker Superpowers in `Required Superpowers`, and allows docs-only TDD skips with a reason.

--- a/docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md
+++ b/docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md
@@ -18,3 +18,17 @@ For each external change, append:
 ```
 
 No external changes have been applied yet.
+
+### 2026-05-20 Task 2: swarm plan allocation and orchestrator boundary
+
+- Files changed:
+  - `/home/user/.codex/skills/swarm-plan/SKILL.md`
+  - `/home/user/.codex/skills/swarm-orchestrator/SKILL.md`
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_swarm_plan_contract.py`
+- Backup paths: none
+- Verification commands:
+  - `pytest tests/test_swarm_plan_contract.py -q` from `/home/user/.codex/skills/tmux-swarm-orchestration` failed because `pytest` is not installed on PATH.
+  - `uv run pytest tests/test_swarm_plan_contract.py -q` from `/home/user/.codex/skills/tmux-swarm-orchestration` failed because the external directory has no pytest environment.
+  - `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_swarm_plan_contract.py -q`
+- Result: `2 passed`
+- Notes: external swarm skill directories are not git repositories on this machine, so these file changes are recorded here rather than committed from the repo.

--- a/docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md
+++ b/docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md
@@ -103,3 +103,26 @@ No external changes have been applied yet.
   - `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_launch_opencode_worker.py tests/test_validate_worker_prompt.py tests/test_validate_worker_signal.py tests/test_swarm_plan_contract.py tests/test_swarm_launch_contract.py tests/test_worker_contract.py tests/test_swarm_acceptance_contract.py tests/test_opencode_agent_contract.py tests/test_swarm_superpowers_dry_run.py -q`
 - Result: `8 passed`; `3 passed`; full external swarm subset `21 passed`.
 - Notes: removed default push/PR language from worker agents, changed legacy signal validation so code-producing workers may finish locally without push by default, and expanded prompt validation to catch forbidden Superpowers in multiline/bullet `Required Superpowers` blocks.
+
+### 2026-05-20 Subagent Audit Autofix: policy hardening
+
+- Files changed:
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/scripts/launch_opencode_worker.sh`
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/scripts/validate_worker_prompt.py`
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_launch_opencode_worker.py`
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_validate_worker_prompt.py`
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_worker_contract.py`
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_opencode_agent_contract.py`
+  - `/home/user/.codex/skills/swarm-worker-contract/SKILL.md`
+  - `/home/user/.config/opencode/agents/pr-worker.md`
+  - `/home/user/.config/opencode/agents/pr-review-fix.md`
+  - `/home/user/.config/opencode/agents/pr-review.md`
+  - `/home/user/.config/opencode/skills/swarm-worker-contract/SKILL.md`
+  - `/home/user/.config/opencode/skills/swarm-pr-finish/SKILL.md`
+- Backup paths: none
+- Verification commands:
+  - `uv run pytest tests/unit/test_agents_contract.py tests/unit/test_ci_deploy_workflow.py -q`
+  - `uv run ruff check tests/unit/test_agents_contract.py tests/unit/test_ci_deploy_workflow.py`
+  - `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_launch_opencode_worker.py tests/test_validate_worker_prompt.py tests/test_validate_worker_signal.py tests/test_swarm_plan_contract.py tests/test_swarm_launch_contract.py tests/test_worker_contract.py tests/test_swarm_acceptance_contract.py tests/test_opencode_agent_contract.py tests/test_swarm_superpowers_dry_run.py -q`
+- Result: repo `10 passed`; ruff passed; external swarm subset `24 passed`.
+- Notes: tightened `.gitignore` plan allowlist in the repo, renamed the AGENTS heading to generic `Workspace Hygiene`, required TDD for code-changing prompts, rejected ORCH_PANE wake-up regardless of tmux option order, accepted numbered Superpowers lists, blocked subagent/review/planning Superpowers in launcher-required worker skills, and clarified OpenCode skill permission versus use policy.

--- a/docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md
+++ b/docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md
@@ -126,3 +126,16 @@ No external changes have been applied yet.
   - `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_launch_opencode_worker.py tests/test_validate_worker_prompt.py tests/test_validate_worker_signal.py tests/test_swarm_plan_contract.py tests/test_swarm_launch_contract.py tests/test_worker_contract.py tests/test_swarm_acceptance_contract.py tests/test_opencode_agent_contract.py tests/test_swarm_superpowers_dry_run.py -q`
 - Result: repo `10 passed`; ruff passed; external swarm subset `24 passed`.
 - Notes: tightened `.gitignore` plan allowlist in the repo, renamed the AGENTS heading to generic `Workspace Hygiene`, required TDD for code-changing prompts, rejected ORCH_PANE wake-up regardless of tmux option order, accepted numbered Superpowers lists, blocked subagent/review/planning Superpowers in launcher-required worker skills, and clarified OpenCode skill permission versus use policy.
+
+### 2026-05-20 Rebase Verification Note
+
+- Files changed:
+  - No external files changed in this step.
+- Backup paths: none
+- Verification commands:
+  - `git rebase origin/dev`
+  - `git diff --name-only origin/dev..HEAD`
+  - `uv run pytest tests/unit/test_agents_contract.py tests/unit/test_ci_deploy_workflow.py -q`
+  - `uv run ruff check tests/unit/test_agents_contract.py tests/unit/test_ci_deploy_workflow.py`
+- Result: rebase succeeded; diff now contains only repo policy/plan/test files; repo `10 passed`; ruff passed.
+- Notes: after rebasing onto current `origin/dev`, the upstream CI job name is `Lint`, so the repo-side CI workflow contract was updated from the stale `Lint & Type Check` expectation.

--- a/docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md
+++ b/docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md
@@ -1,0 +1,20 @@
+# Swarm Superpowers Worker Policy External Changes
+
+This manifest records changes made outside the `rag-fresh` git repository while
+executing `2026-05-20-swarm-superpowers-worker-policy.md`.
+
+## Format
+
+For each external change, append:
+
+```markdown
+### YYYY-MM-DD Task N: short title
+
+- Files changed:
+- Backup paths:
+- Verification commands:
+- Result:
+- Notes:
+```
+
+No external changes have been applied yet.

--- a/docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md
+++ b/docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md
@@ -55,3 +55,33 @@ No external changes have been applied yet.
   - `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_launch_opencode_worker.py tests/test_validate_worker_prompt.py -q`
 - Result: `4 passed`; `8 passed`
 - Notes: validator now requires Superpowers policy and finish-report fields for code-changing workers, rejects forbidden worker Superpowers in `Required Superpowers`, and allows docs-only TDD skips with a reason.
+
+### 2026-05-20 Tasks 5-10: launch, worker, acceptance, OpenCode, signal, dry-run contracts
+
+- Files changed:
+  - `/home/user/.codex/skills/swarm-launch/SKILL.md`
+  - `/home/user/.codex/skills/swarm-worker-contract/SKILL.md`
+  - `/home/user/.codex/skills/swarm-acceptance/SKILL.md`
+  - `/home/user/.config/opencode/skills/swarm-worker-contract/SKILL.md`
+  - `/home/user/.config/opencode/skills/swarm-pr-finish/SKILL.md`
+  - `/home/user/.config/opencode/agents/pr-worker.md`
+  - `/home/user/.config/opencode/agents/pr-review-fix.md`
+  - `/home/user/.config/opencode/agents/pr-review.md`
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/scripts/validate_worker_signal.py`
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_swarm_launch_contract.py`
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_worker_contract.py`
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_swarm_acceptance_contract.py`
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_opencode_agent_contract.py`
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_validate_worker_signal.py`
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_swarm_superpowers_dry_run.py`
+- Backup paths: none
+- Verification commands:
+  - `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_swarm_launch_contract.py -q`
+  - `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_worker_contract.py -q`
+  - `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_swarm_acceptance_contract.py -q`
+  - `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_opencode_agent_contract.py -q`
+  - `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_validate_worker_signal.py -q`
+  - `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_swarm_superpowers_dry_run.py -q`
+  - `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_launch_opencode_worker.py tests/test_validate_worker_prompt.py tests/test_validate_worker_signal.py tests/test_swarm_plan_contract.py tests/test_swarm_launch_contract.py tests/test_worker_contract.py tests/test_swarm_acceptance_contract.py tests/test_opencode_agent_contract.py tests/test_swarm_superpowers_dry_run.py -q`
+- Result: individual task checks passed; full external swarm subset `18 passed`.
+- Notes: `swarm-launch` now documents preflight gates; worker contracts and OpenCode agents now constrain branch/worktree/push behavior; acceptance now verifies `changed_files`/`reserved_files`/Superpowers evidence and disposition; signal validator accepts namespaced Superpowers arrays; dry-run test does not launch tmux/OpenCode.

--- a/docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md
+++ b/docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md
@@ -32,3 +32,14 @@ No external changes have been applied yet.
   - `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_swarm_plan_contract.py -q`
 - Result: `2 passed`
 - Notes: external swarm skill directories are not git repositories on this machine, so these file changes are recorded here rather than committed from the repo.
+
+### 2026-05-20 Task 3: launcher Superpowers skill resolution
+
+- Files changed:
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/scripts/launch_opencode_worker.sh`
+  - `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_launch_opencode_worker.py`
+- Backup paths: none
+- Verification commands:
+  - `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_launch_opencode_worker.py -q`
+- Result: `4 passed`
+- Notes: launcher now accepts `superpowers:<slug>` / `superpowers/<slug>`, searches OpenCode plugin and Codex Superpowers paths, rejects worker-forbidden Superpowers, and bundles namespaced skills under filesystem-safe names.

--- a/docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy.md
+++ b/docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy.md
@@ -1,0 +1,754 @@
+# Swarm Superpowers Worker Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make repo and tmux/OpenCode swarm rules explicit: lint/static gates may run in git hooks, tests stay as deliberate local commands, non-trivial work starts in isolated worktrees, workers use only assigned worktrees, and Superpowers skills are opt-in per worker role.
+
+**Architecture:** Keep `AGENTS.md` as the short gateway and move durable workflow detail into canonical docs and swarm skills. Put planning decisions in `swarm-plan`, enforcement in `swarm-launch`, worker obligations in worker contract/OpenCode agent prompts, and proof/disposition checks in `swarm-acceptance`. Update launcher/validator scripts so namespaced Superpowers skills can be required without globally enabling every Superpower in workers.
+
+**Tech Stack:** Markdown docs, Python unit tests, Bash launcher scripts, git worktrees, tmux/OpenCode swarm skills, pytest.
+
+---
+
+## File Map
+
+- `AGENTS.md` - repo gateway; link to hygiene and validation docs, do not duplicate long policy.
+- `.gitignore` - keep internal Superpowers trees ignored while allowing committed plan documents under `docs/superpowers/plans/*.md`.
+- `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy.md` - this implementation plan.
+- `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md` - manifest for changes made outside this repo under `/home/user/.codex` and `/home/user/.config/opencode`.
+- `docs/LOCAL-DEVELOPMENT.md` - canonical local validation commands and hook/test separation.
+- `docs/engineering/repo-hygiene-runbook.md` - canonical dirty-checkout, worktree, PR, and cleanup runbook.
+- `tests/unit/test_agents_contract.py` - contract tests for `AGENTS.md` and repo hygiene docs.
+- `tests/unit/test_ci_deploy_workflow.py` - contract tests for hook/test separation in docs/config.
+- `/home/user/.codex/skills/swarm-plan/SKILL.md` - require worktree allocation and worker skill declarations in plans.
+- `/home/user/.codex/skills/swarm-launch/SKILL.md` - enforce worktree/branch/reservation/required-skill preflight before launching workers.
+- `/home/user/.codex/skills/swarm-acceptance/SKILL.md` - verify worker reports, diffs, skill usage, and final disposition.
+- `/home/user/.codex/skills/swarm-worker-contract/SKILL.md` - worker finish-report schema and forbidden git operations.
+- `/home/user/.codex/skills/swarm-orchestrator/SKILL.md` - clarify orchestration boundary only; no direct worktree creation for worker implementation.
+- `/home/user/.config/opencode/agents/pr-worker.md` - OpenCode worker invariant: load only prompt-required skills, stay in assigned worktree.
+- `/home/user/.config/opencode/agents/pr-review-fix.md` - review-fix worker invariant with same boundaries.
+- `/home/user/.config/opencode/agents/pr-review.md` - reviewer invariant: read-only unless explicitly assigned.
+- `/home/user/.config/opencode/skills/swarm-worker-contract/SKILL.md` - OpenCode-facing worker finish-report schema.
+- `/home/user/.config/opencode/skills/swarm-pr-finish/SKILL.md` - OpenCode-facing final report fields and local verification evidence.
+- `/home/user/.codex/skills/tmux-swarm-orchestration/scripts/launch_opencode_worker.sh` - resolve and bundle namespaced Superpowers required skills.
+- `/home/user/.codex/skills/tmux-swarm-orchestration/scripts/validate_worker_prompt.py` - validate worker prompts include/forbid correct Superpowers policy.
+- `/home/user/.codex/skills/tmux-swarm-orchestration/scripts/validate_worker_signal.py` - allow namespaced skills in signal/report validation if currently rejected.
+- `/home/user/.codex/skills/tmux-swarm-orchestration/tests/` - add/update launcher and validator tests.
+
+External paths under `/home/user/.codex` and `/home/user/.config/opencode` are not git repositories on this machine. Tasks that edit those paths must record an external-change manifest in this repo plan directory, or use an owning upstream repository if one is intentionally introduced later. Do not run `git add /home/user/.codex/...` or `git add /home/user/.config/opencode/...` from the repo.
+
+## Policy Decisions
+
+- Hooks and push gates are for lint/static guardrails only. Tests are run locally through explicit commands such as `make test-unit` or `make local-pr-ready`.
+- Do not start non-trivial edits in a dirty checkout. Use `.worktrees/<branch>` for feature work or when unrelated changes exist.
+- Orchestrator coordinates and routes. It may request plan/launch/acceptance/disposition, but it does not implement worker tasks itself.
+- `swarm-plan` owns worker allocation: worktree, base branch, target branch, reserved files, and required role skills.
+- `swarm-launch` enforces the allocation before any worker starts.
+- Workers do not create worktrees, switch branches, rebase, merge, push, clean, stash, delete branches, or finish PR disposition unless explicitly assigned.
+- Workers may use Superpowers only when required by the prompt or plan. Never auto-load `superpowers:using-superpowers`, `superpowers:using-git-worktrees`, or `superpowers:finishing-a-development-branch` into ordinary workers.
+- Code-changing workers should normally require `superpowers:test-driven-development` and `superpowers:verification-before-completion`. Bugfix/review-fix work should add `superpowers:systematic-debugging` or `superpowers:receiving-code-review` when applicable.
+
+---
+
+### Task 1: Repo Gateway And Hygiene Policy
+
+**Files:**
+- Modify: `.gitignore`
+- Modify: `AGENTS.md`
+- Modify: `docs/LOCAL-DEVELOPMENT.md`
+- Modify: `docs/engineering/repo-hygiene-runbook.md`
+- Test: `tests/unit/test_agents_contract.py`
+- Test: `tests/unit/test_ci_deploy_workflow.py`
+
+- [ ] **Step 1: Write failing AGENTS contract tests**
+
+Add tests asserting:
+
+```python
+def test_agents_declares_workspace_isolation_policy():
+    text = Path("AGENTS.md").read_text()
+    assert "Do not start non-trivial edits in a dirty checkout" in text
+    assert "Use an isolated git worktree" in text
+    assert "docs/engineering/repo-hygiene-runbook.md" in text
+
+def test_agents_declares_hooks_static_tests_local_policy():
+    text = Path("AGENTS.md").read_text()
+    assert "Git hooks and push gates run lint/static guardrails only" in text
+    assert "Run tests explicitly as local validation" in text
+    assert "docs/LOCAL-DEVELOPMENT.md" in text
+
+def test_gitignore_allows_superpowers_plan_documents():
+    text = Path(".gitignore").read_text()
+    assert "docs/superpowers/" in text
+    assert "!docs/superpowers/plans/" in text
+    assert "!docs/superpowers/plans/*.md" in text
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `uv run pytest tests/unit/test_agents_contract.py tests/unit/test_ci_deploy_workflow.py -q`
+Expected: fail because the gateway/hygiene phrases are not all present.
+
+- [ ] **Step 3: Update gateway and canonical docs**
+
+Add a short `AGENTS.md` section named `Workspace And Swarm Hygiene`:
+
+```markdown
+Do not start non-trivial edits in a dirty checkout. Use an isolated git
+worktree for feature work or when unrelated local changes exist; see
+[`docs/engineering/repo-hygiene-runbook.md`](docs/engineering/repo-hygiene-runbook.md).
+
+Git hooks and push gates run lint/static guardrails only. Run tests explicitly
+as local validation; see [`docs/LOCAL-DEVELOPMENT.md`](docs/LOCAL-DEVELOPMENT.md).
+```
+
+In `.gitignore`, allow tracked plan documents while keeping generated/internal Superpowers content ignored:
+
+```gitignore
+docs/superpowers/
+!docs/superpowers/
+docs/superpowers/*
+!docs/superpowers/plans/
+!docs/superpowers/plans/*.md
+```
+
+In `docs/engineering/repo-hygiene-runbook.md`, add a `Before Starting New Work` section covering:
+
+```bash
+make git-hygiene
+git fetch origin
+git worktree add .worktrees/<branch> -b <branch> origin/dev
+```
+
+In `docs/LOCAL-DEVELOPMENT.md`, state that hooks may run static checks and tests remain explicit local commands.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/unit/test_agents_contract.py tests/unit/test_ci_deploy_workflow.py -q`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .gitignore AGENTS.md docs/LOCAL-DEVELOPMENT.md docs/engineering/repo-hygiene-runbook.md tests/unit/test_agents_contract.py tests/unit/test_ci_deploy_workflow.py docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy.md
+git commit -m "docs: define agent workspace hygiene policy"
+```
+
+---
+
+### Task 2: Swarm Plan Worker Allocation And Orchestrator Boundary Contract
+
+**Files:**
+- Modify: `/home/user/.codex/skills/swarm-orchestrator/SKILL.md`
+- Modify: `/home/user/.codex/skills/swarm-plan/SKILL.md`
+- Modify: `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md`
+- Test: `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_swarm_plan_contract.py`
+
+- [ ] **Step 1: Write failing test or fixture check**
+
+Add tests that read `swarm-plan/SKILL.md` and `swarm-orchestrator/SKILL.md` separately:
+
+```python
+def test_swarm_plan_requires_worker_allocation_fields():
+    text = Path("/home/user/.codex/skills/swarm-plan/SKILL.md").read_text()
+    for literal in [
+        "worktree",
+        "base_branch",
+        "target_branch",
+        "reserved_files",
+        "required_superpowers",
+        "forbidden_superpowers",
+        "superpowers:verification-before-completion",
+    ]:
+        assert literal in text
+
+def test_swarm_orchestrator_is_control_plane_only():
+    text = Path("/home/user/.codex/skills/swarm-orchestrator/SKILL.md").read_text()
+    assert "control plane" in text
+    assert "do not implement worker tasks directly" in text
+    assert "reserved worker files" in text
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run from `/home/user/.codex/skills/tmux-swarm-orchestration`: `pytest tests/test_swarm_plan_contract.py -q`
+Expected: fail on missing allocation fields or missing orchestrator boundary text.
+
+- [ ] **Step 3: Update `swarm-plan`**
+
+Add a worker allocation block to the plan template:
+
+```markdown
+### Worker Allocation
+- id:
+- kind: implementation | review-fix | review | docs | secretary
+- worktree:
+- base_branch:
+- target_branch:
+- reserved_files:
+- required_skills:
+- required_superpowers:
+- forbidden_superpowers:
+- local_validation:
+- disposition: pr | merge_done | keep_worktree | discard_with_confirmation
+```
+
+Add mapping rules:
+
+```markdown
+- Code-changing implementation: require `superpowers:test-driven-development`
+  and `superpowers:verification-before-completion`.
+- Bugfix or failing-test work: add `superpowers:systematic-debugging`.
+- Review-fix work: add `superpowers:receiving-code-review` when handling
+  reviewer feedback.
+- Never require `superpowers:using-superpowers`,
+  `superpowers:using-git-worktrees`, or
+  `superpowers:finishing-a-development-branch` for ordinary workers.
+```
+
+In `swarm-orchestrator/SKILL.md`, make the boundary explicit:
+
+```markdown
+The orchestrator is a control plane. It routes intake, planning, launch,
+acceptance, recovery, and disposition. It must not implement worker tasks
+directly, edit reserved worker files, or create ad hoc worker branches outside
+the plan/launch flow.
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `pytest tests/test_swarm_plan_contract.py -q`
+Expected: pass.
+
+- [ ] **Step 5: Record external change manifest**
+
+Append a section to `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md` listing changed external files, verification command output, and backup paths if backups were made. Do not run `git add` on `/home/user/.codex`.
+
+---
+
+### Task 3: Launcher Superpowers Skill Resolution
+
+**Files:**
+- Modify: `/home/user/.codex/skills/tmux-swarm-orchestration/scripts/launch_opencode_worker.sh`
+- Modify: `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md`
+- Test: `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_launch_opencode_worker.py`
+
+- [ ] **Step 1: Write failing launcher tests**
+
+Add tests for:
+
+```python
+def test_required_skills_accept_namespaced_superpowers():
+    assert launch_with_required("superpowers:test-driven-development").returncode == 0
+
+def test_required_superpower_is_bundled_with_safe_directory_name():
+    assert ".codex/required-skills/superpowers-test-driven-development/SKILL.md" in files
+
+def test_using_superpowers_is_rejected_for_worker_prompt():
+    assert launch_with_required("superpowers:using-superpowers").returncode != 0
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `pytest tests/test_launch_opencode_worker.py -q`
+Expected: fail because current validation only accepts unnamespaced slugs and does not search Superpowers plugin paths.
+
+- [ ] **Step 3: Update launcher**
+
+Implement:
+
+```bash
+is_valid_skill_name() {
+  [[ "$1" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]] && return 0
+  [[ "$1" =~ ^superpowers[:/][a-z0-9]+(-[a-z0-9]+)*$ ]] && return 0
+  return 1
+}
+```
+
+Search these locations for Superpowers:
+
+```bash
+$HOME/.config/opencode/node_modules/superpowers/skills/<slug>/SKILL.md
+$CODEX_HOME/superpowers/skills/<slug>/SKILL.md
+$HOME/.codex/superpowers/skills/<slug>/SKILL.md
+```
+
+Bundle namespaced skills under a filesystem-safe directory:
+
+```bash
+bundle_name="${skill//:/-}"
+bundle_name="${bundle_name//\//-}"
+```
+
+Reject forbidden worker Superpowers:
+
+```bash
+superpowers:using-superpowers
+superpowers:using-git-worktrees
+superpowers:finishing-a-development-branch
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `pytest tests/test_launch_opencode_worker.py -q`
+Expected: pass.
+
+- [ ] **Step 5: Record external change manifest**
+
+Append changed external files and verification output to `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md`. Do not run `git add` on `/home/user/.codex`.
+
+---
+
+### Task 4: Prompt Validator Superpowers Policy
+
+**Files:**
+- Modify: `/home/user/.codex/skills/tmux-swarm-orchestration/scripts/validate_worker_prompt.py`
+- Modify: `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md`
+- Test: `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_validate_worker_prompt.py`
+
+- [ ] **Step 1: Write failing validator tests**
+
+Add tests asserting:
+
+```python
+def test_code_changing_prompt_requires_superpowers_policy():
+    prompt = "Role: implementation\nReserved files:\n- src/a.py\n"
+    assert validate(prompt).fails_with("Required Superpowers")
+
+def test_worker_prompt_rejects_forbidden_superpowers():
+    prompt = "Required Superpowers: superpowers:using-git-worktrees"
+    assert validate(prompt).fails_with("forbidden")
+
+def test_docs_only_prompt_may_skip_tdd_with_reason():
+    prompt = "Required Superpowers: none\nSkipped Superpowers: superpowers:test-driven-development - docs-only"
+    assert validate(prompt).ok
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `pytest tests/test_validate_worker_prompt.py -q`
+Expected: fail on missing Superpowers prompt checks.
+
+- [ ] **Step 3: Update validator**
+
+Require code-changing worker prompts to include:
+
+```text
+Required Superpowers:
+Forbidden Superpowers:
+Finish Report Must Include:
+- superpowers_used
+- skipped_superpowers
+- evidence_commands
+```
+
+Reject forbidden worker skills from Task 3. Allow docs/read-only prompts to skip TDD only with a reason.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `pytest tests/test_validate_worker_prompt.py -q`
+Expected: pass.
+
+- [ ] **Step 5: Record external change manifest**
+
+Append changed external files and verification output to `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md`. Do not run `git add` on `/home/user/.codex`.
+
+---
+
+### Task 5: Swarm Launch Enforcement
+
+**Files:**
+- Modify: `/home/user/.codex/skills/swarm-launch/SKILL.md`
+- Modify: `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md`
+- Test: `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_swarm_launch_contract.py`
+
+- [ ] **Step 1: Write failing contract test**
+
+Assert `swarm-launch/SKILL.md` requires:
+
+```python
+[
+    "git -C <worktree> status --short",
+    "git -C <worktree> branch --show-current",
+    "reserved_files",
+    "OPENCODE_REQUIRED_SKILLS",
+    "Required Superpowers",
+]
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `pytest tests/test_swarm_launch_contract.py -q`
+Expected: fail if launch skill does not specify these gates.
+
+- [ ] **Step 3: Update launch skill**
+
+Add preflight checklist:
+
+```markdown
+Before launch, verify:
+- `git -C <worktree> status --short` has no unrelated dirt.
+- `git -C <worktree> branch --show-current` equals `target_branch`.
+- Reserved files are present in the worker prompt.
+- `OPENCODE_REQUIRED_SKILLS` includes required swarm role skills and required Superpowers.
+- Worker prompt names forbidden Superpowers and final report fields.
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `pytest tests/test_swarm_launch_contract.py -q`
+Expected: pass.
+
+- [ ] **Step 5: Record external change manifest**
+
+Append changed external files and verification output to `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md`. Do not run `git add` on `/home/user/.codex`.
+
+---
+
+### Task 6: Worker Contract And OpenCode Finish Reports
+
+**Files:**
+- Modify: `/home/user/.codex/skills/swarm-worker-contract/SKILL.md`
+- Modify: `/home/user/.config/opencode/skills/swarm-worker-contract/SKILL.md`
+- Modify: `/home/user/.config/opencode/skills/swarm-pr-finish/SKILL.md`
+- Modify: `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md`
+- Test: `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_worker_contract.py`
+
+- [ ] **Step 1: Write failing contract tests**
+
+Require both Codex and OpenCode worker contracts to mention:
+
+```python
+[
+    "superpowers_used",
+    "skipped_superpowers",
+    "evidence_commands",
+    "reserved_files",
+    "changed_files",
+    "head_sha",
+    "Do not switch branches",
+    "Do not push",
+]
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `pytest tests/test_worker_contract.py -q`
+Expected: fail on missing report fields or forbidden git operation text.
+
+- [ ] **Step 3: Update worker contracts**
+
+Add finish report schema:
+
+```markdown
+## Finish Report
+- status: DONE | FAILED | BLOCKED
+- worker:
+- task:
+- worktree:
+- branch:
+- head_sha:
+- reserved_files:
+- changed_files:
+- superpowers_used:
+- skipped_superpowers:
+- docs_impact:
+- new_bugs:
+- evidence_commands:
+- skipped_checks:
+- blockers:
+- next:
+```
+
+Add forbidden operations:
+
+```markdown
+Workers must not switch branches, rebase, merge, push, stash, clean, delete
+branches, create extra worktrees, or edit outside reserved files unless the
+prompt explicitly expands the reservation.
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `pytest tests/test_worker_contract.py -q`
+Expected: pass.
+
+- [ ] **Step 5: Record external change manifest**
+
+Append changed external files and verification output to `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md`. Do not run `git add` on `/home/user/.codex` or `/home/user/.config/opencode`.
+
+---
+
+### Task 7: Acceptance Verification And Disposition
+
+**Files:**
+- Modify: `/home/user/.codex/skills/swarm-acceptance/SKILL.md`
+- Modify: `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md`
+- Test: `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_swarm_acceptance_contract.py`
+
+- [ ] **Step 1: Write failing acceptance tests**
+
+Assert acceptance skill requires checks for:
+
+```python
+[
+    "changed_files",
+    "reserved_files",
+    "superpowers_used",
+    "skipped_superpowers",
+    "git -C <worktree> diff --name-only",
+    "disposition",
+    "pr",
+    "merge_done",
+    "keep_worktree",
+    "discard_with_confirmation",
+]
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `pytest tests/test_swarm_acceptance_contract.py -q`
+Expected: fail while acceptance does not require all checks.
+
+- [ ] **Step 3: Update acceptance skill**
+
+Add acceptance gates:
+
+```markdown
+- Compare actual changed files from `git -C <worktree> diff --name-only` and
+  staged files against `reserved_files`.
+- Compare required Superpowers from the plan against `superpowers_used` and
+  `skipped_superpowers`.
+- Require evidence commands for claimed lint/test/static status.
+- Choose disposition: `pr`, `merge_done`, `keep_worktree`, or
+  `discard_with_confirmation`.
+- Never delete or discard a dirty worktree without explicit confirmation.
+```
+
+Define disposition semantics:
+
+```markdown
+- `pr`: leave the worker worktree and branch intact, create or update the PR,
+  report branch/head SHA/PR URL, and do not delete anything.
+- `merge_done`: only after merge is externally verified; fetch, verify the
+  merged head contains the worker head or PR merge commit, then remove the
+  clean worker worktree and delete the local branch only if it is fully merged.
+- `keep_worktree`: leave worktree and branch intact, record reason and next
+  owner/action.
+- `discard_with_confirmation`: require explicit human confirmation naming the
+  exact worktree and branch; archive `git -C <worktree> diff` first; then remove
+  only the confirmed worktree/branch.
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `pytest tests/test_swarm_acceptance_contract.py -q`
+Expected: pass.
+
+- [ ] **Step 5: Record external change manifest**
+
+Append changed external files and verification output to `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md`. Do not run `git add` on `/home/user/.codex`.
+
+---
+
+### Task 8: OpenCode Agent Invariants
+
+**Files:**
+- Modify: `/home/user/.config/opencode/agents/pr-worker.md`
+- Modify: `/home/user/.config/opencode/agents/pr-review-fix.md`
+- Modify: `/home/user/.config/opencode/agents/pr-review.md`
+- Modify: `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md`
+- Test: `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_opencode_agent_contract.py`
+
+- [ ] **Step 1: Write failing agent prompt tests**
+
+Assert each worker/review-fix agent contains:
+
+```python
+"Load only prompt-required skills"
+"assigned worktree"
+"Do not switch branches"
+"Do not push"
+```
+
+For `pr-review.md`, assert read-only behavior unless explicit assignment exists.
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `pytest tests/test_opencode_agent_contract.py -q`
+Expected: fail if agent prompts do not contain the invariants.
+
+- [ ] **Step 3: Update agent prompts**
+
+Add concise invariant:
+
+```markdown
+Load only prompt-required skills. Stay in the assigned worktree and branch.
+Do not switch branches, create worktrees, push, merge, rebase, stash, clean, or
+perform PR disposition unless the prompt explicitly assigns that operation.
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `pytest tests/test_opencode_agent_contract.py -q`
+Expected: pass.
+
+- [ ] **Step 5: Record external change manifest**
+
+Append changed external files and verification output to `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md`. Do not run `git add` on `/home/user/.codex` or `/home/user/.config/opencode`.
+
+---
+
+### Task 9: Signal Validator Compatibility For Namespaced Skills
+
+**Files:**
+- Modify: `/home/user/.codex/skills/tmux-swarm-orchestration/scripts/validate_worker_signal.py`
+- Modify: `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md`
+- Test: `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_validate_worker_signal.py`
+
+- [ ] **Step 1: Write failing validator test**
+
+Add a report fixture with:
+
+```json
+{
+  "superpowers_used": ["superpowers:test-driven-development", "superpowers:verification-before-completion"],
+  "skipped_superpowers": []
+}
+```
+
+Assert validation accepts the namespaced values.
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `pytest tests/test_validate_worker_signal.py -q`
+Expected: fail if validator rejects colon-separated skill names or unknown fields.
+
+- [ ] **Step 3: Update signal validator**
+
+Allow namespaced Superpowers in `superpowers_used` and `skipped_superpowers` fields. Keep strict validation for status values, required evidence fields, and malformed JSON if legacy strict mode is used.
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `pytest tests/test_validate_worker_signal.py -q`
+Expected: pass.
+
+- [ ] **Step 5: Record external change manifest**
+
+Append changed external files and verification output to `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md`. Do not run `git add` on `/home/user/.codex`.
+
+---
+
+### Task 10: End-To-End Dry Run Without Real Worker Launch
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md`
+- Test: `/home/user/.codex/skills/tmux-swarm-orchestration/tests/test_swarm_superpowers_dry_run.py`
+
+- [ ] **Step 1: Write dry-run test**
+
+Create a temporary repo/worktree fixture and simulate:
+
+```python
+plan = WorkerAllocation(
+    worktree=temp_worktree,
+    target_branch="feature/example",
+    reserved_files=["src/example.py"],
+    required_superpowers=[
+        "superpowers:test-driven-development",
+        "superpowers:verification-before-completion",
+    ],
+)
+```
+
+Assert launch prompt generation includes required skills, validation passes, and a fake DONE report with matching `changed_files` and `superpowers_used` is accepted.
+
+- [ ] **Step 2: Run dry-run test to verify failure**
+
+Run: `pytest tests/test_swarm_superpowers_dry_run.py -q`
+Expected: fail before the launcher/validator/acceptance updates are complete.
+
+- [ ] **Step 3: Wire minimal integration helpers**
+
+Reuse existing launcher/validator helpers. Do not launch real tmux/OpenCode. Keep this as a pure local test around generated prompts, copied required skills, and report validation.
+
+- [ ] **Step 4: Run full swarm orchestration test subset**
+
+Run: `pytest tests/test_launch_opencode_worker.py tests/test_validate_worker_prompt.py tests/test_validate_worker_signal.py tests/test_swarm_superpowers_dry_run.py -q`
+Expected: pass.
+
+- [ ] **Step 5: Record external change manifest**
+
+Append changed external files and verification output to `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md`. Do not run `git add` on `/home/user/.codex`.
+
+---
+
+### Task 11: Final Review And Handoff
+
+**Files:**
+- Modify: `docs/engineering/repo-hygiene-runbook.md` if execution discovers missing cleanup details.
+- Modify: `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md` if review fixes touch external skill/config files.
+- Modify: relevant external skill/config files only for review fixes.
+
+- [ ] **Step 1: Run repo verification**
+
+Run from repo worktree:
+
+```bash
+uv run pytest tests/unit/test_agents_contract.py tests/unit/test_ci_deploy_workflow.py -q
+uv run ruff check tests/unit/test_agents_contract.py tests/unit/test_ci_deploy_workflow.py
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Run swarm tooling verification**
+
+Run from `/home/user/.codex/skills/tmux-swarm-orchestration`:
+
+```bash
+pytest tests/test_launch_opencode_worker.py tests/test_validate_worker_prompt.py tests/test_validate_worker_signal.py tests/test_swarm_plan_contract.py tests/test_swarm_launch_contract.py tests/test_worker_contract.py tests/test_swarm_acceptance_contract.py tests/test_opencode_agent_contract.py tests/test_swarm_superpowers_dry_run.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run manual policy spot checks**
+
+Run:
+
+```bash
+rg "superpowers:using-superpowers|superpowers:using-git-worktrees|superpowers:finishing-a-development-branch" /home/user/.codex/skills/swarm-* /home/user/.config/opencode/agents /home/user/.config/opencode/skills
+rg "superpowers:test-driven-development|superpowers:verification-before-completion" /home/user/.codex/skills/swarm-* /home/user/.config/opencode/skills
+```
+
+Expected: forbidden Superpowers appear only in “do not require/use in workers” text; required Superpowers appear in plan/launch/contract policy.
+
+- [ ] **Step 4: Request code review**
+
+Use `superpowers:requesting-code-review` or the local `review` skill for changed repo files and changed swarm tooling files.
+
+- [ ] **Step 5: Apply review fixes**
+
+If review finds blockers, use `superpowers:receiving-code-review` before changing code or docs. If fixes touch `/home/user/.codex` or `/home/user/.config/opencode`, append those files and fresh verification output to `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md`. Repeat verification after fixes.
+
+- [ ] **Step 6: Final disposition**
+
+Use `superpowers:finishing-a-development-branch` only after verification is fresh and implementation is complete. Choose one disposition:
+
+```text
+pr
+merge_done
+keep_worktree
+discard_with_confirmation
+```
+
+Do not delete dirty worktrees automatically.
+
+---
+
+## Execution Notes
+
+- Keep repo edits in a dedicated worktree, not the dirty main checkout.
+- External skill/config edits under `/home/user/.codex` and `/home/user/.config/opencode` are outside the repo; verify them separately and do not mix their commit assumptions with repo commits.
+- If a test path under `/home/user/.codex/skills/tmux-swarm-orchestration/tests/` does not exist yet, create the smallest focused test file named in the task.
+- Do not globally enable all Superpowers for workers. Required Superpowers must be role-specific and visible in the worker prompt.
+- Treat worker reports as leads until acceptance verifies actual git diff, branch, head SHA, reserved files, and evidence commands.

--- a/tests/unit/test_agents_contract.py
+++ b/tests/unit/test_agents_contract.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+def test_agents_declares_workspace_isolation_policy() -> None:
+    text = Path("AGENTS.md").read_text(encoding="utf-8")
+    assert "Do not start non-trivial edits in a dirty checkout" in text
+    assert "Use an isolated git worktree" in text
+    assert "docs/engineering/repo-hygiene-runbook.md" in text
+
+
+def test_agents_declares_hooks_static_tests_local_policy() -> None:
+    text = Path("AGENTS.md").read_text(encoding="utf-8")
+    assert "Git hooks and push gates run lint/static guardrails only" in text
+    assert "Run tests explicitly as local validation" in text
+    assert "docs/LOCAL-DEVELOPMENT.md" in text
+
+
+def test_gitignore_allows_superpowers_plan_documents() -> None:
+    text = Path(".gitignore").read_text(encoding="utf-8")
+    assert "docs/superpowers/" in text
+    assert "!docs/superpowers/plans/" in text
+    assert "!docs/superpowers/plans/*.md" in text
+
+
+def test_repo_hygiene_runbook_documents_worktree_start_rule() -> None:
+    text = Path("docs/engineering/repo-hygiene-runbook.md").read_text(encoding="utf-8")
+    assert "Before Starting New Work" in text
+    assert "make git-hygiene" in text
+    assert "git worktree add .worktrees/<branch>" in text

--- a/tests/unit/test_agents_contract.py
+++ b/tests/unit/test_agents_contract.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 
 
@@ -20,6 +21,26 @@ def test_gitignore_allows_superpowers_plan_documents() -> None:
     assert "docs/superpowers/" in text
     assert "!docs/superpowers/plans/" in text
     assert "!docs/superpowers/plans/*.md" in text
+
+
+def test_gitignore_allows_only_superpowers_plan_markdown_files() -> None:
+    ignored = subprocess.run(
+        ["git", "check-ignore", "-q", "docs/superpowers/plans/generated.txt"],
+        check=False,
+    )
+    assert ignored.returncode == 0
+
+    nested = subprocess.run(
+        ["git", "check-ignore", "-q", "docs/superpowers/plans/nested/generated.md"],
+        check=False,
+    )
+    assert nested.returncode == 0
+
+    allowed = subprocess.run(
+        ["git", "check-ignore", "-q", "docs/superpowers/plans/handwritten.md"],
+        check=False,
+    )
+    assert allowed.returncode == 1
 
 
 def test_repo_hygiene_runbook_documents_worktree_start_rule() -> None:

--- a/tests/unit/test_ci_deploy_workflow.py
+++ b/tests/unit/test_ci_deploy_workflow.py
@@ -35,11 +35,11 @@ def test_no_sensitive_deploy_patterns() -> None:
 
 
 def test_validation_jobs_exist() -> None:
-    """Core validation: the Lint & Type Check job runs."""
+    """Core validation: the Lint job runs."""
     text = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
     data = yaml.safe_load(text)
     assert "lint" in data["jobs"], "missing 'lint' job key"
-    assert data["jobs"]["lint"].get("name") == "Lint & Type Check"
+    assert data["jobs"]["lint"].get("name") == "Lint"
 
 
 def test_ruff_lint_runs() -> None:


### PR DESCRIPTION
## Summary
- Define repo agent workspace hygiene: static git hooks, explicit local tests, and isolated worktrees for non-trivial work.
- Add a reviewed Superpowers/swarm worker policy plan plus manifest for external Codex/OpenCode skill changes.
- Add contract tests for AGENTS.md, gitignore plan allowlist, repo hygiene docs, and current CI lint workflow naming.

## External Changes Documented
- Updated local Codex swarm skills, launch/prompt/signal validators, and OpenCode worker agents/finish contracts.
- See `docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md` for exact paths and verification evidence.

## Test Plan
- [x] `uv run pytest tests/unit/test_agents_contract.py tests/unit/test_ci_deploy_workflow.py -q`
- [x] `uv run ruff check tests/unit/test_agents_contract.py tests/unit/test_ci_deploy_workflow.py`
- [x] `/home/user/projects/rag-fresh/.worktrees/plan-swarm-superpowers-worker-policy/.venv/bin/python -m pytest tests/test_launch_opencode_worker.py tests/test_validate_worker_prompt.py tests/test_validate_worker_signal.py tests/test_swarm_plan_contract.py tests/test_swarm_launch_contract.py tests/test_worker_contract.py tests/test_swarm_acceptance_contract.py tests/test_opencode_agent_contract.py tests/test_swarm_superpowers_dry_run.py -q`
