### PR TITLE
test(observability): add voice trace validation gate via Langfuse API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1152,7 +1152,7 @@ qdrant-cleanup: ## Prune Qdrant storage: snapshot then trigger optimiser (#1545)
 # TRACE VALIDATION (#110)
 # =============================================================================
 
-.PHONY: validate-traces validate-traces-fast
+.PHONY: validate-traces validate-traces-fast validate-voice-traces
 
 # Local host defaults for native trace validation (issue #1380).
 # Callers can override per-variable: make validate-traces-fast QDRANT_URL=http://custom:6333 REDIS_URL=redis://:x@custom:6379
@@ -1179,6 +1179,14 @@ validate-traces-fast: ## No rebuild; trace validation fails if required trace fa
 	LANGFUSE_SECRET_KEY="$(or $(LANGFUSE_SECRET_KEY),sk-lf-dev)" \
 	uv run python scripts/validate_traces.py --report
 	@echo "$(GREEN)Validation complete — see docs/reports/$(NC)"
+
+validate-voice-traces: ## Voice trace validation gate (reads Langfuse, validates presence + attribution)
+	@echo "$(BLUE)Voice trace validation gate...$(NC)"
+	LANGFUSE_HOST="$(or $(LANGFUSE_HOST),http://localhost:3001)" \
+	LANGFUSE_PUBLIC_KEY="$(or $(LANGFUSE_PUBLIC_KEY),pk-lf-dev)" \
+	LANGFUSE_SECRET_KEY="$(or $(LANGFUSE_SECRET_KEY),sk-lf-dev)" \
+	uv run python scripts/validate_voice_traces.py
+	@echo "$(GREEN)Voice trace validation complete$(NC)"
 
 # =============================================================================
 # K3S DEPLOYMENT

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -150,6 +150,14 @@ make validate-traces-fast
 
 This target runs natively on the host and automatically points to local Docker service endpoints (`localhost:6333`, `localhost:8000`, `localhost:4000`, etc.). You can override individual endpoints if needed: `make validate-traces-fast QDRANT_URL=http://custom:6333`.
 
+Voice trace validation gate (after voice-agent wiring changes):
+
+```bash
+make validate-voice-traces
+```
+
+This gate validates voice-session traces are present in Langfuse with correct service attribution (`user_id=voice-agent`, `session_id=voice-*`, tags). Run after modifying voice observability code or compose service identity.
+
 When `.env` is absent, `validate-traces-fast` runs a preflight guard before `docker compose up`. If fallback uses `tests/fixtures/compose.ci.env` with the local default `POSTGRES_PASSWORD=postgres`, reusing `dev_postgres_data` is allowed. The guard fails fast only when fallback password and existing volume credentials can mismatch, preventing an unhealthy Langfuse/Postgres auth loop.
 
 If Langfuse CLI returns `401` or points to wrong host, run with explicit host:

--- a/docs/runbooks/LANGFUSE_TRACING_GAPS.md
+++ b/docs/runbooks/LANGFUSE_TRACING_GAPS.md
@@ -29,6 +29,8 @@ When traces appear missing, validate **app pipeline coverage** first:
 
 If direct families and nested Telegram families are present and root input is sanitized, flat `litellm-acompletion` traces do **not** indicate a defect.
 
+- Voice-agent trace gate: **`make validate-voice-traces`** (validates voice-session presence and attribution)
+
 ### Cache-smoke behavior check
 
 For cache regression checks:
@@ -292,6 +294,70 @@ docker compose restart bot
 - Monitor Langfuse ingestion rate
 - Alert on trace family gaps
 - Distinguish proxy-generated `litellm-acompletion` traces from app-instrumented `telegram-message` traces when triaging gaps
+
+## Voice-Agent Trace Validation Gate (#1517)
+
+A dedicated validation gate for voice-session traces that verifies trace
+presence and service attribution without requiring a running LiveKit/SIP stack.
+
+### Command
+
+```bash
+make validate-voice-traces
+```
+
+### What It Checks
+
+1. **Langfuse connectivity** - verifies API is reachable with configured credentials
+2. **OTEL_SERVICE_NAME** - static check that `voice-agent` is set in compose.yml
+3. **Trace production** - calls `update_voice_trace()` to produce a deterministic trace
+4. **Trace presence** - reads back `voice-session` traces via Langfuse API
+5. **Service attribution** - validates `user_id=voice-agent`, `session_id` matches `voice-*` pattern, tags include `voice` and `call-lifecycle`
+
+### How to Run Locally
+
+```bash
+# Start local Langfuse (part of ml profile)
+make docker-ml-up
+
+# Run the gate
+make validate-voice-traces
+
+# Or with custom credentials
+make validate-voice-traces LANGFUSE_HOST=http://localhost:3001
+```
+
+### Expected Output
+
+```
+Voice Trace Validation Gate
+[1/5] Checking Langfuse connectivity...
+OK: Langfuse connectivity verified (host=http://localhost:3001)
+[2/5] Checking OTEL_SERVICE_NAME in compose.yml...
+OK: OTEL_SERVICE_NAME=voice-agent found in compose.yml
+[3/5] Producing voice-session trace...
+OK: Produced voice-session trace (session_id=voice-validate-...)
+[4/5] Waiting for ingestion...
+[5/5] Validating voice-session traces...
+
+Evidence Summary (redacted):
+  trace_id:     <uuid>
+  session_id:   voice-validate-...
+  user_id:      voice-agent
+  tags:         ['voice', 'call-lifecycle']
+  traces_found: 1
+
+PASS: Voice trace validation gate passed
+```
+
+### Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| Langfuse connectivity failed | Ensure local Langfuse is running (`make docker-ml-up`) |
+| No voice-session traces found | Check that `update_voice_trace` is not swallowing errors; verify Langfuse ingestion is working |
+| Wrong user_id | Check `src/voice/observability.py` sets `user_id="voice-agent"` in `propagate_attributes` |
+| Session ID pattern mismatch | Verify `voice_session_id()` prepends `voice-` prefix |
 
 ## See Also
 

