### PR TITLE
chore: add CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main, dev]
+  push:
+    branches: [main, dev]
+  schedule:
+    - cron: "30 3 * * 0"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (Python)
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: python
+          build-mode: none
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:python"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,13 +29,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
         with:
           languages: python
           build-mode: none
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
         with:
           category: "/language:python"

--- a/tests/unit/test_codeql_workflow.py
+++ b/tests/unit/test_codeql_workflow.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import yaml
+
+
+WORKFLOW = Path(".github/workflows/codeql.yml")
+
+
+def test_codeql_workflow_actions_are_sha_pinned() -> None:
+    """CodeQL workflow actions must follow the repo SHA-pinning convention."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4" in text
+    assert "github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4" in text
+    assert "github/codeql-action/init@v4" not in text
+    assert "github/codeql-action/analyze@v4" not in text
+
+
+def test_codeql_workflow_uses_least_privilege_permissions() -> None:
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    assert data["permissions"] == {"contents": "read"}
+    assert data["jobs"]["analyze"]["permissions"] == {
+        "contents": "read",
+        "security-events": "write",
+    }


### PR DESCRIPTION
## Summary
- Add a Python CodeQL workflow for GitHub code scanning.
- Use least-privilege permissions, including job-level contents: read and security-events: write.
- Match existing Actions conventions for triggers, concurrency, and pinned checkout.

## Validation
- YAML parse checked locally.
- git diff --check passed.
- pre-commit/push hooks passed, including actionlint.