### PR TITLE
test(integration): require non-empty Qdrant data and non-empty results (#1631)

### DIFF
--- a/tests/contract/test_qdrant_integration_assertions_contract.py
+++ b/tests/contract/test_qdrant_integration_assertions_contract.py
@@ -1,0 +1,164 @@
+"""Contract: Qdrant integration tests must not pass with empty data (#1631).
+
+Two read-path integration tests previously reported success without proving
+that anything was actually read:
+
+- ``tests/integration/test_qdrant_read.py`` — ``_run_qdrant_read_checks``
+  returned ``True`` when the Qdrant instance had zero collections, and the
+  wrapper test only port-checked Qdrant before asserting the helper. So a
+  brand-new empty Qdrant gave a green test.
+
+- ``tests/integration/test_hybrid_search_sparse.py`` — the test executed
+  search queries and printed result counts but never asserted that any
+  query returned at least one result. Sparse search returning zero hits
+  for every probe query was reported as success.
+
+This contract uses AST inspection to keep both files honest:
+
+1. The wrapper ``test_qdrant_read`` must skip when collections are empty
+   or the candidate collection has zero points, instead of returning
+   success.
+2. ``test_hybrid_search_with_sparse`` must contain an assertion that
+   checks query results were non-empty (e.g. ``assert ... > 0``).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+QDRANT_READ = REPO_ROOT / "tests" / "integration" / "test_qdrant_read.py"
+HYBRID_SPARSE = REPO_ROOT / "tests" / "integration" / "test_hybrid_search_sparse.py"
+
+
+def _function(tree: ast.AST, name: str) -> ast.FunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node  # type: ignore[return-value]
+    raise AssertionError(f"function '{name}' not found")
+
+
+def _calls(tree: ast.AST, dotted: str) -> list[ast.Call]:
+    """Return every Call node whose target is the given dotted name."""
+    parts = dotted.split(".")
+    out: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        target = node.func
+        chain: list[str] = []
+        while isinstance(target, ast.Attribute):
+            chain.append(target.attr)
+            target = target.value
+        if isinstance(target, ast.Name):
+            chain.append(target.id)
+        if list(reversed(chain)) == parts:
+            out.append(node)
+    return out
+
+
+def test_qdrant_read_skips_on_empty_collections() -> None:
+    """``test_qdrant_read`` must call ``pytest.skip`` when no collections exist (#1631)."""
+    assert QDRANT_READ.exists(), f"missing: {QDRANT_READ}"
+    tree = ast.parse(QDRANT_READ.read_text(encoding="utf-8"))
+    test_func = _function(tree, "test_qdrant_read")
+
+    # Need at least two pytest.skip() calls (one for port-down, one for empty data).
+    skip_calls = _calls(test_func, "pytest.skip")
+    assert len(skip_calls) >= 2, (
+        "test_qdrant_read must skip on BOTH 'Qdrant unreachable' AND 'no data "
+        "in Qdrant' before asserting the read helper. Found "
+        f"{len(skip_calls)} pytest.skip(...) call(s)."
+    )
+
+    # The skip messages must signal the empty-data path explicitly.
+    skip_messages = []
+    for call in skip_calls:
+        if call.args and isinstance(call.args[0], (ast.Constant, ast.JoinedStr)):
+            try:
+                skip_messages.append(ast.unparse(call.args[0]).lower())
+            except Exception:  # pragma: no cover - defensive
+                pass
+    has_empty_data_skip = any(
+        any(token in msg for token in ("collection", "data", "point", "empty"))
+        for msg in skip_messages
+    )
+    assert has_empty_data_skip, (
+        "At least one pytest.skip(...) message in test_qdrant_read must "
+        "reference the missing-collection / empty-data condition. "
+        f"Found messages: {skip_messages!r}"
+    )
+
+
+def test_qdrant_read_helper_does_not_return_true_on_empty_collections() -> None:
+    """The helper must not silently succeed when ``collections.collections`` is empty (#1631)."""
+    tree = ast.parse(QDRANT_READ.read_text(encoding="utf-8"))
+    helper = _function(tree, "_run_qdrant_read_checks")
+
+    # Walk every `if not collections.collections:` branch and ensure the
+    # body does not unconditionally return True.
+    for node in ast.walk(helper):
+        if not isinstance(node, ast.If):
+            continue
+        try:
+            test_src = ast.unparse(node.test)
+        except Exception:  # pragma: no cover - defensive
+            continue
+        if "collections.collections" not in test_src or "not " not in test_src:
+            continue
+        for sub in ast.walk(node):
+            if (
+                isinstance(sub, ast.Return)
+                and isinstance(sub.value, ast.Constant)
+                and sub.value.value is True
+            ):
+                raise AssertionError(
+                    "_run_qdrant_read_checks must not 'return True' inside the "
+                    "'if not collections.collections:' branch. Either skip in "
+                    "the test wrapper before calling the helper, or fail the "
+                    "assertion when no collections are present."
+                )
+
+
+def test_hybrid_search_with_sparse_asserts_nonempty_results() -> None:
+    """``test_hybrid_search_with_sparse`` must assert at least one query returned hits (#1631)."""
+    assert HYBRID_SPARSE.exists(), f"missing: {HYBRID_SPARSE}"
+    tree = ast.parse(HYBRID_SPARSE.read_text(encoding="utf-8"))
+    test_func = _function(tree, "test_hybrid_search_with_sparse")
+
+    # Pull every Assert in the function body and inspect their condition source.
+    assert_sources: list[str] = []
+    for node in ast.walk(test_func):
+        if isinstance(node, ast.Assert):
+            try:
+                assert_sources.append(ast.unparse(node.test))
+            except Exception:  # pragma: no cover - defensive
+                continue
+
+    has_nonempty_results_assertion = any(
+        ("> 0" in src or ">= 1" in src or "any(" in src or " is True" in src)
+        and any(tok in src.lower() for tok in ("result", "hit", "total", "found", "len(", "count"))
+        for src in assert_sources
+    )
+    assert has_nonempty_results_assertion, (
+        "test_hybrid_search_with_sparse must assert that the search path "
+        "actually returned data (e.g. `assert total_results > 0`). "
+        f"Found assertions: {assert_sources!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "src,target,expected",
+    [
+        ("import x\nx.foo()\n", "x.foo", 1),
+        ("import x\ny.foo()\nx.foo(1)\n", "x.foo", 1),
+        ("import a.b\na.b.c.d()\n", "a.b.c.d", 1),
+    ],
+)
+def test_calls_helper_walks_dotted_chain(src: str, target: str, expected: int) -> None:
+    tree = ast.parse(src)
+    assert len(_calls(tree, target)) == expected

--- a/tests/contract/test_qdrant_integration_assertions_contract.py
+++ b/tests/contract/test_qdrant_integration_assertions_contract.py
@@ -25,6 +25,7 @@ This contract uses AST inspection to keep both files honest:
 from __future__ import annotations
 
 import ast
+from contextlib import suppress
 from pathlib import Path
 
 import pytest
@@ -79,10 +80,8 @@ def test_qdrant_read_skips_on_empty_collections() -> None:
     skip_messages = []
     for call in skip_calls:
         if call.args and isinstance(call.args[0], (ast.Constant, ast.JoinedStr)):
-            try:
+            with suppress(Exception):
                 skip_messages.append(ast.unparse(call.args[0]).lower())
-            except Exception:  # pragma: no cover - defensive
-                pass
     has_empty_data_skip = any(
         any(token in msg for token in ("collection", "data", "point", "empty"))
         for msg in skip_messages

--- a/tests/integration/test_hybrid_search_sparse.py
+++ b/tests/integration/test_hybrid_search_sparse.py
@@ -50,6 +50,7 @@ def _run_hybrid_search_with_sparse() -> bool:
         "Що таке крайня необхідність?",  # Legal concept
     ]
 
+    total_results = 0
     for i, query in enumerate(test_queries, 1):
         print(f"\n{'=' * 80}")
         print(f"🔍 Test Query {i}: {query}")
@@ -64,6 +65,7 @@ def _run_hybrid_search_with_sparse() -> bool:
             )
 
             print(f"\n   ✅ Found {len(results)} results")
+            total_results += len(results)
 
             for j, result in enumerate(results, 1):
                 print(f"\n   📄 Result {j}:")
@@ -80,10 +82,10 @@ def _run_hybrid_search_with_sparse() -> bool:
             return False
 
     print(f"\n{'=' * 80}")
-    print("✅ ALL TESTS PASSED!")
+    print(f"✅ ALL TESTS PASSED — total results across queries: {total_results}")
     print(f"{'=' * 80}\n")
 
-    return True
+    return total_results
 
 
 def _is_port_open(host: str, port: int, timeout: float = 1.0) -> bool:
@@ -119,9 +121,20 @@ def test_hybrid_search_with_sparse():
         settings.qdrant_url, settings.qdrant_api_key, settings.collection_name
     ):
         pytest.skip(f"Collection not found: {settings.collection_name}")
