### PR TITLE
docs(#1956): refresh RAG quality scores doc and pin doc/code parity

### DIFF
--- a/docs/RAG_QUALITY_SCORES.md
+++ b/docs/RAG_QUALITY_SCORES.md
@@ -9,6 +9,11 @@ Scores are computed and written via `telegram_bot/scoring.py`:
 - `write_history_scores()` — history search scores
 - `write_crm_scores()` — CRM tool usage scores
 
+> **Drift guard:** the doc/code parity is enforced by
+> [`tests/contract/test_rag_quality_scores_doc_drift.py`](../tests/contract/test_rag_quality_scores_doc_drift.py).
+> Whenever a new `name=...` is added to `scoring.py`, add a row below or
+> entry in `DOC_EXEMPT_SCORE_NAMES`.
+
 ## Main Query Scores
 
 | Score | Type | Description |
@@ -44,6 +49,7 @@ Scores are computed and written via `telegram_bot/scoring.py`:
 | `voice_duration_s` | numeric | Voice input duration (voice only) |
 | `bge_embed_error` | boolean | Embedding service error occurred |
 | `bge_embed_latency_ms` | numeric | Embedding latency |
+| `bge_model_processing_ms` | numeric | Pure model-side BGE-M3 processing time (separates network/queue from inference) |
 | `security_alert` | boolean | Prompt injection detected |
 | `injection_risk_score` | numeric | Injection risk score (0-1) |
 | `injection_pattern` | categorical | Type of injection pattern detected |
@@ -56,6 +62,8 @@ Scores are computed and written via `telegram_bot/scoring.py`:
 | `semantic_cache_safe_reuse` | boolean | Cache reuse was safe |
 | `safe_fallback_used` | boolean | Safe fallback response used |
 | `checkpointer_overhead_proxy_ms` | numeric | Checkpoint overhead proxy |
+| `checkpointer_overhead_ms` | numeric | Direct checkpointer Redis I/O time, summed from `InstrumentedCheckpointer` (#1258); excludes Pregel framework overhead unlike the proxy |
+| `checkpointer_op_count` | numeric | Number of timed checkpointer operations (`aput`/`aget`/`aput_writes`/`aget_tuple`) per query (#1258) |
 | `nurturing_batch_size` | numeric | Nurturing batch size |
 | `nurturing_sent_count` | numeric | Nurturing messages sent |
 | `funnel_conversion_rate` | numeric | Funnel conversion rate |

--- a/docs/engineering/sdk-registry.md
+++ b/docs/engineering/sdk-registry.md
@@ -167,7 +167,7 @@ paths: "telegram_bot/**,src/**,mini_app/**,pyproject.toml"
 - **как_у_нас:**
   - `telegram_bot/observability.py` — центральный модуль (init, observe, callback handler)
   - `telegram_bot/integrations/prompt_manager.py` — prompt management
-  - `telegram_bot/scoring.py` — 14 RAG scores
+  - `telegram_bot/scoring.py` — RAG quality scores written to Langfuse per query (see [`docs/RAG_QUALITY_SCORES.md`](../RAG_QUALITY_SCORES.md) for the full enumeration; parity is enforced by `tests/contract/test_rag_quality_scores_doc_drift.py`)
   - `src/ingestion/unified/observability.py` — ingestion-side @observe
 - **паттерны:**
   - @observe(name="node-X", capture_input=False, capture_output=False) на каждый node/step

--- a/tests/contract/test_rag_quality_scores_doc_drift.py
+++ b/tests/contract/test_rag_quality_scores_doc_drift.py
@@ -1,0 +1,137 @@
+"""Contract: ``docs/RAG_QUALITY_SCORES.md`` matches ``telegram_bot/scoring.py`` (#1956).
+
+The doc enumerates every Langfuse score we emit per query. Whenever a new
+``name=...`` lands in ``write_langfuse_scores``, ``write_history_scores``, or
+``write_crm_scores``, the doc table must gain a corresponding row. This
+contract pins parity in both directions:
+
+* every score name emitted by the scoring module appears in the doc;
+* every score name listed in the doc is actually emitted by the scoring module.
+
+Scope:
+
+* Source of truth (code): ``telegram_bot/scoring.py``. We collect every
+  string literal passed as ``name=...`` to ``score(...)`` or
+  ``lf.create_score(...)``, plus every key of the always-written ``scores``
+  dict literal in ``write_langfuse_scores``.
+* Source of truth (doc): ``docs/RAG_QUALITY_SCORES.md``. We collect every
+  backtick-wrapped identifier in the first column of any Markdown table
+  whose header is ``| Score |``.
+
+If a name is intentionally not user-facing (e.g. an internal helper), add
+it to ``DOC_EXEMPT_SCORE_NAMES`` with a reason; do not silence the test by
+trimming the doc.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCORING_PY = REPO_ROOT / "telegram_bot" / "scoring.py"
+DOC_PATH = REPO_ROOT / "docs" / "RAG_QUALITY_SCORES.md"
+
+# Score names emitted by scoring.py that intentionally do not appear in the
+# operator-facing table. Keep this set empty unless there is a documented
+# reason; the goal of #1956 is parity.
+DOC_EXEMPT_SCORE_NAMES: frozenset[str] = frozenset()
+
+_SCORE_TABLE_HEADER_RE = re.compile(r"^\s*\|\s*Score\s*\|", re.IGNORECASE)
+_SCORE_ROW_RE = re.compile(r"^\s*\|\s*`([a-z][a-z0-9_]*)`\s*\|")
+
+
+def _collect_score_names_from_code() -> set[str]:
+    tree = ast.parse(SCORING_PY.read_text(encoding="utf-8"))
+    names: set[str] = set()
+
+    for node in ast.walk(tree):
+        # Capture name="..." kwargs on score(...) / lf.create_score(...) calls.
+        if isinstance(node, ast.Call):
+            for kw in node.keywords:
+                if kw.arg != "name":
+                    continue
+                value = kw.value
+                if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                    names.add(value.value)
+        # Capture keys of the always-written ``scores = {...}`` dict literal
+        # inside write_langfuse_scores plus any later ``scores["..."] = ...``
+        # subscript assignments (e.g. results_count, no_results).
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Name)
+                    and target.id == "scores"
+                    and isinstance(node.value, ast.Dict)
+                ):
+                    for key in node.value.keys:
+                        if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                            names.add(key.value)
+                if (
+                    isinstance(target, ast.Subscript)
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == "scores"
+                    and isinstance(target.slice, ast.Constant)
+                    and isinstance(target.slice.value, str)
+                ):
+                    names.add(target.slice.value)
+
+    return names
+
+
+def _collect_score_names_from_doc() -> set[str]:
+    lines = DOC_PATH.read_text(encoding="utf-8").splitlines()
+    in_score_table = False
+    names: set[str] = set()
+
+    for line in lines:
+        if _SCORE_TABLE_HEADER_RE.match(line):
+            in_score_table = True
+            continue
+        if in_score_table and not line.strip().startswith("|"):
+            in_score_table = False
+            continue
+        if not in_score_table:
+            continue
+        match = _SCORE_ROW_RE.match(line)
+        if match:
+            names.add(match.group(1))
+
+    return names
+
+
+def test_every_emitted_score_is_documented() -> None:
+    code_names = _collect_score_names_from_code() - DOC_EXEMPT_SCORE_NAMES
+    doc_names = _collect_score_names_from_doc()
+    missing = sorted(code_names - doc_names)
+    assert not missing, (
+        "#1956: docs/RAG_QUALITY_SCORES.md is missing rows for scores emitted by "
+        "telegram_bot/scoring.py. Add a row per name with type and description, "
+        "or add an entry to DOC_EXEMPT_SCORE_NAMES with a reason. Missing names: "
+        f"{missing}"
+    )
+
+
+def test_every_documented_score_is_emitted_by_code() -> None:
+    code_names = _collect_score_names_from_code()
+    doc_names = _collect_score_names_from_doc()
+    stale = sorted(doc_names - code_names)
+    assert not stale, (
+        "#1956: docs/RAG_QUALITY_SCORES.md lists scores that are not emitted by "
+        "telegram_bot/scoring.py. Remove the stale rows or restore the missing "
+        f"score writes. Stale names: {stale}"
+    )
+
+
+def test_main_query_score_count_is_above_legacy_14() -> None:
+    code_names = _collect_score_names_from_code()
+    # Legacy SDK registry claimed "14 RAG scores"; the live emitter is far
+    # broader (latency breakdown, voice path, injection defense, memory,
+    # checkpointer, sources, nurturing). Pin a floor so the legacy number
+    # cannot creep back in silently.
+    assert len(code_names) > 30, (
+        f"Expected scoring.py to emit more than 30 distinct score names, found {len(code_names)}: "
+        f"{sorted(code_names)}"
+    )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Sub-issue of the docs refresh epic #1193. The `docs/RAG_QUALITY_SCORES.md` table drifted from `telegram_bot/scoring.py` and the SDK registry still claimed "14 RAG scores" while the live emitter writes ~50 distinct names. This PR closes the drift and adds a contract test that pins parity for future changes.

## Files touched

- `docs/RAG_QUALITY_SCORES.md` — added missing rows, drift-guard pointer.
- `docs/engineering/sdk-registry.md` — retired the stale "14 RAG scores" claim under `## langfuse`.
- `tests/contract/test_rag_quality_scores_doc_drift.py` — new contract test (AST + Markdown table parser).

## Specific drift fixed

Score names emitted by `telegram_bot/scoring.py` that were missing from the doc table:

- `bge_model_processing_ms` (BGE-M3 model-side timing — #210)
- `checkpointer_overhead_ms` (direct `InstrumentedCheckpointer` Redis I/O time — #1258)
- `checkpointer_op_count` (timed checkpointer op count — #1258)

The contract test confirmed there are no stale rows in the doc, no other missing names, and that the score-emit count is well above the legacy 14-score floor (catches a future regression to the old shape).

## Validation

- [x] `uv run pytest tests/contract/test_rag_quality_scores_doc_drift.py tests/unit/observability/test_score_coverage.py -q --no-cov` → 65 passed (3 new contract tests + 62 from the pre-existing per-score parametrized coverage test)
- [x] `python3 scripts/check_markdown_links.py` → `All relative Markdown links OK.`
- [x] `uv run ruff check` + `ruff format --check` on the new contract test file
- [ ] `make check` — skipped, mypy fails on pre-existing unrelated errors per #2011 PR notes; this PR does not introduce new typing regressions
- [ ] `make test-unit` — skipped, broader unit suite needs full extras

## Runtime Impact

- [x] No runtime impact (docs + new contract test only)

## Reviewer Notes

- The contract test is intentionally parsed-driven, not hand-maintained: it AST-walks `scoring.py` for every `name="..."`, `scores = {...}` key, and `scores["..."]=...` subscript assignment, and parses every Markdown table whose first column header is `Score` for the backtick-wrapped name in column 1.
- If a future score is genuinely operator-internal, add it to `DOC_EXEMPT_SCORE_NAMES` in the contract test with a reason instead of leaving it undocumented.
- The existing parametrized `tests/unit/observability/test_score_coverage.py` complements this by asserting the score *values* are written; this PR adds the doc-side counterpart.

Closes #1956.