### PR TITLE
refactor(ingestion): drop redundant ruff ignores + add #1532 contract probe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,8 +266,12 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 "test_*.py" = ["E402", "T201", "SIM117"]  # Allow late imports, print(), nested with in tests
 "tests/**/*.py" = ["E402", "T201", "SIM117"]  # Same for tests/ directory
 "legacy/*.py" = ["ASYNC210"]      # Allow blocking HTTP calls in async functions (legacy code)
-"src/ingestion/docling_client.py" = ["ASYNC240"]  # Legacy ingestion (replaced by unified pipeline)
-"src/ingestion/service.py" = ["ASYNC240"]          # Legacy ingestion (replaced by unified pipeline)
+# Per-file ASYNC240 ignores for src/ingestion/docling_client.py and
+# src/ingestion/service.py removed in #1532: ASYNC240 is already in the
+# global ignore list above, so the per-file entries were redundant. The
+# modules themselves cannot be deleted yet because there are live runtime
+# callers; see tests/contract/test_legacy_ingestion_removed_contract.py
+# for the full audit.
 
 "*.py" = ["ARG001"]               # Allow unused function arguments (common in callbacks)
 

--- a/tests/contract/test_legacy_ingestion_removed_contract.py
+++ b/tests/contract/test_legacy_ingestion_removed_contract.py
@@ -1,0 +1,260 @@
+# tests/contract/test_legacy_ingestion_removed_contract.py
+"""Contract: legacy ingestion modules listed in #1532 must be removed and
+their per-file Ruff ignores must be cleaned from ``pyproject.toml``.
+
+Issue #1532 (https://github.com/yastman/rag/issues/1532) lists three legacy
+files claimed to be "replaced by the unified pipeline" (`src/ingestion/unified/`):
+
+    - src/ingestion/docling_client.py
+    - src/ingestion/gdrive_flow.py
+    - src/ingestion/service.py
+
+In addition, ``pyproject.toml`` carries per-file Ruff ignores for these paths
+that need to disappear once the modules are gone.
+
+Audit (2026-05-21) — actual repository state:
+
+    | File | Status |
+    |------|--------|
+    | ``src/ingestion/gdrive_flow.py`` | Already removed (see #1793). |
+    | ``src/ingestion/docling_client.py`` | **STILL LIVE.** Imported by `src/ingestion/docling_native.py` (`NativeDoclingAdapter` subclasses `DoclingClient`) and by `src/ingestion/unified/targets/qdrant_hybrid_target.py` (the unified pipeline itself uses `DoclingClient` / `DoclingConfig`). |
+    | ``src/ingestion/service.py`` | **STILL LIVE.** Imported by `telegram_bot/services/ingestion_cocoindex.py`, which re-exports `IngestionService`, `IngestionStats`, `ingest_from_directory`, `ingest_from_gdrive`, `get_ingestion_status` as the bot's CLI entrypoint (`python -m telegram_bot.services.ingestion_cocoindex`). |
+
+Per-file Ruff ignores in ``pyproject.toml`` (line 269-270) declare
+``ASYNC240`` for ``docling_client.py`` and ``service.py``, but ``ASYNC240``
+is *also* in the global ``ignore`` list (line 252), so the per-file entries
+are redundant and can be removed without touching the modules themselves.
+
+This contract test therefore enforces three layers:
+
+1.  ``gdrive_flow.py`` must remain absent (regression guard).
+2.  Per-file Ruff ignores for the three paths must be absent from
+    ``pyproject.toml`` — safe because ``ASYNC240`` is globally ignored.
+3.  No non-test runtime module under ``src/`` (excluding deprecated shims),
+    ``telegram_bot/``, ``mini_app/``, ``services/``, or ``scripts/`` may
+    import any of the three modules. The two known live callers are tracked
+    via `xfail` markers so this contract documents the blocker without
+    breaking CI; once the live callers are migrated to the unified pipeline,
+    the `xfail` markers must be removed.
+
+Cross-refs:
+    - #1532 — original issue.
+    - #1793 — already removed `gdrive_flow.py` and orphaned tests.
+    - `tests/contract/test_no_deprecated_gdrive_ingestion.py` — sibling
+      contract for the gdrive_flow / gdrive_indexer surface.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import tomllib
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+LEGACY_MODULES: tuple[str, ...] = (
+    "src/ingestion/docling_client.py",
+    "src/ingestion/gdrive_flow.py",
+    "src/ingestion/service.py",
+)
+
+# Module names (importable form) used by the AST walker below.
+LEGACY_DOTTED_MODULES: tuple[str, ...] = (
+    "src.ingestion.docling_client",
+    "src.ingestion.gdrive_flow",
+    "src.ingestion.service",
+)
+
+# Roots scanned for runtime imports of the legacy modules. Tests are excluded
+# (each test file may be migrated/removed independently).
+RUNTIME_ROOTS: tuple[str, ...] = (
+    "src",
+    "telegram_bot",
+    "mini_app",
+    "services",
+    "scripts",
+)
+
+
+@pytest.mark.parametrize("module_path", LEGACY_MODULES)
+def test_legacy_ingestion_module_is_absent(module_path: str) -> None:
+    """Each legacy ingestion module file must be deleted from the repository."""
+    target = REPO_ROOT / module_path
+    if module_path in {"src/ingestion/docling_client.py", "src/ingestion/service.py"}:
+        pytest.xfail(
+            f"{module_path} cannot be deleted yet: live runtime callers exist. "
+            "See module docstring for the audit (DoclingClient is reused by "
+            "src/ingestion/docling_native.py and src/ingestion/unified/targets/"
+            "qdrant_hybrid_target.py; service.py is re-exported by "
+            "telegram_bot/services/ingestion_cocoindex.py). Migrate those "
+            "callers to the unified pipeline first, then drop this xfail."
+        )
+    assert not target.exists(), (
+        f"{module_path} still exists; #1532 requires it to be removed "
+        "(replaced by src/ingestion/unified/)."
+    )
+
+
+@pytest.mark.parametrize("module_path", LEGACY_MODULES)
+def test_pyproject_has_no_per_file_ignore_for_legacy_module(module_path: str) -> None:
+    """``pyproject.toml`` must not list the legacy module under
+    ``[tool.ruff.lint.per-file-ignores]``.
+
+    Safe to assert even while the module file exists, because every rule
+    currently pinned per-file (``ASYNC240``) is also in the global
+    ``[tool.ruff.lint] ignore`` list.
+    """
+    pyproject_path = REPO_ROOT / "pyproject.toml"
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    per_file = (
+        data.get("tool", {})
+        .get("ruff", {})
+        .get("lint", {})
+        .get("per-file-ignores", {})
+    )
+    assert module_path not in per_file, (
+        f"pyproject.toml still has a per-file Ruff ignore for {module_path!r}: "
+        f"{per_file[module_path]!r}. Remove it — the rules are already in the "
+        "global ignore list."
+    )
+
+
+def _iter_runtime_python_files() -> Iterator[Path]:
+    """Yield every non-test ``*.py`` file under the runtime roots."""
+    for root_name in RUNTIME_ROOTS:
+        root = REPO_ROOT / root_name
+        if not root.exists():
+            continue
+        for py_file in root.rglob("*.py"):
+            # Skip vendored or virtualenv stuff, just in case.
+            parts = py_file.parts
+            if any(p in {".venv", "venv", "__pycache__"} for p in parts):
+                continue
+            # Skip files that are themselves tests.
+            if py_file.name.startswith("test_") or py_file.name.endswith("_test.py"):
+                continue
+            yield py_file
+
+
+def _module_imports_legacy(py_file: Path) -> set[str]:
+    """Return the set of legacy dotted module names imported by ``py_file``."""
+    try:
+        source = py_file.read_text(encoding="utf-8")
+    except OSError:
+        return set()
+    try:
+        tree = ast.parse(source, filename=str(py_file))
+    except SyntaxError:
+        return set()
+
+    hits: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            if mod in LEGACY_DOTTED_MODULES:
+                hits.add(mod)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in LEGACY_DOTTED_MODULES:
+                    hits.add(alias.name)
+    return hits
+
+
+# Files that the audit identified as live runtime callers. Each one is xfail'd
+# with the precise reason so the contract documents *why* the assertion can't
+# pass yet.
+KNOWN_LIVE_CALLERS: dict[str, str] = {
+    "src/ingestion/docling_native.py": (
+        "NativeDoclingAdapter subclasses DoclingClient and reuses DoclingChunk "
+        "/ DoclingConfig. The unified ingestion pipeline depends on it."
+    ),
+    "src/ingestion/unified/targets/qdrant_hybrid_target.py": (
+        "QdrantHybridTargetConnector — the *unified* pipeline target itself — "
+        "imports DoclingClient and DoclingConfig directly. The premise of "
+        "#1532 (\"replaced by unified pipeline\") does not hold for this file."
+    ),
+    "telegram_bot/services/ingestion_cocoindex.py": (
+        "Telegram bot CLI entrypoint re-exports IngestionService, "
+        "IngestionStats, ingest_from_directory, ingest_from_gdrive, "
+        "get_ingestion_status from src.ingestion.service. Wired into the "
+        "Makefile via `python -m telegram_bot.services.ingestion_cocoindex`."
+    ),
+    # The package __init__ self-references its own deprecation shims via
+    # string targets; those go through importlib at attribute-access time and
+    # are not real `import` statements, but they still pin the legacy modules
+    # as part of the public deprecated surface (see _DEPRECATED_EXPORTS in
+    # src/ingestion/__init__.py).
+    "src/ingestion/__init__.py": (
+        "src.ingestion declares deprecation shims pointing at "
+        "src.ingestion.docling_client and src.ingestion.service in "
+        "_DEPRECATED_EXPORTS. The shims emit DeprecationWarning at access "
+        "time. They can only be removed once the underlying modules are "
+        "gone (i.e. after the live callers above are migrated)."
+    ),
+}
+
+
+def test_no_runtime_imports_of_legacy_ingestion_modules() -> None:
+    """No production runtime module may import the three legacy ingestion modules.
+
+    Every violation found is reported. Known live callers are surfaced as a
+    soft `xfail`, so this test stays green in CI while documenting the
+    pending migration. Any *new* caller of the legacy modules will fail this
+    test loudly.
+    """
+    findings: dict[str, set[str]] = {}
+    for py_file in _iter_runtime_python_files():
+        hits = _module_imports_legacy(py_file)
+        if not hits:
+            continue
+        rel = str(py_file.relative_to(REPO_ROOT))
+        findings[rel] = hits
+
+    unexpected: dict[str, set[str]] = {
+        rel: hits for rel, hits in findings.items() if rel not in KNOWN_LIVE_CALLERS
+    }
+
+    if unexpected:
+        formatted = "\n".join(
+            f"  {rel}: imports {sorted(hits)}" for rel, hits in sorted(unexpected.items())
+        )
+        pytest.fail(
+            "Unexpected runtime imports of legacy ingestion modules detected:\n"
+            f"{formatted}\n"
+            "Either migrate the caller to the unified pipeline or, if the "
+            "import is truly required for now, add it to KNOWN_LIVE_CALLERS "
+            "in this contract test with a clear migration note."
+        )
+
+    # If we got here, every violation was an already-documented live caller.
+    if findings:
+        pytest.xfail(
+            "Documented live callers still import legacy ingestion modules. "
+            "These are tracked in KNOWN_LIVE_CALLERS in this contract test "
+            "and must be migrated to the unified pipeline before the legacy "
+            "modules can be deleted (#1532). Current callers:\n"
+            + "\n".join(
+                f"  {rel}: {KNOWN_LIVE_CALLERS[rel]}" for rel in sorted(findings)
+            )
+        )
+
+
+# Keep a separate, structural assertion that is independent of the imports
+# walker above: the existing contract guard for the gdrive_flow surface
+# already asserts deletion, so re-asserting here would be redundant. We
+# intentionally don't duplicate it — see
+# tests/contract/test_no_deprecated_gdrive_ingestion.py for the gdrive_flow
+# regression guard.
+
+
+_ISSUE_LINK_RE = re.compile(r"#1532")
+
+
+def test_contract_links_to_issue() -> None:
+    """Sanity check: the contract module references its tracking issue."""
+    assert _ISSUE_LINK_RE.search(Path(__file__).read_text(encoding="utf-8"))


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Issue #1532 asks to remove three "legacy" ingestion files that are claimed to be replaced by `src/ingestion/unified/`:

- `src/ingestion/docling_client.py`
- `src/ingestion/gdrive_flow.py`
- `src/ingestion/service.py`

I audited the actual repository state before touching anything. **The premise of the issue is only partially correct** — `gdrive_flow.py` is already gone, but the other two modules are still live runtime dependencies (in fact, the unified pipeline itself imports `docling_client.py`).

This PR therefore lands the **safe** part of the cleanup, codifies the desired end state as a contract test, and explicitly tracks the remaining migration work as `xfail` so it cannot silently regress.

## Reference audit results

```bash
grep -RIn "from src.ingestion.(docling_client|gdrive_flow|service)|import src.ingestion.(docling_client|gdrive_flow|service)|ingestion\.(docling_client|gdrive_flow|service)\b" --include="*.py" .
```

| Caller | Module imported | Category |
|---|---|---|
| `src/ingestion/__init__.py` (`_DEPRECATED_EXPORTS`) | `docling_client`, `service` | Self-reference (deprecation shim) |
| `src/ingestion/docling_native.py` | `docling_client` (`DoclingChunk`, `DoclingClient`, `DoclingConfig`) | **LIVE BLOCKER** — `NativeDoclingAdapter` subclasses `DoclingClient` |
| `src/ingestion/unified/targets/qdrant_hybrid_target.py` | `docling_client` (`DoclingClient`, `DoclingConfig`) | **LIVE BLOCKER** — the *unified* pipeline target itself uses it |
| `telegram_bot/services/ingestion_cocoindex.py` | `service` (`IngestionService`, `IngestionStats`, `ingest_from_directory`, `ingest_from_gdrive`, `get_ingestion_status`) | **LIVE BLOCKER** — bot CLI entrypoint, wired into Makefile |
| `tests/unit/test_ingestion_service.py` | `service` | Test of live module |
| `tests/unit/ingestion/test_docling_client.py` | `docling_client` | Test of live module |
| `tests/unit/test_lazy_imports.py` | `docling_client` (via deprecation shim) | Test of live module |
| `tests/contract/test_no_deprecated_gdrive_ingestion.py` | string ref to `gdrive_flow` | Existing regression guard (PASSES — module is gone) |

`gdrive_flow.py` does not exist on `dev` (`origin/dev` HEAD `a3cab13`), and there is no per-file Ruff ignore for it in `pyproject.toml`. That part of #1532 was completed by #1793.

## Files removed

None. Per the workflow's "If there are LIVE callers... do NOT delete those files" rule, the two surviving modules stay because they are imported by:

1. **Unified pipeline target** (`src/ingestion/unified/targets/qdrant_hybrid_target.py`) — depends on `DoclingClient` / `DoclingConfig` from `docling_client.py`. The "replaced by unified pipeline" framing in #1532 is incorrect for this file: the unified pipeline is the consumer.
2. **Native Docling adapter** (`src/ingestion/docling_native.py`) — `NativeDoclingAdapter(DoclingClient)`.
3. **Bot CocoIndex CLI wrapper** (`telegram_bot/services/ingestion_cocoindex.py`) — re-exports the public `service.py` API.

Until those callers are migrated, deleting the modules would break runtime ingestion. They are tracked as `KNOWN_LIVE_CALLERS` in the new contract test with explicit migration notes.

## `pyproject.toml` changes

Two redundant per-file Ruff ignores removed:

```diff
-"src/ingestion/docling_client.py" = ["ASYNC240"]  # Legacy ingestion (replaced by unified pipeline)
-"src/ingestion/service.py" = ["ASYNC240"]          # Legacy ingestion (replaced by unified pipeline)
```

Both pinned `ASYNC240`, which is already in the global `[tool.ruff.lint] ignore` list (line 252 of `pyproject.toml`). The per-file entries had no effect. A short comment was added explaining the cleanup and pointing at the new contract test.

`uv run ruff check src/ingestion/` still passes after the removal.

## New contract test

`tests/contract/test_legacy_ingestion_removed_contract.py` (RED → GREEN per TDD pattern):

- **GREEN now**:
  - `gdrive_flow.py` is absent.
  - `pyproject.toml` has no per-file ignore for any of the three paths.
  - `#1532` is referenced from the test (anchor for future grep).
- **xfail with reason** (will GREEN once the listed callers migrate):
  - `docling_client.py` deletion.
  - `service.py` deletion.
  - "no runtime imports" — known live callers are listed inline; any *new* unintended caller fails the test loudly (the test only `xfail`s when every violation is one of the three documented callers).

The test uses `ast.parse` to walk every `*.py` file under `src/`, `telegram_bot/`, `mini_app/`, `services/`, `scripts/` (excluding tests) and reports unexpected import statements rather than accepting them.

## Validation

`uv run pytest tests/contract/test_legacy_ingestion_removed_contract.py -q` (last 5 lines):
```
x.x...x.                                                                 [100%]
=========================== short test summary info ============================
XFAIL tests/contract/test_legacy_ingestion_removed_contract.py::test_legacy_ingestion_module_is_absent[src/ingestion/docling_client.py] - ...
XFAIL tests/contract/test_legacy_ingestion_removed_contract.py::test_legacy_ingestion_module_is_absent[src/ingestion/service.py] - ...
5 passed, 3 xfailed in 0.86s
```

`uv run pytest tests/unit/ingestion/ -q --ignore=tests/unit/ingestion/test_qdrant_writer_behavior.py`:
```
155 passed, 17 skipped in 2.66s
```

`uv run ruff check src/ingestion/`:
```
All checks passed!
```

`uv run pytest tests/contract -q` reports `13 failed, 577 passed, 4 skipped, 3 xfailed`. **All 13 failures are pre-existing on `dev`** (verified by re-running the same tests against an unmodified `origin/dev` working tree); they live in `test_error_contract.py`, `test_span_coverage_contract.py`, and `test_no_new_duplicate_test_names.py` and are unrelated to this PR.

## Pre-existing issues left untouched

- `tests/unit/ingestion/test_qdrant_writer_behavior.py` — known cocoindex-extra import errors on `dev` post-#1831; excluded per the task brief.
- 13 unrelated `tests/contract/...` failures pre-existing on `dev` (see above) — out of scope.

## Closes / Refs

Refs #1532 — does **not** close it. The `xfail` markers in the new contract test are the authoritative todo list for finishing the issue. The remaining work is:

1. Migrate `src/ingestion/unified/targets/qdrant_hybrid_target.py` and `src/ingestion/docling_native.py` off `src.ingestion.docling_client` (likely by lifting the `DoclingClient` / `DoclingConfig` / `DoclingChunk` types into `src/ingestion/unified/`).
2. Migrate `telegram_bot/services/ingestion_cocoindex.py` to call the unified pipeline directly.
3. Remove `_DEPRECATED_EXPORTS` shims in `src/ingestion/__init__.py` once nothing imports the old paths.
4. Delete the three `xfail`s — the contract will then go fully GREEN, and `git rm` of the modules can land in the same PR.