### PR TITLE
refactor(contextualization): SDK-native cost tracking + configurable prompt (#1234)

### DIFF
--- a/src/contextualization/base.py
+++ b/src/contextualization/base.py
@@ -74,6 +74,10 @@ class ContextualizeProvider(ABC):
     - Cost: Varies by provider (Claude: ~$0.01/chunk)
     """
 
+    def __init__(self, *, system_prompt: str | None = None) -> None:
+        """Initialize shared provider state."""
+        self.system_prompt = self.get_system_prompt(system_prompt)
+
     @abstractmethod
     async def contextualize(
         self,

--- a/src/contextualization/base.py
+++ b/src/contextualization/base.py
@@ -11,6 +11,25 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+# Anthropic prompt-caching pricing multipliers (relative to base input price).
+# Source: Anthropic pricing docs — cache creation is billed at 1.25× input
+# price, cache reads at 0.10× input price.
+_CACHE_CREATION_MULTIPLIER = 1.25
+_CACHE_READ_MULTIPLIER = 0.10
+
+_DEFAULT_SYSTEM_PROMPT = """You are an expert legal document analyzer for Ukrainian law.
+Your task is to generate brief, focused contextual summaries of legal text snippets.
+
+Guidelines:
+1. Create a 1-2 sentence summary that captures the essential legal meaning
+2. Highlight key concepts, obligations, or rights mentioned
+3. Maintain legal accuracy and formality
+4. Keep summaries concise (max 100 words)
+5. Focus on what makes this clause important in its legal context
+
+Respond ONLY with the summary, no additional explanation."""
+
+
 @dataclass
 class ContextualizedChunk:
     """Chunk with added context and metadata."""
@@ -155,19 +174,17 @@ class ContextualizeProvider(ABC):
         return results
 
     @staticmethod
-    def get_system_prompt() -> str:
-        """Get the system prompt for contextualization."""
-        return """You are an expert legal document analyzer for Ukrainian law.
-Your task is to generate brief, focused contextual summaries of legal text snippets.
+    def get_system_prompt(prompt: str | None = None) -> str:
+        """Return the system prompt for contextualization (issue #1234).
 
-Guidelines:
-1. Create a 1-2 sentence summary that captures the essential legal meaning
-2. Highlight key concepts, obligations, or rights mentioned
-3. Maintain legal accuracy and formality
-4. Keep summaries concise (max 100 words)
-5. Focus on what makes this clause important in its legal context
-
-Respond ONLY with the summary, no additional explanation."""
+        Callers can pass a custom prompt to reuse the contextualizers in
+        non-legal domains. When no prompt is given (or the override is
+        empty/whitespace), the default Ukrainian-legal prompt is returned
+        so existing callers keep working unchanged.
+        """
+        if prompt is not None and prompt.strip():
+            return prompt
+        return _DEFAULT_SYSTEM_PROMPT
 
     @staticmethod
     def get_user_prompt(text: str, query: str | None = None) -> str:
@@ -176,3 +193,83 @@ Respond ONLY with the summary, no additional explanation."""
         if query:
             base += f"\n\nUser is searching for: {query}"
         return base
+
+    # ------------------------------------------------------------------
+    # Cost tracking helpers (issue #1234) — shared across providers.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _calculate_token_cost(
+        *,
+        input_tokens: int,
+        output_tokens: int,
+        input_price_per_mtok: float,
+        output_price_per_mtok: float,
+        cache_creation_tokens: int = 0,
+        cache_read_tokens: int = 0,
+    ) -> float:
+        """Compute USD cost for a single API call.
+
+        ``input_price_per_mtok`` and ``output_price_per_mtok`` are USD per 1M
+        tokens — the convention every major SDK pricing page uses.
+
+        Anthropic prompt caching is supported via the optional
+        ``cache_creation_tokens`` and ``cache_read_tokens`` arguments. Cache
+        creation tokens are billed at 1.25× the base input price, cache reads
+        at 0.10× — both relative to ``input_price_per_mtok``. Providers without
+        prompt caching (OpenAI, Groq) simply omit these arguments.
+        """
+        cost = (
+            input_tokens * input_price_per_mtok
+            + output_tokens * output_price_per_mtok
+            + cache_creation_tokens * input_price_per_mtok * _CACHE_CREATION_MULTIPLIER
+            + cache_read_tokens * input_price_per_mtok * _CACHE_READ_MULTIPLIER
+        )
+        return cost / 1_000_000
+
+    @staticmethod
+    def _coerce_token_count(value: Any) -> int:
+        """Return ``value`` as a non-negative int, treating non-numeric input as 0.
+
+        Used to defend against ``MagicMock`` auto-attributes (whose ``__int__``
+        defaults to 1) leaking into token accounting from test fixtures.
+        """
+        if isinstance(value, bool):
+            return 0
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            return int(value)
+        return 0
+
+    @staticmethod
+    def _total_input_tokens_from_anthropic_usage(usage: Any) -> int:
+        """Sum the three input-token fields the Anthropic SDK exposes.
+
+        Per the Anthropic SDK docstring (``anthropic.types.message.Usage``)::
+
+            Total input tokens in a request is the summation of input_tokens,
+            cache_creation_input_tokens, and cache_read_input_tokens.
+
+        Cache fields are optional on the Usage object and may be absent or
+        ``None`` when prompt caching is not used; the helper treats both
+        cases as zero so non-cached requests still report correctly.
+        """
+
+        def _coerce(value: Any) -> int:
+            # Strict numeric check so a MagicMock auto-attribute (which
+            # answers ``__int__`` with ``1``) is not mistaken for a real
+            # token count from the SDK.
+            if isinstance(value, bool):
+                return 0
+            if isinstance(value, int):
+                return value
+            if isinstance(value, float):
+                return int(value)
+            return 0
+
+        return (
+            _coerce(getattr(usage, "input_tokens", 0))
+            + _coerce(getattr(usage, "cache_creation_input_tokens", 0))
+            + _coerce(getattr(usage, "cache_read_input_tokens", 0))
+        )

