### PR TITLE
docs(runbooks): coverage gap audit and index refresh

### DIFF
--- a/docs/runbooks/COVERAGE_MATRIX.md
+++ b/docs/runbooks/COVERAGE_MATRIX.md
@@ -1,0 +1,151 @@
+# Alert-to-Runbook Coverage Matrix
+
+Maps every alert from `docker/monitoring/rules/*.yaml` to its resolution status.
+
+**Legend**
+
+| Status | Meaning |
+|--------|---------|
+| covered | Alert maps directly to an existing runbook addressing its symptoms and resolution |
+| gap-accepted | Alert is low-priority or its impact is already addressed by an adjacent runbook |
+| gap-to-fill | No existing runbook covers this alert class; a new runbook is needed |
+
+---
+
+## telegram-bot.yaml - Service: bot
+
+| Alert Name | Severity | Service | Runbook | Status | Notes |
+|------------|----------|---------|---------|--------|-------|
+| BotContainerDown | critical | bot | TELEGRAM_BOT_FAILURE.md | gap-to-fill | New runbook needed |
+| BotHighErrorRate | warning | bot | TELEGRAM_BOT_FAILURE.md | gap-to-fill | New runbook needed |
+| BotCriticalError | critical | bot | TELEGRAM_BOT_FAILURE.md | gap-to-fill | New runbook needed |
+| TelegramAPIError | warning | bot | TELEGRAM_BOT_FAILURE.md | gap-to-fill | New runbook needed |
+| BotRestarted | info | bot | TELEGRAM_BOT_FAILURE.md | gap-to-fill | New runbook needed |
+| QueryProcessingError | warning | bot | TELEGRAM_BOT_FAILURE.md | gap-to-fill | New runbook needed |
+| LLMGenerationError | warning | bot | [LITEllm_FAILURE.md](LITEllm_FAILURE.md) | covered | LLM proxy runbook covers generation errors |
+| CacheError | warning | bot | [REDIS_CACHE_DEGRADATION.md](REDIS_CACHE_DEGRADATION.md) | covered | Redis runbook covers cache errors |
+| SlowBotResponse | warning | bot | TELEGRAM_BOT_FAILURE.md | gap-to-fill | New runbook needed |
+| BotMemoryWarning | warning | bot | TELEGRAM_BOT_FAILURE.md | gap-to-fill | New runbook needed |
+
+## infrastructure.yaml - Service: qdrant
+
+| Alert Name | Severity | Service | Runbook | Status | Notes |
+|------------|----------|---------|---------|--------|-------|
+| QdrantDown | critical | qdrant | [QDRANT_TROUBLESHOOTING.md](QDRANT_TROUBLESHOOTING.md) | covered | |
+| QdrantError | warning | qdrant | [QDRANT_TROUBLESHOOTING.md](QDRANT_TROUBLESHOOTING.md) | covered | |
+| QdrantSlowQuery | warning | qdrant | [QDRANT_TROUBLESHOOTING.md](QDRANT_TROUBLESHOOTING.md) | covered | |
+
+## infrastructure.yaml - Service: redis
+
+| Alert Name | Severity | Service | Runbook | Status | Notes |
+|------------|----------|---------|---------|--------|-------|
+| RedisDown | critical | redis | [REDIS_CACHE_DEGRADATION.md](REDIS_CACHE_DEGRADATION.md) | covered | |
+| RedisMemoryWarning | warning | redis | [REDIS_CACHE_DEGRADATION.md](REDIS_CACHE_DEGRADATION.md) | covered | |
+| RedisConnectionError | warning | redis | [REDIS_CACHE_DEGRADATION.md](REDIS_CACHE_DEGRADATION.md) | covered | |
+
+## infrastructure.yaml - Service: litellm
+
+| Alert Name | Severity | Service | Runbook | Status | Notes |
+|------------|----------|---------|---------|--------|-------|
+| LiteLLMDown | critical | litellm | [LITEllm_FAILURE.md](LITEllm_FAILURE.md) | covered | |
+| LiteLLMRateLimited | warning | litellm | [LITEllm_FAILURE.md](LITEllm_FAILURE.md) | covered | |
+| LiteLLMProviderError | warning | litellm | [LITEllm_FAILURE.md](LITEllm_FAILURE.md) | covered | |
+| LiteLLMFallbackTriggered | info | litellm | [LITEllm_FAILURE.md](LITEllm_FAILURE.md) | covered | |
+
+## infrastructure.yaml - Service: langfuse
+
+| Alert Name | Severity | Service | Runbook | Status | Notes |
+|------------|----------|---------|---------|--------|-------|
+| LangfuseDown | warning | langfuse | [LANGFUSE_TRACING_GAPS.md](LANGFUSE_TRACING_GAPS.md) | covered | |
+| LangfuseWorkerDown | warning | langfuse | [LANGFUSE_TRACING_GAPS.md](LANGFUSE_TRACING_GAPS.md) | covered | |
+| LangfuseError | warning | langfuse | [LANGFUSE_TRACING_GAPS.md](LANGFUSE_TRACING_GAPS.md) | covered | |
+
+## infrastructure.yaml - Service: bge-m3 / embeddings
+
+| Alert Name | Severity | Service | Runbook | Status | Notes |
+|------------|----------|---------|---------|--------|-------|
+| BGEServiceDown | warning | bge-m3 | EMBEDDING_SERVICE_FAILURE.md | gap-to-fill | New runbook needed |
+| BM42ServiceDown | warning | bm42 | EMBEDDING_SERVICE_FAILURE.md | gap-to-fill | New runbook needed |
+| EmbeddingServiceError | warning | embeddings | EMBEDDING_SERVICE_FAILURE.md | gap-to-fill | New runbook needed |
+| BGEEmbedRetryFromBot | warning | bge-m3 | EMBEDDING_SERVICE_FAILURE.md | gap-to-fill | New runbook needed |
+| BGEEmbedErrorFromBot | critical | bge-m3 | EMBEDDING_SERVICE_FAILURE.md | gap-to-fill | New runbook needed |
+
+## infrastructure.yaml - Service: postgres
+
+| Alert Name | Severity | Service | Runbook | Status | Notes |
+|------------|----------|---------|---------|--------|-------|
+| PostgresDown | critical | postgres | [POSTGRESQL_WAL_RECOVERY.md](POSTGRESQL_WAL_RECOVERY.md) | covered | |
+| PostgresError | warning | postgres | [POSTGRESQL_WAL_RECOVERY.md](POSTGRESQL_WAL_RECOVERY.md) | covered | |
+
+## infrastructure.yaml - Service: clickhouse
+
+| Alert Name | Severity | Service | Runbook | Status | Notes |
+|------------|----------|---------|---------|--------|-------|
+| ClickHouseDown | warning | clickhouse | [LANGFUSE_TRACING_GAPS.md](LANGFUSE_TRACING_GAPS.md) | gap-accepted | ClickHouse only backs Langfuse analytics; Langfuse runbook covers upstream impact |
+
+## extended-services.yaml - Service: docling
+
+| Alert Name | Severity | Service | Runbook | Status | Notes |
+|------------|----------|---------|---------|--------|-------|
+| DoclingDown | critical | docling | DOCLING_FAILURE.md | gap-to-fill | New runbook needed |
+| DoclingOOM | critical | docling | DOCLING_FAILURE.md | gap-to-fill | New runbook needed |
+| DoclingConversionFailed | warning | docling | DOCLING_FAILURE.md | gap-to-fill | New runbook needed |
+| DoclingError | warning | docling | DOCLING_FAILURE.md | gap-to-fill | New runbook needed |
+
+## extended-services.yaml - Service: minio
+
+| Alert Name | Severity | Service | Runbook | Status | Notes |
+|------------|----------|---------|---------|--------|-------|
+| MinioDown | critical | minio | MINIO_FAILURE.md | gap-to-fill | New runbook needed |
+| MinioDiskFull | critical | minio | MINIO_FAILURE.md | gap-to-fill | New runbook needed |
+| MinioCorruption | critical | minio | MINIO_FAILURE.md | gap-to-fill | New runbook needed |
+| MinioHealingFailed | warning | minio | MINIO_FAILURE.md | gap-to-fill | New runbook needed |
+| MinioError | warning | minio | MINIO_FAILURE.md | gap-to-fill | New runbook needed |
+
+## extended-services.yaml - Service: redis-langfuse
+
+| Alert Name | Severity | Service | Runbook | Status | Notes |
+|------------|----------|---------|---------|--------|-------|
+| RedisLangfuseDown | critical | redis-langfuse | [LANGFUSE_TRACING_GAPS.md](LANGFUSE_TRACING_GAPS.md) | gap-accepted | Langfuse-internal Redis; impact covered by Langfuse runbook |
+| RedisLangfuseConnectionError | critical | redis-langfuse | [LANGFUSE_TRACING_GAPS.md](LANGFUSE_TRACING_GAPS.md) | gap-accepted | Langfuse-internal Redis; impact covered by Langfuse runbook |
+| RedisLangfuseMemory | warning | redis-langfuse | [LANGFUSE_TRACING_GAPS.md](LANGFUSE_TRACING_GAPS.md) | gap-accepted | Langfuse-internal Redis; impact covered by Langfuse runbook |
+
+## extended-services.yaml - Service: lightrag
+
+| Alert Name | Severity | Service | Runbook | Status | Notes |
+|------------|----------|---------|---------|--------|-------|
+| LightRAGDown | critical | lightrag | LIGHTRAG_FAILURE.md | gap-to-fill | New runbook needed |
+| LightRAGError | warning | lightrag | LIGHTRAG_FAILURE.md | gap-to-fill | New runbook needed |
+| LightRAGAPIError | warning | lightrag | LIGHTRAG_FAILURE.md | gap-to-fill | New runbook needed |
+
+## ingestion.yaml - Service: ingestion
+
+| Alert Name | Severity | Service | Runbook | Status | Notes |
+|------------|----------|---------|---------|--------|-------|
+| IngestionPipelineStalled | warning | ingestion | [vps-gdrive-ingestion-recovery.md](vps-gdrive-ingestion-recovery.md) | covered | |
+| IngestionHighFailureRate | warning | ingestion | [vps-gdrive-ingestion-recovery.md](vps-gdrive-ingestion-recovery.md) | covered | |
+| IngestionDLQGrowing | warning | ingestion | [vps-gdrive-ingestion-recovery.md](vps-gdrive-ingestion-recovery.md) | covered | |
+| DoclingErrors | warning | ingestion | [vps-gdrive-ingestion-recovery.md](vps-gdrive-ingestion-recovery.md) | covered | Also gap-to-fill for service-level in DOCLING_FAILURE.md |
+| VoyageRateLimited | warning | ingestion | EMBEDDING_SERVICE_FAILURE.md | gap-to-fill | New embedding service runbook will cover Voyage rate limiting |
+| IngestionContainerDown | critical | ingestion | [vps-gdrive-ingestion-recovery.md](vps-gdrive-ingestion-recovery.md) | covered | |
+
+---
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| **Total alerts** | 52 |
+| **Covered** | 22 |
+| **Gap-accepted** | 4 |
+| **Gap-to-fill** | 26 |
+
+### New runbooks needed
+
+| Runbook | Alerts covered |
+|---------|---------------|
+| `TELEGRAM_BOT_FAILURE.md` | BotContainerDown, BotHighErrorRate, BotCriticalError, TelegramAPIError, BotRestarted, QueryProcessingError, SlowBotResponse, BotMemoryWarning |
+| `EMBEDDING_SERVICE_FAILURE.md` | BGEServiceDown, BM42ServiceDown, EmbeddingServiceError, BGEEmbedRetryFromBot, BGEEmbedErrorFromBot, VoyageRateLimited |
+| `DOCLING_FAILURE.md` | DoclingDown, DoclingOOM, DoclingConversionFailed, DoclingError |
+| `MINIO_FAILURE.md` | MinioDown, MinioDiskFull, MinioCorruption, MinioHealingFailed, MinioError |
+| `LIGHTRAG_FAILURE.md` | LightRAGDown, LightRAGError, LightRAGAPIError |

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,62 +1,23 @@
-# Operational Runbooks Index
+# Operational Runbooks
 