--- a/scripts/validate_voice_traces.py
+++ b/scripts/validate_voice_traces.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Voice trace validation gate.
+
+Validates that voice-session traces are present in Langfuse with correct
+service attribution. Designed for local/dev execution against local Langfuse.
+
+Usage:
+    uv run python scripts/validate_voice_traces.py
+    uv run python scripts/validate_voice_traces.py --host http://localhost:3001
+    uv run python scripts/validate_voice_traces.py --help
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+
+# Ensure project root is importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments with env-var defaults."""
+    parser = argparse.ArgumentParser(
+        description="Voice trace validation gate for Langfuse",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.environ.get("LANGFUSE_HOST", "http://localhost:3001"),
+        help="Langfuse host URL (default: $LANGFUSE_HOST or http://localhost:3001)",
+    )
+    parser.add_argument(
+        "--public-key",
+        default=os.environ.get("LANGFUSE_PUBLIC_KEY", "pk-lf-dev"),
+        help="Langfuse public key (default: $LANGFUSE_PUBLIC_KEY or pk-lf-dev)",
+    )
+    parser.add_argument(
+        "--secret-key",
+        default=os.environ.get("LANGFUSE_SECRET_KEY", "sk-lf-dev"),
+        help="Langfuse secret key (default: $LANGFUSE_SECRET_KEY or sk-lf-dev)",
+    )
+    parser.add_argument(
+        "--lookback-minutes",
+        type=int,
+        default=5,
+        help="How far back to look for traces (default: 5 minutes)",
+    )
+    parser.add_argument(
+        "--skip-produce",
+        action="store_true",
+        help="Skip producing a new trace; only validate existing traces",
+    )
+    return parser.parse_args()
+
+
+def check_langfuse_connectivity(host: str, public_key: str, secret_key: str) -> bool:
+    """Verify Langfuse API is reachable and auth works."""
+    os.environ["LANGFUSE_HOST"] = host
+    os.environ["LANGFUSE_PUBLIC_KEY"] = public_key
+    os.environ["LANGFUSE_SECRET_KEY"] = secret_key
+
+    from langfuse import Langfuse
+
+    try:
+        lf = Langfuse()
+        result = lf.auth_check()
+        lf.flush()
+        if not result:
+            print("ERROR: Langfuse auth_check returned False")
+            return False
+        print(f"OK: Langfuse connectivity verified (host={host})")
+        return True
+    except Exception as e:
+        print(f"ERROR: Langfuse connectivity failed: {e}")
+        return False
+
+
+def produce_voice_trace() -> str:
+    """Produce a deterministic voice-session trace via update_voice_trace.
+
+    Returns the expected session_id.
+    """
+    from src.voice.observability import update_voice_trace
+
+    call_id = f"validate-{int(time.time())}"
+    session_id = f"voice-{call_id}"
+
+    update_voice_trace(
+        call_id=call_id,
+        status="completed",
+        duration_sec=10,
+        session_id=session_id,
+    )
+    print(f"OK: Produced voice-session trace (session_id={session_id})")
+    return session_id
+
+
+def wait_for_ingestion(seconds: int = 3) -> None:
+    """Wait briefly for Langfuse to ingest the trace."""
+    print(f"    Waiting {seconds}s for Langfuse ingestion...")
+    time.sleep(seconds)
+
+
+def validate_traces(lookback_minutes: int) -> dict:
+    """Read back voice-session traces from Langfuse and validate.
+
+    Returns a result dict with 'ok', 'evidence', and 'errors' keys.
+    """
+    from langfuse import Langfuse
+
+    lf = Langfuse()
+    from_ts = datetime.now(UTC) - timedelta(minutes=lookback_minutes)
+
+    try:
+        traces_page = lf.api.trace.list(
+            name="voice-session",
+            from_timestamp=from_ts,
+            order_by="timestamp.desc",
+            limit=10,
+        )
+    except Exception as e:
+        return {"ok": False, "evidence": None, "errors": [f"API call failed: {e}"]}
+    finally:
+        lf.flush()
+
+    traces_data = getattr(traces_page, "data", []) or []
+
+    if not traces_data:
+        return {
+            "ok": False,
+            "evidence": None,
+            "errors": [f"No voice-session traces found in last {lookback_minutes} minutes"],
+        }
+
+    # Validate the most recent trace
+    trace = traces_data[0]
+    errors: list[str] = []
+
+    # Check service attribution
+    user_id = getattr(trace, "user_id", None)
+    if user_id != "voice-agent":
+        errors.append(f"user_id={user_id!r}, expected 'voice-agent'")
+
+    session_id = getattr(trace, "session_id", None) or ""
+    if not session_id.startswith("voice-"):
+        errors.append(f"session_id={session_id!r} does not match 'voice-*' pattern")
+
+    tags = getattr(trace, "tags", None) or []
+    if "voice" not in tags:
+        errors.append("Missing 'voice' tag")
+    if "call-lifecycle" not in tags:
+        errors.append("Missing 'call-lifecycle' tag")
+
+    # Build evidence summary (redacted, no PII)
+    trace_id = getattr(trace, "id", "unknown")
+    evidence = {
+        "trace_id": trace_id,
+        "session_id": session_id,
+        "user_id": user_id,
+        "tags": tags,
+        "traces_found": len(traces_data),
+    }
+
+    return {"ok": len(errors) == 0, "evidence": evidence, "errors": errors}
+
+
+def check_compose_service_name() -> bool:
+    """Static check: verify OTEL_SERVICE_NAME=voice-agent is set in compose.yml."""
+    compose_path = Path(__file__).resolve().parent.parent / "compose.yml"
+    if not compose_path.exists():
+        print("WARNING: compose.yml not found; skipping static OTEL check")
+        return True
+
+    content = compose_path.read_text()
+    if "OTEL_SERVICE_NAME" in content and "voice-agent" in content:
+        print("OK: OTEL_SERVICE_NAME=voice-agent found in compose.yml")
+        return True
+
+    print("WARNING: OTEL_SERVICE_NAME=voice-agent not found in compose.yml")
+    return False
+
+
+def main() -> None:
+    """Run the voice trace validation gate."""
+    args = parse_args()
+
+    print("=" * 60)
+    print("Voice Trace Validation Gate")
+    print("=" * 60)
+    print()
+
+    # Step 1: Connectivity check
+    print("[1/5] Checking Langfuse connectivity...")
+    if not check_langfuse_connectivity(args.host, args.public_key, args.secret_key):
+        sys.exit(1)
+    print()
+
+    # Step 2: Static compose check
+    print("[2/5] Checking OTEL_SERVICE_NAME in compose.yml...")
+    check_compose_service_name()
+    print()
+
+    # Step 3: Produce trace (unless --skip-produce)
+    if not args.skip_produce:
+        print("[3/5] Producing voice-session trace...")
+        try:
+            produce_voice_trace()
+        except Exception as e:
+            print(f"WARNING: Could not produce trace: {e}")
+            print("    Continuing with validation of existing traces...")
+        print()
+
+        # Step 4: Wait for ingestion
+        print("[4/5] Waiting for ingestion...")
+        wait_for_ingestion(3)
+        print()
+    else:
+        print("[3/5] Skipping trace production (--skip-produce)")
+        print("[4/5] Skipping wait")
+        print()
+
+    # Step 5: Validate
+    print("[5/5] Validating voice-session traces...")
+    result = validate_traces(args.lookback_minutes)
+
+    if result["evidence"]:
+        print()
+        print("Evidence Summary (redacted):")
+        evidence = result["evidence"]
+        print(f"  trace_id:     {evidence['trace_id']}")
+        print(f"  session_id:   {evidence['session_id']}")
+        print(f"  user_id:      {evidence['user_id']}")
+        print(f"  tags:         {evidence['tags']}")
+        print(f"  traces_found: {evidence['traces_found']}")
+
+    print()
+    if result["ok"]:
+        print("PASS: Voice trace validation gate passed")
+        sys.exit(0)
+    else:
+        print("FAIL: Voice trace validation gate failed")
+        for err in result["errors"]:
+            print(f"  - {err}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_voice_traces.py
+++ b/scripts/validate_voice_traces.py
@@ -87,6 +87,7 @@ def produce_voice_trace() -> str:
     Returns the expected session_id.
     """
     from src.voice.observability import update_voice_trace
+    from telegram_bot.observability import get_client
 
     call_id = f"validate-{int(time.time())}"
     session_id = f"voice-{call_id}"
@@ -97,6 +98,9 @@ def produce_voice_trace() -> str:
         duration_sec=10,
         session_id=session_id,
     )
+    lf = get_client()
+    if lf is not None:
+        lf.flush()
     print(f"OK: Produced voice-session trace (session_id={session_id})")
     return session_id
 
@@ -145,10 +149,7 @@ def validate_traces(lookback_minutes: int, expected_session_id: str | None = Non
 
     # Filter by expected session_id if provided
     if expected_session_id:
-        matching = [
-            t for t in traces_data
-            if getattr(t, "session_id", "") == expected_session_id
-        ]
+        matching = [t for t in traces_data if getattr(t, "session_id", "") == expected_session_id]
         if not matching:
             return {
                 "ok": False,
@@ -241,8 +242,10 @@ def main() -> None:
         try:
             produced_session_id = produce_voice_trace()
         except Exception as e:
-            print(f"WARNING: Could not produce trace: {e}")
-            print("    Continuing with validation of existing traces...")
+            print(f"ERROR: Could not produce trace: {e}")
+            print("    Refusing to validate existing traces in default mode.")
+            print("    Re-run with --skip-produce to explicitly validate existing traces.")
+            sys.exit(1)
         print()
 
         # Step 4: Wait for ingestion

--- a/scripts/validate_voice_traces.py
+++ b/scripts/validate_voice_traces.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import sys
 import time
 from datetime import UTC, datetime, timedelta
@@ -60,14 +61,14 @@ def parse_args() -> argparse.Namespace:
 
 def check_langfuse_connectivity(host: str, public_key: str, secret_key: str) -> bool:
     """Verify Langfuse API is reachable and auth works."""
-    os.environ["LANGFUSE_HOST"] = host
-    os.environ["LANGFUSE_PUBLIC_KEY"] = public_key
-    os.environ["LANGFUSE_SECRET_KEY"] = secret_key
-
     from langfuse import Langfuse
 
     try:
-        lf = Langfuse()
+        lf = Langfuse(
+            host=host,
+            public_key=public_key,
+            secret_key=secret_key,
+        )
         result = lf.auth_check()
         lf.flush()
         if not result:
@@ -106,8 +107,13 @@ def wait_for_ingestion(seconds: int = 3) -> None:
     time.sleep(seconds)
 
 
-def validate_traces(lookback_minutes: int) -> dict:
+def validate_traces(lookback_minutes: int, expected_session_id: str | None = None) -> dict:
     """Read back voice-session traces from Langfuse and validate.
+
+    Args:
+        lookback_minutes: How far back to look for traces.
+        expected_session_id: If provided, filter traces to match this session_id.
+            When None (e.g., --skip-produce mode), validate the most recent trace.
 
     Returns a result dict with 'ok', 'evidence', and 'errors' keys.
     """
@@ -137,8 +143,26 @@ def validate_traces(lookback_minutes: int) -> dict:
             "errors": [f"No voice-session traces found in last {lookback_minutes} minutes"],
         }
 
-    # Validate the most recent trace
-    trace = traces_data[0]
+    # Filter by expected session_id if provided
+    if expected_session_id:
+        matching = [
+            t for t in traces_data
+            if getattr(t, "session_id", "") == expected_session_id
+        ]
+        if not matching:
+            return {
+                "ok": False,
+                "evidence": None,
+                "errors": [
+                    f"No trace with session_id={expected_session_id!r} found "
+                    f"(found {len(traces_data)} other voice-session traces)"
+                ],
+            }
+        trace = matching[0]
+    else:
+        # Validate the most recent trace
+        trace = traces_data[0]
+
     errors: list[str] = []
 
     # Check service attribution
@@ -170,14 +194,14 @@ def validate_traces(lookback_minutes: int) -> dict:
 
 
 def check_compose_service_name() -> bool:
-    """Static check: verify OTEL_SERVICE_NAME=voice-agent is set in compose.yml."""
+    """Static check: verify OTEL_SERVICE_NAME is associated with voice-agent in compose.yml."""
     compose_path = Path(__file__).resolve().parent.parent / "compose.yml"
     if not compose_path.exists():
         print("WARNING: compose.yml not found; skipping static OTEL check")
         return True
 
     content = compose_path.read_text()
-    if "OTEL_SERVICE_NAME" in content and "voice-agent" in content:
+    if re.search(r"OTEL_SERVICE_NAME.*voice-agent", content):
         print("OK: OTEL_SERVICE_NAME=voice-agent found in compose.yml")
         return True
 
@@ -194,6 +218,11 @@ def main() -> None:
     print("=" * 60)
     print()
 
+    # Set environment variables for Langfuse client instances used later
+    os.environ["LANGFUSE_HOST"] = args.host
+    os.environ["LANGFUSE_PUBLIC_KEY"] = args.public_key
+    os.environ["LANGFUSE_SECRET_KEY"] = args.secret_key
+
     # Step 1: Connectivity check
     print("[1/5] Checking Langfuse connectivity...")
     if not check_langfuse_connectivity(args.host, args.public_key, args.secret_key):
@@ -206,10 +235,11 @@ def main() -> None:
     print()
 
     # Step 3: Produce trace (unless --skip-produce)
+    produced_session_id: str | None = None
     if not args.skip_produce:
         print("[3/5] Producing voice-session trace...")
         try:
-            produce_voice_trace()
+            produced_session_id = produce_voice_trace()
         except Exception as e:
             print(f"WARNING: Could not produce trace: {e}")
             print("    Continuing with validation of existing traces...")
@@ -226,7 +256,7 @@ def main() -> None:
 
     # Step 5: Validate
     print("[5/5] Validating voice-session traces...")
-    result = validate_traces(args.lookback_minutes)
+    result = validate_traces(args.lookback_minutes, expected_session_id=produced_session_id)
 
     if result["evidence"]:
         print()

--- a/tests/observability/conftest.py
+++ b/tests/observability/conftest.py
@@ -1,0 +1,43 @@
+"""Shared fixtures for the observability test module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+
+CONTRACT_PATH = Path(__file__).resolve().parent / "trace_contract.yaml"
+
+# Voice-agent service identity constants
+VOICE_AGENT_SERVICE_NAME = "voice-agent"
+VOICE_SESSION_TRACE_NAME = "voice-session"
+VOICE_TRACE_TAGS = ["voice", "call-lifecycle"]
+
+
+@pytest.fixture(scope="session")
+def trace_contract() -> dict:
+    """Load the canonical trace contract YAML."""
+    with open(CONTRACT_PATH) as f:
+        return yaml.safe_load(f)
+
+
+@pytest.fixture(scope="session")
+def required_families(trace_contract: dict) -> list[str]:
+    """Required trace family names from contract."""
+    return trace_contract["required_families"]
+
+
+@pytest.fixture()
+def mock_langfuse_client() -> MagicMock:
+    """Provide a mocked Langfuse client with common API structure."""
+    client = MagicMock()
+    client.auth_check.return_value = True
+    client.api = MagicMock()
+    client.api.trace = MagicMock()
+    client.api.trace.list.return_value = MagicMock(data=[])
+    client.api.trace.get.return_value = MagicMock()
+    client.flush.return_value = None
+    return client

--- a/tests/observability/gate_logic.py
+++ b/tests/observability/gate_logic.py
@@ -1,0 +1,72 @@
+"""Shared gate logic for voice trace validation.
+
+Contains validation functions and test helpers used by both the integration
+tests (test_voice_trace_gate.py) and unit tests (test_voice_trace_gate_unit.py).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeTrace:
+    """Minimal Langfuse trace representation for assertions."""
+
+    id: str
+    name: str
+    user_id: str | None = None
+    session_id: str | None = None
+    tags: list[str] | None = None
+    metadata: dict | None = None
+    observations: list | None = None
+
+
+@dataclass
+class FakeObservation:
+    """Minimal Langfuse observation for assertions."""
+
+    name: str
+    type: str = "SPAN"
+
+
+# ---------------------------------------------------------------------------
+# Core gate logic
+# ---------------------------------------------------------------------------
+
+
+def validate_voice_trace_presence(traces_data: list) -> bool:
+    """Return True if at least one voice-session trace is present."""
+    return len(traces_data) > 0
+
+
+def validate_voice_trace_attribution(trace: object) -> dict[str, bool]:
+    """Validate service attribution fields on a trace object."""
+    user_id = getattr(trace, "user_id", None)
+    session_id = getattr(trace, "session_id", None) or ""
+    tags = getattr(trace, "tags", None) or []
+
+    return {
+        "user_id_correct": user_id == "voice-agent",
+        "session_id_pattern": session_id.startswith("voice-"),
+        "has_voice_tag": "voice" in tags,
+        "has_lifecycle_tag": "call-lifecycle" in tags,
+    }
+
+
+def build_evidence_summary(trace: object) -> dict[str, str | list[str]]:
+    """Build a redacted evidence summary from a trace (no PII)."""
+    observations = getattr(trace, "observations", None) or []
+    obs_names = [getattr(o, "name", "unknown") for o in observations]
+    return {
+        "trace_id": getattr(trace, "id", "unknown"),
+        "session_id": getattr(trace, "session_id", "unknown"),
+        "observation_names": obs_names,
+        "user_id": getattr(trace, "user_id", "unknown"),
+        "tags": getattr(trace, "tags", None) or [],
+    }

--- a/tests/observability/test_voice_trace_gate.py
+++ b/tests/observability/test_voice_trace_gate.py
@@ -13,36 +13,22 @@ A live-Langfuse variant is gated by LANGFUSE_PUBLIC_KEY presence.
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+from tests.observability.gate_logic import (
+    FakeObservation,
+    FakeTrace,
+    build_evidence_summary,
+    validate_voice_trace_attribution,
+    validate_voice_trace_presence,
+)
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-@dataclass
-class FakeTrace:
-    """Minimal Langfuse trace representation for assertions."""
-
-    id: str
-    name: str
-    user_id: str | None = None
-    session_id: str | None = None
-    tags: list[str] | None = None
-    metadata: dict | None = None
-    observations: list | None = None
-
-
-@dataclass
-class FakeObservation:
-    """Minimal Langfuse observation for assertions."""
-
-    name: str
-    type: str = "SPAN"
 
 
 def _build_mock_trace(
@@ -65,43 +51,6 @@ def _build_mock_trace(
         metadata=metadata or {"call_id": "test-call-1", "status": "completed"},
         observations=observations or [FakeObservation(name="voice-session")],
     )
-
-
-# ---------------------------------------------------------------------------
-# Core gate logic (extracted for reuse in unit tests)
-# ---------------------------------------------------------------------------
-
-
-def validate_voice_trace_presence(traces_data: list) -> bool:
-    """Return True if at least one voice-session trace is present."""
-    return len(traces_data) > 0
-
-
-def validate_voice_trace_attribution(trace: object) -> dict[str, bool]:
-    """Validate service attribution fields on a trace object."""
-    user_id = getattr(trace, "user_id", None)
-    session_id = getattr(trace, "session_id", None) or ""
-    tags = getattr(trace, "tags", None) or []
-
-    return {
-        "user_id_correct": user_id == "voice-agent",
-        "session_id_pattern": session_id.startswith("voice-"),
-        "has_voice_tag": "voice" in tags,
-        "has_lifecycle_tag": "call-lifecycle" in tags,
-    }
-
-
-def build_evidence_summary(trace: object) -> dict[str, str | list[str]]:
-    """Build a redacted evidence summary from a trace (no PII)."""
-    observations = getattr(trace, "observations", None) or []
-    obs_names = [getattr(o, "name", "unknown") for o in observations]
-    return {
-        "trace_id": getattr(trace, "id", "unknown"),
-        "session_id": getattr(trace, "session_id", "unknown"),
-        "observation_names": obs_names,
-        "user_id": getattr(trace, "user_id", "unknown"),
-        "tags": getattr(trace, "tags", None) or [],
-    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/observability/test_voice_trace_gate.py
+++ b/tests/observability/test_voice_trace_gate.py
@@ -1,0 +1,241 @@
+"""Voice trace validation gate tests.
+
+Validates Langfuse traces for the voice-session family:
+- Trace presence after calling update_voice_trace
+- Service attribution (user_id='voice-agent')
+- Required tags and session_id pattern
+- Observation/span presence per trace_contract.yaml
+
+These tests use mocked Langfuse responses for deterministic unit-lane execution.
+A live-Langfuse variant is gated by LANGFUSE_PUBLIC_KEY presence.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeTrace:
+    """Minimal Langfuse trace representation for assertions."""
+
+    id: str
+    name: str
+    user_id: str | None = None
+    session_id: str | None = None
+    tags: list[str] | None = None
+    metadata: dict | None = None
+    observations: list | None = None
+
+
+@dataclass
+class FakeObservation:
+    """Minimal Langfuse observation for assertions."""
+
+    name: str
+    type: str = "SPAN"
+
+
+def _build_mock_trace(
+    *,
+    trace_id: str = "trace-voice-test-001",
+    name: str = "voice-session",
+    user_id: str = "voice-agent",
+    session_id: str = "voice-test-call-1",
+    tags: list[str] | None = None,
+    metadata: dict | None = None,
+    observations: list | None = None,
+) -> FakeTrace:
+    """Build a mock trace matching expected voice-session structure."""
+    return FakeTrace(
+        id=trace_id,
+        name=name,
+        user_id=user_id,
+        session_id=session_id,
+        tags=tags or ["voice", "call-lifecycle"],
+        metadata=metadata or {"call_id": "test-call-1", "status": "completed"},
+        observations=observations or [FakeObservation(name="voice-session")],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core gate logic (extracted for reuse in unit tests)
+# ---------------------------------------------------------------------------
+
+
+def validate_voice_trace_presence(traces_data: list) -> bool:
+    """Return True if at least one voice-session trace is present."""
+    return len(traces_data) > 0
+
+
+def validate_voice_trace_attribution(trace: object) -> dict[str, bool]:
+    """Validate service attribution fields on a trace object."""
+    user_id = getattr(trace, "user_id", None)
+    session_id = getattr(trace, "session_id", None) or ""
+    tags = getattr(trace, "tags", None) or []
+
+    return {
+        "user_id_correct": user_id == "voice-agent",
+        "session_id_pattern": session_id.startswith("voice-"),
+        "has_voice_tag": "voice" in tags,
+        "has_lifecycle_tag": "call-lifecycle" in tags,
+    }
+
+
+def build_evidence_summary(trace: object) -> dict[str, str | list[str]]:
+    """Build a redacted evidence summary from a trace (no PII)."""
+    observations = getattr(trace, "observations", None) or []
+    obs_names = [getattr(o, "name", "unknown") for o in observations]
+    return {
+        "trace_id": getattr(trace, "id", "unknown"),
+        "session_id": getattr(trace, "session_id", "unknown"),
+        "observation_names": obs_names,
+        "user_id": getattr(trace, "user_id", "unknown"),
+        "tags": getattr(trace, "tags", None) or [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: Mocked (unit-lane, always run)
+# ---------------------------------------------------------------------------
+
+
+class TestVoiceTraceGateMocked:
+    """Voice trace gate tests using mocked Langfuse API responses."""
+
+    def test_trace_presence_success(self, mock_langfuse_client: MagicMock) -> None:
+        """Gate passes when voice-session trace is found."""
+        mock_trace = _build_mock_trace()
+        mock_langfuse_client.api.trace.list.return_value = MagicMock(data=[mock_trace])
+        mock_langfuse_client.api.trace.get.return_value = mock_trace
+
+        traces = mock_langfuse_client.api.trace.list(name="voice-session").data
+        assert validate_voice_trace_presence(traces)
+
+    def test_trace_presence_failure(self, mock_langfuse_client: MagicMock) -> None:
+        """Gate fails when no voice-session trace is found."""
+        mock_langfuse_client.api.trace.list.return_value = MagicMock(data=[])
+
+        traces = mock_langfuse_client.api.trace.list(name="voice-session").data
+        assert not validate_voice_trace_presence(traces)
+
+    def test_attribution_correct(self) -> None:
+        """Gate validates correct service attribution."""
+        trace = _build_mock_trace()
+        result = validate_voice_trace_attribution(trace)
+        assert all(result.values()), f"Attribution check failed: {result}"
+
+    def test_attribution_wrong_user_id(self) -> None:
+        """Gate detects wrong user_id."""
+        trace = _build_mock_trace(user_id="wrong-agent")
+        result = validate_voice_trace_attribution(trace)
+        assert not result["user_id_correct"]
+
+    def test_attribution_wrong_session_pattern(self) -> None:
+        """Gate detects session_id not matching voice-* pattern."""
+        trace = _build_mock_trace(session_id="other-session")
+        result = validate_voice_trace_attribution(trace)
+        assert not result["session_id_pattern"]
+
+    def test_attribution_missing_tags(self) -> None:
+        """Gate detects missing voice tags."""
+        trace = _build_mock_trace(tags=["other"])
+        result = validate_voice_trace_attribution(trace)
+        assert not result["has_voice_tag"]
+        assert not result["has_lifecycle_tag"]
+
+    def test_evidence_summary_structure(self) -> None:
+        """Evidence summary contains expected fields without PII."""
+        trace = _build_mock_trace()
+        summary = build_evidence_summary(trace)
+        assert summary["trace_id"] == "trace-voice-test-001"
+        assert summary["session_id"] == "voice-test-call-1"
+        assert "voice-session" in summary["observation_names"]
+        assert summary["user_id"] == "voice-agent"
+        assert "voice" in summary["tags"]
+
+    def test_voice_session_in_required_families(self, trace_contract: dict) -> None:
+        """voice-session is listed in required_families in trace_contract."""
+        assert "voice-session" in trace_contract["required_families"]
+
+    def test_voice_session_in_coverage_tiers(self, trace_contract: dict) -> None:
+        """voice-session is in opportunistic_for_1307 coverage tier."""
+        tiers = trace_contract.get("coverage_tiers", {})
+        assert "voice-session" in tiers.get("opportunistic_for_1307", [])
+
+    def test_update_voice_trace_produces_expected_calls(self) -> None:
+        """Calling update_voice_trace produces the expected Langfuse calls."""
+        mock_lf = MagicMock()
+        mock_observation = MagicMock()
+        mock_obs_ctx = MagicMock()
+        mock_obs_ctx.__enter__ = MagicMock(return_value=mock_observation)
+        mock_obs_ctx.__exit__ = MagicMock(return_value=None)
+        mock_lf.start_as_current_observation.return_value = mock_obs_ctx
+        mock_lf.create_trace_id.return_value = "trace-gate-test"
+        mock_prop_ctx = MagicMock()
+        mock_prop_ctx.__enter__ = MagicMock(return_value=None)
+        mock_prop_ctx.__exit__ = MagicMock(return_value=None)
+
+        with (
+            patch("src.voice.observability.get_client", return_value=mock_lf),
+            patch(
+                "src.voice.observability.propagate_attributes",
+                return_value=mock_prop_ctx,
+            ) as mock_prop,
+        ):
+            from src.voice.observability import update_voice_trace
+
+            update_voice_trace(
+                call_id="gate-test-1",
+                status="completed",
+                duration_sec=15,
+            )
+
+        # Verify trace was created with voice-agent attribution
+        mock_prop.assert_called_once()
+        call_kwargs = mock_prop.call_args[1]
+        assert call_kwargs["user_id"] == "voice-agent"
+        assert call_kwargs["tags"] == ["voice", "call-lifecycle"]
+        assert call_kwargs["session_id"] == "voice-gate-test-1"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Live Langfuse (gated by env var)
+# ---------------------------------------------------------------------------
+
+_LIVE_LANGFUSE_AVAILABLE = bool(os.environ.get("LANGFUSE_PUBLIC_KEY"))
+
+
+@pytest.mark.skipif(
+    not _LIVE_LANGFUSE_AVAILABLE,
+    reason="LANGFUSE_PUBLIC_KEY not set; skipping live Langfuse tests",
+)
+class TestVoiceTraceGateLive:
+    """Voice trace gate tests against live local Langfuse (opt-in)."""
+
+    def test_live_trace_lookup(self) -> None:
+        """Query Langfuse API for recent voice-session traces."""
+        from datetime import UTC, datetime, timedelta
+
+        from langfuse import Langfuse
+
+        lf = Langfuse()
+        from_ts = datetime.now(UTC) - timedelta(hours=1)
+        traces = lf.api.trace.list(
+            name="voice-session",
+            from_timestamp=from_ts,
+            order_by="timestamp.desc",
+            limit=5,
+        )
+        # This test just verifies connectivity; trace may or may not exist
+        assert hasattr(traces, "data")
+        lf.flush()

--- a/tests/unit/observability/test_voice_trace_gate_unit.py
+++ b/tests/unit/observability/test_voice_trace_gate_unit.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.observability.test_voice_trace_gate import (
+from tests.observability.gate_logic import (
     FakeObservation,
     FakeTrace,
     build_evidence_summary,

--- a/tests/unit/observability/test_voice_trace_gate_unit.py
+++ b/tests/unit/observability/test_voice_trace_gate_unit.py
@@ -7,7 +7,10 @@ and evidence summary generation.
 
 from __future__ import annotations
 
+import sys
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from tests.observability.gate_logic import (
     FakeObservation,
@@ -275,3 +278,66 @@ class TestUpdateVoiceTraceIntegration:
 
         kwargs = mock_prop.call_args[1]
         assert kwargs["session_id"].startswith("voice-")
+
+
+class TestValidateVoiceTracesCli:
+    """CLI behavior tests for the live validation gate."""
+
+    def test_fails_when_fresh_trace_production_fails(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Default mode must fail instead of validating stale traces."""
+        from scripts import validate_voice_traces as gate
+
+        validate_called = False
+
+        def _raise_production_error() -> str:
+            raise RuntimeError("trace producer unavailable")
+
+        def _validate_existing_traces(
+            lookback_minutes: int,
+            expected_session_id: str | None = None,
+        ) -> dict:
+            nonlocal validate_called
+            validate_called = True
+            return {
+                "ok": True,
+                "evidence": {
+                    "trace_id": "old-trace",
+                    "session_id": "voice-old",
+                    "user_id": "voice-agent",
+                    "tags": ["voice", "call-lifecycle"],
+                    "traces_found": 1,
+                },
+                "errors": [],
+            }
+
+        monkeypatch.setattr(sys, "argv", ["validate_voice_traces.py"])
+        monkeypatch.setattr(gate, "check_langfuse_connectivity", lambda *_: True)
+        monkeypatch.setattr(gate, "check_compose_service_name", lambda: True)
+        monkeypatch.setattr(gate, "produce_voice_trace", _raise_production_error)
+        monkeypatch.setattr(gate, "wait_for_ingestion", lambda _: None)
+        monkeypatch.setattr(gate, "validate_traces", _validate_existing_traces)
+
+        with pytest.raises(SystemExit) as exc_info:
+            gate.main()
+
+        assert exc_info.value.code == 1
+        assert validate_called is False
+
+    def test_produce_voice_trace_flushes_before_readback(self) -> None:
+        """Short-lived CLI must flush the produced trace before polling."""
+        from scripts import validate_voice_traces as gate
+
+        mock_lf = MagicMock()
+
+        with (
+            patch("src.voice.observability.update_voice_trace") as mock_update,
+            patch("telegram_bot.observability.get_client", return_value=mock_lf),
+        ):
+            session_id = gate.produce_voice_trace()
+
+        assert session_id.startswith("voice-validate-")
+        mock_update.assert_called_once()
+        mock_lf.flush.assert_called_once_with()

--- a/tests/unit/observability/test_voice_trace_gate_unit.py
+++ b/tests/unit/observability/test_voice_trace_gate_unit.py
@@ -1,0 +1,277 @@
+"""Unit tests for voice trace validation gate logic.
+
+Tests the core validation functions without requiring a live Langfuse instance.
+Validates both success and failure cases for trace presence, attribution,
+and evidence summary generation.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from tests.observability.test_voice_trace_gate import (
+    FakeObservation,
+    FakeTrace,
+    build_evidence_summary,
+    validate_voice_trace_attribution,
+    validate_voice_trace_presence,
+)
+
+
+# ---------------------------------------------------------------------------
+# validate_voice_trace_presence
+# ---------------------------------------------------------------------------
+
+
+class TestValidateVoiceTracePresence:
+    """Tests for trace presence check."""
+
+    def test_returns_true_when_traces_exist(self) -> None:
+        traces = [MagicMock()]
+        assert validate_voice_trace_presence(traces) is True
+
+    def test_returns_false_when_empty(self) -> None:
+        assert validate_voice_trace_presence([]) is False
+
+    def test_returns_true_for_multiple_traces(self) -> None:
+        traces = [MagicMock(), MagicMock(), MagicMock()]
+        assert validate_voice_trace_presence(traces) is True
+
+
+# ---------------------------------------------------------------------------
+# validate_voice_trace_attribution
+# ---------------------------------------------------------------------------
+
+
+class TestValidateVoiceTraceAttribution:
+    """Tests for service attribution validation."""
+
+    def test_all_correct(self) -> None:
+        trace = FakeTrace(
+            id="t1",
+            name="voice-session",
+            user_id="voice-agent",
+            session_id="voice-call-123",
+            tags=["voice", "call-lifecycle"],
+        )
+        result = validate_voice_trace_attribution(trace)
+        assert result == {
+            "user_id_correct": True,
+            "session_id_pattern": True,
+            "has_voice_tag": True,
+            "has_lifecycle_tag": True,
+        }
+
+    def test_wrong_user_id(self) -> None:
+        trace = FakeTrace(
+            id="t1",
+            name="voice-session",
+            user_id="telegram-bot",
+            session_id="voice-abc",
+            tags=["voice", "call-lifecycle"],
+        )
+        result = validate_voice_trace_attribution(trace)
+        assert result["user_id_correct"] is False
+        assert result["session_id_pattern"] is True
+
+    def test_missing_user_id(self) -> None:
+        trace = FakeTrace(
+            id="t1",
+            name="voice-session",
+            user_id=None,
+            session_id="voice-abc",
+            tags=["voice", "call-lifecycle"],
+        )
+        result = validate_voice_trace_attribution(trace)
+        assert result["user_id_correct"] is False
+
+    def test_wrong_session_pattern(self) -> None:
+        trace = FakeTrace(
+            id="t1",
+            name="voice-session",
+            user_id="voice-agent",
+            session_id="session-123",
+            tags=["voice", "call-lifecycle"],
+        )
+        result = validate_voice_trace_attribution(trace)
+        assert result["session_id_pattern"] is False
+
+    def test_empty_session_id(self) -> None:
+        trace = FakeTrace(
+            id="t1",
+            name="voice-session",
+            user_id="voice-agent",
+            session_id="",
+            tags=["voice", "call-lifecycle"],
+        )
+        result = validate_voice_trace_attribution(trace)
+        assert result["session_id_pattern"] is False
+
+    def test_missing_voice_tag(self) -> None:
+        trace = FakeTrace(
+            id="t1",
+            name="voice-session",
+            user_id="voice-agent",
+            session_id="voice-x",
+            tags=["call-lifecycle"],
+        )
+        result = validate_voice_trace_attribution(trace)
+        assert result["has_voice_tag"] is False
+        assert result["has_lifecycle_tag"] is True
+
+    def test_missing_lifecycle_tag(self) -> None:
+        trace = FakeTrace(
+            id="t1",
+            name="voice-session",
+            user_id="voice-agent",
+            session_id="voice-x",
+            tags=["voice"],
+        )
+        result = validate_voice_trace_attribution(trace)
+        assert result["has_voice_tag"] is True
+        assert result["has_lifecycle_tag"] is False
+
+    def test_none_tags(self) -> None:
+        trace = FakeTrace(
+            id="t1",
+            name="voice-session",
+            user_id="voice-agent",
+            session_id="voice-x",
+            tags=None,
+        )
+        result = validate_voice_trace_attribution(trace)
+        assert result["has_voice_tag"] is False
+        assert result["has_lifecycle_tag"] is False
+
+
+# ---------------------------------------------------------------------------
+# build_evidence_summary
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEvidenceSummary:
+    """Tests for redacted evidence summary generation."""
+
+    def test_complete_trace(self) -> None:
+        trace = FakeTrace(
+            id="trace-abc-123",
+            name="voice-session",
+            user_id="voice-agent",
+            session_id="voice-call-42",
+            tags=["voice", "call-lifecycle"],
+            observations=[
+                FakeObservation(name="voice-session"),
+                FakeObservation(name="llm-call"),
+            ],
+        )
+        summary = build_evidence_summary(trace)
+        assert summary["trace_id"] == "trace-abc-123"
+        assert summary["session_id"] == "voice-call-42"
+        assert summary["user_id"] == "voice-agent"
+        assert "voice-session" in summary["observation_names"]
+        assert "llm-call" in summary["observation_names"]
+        assert "voice" in summary["tags"]
+
+    def test_empty_observations(self) -> None:
+        trace = FakeTrace(
+            id="t1",
+            name="voice-session",
+            user_id="voice-agent",
+            session_id="voice-x",
+            observations=[],
+        )
+        summary = build_evidence_summary(trace)
+        assert summary["observation_names"] == []
+
+    def test_none_observations(self) -> None:
+        trace = FakeTrace(
+            id="t1",
+            name="voice-session",
+            user_id="voice-agent",
+            session_id="voice-x",
+            observations=None,
+        )
+        summary = build_evidence_summary(trace)
+        assert summary["observation_names"] == []
+
+    def test_no_pii_leaked(self) -> None:
+        """Ensure evidence summary does not expose raw call content."""
+        trace = FakeTrace(
+            id="t1",
+            name="voice-session",
+            user_id="voice-agent",
+            session_id="voice-x",
+            metadata={"call_id": "secret-call", "status": "completed"},
+        )
+        summary = build_evidence_summary(trace)
+        # metadata is not part of evidence summary
+        assert "secret-call" not in str(summary)
+
+
+# ---------------------------------------------------------------------------
+# Integration: update_voice_trace produces correct attribution
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateVoiceTraceIntegration:
+    """Test that update_voice_trace wiring matches gate expectations."""
+
+    def test_produces_voice_agent_user_id(self) -> None:
+        """update_voice_trace sets user_id='voice-agent' for attribution."""
+        mock_lf = MagicMock()
+        mock_obs = MagicMock()
+        mock_obs_ctx = MagicMock()
+        mock_obs_ctx.__enter__ = MagicMock(return_value=mock_obs)
+        mock_obs_ctx.__exit__ = MagicMock(return_value=None)
+        mock_lf.start_as_current_observation.return_value = mock_obs_ctx
+        mock_lf.create_trace_id.return_value = "trace-unit-001"
+        mock_prop_ctx = MagicMock()
+        mock_prop_ctx.__enter__ = MagicMock(return_value=None)
+        mock_prop_ctx.__exit__ = MagicMock(return_value=None)
+
+        with (
+            patch("src.voice.observability.get_client", return_value=mock_lf),
+            patch(
+                "src.voice.observability.propagate_attributes",
+                return_value=mock_prop_ctx,
+            ) as mock_prop,
+        ):
+            from src.voice.observability import update_voice_trace
+
+            update_voice_trace(call_id="unit-1", status="answered")
+
+        kwargs = mock_prop.call_args[1]
+        assert kwargs["user_id"] == "voice-agent"
+        assert kwargs["tags"] == ["voice", "call-lifecycle"]
+        assert kwargs["session_id"] == "voice-unit-1"
+
+    def test_produces_correct_session_id_pattern(self) -> None:
+        """Session ID follows voice-* pattern."""
+        mock_lf = MagicMock()
+        mock_obs = MagicMock()
+        mock_obs_ctx = MagicMock()
+        mock_obs_ctx.__enter__ = MagicMock(return_value=mock_obs)
+        mock_obs_ctx.__exit__ = MagicMock(return_value=None)
+        mock_lf.start_as_current_observation.return_value = mock_obs_ctx
+        mock_lf.create_trace_id.return_value = "trace-unit-002"
+        mock_prop_ctx = MagicMock()
+        mock_prop_ctx.__enter__ = MagicMock(return_value=None)
+        mock_prop_ctx.__exit__ = MagicMock(return_value=None)
+
+        with (
+            patch("src.voice.observability.get_client", return_value=mock_lf),
+            patch(
+                "src.voice.observability.propagate_attributes",
+                return_value=mock_prop_ctx,
+            ) as mock_prop,
+        ):
+            from src.voice.observability import update_voice_trace
+
+            update_voice_trace(
+                call_id="my-call-id",
+                status="completed",
+                session_id="voice-custom-session",
+            )
+
+        kwargs = mock_prop.call_args[1]
+        assert kwargs["session_id"].startswith("voice-")


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #1517. Adds a focused observability gate that reads Langfuse via API after a trace-producing scenario and validates trace presence and service attribution for the `voice-agent` service.

## Changes

**New files (6):**
- `scripts/validate_voice_traces.py` - Standalone CLI gate with 5-step validation: connectivity check, compose OTEL check, trace production, ingestion wait, trace read-back/validation
- `tests/observability/__init__.py` - Package init
- `tests/observability/conftest.py` - Shared fixtures (trace contract, mock Langfuse client)
- `tests/observability/gate_logic.py` - Shared validation logic
- `tests/observability/test_voice_trace_gate.py` - Integration tests (10 pass, 1 live-gated skip)
- `tests/unit/observability/test_voice_trace_gate_unit.py` - Unit tests (17 pass)

**Modified files (3):**
- `Makefile` - Added `validate-voice-traces` target
- `docs/runbooks/LANGFUSE_TRACING_GAPS.md` - New "Voice-Agent Trace Validation Gate (#1517)" section
- `docs/LOCAL-DEVELOPMENT.md` - New gate reference

## Acceptance Criteria

- [x] Documented command: `make validate-voice-traces` (canonical gate)
- [x] Reads Langfuse via API (`langfuse.Langfuse` SDK `lf.api.trace.list/get`)
- [x] Validates trace presence (voice-session family) and service attribution (user_id=voice-agent, session_id=voice-*, tags=[voice, call-lifecycle])
- [x] Safe for local/dev execution (defaults to pk-lf-dev/sk-lf-dev, no production credentials)
- [x] Documented in `docs/runbooks/LANGFUSE_TRACING_GAPS.md` and `docs/LOCAL-DEVELOPMENT.md`

## Testing

- 27 new tests pass (10 integration + 17 unit)
- All 168 observability tests pass
- Lint clean (ruff check/format)
- Live Langfuse tests gated by `LANGFUSE_PUBLIC_KEY` env var (skipped in CI unless credentials set)

## Usage

```bash
# Run the voice trace validation gate (requires local Langfuse)
make validate-voice-traces

# Or directly:
uv run python scripts/validate_voice_traces.py --host http://localhost:3001

# Skip trace production, validate existing traces only:
uv run python scripts/validate_voice_traces.py --skip-produce
```