### PR TITLE
chore(steering): codify TDD + per-issue worktree + cleanup workflow

### DIFF
--- a/.kiro/steering/agent-workflow.md
+++ b/.kiro/steering/agent-workflow.md
@@ -20,12 +20,53 @@ For GitHub issue tasks:
 
 1. Identify the issue number.
 2. Read `skills/superpowers/issue-skill-map.md` and load the required skills.
-3. Create isolated work in a dedicated branch/worktree or Kiro sandbox.
-4. Use test-first workflow for bug, feature, refactor, and behavior changes.
-5. Do not use production, secrets, SSH, cloud credentials, or live CRM writes
-   unless the issue explicitly approves it.
-6. Before opening a PR or claiming completion, include fresh verification
-   evidence and list skipped checks.
+3. **Per-issue git worktree (mandatory).**
+   Each issue gets its own worktree under `../wt-<issue>-<slug>/` branched off
+   `dev`. Never commit to `main`/`dev` directly. Never reuse a worktree across
+   unrelated issues. Example:
+
+   ```bash
+   git fetch origin dev
+   git worktree add -b kiro/<issue>-<slug> ../wt-<issue>-<slug> origin/dev
+   ```
+
+4. **TDD is the default flow.**
+   Red → green → refactor for every bug, feature, refactor, or behavior change:
+   1. Write a failing test that pins the missing/wrong behavior. Run it; confirm
+      it fails for the expected reason.
+   2. Make the smallest change that turns it green.
+   3. Refactor with tests still green; rerun the focused test set after every
+      step. Commit the failing test separately from the fix when scope allows,
+      so the diff records the contract.
+   Skip TDD only for trivial doc/config moves with no behavior change, and
+   record that decision in the PR body.
+
+5. **SDK-first via Context7.**
+   Before reimplementing anything that an SDK already provides, query Context7
+   (`resolve-library-id` then `query-docs`) for the relevant library. Cite the
+   library ID and the specific behavior in the PR body. Custom code is allowed
+   only when the SDK lacks the capability, and that gap must be named.
+
+6. Do not use production, secrets, SSH, cloud credentials, or live CRM writes
+   unless the issue explicitly approves it. Default verification scope is
+   `verify:repo-only` (lint + focused unit tests + relevant contract tests).
+
+7. **PR + cleanup.**
+   - Push the branch via the sandbox push tool, open the PR against `dev`,
+     reference the issue with `Fixes #N`.
+   - In the PR body include: TDD summary (which test was added first), Context7
+     library IDs consulted, full verification commands and their results, and
+     any skipped checks with justification.
+   - After the PR is created, remove the worktree to free disk and avoid stale
+     state:
+
+     ```bash
+     git worktree remove ../wt-<issue>-<slug>
+     git worktree prune
+     ```
+
+     Keep the remote branch until merge; only the local worktree is removed.
 
 When the issue lacks acceptance criteria, ask for clarification or add a short
-plan before implementation.
+plan before implementation. Do not start coding on `manual-control` or
+`kiro-plan-only` issues without an approved plan in the issue thread.


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Codifies the workflow Kiro/agent sessions are expected to follow when working
on GitHub issues. The previous `agent-workflow.md` was a 7-line skeleton; this
makes the contract explicit and auto-included so every future session inherits
the same rules.

## What changes

- **Per-issue git worktree (mandatory).** Each issue gets its own worktree
  under `../wt-<issue>-<slug>/` branched off `dev`. No commits to `main`/`dev`,
  no worktree reuse across unrelated issues.
- **TDD is the default flow.** Red -> green -> refactor for every bug,
  feature, refactor, or behavior change. The failing test should be committed
  separately when scope allows, so the diff records the contract.
- **SDK-first via Context7.** Query `resolve-library-id` then `query-docs`
  before reimplementing anything an SDK already provides. Library IDs and the
  specific behavior get cited in the PR body.
- **PR + cleanup.** Push via the sandbox tool, open the PR against `dev`,
  reference the issue with `Fixes #N`, and run `git worktree remove` after the
  PR is created to free disk and avoid stale state.
- Default verification scope stays `verify:repo-only`. Security/VPS/credentials
  remain forbidden unless the issue explicitly approves them.

## Why

This PR is the prep step for Wave 1 of issue execution. Subsequent PRs (#1532,
#1721, #1306, #1275, #1239) will follow this workflow, so the rules need to
be live before the first one lands.

## Verification

- Steering-only change. No code, no tests, no behavior change.
- File renders as Markdown; front-matter `inclusion: always` preserved.
- No links broken: only references files that already exist
  (`skills/superpowers/`, `AGENTS.md`, `docs/README.md`,
  `docs/engineering/test-writing-guide.md`, `docs/LOCAL-DEVELOPMENT.md`).

## Skipped checks

None. Pure docs/process file. Lint/test gates are not applicable to
`.kiro/steering/*.md`.