### PR TITLE
docs: deduplicate cache degradation docs (3 sources)

### DIFF
--- a/docs/CACHE_DEGRADATION.md
+++ b/docs/CACHE_DEGRADATION.md
@@ -1,66 +1,99 @@
 # Cache Degradation Behavior
 
-Multi-tier semantic caching with graceful degradation when cache fails.
+> **Scope:** Design and architecture of the multi-tier cache system and its
+> graceful degradation modes.
+>
+> Related docs:
+> - [Troubleshooting Cache](TROUBLESHOOTING_CACHE.md) - debugging guide for cache issues
+> - [Redis Cache Degradation Runbook](runbooks/REDIS_CACHE_DEGRADATION.md) - operator incident runbook
 
 ## Cache Tiers
 
-### Tier 1: Embeddings Cache (RedisVL)
-- **Purpose:** Skip re-encoding of repeated queries
-- **Index:** `embeddings:v5`
-- **TTL:** 7 days
-- **Lookup:** Query text → cached embedding vector
+The `CacheLayerManager` (`telegram_bot/integrations/cache.py`) implements a
+5-tier Redis cache for the RAG pipeline:
 
-### Tier 2: Semantic Result Cache (RedisVL)
-- **Purpose:** Skip retrieval + generation for similar queries
-- **Index:** `sem:v8:bge1024`
-- **Threshold:** Varies by query type (see below)
-- **TTL:** Per query type (configurable)
+| # | Tier | Type | Index / Prefix | TTL |
+|---|------|------|----------------|-----|
+| 1 | Semantic | RedisVL SemanticCache | `sem:v8:bge1024` | Per query type |
+| 2 | Embeddings | RedisVL EmbeddingsCache | `embeddings:v5` | 7 days |
+| 3 | Sparse | Redis exact | `sparse:v5:` | 7 days |
+| 4 | Search | Redis exact | `search:v5:` | 2 hours |
+| 5 | Rerank | Redis exact | `rerank:v5:` | 2 hours |
+
+Additionally, conversation history is stored as a Redis LIST (20 messages max,
+2h TTL) keyed by `conversation:<user_id>`.
+
+Version constants in source: `CACHE_VERSION = "v5"`, `SEMANTIC_CACHE_VERSION = "v8"`.
+
+### Tier Details
+
+**Semantic cache** - Skips retrieval + generation for similar queries. Uses
+BGE-M3 1024-dim embeddings with per-query-type distance thresholds.
+
+**Embeddings cache** - Skips re-encoding of repeated queries. Stores dense
+vectors and BGE-M3 query-bundle payload.
+
+**Sparse cache** - Stores sparse embedding vectors to avoid recomputation.
+
+**Search cache** - Stores Qdrant search results to skip repeated retrieval.
+
+**Rerank cache** - Stores reranked results to skip repeated reranking.
 
 ## Per-Query-Type Thresholds
 
-| Query Type | Distance Threshold | Rationale |
-|------------|-------------------|-----------|
-| `FAQ` | 0.12 | High precision required |
-| `ENTITY` | 0.10 | Entity/history-style specificity |
-| `GENERAL` | 0.08 | Balanced |
-| `STRUCTURED` | 0.05 | Most specific; strictest reuse |
+| Query Type | Distance Threshold | TTL | Rationale |
+|------------|-------------------|-----|-----------|
+| `FAQ` | 0.12 | 24h | High precision required |
+| `ENTITY` | 0.10 | 1h | Entity/history-style specificity |
+| `GENERAL` | 0.08 | 1h | Balanced |
+| `STRUCTURED` | 0.05 | 2h | Most specific; strictest reuse |
 
 **Note:** Semantic thresholds are RedisVL vector-distance cutoffs; lower values
 are stricter. The separate store guard still uses `grade_confidence` on the RRF
 scale.
 
