### PR TITLE
fix(docker): pin Langfuse runtimes to Python 3.13 + Mini App to Node 20.20.2 (#1814)

### DIFF
--- a/Dockerfile.ingestion
+++ b/Dockerfile.ingestion
@@ -7,7 +7,7 @@
 # Build stage
 # =============================================================================
 # Pin uv version — checked 2026-02-09
-FROM ghcr.io/astral-sh/uv:0.9-python3.14-bookworm-slim@sha256:7cf77f594be8042dab6daa9fe326f90962252268b4f120a7f5dccce4d947e6c1 AS builder
+FROM ghcr.io/astral-sh/uv:0.9-python3.13-bookworm-slim@sha256:531f855bda2c73cd6ef67d56b733b357cea384185b3022bd09f05e002cd144ca AS builder
 
 WORKDIR /app
 
@@ -43,7 +43,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # =============================================================================
 # Runtime stage
 # =============================================================================
-FROM python:3.14-slim-bookworm@sha256:a9bee15510a364124aa24692899d269835683b883de42f7ebec8c293cf679ccb AS runtime
+FROM python:3.13-slim-bookworm@sha256:e4fa1f978c539608a10cdf74700ac32a3f719dfc6e8b6b6001da82deb36302a2 AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/yastman/rag"
 

--- a/mini_app/Dockerfile
+++ b/mini_app/Dockerfile
@@ -2,7 +2,7 @@
 # Mini App FastAPI backend — uv sync pattern (2026 best practices)
 
 # ====== BUILD STAGE ======
-FROM ghcr.io/astral-sh/uv:0.9-python3.14-bookworm-slim@sha256:7cf77f594be8042dab6daa9fe326f90962252268b4f120a7f5dccce4d947e6c1 AS builder
+FROM ghcr.io/astral-sh/uv:0.9-python3.13-bookworm-slim@sha256:531f855bda2c73cd6ef67d56b733b357cea384185b3022bd09f05e002cd144ca AS builder
 
 WORKDIR /app
 
@@ -31,7 +31,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --extra mini-app
 
 # ====== RUNTIME STAGE ======
-FROM python:3.14-slim-bookworm@sha256:a9bee15510a364124aa24692899d269835683b883de42f7ebec8c293cf679ccb AS runtime
+FROM python:3.13-slim-bookworm@sha256:e4fa1f978c539608a10cdf74700ac32a3f719dfc6e8b6b6001da82deb36302a2 AS runtime
 
 WORKDIR /app
 

--- a/mini_app/frontend/Dockerfile
+++ b/mini_app/frontend/Dockerfile
@@ -2,7 +2,7 @@
 # Mini App React frontend — Node build + nginx serve
 
 # ====== BUILD STAGE ======
-FROM node:24.15.0-slim@sha256:4e6b70dd6cbfc88c8157ba19aa3d9f9cce6ba4703576d55459e45efcbc9c5f5d AS builder
+FROM node:20.20.2-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0 AS builder
 
 WORKDIR /app
 

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -2,7 +2,7 @@
 # RAG API — uv sync pattern (2026 best practices)
 
 # ====== BUILD STAGE ======
-FROM ghcr.io/astral-sh/uv:0.9-python3.14-bookworm-slim@sha256:7cf77f594be8042dab6daa9fe326f90962252268b4f120a7f5dccce4d947e6c1 AS builder
+FROM ghcr.io/astral-sh/uv:0.9-python3.13-bookworm-slim@sha256:531f855bda2c73cd6ef67d56b733b357cea384185b3022bd09f05e002cd144ca AS builder
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --extra voice
 
 # ====== RUNTIME STAGE ======
-FROM python:3.14-slim-bookworm@sha256:a9bee15510a364124aa24692899d269835683b883de42f7ebec8c293cf679ccb AS runtime
+FROM python:3.13-slim-bookworm@sha256:e4fa1f978c539608a10cdf74700ac32a3f719dfc6e8b6b6001da82deb36302a2 AS runtime
 
 WORKDIR /app
 

--- a/telegram_bot/Dockerfile
+++ b/telegram_bot/Dockerfile
@@ -2,7 +2,7 @@
 # Telegram Bot — uv sync pattern (2026 best practices)
 
 # ====== BUILD STAGE ======
-FROM ghcr.io/astral-sh/uv:0.9-python3.14-bookworm-slim@sha256:7cf77f594be8042dab6daa9fe326f90962252268b4f120a7f5dccce4d947e6c1 AS builder
+FROM ghcr.io/astral-sh/uv:0.9-python3.13-bookworm-slim@sha256:531f855bda2c73cd6ef67d56b733b357cea384185b3022bd09f05e002cd144ca AS builder
 
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
@@ -30,7 +30,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev
 
 # ====== RUNTIME STAGE ======
-FROM python:3.14-slim-bookworm@sha256:a9bee15510a364124aa24692899d269835683b883de42f7ebec8c293cf679ccb AS runtime
+FROM python:3.13-slim-bookworm@sha256:e4fa1f978c539608a10cdf74700ac32a3f719dfc6e8b6b6001da82deb36302a2 AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/yastman/rag"
 

--- a/tests/contract/test_dockerfile_runtime_policy_contract.py
+++ b/tests/contract/test_dockerfile_runtime_policy_contract.py
@@ -1,0 +1,204 @@
+"""Contract: Single source of truth for Dockerfile base-image runtime policy.
+
+Closes #1814. Related: #1307, #1346–#1348, #1381 (Langfuse+Pydantic v1 vs Python 3.14).
+
+Why this file exists
+--------------------
+Two pre-existing test suites were enforcing the same runtime policy from
+different angles:
+
+* ``tests/unit/test_docker_static_validation.py`` — checked Python 3.14
+  is absent and Python 3.13 is present in Langfuse-importing app images.
+* ``tests/unit/mini_app/test_frontend_runtime_contract.py`` — checked the
+  Mini App frontend Node builder pins ``node:20.20.2-slim``.
+
+When Renovate updates (#1776, #1783) bumped Python and Node base images
+without updating either test, the two contracts silently drifted out of
+agreement with reality. This contract consolidates **the policy itself** in
+a single place so that any future drift surfaces immediately and a single
+edit is enough to evolve the policy intentionally.
+
+Policy
+------
+``LANGFUSE_PY_FLOOR = "3.13"``
+    Langfuse 4.x imports ``pydantic.v1.datetime_parse`` for SDK back-compat.
+    Pydantic v1 emits ``UserWarning: Core Pydantic V1 functionality isn't
+    compatible with Python 3.14 or greater`` on import (#1381) and crashes
+    with ``pydantic.v1.errors.ConfigError`` at runtime under 3.14 (#1307).
+    All Langfuse-importing Docker runtimes therefore pin Python 3.13.
+
+``MINI_APP_NODE_FLOOR = "20.20.2"``
+    Aligns with ``mini_app/frontend/package.json`` ``engines.node`` upper
+    floor of ``^20.19.0`` (and lock file). Renovate bumped to Node 24
+    without revalidating the React 19 / Vite 8 toolchain matrix (#1783),
+    so we stay on the supported floor until that revalidation lands.
+
+Digest pinning
+--------------
+The acceptance criteria for #1814 explicitly require digest pinning to be
+preserved. The contract therefore asserts both the tag and that an
+``@sha256:<64 hex>`` digest is present.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+# ── Policy: single source of truth ───────────────────────────────────────────
+
+LANGFUSE_PY_FLOOR: str = "3.13"
+"""Required Python minor version for Langfuse-importing app runtimes."""
+
+LANGFUSE_PY_FORBIDDEN: tuple[str, ...] = ("3.14",)
+"""Python minor versions that MUST NOT appear in Langfuse-importing runtimes."""
+
+MINI_APP_NODE_FLOOR: str = "20.20.2"
+"""Required Node version for the Mini App frontend builder stage."""
+
+
+# ── Subjects under contract ──────────────────────────────────────────────────
+
+REPO_ROOT: Path = Path(__file__).resolve().parents[2]
+
+LANGFUSE_RUNTIME_DOCKERFILES: tuple[str, ...] = (
+    "telegram_bot/Dockerfile",
+    "mini_app/Dockerfile",
+    "src/api/Dockerfile",
+    "Dockerfile.ingestion",
+)
+"""Dockerfiles whose runtime imports ``telegram_bot.observability`` (Langfuse)."""
+
+MINI_APP_FRONTEND_DOCKERFILE: str = "mini_app/frontend/Dockerfile"
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+_DIGEST_RE = re.compile(r"@sha256:[a-f0-9]{64}")
+
+
+def _read(rel: str) -> str:
+    path = REPO_ROOT / rel
+    assert path.is_file(), f"{rel} not found at {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def _from_lines(text: str) -> list[str]:
+    return [line for line in text.splitlines() if line.lstrip().startswith("FROM ")]
+
+
+# ── Langfuse Python runtime contract ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize("dockerfile", LANGFUSE_RUNTIME_DOCKERFILES)
+def test_langfuse_runtime_uses_floor_python(dockerfile: str) -> None:
+    """Langfuse-importing runtimes must use the policy-defined Python floor."""
+    text = _read(dockerfile)
+    floor = LANGFUSE_PY_FLOOR
+    # Accept ``python:3.13-...`` (runtime image) OR ``python3.13-...`` (uv image).
+    assert (f"python:{floor}" in text) or (f"python{floor}" in text), (
+        f"{dockerfile} must pin Python {floor} runtime per the runtime policy "
+        f"(see #1307, #1381). Found FROM lines: {_from_lines(text)}"
+    )
+
+
+@pytest.mark.parametrize("dockerfile", LANGFUSE_RUNTIME_DOCKERFILES)
+def test_langfuse_runtime_does_not_use_forbidden_python(dockerfile: str) -> None:
+    """Forbidden Python versions must not appear in Langfuse-importing runtimes."""
+    text = _read(dockerfile)
+    for forbidden in LANGFUSE_PY_FORBIDDEN:
+        assert f"python:{forbidden}" not in text, (
+            f"{dockerfile} pins forbidden runtime python:{forbidden} "
+            f"(Langfuse SDK uses pydantic.v1 incompatible with Python {forbidden}; "
+            f"see #1307, #1381)."
+        )
+        assert f"python{forbidden}" not in text, (
+            f"{dockerfile} pins forbidden uv image python{forbidden} "
+            f"(see #1307, #1381)."
+        )
+
+
+@pytest.mark.parametrize("dockerfile", LANGFUSE_RUNTIME_DOCKERFILES)
+def test_langfuse_runtime_preserves_digest_pinning(dockerfile: str) -> None:
+    """Every base image FROM line must keep an ``@sha256:<digest>`` pin (#1814)."""
+    text = _read(dockerfile)
+    base_image_lines = [
+        line
+        for line in _from_lines(text)
+        # Skip multi-stage refs of the form ``FROM <stage> AS ...`` where
+        # ``<stage>`` is a previously declared stage name (no ``/`` or ``:``).
+        if (":" in line.split(" AS ")[0] or "/" in line.split(" AS ")[0])
+    ]
+    assert base_image_lines, f"{dockerfile} has no external FROM lines"
+    for line in base_image_lines:
+        assert _DIGEST_RE.search(line), (
+            f"{dockerfile}: FROM line missing @sha256 digest pin (policy #1814): {line!r}"
+        )
+
+
+# ── Mini App frontend Node policy ────────────────────────────────────────────
+
+
+def test_mini_app_frontend_builder_uses_node_floor() -> None:
+    """The Mini App frontend builder must pin ``node:<floor>-slim``."""
+    text = _read(MINI_APP_FRONTEND_DOCKERFILE)
+    pattern = re.compile(
+        rf"FROM node:{re.escape(MINI_APP_NODE_FLOOR)}-slim(?:@sha256:[a-f0-9]{{64}})? AS builder"
+    )
+    assert pattern.search(text), (
+        f"{MINI_APP_FRONTEND_DOCKERFILE} must pin "
+        f"node:{MINI_APP_NODE_FLOOR}-slim AS builder per Mini App Node policy "
+        f"(#1814). Found FROM lines: {_from_lines(text)}"
+    )
+
+
+def test_mini_app_frontend_builder_preserves_digest_pinning() -> None:
+    """The Mini App frontend builder Node image must keep an ``@sha256:`` pin."""
+    text = _read(MINI_APP_FRONTEND_DOCKERFILE)
+    builder_lines = [line for line in _from_lines(text) if "node:" in line]
+    assert builder_lines, (
+        f"{MINI_APP_FRONTEND_DOCKERFILE}: no Node FROM line found"
+    )
+    for line in builder_lines:
+        assert _DIGEST_RE.search(line), (
+            f"{MINI_APP_FRONTEND_DOCKERFILE}: Node FROM line missing "
+            f"@sha256 digest pin (policy #1814): {line!r}"
+        )
+
+
+# ── Cross-suite consistency: this contract drives the existing unit tests ────
+
+
+def test_policy_matches_legacy_unit_test_constants() -> None:
+    """Sanity: legacy unit tests must encode the same policy as this contract.
+
+    Guards against silent drift where one suite is updated and the other
+    is forgotten. The legacy ``_LANGFUSE_RUNTIME_DOCKERFILES`` list and the
+    Mini App Node floor regex must continue to match this contract.
+    """
+    docker_static = _read("tests/unit/test_docker_static_validation.py")
+    frontend_unit = _read("tests/unit/mini_app/test_frontend_runtime_contract.py")
+
+    # Legacy suite must enforce the same Python floor.
+    assert f'"python3.{LANGFUSE_PY_FLOOR.split(".")[1]}"' in docker_static or (
+        f'python:{LANGFUSE_PY_FLOOR}' in docker_static
+    ), (
+        "tests/unit/test_docker_static_validation.py must reference Python "
+        f"{LANGFUSE_PY_FLOOR}; if the policy changes, update both files."
+    )
+
+    # Legacy suite must list the same Langfuse Dockerfiles.
+    for dockerfile in LANGFUSE_RUNTIME_DOCKERFILES:
+        assert f'"{dockerfile}"' in docker_static, (
+            f"tests/unit/test_docker_static_validation.py "
+            f"_LANGFUSE_RUNTIME_DOCKERFILES must include {dockerfile}"
+        )
+
+    # Frontend unit test must reference the same Node floor.
+    assert MINI_APP_NODE_FLOOR.replace(".", r"\.") in frontend_unit, (
+        "tests/unit/mini_app/test_frontend_runtime_contract.py must reference "
+        f"Node floor {MINI_APP_NODE_FLOOR}; if the policy changes, update both files."
+    )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Resolves the 9 Docker static runtime contract failures introduced when Renovate PRs #1776 (Python → 3.14) and #1783 (Node → 24) bumped base images without revalidating the runtime contracts. **Path A** (revert images, keep contracts).

Closes #1814.
Refs #1381, #1307.

## Decision: Path A — revert images

The acceptance criteria for #1814 say: *"The issue resolution documents whether Python 3.14 + current Langfuse is supported or explicitly avoided."* Evidence collected:

| Source | Finding |
| --- | --- |
| **Issue [#1381](https://github.com/yastman/rag/issues/1381)** (still OPEN) | Langfuse 4.3.1 emits `UserWarning: Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.` from `langfuse/api/core/pydantic_utilities.py` (`from pydantic.v1.datetime_parse import parse_date`). |
| **Test #1307 ref** (in `_LANGFUSE_RUNTIME_DOCKERFILES` docstring) | bot and mini-app-api containers crash with `pydantic.v1.errors.ConfigError` under Python 3.14. |
| **Context7 → `/langfuse/langfuse-python`** | Current docs demonstrate API usage; **no Python 3.14 support announcement**. SDK still imports `pydantic.v1` back-compat code in `langfuse/api/core/pydantic_utilities.py`. The README states the SDK underwent a v4 rewrite (March 2026) but does not advertise Python 3.14 support. |
| **`pyproject.toml`** | `requires-python = ">=3.11"`, ruff & pylint `target-version = "py313"`, mypy `python_version = "3.13"`. The repo's official runtime target is **Python 3.13**. |
| **`mini_app/frontend/package.json`** | `engines.node = "^20.19.0 \|\| >=22.12.0"`. Node 24 is technically allowed by the constraint but was not validated against the React 19 / Vite 8 / TypeScript 6 toolchain matrix; lockfile and existing test contract pin **20.20.2** as the supported floor. |

Conclusion: Renovate updates were premature. Revert to known-good images and let Renovate re-propose once Langfuse announces Python 3.14 support and the frontend toolchain matrix is revalidated.

## Files touched

**Reverted base images (digest pins preserved per acceptance criteria):**

- `telegram_bot/Dockerfile`
- `mini_app/Dockerfile`
- `src/api/Dockerfile`
- `Dockerfile.ingestion`
  - builder: `ghcr.io/astral-sh/uv:0.9-python3.13-bookworm-slim@sha256:531f855bda2c73cd6ef67d56b733b357cea384185b3022bd09f05e002cd144ca`
  - runtime: `python:3.13-slim-bookworm@sha256:e4fa1f978c539608a10cdf74700ac32a3f719dfc6e8b6b6001da82deb36302a2`
- `mini_app/frontend/Dockerfile`
  - builder: `node:20.20.2-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0`

**New consolidating contract:**

- `tests/contract/test_dockerfile_runtime_policy_contract.py` — single source of truth for `LANGFUSE_PY_FLOOR`, `LANGFUSE_PY_FORBIDDEN`, `MINI_APP_NODE_FLOOR`, plus a cross-suite consistency check that asserts the legacy unit tests in `test_docker_static_validation.py` and `test_frontend_runtime_contract.py` still encode the same policy. Prevents the kind of silent drift this issue uncovered.

## Validation

**Before** (clean `dev` @ `a3cab13`):

```
FAILED tests/unit/test_docker_static_validation.py::test_langfuse_dockerfile_does_not_use_python314[telegram_bot/Dockerfile]
FAILED tests/unit/test_docker_static_validation.py::test_langfuse_dockerfile_does_not_use_python314[mini_app/Dockerfile]
FAILED tests/unit/test_docker_static_validation.py::test_langfuse_dockerfile_does_not_use_python314[src/api/Dockerfile]
FAILED tests/unit/test_docker_static_validation.py::test_langfuse_dockerfile_does_not_use_python314[Dockerfile.ingestion]
FAILED tests/unit/test_docker_static_validation.py::test_langfuse_dockerfile_uses_python313[telegram_bot/Dockerfile]
FAILED tests/unit/test_docker_static_validation.py::test_langfuse_dockerfile_uses_python313[mini_app/Dockerfile]
FAILED tests/unit/test_docker_static_validation.py::test_langfuse_dockerfile_uses_python313[src/api/Dockerfile]
FAILED tests/unit/test_docker_static_validation.py::test_langfuse_dockerfile_uses_python313[Dockerfile.ingestion]
FAILED tests/unit/mini_app/test_frontend_runtime_contract.py::test_frontend_builder_pins_supported_node_floor
9 failed, 24 passed in 2.31s
```

**After** (this branch):

```
$ uv run pytest tests/unit/test_docker_static_validation.py \
    tests/unit/mini_app/test_frontend_runtime_contract.py \
    tests/contract/test_dockerfile_runtime_policy_contract.py -q \
    --deselect tests/unit/test_docker_static_validation.py::test_compose_dev_config_renders \
    --deselect tests/unit/test_docker_static_validation.py::test_compose_dev_config_renders_with_full_profile
................................................                         [100%]
48 passed, 2 deselected in 0.91s
```

The two deselected `test_compose_dev_config_renders*` tests fail on this sandbox because the `docker-compose` plugin isn't installed; they pass in CI and are **unrelated to #1814**. They were flagged in the issue baseline run (10 total failures) but the issue's target list explicitly only enumerates the 9 Langfuse + frontend tests.

`tests/contract` shows the same 13 pre-existing failures from `dev` (error-span and span-coverage contracts) — unrelated to this change.

## Runtime Impact

- [x] Dockerfile change — re-builds will pull the previously known-good Python 3.13 and Node 20.20.2 images. No production deploy, no `docker build` performed (per acceptance-criteria safety).
- [ ] No runtime code changes
- [ ] No DB schema changes

## Follow-ups

- **#1381** stays open until Langfuse ships Pydantic v2-only Python 3.14 support; Renovate's Python 3.14 PR can be re-evaluated then.
- Frontend Node 24 should be re-attempted once the React 19 / Vite 8 / TypeScript 6 toolchain matrix is validated against Node 24, and `package.json` engines + lockfile are aligned.

[STEERING steer-f60ccc8a-d02a-41c6-86b3-78ff904314fe: handled by parent — proceeded with #1814 as instructed; the Russian "Гит Иссуя" nudge was acknowledged by the prior subagent and required no course correction.]