--- a/src/contextualization/claude.py
+++ b/src/contextualization/claude.py
@@ -44,13 +44,20 @@ class ClaudeContextualizer(ContextualizeProvider):
     - Quality: Highest among available providers
     """
 
-    def __init__(self, settings: Settings | None = None, use_cache: bool = True) -> None:
+    def __init__(
+        self,
+        settings: Settings | None = None,
+        use_cache: bool = True,
+        system_prompt: str | None = None,
+    ) -> None:
         """Initialize Claude contextualizer.
 
         Args:
             settings: Configuration settings (uses global if None)
             use_cache: Enable prompt caching for cost reduction
+            system_prompt: Optional custom contextualization system prompt
         """
+        super().__init__(system_prompt=system_prompt)
         self.settings = settings or Settings()
         self.use_cache = use_cache
         self.client = AsyncAnthropic(api_key=self.settings.anthropic_api_key)
@@ -95,7 +102,7 @@ class ClaudeContextualizer(ContextualizeProvider):
         ``Total input tokens = input_tokens + cache_creation_input_tokens
         + cache_read_input_tokens`` (issue #1234).
         """
-        system_prompt = self.get_system_prompt()
+        system_prompt = self.system_prompt
         user_prompt = self.get_user_prompt(text, query)
         model_name = self.settings.model_name or "claude-3-5-haiku-latest"
 
@@ -162,7 +169,7 @@ class ClaudeContextualizer(ContextualizeProvider):
         query: str | None = None,
     ) -> ContextualizedChunk:
         """Synchronous contextualization (blocking)."""
-        system_prompt = self.get_system_prompt()
+        system_prompt = self.system_prompt
         user_prompt = self.get_user_prompt(text, query)
         model_name = self.settings.model_name or "claude-3-5-haiku-latest"
 

--- a/src/contextualization/claude.py
+++ b/src/contextualization/claude.py
@@ -11,6 +11,13 @@ from src.config import Settings
 from .base import ContextualizedChunk, ContextualizeProvider
 
 
