### PR TITLE
fix(k8s): sync postgres-init ConfigMap with docker init scripts 04-08 (#1402)

### DIFF
--- a/k8s/base/configmaps/postgres-init.yaml
+++ b/k8s/base/configmaps/postgres-init.yaml
@@ -11,6 +11,11 @@ data:
     GRANT ALL PRIVILEGES ON DATABASE mlflow TO postgres;
     CREATE DATABASE litellm;
     GRANT ALL PRIVILEGES ON DATABASE litellm TO postgres;
+    -- Real Estate CRM/Funnel database (required by 05-08 init scripts).
+    -- Mirrors docker/postgres/init/00-init-databases.sql so K8s and Compose
+    -- both have a `realestate` DB before 05+ run `\c realestate`.
+    CREATE DATABASE realestate;
+    GRANT ALL PRIVILEGES ON DATABASE realestate TO postgres;
 
   02-cocoindex.sql: |
     CREATE DATABASE cocoindex;
@@ -88,3 +93,174 @@ data:
         END IF;
     END $$;
     COMMENT ON TABLE ingestion_state IS 'Unified ingestion state tracking (v3.2.1)';
+
+  04-voice-schema.sql: |
+    -- Voice bot: call transcripts storage
+    CREATE TABLE IF NOT EXISTS call_transcripts (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        phone VARCHAR(20) NOT NULL,
+        lead_data JSONB DEFAULT '{}',
+        transcript JSONB DEFAULT '[]',
+        langfuse_trace_id VARCHAR(64),
+        status VARCHAR(20) NOT NULL DEFAULT 'initiated',
+        duration_sec INTEGER DEFAULT 0,
+        validation_result JSONB,
+        callback_chat_id BIGINT,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_call_transcripts_phone ON call_transcripts(phone);
+    CREATE INDEX IF NOT EXISTS idx_call_transcripts_status ON call_transcripts(status);
+    CREATE INDEX IF NOT EXISTS idx_call_transcripts_created ON call_transcripts(created_at DESC);
+
+  05-realestate-schema.sql: |
+    -- Real Estate: users, leads, funnel events
+    -- Runs in default postgres DB (tables created there, not in realestate DB)
+    -- because init scripts run against default DB
+
+    \c realestate;
+
+    CREATE TABLE IF NOT EXISTS users (
+        id SERIAL PRIMARY KEY,
+        telegram_id BIGINT UNIQUE NOT NULL,
+        locale VARCHAR(5) DEFAULT 'ru',
+        role VARCHAR(20) DEFAULT 'client',
+        first_name VARCHAR(100),
+        telegram_language_code VARCHAR(10),
+        notifications_enabled BOOLEAN DEFAULT true,
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        updated_at TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS leads (
+        id SERIAL PRIMARY KEY,
+        user_id INTEGER REFERENCES users(id),
+        stage VARCHAR(30) DEFAULT 'new',
+        score INTEGER DEFAULT 0,
+        preferences JSONB DEFAULT '{}',
+        kommo_lead_id BIGINT,
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        updated_at TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS funnel_events (
+        id SERIAL PRIMARY KEY,
+        user_id INTEGER REFERENCES users(id),
+        event_type VARCHAR(50) NOT NULL,
+        metadata JSONB DEFAULT '{}',
+        created_at TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_users_telegram_id ON users(telegram_id);
+    CREATE INDEX IF NOT EXISTS idx_leads_user_id ON leads(user_id);
+    CREATE INDEX IF NOT EXISTS idx_leads_stage ON leads(stage);
+    CREATE INDEX IF NOT EXISTS idx_funnel_events_user_id ON funnel_events(user_id);
+    CREATE INDEX IF NOT EXISTS idx_funnel_events_created ON funnel_events(created_at DESC);
+
+  06-lead-scoring-sync.sql: |
+    -- Lead Scoring + Kommo CRM Sync State (#384)
+    -- Depends on: 05-realestate-schema.sql (leads table)
+
+    \c realestate;
+
+    CREATE TABLE IF NOT EXISTS lead_scores (
+        id BIGSERIAL PRIMARY KEY,
+        lead_id BIGINT NOT NULL REFERENCES leads(id) ON DELETE CASCADE,
+        user_id BIGINT NOT NULL,
+        session_id TEXT NOT NULL,
+        -- score_value: rule-based 0-100 now; ML model probability * 100 in v2
+        score_value INTEGER NOT NULL CHECK (score_value BETWEEN 0 AND 100),
+        score_band TEXT NOT NULL CHECK (score_band IN ('hot', 'warm', 'cold')),
+        -- reason_codes: rule-based codes now; SHAP feature importances in ML v2
+        reason_codes JSONB NOT NULL DEFAULT '[]'::jsonb,
+        kommo_lead_id BIGINT,
+        sync_status TEXT NOT NULL DEFAULT 'pending' CHECK (sync_status IN ('pending', 'synced', 'failed')),
+        sync_attempts INTEGER NOT NULL DEFAULT 0,
+        last_synced_at TIMESTAMPTZ,
+        sync_error TEXT,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        UNIQUE (lead_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS lead_score_sync_audit (
+        id BIGSERIAL PRIMARY KEY,
+        lead_score_id BIGINT NOT NULL REFERENCES lead_scores(id) ON DELETE CASCADE,
+        idempotency_key TEXT NOT NULL,
+        sync_status TEXT NOT NULL,
+        http_status INTEGER,
+        response_excerpt TEXT,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_lead_scores_pending_sync
+        ON lead_scores (sync_status, updated_at DESC);
+
+    CREATE INDEX IF NOT EXISTS idx_lead_scores_band_sync
+        ON lead_scores (score_band, sync_status, updated_at DESC);
+
+  07-nurturing-funnel-analytics.sql: |
+    -- Nurturing Jobs + Funnel Analytics (#390)
+    -- Depends on: 05-realestate-schema.sql (funnel_events), 06-lead-scoring-sync.sql (lead_scores)
+
+    \c realestate;
+
+    CREATE TABLE IF NOT EXISTS nurturing_jobs (
+        id BIGSERIAL PRIMARY KEY,
+        lead_score_id BIGINT NOT NULL REFERENCES lead_scores(id) ON DELETE CASCADE,
+        scheduled_for TIMESTAMPTZ NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'running', 'sent', 'failed', 'skipped')),
+        channel TEXT NOT NULL DEFAULT 'telegram',
+        payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+        attempt_count INTEGER NOT NULL DEFAULT 0,
+        last_error TEXT,
+        sent_at TIMESTAMPTZ,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        UNIQUE (lead_score_id, scheduled_for)
+    );
+
+    CREATE TABLE IF NOT EXISTS funnel_metrics_daily (
+        id BIGSERIAL PRIMARY KEY,
+        metric_date DATE NOT NULL,
+        stage_name TEXT NOT NULL,
+        entered_count INTEGER NOT NULL DEFAULT 0,
+        converted_count INTEGER NOT NULL DEFAULT 0,
+        dropoff_count INTEGER NOT NULL DEFAULT 0,
+        conversion_rate NUMERIC(6,4) NOT NULL DEFAULT 0,
+        prev_stage_count INTEGER NOT NULL DEFAULT 0,
+        step_conversion_rate NUMERIC(6,4) NOT NULL DEFAULT 0,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        UNIQUE (metric_date, stage_name)
+    );
+
+    CREATE TABLE IF NOT EXISTS scheduler_leases (
+        lease_name TEXT PRIMARY KEY,
+        owner_id TEXT NOT NULL,
+        lease_until TIMESTAMPTZ NOT NULL,
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_nurturing_jobs_pending
+        ON nurturing_jobs (status, scheduled_for ASC);
+
+    -- Add stage_name to funnel_events (#387 dependency — needed by analytics queries)
+    ALTER TABLE funnel_events ADD COLUMN IF NOT EXISTS stage_name TEXT;
+
+    CREATE INDEX IF NOT EXISTS idx_funnel_events_created_stage
+        ON funnel_events (created_at DESC, stage_name);
+
+  08-user-favorites.sql: |
+    \c realestate;
+
+    CREATE TABLE IF NOT EXISTS user_favorites (
+        id BIGSERIAL PRIMARY KEY,
+        telegram_id BIGINT NOT NULL,
+        property_id TEXT NOT NULL,
+        property_data JSONB NOT NULL DEFAULT '{}'::jsonb,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        UNIQUE (telegram_id, property_id)
+    );
+
+    CREATE INDEX idx_user_favorites_telegram_id ON user_favorites (telegram_id);
+    CREATE INDEX idx_user_favorites_created_at ON user_favorites (created_at DESC);

--- a/tests/contract/test_k8s_postgres_init_parity_contract.py
+++ b/tests/contract/test_k8s_postgres_init_parity_contract.py
@@ -1,0 +1,120 @@
+# tests/contract/test_k8s_postgres_init_parity_contract.py
+"""Contract: K8s postgres-init ConfigMap must mirror docker init scripts.
+
+Closes #1402.
+
+Problem reproduced: ``docker/postgres/init/`` contains eight SQL bootstrap
+scripts (00, 02, 03, 04, 05, 06, 07, 08) that the Compose stack mounts into
+``/docker-entrypoint-initdb.d/`` for first-boot Postgres initialization. The
+K8s ConfigMap at ``k8s/base/configmaps/postgres-init.yaml`` previously
+embedded only 00, 02, 03 — leaving voice transcripts (04), real-estate CRM
+(05), lead scoring (06), nurturing analytics (07) and user favorites (08)
+schemas uncreated on K8s-deployed Postgres pods.
+
+This contract pins three things:
+
+1. The ConfigMap parses as valid YAML and is shaped as a Kubernetes
+   ConfigMap (kind, data mapping).
+2. Every ``*.sql`` file in ``docker/postgres/init/`` has a corresponding
+   ``data:`` key in the ConfigMap (so kubelet projects it into the init
+   directory at the same filename).
+3. For the scripts synchronized by issue #1402 (04 through 08), the
+   ConfigMap value is byte-identical to the docker source — they MUST be
+   copied verbatim so the K8s and Compose paths produce the same schema.
+
+The pre-existing keys 00/02/03 are NOT enforced byte-identical here because
+they have intentional K8s-only divergence (e.g. an additional ``mlflow``
+database) that pre-dates this issue and is out of scope for the sync.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKER_INIT_DIR = REPO_ROOT / "docker" / "postgres" / "init"
+K8S_CONFIGMAP = REPO_ROOT / "k8s" / "base" / "configmaps" / "postgres-init.yaml"
+
+# Scripts explicitly synchronized by issue #1402. Their ConfigMap value
+# must be byte-identical to the docker source.
+SYNCED_SCRIPTS = (
+    "04-voice-schema.sql",
+    "05-realestate-schema.sql",
+    "06-lead-scoring-sync.sql",
+    "07-nurturing-funnel-analytics.sql",
+    "08-user-favorites.sql",
+)
+
+
+def _load_configmap() -> dict:
+    """Parse the postgres-init ConfigMap as YAML."""
+    with open(K8S_CONFIGMAP, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def test_configmap_parses_as_valid_yaml() -> None:
+    """The ConfigMap must be valid YAML and a Kubernetes ConfigMap."""
+    doc = _load_configmap()
+    assert isinstance(doc, dict), "ConfigMap must be a YAML mapping"
+    assert doc.get("kind") == "ConfigMap", (
+        f"expected kind=ConfigMap, got {doc.get('kind')!r}"
+    )
+    assert "data" in doc and isinstance(doc["data"], dict), (
+        "ConfigMap must have a non-empty `data:` mapping"
+    )
+
+
+def test_every_docker_init_script_has_a_configmap_key() -> None:
+    """Every ``*.sql`` in ``docker/postgres/init/`` must be embedded.
+
+    Kubelet projects each ``data:`` key as a file at the same path under
+    the volume mount (``/docker-entrypoint-initdb.d/``), so missing keys
+    mean missing files at first-boot init.
+    """
+    docker_scripts = sorted(p.name for p in DOCKER_INIT_DIR.glob("*.sql"))
+    assert docker_scripts, (
+        "expected SQL init scripts under docker/postgres/init/"
+    )
+    data = _load_configmap()["data"]
+    missing = [name for name in docker_scripts if name not in data]
+    assert not missing, (
+        "K8s postgres-init ConfigMap is missing keys for these docker "
+        "init scripts (Compose stack runs them, K8s does not):\n"
+        + "\n".join(f"  - {name}" for name in missing)
+    )
+
+
+@pytest.mark.parametrize("script_name", SYNCED_SCRIPTS)
+def test_synced_script_content_matches_docker(script_name: str) -> None:
+    """Newly-synced scripts (04-08) must be byte-identical to docker.
+
+    These scripts are pure SQL with no shell or env interpolation, so the
+    Compose path runs the file directly while the K8s path runs the
+    ConfigMap projection. To guarantee parity, the embedded value must
+    equal the docker source character-for-character (including trailing
+    newline). Any drift means K8s Postgres has a different schema than
+    Compose Postgres.
+    """
+    docker_path = DOCKER_INIT_DIR / script_name
+    assert docker_path.exists(), (
+        f"docker source missing: {docker_path}"
+    )
+    docker_content = docker_path.read_text(encoding="utf-8")
+
+    data = _load_configmap()["data"]
+    assert script_name in data, (
+        f"{script_name} not found in ConfigMap data — sync the docker "
+        f"init script into k8s/base/configmaps/postgres-init.yaml"
+    )
+    k8s_content = data[script_name]
+
+    assert k8s_content == docker_content, (
+        f"{script_name} drifted between docker source and K8s ConfigMap.\n"
+        f"  docker bytes: {len(docker_content)}\n"
+        f"  k8s    bytes: {len(k8s_content)}\n"
+        f"Copy verbatim from docker/postgres/init/{script_name}."
+    )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Sync `k8s/base/configmaps/postgres-init.yaml` with `docker/postgres/init/` so the K8s-deployed Postgres runs the same first-boot bootstrap scripts as the Compose stack. Per `docs/QDRANT_STACK.md` ("SQL Index Navigation (Postgres Init Drift)"), the K8s ConfigMap previously embedded only `00`, `02`, `03` — leaving voice transcripts, real-estate CRM tables, lead scoring, nurturing analytics, and user favorites schemas uncreated on K8s pods.

Closes #1402.

## Files touched

| File | Change |
|------|--------|
| `k8s/base/configmaps/postgres-init.yaml` | +5 `data:` keys for scripts 04–08 (verbatim copy from docker); + `CREATE DATABASE realestate` lines added to the existing `00-init-databases.sql` entry (precondition for 05+) |
| `tests/contract/test_k8s_postgres_init_parity_contract.py` | New — 7-case parity contract |

The ConfigMap is mounted as `init-scripts` at `/docker-entrypoint-initdb.d/` (`k8s/base/postgres/deployment.yaml`) without an `items:` projection filter, so every key auto-projects as a file. No Deployment manifest change required.

## Evidence of parity

After the sync, the ConfigMap contains all eight init scripts (length = decoded UTF-8 chars):

| Key | Length | Matches docker source |
|---|---:|:---:|
| `00-init-databases.sql` | 565 | (intentional K8s-only mlflow + new realestate; not enforced byte-identical) |
| `02-cocoindex.sql` | 1433 | (pre-existing K8s formatting; not enforced byte-identical) |
| `03-unified-ingestion-alter.sql` | 1903 | (pre-existing K8s formatting; not enforced byte-identical) |
| `04-voice-schema.sql` | 784 | yes |
| `05-realestate-schema.sql` | 1475 | yes |
| `06-lead-scoring-sync.sql` | 1581 | yes |
| `07-nurturing-funnel-analytics.sql` | 1849 | yes |
| `08-user-favorites.sql` | 458 | yes |

Total ConfigMap data: ~10 KiB — well under the 1 MiB ConfigMap hard limit.

No Postgres extensions are required by the new scripts (`grep` for `CREATE EXTENSION|pgvector|pg_trgm` returned no matches in 04–08). The K8s image is already `pgvector/pgvector:pg17`.

## Validation

```
$ uv run --python 3.12 pytest tests/contract/test_k8s_postgres_init_parity_contract.py -v
tests/contract/test_k8s_postgres_init_parity_contract.py::test_configmap_parses_as_valid_yaml PASSED
tests/contract/test_k8s_postgres_init_parity_contract.py::test_every_docker_init_script_has_a_configmap_key PASSED
tests/contract/test_k8s_postgres_init_parity_contract.py::test_synced_script_content_matches_docker[04-voice-schema.sql] PASSED
tests/contract/test_k8s_postgres_init_parity_contract.py::test_synced_script_content_matches_docker[05-realestate-schema.sql] PASSED
tests/contract/test_k8s_postgres_init_parity_contract.py::test_synced_script_content_matches_docker[06-lead-scoring-sync.sql] PASSED
tests/contract/test_k8s_postgres_init_parity_contract.py::test_synced_script_content_matches_docker[07-nurturing-funnel-analytics.sql] PASSED
tests/contract/test_k8s_postgres_init_parity_contract.py::test_synced_script_content_matches_docker[08-user-favorites.sql] PASSED
============================== 7 passed in 0.08s ===============================
```

Pre-RED (before the ConfigMap edit): the same suite reported `6 failed, 1 passed` — 1 missing-keys assertion + 5 missing-content assertions for 04–08 — confirming the contract genuinely reproduces the issue.

The wider `tests/contract` run shows the 7 new tests passing. The 13 unrelated failures (`test_error_contract`, `test_no_new_duplicate_test_names`, `test_span_coverage_contract`) are pre-existing on `dev` and reproduce identically with or without this branch's changes.

## Runtime impact

- This is a static K8s manifest change. No runtime code is touched.
- After deploy, only **fresh** Postgres pods will execute the init directory; existing PVCs already past first-boot are untouched (postgres' `docker-entrypoint.sh` skips `/docker-entrypoint-initdb.d` when `PGDATA` is initialized).
- For environments needing the new tables on existing data, run the new SQL files manually or recreate the PVC. (Out of scope for this PR.)
- Scripts 05–08 use `\c realestate;`, so the existing K8s `00-init-databases.sql` was extended to `CREATE DATABASE realestate` — without this, postgres would fail at first-boot init with `database "realestate" does not exist`. The K8s-only `mlflow` DB is preserved.

## Notes / non-goals

- Existing 00/02/03 entries have intentional K8s-side formatting differences (comments stripped, `mlflow` added). The contract enforces byte-parity only for the newly-synced 04–08 scripts; reconciling 00/02/03 line-by-line with docker is out of scope for #1402.
- No production cluster operations performed (no `kubectl apply`).