### PR TITLE
deps: drop unused langgraph-checkpoint-postgres (#1254)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,11 @@ dependencies = [
     # LangGraph Pipeline (2026-02-09)
     "langgraph>=1.0.3,<2.0",               # State graph for RAG pipeline
     "langchain-core>=1.2",                # Core abstractions (Embeddings, etc.)
-    "langgraph-checkpoint-postgres>=2.0", # Postgres checkpointing for LangGraph
     # Conversation memory (#154)
+    # NOTE (#1254): only the Redis checkpointer is wired (telegram_bot/integrations/memory.py
+    # uses AsyncRedisSaver / MemorySaver). The Postgres checkpointer was never instantiated,
+    # so langgraph-checkpoint-postgres is intentionally NOT a dependency. Re-add it (and a
+    # CheckpointerKind config flag) only when the Postgres path is actually wired.
     "langgraph-checkpoint-redis>=0.3.6",  # Redis checkpointer for LangGraph (0.3.0 fixes HumanMessage serialization #128)
     "langmem>=0.0.30",                    # SummarizationNode for conversation compression
     # Scheduled nurturing + analytics (#390)

--- a/uv.lock
+++ b/uv.lock
@@ -871,7 +871,6 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langfuse" },
     { name = "langgraph" },
-    { name = "langgraph-checkpoint-postgres" },
     { name = "langgraph-checkpoint-redis" },
     { name = "langmem" },
     { name = "numpy" },
@@ -1021,7 +1020,6 @@ requires-dist = [
     { name = "langchain-core", specifier = ">=1.2" },
     { name = "langfuse", specifier = ">=4.0.0,<5.0" },
     { name = "langgraph", specifier = ">=1.0.3,<2.0" },
-    { name = "langgraph-checkpoint-postgres", specifier = ">=2.0" },
     { name = "langgraph-checkpoint-redis", specifier = ">=0.3.6" },
     { name = "langmem", specifier = ">=0.0.30" },
     { name = "livekit", marker = "extra == 'voice'", specifier = "~=1.0" },
@@ -3278,21 +3276,6 @@ wheels = [
 ]
 
 [[package]]
-name = "langgraph-checkpoint-postgres"
-version = "3.0.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "langgraph-checkpoint" },
-    { name = "orjson" },
-    { name = "psycopg" },
-    { name = "psycopg-pool" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/95/7a/8f439966643d32111248a225e6cb33a182d07c90de780c4dbfc1e0377832/langgraph_checkpoint_postgres-3.0.5.tar.gz", hash = "sha256:a8fd7278a63f4f849b5cbc7884a15ca8f41e7d5f7467d0a66b31e8c24492f7eb", size = 127856, upload-time = "2026-03-18T21:25:29.785Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/87/b0f98b33a67204bca9d5619bcd9574222f6b025cf3c125eedcec9a50ecbc/langgraph_checkpoint_postgres-3.0.5-py3-none-any.whl", hash = "sha256:86d7040a88fd70087eaafb72251d796696a0a2d856168f5c11ef620771411552", size = 42907, upload-time = "2026-03-18T21:25:28.75Z" },
-]
-
-[[package]]
 name = "langgraph-checkpoint-redis"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5476,31 +5459,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
     { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
     { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
-]
-
-[[package]]
-name = "psycopg"
-version = "3.3.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/1a/7d9ef4fdc13ef7f15b934c393edc97a35c281bb7d3c3329fbfcbe915a7c2/psycopg-3.3.2.tar.gz", hash = "sha256:707a67975ee214d200511177a6a80e56e654754c9afca06a7194ea6bbfde9ca7", size = 165630, upload-time = "2025-12-06T17:34:53.899Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/51/2779ccdf9305981a06b21a6b27e8547c948d85c41c76ff434192784a4c93/psycopg-3.3.2-py3-none-any.whl", hash = "sha256:3e94bc5f4690247d734599af56e51bae8e0db8e4311ea413f801fef82b14a99b", size = 212774, upload-time = "2025-12-06T17:31:41.414Z" },
-]
-
-[[package]]
-name = "psycopg-pool"
-version = "3.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/56/9a/9470d013d0d50af0da9c4251614aeb3c1823635cab3edc211e3839db0bcf/psycopg_pool-3.3.0.tar.gz", hash = "sha256:fa115eb2860bd88fce1717d75611f41490dec6135efb619611142b24da3f6db5", size = 31606, upload-time = "2025-12-01T11:34:33.11Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/c3/26b8a0908a9db249de3b4169692e1c7c19048a9bc41a4d3209cee7dbb758/psycopg_pool-3.3.0-py3-none-any.whl", hash = "sha256:2e44329155c410b5e8666372db44276a8b1ebd8c90f1c3026ebba40d4bc81063", size = 39995, upload-time = "2025-12-01T11:34:29.761Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #1254. Removes `langgraph-checkpoint-postgres>=2.0` from the root `pyproject.toml` because it has never been wired in code.

## Verification

```bash
$ grep -rn -E "AsyncPostgresSaver|PostgresSaver|langgraph[._-]checkpoint[._-]postgres" --include="*.py" .
# 0 hits
$ grep -rn -E "^\s*(import|from)\s+psycopg" --include="*.py" .
# 0 hits
```

The only mention was the line in `pyproject.toml` itself. `telegram_bot/integrations/memory.py` only constructs `AsyncRedisSaver` (and `MemorySaver` as a test fallback). `telegram_bot/pyproject.toml` (the bot subproject) never listed Postgres.

## Lockfile impact

`uv lock` resolved cleanly and dropped 3 packages from `uv.lock`:

- `langgraph-checkpoint-postgres v3.0.5`
- `psycopg v3.3.2`
- `psycopg-pool v3.3.0`

`asyncpg` is **kept** — it is used by code paths unrelated to LangGraph checkpointing (e.g. direct Postgres for nurturing/analytics).

## What was tested

- `uv lock` exit 0, 372 packages resolved.
- Repo-wide grep confirms no direct `psycopg` imports.

## Follow-up

If a Postgres checkpointer is later required (multi-instance, durable conversation state across restarts beyond Redis TTL), it should be reintroduced **with** a `CheckpointerKind` config flag and a wiring path in `memory.py`, not as a silent transitive dep. An inline comment in `pyproject.toml` marks the slot so this is explicit.

## Known limitations

- Did not run `uv sync` in the sandbox (heavy install) — `uv lock` is sufficient to prove the manifest resolves; CI on `dev` will exercise the full sync + tests.