### PR TITLE
docs: deduplicate cache degradation docs (3 sources)

### DIFF
--- a/docs/CACHE_DEGRADATION.md
+++ b/docs/CACHE_DEGRADATION.md
@@ -1,95 +1,112 @@
 # Cache Degradation Behavior
 
+> **Role:** Design behaviour -- cache tier architecture, degradation modes, and design rationale.
+>
+> | Related doc | Role |
+> |---|---|
+> | [TROUBLESHOOTING_CACHE.md](TROUBLESHOOTING_CACHE.md) | Debugging guide -- diagnose misses, inspect keys, read metrics |
+> | [runbooks/REDIS_CACHE_DEGRADATION.md](runbooks/REDIS_CACHE_DEGRADATION.md) | Incident runbook -- operator response when Redis service fails |
+
 Multi-tier semantic caching with graceful degradation when cache fails.
 
 ## Cache Tiers
 
-### Tier 1: Embeddings Cache (RedisVL)
-- **Purpose:** Skip re-encoding of repeated queries
-- **Index:** `embeddings:v5`
-- **TTL:** 7 days
-- **Lookup:** Query text → cached embedding vector
+`CacheLayerManager` in [`telegram_bot/integrations/cache.py`](../telegram_bot/integrations/cache.py)
+implements five cache tiers plus a conversation store:
 
-### Tier 2: Semantic Result Cache (RedisVL)
-- **Purpose:** Skip retrieval + generation for similar queries
-- **Index:** `sem:v8:bge1024`
-- **Threshold:** Varies by query type (see below)
-- **TTL:** Per query type (configurable)
+| # | Tier | Backend | Index / Key pattern | TTL |
+|---|------|---------|---------------------|-----|
+| 1 | Semantic | RedisVL SemanticCache | `sem:v8:bge1024` | Per query type |
+| 2 | Embeddings | RedisVL EmbeddingsCache | `embeddings:v5` | 7 days |
+| 3 | Sparse | Redis exact (SET/GET) | `sparse:v5:{hash}` | 7 days |
+| 4 | Search | Redis exact (SET/GET) | `search:v5:{hash}` | 2 hours |
+| 5 | Rerank | Redis exact (SET/GET) | `rerank:v5:{hash}` | 2 hours |
+| 6 | Conversation | Redis LIST | `conversation:{user_id}` | 2 hours (20 msgs) |
+
+The EmbeddingsCache (tier 2) also stores BGE-M3 query bundles (dense + sparse +
+ColBERT as metadata in the same payload). This is an app-level optimization;
+retrieval remains in Qdrant.
+
+Version constants in source:
+
+```
+CACHE_VERSION = "v5"            # exact cache key prefix
+SEMANTIC_CACHE_VERSION = "v8"   # semantic cache index prefix
+```
 
 ## Per-Query-Type Thresholds
 
-| Query Type | Distance Threshold | Rationale |
-|------------|-------------------|-----------|
-| `FAQ` | 0.12 | High precision required |
-| `ENTITY` | 0.10 | Entity/history-style specificity |
-| `GENERAL` | 0.08 | Balanced |
-| `STRUCTURED` | 0.05 | Most specific; strictest reuse |
+| Query Type | Distance Threshold | TTL | Rationale |
+|------------|-------------------|-----|-----------|
+| `FAQ` | 0.12 | 24 h | High precision required |
+| `ENTITY` | 0.10 | 1 h | Entity/history-style specificity |
+| `GENERAL` | 0.08 | 1 h | Balanced |
+| `STRUCTURED` | 0.05 | 2 h | Most specific; strictest reuse |
 
-**Note:** Semantic thresholds are RedisVL vector-distance cutoffs; lower values
-are stricter. The separate store guard still uses `grade_confidence` on the RRF
-scale.
+Semantic thresholds are RedisVL vector-distance cutoffs; lower values are
+stricter. The separate store guard uses `grade_confidence` on the RRF scale
+(see [TROUBLESHOOTING_CACHE.md](TROUBLESHOOTING_CACHE.md) for common confusion).
 