+# Claude pricing — USD per 1M tokens. Per-model rates are application-level
+# concerns (the SDK does not surface pricing); centralized here so the shared
+# cost helper in base.py drives the math (issue #1234).
+_CLAUDE_INPUT_PRICE_PER_MTOK = 5.0
+_CLAUDE_OUTPUT_PRICE_PER_MTOK = 15.0
+
+
 def _extract_claude_text(content_blocks: Any) -> str:
     """Extract plain text from Anthropic content blocks."""
     parts: list[str] = []
@@ -27,7 +34,7 @@ class ClaudeContextualizer(ContextualizeProvider):
 
     Features:
     - Prompt caching for 90% cost reduction
-    - Token tracking for cost estimation
+    - Token tracking for cost estimation (cache-aware after #1234)
     - Async/sync support
     - Automatic fallback on failures
 
@@ -83,7 +90,10 @@ class ClaudeContextualizer(ContextualizeProvider):
         """
         Contextualize a single chunk using Claude.
 
-        Implements prompt caching for cost efficiency.
+        Implements prompt caching for cost efficiency. Token + cost
+        accounting honours Anthropic's SDK contract that
+        ``Total input tokens = input_tokens + cache_creation_input_tokens
+        + cache_read_input_tokens`` (issue #1234).
         """
         system_prompt = self.get_system_prompt()
         user_prompt = self.get_user_prompt(text, query)
@@ -105,12 +115,28 @@ class ClaudeContextualizer(ContextualizeProvider):
             messages=[{"role": "user", "content": user_prompt}],
         )
 
-        # Track tokens and cost
-        self.total_tokens += response.usage.input_tokens + response.usage.output_tokens
-        # Rough cost estimation: $5/MTok input, $15/MTok output
-        self.total_cost += (
-            response.usage.input_tokens * 5 + response.usage.output_tokens * 15
-        ) / 1_000_000
+        # SDK-correct accounting (issue #1234):
+        #   Total input = input + cache_creation_input + cache_read_input
+        # The previous code summed only input_tokens + output_tokens which
+        # silently undercounted whenever prompt caching was active.
+        usage = response.usage
+        total_input_tokens = self._total_input_tokens_from_anthropic_usage(usage)
+        output_tokens = self._coerce_token_count(getattr(usage, "output_tokens", 0))
+        cache_creation_tokens = self._coerce_token_count(
+            getattr(usage, "cache_creation_input_tokens", 0)
+        )
+        cache_read_tokens = self._coerce_token_count(getattr(usage, "cache_read_input_tokens", 0))
+        regular_input_tokens = self._coerce_token_count(getattr(usage, "input_tokens", 0))
+
+        self.total_tokens += total_input_tokens + output_tokens
+        self.total_cost += self._calculate_token_cost(
+            input_tokens=regular_input_tokens,
+            output_tokens=output_tokens,
+            input_price_per_mtok=_CLAUDE_INPUT_PRICE_PER_MTOK,
+            output_price_per_mtok=_CLAUDE_OUTPUT_PRICE_PER_MTOK,
+            cache_creation_tokens=cache_creation_tokens,
+            cache_read_tokens=cache_read_tokens,
+        )
 
         summary = _extract_claude_text(response.content)
         if not summary.strip():
@@ -147,8 +173,11 @@ class ClaudeContextualizer(ContextualizeProvider):
             messages=[{"role": "user", "content": user_prompt}],
         )
 
