### PR TITLE
feat: non-interactive OpenCode worker launcher for swarm

### DIFF
--- a/.agents/tasks/task-swarm-opencode-noninteractive/context.json
+++ b/.agents/tasks/task-swarm-opencode-noninteractive/context.json
@@ -1,0 +1,22 @@
+{
+  "project_type": "Python RAG pipeline with Telegram bot, LangGraph, Qdrant vector DB",
+  "language": "Python (primary), Bash (scripts)",
+  "build_system": "uv (Python package manager), Makefile targets, pyproject.toml",
+  "test_framework": "pytest with pytest-xdist for parallel execution, strict-markers, 30s timeout",
+  "build_command": "uv sync",
+  "test_command": "uv run pytest tests/unit/scripts/ -q --timeout=30",
+  "verification_instructions": "1. Run `bash -n scripts/swarm_opencode_run_unattended.sh` for syntax check. 2. Run `uv run pytest tests/unit/scripts/test_swarm_opencode_run_unattended.py -q --timeout=30` for unit tests. 3. Run `make test-unit` for full unit suite.",
+  "snapshot_or_generated_files": null,
+  "setup_instructions": "uv sync (installs all dev dependencies)",
+  "environment_constraints": "No Docker daemon available for container tests. No external network for real opencode binary. Use shell stubs for testing.",
+  "contribution_requirements": "Branch from dev. Shell scripts must start with #!/usr/bin/env bash and set -euo pipefail. Scripts must be idempotent. Test-first workflow for behavior changes. Include fresh verification evidence.",
+  "key_patterns": "Shell script tests in tests/unit/scripts/ use Path().read_text() for contract checks on script content, or subprocess for behavioral tests. Scripts use #!/usr/bin/env bash + set -euo pipefail. Test files: test_<feature>.py. Test functions: test_<behavior>_<expected_outcome>(). pythonpath=['.'] in pytest config allows direct imports.",
+  "relevant_files": [
+    "scripts/AGENTS.override.md",
+    "tests/unit/scripts/test_bot_health_script.py",
+    "tests/unit/scripts/test_git_hygiene.py",
+    "docs/engineering/repo-hygiene-runbook.md",
+    "docs/engineering/README.md"
+  ],
+  "directory_structure": "scripts/ - operational shell/python scripts; tests/unit/scripts/ - unit tests for scripts; docs/engineering/ - engineering runbooks and guides"
+}

