### PR TITLE
refactor(observability): replace log-as-metric events with prometheus_client.Counter — slice 3/4 (#1648)

### DIFF
--- a/telegram_bot/services/metrics.py
+++ b/telegram_bot/services/metrics.py
@@ -1,23 +1,30 @@
 """Pipeline metrics for the RAG bot — SDK-native via prometheus_client.
 
 This module is the canonical observability surface for RAG pipeline
-latency. It exports:
+latency and event counts. It exports:
 
 * ``pipeline_latency_seconds`` — a module-level
   :class:`prometheus_client.Histogram` with a single ``stage`` label
   (matching the legacy rolling-window keys: ``retrieve``, ``rerank``,
   ``generate``). Registered with the default ``prometheus_client.REGISTRY``
   so the planned ASGI ``/metrics`` mount in slice 4/4 can scrape it
-  without any extra wiring.
+  without any extra wiring. (Slice 2/4 of #1648.)
 
 * ``record_pipeline_latency(stage, seconds)`` — the canonical SDK-native
-  recording API. New code must use this.
+  latency recording API. New code must use this. (Slice 2/4.)
+
+* ``rag_pipeline_events_total`` — a module-level
+  :class:`prometheus_client.Counter` with a single ``event`` label,
+  replacing log-as-metric events previously emitted in
+  ``rag_pipeline.py`` and ``qdrant.py``. (Slice 3/4 of #1648.)
+
+* ``record_pipeline_event(event, amount)`` — the canonical SDK-native
+  event recording API. New code must use this. (Slice 3/4.)
 
 * ``PipelineMetrics`` — the legacy facade kept for backward
-  compatibility (slice 2/4 of #1648). Existing call-sites
-  ``PipelineMetrics.get().record(stage, ms)`` keep working unchanged;
-  internally they now ALSO observe into the Histogram (after ms→s
-  conversion). The rolling p50/p95 / counter / observation surface
+  compatibility. Existing call-sites ``PipelineMetrics.get().record(stage, ms)``
+  keep working unchanged; ``PipelineMetrics.get().inc(name)`` now ALSO
+  increments ``rag_pipeline_events_total``. The rolling p50/p95 surface
   remains for the bot's admin ``/metrics`` Telegram command, but
   ``get_stats()`` / ``format_text()`` emit ``DeprecationWarning`` —
   slice 4/4 deletes that surface entirely.
@@ -26,15 +33,9 @@ Context7 baseline (``/prometheus/client_python``):
 
   * ``Histogram(name, documentation, labelnames=(...,))`` — registered
     against ``prometheus_client.REGISTRY`` by default.
-  * ``Histogram.labels(stage="rerank").observe(seconds)`` records into
-    the bucket containing ``seconds``, plus the ``_count`` and ``_sum``
-    series.
-  * Default buckets ``(.005, .01, .025, .05, .075, .1, .25, .5, .75,
-    1.0, 2.5, 5.0, 7.5, 10.0, +Inf)`` are tuned for web/RPC latencies
-    and cover the RAG pipeline stages well (retrieve ≈ 50–500 ms,
-    rerank ≈ 50–500 ms, generate ≈ 0.5–5 s). We adopt them as-is to
-    avoid premature bucket tuning; revisit per slice 4/4 once we have
-    real Prometheus dashboards.
+  * ``Counter(name, documentation, labelnames=(...,))`` — registered
+    against ``prometheus_client.REGISTRY`` by default.
+  * ``Counter.labels(event="name").inc()`` increments the counter.
 
 Content was rephrased for compliance with licensing restrictions.
 
@@ -51,7 +52,7 @@ import time
 import warnings
 from collections import deque
 
-from prometheus_client import Histogram
+from prometheus_client import Counter, Histogram
 
 
 logger = logging.getLogger(__name__)
@@ -73,6 +74,46 @@ pipeline_latency_seconds: Histogram = Histogram(
     # distribution of every existing pipeline stage. Slice 4/4 will
     # revisit bucket tuning once dashboards are in place.
 )
+
+# ---------------------------------------------------------------------------
+# SDK-native module-level Counter (#1648 slice 3/4).
+# ---------------------------------------------------------------------------
+
+# Single ``event`` label keeps cardinality low.  Known event values at the
+# time of slice 3/4:
+#   colbert_rerank_attempted, topic_filter_fallback, retrieval_zero_docs,
+#   score_gap_confident   (from rag_pipeline.py)
+#   colbert_rerank_empty, colbert_fallback_to_rrf   (from qdrant.py)
+#
+# Context7 baseline (``/prometheus/client_python``):
+#   Counter(name, documentation, labelnames=('label',))
+#   counter.labels(label='value').inc()
+#
+# Content was rephrased for compliance with licensing restrictions.
+# Refs #1648.
+rag_pipeline_events_total: Counter = Counter(
+    "rag_pipeline_events_total",
+    "RAG pipeline event counter (cache_hit, cache_miss, colbert_rerank_attempted, etc.).",
+    labelnames=("event",),
+)
+
+
+def record_pipeline_event(event: str, amount: int = 1) -> None:
+    """Record one pipeline event by incrementing the labeled Counter.
+
+    This is the SDK-native API for slice 3/4.  New call-sites must use
+    this function directly; existing ``PipelineMetrics.get().inc(name)``
+    call-sites are backward-compatible because the facade delegates here.
+
+    Args:
+        event: Event label value (e.g. ``"colbert_rerank_attempted"``,
+            ``"retrieval_zero_docs"``).  Cardinality must stay low.
+        amount: Increment amount (default 1, must be non-negative).
+    """
+    if amount <= 0:
+        return
+    rag_pipeline_events_total.labels(event=event).inc(amount)
+
 
 # Rolling window size per stage — only used by the deprecated facade.
 _WINDOW_SIZE = 1000
@@ -105,7 +146,13 @@ def record_pipeline_latency(stage: str, seconds: float) -> None:
 
 
 def record_counter_metric(name: str, value: int = 1) -> None:
-    """Record a named counter metric through the bot metrics registry."""
+    """Record a named counter metric through the bot metrics registry.
+
+    Slice 3/4 of #1648: also increments the SDK-native
+    :data:`rag_pipeline_events_total` Counter so existing call-sites
+    that have NOT yet been migrated to ``record_pipeline_event()``
+    still produce Prometheus-visible signals.
+    """
     if value <= 0:
         return
     PipelineMetrics.get().inc(name, value)
@@ -193,9 +240,16 @@ class PipelineMetrics:
     def inc(self, counter: str, amount: int = 1) -> None:
         """Increment a named counter.
 
-        Out of scope for slice 2/4. Slice 3/4 of #1648 migrates this
-        surface to :class:`prometheus_client.Counter`.
+        Slice 3/4 of #1648: this facade now ALSO increments the
+        SDK-native :data:`rag_pipeline_events_total` Counter so existing
+        call-sites get Prometheus visibility without code changes.
+        The in-memory ``_counters`` dict is retained for the deprecated
+        admin ``/metrics`` Telegram command; it is deleted in slice 4/4.
         """
+        # SDK-native side: forward to the Counter first so a programming
+        # error in the facade dict does not silently lose the Prometheus signal.
+        record_pipeline_event(counter, amount)
+        # Legacy in-memory side (deprecated, see slice 4/4).
         with self._mu:
             self._counters[counter] = self._counters.get(counter, 0) + amount
 
@@ -333,5 +387,7 @@ class PipelineMetrics:
 __all__ = [
     "PipelineMetrics",
     "pipeline_latency_seconds",
+    "rag_pipeline_events_total",
+    "record_pipeline_event",
     "record_pipeline_latency",
 ]

--- a/tests/unit/services/test_pipeline_counters_prometheus.py
+++ b/tests/unit/services/test_pipeline_counters_prometheus.py
@@ -1,0 +1,229 @@
+"""Tests for SDK-native pipeline event Counter (#1648 slice 3/4).
+
+Slice 3/4 of the observability migration replaces log-as-metric events
+with a labeled ``prometheus_client.Counter`` in
+``telegram_bot.services.metrics``.
+
+Hot-path events identified during investigation:
+
+  rag_pipeline.py (via ``record_counter_metric``):
+    - ``colbert_rerank_attempted``  — ColBERT rerank path taken
+    - ``topic_filter_fallback``     — retrieval relaxed from topic filter
+    - ``retrieval_zero_docs``       — Qdrant returned no documents
+    - ``score_gap_confident``       — grading found a confident score gap
+
+  qdrant.py (via ``record_counter_metric``):
+    - ``colbert_rerank_empty``      — ColBERT returned 0 docs
+    - ``colbert_fallback_to_rrf``   — fallback from ColBERT to RRF
+
+Context7 baseline (``/prometheus/client_python``):
+
+    Counter(name, documentation, labelnames=('label',))
+    counter.labels(label='value').inc()
+    counter.labels(label='value').inc(amount)
+
+Counter-level cardinality stays low: a single ``event`` label whose
+values are the six event names above (and any future hot-path counters
+added in subsequent sprints).
+
+Refs #1648.
+"""
+
+from __future__ import annotations
+
+import pytest
+from prometheus_client import REGISTRY, Counter
+
+from telegram_bot.services.metrics import (
+    PipelineMetrics,
+    rag_pipeline_events_total,
+    record_pipeline_event,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_counter_children():
+    """Clear Counter label-children between tests.
+
+    The Counter is module-level and registered exactly once with
+    ``prometheus_client.REGISTRY``. We drop only per-label children so
+    each test starts from zero counts; we never recreate the Counter
+    itself (that would raise ``ValueError: Duplicated timeseries``).
+    """
+    rag_pipeline_events_total.clear()
+    PipelineMetrics.reset()
+    yield
+    rag_pipeline_events_total.clear()
+    PipelineMetrics.reset()
+
+
+# ---------------------------------------------------------------------------
+# 1. Counter object exists and has the right shape
+# ---------------------------------------------------------------------------
+
+
+class TestCounterDefinition:
+    """Module-level Counter is exported with the right shape."""
+
+    def test_rag_pipeline_counter_exists(self):
+        """A module-level Counter named rag_pipeline_events_total is exported."""
+        assert isinstance(rag_pipeline_events_total, Counter), (
+            "rag_pipeline_events_total must be a prometheus_client.Counter"
+        )
+
+    def test_rag_pipeline_counter_metric_name(self):
+        """Counter metric name base is rag_pipeline_events (prometheus_client strips _total from _name)."""
+        # prometheus_client strips the ``_total`` suffix from ``._name``
+        # but exposes the sample as ``rag_pipeline_events_total``.
+        assert rag_pipeline_events_total._name == "rag_pipeline_events", (
+            f"Expected '_name' == 'rag_pipeline_events', got '{rag_pipeline_events_total._name}'. "
+            "prometheus_client strips the _total suffix from the internal _name attribute."
+        )
+
+    def test_rag_pipeline_counter_has_correct_labels(self):
+        """Counter must have a single 'event' label (low cardinality)."""
+        assert tuple(rag_pipeline_events_total._labelnames) == ("event",), (
+            "rag_pipeline_events_total must have exactly one label: 'event'"
+        )
+
+    def test_rag_pipeline_counter_uses_default_registry(self):
+        """Counter must be in prometheus_client.REGISTRY (no custom registry)."""
+        # prometheus_client stores the family name without _total suffix in REGISTRY.collect()
+        names = {m.name for m in REGISTRY.collect()}
+        assert "rag_pipeline_events" in names, (
+            "rag_pipeline_events is not in prometheus_client.REGISTRY. "
+            "Do not pass a custom CollectorRegistry (see contract test)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. record_pipeline_event() helper
+# ---------------------------------------------------------------------------
+
+
+class TestRecordPipelineEvent:
+    """``record_pipeline_event(event)`` increments the Counter by 1."""
+
+    def test_record_event_increments_counter(self):
+        """Calling record_pipeline_event once increments _total by 1."""
+        before = (
+            REGISTRY.get_sample_value(
+                "rag_pipeline_events_total",
+                {"event": "cache_hit"},
+            )
+            or 0.0
+        )
+
+        record_pipeline_event("cache_hit")
+
+        after = REGISTRY.get_sample_value(
+            "rag_pipeline_events_total",
+            {"event": "cache_hit"},
+        )
+        assert after is not None
+        assert after - before == pytest.approx(1.0), (
+            "record_pipeline_event('cache_hit') must increment counter by 1"
+        )
+
+    def test_multiple_calls_accumulate(self):
+        """Counter is monotonically increasing across multiple calls."""
+        for _ in range(3):
+            record_pipeline_event("retrieval_zero_docs")
+
+        value = REGISTRY.get_sample_value(
+            "rag_pipeline_events_total",
+            {"event": "retrieval_zero_docs"},
+        )
+        assert value == pytest.approx(3.0)
+
+    def test_different_events_have_independent_label_children(self):
+        """Each event label maps to an independent time series."""
+        record_pipeline_event("colbert_rerank_attempted")
+        record_pipeline_event("topic_filter_fallback")
+        record_pipeline_event("topic_filter_fallback")
+
+        colbert_val = REGISTRY.get_sample_value(
+            "rag_pipeline_events_total",
+            {"event": "colbert_rerank_attempted"},
+        )
+        topic_val = REGISTRY.get_sample_value(
+            "rag_pipeline_events_total",
+            {"event": "topic_filter_fallback"},
+        )
+        assert colbert_val == pytest.approx(1.0)
+        assert topic_val == pytest.approx(2.0)
+
+    def test_known_hot_path_events_can_be_recorded(self):
+        """All six hot-path event names from the codebase must be accepted."""
+        hot_path_events = [
+            "colbert_rerank_attempted",
+            "topic_filter_fallback",
+            "retrieval_zero_docs",
+            "score_gap_confident",
+            "colbert_rerank_empty",
+            "colbert_fallback_to_rrf",
+        ]
+        for event in hot_path_events:
+            record_pipeline_event(event)  # must not raise
+
+        for event in hot_path_events:
+            val = REGISTRY.get_sample_value(
+                "rag_pipeline_events_total",
+                {"event": event},
+            )
+            assert val == pytest.approx(1.0), (
+                f"Expected counter=1 for event '{event}', got {val}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 3. Backward-compat: PipelineMetrics.inc() still works
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineMetricsIncBackwardCompat:
+    """``PipelineMetrics.get().inc(counter)`` still works and also feeds the Counter.
+
+    Slice 3/4 must not break any existing call-site that goes through the
+    deprecated facade. The facade's in-memory ``_counters`` dict is kept
+    intact (slice 4/4 deletes it); additionally, each ``inc()`` call now
+    also increments ``rag_pipeline_events_total`` so the event is visible
+    to Prometheus scraping.
+    """
+
+    def test_existing_callers_of_PipelineMetrics_inc_still_work(self):
+        """PipelineMetrics.get().inc('cache_hit') does not raise."""
+        m = PipelineMetrics.get()
+        m.inc("cache_hit")  # must not raise
+        m.inc("cache_hit", 2)
+
+    def test_PipelineMetrics_inc_also_feeds_prometheus_counter(self):
+        """Calling PipelineMetrics.inc('cache_hit') increments rag_pipeline_events_total."""
+        m = PipelineMetrics.get()
+        m.inc("cache_hit")
+
+        val = REGISTRY.get_sample_value(
+            "rag_pipeline_events_total",
+            {"event": "cache_hit"},
+        )
+        assert val is not None and val >= 1.0, (
+            "PipelineMetrics.inc() must forward the event to rag_pipeline_events_total"
+        )
+
+    def test_PipelineMetrics_inc_with_amount_feeds_counter_once(self):
+        """PipelineMetrics.inc('ev', amount=2) increments counter by 2."""
+        m = PipelineMetrics.get()
+        m.inc("cache_miss", 2)
+
+        val = REGISTRY.get_sample_value(
+            "rag_pipeline_events_total",
+            {"event": "cache_miss"},
+        )
+        assert val == pytest.approx(2.0), (
+            "PipelineMetrics.inc('cache_miss', 2) must increment counter by 2"
+        )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary (slice 3/4 of #1648)

This PR adds a labeled `prometheus_client.Counter` to replace log-as-metric events that were only visible in the deprecated `PipelineMetrics._counters` in-memory dict and invisible to Prometheus scraping.

### What was log-as-metric (before)

| File | Event | Old path |
|------|-------|----------|
| `telegram_bot/agents/rag_pipeline.py` | `colbert_rerank_attempted` | `record_counter_metric()` → `PipelineMetrics._counters` |
| `telegram_bot/agents/rag_pipeline.py` | `topic_filter_fallback` | same |
| `telegram_bot/agents/rag_pipeline.py` | `retrieval_zero_docs` | same |
| `telegram_bot/agents/rag_pipeline.py` | `score_gap_confident` | same |
| `telegram_bot/services/qdrant.py` | `colbert_rerank_empty` | same |
| `telegram_bot/services/qdrant.py` | `colbert_fallback_to_rrf` | same |

### What Counter was added

```python
# telegram_bot/services/metrics.py
rag_pipeline_events_total = Counter(
    "rag_pipeline_events_total",
    "RAG pipeline event counter (cache_hit, cache_miss, colbert_rerank_attempted, etc.).",
    labelnames=("event",),
)

def record_pipeline_event(event: str, amount: int = 1) -> None:
    rag_pipeline_events_total.labels(event=event).inc(amount)
```

**Context7 baseline** (`/prometheus/client_python`, High reputation, 299 snippets):
- `Counter(name, documentation, labelnames=('label',))` — registered against default `prometheus_client.REGISTRY`
- `counter.labels(label='value').inc()` — labeled increment
- Single `event` label keeps cardinality low

### Backward-compat bridge

`PipelineMetrics.inc(counter, amount)` now **also** calls `record_pipeline_event(counter, amount)`. Since `record_counter_metric()` delegates through `PipelineMetrics.inc()`, **all existing call-sites in `rag_pipeline.py` and `qdrant.py` gain Prometheus visibility without any call-site changes in this slice**.

### Files touched

| File | Change |
|------|--------|
| `telegram_bot/services/metrics.py` | Added `rag_pipeline_events_total` Counter + `record_pipeline_event()` + updated `PipelineMetrics.inc()` + updated `__all__` |
| `tests/unit/services/test_pipeline_counters_prometheus.py` | **New** — 11 TDD tests (RED → GREEN cycle documented in commit) |

### Validation

```
uv run pytest tests/unit/services/test_pipeline_counters_prometheus.py -q
# 11 passed in 0.44s

uv run pytest tests/unit/services/ tests/contract/test_no_custom_metrics_registry_contract.py -q
# 1622 passed, 1 skipped in 13.63s

uv run ruff check telegram_bot/services/metrics.py
# All checks passed!
```

No custom `CollectorRegistry` — uses default `prometheus_client.REGISTRY` (contract test passes).

### Remaining for slice 4/4

- ASGI `/metrics` mount (expose the default registry via an HTTP endpoint)
- Delete `PipelineMetrics` rolling p50/p95 surface entirely
- Rework the admin `/metrics` Telegram command to render Histogram/Counter data

Refs #1648