### PR TITLE
test(e2e): cache regression must fail, not skip, after live stack responded (#1630)

### DIFF
--- a/tests/contract/test_e2e_cache_regression_contract.py
+++ b/tests/contract/test_e2e_cache_regression_contract.py
@@ -1,0 +1,88 @@
+"""Contract: live E2E cache test must FAIL on missing transitions, not skip (#1630).
+
+Once ``_require_live_stack()`` confirms the RAG API and Redis responded, the
+remainder of the test owns post-query assertions. Skipping when no
+miss→hit transition is observed conflates "stack not available" (legitimate
+skip) with "cache regression" (must fail). This contract uses AST analysis
+to keep the cache test honest:
+
+1. Inside ``test_cache_miss_then_hit_on_repeated_query``, a ``pytest.skip(...)``
+   call may only appear BEFORE the live-stack preflight returns successfully
+   (or as the preflight itself via ``_require_live_stack``). After the
+   queries have run, the missing transition must be expressed as an
+   ``assert``.
+
+2. The test must contain an ``assert`` that requires both
+   ``hits >= 1`` (or ``> 0``) and ``misses >= 1`` (or ``> 0``).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TARGET = REPO_ROOT / "tests" / "e2e" / "test_core_flows_live.py"
+
+
+def _function(tree: ast.AST, name: str) -> ast.AST:
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"function '{name}' not found in {TARGET}")
+
+
+def _is_pytest_skip(call: ast.Call) -> bool:
+    target = call.func
+    chain: list[str] = []
+    while isinstance(target, ast.Attribute):
+        chain.append(target.attr)
+        target = target.value
+    if isinstance(target, ast.Name):
+        chain.append(target.id)
+    return list(reversed(chain)) == ["pytest", "skip"]
+
+
+def test_target_file_exists() -> None:
+    assert TARGET.exists(), f"missing target: {TARGET}"
+
+
+def test_cache_test_does_not_skip_after_queries_ran() -> None:
+    """No ``pytest.skip()`` is allowed after the cache queries have executed (#1630)."""
+    tree = ast.parse(TARGET.read_text(encoding="utf-8"))
+    func = _function(tree, "test_cache_miss_then_hit_on_repeated_query")
+    skip_calls = [
+        node
+        for node in ast.walk(func)
+        if isinstance(node, ast.Call) and _is_pytest_skip(node)
+    ]
+    assert not skip_calls, (
+        "test_cache_miss_then_hit_on_repeated_query must not call "
+        "pytest.skip() after the live-stack preflight. Live-stack readiness "
+        "is owned by _require_live_stack(); a missing miss/hit transition "
+        f"must be an assert. Found {len(skip_calls)} skip call(s) inline."
+    )
+
+
+def test_cache_test_asserts_miss_and_hit_observed() -> None:
+    """Test must assert both ``hits`` and ``misses`` are positive (#1630)."""
+    tree = ast.parse(TARGET.read_text(encoding="utf-8"))
+    func = _function(tree, "test_cache_miss_then_hit_on_repeated_query")
+
+    assert_sources = [
+        ast.unparse(node.test)
+        for node in ast.walk(func)
+        if isinstance(node, ast.Assert)
+    ]
+    has_hits = any(
+        "hits" in src and (">= 1" in src or "> 0" in src) for src in assert_sources
+    )
+    has_misses = any(
+        "misses" in src and (">= 1" in src or "> 0" in src) for src in assert_sources
+    )
+    assert has_hits and has_misses, (
+        "test_cache_miss_then_hit_on_repeated_query must assert both "
+        "hits >= 1 and misses >= 1 (or > 0) once the live stack has "
+        f"responded. Found assertions: {assert_sources!r}"
+    )

--- a/tests/e2e/test_core_flows_live.py
+++ b/tests/e2e/test_core_flows_live.py
@@ -122,9 +122,17 @@ async def test_cache_miss_then_hit_on_repeated_query() -> None:
             if hits >= 1 and misses >= 1:
                 break
 
-    if not (hits >= 1 and misses >= 1):
-        pytest.skip("Cache hit/miss transition not observable in this environment")
-
+    # Live stack already responded by the time we got here (#1630). Missing
+    # miss/hit transition is a real cache regression, not a skipped test.
+    assert misses >= 1, (
+        "Live cache test never observed a cache miss across 4 queries. "
+        "Either the test fixture leaked across runs or cache logic is "
+        "writing-without-reading."
+    )
+    assert hits >= 1, (
+        "Live cache test observed misses but no cache hit across 4 "
+        "repeated queries — cache is not promoting recent answers."
+    )
 
 @pytest.mark.asyncio
 async def test_multi_turn_conversation_same_session() -> None:


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Closes #1630.

## Problem
`tests/e2e/test_core_flows_live.py::test_cache_miss_then_hit_on_repeated_query` already runs `_require_live_stack()` (skips on unreachable RAG API or Redis). When the live stack responded but repeated queries did not produce both a miss and a hit, the test then ran `pytest.skip("Cache hit/miss transition not observable...")`. A real cache regression was therefore reported as "skipped" rather than "failed".

## TDD steps
1. **RED** — `tests/contract/test_e2e_cache_regression_contract.py`:
   - Forbids inline `pytest.skip(...)` inside the cache test (live-stack readiness is owned by `_require_live_stack`, period).
   - Requires explicit assertions for both `hits >= 1` (or `> 0`) AND `misses >= 1`.
   First run: 2 contract tests failed.
2. **GREEN** — replaced the post-query `pytest.skip` with two distinct asserts:
   - `assert misses >= 1` (diagnostic: fixture leaked / cache writing-without-reading)
   - `assert hits >= 1` (diagnostic: cache not promoting recent answers)
   Re-run: 3 passed; AST parse of edited file is clean.

## Tested
```bash
python -m pytest tests/contract/test_e2e_cache_regression_contract.py -q
# 3 passed
```