### PR TITLE
fix: use 'bm42' sparse vector name in eval search engines

### DIFF
--- a/.agents/tasks/task-fix-sparse-vector-name-mismatch/2025-01-15-120000-review.md
+++ b/.agents/tasks/task-fix-sparse-vector-name-mismatch/2025-01-15-120000-review.md
@@ -1,0 +1,42 @@
+# Sparse vector name fix in evaluation search engines
+
+The evaluation module's three hybrid search engine classes (`HybridSearchEngine`, `HybridDBSFColBERTSearchEngine`, `HybridRRFColBERTSearchEngine`) were passing `using="sparse"` in their Qdrant Prefetch queries, while the collection is configured with `"bm42"` as the sparse vector name. This would cause Qdrant to reject queries at runtime with an invalid vector name error. The fix is a one-token change in three locations, plus regression tests that lock the correct name in place.
+
+**Watch for:** The string `"bm42"` is now hardcoded in four separate modules (evaluation, retrieval, telegram bot, and tests) with no shared constant — a future rename requires a multi-file grep (possible, low severity).
+
+## High-level view
+
+Three string literals change from `"sparse"` to `"bm42"`, matching what the retrieval module, the telegram bot, and the collection setup scripts already use. This brings the evaluation module into consistency with the rest of the codebase.
+
+The regression tests mock `QdrantClient.query_points`, invoke each engine's `search` method, and assert that the Prefetch objects passed to Qdrant carry `using="bm42"`. They correctly navigate the nested prefetch structure for the DBSF and RRF ColBERT engines, and assert the positive case (name equals `"bm42"`) so they'll catch any future drift, not just a revert.
+
+No shared constant exists for the sparse vector name. The telegram bot parameterizes it via constructor (defaulting to `"bm42"`), but retrieval and evaluation hardcode the string. Pre-existing, not introduced here, but worth noting for future maintenance.
+
+<details>
+<summary>Issues (1)</summary>
+
+1. **No shared constant for sparse vector name** — `"bm42"` is hardcoded across four modules (`src/evaluation/search_engines.py`, `src/retrieval/search_engines.py`, `telegram_bot/services/qdrant.py`, and tests). A future sparse encoder migration would require a multi-file grep. Consider extracting to `src/config/constants.py`. (possible, informational, not blocking)
+
+</details>
+
+<details>
+<summary>Details</summary>
+
+## Hardcoded vector name without a constant
+
+The codebase has no `SPARSE_VECTOR_NAME = "bm42"` constant in `src/config/constants.py`. The telegram bot parameterizes it through its constructor, but the retrieval and evaluation modules both use bare string literals. A future model migration (e.g., switching to a different sparse encoder) would require finding and updating every occurrence across four modules and their tests. This is a pre-existing pattern not introduced here, but the PR was an opportunity to extract the constant.
+
+</details>
+
+<details>
+<summary>File map</summary>
+
+| File | Change |
+|------|--------|
+| `src/evaluation/search_engines.py` | `using="sparse"` → `using="bm42"` in 3 Prefetch calls |
+| `tests/unit/evaluation/test_search_engines_eval.py` | +112 lines: 3 regression tests asserting correct sparse vector name |
+| `.agents/tasks/task-fix-sparse-vector-name-mismatch/task.json` | Task metadata (completed status, verification results) |
+| `.agents/tasks/task-fix-sparse-vector-name-mismatch/features/FEAT-001.json` | Feature spec and steps |
+| `.agents/tasks/task-fix-sparse-vector-name-mismatch/context.json` | Project context captured during planning |
+
+</details>

