### PR TITLE
fix(test): point bge_m3_client_health contract at src/services after class move

### DIFF
--- a/tests/contract/test_dead_code_removed_contract.py
+++ b/tests/contract/test_dead_code_removed_contract.py
@@ -152,8 +152,12 @@ def test_bge_m3_client_health_method_is_gone() -> None:
     The preflight check uses a raw ``client._client.get(...)`` against the
     ``/health`` endpoint, not this convenience wrapper, so removing the
     method does not regress runtime behaviour.
+
+    Note: the class lives in ``src/services/bge_m3_client.py`` after the
+    services consolidation; ``telegram_bot/services/bge_m3_client.py`` is
+    a thin re-export shim and no longer contains the class definition.
     """
-    tree = _parse("telegram_bot/services/bge_m3_client.py")
+    tree = _parse("src/services/bge_m3_client.py")
     bge_class: ast.ClassDef | None = None
     for node in tree.body:
         if isinstance(node, ast.ClassDef) and node.name == "BGEM3Client":


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Failing test (TDD red)

```
FAILED tests/contract/test_dead_code_removed_contract.py::test_bge_m3_client_health_method_is_gone
  AssertionError: BGEM3Client class must exist in bge_m3_client.py
  assert None is not None
```

## Root cause

`BGEM3Client` was relocated `telegram_bot/services/bge_m3_client.py` → `src/services/bge_m3_client.py`. The old path is now a thin re-export shim:

```python
# telegram_bot/services/bge_m3_client.py
from src.services.bge_m3_client import (BGEM3Client, ...)
```

The contract test still parsed the old path, found no class definition (only the import), and failed at the existence guard.

The test's actual intent — *no `health` method on the class* (#1541 item #9) — is preserved: verified that `src/services/bge_m3_client.py:73` has the class and no `health` method.

## Fix

`tests/contract/test_dead_code_removed_contract.py::test_bge_m3_client_health_method_is_gone`: update `_parse(...)` argument to the canonical class home `src/services/bge_m3_client.py`; clarify in the docstring that the old `telegram_bot/services/bge_m3_client.py` is a re-export shim.

No production-code change.

## Verification (TDD green)

```
$ uv run pytest tests/contract/test_dead_code_removed_contract.py::test_bge_m3_client_health_method_is_gone
1 passed in 0.04s
```

(was 1 failed before the fix.)

Closes #1927