### PR TITLE
fix(test): defensive guards for env-fragile tests (FSM perf, docker plugin, SystemExit, fastapi import)

### DIFF
--- a/tests/contract/test_mini_app_log_endpoint_contract.py
+++ b/tests/contract/test_mini_app_log_endpoint_contract.py
@@ -8,6 +8,11 @@ These tests guard the structural invariants of the remote-log endpoint:
 They are intentionally separate from the unit tests so that the RED/GREEN TDD
 cycle is visible in CI history and so the contract remains enforceable
 independently of the ASGI test client.
+
+Tests 2-4 introspect Pydantic v2 model metadata which is only computed at
+class instantiation time, so they need the real ``mini_app.api`` module.
+``mini_app.api`` imports ``fastapi`` (in the ``voice`` extra), so when that
+extra is not installed the whole file skips cleanly via ``importorskip``.
 """
 
 from __future__ import annotations
@@ -16,6 +21,11 @@ import ast
 import inspect
 from pathlib import Path
 from typing import get_type_hints
+
+import pytest
+
+
+pytest.importorskip("fastapi", reason="mini_app.api requires fastapi (voice extra)")
 
 
 def _get_remote_log_function():

--- a/tests/contract/test_mini_app_log_endpoint_contract.py
+++ b/tests/contract/test_mini_app_log_endpoint_contract.py
@@ -9,28 +9,35 @@ They are intentionally separate from the unit tests so that the RED/GREEN TDD
 cycle is visible in CI history and so the contract remains enforceable
 independently of the ASGI test client.
 
+Contract 1 is AST-only and must run in the core environment without FastAPI.
 Tests 2-4 introspect Pydantic v2 model metadata which is only computed at
-class instantiation time, so they need the real ``mini_app.api`` module.
-``mini_app.api`` imports ``fastapi`` (in the ``voice`` extra), so when that
-extra is not installed the whole file skips cleanly via ``importorskip``.
+class instantiation time, so they need the real ``mini_app.api`` module and
+skip individually when the optional Mini App/FastAPI extra is not installed.
 """
 
 from __future__ import annotations
 
 import ast
-import inspect
 from pathlib import Path
 from typing import get_type_hints
 
 import pytest
 
 
-pytest.importorskip("fastapi", reason="mini_app.api requires fastapi (voice extra)")
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MINI_APP_API = REPO_ROOT / "mini_app" / "api.py"
+
+
+def _import_mini_app_api():
+    pytest.importorskip("fastapi", reason="mini_app.api requires fastapi (mini-app extra)")
+    import mini_app.api as api_module
+
+    return api_module
 
 
 def _get_remote_log_function():
     """Return the ``remote_log`` handler object from ``mini_app.api``."""
-    import mini_app.api as api_module
+    api_module = _import_mini_app_api()
 
     func = getattr(api_module, "remote_log", None)
     assert func is not None, "remote_log not found in mini_app.api"
@@ -39,9 +46,7 @@ def _get_remote_log_function():
 
 def _get_remote_log_ast_node() -> tuple[ast.AsyncFunctionDef, str]:
     """Return (AST node, full source) for the remote_log handler."""
-    import mini_app.api as api_module
-
-    src = inspect.getsource(api_module)
+    src = MINI_APP_API.read_text(encoding="utf-8")
     tree = ast.parse(src)
     for node in ast.walk(tree):
         if isinstance(node, ast.AsyncFunctionDef) and node.name == "remote_log":
@@ -70,8 +75,7 @@ def test_remote_log_handler_has_no_print_statement():
                 )
             if isinstance(func, ast.Attribute) and func.attr == "print":
                 raise AssertionError(
-                    "remote_log handler contains a *.print() call — "
-                    "replace with structured logging"
+                    "remote_log handler contains a *.print() call — replace with structured logging"
                 )
 
 
@@ -92,16 +96,12 @@ def test_remote_log_handler_uses_pydantic_model_not_dict():
 
     # FastAPI injects ``request`` as the body parameter name.
     param_type = hints.get("request")
-    assert param_type is not None, (
-        "remote_log has no 'request' parameter type annotation"
-    )
+    assert param_type is not None, "remote_log has no 'request' parameter type annotation"
     assert param_type is not dict, (
-        f"remote_log 'request' parameter must be a Pydantic model, not dict — "
-        f"got {param_type!r}"
+        f"remote_log 'request' parameter must be a Pydantic model, not dict — got {param_type!r}"
     )
     assert issubclass(param_type, BaseModel), (
-        f"remote_log 'request' parameter must subclass pydantic.BaseModel — "
-        f"got {param_type!r}"
+        f"remote_log 'request' parameter must subclass pydantic.BaseModel — got {param_type!r}"
     )
 
 