-Operator entrypoint for container/service investigations and incident response. If a Docker service breaks, start here before ad hoc log searching.
+Operator entrypoint for incident response and service investigations. Start here when an alert fires or a service misbehaves.
 
-## Quick Access
+## Runbook Index
 
-| Operator request | First command / doc |
-|---|---|
-| Remote Docker workflow (SSH, Colima, env sync, bot container) | See Docker runbook below |
-| Native Git/GitHub hygiene | [`GIT_PR_ISSUE_NATIVE.md`](GIT_PR_ISSUE_NATIVE.md) |
-| Recent Langfuse traces (Russian: "изучи последние трейсы") | `make validate-traces-fast` → [`LANGFUSE_TRACING_GAPS.md`](LANGFUSE_TRACING_GAPS.md) |
-| Qdrant health / query / index issues (Russian: "изучи последние qdrant запросы") | `curl -fsS http://localhost:6333/readyz` → [`QDRANT_TROUBLESHOOTING.md`](QDRANT_TROUBLESHOOTING.md) |
-| Redis / cache degradation (Russian: "сломался redis") | `COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec redis sh -lc 'redis-cli -a "$REDIS_PASSWORD" ping'` → [`REDIS_CACHE_DEGRADATION.md`](REDIS_CACHE_DEGRADATION.md) |
-| LiteLLM / provider failure (Russian: "сломался litellm") | `curl -s http://localhost:4000/health` → [`LITEllm_FAILURE.md`](LITEllm_FAILURE.md) |
-| Compose service health | `make docker-ps` → [`DOCKER.md`](../../DOCKER.md) |
-| Self-hosted runner offline / nightly-heavy queued | `scripts/check_self_hosted_runner.sh` → [`SELF_HOSTED_RUNNER.md`](SELF_HOSTED_RUNNER.md) |
+| Runbook | Scope | Description |
+|---------|-------|-------------|
+| [GIT_PR_ISSUE_NATIVE.md](GIT_PR_ISSUE_NATIVE.md) | Git / GitHub | Branch, PR, issue, and worktree hygiene |
+| [LANGFUSE_TRACING_GAPS.md](LANGFUSE_TRACING_GAPS.md) | Observability | Langfuse missing traces, spans, and scores |
+| [LITEllm_FAILURE.md](LITEllm_FAILURE.md) | LLM Proxy | LiteLLM proxy outages, provider errors, fallback routing |
+| [POSTGRESQL_WAL_RECOVERY.md](POSTGRESQL_WAL_RECOVERY.md) | Database | PostgreSQL WAL corruption and recovery procedures |
+| [QDRANT_TROUBLESHOOTING.md](QDRANT_TROUBLESHOOTING.md) | Vector DB | Qdrant health, collections, and query issues |
+| [REDIS_CACHE_DEGRADATION.md](REDIS_CACHE_DEGRADATION.md) | Cache | Redis cache misses, eviction, and connection failures |
+| [SELF_HOSTED_RUNNER.md](SELF_HOSTED_RUNNER.md) | CI/CD | GitHub Actions self-hosted runner for nightly-heavy CI |
+| [vps-gdrive-ingestion-recovery.md](vps-gdrive-ingestion-recovery.md) | Ingestion | VPS ingestion pipeline and Google Drive sync recovery |
 
