### PR TITLE
fix(observability): suppress Langfuse Pydantic V1 UserWarning (#1381)

### DIFF
--- a/telegram_bot/observability.py
+++ b/telegram_bot/observability.py
@@ -13,6 +13,7 @@ import contextlib
 import json
 import logging
 import os
+import warnings
 from datetime import UTC, datetime
 from typing import Any
 
@@ -26,6 +27,37 @@ from telegram_bot.observability_bootstrap import (
 
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Issue #1381 — suppress the Langfuse SDK Pydantic V1 UserWarning
+# ---------------------------------------------------------------------------
+
+
+def _install_langfuse_warning_filters() -> None:
+    """Suppress the Langfuse Pydantic V1 ``UserWarning`` on Python 3.14+.
+
+    Langfuse SDK 4.3.x's internal compat shim imports ``pydantic.v1`` which
+    Pydantic 2 deliberately deprecates on Python 3.14 with::
+
+        UserWarning: Core Pydantic V1 functionality isn't compatible with
+        Python 3.14 or greater.
+
+    The warning is harmless today — Langfuse only touches a tiny v1 surface —
+    but it pollutes every bot run, test, and validation script. We install a
+    *narrowly scoped* filter that drops only this specific message, so any
+    unrelated ``UserWarning`` (e.g. from our own code) still surfaces.
+    """
+    warnings.filterwarnings(
+        "ignore",
+        message=r"Core Pydantic V1 functionality isn't compatible with Python 3\.14.*",
+        category=UserWarning,
+    )
+
+
+# Apply the filter as early as possible — before the guarded Langfuse import
+# below — so the warning never reaches stderr / Loki / pytest captures.
+_install_langfuse_warning_filters()
 
 _MAX_PII_TEXT_LENGTH = 4000
 _MODEL_DEFINITIONS_ENV = "LANGFUSE_MODEL_DEFINITIONS_JSON"

--- a/tests/unit/test_langfuse_pydantic_warning.py
+++ b/tests/unit/test_langfuse_pydantic_warning.py
@@ -1,0 +1,133 @@
+"""Contract tests for Issue #1381: suppress Langfuse Pydantic V1 warning.
+
+Langfuse SDK 4.3.x emits a ``UserWarning`` on every import under
+Python 3.14 because its internal compat shim still touches
+``pydantic.v1``::
+
+    UserWarning: Core Pydantic V1 functionality isn't compatible with
+    Python 3.14 or greater.
+
+The warning is harmless today but pollutes every bot run, test, and
+validation script. The fix is a *narrowly scoped* warning filter
+installed by ``telegram_bot.observability`` before the Langfuse import
+so the noise is gone in CI logs and ``logs/bot-run.log``.
+
+These tests do not require Python 3.14 — they exercise the filter
+helper directly with a synthetic warning, which is how aiogram's own
+test-suite validates filter contracts.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+
+# ---------------------------------------------------------------------------
+# Filter helper contract
+# ---------------------------------------------------------------------------
+
+
+def test_install_langfuse_warning_filters_is_exposed() -> None:
+    """The observability module must expose the filter installer publicly."""
+    from telegram_bot import observability
+
+    assert hasattr(observability, "_install_langfuse_warning_filters"), (
+        "telegram_bot.observability must expose `_install_langfuse_warning_filters` "
+        "so the suppression target is documented and testable (issue #1381)."
+    )
+
+
+def test_filter_suppresses_pydantic_v1_warning() -> None:
+    """The installed filter must drop the Langfuse Pydantic V1 UserWarning."""
+    from telegram_bot.observability import _install_langfuse_warning_filters
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.resetwarnings()
+        warnings.simplefilter("always")
+        _install_langfuse_warning_filters()
+        # Replay the exact warning Langfuse emits at import time.
+        warnings.warn(
+            "Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.",
+            UserWarning,
+            stacklevel=1,
+        )
+
+    pydantic_warnings = [w for w in captured if "Core Pydantic V1" in str(w.message)]
+    assert not pydantic_warnings, (
+        "issue #1381: Langfuse Pydantic V1 UserWarning must be suppressed; "
+        f"saw: {[str(w.message) for w in pydantic_warnings]!r}"
+    )
+
+
+def test_filter_does_not_swallow_unrelated_warnings() -> None:
+    """The filter must be narrow — only the Pydantic V1 message is dropped."""
+    from telegram_bot.observability import _install_langfuse_warning_filters
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.resetwarnings()
+        warnings.simplefilter("always")
+        _install_langfuse_warning_filters()
+        # Unrelated UserWarning must still surface.
+        warnings.warn("totally unrelated warning", UserWarning, stacklevel=1)
+        # DeprecationWarning must still surface.
+        warnings.warn("totally unrelated deprecation", DeprecationWarning, stacklevel=1)
+
+    user_msgs = [str(w.message) for w in captured if w.category is UserWarning]
+    deprecation_msgs = [str(w.message) for w in captured if w.category is DeprecationWarning]
+    assert "totally unrelated warning" in user_msgs, (
+        "Filter must only drop the Pydantic V1 message; unrelated UserWarnings "
+        f"must still be visible. Captured: {user_msgs!r}"
+    )
+    assert "totally unrelated deprecation" in deprecation_msgs, (
+        f"Filter must not drop DeprecationWarning. Captured: {deprecation_msgs!r}"
+    )
+
+
+def test_filter_runs_at_module_import() -> None:
+    """The filter must be applied as a side-effect of importing the module.
+
+    Pytest's own ``filterwarnings`` plugin resets ``warnings.filters`` between
+    tests, so we re-import the module under a clean filter state and then
+    inspect ``warnings.filters`` to confirm the import installs the filter.
+    """
+    import importlib
+    import sys
+
+    # Reset filter state so we observe the import-time side effect cleanly.
+    with warnings.catch_warnings():
+        warnings.resetwarnings()
+        # Force re-import so module-level code runs again.
+        sys.modules.pop("telegram_bot.observability", None)
+        importlib.import_module("telegram_bot.observability")
+
+        # Each entry in warnings.filters is a 5-tuple:
+        # (action, message-regex, category, module-regex, lineno).
+        pydantic_filters = [
+            f for f in warnings.filters if f[1] is not None and "Pydantic V1" in f[1].pattern
+        ]
+        assert pydantic_filters, (
+            "issue #1381: importing telegram_bot.observability must install a "
+            "warnings filter targeting the Langfuse Pydantic V1 message"
+        )
+        actions = {f[0] for f in pydantic_filters}
+        assert "ignore" in actions, (
+            "The Pydantic V1 filter must use action='ignore' to suppress the warning; "
+            f"saw actions={actions!r}"
+        )
+
+
+def test_no_blanket_userwarning_filter_added() -> None:
+    """The fix must not blanket-ignore *all* UserWarnings."""
+    from telegram_bot import observability  # noqa: F401
+
+    # Look for any UserWarning filter without a message regex — that would be
+    # a blanket suppression and would hide unrelated warnings.
+    blanket = [
+        f
+        for f in warnings.filters
+        if f[0] == "ignore" and f[2] is UserWarning and (f[1] is None or f[1].pattern in {".*", ""})
+    ]
+    assert not blanket, (
+        "issue #1381: filter must target the specific Langfuse Pydantic V1 "
+        f"message, not blanket-ignore UserWarning. Found: {blanket!r}"
+    )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Suppresses the noisy `UserWarning` Langfuse SDK 4.3.x emits on every import under Python 3.14:

```
UserWarning: Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.
```

The warning is harmless today (Langfuse only touches a tiny `pydantic.v1` surface) but pollutes every bot run, every test, every validation script — and masks unrelated warnings from our own code.

## Approach

- Adds `_install_langfuse_warning_filters()` in `telegram_bot.observability` and applies it as a module-import side effect, **before** the guarded Langfuse import.
- The filter is narrowly scoped: it only matches the exact Pydantic V1 / 3.14 message — unrelated `UserWarning` and `DeprecationWarning` still surface.

## Tests

`tests/unit/test_langfuse_pydantic_warning.py` (5 cases, TDD red → green):
- The helper is exposed publicly.
- The filter drops the exact Langfuse Pydantic V1 message.
- The filter does **not** blanket-ignore `UserWarning` or `DeprecationWarning`.
- Importing `telegram_bot.observability` installs the filter as a side effect (verified via `importlib.reload` under a clean `warnings.filters` state).

```
$ uv run --python 3.12 pytest tests/unit/test_langfuse_pydantic_warning.py -q
.....                                                                    [100%]
5 passed in 0.45s
```

## Limitations

- Tested on Python 3.12 by replaying the warning synthetically (the same approach aiogram and other SDKs use to validate filter contracts). The actual Python 3.14 reproduction was confirmed in issue #1381.
- This is a forward-compatible workaround. When Langfuse SDK drops the `pydantic.v1` shim upstream, the filter becomes a no-op (no message → nothing to suppress) and can be removed.

Refs #1381