### PR TITLE
fix(ingestion): build-then-delete — preserve last-good Qdrant points on upsert failure (#1602)

### DIFF
--- a/src/ingestion/unified/qdrant_writer.py
+++ b/src/ingestion/unified/qdrant_writer.py
@@ -12,6 +12,7 @@ from qdrant_client import QdrantClient
 from qdrant_client.models import (
     FieldCondition,
     Filter,
+    HasIdCondition,
     MatchValue,
     PointStruct,
     SparseVector,
@@ -550,6 +551,14 @@ class QdrantHybridWriter:
         """Sync version of upsert_chunks.
 
         Uses sync Voyage client and sync Qdrant operations.
+
+        # (#1602) build-then-delete: upsert new points first, delete stale old ones after.
+        # Previously delete_file_sync ran before embedding; any failure during
+        # embedding or upsert left retrieval with zero points for that document.
+        # New order:
+        #   1. Build + embed points
+        #   2. Upsert new points
+        #   3. Delete ONLY stale old points (file_id match AND id NOT IN new_ids)
         """
         stats = WriteStats()
 
@@ -557,13 +566,10 @@ class QdrantHybridWriter:
             return stats
 
         try:
-            # Step 1: Delete existing (replace semantics)
-            stats.points_deleted = self.delete_file_sync(file_id, collection_name)
-
-            # Step 2: Extract texts
+            # Step 1: Extract texts
             texts = [chunk.text for chunk in chunks]
 
-            # Step 3: Generate embeddings — single hybrid call when local BGE-M3
+            # Step 2: Generate embeddings — single hybrid call when local BGE-M3
             all_dense_embeddings: list[list[float]]
             if self.use_local_embeddings:
                 hybrid_result = self._bge_client.encode_hybrid(texts)
@@ -589,13 +595,15 @@ class QdrantHybridWriter:
                 sparse_embeddings = self._embed_sparse(texts)
                 colbert_embeddings = []
 
-            # Step 4: Build points
+            # Step 3: Build points with deterministic IDs
             points = []
+            new_point_ids: list[str] = []
             for i, (chunk, dense_vec, sparse_emb) in enumerate(
                 zip(chunks, all_dense_embeddings, sparse_embeddings, strict=True)
             ):
                 chunk_location = self.get_chunk_location(chunk, i)
                 point_id = self.generate_point_id(file_id, chunk_location)
+                new_point_ids.append(point_id)
                 payload = self.build_payload(
                     chunk, file_id, source_path, chunk_location, file_metadata
                 )
@@ -614,16 +622,46 @@ class QdrantHybridWriter:
                 )
                 points.append(point)
 
-            # Step 5: Upsert in request-size-safe batches
+            # Step 4: Upsert new points FIRST (preserves last-good state on failure)
             stats.points_upserted = self._upsert_points_in_batches(
                 collection_name=collection_name,
                 points=points,
                 source_path=source_path,
             )
 
+            # Step 5: (#1602) Delete stale points ONLY after successful upsert.
+            # Stale = same file_id but point_id not in the new set.
+            # Uses HasIdCondition with must_not so only truly orphaned points are removed.
+            stale_filter = Filter(
+                must=[
+                    FieldCondition(
+                        key="metadata.file_id", match=MatchValue(value=file_id)
+                    )
+                ],
+                must_not=[
+                    HasIdCondition(has_id=new_point_ids),
+                ],
+            )
+            count_result = self.client.count(
+                collection_name=collection_name,
+                count_filter=stale_filter,
+            )
+            stale_count = count_result.count
+            if stale_count > 0:
+                self.client.delete(
+                    collection_name=collection_name,
+                    points_selector=stale_filter,
+                )
+                logger.info(
+                    "Deleted %d stale points for file_id=%s after successful upsert",
+                    stale_count,
+                    file_id,
+                )
+            stats.points_deleted = stale_count
+
             logger.info(
                 f"Upserted {stats.points_upserted} points for {source_path} "
-                f"(replaced {stats.points_deleted})"
+                f"(deleted {stats.points_deleted} stale)"
             )
 
         except Exception as e:

--- a/tests/contract/test_qdrant_writer_no_delete_before_upsert_contract.py
+++ b/tests/contract/test_qdrant_writer_no_delete_before_upsert_contract.py
@@ -1,0 +1,128 @@
+# tests/contract/test_qdrant_writer_no_delete_before_upsert_contract.py
+"""AST contract: no delete call before upsert call in upsert_chunks_sync (#1602).
+
+Walks the AST of upsert_chunks_sync and asserts that any call that looks like
+a 'delete' / 'delete_file_sync' appears only AFTER the first call that looks
+like 'upsert' / '_upsert_points_in_batches'.
+
+This is a static structural guard — it catches regressions even if mocks
+change or new callers are added.
+"""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+
+
+SOURCE_FILE = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "ingestion"
+    / "unified"
+    / "qdrant_writer.py"
+)
+
+# Names that constitute an "upsert" operation
+UPSERT_NAMES = {"upsert", "_upsert_points_in_batches", "upsert_chunks_sync"}
+
+# Names that constitute a "delete" operation
+DELETE_NAMES = {"delete", "delete_file_sync", "delete_file"}
+
+
+def _extract_call_names_in_order(func_node: ast.FunctionDef) -> list[str]:
+    """Walk the function body and return call names in source order.
+
+    Captures both:
+    - ``foo(...)``           → "foo"
+    - ``self.foo(...)``      → "foo"
+    - ``obj.attr.foo(...)``  → "foo"
+    """
+    call_names: list[str] = []
+
+    class _CallCollector(ast.NodeVisitor):
+        def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+            func = node.func
+            if isinstance(func, ast.Attribute):
+                call_names.append(func.attr)
+            elif isinstance(func, ast.Name):
+                call_names.append(func.id)
+            self.generic_visit(node)
+
+    _CallCollector().visit(func_node)
+    return call_names
+
+
+def _find_function(tree: ast.Module, name: str) -> ast.FunctionDef | None:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    return None
+
+
+def test_no_delete_before_upsert_in_upsert_chunks_sync() -> None:
+    """upsert_chunks_sync must not call delete before upsert."""
+    source = SOURCE_FILE.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(SOURCE_FILE))
+
+    func = _find_function(tree, "upsert_chunks_sync")
+    assert func is not None, (
+        f"Could not find 'upsert_chunks_sync' in {SOURCE_FILE}. "
+        "Was it renamed or removed?"
+    )
+
+    call_names = _extract_call_names_in_order(func)
+
+    upsert_positions = [i for i, name in enumerate(call_names) if name in UPSERT_NAMES]
+    delete_positions = [i for i, name in enumerate(call_names) if name in DELETE_NAMES]
+
+    # If there's no upsert call something is very wrong
+    assert upsert_positions, (
+        f"No upsert-family call found in upsert_chunks_sync. Calls seen: {call_names}"
+    )
+
+    if not delete_positions:
+        # No delete at all is also fine (all-new content, nothing stale to remove)
+        return
+
+    first_upsert = min(upsert_positions)
+    first_delete = min(delete_positions)
+
+    assert first_upsert < first_delete, (
+        f"CONTRACT VIOLATION (#1602): delete-family call ('{call_names[first_delete]}', "
+        f"call-index {first_delete}) appears before "
+        f"upsert-family call ('{call_names[first_upsert]}', call-index {first_upsert}) "
+        f"in upsert_chunks_sync.\n"
+        f"Full call sequence: {call_names}\n"
+        "Fix: move delete to AFTER successful upsert."
+    )
+
+
+def test_upsert_chunks_sync_has_no_delete_file_sync_early_call() -> None:
+    """Explicit check: delete_file_sync must not appear before _upsert_points_in_batches."""
+    source = SOURCE_FILE.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(SOURCE_FILE))
+
+    func = _find_function(tree, "upsert_chunks_sync")
+    assert func is not None
+
+    call_names = _extract_call_names_in_order(func)
+
+    try:
+        upsert_idx = call_names.index("_upsert_points_in_batches")
+    except ValueError:
+        pytest.fail(
+            f"'_upsert_points_in_batches' not found in upsert_chunks_sync calls: {call_names}"
+        )
+
+    delete_file_positions = [
+        i for i, name in enumerate(call_names) if name == "delete_file_sync"
+    ]
+
+    early_deletes = [pos for pos in delete_file_positions if pos < upsert_idx]
+    assert not early_deletes, (
+        f"CONTRACT VIOLATION (#1602): delete_file_sync called at position(s) {early_deletes} "
+        f"which is before _upsert_points_in_batches at position {upsert_idx}.\n"
+        f"Full call sequence: {call_names}"
+    )