-## Start Here
+## Coverage & Gaps
 
-| Symptom / Request | Runbook |
-|---|---|
-| Remote Docker workflow (SSH, Colima, env sync, bot container) | See Docker runbook below |
-| Git/GitHub branch, PR, issue, worktree, and stash hygiene | [`GIT_PR_ISSUE_NATIVE.md`](GIT_PR_ISSUE_NATIVE.md) |
-| Langfuse traces missing, gaps, or drift | [`LANGFUSE_TRACING_GAPS.md`](LANGFUSE_TRACING_GAPS.md) |
-| LiteLLM / LLM connection failures or proxy errors | [`LITEllm_FAILURE.md`](LITEllm_FAILURE.md) |
-| Redis cache degradation, eviction, or latency | [`REDIS_CACHE_DEGRADATION.md`](REDIS_CACHE_DEGRADATION.md) |
-| Qdrant health, collection, or vector search issues | [`QDRANT_TROUBLESHOOTING.md`](QDRANT_TROUBLESHOOTING.md) |
-| Postgres WAL recovery or replication issues | [`POSTGRESQL_WAL_RECOVERY.md`](POSTGRESQL_WAL_RECOVERY.md) |
-| VPS / Google Drive ingestion recovery | [`vps-gdrive-ingestion-recovery.md`](vps-gdrive-ingestion-recovery.md) |
-| Self-hosted GitHub Actions runner for `nightly-heavy.yml` is offline | [`SELF_HOSTED_RUNNER.md`](SELF_HOSTED_RUNNER.md) |
-| Weekly git/pr/issue hygiene workflow | [`GIT_PR_ISSUE_NATIVE.md`](GIT_PR_ISSUE_NATIVE.md) |
-
-## Container / Service Map
-
-| Service (Compose name) | Common container names | Runbook |
-|---|---|---|
-| `qdrant` | `dev-qdrant-1`, `dev_qdrant_1` | [`QDRANT_TROUBLESHOOTING.md`](QDRANT_TROUBLESHOOTING.md) |
-| `redis` (app cache) and cache Redis containers | `dev-redis-1`, `dev_redis_1` | [`REDIS_CACHE_DEGRADATION.md`](REDIS_CACHE_DEGRADATION.md) |
-| `langfuse`, `langfuse-worker`, ClickHouse, MinIO, Langfuse Postgres/Redis | `dev-langfuse-1`, `dev-langfuse-worker-1`, `dev-clickhouse-1`, `dev-minio-1` | [`LANGFUSE_TRACING_GAPS.md`](LANGFUSE_TRACING_GAPS.md) |
-| `litellm` | `dev-litellm-1`, `dev_litellm_1` | [`LITEllm_FAILURE.md`](LITEllm_FAILURE.md) |
-| `postgres` | `dev-postgres-1`, `dev_postgres_1` | [`POSTGRESQL_WAL_RECOVERY.md`](POSTGRESQL_WAL_RECOVERY.md) |
-| Ingestion-related services | `dev-ingestion-1`, `dev-docling-1`, `dev-bge-m3-1` | [`vps-gdrive-ingestion-recovery.md`](vps-gdrive-ingestion-recovery.md) |
-
-> **Note:** Container names may differ between Compose versions (`dev-qdrant-1` vs `dev_qdrant_1`). Prefer `docker compose ps` and service names in docs.
-
-## Fast Search Commands
-
-Search runbooks and source areas by topic:
-
-```bash
-# Langfuse / traces / observability
-rg -n "Langfuse|trace|score|observation" docs/runbooks docs/audits telegram_bot src scripts
-
-# Redis / cache
-rg -n "Redis|cache|semantic cache|redis-cli" docs/runbooks telegram_bot src tests
-
-# Qdrant / vectors
-rg -n "Qdrant|collection|vector|ColBERT|hybrid" docs/runbooks src telegram_bot tests
-```
+See [COVERAGE_MATRIX.md](COVERAGE_MATRIX.md) for a full mapping of every Prometheus alert rule to its resolution runbook, including identified gaps and planned new runbooks.
 
 ## Safety Notes
 


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Fixes #1957