-`CHITCHAT` and `OFF_TOPIC` are not RAG cacheable query types. Structured catalog search
-uses separate catalog tooling and should not be documented as a semantic
+`CHITCHAT` and `OFF_TOPIC` are not RAG cacheable query types. Structured catalog
+search uses separate catalog tooling and should not be documented as a semantic
 response-cache type unless the runtime policy changes.
 
 ## Degradation Modes
 
 ### Mode 1: Cache Unavailable (Redis Down)
-- Embeddings cache miss → re-encode
-- Semantic cache miss → proceed without caching
+
+- All exact caches (embeddings, sparse, search, rerank) miss - recompute
+- Semantic cache miss - proceed without caching
 - **User impact:** Slower response, no cache benefits
 - **Monitoring:** `cache_errors` metric
 
 ### Mode 2: Embedding Service Down
-- Cannot compute embedding → bypass cache lookup
+
+- Cannot compute embedding - bypass semantic and embeddings cache lookup
 - Proceed to full retrieval pipeline
 - **User impact:** Full latency, no cache hit possible
 
 ### Mode 3: Qdrant Unavailable
-- Cache hit → attempt to use cached response
-- Cache miss → fail with error
+
+- Cache hit - attempt to use cached response
+- Cache miss - fail with error
 - **User impact:** Degraded quality if cache miss
+
+The system degrades gracefully in all modes: users still get responses, just
+without cache benefits. See the
+[incident runbook](runbooks/REDIS_CACHE_DEGRADATION.md) for remediation steps.
 
 ## Cache Key Structure
 
 ```
+# Semantic result cache
+Index: sem:v8:bge1024
+Schema: query_text, query_type, language, response, sources, metadata
+
 # Embeddings cache
 Index: embeddings:v5
 Schema: text (str), embedding (dense[1024])
 
-# Semantic result cache
-Index: sem:v8:bge1024
-Schema: query_text, query_type, language, response, sources, metadata
+# Exact caches use key format: <tier>:<CACHE_VERSION>:<hash>
+# e.g. sparse:v5:<sha256_prefix>, search:v5:<sha256_prefix>, rerank:v5:<sha256_prefix>
 ```
 
 ## Cache Scope
@@ -78,18 +111,21 @@ use `cache_scope="rag"`; history lookups use `cache_scope="history"`.
 | `cache_error_total` | Cache errors by tier |
 | `cache_latency_ms` | Cache operation latency |
 
+For debugging cache behavior (inspecting keys, verifying hits), see the
+[Troubleshooting Cache](TROUBLESHOOTING_CACHE.md) guide.
+
 ## Configuration
 
 Environment variables:
-- `REDIS_PASSWORD` — Redis auth (required)
-- `CACHE_TTL_DEFAULT` — Default TTL in seconds
-- `CACHE_EMBEDDING_TTL` — Embeddings cache TTL (default: 604800 = 7 days)
+- `REDIS_PASSWORD` - Redis auth (required)
+- `CACHE_TTL_DEFAULT` - Default TTL in seconds
+- `CACHE_EMBEDDING_TTL` - Embeddings cache TTL (default: 604800 = 7 days)
 
 ## Code Locations
 
 | File | Purpose |
 |------|---------|
-| `telegram_bot/integrations/cache.py` | CacheLayerManager |
+| `telegram_bot/integrations/cache.py` | CacheLayerManager (5-tier manager) |
 | `telegram_bot/services/cache_policy.py` | Cacheability decisions |
 | `telegram_bot/graph/nodes/cache.py` | Graph cache lookup/store nodes |
 | `telegram_bot/pipelines/client.py` | Client direct cache lookup/store flow |

--- a/docs/TROUBLESHOOTING_CACHE.md
+++ b/docs/TROUBLESHOOTING_CACHE.md
@@ -1,8 +1,17 @@
 # Troubleshooting: Semantic Cache
 