--- a/.agents/tasks/task-fix-sparse-vector-name-mismatch/context.json
+++ b/.agents/tasks/task-fix-sparse-vector-name-mismatch/context.json
@@ -1,0 +1,24 @@
+{
+  "project_type": "Python RAG pipeline with FastAPI, Telegram bot, Qdrant vector DB, and evaluation tools",
+  "language": "Python 3.12+",
+  "build_system": "uv (package manager), Makefile targets for common operations",
+  "test_framework": "pytest with pytest-asyncio, pytest-xdist for parallelism, pytest-httpx; tests in tests/unit/, tests/integration/, etc.",
+  "build_command": "uv sync",
+  "test_command": "uv run --python 3.12 pytest tests/unit/ --ignore=tests/unit/test_document_parser.py --ignore=tests/unit/test_evaluator.py --ignore=tests/unit/evaluation/test_ragas_evaluation.py --ignore=tests/unit/voice/test_sip_setup.py --ignore=tests/unit/voice/test_voice_agent.py --ignore=tests/unit/ingestion/test_cocoindex_init.py --ignore=tests/unit/ingestion/test_qdrant_hybrid_target.py --ignore=tests/unit/ingestion/test_qdrant_hybrid_target_helpers.py --ignore=tests/unit/ingestion/test_qdrant_hybrid_target_state_paths.py --ignore=tests/unit/ingestion/test_target_sync_execution.py --ignore=tests/unit/ingestion/test_unified_cli.py --ignore=tests/unit/ingestion/test_unified_flow.py --ignore=tests/unit/ingestion/test_unified_flow_wiring.py -n auto --dist=worksteal -q --timeout=30 -m 'not legacy_api and not requires_extras and not slow'",
+  "verification_instructions": "1. Run `make check` for linting/formatting. 2. Run `make test-unit` for unit tests.",
+  "snapshot_or_generated_files": null,
+  "setup_instructions": "1. `uv sync` to install dependencies.",
+  "environment_constraints": "OPEN_INTERNET mode - full network access available. No Docker daemon needed for unit tests.",
+  "contribution_requirements": "Test-first workflow for bug fixes. Create work on a dedicated branch. Include fresh verification evidence before claiming completion.",
+  "key_patterns": "The Qdrant collection uses sparse vector name 'bm42' (configured in setup scripts and collection creation). The retrieval module (src/retrieval/search_engines.py) correctly uses 'bm42'. The telegram bot service uses a configurable _sparse_vector_name (default 'bm42'). The evaluation module (src/evaluation/search_engines.py) incorrectly uses 'sparse'.",
+  "relevant_files": [
+    "src/evaluation/search_engines.py",
+    "src/retrieval/search_engines.py",
+    "tests/unit/evaluation/test_search_engines_eval.py",
+    "telegram_bot/services/qdrant.py",
+    "scripts/setup_qdrant_collection.py",
+    "src/ingestion/indexer.py",
+    "src/config/constants.py"
+  ],
+  "directory_structure": "src/ - main source (retrieval, evaluation, ingestion, config, api). telegram_bot/ - Telegram bot service code. tests/ - test suites (unit, integration, smoke, etc). scripts/ - utility scripts. services/ - microservice containers."
+}

--- a/.agents/tasks/task-fix-sparse-vector-name-mismatch/features/FEAT-001.json
+++ b/.agents/tasks/task-fix-sparse-vector-name-mismatch/features/FEAT-001.json
@@ -1,0 +1,31 @@
+{
+  "id": "FEAT-001",
+  "type": "fix",
+  "description": "Fix sparse vector name mismatch in src/evaluation/search_engines.py: change 'sparse' to 'bm42' in all Prefetch queries, and add a regression test that asserts the correct vector name is used in query construction.",
+  "status": "in_progress",
+  "steps": [
+    "Create a dedicated branch named 'fix/1083-sparse-vector-name-mismatch' from dev.",
+    "Write a failing test in tests/unit/evaluation/test_search_engines_eval.py that asserts the sparse vector name passed to Qdrant Prefetch queries is 'bm42' (not 'sparse'). The test should cover all 3 engine classes that use sparse vectors: HybridSearchEngine, HybridDBSFColBERTSearchEngine, and HybridRRFColBERTSearchEngine. Follow the existing test patterns that mock QdrantClient and Settings. The test should inspect the prefetch argument of the call to client.query_points and verify the 'using' field of the sparse Prefetch is 'bm42'.",
+    "Run the new tests and confirm they FAIL (RED) because the code currently uses 'sparse'.",
+    "Fix src/evaluation/search_engines.py line 162: change using='sparse' to using='bm42' in HybridSearchEngine._search method.",
+    "Fix src/evaluation/search_engines.py line 233: change using='sparse' to using='bm42' in HybridDBSFColBERTSearchEngine.search method.",
+    "Fix src/evaluation/search_engines.py line 311: change using='sparse' to using='bm42' in HybridRRFColBERTSearchEngine.search method.",
+    "Run the new regression tests and confirm they PASS (GREEN).",
+    "Run the full unit test suite with `make test-unit` and confirm no regressions.",
+    "Run `make check` (ruff lint + format check) to confirm code quality."
+  ],
+  "acceptance_criteria": [
+    "All 3 occurrences of using='sparse' in src/evaluation/search_engines.py are replaced with using='bm42'.",
+    "New regression tests exist that verify the sparse vector name is 'bm42' for HybridSearchEngine, HybridDBSFColBERTSearchEngine, and HybridRRFColBERTSearchEngine.",
+    "Running `uv run pytest tests/unit/evaluation/test_search_engines_eval.py -q` passes all tests.",
+    "Running `make test-unit` passes with no regressions.",
+    "Running `make check` (lint + format) passes."
+  ],
+  "verification": [
+    "uv run pytest tests/unit/evaluation/test_search_engines_eval.py -q --timeout=30",
+    "make test-unit",
+    "make check"
+  ],
+  "blocked_reason": null,
+  "findings": ""
+}

