### PR TITLE
test(#1515): pin B1/B5/B6 test audit fixes + S1 stylistic refactor

### DIFF
--- a/tests/contract/test_test_audit_1515_pinning_contract.py
+++ b/tests/contract/test_test_audit_1515_pinning_contract.py
@@ -1,0 +1,146 @@
+"""Test infrastructure audit pinning contract (#1515).
+
+Issue #1515 audited the test suite and called out six concrete bugs
+(B1..B6) plus a series of duplicate / smell observations. By the time
+this contract is added to ``dev`` the audit's B1, B3, B4, B5, B6 are
+already resolved on disk. This contract pins those resolutions so a
+future change cannot silently regress them.
+
+Pinned invariants:
+
+- **B1**: ``tests/conftest.py`` and ``tests/smoke/conftest.py`` must not
+  introduce new ``asyncio.get_event_loop()`` calls in non-mock contexts.
+- **B5**: ``tests/conftest.py::pytest_collection_modifyitems`` must apply
+  directory markers to every advertised test tier (``unit``,
+  ``integration``, ``smoke``, ``e2e``, ``chaos``, ``load``,
+  ``benchmark``, ``contract``, ``baseline``) so ``-m <tier>`` filtering
+  works end-to-end.
+- **B6**: ``pyproject.toml`` coverage omit must exclude
+  ``telegram_bot/.venv/*`` so a stray local venv does not pollute the
+  coverage source set.
+
+Companion contract ``tests/contract/test_no_get_event_loop.py`` already
+covers production code (src/, scripts/, telegram_bot/, mini_app/,
+services/). This contract complements it by covering the *test suite
+infrastructure* surface that #1515 specifically named.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# B1 pin: no raw asyncio.get_event_loop() in conftest sync paths
+# ---------------------------------------------------------------------------
+
+
+def _find_unmocked_get_event_loop(source: str, path: Path) -> list[int]:
+    """Return line numbers of `asyncio.get_event_loop(...)` *call expressions*
+    in the given source, excluding `patch("asyncio.get_event_loop")` mock
+    targets and string occurrences inside other call args.
+    """
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+    offenders: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # Match: asyncio.get_event_loop()  / loop.get_event_loop()
+        if isinstance(func, ast.Attribute) and func.attr == "get_event_loop":
+            offenders.append(node.lineno)
+    return offenders
+
+
+@pytest.mark.parametrize(
+    "rel_path",
+    [
+        "tests/conftest.py",
+        "tests/smoke/conftest.py",
+    ],
+)
+def test_no_get_event_loop_in_test_conftests(rel_path: str) -> None:
+    """B1 pin: no `asyncio.get_event_loop()` call expressions in conftests."""
+    path = REPO_ROOT / rel_path
+    if not path.exists():
+        pytest.skip(f"{rel_path} not present in this checkout")
+    offenders = _find_unmocked_get_event_loop(path.read_text(), path)
+    assert offenders == [], (
+        f"B1 regression (#1515): {rel_path} reintroduced "
+        f"asyncio.get_event_loop() at line(s) {offenders}. Use "
+        f"asyncio.run(...) or asyncio.get_running_loop() instead."
+    )
+
+
+# ---------------------------------------------------------------------------
+# B5 pin: path_to_marker covers every advertised test tier
+# ---------------------------------------------------------------------------
+
+
+REQUIRED_TIER_MARKERS = frozenset(
+    {
+        "unit",
+        "integration",
+        "smoke",
+        "e2e",
+        "chaos",
+        "load",
+        "benchmark",
+        "contract",
+        "baseline",
+    }
+)
+
+
+def test_root_conftest_path_to_marker_covers_all_tiers() -> None:
+    """B5 pin: `pytest_collection_modifyitems` maps every tier directory."""
+    conftest = (REPO_ROOT / "tests" / "conftest.py").read_text()
+    # Match `root / "<dir>": "<marker>",` style entries.
+    entries = set(re.findall(r'root\s*/\s*"([^"]+)"\s*:\s*"([^"]+)"', conftest))
+    if not entries:
+        pytest.skip("path_to_marker dict shape changed; update this contract")
+    mapped_dirs = {dir_name for dir_name, _ in entries}
+    missing = REQUIRED_TIER_MARKERS - mapped_dirs
+    assert not missing, (
+        f"B5 regression (#1515): tests/conftest.py::pytest_collection_modify"
+        f"items is missing directory entries for {sorted(missing)}. Tests in "
+        f"these directories cannot be filtered with `-m <tier>`."
+    )
+
+
+# ---------------------------------------------------------------------------
+# B6 pin: coverage omit excludes the bot-local .venv
+# ---------------------------------------------------------------------------
+
+
+def test_coverage_omit_excludes_bot_local_venv() -> None:
+    """B6 pin: `[tool.coverage.run].omit` excludes telegram_bot/.venv paths.
+
+    The bot package historically had a co-located venv. If a developer
+    creates one again, coverage must not scan it as production source.
+    """
+    pyproject = (REPO_ROOT / "pyproject.toml").read_bytes()
+    data = tomllib.loads(pyproject.decode())
+    omit = data.get("tool", {}).get("coverage", {}).get("run", {}).get("omit", [])
+    omit_set = set(omit)
+    required = {"telegram_bot/.venv/*", "telegram_bot/.venv/**/*"}
+    missing = required - omit_set
+    # Tolerate equivalent broader patterns.
+    if missing and any(p in omit_set for p in ("*/.venv/*", "**/.venv/**", "*.venv/*")):
+        return
+    assert not missing, (
+        f"B6 regression (#1515): pyproject.toml [tool.coverage.run].omit "
+        f"missing {sorted(missing)}. Without this, a stray "
+        f"telegram_bot/.venv/ pollutes coverage with site-packages."
+    )

--- a/tests/unit/test_query_preprocessor.py
+++ b/tests/unit/test_query_preprocessor.py
@@ -77,12 +77,17 @@ class TestQueryPreprocessorTranslitPrecompiled:
         with patch("re.compile", wraps=re.compile) as mock_compile:
             for q in queries:
                 pp.normalize_translit(q)
-            assert mock_compile.call_count == 0, (
-                "normalize_translit should not call re.compile in the hot path; "
-                f"got {mock_compile.call_count} compilations across "
-                f"{len(queries)} queries. Precompile patterns at class/module "
-                "load time."
-            )
+            # #1515 audit S1: prefer assert_not_called() over call_count == 0
+            # because Mock raises a clearer AssertionError on regression.
+            try:
+                mock_compile.assert_not_called()
+            except AssertionError as exc:  # pragma: no cover - hot-path regression
+                raise AssertionError(
+                    "normalize_translit should not call re.compile in the hot path; "
+                    f"got {mock_compile.call_count} compilations across "
+                    f"{len(queries)} queries. Precompile patterns at class/module "
+                    "load time."
+                ) from exc
 
     @pytest.mark.parametrize(
         ("latin_input", "expected_output"),


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Smallest concrete contribution to the #1515 test-audit backlog: pin the audit's already-resolved infrastructure bugs (B1, B5, B6) into a contract test so they cannot silently regress, and apply the trivial S1 stylistic fix.

The audit (#1515) called out six bugs B1..B6 plus duplicate/architecture/code-smell observations. When this PR was prepared on `dev`:

| ID | Audit claim | Status on `dev` |
|----|-------------|----------------|
| B1 | `asyncio.get_event_loop()` in `tests/smoke/conftest.py:62` | **already fixed**: now `asyncio.run(check_redis())` |
| B2 | `tests/e2e/test_rag_pipeline.py` mock-only | **gone**: file no longer exists |
| B3 | `src/_compat.py` 0 tests | **fixed**: `tests/unit/test_compat.py` exists |
| B4 | `src/evaluation/config_snapshot.py` 0 tests | **fixed**: `tests/unit/evaluation/test_config_snapshot.py` exists |
| B5 | `path_to_marker` missing `contract`/`baseline` | **already fixed**: dict has all 9 tiers |
| B6 | `telegram_bot/.venv/` polluting coverage | **fixed**: `[tool.coverage.run].omit` lists `telegram_bot/.venv/*` |

This PR's value is locking that state in.

## TDD trail

- **TDD-pin** (commit `fc706640`): added `tests/contract/test_test_audit_1515_pinning_contract.py` with 4 assertions:
  - `test_no_get_event_loop_in_test_conftests[tests/conftest.py]` (B1)
  - `test_no_get_event_loop_in_test_conftests[tests/smoke/conftest.py]` (B1)
  - `test_root_conftest_path_to_marker_covers_all_tiers` (B5) — extracts `path_to_marker` entries via regex and asserts every required tier is mapped
  - `test_coverage_omit_excludes_bot_local_venv` (B6) — parses `pyproject.toml` and asserts the `omit` set covers `telegram_bot/.venv/*`/`telegram_bot/.venv/**/*`

  Genuine RED phase is not applicable here because the bugs are already fixed; the PR body and module docstring document this. To verify the contract bites, mutate `tests/conftest.py` (remove `contract` from `path_to_marker`) and the corresponding test fails with a precise message — confirmed locally during development.

- **Refactor** (commit `98b0f493`): replaced `assert mock_compile.call_count == 0` with `mock_compile.assert_not_called()` + re-raise pattern in `tests/unit/test_query_preprocessor.py::test_normalize_translit_no_recompile_in_hot_path`. Behaviour unchanged — same pass/fail conditions, richer diagnostic preserved. Per agent-workflow steering, TDD is skipped for stylistic refactors with no behaviour change.

## Out of scope (left for follow-ups)

The audit body lists more items that are deliberately not in this PR:

- B2: `tests/e2e/test_rag_pipeline.py` is already gone, no action.
- D1..D9: duplicate fixtures / patterns — substantial refactors, separate issues per duplicate.
- A1..A6: architecture moves (split root conftest, move misclassified tests, decide `src/governance/` and `tests/eval/`) — design-first work.
- S2..S7: async-without-await, real-time usage, long test names, `uuid4()` in module-level constants — separate hygiene PRs.
- S3 `random.seed()`: already mitigated locally with `random.getstate()`/`setstate()` save-restore around each `seed(42)` call in `tests/unit/scripts/test_kommo_seed.py`. Promoting to local `random.Random(42)` requires changing `scripts/kommo_seed.py` callee signatures — out of audit scope.

## Verification

Ran in worktree `../wt-1515-test-audit`:

```bash
uv run --python 3.12 pytest tests/contract/test_test_audit_1515_pinning_contract.py -v --timeout=30
# 4 passed in 0.04s

uv run --python 3.12 pytest tests/unit/test_query_preprocessor.py --timeout=30 -q -k normalize_translit
# 6 passed, 33 deselected in 2.64s

uv run --python 3.12 pytest tests/contract/ --timeout=30 -q
# 766 passed, 7 skipped, 3 xfailed in 37.00s   (no regression)

uv run --python 3.12 ruff check tests/contract/test_test_audit_1515_pinning_contract.py tests/unit/test_query_preprocessor.py
uv run --python 3.12 ruff format --check tests/contract/test_test_audit_1515_pinning_contract.py tests/unit/test_query_preprocessor.py
# clean
```

Skipped checks: `make test-unit` / `make check` (touched files are limited to the two listed; full unit suite and mypy on the rest are out of scope for this audit-pin slice).

## Context7

Not applicable — pure repo-config and contract-test work, no SDK behaviour exercised.

## Worktree cleanup

Will be removed after merge per `.kiro/steering/agent-workflow.md`:

```bash
git worktree remove ../wt-1515-test-audit
git worktree prune
git branch -D kiro/1515-test-audit-fixes
```

Refs #1515 (pins B1, B5, B6 + applies S1; the broader audit Phase 2/3/4 items remain open).