--- a/tests/unit/ingestion/test_qdrant_writer_build_then_delete.py
+++ b/tests/unit/ingestion/test_qdrant_writer_build_then_delete.py
@@ -1,0 +1,233 @@
+# tests/unit/ingestion/test_qdrant_writer_build_then_delete.py
+"""TDD tests for build-then-delete ordering in upsert_chunks_sync (#1602).
+
+Verifies that:
+1. upsert calls precede delete calls in method_calls order
+2. Embedding failure does NOT trigger delete_file_sync
+3. Upsert failure does NOT trigger delete_file_sync
+4. Happy path: stale points ARE deleted AFTER successful upsert
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+from qdrant_client.models import PointStruct, SparseVector
+
+from src.ingestion.unified.qdrant_writer import QdrantHybridWriter
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_chunk(
+    *,
+    text: str = "hello world",
+    order: int = 0,
+) -> MagicMock:
+    chunk = MagicMock()
+    chunk.text = text
+    chunk.order = order
+    chunk.extra_metadata = {}
+    chunk.document_name = "doc.pdf"
+    chunk.page_range = None
+    chunk.section = None
+    chunk.chunk_id = order
+    return chunk
+
+
+def _make_hybrid_result(n: int = 1) -> MagicMock:
+    """Return a mock HybridResult with *n* vectors."""
+    result = MagicMock()
+    result.dense_vecs = [[0.1] * 1024 for _ in range(n)]
+    result.lexical_weights = [{"indices": [0, 1], "values": [0.5, 0.5]}] * n
+    result.colbert_vecs = []
+    return result
+
+
+def _build_writer() -> QdrantHybridWriter:
+    """Build a QdrantHybridWriter with all heavy deps mocked."""
+    with (
+        patch("src.ingestion.unified.qdrant_writer.QdrantClient"),
+        patch("telegram_bot.services.bge_m3_client.BGEM3SyncClient"),
+    ):
+        writer = QdrantHybridWriter.__new__(QdrantHybridWriter)
+
+    writer.use_local_embeddings = True
+    writer.voyage = None
+
+    # Sync Qdrant client mock
+    writer.client = MagicMock()
+    writer.client.count.return_value = MagicMock(count=3)  # 3 old points exist
+    writer.client.delete = MagicMock()
+    writer.client.upsert = MagicMock()
+
+    # BGE-M3 client mock
+    writer._bge_client = MagicMock()
+    writer._bge_client.encode_hybrid.return_value = _make_hybrid_result(1)
+
+    return writer
+
+
+# ---------------------------------------------------------------------------
+# Test 1: upsert precedes delete in method_calls
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_chunks_sync_does_not_delete_before_upsert():
+    """After fix: first significant call on client must be upsert, not delete.
+
+    This test verifies the build-then-delete ordering: we should see an
+    upsert call before any delete call.
+    """
+    writer = _build_writer()
+    chunks = [_make_chunk()]
+
+    writer.upsert_chunks_sync(
+        chunks=chunks,
+        file_id="file-abc",
+        source_path="test/doc.pdf",
+        file_metadata={"language": "en"},
+        collection_name="test_col",
+    )
+
+    # Collect call names on writer.client in order
+    call_names = [c[0] for c in writer.client.method_calls]
+
+    upsert_positions = [i for i, name in enumerate(call_names) if name == "upsert"]
+    delete_positions = [i for i, name in enumerate(call_names) if name == "delete"]
+
+    assert upsert_positions, "Expected at least one client.upsert() call"
+    # Either no delete at all (if IDs are identical), or delete comes AFTER first upsert
+    if delete_positions:
+        first_upsert = min(upsert_positions)
+        first_delete = min(delete_positions)
+        assert first_upsert < first_delete, (
+            f"delete (pos {first_delete}) must come AFTER upsert (pos {first_upsert}), "
+            "but delete happened first — data-loss risk (#1602)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: embed failure → delete_file_sync NOT called
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_chunks_sync_preserves_old_points_on_embed_failure():
+    """If embedding raises, delete_file_sync must NOT be called."""
+    writer = _build_writer()
+    writer._bge_client.encode_hybrid.side_effect = RuntimeError("BGE-M3 timeout")
+
+    chunks = [_make_chunk()]
+
+    with patch.object(writer, "delete_file_sync", wraps=writer.delete_file_sync) as mock_del:
+        stats = writer.upsert_chunks_sync(
+            chunks=chunks,
+            file_id="file-abc",
+            source_path="test/doc.pdf",
+            file_metadata={"language": "en"},
+            collection_name="test_col",
+        )
+
+    mock_del.assert_not_called(), (
+        "delete_file_sync must NOT be called when embedding fails — "
+        "last-good points would be lost (#1602)"
+    )
+    assert stats.errors, "Expected errors to be populated on embed failure"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: upsert failure → delete_file_sync NOT called
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_chunks_sync_preserves_old_points_on_upsert_failure():
+    """If _upsert_points_in_batches raises, delete_file_sync must NOT be called."""
+    writer = _build_writer()
+
+    chunks = [_make_chunk()]
+
+    with (
+        patch.object(
+            writer,
+            "_upsert_points_in_batches",
+            side_effect=RuntimeError("Qdrant upsert error"),
+        ),
+        patch.object(writer, "delete_file_sync", wraps=writer.delete_file_sync) as mock_del,
+    ):
+        stats = writer.upsert_chunks_sync(
+            chunks=chunks,
+            file_id="file-abc",
+            source_path="test/doc.pdf",
+            file_metadata={"language": "en"},
+            collection_name="test_col",
+        )
+
+    mock_del.assert_not_called(), (
+        "delete_file_sync must NOT be called when upsert fails — "
+        "last-good points would be lost (#1602)"
+    )
+    assert stats.errors, "Expected errors to be populated on upsert failure"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: happy path — stale points deleted AFTER successful upsert
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_chunks_sync_deletes_stale_points_after_successful_upsert():
+    """Happy path: after successful upsert, stale old points are deleted.
+
+    The delete must happen AFTER upsert, and must target only stale points
+    (either via filter or point ID exclusion).
+    """
+    writer = _build_writer()
+
+    chunks = [_make_chunk(text="chunk 0", order=0)]
+
+    # Track call order on client
+    call_order: list[str] = []
+    original_upsert = writer.client.upsert
+    original_delete = writer.client.delete
+
+    def tracking_upsert(**kwargs):
+        call_order.append("upsert")
+        return original_upsert(**kwargs)
+
+    def tracking_delete(**kwargs):
+        call_order.append("delete")
+        return original_delete(**kwargs)
+
+    writer.client.upsert = tracking_upsert
+    writer.client.delete = tracking_delete
+
+    stats = writer.upsert_chunks_sync(
+        chunks=chunks,
+        file_id="file-abc",
+        source_path="test/doc.pdf",
+        file_metadata={"language": "en"},
+        collection_name="test_col",
+    )
+
+    assert stats.errors is None or stats.errors == [], (
+        f"Expected no errors in happy path, got: {stats.errors}"
+    )
+    assert stats.points_upserted > 0, "Expected points to be upserted"
+
+    # Delete must have been called (stale cleanup)
+    assert "delete" in call_order, (
+        "Expected client.delete() to be called for stale point cleanup"
+    )
+
+    # And upsert must precede delete
+    upsert_idx = call_order.index("upsert")
+    delete_idx = call_order.index("delete")
+    assert upsert_idx < delete_idx, (
+        f"upsert (pos {upsert_idx}) must precede delete (pos {delete_idx})"
+    )
+
+    # points_deleted should be populated
+    assert stats.points_deleted >= 0, "stats.points_deleted should be non-negative"


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Fixes the data-loss risk reported in #1602: `upsert_chunks_sync` previously deleted all Qdrant points for a document **before** generating replacement embeddings. Any failure during embedding or upsert left retrieval with **zero points** for that document until the next successful retry.

## Data-loss scenario — before vs after

**Before (dangerous order):**
```
1. DELETE file's Qdrant points      ← ❌ data gone
2. encode_hybrid(texts)             ← if this raises → zero points forever
3. build points
4. _upsert_points_in_batches(...)   ← if this raises → zero points forever
```

**After (build-then-delete, safe):**
```
1. encode_hybrid(texts)             ← if this raises → old points preserved ✅
2. build points (deterministic IDs)
3. _upsert_points_in_batches(...)   ← if this raises → old points preserved ✅
4. DELETE only stale points         ← only runs after successful upsert ✅
   (file_id match AND id NOT IN new_point_ids)
```

The key insight: `generate_point_id(file_id, chunk_location)` produces **deterministic UUIDs**. After a successful upsert, we delete only points for this `file_id` whose IDs are **not** in the new set — using `HasIdCondition` with `must_not`. Re-ingesting identical content produces zero deletions.

## Files touched

| File | Change |
|------|--------|
| `src/ingestion/unified/qdrant_writer.py` | Reordered `upsert_chunks_sync`: build+upsert first, stale-delete after. Added `HasIdCondition` import. |
| `tests/unit/ingestion/test_qdrant_writer_build_then_delete.py` | **New** — 4 TDD unit tests (RED→GREEN) |
| `tests/contract/test_qdrant_writer_no_delete_before_upsert_contract.py` | **New** — 2 AST-based structural contract tests |

## Validation

```
uv run pytest tests/unit/ingestion/test_qdrant_writer_build_then_delete.py tests/contract/test_qdrant_writer_no_delete_before_upsert_contract.py -q
# 6 passed in 1.13s

uv run pytest tests/unit/ingestion/ --ignore=tests/unit/ingestion/test_qdrant_writer_behavior.py -q
# 159 passed, 17 skipped in 1.84s

uv run pytest tests/contract -q
# 676 passed, 4 skipped, 3 xfailed in 23.03s

uv run ruff check src/ingestion/unified/qdrant_writer.py
# All checks passed!
```

## Backward compatibility

- `delete_file_sync` method is **not removed** — still available for callers that need full-replace semantics (e.g. explicit document deletion).
- `stats.points_deleted` is still populated (now counts stale points removed after upsert).
- No schema changes.

## Pre-existing failures (not introduced by this PR)

- `tests/unit/ingestion/test_qdrant_writer_behavior.py` — skipped per #1831 (cocoindex import errors, pre-existing).

Closes #1602