### PR TITLE
feat(scripts): add event-driven swarm watchdog snapshot tool (#1275)

### DIFF
--- a/docs/engineering/swarm-event-driven-wait.md
+++ b/docs/engineering/swarm-event-driven-wait.md
@@ -1,0 +1,216 @@
+# Event-Driven Worker Wait for the Swarm Orchestrator
+
+Reference for the orchestrator (Codex/Kiro) and worker launchers so the
+wait-for-worker phase consumes near-zero context tokens. Tracks issue
+[#1275](https://github.com/yastman/rag/issues/1275).
+
+## The Problem
+
+The historical wait loop runs in the orchestrator's turn:
+
+```text
+while not done:
+    sleep
+    find .signals/
+    git status
+```
+
+Every iteration spends tool-call budget even when nothing changed. Long
+worker tasks encourage repeated "still waiting" checks. If the user
+interrupts the turn, background worker state becomes hard to track.
+
+## The Contract
+
+The orchestrator should not poll. After launching workers it should:
+
+1. Persist `.signals/active-workers.jsonl` with one JSON line per worker:
+
+   ```json
+   {
+     "worker": "W-name",
+     "signal_file": "/abs/path/.signals/worker-W-name.json",
+     "heartbeat_file": "/abs/path/.signals/heartbeat-W-name.json",
+     "branch": "kiro/<n>-<slug>",
+     "base": "dev",
+     "started_at": "2026-05-21T11:00:00Z",
+     "tmux_window": "swarm:W-name",
+     "pane_pid": 12345,
+     "prompt_sha256": "..."
+   }
+   ```
+
+2. Tell the user that workers are running and end the turn.
+
+The orchestrator resumes only when:
+
+- A worker writes its terminal signal JSON and wakes the orchestrator
+  via the canonical tmux send-keys form pinned by issue
+  [#1721](https://github.com/yastman/rag/issues/1721) and the contract
+  test [`tests/contract/test_tmux_send_keys_pattern_contract.py`](../../tests/contract/test_tmux_send_keys_pattern_contract.py):
+
+  ```bash
+  tmux send-keys -t "$ORCH_TARGET" -l "[DONE] $WORKER_NAME $REPORT_FILE"
+  sleep 0.25
+  tmux send-keys -t "$ORCH_TARGET" C-m
+  ```
+
+  The repo ships the user-runnable fixer
+  [`scripts/swarm_fix_send_keys_pattern.py`](../../scripts/swarm_fix_send_keys_pattern.py)
+  to migrate any legacy launcher that still uses the broken trailing
+  `Enter` form.
+
+- The user explicitly asks for status. In that case the orchestrator
+  reads a single compact JSON snapshot via the watchdog (below) and
+  reports — without scanning files manually.
+
+## The Watchdog
+
+[`scripts/swarm_watchdog.py`](../../scripts/swarm_watchdog.py) is a
+read-only watchdog that produces that snapshot. One call returns one
+JSON document covering every active worker, derived from
+`.signals/active-workers.jsonl` plus each worker's signal/heartbeat
+artifacts.
+
+### One-shot mode (default)
+
+```bash
+python scripts/swarm_watchdog.py --once \
+  --registry .signals/active-workers.jsonl
+```
+
+Output (single JSON line plus an optional `[ALL_DONE]` marker):
+
+```text
+{"timestamp": "2026-05-21T16:36:58Z",
+ "signals_dir": ".signals",
+ "registry": ".signals/active-workers.jsonl",
+ "workers": [
+   {"worker": "W-alpha", "phase": "done",  "signal_exists": true,  "heartbeat_age_s": null},
+   {"worker": "W-beta",  "phase": "active","signal_exists": false, "heartbeat_age_s": 12.3}
+ ]}
+```
+
+The orchestrator reads one line, parses one JSON, and decides — no
+filesystem walk, no `git status`, no per-worker `cat`.
+
+The `[ALL_DONE]` marker on its own line is intentional: a tmux watcher
+pane can grep for it without parsing JSON. When every active worker has
+reached a terminal phase, the marker is printed.
+
+### Watch mode
+
+For sidecar tmux panes that should wake the orchestrator on transition:
+
+```bash
+python scripts/swarm_watchdog.py --watch \
+  --interval 5 \
+  --timeout 1800 \
+  --registry .signals/active-workers.jsonl
+```
+
+The script polls every `--interval` seconds and exits 0 when either
+`[ALL_DONE]` or `[TIMEOUT]` is reached. Combine with tmux send-keys to
+notify the orchestrator pane when state changes.
+
+### Reported phases
+
+| Phase | Meaning |
+|---|---|
+| `active` | Registered, no terminal signal, heartbeat (if any) is fresh. |
+| `done` | Signal JSON status is `done`. |
+| `failed` | Signal JSON status is `failed`, **or** the signal file exists but is corrupt (`error` field set). |
+| `blocked` | Signal JSON status is `blocked`. |
+| `stale` | No terminal signal yet, heartbeat older than `--stale-threshold` seconds (default 600). Investigate before resuming. |
+
+Terminal status from the signal JSON always wins over heartbeat
+liveness: a `done` worker is `done` even if its heartbeat went stale
+(common when the worker exited cleanly without one last heartbeat
+write).
+
+## Worker Heartbeat Format
+
+Optional, recommended for tasks expected to run longer than ~5 minutes.
+The worker writes `~/.signals/heartbeat-W-name.json` periodically:
+
+```json
+{
+  "worker": "W-name",
+  "phase": "editing|testing|creating_pr|blocked",
+  "last_artifact": "tests/unit/test_x.py",
+  "updated_at": "2026-05-21T11:42:00Z"
+}
+```
+
+The watchdog uses **mtime** of the file as the heartbeat age, so the
+worker can either rewrite the file in full or `touch` it. The `phase`
+and `last_artifact` fields are diagnostic — Codex reads them only when
+the user asks for status.
+
+## Worker-Side Wake-Up Etiquette
+
+After writing the authoritative signal JSON, a worker may send a
+single-line tmux pointer to the orchestrator pane:
+
+```bash
+tmux send-keys -t "$ORCH_TARGET" -l "[DONE] W-name /abs/path/.signals/worker-W-name.json"
+sleep 0.25
+tmux send-keys -t "$ORCH_TARGET" C-m
+```
+
+Allowed transition pointers (one line, no logs/diffs/long summaries):
+
+```text
+[DONE]    W-name /abs/path/.signals/worker-W-name.json
+[FAILED]  W-name /abs/path/.signals/worker-W-name.json
+[BLOCKED] W-name /abs/path/.signals/worker-W-name.json
+[STATUS]  W-name /abs/path/.signals/heartbeat-W-name.json
+```
+
+Rules:
+
+- The JSON artifact is the **truth**. The tmux pointer is just a hint.
+- Codex validates the pointer against `.signals/active-workers.jsonl`,
+  reserved files, branch/base, prompt checksum, and PR metadata before
+  accepting it. A stray pointer that doesn't match a registered worker
+  is ignored.
+- Use only the four transition pointers above, not chatty progress.
+
+## Verification
+
+The watchdog contract is pinned by 17 unit tests in
+[`tests/unit/scripts/test_swarm_watchdog.py`](../../tests/unit/scripts/test_swarm_watchdog.py)
+covering registry parsing (incl. malformed JSONL), per-worker
+inspection (active / terminal status / stale heartbeat / corrupt
+signal), the full snapshot, and CLI behaviour (`--once` modes,
+`[ALL_DONE]` marker emission).
+
+Run from the repo root:
+
+```bash
+uv run pytest tests/unit/scripts/test_swarm_watchdog.py -q
+```
+
+The send-keys wake-up form is enforced by
+[`tests/contract/test_tmux_send_keys_pattern_contract.py`](../../tests/contract/test_tmux_send_keys_pattern_contract.py)
+(refs #1721, #1590).
+
+## Maintainer Steps (out of repo)
+
+The user-level swarm-orchestration skills under
+`~/.codex/skills/tmux-swarm-orchestration/` and
+`~/.config/opencode/skills/swarm-*/` should:
+
+1. Document the event-driven wait policy: launch workers, persist the
+   active-workers registry, end the turn.
+2. Resume only on a tmux wake-up pointer or an explicit user status
+   request.
+3. Use `python scripts/swarm_watchdog.py --once` to read worker state
+   instead of scanning `.signals/` manually.
+4. (Optional) Run `python scripts/swarm_watchdog.py --watch` in a
+   sidecar tmux pane and wire its `[ALL_DONE]` line to a wake-up
+   send-keys back to the orchestrator pane.
+
+These external-skill changes are tracked in
+[`docs/superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md`](../superpowers/plans/2026-05-20-swarm-superpowers-worker-policy-external-changes.md)
+and remain a maintainer task — the autonomous repo PR cannot edit
+files outside the repository.

--- a/scripts/swarm_watchdog.py
+++ b/scripts/swarm_watchdog.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Read-only watchdog snapshot for swarm worker state (issue #1275).
+
+The orchestrator (Codex/Kiro) currently wastes context tokens periodically
+running ``sleep; find .signals; git status`` while waiting for workers.
+Issue #1275 proposes an event-driven flow where the orchestrator instead
+ends its turn after launching workers and resumes only when:
+
+* a worker writes its signal JSON and wakes the orchestrator via tmux
+  ``send-keys -l '[DONE] <worker> <path>' ; sleep 0.25 ; send-keys C-m``
+  (the canonical wake-up form pinned by issue #1721 and the contract test
+  ``tests/contract/test_tmux_send_keys_pattern_contract.py``);
+* the user explicitly asks for status.
+
+Either way, the orchestrator should not have to scan ``.signals/``
+manually. This script reads ``.signals/active-workers.jsonl`` plus each
+worker's signal/heartbeat artifacts and emits one compact JSON snapshot
+per call. A single ``cat ${watchdog --once}`` gives the orchestrator
+everything it needs in one read.
+
+Two modes:
+
+* ``--once`` (default): scan, print a single JSON line on stdout, exit.
+  Print ``[ALL_DONE]`` on its own line when every active worker has
+  reached a terminal phase (``done``/``failed``/``blocked``). The marker
+  makes it cheap for a tmux watcher pane to grep without parsing JSON.
+
+* ``--watch``: run ``--once`` every ``--interval`` seconds until
+  ``[ALL_DONE]`` is reported or ``--timeout`` elapses. Useful as a
+  sidecar pane that wakes the orchestrator only on state transitions.
+
+Phases reported:
+
+* ``active`` — worker is registered, no terminal signal, heartbeat (if
+  any) is fresh.
+* ``done`` / ``failed`` / ``blocked`` — terminal status read from the
+  worker's signal JSON.
+* ``stale`` — no signal yet, but heartbeat is older than
+  ``--stale-threshold`` seconds.
+
+A corrupt signal JSON is reported as ``failed`` with an ``error`` field
+rather than crashing the whole snapshot.
+
+Refs #1275, #1721.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+# Statuses considered terminal (no further work expected from the worker).
+_TERMINAL_STATUSES: frozenset[str] = frozenset({"done", "failed", "blocked"})
+
+# Default heartbeat staleness threshold. Workers that update a heartbeat
+# but go quiet for longer than this (without a terminal signal) are
+# reported as ``stale`` so the orchestrator can investigate.
+DEFAULT_STALE_THRESHOLD_S: float = 600.0
+
+# Default polling interval for ``--watch`` mode.
+DEFAULT_WATCH_INTERVAL_S: float = 5.0
+
+# Default registry path relative to CWD.
+DEFAULT_REGISTRY_REL_PATH: str = ".signals/active-workers.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def load_active_workers(registry_path: Path | str) -> list[dict[str, Any]]:
+    """Parse ``.signals/active-workers.jsonl`` into a list of worker entries.
+
+    Missing files yield an empty list (not an error: the orchestrator may
+    legitimately scan a clean session). Blank lines and malformed JSON
+    lines are skipped without raising, so a partially-corrupt registry is
+    still readable.
+    """
+    path = Path(registry_path)
+    if not path.is_file():
+        return []
+    workers: list[dict[str, Any]] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(entry, dict) and "worker" in entry and "signal_file" in entry:
+            workers.append(entry)
+    return workers
+
+
+def inspect_worker(
+    worker: dict[str, Any],
+    *,
+    now: float,
+    stale_threshold_s: float = DEFAULT_STALE_THRESHOLD_S,
+) -> dict[str, Any]:
+    """Return a single observation dict for ``worker``.
+
+    Required keys in ``worker``: ``worker``, ``signal_file``.
+    Optional keys: ``heartbeat_file``.
+
+    The returned dict always contains:
+
+    * ``worker``: the worker name (unchanged).
+    * ``phase``: ``active`` | ``done`` | ``failed`` | ``blocked`` | ``stale``.
+    * ``signal_exists``: bool.
+    * ``signal_path``: str — the configured signal_file path (for diagnostics).
+    * ``heartbeat_age_s``: float | None.
+
+    Optional extras when relevant:
+
+    * ``error``: str — present when the signal file exists but is
+      unreadable/corrupt; phase is forced to ``failed``.
+    * ``heartbeat_path``: str — present when ``heartbeat_file`` was set.
+    """
+    name = worker["worker"]
+    signal_path = Path(worker["signal_file"])
+    heartbeat_path: Path | None = None
+    if worker.get("heartbeat_file"):
+        heartbeat_path = Path(worker["heartbeat_file"])
+
+    obs: dict[str, Any] = {
+        "worker": name,
+        "phase": "active",
+        "signal_exists": False,
+        "signal_path": str(signal_path),
+        "heartbeat_age_s": None,
+    }
+    if heartbeat_path is not None:
+        obs["heartbeat_path"] = str(heartbeat_path)
+
+    # 1) Terminal signal takes precedence over everything else: a worker
+    # that has finished is finished, even if its heartbeat went stale.
+    if signal_path.exists():
+        obs["signal_exists"] = True
+        try:
+            payload = json.loads(signal_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            obs["phase"] = "failed"
+            obs["error"] = f"corrupt signal file: {exc}"
+            return obs
+        status = str(payload.get("status", "")).lower()
+        if status in _TERMINAL_STATUSES:
+            obs["phase"] = status
+            return obs
+        # Signal exists but doesn't carry a recognised terminal status —
+        # treat it as still active until the worker writes a real terminal
+        # status. The signal_exists flag stays true so callers can see it.
+
+    # 2) No terminal signal -> consult the heartbeat.
+    if heartbeat_path is not None and heartbeat_path.exists():
+        try:
+            mtime = heartbeat_path.stat().st_mtime
+            age = max(now - mtime, 0.0)
+            obs["heartbeat_age_s"] = round(age, 3)
+            if age > stale_threshold_s:
+                obs["phase"] = "stale"
+        except OSError as exc:
+            obs["error"] = f"unreadable heartbeat: {exc}"
+
+    return obs
+
+
+def scan(
+    registry_path: Path | str,
+    *,
+    now: float | None = None,
+    stale_threshold_s: float = DEFAULT_STALE_THRESHOLD_S,
+) -> dict[str, Any]:
+    """Return a complete snapshot of every worker in the registry."""
+    if now is None:
+        now = time.time()
+    registry = Path(registry_path)
+    workers = load_active_workers(registry)
+    observations = [
+        inspect_worker(w, now=now, stale_threshold_s=stale_threshold_s) for w in workers
+    ]
+    return {
+        "timestamp": _iso_utc(now),
+        "signals_dir": str(registry.parent),
+        "registry": str(registry),
+        "workers": observations,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _CLIArgs:
+    once: bool
+    watch: bool
+    registry: Path
+    interval: float
+    timeout: float
+    stale_threshold: float
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if args.watch:
+        return _run_watch(args)
+    return _run_once(args)
+
+
+def _parse_args(argv: list[str] | None) -> _CLIArgs:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Read-only watchdog for swarm worker state. Emits a single "
+            "JSON snapshot on stdout (one line) plus an [ALL_DONE] marker "
+            "when every worker has reached a terminal phase."
+        )
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--once",
+        action="store_true",
+        default=True,
+        help="scan once and exit (default)",
+    )
+    mode.add_argument(
+        "--watch",
+        action="store_true",
+        help="poll every --interval seconds until [ALL_DONE] or --timeout",
+    )
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        default=Path(DEFAULT_REGISTRY_REL_PATH),
+        help=f"path to active-workers.jsonl (default: {DEFAULT_REGISTRY_REL_PATH})",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=DEFAULT_WATCH_INTERVAL_S,
+        help=f"--watch poll interval in seconds (default: {DEFAULT_WATCH_INTERVAL_S})",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=0.0,
+        help="--watch timeout in seconds; 0 means no timeout",
+    )
+    parser.add_argument(
+        "--stale-threshold",
+        type=float,
+        default=DEFAULT_STALE_THRESHOLD_S,
+        help=(
+            "heartbeat age in seconds beyond which a worker is reported as "
+            f"stale (default: {DEFAULT_STALE_THRESHOLD_S})"
+        ),
+    )
+    parsed = parser.parse_args(argv)
+    return _CLIArgs(
+        once=not parsed.watch,
+        watch=parsed.watch,
+        registry=parsed.registry,
+        interval=parsed.interval,
+        timeout=parsed.timeout,
+        stale_threshold=parsed.stale_threshold,
+    )
+
+
+def _run_once(args: _CLIArgs) -> int:
+    snap = scan(args.registry, stale_threshold_s=args.stale_threshold)
+    print(json.dumps(snap, ensure_ascii=False))
+    if _all_terminal(snap):
+        print("[ALL_DONE]")
+    return 0
+
+
+def _run_watch(args: _CLIArgs) -> int:
+    deadline = time.time() + args.timeout if args.timeout > 0 else None
+    while True:
+        snap = scan(args.registry, stale_threshold_s=args.stale_threshold)
+        print(json.dumps(snap, ensure_ascii=False), flush=True)
+        if _all_terminal(snap):
+            print("[ALL_DONE]", flush=True)
+            return 0
+        if deadline is not None and time.time() >= deadline:
+            print("[TIMEOUT]", flush=True)
+            return 0
+        with contextlib.suppress(KeyboardInterrupt):
+            time.sleep(args.interval)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _all_terminal(snap: dict[str, Any]) -> bool:
+    """True when every worker is in a terminal phase (or there are none)."""
+    workers = snap.get("workers") or []
+    return all(w["phase"] in _TERMINAL_STATUSES for w in workers)
+
+
+def _iso_utc(epoch: float) -> str:
+    """Return an ISO-8601 UTC timestamp without microseconds."""
+    # Match the time.gmtime view rather than depending on the host TZ so the
+    # snapshot is reproducible across machines.
+    t = time.gmtime(epoch)
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", t)
+
+
+# Silence unused-import warnings on minimal builds.
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_swarm_watchdog.py
+++ b/tests/unit/scripts/test_swarm_watchdog.py
@@ -1,0 +1,389 @@
+# tests/unit/scripts/test_swarm_watchdog.py
+"""Unit tests for ``scripts/swarm_watchdog.py``.
+
+Issue #1275 argues that the orchestrator (Codex) should not waste tokens
+polling ``.signals/`` and ``git status`` in a loop while waiting for
+workers. Instead a single observation should give a complete state
+snapshot when the orchestrator chooses to look (or when a worker wakes
+the orchestrator via tmux send-keys).
+
+This module pins the contract of the read-only watchdog used to produce
+that snapshot. The watchdog reads ``.signals/active-workers.jsonl`` plus
+each worker's signal/heartbeat files and emits one compact JSON event
+per worker. The orchestrator can call it once on resume, or run it in a
+``--watch`` loop in a sidecar tmux pane.
+
+Behavioural pins:
+
+1. ``load_active_workers(path)`` parses a JSONL registry into a list of
+   dicts with required keys ``worker``, ``signal_file``, optional
+   ``heartbeat_file``, ``branch``, ``base``, ``started_at``.
+   Malformed/blank lines are skipped without raising.
+2. ``inspect_worker(worker, now=...)`` returns a per-worker observation:
+   ``phase`` is one of ``active``, ``done``, ``failed``, ``blocked``,
+   ``stale``; ``signal_exists`` is a bool; ``heartbeat_age_s`` is a
+   float (or ``None`` if no heartbeat is registered/present).
+3. ``scan(active_workers_path, now=...)`` returns a snapshot dict with
+   ``timestamp``, ``signals_dir``, and ``workers`` (list of observations).
+4. CLI ``--once`` prints the snapshot as a single JSON line and exits 0.
+5. CLI emits an ``[ALL_DONE]`` line on stdout when every worker reaches
+   a terminal phase, so a tmux watcher can consume it without parsing
+   JSON.
+
+Refs #1275, #1721 (worker -> orchestrator wake-up via tmux send-keys).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "swarm_watchdog.py"
+
+
+@pytest.fixture(scope="module")
+def watchdog_module():
+    """Load ``scripts/swarm_watchdog.py`` as a module."""
+    spec = importlib.util.spec_from_file_location("_swarm_watchdog", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None, SCRIPT_PATH
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so dataclasses + other machinery that look up
+    # cls.__module__ in sys.modules can find it.
+    sys.modules["_swarm_watchdog"] = module
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.modules.pop("_swarm_watchdog", None)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _write_registry(path: Path, entries: list[dict]) -> None:
+    """Write ``entries`` to ``path`` as JSONL. Creates parent dirs."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for entry in entries:
+            fh.write(json.dumps(entry) + "\n")
+
+
+def _write_signal(path: Path, status: str = "done") -> None:
+    """Write a worker signal JSON file with the given status."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "worker": path.stem,
+                "status": status,
+                "completed_at": "2026-05-21T12:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_heartbeat(path: Path, *, age_s: float = 0.0) -> None:
+    """Write a heartbeat JSON file with mtime ``now - age_s``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"worker": path.stem, "phase": "running"}),
+        encoding="utf-8",
+    )
+    if age_s > 0:
+        mtime = time.time() - age_s
+        import os
+
+        os.utime(path, (mtime, mtime))
+
+
+# ---------------------------------------------------------------------------
+# load_active_workers
+# ---------------------------------------------------------------------------
+
+
+class TestLoadActiveWorkers:
+    def test_returns_empty_list_when_registry_does_not_exist(self, watchdog_module, tmp_path):
+        registry = tmp_path / ".signals" / "active-workers.jsonl"
+        # Do not create the file.
+        result = watchdog_module.load_active_workers(registry)
+        assert result == []
+
+    def test_parses_one_worker_entry(self, watchdog_module, tmp_path):
+        registry = tmp_path / ".signals" / "active-workers.jsonl"
+        entry = {
+            "worker": "W-foo",
+            "signal_file": str(tmp_path / ".signals" / "worker-W-foo.json"),
+            "branch": "kiro/1234-foo",
+            "base": "dev",
+            "started_at": "2026-05-21T11:00:00Z",
+        }
+        _write_registry(registry, [entry])
+
+        result = watchdog_module.load_active_workers(registry)
+
+        assert result == [entry]
+
+    def test_skips_blank_lines_and_malformed_json(self, watchdog_module, tmp_path):
+        registry = tmp_path / ".signals" / "active-workers.jsonl"
+        registry.parent.mkdir(parents=True)
+        registry.write_text(
+            "\n"
+            + json.dumps({"worker": "W-ok", "signal_file": "/tmp/W-ok.json"})
+            + "\n"
+            + "{not valid json}\n"
+            + "\n"
+            + json.dumps({"worker": "W-also", "signal_file": "/tmp/W-also.json"})
+            + "\n"
+        )
+
+        result = watchdog_module.load_active_workers(registry)
+
+        assert [w["worker"] for w in result] == ["W-ok", "W-also"]
+
+
+# ---------------------------------------------------------------------------
+# inspect_worker
+# ---------------------------------------------------------------------------
+
+
+class TestInspectWorker:
+    def test_active_when_signal_missing_and_no_heartbeat(self, watchdog_module, tmp_path):
+        worker = {
+            "worker": "W-running",
+            "signal_file": str(tmp_path / "worker-W-running.json"),
+        }
+
+        obs = watchdog_module.inspect_worker(worker, now=time.time())
+
+        assert obs["worker"] == "W-running"
+        assert obs["phase"] == "active"
+        assert obs["signal_exists"] is False
+        assert obs["heartbeat_age_s"] is None
+
+    def test_done_when_signal_present_with_status_done(self, watchdog_module, tmp_path):
+        signal_path = tmp_path / "worker-W-done.json"
+        _write_signal(signal_path, status="done")
+        worker = {"worker": "W-done", "signal_file": str(signal_path)}
+
+        obs = watchdog_module.inspect_worker(worker, now=time.time())
+
+        assert obs["phase"] == "done"
+        assert obs["signal_exists"] is True
+
+    def test_failed_when_signal_status_failed(self, watchdog_module, tmp_path):
+        signal_path = tmp_path / "worker-W-fail.json"
+        _write_signal(signal_path, status="failed")
+        worker = {"worker": "W-fail", "signal_file": str(signal_path)}
+
+        obs = watchdog_module.inspect_worker(worker, now=time.time())
+
+        assert obs["phase"] == "failed"
+
+    def test_blocked_when_signal_status_blocked(self, watchdog_module, tmp_path):
+        signal_path = tmp_path / "worker-W-block.json"
+        _write_signal(signal_path, status="blocked")
+        worker = {"worker": "W-block", "signal_file": str(signal_path)}
+
+        obs = watchdog_module.inspect_worker(worker, now=time.time())
+
+        assert obs["phase"] == "blocked"
+
+    def test_stale_when_heartbeat_older_than_threshold(self, watchdog_module, tmp_path):
+        hb = tmp_path / "heartbeat-W-stale.json"
+        _write_heartbeat(hb, age_s=900.0)  # 15 minutes
+        worker = {
+            "worker": "W-stale",
+            "signal_file": str(tmp_path / "worker-W-stale.json"),
+            "heartbeat_file": str(hb),
+        }
+
+        obs = watchdog_module.inspect_worker(worker, now=time.time(), stale_threshold_s=600.0)
+
+        assert obs["phase"] == "stale"
+        assert obs["heartbeat_age_s"] is not None
+        assert obs["heartbeat_age_s"] > 600
+
+    def test_active_when_heartbeat_recent(self, watchdog_module, tmp_path):
+        hb = tmp_path / "heartbeat-W-fresh.json"
+        _write_heartbeat(hb, age_s=10.0)
+        worker = {
+            "worker": "W-fresh",
+            "signal_file": str(tmp_path / "worker-W-fresh.json"),
+            "heartbeat_file": str(hb),
+        }
+
+        obs = watchdog_module.inspect_worker(worker, now=time.time(), stale_threshold_s=600.0)
+
+        assert obs["phase"] == "active"
+        assert obs["heartbeat_age_s"] is not None
+        assert 9 <= obs["heartbeat_age_s"] <= 12
+
+    def test_signal_takes_precedence_over_stale_heartbeat(self, watchdog_module, tmp_path):
+        """A stale heartbeat plus a DONE signal must report ``done`` (terminal)."""
+        signal_path = tmp_path / "worker-W-finished.json"
+        _write_signal(signal_path, status="done")
+        hb = tmp_path / "heartbeat-W-finished.json"
+        _write_heartbeat(hb, age_s=900.0)
+
+        worker = {
+            "worker": "W-finished",
+            "signal_file": str(signal_path),
+            "heartbeat_file": str(hb),
+        }
+
+        obs = watchdog_module.inspect_worker(worker, now=time.time(), stale_threshold_s=600.0)
+
+        # Terminal status wins over stale liveness check.
+        assert obs["phase"] == "done"
+
+    def test_handles_corrupt_signal_file_gracefully(self, watchdog_module, tmp_path):
+        signal_path = tmp_path / "worker-W-corrupt.json"
+        signal_path.write_text("{not valid json}", encoding="utf-8")
+        worker = {"worker": "W-corrupt", "signal_file": str(signal_path)}
+
+        obs = watchdog_module.inspect_worker(worker, now=time.time())
+
+        # Corrupt signal must be reported, not crash.
+        assert obs["phase"] == "failed"
+        assert obs["signal_exists"] is True
+        assert "error" in obs
+
+
+# ---------------------------------------------------------------------------
+# scan
+# ---------------------------------------------------------------------------
+
+
+class TestScan:
+    def test_scan_returns_snapshot_with_required_fields(self, watchdog_module, tmp_path):
+        registry = tmp_path / ".signals" / "active-workers.jsonl"
+        _write_registry(
+            registry,
+            [
+                {
+                    "worker": "W-a",
+                    "signal_file": str(tmp_path / ".signals" / "worker-W-a.json"),
+                },
+                {
+                    "worker": "W-b",
+                    "signal_file": str(tmp_path / ".signals" / "worker-W-b.json"),
+                },
+            ],
+        )
+        _write_signal(tmp_path / ".signals" / "worker-W-a.json", status="done")
+        # W-b has no signal yet -> active.
+
+        snap = watchdog_module.scan(registry)
+
+        assert "timestamp" in snap
+        assert "signals_dir" in snap
+        assert {w["worker"] for w in snap["workers"]} == {"W-a", "W-b"}
+        phases = {w["worker"]: w["phase"] for w in snap["workers"]}
+        assert phases == {"W-a": "done", "W-b": "active"}
+
+    def test_scan_with_empty_registry(self, watchdog_module, tmp_path):
+        registry = tmp_path / ".signals" / "active-workers.jsonl"
+        # File doesn't exist.
+
+        snap = watchdog_module.scan(registry)
+
+        assert snap["workers"] == []
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def _run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_once_mode_emits_single_json_line_to_stdout(self, tmp_path):
+        registry = tmp_path / ".signals" / "active-workers.jsonl"
+        _write_registry(
+            registry,
+            [
+                {
+                    "worker": "W-a",
+                    "signal_file": str(tmp_path / ".signals" / "worker-W-a.json"),
+                }
+            ],
+        )
+
+        result = self._run("--once", "--registry", str(registry))
+
+        assert result.returncode == 0, result.stderr
+        # Stdout: one JSON snapshot line + optional [ALL_DONE] line.
+        json_lines = [
+            line
+            for line in result.stdout.splitlines()
+            if line.startswith("{") and line.endswith("}")
+        ]
+        assert len(json_lines) == 1, result.stdout
+        snap = json.loads(json_lines[0])
+        assert snap["workers"][0]["worker"] == "W-a"
+        assert snap["workers"][0]["phase"] == "active"
+
+    def test_once_mode_prints_all_done_marker_when_terminal(self, tmp_path):
+        registry = tmp_path / ".signals" / "active-workers.jsonl"
+        signal = tmp_path / ".signals" / "worker-W-x.json"
+        _write_registry(
+            registry,
+            [{"worker": "W-x", "signal_file": str(signal)}],
+        )
+        _write_signal(signal, status="done")
+
+        result = self._run("--once", "--registry", str(registry))
+
+        assert result.returncode == 0, result.stderr
+        assert "[ALL_DONE]" in result.stdout
+
+    def test_once_mode_with_no_workers_exits_zero(self, tmp_path):
+        registry = tmp_path / ".signals" / "active-workers.jsonl"
+        # Empty registry path.
+
+        result = self._run("--once", "--registry", str(registry))
+
+        assert result.returncode == 0, result.stderr
+        # When there are no workers, ALL_DONE is the natural state.
+        assert "[ALL_DONE]" in result.stdout
+
+    def test_once_mode_with_only_partial_done_omits_all_done(self, tmp_path):
+        registry = tmp_path / ".signals" / "active-workers.jsonl"
+        _write_registry(
+            registry,
+            [
+                {
+                    "worker": "W-a",
+                    "signal_file": str(tmp_path / ".signals" / "worker-W-a.json"),
+                },
+                {
+                    "worker": "W-b",
+                    "signal_file": str(tmp_path / ".signals" / "worker-W-b.json"),
+                },
+            ],
+        )
+        _write_signal(tmp_path / ".signals" / "worker-W-a.json", status="done")
+        # W-b still active.
+
+        result = self._run("--once", "--registry", str(registry))
+
+        assert result.returncode == 0, result.stderr
+        assert "[ALL_DONE]" not in result.stdout


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Issue #1275 argues that the orchestrator (Codex/Kiro) should not waste
context tokens periodically running `sleep; find .signals/; git status`
while waiting for workers. Instead a single observation should give a
complete state snapshot when the orchestrator chooses to look or when a
worker wakes the orchestrator via tmux send-keys.

This PR ships the read-only watchdog that produces that snapshot, the
operator runbook for the event-driven wait policy, and 17 contract
tests pinning the snapshot/CLI behaviour.

## TDD trail

1. Wrote `tests/unit/scripts/test_swarm_watchdog.py` first (17 tests; all
   RED — script did not exist yet).
2. Implemented `scripts/swarm_watchdog.py`. First green run exposed a
   subtle bug: my dynamic-module-load fixture didn't register the module
   in `sys.modules`, so `@dataclass` machinery failed when looking up
   `cls.__module__`. Fixed the fixture (register before exec, pop after)
   and reran — 17 GREEN.
3. Cleaned ruff (unused `import os`/`import sys` dropped) and
   ruff-formatted both files.
4. End-to-end smoke against a synthetic `/tmp/swarm-wd/` tree with two
   workers (W-alpha terminal, W-beta heartbeating). Verified the
   `[ALL_DONE]` marker appears only after every worker is terminal.

## Artifacts

### `scripts/swarm_watchdog.py`
Read-only watchdog. Pure stdlib (no `uv sync` needed):

- **`load_active_workers(path)`** — parse `.signals/active-workers.jsonl`,
  silently skip blank/malformed lines, missing file → empty list.
- **`inspect_worker(worker, *, now, stale_threshold_s)`** — per-worker
  observation. Terminal signal status (`done`/`failed`/`blocked`) wins
  over heartbeat liveness; corrupt signal files surface as `failed`
  with an `error` field instead of crashing the snapshot.
- **`scan(registry, *, now, stale_threshold_s)`** — full snapshot dict
  with `timestamp`, `signals_dir`, `registry`, and a `workers` list.
- **CLI**: `--once` prints one JSON line + an `[ALL_DONE]` marker line
  when every worker is terminal (so a tmux watcher can grep without
  parsing JSON). `--watch --interval --timeout` polls until `[ALL_DONE]`
  or `[TIMEOUT]`.

### `tests/unit/scripts/test_swarm_watchdog.py` (17 tests)
- `TestLoadActiveWorkers` (3): missing registry, single entry,
  blank/malformed-JSON resilience.
- `TestInspectWorker` (8): active without heartbeat, done/failed/blocked
  status mapping, stale heartbeat detection, fresh heartbeat reported
  active, terminal status precedence over stale heartbeat, corrupt
  signal → `failed`+`error`.
- `TestScan` (2): snapshot has required fields, empty registry yields
  empty workers list.
- `TestCLI` (4): `--once` prints exactly one JSON line, `[ALL_DONE]`
  emitted only when all terminal, empty registry → `[ALL_DONE]`,
  partial done omits `[ALL_DONE]`.

### `docs/engineering/swarm-event-driven-wait.md`
Operator-facing runbook covering:

- The wait-loop antipattern and the event-driven contract.
- Active-workers registry shape (with all cold-resume fields).
- Watchdog usage (`--once` and `--watch`) with the reported phases
  table.
- Worker heartbeat JSON format and `mtime`-based age semantics.
- Worker-side wake-up etiquette using the canonical
  `send-keys -l ; sleep 0.25 ; send-keys C-m` form pinned by issue
  #1721 and `tests/contract/test_tmux_send_keys_pattern_contract.py`.
- Cross-reference to the user-runnable fixer
  `scripts/swarm_fix_send_keys_pattern.py` (PR #1904).
- Maintainer-step section flagging the out-of-repo skill files (under
  `~/.codex/skills/` and `~/.config/opencode/skills/`) that should
  start calling `python scripts/swarm_watchdog.py --once` in place of
  manual filesystem scans.

## Verification

```text
uv run pytest tests/unit/scripts/test_swarm_watchdog.py
17 passed in 0.89s

uv run ruff check scripts/swarm_watchdog.py \
                  tests/unit/scripts/test_swarm_watchdog.py
All checks passed!

uv run ruff format --check ...
already formatted
```

E2E smoke produced:

```text
# Two workers, one done, one heartbeating:
{"timestamp":"2026-05-21T16:36:58Z",
 "workers":[
   {"worker":"W-alpha","phase":"done","signal_exists":true,...},
   {"worker":"W-beta","phase":"active","signal_exists":false,
    "heartbeat_age_s":12.3,"heartbeat_path":"..."}]}
# (no [ALL_DONE])

# After W-beta finishes:
{...both done...}
[ALL_DONE]
```

## Skipped checks

- No live multi-worker tmux session in the sandbox; the watchdog is
  exercised only via fixture data. This is by design — the watchdog is
  pure-stdlib and depends only on file artifacts the worker contract
  already produces.
- Updating the user-level swarm skills (under `~/.codex/skills/` and
  `~/.config/opencode/skills/`) to call `swarm_watchdog.py` is out of
  repo scope per the swarm worker policy. Documented as a maintainer
  step in the runbook.

Refs #1275, #1721