-`CHITCHAT` and `OFF_TOPIC` are not RAG cacheable query types. Structured catalog search
-uses separate catalog tooling and should not be documented as a semantic
-response-cache type unless the runtime policy changes.
+`CHITCHAT` and `OFF_TOPIC` are not RAG-cacheable query types. Structured catalog
+search uses separate catalog tooling.
 
 ## Degradation Modes
 
 ### Mode 1: Cache Unavailable (Redis Down)
-- Embeddings cache miss → re-encode
-- Semantic cache miss → proceed without caching
+
+- Embeddings cache miss: re-encode via BGE-M3 service
+- Semantic cache miss: proceed without caching
 - **User impact:** Slower response, no cache benefits
 - **Monitoring:** `cache_errors` metric
 
 ### Mode 2: Embedding Service Down
-- Cannot compute embedding → bypass cache lookup
+
+- Cannot compute embedding: bypass cache lookup
 - Proceed to full retrieval pipeline
 - **User impact:** Full latency, no cache hit possible
 
 ### Mode 3: Qdrant Unavailable
-- Cache hit → attempt to use cached response
-- Cache miss → fail with error
+
+- Cache hit: attempt to use cached response
+- Cache miss: fail with error
 - **User impact:** Degraded quality if cache miss
 
 ## Cache Key Structure
 
 ```
-# Embeddings cache
-Index: embeddings:v5
-Schema: text (str), embedding (dense[1024])
-
-# Semantic result cache
+# Semantic result cache (RedisVL SemanticCache)
 Index: sem:v8:bge1024
 Schema: query_text, query_type, language, response, sources, metadata
+Filterable: query_type, language, user_id, cache_scope, agent_role,
+            grounding_mode, filter_signature, semantic_cache_safe_reuse,
+            response_state, cache_eligible, schema_version
+
+# Embeddings cache (RedisVL EmbeddingsCache)
+Index: embeddings:v5
+Schema: text (content), embedding (dense[1024])
 ```
 
 ## Cache Scope
 
-There is no explicit runtime bypass scope. RAG semantic-cache checks and stores
-use `cache_scope="rag"`; history lookups use `cache_scope="history"`.
-`CHITCHAT` and `OFF_TOPIC` skip the RAG path before semantic cache lookup.
-
-## Monitoring
-
-| Metric | Description |
-|--------|-------------|
-| `cache_hit_total` | Total cache hits by type |
-| `cache_miss_total` | Total cache misses by type |
-| `cache_error_total` | Cache errors by tier |
-| `cache_latency_ms` | Cache operation latency |
+RAG semantic-cache checks and stores use `cache_scope="rag"`; history lookups
+use `cache_scope="history"`. `CHITCHAT` and `OFF_TOPIC` skip the RAG path before
+semantic cache lookup.
 
 ## Configuration
 
 Environment variables:
-- `REDIS_PASSWORD` — Redis auth (required)
-- `CACHE_TTL_DEFAULT` — Default TTL in seconds
-- `CACHE_EMBEDDING_TTL` — Embeddings cache TTL (default: 604800 = 7 days)
 
-## Code Locations
+| Variable | Purpose |
+|----------|---------|
+| `REDIS_PASSWORD` | Redis auth (required) |
+| `CACHE_TTL_DEFAULT` | Default TTL in seconds |
+| `CACHE_EMBEDDING_TTL` | Embeddings cache TTL (default: 604800 = 7 days) |
+
+## Source of Truth
 
 | File | Purpose |
 |------|---------|