-    assert _run_hybrid_search_with_sparse()
+
+    # Run the search; the helper returns the total result count across probe
+    # queries. Zero results across every query means the sparse search path
+    # is silently empty — fail instead of reporting green (#1631).
+    total_results = _run_hybrid_search_with_sparse()
+    assert total_results is not False, "hybrid search execution failed"
+    assert total_results > 0, (
+        "hybrid search returned 0 results across all probe queries — "
+        "sparse search path is empty or misconfigured (#1631)"
+    )
 
 
 if __name__ == "__main__":
-    success = _run_hybrid_search_with_sparse()
-    sys.exit(0 if success else 1)
+    result = _run_hybrid_search_with_sparse()
+    if result is False:
+        sys.exit(1)
+    sys.exit(0 if int(result) > 0 else 2)

--- a/tests/integration/test_qdrant_read.py
+++ b/tests/integration/test_qdrant_read.py
@@ -50,7 +50,11 @@ def _run_qdrant_read_checks() -> bool:
 
         if not collections.collections:
             print("   ℹ️  Нет коллекций для тестирования")
-            return True
+            # Empty Qdrant is not a successful read test (#1631).
+            # The wrapper test skips earlier, so reaching this point during
+            # an actual run means we lost data between the skip check and
+            # the helper invocation — fail loudly.
+            return False
 
         # Детали первой коллекции
         collection_name = collections.collections[0].name
