### PR TITLE
fix(voice): downgrade Dockerfile to Python 3.13

### DIFF
--- a/src/voice/Dockerfile
+++ b/src/voice/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89
 # Voice Agent — uv sync pattern (2026 best practices)
-# NOTE: Using Python 3.13 to match all other services. See issue #1548.
+# NOTE: Using Python 3.13 to match all other services. See issue #1349.
 
 # ====== BUILD STAGE ======
-FROM ghcr.io/astral-sh/uv:0.9-python3.14-bookworm-slim@sha256:7cf77f594be8042dab6daa9fe326f90962252268b4f120a7f5dccce4d947e6c1 AS builder
+FROM ghcr.io/astral-sh/uv:0.9-python3.13-bookworm-slim@sha256:531f855bda2c73cd6ef67d56b733b357cea384185b3022bd09f05e002cd144ca AS builder
 
 WORKDIR /app
 
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --extra voice
 
 # ====== RUNTIME STAGE ======
-FROM python:3.14-slim-bookworm@sha256:a9bee15510a364124aa24692899d269835683b883de42f7ebec8c293cf679ccb AS runtime
+FROM python:3.13-slim-bookworm@sha256:e4fa1f978c539608a10cdf74700ac32a3f719dfc6e8b6b6001da82deb36302a2 AS runtime
 WORKDIR /app
 
 RUN groupadd -g 1001 appuser && \


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Downgrades `src/voice/Dockerfile` from Python 3.14 to Python 3.13, aligning it with all other services that import the Langfuse SDK (which depends on Pydantic v1 internals incompatible with Python 3.14).

## Changes

- **Build stage**: `ghcr.io/astral-sh/uv:0.9-python3.14-bookworm-slim` → `ghcr.io/astral-sh/uv:0.9-python3.13-bookworm-slim` (pinned digest)
- **Runtime stage**: `python:3.14-slim-bookworm` → `python:3.13-slim-bookworm` (pinned digest)
- Updated comment to reference the correct tracking issue (#1349)

## Context

PR #1348 fixed the same Pydantic v1 / Python 3.14 crash for `telegram_bot` and `mini_app`. The voice service was left on 3.14 because LiveKit was out of scope at that time. This PR completes that work.

Closes #1349