--- a/.agents/tasks/task-swarm-opencode-noninteractive/features/FEAT-001.json
+++ b/.agents/tasks/task-swarm-opencode-noninteractive/features/FEAT-001.json
@@ -1,0 +1,29 @@
+{
+  "id": "FEAT-001",
+  "type": "feat",
+  "description": "Create the swarm_opencode_run_unattended.sh wrapper script, its pytest test file, and the engineering runbook documentation for non-interactive OpenCode worker launches.",
+  "status": "in_progress",
+  "steps": [
+    "Create `scripts/swarm_opencode_run_unattended.sh` with: shebang `#!/usr/bin/env bash`, `set -euo pipefail`, check if `opencode` is in PATH (exit 127 with friendly diagnostic if missing), conditionally export `OPENCODE_CONFIG_CONTENT='{\"permission\":\"allow\"}'` only when neither `OPENCODE_CONFIG` nor `OPENCODE_CONFIG_CONTENT` is already set, then `exec opencode \"$@\"`. Make executable (chmod +x).",
+    "Create `tests/unit/scripts/test_swarm_opencode_run_unattended.py` with 9 contract tests using subprocess to invoke the script with a stub opencode binary (a shell script in tmp_path that records env/args to stdout). Tests must cover: (1) default OPENCODE_CONFIG_CONTENT injection, (2) respects existing OPENCODE_CONFIG, (3) respects existing OPENCODE_CONFIG_CONTENT, (4) passes all arguments through, (5) exit 127 when opencode not in PATH, (6) friendly diagnostic message on missing opencode, (7) exits with opencode success code, (8) exits with opencode failure code, (9) injected config is valid JSON with permission=allow. Follow test naming pattern `test_<behavior>_<expected_outcome>()` and use Arrange/Act/Assert structure. Use tmp_path fixture to create the stub.",
+    "Create `docs/engineering/swarm-non-interactive-launch.md` with sections: Problem, Root Cause, Canonical Mechanism, Recommended Launcher Pattern, Verification Checklist, Per-Worker Policy Overrides, References. Document that OPENCODE_PERMISSION env var is silently ignored, the canonical mechanism is the opencode.json permission field loadable via OPENCODE_CONFIG or OPENCODE_CONFIG_CONTENT env vars, and recommend using the repo wrapper script.",
+    "Verify: run `bash -n scripts/swarm_opencode_run_unattended.sh` to confirm no syntax errors.",
+    "Verify: run `uv run pytest tests/unit/scripts/test_swarm_opencode_run_unattended.py -v --timeout=30` to confirm all 9 tests pass."
+  ],
+  "acceptance_criteria": [
+    "scripts/swarm_opencode_run_unattended.sh exists, is executable, and passes bash -n syntax check",
+    "Running `uv run pytest tests/unit/scripts/test_swarm_opencode_run_unattended.py -v --timeout=30` passes all 9 tests",
+    "docs/engineering/swarm-non-interactive-launch.md exists with all required sections",
+    "The script exits 127 with a diagnostic when opencode is not in PATH",
+    "The script injects OPENCODE_CONFIG_CONTENT only when neither OPENCODE_CONFIG nor OPENCODE_CONFIG_CONTENT is set",
+    "The script respects existing OPENCODE_CONFIG or OPENCODE_CONFIG_CONTENT without overriding"
+  ],
+  "verification": [
+    "bash -n scripts/swarm_opencode_run_unattended.sh",
+    "uv run pytest tests/unit/scripts/test_swarm_opencode_run_unattended.py -v --timeout=30",
+    "test -x scripts/swarm_opencode_run_unattended.sh && echo 'executable OK'",
+    "test -f docs/engineering/swarm-non-interactive-launch.md && echo 'doc exists OK'"
+  ],
+  "blocked_reason": null,
+  "findings": ""
+}

--- a/.agents/tasks/task-swarm-opencode-noninteractive/features/FEAT-001.json
+++ b/.agents/tasks/task-swarm-opencode-noninteractive/features/FEAT-001.json
@@ -2,7 +2,7 @@
   "id": "FEAT-001",
   "type": "feat",
   "description": "Create the swarm_opencode_run_unattended.sh wrapper script, its pytest test file, and the engineering runbook documentation for non-interactive OpenCode worker launches.",
-  "status": "in_progress",
+  "status": "completed",
   "steps": [
     "Create `scripts/swarm_opencode_run_unattended.sh` with: shebang `#!/usr/bin/env bash`, `set -euo pipefail`, check if `opencode` is in PATH (exit 127 with friendly diagnostic if missing), conditionally export `OPENCODE_CONFIG_CONTENT='{\"permission\":\"allow\"}'` only when neither `OPENCODE_CONFIG` nor `OPENCODE_CONFIG_CONTENT` is already set, then `exec opencode \"$@\"`. Make executable (chmod +x).",
     "Create `tests/unit/scripts/test_swarm_opencode_run_unattended.py` with 9 contract tests using subprocess to invoke the script with a stub opencode binary (a shell script in tmp_path that records env/args to stdout). Tests must cover: (1) default OPENCODE_CONFIG_CONTENT injection, (2) respects existing OPENCODE_CONFIG, (3) respects existing OPENCODE_CONFIG_CONTENT, (4) passes all arguments through, (5) exit 127 when opencode not in PATH, (6) friendly diagnostic message on missing opencode, (7) exits with opencode success code, (8) exits with opencode failure code, (9) injected config is valid JSON with permission=allow. Follow test naming pattern `test_<behavior>_<expected_outcome>()` and use Arrange/Act/Assert structure. Use tmp_path fixture to create the stub.",
@@ -25,5 +25,5 @@
     "test -f docs/engineering/swarm-non-interactive-launch.md && echo 'doc exists OK'"
   ],
   "blocked_reason": null,
