### PR TITLE
fix(tests): remove deprecated asyncio fallback (B1, #1515)

### DIFF
--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -49,11 +49,7 @@ def require_live_services(request):
         except Exception:
             pytest.skip("Redis not available")
 
-    try:
-        asyncio.run(check_redis())
-    except RuntimeError:
-        loop = asyncio.get_running_loop()
-        loop.run_until_complete(check_redis())
+    asyncio.run(check_redis())
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Fixes **B1** from issue #1515 (Test Audit Phase 1 - Critical Bugs).

### Change

Removed the `try/except RuntimeError` fallback in `tests/smoke/conftest.py` that called `asyncio.get_running_loop().run_until_complete(check_redis())`. This pattern is deprecated since Python 3.10 and will raise `RuntimeError` on Python 3.13+ when no event loop is running during test collection.

Now uses a clean `asyncio.run(check_redis())` call directly.

### Status of other Phase 1 bugs

After investigation, the remaining 5 bugs from Phase 1 were **already addressed** in the current codebase:

| Bug | Description | Status |
|-----|-------------|--------|
| B2 | Fake E2E tests (mock-only) | `test_rag_pipeline.py` no longer exists in `tests/e2e/`. `test_core_flows_live.py` is a legitimate live E2E test |
| B3 | `src/_compat.py` has 0 tests | `tests/unit/test_compat.py` exists with comprehensive tests |
| B4 | `src/evaluation/config_snapshot.py` has 0 tests | `tests/unit/evaluation/test_config_snapshot.py` exists with 10+ tests |
| B5 | Missing `contract` and `baseline` markers | Both entries present in `tests/conftest.py` path_to_marker dict |
| B6 | `telegram_bot/.venv/` pollutes coverage | `.gitignore` has `**/.venv/` pattern, `pyproject.toml` has `telegram_bot/.venv/*` in coverage omit |

### Testing

- File parses without syntax errors
- `ruff check` passes
- No remaining deprecated `get_event_loop`/`get_running_loop`/`run_until_complete` patterns in smoke conftest

Closes part of #1515