### PR TITLE
chore(repo): remove stale tmp.*/ and workflows.disabled/ (#1526, #1527)

### DIFF
--- a/tests/contract/test_no_stale_root_dirs_contract.py
+++ b/tests/contract/test_no_stale_root_dirs_contract.py
@@ -1,0 +1,75 @@
+"""Contract: no stale infra directories at repo root (#1526, #1527).
+
+Two cleanup themes share the same shape — leftover throwaway scratch
+directories that drifted into the working tree from past swarm /
+orchestration sessions and never got pruned:
+
+- Three ``tmp.<random>/`` directories left over from March 2026 swarm
+  work (#1526):
+
+  - ``tmp.CwOPYeK8wR/``
+  - ``tmp.QApjFztnuW/``
+  - ``tmp.vS0FKeuPSl/``
+
+  ``tmp.*`` is gitignored at ``.gitignore`` line 290, but the
+  directories themselves were never removed from the working tree on
+  every developer's clone. They are not tracked, but they show up in
+  ``git status`` as untracked noise and make ``ls`` at the repo root
+  confusing.
+
+- ``.github/workflows.disabled/`` (#1527): an old duplicate of the
+  active CI workflows, gitignored at ``.gitignore`` line 248. Like the
+  ``tmp.*`` dirs, it is gitignored but not tracked, so it survives on
+  developer machines where it was created before the gitignore rule
+  landed.
+
+This contract guards the cleanup: if any of these directories reappear
+at the repo root (tracked or untracked), the test fails. Re-introducing
+one of them on a future branch will be caught in CI.
+
+The check uses ``Path.exists()`` rather than ``git ls-files`` so that
+it catches both tracked reintroductions and untracked-on-disk
+reappearances inside CI checkouts and developer worktrees.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+FORBIDDEN: tuple[Path, ...] = (
+    REPO_ROOT / "tmp.CwOPYeK8wR",
+    REPO_ROOT / "tmp.QApjFztnuW",
+    REPO_ROOT / "tmp.vS0FKeuPSl",
+    REPO_ROOT / ".github" / "workflows.disabled",
+)
+
+
+@pytest.mark.parametrize(
+    "path",
+    FORBIDDEN,
+    ids=lambda p: str(p.relative_to(REPO_ROOT)),
+)
+def test_stale_root_dir_is_absent(path: Path) -> None:
+    """Each forbidden infra directory must not exist at the repo root.
+
+    The companion ``.gitignore`` entries (``tmp.*`` and
+    ``.github/workflows.disabled/``) prevent accidental re-tracking,
+    but the directories must also be physically absent from the
+    working tree to keep ``git status`` clean and the root tidy
+    (#1526, #1527).
+    """
+    if path.exists():
+        rel = path.relative_to(REPO_ROOT)
+        raise AssertionError(
+            f"Stale infra directory '{rel}' has reappeared at the repo root. "
+            "These directories are leftover scratch space from prior swarm / "
+            "orchestration sessions and must not be reintroduced. Remove the "
+            "directory (it is already gitignored) and, if a tool created it, "
+            "fix the tool to write under a temp dir outside the working tree "
+            "(#1526, #1527)."
+        )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

- Closes #1526 — three stale `tmp.*/` directories (`tmp.CwOPYeK8wR/`, `tmp.QApjFztnuW/`, `tmp.vS0FKeuPSl/`) and the related infra dir `.github/workflows.disabled/` (#1527) are confirmed absent on `dev`; both were already gitignored (`.gitignore` lines 290 and 248) and never tracked. No filesystem removal commit is needed against `origin/dev a3cab13` — the worktree was clean.
- Adds a forward-looking RED→GREEN guardrail at `tests/contract/test_no_stale_root_dirs_contract.py` that fails if any of those four directories reappear at the repo root, so the cleanup cannot silently regress in CI.

## Scope

- [x] Refactor (repo hygiene)
- [x] Documentation / portfolio cleanup

## Files touched

- `tests/contract/test_no_stale_root_dirs_contract.py` (new) — parametrized contract over the four forbidden paths, uses `Path.exists()` so it catches both tracked reintroductions and untracked-on-disk reappearances.

## Validation

Focused contract test on the new guardrail (RED would only trigger if any of the dirs existed; on a fresh checkout from `origin/dev` they do not, so this commit lands the test as a forward-looking guardrail per the issue spec):

```
$ uv run pytest tests/contract/test_no_stale_root_dirs_contract.py -q
....                                                                     [100%]
4 passed in 0.02s
```

Investigation evidence (run inside the worktree at `origin/dev a3cab13`):

```
$ git ls-files | grep -E '^(tmp\.|\.github/workflows\.disabled/)'
NO_TRACKED_MATCHES

$ ls -la tmp.CwOPYeK8wR tmp.QApjFztnuW tmp.vS0FKeuPSl
ls: cannot access 'tmp.CwOPYeK8wR': No such file or directory
ls: cannot access 'tmp.QApjFztnuW': No such file or directory
ls: cannot access 'tmp.vS0FKeuPSl': No such file or directory

$ ls -la .github/workflows.disabled
ls: cannot access '.github/workflows.disabled': No such file or directory
```

Both #1526 and #1527 are therefore "already gone on dev"; the tracked artifact of this PR is the contract test that prevents reintroduction.

- [x] Focused pytest on touched files (`uv run pytest tests/contract/test_no_stale_root_dirs_contract.py -q`)
- [ ] `make check` — skipped: no production code touched, only a new contract test.
- [ ] `make test-unit` / `make test` — skipped for the same reason; full `tests/contract` suite has 13 pre-existing failures on `origin/dev a3cab13` (in `test_error_contract.py`, `test_no_new_duplicate_test_names.py`, `test_span_coverage_contract.py`) that are unrelated to this change.

## Runtime Impact

- [x] No runtime impact

Test-only change. No service, Dockerfile, compose, or k8s file is touched.

## Reviewer Notes

- The directories targeted by #1526 and #1527 are gitignored (`.gitignore` lines 290 and 248) and do not exist on `dev`, so this PR is intentionally a "guardrail-only" cleanup — exactly the closing condition described in #1527 ("If just on disk and gitignored: nothing to commit; close the issue with explanation").
- The contract uses `Path.exists()` rather than `git ls-files` on purpose: an untracked-but-on-disk reappearance (e.g. a tool dropping `tmp.<random>/` at repo root again) should still fail the contract in CI, even though it would not show up in tracked files.

Closes #1526
Closes #1527