## Summary

Runbook coverage gap audit for high-value incidents, comparing all 52 Prometheus alert rules in `docker/monitoring/rules/*.yaml` against existing runbooks.

### Changes

- **`docs/runbooks/COVERAGE_MATRIX.md`** (new) - Full alert-to-runbook mapping with each row resolved as `covered` / `gap-accepted` / `gap-to-fill`:
  - 22 alerts covered by existing runbooks
  - 4 alerts gap-accepted (low-priority or covered by adjacent runbooks)
  - 26 alerts identified as gap-to-fill (5 new runbooks needed)

- **`docs/runbooks/README.md`** (rewritten) - Clean single index with one-liner descriptions for all 8 existing runbooks, plus link to coverage matrix.

### Sub-issues opened for gap-to-fill runbooks

- #1960: `TELEGRAM_BOT_FAILURE.md` (8 alerts)
- #1961: `EMBEDDING_SERVICE_FAILURE.md` (6 alerts)
- #1962: `DOCLING_FAILURE.md` (4 alerts)
- #1963: `MINIO_FAILURE.md` (5 alerts)
- #1964: `LIGHTRAG_FAILURE.md` (3 alerts)

### Verification

- `python3 scripts/check_markdown_links.py` exits 0 (clean)
- TDD skipped: docs-only change with no behavior change
- No Context7 libraries consulted (documentation task)