### PR TITLE
test(chaos): exercise real Kommo Auth flow via httpx.MockTransport (#1934)

### DIFF
--- a/tests/chaos/test_service_resilience.py
+++ b/tests/chaos/test_service_resilience.py
@@ -100,22 +100,47 @@ async def test_kommo_429_retries_then_succeeds():
 
 
 async def test_kommo_401_refreshes_token_and_recovers():
-    """Kommo 401 should force token refresh and retry request."""
+    """Kommo 401 should force token refresh and retry request.
+
+    Regression for #1934: previously this test patched ``client._client.request``,
+    which is the high-level method that *contains* the ``KommoOAuthAuth.async_auth_flow``
+    retry loop. Patching at that level bypassed the very flow being tested. We now
+    use ``httpx.MockTransport`` so the real auth flow runs against a fake transport;
+    see https://github.com/encode/httpx/blob/master/docs/advanced/transports.md.
+    """
     token_store = AsyncMock()
     token_store.get_valid_token = AsyncMock(return_value="expired")
     token_store.force_refresh = AsyncMock(return_value="fresh-token")
     client = KommoClient(subdomain="testcompany", token_store=token_store)
 
-    req = httpx.Request("GET", "https://testcompany.kommo.com/api/v4/leads")
-    resp_401 = httpx.Response(401, request=req)
-    resp_200 = httpx.Response(
-        200,
-        json={"_embedded": {"leads": [{"id": 2, "name": "Lead B"}]}},
-        request=req,
+    # MockTransport receives every request before the auth flow inspects the
+    # response, so the flow's "if response.status_code == 401: refresh + retry"
+    # branch executes naturally.
+    responses = iter(
+        [
+            httpx.Response(401),
+            httpx.Response(
+                200,
+                json={"_embedded": {"leads": [{"id": 2, "name": "Lead B"}]}},
+            ),
+        ]
     )
 
-    with patch.object(client._client, "request", side_effect=[resp_401, resp_200]):
-        leads = await client.search_leads(responsible_user_id=7, limit=5)
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return next(responses)
+
+    # Swap the underlying AsyncClient for one that goes through MockTransport
+    # while keeping the production KommoOAuthAuth attached so the 401 path
+    # actually runs.
+    await client._client.aclose()
+    client._client = httpx.AsyncClient(
+        base_url="https://testcompany.kommo.com/api/v4",
+        transport=httpx.MockTransport(handler),
+        auth=client._client.auth,
+        headers={"Content-Type": "application/json"},
+    )
+
+    leads = await client.search_leads(responsible_user_id=7, limit=5)
 
     assert len(leads) == 1
     assert leads[0].id == 2


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## What

Fixes the only remaining failing test in `tests/chaos/` — `test_kommo_401_refreshes_token_and_recovers` was mocking at the wrong level and never exercised the auth flow it claims to verify.

## Why

`KommoOAuthAuth.async_auth_flow` (per [httpx multi-request auth pattern](https://github.com/encode/httpx/blob/master/docs/advanced/authentication.md)) handles the 401-refresh-and-retry. That flow runs **inside** `httpx.AsyncClient.request(...)`. Patching `client._client.request` replaces the very method that hosts the flow, so the mock returns the 401 directly to production code, which then surfaces `HTTPStatusError`. The retry was never tested.

## How

Use `httpx.MockTransport(handler)` to mock at the transport layer. The handler iterator returns 401 → 200, the real auth flow runs in between, and the test now asserts both the second-response payload and that `token_store.force_refresh` was awaited exactly once.

## Verification

- `uv run pytest tests/chaos/test_service_resilience.py` → **15 passed** (was 14 passed / 1 failed).
- `uv run ruff check tests/chaos/test_service_resilience.py` → **All checks passed**.

Closes #1934.