### PR TITLE
refactor(agent): make message-count trimmer intent explicit (#1257)

### DIFF
--- a/telegram_bot/agents/agent.py
+++ b/telegram_bot/agents/agent.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from langchain.agents import create_agent
 from langchain.agents.middleware import AgentState, before_model
-from langchain_core.messages import RemoveMessage
+from langchain_core.messages import BaseMessage, RemoveMessage
 from langchain_core.messages.utils import trim_messages
 from langchain_openai import ChatOpenAI
 from langgraph.graph.message import REMOVE_ALL_MESSAGES
@@ -29,6 +29,27 @@ LOCALE_TO_LANGUAGE: dict[str, str] = {
 }
 
 
+def _count_message_count(messages: list[BaseMessage]) -> int:
+    """Token-counter adapter that returns the message count rather than tokens.
+
+    Used as ``token_counter`` for :func:`trim_messages` to switch its behaviour
+    from token-budget trimming to message-count trimming. This is the
+    documented ``trim_messages`` pattern in langchain-core: when
+    ``token_counter=len`` is supplied, ``max_tokens`` is interpreted as the
+    maximum number of messages allowed in the window.
+
+    See: ``langchain_core.messages.utils.trim_messages`` reference docs,
+    "Token Counting Strategies" / "Using Message Count" sections.
+
+    The bare ``len`` works equally well, but a named adapter makes the intent
+    explicit at the call site and prevents an accidental future swap to a real
+    token counter without re-calibrating ``max_tokens`` from a message budget
+    to a token budget.
+    """
+
+    return len(messages)
+
+
 def _create_history_trimmer(max_messages: int) -> Any:
     """Return a before_model middleware that enforces a sliding-window history.
 
@@ -37,6 +58,13 @@ def _create_history_trimmer(max_messages: int) -> Any:
     actually deletes them (not just hides them).  trim_messages with
     start_on="human" ensures the remaining window starts on a clean turn
     boundary (no orphaned ToolMessages).
+
+    Implementation note (#1257): we use the documented langchain-core pattern
+    where ``token_counter`` returns a message count instead of tokens, so
+    ``max_tokens`` is interpreted as a message-count limit. The named adapter
+    :func:`_count_message_count` makes this intent explicit and prevents a
+    silent future regression where someone replaces the counter with a real
+    token counter without also rescaling ``max_tokens``.
 
     Args:
         max_messages: Maximum number of messages kept in state.
@@ -54,8 +82,11 @@ def _create_history_trimmer(max_messages: int) -> Any:
         to_keep = trim_messages(
             messages,
             strategy="last",
+            # Documented pattern: with token_counter=_count_message_count
+            # (i.e. message count), max_tokens is interpreted as the
+            # max number of messages, not tokens. See _count_message_count.
             max_tokens=max_messages,
-            token_counter=len,
+            token_counter=_count_message_count,
             start_on="human",
         )
 


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Pure semantic-clarity refactor for `_create_history_trimmer` in `telegram_bot/agents/agent.py`. Closes #1257.

The current call uses `trim_messages(..., token_counter=len, max_tokens=max_messages, ...)`. As confirmed via Context7 against the langchain-core reference docs, this **is** the documented `trim_messages` pattern for message-count-based trimming (see "Token Counting Strategies" / "Using Message Count" in `langchain_core.messages.utils.trim_messages`) — `trim_messages` has no `max_messages` parameter, so `token_counter=len` is the SDK-native idiom. The bug here is purely readability: at the call site `len` reads as a workaround and `max_tokens=max_messages` looks like a unit mismatch.

This PR replaces the bare `len` with a tiny named adapter `_count_message_count(messages) -> int` and adds docstring + inline-comment notes that point at the documented pattern.

## Why a thin adapter (not a code change)

- `_count_message_count` is a 1-line wrapper over `len` — zero behavior change.
- The named callable makes the intent explicit at the call site: "we are intentionally counting messages, not tokens".
- Prevents a silent future regression where someone swaps the counter for a real token counter (e.g. `count_tokens_approximately`) without also rescaling `max_tokens` from a message budget to a token budget — the named adapter is unique enough to surface in code review and refactor searches.

## Scope

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation / portfolio cleanup
- [ ] Infrastructure / deploy

## Files touched

- `telegram_bot/agents/agent.py` (+33 / -2)

## Validation

- [ ] `make check`
- [ ] `make test-unit`
- [ ] `make test`
- [x] Focused pytest on touched files (covered by existing tests at PR-time CI)
- [x] Other: `python3 -m py_compile telegram_bot/agents/agent.py` OK; `ruff check telegram_bot/agents/agent.py` → `All checks passed!`; AST analysis confirmed the only `trim_messages` call site now uses `token_counter=_count_message_count` and `max_tokens=max_messages`.

If any check above was skipped, state the reason explicitly:
> Skipped local `make test-unit` and full `pytest tests/unit/agents/test_agent_factory.py`: bootstrapping a full `uv sync` venv was unreliable in the sandbox where this PR was produced. The change is a pure rename refactor (`len` → `_count_message_count`, both `Callable[[list[BaseMessage]], int]`), so the contract that the existing 5 tests in `tests/unit/agents/test_agent_factory.py` already encode (`test_history_trimmer_noop_when_within_limit`, `test_history_trimmer_removes_old_messages_when_over_limit`, `test_history_trimmer_respects_start_on_human`, `test_history_trimmer_noop_when_no_human_message_fits_window`, `test_history_trimmer_handles_messages_without_ids`) is preserved by definition. CI is the gate.

## Runtime Impact

- [x] No runtime impact

## Reviewer Notes

- Behavior is identical: `_count_message_count` returns `len(messages)`. Imports add `BaseMessage` from `langchain_core.messages` for the adapter's type annotation.
- The choice of "thin named adapter + docstring" over "leave `len` and just add a comment" is intentional: a comment can drift from the code, a unique callable name is enforced by the import graph and is searchable.
- Followups for the rest of "repo-only Wave 1: SDK & Quick Fixes" milestone are intentionally out of scope.

## References

- Issue #1257
- Context7 source: `langchain-core` reference docs, `langchain_core.messages.utils.trim_messages` page — "Token Counting Strategies" and "Using Message Count" sections.
- Milestone: repo-only Wave 1: SDK & Quick Fixes