### PR TITLE
fix(evaluation): use canonical bm42 sparse vector name (#1083)

### DIFF
--- a/src/evaluation/search_engines.py
+++ b/src/evaluation/search_engines.py
@@ -157,9 +157,13 @@ class HybridSearchEngine(SearchEngine):
         sparse_vector = _lexical_weights_to_sparse(query_embeddings["lexical_weights"])
 
         # Build hybrid search with RRF using query API
+        # ``using="bm42"`` matches the sparse vector registered by the
+        # unified ingestion pipeline (src/ingestion/unified/cli.py). Querying
+        # with ``using="sparse"`` produces "Not existing vector name" gRPC
+        # errors against the canonical collection — see issue #1083.
         prefetch = [
             models.Prefetch(query=dense_vector, using="dense", limit=100),
-            models.Prefetch(query=sparse_vector, using="sparse", limit=100),
+            models.Prefetch(query=sparse_vector, using="bm42", limit=100),
         ]
 
         response = self.client.query_points(
@@ -230,7 +234,9 @@ class HybridDBSFColBERTSearchEngine(SearchEngine):
         dbsf_prefetch = models.Prefetch(
             prefetch=[
                 models.Prefetch(query=dense_vector, using="dense", limit=self.stage1_limit),
-                models.Prefetch(query=sparse_vector, using="sparse", limit=self.stage1_limit),
+                # See issue #1083: sparse vector name must match the
+                # ingestion schema (``bm42``).
+                models.Prefetch(query=sparse_vector, using="bm42", limit=self.stage1_limit),
             ],
             query=models.FusionQuery(fusion=models.Fusion.DBSF),
         )
@@ -308,7 +314,9 @@ class HybridRRFColBERTSearchEngine(SearchEngine):
         rrf_prefetch = models.Prefetch(
             prefetch=[
                 models.Prefetch(query=dense_vector, using="dense", limit=self.stage1_limit),
-                models.Prefetch(query=sparse_vector, using="sparse", limit=self.stage1_limit),
+                # See issue #1083: sparse vector name must match the
+                # ingestion schema (``bm42``).
+                models.Prefetch(query=sparse_vector, using="bm42", limit=self.stage1_limit),
             ],
             query=models.RrfQuery(rrf=models.Rrf(k=self.rrf_k)),
         )

--- a/tests/unit/evaluation/test_sparse_vector_name_contract.py
+++ b/tests/unit/evaluation/test_sparse_vector_name_contract.py
@@ -1,0 +1,128 @@
+"""Contract tests for issue #1083: sparse vector name must match collection schema.
+
+The unified ingestion pipeline creates the Qdrant collection with the
+sparse vector named ``bm42`` (see ``src/ingestion/unified/cli.py``::
+
+    sparse_vectors_config = {"bm42": SparseVectorParams(modifier=Modifier.IDF)}
+
+Per Qdrant Python Client docs (Context7 ``/qdrant/qdrant-client``),
+``client.query_points(... using="<name>", ...)`` and
+``models.Prefetch(... using="<name>", ...)`` require ``<name>`` to match
+the named vector in the collection. Using a different name produces::
+
+    gRPC /qdrant.Points/Query failed with
+    Client specified an invalid argument
+    "Wrong input: Not existing vector name error: \"sparse\""
+
+— exactly the error captured in issue #1083.
+
+These tests guard the contract by parsing the AST of any production
+module that issues Qdrant queries and asserting it never uses
+``using="sparse"``. The single legal sparse vector name in this repo
+is ``"bm42"``.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Modules that issue Qdrant queries against the canonical collection
+# (gdrive_documents_bge / mirrored eval collections). Tests and scripts
+# that build their *own* schema with a different name (e.g. throwaway
+# in-memory ":memory:" collections) are intentionally excluded.
+SCAN_FILES: tuple[Path, ...] = (
+    REPO_ROOT / "src" / "evaluation" / "search_engines.py",
+    REPO_ROOT / "src" / "retrieval" / "search_engines.py",
+    REPO_ROOT / "telegram_bot" / "services" / "qdrant.py",
+    REPO_ROOT / "telegram_bot" / "services" / "apartments_service.py",
+)
+
+CANONICAL_SPARSE_VECTOR_NAME = "bm42"
+
+
+def _iter_using_keywords(source: str) -> list[tuple[int, str]]:
+    """Return ``(lineno, value)`` for every ``using=<str>`` keyword arg."""
+    tree = ast.parse(source)
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if kw.arg != "using":
+                continue
+            value = kw.value
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                hits.append((kw.value.lineno, value.value))
+    return hits
+
+
+@pytest.mark.parametrize("module_path", SCAN_FILES, ids=lambda p: p.name)
+def test_no_using_sparse_in_production_qdrant_queries(module_path: Path) -> None:
+    """No production Qdrant query may use ``using="sparse"`` — issue #1083.
+
+    The collection created by the unified ingestion pipeline names the
+    sparse vector ``"bm42"``, so any caller that queries with
+    ``using="sparse"`` triggers a Wrong input gRPC error.
+    """
+    assert module_path.exists(), f"Expected {module_path} to exist"
+    source = module_path.read_text(encoding="utf-8")
+    offenders = [
+        (lineno, value) for lineno, value in _iter_using_keywords(source) if value == "sparse"
+    ]
+    assert not offenders, (
+        f'{module_path.relative_to(REPO_ROOT)} uses ``using="sparse"`` at '
+        f"{[lineno for lineno, _ in offenders]!r}. The canonical sparse vector "
+        f"name in the repo is {CANONICAL_SPARSE_VECTOR_NAME!r} — see issue #1083 "
+        "and src/ingestion/unified/cli.py for the schema."
+    )
+
+
+@pytest.mark.parametrize("module_path", SCAN_FILES, ids=lambda p: p.name)
+def test_sparse_using_keyword_is_canonical_name(module_path: Path) -> None:
+    """Every sparse-vector ``using=...`` must use the canonical name.
+
+    A future refactor that introduces a new name (e.g. ``"sparse_v2"``)
+    must also update the ingestion schema; this test fails-loud when
+    the names drift apart.
+    """
+    assert module_path.exists()
+    source = module_path.read_text(encoding="utf-8")
+    # We only flag values that look like sparse-vector names. The dense
+    # path uses ``"dense"``, the multi-vector ColBERT path uses
+    # ``"colbert"`` — those are valid and should not be touched.
+    sparse_like_values = {
+        value
+        for _, value in _iter_using_keywords(source)
+        if "sparse" in value or "bm" in value.lower()
+    }
+    illegal = sparse_like_values - {CANONICAL_SPARSE_VECTOR_NAME}
+    assert not illegal, (
+        f"{module_path.relative_to(REPO_ROOT)} uses non-canonical sparse "
+        f"vector name(s): {sorted(illegal)!r}. Only "
+        f"{CANONICAL_SPARSE_VECTOR_NAME!r} is registered in the unified "
+        "ingestion pipeline schema (issue #1083)."
+    )
+
+
+def test_canonical_sparse_name_matches_ingestion_schema() -> None:
+    """Sanity guard: ``CANONICAL_SPARSE_VECTOR_NAME`` must match the schema
+    declared by the unified ingestion CLI."""
+    cli_path = REPO_ROOT / "src" / "ingestion" / "unified" / "cli.py"
+    assert cli_path.exists(), f"Expected {cli_path} to exist"
+    text = cli_path.read_text(encoding="utf-8")
+    assert re.search(
+        rf'"\b{re.escape(CANONICAL_SPARSE_VECTOR_NAME)}\b"\s*:\s*SparseVectorParams',
+        text,
+    ), (
+        f"src/ingestion/unified/cli.py no longer registers "
+        f"{CANONICAL_SPARSE_VECTOR_NAME!r} as the sparse vector name. "
+        "Update CANONICAL_SPARSE_VECTOR_NAME in this contract test "
+        "AND every place that queries the collection."
+    )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

`src/evaluation/search_engines.py` issued Qdrant queries with `using="sparse"` in 3 places, but the unified ingestion pipeline registers the sparse vector as `"bm42"`. Per Qdrant Python Client docs (Context7 `/qdrant/qdrant-client`), `using=...` must match the named vector in the collection — every eval hybrid/RRF/DBSF query was silently failing its sparse leg with the `"Not existing vector name"` gRPC error logged in #1083.

## Changes

- `src/evaluation/search_engines.py`: 3× `using="sparse"` → `using="bm42"` (BaselineSearchEngine RRF, ColbertSearchEngine DBSF stage 1, ColbertSearchEngine RRF stage 1) with inline comments.
- `tests/unit/evaluation/test_sparse_vector_name_contract.py`: 9 new AST contract tests parsing every `using=<str>` kwarg in production Qdrant modules; fails-loud if any uses `"sparse"` or drifts from the schema in `src/ingestion/unified/cli.py`.

## Verification

- `uv run --python 3.12 pytest tests/unit/evaluation/ -q` → **193 passed, 1 skipped (eval extra)**
- TDD: tests added first reproduced the bug (`['sparse']` non-canonical), then went green after the fix.
- Context7-verified: `models.Prefetch(... using=<name>, ...)` requires `<name>` to match collection's named vector.

## Notes

- Production retrieval already used `bm42` correctly. Bug was eval-only.
- Contract tests will catch any future drift between ingestion schema and query callers.

Closes #1083