@@ -141,6 +145,18 @@ def test_qdrant_read():
     port = parsed.port or 6333
     if not _is_port_open(host, port):
         pytest.skip(f"Qdrant not running on {host}:{port}")
+
+    # Empty Qdrant is not a successful read test (#1631) — skip BEFORE the
+    # helper runs so absent data is reported as skipped, not green.
+    client = QdrantClient(url=QDRANT_URL, api_key=QDRANT_API_KEY or None)
+    collections = client.get_collections().collections
+    if not collections:
+        pytest.skip("No Qdrant collections available — read test requires existing data")
+    target = collections[0].name
+    info = client.get_collection(target)
+    if not info.points_count:
+        pytest.skip(f"Collection '{target}' has zero points — read test requires data")
+
     assert _run_qdrant_read_checks()
 
 


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Closes #1631.

## Problem
Two Qdrant read-path integration tests reported success without proving any read actually happened:

- `tests/integration/test_qdrant_read.py` — `_run_qdrant_read_checks` returned `True` when Qdrant had zero collections, and the wrapper only port-checked Qdrant. Empty Qdrant ⇒ green test.
- `tests/integration/test_hybrid_search_sparse.py` — the test executed probe queries and printed result counts but never asserted any query returned ≥1 result. Sparse search returning 0 hits for every query ⇒ green test.

## TDD steps
1. **RED** — `tests/contract/test_qdrant_integration_assertions_contract.py`: AST inspection of both files.
   - `test_qdrant_read` must call `pytest.skip(...)` at least twice (port-down + empty-data), with at least one skip message referencing the empty-data condition.
   - `_run_qdrant_read_checks` must NOT have a `return True` reachable inside the `if not collections.collections:` branch.
   - `test_hybrid_search_with_sparse` must contain an assertion of the form `... > 0` referencing results/hits/total.
   First run: 3 contract tests failed (one per bug).
2. **GREEN** — applied minimal refactors:
   - `test_qdrant_read.py`: skip BEFORE the helper if no collections exist OR the chosen collection has zero points; helper now returns `False` in the unreachable empty branch.
   - `test_hybrid_search_sparse.py`: helper accumulates a `total_results` count across probe queries and returns the integer; wrapper asserts `total_results > 0` (and `is not False` to surface a hard failure).
   Re-run: 6 passed.

## Why these are minimal
- Skip semantics are preserved when the live stack is genuinely unreachable or empty — CI green stays green.
- Once the live stack has data, an actual read regression now fails instead of silently passing.

## Tested
```bash
python -m pytest tests/contract/test_qdrant_integration_assertions_contract.py -q
# 6 passed
python -c "import ast; [ast.parse(open(f).read()) for f in ['tests/integration/test_qdrant_read.py','tests/integration/test_hybrid_search_sparse.py']]"
# parses cleanly
```