@@ -112,7 +112,7 @@ def test_remote_log_handler_uses_pydantic_model_not_dict():
 
 def test_log_request_model_has_max_length_on_message():
     """LogRequest.message must declare a max_length constraint."""
-    from mini_app.api import LogRequest
+    LogRequest = _import_mini_app_api().LogRequest
 
     field_info = LogRequest.model_fields.get("message")
     assert field_info is not None, "LogRequest has no 'message' field"
@@ -141,7 +141,7 @@ def test_log_request_model_restricts_level_to_known_values():
     import typing
     from typing import Literal
 
-    from mini_app.api import LogRequest
+    LogRequest = _import_mini_app_api().LogRequest
 
     field_info = LogRequest.model_fields.get("level")
     assert field_info is not None, "LogRequest has no 'level' field"

--- a/tests/unit/dialogs/test_dialogs_fsm_coverage.py
+++ b/tests/unit/dialogs/test_dialogs_fsm_coverage.py
@@ -203,9 +203,19 @@ def _all_production_files() -> list[Path]:
     States can legitimately be wired by handler modules (e.g. raw aiogram FSM
     in ``telegram_bot/handlers/crm_callbacks.py``) or by the top-level bot
     module, not only by dialog windows.
+
+    We filter out third-party / cache directories so a stray virtualenv at
+    ``telegram_bot/.venv/`` (gitignored but easy to create accidentally with
+    ``python -m venv`` from the wrong cwd) doesn't pull ~80 MB of stdlib +
+    dep source into the regex search and time the test out.
     """
     root = DIALOGS_DIR.parent  # telegram_bot/
-    return sorted(p for p in root.rglob("*.py") if p.name != "states.py")
+    skip_parts = {".venv", "venv", "__pycache__", ".tox", "node_modules", ".mypy_cache"}
+    return sorted(
+        p
+        for p in root.rglob("*.py")
+        if p.name != "states.py" and skip_parts.isdisjoint(p.parts)
+    )
 
 
 def _state_is_referenced(group_name: str, state_name: str, dialog_sources: str) -> bool:

--- a/tests/unit/services/test_ingestion_cocoindex.py
+++ b/tests/unit/services/test_ingestion_cocoindex.py
@@ -35,10 +35,11 @@ async def test_get_ingestion_status_delegates(monkeypatch) -> None:
 def test_main_without_args_exits_with_usage(monkeypatch, capsys) -> None:
     monkeypatch.setattr(cocoindex.sys, "argv", ["ingestion_cocoindex"])
 
-    with pytest.raises(SystemExit) as exc:
-        cocoindex.main()
+    # main() returns the exit code per #1072 (sys.exit(main()) lives at the
+    # __main__ guard so the function is testable in-process).
+    rc = cocoindex.main()
 
-    assert exc.value.code == 1
+    assert rc == 1
     output = capsys.readouterr().out
     assert "Usage:" in output
     assert "ingest-dir" in output
@@ -47,18 +48,16 @@ def test_main_without_args_exits_with_usage(monkeypatch, capsys) -> None:
 def test_main_ingest_dir_without_path_exits(monkeypatch, capsys) -> None:
     monkeypatch.setattr(cocoindex.sys, "argv", ["ingestion_cocoindex", "ingest-dir"])
 
-    with pytest.raises(SystemExit) as exc:
-        cocoindex.main()
+    rc = cocoindex.main()
 
-    assert exc.value.code == 1
+    assert rc == 1
     assert "Directory path required" in capsys.readouterr().out
 
 
 def test_main_unknown_command_exits(monkeypatch, capsys) -> None:
     monkeypatch.setattr(cocoindex.sys, "argv", ["ingestion_cocoindex", "bad-command"])
 
-    with pytest.raises(SystemExit) as exc:
-        cocoindex.main()
+    rc = cocoindex.main()
 
-    assert exc.value.code == 1
+    assert rc == 1
     assert "Unknown command: bad-command" in capsys.readouterr().out

--- a/tests/unit/test_docker_static_validation.py
+++ b/tests/unit/test_docker_static_validation.py
@@ -44,7 +44,27 @@ QDRANT_STACK_DOC = Path("docs/QDRANT_STACK.md")
 
 
 def _docker_available() -> bool:
-    return shutil.which("docker") is not None
+    """True only when the docker CLI *and* the compose plugin are usable.
+
+    A bare ``shutil.which("docker")`` is not enough: CI / sandbox environments
+    can ship the docker CLI without the ``docker compose`` plugin (or the
+    legacy ``docker-compose`` binary). In that case ``docker compose ...``
+    exits 125 with ``looking up compose provider failed``, which surfaces as
+    a hard test failure instead of the intended skip. Probe the plugin
+    explicitly so the compose tests skip gracefully when it is absent.
+    """
+    if shutil.which("docker") is None:
+        return False
+    try:
+        probe = subprocess.run(
+            ["docker", "compose", "version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    return probe.returncode == 0
 
 
 def _run_docker_command(args: list[str]) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Failing tests (TDD red — 10 across 4 root causes)

```
FAILED tests/unit/dialogs/test_dialogs_fsm_coverage.py::test_every_declared_state_is_referenced_by_a_dialog (timeout >30s)
FAILED tests/unit/test_docker_static_validation.py::test_compose_dev_config_renders
FAILED tests/unit/test_docker_static_validation.py::test_compose_dev_config_renders_with_full_profile
FAILED tests/unit/services/test_ingestion_cocoindex.py::test_main_without_args_exits_with_usage
FAILED tests/unit/services/test_ingestion_cocoindex.py::test_main_ingest_dir_without_path_exits
FAILED tests/unit/services/test_ingestion_cocoindex.py::test_main_unknown_command_exits
FAILED tests/contract/test_mini_app_log_endpoint_contract.py::test_remote_log_handler_has_no_print_statement
FAILED tests/contract/test_mini_app_log_endpoint_contract.py::test_remote_log_handler_uses_pydantic_model_not_dict
FAILED tests/contract/test_mini_app_log_endpoint_contract.py::test_log_request_model_has_max_length_on_message
FAILED tests/contract/test_mini_app_log_endpoint_contract.py::test_log_request_model_restricts_level_to_known_values
```

## Four root causes, four narrow fixes

### 1. FSM coverage timeout — `.venv` directory leak

`tests/unit/dialogs/test_dialogs_fsm_coverage.py::_all_production_files()` does `telegram_bot/.rglob("*.py")`. If a developer ever creates a stray virtualenv at `telegram_bot/.venv/` (gitignored but easy to create accidentally with `python -m venv` from the wrong cwd), the rglob walks 7 088 stdlib + dep `.py` files (~78 MB joined source). Each regex search takes ~1 s; ~100+ states triggers the 30 s `pytest-timeout`.

**Fix:** filter `.venv`, `venv`, `__pycache__`, `.tox`, `node_modules`, `.mypy_cache` from the rglob result.

### 2. Docker compose tests — plugin probe is too lax

`_docker_available()` returned True for `shutil.which("docker")`. CI / sandbox environments can ship the docker CLI without the `docker compose` plugin. When the plugin is absent, `docker compose ...` exits 125 with `looking up compose provider failed`, surfacing as a hard test failure.

**Fix:** probe `docker compose version` explicitly so the helper returns False (→ skip) when the plugin is unavailable.

### 3. `test_ingestion_cocoindex` main() — stale `pytest.raises(SystemExit)`

`telegram_bot/services/ingestion_cocoindex.py::main()` was refactored in #1072 to **return** an int exit code (production docstring: *"Single `sys.exit(main())` lives at the `__main__` guard so the function is testable in-process"*). The 3 main() tests still used `with pytest.raises(SystemExit)` and `exc.value.code == 1` from the pre-#1072 era.

**Fix:** replace with `rc = cocoindex.main(); assert rc == 1` in 3 tests.

### 4. Mini App log endpoint contract — `mini_app.api` import requires fastapi

`tests/contract/test_mini_app_log_endpoint_contract.py` imports `mini_app.api` at module level (transitively requires fastapi from the voice extra). In environments without the extra, all 4 contract tests fail at collection. Tests 2-4 introspect Pydantic v2 `model_fields`, which is computed at class instantiation, so AST-only inspection would be fragile.

**Fix:** add module-level `pytest.importorskip("fastapi")` so the file skips cleanly when the extra is absent and runs as before when it's installed.

## Verification (TDD green)

```
$ uv run pytest tests/unit/dialogs/test_dialogs_fsm_coverage.py
36 passed in 2.51s    # was timeout >30s

$ uv run pytest tests/unit/test_docker_static_validation.py::test_compose_dev_config_renders ::test_compose_dev_config_renders_with_full_profile
2 skipped in 0.48s    # was 2 failed

$ uv run pytest tests/unit/services/test_ingestion_cocoindex.py
5 passed in 0.97s     # was 3 failed / 2 passed

$ uv run pytest tests/contract/test_mini_app_log_endpoint_contract.py
1 skipped in 0.03s    # was 4 failed at collection
```

Closes #1931