### PR TITLE
fix(mini-app): typecheck frontend tests via tsconfig.test.json + drop stale thread_id (#1616)

### DIFF
--- a/mini_app/frontend/package.json
+++ b/mini_app/frontend/package.json
@@ -11,7 +11,8 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "typecheck:test": "tsc --noEmit -p tsconfig.test.json"
   },
   "dependencies": {
     "@tma.js/sdk-react": "^3.0.19",

--- a/mini_app/frontend/src/__tests__/App.test.tsx
+++ b/mini_app/frontend/src/__tests__/App.test.tsx
@@ -1,7 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
-import { HashRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { App } from '../App';
 import * as api from '../api';
 

--- a/mini_app/frontend/src/__tests__/api.test.ts
+++ b/mini_app/frontend/src/__tests__/api.test.ts
@@ -59,7 +59,11 @@ describe('startExpert', () => {
     const mockFetch = vi.mocked(fetch);
     mockFetch.mockResolvedValue({
       ok: true,
-      json: async () => ({ thread_id: 42, expert_name: 'Консультант', status: 'ok' }),
+      json: async () => ({
+        start_link: 'https://t.me/FortnoksBot?start=consultant_42',
+        expert_name: 'Консультант',
+        status: 'ok',
+      }),
     } as Response);
 
     const result = await startExpert(123, 'consultant', 'Подбери квартиру');
@@ -69,15 +73,20 @@ describe('startExpert', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ user_id: 123, expert_id: 'consultant', message: 'Подбери квартиру' }),
     });
-    expect(result.thread_id).toBe(42);
+    expect(result.start_link).toBe('https://t.me/FortnoksBot?start=consultant_42');
     expect(result.expert_name).toBe('Консультант');
+    expect(result.status).toBe('ok');
   });
 
   it('sends without message when not provided', async () => {
     const mockFetch = vi.mocked(fetch);
     mockFetch.mockResolvedValue({
       ok: true,
-      json: async () => ({ thread_id: 1, expert_name: 'Test', status: 'ok' }),
+      json: async () => ({
+        start_link: 'https://t.me/FortnoksBot?start=consultant_1',
+        expert_name: 'Test',
+        status: 'ok',
+      }),
     } as Response);
 
     await startExpert(123, 'consultant');

--- a/mini_app/frontend/src/pages/__tests__/ExpertSheet.test.tsx
+++ b/mini_app/frontend/src/pages/__tests__/ExpertSheet.test.tsx
@@ -80,7 +80,7 @@ describe('ExpertSheet', () => {
   });
 
   it('closes Mini App after successful startExpert', async () => {
-    const closeMock = sdkReact.miniApp.close as ReturnType<typeof vi.fn> & {
+    const closeMock = sdkReact.miniApp.close as unknown as ReturnType<typeof vi.fn> & {
       ifAvailable: ReturnType<typeof vi.fn>;
     };
     vi.spyOn(api, 'startExpert').mockResolvedValue({
@@ -99,7 +99,7 @@ describe('ExpertSheet', () => {
   });
 
   it('shows error alert when userId is null', async () => {
-    vi.spyOn(sdkReact.initData, 'user').mockReturnValue(null);
+    vi.spyOn(sdkReact.initData, 'user').mockReturnValue(undefined);
     const alertMock = vi.spyOn(window, 'alert').mockImplementation(() => {});
 
     renderExpertSheet();

--- a/mini_app/frontend/src/pages/__tests__/QuestionSheet.test.tsx
+++ b/mini_app/frontend/src/pages/__tests__/QuestionSheet.test.tsx
@@ -57,7 +57,7 @@ describe('QuestionSheet', () => {
   });
 
   it('calls sendData.ifAvailable on prompt click', async () => {
-    const sendDataMock = sdkReact.sendData as ReturnType<typeof vi.fn> & {
+    const sendDataMock = sdkReact.sendData as unknown as ReturnType<typeof vi.fn> & {
       ifAvailable: ReturnType<typeof vi.fn>;
     };
 
@@ -69,7 +69,9 @@ describe('QuestionSheet', () => {
   });
 
   it('calls miniApp.close.ifAvailable on prompt click', async () => {
-    const miniAppMock = sdkReact.miniApp as { close: ReturnType<typeof vi.fn> & { ifAvailable: ReturnType<typeof vi.fn> } };
+    const miniAppMock = sdkReact.miniApp as unknown as {
+      close: ReturnType<typeof vi.fn> & { ifAvailable: ReturnType<typeof vi.fn> };
+    };
 
     renderQuestionSheet();
     await waitFor(() => screen.getByText('С чего начать поиск квартиры?'));

--- a/mini_app/frontend/tsconfig.test.json
+++ b/mini_app/frontend/tsconfig.test.json
@@ -5,7 +5,7 @@
   },
   "include": [
     "src",
-    "src/**/__tests__/**",
+    "src/**/__tests__/**/*",
     "src/**/*.test.*"
   ],
   "exclude": []

--- a/mini_app/frontend/tsconfig.test.json
+++ b/mini_app/frontend/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": [
+    "src",
+    "src/**/__tests__/**",
+    "src/**/*.test.*"
+  ],
+  "exclude": []
+}

--- a/tests/contract/test_mini_app_frontend_test_typecheck_contract.py
+++ b/tests/contract/test_mini_app_frontend_test_typecheck_contract.py
@@ -8,7 +8,7 @@ under ``mini_app/frontend/src/__tests__/`` are excluded from
    (with comments stripped — TypeScript JSONC is allowed).
 
 2. ``tsconfig.test.json`` includes the test glob patterns
-   ``src/**/__tests__/**`` and/or ``src/**/*.test.*`` so the test files
+   ``src/**/__tests__/**/*`` and/or ``src/**/*.test.*`` so the test files
    are actually covered by ``tsc``.
 
 3. ``mini_app/frontend/package.json`` declares a ``typecheck:test`` script
@@ -113,7 +113,7 @@ def test_tsconfig_test_json_includes_test_globs() -> None:
         )
     cfg = json.loads(_strip_jsonc(TSCONFIG_TEST.read_text()))
     include = cfg.get("include") or []
-    expected_any = {"src/**/__tests__/**", "src/**/*.test.*"}
+    expected_any = {"src/**/__tests__/**/*", "src/**/*.test.*"}
     assert any(glob in include for glob in expected_any), (
         f"tsconfig.test.json `include` must reference at least one of "
         f"{sorted(expected_any)} so test files are typechecked. Got: {include!r}"

--- a/tests/contract/test_mini_app_frontend_test_typecheck_contract.py
+++ b/tests/contract/test_mini_app_frontend_test_typecheck_contract.py
@@ -1,0 +1,158 @@
+"""Contract test for Mini App frontend test-typecheck gate (#1616).
+
+Asserts four structural invariants that close the gap where Vitest tests
+under ``mini_app/frontend/src/__tests__/`` are excluded from
+``tsc --noEmit`` (so stale API assertions drift from runtime types):
+
+1. ``mini_app/frontend/tsconfig.test.json`` exists and is valid JSON
+   (with comments stripped — TypeScript JSONC is allowed).
+
+2. ``tsconfig.test.json`` includes the test glob patterns
+   ``src/**/__tests__/**`` and/or ``src/**/*.test.*`` so the test files
+   are actually covered by ``tsc``.
+
+3. ``mini_app/frontend/package.json`` declares a ``typecheck:test`` script
+   that invokes ``tsc --noEmit`` against ``tsconfig.test.json``.
+
+4. ``mini_app/frontend/src/__tests__/api.test.ts`` no longer references the
+   stale ``thread_id`` field — the live ``StartExpertResponse`` shape
+   (see ``mini_app/expert_start.py``) returns ``start_link``,
+   ``expert_name``, ``status``, and contains no ``thread_id`` member.
+
+The check uses static parsing (regex / JSON load) — no Node toolchain is
+invoked, so it runs identically on developer machines and in CI.
+
+Refs #1616.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+FRONTEND_DIR = REPO_ROOT / "mini_app" / "frontend"
+TSCONFIG_TEST = FRONTEND_DIR / "tsconfig.test.json"
+PACKAGE_JSON = FRONTEND_DIR / "package.json"
+API_TEST = FRONTEND_DIR / "src" / "__tests__" / "api.test.ts"
+
+
+def _strip_jsonc(text: str) -> str:
+    """Strip ``//`` line and ``/* */`` block comments from JSONC text.
+
+    Implemented as a tiny string-aware scanner so glob patterns like
+    ``src/**/*.test.*`` inside JSON strings survive intact.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    in_string = False
+    while i < n:
+        ch = text[i]
+        if in_string:
+            out.append(ch)
+            if ch == "\\" and i + 1 < n:
+                out.append(text[i + 1])
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "/" and i + 1 < n and text[i + 1] == "/":
+            # Line comment: skip to EOL.
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        if ch == "/" and i + 1 < n and text[i + 1] == "*":
+            # Block comment: skip to next ``*/``.
+            i += 2
+            while i + 1 < n and not (text[i] == "*" and text[i + 1] == "/"):
+                i += 1
+            i += 2
+            continue
+        out.append(ch)
+        i += 1
+    cleaned = "".join(out)
+    # Drop trailing commas before closing braces/brackets.
+    cleaned = re.sub(r",(\s*[}\]])", r"\1", cleaned)
+    return cleaned
+
+
+def test_tsconfig_test_json_exists_and_parses() -> None:
+    """tsconfig.test.json must exist as parseable JSON(C)."""
+    assert TSCONFIG_TEST.exists(), (
+        f"{TSCONFIG_TEST.relative_to(REPO_ROOT)} is missing. Add it to "
+        "extend tsconfig.json and include the test files so "
+        "`tsc --noEmit -p tsconfig.test.json` typechecks tests."
+    )
+    raw = TSCONFIG_TEST.read_text()
+    try:
+        json.loads(_strip_jsonc(raw))
+    except json.JSONDecodeError as exc:  # pragma: no cover - assertion path
+        pytest.fail(
+            f"{TSCONFIG_TEST.relative_to(REPO_ROOT)} is not valid JSON(C): {exc}"
+        )
+
+
+def test_tsconfig_test_json_includes_test_globs() -> None:
+    """tsconfig.test.json must include test source globs."""
+    if not TSCONFIG_TEST.exists():
+        pytest.fail(
+            f"{TSCONFIG_TEST.relative_to(REPO_ROOT)} missing — see "
+            "test_tsconfig_test_json_exists_and_parses."
+        )
+    cfg = json.loads(_strip_jsonc(TSCONFIG_TEST.read_text()))
+    include = cfg.get("include") or []
+    expected_any = {"src/**/__tests__/**", "src/**/*.test.*"}
+    assert any(glob in include for glob in expected_any), (
+        f"tsconfig.test.json `include` must reference at least one of "
+        f"{sorted(expected_any)} so test files are typechecked. Got: {include!r}"
+    )
+
+
+def test_package_json_has_typecheck_test_script() -> None:
+    """package.json must wire a typecheck:test script to tsconfig.test.json."""
+    pkg = json.loads(PACKAGE_JSON.read_text())
+    scripts = pkg.get("scripts", {})
+    assert "typecheck:test" in scripts, (
+        "mini_app/frontend/package.json must declare a `typecheck:test` script "
+        "that runs `tsc --noEmit -p tsconfig.test.json` (#1616)."
+    )
+    cmd = scripts["typecheck:test"]
+    assert "tsc" in cmd and "--noEmit" in cmd, (
+        f"`typecheck:test` should call `tsc --noEmit`; got: {cmd!r}"
+    )
+    assert "tsconfig.test.json" in cmd, (
+        f"`typecheck:test` must point at tsconfig.test.json; got: {cmd!r}"
+    )
+
+
+def test_api_test_does_not_reference_stale_thread_id() -> None:
+    """api.test.ts must not mock/assert the removed `thread_id` field.
+
+    StartExpertResponse (mini_app/expert_start.py + mini_app/frontend/src/api.ts)
+    returns ``start_link``, ``expert_name``, ``status``. The frontend test
+    used to assert ``thread_id`` which is no longer part of the contract.
+    """
+    text = API_TEST.read_text()
+    offenders = [
+        (idx + 1, line)
+        for idx, line in enumerate(text.splitlines())
+        if "thread_id" in line
+    ]
+    assert not offenders, (
+        "Found stale `thread_id` references in api.test.ts at lines "
+        + ", ".join(str(n) for n, _ in offenders)
+        + ". Update the mock/assertion to match StartExpertResponse "
+        "(`start_link`, `expert_name`, `status`)."
+    )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Mini App frontend Vitest tests under `mini_app/frontend/src/__tests__/` were silently excluded from `tsc --noEmit`. As a result, a stale assertion in `api.test.ts` that mocked and asserted a `thread_id` field stayed green even though the live `StartExpertResponse` (`mini_app/expert_start.py` + `mini_app/frontend/src/api.ts`) returns `start_link`, `expert_name`, `status` — and has no `thread_id` member.

This PR follows the RED→GREEN contract pattern used by recent Mini App PRs (e.g. #1829 `refactor/issue-1597-mini-app-cleanup`):

1. Add a Python contract test asserting the four structural invariants → fails RED.
2. Wire `tsconfig.test.json` + `typecheck:test` script and refresh the stale assertion → GREEN.

Closes #1616.

## Evidence (pre-fix)

- `mini_app/frontend/package.json:13` — `"test": "vitest run"`.
- `mini_app/frontend/tsconfig.json:19-20` — `include: ["src"]`, but `exclude: ["src/**/__tests__/**", "src/**/*.test.*"]`.
- `mini_app/frontend/src/api.ts:23-27` — `interface StartExpertResponse { start_link; expert_name; status }` (no `thread_id`).
- `mini_app/frontend/src/__tests__/api.test.ts:60-72` (pre-fix) — mocked `{ thread_id: 42, ... }` and `expect(result.thread_id).toBe(42)`.

## Files touched

| File | Change |
| --- | --- |
| `mini_app/frontend/tsconfig.test.json` | **new** — extends `tsconfig.json`, includes `src/**/__tests__/**` + `src/**/*.test.*`, pulls in vitest + jest-dom ambient types. |
| `mini_app/frontend/package.json` | added `"typecheck:test": "tsc --noEmit -p tsconfig.test.json"` script. |
| `mini_app/frontend/src/__tests__/api.test.ts` | replaced both `thread_id` mock/assert pairs with the live `start_link` / `expert_name` / `status` shape. |
| `tests/contract/test_mini_app_frontend_test_typecheck_contract.py` | **new** — 4 static-parsing assertions enforcing the gate (no Node required). |

## Validation

### Contract test (RED → GREEN)

RED (before adding `tsconfig.test.json`, before script change, before fixing `api.test.ts`):
```
4 failed in 0.09s
- test_tsconfig_test_json_exists_and_parses
- test_tsconfig_test_json_includes_test_globs
- test_package_json_has_typecheck_test_script
- test_api_test_does_not_reference_stale_thread_id
```

GREEN after the changes in this PR:
```
$ uv run pytest tests/contract/test_mini_app_frontend_test_typecheck_contract.py -v
tests/contract/test_mini_app_frontend_test_typecheck_contract.py::test_tsconfig_test_json_exists_and_parses PASSED
tests/contract/test_mini_app_frontend_test_typecheck_contract.py::test_tsconfig_test_json_includes_test_globs PASSED
tests/contract/test_mini_app_frontend_test_typecheck_contract.py::test_package_json_has_typecheck_test_script PASSED
tests/contract/test_mini_app_frontend_test_typecheck_contract.py::test_api_test_does_not_reference_stale_thread_id PASSED
============================== 4 passed in 0.04s ===============================
```

Sibling Mini App contract suite still green:
```
$ uv run pytest tests/contract/test_mini_app_frontend_test_typecheck_contract.py tests/contract/test_mini_app_frontend_cleanup_contract.py -v
============================== 7 passed in 0.05s ===============================
```

Full `tests/contract` suite: 13 unrelated pre-existing failures (`test_error_contract`, `test_no_new_duplicate_test_names`, `test_span_coverage_contract`) — confirmed identical on `origin/dev` before any change in this branch (verified by stashing the working tree and re-running). Not introduced by this PR.

### `tsc --noEmit` against `tsconfig.test.json`

**Skipped because the agent sandbox has no Node/npm/npx** (`which node` → `not found`). The Python contract test verifies the file-structure gate; the live `tsc` run is expected to execute in CI / on a developer machine. To run locally:

```
cd mini_app/frontend
npm ci
npm run typecheck:test    # tsc --noEmit -p tsconfig.test.json
npm test -- --run
```

## Scope discipline

Touches only the surfaces called out in #1616's "Primary files/surfaces": `mini_app/frontend/{package,tsconfig*}.json`, `mini_app/frontend/src/__tests__/`, plus the matching contract test under `tests/contract/`. No production, secrets, SSH, or CRM paths.

Closes #1616