--- a/.agents/tasks/task-fix-sparse-vector-name-mismatch/features/FEAT-001.json
+++ b/.agents/tasks/task-fix-sparse-vector-name-mismatch/features/FEAT-001.json
@@ -2,7 +2,7 @@
   "id": "FEAT-001",
   "type": "fix",
   "description": "Fix sparse vector name mismatch in src/evaluation/search_engines.py: change 'sparse' to 'bm42' in all Prefetch queries, and add a regression test that asserts the correct vector name is used in query construction.",
-  "status": "in_progress",
+  "status": "completed",
   "steps": [
     "Create a dedicated branch named 'fix/1083-sparse-vector-name-mismatch' from dev.",
     "Write a failing test in tests/unit/evaluation/test_search_engines_eval.py that asserts the sparse vector name passed to Qdrant Prefetch queries is 'bm42' (not 'sparse'). The test should cover all 3 engine classes that use sparse vectors: HybridSearchEngine, HybridDBSFColBERTSearchEngine, and HybridRRFColBERTSearchEngine. Follow the existing test patterns that mock QdrantClient and Settings. The test should inspect the prefetch argument of the call to client.query_points and verify the 'using' field of the sparse Prefetch is 'bm42'.",
@@ -27,5 +27,5 @@
     "make check"
   ],
   "blocked_reason": null,
-  "findings": ""
+  "findings": "All 3 occurrences fixed. Pre-existing test failures in mini_app (import errors), docker validation, markdown links, and cocoindex tests are unrelated. The mypy error in telegram_bot/bot.py:4059 is also pre-existing and unrelated to this change."
 }

--- a/.agents/tasks/task-fix-sparse-vector-name-mismatch/task.json
+++ b/.agents/tasks/task-fix-sparse-vector-name-mismatch/task.json
@@ -1,0 +1,7 @@
+{
+  "task_id": "task-fix-sparse-vector-name-mismatch",
+  "task_description": "Fix GitHub issue #1083: sparse vector name mismatch ('sparse' vs 'bm42') in src/evaluation/search_engines.py that triggers invalid vector name queries against Qdrant. The retrieval module correctly uses 'bm42' but the evaluation module uses 'sparse'.",
+  "status": "in_progress",
+  "feature_order": ["FEAT-001"],
+  "blocked_reason": null
+}

--- a/.agents/tasks/task-fix-sparse-vector-name-mismatch/task.json
+++ b/.agents/tasks/task-fix-sparse-vector-name-mismatch/task.json
@@ -1,7 +1,14 @@
 {
   "task_id": "task-fix-sparse-vector-name-mismatch",
   "task_description": "Fix GitHub issue #1083: sparse vector name mismatch ('sparse' vs 'bm42') in src/evaluation/search_engines.py that triggers invalid vector name queries against Qdrant. The retrieval module correctly uses 'bm42' but the evaluation module uses 'sparse'.",
-  "status": "in_progress",
+  "status": "completed",
   "feature_order": ["FEAT-001"],
-  "blocked_reason": null
+  "blocked_reason": null,
+  "verification": {
+    "build": "pass",
+    "tests": "pass",
+    "test_quality": "pass",
+    "docker_build": "skipped",
+    "summary": "All 41 evaluation tests pass (including 3 new regression tests for #1083). Unit suite: 6877 passed, 14 pre-existing failures unrelated to this change. Ruff lint and format checks pass."
+  }
 }

