### PR TITLE
fix(gates): align post-merge contracts and bot lock

### DIFF
--- a/src/evaluation/smoke_test.py
+++ b/src/evaluation/smoke_test.py
@@ -277,6 +277,32 @@ SLO_THRESHOLDS = {
 }
 
 
+def _load_embedding_model() -> Any:
+    """Load the BGE-M3 model required by evaluation search engines."""
+    try:
+        from FlagEmbedding import BGEM3FlagModel
+    except ImportError as e:
+        raise ImportError(
+            "FlagEmbedding is not installed. Install ml-local extra: uv sync --extra ml-local"
+        ) from e
+
+    return BGEM3FlagModel("BAAI/bge-m3", use_fp16=True)
+
+
+def _article_number(result: Any) -> int:
+    """Extract article_number from either evaluation dicts or Qdrant-like points."""
+    if isinstance(result, dict):
+        raw = result.get("article_number", 0)
+    else:
+        payload = getattr(result, "payload", {}) or {}
+        raw = payload.get("article_number", 0) if isinstance(payload, dict) else 0
+
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 0
+
+
 def run_smoke_test(
     engine_name: str = "dbsf_colbert",
     collection: str = "uk_civil_code_v2",
@@ -307,12 +333,17 @@ def run_smoke_test(
 
     # Initialize engine
     print(f"\n🔧 Initializing {engine_name} engine...")
+    embedding_model = _load_embedding_model()
+    engine: Any
     if engine_name == "baseline":
-        engine = BaselineSearchEngine(collection_name=collection)
+        engine = BaselineSearchEngine(collection_name=collection, embedding_model=embedding_model)
     elif engine_name == "hybrid":
-        engine = HybridSearchEngine(collection_name=collection)
+        engine = HybridSearchEngine(collection_name=collection, embedding_model=embedding_model)
     elif engine_name == "dbsf_colbert":
-        engine = HybridDBSFColBERTSearchEngine(collection_name=collection)
+        engine = HybridDBSFColBERTSearchEngine(
+            collection_name=collection,
+            embedding_model=embedding_model,
+        )
     else:
         raise ValueError(f"Unknown engine: {engine_name}")
 
@@ -323,16 +354,16 @@ def run_smoke_test(
 
     print(f"\n🏃 Running {len(queries)} smoke queries...")
     for i, query_data in enumerate(queries, 1):
-        query = query_data["query"]
-        expected = int(query_data["expected_article"])  # type: ignore[call-overload]
+        query = str(query_data["query"])
+        expected = int(str(query_data["expected_article"]))
 
         start_time = time.time()
-        search_results = engine.search(query, limit=10)
+        search_results = engine.search(query, top_k=10)
         latency_ms = (time.time() - start_time) * 1000
         latencies.append(latency_ms)
 
         # Check if expected article in results
-        retrieved_articles = [int(r.payload.get("article_number", 0)) for r in search_results]
+        retrieved_articles = [_article_number(result) for result in search_results]
         precision_at_1 = 1.0 if retrieved_articles and retrieved_articles[0] == expected else 0.0
         recall_at_10 = 1.0 if expected in retrieved_articles else 0.0
 

--- a/telegram_bot/pyproject.toml
+++ b/telegram_bot/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "asyncpg>=0.31.0",
     "apscheduler>=3.11.2,<4.0",
     "phonenumbers>=9.0.25",
+    "prometheus-client>=0.20.0,<1.0",
 ]
 
 [project.optional-dependencies]

--- a/telegram_bot/uv.lock
+++ b/telegram_bot/uv.lock
@@ -1716,6 +1716,15 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2068,6 +2077,7 @@ dependencies = [
     { name = "langmem" },
     { name = "openai" },
     { name = "phonenumbers" },
+    { name = "prometheus-client" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "qdrant-client" },
@@ -2105,6 +2115,7 @@ requires-dist = [
     { name = "langmem", specifier = ">=0.0.30" },
     { name = "openai", specifier = ">=1.10.0" },
     { name = "phonenumbers", specifier = ">=9.0.25" },
+    { name = "prometheus-client", specifier = ">=0.20.0,<1.0" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "qdrant-client", specifier = ">=1.14.0" },

--- a/tests/unit/evaluation/test_smoke_test.py
+++ b/tests/unit/evaluation/test_smoke_test.py
@@ -102,11 +102,12 @@ class TestRunSmokeTestEngineSelection:
                 self.payload = {"article_number": article}
 
         class _FakeEngine:
-            def __init__(self, collection_name: str) -> None:
+            def __init__(self, collection_name: str, embedding_model: object) -> None:
                 captured["collection_name"] = collection_name
+                captured["embedding_model"] = embedding_model
                 captured["query_count"] = 0
 
-            def search(self, query: str, limit: int = 10):  # noqa: D401, ARG002
+            def search(self, query: str, top_k: int = 10):  # noqa: D401, ARG002
                 captured["query_count"] = int(captured.get("query_count", 0)) + 1
                 # Always return an empty list — we only care about wiring here.
                 return []
@@ -114,6 +115,7 @@ class TestRunSmokeTestEngineSelection:
         # Patch the symbol in the smoke_test module's namespace.
         smoke_module = sys.modules["src.evaluation.smoke_test"]
         monkeypatch.setattr(smoke_module, "BaselineSearchEngine", _FakeEngine)
+        monkeypatch.setattr(smoke_module, "_load_embedding_model", lambda: "fake-bge-m3")
 
         result = run_smoke_test(
             engine_name="baseline",
@@ -122,6 +124,7 @@ class TestRunSmokeTestEngineSelection:
         )
 
         assert captured["collection_name"] == "unit-test-collection"
+        assert captured["embedding_model"] == "fake-bge-m3"
         # quick=True selects the first 10 queries.
         assert captured["query_count"] == 10
         assert result["engine"] == "baseline"
@@ -141,10 +144,11 @@ class TestRunSmokeTestSloEvaluation:
                 self.payload = {"article_number": article}
 
         class _PerfectEngine:
-            def __init__(self, collection_name: str) -> None:
+            def __init__(self, collection_name: str, embedding_model: object) -> None:
                 self.collection_name = collection_name
+                self.embedding_model = embedding_model
 
-            def search(self, query: str, limit: int = 10):  # noqa: ARG002
+            def search(self, query: str, top_k: int = 10):  # noqa: ARG002
                 # Inverse-lookup the expected article from the query string is
                 # heavy — instead, return all 30 expected articles in order so
                 # the first hit matches whichever query came in. ``run_smoke_test``
@@ -164,6 +168,7 @@ class TestRunSmokeTestSloEvaluation:
         _PerfectEngine.next_expected = [int(q["expected_article"]) for q in SMOKE_QUERIES[:10]]
 
         monkeypatch.setattr(smoke_module, "BaselineSearchEngine", _PerfectEngine)
+        monkeypatch.setattr(smoke_module, "_load_embedding_model", lambda: object())
 
         result = run_smoke_test(
             engine_name="baseline",
@@ -187,14 +192,15 @@ class TestSmokeTestResultStructure:
 
     def test_result_dict_keys(self, monkeypatch) -> None:
         class _FakeEngine:
-            def __init__(self, collection_name: str) -> None:
+            def __init__(self, collection_name: str, embedding_model: object) -> None:
                 pass
 
-            def search(self, query: str, limit: int = 10):  # noqa: ARG002
+            def search(self, query: str, top_k: int = 10):  # noqa: ARG002
                 return []
 
         smoke_module = sys.modules["src.evaluation.smoke_test"]
         monkeypatch.setattr(smoke_module, "BaselineSearchEngine", _FakeEngine)
+        monkeypatch.setattr(smoke_module, "_load_embedding_model", lambda: object())
 
         result = run_smoke_test(engine_name="baseline", quick=True)
 

--- a/tests/unit/test_release_gate_contract.py
+++ b/tests/unit/test_release_gate_contract.py
@@ -7,6 +7,7 @@ from pathlib import Path
 ROOT = Path(__file__).parents[2]
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 RELEASE_SMOKE_SCRIPT = ROOT / "scripts" / "test_release_health_vps.sh"
+VPS_NONCORE_SERVICES_LIB = ROOT / "scripts" / "lib" / "vps_noncore_services.sh"
 
 
 def test_release_smoke_script_does_not_allow_profile_mode() -> None:
@@ -21,6 +22,7 @@ def test_release_smoke_script_does_not_allow_profile_mode() -> None:
 
 def test_release_smoke_asserts_removed_services_absent() -> None:
     script = RELEASE_SMOKE_SCRIPT.read_text()
+    noncore_services = VPS_NONCORE_SERVICES_LIB.read_text()
     for service in [
         "mini-app-api",
         "mini-app-frontend",
@@ -32,8 +34,9 @@ def test_release_smoke_asserts_removed_services_absent() -> None:
         "minio",
         "redis-langfuse",
     ]:
-        assert service in script
-    assert "removed_services" in script
+        assert service in noncore_services
+    assert "VPS_NONCORE_SERVICES" in script
+    assert "removed_service" in script
 
 
 def test_public_ci_does_not_run_release_smoke() -> None:


### PR DESCRIPTION
Post-merge gate fix after merging the open PR stack.\n\nChanges:\n- add prometheus-client to telegram_bot/pyproject.toml and telegram_bot/uv.lock so bot-local frozen imports can load telegram_bot.services.metrics\n- align src/evaluation/smoke_test.py with current evaluation search engine API: embedding_model, top_k, dict result shape\n- update release gate unit contract to read removed VPS services from scripts/lib/vps_noncore_services.sh, the current single source of truth\n\nValidation run locally:\n- make check\n- npm run typecheck:test && npm test -- --run && npm run build (mini_app/frontend)\n- PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit -> 7036 passed, 1 skipped