### PR TITLE
fix(test): bound test-full parallelism to prevent WSL OOM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ export TMPDIR TMP TEMP
 # Override: PYTHON_VERSION=3.13 make test-unit
 PYTHON_VERSION ?= 3.12
 PYTEST_PARALLEL_ARGS ?= -n auto --dist=worksteal
+PYTEST_FULL_PARALLEL_ARGS ?= -n 2 --dist=worksteal
 PYTEST_FULL_PARALLEL_DIRS ?= tests/baseline/ tests/benchmark/ tests/chaos/ tests/contract/ tests/unit/
 PYTEST_FULL_SEQUENTIAL_DIRS ?= tests/e2e/ tests/integration/ tests/load/ tests/smoke/
 PYTEST_REQUIRES_EXTRAS_IGNORE := $(addprefix --ignore=, \
@@ -187,7 +188,7 @@ test-full: ## Run full test suite with hybrid parallelism (all tiers)
 	@echo "$(BLUE)Running full test suite...$(NC)"
 	uv sync --all-extras --all-groups
 	@echo "$(BLUE)Phase 1/2: parallel-safe suites...$(NC)"
-	PYTHONDONTWRITEBYTECODE=1 RUN_BENCHMARK_TESTS=1 uv run pytest $(PYTEST_FULL_PARALLEL_DIRS) $(PYTEST_PARALLEL_ARGS) --timeout=30 $(PYTEST_ADDOPTS)
+	PYTHONDONTWRITEBYTECODE=1 RUN_BENCHMARK_TESTS=1 uv run pytest $(PYTEST_FULL_PARALLEL_DIRS) $(PYTEST_FULL_PARALLEL_ARGS) --timeout=30 $(PYTEST_ADDOPTS)
 	@echo "$(BLUE)Phase 2/2: stateful/live suites sequentially...$(NC)"
 	PYTHONDONTWRITEBYTECODE=1 uv run pytest $(PYTEST_FULL_SEQUENTIAL_DIRS) --timeout=30 $(PYTEST_ADDOPTS)
 	@echo "$(GREEN)✓ Full test suite complete$(NC)"

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -142,6 +142,35 @@ make test
 make test-full
 ```
 
+### Heavy test gate (`make test-full`)
+
+`make test-full` runs the entire test suite (all tiers) and is intended as a
+**manual** pre-merge validation step, not a routine development loop command.
+
+It defaults to bounded parallelism (`-n 2 --dist=worksteal`) via
+`PYTEST_FULL_PARALLEL_ARGS` to prevent memory saturation on WSL/Docker
+environments where RAM is limited (8-10 GiB typical).
+
+Fast gates (`make test`, `make test-unit`) keep `-n auto` via
+`PYTEST_PARALLEL_ARGS` for quick local feedback since they exercise a smaller
+test surface that fits comfortably in memory.
+
+To override parallelism for a specific run:
+
+```bash
+PYTEST_FULL_PARALLEL_ARGS='-n 4 --dist=worksteal' make test-full
+```
+
+**WSL considerations:** On WSL with constrained memory, unbounded `-n auto`
+during heavy test runs can exhaust RAM + swap, cause unkillable `D`-state
+processes, and destabilize Docker Desktop integration. Keep parallelism low
+(`-n 2` or `-n 4` max) and ensure no stale pytest-xdist workers are running
+before starting a heavy session:
+
+```bash
+pgrep -af 'pytest|docker compose'
+```
+
 Trace coverage gate:
 
 ```bash

--- a/tests/unit/test_makefile_contract.py
+++ b/tests/unit/test_makefile_contract.py
@@ -344,3 +344,45 @@ def test_local_all_test_targets_are_phony() -> None:
     combined = " ".join(phony_blocks)
     assert "test-frontend" in combined
     assert "test-all-local" in combined
+
+
+# --- #1778 bounded parallelism contract tests ---
+
+
+def test_test_full_uses_bounded_parallelism_by_default() -> None:
+    """Regression test for #1778.
+
+    test-full must use PYTEST_FULL_PARALLEL_ARGS (bounded, e.g. -n 2) instead of
+    PYTEST_PARALLEL_ARGS (-n auto) to prevent WSL/Docker OOM under heavy local
+    test sessions.
+    """
+    text = _makefile_text()
+
+    # 1. PYTEST_FULL_PARALLEL_ARGS must be defined
+    var_match = re.search(
+        r"^PYTEST_FULL_PARALLEL_ARGS\s*\?=\s*(.+)$", text, re.MULTILINE
+    )
+    assert var_match, "PYTEST_FULL_PARALLEL_ARGS not found in Makefile"
+
+    # 2. Its default must NOT be unbounded -n auto
+    default_value = var_match.group(1).strip()
+    assert "-n auto" not in default_value, (
+        f"PYTEST_FULL_PARALLEL_ARGS must use bounded parallelism, "
+        f"got {default_value!r} which contains '-n auto'"
+    )
+
+    # 3. test-full target must reference PYTEST_FULL_PARALLEL_ARGS, not PYTEST_PARALLEL_ARGS
+    block_match = re.search(
+        r"^test-full:.*?(?=^[A-Za-z0-9_.-]+:|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert block_match, "test-full target not found in Makefile"
+    block = block_match.group(0)
+    assert "$(PYTEST_FULL_PARALLEL_ARGS)" in block, (
+        "test-full must use $(PYTEST_FULL_PARALLEL_ARGS) for bounded parallelism"
+    )
+    assert "$(PYTEST_PARALLEL_ARGS)" not in block, (
+        "test-full must NOT use $(PYTEST_PARALLEL_ARGS) (unbounded -n auto); "
+        "use $(PYTEST_FULL_PARALLEL_ARGS) instead"
+    )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #1778

Implements the code-side hardening to prevent `make test-full` from saturating WSL memory with unbounded pytest-xdist parallelism.

## Changes

- **Makefile**: Added `PYTEST_FULL_PARALLEL_ARGS ?= -n 2 --dist=worksteal` and switched `test-full` Phase 1 to use it instead of `$(PYTEST_PARALLEL_ARGS)` (which remains `-n auto` for fast gates)
- **docs/LOCAL-DEVELOPMENT.md**: Documented the heavy gate vs fast gate distinction, WSL memory considerations, and the override mechanism
- **tests/unit/test_makefile_contract.py**: Added `test_test_full_uses_bounded_parallelism_by_default` contract test that prevents silent reversion to unbounded `-n auto`

## Verification

- `git diff --check` passes (no whitespace issues)
- Contract test assertions verified against the modified Makefile
- Python syntax check passes on the test file

## Not in scope (manual local steps from the issue)

The remaining tasks in #1778 are manual workstation operations (WSL shutdown/restart, Docker recovery, confirming system health) that must be performed locally by the developer after merging this PR."