### PR TITLE
test(graph): voice subgraph error propagation coverage (#1089 slice)

### DIFF
--- a/tests/integration/test_graph_paths.py
+++ b/tests/integration/test_graph_paths.py
@@ -741,6 +741,104 @@ async def test_path_voice_transcribe_full_rag():
 
 
 # ---------------------------------------------------------------------------
+# Voice path error propagation (#1089)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_voice_transcribe_api_error_propagates():
+    """STT API exception bubbles out of graph.ainvoke; downstream nodes skipped.
+
+    Issue #1089 calls for "Error propagation through subgraph" coverage. The
+    voice path's first node is `transcribe`, and Whisper API failures are
+    re-raised by `make_transcribe_node` (after Langfuse status update). This
+    test pins that the exception leaves the graph as-is and that no
+    downstream node (classify / retrieve / generate) was invoked.
+    """
+    api_error = RuntimeError("Whisper API 503 Service Unavailable")
+
+    mocks = _make_graph_mocks()
+    mocks["llm"].audio.transcriptions.create = AsyncMock(side_effect=api_error)
+
+    mock_gc = _make_mock_graph_config(mocks["llm"])
+
+    with _patch_graph_configs(mock_gc):
+        graph = build_graph(
+            cache=mocks["cache"],
+            embeddings=mocks["embeddings"],
+            sparse_embeddings=mocks["sparse_embeddings"],
+            qdrant=mocks["qdrant"],
+            reranker=mocks["reranker"],
+            llm=mocks["llm"],
+            message=mocks["message"],
+            show_transcription=True,
+            voice_language="ru",
+            stt_model="whisper",
+        )
+
+    state = make_initial_state(user_id=81, session_id="test-voice-error-1", query="")
+    state["voice_audio"] = b"fake-ogg-data"
+    state["voice_duration_s"] = 5.0
+    state["input_type"] = "voice"
+
+    with traced_pipeline(session_id="test-voice-error-api", user_id="integration"):
+        with _patch_graph_configs(mock_gc), pytest.raises(RuntimeError, match="503"):
+            await graph.ainvoke(state)
+
+    # transcribe was attempted exactly once — no retry layer in the graph
+    mocks["llm"].audio.transcriptions.create.assert_awaited_once()
+    # Downstream nodes must NOT have been called
+    mocks["qdrant"].hybrid_search_rrf.assert_not_awaited()
+    mocks["reranker"].rerank.assert_not_awaited()
+    mocks["llm"].chat.completions.create.assert_not_awaited()
+
+
+@pytest.mark.integration
+async def test_voice_transcribe_empty_text_raises_value_error():
+    """Empty Whisper output raises ValueError; downstream nodes skipped.
+
+    Issue #1089 — pins the contract that ``transcribe_node`` rejects empty
+    transcripts (whitespace-only counts as empty after ``.strip()``).
+    Empty audio / silent recordings must surface as a clear error rather
+    than feeding an empty string into ``classify`` / ``retrieve``.
+    """
+    transcript_mock = MagicMock(text="   ")  # whitespace only -> empty after strip()
+
+    mocks = _make_graph_mocks()
+    mocks["llm"].audio.transcriptions.create = AsyncMock(return_value=transcript_mock)
+
+    mock_gc = _make_mock_graph_config(mocks["llm"])
+
+    with _patch_graph_configs(mock_gc):
+        graph = build_graph(
+            cache=mocks["cache"],
+            embeddings=mocks["embeddings"],
+            sparse_embeddings=mocks["sparse_embeddings"],
+            qdrant=mocks["qdrant"],
+            reranker=mocks["reranker"],
+            llm=mocks["llm"],
+            message=mocks["message"],
+            show_transcription=True,
+            voice_language="ru",
+            stt_model="whisper",
+        )
+
+    state = make_initial_state(user_id=82, session_id="test-voice-error-2", query="")
+    state["voice_audio"] = b"fake-ogg-data"
+    state["voice_duration_s"] = 5.0
+    state["input_type"] = "voice"
+
+    with traced_pipeline(session_id="test-voice-error-empty", user_id="integration"):
+        with _patch_graph_configs(mock_gc), pytest.raises(ValueError, match="Empty transcription"):
+            await graph.ainvoke(state)
+
+    mocks["llm"].audio.transcriptions.create.assert_awaited_once()
+    mocks["qdrant"].hybrid_search_rrf.assert_not_awaited()
+    mocks["reranker"].rerank.assert_not_awaited()
+    mocks["llm"].chat.completions.create.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
 # Conversation Memory: checkpointer persists messages across invocations
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.

## Summary

Fills a focused coverage gap from the #1089 checklist — **"Error propagation through subgraph"** — by adding two voice-path integration tests to `tests/integration/test_graph_paths.py`. The happy-path test `test_path_voice_transcribe_full_rag` already existed; the error paths did not.

## Tests added

| Test | What it pins |
|------|--------------|
| `test_voice_transcribe_api_error_propagates` | Whisper API exception (`RuntimeError("Whisper API 503 ...")`) bubbles out of `graph.ainvoke()`. `qdrant.hybrid_search_rrf`, `reranker.rerank`, and `llm.chat.completions.create` are **not** awaited. |
| `test_voice_transcribe_empty_text_raises_value_error` | Whitespace-only Whisper output (`.strip() == ""`) raises `ValueError("Empty transcription from Whisper API")`. Same downstream-skip assertions. |

Both reuse the existing `_make_graph_mocks` / `_make_mock_graph_config` / `_patch_graph_configs` helpers and mark themselves `@pytest.mark.integration`. No Docker / network needed.

## TDD note

The tests were written *against the live `transcribe_node` implementation* in `telegram_bot/graph/nodes/transcribe.py`, which already raises on both error conditions. So this is **pinning** behaviour, not driving new behaviour. Per `.kiro/steering/agent-workflow.md` and the pattern used in PR #1940 / #1941, pinning contracts of an already-correct implementation is treated as an acceptable substitute for a strict RED→GREEN cycle when the documented invariant is otherwise unenforced.

A 3rd test (`test_voice_missing_audio_payload_raises_value_error`) was prototyped but **removed** — `route_start` sends states without `voice_audio` down the text classify path, so the `ValueError("voice_audio is None ...")` guard inside `transcribe_node` is unreachable from `graph.ainvoke()`. The guard still has value for direct-call protection and stays in place; this is documented in the commit message.

## What is **out of scope** for this PR

The #1089 checklist is broader than what one PR should carry. The remaining items are best handled as follow-up slices:

- HITL escalation / resume through the full graph (existing `tests/unit/agents/test_hitl.py` is unit-level; a graph-level HITL integration test deserves its own focused PR).
- Explicit `RAGState` transition assertions across every node in one place (today the path tests assert state implicitly).

If desired, I can open a follow-up sub-issue for these once this PR lands.

## Validation

- [x] `uv run --python 3.12 pytest tests/integration/test_graph_paths.py --timeout=60 -q` — 20 passed, 14 warnings (warnings pre-existing)
- [x] `uv run --python 3.12 pytest tests/integration/test_graph_paths.py -v --timeout=60 -k voice` — 3 passed (1 happy-path + 2 new error paths)
- [x] `uv run --python 3.12 ruff check tests/integration/test_graph_paths.py` — All checks passed!

## Runtime Impact

- [x] No runtime impact

## Reviewer Notes

- Tests-only change. No production code touched.
- Single file edit; the new tests are placed immediately after `test_path_voice_transcribe_full_rag` and before the `TestConversationMemory` class so they share section context.

Fixes part of #1089.