### PR TITLE
feat(scripts): add user-runnable fixer for tmux send-keys ... Enter pattern (#1721)

### DIFF
--- a/scripts/swarm_fix_send_keys_pattern.py
+++ b/scripts/swarm_fix_send_keys_pattern.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""User-runnable helper for issue #1721.
+
+Replaces the broken ``tmux send-keys ... Enter`` pattern with the canonical
+three-line form across the swarm orchestration prompt/skill files. The
+affected files referenced by issue #1721 live *outside* the rag-fresh
+repository, under ``~/.codex/`` and ``~/.config/opencode/skills/``, so this
+fix cannot be done by a repo PR alone — running this script on the user's
+local machine is the supported path.
+
+The repo also enforces a regression guard
+(``tests/contract/test_tmux_send_keys_pattern_contract.py``) so the broken
+pattern never lands inside the rag-fresh repository again.
+
+Usage:
+    # Default targets: ~/.codex and ~/.config/opencode/skills
+    python scripts/swarm_fix_send_keys_pattern.py
+    python scripts/swarm_fix_send_keys_pattern.py --dry-run
+
+    # Or pass explicit paths:
+    python scripts/swarm_fix_send_keys_pattern.py path/to/skills
+
+The rewrite preserves indentation, target/text arguments, and trailing
+newline policy. It is idempotent: running the script twice in a row produces
+no further changes. Markdown files are scanned only inside fenced
+shell-flavoured code blocks (``bash``/``sh``/``shell``/``console``/``zsh``
+or unlabelled), matching the contract test's behaviour.
+
+Refs #1721, #1590.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shlex
+import sys
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+
+
+# Forbidden pattern, mirrored from
+# tests/contract/test_tmux_send_keys_pattern_contract.py. Kept in lockstep so
+# every line the contract test would flag is also a candidate for rewrite by
+# this script. The named groups support the rewrite path below.
+_BROKEN = re.compile(
+    r"""
+    ^
+    (?P<indent>\s*)
+    (?!\#)
+    (?P<body>
+        .*\btmux\s+send-keys\b
+        (?!.*\s-l\b)
+        .*?
+    )
+    \s+Enter
+    \s*
+    (?P<comment>\#.*)?
+    $
+    """,
+    re.VERBOSE,
+)
+
+# Markdown fenced-code languages that count as "shell" for our purposes.
+# Empty string covers unlabelled fences (```...```) which are conventionally
+# treated as shell in operations runbooks.
+_SHELL_FENCE_LANGS: frozenset[str] = frozenset({"", "bash", "sh", "shell", "console", "zsh"})
+
+# Files we touch. JSON/YAML/TXT etc. are not orchestration surfaces and could
+# legitimately quote the broken pattern as data.
+_SCAN_GLOBS: tuple[str, ...] = ("*.md", "*.sh")
+
+# Default search roots when no path argument is supplied.
+DEFAULT_TARGETS: tuple[str, ...] = ("~/.codex", "~/.config/opencode/skills")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def find_offenders(root: Path | str) -> list[tuple[Path, int, str]]:
+    """Return ``(path, lineno, line)`` for every offending line under ``root``.
+
+    ``root`` may be a directory or a single file. Lines are reported in stable
+    sorted order by path, then by line number.
+    """
+    root = Path(root)
+    offenders: list[tuple[Path, int, str]] = []
+    for path in _iter_target_files(root):
+        for lineno, line in _scan_offender_lines(path):
+            offenders.append((path, lineno, line))
+    return offenders
+
+
+def fix_file(path: Path | str) -> int:
+    """Rewrite offending lines in ``path`` in place; return replacement count.
+
+    Returns ``0`` (no write) if the file contains no offenders.
+    """
+    path = Path(path)
+    original = path.read_text(encoding="utf-8", errors="replace")
+    new_text, replacements = _rewrite_text(path, original)
+    if replacements > 0 and new_text != original:
+        path.write_text(new_text, encoding="utf-8")
+    return replacements
+
+
+def fix_directory(root: Path | str, *, dry_run: bool = False) -> tuple[int, int]:
+    """Walk ``root`` and apply (or report) fixes. Returns ``(files_touched, replacements)``."""
+    root = Path(root)
+    files_touched = 0
+    replacements_total = 0
+    for path in _iter_target_files(root):
+        if dry_run:
+            offenders = list(_scan_offender_lines(path))
+            if offenders:
+                files_touched += 1
+                replacements_total += len(offenders)
+                for lineno, line in offenders:
+                    print(f"{path}:{lineno}: {line}")
+        else:
+            n = fix_file(path)
+            if n > 0:
+                files_touched += 1
+                replacements_total += n
+                suffix = "s" if n != 1 else ""
+                print(f"FIXED {path} ({n} replacement{suffix})")
+    return files_touched, replacements_total
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _iter_target_files(root: Path) -> Iterator[Path]:
+    """Yield every shell/markdown file under ``root`` (or just ``root`` itself)."""
+    if root.is_file():
+        if any(root.match(g) for g in _SCAN_GLOBS):
+            yield root
+        return
+    if not root.exists():
+        return
+    seen: set[Path] = set()
+    for pattern in _SCAN_GLOBS:
+        for p in sorted(root.rglob(pattern)):
+            if p.is_file() and p not in seen:
+                seen.add(p)
+                yield p
+
+
+def _iter_processed_lines(path: Path, lines: Iterable[str]) -> Iterator[tuple[int, str, bool]]:
+    """Yield ``(lineno, raw_line, is_in_shell_context)`` for each input line.
+
+    For ``.sh`` files every line is in shell context. For ``.md`` files only
+    lines inside a shell-flavoured fenced code block are. Fence-delimiter
+    lines themselves are reported as *not* in shell context, so they are
+    never matched against the broken-pattern regex.
+    """
+    is_markdown = path.suffix.lower() == ".md"
+    in_fence = not is_markdown
+    fence_lang: str | None = None
+    for lineno, raw in enumerate(lines, start=1):
+        if is_markdown:
+            stripped = raw.strip()
+            if stripped.startswith("```"):
+                if not in_fence:
+                    in_fence = True
+                    label = stripped.removeprefix("```").strip().lower()
+                    fence_lang = label
+                else:
+                    in_fence = False
+                    fence_lang = None
+                yield lineno, raw, False
+                continue
+            if not in_fence:
+                yield lineno, raw, False
+                continue
+            if fence_lang is not None and fence_lang not in _SHELL_FENCE_LANGS:
+                yield lineno, raw, False
+                continue
+        yield lineno, raw, True
+
+
+def _scan_offender_lines(path: Path) -> Iterator[tuple[int, str]]:
+    """Yield ``(lineno, raw_line)`` for every offending line in ``path``."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    for lineno, raw, in_shell in _iter_processed_lines(path, text.splitlines()):
+        if not in_shell:
+            continue
+        if _BROKEN.match(raw):
+            yield lineno, raw.rstrip()
+
+
+def _split_send_keys_tokens(tokens: list[str]) -> tuple[list[str], list[str]]:
+    """Split a tokenised ``tmux send-keys`` invocation into (prefix, text).
+
+    ``prefix`` is the verb plus any flags and their values
+    (e.g. ``["tmux", "send-keys", "-t", "$T"]``).
+    ``text`` is the trailing positional payload list (often a single quoted
+    string, possibly empty).
+    """
+    if tokens[:2] != ["tmux", "send-keys"]:
+        raise ValueError(f"Expected leading 'tmux send-keys', got {tokens[:2]!r}")
+    prefix: list[str] = list(tokens[:2])
+    rest = tokens[2:]
+    i = 0
+    # Flags that consume a value. tmux send-keys uses -t <target>; -N/-T
+    # historically take a value too; -l/-X/-R/-H/-K/-M are bare flags.
+    value_consuming = {"-t", "-T", "-N"}
+    while i < len(rest) and rest[i].startswith("-"):
+        flag = rest[i]
+        prefix.append(flag)
+        if flag in value_consuming and i + 1 < len(rest):
+            prefix.append(rest[i + 1])
+            i += 2
+        else:
+            i += 1
+    return prefix, rest[i:]
+
+
+def _rewrite_offender(line: str) -> list[str]:
+    """Rewrite a single offending line into the canonical 3-line form.
+
+    Returns the replacement lines (no trailing newlines). When the original
+    line carried an inline comment, it is preserved on the first replacement
+    line so the intent is not lost.
+    """
+    match = _BROKEN.match(line)
+    if not match:
+        raise ValueError(f"_rewrite_offender called on a non-offender: {line!r}")
+    indent = match.group("indent")
+    body = match.group("body")
+    trailing_comment = match.group("comment") or ""
+    # Tokenise non-POSIX so quotes/dollar-signs/$VARS pass through unchanged.
+    try:
+        tokens = shlex.split(body, posix=False)
+    except ValueError:
+        # Unbalanced quote — leave the line untouched rather than corrupt it.
+        return [line]
+    if tokens[:2] != ["tmux", "send-keys"]:
+        # Defensive: regex should have prevented this.
+        return [line]
+    prefix_tokens, text_tokens = _split_send_keys_tokens(tokens)
+    prefix_str = " ".join(prefix_tokens)
+    comment_suffix = f"  {trailing_comment}" if trailing_comment else ""
+    if text_tokens:
+        text_str = " ".join(text_tokens)
+        return [
+            f"{indent}{prefix_str} -l {text_str}{comment_suffix}",
+            f"{indent}sleep 0.25",
+            f"{indent}{prefix_str} C-m",
+        ]
+    # No text payload: the original was just `tmux send-keys -t "$T" Enter`.
+    # The submit-only form is one line.
+    return [f"{indent}{prefix_str} C-m{comment_suffix}"]
+
+
+def _rewrite_text(path: Path, text: str) -> tuple[str, int]:
+    """Rewrite the contents of ``text`` (read from ``path``); return new text + count."""
+    new_lines: list[str] = []
+    replacements = 0
+    for _lineno, raw, in_shell in _iter_processed_lines(path, text.splitlines()):
+        if in_shell and _BROKEN.match(raw):
+            new_lines.extend(_rewrite_offender(raw))
+            replacements += 1
+        else:
+            new_lines.append(raw)
+    new_text = "\n".join(new_lines)
+    if text.endswith("\n"):
+        new_text += "\n"
+    return new_text, replacements
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fix the broken `tmux send-keys ... Enter` pattern in swarm "
+            "worker prompts and skill files (issue #1721)."
+        )
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help=(f"paths to scan recursively. If omitted, defaults to {', '.join(DEFAULT_TARGETS)}."),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="only report offenders; do not modify files",
+    )
+    args = parser.parse_args(argv)
+
+    paths = args.paths or [os.path.expanduser(p) for p in DEFAULT_TARGETS]
+
+    total_files = 0
+    total_reps = 0
+    for raw_path in paths:
+        path = Path(raw_path).expanduser()
+        if not path.exists():
+            print(f"warning: skipping nonexistent path: {path}", file=sys.stderr)
+            continue
+        files, reps = fix_directory(path, dry_run=args.dry_run)
+        total_files += files
+        total_reps += reps
+
+    verb = "Found" if args.dry_run else "Fixed"
+    print(
+        f"\n{verb} {total_reps} occurrence(s) across {total_files} file(s).",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_swarm_fix_send_keys_pattern.py
+++ b/tests/unit/scripts/test_swarm_fix_send_keys_pattern.py
@@ -1,0 +1,323 @@
+# tests/unit/scripts/test_swarm_fix_send_keys_pattern.py
+"""Unit tests for ``scripts/swarm_fix_send_keys_pattern.py``.
+
+Issue #1721 (and its older sibling #1590) describes the broken
+``tmux send-keys ... Enter`` pattern used by swarm worker prompts and
+skill files to wake the orchestrator. The trailing literal ``Enter``
+token sends ``\\r``, which Codex TUI does not interpret as composer
+submit, and the worker/orchestrator deadlocks.
+
+The repo already ships a regression guard
+(``tests/contract/test_tmux_send_keys_pattern_contract.py``) that fails
+CI if the broken pattern lands in a tracked Markdown/shell file. The
+actual broken files referenced in #1721 live *outside* the repository,
+under ``~/.codex/`` and ``~/.config/opencode/skills/``. They cannot be
+fixed by a repo PR alone.
+
+This module pins the contract for a *user-runnable helper script*,
+``scripts/swarm_fix_send_keys_pattern.py``, that:
+
+1. Finds every offending line in a target directory tree (``.md`` and
+   ``.sh`` files, Markdown-aware so fenced code is the only Markdown
+   surface checked).
+2. Rewrites each offender into the canonical three-line form, preserving
+   the existing indentation and the original target/text arguments.
+3. Is idempotent (running it twice in a row produces no further
+   changes).
+4. Supports a non-destructive dry-run mode that only reports.
+5. Exposes a small Python API used by the CLI and by these tests.
+
+Refs #1721, #1590.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Module loader (the script lives under ``scripts/``, which is not a package)
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "swarm_fix_send_keys_pattern.py"
+
+
+@pytest.fixture(scope="module")
+def fix_module():
+    """Load ``scripts/swarm_fix_send_keys_pattern.py`` as a module."""
+    spec = importlib.util.spec_from_file_location("_swarm_fix_send_keys_pattern", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None, SCRIPT_PATH
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Sample texts
+# ---------------------------------------------------------------------------
+
+# Canonical broken sample directly from issue #1721's "Affected files" list.
+BROKEN_SH = textwrap.dedent(
+    """\
+    #!/usr/bin/env bash
+    set -euo pipefail
+    tmux send-keys -t "$ORCH_TARGET" "[DONE] $WORKER_NAME $REPORT_FILE" Enter
+    """
+)
+
+# What the canonical broken sample must become after the fix runs. Indentation
+# of the original line is preserved; the same target and text-payload are
+# reused; the three-line form is written immediately in place of the offender.
+FIXED_SH = textwrap.dedent(
+    """\
+    #!/usr/bin/env bash
+    set -euo pipefail
+    tmux send-keys -t "$ORCH_TARGET" -l "[DONE] $WORKER_NAME $REPORT_FILE"
+    sleep 0.25
+    tmux send-keys -t "$ORCH_TARGET" C-m
+    """
+)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# find_offenders: read-only audit
+# ---------------------------------------------------------------------------
+
+
+class TestFindOffenders:
+    def test_flags_canonical_sh_offender(self, fix_module, tmp_path):
+        target = tmp_path / "wake.sh"
+        _write(target, BROKEN_SH)
+
+        offenders = fix_module.find_offenders(tmp_path)
+
+        assert len(offenders) == 1
+        path, lineno, line = offenders[0]
+        assert path == target
+        assert lineno == 3
+        assert "Enter" in line
+        assert " -l " not in line
+
+    def test_ignores_correct_three_line_form(self, fix_module, tmp_path):
+        _write(tmp_path / "ok.sh", FIXED_SH)
+
+        offenders = fix_module.find_offenders(tmp_path)
+
+        assert offenders == []
+
+    def test_ignores_comment_lines(self, fix_module, tmp_path):
+        _write(
+            tmp_path / "doc.sh",
+            '# tmux send-keys -t "$T" "msg" Enter   (commented out)\n',
+        )
+
+        offenders = fix_module.find_offenders(tmp_path)
+
+        assert offenders == []
+
+    def test_ignores_quoted_press_enter_prose(self, fix_module, tmp_path):
+        _write(
+            tmp_path / "ui.sh",
+            'tmux send-keys -t "$T" "Press Enter to continue" C-m\n',
+        )
+
+        offenders = fix_module.find_offenders(tmp_path)
+
+        assert offenders == []
+
+    def test_markdown_only_flags_inside_shell_fenced_blocks(self, fix_module, tmp_path):
+        markdown = textwrap.dedent(
+            """\
+            # Title
+
+            Inline prose: tmux send-keys -t "$T" "msg" Enter (this is documentation).
+
+            ```python
+            # python code, must not be flagged even though Enter appears:
+            tmux send-keys -t "$T" "msg" Enter
+            ```
+
+            ```bash
+            tmux send-keys -t "$T" "[DONE]" Enter
+            ```
+            """
+        )
+        target = tmp_path / "guide.md"
+        _write(target, markdown)
+
+        offenders = fix_module.find_offenders(tmp_path)
+
+        assert len(offenders) == 1
+        path, lineno, _line = offenders[0]
+        assert path == target
+        # Line 11 is the offender inside the bash fence.
+        assert lineno == 11
+
+    def test_recurses_into_subdirectories(self, fix_module, tmp_path):
+        nested = tmp_path / "a" / "b" / "c"
+        _write(nested / "wake.sh", BROKEN_SH)
+
+        offenders = fix_module.find_offenders(tmp_path)
+
+        assert len(offenders) == 1
+        assert offenders[0][0] == nested / "wake.sh"
+
+    def test_skips_unrelated_extensions(self, fix_module, tmp_path):
+        # JSON/YAML/TXT files are not orchestration surfaces and must be
+        # ignored even if they happen to contain the broken pattern in a
+        # quoted string.
+        _write(
+            tmp_path / "config.json",
+            '{"hint": "tmux send-keys -t \\"$T\\" \\"msg\\" Enter"}\n',
+        )
+
+        offenders = fix_module.find_offenders(tmp_path)
+
+        assert offenders == []
+
+
+# ---------------------------------------------------------------------------
+# fix_file: the rewrite engine
+# ---------------------------------------------------------------------------
+
+
+class TestFixFile:
+    def test_canonical_sh_is_rewritten_to_three_line_form(self, fix_module, tmp_path):
+        target = tmp_path / "wake.sh"
+        _write(target, BROKEN_SH)
+
+        replacements = fix_module.fix_file(target)
+
+        assert replacements == 1
+        assert target.read_text(encoding="utf-8") == FIXED_SH
+
+    def test_idempotent_second_run_is_a_noop(self, fix_module, tmp_path):
+        target = tmp_path / "wake.sh"
+        _write(target, BROKEN_SH)
+        fix_module.fix_file(target)
+        first_pass = target.read_text(encoding="utf-8")
+
+        replacements = fix_module.fix_file(target)
+
+        assert replacements == 0
+        assert target.read_text(encoding="utf-8") == first_pass == FIXED_SH
+
+    def test_preserves_leading_indentation(self, fix_module, tmp_path):
+        target = tmp_path / "wake.sh"
+        _write(
+            target,
+            '    tmux send-keys -t "$ORCH" "[DONE]" Enter\n',
+        )
+
+        replacements = fix_module.fix_file(target)
+
+        assert replacements == 1
+        rewritten = target.read_text(encoding="utf-8")
+        # Each of the 3 replacement lines should keep the original 4-space
+        # indent.
+        for line in rewritten.splitlines():
+            assert line == "" or line.startswith("    "), line
+        assert '    tmux send-keys -t "$ORCH" -l "[DONE]"' in rewritten
+        assert "    sleep 0.25" in rewritten
+        assert '    tmux send-keys -t "$ORCH" C-m' in rewritten
+
+    def test_multiple_offenders_in_same_file_are_all_rewritten(self, fix_module, tmp_path):
+        target = tmp_path / "multi.sh"
+        _write(
+            target,
+            textwrap.dedent(
+                """\
+                tmux send-keys -t "$T" "first" Enter
+                echo between
+                tmux send-keys -t "$T" "second" Enter
+                """
+            ),
+        )
+
+        replacements = fix_module.fix_file(target)
+
+        assert replacements == 2
+        rewritten = target.read_text(encoding="utf-8")
+        assert rewritten.count("sleep 0.25") == 2
+        assert rewritten.count("C-m") == 2
+        assert " Enter\n" not in rewritten
+
+    def test_only_rewrites_inside_markdown_fenced_shell_blocks(self, fix_module, tmp_path):
+        target = tmp_path / "guide.md"
+        original = textwrap.dedent(
+            """\
+            Prose line: tmux send-keys -t "$T" "msg" Enter (do not touch).
+
+            ```bash
+            tmux send-keys -t "$T" "[DONE]" Enter
+            ```
+            """
+        )
+        _write(target, original)
+
+        replacements = fix_module.fix_file(target)
+
+        assert replacements == 1
+        rewritten = target.read_text(encoding="utf-8")
+        # Prose line untouched.
+        assert 'Prose line: tmux send-keys -t "$T" "msg" Enter (do not touch).' in rewritten
+        # Fenced block rewritten.
+        assert 'tmux send-keys -t "$T" -l "[DONE]"' in rewritten
+        assert "sleep 0.25" in rewritten
+        assert 'tmux send-keys -t "$T" C-m' in rewritten
+
+
+# ---------------------------------------------------------------------------
+# CLI behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def _run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_dry_run_reports_offenders_without_modifying_files(self, tmp_path):
+        target = tmp_path / "wake.sh"
+        _write(target, BROKEN_SH)
+
+        result = self._run("--dry-run", str(tmp_path))
+
+        assert result.returncode == 0, result.stderr
+        # The dry-run must mention the offending file and line number.
+        assert str(target) in result.stdout
+        assert "wake.sh:3" in result.stdout
+        # File content must be unchanged.
+        assert target.read_text(encoding="utf-8") == BROKEN_SH
+
+    def test_default_invocation_rewrites_in_place(self, tmp_path):
+        target = tmp_path / "wake.sh"
+        _write(target, BROKEN_SH)
+
+        result = self._run(str(tmp_path))
+
+        assert result.returncode == 0, result.stderr
+        assert target.read_text(encoding="utf-8") == FIXED_SH
+
+    def test_clean_tree_exits_zero(self, tmp_path):
+        _write(tmp_path / "ok.sh", FIXED_SH)
+
+        result = self._run(str(tmp_path))
+
+        assert result.returncode == 0, result.stderr


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Issue #1721 documents the broken `tmux send-keys ... Enter` pattern used by
swarm worker prompts and skill files to wake the orchestrator. The trailing
literal `Enter` token sends `\r`, which Codex TUI does not interpret as
composer submit, and the worker/orchestrator deadlocks.

The repo already enforces a regression guard in
`tests/contract/test_tmux_send_keys_pattern_contract.py` (refs #1721, #1590)
so the broken pattern cannot land inside this repository. The actual files
listed in #1721, however, live *outside* the repo under `~/.codex/`
(gitignored) and `~/.config/opencode/skills/`. They cannot be fixed by a
repo PR alone — running a helper on the user's local machine is the
supported path.

This PR adds that helper.

## TDD trail

1. Wrote `tests/unit/scripts/test_swarm_fix_send_keys_pattern.py` first
   (15 tests; all RED — script did not exist yet).
2. Implemented `scripts/swarm_fix_send_keys_pattern.py`. All 15 tests
   GREEN.
3. Ran the existing contract test alongside: 18 passed total, 0 regressions.
4. Ran an end-to-end smoke on a synthetic `/tmp/swarm-smoke/` tree carrying
   the canonical broken sample from #1721 plus three negative cases:
   - Inline prose `... tmux send-keys ... Enter ...` outside a fence — must
     not touch.
   - Python-fenced block containing a lookalike — must not touch.
   - Indented-fence (4-space) inside a SKILL-style Markdown — must rewrite.
   All four offenders were correctly identified and rewritten; the two
   negative cases were preserved verbatim; second run reported 0 occurrences
   (idempotent).

## Behavior

```bash
# Default targets: ~/.codex and ~/.config/opencode/skills
python scripts/swarm_fix_send_keys_pattern.py
python scripts/swarm_fix_send_keys_pattern.py --dry-run

# Or explicit paths
python scripts/swarm_fix_send_keys_pattern.py ~/.codex/prompts
```

For each offender:

```text
tmux send-keys -t "$ORCH" "[DONE] $W $REPORT" Enter
```

becomes:

```text
tmux send-keys -t "$ORCH" -l "[DONE] $W $REPORT"
sleep 0.25
tmux send-keys -t "$ORCH" C-m
```

Indentation, target spec, and text payload are preserved verbatim.
Trailing comments are preserved on the first replacement line. The no-text
form `tmux send-keys -t "$T" Enter` collapses to a single
`tmux send-keys -t "$T" C-m`. Markdown is scanned only inside fenced
shell-flavoured blocks (`bash`/`sh`/`shell`/`console`/`zsh` or unlabelled),
matching the contract test's behavior. Non-shell extensions
(`*.json`/`*.yaml`/`*.txt`/...) are skipped.

## Verification

```text
uv run pytest tests/unit/scripts/test_swarm_fix_send_keys_pattern.py \
              tests/contract/test_tmux_send_keys_pattern_contract.py
18 passed in 0.78s

uv run ruff check scripts/swarm_fix_send_keys_pattern.py \
                  tests/unit/scripts/test_swarm_fix_send_keys_pattern.py
All checks passed!

uv run ruff format --check scripts/swarm_fix_send_keys_pattern.py \
                           tests/unit/scripts/test_swarm_fix_send_keys_pattern.py
already formatted

# E2E smoke against canonical broken samples:
python scripts/swarm_fix_send_keys_pattern.py --dry-run /tmp/swarm-smoke
Found 4 occurrence(s) across 3 file(s).

python scripts/swarm_fix_send_keys_pattern.py /tmp/swarm-smoke
Fixed 4 occurrence(s) across 3 file(s).

# Idempotence:
python scripts/swarm_fix_send_keys_pattern.py /tmp/swarm-smoke
Fixed 0 occurrence(s) across 0 file(s).
```

## Skipped checks

- The script is a user-runnable utility — there is no CI integration for it
  and no Docker/integration/e2e gate is appropriate. The existing repo
  contract test continues to enforce that no broken pattern lands here.
- The actual user-level remediation (running this script on the maintainer's
  `~/.codex/` and `~/.config/opencode/skills/`) is by design out of scope
  for an autonomous PR; #1721 will be closed with a comment pointing
  maintainers at this script.

Refs #1721, #1590