-| `telegram_bot/integrations/cache.py` | CacheLayerManager |
-| `telegram_bot/services/cache_policy.py` | Cacheability decisions |
-| `telegram_bot/graph/nodes/cache.py` | Graph cache lookup/store nodes |
-| `telegram_bot/pipelines/client.py` | Client direct cache lookup/store flow |
+| [`telegram_bot/integrations/cache.py`](../telegram_bot/integrations/cache.py) | CacheLayerManager (tier implementations, versions, TTLs) |
+| [`telegram_bot/services/cache_policy.py`](../telegram_bot/services/cache_policy.py) | Cacheability decisions |
+| [`telegram_bot/graph/nodes/cache.py`](../telegram_bot/graph/nodes/cache.py) | Graph cache lookup/store nodes |
+| [`telegram_bot/pipelines/client.py`](../telegram_bot/pipelines/client.py) | Client direct cache lookup/store flow |

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,7 @@ For fast orientation by goal rather than by subsystem, see [`indexes/`](indexes/
 - [`GDRIVE_INGESTION.md`](GDRIVE_INGESTION.md) — Google Drive sync runbook.
 - [`QDRANT_STACK.md`](QDRANT_STACK.md) — Vector collections, schema, and operations.
 - [`ALERTING.md`](ALERTING.md) — Loki/Alertmanager setup.
-- [`TROUBLESHOOTING_CACHE.md`](TROUBLESHOOTING_CACHE.md) — Cache troubleshooting guide.
+- [`TROUBLESHOOTING_CACHE.md`](TROUBLESHOOTING_CACHE.md) — Cache debugging guide (diagnose misses, inspect keys, metrics).
 - [`runbooks/`](runbooks/) — Incident-specific runbooks.
 
 ## Quality & Evaluation
@@ -73,7 +73,7 @@ For fast orientation by goal rather than by subsystem, see [`indexes/`](indexes/
 - [`ERROR_RESPONSES.md`](ERROR_RESPONSES.md) — Error response taxonomy.
 - [`HITL.md`](HITL.md) — Human-in-the-loop design.
 - [`HITL_CRM_FLOW.md`](HITL_CRM_FLOW.md) — CRM-specific HITL flow.
-- [`CACHE_DEGRADATION.md`](CACHE_DEGRADATION.md) — Cache failure modes.
+- [`CACHE_DEGRADATION.md`](CACHE_DEGRADATION.md) — Cache tier design and degradation behaviour.
 - [`CLIENT_PIPELINE.md`](CLIENT_PIPELINE.md) — Client pipeline details.
 
 ## Fast Doc Search

--- a/docs/TROUBLESHOOTING_CACHE.md
+++ b/docs/TROUBLESHOOTING_CACHE.md
@@ -1,18 +1,16 @@
 # Troubleshooting: Semantic Cache
 
-The semantic cache is a multi-tier system (`CacheLayerManager` in `telegram_bot/integrations/cache.py`). This guide helps debug cache behavior.
+> **Role:** Debugging guide -- diagnose cache misses, inspect keys, read metrics, and resolve staleness.
+>
+> | Related doc | Role |
+> |---|---|
+> | [CACHE_DEGRADATION.md](CACHE_DEGRADATION.md) | Design behaviour -- tier architecture, degradation modes, thresholds |
+> | [runbooks/REDIS_CACHE_DEGRADATION.md](runbooks/REDIS_CACHE_DEGRADATION.md) | Incident runbook -- operator response when Redis service fails |
 
-## Cache Architecture
-
-The `CacheLayerManager` implements 5 cache tiers:
-
-| Tier | Type | TTL | Purpose |
-|------|------|-----|---------|
-| Semantic | RedisVL SemanticCache | Query-type dependent | LLM response caching |
-| Embeddings | RedisVL EmbeddingsCache | 7 days | Dense embedding cache |
-| Sparse | Redis exact | 7 days | Sparse embedding cache |
-| Search | Redis exact | 2 hours | Search results cache |
-| Rerank | Redis exact | 2 hours | Reranked results cache |
+This guide helps debug cache behavior in `CacheLayerManager`
+([`telegram_bot/integrations/cache.py`](../telegram_bot/integrations/cache.py)).
+For tier design and degradation modes, see
+[CACHE_DEGRADATION.md](CACHE_DEGRADATION.md).
 
 ## Common Issues
 
@@ -24,53 +22,62 @@ The `CacheLayerManager` implements 5 cache tiers:
 
 #### RRF Scale vs Cosine Similarity Confusion
 
-The `grade_confidence` threshold uses **RRF scale** (~0.0006 to 0.016), NOT cosine similarity [0-1].
+The `grade_confidence` threshold uses **RRF scale** (~0.0006 to 0.016), NOT
+cosine similarity [0-1].
 
 The store guard in `pipelines/client.py` requires:
+
 ```python
 grade_confidence >= config.relevance_threshold_rrf  # Default: 0.005
 ```
 
-If your threshold is set to `0.8` thinking it's cosine similarity, nothing will store.
+If your threshold is set to `0.8` thinking it is cosine similarity, nothing will
+store.
 
 **Fix:** Use RRF scale thresholds. A good starting point is `0.005`.
 
 #### Cache Key Versioning
 
 Each tier has a version prefix:
-- `sem:v8:` / index `sem:v8:bge1024` — Semantic cache
-- `embeddings:v5:` — Embeddings
-- `sparse:v5:` — Sparse embeddings
-- `search:v5:` — Search results
+
+- `sem:v8:` / index `sem:v8:bge1024` -- Semantic cache
+- `embeddings:v5` -- Embeddings (RedisVL EmbeddingsCache)
+- `sparse:v5:` -- Sparse embeddings
+- `search:v5:` -- Search results
+- `rerank:v5:` -- Reranked results
 
 When models change, bump the version in `integrations/cache.py`:
+
 ```python
 CACHE_VERSION = "v5"  # Bump to invalidate exact caches
 SEMANTIC_CACHE_VERSION = "v8"  # Bump for semantic cache
 ```
 
+For full tier design details, see
+[CACHE_DEGRADATION.md - Cache Tiers](CACHE_DEGRADATION.md#cache-tiers).
+
 ### 2. How to Verify Cache is Being Checked
 
 Check Langfuse traces for `cache-semantic-check` span:
 
-```python
-# In Langfuse UI:
-# 1. Find your trace
-# 2. Look for "cache-semantic-check" span
-# 3. Check output fields:
-#    - hit: true/false
-#    - distance: actual RRF distance (lower = better match)
-#    - threshold: configured threshold
+```
+In Langfuse UI:
+1. Find your trace
+2. Look for "cache-semantic-check" span
+3. Check output fields:
+   - hit: true/false
+   - distance: actual vector distance (lower = better match)
+   - threshold: configured threshold
 ```
 
 Or check bot logs for cache hit/miss:
 
-```python
+```
 # Cache hit log:
-logger.info("Semantic HIT (%.0fms, dist=%.3f, threshold=%.2f, type=%s)", ...)
+Semantic HIT (Xms, dist=Y, threshold=Z, type=T)
 
 # Cache miss log:
-logger.debug("Semantic MISS (%.0fms, type=%s)", ...)
+Semantic MISS (Xms, type=T)
 ```
 
 ### 3. Multi-Tier Cache Debugging
@@ -95,17 +102,16 @@ stats = cache.get_metrics()
 redis-cli -p 6379 -a "$REDIS_PASSWORD"
 
 # Check semantic cache keys
-KEYS sem:v8:*
+SCAN 0 MATCH "sem:v8:bge1024:*" COUNT 100
 
 # Check embedding cache
-KEYS embeddings:v5:*
+SCAN 0 MATCH "embeddings:v5:*" COUNT 100
 
 # Check search cache
-KEYS search:v5:*
-
-# Inspect a semantic cache entry
-GET "sem:v8:bge1024:somekey"
+SCAN 0 MATCH "search:v5:*" COUNT 100
 ```
+
+> **Avoid `KEYS *`** in production or large keyspaces. Use `SCAN` instead.
 
 ## Cache Poisoning / Staleness
 
@@ -119,19 +125,8 @@ GET "sem:v8:bge1024:somekey"
 
 ### Manual Cache Clear
 
-```python
-# Clear specific tier
-await cache.clear_by_tier("embeddings")
-
-# Clear semantic cache
-await cache.clear_semantic_cache()
-
-# Clear all tiers
-results = await cache.clear_all_caches()
-# Returns: {"semantic": N, "embeddings": N, "sparse": N, ...}
-```
-
-Or via bot command: `/clearcache`
+For cache clear commands and procedures (programmatic, CLI, and bot command),
+see [runbooks/REDIS_CACHE_DEGRADATION.md - Cache Corruption or Version Drift](runbooks/REDIS_CACHE_DEGRADATION.md#cache-corruption-or-version-drift).
 
 ## Cache vs Query Type Mapping
 
@@ -147,17 +142,13 @@ _SEMANTIC_CACHEABLE_QUERY_TYPES = {"FAQ", "GENERAL", "ENTITY", "STRUCTURED"}
 
 | Query Pattern | Reason |
 |---------------|--------|
-| Contextual follow-ups ("подробнее"/"more details", "первый"/"the first one", "это"/"this", "ещё"/"more") | Different context |
-| CHITCHAT/OFF_TOPIC | Not RAG queries |
+| Contextual follow-ups ("more details", "the first one", "this") | Different context |
+| CHITCHAT / OFF_TOPIC | Not RAG queries |
 
-### Cache Thresholds by Query Type
+### Cache Thresholds and TTLs by Query Type
 
-| Query Type | Distance Threshold | TTL |
-|------------|-------------------|-----|
-| FAQ | 0.12 | 24h |
-| ENTITY | 0.10 | 1h |
-| GENERAL | 0.08 | 1h |
-| STRUCTURED | 0.05 | 2h |
+See the authoritative table in
+[CACHE_DEGRADATION.md - Per-Query-Type Thresholds](CACHE_DEGRADATION.md#per-query-type-thresholds).
 
 ## Metrics and Monitoring
 
@@ -168,6 +159,7 @@ Shows p50/p95 pipeline timing including cache performance.
 ### Langfuse Score: semantic_cache_hit
 
 Track over time:
+
 ```sql
 SELECT
   date_trunc('hour', timestamp),

--- a/docs/runbooks/REDIS_CACHE_DEGRADATION.md
+++ b/docs/runbooks/REDIS_CACHE_DEGRADATION.md
@@ -1,5 +1,12 @@
 # Runbook: Redis Cache Degradation
 
+> **Role:** Incident runbook -- operator response when Redis cache service fails or degrades.
+>
+> | Related doc | Role |
+> |---|---|
+> | [CACHE_DEGRADATION.md](../CACHE_DEGRADATION.md) | Design behaviour -- tier architecture, degradation modes, thresholds |
+> | [TROUBLESHOOTING_CACHE.md](../TROUBLESHOOTING_CACHE.md) | Debugging guide -- diagnose misses, inspect keys, read metrics |
+
 > **Owner:** Retrieval & Cache subsystems
 > **Last verified:** 2026-05-12
 > **Verification command:**
@@ -34,11 +41,19 @@ Use this runbook when Redis cache issues affect RAG performance.
 
 ## Cache Tiers in the App
 
-- RedisVL **SemanticCache**: `sem:v8:bge1024`
-- RedisVL **EmbeddingsCache**: `embeddings:v5` (dense vectors and BGE-M3 query-bundle payload)
-- Exact async Redis caches (redis-py): `embeddings`, `sparse`, `search`, `rerank`, and `conversation`/state keys (`conversation:<user_id>`)
+For full tier design and degradation modes, see
+[CACHE_DEGRADATION.md](../CACHE_DEGRADATION.md#cache-tiers).
 
-BGE-M3 query-bundle optimization uses **RedisVL EmbeddingsCache** for dense vectors and stores sparse/ColBERT parts as metadata in the same payload. It is still an app-level cache optimization; retrieval remains in Qdrant.
+Key patterns for operator inspection:
+
+| Tier | Key pattern | Backend |
+|------|-------------|---------|
+| Semantic | `sem:v8:bge1024` | RedisVL SemanticCache |
+| Embeddings | `embeddings:v5` | RedisVL EmbeddingsCache |
+| Sparse | `sparse:v5:{hash}` | Redis exact |
+| Search | `search:v5:{hash}` | Redis exact |
+| Rerank | `rerank:v5:{hash}` | Redis exact |
+| Conversation | `conversation:{user_id}` | Redis LIST |
 
 ## Fast-Path Diagnosis (read-only)
 
@@ -99,9 +114,9 @@ Check for:
 | `redis-cli ping` works, but bot logs show `Connection refused` | App bug | Verify `REDIS_URL` in bot env; check password encoding |
 | Bot preflight shows `invalid username-password pair` / `WRONGPASS` / `NOAUTH` after local `.env` edit | Local auth drift | Run `make local-redis-recreate`, then `make test-bot-health` |
 | Redis memory is near limit and `evicted_keys` is rising | Service failure / capacity | Scale `maxmemory` or reduce TTL; see Remediation |
-| Cache hit rate is 0% but Redis is healthy and has keys | App bug | Check semantic cache threshold, query_type mapping, or `CACHE_VERSION` drift in `telegram_bot/integrations/cache.py` |
-| High latency **with** cache hits | App bug | Profile embedding or rerank tiers; latency may be upstream of Redis |
-| Only specific tiers miss (e.g. `search` hits, `semantic` misses) | App bug | Inspect tier-specific TTLs and `distance_threshold` in source |
+| Cache hit rate is 0% but Redis is healthy and has keys | App bug | See [TROUBLESHOOTING_CACHE.md](../TROUBLESHOOTING_CACHE.md) for threshold, query_type, and `CACHE_VERSION` debugging |
+| High latency **with** cache hits | App bug | Profile embedding or rerank tiers; see [TROUBLESHOOTING_CACHE.md](../TROUBLESHOOTING_CACHE.md) |
+| Only specific tiers miss (e.g. `search` hits, `semantic` misses) | App bug | Inspect tier-specific TTLs and `distance_threshold`; see [TROUBLESHOOTING_CACHE.md](../TROUBLESHOOTING_CACHE.md) |
 
 ### Cache Smoke Validation (for cache-hit health)
 
@@ -219,6 +234,8 @@ The system degrades gracefully — users still get responses, just without cache
 
 ## See Also
 
+- [Cache Degradation Behavior (design)](../CACHE_DEGRADATION.md)
+- [Troubleshooting: Semantic Cache (debugging)](../TROUBLESHOOTING_CACHE.md)
 - [Qdrant Troubleshooting](QDRANT_TROUBLESHOOTING.md)
 - [VPS Google Drive Ingestion Recovery](vps-gdrive-ingestion-recovery.md)
 - [Docker Services Reference](../../DOCKER.md)


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Resolves #1954. Deduplicates the three cache degradation/troubleshooting docs by establishing clear role boundaries and replacing duplicated content with cross-links.

### Boundary Definition

| Doc | Role |
|-----|------|
| `docs/CACHE_DEGRADATION.md` | **Design behaviour** - tier architecture, degradation modes, thresholds, rationale |
| `docs/TROUBLESHOOTING_CACHE.md` | **Debugging guide** - diagnose misses, inspect keys, read metrics |
| `docs/runbooks/REDIS_CACHE_DEGRADATION.md` | **Incident runbook** - operator response when Redis service fails |

### Changes

- **Top-of-file navigation**: Each doc now has a cross-link table at the top pointing to the other two with role labels.
- **Removed duplication**: Duplicated tier tables, threshold tables, and cache-clear procedures replaced with links to the authoritative location.
- **Tier name verification**: All tier names verified against `telegram_bot/integrations/cache.py` (`CacheLayerManager`): `sem:v8:bge1024`, `embeddings:v5`, `sparse:v5:{hash}`, `search:v5:{hash}`, `rerank:v5:{hash}`, `conversation:{user_id}`.
- **docs/README.md**: Updated one-line descriptions to distinguish each doc's role.
- **SCAN over KEYS**: Switched unsafe `KEYS *` examples to `SCAN` in troubleshooting doc.

### Verification

- `scripts/check_markdown_links.py` exits 0 (all relative links valid)
- No code changes - docs only
- 4 files modified: +145 / -119 lines

### Acceptance Criteria

- [x] Boundary defined (design behaviour / debugging guide / incident runbook)
- [x] Duplicated step-by-step content removed; cross-links added
- [x] Top-of-file note in each doc pointing at the other two
- [x] Cache tier names verified against source (`CacheLayerManager`)
- [x] `scripts/check_markdown_links.py` clean