### PR TITLE
docs: consolidate RAG API reference (RAG_API.md vs API_REFERENCE.md)

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,45 +1,29 @@
-# API Reference
+# API Quick-Start Guide
 
-Quick reference for calling the RAG API. [`RAG_API.md`](RAG_API.md) is the canonical request/response contract and owns field-level schema details.
+Integration examples for calling the RAG API. This page owns curl/httpx recipes and deployment URLs. For the full contract (field definitions, error shapes, schema details), see [`RAG_API.md`](RAG_API.md).
 
 ## Base URL
 
-```
-http://localhost:8080  # Local development
-http://rag-api:8080   # Docker Compose
-```
+| Environment | URL |
+|---|---|
+| Local development | `http://localhost:8080` |
+| Docker Compose (inter-service) | `http://rag-api:8080` |
 
-## Endpoints
+---
 
-### POST /query
+## Examples
 
-Run a RAG query through the LangGraph pipeline.
+### Health Check
 
-Minimal request:
+```bash
+# Shallow (liveness)
+curl -fsS http://localhost:8080/health
 
-```json
-{
-  "query": "What documents are needed for buying property?",
-  "user_id": 12345,
-  "channel": "api"
-}
+# Deep (readiness -- probes Redis and Qdrant)
+curl -fsS "http://localhost:8080/health?deep=true"
 ```
 
-Response shape is `QueryResponse`; see [`RAG_API.md`](RAG_API.md#post-query) for the full schema. Current `query_type` values are `CHITCHAT`, `OFF_TOPIC`, `STRUCTURED`, `FAQ`, `ENTITY`, and `GENERAL`.
-
-```json
-{
-  "response": "string",
-  "query_type": "string",
-  "cache_hit": false,
-  "documents_count": 0,
-  "rerank_applied": false,
-  "latency_ms": 0.0,
-  "context": []
-}
-```
-
-**Example:**
+### Query (curl)
 
 ```bash
 curl -X POST http://localhost:8080/query \
@@ -52,40 +36,7 @@ curl -X POST http://localhost:8080/query \
   }'
 ```
 
-### GET /health
-
-Readiness probe for the RAG API.
-
-**Response:**
-
-```json
-{
-  "status": "ok"
-}
-```
-
-## Error Responses
-
-Unhandled exceptions return the structured shape implemented in `src/api/main.py`:
-
-```json
-{
-  "error": "internal_error",
-  "message": "Internal server error",
-  "trace_id": "abc123...",
-  "recoverable": false
-}
-```
-
-Validation errors use FastAPI/Pydantic's standard 422 response. `GraphRecursionError` is handled inside `/query` as a successful `QueryResponse` with `query_type: "ERROR"` and a fallback user response.
-
-## Request/Response Schemas
-
-The Pydantic models live in `src/api/schemas.py`. Field-level documentation is maintained in [`RAG_API.md`](RAG_API.md#post-query).
-
-## Integration Examples
-
-### Python (httpx)
+### Query (Python / httpx)
 
 ```python
 import httpx
@@ -107,7 +58,7 @@ async def query_rag(question: str, user_id: int) -> dict:
 
 ### Voice Agent Integration
 
-The voice agent calls RAG API via `httpx`:
+The voice agent calls the RAG API via `httpx` with cross-trace linking:
 
 ```python
 async def search_knowledge_base(query: str, trace_id: str | None = None) -> str:
@@ -125,33 +76,17 @@ async def search_knowledge_base(query: str, trace_id: str | None = None) -> str:
         return data["response"]
 ```
 
+---
+
 ## Rate Limits
 
 No rate limiting is currently enforced on the RAG API.
 
-## Health Check Semantics
-
-The `/health` endpoint checks:
-- FastAPI application is running
-- Does NOT check: Redis, Qdrant, BGE-M3, LLM availability
-
-For local bot/runtime dependency checks, use the local development preflight:
-
-```bash
-make test-bot-health
-```
-
-The RAG API also initializes Redis, Qdrant, embeddings, and LLM clients in FastAPI lifespan startup. A successful `/health` response is therefore a cheap liveness/readiness signal for the app process, not a deep dependency probe.
-
-## Langfuse Tracing
-
-All queries are traced in Langfuse with:
-- **Trace family:** `rag-api-query`
-- **Tags:** `["api", "rag", "{channel}"]`
-- **Metadata:** `query_type`, `source`
+---
 
 ## Related Documentation
 
-- [RAG API Contract](RAG_API.md)
-- [Pipeline Overview](PIPELINE_OVERVIEW.md)
-- [Bot Architecture](BOT_ARCHITECTURE.md)
+- [RAG API Contract](RAG_API.md) -- full schema, error model, architecture
+- [Error Response Taxonomy](ERROR_RESPONSES.md) -- system-wide error reference
+- [Pipeline Overview](PIPELINE_OVERVIEW.md) -- end-to-end pipeline flows
+- [Bot Architecture](BOT_ARCHITECTURE.md) -- Telegram bot layer

