### PR TITLE
test: remove redundant sys.path manipulations in tests/

### DIFF
--- a/tests/integration/test_hybrid_search_sparse.py
+++ b/tests/integration/test_hybrid_search_sparse.py
@@ -8,15 +8,9 @@ import socket
 import sys
 import urllib.error
 import urllib.request
-from pathlib import Path
 from urllib.parse import urlparse
 
 import pytest
-
-
-# Add project root to path
-project_root = Path(__file__).parent.parent
-sys.path.insert(0, str(project_root))
 
 from src.config import Settings
 from src.retrieval import HybridRRFSearchEngine

--- a/tests/integration/test_qdrant_read.py
+++ b/tests/integration/test_qdrant_read.py
@@ -4,16 +4,10 @@
 Проверяет поиск и получение точек из существующей коллекции.
 """
 
+import os
 import socket
 import sys
-from pathlib import Path
 from urllib.parse import urlparse
-
-
-project_root = Path(__file__).parent
-sys.path.insert(0, str(project_root))
-
-import os
 
 import pytest
 from dotenv import load_dotenv

--- a/tests/unit/test_compose.py
+++ b/tests/unit/test_compose.py
@@ -6,11 +6,12 @@ Covers:
 - #810: qdrant_ensure_indexes.py exists and creates correct indexes
 """
 
-import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import yaml
+
+from scripts import qdrant_ensure_indexes as _qdrant_ensure_indexes_module
 
 
 REPO_ROOT = Path(__file__).parent.parent.parent
@@ -113,11 +114,7 @@ def test_qdrant_ensure_indexes_script_exists():
 
 def test_qdrant_ensure_indexes_creates_keyword_indexes():
     """ensure_indexes() must create keyword payload indexes for filter fields."""
-    script_dir = str(REPO_ROOT / "scripts")
-    if script_dir not in sys.path:
-        sys.path.insert(0, script_dir)
-
-    import qdrant_ensure_indexes as m
+    m = _qdrant_ensure_indexes_module
 
     mock_client = MagicMock()
     mock_client.create_payload_index = MagicMock()
@@ -144,11 +141,7 @@ def test_qdrant_ensure_indexes_creates_keyword_indexes():
 
 def test_qdrant_ensure_indexes_creates_integer_indexes():
     """ensure_indexes() must create integer payload indexes for order/chunk_id."""
-    script_dir = str(REPO_ROOT / "scripts")
-    if script_dir not in sys.path:
-        sys.path.insert(0, script_dir)
-
-    import qdrant_ensure_indexes as m
+    m = _qdrant_ensure_indexes_module
 
     mock_client = MagicMock()
 

--- a/tests/unit/test_validate_done_json.py
+++ b/tests/unit/test_validate_done_json.py
@@ -8,12 +8,10 @@ from pathlib import Path
 
 import pytest
 
+from scripts.validate_done_json import extra_fields, validate
+
 
 SCRIPT = Path("scripts/validate_done_json.py")
-
-# Import the validate function directly for unit tests.
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
-from validate_done_json import extra_fields, validate
 
 
 def _valid_done() -> dict:


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Project already configures `pythonpath = ["."]` in `[tool.pytest.ini_options]` (see `pyproject.toml`), and `scripts/`, `src/`, `telegram_bot/` are all importable packages (`__init__.py` present). Every `sys.path.insert` in `tests/` (outside the runnable benchmark scripts) is therefore redundant or wrong.

## Changes

| File | Before | After |
|---|---|---|
| `tests/integration/test_qdrant_read.py` | inserted `tests/integration/` (the test's own dir) | nothing — was dead code |
| `tests/integration/test_hybrid_search_sparse.py` | inserted `tests/` | nothing — `from src.config import Settings` already resolves |
| `tests/unit/test_compose.py` | two in-test `sys.path.insert` + `import qdrant_ensure_indexes as m` | single module-level `from scripts import qdrant_ensure_indexes` |
| `tests/unit/test_validate_done_json.py` | `sys.path.insert` + `from validate_done_json import ...` | `from scripts.validate_done_json import ...` |

`tests/benchmark/*` keeps `sys.path.insert` because those files are intentionally runnable as standalone scripts (`if __name__ == "__main__":`) — out of scope here.

## Verification

- `uv run ruff check` on all 4 files: All checks passed.
- `uv run pytest tests/unit/test_compose.py tests/unit/test_validate_done_json.py` → 30 passed.
- `uv run pytest --collect-only` on the 2 integration files → 2 tests collected.

Closes #1913