--- a/src/evaluation/search_engines.py
+++ b/src/evaluation/search_engines.py
@@ -159,7 +159,7 @@ class HybridSearchEngine(SearchEngine):
         # Build hybrid search with RRF using query API
         prefetch = [
             models.Prefetch(query=dense_vector, using="dense", limit=100),
-            models.Prefetch(query=sparse_vector, using="sparse", limit=100),
+            models.Prefetch(query=sparse_vector, using="bm42", limit=100),
         ]
 
         response = self.client.query_points(
@@ -230,7 +230,7 @@ class HybridDBSFColBERTSearchEngine(SearchEngine):
         dbsf_prefetch = models.Prefetch(
             prefetch=[
                 models.Prefetch(query=dense_vector, using="dense", limit=self.stage1_limit),
-                models.Prefetch(query=sparse_vector, using="sparse", limit=self.stage1_limit),
+                models.Prefetch(query=sparse_vector, using="bm42", limit=self.stage1_limit),
             ],
             query=models.FusionQuery(fusion=models.Fusion.DBSF),
         )
@@ -308,7 +308,7 @@ class HybridRRFColBERTSearchEngine(SearchEngine):
         rrf_prefetch = models.Prefetch(
             prefetch=[
                 models.Prefetch(query=dense_vector, using="dense", limit=self.stage1_limit),
-                models.Prefetch(query=sparse_vector, using="sparse", limit=self.stage1_limit),
+                models.Prefetch(query=sparse_vector, using="bm42", limit=self.stage1_limit),
             ],
             query=models.RrfQuery(rrf=models.Rrf(k=self.rrf_k)),
         )

--- a/tests/unit/evaluation/test_search_engines_eval.py
+++ b/tests/unit/evaluation/test_search_engines_eval.py
@@ -780,3 +780,115 @@ class TestLexicalWeightsToSparse:
         assert isinstance(sparse, models.SparseVector)
         assert sparse.indices == [100, 200]
         assert sparse.values == pytest.approx([0.5, 0.8])
+
+
+class TestSparseVectorNameInPrefetch:
+    """Regression tests for GitHub issue #1083: sparse vector name must be 'bm42'."""
+
+    @patch("src.evaluation.search_engines.QdrantClient")
+    @patch("src.evaluation.search_engines.Settings")
+    def test_hybrid_search_engine_uses_bm42_sparse_name(self, mock_settings_cls, mock_qdrant):
+        """HybridSearchEngine must use 'bm42' as the sparse vector name in Prefetch."""
+        from src.evaluation.search_engines import HybridSearchEngine
+
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings.qdrant_api_key = "test-key"
+        mock_settings_cls.return_value = mock_settings
+
+        mock_model = MagicMock()
+        mock_model.encode.return_value = {
+            "dense_vecs": np.array([0.1, 0.2]),
+            "lexical_weights": {"100": 0.5, "200": 0.8},
+            "colbert_vecs": np.array([[0.1, 0.2]]),
+        }
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.points = []
+        mock_client.query_points.return_value = mock_response
+        mock_qdrant.return_value = mock_client
+
+        engine = HybridSearchEngine("test_collection", mock_model)
+        engine.search("test query", top_k=5)
+
+        call_kwargs = mock_client.query_points.call_args[1]
+        prefetch = call_kwargs["prefetch"]
+        sparse_prefetches = [p for p in prefetch if p.using == "bm42"]
+        assert len(sparse_prefetches) == 1, (
+            f"Expected exactly one Prefetch with using='bm42', got: {[p.using for p in prefetch]}"
+        )
+
+    @patch("src.evaluation.search_engines.QdrantClient")
+    @patch("src.evaluation.search_engines.Settings")
+    def test_hybrid_dbsf_colbert_uses_bm42_sparse_name(self, mock_settings_cls, mock_qdrant):
+        """HybridDBSFColBERTSearchEngine must use 'bm42' as the sparse vector name."""
+        from src.evaluation.search_engines import HybridDBSFColBERTSearchEngine
+
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings.qdrant_api_key = "test-key"
+        mock_settings_cls.return_value = mock_settings
+
+        mock_model = MagicMock()
+        mock_model.encode.return_value = {
+            "dense_vecs": np.array([0.1, 0.2]),
+            "lexical_weights": {"100": 0.5, "200": 0.8},
+            "colbert_vecs": np.array([[0.1, 0.2]]),
+        }
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.points = []
+        mock_client.query_points.return_value = mock_response
+        mock_qdrant.return_value = mock_client
+
+        engine = HybridDBSFColBERTSearchEngine("test_collection", mock_model)
+        engine.search("test query", top_k=5)
+
+        call_kwargs = mock_client.query_points.call_args[1]
+        # The outer prefetch contains a DBSF fusion prefetch with nested dense+sparse
+        outer_prefetch = call_kwargs["prefetch"]
+        inner_prefetch_list = outer_prefetch[0].prefetch
+        sparse_prefetches = [p for p in inner_prefetch_list if p.using == "bm42"]
+        assert len(sparse_prefetches) == 1, (
+            f"Expected exactly one inner Prefetch with using='bm42', "
+            f"got: {[p.using for p in inner_prefetch_list]}"
+        )
+
+    @patch("src.evaluation.search_engines.QdrantClient")
+    @patch("src.evaluation.search_engines.Settings")
+    def test_hybrid_rrf_colbert_uses_bm42_sparse_name(self, mock_settings_cls, mock_qdrant):
+        """HybridRRFColBERTSearchEngine must use 'bm42' as the sparse vector name."""
+        from src.evaluation.search_engines import HybridRRFColBERTSearchEngine
+
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://localhost:6333"
+        mock_settings.qdrant_api_key = "test-key"
+        mock_settings_cls.return_value = mock_settings
+
+        mock_model = MagicMock()
+        mock_model.encode.return_value = {
+            "dense_vecs": np.array([0.1, 0.2]),
+            "lexical_weights": {"100": 0.5, "200": 0.8},
+            "colbert_vecs": np.array([[0.1, 0.2]]),
+        }
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.points = []
+        mock_client.query_points.return_value = mock_response
+        mock_qdrant.return_value = mock_client
+
+        engine = HybridRRFColBERTSearchEngine("test_collection", mock_model)
+        engine.search("test query", top_k=5)
+
+        call_kwargs = mock_client.query_points.call_args[1]
+        # The outer prefetch contains an RRF fusion prefetch with nested dense+sparse
+        outer_prefetch = call_kwargs["prefetch"]
+        inner_prefetch_list = outer_prefetch[0].prefetch
+        sparse_prefetches = [p for p in inner_prefetch_list if p.using == "bm42"]
+        assert len(sparse_prefetches) == 1, (
+            f"Expected exactly one inner Prefetch with using='bm42', "
+            f"got: {[p.using for p in inner_prefetch_list]}"
+        )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Fixes #1083 - sparse vector name mismatch (`sparse` vs `bm42`) causing Qdrant to reject queries with "Not existing vector name" errors.

## Changes

**Bug Fix** (`src/evaluation/search_engines.py`):
- `HybridSearchEngine` (line 162): changed `using="sparse"` → `using="bm42"`
- `HybridDBSFColBERTSearchEngine` (line 233): changed `using="sparse"` → `using="bm42"`
- `HybridRRFColBERTSearchEngine` (line 311): changed `using="sparse"` → `using="bm42"`

The retrieval module already uses the correct `"bm42"` name; only the evaluation module had the mismatch.

**Regression Tests** (`tests/unit/evaluation/test_search_engines_eval.py`):
- Added `TestSparseVectorNameInPrefetch` class with 3 targeted regression tests asserting the correct sparse vector name is used in Prefetch queries for all three hybrid engine classes.

## Verification

- `uv run pytest tests/unit/evaluation/test_search_engines_eval.py -q` - **41 passed**
- `make test-unit` - **6877 passed** (14 failures are all pre-existing/unrelated)
- `ruff check` and `ruff format --check` - **all passed**

## Limitations

- Telemetry error (part 1 of the issue) is a network connectivity issue in the dev container and not addressable via code changes.