### PR TITLE
test: replace bare 'except Exception:' in test helpers with narrowed handlers + logging

### DIFF
--- a/tests/baseline/collector.py
+++ b/tests/baseline/collector.py
@@ -1,5 +1,6 @@
 """Collect metrics from Langfuse v3 API, Qdrant, and Redis."""
 
+import logging
 import re
 from dataclasses import dataclass
 from datetime import datetime
@@ -8,6 +9,9 @@ from typing import Any
 import httpx
 import redis
 from langfuse import Langfuse
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -314,7 +318,8 @@ class LangfuseMetricsCollector:
                 "points_total": extract("app_info_points_total"),
                 "available": True,
             }
-        except Exception:
+        except (httpx.HTTPError, OSError, ValueError) as exc:
+            logger.debug("Qdrant metrics scrape failed: %s", exc)
             return {"available": False}
 
     @staticmethod
@@ -344,5 +349,6 @@ class LangfuseMetricsCollector:
                 "keyspace_misses": info_stats.get("keyspace_misses", 0),
                 "available": True,
             }
-        except Exception:
+        except (redis.RedisError, OSError) as exc:
+            logger.debug("Redis metrics scrape failed: %s", exc)
             return {"available": False}

--- a/tests/e2e/test_core_flows_live.py
+++ b/tests/e2e/test_core_flows_live.py
@@ -39,7 +39,7 @@ async def _require_live_stack() -> None:
     redis_client = aioredis.from_url(REDIS_URL, decode_responses=True)
     try:
         await redis_client.ping()
-    except Exception:
+    except (aioredis.RedisError, OSError):
         pytest.skip("Redis not running or inaccessible")
     finally:
         await redis_client.aclose()

--- a/tests/e2e/test_core_flows_live.py
+++ b/tests/e2e/test_core_flows_live.py
@@ -134,6 +134,7 @@ async def test_cache_miss_then_hit_on_repeated_query() -> None:
         "repeated queries — cache is not promoting recent answers."
     )
 
+
 @pytest.mark.asyncio
 async def test_multi_turn_conversation_same_session() -> None:
     await _require_live_stack()

--- a/tests/load/chat_simulator.py
+++ b/tests/load/chat_simulator.py
@@ -2,11 +2,15 @@
 """Realistic chat conversation simulator for load tests."""
 
 import asyncio
+import logging
 import random
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
 from tests.smoke.queries import ExpectedQueryType
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -81,6 +85,14 @@ async def simulate_chat(
             latency = await process_message(msg.text, chat_id)
             total_latency += latency
         except Exception:
+            # Load-test counter — every error is part of the SLO measurement, so
+            # we cannot narrow the type without dropping signal. Log the full
+            # traceback so per-chat failures are debuggable.
+            logger.exception(
+                "chat %d: process_message failed for query_type=%s",
+                chat_id,
+                msg.query_type.value,
+            )
             errors += 1
 
         if i < len(conversation) - 1:

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -37,7 +37,7 @@ def require_live_services(request):
         resp = httpx.get(f"{qdrant_url}/collections", timeout=2)
         if resp.status_code != 200:
             pytest.skip("Qdrant not available")
-    except Exception:
+    except (httpx.HTTPError, OSError):
         pytest.skip("Qdrant not available")
 
     # Check Redis
@@ -46,7 +46,7 @@ def require_live_services(request):
             client = redis.from_url(redis_url, socket_connect_timeout=2)
             await client.ping()
             await client.aclose()
-        except Exception:
+        except (redis.RedisError, OSError):
             pytest.skip("Redis not available")
 
     asyncio.run(check_redis())

--- a/tests/smoke/test_smoke_bge_litellm_cache.py
+++ b/tests/smoke/test_smoke_bge_litellm_cache.py
@@ -120,7 +120,7 @@ async def test_qdrant_hybrid_search_execution(require_live_services, qdrant_serv
             dense_size = int(getattr(first, "size", 1024))
         else:
             dense_size = int(getattr(dense_cfg, "size", 1024))
-    except Exception:
+    except (AttributeError, TypeError, ValueError):
         dense_size = 1024
 
     results = await qdrant_service.hybrid_search_rrf(


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Six handlers in test helper / fixture code were swallowing every exception with bare `except Exception:`, hiding real bugs (KeyErrors, AttributeErrors, typos) behind "service not running" skips or silent error counts. Narrowed each to the actual transport / connection error types and added visibility.

## Changes

| File | Site | Now catches |
|---|---|---|
| `tests/baseline/collector.py` | `get_qdrant_metrics` | `(httpx.HTTPError, OSError, ValueError)` + `logger.debug(...)` |
| `tests/baseline/collector.py` | `get_redis_metrics` | `(redis.RedisError, OSError)` + `logger.debug(...)` |
| `tests/load/chat_simulator.py` | `simulate_chat` per-message counter | kept broad — load-test SLO counter must not drop signal — but now `logger.exception(...)` logs the full traceback so per-chat failures are debuggable. Comment explains the rationale. |
| `tests/e2e/test_core_flows_live.py` | `_require_live_stack` redis ping | `(aioredis.RedisError, OSError)` |
| `tests/smoke/conftest.py` | qdrant probe | `(httpx.HTTPError, OSError)` |
| `tests/smoke/conftest.py` | redis probe | `(redis.RedisError, OSError)` |
| `tests/smoke/test_smoke_bge_litellm_cache.py` | `dense_size` detection | `(AttributeError, TypeError, ValueError)` |

Module-level loggers added in `collector.py` and `chat_simulator.py`.

## Verification

- `uv run ruff check` on all 5 files: All checks passed.
- `uv run pytest tests/baseline/`: 36 passed.

Closes #1918