-The semantic cache is a multi-tier system (`CacheLayerManager` in `telegram_bot/integrations/cache.py`). This guide helps debug cache behavior.
+> **Scope:** Debugging guide for application-level cache behavior issues.
+>
+> Related docs:
+> - [Cache Degradation Behavior](CACHE_DEGRADATION.md) - architecture, tiers, and degradation modes
+> - [Redis Cache Degradation Runbook](runbooks/REDIS_CACHE_DEGRADATION.md) - operator incident runbook
 
-## Cache Architecture
+The semantic cache is a multi-tier system (`CacheLayerManager` in
+`telegram_bot/integrations/cache.py`). This guide helps debug cache behavior
+at the application level. For infrastructure issues (Redis down, container
+failures), see the [incident runbook](runbooks/REDIS_CACHE_DEGRADATION.md).
+
+## Cache Architecture Overview
 
 The `CacheLayerManager` implements 5 cache tiers:
 
@@ -14,6 +23,9 @@ The `CacheLayerManager` implements 5 cache tiers:
 | Search | Redis exact | 2 hours | Search results cache |
 | Rerank | Redis exact | 2 hours | Reranked results cache |
 
+For full tier details, thresholds, and degradation modes, see
+[Cache Degradation Behavior](CACHE_DEGRADATION.md).
+
 ## Common Issues
 
 ### 1. Cache Always MISS Despite Correct Query
@@ -24,24 +36,27 @@ The `CacheLayerManager` implements 5 cache tiers:
 
 #### RRF Scale vs Cosine Similarity Confusion
 
-The `grade_confidence` threshold uses **RRF scale** (~0.0006 to 0.016), NOT cosine similarity [0-1].
+The `grade_confidence` threshold uses **RRF scale** (~0.0006 to 0.016), NOT
+cosine similarity [0-1].
 
 The store guard in `pipelines/client.py` requires:
 ```python
 grade_confidence >= config.relevance_threshold_rrf  # Default: 0.005
 ```
 
-If your threshold is set to `0.8` thinking it's cosine similarity, nothing will store.
+If your threshold is set to `0.8` thinking it's cosine similarity, nothing will
+store.
 
 **Fix:** Use RRF scale thresholds. A good starting point is `0.005`.
 
 #### Cache Key Versioning
 
 Each tier has a version prefix:
-- `sem:v8:` / index `sem:v8:bge1024` — Semantic cache
-- `embeddings:v5:` — Embeddings
-- `sparse:v5:` — Sparse embeddings
-- `search:v5:` — Search results
+- `sem:v8:` / index `sem:v8:bge1024` - Semantic cache
+- `embeddings:v5:` - Embeddings
+- `sparse:v5:` - Sparse embeddings
+- `search:v5:` - Search results
+- `rerank:v5:` - Rerank results
 
 When models change, bump the version in `integrations/cache.py`:
 ```python
@@ -103,6 +118,12 @@ KEYS embeddings:v5:*
 # Check search cache
 KEYS search:v5:*
 
+# Check sparse cache
+KEYS sparse:v5:*
+
+# Check rerank cache
+KEYS rerank:v5:*
+
 # Inspect a semantic cache entry
 GET "sem:v8:bge1024:somekey"
 ```
@@ -133,6 +154,9 @@ results = await cache.clear_all_caches()
 
 Or via bot command: `/clearcache`
 
