### PR TITLE
fix(ingestion): replace sys.exit() in service main() with return codes (#1072 slice 1)

### DIFF
--- a/telegram_bot/services/ingestion_cocoindex.py
+++ b/telegram_bot/services/ingestion_cocoindex.py
@@ -64,21 +64,28 @@ async def get_ingestion_status(collection_name: str = "documents") -> dict[str, 
     return await _get_ingestion_status(collection_name)
 
 
-def main():
-    """CLI entry point for Makefile integration."""
+def main() -> int:
+    """CLI entry point for Makefile integration.
+
+    Returns the process exit code (0 on success, 1 on usage error or unknown
+    command) rather than calling ``sys.exit`` from inside the function body
+    (#1072). Single ``sys.exit(main())`` lives at the ``__main__`` guard so
+    the function is testable in-process and any caller that imports
+    :func:`main` cannot accidentally terminate its host interpreter.
+    """
     if len(sys.argv) < 2:
         print("Usage:")
         print("  python -m telegram_bot.services.ingestion_cocoindex ingest-dir <path>")
         print("  python -m telegram_bot.services.ingestion_cocoindex ingest-gdrive <folder_id>")
         print("  python -m telegram_bot.services.ingestion_cocoindex status")
-        sys.exit(1)
+        return 1
 
     command = sys.argv[1]
 
     if command == "ingest-dir":
         if len(sys.argv) < 3:
             print("Error: Directory path required")
-            sys.exit(1)
+            return 1
         directory = sys.argv[2]
         stats = asyncio.run(ingest_from_directory(directory))
         print("\nIngestion complete:")
@@ -87,11 +94,12 @@ def main():
         print(f"  Duration: {stats.duration_seconds:.2f}s")
         if stats.errors:
             print(f"  Errors: {stats.errors}")
+        return 0
 
-    elif command == "ingest-gdrive":
+    if command == "ingest-gdrive":
         if len(sys.argv) < 3:
             print("Error: Folder ID required")
-            sys.exit(1)
+            return 1
         folder_id = sys.argv[2]
         stats = asyncio.run(ingest_from_gdrive(folder_id))
         print("\nIngestion complete:")
@@ -100,17 +108,18 @@ def main():
         print(f"  Duration: {stats.duration_seconds:.2f}s")
         if stats.errors:
             print(f"  Errors: {stats.errors}")
+        return 0
 
-    elif command == "status":
+    if command == "status":
         status = asyncio.run(get_ingestion_status())
         print("\nCollection status:")
         for key, value in status.items():
             print(f"  {key}: {value}")
+        return 0
 
-    else:
-        print(f"Unknown command: {command}")
-        sys.exit(1)
+    print(f"Unknown command: {command}")
+    return 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Refs #1072. Slice 1 of N.

## What

`telegram_bot/services/ingestion_cocoindex.main` previously called `sys.exit(1)` from inside the function body in 4 spots — issue's bullet 5 (sudden process termination in service code).

This PR refactors `main()` to return an `int` exit code and moves the single `sys.exit` to the `__main__` guard — the standard Python CLI idiom that keeps `main()` testable in-process and prevents accidental host-interpreter termination from any future caller that imports `main`.

| Before | After |
|---|---|
| 4× `sys.exit(1)` inside `main()` body | 7× `return 0/1` (one per branch), single `sys.exit(main())` at `__main__` guard |
| `def main():` | `def main() -> int:` |
| not testable | testable in-process |

No external behavior change — Makefile / shell consumers get the same exit codes.

## Why this slice

Issue #1072 enumerates ~200+ findings across 5 categories. A single PR cannot review all of them. Slice 1 picks the **narrowest, fully-bounded** fix from bullet 5 — one file, no behaviour change for callers, demonstrates the pattern other CLI mains can follow.

Some of the issue's claims are **already resolved at HEAD**:
- `TELEGRAM_MESSAGE_LIMIT` lives in `telegram_bot/constants/__init__.py`; the dup `_TELEGRAM_MESSAGE_LIMIT = 4096` in `bot.py` + `pipelines/client.py` is gone.
- `CACHE_KEY_PREFIXES` is no longer dup'd between `preflight.py` and `services/cache.py` — only `preflight.py` defines it.

## Out of scope (explicit follow-ups, not regressed by this PR)

| Slice | Scope | Notes |
|---|---|---|
| 2 | Bare `except Exception` cleanup (216 at HEAD, was 188) | One PR per module: observability.py / error_handler.py / rag_pipeline.py / agent.py / voice/agent.py |
| 3 | Move `_FEEDBACK_CONFIRMATION_TTL_S`, `_APARTMENT_PAGE_SIZE`, scattered 3600/86400 TTL → `constants` | Mechanical, but per-touch needs migration assertion |
| 4 | Replace `global _langfuse_*` (observability.py:371-373, 499-501), `_force_chat_completions_fallback`/`_compat_checked` (session_summary.py), `_writer_instance` (runtime_events.py) with module-level dataclass | Hot path; needs focused review |
| 5 | Same `sys.exit` → return-code refactor for the other 5 CLIs (`evaluation/ragas_evaluation.py`, `evaluation/smoke_test.py`, `ingestion/unified/cli.py`, `src/config/settings.py`) | This PR's pattern is the template |

## Verification

- `python3 -m py_compile telegram_bot/services/ingestion_cocoindex.py` OK.
- `ruff check telegram_bot/services/ingestion_cocoindex.py` `All checks passed!`
- AST sanity:
  - 0 `sys.exit` calls inside `main()` body.
  - `main` return annotation is `int`.
  - 7 typed `return` statements (1 per branch).
  - Exactly 1 `sys.exit` at module level — the `__main__` guard.
- `grep -r ingestion_cocoindex.main` — no external callers of `main`, so changing its return type is safe.