### PR TITLE
fix(test): add MINI_APP_ALLOWED_ORIGIN to .env.example; allowlist BOT_TOKEN legacy alias

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,10 @@ LOG_FORMAT=text                  # text | json (json for prod log shipping)
 # BOT_START_RETRY_MAX_SEC=60
 # Mini App / WebApp launch URL surfaced in inline keyboards.
 # MINI_APP_URL=https://example.com/miniapp
+# Mini App API CORS — origin allowed to load the WebApp. Defaults to
+# https://t.me when unset; override only if you serve the WebApp from a
+# different operator-controlled domain (rare).
+# MINI_APP_ALLOWED_ORIGIN=https://t.me
 
 # ==============================================================================
 # LOCAL EMBEDDINGS (BGE-M3, default for dev and VPS)

--- a/tests/contract/test_env_example_completeness_contract.py
+++ b/tests/contract/test_env_example_completeness_contract.py
@@ -107,6 +107,12 @@ ALLOWLIST_NOT_IN_ENV_EXAMPLE: dict[str, str] = {
     "RUN_E2E_TESTS": "E2E suite gate; test-only flag",
     "RUN_LOAD_TESTS": "Load suite gate; test-only flag",
     "PYTEST_INTEGRATION": "Integration-suite gate; test-only flag",
+    # --- Legacy aliases (kept for back-compat, not promoted) -----------------
+    "BOT_TOKEN": (
+        "Legacy alias read in mini_app/api.py as fallback after "
+        "TELEGRAM_BOT_TOKEN; not promoted to .env.example to avoid "
+        "encouraging dual-config of the same secret."
+    ),
     # --- E2E test fixtures (read by tests/e2e harnesses, never by bot) -----
     "E2E_COLLECTION_NAME": "E2E harness fixture (tests/e2e); never an operator var",
     "E2E_JUDGE_API_KEY": "E2E LLM-judge harness fixture",


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Failing test (TDD red)

```
FAILED tests/contract/test_env_example_completeness_contract.py::test_no_env_vars_used_in_code_missing_from_env_example
  - BOT_TOKEN
  - MINI_APP_ALLOWED_ORIGIN
```

## Root cause

The bidirectional `.env.example` ↔ source-code contract (`#1268`) caught two operator-facing env var drifts in `mini_app/api.py`:

- **`MINI_APP_ALLOWED_ORIGIN`** (line 144) — real omission. Used by the FastAPI CORS middleware to lock the allowed WebApp origin (defaults to `https://t.me`). Operators may need to override it if they serve the WebApp from a different domain.

- **`BOT_TOKEN`** (line 82) — legacy fallback alias used as `os.environ.get('TELEGRAM_BOT_TOKEN') or os.environ.get('BOT_TOKEN', '')`. The canonical name `TELEGRAM_BOT_TOKEN` is already documented; promoting `BOT_TOKEN` to `.env.example` would encourage dual-config of the same secret (footgun).

## Fix

- `.env.example` Mini-App section: add `MINI_APP_ALLOWED_ORIGIN` with a one-line comment explaining the default and when to override.
- `tests/contract/test_env_example_completeness_contract.py`: add `BOT_TOKEN` to `ALLOWLIST_NOT_IN_ENV_EXAMPLE` with a comment marking it as a legacy alias not promoted to operator-facing config.

## Verification (TDD green)

```
$ uv run pytest tests/contract/test_env_example_completeness_contract.py
4 passed in 1.65s
```

(was 1 failed / 3 passed before the fix.)

Closes #1925