-        # Track tokens
-        self.total_tokens += response.usage.input_tokens + response.usage.output_tokens
+        # SDK-correct accounting (issue #1234) — also covers the sync path.
+        usage = response.usage
+        total_input_tokens = self._total_input_tokens_from_anthropic_usage(usage)
+        output_tokens = self._coerce_token_count(getattr(usage, "output_tokens", 0))
+        self.total_tokens += total_input_tokens + output_tokens
 
         return ContextualizedChunk(
             original_text=text,

--- a/src/contextualization/groq.py
+++ b/src/contextualization/groq.py
@@ -21,8 +21,9 @@ class GroqContextualizer(ContextualizeProvider):
     Note: Fast inference on LLaMA, trade-off with quality.
     """
 
-    def __init__(self, settings: Settings | None = None) -> None:
+    def __init__(self, settings: Settings | None = None, system_prompt: str | None = None) -> None:
         """Initialize Groq contextualizer."""
+        super().__init__(system_prompt=system_prompt)
         self.settings = settings or Settings()
         self.client = AsyncGroq(api_key=self.settings.groq_api_key)
         self.sync_client = Groq(api_key=self.settings.groq_api_key)
@@ -57,7 +58,7 @@ class GroqContextualizer(ContextualizeProvider):
         query: str | None = None,
     ) -> ContextualizedChunk:
         """Contextualize a single chunk using Groq."""
-        system_prompt = self.get_system_prompt()
+        system_prompt = self.system_prompt
         user_prompt = self.get_user_prompt(text, query)
 
         response = await self.client.chat.completions.create(
@@ -95,7 +96,7 @@ class GroqContextualizer(ContextualizeProvider):
         query: str | None = None,
     ) -> ContextualizedChunk:
         """Synchronous contextualization using Groq."""
-        system_prompt = self.get_system_prompt()
+        system_prompt = self.system_prompt
         user_prompt = self.get_user_prompt(text, query)
 
         response = self.sync_client.chat.completions.create(

--- a/src/contextualization/openai.py
+++ b/src/contextualization/openai.py
@@ -35,8 +35,9 @@ class OpenAIContextualizer(ContextualizeProvider):
     client parameter (#1651). No Tenacity decorator wraps the per-call path.
     """
 
-    def __init__(self, settings: Settings | None = None) -> None:
+    def __init__(self, settings: Settings | None = None, system_prompt: str | None = None) -> None:
         """Initialize OpenAI contextualizer."""
+        super().__init__(system_prompt=system_prompt)
         self.settings = settings or Settings()
         self.client = AsyncOpenAI(
             api_key=self.settings.openai_api_key,
@@ -78,7 +79,7 @@ class OpenAIContextualizer(ContextualizeProvider):
         cover RateLimitError, APIStatusError (>=500), connection errors,
         408 and 409. No additional retry layer is required.
         """
-        system_prompt = self.get_system_prompt()
+        system_prompt = self.system_prompt
         user_prompt = self.get_user_prompt(text, query)
         model_name = self.settings.model_name or "gpt-4o-mini"
 
@@ -123,7 +124,7 @@ class OpenAIContextualizer(ContextualizeProvider):
 
         SDK-native retries via ``max_retries`` on the sync OpenAI client.
         """
-        system_prompt = self.get_system_prompt()
+        system_prompt = self.system_prompt
         user_prompt = self.get_user_prompt(text, query)
         model_name = self.settings.model_name or "gpt-4o-mini"
 

--- a/src/contextualization/openai.py
+++ b/src/contextualization/openai.py
@@ -16,6 +16,11 @@ from .base import ContextualizedChunk, ContextualizeProvider
 # that retry budget without duplicating the policy.
 _OPENAI_MAX_RETRIES = 3
 
+# OpenAI gpt-4 pricing — USD per 1M tokens. Centralized so issue #1234's
+# shared cost helper in base.py can drive the math.
+_OPENAI_INPUT_PRICE_PER_MTOK = 5.0
+_OPENAI_OUTPUT_PRICE_PER_MTOK = 15.0
+
 
 class OpenAIContextualizer(ContextualizeProvider):
     """
@@ -87,15 +92,18 @@ class OpenAIContextualizer(ContextualizeProvider):
             ],
         )
 
-        # Track tokens and cost
+        # Track tokens and cost via the shared helper (issue #1234).
         usage = response.usage
         if usage is not None:
-            total_tokens = int(usage.total_tokens or 0)
             prompt_tokens = int(usage.prompt_tokens or 0)
             completion_tokens = int(usage.completion_tokens or 0)
-            self.total_tokens += total_tokens
-            # OpenAI pricing: $5/MTok input (gpt-4), $15/MTok output
-            self.total_cost += (prompt_tokens * 5 + completion_tokens * 15) / 1_000_000
+            self.total_tokens += int(usage.total_tokens or 0)
+            self.total_cost += self._calculate_token_cost(
+                input_tokens=prompt_tokens,
+                output_tokens=completion_tokens,
+                input_price_per_mtok=_OPENAI_INPUT_PRICE_PER_MTOK,
+                output_price_per_mtok=_OPENAI_OUTPUT_PRICE_PER_MTOK,
+            )
 
         return ContextualizedChunk(
             original_text=text,

--- a/tests/unit/contextualization/test_cost_tracking.py
+++ b/tests/unit/contextualization/test_cost_tracking.py
@@ -34,6 +34,7 @@ the helpers directly with simple objects.
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -213,3 +214,97 @@ def test_get_system_prompt_treats_empty_string_as_no_override() -> None:
 
     prompt = ContextualizeProvider.get_system_prompt("   \n\n  ")
     assert "Ukrainian law" in prompt
+
+
+# ---------------------------------------------------------------------------
+# 4. Provider wiring for configurable prompts
+# ---------------------------------------------------------------------------
+
+
+def _settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        anthropic_api_key="anthropic-key",
+        openai_api_key="openai-key",
+        groq_api_key="groq-key",
+        model_name=None,
+        temperature=0.2,
+    )
+
+
+@pytest.mark.asyncio
+async def test_openai_contextualizer_uses_constructor_system_prompt_override() -> None:
+    """OpenAI provider must send the configured prompt to the SDK request."""
+    from src.contextualization.openai import OpenAIContextualizer
+
+    custom_prompt = "You summarize real-estate listing fragments."
+    async_client = MagicMock()
+    async_client.chat.completions.create = AsyncMock(
+        return_value=SimpleNamespace(
+            usage=SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+            choices=[SimpleNamespace(message=SimpleNamespace(content="summary"))],
+        )
+    )
+
+    with (
+        patch("src.contextualization.openai.AsyncOpenAI", return_value=async_client),
+        patch("src.contextualization.openai.OpenAI", return_value=MagicMock()),
+    ):
+        contextualizer = OpenAIContextualizer(settings=_settings(), system_prompt=custom_prompt)
+        await contextualizer.contextualize_single("text", "article-1")
+
+    kwargs = async_client.chat.completions.create.call_args.kwargs
+    assert kwargs["messages"][0]["content"] == custom_prompt
+
+
+@pytest.mark.asyncio
+async def test_claude_contextualizer_uses_constructor_system_prompt_override() -> None:
+    """Claude provider must send the configured prompt to the SDK request."""
+    from src.contextualization.claude import ClaudeContextualizer
+
+    custom_prompt = "You summarize product support documents."
+    async_client = MagicMock()
+    async_client.messages.create = AsyncMock(
+        return_value=SimpleNamespace(
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+            content=[SimpleNamespace(text="summary")],
+        )
+    )
+
+    with (
+        patch("src.contextualization.claude.AsyncAnthropic", return_value=async_client),
+        patch("src.contextualization.claude.Anthropic", return_value=MagicMock()),
+    ):
+        contextualizer = ClaudeContextualizer(
+            settings=_settings(),
+            use_cache=False,
+            system_prompt=custom_prompt,
+        )
+        await contextualizer.contextualize_single("text", "article-1")
+
+    kwargs = async_client.messages.create.call_args.kwargs
+    assert kwargs["system"] == custom_prompt
+
+
+@pytest.mark.asyncio
+async def test_groq_contextualizer_uses_constructor_system_prompt_override() -> None:
+    """Groq provider must send the configured prompt to the SDK request."""
+    from src.contextualization.groq import GroqContextualizer
+
+    custom_prompt = "You summarize engineering runbooks."
+    async_client = MagicMock()
+    async_client.chat.completions.create = AsyncMock(
+        return_value=SimpleNamespace(
+            usage=SimpleNamespace(total_tokens=15),
+            choices=[SimpleNamespace(message=SimpleNamespace(content="summary"))],
+        )
+    )
+
+    with (
+        patch("src.contextualization.groq.AsyncGroq", return_value=async_client),
+        patch("src.contextualization.groq.Groq", return_value=MagicMock()),
+    ):
+        contextualizer = GroqContextualizer(settings=_settings(), system_prompt=custom_prompt)
+        await contextualizer.contextualize_single("text", "article-1")
+
+    kwargs = async_client.chat.completions.create.call_args.kwargs
+    assert kwargs["messages"][0]["content"] == custom_prompt

--- a/tests/unit/contextualization/test_cost_tracking.py
+++ b/tests/unit/contextualization/test_cost_tracking.py
@@ -1,0 +1,215 @@
+"""Cost tracking + configurable prompt contract tests (issue #1234).
+
+These tests pin the cleanup contract from issue #1234:
+
+1. ``ContextualizeProvider`` exposes a shared ``_calculate_token_cost`` helper
+   so each provider does not redo the same ``(in*p_in + out*p_out)/1_000_000``
+   formula. Per Context7 the OpenAI SDK only surfaces token counts via
+   ``response.usage`` (``prompt_tokens``/``completion_tokens``); pricing is an
+   application-level concern, so we own the helper.
+
+2. ``_total_input_tokens_from_anthropic_usage`` adds the prompt-cache fields
+   the Anthropic SDK documents on the ``Usage`` object::
+
+       Total input tokens = input_tokens
+                          + cache_creation_input_tokens
+                          + cache_read_input_tokens
+
+   (Source: ``anthropic-sdk-python/src/anthropic/types/message.py`` Usage
+   docstring, fetched via Context7 /anthropics/anthropic-sdk-python.)
+   The previous ``ClaudeContextualizer.contextualize_single`` summed only
+   ``input_tokens + output_tokens`` and silently undercounted token usage
+   (and cost) whenever Anthropic prompt caching kicked in. The helper makes
+   the SDK-correct accounting reusable.
+
+3. The system prompt used by every provider is configurable. The legacy
+   hard-coded Ukrainian-legal prompt is preserved as the default so existing
+   callers keep working, but ``ContextualizeProvider.get_system_prompt(...)``
+   now also honours an explicit ``prompt`` argument.
+
+The tests do not require live Anthropic / OpenAI / Groq SDKs — they exercise
+the helpers directly with simple objects.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.contextualization.base import ContextualizeProvider
+
+
+# ---------------------------------------------------------------------------
+# 1. Shared cost helper
+# ---------------------------------------------------------------------------
+
+
+def test_calculate_token_cost_helper_exists() -> None:
+    """The base provider must expose ``_calculate_token_cost`` so all three
+    provider implementations share one cost formula (issue #1234)."""
+    assert hasattr(ContextualizeProvider, "_calculate_token_cost"), (
+        "ContextualizeProvider._calculate_token_cost must exist (issue #1234)"
+    )
+
+
+def test_calculate_token_cost_uses_per_million_pricing() -> None:
+    """The standard SDK pricing convention is USD per 1M tokens."""
+    cost = ContextualizeProvider._calculate_token_cost(
+        input_tokens=1_000_000,
+        output_tokens=0,
+        input_price_per_mtok=5.0,
+        output_price_per_mtok=15.0,
+    )
+    assert cost == pytest.approx(5.0), f"1M input tokens at $5/Mtok must equal $5.00; got {cost!r}"
+
+    cost = ContextualizeProvider._calculate_token_cost(
+        input_tokens=0,
+        output_tokens=1_000_000,
+        input_price_per_mtok=5.0,
+        output_price_per_mtok=15.0,
+    )
+    assert cost == pytest.approx(15.0), (
+        f"1M output tokens at $15/Mtok must equal $15.00; got {cost!r}"
+    )
+
+
+def test_calculate_token_cost_handles_zero_tokens() -> None:
+    """Zero-token request (e.g. empty response) must return $0.00, not crash."""
+    cost = ContextualizeProvider._calculate_token_cost(
+        input_tokens=0,
+        output_tokens=0,
+        input_price_per_mtok=5.0,
+        output_price_per_mtok=15.0,
+    )
+    assert cost == 0.0
+
+
+def test_calculate_token_cost_charges_cache_creation_premium() -> None:
+    """Anthropic charges 1.25× input price for cache creation tokens."""
+    cost = ContextualizeProvider._calculate_token_cost(
+        input_tokens=0,
+        output_tokens=0,
+        input_price_per_mtok=5.0,
+        output_price_per_mtok=15.0,
+        cache_creation_tokens=1_000_000,
+    )
+    # 1M cache_creation tokens × $5/Mtok × 1.25 = $6.25
+    assert cost == pytest.approx(6.25), (
+        f"1M cache_creation tokens at $5/Mtok with 1.25 multiplier must equal $6.25; got {cost!r}"
+    )
+
+
+def test_calculate_token_cost_discounts_cache_read() -> None:
+    """Anthropic charges 0.1× input price for cache read tokens."""
+    cost = ContextualizeProvider._calculate_token_cost(
+        input_tokens=0,
+        output_tokens=0,
+        input_price_per_mtok=5.0,
+        output_price_per_mtok=15.0,
+        cache_read_tokens=1_000_000,
+    )
+    # 1M cache_read tokens × $5/Mtok × 0.1 = $0.50
+    assert cost == pytest.approx(0.5), (
+        f"1M cache_read tokens at $5/Mtok with 0.1 multiplier must equal $0.50; got {cost!r}"
+    )
+
+
+def test_calculate_token_cost_combines_all_components() -> None:
+    """Combined invocation: regular input + output + cache creation + cache read."""
+    cost = ContextualizeProvider._calculate_token_cost(
+        input_tokens=1_000,
+        output_tokens=500,
+        input_price_per_mtok=5.0,
+        output_price_per_mtok=15.0,
+        cache_creation_tokens=2_000,
+        cache_read_tokens=10_000,
+    )
+    expected = (1_000 * 5 + 500 * 15 + 2_000 * 5 * 1.25 + 10_000 * 5 * 0.1) / 1_000_000
+    assert cost == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# 2. Anthropic-style total_input_tokens helper
+# ---------------------------------------------------------------------------
+
+
+def test_total_input_tokens_from_anthropic_usage_helper_exists() -> None:
+    """Helper must exist so Claude can correctly sum prompt-cache fields."""
+    assert hasattr(ContextualizeProvider, "_total_input_tokens_from_anthropic_usage"), (
+        "ContextualizeProvider._total_input_tokens_from_anthropic_usage must "
+        "exist (issue #1234) so prompt caching is accounted for correctly"
+    )
+
+
+def test_total_input_tokens_includes_cache_creation_and_cache_read() -> None:
+    """SDK contract: total = input + cache_creation + cache_read."""
+    usage = SimpleNamespace(
+        input_tokens=100,
+        output_tokens=50,
+        cache_creation_input_tokens=200,
+        cache_read_input_tokens=300,
+    )
+    total = ContextualizeProvider._total_input_tokens_from_anthropic_usage(usage)
+    assert total == 100 + 200 + 300, (
+        "Total input must include cache_creation + cache_read tokens (Anthropic "
+        f"SDK contract). Got {total!r}; expected 600."
+    )
+
+
+def test_total_input_tokens_handles_missing_cache_fields() -> None:
+    """Older Usage objects (or non-cached responses) may omit cache fields."""
+    usage = SimpleNamespace(input_tokens=100, output_tokens=50)
+    total = ContextualizeProvider._total_input_tokens_from_anthropic_usage(usage)
+    assert total == 100, (
+        "When cache fields are absent the helper must fall back to "
+        f"input_tokens. Got {total!r}; expected 100."
+    )
+
+
+def test_total_input_tokens_handles_none_cache_fields() -> None:
+    """SDK sometimes returns ``None`` for unset cache fields."""
+    usage = SimpleNamespace(
+        input_tokens=100,
+        output_tokens=50,
+        cache_creation_input_tokens=None,
+        cache_read_input_tokens=None,
+    )
+    total = ContextualizeProvider._total_input_tokens_from_anthropic_usage(usage)
+    assert total == 100
+
+
+# ---------------------------------------------------------------------------
+# 3. Configurable system prompt
+# ---------------------------------------------------------------------------
+
+
+def test_get_system_prompt_returns_default_when_no_argument() -> None:
+    """Default behaviour preserves the legacy Ukrainian-legal prompt."""
+    prompt = ContextualizeProvider.get_system_prompt()
+    assert "Ukrainian law" in prompt, (
+        "Default system prompt must remain backward-compatible with existing "
+        "callers (Ukrainian legal domain)."
+    )
+
+
+def test_get_system_prompt_accepts_explicit_override() -> None:
+    """Issue #1234: callers should be able to pass a custom prompt."""
+    custom = "You are an expert in property listings."
+    prompt = ContextualizeProvider.get_system_prompt(custom)
+    assert prompt == custom, (
+        "When an explicit prompt is supplied it must be returned unchanged so "
+        f"non-legal domains can reuse the contextualizers. Got {prompt!r}."
+    )
+
+
+def test_get_system_prompt_treats_empty_string_as_no_override() -> None:
+    """Whitespace-only / empty overrides fall back to the default to avoid
+    silently sending an empty system prompt to the LLM."""
+    prompt = ContextualizeProvider.get_system_prompt("")
+    assert "Ukrainian law" in prompt, (
+        f"Empty override must fall back to the default prompt; got {prompt!r}"
+    )
+
+    prompt = ContextualizeProvider.get_system_prompt("   \n\n  ")
+    assert "Ukrainian law" in prompt


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Cleans up the three contextualization providers around the three axes called out in #1234, while fixing a real Anthropic prompt-cache accounting bug surfaced by Context7 (`/anthropics/anthropic-sdk-python`).

## Changes

### 1. Shared cost helper in `base.py`
`ContextualizeProvider._calculate_token_cost(...)` now owns the USD-per-1M-token formula that openai.py and claude.py were each duplicating. Pricing is application-level (the OpenAI and Anthropic SDKs only expose token counts via `response.usage`, not pricing), so the helper accepts pricing as inputs.

The helper natively supports Anthropic prompt caching multipliers (1.25× input price for cache creation, 0.10× for cache read).

### 2. SDK-correct token accounting for Claude (bug fix)
Per the Anthropic SDK `Usage` docstring (fetched via Context7):
> Total input tokens in a request is the summation of `input_tokens`, `cache_creation_input_tokens`, and `cache_read_input_tokens`.

`ClaudeContextualizer.contextualize_single` previously summed only `input_tokens + output_tokens`, silently **undercounting tokens and cost on every prompt-cached request**. The fix uses a new `_total_input_tokens_from_anthropic_usage(...)` helper that respects the SDK contract.

### 3. Configurable system prompt
`get_system_prompt(prompt=None)` accepts an explicit override so the contextualizers can be reused outside the Ukrainian-legal domain. The default prompt is preserved for all existing callers.

## Tests

- `tests/unit/contextualization/test_cost_tracking.py` — 13 new contract tests (TDD red→green)
- All 152 tests in `tests/unit/contextualization/` pass

## SDK research
- Context7 `/openai/openai-python` — confirmed pricing is application-level, SDK only exposes `usage.prompt_tokens` / `usage.completion_tokens`
- Context7 `/anthropics/anthropic-sdk-python` — surfaced the `cache_creation_input_tokens` / `cache_read_input_tokens` accounting contract that drove the bug fix

Closes #1234