+For operator-level cache clearing via Docker, see the
+[incident runbook](runbooks/REDIS_CACHE_DEGRADATION.md#cache-corruption-or-version-drift).
+
 ## Cache vs Query Type Mapping
 
 ### Cacheable Query Types
@@ -147,17 +171,8 @@ _SEMANTIC_CACHEABLE_QUERY_TYPES = {"FAQ", "GENERAL", "ENTITY", "STRUCTURED"}
 
 | Query Pattern | Reason |
 |---------------|--------|
-| Contextual follow-ups ("подробнее"/"more details", "первый"/"the first one", "это"/"this", "ещё"/"more") | Different context |
+| Contextual follow-ups ("more details", "the first one", "this", "more") | Different context |
 | CHITCHAT/OFF_TOPIC | Not RAG queries |
-
-### Cache Thresholds by Query Type
-
-| Query Type | Distance Threshold | TTL |
-|------------|-------------------|-----|
-| FAQ | 0.12 | 24h |
-| ENTITY | 0.10 | 1h |
-| GENERAL | 0.08 | 1h |
-| STRUCTURED | 0.05 | 2h |
 
 ## Metrics and Monitoring
 

--- a/docs/runbooks/REDIS_CACHE_DEGRADATION.md
+++ b/docs/runbooks/REDIS_CACHE_DEGRADATION.md
@@ -1,5 +1,11 @@
 # Runbook: Redis Cache Degradation
 
+> **Scope:** Operator incident runbook for Redis cache infrastructure issues.
+>
+> Related docs:
+> - [Cache Degradation Behavior](../CACHE_DEGRADATION.md) - architecture, tiers, and degradation design
+> - [Troubleshooting Cache](../TROUBLESHOOTING_CACHE.md) - application-level debugging guide
+
 > **Owner:** Retrieval & Cache subsystems
 > **Last verified:** 2026-05-12
 > **Verification command:**
@@ -7,7 +13,10 @@
 > COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec redis sh -lc 'redis-cli -a "$REDIS_PASSWORD" ping'
 > ```
 
-Use this runbook when Redis cache issues affect RAG performance.
+Use this runbook when Redis cache infrastructure issues affect RAG performance.
+For application-level cache debugging (threshold tuning, key inspection, cache
+misses due to config), see
+[Troubleshooting Cache](../TROUBLESHOOTING_CACHE.md).
 
 ## Symptoms
 
@@ -34,15 +43,22 @@ Use this runbook when Redis cache issues affect RAG performance.
 
 ## Cache Tiers in the App
 
+The `CacheLayerManager` manages 5 tiers (see
+[Cache Degradation Behavior](../CACHE_DEGRADATION.md) for full architecture):
+
 - RedisVL **SemanticCache**: `sem:v8:bge1024`
 - RedisVL **EmbeddingsCache**: `embeddings:v5` (dense vectors and BGE-M3 query-bundle payload)
-- Exact async Redis caches (redis-py): `embeddings`, `sparse`, `search`, `rerank`, and `conversation`/state keys (`conversation:<user_id>`)
+- Exact async Redis caches (redis-py): `sparse:v5:`, `search:v5:`, `rerank:v5:`
+- Conversation/state keys: `conversation:<user_id>`
 
-BGE-M3 query-bundle optimization uses **RedisVL EmbeddingsCache** for dense vectors and stores sparse/ColBERT parts as metadata in the same payload. It is still an app-level cache optimization; retrieval remains in Qdrant.
+BGE-M3 query-bundle optimization uses **RedisVL EmbeddingsCache** for dense
+vectors and stores sparse/ColBERT parts as metadata in the same payload. It is
+still an app-level cache optimization; retrieval remains in Qdrant.
 
 ## Fast-Path Diagnosis (read-only)
 
-Run these commands before deciding whether the issue is a service failure or an application bug.
+Run these commands before deciding whether the issue is a service failure or an
+application bug.
 
 ### 1. Container health and reachability
 
@@ -55,7 +71,8 @@ COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env
 ```
 
 Expected: `PONG`.
-If this fails, treat as **service failure** (container down, network partition, or auth misconfiguration at the Compose level).
+If this fails, treat as **service failure** (container down, network partition,
+or auth misconfiguration at the Compose level).
 
 ### 1b. Verify container/runtime version before conclusions
 
@@ -64,7 +81,8 @@ COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env
 COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec redis-langfuse sh -lc 'if [ -n "${LANGFUSE_REDIS_PASSWORD:-}" ]; then redis-cli -a "$LANGFUSE_REDIS_PASSWORD" INFO server; else redis-cli INFO server; fi | grep "^redis_version"'
 ```
 
-Run both commands independently and compare output before concluding a cache failure is app-Redis-specific.
+Run both commands independently and compare output before concluding a cache
+failure is app-Redis-specific.
 
 ### 2. Read-only keyspace and memory inspection
 
@@ -76,9 +94,9 @@ COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env
 ```
 
 Look for:
-- `used_memory_human` — compare against the `redis` service `deploy.resources.limits.memory` in [`compose.yml`](../../compose.yml)
-- `maxmemory` — verify against the `redis` service definition in [`compose.yml`](../../compose.yml) and dev overrides in [`compose.dev.yml`](../../compose.dev.yml); canonical values are in [`DOCKER.md`](../../DOCKER.md)
-- `evicted_keys` > 0 — confirms aggressive eviction due to memory pressure
+- `used_memory_human` - compare against the `redis` service `deploy.resources.limits.memory` in [`compose.yml`](../../compose.yml)
+- `maxmemory` - verify against the `redis` service definition in [`compose.yml`](../../compose.yml) and dev overrides in [`compose.dev.yml`](../../compose.dev.yml); canonical values are in [`DOCKER.md`](../../DOCKER.md)
+- `evicted_keys` > 0 - confirms aggressive eviction due to memory pressure
 
 ### 3. Logs (read-only)
 
@@ -99,9 +117,9 @@ Check for:
 | `redis-cli ping` works, but bot logs show `Connection refused` | App bug | Verify `REDIS_URL` in bot env; check password encoding |
 | Bot preflight shows `invalid username-password pair` / `WRONGPASS` / `NOAUTH` after local `.env` edit | Local auth drift | Run `make local-redis-recreate`, then `make test-bot-health` |
 | Redis memory is near limit and `evicted_keys` is rising | Service failure / capacity | Scale `maxmemory` or reduce TTL; see Remediation |
-| Cache hit rate is 0% but Redis is healthy and has keys | App bug | Check semantic cache threshold, query_type mapping, or `CACHE_VERSION` drift in `telegram_bot/integrations/cache.py` |
+| Cache hit rate is 0% but Redis is healthy and has keys | App bug | See [Troubleshooting Cache](../TROUBLESHOOTING_CACHE.md) for threshold/version debugging |
 | High latency **with** cache hits | App bug | Profile embedding or rerank tiers; latency may be upstream of Redis |
-| Only specific tiers miss (e.g. `search` hits, `semantic` misses) | App bug | Inspect tier-specific TTLs and `distance_threshold` in source |
+| Only specific tiers miss (e.g. `search` hits, `semantic` misses) | App bug | See [Troubleshooting Cache](../TROUBLESHOOTING_CACHE.md#1-cache-always-miss-despite-correct-query) |
 
 ### Cache Smoke Validation (for cache-hit health)
 
@@ -134,7 +152,8 @@ Use a canonical query twice, once with a cleared cache and once immediately afte
 
 ## Remediation
 
-> ⚠️ **Caution:** Commands in this section mutate state. Run only after fast-path diagnosis confirms the issue is not an app bug.
+> **Caution:** Commands in this section mutate state. Run only after fast-path
+> diagnosis confirms the issue is not an app bug.
 
 ### Redis Connection Refused
 
@@ -155,7 +174,9 @@ Use a canonical query twice, once with a cleared cache and once immediately afte
 
 ### Local `REDIS_PASSWORD` Drift After `.env` Change
 
-When local bot preflight reports auth failures (`invalid username-password pair`, `WRONGPASS`, `NOAUTH`), your running Redis container may still use the previous password.
+When local bot preflight reports auth failures (`invalid username-password pair`,
+`WRONGPASS`, `NOAUTH`), your running Redis container may still use the previous
+password.
 
 1. Recreate local Redis with current `.env` values:
    ```bash
@@ -168,7 +189,8 @@ When local bot preflight reports auth failures (`invalid username-password pair`
 
 ### Cache Corruption or Version Drift
 
-If cache data appears corrupted or keys use an old `CACHE_VERSION` / `SEMANTIC_CACHE_VERSION`:
+If cache data appears corrupted or keys use an old `CACHE_VERSION` /
+`SEMANTIC_CACHE_VERSION`:
 
 1. Clear caches programmatically (safe, uses SCAN not `KEYS *`):
    ```bash
@@ -187,7 +209,12 @@ If cache data appears corrupted or keys use an old `CACHE_VERSION` / `SEMANTIC_C
 
 2. Or use the bot command: `/clearcache`
 
-> **Avoid `KEYS *`** in production or large keyspaces. The `CacheLayerManager.clear_by_tier()` and `clear_semantic_cache()` methods use `SCAN` iteratively instead.
+> **Avoid `KEYS *`** in production or large keyspaces. The
+> `CacheLayerManager.clear_by_tier()` and `clear_semantic_cache()` methods use
+> `SCAN` iteratively instead.
+
+For details on version bump triggers and manual cache clearing options, see
+[Troubleshooting Cache](../TROUBLESHOOTING_CACHE.md#cache-poisoning--staleness).
 
 ### Memory Issues
 
@@ -200,15 +227,6 @@ If cache data appears corrupted or keys use an old `CACHE_VERSION` / `SEMANTIC_C
    - Increasing `maxmemory` in `compose.dev.yml` (dev) or the host Redis config (production)
    - Reducing exact-cache TTLs in `telegram_bot/integrations/cache.py` (`DEFAULT_TTLS`)
    - Clearing old cache entries via tiered `clear_by_tier()`
-
-## Impact on Users
-
-When Redis is down:
-- **Semantic cache unavailable** — queries still work but no cache hits
-- **Embeddings cache unavailable** — fresh embeddings computed each time
-- **Session history unavailable** — new sessions don't retain context
-
-The system degrades gracefully — users still get responses, just without cache benefits.
 
 ## Prevention
 


### PR DESCRIPTION
## Summary

Deduplicates three overlapping cache degradation docs by defining a clear boundary:

| Doc | Scope |
|-----|-------|
| `docs/CACHE_DEGRADATION.md` | Design/architecture: cache tiers, degradation modes, key structure |
| `docs/TROUBLESHOOTING_CACHE.md` | Debugging guide: common issues, key inspection, metrics |
| `docs/runbooks/REDIS_CACHE_DEGRADATION.md` | Operator incident runbook: container health, remediation |

Changes:
- Added top-of-file scope note and cross-links to all three docs
- Removed duplicated step-by-step content from CACHE_DEGRADATION.md (debugging details now only in TROUBLESHOOTING_CACHE.md)
- Removed duplicated architecture details from the runbook (now references CACHE_DEGRADATION.md)
- Added cross-links between app-level debugging and operator-level remediation
- Verified all cache tier names against `CacheLayerManager` in `telegram_bot/integrations/cache.py`

## TDD Skip Justification

Trivial doc/config moves with no behavior change. No code was modified. Per agent-workflow.md steering, TDD is skipped for this category.

## Verification

```bash
python3 scripts/check_markdown_links.py
# Result: "All relative Markdown links OK." (exit 0)
```

Cache tier names verified against source (`telegram_bot/integrations/cache.py`):
- Semantic: `sem:v8:bge1024` (matches `SEMANTIC_CACHE_VERSION = "v8"`)
- Embeddings: `embeddings:v5` (matches `CACHE_VERSION = "v5"`)
- Sparse: `sparse:v5:` (matches `CACHE_VERSION = "v5"`)
- Search: `search:v5:` (matches `CACHE_VERSION = "v5"`)
- Rerank: `rerank:v5:` (matches `CACHE_VERSION = "v5"`)
- Per-query thresholds: FAQ=0.12, ENTITY=0.10, GENERAL=0.08, STRUCTURED=0.05 (match `self.cache_thresholds`)

## Skipped Checks

- No unit tests (docs-only, no code changes)
- No Docker build (docs-only)

Fixes #1954