### PR TITLE
fix(ingestion): atomic replace for qdrant_writer (#1602)

### DIFF
--- a/src/ingestion/unified/qdrant_writer.py
+++ b/src/ingestion/unified/qdrant_writer.py
@@ -12,6 +12,7 @@ from qdrant_client import QdrantClient
 from qdrant_client.models import (
     FieldCondition,
     Filter,
+    HasIdCondition,
     MatchValue,
     PointStruct,
     SparseVector,
@@ -417,12 +418,17 @@ class QdrantHybridWriter:
         file_metadata: dict[str, Any],
         collection_name: str,
     ) -> WriteStats:
-        """Upsert chunks with replace semantics.
+        """Upsert chunks with atomic replace semantics (#1602).
 
-        1. Delete existing points for file_id
-        2. Generate embeddings
-        3. Build points with payload contract
-        4. Upsert to Qdrant
+        1. Generate embeddings and build replacement points first.
+        2. Upsert replacement points with deterministic IDs (overwrites the
+           same chunk_locations in place).
+        3. Only after a successful upsert, delete points whose IDs belong to
+           ``file_id`` but are not part of the new batch (stale orphans).
+
+        If any step before the stale-id sweep fails, no destructive delete is
+        executed, so the previous good version of the document remains
+        searchable.
         """
         stats = WriteStats()
         try_update_ingestion_trace(
@@ -440,13 +446,11 @@ class QdrantHybridWriter:
             return stats
 
         try:
-            # Step 1: Delete existing (replace semantics)
-            stats.points_deleted = await self.delete_file(file_id, collection_name)
-
-            # Step 2: Extract texts
+            # Step 1: Extract texts
             texts = [chunk.text for chunk in chunks]
 
-            # Step 3: Generate embeddings (local BGE-M3 or Voyage API)
+            # Step 2: Generate embeddings (local BGE-M3 or Voyage API).
+            # Any failure here exits via `except` BEFORE any destructive call.
             if self.use_local_embeddings:
                 dense_embeddings = self._embed_documents_local(texts)
             else:
@@ -456,8 +460,9 @@ class QdrantHybridWriter:
             sparse_embeddings = self._embed_sparse(texts)
             colbert_embeddings = self._embed_colbert(texts) if self.use_local_embeddings else []
 
-            # Step 4: Build points
-            points = []
+            # Step 3: Build points
+            points: list[PointStruct] = []
+            new_ids: list[str] = []
             for i, (chunk, dense_vec, sparse_emb) in enumerate(
                 zip(chunks, dense_embeddings, sparse_embeddings, strict=True)
             ):
@@ -480,17 +485,28 @@ class QdrantHybridWriter:
                     payload=payload,
                 )
                 points.append(point)
+                new_ids.append(point_id)
 
-            # Step 5: Upsert in request-size-safe batches
+            # Step 4: Upsert replacement points first (deterministic IDs
+            # overwrite same-location points, so readers always see a valid
+            # version of the document during the swap).
             stats.points_upserted = self._upsert_points_in_batches(
                 collection_name=collection_name,
                 points=points,
                 source_path=source_path,
             )
 
+            # Step 5: Sweep stale orphans (old points for this file_id that
+            # are not part of the new batch). Safe because Step 4 succeeded.
+            stats.points_deleted = self._delete_stale_points_sync(
+                file_id=file_id,
+                collection_name=collection_name,
+                new_ids=set(new_ids),
+            )
+
             logger.info(
                 f"Upserted {stats.points_upserted} points for {source_path} "
-                f"(replaced {stats.points_deleted})"
+                f"(swept {stats.points_deleted} stale points)"
             )
 
         except Exception as e:
@@ -547,9 +563,11 @@ class QdrantHybridWriter:
         file_metadata: dict[str, Any],
         collection_name: str,
     ) -> WriteStats:
-        """Sync version of upsert_chunks.
+        """Sync atomic-replace counterpart of ``upsert_chunks`` (#1602).
 
-        Uses sync Voyage client and sync Qdrant operations.
+        Build replacement points first, upsert them with deterministic IDs,
+        and only delete stale orphan IDs after the upsert succeeds. If any
+        step before the stale-id sweep fails, no destructive delete runs.
         """
         stats = WriteStats()
 
@@ -557,13 +575,11 @@ class QdrantHybridWriter:
             return stats
 
         try:
-            # Step 1: Delete existing (replace semantics)
-            stats.points_deleted = self.delete_file_sync(file_id, collection_name)
-
-            # Step 2: Extract texts
+            # Step 1: Extract texts
             texts = [chunk.text for chunk in chunks]
 
-            # Step 3: Generate embeddings — single hybrid call when local BGE-M3
+            # Step 2: Generate embeddings — single hybrid call when local BGE-M3.
+            # Any failure here exits via `except` BEFORE any destructive call.
             all_dense_embeddings: list[list[float]]
             if self.use_local_embeddings:
                 hybrid_result = self._bge_client.encode_hybrid(texts)
@@ -589,8 +605,9 @@ class QdrantHybridWriter:
                 sparse_embeddings = self._embed_sparse(texts)
                 colbert_embeddings = []
 
-            # Step 4: Build points
-            points = []
+            # Step 3: Build points
+            points: list[PointStruct] = []
+            new_ids: list[str] = []
             for i, (chunk, dense_vec, sparse_emb) in enumerate(
                 zip(chunks, all_dense_embeddings, sparse_embeddings, strict=True)
             ):
@@ -613,17 +630,25 @@ class QdrantHybridWriter:
                     payload=payload,
                 )
                 points.append(point)
+                new_ids.append(point_id)
 
-            # Step 5: Upsert in request-size-safe batches
+            # Step 4: Upsert replacement points first.
             stats.points_upserted = self._upsert_points_in_batches(
                 collection_name=collection_name,
                 points=points,
                 source_path=source_path,
             )
 
+            # Step 5: Now safe to sweep stale orphan IDs.
+            stats.points_deleted = self._delete_stale_points_sync(
+                file_id=file_id,
+                collection_name=collection_name,
+                new_ids=set(new_ids),
+            )
+
             logger.info(
                 f"Upserted {stats.points_upserted} points for {source_path} "
-                f"(replaced {stats.points_deleted})"
+                f"(swept {stats.points_deleted} stale points)"
             )
 
         except Exception as e:
@@ -631,3 +656,54 @@ class QdrantHybridWriter:
             logger.error(f"Error upserting chunks: {e}", exc_info=True)
 
         return stats
+
+    def _delete_stale_points_sync(
+        self,
+        *,
+        file_id: str,
+        collection_name: str,
+        new_ids: set[str],
+    ) -> int:
+        """Delete points that belong to ``file_id`` but are not in ``new_ids``.
+
+        This is the post-upsert sweep half of the atomic-replace pattern from
+        #1602: by the time we run, replacement points are already live in the
+        collection (Step 4 of ``upsert_chunks_sync``), so we only need to drop
+        whichever historical chunk IDs no longer participate in the file.
+
+        Returns the number of stale point IDs that were deleted.
+        """
+        stale_ids: list[int | str | uuid.UUID] = []
+        next_offset: Any = None
+        while True:
+            records, next_offset = self.client.scroll(
+                collection_name=collection_name,
+                scroll_filter=Filter(
+                    must=[
+                        FieldCondition(
+                            key="metadata.file_id",
+                            match=MatchValue(value=file_id),
+                        )
+                    ]
+                ),
+                limit=512,
+                offset=next_offset,
+                with_payload=False,
+                with_vectors=False,
+            )
+            for record in records or []:
+                rid = record.id
+                if rid not in new_ids:
+                    stale_ids.append(rid)
+            if not next_offset:
+                break
+
+        if not stale_ids:
+            return 0
+
+        self.client.delete(
+            collection_name=collection_name,
+            points_selector=Filter(must=[HasIdCondition(has_id=stale_ids)]),
+        )
+        logger.info("Swept %d stale points for file_id=%s (post-upsert)", len(stale_ids), file_id)
+        return len(stale_ids)

--- a/tests/contract/test_qdrant_writer_atomic_replace_contract.py
+++ b/tests/contract/test_qdrant_writer_atomic_replace_contract.py
@@ -1,0 +1,111 @@
+# tests/contract/test_qdrant_writer_atomic_replace_contract.py
+"""Static guardrail for #1602 — qdrant_writer must not delete-before-upsert.
+
+The bug: ``upsert_chunks_sync`` previously called ``delete_file_sync`` at the
+top of the function, before any embedding work or upsert. If embedding or
+upsert failed afterwards, the document was wiped from search until the next
+successful retry.
+
+The fix: build replacement points first, upsert with deterministic IDs, and
+then sweep stale orphan IDs via ``_delete_stale_points_sync``.
+
+This contract enforces the structural shape of the fix so a refactor can't
+silently regress to the destructive delete-first pattern.
+"""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+_WRITER_PATH = (
+    Path(__file__).resolve().parents[2] / "src" / "ingestion" / "unified" / "qdrant_writer.py"
+)
+
+
+def _load_function(name: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    """Return the AST node for ``QdrantHybridWriter.<name>``."""
+    tree = ast.parse(_WRITER_PATH.read_text(encoding="utf-8"))
+    for cls in ast.walk(tree):
+        if not isinstance(cls, ast.ClassDef) or cls.name != "QdrantHybridWriter":
+            continue
+        for node in cls.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+                return node
+    pytest.fail(f"QdrantHybridWriter.{name} not found in {_WRITER_PATH}")
+
+
+def _self_method_calls(func: ast.AST) -> list[str]:
+    """Return the list of ``self.<method>`` call targets in ``func``."""
+    calls: list[str] = []
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Call):
+            continue
+        target = node.func
+        if (
+            isinstance(target, ast.Attribute)
+            and isinstance(target.value, ast.Name)
+            and target.value.id == "self"
+        ):
+            calls.append(target.attr)
+    return calls
+
+
+@pytest.mark.parametrize("func_name", ["upsert_chunks", "upsert_chunks_sync"])
+def test_upsert_does_not_call_destructive_delete_helpers(func_name: str) -> None:
+    """``upsert_chunks*`` must not call ``delete_file`` / ``delete_file_sync``."""
+    func = _load_function(func_name)
+    calls = _self_method_calls(func)
+    forbidden = {"delete_file", "delete_file_sync"}
+    found = forbidden.intersection(calls)
+    assert not found, textwrap.dedent(
+        f"""
+        QdrantHybridWriter.{func_name} must not invoke {sorted(found)}; they
+        delete by metadata.file_id Filter and run BEFORE the upsert, which is
+        the data-loss pattern called out in #1602. Use
+        ``self._delete_stale_points_sync`` AFTER a successful upsert instead.
+        """
+    ).strip()
+
+
+@pytest.mark.parametrize("func_name", ["upsert_chunks", "upsert_chunks_sync"])
+def test_upsert_calls_post_upsert_stale_sweep(func_name: str) -> None:
+    """``upsert_chunks*`` must perform the stale-id sweep after the upsert."""
+    func = _load_function(func_name)
+    calls = _self_method_calls(func)
+    assert "_delete_stale_points_sync" in calls, textwrap.dedent(
+        f"""
+        QdrantHybridWriter.{func_name} must call
+        ``self._delete_stale_points_sync`` after the replacement upsert
+        completes successfully. This is the safe orphan-sweep half of the
+        atomic-replace pattern from #1602.
+        """
+    ).strip()
+
+
+@pytest.mark.parametrize("func_name", ["upsert_chunks", "upsert_chunks_sync"])
+def test_stale_sweep_runs_after_upsert(func_name: str) -> None:
+    """Inside the function body, ``_upsert_points_in_batches`` must precede
+    ``_delete_stale_points_sync``."""
+    func = _load_function(func_name)
+    calls = _self_method_calls(func)
+    if "_upsert_points_in_batches" not in calls or "_delete_stale_points_sync" not in calls:
+        pytest.fail(
+            f"{func_name} must call both _upsert_points_in_batches and "
+            f"_delete_stale_points_sync; got {calls}"
+        )
+    assert calls.index("_upsert_points_in_batches") < calls.index("_delete_stale_points_sync"), (
+        textwrap.dedent(
+            f"""
+        In QdrantHybridWriter.{func_name}, the call to
+        ``self._upsert_points_in_batches`` must precede the call to
+        ``self._delete_stale_points_sync``. If the order is inverted the
+        function falls back to the destructive delete-first pattern from
+        #1602.
+        """
+        ).strip()
+    )

--- a/tests/unit/ingestion/test_qdrant_writer_atomic_replace.py
+++ b/tests/unit/ingestion/test_qdrant_writer_atomic_replace.py
@@ -1,0 +1,267 @@
+# tests/unit/ingestion/test_qdrant_writer_atomic_replace.py
+"""Atomic replace semantics for QdrantHybridWriter (issue #1602).
+
+The bug: ``upsert_chunks_sync`` previously deleted existing points for a
+``file_id`` BEFORE generating replacement embeddings/points and upserting them.
+If embedding generation, ColBERT inference, or the upsert call failed, the
+collection lost the last good version of the document until the next
+successful retry.
+
+The fix: build replacement embeddings and points FIRST, upsert them with
+deterministic IDs, and only then delete points that became stale (those that
+belong to ``file_id`` but are not part of the new upsert batch).
+
+These tests pin the new contract so we do not regress to the destructive
+delete-first ordering.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from qdrant_client.models import HasIdCondition
+
+from src.ingestion.unified.qdrant_writer import QdrantHybridWriter
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_chunk(
+    *,
+    text: str = "Sample chunk text",
+    order: int = 0,
+    extra_metadata: dict | None = None,
+) -> MagicMock:
+    chunk = MagicMock()
+    chunk.text = text
+    chunk.order = order
+    chunk.extra_metadata = extra_metadata or {}
+    chunk.document_name = "test.pdf"
+    chunk.page_range = None
+    chunk.section = None
+    chunk.chunk_id = order
+    return chunk
+
+
+# ---------------------------------------------------------------------------
+# Atomic-replace failure-recovery contract (#1602)
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingFailureLeavesOldPointsIntact:
+    """If embedding/upsert fails, no destructive delete must have happened.
+
+    Reproduces the data-loss condition called out in #1602: the writer
+    previously deleted by file_id filter before any embedding work, so any
+    embedding error wiped the file from search even though no replacement
+    was upserted.
+    """
+
+    def test_voyage_embedding_failure_does_not_call_delete(
+        self, writer_voyage, mock_qdrant_client, mock_voyage, mock_bge_client
+    ):
+        """When Voyage embedding raises, delete must not have been called."""
+        mock_qdrant_client.count.return_value = MagicMock(count=5)
+        mock_voyage._client.embed.side_effect = RuntimeError("Voyage API down")
+        mock_bge_client.encode_sparse.return_value = MagicMock(
+            weights=[{"indices": [1], "values": [0.5]}]
+        )
+
+        chunk = _make_chunk()
+        stats = writer_voyage.upsert_chunks_sync([chunk], "file_1", "/p", {}, "col")
+
+        assert stats.errors is not None
+        assert "Voyage API down" in stats.errors[0]
+        # The destructive delete must not have run before the failed embed
+        mock_qdrant_client.delete.assert_not_called()
+        # And no upsert happened either, so points_upserted stays 0
+        assert stats.points_upserted == 0
+        mock_qdrant_client.upsert.assert_not_called()
+
+    def test_sparse_embedding_failure_does_not_call_delete(
+        self, writer_voyage, mock_qdrant_client, mock_voyage, mock_bge_client
+    ):
+        """When BGE-M3 sparse encode raises, delete must not have been called."""
+        mock_qdrant_client.count.return_value = MagicMock(count=3)
+        mock_voyage._client.embed.return_value = MagicMock(embeddings=[[0.1] * 1024])
+        mock_bge_client.encode_sparse.side_effect = RuntimeError("BGE-M3 timeout")
+
+        chunk = _make_chunk()
+        stats = writer_voyage.upsert_chunks_sync([chunk], "file_1", "/p", {}, "col")
+
+        assert stats.errors is not None
+        assert "BGE-M3 timeout" in stats.errors[0]
+        mock_qdrant_client.delete.assert_not_called()
+        mock_qdrant_client.upsert.assert_not_called()
+
+    def test_local_hybrid_failure_does_not_call_delete(
+        self, writer_local, mock_qdrant_client, mock_bge_client
+    ):
+        """When local BGE-M3 hybrid encode raises, delete must not have been called."""
+        mock_qdrant_client.count.return_value = MagicMock(count=7)
+        mock_bge_client.encode_hybrid.side_effect = RuntimeError("hybrid encode failed")
+
+        chunk = _make_chunk()
+        stats = writer_local.upsert_chunks_sync([chunk], "file_1", "/p", {}, "col")
+
+        assert stats.errors is not None
+        assert "hybrid encode failed" in stats.errors[0]
+        mock_qdrant_client.delete.assert_not_called()
+        mock_qdrant_client.upsert.assert_not_called()
+
+    def test_upsert_failure_does_not_call_delete(
+        self, writer_voyage, mock_qdrant_client, mock_voyage, mock_bge_client
+    ):
+        """When the upsert call to Qdrant raises, delete must not have been called."""
+        mock_qdrant_client.count.return_value = MagicMock(count=4)
+        mock_voyage._client.embed.return_value = MagicMock(embeddings=[[0.1] * 1024])
+        mock_bge_client.encode_sparse.return_value = MagicMock(
+            weights=[{"indices": [1], "values": [0.5]}]
+        )
+        mock_qdrant_client.upsert.side_effect = RuntimeError("Qdrant upsert failed")
+
+        chunk = _make_chunk()
+        stats = writer_voyage.upsert_chunks_sync([chunk], "file_1", "/p", {}, "col")
+
+        assert stats.errors is not None
+        assert "Qdrant upsert failed" in stats.errors[0]
+        mock_qdrant_client.delete.assert_not_called()
+
+
+class TestSuccessPathOrderingIsUpsertThenDelete:
+    """On success, upsert must happen BEFORE the stale-id delete sweep.
+
+    Old contract (delete-first) was the bug. New contract: replacement points
+    are visible to readers throughout, then stale chunks (by id) are removed.
+    """
+
+    def test_upsert_called_before_delete_on_success(
+        self, writer_voyage, mock_qdrant_client, mock_voyage, mock_bge_client
+    ):
+        """Calls to client.upsert must precede client.delete in time."""
+        call_order: list[str] = []
+        # Pretend there are stale points so a delete sweep is required after upsert
+        mock_qdrant_client.count.return_value = MagicMock(count=2)
+        mock_qdrant_client.scroll.return_value = (
+            [
+                MagicMock(id="00000000-0000-0000-0000-000000000aaa"),
+                MagicMock(id="00000000-0000-0000-0000-000000000bbb"),
+            ],
+            None,
+        )
+        mock_qdrant_client.delete.side_effect = lambda **_: call_order.append("delete")
+        mock_qdrant_client.upsert.side_effect = lambda **_: call_order.append("upsert")
+        mock_voyage._client.embed.return_value = MagicMock(embeddings=[[0.1] * 1024])
+        mock_bge_client.encode_sparse.return_value = MagicMock(
+            weights=[{"indices": [1], "values": [0.5]}]
+        )
+
+        chunk = _make_chunk()
+        stats = writer_voyage.upsert_chunks_sync([chunk], "file_1", "/p", {}, "col")
+
+        assert stats.errors is None
+        # Upsert must come before any delete
+        assert call_order[0] == "upsert"
+        # delete may or may not be present depending on whether stale ids exist;
+        # if it is present, every delete is strictly after the first upsert
+        upsert_indices = [i for i, c in enumerate(call_order) if c == "upsert"]
+        delete_indices = [i for i, c in enumerate(call_order) if c == "delete"]
+        if delete_indices:
+            assert min(delete_indices) > min(upsert_indices)
+
+
+class TestStaleDeleteScopeIsRestrictedToOrphanIds:
+    """Delete must target stale ids only, never blanket-delete by file_id.
+
+    This is the structural guard against re-introducing the original bug.
+    A whole-file ``Filter(must=[FieldCondition(metadata.file_id ...)])``
+    delete is exactly what #1602 forbids — even if it runs after upsert,
+    a future refactor must not blindly drop the whole file.
+    """
+
+    def test_stale_delete_uses_id_based_selector_when_orphans_exist(
+        self, writer_voyage, mock_qdrant_client, mock_voyage, mock_bge_client
+    ):
+        """When stale chunks exist (old ids not in the new batch), delete uses HasId."""
+        mock_qdrant_client.count.return_value = MagicMock(count=3)
+        # Existing stored points: 1 will be replaced (same chunk_location: order_0),
+        # 2 are stale orphans that should be swept after the upsert.
+        new_chunk_id = QdrantHybridWriter.generate_point_id("file_1", "order_0")
+        stale_id_a = "00000000-0000-0000-0000-aaaaaaaaaaaa"
+        stale_id_b = "00000000-0000-0000-0000-bbbbbbbbbbbb"
+        mock_qdrant_client.scroll.return_value = (
+            [
+                MagicMock(id=new_chunk_id),  # will collide with the upsert
+                MagicMock(id=stale_id_a),
+                MagicMock(id=stale_id_b),
+            ],
+            None,
+        )
+        mock_voyage._client.embed.return_value = MagicMock(embeddings=[[0.1] * 1024])
+        mock_bge_client.encode_sparse.return_value = MagicMock(
+            weights=[{"indices": [1], "values": [0.5]}]
+        )
+
+        chunk = _make_chunk(text="text 0", order=0)
+        stats = writer_voyage.upsert_chunks_sync([chunk], "file_1", "/p", {}, "col")
+
+        assert stats.errors is None
+        assert stats.points_upserted == 1
+
+        # Exactly one delete call, and it is restricted to the stale ids only
+        assert mock_qdrant_client.delete.call_count == 1
+        selector = mock_qdrant_client.delete.call_args.kwargs["points_selector"]
+        # Selector must reference the stale ids, not the file_id filter pattern
+        deleted_ids: list[str] = []
+        if isinstance(selector, list):
+            deleted_ids = [str(x) for x in selector]
+        elif hasattr(selector, "points"):
+            deleted_ids = [str(x) for x in selector.points]
+        else:
+            # Filter form: must be a HasIdCondition over stale ids, NOT the file_id field condition
+            for cond in getattr(selector, "must", []) or []:
+                if isinstance(cond, HasIdCondition):
+                    deleted_ids.extend(str(x) for x in cond.has_id)
+                    continue
+                # Forbid the legacy whole-file metadata.file_id selector
+                if hasattr(cond, "key"):
+                    pytest.fail(
+                        "Stale-delete must not use a metadata.file_id Filter; "
+                        f"got FieldCondition on key={cond.key!r}"
+                    )
+
+        assert set(deleted_ids) == {stale_id_a, stale_id_b}
+        # The new chunk id must NOT be in the delete set
+        assert new_chunk_id not in deleted_ids
+
+    def test_no_stale_delete_when_every_old_id_is_replaced(
+        self, writer_voyage, mock_qdrant_client, mock_voyage, mock_bge_client
+    ):
+        """If every existing point is replaced by an upsert with the same id, skip delete."""
+        mock_qdrant_client.count.return_value = MagicMock(count=2)
+        # _make_chunk(order=N) maps to chunk_location "order_N"
+        new_id_0 = QdrantHybridWriter.generate_point_id("file_1", "order_0")
+        new_id_1 = QdrantHybridWriter.generate_point_id("file_1", "order_1")
+        mock_qdrant_client.scroll.return_value = (
+            [MagicMock(id=new_id_0), MagicMock(id=new_id_1)],
+            None,
+        )
+        mock_voyage._client.embed.return_value = MagicMock(embeddings=[[0.1] * 1024] * 2)
+        mock_bge_client.encode_sparse.return_value = MagicMock(
+            weights=[{"indices": [1], "values": [0.5]}] * 2
+        )
+
+        chunks = [_make_chunk(text=f"text {i}", order=i) for i in range(2)]
+        stats = writer_voyage.upsert_chunks_sync(chunks, "file_1", "/p", {}, "col")
+
+        assert stats.errors is None
+        assert stats.points_upserted == 2
+        mock_qdrant_client.delete.assert_not_called()
+
+
+# Reuse fixtures from the sibling behavior test module
+pytest_plugins = ["tests.unit.ingestion.test_qdrant_writer_behavior"]

--- a/tests/unit/ingestion/test_qdrant_writer_behavior.py
+++ b/tests/unit/ingestion/test_qdrant_writer_behavior.py
@@ -53,6 +53,9 @@ def mock_qdrant_client():
     client.count.return_value = MagicMock(count=0)
     client.delete = MagicMock()
     client.upsert = MagicMock()
+    # Default: no orphan points exist for the file_id, so the post-upsert
+    # stale-id sweep finds nothing to delete (#1602 atomic-replace).
+    client.scroll.return_value = ([], None)
     return client
 
 
@@ -294,12 +297,17 @@ class TestUpsertChunksSyncBehavior:
         points = mock_qdrant_client.upsert.call_args.kwargs["points"]
         assert points[0].payload["file_id"] == "flat_fid"
 
-    def test_delete_called_before_upsert_replace_semantics(
+    def test_upsert_called_before_stale_delete_atomic_swap(
         self, writer_voyage, mock_qdrant_client, mock_voyage, mock_bge_client
     ):
-        """delete_file_sync must run before upsert (replace semantics)."""
+        """Upsert must run BEFORE the post-upsert stale-id sweep (#1602)."""
         call_order: list[str] = []
-        mock_qdrant_client.count.return_value = MagicMock(count=2)
+        # Pretend there's a stale orphan so a delete sweep is required after upsert
+        mock_qdrant_client.count.return_value = MagicMock(count=1)
+        mock_qdrant_client.scroll.return_value = (
+            [MagicMock(id="00000000-0000-0000-0000-stalexxxxxxx")],
+            None,
+        )
         mock_qdrant_client.delete.side_effect = lambda **_: call_order.append("delete")
         mock_qdrant_client.upsert.side_effect = lambda **_: call_order.append("upsert")
         mock_voyage._client.embed.return_value = MagicMock(embeddings=[[0.1] * 1024])
@@ -310,7 +318,8 @@ class TestUpsertChunksSyncBehavior:
         chunk = _make_chunk()
         writer_voyage.upsert_chunks_sync([chunk], "file_1", "/p", {}, "col")
 
-        assert call_order == ["delete", "upsert"]
+        # Replacement points become live first; stale ids are swept after.
+        assert call_order == ["upsert", "delete"]
 
     def test_stats_points_upserted_matches_chunk_count(
         self, writer_voyage, mock_qdrant_client, mock_voyage, mock_bge_client


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Closes #1602.

## Problem

`upsert_chunks_sync` / `upsert_chunks` in `src/ingestion/unified/qdrant_writer.py` deleted existing points for `file_id` **before** generating replacement embeddings and upserting them. Any failure during BGE-M3 sparse, Voyage, ColBERT, or the Qdrant upsert itself wiped the document from search until the next successful retry. The audit comment on the issue (2026-05-21) confirmed both `upsert_chunks` and `upsert_chunks_sync` still exhibited the bug on `dev`.

## Fix — atomic replace (write-then-delete-stale)

1. Build replacement embeddings + `PointStruct` list **first**.
2. Upsert with deterministic IDs (UUID5 over `file_id::chunk_location`), so any point at the same `chunk_location` is overwritten in place.
3. Only **after** a successful upsert, sweep stale orphan IDs: scroll the existing points by `metadata.file_id`, take the set difference vs. the new IDs, and delete those orphans via `HasIdCondition`. The legacy whole-file `Filter(must=[FieldCondition(metadata.file_id ...)])` delete is no longer used inside `upsert_chunks*`.

If any step before the post-upsert sweep raises, no destructive delete runs and the previous good version of the document remains searchable.

`delete_file` / `delete_file_sync` are kept untouched — they are still used by `qdrant_hybrid_target` for legitimate full-file deletion when a source file is removed.

## TDD trace (RED → GREEN)

### RED — `tests/unit/ingestion/test_qdrant_writer_atomic_replace.py` (new, 7 tests)

Initial run on `dev`:

```
FAILED ::TestEmbeddingFailureLeavesOldPointsIntact::test_voyage_embedding_failure_does_not_call_delete
FAILED ::TestEmbeddingFailureLeavesOldPointsIntact::test_sparse_embedding_failure_does_not_call_delete
FAILED ::TestEmbeddingFailureLeavesOldPointsIntact::test_local_hybrid_failure_does_not_call_delete
FAILED ::TestEmbeddingFailureLeavesOldPointsIntact::test_upsert_failure_does_not_call_delete
FAILED ::TestSuccessPathOrderingIsUpsertThenDelete::test_upsert_called_before_delete_on_success
FAILED ::TestStaleDeleteScopeIsRestrictedToOrphanIds::test_stale_delete_uses_id_based_selector_when_orphans_exist
FAILED ::TestStaleDeleteScopeIsRestrictedToOrphanIds::test_no_stale_delete_when_every_old_id_is_replaced
7 failed
```

### GREEN — after the fix

```
$ uv run --python 3.12 pytest tests/unit/ingestion/test_qdrant_writer_atomic_replace.py \
        tests/unit/ingestion/test_qdrant_writer_behavior.py -q
29 passed in 9.17s
```

## Files touched

| File | Change |
|---|---|
| `src/ingestion/unified/qdrant_writer.py` | Rewrote `upsert_chunks` and `upsert_chunks_sync` to build → upsert → stale-sweep order. Added `_delete_stale_points_sync` helper. Imported `HasIdCondition`. |
| `tests/unit/ingestion/test_qdrant_writer_atomic_replace.py` | **new** — 7 behaviour tests pinning failure-recovery, success-path ordering, and HasId stale-delete scope. |
| `tests/contract/test_qdrant_writer_atomic_replace_contract.py` | **new** — 6 AST guards forbidding `delete_file*` inside `upsert_chunks*`, requiring `_delete_stale_points_sync`, and pinning the upsert-before-sweep order. |
| `tests/unit/ingestion/test_qdrant_writer_behavior.py` | Inverted the obsolete `test_delete_called_before_upsert_replace_semantics` to `test_upsert_called_before_stale_delete_atomic_swap`, plus a default `client.scroll.return_value = ([], None)` on the shared `mock_qdrant_client` fixture. |

## Verification (fresh run)

```
$ uv run --python 3.12 pytest tests/unit/ingestion/ \
        tests/contract/test_qdrant_writer_atomic_replace_contract.py \
        tests/contract/test_writer_spec_fingerprint_contract.py \
        tests/contract/test_processing_fingerprint_contract.py -q
213 passed, 21 skipped (cocoindex extra not installed)

$ uv run --python 3.12 ruff check src/ingestion/unified/qdrant_writer.py \
        tests/unit/ingestion/test_qdrant_writer_atomic_replace.py \
        tests/contract/test_qdrant_writer_atomic_replace_contract.py
All checks passed!

$ uv run --python 3.12 ruff format --check src/ingestion/unified/qdrant_writer.py \
        tests/unit/ingestion/test_qdrant_writer_atomic_replace.py \
        tests/contract/test_qdrant_writer_atomic_replace_contract.py
4 files already formatted.

$ uv run --python 3.12 mypy src/ingestion/unified/qdrant_writer.py \
        --ignore-missing-imports --no-error-summary
(silent, exit 0)
```

## Context7 SDK check

Confirmed against `/qdrant/qdrant-client` (fresh): `client.scroll(collection_name, scroll_filter, limit, offset, with_payload, with_vectors)` returns `(records, next_offset)`; `client.delete(collection_name, points_selector=Filter(must=[HasIdCondition(has_id=[...])]))` removes points by ID list. Content was rephrased for compliance with licensing restrictions.

## Out of scope

- Async-path behaviour test — async `upsert_chunks` was rewritten symmetrically and is structurally protected by the new contract test, but a dedicated async fixture is not included to keep the PR focused. Async coverage can land in a follow-up.
- `try_update_ingestion_trace` event for the new `qdrant-delete-stale-points` span — not added; covered by existing `qdrant-upsert-chunks` span. Adding a new span would broaden the observability surface beyond the data-loss fix.
- Issue #1401 (furniture/furnished schema reconciliation) — separate iSP scope.

## Skill annotations

`using-git-worktrees` — work landed in `.worktrees/issue-1602/` against fresh `dev`.
`test-driven-development` — RED first (7 fails), then GREEN; old test inverted; new contract added.
`verification-before-completion` — `pytest`, `ruff check`, `ruff format --check`, `mypy` all clean; pre-existing `tests/contract` failures (#1810 / unrelated docker-compose) are out of scope.

Closes #1602