### PR TITLE
docs(indexes): fix stale LOCAL-DEVELOPMENT.md anchors in runtime index (#1612)

### DIFF
--- a/docs/indexes/local-runtime.md
+++ b/docs/indexes/local-runtime.md
@@ -6,14 +6,14 @@ in [`../../DOCKER.md`](../../DOCKER.md).
 
 | Goal / Symptom | Canonical Doc | Focused Check |
 |---|---|---|
-| Bootstrap local services for native bot iteration | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#7-minimal-stack-fast-iteration) | `make local-up && make test-bot-health` |
-| Run the bot natively from `.env` | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#7-minimal-stack-fast-iteration) | `make bot` |
+| Bootstrap local services for native bot iteration | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#8-minimal-stack-fast-iteration) | `make local-up && make test-bot-health` |
+| Run the bot natively from `.env` | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#8-minimal-stack-fast-iteration) | `make bot` |
 | Check the bot username behind the current token | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#1-bootstrap-workspace) | Telegram `getMe` snippet in the local guide |
 | Configure Telegram E2E userbot credentials | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#1-bootstrap-workspace) | `TELEGRAM_API_ID`, `TELEGRAM_API_HASH`, `E2E_BOT_USERNAME` |
 | Create or refresh the Telethon session | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#1-bootstrap-workspace) and [`../../tests/README.md`](../../tests/README.md#e2e) | `uv run python -m scripts.e2e.auth --phone ... --code ...` |
 | Smoke test Telegram bot response through Telethon | [`../../tests/README.md`](../../tests/README.md#e2e) | `uv run python -m scripts.e2e.quick_test` |
-| `make bot` fails with polling lock busy | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#8-common-issues) | Stop the Docker bot container or wait for Redis lock TTL |
-| Telethon session file exists but is not authorized | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#8-common-issues) | Refresh with `scripts.e2e.auth` |
+| `make bot` fails with polling lock busy | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#11-common-issues) | Stop the Docker bot container or wait for Redis lock TTL |
+| Telethon session file exists but is not authorized | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#11-common-issues) | Refresh with `scripts.e2e.auth` |
 
 Runtime reminders:
 

--- a/tests/contract/test_local_runtime_index_anchors.py
+++ b/tests/contract/test_local_runtime_index_anchors.py
@@ -1,0 +1,81 @@
+"""Contract: ``docs/indexes/local-runtime.md`` anchors must point at real headings (#1612).
+
+The runtime index links to ``docs/LOCAL-DEVELOPMENT.md`` using GitHub-style
+slugified anchors. When section numbers in LOCAL-DEVELOPMENT.md change, the
+index links go stale silently. This contract slugifies every ``##`` heading
+in LOCAL-DEVELOPMENT.md and asserts that every ``LOCAL-DEVELOPMENT.md#anchor``
+link in the runtime index resolves to one of those slugs.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNTIME_INDEX = REPO_ROOT / "docs" / "indexes" / "local-runtime.md"
+LOCAL_DEV = REPO_ROOT / "docs" / "LOCAL-DEVELOPMENT.md"
+
+
+_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$", re.MULTILINE)
+
+
+def _github_slugify(heading_text: str) -> str:
+    """Approximate GitHub's heading slug algorithm.
+
+    Lowercase, drop characters that are not alphanumeric/hyphen/space, then
+    collapse whitespace to single hyphens.
+    """
+    text = heading_text.lower()
+    text = re.sub(r"[^\w\s\-]", "", text)
+    text = re.sub(r"\s+", "-", text.strip())
+    return text
+
+
+def _collect_anchors(md_text: str) -> set[str]:
+    return {_github_slugify(m.group(2)) for m in _HEADING_RE.finditer(md_text)}
+
+
+def _collect_local_dev_links(index_text: str) -> list[str]:
+    """Return every fragment that targets LOCAL-DEVELOPMENT.md."""
+    targets = []
+    for match in _LINK_RE.finditer(index_text):
+        href = match.group(1)
+        if "LOCAL-DEVELOPMENT.md#" not in href:
+            continue
+        # Split on '#' once; we only care about the fragment part.
+        fragment = href.split("#", 1)[1]
+        targets.append(fragment)
+    return targets
+
+
+def test_runtime_index_local_dev_anchors_resolve() -> None:
+    assert RUNTIME_INDEX.exists(), f"missing: {RUNTIME_INDEX}"
+    assert LOCAL_DEV.exists(), f"missing: {LOCAL_DEV}"
+
+    anchors = _collect_anchors(LOCAL_DEV.read_text(encoding="utf-8"))
+    fragments = _collect_local_dev_links(RUNTIME_INDEX.read_text(encoding="utf-8"))
+    assert fragments, "Runtime index must reference at least one LOCAL-DEVELOPMENT.md anchor"
+
+    missing = sorted({frag for frag in fragments if frag not in anchors})
+    if missing:
+        # Surface a few candidate slugs to make fixing the link obvious.
+        candidates = sorted(a for a in anchors if "minimal" in a or "common" in a or "issues" in a)
+        raise AssertionError(
+            "Runtime index links point to anchors that do not exist in "
+            "LOCAL-DEVELOPMENT.md:\n  - "
+            + "\n  - ".join(missing)
+            + "\nClosest candidate slugs in LOCAL-DEVELOPMENT.md:\n  - "
+            + "\n  - ".join(candidates or ["<none>"])
+        )
+
+
+def test_slugify_handles_numbered_section_headings() -> None:
+    """Ensure the slug algorithm matches GitHub for the numbered headings used here."""
+    assert _github_slugify("8. Minimal Stack (Fast Iteration)") == (
+        "8-minimal-stack-fast-iteration"
+    )
+    assert _github_slugify("11. Common Issues") == "11-common-issues"
+    assert _github_slugify("1. Bootstrap Workspace") == "1-bootstrap-workspace"

--- a/tests/contract/test_local_runtime_index_anchors.py
+++ b/tests/contract/test_local_runtime_index_anchors.py
@@ -30,8 +30,7 @@ def _github_slugify(heading_text: str) -> str:
     """
     text = heading_text.lower()
     text = re.sub(r"[^\w\s\-]", "", text)
-    text = re.sub(r"\s+", "-", text.strip())
-    return text
+    return re.sub(r"\s+", "-", text.strip())
 
 
 def _collect_anchors(md_text: str) -> set[str]:


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Closes #1612 (anchor part).

## Problem
`docs/indexes/local-runtime.md` linked to:
- `LOCAL-DEVELOPMENT.md#7-minimal-stack-fast-iteration`
- `LOCAL-DEVELOPMENT.md#8-common-issues`

But the live headings in `docs/LOCAL-DEVELOPMENT.md` are:
- `## 8. Minimal Stack (Fast Iteration)`
- `## 11. Common Issues`

Both index anchors silently 404 in the GitHub viewer.

## TDD steps
1. **RED** — added `tests/contract/test_local_runtime_index_anchors.py`. It GitHub-slugifies every `##` heading in `LOCAL-DEVELOPMENT.md` and asserts every `LOCAL-DEVELOPMENT.md#anchor` link in the runtime index resolves. First run failed listing the two missing anchors and surfacing the closest candidates (`8-minimal-stack-fast-iteration`, `11-common-issues`).
2. **GREEN** — updated the four index links to `#8-minimal-stack-fast-iteration` and `#11-common-issues`. Re-run: 2 passed.

## Scope note
This PR addresses only the anchor-drift half of #1612. The companion finding about `scripts/check_markdown_links.py` reporting 12 broken links under `kimi-cli/src/kimi_cli/deps/tmp/...` could not be reproduced — that vendored tmp tree is not present in `dev`. If it returns, that part should be tracked separately.

## Tested
```bash
python -m pytest tests/contract/test_local_runtime_index_anchors.py -q
# 2 passed
```