### PR TITLE
docs+test(#1538): refresh SDK-native audit and pin streaming contract

### DIFF
--- a/docs/engineering/sdk-native-audit-2026-05.md
+++ b/docs/engineering/sdk-native-audit-2026-05.md
@@ -1,0 +1,120 @@
+# SDK-Native vs Custom Implementation Audit — 2026-05 Refresh
+
+Refresh of the audit captured in
+[#1538](https://github.com/yastman/rag/issues/1538). The original issue body
+was filed on 2026-05-14. This document re-verifies each item against the
+current `dev` branch and the relevant Context7 SDK references.
+
+> **Source of truth for SDK choices:** [`sdk-registry.md`](sdk-registry.md).
+> This file is a one-time **audit refresh**, not a replacement for the
+> registry. Once the open items below are closed (or moved to dedicated
+> tracking issues), this file can be archived.
+
+## Methodology
+
+For each item from the original audit:
+
+1. Read the live source on `dev`.
+2. If the audit claimed an SDK alternative, query Context7 to confirm the
+   alternative still exists and the cited shape (function name, kwargs,
+   return type) is current.
+3. Mark one of:
+   - **closed-on-dev** — already SDK-native; no work to do, candidate for a
+     contract pin to prevent regression.
+   - **still-open** — custom code still in place; needs follow-up issue or
+     PR.
+   - **misclassified** — original audit conflated two SDK concepts; no work
+     beyond updating the registry / this doc.
+
+Context7 verification was done with library IDs from
+[`sdk-registry.md`](sdk-registry.md):
+[`/langchain-ai/langgraph`](https://github.com/langchain-ai/langgraph),
+[`/qdrant/qdrant-client`](https://github.com/qdrant/qdrant-client),
+[`/aiogram/aiogram`](https://github.com/aiogram/aiogram),
+[`/aiogram/aiogram-dialog`](https://github.com/aiogram/aiogram-dialog),
+[`/langfuse/langfuse-python`](https://github.com/langfuse/langfuse-python).
+
+## Results
+
+### ✅ Already SDK-native — confirmed on dev
+
+These match the issue's "Already using SDK correctly" table and were
+re-verified:
+
+| Area | SDK | Live entry point | Notes |
+|------|-----|------------------|-------|
+| Bot router / dispatcher | `aiogram.Router` + `Dispatcher` | `telegram_bot/bot.py::PropertyBot` | `dp.include_router(...)` chain |
+| Dialogs / FSM | `aiogram_dialog.Dialog` + `Window` | `telegram_bot/dialogs/` | states centralised in `states.py` |
+| Text agent | `langchain.agents.create_agent` | `telegram_bot/agents/agent.py:334` | `from langchain.agents import create_agent` |
+| Vector search | `qdrant_client.AsyncQdrantClient.query_points` + `models.Prefetch` + `models.RrfQuery` | `telegram_bot/services/qdrant.py` | pinned by `tests/contract/test_qdrant_sdk_native_usage_contract.py` |
+| Chunking | Docling / CocoIndex chain | `src/ingestion/unified/` | pinned by `tests/contract/test_chunking_strategy_sdk_native_contract.py` |
+| Observability | Langfuse SDK + OTEL | `telegram_bot/observability.py` | pinned by `tests/contract/test_langfuse_sdk_native_contract.py` |
+| Type / lint | `mypy`, `ruff` | `pyproject.toml`, `Makefile` | repo-wide |
+| Pre-commit security | `bandit`, `gitleaks`, `pre-commit-hooks` | `.pre-commit-config.yaml` | enforced in CI |
+
+### 🟡 Audit claim was correct in 2026-05-14 but **closed-on-dev** today
+
+These items were "Custom code that HAS an SDK equivalent" in the original
+issue body. Re-reading the source on `dev` shows they have already been
+migrated, several without an explicit cross-link in the issue thread.
+
+| Audit claim | Today's status on dev | Evidence |
+|-------------|----------------------|----------|
+| **P2 — `DraftStreamer` polling** | **gone**: file `telegram_bot/services/draft_streamer.py` no longer exists | `find . -name 'draft_streamer*'` returns nothing |
+| **P2 — `_stream_agent_to_draft` should use `agent.astream(stream_mode="messages")`** | **already SDK-native**: function uses `agent.astream(payload, config=config, stream_mode=["messages", "values"])` and unpacks `(msg, metadata)` per `MessagesStreamPart` | `telegram_bot/bot.py:323`; docstring states "the streaming path stays SDK-only" (#1671) |
+| **P3 — Custom Conversation memory lifecycle** | **already SDK-native**: `integrations/memory.py` wires `langgraph.checkpoint.redis.aio.AsyncRedisSaver` and falls back to `langgraph.checkpoint.memory.MemorySaver`; module docstring is explicit: "Zero custom logic — SDK wiring only" | `telegram_bot/integrations/memory.py:26,167,184` |
+| **P3 — Custom checkpoint namespace management** | **already SDK-native**: `_supervisor_thread_id` derives a `thread_id` and passes it through `config["configurable"]["thread_id"]`, which is the LangGraph-canonical way Context7 documents (`/langchain-ai/langgraph`: "Checkpoints are accessed by thread_id") | `telegram_bot/bot.py` (`_supervisor_thread_id`) |
+
+Context7 evidence for the streaming claim
+([`/langchain-ai/langgraph` `MessagesStreamPart`](https://github.com/langchain-ai/langgraph/blob/main/langgraph/libs/langgraph/langgraph/types.py)):
+> `MessagesStreamPart` carries `data` as a 2-tuple of `(message, metadata)`
+> where `message` is a `BaseMessage` (e.g. `AIMessageChunk`) and
+> `metadata` is a dict containing keys like `langgraph_node`,
+> `langgraph_step`, `langgraph_triggers`. Content was paraphrased for
+> licensing compliance.
+
+### 🔴 Audit claim was misclassified
+
+| Audit claim | Reality on dev | Why misclassified |
+|-------------|----------------|-------------------|
+| **P3 — "Manual `content_filter` injection detection (regex)" → use `LangChain InjectedState` + guard middleware** | The regex in `telegram_bot/graph/nodes/guard.py` is a **prompt-injection security heuristic** (21+ patterns, EN+RU, three guard modes hard/soft/log). `InjectedState` is a LangChain primitive for injecting **graph state into tool calls**. The two solve different problems and are not substitutable. | Concept conflation. `InjectedState` is not a prompt-injection detector. The right SDK-comparison for guard.py is "LangChain has no canonical prompt-injection guard"; the closest community options (LLM Guard, Rebuff, OpenAI moderation) are not in the registry today. |
+
+### 🟠 Still open — real follow-up items
+
+| ID | Issue body claim | Status | Recommended next step |
+|----|------------------|--------|------------------------|
+| **P1** | `build_graph()` — voice path uses 11-node custom `StateGraph` while text path uses `create_agent` SDK | **still-open**: `telegram_bot/graph/graph.py:100` builds a raw `StateGraph(RAGState, context_schema=GraphContext)` with conditional edges around guard/classify/rewrite/retrieve/cache/rerank/grade/respond/transcribe nodes | Tracked by **#1535** (currently `status:blocked`). Plan migration to `create_agent` with `before_model` / `tools` middleware. ADR [0010](../adr/0010-voice-path-create-agent-migration-plan.md) already exists. |
+
+The original issue body listed P1 only once; everything else under "Custom
+code that HAS an SDK equivalent" reduces to one of the closed-on-dev or
+misclassified rows above.
+
+## Bot.py size — informational
+
+The audit body cited `bot.py` at ~5099 lines. As of `dev` `51e52fd9` the file
+is **4987 lines** (slight reduction). Decomposition is tracked separately under
+**#1265**. Not directly an SDK-native question.
+
+## Recommendations for #1538
+
+1. **Close the issue** as substantially completed; the only live item is P1
+   (voice path migration) which is already tracked under #1535.
+2. **Pin the streaming claim** with a contract test so a regression to a
+   custom polling abstraction is caught at PR time. Implemented in
+   `tests/contract/test_streaming_sdk_native_contract.py` in this same PR.
+3. **Update the registry** entry for guard.py so future audits don't repeat
+   the `InjectedState` confusion. (Not done in this PR — out of scope; raise
+   a docs follow-up if desired.)
+
+## Refs
+
+- #1538 — original audit (this doc refreshes it).
+- #1535 — voice path migration to `create_agent` (P1 follow-up).
+- #1671 — historical PR that already moved DraftStreamer's behaviour into
+  `_stream_agent_to_draft` with native `stream_mode`.
+- #1265 — `bot.py` decomposition (separate from SDK question).
+- [`sdk-registry.md`](sdk-registry.md) — canonical SDK lookup.
+- ADR [0010](../adr/0010-voice-path-create-agent-migration-plan.md) — voice
+  path migration plan.
+- ADR [0012](../adr/0012-langgraph-orchestration.md) — LangGraph
+  orchestration choices.

--- a/tests/contract/test_streaming_sdk_native_contract.py
+++ b/tests/contract/test_streaming_sdk_native_contract.py
@@ -1,0 +1,120 @@
+"""Contract test: bot streaming path stays on the LangGraph native API.
+
+Issue #1538 audited SDK-native vs custom code. The live finding (after the
+2026-05 refresh) is that ``_stream_agent_to_draft`` already streams via
+``agent.astream(..., stream_mode=["messages", "values"])`` and unpacks the
+``(message, metadata)`` 2-tuple that ``MessagesStreamPart`` documents. No
+custom polling / `DraftStreamer` abstraction lives between the agent and
+the Telegram ``send_message_draft`` call.
+
+This contract pins that state. If a future refactor:
+
+- removes the call to ``agent.astream(...)`` from the streaming function,
+- drops ``"messages"`` from ``stream_mode``, or
+- reintroduces a class named ``DraftStreamer`` (the name from the audit
+  body),
+
+the contract fails with an actionable message pointing at #1538.
+
+Context7-verified (``/langchain-ai/langgraph``,
+``MessagesStreamPart``): the ``messages`` stream mode emits a 2-tuple
+``(message, metadata)`` where ``message`` is a ``BaseMessage``
+(typically ``AIMessageChunk``) and ``metadata`` carries
+``langgraph_node`` / ``langgraph_step`` / ``langgraph_triggers``.
+Content was rephrased for licensing compliance.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BOT_PY = REPO_ROOT / "telegram_bot" / "bot.py"
+
+
+def _function_node(tree: ast.AST, name: str) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    return None
+
+
+def _calls_in(node: ast.AST) -> list[ast.Call]:
+    return [n for n in ast.walk(node) if isinstance(n, ast.Call)]
+
+
+def test_stream_agent_to_draft_uses_native_astream_with_messages_mode() -> None:
+    """`_stream_agent_to_draft` must call `agent.astream(..., stream_mode=[...])`
+    with `"messages"` included in the mode list.
+    """
+    assert BOT_PY.exists(), "telegram_bot/bot.py not found"
+    tree = ast.parse(BOT_PY.read_text(), filename=str(BOT_PY))
+    fn = _function_node(tree, "_stream_agent_to_draft")
+    assert fn is not None, (
+        "Streaming entry point `_stream_agent_to_draft` is missing from "
+        "telegram_bot/bot.py. If it was renamed, update this contract "
+        "(#1538) so the SDK pin still applies."
+    )
+
+    astream_calls = [
+        call
+        for call in _calls_in(fn)
+        if isinstance(call.func, ast.Attribute) and call.func.attr == "astream"
+    ]
+    assert astream_calls, (
+        "`_stream_agent_to_draft` must call `<agent>.astream(...)` (LangGraph "
+        "native streaming). Issue #1538 prohibits replacing this with a "
+        "custom polling helper or a `DraftStreamer`-style abstraction."
+    )
+
+    found_messages_mode = False
+    for call in astream_calls:
+        for kw in call.keywords:
+            if kw.arg != "stream_mode":
+                continue
+            value = kw.value
+            # Accept stream_mode=["messages", ...] or stream_mode="messages"
+            if isinstance(value, ast.List):
+                for elt in value.elts:
+                    if isinstance(elt, ast.Constant) and elt.value == "messages":
+                        found_messages_mode = True
+            elif isinstance(value, ast.Constant) and value.value == "messages":
+                found_messages_mode = True
+    assert found_messages_mode, (
+        "`_stream_agent_to_draft` calls `agent.astream(...)` but does not pass "
+        '`stream_mode` containing "messages". Per LangGraph SDK '
+        "(`/langchain-ai/langgraph` `MessagesStreamPart`), this mode is the "
+        "canonical way to stream `(AIMessageChunk, metadata)` pairs to a "
+        "draft surface. Restore it (#1538)."
+    )
+
+
+def test_no_draft_streamer_class_reintroduced() -> None:
+    """The audit (#1538) called out a `DraftStreamer` polling abstraction
+    that was removed by #1671. Reintroducing a class with that name is a
+    regression — the current path goes through `agent.astream(...)`
+    directly, no extra layer.
+    """
+    candidates: list[Path] = []
+    for parent in (REPO_ROOT / "telegram_bot", REPO_ROOT / "src"):
+        if not parent.exists():
+            continue
+        for py in parent.rglob("*.py"):
+            if "/.venv/" in str(py):
+                continue
+            try:
+                tree = ast.parse(py.read_text(), filename=str(py))
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ClassDef) and node.name == "DraftStreamer":
+                    candidates.append(py.relative_to(REPO_ROOT))
+                    break
+    assert candidates == [], (
+        f"`DraftStreamer` class reintroduced in {candidates}. Issue "
+        f"#1538 requires the streaming path to remain SDK-only via "
+        f"`agent.astream(stream_mode=[...])`; do not add a custom "
+        f"polling abstraction (#1671 removed the original)."
+    )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Refresh of the SDK-native audit captured in #1538. The original audit (filed 2026-05-14) is **substantially completed on `dev`**; this PR documents that, pins the one remaining surface that needs guarding, and points the one genuinely open item at its existing tracking issue.

## TDD trail

- **Doc** (commit `16a4dc64`): `docs/engineering/sdk-native-audit-2026-05.md` (140 lines) — re-verifies every line of the original audit body against current `dev` and Context7. Each item is marked **closed-on-dev / still-open / misclassified** with evidence and live code references.
- **Pin** (same commit): `tests/contract/test_streaming_sdk_native_contract.py` with 2 assertions guarding the streaming surface against regression to a custom abstraction.

Genuine RED phase is not applicable for the pin — the bugs the audit cited are already fixed on `dev`, so the contract passes from commit one. Verified locally that mutating `_stream_agent_to_draft` to drop `stream_mode` or renaming the function trips the contract with a precise message.

## Refresh results

### ✅ Confirmed SDK-native (8 items)
All entries from the original "Already using SDK correctly" table re-verified against live source on `dev`. Most are already pinned by sibling contracts (`test_qdrant_sdk_native_usage_contract`, `test_chunking_strategy_sdk_native_contract`, `test_langfuse_sdk_native_contract`).

### 🟡 Audit claim correct in May 2026 but **closed-on-dev** today (4 items)

| Audit claim | Today on `dev` | Evidence |
|---|---|---|
| `DraftStreamer` polling abstraction | **gone** | `find . -name 'draft_streamer*'` returns nothing |
| `_stream_agent_to_draft` should use `agent.astream(stream_mode="messages")` | **already SDK-native** | `bot.py:323` calls `agent.astream(payload, config=config, stream_mode=["messages", "values"])`; docstring says "the streaming path stays SDK-only" (#1671) |
| Custom Conversation memory lifecycle | **already SDK-native** | `integrations/memory.py:26,167,184` wires `AsyncRedisSaver` + `MemorySaver`; module docstring: "Zero custom logic — SDK wiring only" |
| Custom checkpoint namespace management | **already SDK-native** | `_supervisor_thread_id` → `config["configurable"]["thread_id"]` (LangGraph canonical) |

### 🔴 Misclassified (1 item)

`guard.py` is a **prompt-injection security heuristic** (21+ regex patterns, EN+RU, three modes hard/soft/log). The audit suggested replacing it with `LangChain InjectedState`, but `InjectedState` is for **injecting graph state into tool calls** — a different problem entirely. No SDK substitution exists today. Documented in the doc.

### 🟠 Still open (1 item)

**P1 voice path** — `telegram_bot/graph/graph.py:100` builds a raw `StateGraph(RAGState, context_schema=GraphContext)` while the text path uses `create_agent`. Already tracked under **#1535** (currently `status:blocked`); ADR-0010 documents the migration plan.

## Context7 evidence

Library IDs consulted (all from `docs/engineering/sdk-registry.md`):

- [`/langchain-ai/langgraph`](https://github.com/langchain-ai/langgraph) — `MessagesStreamPart` 2-tuple shape `(message, metadata)` with `langgraph_node` / `langgraph_step` keys; `thread_id` lives in `config["configurable"]`; `create_agent` prebuilt with tools / middleware. **Content was paraphrased for licensing compliance** (≤30 consecutive words from any single source).

## Verification

Ran in worktree `../wt-1538-sdk-audit`:

```bash
uv run --python 3.12 pytest tests/contract/test_streaming_sdk_native_contract.py -v --timeout=30
# 2 passed in 0.63s

uv run --python 3.12 pytest tests/contract/ --timeout=30 -q
# 764 passed, 7 skipped, 3 xfailed in 39.55s   (no regression)

uv run --python 3.12 ruff check tests/contract/test_streaming_sdk_native_contract.py
uv run --python 3.12 ruff format --check tests/contract/test_streaming_sdk_native_contract.py
# clean

uv run --python 3.12 python scripts/check_markdown_links.py docs/engineering/sdk-native-audit-2026-05.md
# All relative Markdown links OK.
```

Skipped: `make check` / `make test-unit` (touched files limited to `docs/engineering/`, `tests/contract/`).

## Recommendation for #1538

The doc proposes closing #1538 as substantially completed; the only live SDK-native opportunity is P1, already tracked under #1535. If you'd like, I can post that recommendation as a separate issue comment after merge.

## Worktree cleanup

Will be removed after merge per `.kiro/steering/agent-workflow.md`:

```bash
git worktree remove ../wt-1538-sdk-audit
git worktree prune
git branch -D kiro/1538-sdk-native-audit
```

Refs #1538 (refreshes audit + pins streaming SDK-native shape; the lone open P1 item is tracked under #1535).