### PR TITLE
fix(ingestion): path-aware file_id prevents copy-collapse in manifest (#1603)

### DIFF
--- a/src/ingestion/unified/manifest.py
+++ b/src/ingestion/unified/manifest.py
@@ -1,10 +1,20 @@
 # src/ingestion/unified/manifest.py
-"""Manifest-based file identity with rename/move stability.
+"""Manifest-based file identity with copy-vs-rename detection.
 
-Uses content_hash as the primary identity key so that a renamed or moved
-file keeps its original file_id.  Falls back to the legacy composite key
-``relative_path:content_hash`` for backward-compatibility with existing
-manifests.
+Identity strategy (Option B — copy detection, fixes #1603):
+
+  A file_id is tied to *both* content_hash and original path.  When the same
+  content_hash appears at a new path we decide whether it is a rename/move or
+  a copy by checking whether the original path is still active:
+
+  - **Rename/move** (original path no longer active): reuse the original
+    file_id so downstream Qdrant records are not orphaned.
+  - **Copy** (original path still active): the new path is a distinct source
+    record and must receive its own file_id.
+
+Before this fix the manifest only checked ``hash_to_id[content_hash]``,
+meaning every second file with identical bytes silently collapsed to the same
+file_id regardless of whether the first path was still active (#1603).
 
 The manifest is persisted as `.gdrive_manifest.json` in the drive-sync
 root directory.
@@ -22,18 +32,23 @@ logger = logging.getLogger(__name__)
 
 
 class GDriveManifest:
-    """Manages stable file identity with rename/move stability.
+    """Manages stable file identity with copy-vs-rename detection (#1603).
 
     Identity strategy (in priority order):
     1. Exact composite key ``path:content_hash`` — same file, same content.
-    2. Content hash lookup ``hash_to_id[content_hash]`` — file renamed/moved
-       but content unchanged.  Reuses the original file_id.
-    3. New file — generate fresh UUID.
+       Returns the existing file_id immediately.
+    2. Content-hash seen before AND original path is **no longer active**
+       (``path_to_hash`` does not contain the original path) — this is a
+       rename/move.  Reuses the original file_id for downstream stability.
+    3. Content-hash seen before BUT original path is **still active** — this
+       is a copy.  Generates a fresh file_id so both source records remain
+       distinct.  Prevents copy-collapse (#1603).
+    4. Genuinely new file — generate fresh UUID.
 
     Stores three mappings:
-    - key_to_id: ``path:content_hash`` → file_id (legacy, kept for compat)
-    - hash_to_id: content_hash → file_id (primary identity, rename-stable)
-    - path_to_hash: relative_path → content_hash (tracks current locations)
+    - key_to_id: ``path:content_hash`` → file_id (includes copy entries)
+    - hash_to_id: content_hash → file_id  (first-seen / rename-stable anchor)
+    - path_to_hash: relative_path → content_hash (tracks currently active paths)
     """
 
     def __init__(self, manifest_dir: Path) -> None:
@@ -94,32 +109,58 @@ class GDriveManifest:
     def get_or_create_id(self, path: str, content_hash: str) -> str:
         """Return a stable file_id for the given path and content hash.
 
-        Rename/move stable: if content_hash was seen before (at any path),
-        the original file_id is reused.
+        Copy-vs-rename detection (Option B, fixes #1603):
+        - If the same content_hash was seen before at a path that is *no
+          longer active* in ``_path_to_hash``, this is a rename/move → reuse
+          the original file_id.
+        - If the same content_hash was seen before at a path that is *still
+          active*, this is a copy → generate a new file_id so both source
+          records remain distinct.
         """
         composite_key = f"{path}:{content_hash}"
         with self._lock:
-            # 1. Exact match: same path + same content (most common)
+            # 1. Exact match: same path + same content (most common / idempotent)
             if composite_key in self._key_to_id:
                 file_id = self._key_to_id[composite_key]
-            # 2. Content seen before at different path (rename/move)
+
             elif content_hash in self._hash_to_id:
-                file_id = self._hash_to_id[content_hash]
-                self._key_to_id[composite_key] = file_id
-                logger.info(
-                    "Manifest: reused file_id=%s for renamed path=%s (content_hash=%s)",
-                    file_id,
-                    path,
-                    content_hash,
-                )
-            # 3. Genuinely new file
+                # Hash was seen before — determine rename vs copy.
+                # Find which paths currently hold this hash.
+                active_paths_for_hash = {
+                    p for p, h in self._path_to_hash.items() if h == content_hash
+                }
+                if not active_paths_for_hash:
+                    # 2. Rename/move: original path no longer active → reuse id.
+                    file_id = self._hash_to_id[content_hash]
+                    self._key_to_id[composite_key] = file_id
+                    logger.info(
+                        "Manifest: reused file_id=%s for renamed path=%s (content_hash=%s)",
+                        file_id,
+                        path,
+                        content_hash,
+                    )
+                else:
+                    # 3. Copy: at least one path with this hash is still active
+                    #    → generate a distinct file_id to prevent copy-collapse (#1603).
+                    file_id = uuid.uuid4().hex[:16]
+                    self._key_to_id[composite_key] = file_id
+                    logger.info(
+                        "Manifest: new copy file_id=%s for path=%s "
+                        "(content_hash=%s, original paths still active: %s)",
+                        file_id,
+                        path,
+                        content_hash,
+                        active_paths_for_hash,
+                    )
+
             else:
+                # 4. Genuinely new file
                 file_id = uuid.uuid4().hex[:16]
                 self._key_to_id[composite_key] = file_id
+                self._hash_to_id[content_hash] = file_id
                 logger.info("Manifest: new file_id=%s for path=%s", file_id, path)
 
             # Always update reverse mappings
-            self._hash_to_id[content_hash] = file_id
             self._path_to_hash[path] = content_hash
             self.save()
             return file_id

--- a/tests/contract/test_manifest_no_content_hash_collapse_contract.py
+++ b/tests/contract/test_manifest_no_content_hash_collapse_contract.py
@@ -1,0 +1,176 @@
+# tests/contract/test_manifest_no_content_hash_collapse_contract.py
+"""Contract test: get_or_create_id must use copy-vs-rename detection (#1603).
+
+AST-based check that the implementation of ``GDriveManifest.get_or_create_id``
+in ``manifest.py``:
+1. References ``_path_to_hash`` (or ``path_to_hash``) when deciding whether to
+   reuse a file_id — i.e., the active-paths set is consulted (Option B
+   copy-detection).
+2. Does NOT unconditionally reuse ``hash_to_id[content_hash]`` when the hash
+   was seen before (the pre-#1603 bug was a bare ``elif content_hash in
+   self._hash_to_id`` that always returned the stored id without checking
+   active paths).
+
+This contract prevents regression to the old behaviour where two files with
+identical bytes collapsed to the same file_id regardless of whether the
+original path was still active.
+"""
+
+import ast
+import textwrap
+from pathlib import Path
+
+
+MANIFEST_PATH = Path(__file__).parents[2] / "src" / "ingestion" / "unified" / "manifest.py"
+
+_FUNCTION_NAME = "get_or_create_id"
+
+
+def _get_function_source() -> str:
+    """Return the source of GDriveManifest.get_or_create_id."""
+    source = MANIFEST_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "GDriveManifest":
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == _FUNCTION_NAME:
+                    return ast.get_source_segment(source, item) or ""
+
+    return ""
+
+
+def _get_function_ast() -> ast.FunctionDef | None:
+    source = MANIFEST_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "GDriveManifest":
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == _FUNCTION_NAME:
+                    return item
+
+    return None
+
+
+class TestManifestNoCopyCollapse:
+    """Contract: get_or_create_id implements copy-detection, not hash-only dedup."""
+
+    def test_manifest_file_exists(self) -> None:
+        """manifest.py exists at the expected path."""
+        assert MANIFEST_PATH.exists(), f"manifest.py not found at {MANIFEST_PATH}"
+
+    def test_get_or_create_id_exists(self) -> None:
+        """GDriveManifest.get_or_create_id method must exist."""
+        fn = _get_function_ast()
+        assert fn is not None, (
+            f"Method '{_FUNCTION_NAME}' not found in GDriveManifest "
+            f"in {MANIFEST_PATH}"
+        )
+
+    def test_function_references_path_to_hash(self) -> None:
+        """get_or_create_id must reference _path_to_hash for active-path lookup.
+
+        Option B copy-detection requires checking whether the original path is
+        still active.  This is done via ``_path_to_hash``.
+        """
+        source = _get_function_source()
+        assert source, f"Could not extract source for '{_FUNCTION_NAME}'"
+        assert "_path_to_hash" in source, (
+            f"'{_FUNCTION_NAME}' does not reference '_path_to_hash'. "
+            "The function must consult active paths to distinguish copies from "
+            "renames (Option B, #1603).  If the implementation changed the "
+            "attribute name, update this contract."
+        )
+
+    def test_copy_detection_uses_active_path_set(self) -> None:
+        """get_or_create_id must check active paths before reusing hash identity.
+
+        The function must NOT blindly return ``hash_to_id[content_hash]`` when
+        the hash was seen before.  It must first verify that no active path
+        still holds that hash (i.e., build the set of active_paths_for_hash or
+        equivalent) before deciding rename vs copy.
+        """
+        fn = _get_function_ast()
+        assert fn is not None
+
+        # Walk the AST looking for any reference to _path_to_hash inside the
+        # branch that handles the elif-content_hash-in-_hash_to_id case.
+        # A simpler proxy: verify the function body contains at least one
+        # comprehension or loop that iterates _path_to_hash items/values.
+
+        source = _get_function_source()
+        assert source
+
+        # The implementation must iterate _path_to_hash to find active paths.
+        # Accept any of the common patterns:
+        #   {p for p, h in self._path_to_hash.items() if h == content_hash}
+        #   for p, h in self._path_to_hash.items(): ...
+        #   self._path_to_hash.values() / .items()
+        iteration_patterns = [
+            "_path_to_hash.items()",
+            "_path_to_hash.values()",
+            "_path_to_hash.keys()",
+        ]
+        assert any(pat in source for pat in iteration_patterns), (
+            f"'{_FUNCTION_NAME}' does not iterate _path_to_hash to determine "
+            "active paths for a given hash.  Copy-detection (Option B, #1603) "
+            "requires building the set of currently active paths for the hash "
+            "before deciding whether to reuse or generate a new file_id."
+        )
+
+    def test_no_unconditional_hash_reuse(self) -> None:
+        """get_or_create_id must not unconditionally reuse hash_to_id.
+
+        The pre-#1603 bug was:
+            elif content_hash in self._hash_to_id:
+                file_id = self._hash_to_id[content_hash]   # ← always returned old id
+                self._key_to_id[composite_key] = file_id
+
+        The fix adds a conditional: only reuse if active_paths_for_hash is
+        empty.  We verify this by checking that the function does NOT immediately
+        assign ``file_id = self._hash_to_id[content_hash]`` right after the
+        ``elif`` without first checking active paths.
+
+        We do this by looking at the AST: the elif branch must NOT have
+        ``file_id = self._hash_to_id[content_hash]`` as its first statement
+        (it should instead compute active_paths_for_hash first).
+        """
+        fn = _get_function_ast()
+        assert fn is not None
+
+        # Find the elif branch body (IfExp or If node with content_hash test)
+        for node in ast.walk(fn):
+            if not isinstance(node, ast.If):
+                continue
+
+            # Look for: if/elif ... content_hash in self._hash_to_id ...
+            test_src = ast.unparse(node.test) if hasattr(ast, "unparse") else ""
+            if "_hash_to_id" not in test_src:
+                continue
+
+            # This is the elif content_hash in self._hash_to_id branch.
+            # Its body must NOT start with a simple assignment
+            # file_id = self._hash_to_id[content_hash].
+            body = node.body
+            if not body:
+                continue
+
+            first_stmt = body[0]
+            if isinstance(first_stmt, ast.Assign):
+                # Check if it's file_id = self._hash_to_id[...]
+                rhs = first_stmt.value
+                if (
+                    isinstance(rhs, ast.Subscript)
+                    and isinstance(rhs.value, ast.Attribute)
+                    and rhs.value.attr == "_hash_to_id"
+                ):
+                    raise AssertionError(
+                        "Regression detected: the elif-content_hash branch "
+                        "immediately assigns file_id = self._hash_to_id[...] "
+                        "without first checking active paths. "
+                        "This is the pre-#1603 bug pattern.  Add copy-detection "
+                        "logic (active_paths_for_hash check) before the assignment."
+                    )
+            # Branch body starts with something else → OK
+            break

--- a/tests/unit/ingestion/test_manifest_copy_rename.py
+++ b/tests/unit/ingestion/test_manifest_copy_rename.py
@@ -1,0 +1,146 @@
+# tests/unit/ingestion/test_manifest_copy_rename.py
+"""TDD tests for copy-vs-rename detection in GDriveManifest.
+
+Issue #1603: unified manifest collapses duplicate-content files across paths.
+
+Problem: get_or_create_id() reuses file_id whenever content_hash was seen
+before, regardless of whether the original path is still active. This means
+a *copy* (path A still active, path B is new) is treated the same as a
+*rename* (path A gone, path B is new), collapsing two distinct source records
+into one file_id.
+
+Fix (Option B — copy detection): reuse content_hash identity ONLY when the
+old path is no longer active in _path_to_hash. If the original path is still
+active, the new path is a copy and must receive a distinct file_id.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from src.ingestion.unified.manifest import GDriveManifest
+
+
+class TestCopyVsRenameDetection:
+    """Verify that copies get distinct file_ids and renames reuse the old one."""
+
+    @pytest.fixture
+    def manifest(self, tmp_path: Path) -> GDriveManifest:
+        return GDriveManifest(tmp_path)
+
+    # ------------------------------------------------------------------
+    # RED test 1: copy case — two ACTIVE paths with identical content must
+    # get DIFFERENT file_ids.
+    # ------------------------------------------------------------------
+    def test_same_content_different_paths_get_different_file_ids(
+        self, manifest: GDriveManifest
+    ) -> None:
+        """Two files with identical bytes at different paths are copies.
+
+        Both paths are simultaneously active, so each must receive its own
+        file_id. Collapsing them would make deletion/update of one silently
+        affect the other.
+        """
+        HASH = "deadbeef12345678"
+
+        id_a = manifest.get_or_create_id("docs/original.pdf", HASH)
+        id_b = manifest.get_or_create_id("archive/copy.pdf", HASH)
+
+        assert id_a != id_b, (
+            "Two active paths with the same content hash must get different "
+            "file_ids (copy case, not rename case)."
+        )
+
+    # ------------------------------------------------------------------
+    # RED test 2: rename case — old path removed BEFORE new path appears.
+    # Must reuse the original file_id.
+    # ------------------------------------------------------------------
+    def test_rename_preserves_file_id(self, manifest: GDriveManifest) -> None:
+        """File at path A is deleted (removed), then appears at path B.
+
+        Because the original path is no longer active, this is a rename/move.
+        The new path should reuse the original file_id for downstream
+        deduplication stability.
+        """
+        HASH = "cafebabe11223344"
+
+        original_id = manifest.get_or_create_id("folder/original.pdf", HASH)
+        # Simulate the file being removed from its original location
+        manifest.remove("folder/original.pdf")
+        # Now the same content appears at a new path (rename/move)
+        renamed_id = manifest.get_or_create_id("new_folder/renamed.pdf", HASH)
+
+        assert original_id == renamed_id, (
+            "After the original path is removed, the same content hash at a "
+            "new path should reuse the original file_id (rename/move case)."
+        )
+
+    # ------------------------------------------------------------------
+    # RED test 3: delete one copy must not affect the other copy's file_id.
+    # ------------------------------------------------------------------
+    def test_delete_one_copy_doesnt_affect_other(
+        self, manifest: GDriveManifest
+    ) -> None:
+        """Two copies exist; deleting one must not disturb the other's file_id.
+
+        After copy A and copy B each have their own distinct file_id, removing
+        A from the manifest must leave B's file_id unchanged.
+        """
+        HASH = "aabbccdd00112233"
+
+        id_a = manifest.get_or_create_id("root/copy_a.pdf", HASH)
+        id_b = manifest.get_or_create_id("root/copy_b.pdf", HASH)
+
+        # Verify they differ (copy case)
+        assert id_a != id_b
+
+        # Delete copy A
+        manifest.remove("root/copy_a.pdf")
+
+        # B's identity must be unchanged
+        id_b_after = manifest.get_or_create_id("root/copy_b.pdf", HASH)
+        assert id_b_after == id_b, (
+            "Deleting one copy must not change the other copy's file_id."
+        )
+
+    # ------------------------------------------------------------------
+    # RED test 4: determinism — same path+hash always returns the same ID.
+    # ------------------------------------------------------------------
+    def test_path_aware_file_id_is_deterministic(
+        self, manifest: GDriveManifest
+    ) -> None:
+        """Calling get_or_create_id twice with the same path+hash returns the same ID."""
+        HASH = "f0f0f0f0a1a1a1a1"
+        PATH = "reports/q1.pdf"
+
+        id1 = manifest.get_or_create_id(PATH, HASH)
+        id2 = manifest.get_or_create_id(PATH, HASH)
+
+        assert id1 == id2, (
+            "get_or_create_id must be idempotent: same path+hash → same file_id."
+        )
+
+    # ------------------------------------------------------------------
+    # Bonus: after copy A is removed and the content re-appears at path C,
+    # the surviving copy B's id is NOT reused — path C gets a fresh id.
+    # (Because B is still active — path C is a new copy of B, not a rename.)
+    # ------------------------------------------------------------------
+    def test_third_copy_after_first_deleted_gets_new_id(
+        self, manifest: GDriveManifest
+    ) -> None:
+        """Adding a third path while one copy still exists is still a copy."""
+        HASH = "112233440aabbccd"
+
+        id_a = manifest.get_or_create_id("dir/file_a.pdf", HASH)
+        id_b = manifest.get_or_create_id("dir/file_b.pdf", HASH)
+        assert id_a != id_b
+
+        # Remove A
+        manifest.remove("dir/file_a.pdf")
+
+        # B is still active → C is a copy of B, not a rename
+        id_c = manifest.get_or_create_id("dir/file_c.pdf", HASH)
+        assert id_c != id_b, (
+            "When at least one path with the same hash is still active, "
+            "a new path is a copy and must receive its own file_id."
+        )

--- a/tests/unit/ingestion/test_unified_manifest.py
+++ b/tests/unit/ingestion/test_unified_manifest.py
@@ -118,8 +118,14 @@ class TestGDriveManifest:
         assert id1 == id2
 
     def test_renamed_file_reuses_id(self, manifest: GDriveManifest):
-        """Same content hash at different path → reuses original file_id (rename-stable)."""
+        """Same content hash: old path removed, new path appears → reuses file_id (rename-stable).
+
+        Updated for #1603 copy-detection: a rename is only detected when the
+        original path is *no longer active* (i.e., ``remove()`` was called).
+        """
         id_original = manifest.get_or_create_id("old/path.pdf", "hash_content")
+        # Simulate the file being removed from its original location (rename/move)
+        manifest.remove("old/path.pdf")
         id_renamed = manifest.get_or_create_id("new/path.pdf", "hash_content")
         assert id_original == id_renamed
 
@@ -189,9 +195,15 @@ class TestGDriveManifest:
         assert m._hash_to_id["hash_aaa"] == "id_current"
 
     def test_rename_after_reload_still_stable(self, manifest_dir: Path):
-        """File identity survives manifest reload + rename."""
+        """File identity survives manifest reload + rename.
+
+        Updated for #1603 copy-detection: ``remove()`` must be called for the
+        original path before the new path is registered, to signal a rename.
+        """
         m1 = GDriveManifest(manifest_dir)
         original_id = m1.get_or_create_id("old/name.pdf", "hash_x")
+        # Simulate removal of old path before rename appears
+        m1.remove("old/name.pdf")
 
         # Reload from disk (simulates restart)
         m2 = GDriveManifest(manifest_dir)


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Fixes the bug where `GDriveManifest.get_or_create_id()` collapsed two distinct files at different paths into the same `file_id` whenever they had identical bytes — making copy, rename, and delete semantics ambiguous in Qdrant.

## Option chosen: **Option B — Copy Detection**

**Why not Option A** (path-aware identity: `file_id = hash(content_hash + path)`):  
Option A would break rename/move stability — a renamed file would always get a new `file_id`, orphaning existing Qdrant records. This is a worse regression than the copy-collapse bug.

**Option B** (this PR): at `get_or_create_id()` call time, check `_path_to_hash` for currently-active paths holding the same `content_hash`:
- **No active path** → rename/move → reuse original `file_id` (unchanged from before)
- **At least one active path** → copy → generate a fresh `file_id` (the fix)

## Behavior Changes

| Scenario | Before (#1603) | After (this PR) |
|---|---|---|
| Rename/move (old path removed) | ✅ Same `file_id` | ✅ Same `file_id` |
| Copy (old path still active) | ❌ Same `file_id` (collapsed) | ✅ Different `file_id` |
| Delete one copy | ❌ Other copy's `file_id` might be undefined | ✅ Other copy unaffected |
| Idempotent re-call (same path+hash) | ✅ Same `file_id` | ✅ Same `file_id` |

## Files Touched

- `src/ingestion/unified/manifest.py` — core fix in `get_or_create_id()`, updated docstrings
- `tests/unit/ingestion/test_manifest_copy_rename.py` — **new** TDD tests (5 tests, RED→GREEN)
- `tests/unit/ingestion/test_unified_manifest.py` — updated 2 tests to reflect correct rename semantics (now require `remove()` call before rename, as CocoIndex does in practice)
- `tests/contract/test_manifest_no_content_hash_collapse_contract.py` — **new** AST-based contract test preventing regression

## Validation

```
uv run pytest tests/unit/ingestion/test_manifest_copy_rename.py tests/contract/test_manifest_no_content_hash_collapse_contract.py -v
# → 10 passed

uv run pytest tests/unit/ingestion/ --ignore=tests/unit/ingestion/test_qdrant_writer_behavior.py -q
# → 160 passed, 17 skipped

uv run pytest tests/contract -q
# → 679 passed, 4 skipped, 3 xfailed

uv run ruff check src/ingestion/unified/
# → All checks passed!
```

## Backward Compatibility Note

Existing Qdrant collections indexed with the old manifest used hash-only identity. Any path previously treated as a rename will now be treated as a copy on the next run and receive a new `file_id`. **This is a cold-start change for new ingestion runs** — a fresh re-ingestion is recommended for collections where copy-collapse may have occurred. New collections and collections without duplicate-content files are unaffected.

Closes #1603