### PR TITLE
fix(docs): remove stale llm.py row from telegram_bot/services/README.md

### DIFF
--- a/telegram_bot/services/README.md
+++ b/telegram_bot/services/README.md
@@ -17,7 +17,6 @@ Pure computation and I/O wrapper modules used by Telegram handlers and the API. 
 | [`query_analyzer.py`](./query_analyzer.py) | LLM-based filter extraction (price, city, rooms) from natural language |
 | [`generate_response.py`](./generate_response.py) | Canonical response generation with Langfuse prompt management |
 | [`rag_core.py`](./rag_core.py) | Shared RAG core functions (no Langfuse spans, no metrics) |
-| [`llm.py`](./llm.py) | LLM answer generation with streaming and fallback |
 | [`filter_extractor.py`](./filter_extractor.py) | Rule-based filter extraction: price ranges, rooms, city, distance to sea |
 | [`apartment_llm_extractor.py`](./apartment_llm_extractor.py) | LLM-based apartment data extraction |
 | [`ingestion_cocoindex.py`](./ingestion_cocoindex.py) | Thin wrapper around `src.ingestion.service` for bot-side ingestion commands |


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Failing test (TDD red)

```
FAILED tests/unit/scripts/test_check_markdown_links.py::test_current_repository_markdown_links_are_valid
  Left contains one more item:
  (PosixPath('telegram_bot/services/README.md'), 20, './llm.py', ...)
```

## Root cause

`telegram_bot/services/README.md` line 20 listed:

> \| [`llm.py`](./llm.py) \| LLM answer generation with streaming and fallback \|

But there is **no** `telegram_bot/services/llm.py` (`git log` shows zero history on that path; the only `*llm*.py` in the directory is `apartment_llm_extractor.py`). LLM answer generation actually lives in `generate_response.py` (already in the table two rows above with the description "Canonical response generation with Langfuse prompt management").

This is a forgotten copy-paste / planned-but-never-created entry, caught by `scripts/check_markdown_links.py`.

## Fix

Remove the stale row from the table. `generate_response.py` already documents the LLM-generation responsibility — no information is lost.

## Verification (TDD green)

```
$ uv run pytest tests/unit/scripts/test_check_markdown_links.py::test_current_repository_markdown_links_are_valid
1 passed in 0.52s
```

(was 1 failed before the fix.)

Closes #1929