-  "findings": ""
+  "findings": "Tests for missing-opencode scenarios require absolute path to bash (/usr/bin/bash) and system dirs in PATH since subprocess cannot locate bash when PATH is empty. All 9 tests pass in 0.44s."
 }

--- a/.agents/tasks/task-swarm-opencode-noninteractive/task.json
+++ b/.agents/tasks/task-swarm-opencode-noninteractive/task.json
@@ -1,0 +1,7 @@
+{
+  "task_id": "task-swarm-opencode-noninteractive",
+  "task_description": "Implement non-interactive OpenCode worker launches for the swarm orchestration system: a bash wrapper script that injects OPENCODE_CONFIG_CONTENT, 9 contract tests, and an operator runbook.",
+  "status": "in_progress",
+  "feature_order": ["FEAT-001"],
+  "blocked_reason": null
+}

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -11,6 +11,7 @@ Concise index for engineering process docs. These pages describe workflow, valid
 | [`sdk-registry.md`](sdk-registry.md) | Checking SDK/framework ownership and preferred project patterns before code changes. |
 | [`docs-maintenance.md`](docs-maintenance.md) | Updating docs, choosing canonical owners, and running docs verification. |
 | [`script-native-migration-matrix.md`](script-native-migration-matrix.md) | Auditing `scripts/` helpers and deciding keep/archive/native CLI migration paths. |
+| [`swarm-non-interactive-launch.md`](swarm-non-interactive-launch.md) | Launching OpenCode workers in non-interactive swarm mode. |
 
 
 ## Historical Or Resolved Notes

--- a/docs/engineering/swarm-non-interactive-launch.md
+++ b/docs/engineering/swarm-non-interactive-launch.md
@@ -1,0 +1,75 @@
+# Swarm Non-Interactive Launch
+
+## Problem
+
+OpenCode worker processes launched by the swarm orchestrator prompt for permission on repo-local reads/writes/commands, blocking automated pipelines. Workers hang indefinitely waiting for interactive confirmation that will never arrive.
+
+## Root Cause
+
+The `OPENCODE_PERMISSION` environment variable is silently ignored by OpenCode. It has no effect on runtime behavior. Setting it does not suppress permission prompts.
+
+## Canonical Mechanism
+
+OpenCode reads the `permission` field from `opencode.json`. At runtime, this config can be supplied via:
+
+1. **Project-local `./opencode.json`** (highest precedence) - a file in the working directory
+2. **`OPENCODE_CONFIG=/path/to/file.json`** - explicit config file path pointing to a JSON file containing the permission field
+3. **`OPENCODE_CONFIG_CONTENT='{"permission":"allow"}'`** - inline JSON (no file needed), suitable for ephemeral environments
+
+When `permission` is set to `"allow"`, OpenCode grants all read/write/command operations without interactive prompts.
+
+## Recommended Launcher Pattern
+
+Use the repository wrapper script `scripts/swarm_opencode_run_unattended.sh`:
+
+```bash
+scripts/swarm_opencode_run_unattended.sh --model gpt-4 --prompt "Implement feature X"
+```
+
+The wrapper script performs the following steps:
+
+1. Checks that `opencode` is available on PATH (exits 127 with a diagnostic if missing)
+2. If neither `OPENCODE_CONFIG` nor `OPENCODE_CONFIG_CONTENT` is already set, exports `OPENCODE_CONFIG_CONTENT='{"permission":"allow"}'`
+3. If either variable is already set, leaves them untouched (respects caller policy)
+4. Executes `opencode` with all arguments passed through
+
+This ensures workers always launch in non-interactive mode without overriding explicit policy set by the caller.
+
+## Verification Checklist
+
+1. Confirm the script is executable: `test -x scripts/swarm_opencode_run_unattended.sh`
+2. Verify syntax: `bash -n scripts/swarm_opencode_run_unattended.sh`
+3. Test with a stub opencode that prints its environment to confirm `OPENCODE_CONFIG_CONTENT` is set:
+   ```bash
+   mkdir -p /tmp/stub && echo '#!/bin/bash
+   echo "OPENCODE_CONFIG_CONTENT=$OPENCODE_CONFIG_CONTENT"' > /tmp/stub/opencode && chmod +x /tmp/stub/opencode
+   PATH=/tmp/stub:$PATH scripts/swarm_opencode_run_unattended.sh
+   ```
+4. Confirm the output contains `OPENCODE_CONFIG_CONTENT={"permission":"allow"}`
+5. Test that pre-set `OPENCODE_CONFIG` is not overridden:
+   ```bash
+   OPENCODE_CONFIG=/my/config.json PATH=/tmp/stub:$PATH scripts/swarm_opencode_run_unattended.sh
+   ```
+6. Confirm the output shows `OPENCODE_CONFIG_CONTENT=` (empty, not injected)
+
+## Per-Worker Policy Overrides
+
+To set custom policies for specific workers, export `OPENCODE_CONFIG` or `OPENCODE_CONFIG_CONTENT` before invoking the wrapper:
+
+```bash
+# Use a custom config file for a specific worker
+export OPENCODE_CONFIG="/etc/opencode/restricted-worker.json"
+scripts/swarm_opencode_run_unattended.sh --prompt "Run analysis"
+
+# Use inline JSON with a different permission level
+export OPENCODE_CONFIG_CONTENT='{"permission":"deny","allowedCommands":["git status","git diff"]}'
+scripts/swarm_opencode_run_unattended.sh --prompt "Read-only check"
+```
+
+The wrapper script detects these pre-set variables and does not override them, allowing fine-grained control per worker without modifying the launcher.
+
+## References
+
+- OpenCode permissions documentation (permissions.mdx)
+- OpenCode configuration documentation (config.mdx)
+- GitHub issue #1306

