### PR TITLE
feat(scripts): add unattended OpenCode launch wrapper + runbook (#1306)

### DIFF
--- a/docs/engineering/swarm-non-interactive-launch.md
+++ b/docs/engineering/swarm-non-interactive-launch.md
@@ -1,0 +1,128 @@
+# Non-Interactive OpenCode Launches for Swarm Workers
+
+Reference for swarm worker launchers (e.g.
+`~/.codex/skills/tmux-swarm-orchestration/scripts/launch_opencode_*.sh`) so
+unattended workers do not block on permission prompts. Tracks issue
+[#1306](https://github.com/yastman/rag/issues/1306).
+
+## Root Cause
+
+The legacy launcher exported
+
+```bash
+OPENCODE_PERMISSION='{"*":"allow"}'
+```
+
+before invoking OpenCode. **OpenCode does not recognise the
+`OPENCODE_PERMISSION` environment variable.** It is silently ignored and the
+TUI continues to prompt for approval on the first tool call, deadlocking
+the worker.
+
+## Canonical Mechanism
+
+OpenCode's permission policy is defined by the `permission` field in an
+`opencode.json` config file. From the upstream docs (Context7 source IDs
+listed below), the policy can be set globally or per-tool:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": "allow"
+}
+```
+
+Granular form for stricter sandboxes:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "*": "ask",
+    "edit": "deny",
+    "bash": { "git *": "allow", "rm *": "deny", "*": "ask" },
+    "external_directory": { "~/secrets/**": "deny", "*": "allow" }
+  }
+}
+```
+
+### Loading the policy at runtime
+
+OpenCode discovers the policy via three mechanisms, in precedence order:
+
+1. **Project-local config** — `./opencode.json` in the current working
+   directory. Highest precedence.
+2. **Explicit config path** — `OPENCODE_CONFIG=/abs/path/to/file.json`.
+   Loaded between project and global config.
+3. **Inline injection** — `OPENCODE_CONFIG_CONTENT='<JSON>'`. The JSON
+   document is parsed in place; useful for ephemeral worker sessions
+   where writing a file would be unnecessary noise.
+
+Escape hatches (rarely needed):
+
+- `OPENCODE_DISABLE_PROJECT_CONFIG=1` — skip `./opencode.json`.
+- `OPENCODE_CONFIG_DIR=/path` — override the directory used to load
+  agents, commands, modes, and plugins.
+
+Sources (Context7 `/anomalyco/opencode`):
+
+- `dev/packages/web/src/content/docs/permissions.mdx`
+- `dev/packages/web/src/content/docs/config.mdx`
+- `dev/packages/opencode/src/skill/prompt/customize-opencode.md`
+
+## Recommended Launcher Pattern
+
+Use the repo-tracked wrapper
+[`scripts/swarm_opencode_run_unattended.sh`](../../scripts/swarm_opencode_run_unattended.sh)
+in place of bare `opencode`. It injects a permissive policy via
+`OPENCODE_CONFIG_CONTENT` only when the caller has not already set a
+policy of their own, then `exec`s `opencode` with every argument passed
+through:
+
+```bash
+# In ~/.codex/skills/tmux-swarm-orchestration/scripts/launch_opencode_worker.sh:
+RAG_REPO=/path/to/rag
+WRAPPER="$RAG_REPO/scripts/swarm_opencode_run_unattended.sh"
+
+OPENCODE_AGENT=pr-worker \
+OPENCODE_MODEL=opencode-go/kimi-k2.6 \
+  bash "$WRAPPER" run "Implement issue #1234 ..."
+```
+
+`OPENCODE_PERMISSION` should be **removed** from any launcher that still
+exports it; the variable does nothing.
+
+### Per-worker overrides
+
+If a worker should run with a stricter policy than `"allow"`, set
+`OPENCODE_CONFIG_CONTENT` (or `OPENCODE_CONFIG`) before invoking the
+wrapper. The wrapper detects an existing value and leaves it untouched:
+
+```bash
+OPENCODE_CONFIG_CONTENT='{"permission":{"bash":"ask","edit":"allow","*":"deny"}}' \
+  bash "$WRAPPER" run "Read-only audit ..."
+```
+
+## Verification Checklist
+
+When updating a launcher:
+
+- [ ] Remove every reference to `OPENCODE_PERMISSION` (no real var).
+- [ ] Set `OPENCODE_CONFIG_CONTENT` *or* delegate to
+      `swarm_opencode_run_unattended.sh`.
+- [ ] In an isolated test worktree, run a small worker prompt and
+      observe that no permission prompt appears in the tmux pane.
+- [ ] Confirm `.signals/launch-W-name.json` records the chosen
+      permission mode (e.g. `"permission_mode": "allow"` or
+      `"opencode_config_content_set": true`).
+- [ ] Update the swarm skill docs (in `~/.codex/skills/`) to point at
+      this runbook.
+
+## Tests
+
+The wrapper contract is pinned by
+[`tests/unit/scripts/test_swarm_opencode_run_unattended.py`](../../tests/unit/scripts/test_swarm_opencode_run_unattended.py)
+(9 tests). Run from the repo root:
+
+```bash
+uv run pytest tests/unit/scripts/test_swarm_opencode_run_unattended.py -q
+```

--- a/scripts/swarm_opencode_run_unattended.sh
+++ b/scripts/swarm_opencode_run_unattended.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# scripts/swarm_opencode_run_unattended.sh
+#
+# Wrapper for invoking OpenCode in unattended ("non-interactive") mode from
+# swarm worker launchers (e.g. ~/.codex/skills/tmux-swarm-orchestration/
+# scripts/launch_opencode_*.sh).
+#
+# Issue #1306 reports that swarm OpenCode workers stop and require manual
+# permission confirmation, breaking the unattended-worker contract. The
+# existing launcher exports OPENCODE_PERMISSION='{"*":"allow"}', but
+# OpenCode does not recognise that variable. The canonical mechanism is the
+# `permission` field in opencode.json, which can be injected at runtime via:
+#
+#   * a project-local opencode.json (highest precedence),
+#   * OPENCODE_CONFIG=/path/to/file.json (explicit config file),
+#   * OPENCODE_CONFIG_CONTENT='{"permission":"allow"}' (inline JSON).
+#
+# Source: Context7 /anomalyco/opencode docs/permissions.mdx + docs/config.mdx.
+#
+# This wrapper:
+#
+#   * If neither OPENCODE_CONFIG nor OPENCODE_CONFIG_CONTENT is set in the
+#     caller's environment, sets OPENCODE_CONFIG_CONTENT to a permissive
+#     JSON document so worker tool-calls do not block on a prompt.
+#   * Otherwise, leaves both variables alone — the caller has stronger
+#     opinions and the wrapper must not silently override them.
+#   * Execs `opencode` with every positional argument passed through
+#     verbatim, so callers can use it for `opencode run ...`,
+#     `opencode tui`, or any future subcommand.
+#
+# Usage:
+#
+#   bash scripts/swarm_opencode_run_unattended.sh run "Explain Go context"
+#   bash scripts/swarm_opencode_run_unattended.sh tui
+#
+# Refs #1306.
+
+set -euo pipefail
+
+# Only inject the permissive config when the caller hasn't expressed an
+# opinion. We treat *either* OPENCODE_CONFIG or OPENCODE_CONFIG_CONTENT as
+# a signal that the caller is in control. Touching either path while the
+# other is set produces ambiguous load behaviour that is hard to debug.
+if [[ -z "${OPENCODE_CONFIG_CONTENT:-}" && -z "${OPENCODE_CONFIG:-}" ]]; then
+  # Single source of truth for the permissive payload. Kept minimal so
+  # callers can see at a glance what the wrapper grants.
+  export OPENCODE_CONFIG_CONTENT='{"$schema":"https://opencode.ai/config.json","permission":"allow"}'
+fi
+
+# Use `command -v` to give a friendlier diagnostic than the raw exec
+# failure when opencode is not on PATH; in either case we exit non-zero.
+if ! command -v opencode >/dev/null 2>&1; then
+  echo "swarm_opencode_run_unattended.sh: 'opencode' is not on PATH" >&2
+  exit 127
+fi
+
+exec opencode "$@"

--- a/tests/unit/scripts/test_swarm_opencode_run_unattended.py
+++ b/tests/unit/scripts/test_swarm_opencode_run_unattended.py
@@ -1,0 +1,297 @@
+# tests/unit/scripts/test_swarm_opencode_run_unattended.py
+"""Unit tests for ``scripts/swarm_opencode_run_unattended.sh``.
+
+Issue #1306 reports that swarm OpenCode workers stop and require manual
+permission confirmation, which defeats the unattended-worker contract.
+The repo investigation (see PR description on #1306) and Context7
+documentation for ``/anomalyco/opencode`` show that the env variable used
+by the existing launcher (``OPENCODE_PERMISSION``) is not recognised by
+OpenCode. The canonical mechanism is the ``permission`` field in
+``opencode.json``, which can be injected at runtime in three ways:
+
+1. A project-local ``opencode.json`` (highest precedence).
+2. ``OPENCODE_CONFIG=/path/to/file.json`` — load an explicit config file.
+3. ``OPENCODE_CONFIG_CONTENT='{"permission":"allow"}'`` — inline JSON.
+
+This module pins the contract for a small wrapper,
+``scripts/swarm_opencode_run_unattended.sh``, that user-level launchers
+(under ``~/.codex/skills/tmux-swarm-orchestration/scripts/``) can invoke
+in place of bare ``opencode`` to get the correct non-interactive policy
+without each launcher reinventing it.
+
+Wrapper behaviour:
+
+- If neither ``OPENCODE_CONFIG`` nor ``OPENCODE_CONFIG_CONTENT`` is set in
+  the caller's environment, the wrapper sets
+  ``OPENCODE_CONFIG_CONTENT='{"$schema": "...", "permission": "allow"}'``
+  before exec'ing ``opencode``. This grants tool/edit/bash permissions
+  without prompts.
+- If ``OPENCODE_CONFIG_CONTENT`` is already set, leave it alone (caller
+  has stronger opinions; do not override).
+- If ``OPENCODE_CONFIG`` is set, leave it alone for the same reason.
+- Pass through every positional argument verbatim, so callers can use
+  the wrapper for ``opencode run ...``, ``opencode tui``, or any future
+  OpenCode subcommand.
+
+Refs #1306. Context7 sources:
+``/anomalyco/opencode/dev/packages/web/src/content/docs/permissions.mdx``
+``/anomalyco/opencode/dev/packages/web/src/content/docs/config.mdx``
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "swarm_opencode_run_unattended.sh"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_opencode_stub(bin_dir: Path) -> Path:
+    """Write a fake ``opencode`` executable that records env + args.
+
+    The stub writes three lines to ``$OPENCODE_TEST_OUTFILE``:
+
+        OPENCODE_CONFIG_CONTENT=<value or <unset>>
+        OPENCODE_CONFIG=<value or <unset>>
+        ARGS: <space-joined argv>
+
+    and exits 0. Callers compare the captured file against the contract.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    stub = bin_dir / "opencode"
+    stub.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            : "${OPENCODE_TEST_OUTFILE:?OPENCODE_TEST_OUTFILE must be set in tests}"
+            {
+              echo "OPENCODE_CONFIG_CONTENT=${OPENCODE_CONFIG_CONTENT-<unset>}"
+              echo "OPENCODE_CONFIG=${OPENCODE_CONFIG-<unset>}"
+              printf 'ARGS:'
+              for a in "$@"; do printf ' %s' "$a"; done
+              echo
+            } > "$OPENCODE_TEST_OUTFILE"
+            exit 0
+            """
+        )
+    )
+    stub.chmod(0o755)
+    return stub
+
+
+def _run_wrapper(
+    *args: str,
+    env_override: dict[str, str | None] | None = None,
+    bin_dir: Path,
+    outfile: Path,
+) -> subprocess.CompletedProcess[str]:
+    """Run the wrapper with a stubbed ``opencode`` on PATH and capture env+args."""
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["OPENCODE_TEST_OUTFILE"] = str(outfile)
+    # Start from a clean slate for the variables we care about.
+    env.pop("OPENCODE_CONFIG_CONTENT", None)
+    env.pop("OPENCODE_CONFIG", None)
+    if env_override:
+        for key, value in env_override.items():
+            if value is None:
+                env.pop(key, None)
+            else:
+                env[key] = value
+    return subprocess.run(
+        ["bash", str(SCRIPT_PATH), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _parse_outfile(outfile: Path) -> dict[str, str]:
+    """Return the captured env/args from the stub's output."""
+    parsed: dict[str, str] = {}
+    for line in outfile.read_text(encoding="utf-8").splitlines():
+        if line.startswith("OPENCODE_CONFIG_CONTENT="):
+            parsed["OPENCODE_CONFIG_CONTENT"] = line.removeprefix("OPENCODE_CONFIG_CONTENT=")
+        elif line.startswith("OPENCODE_CONFIG="):
+            parsed["OPENCODE_CONFIG"] = line.removeprefix("OPENCODE_CONFIG=")
+        elif line.startswith("ARGS:"):
+            parsed["ARGS"] = line.removeprefix("ARGS:").strip()
+    return parsed
+
+
+# ---------------------------------------------------------------------------
+# Static structural sanity
+# ---------------------------------------------------------------------------
+
+
+class TestScriptShape:
+    def test_script_exists_and_is_executable(self) -> None:
+        assert SCRIPT_PATH.is_file(), SCRIPT_PATH
+        assert os.access(SCRIPT_PATH, os.X_OK), (
+            f"{SCRIPT_PATH} must be executable so launchers can invoke it directly."
+        )
+
+    def test_script_starts_with_bash_shebang(self) -> None:
+        first = SCRIPT_PATH.read_text(encoding="utf-8").splitlines()[0]
+        assert first in (
+            "#!/usr/bin/env bash",
+            "#!/bin/bash",
+        ), f"Unexpected shebang: {first!r}"
+
+
+# ---------------------------------------------------------------------------
+# Behavioural contract
+# ---------------------------------------------------------------------------
+
+
+class TestUnattendedWrapper:
+    def test_injects_permission_allow_when_no_config_set(self, tmp_path) -> None:
+        bin_dir = tmp_path / "bin"
+        outfile = tmp_path / "out"
+        _write_opencode_stub(bin_dir)
+
+        result = _run_wrapper("run", "explain", "context", bin_dir=bin_dir, outfile=outfile)
+
+        assert result.returncode == 0, (result.stdout, result.stderr)
+        captured = _parse_outfile(outfile)
+        assert captured["OPENCODE_CONFIG"] == "<unset>", captured
+        # The injected JSON must be valid and assert a permissive policy.
+        injected = captured["OPENCODE_CONFIG_CONTENT"]
+        assert injected != "<unset>", captured
+        parsed = json.loads(injected)
+        assert parsed.get("permission") == "allow", parsed
+
+    def test_passes_through_positional_args_verbatim(self, tmp_path) -> None:
+        bin_dir = tmp_path / "bin"
+        outfile = tmp_path / "out"
+        _write_opencode_stub(bin_dir)
+
+        _run_wrapper(
+            "run",
+            "Explain the use of context in Go",
+            "--quiet",
+            bin_dir=bin_dir,
+            outfile=outfile,
+        )
+
+        captured = _parse_outfile(outfile)
+        assert captured["ARGS"] == ("run Explain the use of context in Go --quiet"), captured
+
+    def test_does_not_override_existing_opencode_config_content(self, tmp_path) -> None:
+        bin_dir = tmp_path / "bin"
+        outfile = tmp_path / "out"
+        _write_opencode_stub(bin_dir)
+
+        caller_payload = '{"permission": {"bash": "ask"}, "model": "anthropic/x"}'
+        _run_wrapper(
+            "run",
+            "noop",
+            env_override={"OPENCODE_CONFIG_CONTENT": caller_payload},
+            bin_dir=bin_dir,
+            outfile=outfile,
+        )
+
+        captured = _parse_outfile(outfile)
+        assert captured["OPENCODE_CONFIG_CONTENT"] == caller_payload, captured
+
+    def test_does_not_override_existing_opencode_config_path(self, tmp_path) -> None:
+        bin_dir = tmp_path / "bin"
+        outfile = tmp_path / "out"
+        _write_opencode_stub(bin_dir)
+
+        custom_path = "/etc/opencode/custom.json"
+        _run_wrapper(
+            "run",
+            "noop",
+            env_override={"OPENCODE_CONFIG": custom_path},
+            bin_dir=bin_dir,
+            outfile=outfile,
+        )
+
+        captured = _parse_outfile(outfile)
+        assert captured["OPENCODE_CONFIG"] == custom_path, captured
+        # The wrapper must not silently inject CONTENT alongside an existing
+        # CONFIG path: that would be ambiguous to debug.
+        assert captured["OPENCODE_CONFIG_CONTENT"] == "<unset>", captured
+
+    def test_propagates_opencode_exit_code(self, tmp_path) -> None:
+        # Stub that exits non-zero.
+        bin_dir = tmp_path / "bin"
+        outfile = tmp_path / "out"
+        bin_dir.mkdir(parents=True)
+        stub = bin_dir / "opencode"
+        stub.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                : "${OPENCODE_TEST_OUTFILE:?OPENCODE_TEST_OUTFILE must be set in tests}"
+                echo "stubbed failure" >&2
+                exit 7
+                """
+            )
+        )
+        stub.chmod(0o755)
+
+        result = _run_wrapper("run", "fail", bin_dir=bin_dir, outfile=outfile)
+
+        assert result.returncode == 7, (result.stdout, result.stderr)
+
+    def test_errors_when_opencode_not_on_path(self, tmp_path) -> None:
+        # No stub written, so 'opencode' is not provided by us.
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir(parents=True)
+        outfile = tmp_path / "out"
+
+        # If a real opencode is already on the host PATH, this scenario is
+        # impossible to construct without losing access to bash itself.
+        if shutil.which("opencode"):
+            pytest.skip(
+                "A real opencode binary is on PATH; cannot test the "
+                "missing-binary path without trimming PATH past bash too."
+            )
+
+        env = os.environ.copy()
+        # Prepend our empty bin_dir so it doesn't override anything; opencode
+        # remains absent system-wide.
+        env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+        env["OPENCODE_TEST_OUTFILE"] = str(outfile)
+        env.pop("OPENCODE_CONFIG_CONTENT", None)
+        env.pop("OPENCODE_CONFIG", None)
+
+        result = subprocess.run(
+            ["bash", str(SCRIPT_PATH), "run", "noop"],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        # Wrapper must fail loudly, not silently succeed.
+        assert result.returncode != 0
+        # Helpful diagnostic mentions opencode somewhere.
+        combined = (result.stderr or "") + (result.stdout or "")
+        assert "opencode" in combined.lower(), combined
+
+
+# ---------------------------------------------------------------------------
+# Independence check: the test file should not assume bash exists at a
+# specific path, but it does need bash to be installed.
+# ---------------------------------------------------------------------------
+
+
+def test_bash_is_available() -> None:
+    assert shutil.which("bash") is not None, "bash must be on PATH to run the wrapper script tests."


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Issue #1306 reports that swarm OpenCode workers stop and require manual
permission confirmation, breaking the unattended-worker contract. The
existing launcher (which lives outside this repo, under
`~/.codex/skills/tmux-swarm-orchestration/`) exports
`OPENCODE_PERMISSION='{"*":"allow"}'` before invoking `opencode`.

**Root cause (verified via Context7):** OpenCode does not recognise the
`OPENCODE_PERMISSION` environment variable. It is silently ignored. The
canonical mechanism is the `permission` field in `opencode.json`,
loadable at runtime via three precedence-ordered paths:

1. project-local `opencode.json` (highest)
2. `OPENCODE_CONFIG=/path/to/file.json`
3. `OPENCODE_CONFIG_CONTENT='<inline JSON>'`

Sources (Context7 `/anomalyco/opencode`):
- `dev/packages/web/src/content/docs/permissions.mdx`
- `dev/packages/web/src/content/docs/config.mdx`
- `dev/packages/opencode/src/skill/prompt/customize-opencode.md`

This PR adds three repo-side artifacts that close #1306 from the parts
of the surface this repo can reach.

## TDD trail

1. Wrote `tests/unit/scripts/test_swarm_opencode_run_unattended.py`
   first (9 tests; all RED — script did not exist yet).
2. Implemented `scripts/swarm_opencode_run_unattended.sh`. All 9 tests
   GREEN.
3. Verified ruff lint/format and `bash -n`. Wrote the operator runbook.

## Artifacts

### `scripts/swarm_opencode_run_unattended.sh`
Wrapper for `opencode` invocations from worker launchers:
- Sets `OPENCODE_CONFIG_CONTENT` to a permissive JSON document only
  when neither `OPENCODE_CONFIG` nor `OPENCODE_CONFIG_CONTENT` is
  already set (callers with stronger opinions are not overridden).
- `exec opencode "$@"` so every positional argument passes through
  verbatim (`opencode run ...`, `opencode tui`, any future subcommand).
- Exits 127 with a friendly diagnostic when `opencode` is missing from
  PATH instead of failing with a raw exec error.

### `tests/unit/scripts/test_swarm_opencode_run_unattended.py`
Nine contract tests using a recorded-stdout shell stub for `opencode`
so the tests run without a real opencode binary:
- `TestScriptShape`: file is executable and bash-shebanged.
- `TestUnattendedWrapper`: injects `"permission":"allow"` when no
  policy is set, passes positional args through verbatim, does NOT
  override an existing `OPENCODE_CONFIG_CONTENT` or `OPENCODE_CONFIG`,
  propagates the child exit code, and emits a useful error when
  opencode is missing from PATH.

### `docs/engineering/swarm-non-interactive-launch.md`
Operator-facing runbook explaining:
- the root cause (`OPENCODE_PERMISSION` does nothing) with Context7
  citations,
- the canonical opencode.json policy formats (global, granular,
  per-tool with pattern matching),
- the three runtime loaders and the escape-hatch env vars,
- the recommended launcher pattern using this wrapper, with a
  copy-pasteable snippet for `~/.codex/skills/.../launch_opencode_*.sh`,
- a verification checklist for maintainers updating user-level
  launchers.

## Verification

```text
uv run pytest tests/unit/scripts/test_swarm_opencode_run_unattended.py -q
9 passed in 0.63s

uv run ruff check tests/unit/scripts/test_swarm_opencode_run_unattended.py
All checks passed!

uv run ruff format --check tests/unit/scripts/test_swarm_opencode_run_unattended.py
already formatted

bash -n scripts/swarm_opencode_run_unattended.sh
ok
```

The shell stub records `OPENCODE_CONFIG_CONTENT`, `OPENCODE_CONFIG`, and
the args passed to the child, so the tests assert exact behaviour
without needing a real opencode binary.

## Skipped checks

- No live `opencode` binary in the sandbox, so the wrapper was tested
  against a recorded-stdout stub. End-to-end integration with a real
  opencode is the maintainer step on the user's local machine.
- Updating the user-level launcher
  (`~/.codex/skills/tmux-swarm-orchestration/scripts/launch_opencode_*.sh`)
  is out of scope for an autonomous repo PR; the runbook documents the
  patch a maintainer should apply.
- `shellcheck` not installed in the sandbox; `bash -n` was used instead
  for the 30-line wrapper.
- `scripts/check_markdown_links.py` reports 1 pre-existing broken link
  in `telegram_bot/services/README.md` (unrelated to this PR).

Refs #1306