### PR TITLE
fix(mini-app): enforce Telegram initData auth on mutation endpoints (#1595)

### DIFF
--- a/mini_app/api.py
+++ b/mini_app/api.py
@@ -9,9 +9,10 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any
 
-from fastapi import Depends, FastAPI, Request
+from fastapi import Depends, FastAPI, Header, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 
+from mini_app.auth import validate_init_data
 from mini_app.expert_start import StartExpertRequest, StartExpertResponse
 from mini_app.phone import PhoneRequest, submit_phone
 from telegram_bot.observability import get_client, observe, propagate_attributes
@@ -58,13 +59,73 @@ async def get_redis(request: Request) -> Any:
     return request.app.state.redis
 
 
+def _get_bot_token() -> str:
+    """Return the Telegram bot token from environment.
+
+    Reads ``TELEGRAM_BOT_TOKEN`` (the canonical env var shared with
+    telegram_bot) with ``BOT_TOKEN`` as a legacy alias.  Raises
+    ``RuntimeError`` only if neither is set — callers translate this to
+    a 500 so operators see a clear misconfiguration message.
+    """
+    token = os.environ.get("TELEGRAM_BOT_TOKEN") or os.environ.get("BOT_TOKEN", "")
+    if not token:
+        raise RuntimeError("TELEGRAM_BOT_TOKEN not configured")
+    return token
+
+
+async def get_validated_init_data(
+    x_init_data: str | None = Header(
+        default=None,
+        alias="X-Init-Data",
+        description="Telegram WebApp signed initData string",
+    ),
+) -> dict:
+    """FastAPI dependency: validate Telegram initData and return parsed user dict.
+
+    Returns the parsed initData dict (including ``user`` sub-dict) on
+    success.  Raises ``HTTP 401`` for missing header, missing token config,
+    invalid hash, or expired ``auth_date``.
+
+    Debug / test mode: when ``BOT_TOKEN`` equals the known test sentinel
+    ``"TEST"`` (set in CI) validation is bypassed and a synthetic user
+    dict is returned so the rest of the stack is exercised without a
+    real bot token.
+    """
+    if x_init_data is None:
+        raise HTTPException(status_code=401, detail="X-Init-Data header is required")
+
+    try:
+        bot_token = _get_bot_token()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
+
+    # Allow bypass in debug/test mode with the test sentinel token.
+    if bot_token == "TEST":
+        return {"user": {"id": 0, "first_name": "TestUser"}, "auth_date": "0"}
+
+    try:
+        return validate_init_data(x_init_data, bot_token)
+    except ValueError as exc:
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# CORS — restrict to configured origin (not wildcard)
+#
+# Operators MUST set MINI_APP_ALLOWED_ORIGIN in production.
+# Dev default falls back to https://t.me so the app still boots locally
+# without any env configuration. An empty string is treated as missing.
+# ---------------------------------------------------------------------------
+
+_CORS_ORIGIN = os.environ.get("MINI_APP_ALLOWED_ORIGIN", "").strip() or "https://t.me"
+
 app = FastAPI(title="FortNoks Mini App API", version="0.1.0", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_origins=[_CORS_ORIGIN],
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["Content-Type", "X-Init-Data"],
 )
 
 
@@ -86,8 +147,15 @@ def _update_current_span(**kwargs: Any) -> None:
 async def start_expert(
     request: StartExpertRequest,
     redis: Any = Depends(get_redis),
+    init_data: dict = Depends(get_validated_init_data),
 ) -> StartExpertResponse:
     """Store deep-link payload in Redis and return start_link for openTelegramLink.
+
+    ``init_data`` is the validated Telegram initData dict injected by
+    ``get_validated_init_data``.  ``user_id`` is derived from
+    ``init_data["user"]["id"]`` — the JSON body value is accepted for
+    optional fields (expert_id, message, query_id) but the user identity
+    is **always** taken from the server-verified initData (#1595).
 
     Wrapped in ``@observe`` (#1658) so the Mini App entry point lands as a
     named Langfuse span. ``propagate_attributes(session_id="miniapp-{user_id}")``
@@ -99,11 +167,12 @@ async def start_expert(
     ``update_current_span(input=...)`` records only ``expert_id`` plus
     payload-shape booleans — never the message body or raw deep-link UUID.
     """
-    from fastapi import HTTPException
+    # Derive user_id from validated initData — never trust the request body.
+    user_id: int = init_data["user"]["id"]
 
     with propagate_attributes(
-        session_id=f"miniapp-{request.user_id}",
-        user_id=str(request.user_id),
+        session_id=f"miniapp-{user_id}",
+        user_id=str(user_id),
         tags=["miniapp", "start-expert", request.expert_id],
         metadata={"surface": "miniapp"},
     ):
@@ -127,7 +196,7 @@ async def start_expert(
             {
                 "expert_id": request.expert_id,
                 "message": request.message,
-                "user_id": request.user_id,
+                "user_id": user_id,
                 "query_id": request.query_id,
             }
         )
@@ -146,7 +215,7 @@ async def start_expert(
             json.dumps(
                 {
                     "uuid": uid,
-                    "user_id": request.user_id,
+                    "user_id": user_id,
                     "query_id": request.query_id,
                 }
             ),
@@ -179,8 +248,14 @@ async def remote_log(request: dict) -> dict:
 
 @app.post("/api/phone")
 @observe(name="miniapp-submit-phone", capture_input=False, capture_output=False)
-async def phone(request: PhoneRequest) -> Any:
+async def phone(
+    request: PhoneRequest,
+    init_data: dict = Depends(get_validated_init_data),
+) -> Any:
     """Collect phone and create CRM lead.
+
+    ``user_id`` is derived from the validated Telegram initData so callers
+    cannot spoof another user's identity (#1595).
 
     Wrapped in ``@observe`` (#1658) with the same ``miniapp-{user_id}`` session
     grouping as ``start_expert`` so the funnel reconstructs in Langfuse
@@ -191,14 +266,20 @@ async def phone(request: PhoneRequest) -> Any:
     """
     from fastapi.responses import JSONResponse
 
+    # Override user_id with the server-verified value from initData (#1595).
+    user_id: int = init_data["user"]["id"]
+    # Re-create the request with the verified user_id to keep the rest of
+    # the stack unchanged (submit_phone, propagate_attributes).
+    verified_request = request.model_copy(update={"user_id": user_id})
+
     with propagate_attributes(
-        session_id=f"miniapp-{request.user_id}",
-        user_id=str(request.user_id),
+        session_id=f"miniapp-{user_id}",
+        user_id=str(user_id),
         tags=["miniapp", "submit-phone", request.source],
         metadata={"surface": "miniapp"},
     ):
         _update_current_span(input={"source": request.source, "has_name": request.name is not None})
-        result = await submit_phone(request)
+        result = await submit_phone(verified_request)
         if not result.get("success"):
             _update_current_span(level="ERROR", status_message="crm_submission_failed")
             return JSONResponse(status_code=502, content=result)

--- a/mini_app/expert_start.py
+++ b/mini_app/expert_start.py
@@ -6,10 +6,12 @@ from pydantic import BaseModel
 
 
 class StartExpertRequest(BaseModel):
-    user_id: int
     expert_id: str
     message: str | None = None
     query_id: str | None = None
+    # user_id is accepted from the body for backward compat but is always
+    # overridden by the server-verified value from Telegram initData (#1595).
+    user_id: int | None = None
 
 
 class StartExpertResponse(BaseModel):

--- a/tests/contract/test_mini_app_auth_contract.py
+++ b/tests/contract/test_mini_app_auth_contract.py
@@ -1,0 +1,191 @@
+"""Contract tests for Telegram initData enforcement on Mini App endpoints (#1595).
+
+These tests verify structural properties that must never regress:
+
+  1. ``mini_app/api.py`` does NOT contain ``allow_origins=["*"]``.
+  2. ``/api/start-expert`` and ``/api/phone`` handlers reference
+     ``validate_init_data`` via the auth dependency.
+  3. ``mini_app.auth.validate_init_data`` is actually imported in ``api.py``.
+  4. The CORS middleware on the running app instance does not allow wildcard origins.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+API_FILE = REPO_ROOT / "mini_app" / "api.py"
+AUTH_FILE = REPO_ROOT / "mini_app" / "auth.py"
+
+
+# ---------------------------------------------------------------------------
+# 1. No wildcard CORS in source code
+# ---------------------------------------------------------------------------
+
+
+def test_api_does_not_contain_wildcard_cors():
+    """mini_app/api.py must not contain allow_origins=[\"*\"]."""
+    source = API_FILE.read_text(encoding="utf-8")
+    # Match the problematic wildcard pattern (handles whitespace variations)
+    wildcard_pattern = re.compile(r'allow_origins\s*=\s*\[\s*["\']?\*["\']?\s*\]')
+    assert not wildcard_pattern.search(source), (
+        "mini_app/api.py still contains allow_origins=[\"*\"]. "
+        "Set MINI_APP_ALLOWED_ORIGIN env var instead (#1595)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. validate_init_data is imported in api.py
+# ---------------------------------------------------------------------------
+
+
+def test_validate_init_data_imported_in_api():
+    """mini_app.auth.validate_init_data must be imported in mini_app/api.py."""
+    source = API_FILE.read_text(encoding="utf-8")
+    assert "validate_init_data" in source, (
+        "mini_app/api.py must import validate_init_data from mini_app.auth (#1595). "
+        "The function existed before but was never called by the API."
+    )
+    # Also confirm the import comes from mini_app.auth
+    assert re.search(r"from mini_app\.auth import.*validate_init_data", source), (
+        "validate_init_data must be imported from mini_app.auth in api.py (#1595)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Auth dependency referenced in both mutation handlers (AST/source check)
+# ---------------------------------------------------------------------------
+
+
+def test_start_expert_handler_references_auth_dependency():
+    """start_expert handler must use get_validated_init_data dependency."""
+    source = API_FILE.read_text(encoding="utf-8")
+    # The dependency function must exist in the file
+    assert "get_validated_init_data" in source, (
+        "mini_app/api.py must define get_validated_init_data dependency (#1595)."
+    )
+
+    import ast
+
+    tree = ast.parse(source)
+    start_expert_node = None
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+            and node.name == "start_expert"
+        ):
+            start_expert_node = node
+            break
+
+    assert start_expert_node is not None, "start_expert handler not found in api.py"
+
+    # Check that get_validated_init_data appears as a Depends() default in the signature
+    body_text = ast.unparse(start_expert_node)
+    assert "get_validated_init_data" in body_text, (
+        "start_expert handler must inject get_validated_init_data via Depends(). "
+        "Found handler signature/body: " + body_text[:200]
+    )
+
+
+def test_phone_handler_references_auth_dependency():
+    """phone handler must use get_validated_init_data dependency."""
+    source = API_FILE.read_text(encoding="utf-8")
+
+    import ast
+
+    tree = ast.parse(source)
+    phone_node = None
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+            and node.name == "phone"
+        ):
+            phone_node = node
+            break
+
+    assert phone_node is not None, "phone handler not found in api.py"
+
+    body_text = ast.unparse(phone_node)
+    assert "get_validated_init_data" in body_text, (
+        "phone handler must inject get_validated_init_data via Depends(). "
+        "Found handler signature/body: " + body_text[:200]
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Runtime CORS check — no wildcard on the live app instance
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_cors_not_wildcard():
+    """The FastAPI app instance must not have allow_origins=['*'] in CORSMiddleware."""
+    pytest.importorskip("fastapi")
+
+    from fastapi.middleware.cors import CORSMiddleware
+
+    from mini_app.api import app
+
+    cors_middleware = None
+    for mw in app.user_middleware:
+        if hasattr(mw, "cls") and mw.cls is CORSMiddleware:
+            cors_middleware = mw
+            break
+        if isinstance(mw, tuple) and len(mw) >= 1 and mw[0] is CORSMiddleware:
+            cors_middleware = mw
+            break
+
+    assert cors_middleware is not None, "CORSMiddleware must be present on the app"
+
+    if hasattr(cors_middleware, "kwargs"):
+        cors_kwargs = cors_middleware.kwargs
+    else:
+        cors_kwargs = cors_middleware[-1] if isinstance(cors_middleware, tuple) else {}
+
+    allow_origins = cors_kwargs.get("allow_origins", [])
+    assert allow_origins != ["*"], (
+        "CORSMiddleware allow_origins must not be ['*']. "
+        f"Got: {allow_origins}. Set MINI_APP_ALLOWED_ORIGIN env var in production (#1595)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. get_validated_init_data returns 401 (not 422) for missing header
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_init_data_header_returns_401_not_422():
+    """Missing X-Init-Data must produce 401, not the default FastAPI 422."""
+    pytest.importorskip("fastapi")
+
+    from unittest.mock import MagicMock
+
+    from httpx import ASGITransport, AsyncClient
+
+    import mini_app.api as api_mod
+    from mini_app.api import app
+
+    async def _noop_redis(_request=None):
+        return MagicMock()
+
+    app.dependency_overrides[api_mod.get_redis] = _noop_redis
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            se_resp = await client.post(
+                "/api/start-expert", json={"expert_id": "consultant"}
+            )
+            phone_resp = await client.post(
+                "/api/phone", json={"phone": "+359888123456", "source": "t", "user_id": 1}
+            )
+    finally:
+        app.dependency_overrides.pop(api_mod.get_redis, None)
+
+    assert se_resp.status_code == 401, (
+        f"/api/start-expert missing header → expected 401, got {se_resp.status_code}"
+    )
+    assert phone_resp.status_code == 401, (
+        f"/api/phone missing header → expected 401, got {phone_resp.status_code}"
+    )

--- a/tests/unit/mini_app/test_api_config.py
+++ b/tests/unit/mini_app/test_api_config.py
@@ -1,5 +1,7 @@
 """Tests for Mini App config API endpoint."""
 
+import time
+
 import pytest
 
 
@@ -9,7 +11,19 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from httpx import ASGITransport, AsyncClient
 
-from mini_app.api import app
+from mini_app.api import app, get_validated_init_data
+
+
+def _override_init_data(user_id: int = 123) -> None:
+    """Override auth dependency for tests that focus on other logic."""
+    app.dependency_overrides[get_validated_init_data] = lambda: {
+        "user": {"id": user_id, "first_name": "Test"},
+        "auth_date": str(int(time.time())),
+    }
+
+
+def _clear_init_data_override() -> None:
+    app.dependency_overrides.pop(get_validated_init_data, None)
 
 
 @pytest.mark.asyncio
@@ -37,12 +51,18 @@ async def test_phone_endpoint_returns_json():
     mock_kommo = MagicMock()
     mock_kommo.upsert_contact = AsyncMock(return_value={"id": 1})
     mock_kommo.create_lead = AsyncMock(return_value={"id": 2})
-    with patch("mini_app.phone.get_kommo_client", return_value=mock_kommo):
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            resp = await client.post(
-                "/api/phone",
-                json={"phone": "+359888123456", "source": "test", "user_id": 123},
-            )
+    _override_init_data(user_id=123)
+    try:
+        with patch("mini_app.phone.get_kommo_client", return_value=mock_kommo):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.post(
+                    "/api/phone",
+                    json={"phone": "+359888123456", "source": "test", "user_id": 123},
+                )
+    finally:
+        _clear_init_data_override()
     assert resp.status_code == 200
     assert resp.json()["success"] is True
 
@@ -50,5 +70,5 @@ async def test_phone_endpoint_returns_json():
 @pytest.mark.asyncio
 async def test_cors_headers_present():
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/health", headers={"Origin": "https://example.com"})
+        resp = await client.get("/health", headers={"Origin": "https://t.me"})
     assert "access-control-allow-origin" in resp.headers

--- a/tests/unit/mini_app/test_chat.py
+++ b/tests/unit/mini_app/test_chat.py
@@ -1,6 +1,10 @@
 """Tests for Mini App API — /api/start-expert deep link endpoint."""
 
+import hashlib
+import hmac
 import os
+import time
+from urllib.parse import quote
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -10,7 +14,27 @@ pytest.importorskip("fastapi")
 
 from httpx import ASGITransport, AsyncClient
 
-from mini_app.api import app, get_redis
+from mini_app.api import app, get_redis, get_validated_init_data
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TEST_BOT_TOKEN = "1234567890:ABCdefGHIjklMNOpqrsTUVwxyz"
+
+
+def _make_init_data(user_id: int = 123) -> str:
+    """Build a valid Telegram initData string with correct HMAC-SHA256 hash."""
+    params: dict[str, str] = {
+        "auth_date": str(int(time.time())),
+        "user": f'{{"id":{user_id},"first_name":"Test"}}',
+    }
+    data_check = "\n".join(f"{k}={v}" for k, v in sorted(params.items()))
+    secret = hmac.new(b"WebAppData", _TEST_BOT_TOKEN.encode(), hashlib.sha256).digest()
+    hash_val = hmac.new(secret, data_check.encode(), hashlib.sha256).hexdigest()
+    params["hash"] = hash_val
+    return "&".join(f"{k}={quote(v, safe='')}" for k, v in params.items())
 
 
 def _override_redis(mock_redis: AsyncMock) -> None:
@@ -21,6 +45,18 @@ def _override_redis(mock_redis: AsyncMock) -> None:
 def _clear_redis_override() -> None:
     """Remove the dependency override after the test."""
     app.dependency_overrides.pop(get_redis, None)
+
+
+def _override_init_data(user_id: int = 123) -> None:
+    """Override get_validated_init_data to return a synthetic user dict for testing."""
+    app.dependency_overrides[get_validated_init_data] = lambda: {
+        "user": {"id": user_id, "first_name": "Test"},
+        "auth_date": str(int(time.time())),
+    }
+
+
+def _clear_init_data_override() -> None:
+    app.dependency_overrides.pop(get_validated_init_data, None)
 
 
 @pytest.mark.asyncio
@@ -37,6 +73,7 @@ async def test_start_expert_not_found():
     """Unknown expert_id should return 404."""
     mock_redis = AsyncMock()
     _override_redis(mock_redis)
+    _override_init_data(user_id=123)
     try:
         with patch("mini_app.api.load_mini_app_config", return_value={"experts": []}):
             async with AsyncClient(
@@ -44,10 +81,11 @@ async def test_start_expert_not_found():
             ) as client:
                 resp = await client.post(
                     "/api/start-expert",
-                    json={"user_id": 123, "expert_id": "nonexistent"},
+                    json={"expert_id": "nonexistent"},
                 )
     finally:
         _clear_redis_override()
+        _clear_init_data_override()
     assert resp.status_code == 404
 
 
@@ -57,6 +95,7 @@ async def test_start_expert_returns_start_link():
     mock_redis = AsyncMock()
     experts = [{"id": "consultant", "name": "Консультант", "emoji": "👷"}]
     _override_redis(mock_redis)
+    _override_init_data(user_id=123)
     try:
         with patch("mini_app.api.load_mini_app_config", return_value={"experts": experts}):
             with patch.dict(os.environ, {"BOT_USERNAME": "testbot"}):
@@ -66,13 +105,13 @@ async def test_start_expert_returns_start_link():
                     resp = await client.post(
                         "/api/start-expert",
                         json={
-                            "user_id": 123,
                             "expert_id": "consultant",
                             "message": "Подбери квартиру",
                         },
                     )
     finally:
         _clear_redis_override()
+        _clear_init_data_override()
     assert resp.status_code == 200
     data = resp.json()
     assert "start_link" in data
@@ -88,6 +127,7 @@ async def test_start_expert_stores_payload_in_redis():
     mock_redis = AsyncMock()
     experts = [{"id": "consultant", "name": "Консультант", "emoji": "👷"}]
     _override_redis(mock_redis)
+    _override_init_data(user_id=123)
     try:
         with patch("mini_app.api.load_mini_app_config", return_value={"experts": experts}):
             with patch.dict(os.environ, {"BOT_USERNAME": "testbot"}):
@@ -96,10 +136,11 @@ async def test_start_expert_stores_payload_in_redis():
                 ) as client:
                     resp = await client.post(
                         "/api/start-expert",
-                        json={"user_id": 123, "expert_id": "consultant", "message": "Тест"},
+                        json={"expert_id": "consultant", "message": "Тест"},
                     )
     finally:
         _clear_redis_override()
+        _clear_init_data_override()
     assert resp.status_code == 200
     # Redis.set should have been called with TTL=300
     mock_redis.set.assert_called_once()
@@ -119,6 +160,7 @@ async def test_start_expert_fails_without_bot_username():
     mock_redis = AsyncMock()
     experts = [{"id": "consultant", "name": "Консультант", "emoji": "👷"}]
     _override_redis(mock_redis)
+    _override_init_data(user_id=123)
     try:
         with patch("mini_app.api.load_mini_app_config", return_value={"experts": experts}):
             with patch.dict(os.environ, {"BOT_USERNAME": ""}, clear=False):
@@ -127,8 +169,9 @@ async def test_start_expert_fails_without_bot_username():
                 ) as client:
                     resp = await client.post(
                         "/api/start-expert",
-                        json={"user_id": 123, "expert_id": "consultant"},
+                        json={"expert_id": "consultant"},
                     )
     finally:
         _clear_redis_override()
+        _clear_init_data_override()
     assert resp.status_code == 500

--- a/tests/unit/mini_app/test_langfuse_tracing.py
+++ b/tests/unit/mini_app/test_langfuse_tracing.py
@@ -128,6 +128,11 @@ class TestPropagateAttributesContract:
 
         # FastAPI dependency override avoids the real Redis connection.
         app.dependency_overrides[api_mod.get_redis] = _override_redis
+        # Override auth — user_id=42 matches the session_id assertion below.
+        app.dependency_overrides[api_mod.get_validated_init_data] = lambda: {
+            "user": {"id": 42, "first_name": "Test"},
+            "auth_date": "0",
+        }
 
         _, mock_propagate = _make_propagate_recorder()
 
@@ -142,7 +147,6 @@ class TestPropagateAttributesContract:
                     resp = await client.post(
                         "/api/start-expert",
                         json={
-                            "user_id": 42,
                             "expert_id": "consultant",
                             "message": "ignored-secret-content",
                             "query_id": "q-1",
@@ -152,6 +156,7 @@ class TestPropagateAttributesContract:
             assert resp.status_code == 200, resp.text
         finally:
             app.dependency_overrides.pop(api_mod.get_redis, None)
+            app.dependency_overrides.pop(api_mod.get_validated_init_data, None)
 
         assert mock_propagate.call_count >= 1, (
             "start_expert must enter `propagate_attributes(...)` exactly once."
@@ -173,23 +178,33 @@ class TestPropagateAttributesContract:
         mock_kommo.upsert_contact = AsyncMock(return_value={"id": 1})
         mock_kommo.create_lead = AsyncMock(return_value={"id": 2})
 
+        # Override auth — user_id=7 matches the session_id assertion below.
+        app.dependency_overrides[api_mod.get_validated_init_data] = lambda: {
+            "user": {"id": 7, "first_name": "Test"},
+            "auth_date": "0",
+        }
+
         _, mock_propagate = _make_propagate_recorder()
 
-        with (
-            patch.object(api_mod, "propagate_attributes", mock_propagate),
-            patch("mini_app.phone.get_kommo_client", return_value=mock_kommo),
-        ):
-            async with AsyncClient(
-                transport=ASGITransport(app=app), base_url="http://test"
-            ) as client:
-                resp = await client.post(
-                    "/api/phone",
-                    json={
-                        "phone": "+359888123456",
-                        "source": "viewing_consultant",
-                        "user_id": 7,
-                    },
-                )
+        try:
+            with (
+                patch.object(api_mod, "propagate_attributes", mock_propagate),
+                patch("mini_app.phone.get_kommo_client", return_value=mock_kommo),
+            ):
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.post(
+                        "/api/phone",
+                        json={
+                            "phone": "+359888123456",
+                            "source": "viewing_consultant",
+                            "user_id": 7,
+                        },
+                    )
+        finally:
+            app.dependency_overrides.pop(api_mod.get_validated_init_data, None)
+
         assert resp.status_code == 200, resp.text
         assert mock_propagate.call_count >= 1
         kwargs = mock_propagate.call_args.kwargs

--- a/tests/unit/mini_app/test_mini_app_auth_enforcement.py
+++ b/tests/unit/mini_app/test_mini_app_auth_enforcement.py
@@ -1,0 +1,299 @@
+"""TDD tests for Telegram initData enforcement on Mini App mutation endpoints.
+
+Closes #1595 — before this PR, /api/start-expert and /api/phone accepted
+unauthenticated requests from any origin, trusting user_id from the JSON
+body. This test file drives the required fix:
+
+  1. Missing initData  → 401
+  2. Invalid hash      → 401
+  3. Valid initData    → request processed, user_id derived from token
+  4. CORS must not be wildcard
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+from urllib.parse import quote
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from httpx import ASGITransport, AsyncClient
+
+from mini_app.api import app
+import mini_app.api as api_mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+TEST_BOT_TOKEN = "1234567890:ABCdefGHIjklMNOpqrsTUVwxyz"
+
+
+def _make_init_data(bot_token: str, user_id: int = 42, **overrides: str) -> str:
+    """Build a valid Telegram initData string with correct HMAC-SHA256 hash."""
+    params: dict[str, str] = {
+        "auth_date": str(int(time.time())),
+        "user": f'{{"id":{user_id},"first_name":"Test"}}',
+        **overrides,
+    }
+    data_check = "\n".join(f"{k}={v}" for k, v in sorted(params.items()))
+    secret = hmac.new(b"WebAppData", bot_token.encode(), hashlib.sha256).digest()
+    hash_val = hmac.new(secret, data_check.encode(), hashlib.sha256).hexdigest()
+    params["hash"] = hash_val
+    return "&".join(f"{k}={quote(v, safe='')}" for k, v in params.items())
+
+
+def _make_invalid_init_data(bot_token: str, user_id: int = 42) -> str:
+    """Build initData with a valid structure but a wrong hash."""
+    valid = _make_init_data(bot_token, user_id=user_id)
+    parts = dict(pair.split("=", 1) for pair in valid.split("&"))
+    parts["hash"] = "deadbeef" * 8  # 64 hex chars but wrong value
+    return "&".join(f"{k}={v}" for k, v in parts.items())
+
+
+# ---------------------------------------------------------------------------
+# /api/start-expert — auth enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_expert_without_init_data_returns_401():
+    """POST /api/start-expert without X-Init-Data header must return 401."""
+    # Provide a Redis override so the lifespan dependency doesn't error out
+    # independently — the 401 should be the only thing that matters here.
+    async def _noop_redis(_request=None):
+        return MagicMock()
+
+    app.dependency_overrides[api_mod.get_redis] = _noop_redis
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/api/start-expert",
+                json={"expert_id": "consultant"},
+            )
+    finally:
+        app.dependency_overrides.pop(api_mod.get_redis, None)
+
+    assert resp.status_code == 401, (
+        f"Expected 401 when X-Init-Data header is missing, got {resp.status_code}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_expert_with_invalid_init_data_returns_401():
+    """POST /api/start-expert with a wrong HMAC hash must return 401."""
+    invalid_init_data = _make_invalid_init_data(TEST_BOT_TOKEN)
+
+    async def _noop_redis(_request=None):
+        return MagicMock()
+
+    app.dependency_overrides[api_mod.get_redis] = _noop_redis
+    try:
+        with patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": TEST_BOT_TOKEN}, clear=False):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.post(
+                    "/api/start-expert",
+                    json={"expert_id": "consultant"},
+                    headers={"X-Init-Data": invalid_init_data},
+                )
+    finally:
+        app.dependency_overrides.pop(api_mod.get_redis, None)
+
+    assert resp.status_code == 401, (
+        f"Expected 401 for invalid hash, got {resp.status_code}: {resp.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_expert_with_valid_init_data_succeeds():
+    """POST /api/start-expert with valid signed initData must return 200.
+
+    user_id should be derived from initData, not from request body.
+    """
+    valid_init_data = _make_init_data(TEST_BOT_TOKEN, user_id=42)
+
+    mock_redis = MagicMock()
+    mock_redis.set = AsyncMock()
+    mock_redis.publish = AsyncMock()
+
+    async def _override_redis(_request=None):
+        return mock_redis
+
+    app.dependency_overrides[api_mod.get_redis] = _override_redis
+    try:
+        with patch.dict(
+            "os.environ",
+            {"TELEGRAM_BOT_TOKEN": TEST_BOT_TOKEN, "BOT_USERNAME": "testbot"},
+            clear=False,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.post(
+                    "/api/start-expert",
+                    json={"expert_id": "consultant"},
+                    headers={"X-Init-Data": valid_init_data},
+                )
+    finally:
+        app.dependency_overrides.pop(api_mod.get_redis, None)
+
+    assert resp.status_code == 200, (
+        f"Expected 200 for valid initData, got {resp.status_code}: {resp.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_expert_user_id_derived_from_init_data():
+    """user_id must come from validated initData, not from the JSON body."""
+    # initData says user_id=99; if body user_id were trusted we'd see 99 in the
+    # published Redis payload. We verify the validated user is used.
+    valid_init_data = _make_init_data(TEST_BOT_TOKEN, user_id=99)
+
+    mock_redis = MagicMock()
+    mock_redis.set = AsyncMock()
+    published_payloads: list[str] = []
+
+    async def _fake_publish(channel: str, payload: str) -> None:
+        published_payloads.append(payload)
+
+    mock_redis.publish = _fake_publish
+
+    async def _override_redis(_request=None):
+        return mock_redis
+
+    app.dependency_overrides[api_mod.get_redis] = _override_redis
+    try:
+        with patch.dict(
+            "os.environ",
+            {"TELEGRAM_BOT_TOKEN": TEST_BOT_TOKEN, "BOT_USERNAME": "testbot"},
+            clear=False,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                # Body does NOT include user_id — it must be extracted from initData
+                resp = await client.post(
+                    "/api/start-expert",
+                    json={"expert_id": "consultant"},
+                    headers={"X-Init-Data": valid_init_data},
+                )
+    finally:
+        app.dependency_overrides.pop(api_mod.get_redis, None)
+
+    assert resp.status_code == 200, resp.text
+    import json
+
+    assert published_payloads, "Redis publish must have been called"
+    published = json.loads(published_payloads[0])
+    assert published["user_id"] == 99, (
+        f"user_id in Redis payload must be 99 (from initData), got {published['user_id']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# /api/phone — auth enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_phone_without_init_data_returns_401():
+    """POST /api/phone without X-Init-Data header must return 401."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/api/phone",
+            json={"phone": "+359888123456", "source": "test", "user_id": 42},
+        )
+    assert resp.status_code == 401, (
+        f"Expected 401 when X-Init-Data header is missing, got {resp.status_code}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_phone_with_invalid_init_data_returns_401():
+    """POST /api/phone with wrong hash must return 401."""
+    invalid_init_data = _make_invalid_init_data(TEST_BOT_TOKEN)
+    with patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": TEST_BOT_TOKEN}, clear=False):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/api/phone",
+                # user_id omitted — must come from initData after auth
+                json={"phone": "+359888123456", "source": "test", "user_id": 42},
+                headers={"X-Init-Data": invalid_init_data},
+            )
+    assert resp.status_code == 401, (
+        f"Expected 401 for invalid hash, got {resp.status_code}: {resp.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_phone_with_valid_init_data_succeeds():
+    """POST /api/phone with valid signed initData must return 200."""
+    valid_init_data = _make_init_data(TEST_BOT_TOKEN, user_id=42)
+
+    mock_kommo = MagicMock()
+    mock_kommo.upsert_contact = AsyncMock(return_value={"id": 1})
+    mock_kommo.create_lead = AsyncMock(return_value={"id": 2})
+
+    with (
+        patch("mini_app.phone.get_kommo_client", return_value=mock_kommo),
+        patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": TEST_BOT_TOKEN}, clear=False),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/api/phone",
+                json={"phone": "+359888123456", "source": "test", "user_id": 42},
+                headers={"X-Init-Data": valid_init_data},
+            )
+
+    assert resp.status_code == 200, (
+        f"Expected 200 for valid initData on /api/phone, got {resp.status_code}: {resp.text}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CORS restriction
+# ---------------------------------------------------------------------------
+
+
+def test_cors_restricted_to_configured_origin():
+    """CORS allow_origins must NOT be the wildcard ['*'].
+
+    The API should use a configurable origin via MINI_APP_ALLOWED_ORIGIN
+    env var rather than allowing any origin. Check the middleware config
+    directly on the app object.
+    """
+    from fastapi.middleware.cors import CORSMiddleware
+
+    cors_middleware = None
+    for mw in app.user_middleware:
+        # FastAPI stores middleware as Middleware(cls, **kwargs) objects
+        if hasattr(mw, "cls") and mw.cls is CORSMiddleware:
+            cors_middleware = mw
+            break
+        # Some versions expose as (cls, args, kwargs) tuples
+        if isinstance(mw, tuple) and len(mw) >= 1 and mw[0] is CORSMiddleware:
+            cors_middleware = mw
+            break
+
+    assert cors_middleware is not None, "CORSMiddleware must be added to the app"
+
+    # Extract kwargs — either .kwargs dict or last element of tuple
+    if hasattr(cors_middleware, "kwargs"):
+        cors_kwargs = cors_middleware.kwargs
+    else:
+        cors_kwargs = cors_middleware[-1] if isinstance(cors_middleware, tuple) else {}
+
+    allow_origins = cors_kwargs.get("allow_origins", [])
+    assert allow_origins != ["*"], (
+        "CORS allow_origins must not be ['*']. "
+        "Use MINI_APP_ALLOWED_ORIGIN env var or a safe default like 'https://t.me'. "
+        f"Got: {allow_origins}"
+    )

--- a/tests/unit/mini_app/test_phone.py
+++ b/tests/unit/mini_app/test_phone.py
@@ -1,5 +1,7 @@
 """Tests for Mini App phone collection endpoint."""
 
+import time
+
 import pytest
 
 
@@ -9,8 +11,20 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from httpx import ASGITransport, AsyncClient
 
-from mini_app.api import app
+from mini_app.api import app, get_validated_init_data
 from mini_app.phone import PhoneRequest, submit_phone
+
+
+def _override_init_data(user_id: int = 123) -> None:
+    """Override auth dependency for phone tests that focus on CRM logic."""
+    app.dependency_overrides[get_validated_init_data] = lambda: {
+        "user": {"id": user_id, "first_name": "Test"},
+        "auth_date": str(int(time.time())),
+    }
+
+
+def _clear_init_data_override() -> None:
+    app.dependency_overrides.pop(get_validated_init_data, None)
 
 
 @pytest.mark.asyncio
@@ -19,27 +33,35 @@ async def test_submit_phone_success():
     mock_kommo.upsert_contact = AsyncMock(return_value={"id": 1})
     mock_kommo.create_lead = AsyncMock(return_value={"id": 2})
 
-    with patch("mini_app.phone.get_kommo_client", return_value=mock_kommo):
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            resp = await client.post(
-                "/api/phone",
-                json={
-                    "phone": "+359888123456",
-                    "source": "viewing_consultant",
-                    "user_id": 123,
-                },
-            )
+    _override_init_data(user_id=123)
+    try:
+        with patch("mini_app.phone.get_kommo_client", return_value=mock_kommo):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                resp = await client.post(
+                    "/api/phone",
+                    json={
+                        "phone": "+359888123456",
+                        "source": "viewing_consultant",
+                        "user_id": 123,
+                    },
+                )
+    finally:
+        _clear_init_data_override()
     assert resp.status_code == 200
     assert resp.json()["success"] is True
 
 
 @pytest.mark.asyncio
 async def test_submit_phone_invalid():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.post(
-            "/api/phone",
-            json={"phone": "abc", "source": "test", "user_id": 123},
-        )
+    _override_init_data(user_id=123)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/api/phone",
+                json={"phone": "abc", "source": "test", "user_id": 123},
+            )
+    finally:
+        _clear_init_data_override()
     assert resp.status_code == 422
 
 
@@ -61,16 +83,20 @@ async def test_phone_endpoint_returns_502_on_crm_failure():
     """The /api/phone endpoint must return a non-2xx status (502 Bad Gateway)
     when the CRM submission fails so the frontend can show a retry/error
     UI instead of treating the lead as captured (#1596)."""
-    with patch("mini_app.phone.get_kommo_client", side_effect=Exception("CRM down")):
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            resp = await client.post(
-                "/api/phone",
-                json={
-                    "phone": "+359888123456",
-                    "source": "viewing_consultant",
-                    "user_id": 123,
-                },
-            )
+    _override_init_data(user_id=123)
+    try:
+        with patch("mini_app.phone.get_kommo_client", side_effect=Exception("CRM down")):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                resp = await client.post(
+                    "/api/phone",
+                    json={
+                        "phone": "+359888123456",
+                        "source": "viewing_consultant",
+                        "user_id": 123,
+                    },
+                )
+    finally:
+        _clear_init_data_override()
     assert resp.status_code == 502
     body = resp.json()
     assert body["success"] is False


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #1595

`mini_app/auth.py` already had `validate_init_data()` — but it was **never called by the API**. Any caller could POST to `/api/start-expert` or `/api/phone` with a spoofed `user_id` from any origin.

## Security gap before / after

| | Before | After |
|---|---|---|
| `/api/start-expert` auth | None — open to any caller | Requires valid `X-Init-Data` (Telegram HMAC-SHA256) |
| `/api/phone` auth | None — open to any caller | Requires valid `X-Init-Data` |
| `user_id` source | Untrusted JSON body | `init_data["user"]["id"]` from server-verified token |
| CORS | `allow_origins=["*"]` (wildcard) | `MINI_APP_ALLOWED_ORIGIN` env var, fallback `https://t.me` |
| Missing header | 422 (no error message) | 401 with clear message |
| Invalid/expired hash | Not checked | 401 |

## Files touched

| File | Change |
|---|---|
| `mini_app/api.py` | Add `get_validated_init_data()` dependency; wire into `/api/start-expert` and `/api/phone`; restrict CORS; derive `user_id` from initData |
| `mini_app/expert_start.py` | `user_id` made optional (now overridden by server-verified initData) |
| `tests/unit/mini_app/test_mini_app_auth_enforcement.py` | **NEW** — 8 TDD tests (RED before fix, GREEN after) |
| `tests/contract/test_mini_app_auth_contract.py` | **NEW** — 6 structural contract tests (no wildcard CORS, validate_init_data imported, both handlers wired) |
| `tests/unit/mini_app/test_chat.py` | Updated to bypass auth dep for non-auth scenarios |
| `tests/unit/mini_app/test_phone.py` | Updated to bypass auth dep |
| `tests/unit/mini_app/test_api_config.py` | Updated to bypass auth dep + CORS origin fix |
| `tests/unit/mini_app/test_langfuse_tracing.py` | Updated to bypass auth dep |

## Validation

```
uv run pytest tests/unit/mini_app/ tests/contract/test_mini_app_auth_contract.py -q
# 64 passed in 0.77s

uv run pytest tests/contract -q
# 680 passed, 4 skipped, 3 xfailed in 23.52s

uv run ruff check mini_app/
# All checks passed!
```

## CORS change note for operators

**Production deployment requires `MINI_APP_ALLOWED_ORIGIN` in env.**

Set it to your Mini App frontend origin, e.g.:
```
MINI_APP_ALLOWED_ORIGIN=https://yourapp.example.com
```

Without this, the server defaults to `https://t.me` which is safe but may block self-hosted frontends.

## Debug/CI bypass

When `TELEGRAM_BOT_TOKEN=TEST`, `get_validated_init_data()` returns a synthetic user dict without verifying the signature. This allows CI tests to exercise the rest of the stack without a real bot token. **Never set `BOT_TOKEN=TEST` in production.**