--- a/scripts/swarm_opencode_run_unattended.sh
+++ b/scripts/swarm_opencode_run_unattended.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v opencode >/dev/null 2>&1; then
+    echo "ERROR: 'opencode' is not installed or not in PATH." >&2
+    echo "Install opencode and ensure it is available on your PATH before running this script." >&2
+    exit 127
+fi
+
+if [[ -z "${OPENCODE_CONFIG:-}" && -z "${OPENCODE_CONFIG_CONTENT:-}" ]]; then
+    export OPENCODE_CONFIG_CONTENT='{"permission":"allow"}'
+fi
+
+exec opencode "$@"

--- a/scripts/swarm_opencode_run_unattended.sh
+++ b/scripts/swarm_opencode_run_unattended.sh
@@ -8,6 +8,7 @@ if ! command -v opencode >/dev/null 2>&1; then
 fi
 
 if [[ -z "${OPENCODE_CONFIG:-}" && -z "${OPENCODE_CONFIG_CONTENT:-}" ]]; then
+    # NOTE: permission=allow grants full tool access; intended for trusted automation only.
     export OPENCODE_CONFIG_CONTENT='{"permission":"allow"}'
 fi
 

--- a/tests/unit/scripts/test_swarm_opencode_run_unattended.py
+++ b/tests/unit/scripts/test_swarm_opencode_run_unattended.py
@@ -1,0 +1,221 @@
+"""Contract tests for scripts/swarm_opencode_run_unattended.sh."""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+SCRIPT = str(Path("scripts/swarm_opencode_run_unattended.sh").resolve())
+
+
+def _make_stub(tmp_path: Path, exit_code: int = 0) -> str:
+    """Create a stub opencode script that prints env and args to stdout."""
+    stub = tmp_path / "opencode"
+    stub.write_text(
+        f"#!/usr/bin/env bash\n"
+        f"echo \"OPENCODE_CONFIG=${{OPENCODE_CONFIG:-}}\"\n"
+        f"echo \"OPENCODE_CONFIG_CONTENT=${{OPENCODE_CONFIG_CONTENT:-}}\"\n"
+        f"echo \"ARGS=$*\"\n"
+        f"exit {exit_code}\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    return str(tmp_path)
+
+
+def _clean_env() -> dict[str, str]:
+    """Return a copy of os.environ without OPENCODE_CONFIG* variables."""
+    env = os.environ.copy()
+    env.pop("OPENCODE_CONFIG", None)
+    env.pop("OPENCODE_CONFIG_CONTENT", None)
+    return env
+
+
+def test_default_injection_sets_opencode_config_content(tmp_path: Path) -> None:
+    """When neither OPENCODE_CONFIG nor OPENCODE_CONFIG_CONTENT is set, the stub receives OPENCODE_CONFIG_CONTENT."""
+    # Arrange
+    stub_dir = _make_stub(tmp_path)
+    env = _clean_env()
+    env["PATH"] = stub_dir + os.pathsep + env.get("PATH", "")
+
+    # Act
+    result = subprocess.run(
+        ["bash", SCRIPT],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    # Assert
+    assert result.returncode == 0
+    assert 'OPENCODE_CONFIG_CONTENT={"permission":"allow"}' in result.stdout
+
+
+def test_respects_existing_opencode_config(tmp_path: Path) -> None:
+    """When OPENCODE_CONFIG is already set, OPENCODE_CONFIG_CONTENT is NOT injected."""
+    # Arrange
+    stub_dir = _make_stub(tmp_path)
+    env = _clean_env()
+    env["PATH"] = stub_dir + os.pathsep + env.get("PATH", "")
+    env["OPENCODE_CONFIG"] = "/custom/path/opencode.json"
+
+    # Act
+    result = subprocess.run(
+        ["bash", SCRIPT],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    # Assert
+    assert result.returncode == 0
+    assert "OPENCODE_CONFIG_CONTENT=" in result.stdout
+    # The value should be empty (not injected)
+    for line in result.stdout.splitlines():
+        if line.startswith("OPENCODE_CONFIG_CONTENT="):
+            assert line == "OPENCODE_CONFIG_CONTENT="
+
+
+def test_respects_existing_opencode_config_content(tmp_path: Path) -> None:
+    """When OPENCODE_CONFIG_CONTENT is already set, the value is not overwritten."""
+    # Arrange
+    stub_dir = _make_stub(tmp_path)
+    env = _clean_env()
+    env["PATH"] = stub_dir + os.pathsep + env.get("PATH", "")
+    env["OPENCODE_CONFIG_CONTENT"] = '{"permission":"deny"}'
+
+    # Act
+    result = subprocess.run(
+        ["bash", SCRIPT],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    # Assert
+    assert result.returncode == 0
+    assert 'OPENCODE_CONFIG_CONTENT={"permission":"deny"}' in result.stdout
+
+
+def test_passes_all_arguments_through(tmp_path: Path) -> None:
+    """Arguments passed to the wrapper appear in the stub's argv."""
+    # Arrange
+    stub_dir = _make_stub(tmp_path)
+    env = _clean_env()
+    env["PATH"] = stub_dir + os.pathsep + env.get("PATH", "")
+
+    # Act
+    result = subprocess.run(
+        ["bash", SCRIPT, "--model", "gpt-4", "--verbose"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    # Assert
+    assert result.returncode == 0
+    assert "ARGS=--model gpt-4 --verbose" in result.stdout
+
+
+def test_exit_127_when_opencode_missing(tmp_path: Path) -> None:
+    """When opencode is not in PATH, script exits 127."""
+    # Arrange
+    env = _clean_env()
+    # Use a PATH with only system dirs (no opencode) and the empty tmp dir
+    env["PATH"] = str(tmp_path) + ":/usr/bin:/bin"
+
+    # Act
+    result = subprocess.run(
+        ["/usr/bin/bash", SCRIPT],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    # Assert
+    assert result.returncode == 127
+
+
+def test_friendly_diagnostic_when_opencode_missing(tmp_path: Path) -> None:
+    """When opencode is missing, stderr contains a helpful message."""
+    # Arrange
+    env = _clean_env()
+    # Use a PATH with only system dirs (no opencode) and the empty tmp dir
+    env["PATH"] = str(tmp_path) + ":/usr/bin:/bin"
+
+    # Act
+    result = subprocess.run(
+        ["/usr/bin/bash", SCRIPT],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    # Assert
+    assert "opencode" in result.stderr.lower()
+    assert "not" in result.stderr.lower() or "ERROR" in result.stderr
+
+
+def test_exits_with_opencode_success_code(tmp_path: Path) -> None:
+    """When the stub exits 0, the wrapper exits 0."""
+    # Arrange
+    stub_dir = _make_stub(tmp_path, exit_code=0)
+    env = _clean_env()
+    env["PATH"] = stub_dir + os.pathsep + env.get("PATH", "")
+
+    # Act
+    result = subprocess.run(
+        ["bash", SCRIPT],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    # Assert
+    assert result.returncode == 0
+
+
+def test_exits_with_opencode_failure_code(tmp_path: Path) -> None:
+    """When the stub exits non-zero (e.g., 42), the wrapper exits with the same code."""
+    # Arrange
+    stub_dir = _make_stub(tmp_path, exit_code=42)
+    env = _clean_env()
+    env["PATH"] = stub_dir + os.pathsep + env.get("PATH", "")
+
+    # Act
+    result = subprocess.run(
+        ["bash", SCRIPT],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    # Assert
+    assert result.returncode == 42
+
+
+def test_injected_config_is_valid_json_with_permission_allow(tmp_path: Path) -> None:
+    """The injected OPENCODE_CONFIG_CONTENT is valid JSON and contains 'permission': 'allow'."""
+    # Arrange
+    stub_dir = _make_stub(tmp_path)
+    env = _clean_env()
+    env["PATH"] = stub_dir + os.pathsep + env.get("PATH", "")
+
+    # Act
+    result = subprocess.run(
+        ["bash", SCRIPT],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    # Assert
+    assert result.returncode == 0
+    for line in result.stdout.splitlines():
+        if line.startswith("OPENCODE_CONFIG_CONTENT="):
+            value = line[len("OPENCODE_CONFIG_CONTENT="):]
+            parsed = json.loads(value)
+            assert parsed["permission"] == "allow"
+            break
+    else:
+        raise AssertionError("OPENCODE_CONFIG_CONTENT not found in stub output")


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #1306 - Makes OpenCode worker launches non-interactive with auto-permission for the swarm orchestration system.

### Root Cause

The `OPENCODE_PERMISSION` environment variable is silently ignored by OpenCode. The canonical mechanism is the `permission` field in `opencode.json`, loadable at runtime via `OPENCODE_CONFIG` or `OPENCODE_CONFIG_CONTENT` environment variables.

### Changes

- **`scripts/swarm_opencode_run_unattended.sh`** - Bash wrapper that conditionally injects `OPENCODE_CONFIG_CONTENT='{"permission":"allow"}'` only when neither `OPENCODE_CONFIG` nor `OPENCODE_CONFIG_CONTENT` is already set, then execs opencode. Exits 127 with diagnostic if opencode is missing from PATH.
- **`tests/unit/scripts/test_swarm_opencode_run_unattended.py`** - 9 contract tests using a recorded-stdout shell stub (no real opencode binary needed in CI). All passing.
- **`docs/engineering/swarm-non-interactive-launch.md`** - Operator runbook covering root cause, canonical mechanism, recommended launcher pattern, verification checklist, and per-worker policy overrides.
- **`docs/engineering/README.md`** - Added index entry for the new runbook.

### Testing

- `bash -n scripts/swarm_opencode_run_unattended.sh` - syntax OK
- 9/9 contract tests pass (`pytest tests/unit/scripts/test_swarm_opencode_run_unattended.py -v`)
- Full `tests/unit/scripts/` suite: 104 pass (1 pre-existing unrelated failure)

### Acceptance Criteria Status

- [x] Worker launches do not prompt for normal repo-local operations (via permissive policy injection)
- [x] Skill docs show correct command and fallback (runbook)
- [x] Reproducible local smoke check (9 contract tests)
- [ ] Launcher records permission mode in launch JSON (out-of-repo; user-level launcher step documented in runbook)
- [ ] Dangerous operations constrained (granular policy documented; enforcement is a launcher-level concern)

### Maintainer Step (out-of-repo)

Update `~/.codex/skills/tmux-swarm-orchestration/scripts/launch_opencode_worker.sh` to call the repo wrapper instead of setting the defunct `OPENCODE_PERMISSION` variable. See the runbook for the exact pattern.