### PR TITLE
test(#1996): disambiguate test_injection_hard_mode_blocks duplicate

### DIFF
--- a/tests/unit/test_bot_query_supervisor.py
+++ b/tests/unit/test_bot_query_supervisor.py
@@ -68,8 +68,16 @@ def _make_message(text="test query"):
 class TestQuerySupervisorContentFilter:
     """Tests for the pre-agent content filter guard in _handle_query_supervisor."""
 
-    async def test_injection_hard_mode_blocks(self):
-        """Hard mode: detected injection sends blocked response and returns early."""
+    async def test_injection_hard_mode_blocks_in_supervisor(self):
+        """Hard mode: detected injection sends blocked response and returns early.
+
+        Renamed from ``test_injection_hard_mode_blocks`` (#1996) so the
+        ``guard_node`` test of the same name in
+        ``tests/unit/graph/test_guard_node.py`` is no longer a colliding
+        duplicate. The supervisor variant covers the *bot-level pre-agent*
+        guard call site (``_handle_query_supervisor``); the guard_node
+        variant covers the *graph node* directly.
+        """
         config = _make_config(content_filter_enabled=True, guard_mode="hard")
         bot = _create_bot(config)
         message = _make_message("DROP TABLE users;")


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Sub-issue of #1978 dead-code audit. The `#1539` ratchet (`scripts/check_unique_test_names.py`) was failing on `dev` because two distinct test classes shared the same method name `test_injection_hard_mode_blocks`:

- `tests/unit/graph/test_guard_node.py` — graph node test (kept canonical)
- `tests/unit/test_bot_query_supervisor.py` — renamed to `test_injection_hard_mode_blocks_in_supervisor` with a docstring explaining the boundary (bot-level pre-agent guard call site vs. graph node)

## Caveat

The issue body's other claim — three `tests/integration/test_*.py` duplicate pairs — does not apply on current `dev`: those integration files have already been deleted; only the canonical `tests/unit/` versions remain.

## Verification

```
uv run --python 3.12 python scripts/check_unique_test_names.py
# OK: 128 known duplicate test names; no new duplicates introduced.

uv run --python 3.12 pytest tests/unit/test_bot_query_supervisor.py::TestQuerySupervisorContentFilter -q
# 3 passed in 11.02s

uv run --python 3.12 pytest tests/contract/test_no_new_duplicate_test_names.py -q
# 2 passed in 1.49s
```

Fixes #1996