--- a/docs/RAG_API.md
+++ b/docs/RAG_API.md
@@ -5,7 +5,7 @@ FastAPI service wrapping the LangGraph pipeline for external query execution.
 **Entry point:** `src/api/main.py`
 **Port:** 8080 (production via Docker), 8000 (dev via uvicorn)
 
-This page owns the request/response contract. Use [`API_REFERENCE.md`](API_REFERENCE.md) for quick curl/httpx examples.
+This page is the canonical owner of the API contract: endpoints, request/response schemas, error model, and deployment surface. For integration examples (curl, httpx, voice agent), see [`API_REFERENCE.md`](API_REFERENCE.md).
 
 ## Endpoints
 
@@ -13,10 +13,29 @@ This page owns the request/response contract. Use [`API_REFERENCE.md`](API_REFER
 
 Readiness probe. Returns immediately without checking downstream services.
 
-**Response:**
+**Query parameters:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `deep` | bool | false | When true, probes cache and Qdrant; returns 503 if any dependency is unhealthy |
+
+**Shallow response (default):**
 ```json
 { "status": "ok" }
 ```
+
+**Deep response (`?deep=true`):**
+```json
+{
+  "status": "ok",
+  "components": {
+    "cache": { "status": "ok" },
+    "qdrant": { "status": "ok" }
+  }
+}
+```
+
+Returns HTTP 503 with `"status": "degraded"` if any component is unhealthy.
 
 ---
 
@@ -24,22 +43,22 @@ Readiness probe. Returns immediately without checking downstream services.
 
 Execute a RAG query through the full LangGraph pipeline.
 
-**Request body:** `QueryRequest`
+**Request body:** `QueryRequest` (defined in `src/api/schemas.py`)
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `query` | string | required | User query text (1–4096 chars) |
+| `query` | string | required | User query text (1-4096 chars) |
 | `user_id` | int | 0 | Optional user identifier |
 | `session_id` | string | "" | Optional session identifier |
 | `channel` | string | "api" | Source channel: `api`, `voice`, `telegram` |
 | `langfuse_trace_id` | string | null | Optional Langfuse trace ID for cross-trace linking |
 
-**Response:** `QueryResponse`
+**Response:** `QueryResponse` (defined in `src/api/schemas.py`)
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `response` | string | Generated answer |
-| `query_type` | string | Classified query type (e.g., `FAQ`, `GENERAL`, `CHITCHAT`) |
+| `query_type` | string | Classified query type (see values below) |
 | `cache_hit` | bool | Whether semantic cache was hit |
 | `documents_count` | int | Number of retrieved documents |
 | `rerank_applied` | bool | Whether reranking was applied |
@@ -48,43 +67,51 @@ Execute a RAG query through the full LangGraph pipeline.
 
 `query_type` values come from `telegram_bot/graph/nodes/classify.py`: `CHITCHAT`, `OFF_TOPIC`, `STRUCTURED`, `FAQ`, `ENTITY`, `GENERAL`, plus `ERROR` for recursion-limit fallback.
 
-**Example request:**
-```bash
-curl -X POST http://localhost:8080/query \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "What are the requirements for permanent residency?",
-    "user_id": 12345,
-    "channel": "api"
-  }'
-```
+---
 
-**Example response:**
+## Error Model
+
+All error responses share a consistent envelope shape with a `trace_id` for log correlation. The `trace_id` is the current Langfuse trace ID when available; otherwise the handler generates a UUID hex string.
+
+For the full system-wide error taxonomy, see [`ERROR_RESPONSES.md`](ERROR_RESPONSES.md).
+
+### 422 -- Validation Error
+
+Returned when the request body fails Pydantic validation.
+
 ```json
 {
-  "response": "Permanent residency in Bulgaria requires...",
-  "query_type": "FAQ",
-  "cache_hit": false,
-  "documents_count": 5,
-  "rerank_applied": true,
-  "latency_ms": 847.3,
-  "context": [
-    {"id": "doc-123", "text": "...", "score": 0.92},
-    {"id": "doc-456", "text": "...", "score": 0.88}
-  ]
+  "error": "validation_error",
+  "message": "Request validation failed",
+  "details": [
+    {
+      "loc": ["body", "query"],
+      "msg": "String should have at least 1 character",
+      "type": "string_too_short"
+    }
+  ],
+  "trace_id": "abc123...",
+  "recoverable": true
 }
 ```
 
----
+### 4xx -- HTTP Errors
 
-## Error Responses
+Returned for routing/auth errors (404, 401, 403, etc.).
 
-| Status | Body | Cause |
-|--------|------|-------|
-| 422 | Validation error | Invalid request body |
-| 500 | Structured error object | Unhandled exception |
+```json
+{
+  "error": "http_error",
+  "message": "Not Found",
+  "status_code": 404,
+  "trace_id": "abc123...",
+  "recoverable": true
+}
+```
 
-Unhandled exceptions are returned by `src/api/main.py` as:
+### 500 -- Internal Error
+
+Returned for unhandled exceptions.
 
 ```json
 {
@@ -95,9 +122,11 @@ Unhandled exceptions are returned by `src/api/main.py` as:
 }
 ```
 
-The `trace_id` is the current Langfuse trace ID when available; otherwise the handler generates a UUID hex string for log correlation.
+For 500 errors, search Langfuse for the corresponding `rag-api-query` trace using the `trace_id`.
 
-For 500 errors, check Langfuse traces for the corresponding `rag-api-query` trace.
+### GraphRecursionError Handling
+
+`GraphRecursionError` is caught inside `/query` and returns a successful `QueryResponse` (HTTP 200) with `query_type: "ERROR"` and a fallback user response -- it does not surface as an HTTP error.
 
 ---
 
@@ -105,18 +134,18 @@ For 500 errors, check Langfuse traces for the corresponding `rag-api-query` trac
 
 ```
 POST /query
-    ↓
+    |
 FastAPI lifespan initializes:
   - GraphConfig.from_env()
   - CacheLayerManager (Redis)
   - QdrantService
   - Embeddings (BGE-M3)
   - LLM (via LiteLLM)
-    ↓
+    |
 build_graph() from telegram_bot/graph/graph.py
-    ↓
+    |
 ainvoke() with RAGState
-    ↓
+    |
 Returns QueryResponse with context
 ```
 
@@ -125,6 +154,7 @@ Returns QueryResponse with context
 ## Observability
 
 - Trace family: `rag-api-query`
+- Tags: `["api", "rag", "{channel}"]`
 - Langfuse scores written via `write_langfuse_scores()`
 - `langfuse_trace_id` propagation for cross-trace linking with voice sessions
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,8 +40,8 @@ For fast orientation by goal rather than by subsystem, see [`indexes/`](indexes/
 - [`PIPELINE_OVERVIEW.md`](PIPELINE_OVERVIEW.md) — Ingestion, query, and voice runtime flows.
 - [`PIPELINE_ROUTING.md`](PIPELINE_ROUTING.md) — Query routing and state machine design.
 - [`CONTEXTUALIZED_EMBEDDINGS.md`](CONTEXTUALIZED_EMBEDDINGS.md) — Embedding strategy and contextualization.
-- [`RAG_API.md`](RAG_API.md) — FastAPI RAG API contract.
-- [`API_REFERENCE.md`](API_REFERENCE.md) — API reference.
+- [`RAG_API.md`](RAG_API.md) — RAG API contract: endpoints, schemas, error model, architecture.
+- [`API_REFERENCE.md`](API_REFERENCE.md) — RAG API quick-start: curl/httpx examples and integration recipes.
 - [`DEVELOPER_GUIDE.md`](DEVELOPER_GUIDE.md) — Guide for extending graph nodes, tools, query types, and ingestion sources.
 
 ## Operations & Runbooks

--- a/docs/indexes/runtime-services.md
+++ b/docs/indexes/runtime-services.md
@@ -124,6 +124,21 @@ make test-bot-health   # local prerequisite check
 python -m telegram_bot.preflight   # startup health check
 ```
 
+## RAG API
+
+FastAPI service wrapping the LangGraph pipeline for synchronous RAG queries.
+
+- **Entrypoint**: `src/api/main.py`
+- **Service name**: `rag-api`
+- **Local port**: `8080`
+- **Canonical docs**: [`../RAG_API.md`](../RAG_API.md) (contract), [`../API_REFERENCE.md`](../API_REFERENCE.md) (quick-start examples)
+
+Quick check:
+
+```bash
+curl -fsS http://localhost:8080/health
+```
+
 ## Voice Agent
 
 LiveKit-powered voice path. Deferred by default.


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Fixes #1952

## Summary

Consolidates the two overlapping API documentation files into a clear, non-overlapping split:

- **`RAG_API.md`** is the single canonical contract document owning: endpoint definitions, full request/response schemas with field tables, error model (422/500/GraphRecursionError), architecture diagram, and observability details.
- **`API_REFERENCE.md`** is now a pure quick-start/integration guide owning: base URL table, curl/httpx recipes, voice agent integration examples. All schema and error details link back to `RAG_API.md`.

## Changes

- Restructured `docs/RAG_API.md` to consolidate all contract details
- Transformed `docs/API_REFERENCE.md` into integration-only guide with no duplicated schema
- Updated cross-links in `docs/README.md` (descriptions clarify what each file owns)
- Added RAG API section to `docs/indexes/runtime-services.md` with entrypoint, service name, port, and links to both docs

## Verification

- `scripts/check_markdown_links.py` passes cleanly (no broken links)
- Documentation matches the live FastAPI contract in `src/api/main.py` and `src/api/schemas.py`

## TDD

Skipped - docs-only change with no behavior modification.

## Context7

Not applicable - no SDK usage in this change.