### PR TITLE
refactor(keyboards): migrate feedback + services to InlineKeyboardBuilder (#1238)

### DIFF
--- a/telegram_bot/feedback.py
+++ b/telegram_bot/feedback.py
@@ -1,10 +1,15 @@
-"""User feedback utilities — inline keyboard builder and callback parser (#229, #755)."""
+"""User feedback utilities — inline keyboard builder and callback parser (#229, #755).
+
+Keyboards are constructed with :class:`aiogram.utils.keyboard.InlineKeyboardBuilder`
+to follow the SDK convention enforced by issue #1238.
+"""
 
 from __future__ import annotations
 
 import logging
 
-from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from aiogram.types import InlineKeyboardMarkup
+from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 from .callback_data import FeedbackCB, FeedbackReasonCB
 
@@ -34,54 +39,49 @@ _REASON_LABELS: dict[str, str] = {
 
 
 def build_feedback_keyboard(trace_id: str) -> InlineKeyboardMarkup:
-    """Build inline keyboard with like/dislike buttons encoding trace_id."""
-    return InlineKeyboardMarkup(
-        inline_keyboard=[
-            [
-                InlineKeyboardButton(
-                    text="\U0001f44d Полезно",
-                    callback_data=FeedbackCB(action="like", trace_id=trace_id).pack(),
-                ),
-                InlineKeyboardButton(
-                    text="\U0001f44e Не помогло",
-                    callback_data=FeedbackCB(action="dislike", trace_id=trace_id).pack(),
-                ),
-            ]
-        ]
+    """Build inline keyboard with like/dislike buttons encoding ``trace_id``.
+
+    Layout: a single row of 2 buttons.
+    """
+    builder = InlineKeyboardBuilder()
+    builder.button(
+        text="\U0001f44d Полезно",
+        callback_data=FeedbackCB(action="like", trace_id=trace_id),
     )
+    builder.button(
+        text="\U0001f44e Не помогло",
+        callback_data=FeedbackCB(action="dislike", trace_id=trace_id),
+    )
+    builder.adjust(2)
+    return builder.as_markup()
 
 
 def build_dislike_reason_keyboard(trace_id: str) -> InlineKeyboardMarkup:
-    """Build inline keyboard with 6 dislike reason buttons (3 rows × 2) (#755)."""
-    # dict insertion order guaranteed in Python 3.7+; layout follows _REASON_CODES order
-    codes = list(_REASON_CODES.keys())
-    rows = []
-    for i in range(0, len(codes), 2):
-        row = []
-        for code in codes[i : i + 2]:
-            row.append(
-                InlineKeyboardButton(
-                    text=_REASON_LABELS[code],
-                    callback_data=FeedbackReasonCB(code=code, trace_id=trace_id).pack(),
-                )
-            )
-        rows.append(row)
-    return InlineKeyboardMarkup(inline_keyboard=rows)
+    """Build inline keyboard with 6 dislike reason buttons (3 rows × 2) (#755).
+
+    Button order follows :data:`_REASON_CODES` insertion order, which is
+    guaranteed since Python 3.7.
+    """
+    builder = InlineKeyboardBuilder()
+    for code in _REASON_CODES:
+        builder.button(
+            text=_REASON_LABELS[code],
+            callback_data=FeedbackReasonCB(code=code, trace_id=trace_id),
+        )
+    builder.adjust(2)
+    return builder.as_markup()
 
 
 def build_feedback_confirmation(*, liked: bool) -> InlineKeyboardMarkup:
     """Build single-button confirmation keyboard after feedback submitted."""
     emoji = "\u2705" if liked else "\U0001f4dd"
-    return InlineKeyboardMarkup(
-        inline_keyboard=[
-            [
-                InlineKeyboardButton(
-                    text=f"{emoji} Спасибо за отзыв!",
-                    callback_data=FeedbackCB(action="done", trace_id="").pack(),
-                ),
-            ]
-        ]
+    builder = InlineKeyboardBuilder()
+    builder.button(
+        text=f"{emoji} Спасибо за отзыв!",
+        callback_data=FeedbackCB(action="done", trace_id=""),
     )
+    builder.adjust(1)
+    return builder.as_markup()
 
 
 def parse_feedback_callback(data: str) -> tuple[float, str, str | None] | None:

--- a/telegram_bot/keyboards/services_keyboard.py
+++ b/telegram_bot/keyboards/services_keyboard.py
@@ -1,10 +1,15 @@
-"""Services inline keyboard and CTA buttons (#628)."""
+"""Services inline keyboard and CTA buttons (#628).
+
+Keyboards are constructed with :class:`aiogram.utils.keyboard.InlineKeyboardBuilder`
+to follow the SDK convention enforced by issue #1238.
+"""
 
 from __future__ import annotations
 
 from typing import Any
 
-from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from aiogram.types import InlineKeyboardMarkup
+from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 from telegram_bot.services.content_loader import load_services_config
 
@@ -14,29 +19,26 @@ _CTA_PREFIX = "cta:"
 
 
 def build_services_menu(i18n: Any = None) -> InlineKeyboardMarkup:
-    """Build inline keyboard with service list."""
+    """Build inline keyboard with service list (one button per row + back button)."""
     config = load_services_config()
     services = config.get("services", {})
 
-    rows = []
+    builder = InlineKeyboardBuilder()
     for key, svc in services.items():
         ftl_key = f"svc-{key.replace('_', '-')}-title"
         title = (i18n.get(ftl_key) if i18n is not None else None) or svc["title"]  # type: ignore[union-attr]
-        rows.append(
-            [
-                InlineKeyboardButton(
-                    text=f"{svc['emoji']} {title}",
-                    callback_data=svc["callback_id"],
-                )
-            ]
+        builder.button(
+            text=f"{svc['emoji']} {title}",
+            callback_data=svc["callback_id"],
         )
     back_text = (i18n.get("svc-back") if i18n is not None else None) or "Назад"  # type: ignore[union-attr]
-    rows.append([InlineKeyboardButton(text=f"← {back_text}", callback_data=f"{_SVC_PREFIX}back")])
-    return InlineKeyboardMarkup(inline_keyboard=rows)
+    builder.button(text=f"← {back_text}", callback_data=f"{_SVC_PREFIX}back")
+    builder.adjust(1)
+    return builder.as_markup()
 
 
 def build_service_card_buttons(service_key: str, i18n: Any = None) -> InlineKeyboardMarkup:
-    """Build CTA buttons for a service card."""
+    """Build CTA buttons for a service card (3 rows × 1 button)."""
     get_offer_text = (i18n.get("svc-get-offer") if i18n is not None else None) or "Оставить заявку"  # type: ignore[union-attr]
     manager_text = (
         i18n.get("svc-contact-manager") if i18n is not None else None
@@ -44,28 +46,22 @@ def build_service_card_buttons(service_key: str, i18n: Any = None) -> InlineKeyb
     back_text = (
         i18n.get("svc-back-to-services") if i18n is not None else None
     ) or "Назад к услугам"  # type: ignore[union-attr]
-    return InlineKeyboardMarkup(
-        inline_keyboard=[
-            [
-                InlineKeyboardButton(
-                    text=f"📩 {get_offer_text}",
-                    callback_data=f"{_CTA_PREFIX}get_offer:{service_key}",
-                )
-            ],
-            [
-                InlineKeyboardButton(
-                    text=f"👤 {manager_text}",
-                    callback_data=f"{_CTA_PREFIX}manager:{service_key}",
-                )
-            ],
-            [
-                InlineKeyboardButton(
-                    text=f"← {back_text}",
-                    callback_data=f"{_SVC_PREFIX}menu",
-                )
-            ],
-        ]
+
+    builder = InlineKeyboardBuilder()
+    builder.button(
+        text=f"📩 {get_offer_text}",
+        callback_data=f"{_CTA_PREFIX}get_offer:{service_key}",
     )
+    builder.button(
+        text=f"👤 {manager_text}",
+        callback_data=f"{_CTA_PREFIX}manager:{service_key}",
+    )
+    builder.button(
+        text=f"← {back_text}",
+        callback_data=f"{_SVC_PREFIX}menu",
+    )
+    builder.adjust(1)
+    return builder.as_markup()
 
 
 def parse_service_callback(data: str) -> tuple[str, str | None] | None:

--- a/tests/unit/test_inline_keyboard_builder_contract.py
+++ b/tests/unit/test_inline_keyboard_builder_contract.py
@@ -1,0 +1,135 @@
+"""Contract tests for Issue #1238: prefer aiogram InlineKeyboardBuilder.
+
+The SDK registry rule is: "НЕ писать кастомные InlineKeyboard для навигации
+— использовать Select/Button/SwitchTo / InlineKeyboardBuilder".
+
+These tests enforce the migration target in two static-keyboard modules:
+  - telegram_bot/feedback.py
+  - telegram_bot/keyboards/services_keyboard.py
+
+Behavioural contracts (button counts, callback_data, labels) are already
+covered by tests/unit/test_feedback.py and tests/unit/test_feedback_handler.py.
+This file only enforces the *implementation pattern* — that the modules use
+InlineKeyboardBuilder and never construct ``InlineKeyboardMarkup`` manually
+with the ``inline_keyboard=`` kwarg.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+SOURCES = {
+    "feedback": Path("telegram_bot/feedback.py"),
+    "services_keyboard": Path("telegram_bot/keyboards/services_keyboard.py"),
+}
+
+
+def _module_source(key: str) -> str:
+    path = SOURCES[key]
+    assert path.exists(), f"Expected source file {path} to exist"
+    return path.read_text(encoding="utf-8")
+
+
+def _module_ast(key: str) -> ast.Module:
+    return ast.parse(_module_source(key))
+
+
+# ---------------------------------------------------------------------------
+# Import contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("module", ["feedback", "services_keyboard"])
+def test_module_imports_inline_keyboard_builder(module: str) -> None:
+    """Each migrated module must import ``InlineKeyboardBuilder``."""
+    tree = _module_ast(module)
+    found = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "aiogram.utils.keyboard":
+            for alias in node.names:
+                if alias.name == "InlineKeyboardBuilder":
+                    found = True
+                    break
+        if found:
+            break
+    assert found, (
+        f"telegram_bot/{SOURCES[module]} must import InlineKeyboardBuilder from "
+        f"aiogram.utils.keyboard (issue #1238 SDK convention)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Construction contract — no manual InlineKeyboardMarkup(inline_keyboard=...)
+# ---------------------------------------------------------------------------
+
+
+def _calls_inline_keyboard_markup_with_kwarg(tree: ast.Module) -> list[ast.Call]:
+    """Find ``InlineKeyboardMarkup(inline_keyboard=...)`` constructor calls.
+
+    The migration replaces these with ``builder.as_markup()``. A bare
+    ``InlineKeyboardMarkup`` reference (e.g. as a return-type annotation) is
+    still allowed and not flagged here.
+    """
+    offending: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # Match both `InlineKeyboardMarkup(...)` and `aiogram.types.InlineKeyboardMarkup(...)`.
+        is_markup_ctor = (isinstance(func, ast.Name) and func.id == "InlineKeyboardMarkup") or (
+            isinstance(func, ast.Attribute) and func.attr == "InlineKeyboardMarkup"
+        )
+        if not is_markup_ctor:
+            continue
+        # Only flag the manual construction pattern that #1238 wants gone.
+        if any(kw.arg == "inline_keyboard" for kw in node.keywords):
+            offending.append(node)
+    return offending
+
+
+@pytest.mark.parametrize("module", ["feedback", "services_keyboard"])
+def test_module_uses_builder_not_manual_markup(module: str) -> None:
+    """No manual ``InlineKeyboardMarkup(inline_keyboard=...)`` constructions."""
+    tree = _module_ast(module)
+    offending = _calls_inline_keyboard_markup_with_kwarg(tree)
+    if offending:
+        locations = ", ".join(f"line {call.lineno}" for call in offending)
+        pytest.fail(
+            f"telegram_bot/{SOURCES[module]} still constructs InlineKeyboardMarkup "
+            f"manually at {locations}. Issue #1238 requires using "
+            f"InlineKeyboardBuilder().as_markup() instead."
+        )
+
+
+@pytest.mark.parametrize("module", ["feedback", "services_keyboard"])
+def test_module_invokes_builder(module: str) -> None:
+    """At least one ``InlineKeyboardBuilder()`` instantiation must be present."""
+    tree = _module_ast(module)
+    found = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "InlineKeyboardBuilder"
+        ):
+            found = True
+            break
+    assert found, (
+        f"telegram_bot/{SOURCES[module]} must instantiate InlineKeyboardBuilder() at "
+        f"least once after the issue #1238 migration."
+    )
+
+
+@pytest.mark.parametrize("module", ["feedback", "services_keyboard"])
+def test_module_calls_as_markup(module: str) -> None:
+    """Builders must be finalized via ``.as_markup()`` so the public API stays
+    ``InlineKeyboardMarkup`` for callers."""
+    src = _module_source(module)
+    assert ".as_markup()" in src, (
+        f"telegram_bot/{SOURCES[module]} must call ``.as_markup()`` to finalize "
+        f"its InlineKeyboardBuilder (issue #1238)."
+    )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Migrates the two static-keyboard modules called out as low-effort wins in #1238 to the SDK-native `aiogram.utils.keyboard.InlineKeyboardBuilder` pattern already used by `telegram_bot/keyboards/demo_keyboard.py`.

| Module | Function | Layout |
| --- | --- | --- |
| `telegram_bot/feedback.py` | `build_feedback_keyboard` | 1 row × 2 buttons |
| `telegram_bot/feedback.py` | `build_dislike_reason_keyboard` | 3 rows × 2 buttons |
| `telegram_bot/feedback.py` | `build_feedback_confirmation` | 1 row × 1 button |
| `telegram_bot/keyboards/services_keyboard.py` | `build_services_menu` | services + back (1 per row) |
| `telegram_bot/keyboards/services_keyboard.py` | `build_service_card_buttons` | 3 rows × 1 button |

`InlineKeyboardBuilder.button()` accepts typed `CallbackData` instances directly (`FeedbackCB`, `FeedbackReasonCB`), so callback payloads are byte-identical to the previous `.pack()` output — no parser changes needed.

## Behaviour preservation

The behavioural contracts are already covered by:

- `tests/unit/test_feedback.py` — button counts, callback_data format, labels, 64-byte limit, parser
- `tests/unit/test_feedback_handler.py` — 2-step dislike flow, Langfuse score writes, confirmation cleanup
- `tests/unit/test_callback_data.py` — round-trip `FeedbackCB` / `FeedbackReasonCB` → `parse_feedback_callback`

All continue to pass after the refactor (`83 passed`).

## TDD red → green

New AST-based contract tests in `tests/unit/test_inline_keyboard_builder_contract.py` (8 cases):

- both modules import `InlineKeyboardBuilder` from `aiogram.utils.keyboard`
- neither module calls `InlineKeyboardMarkup(inline_keyboard=...)` (the manual pattern called out by #1238)
- both modules instantiate `InlineKeyboardBuilder()` at least once
- both modules finalize via `.as_markup()`

These guard against regression to the manual construction pattern.

```
$ uv run --python 3.12 pytest \
    tests/unit/test_inline_keyboard_builder_contract.py \
    tests/unit/test_feedback.py \
    tests/unit/test_feedback_handler.py \
    tests/unit/test_callback_data.py -q
83 passed, 1 warning in 3.14s

$ uv run --python 3.12 pytest tests/unit/ -k "feedback or service_keyboard or callback_data" \
    --ignore=tests/unit/api --ignore=tests/unit/mini_app --ignore=tests/unit/voice -q
117 passed, 16 skipped, 6698 deselected, 10 warnings in 9.15s
```

## Out of scope (intentional)

The full #1238 issue lists more migration targets (`crm_cards.py`, several call sites in `bot.py`, `phone_collector` keyboards, `property_card.py`, HITL confirmation, `clearcache`). This PR focuses on the two smallest, highest-test-coverage modules to land the SDK convention without churning behaviourally-rich call sites. Follow-ups can take the remaining files one PR at a time, gated by the new AST contract tests, which are scoped per-module via `SOURCES` and easy to extend.

Refs #1238