### PR TITLE
docs(#1960-#1964): add five alert-driven operator runbooks

### DIFF
--- a/docs/runbooks/DOCLING_FAILURE.md
+++ b/docs/runbooks/DOCLING_FAILURE.md
@@ -1,0 +1,146 @@
+# Runbook: Docling Failure
+
+> **Owner:** Ingestion / Document parsing
+> **Last verified:** 2026-05-22
+> **Verification command:**
+> ```bash
+> COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml ps docling
+> ```
+
+Use this runbook when document parsing alerts fire from `docker/monitoring/rules/extended-services.yaml`.
+
+## Covered Alerts
+
+| Alert | Severity | Source |
+|---|---|---|
+| `DoclingDown` | critical | [`extended-services.yaml`](../../docker/monitoring/rules/extended-services.yaml) |
+| `DoclingOOM` | critical | [`extended-services.yaml`](../../docker/monitoring/rules/extended-services.yaml) |
+| `DoclingConversionFailed` | warning | [`extended-services.yaml`](../../docker/monitoring/rules/extended-services.yaml) |
+| `DoclingError` | warning | [`extended-services.yaml`](../../docker/monitoring/rules/extended-services.yaml) |
+
+## Service / Container Map
+
+| Compose service | Typical container names |
+|---|---|
+| `docling` | `dev-docling-1`, `dev_docling_1` |
+
+> Endpoints, ports, profiles: [`DOCKER.md`](../../DOCKER.md). Local dev: [`docs/LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md).
+
+## Fast-Path Diagnosis (read-only)
+
+### 1. Container state
+
+```bash
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml ps docling
+docker inspect dev-docling-1 --format '
+  Name={{.Name}}
+  Status={{.State.Status}}
+  OOMKilled={{.State.OOMKilled}}
+  ExitCode={{.State.ExitCode}}
+  Restarts={{.RestartCount}}
+'
+```
+
+### 2. Bounded log slice
+
+```bash
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml logs docling --tail=200
+```
+
+Pattern → alert mapping:
+
+| Pattern (case-insensitive) | Alert |
+|---|---|
+| no logs for 10m | `DoclingDown` |
+| `killed`, `out of memory`, `oom`, `segmentation fault` | `DoclingOOM` |
+| `failed to convert`, `conversion failed`, `pdf.*error`, `ocr.*error`, `timeout` | `DoclingConversionFailed` |
+| `error`, `exception`, `traceback` (rate based) | `DoclingError` |
+
+### 3. Health endpoint (if exposed)
+
+```bash
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec docling wget -qO- http://localhost:5001/health || true
+```
+
+### 4. Backlog and last document
+
+```bash
+make ingest-unified-status
+make ingest-unified-logs | tail -50
+```
+
+If a single document repeatedly crashes the converter, isolate it before restarting the service.
+
+## Service Failure vs App Bug
+
+| Observation | Interpretation | Next step |
+|---|---|---|
+| `DoclingOOM` with large PDF in last log line | Service failure (memory) | Raise memory limit in `compose.dev.yml`; consider streaming chunked input |
+| `DoclingDown` after deploy of new Docling image | Service failure (regression) | Roll back image tag; pin in [`docs/engineering/sdk-registry.md`](../engineering/sdk-registry.md) |
+| `DoclingConversionFailed` only on specific OCR-heavy PDFs | App bug / data issue | Quarantine offending file; capture sample for the upstream Docling repo |
+| `DoclingError` with `traceback` from `coco*` | App bug (caller) | Check ingestion flow ([`src/ingestion/`](../../src/ingestion/)) for malformed payloads |
+| `DoclingError` from Tesseract / EasyOCR | Service failure (OCR backend) | Reinstall OCR data files or pin language packs |
+
+## Source Paths
+
+| Component | Path |
+|---|---|
+| Docling service | [`services/docling/`](../../services/docling/) |
+| Ingestion flow that calls Docling | [`src/ingestion/`](../../src/ingestion/) |
+| Override ingestion flow | [`src/ingestion/unified/`](../../src/ingestion/unified/) |
+| Compose definitions | [`compose.yml`](../../compose.yml), [`compose.dev.yml`](../../compose.dev.yml) |
+| Alert rules | [`docker/monitoring/rules/extended-services.yaml`](../../docker/monitoring/rules/extended-services.yaml) |
+
+## Logs and Artifacts
+
+| Artifact | Location / command |
+|---|---|
+| Runtime logs | `docker compose logs docling --tail=200` |
+| Container metadata | `docker inspect dev-docling-1` |
+| Ingestion manifest | `make ingest-unified-status` |
+| OCR / model cache | named volume on the docling service (`docker volume inspect`) |
+
+## Remediation
+
+> ⚠️ **Caution:** Mutating commands. Run only after fast-path diagnosis confirms the issue.
+
+### `DoclingDown`
+
+1. Capture exit reason and the last 200 log lines.
+2. If image regression: pin a known-good tag in `compose.yml` and recreate.
+3. Otherwise:
+   ```bash
+   COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml up -d --force-recreate docling
+   ```
+
+### `DoclingOOM`
+
+1. `docker stats dev-docling-1` to capture pre-OOM RSS pattern.
+2. Raise `services.docling.deploy.resources.limits.memory` in `compose.dev.yml`.
+3. If the offending document was huge: split it upstream and add a size guard in the ingestion flow.
+
+### `DoclingConversionFailed`
+
+1. Identify the offending document (filename usually appears in the same log block).
+2. Move the file to a quarantine directory and re-run the batch — should clear the alert without service restart.
+3. File a follow-up issue with the document attached if it is reproducible.
+
+### `DoclingError`
+
+1. Aggregate the most common error class from the last 50 log lines.
+2. Triage: is it a model load issue (restart fixes), a caller payload issue (fix `src/ingestion`), or an OCR backend issue (reinstall data files)?
+3. Restart only after the root class is established.
+
+## Prevention
+
+- Pin Docling image versions in [`docs/engineering/sdk-registry.md`](../engineering/sdk-registry.md) and bump in dedicated PRs.
+- Cap document size in the ingestion flow before it hits Docling.
+- Track conversion latency p95 — sustained drift usually precedes OOM.
+
+## See Also
+
+- [`vps-gdrive-ingestion-recovery.md`](vps-gdrive-ingestion-recovery.md)
+- [`EMBEDDING_SERVICE_FAILURE.md`](EMBEDDING_SERVICE_FAILURE.md)
+- [`MINIO_FAILURE.md`](MINIO_FAILURE.md)
+- [`DOCKER.md`](../../DOCKER.md)
+- [`docs/INGESTION.md`](../INGESTION.md)

--- a/docs/runbooks/EMBEDDING_SERVICE_FAILURE.md
+++ b/docs/runbooks/EMBEDDING_SERVICE_FAILURE.md
@@ -1,0 +1,170 @@
+# Runbook: Embedding Service Failure
+
+> **Owner:** Retrieval / Ingestion subsystems
+> **Last verified:** 2026-05-22
+> **Verification command:**
+> ```bash
+> curl -fsS http://localhost:8081/health || \
+>   COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec bge-m3 wget -qO- http://localhost:8000/health
+> ```
+
+Use this runbook when alerts from `docker/monitoring/rules/infrastructure.yaml` and `docker/monitoring/rules/ingestion.yaml` fire on the embedding tier (BGE-M3, BM42, Voyage).
+
+## Covered Alerts
+
+| Alert | Severity | Source |
+|---|---|---|
+| `BGEServiceDown` | warning | [`infrastructure.yaml`](../../docker/monitoring/rules/infrastructure.yaml) |
+| `BM42ServiceDown` | warning | [`infrastructure.yaml`](../../docker/monitoring/rules/infrastructure.yaml) |
+| `EmbeddingServiceError` | warning | [`infrastructure.yaml`](../../docker/monitoring/rules/infrastructure.yaml) |
+| `BGEEmbedRetryFromBot` | warning | [`infrastructure.yaml`](../../docker/monitoring/rules/infrastructure.yaml) |
+| `BGEEmbedErrorFromBot` | critical | [`infrastructure.yaml`](../../docker/monitoring/rules/infrastructure.yaml) |
+| `VoyageRateLimited` | warning | [`ingestion.yaml`](../../docker/monitoring/rules/ingestion.yaml) |
+
+## Service / Container Map
+
+| Compose service | Typical container names | Role |
+|---|---|---|
+| `bge-m3` | `dev-bge-m3-1`, `dev_bge_m3_1` | Dense + multivec embeddings (primary) |
+| `bm42` | `dev-bm42-1`, `dev_bm42_1` | Sparse embeddings (when enabled) |
+| `user-base` | `dev-user-base-1` | Auxiliary embedding cache; bundled in the embedding family alert |
+| Voyage (external) | n/a — third-party API used by ingestion | Reranker / fallback embeddings |
+
+## Fast-Path Diagnosis (read-only)
+
+### 1. Container state
+
+```bash
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml ps bge-m3 bm42 user-base
+```
+
+If a container is `Exited`/`Restarting`, capture the exit reason:
+
+```bash
+docker inspect dev-bge-m3-1 --format '
+  Name={{.Name}}
+  Status={{.State.Status}}
+  OOMKilled={{.State.OOMKilled}}
+  ExitCode={{.State.ExitCode}}
+  Restarts={{.RestartCount}}
+'
+```
+
+### 2. Bounded log slice
+
+```bash
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml logs bge-m3 --tail=200
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml logs bm42 --tail=200
+```
+
+Patterns the alerts watch for:
+
+| Pattern (case-insensitive) | Alert |
+|---|---|
+| no logs in last 10m | `BGEServiceDown` / `BM42ServiceDown` |
+| `error`, `failed`, `exception` (across embedding family) | `EmbeddingServiceError` |
+| `Retrying telegram_bot.integrations.embeddings` (in `dev-bot`) | `BGEEmbedRetryFromBot` |
+| `Embedding failed after retries` (in `dev-bot`) | `BGEEmbedErrorFromBot` |
+| `voyage.*429`, `rate.*limit` (in `dev-ingestion`) | `VoyageRateLimited` |
+
+### 3. Health endpoint
+
+```bash
+# Host-side dev mapping if exposed
+curl -fsS http://localhost:8081/health || true
+
+# Inside the network
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec bge-m3 wget -qO- http://localhost:8000/health
+```
+
+### 4. Cross-check from the bot
+
+```bash
+make test-bot-health
+```
+
+If `bge_embed_error` rate from the bot is non-zero, `BGEEmbedErrorFromBot` is essentially fact-of-life until embeddings recover.
+
+## Service Failure vs App Bug
+
+| Observation | Interpretation | Next step |
+|---|---|---|
+| `BGEServiceDown` with `OOMKilled=true` | Service failure (memory) | Raise `BGE_M3_MEMORY_LIMIT`; inspect input batch sizes |
+| Container alive, `EmbeddingServiceError` rising | Service failure (model load) | Check model cache volume; restart container after capturing logs |
+| `BGEEmbedRetryFromBot` only, no service-side errors | App bug / network glitch | Inspect bot `httpx` config; rule out DNS issues inside Docker network |
+| `BGEEmbedErrorFromBot` with healthy `bge-m3` | App bug | Check `EMBEDDING_BASE_URL` / collection alignment in bot env |
+| `VoyageRateLimited` repeating | App bug / config | Reduce ingestion concurrency; rotate to local BGE-M3 fallback if Voyage is non-essential |
+| `BM42ServiceDown` while bot is fine | Sparse-only outage | Sparse path may be optional; check `SPARSE_PROVIDER` flag before paging |
+
+## Source Paths
+
+| Component | Path |
+|---|---|
+| BGE-M3 service | [`services/bge-m3-api/`](../../services/bge-m3-api/) |
+| Bot embeddings client | [`telegram_bot/integrations/embeddings.py`](../../telegram_bot/integrations/embeddings.py) |
+| Reranker / Voyage usage | [`src/retrieval/reranker.py`](../../src/retrieval/reranker.py) |
+| Compose definitions | [`compose.yml`](../../compose.yml), [`compose.dev.yml`](../../compose.dev.yml) |
+| Alert rules | [`docker/monitoring/rules/infrastructure.yaml`](../../docker/monitoring/rules/infrastructure.yaml), [`docker/monitoring/rules/ingestion.yaml`](../../docker/monitoring/rules/ingestion.yaml) |
+
+## Logs and Artifacts
+
+| Artifact | Location / command |
+|---|---|
+| BGE-M3 logs | `docker compose logs bge-m3 --tail=200` |
+| BM42 logs | `docker compose logs bm42 --tail=200` |
+| Bot retry counters | `bge_embed_error`, `bge_embed_latency_ms`, `bge_model_processing_ms` Langfuse scores (see [`docs/RAG_QUALITY_SCORES.md`](../RAG_QUALITY_SCORES.md)) |
+| Voyage rate-limit hits | `docker compose logs ingestion --tail=200 | grep -iE "voyage.*429|rate.*limit"` |
+
+## Remediation
+
+> ⚠️ **Caution:** Mutating commands. Run only after fast-path diagnosis confirms the issue.
+
+### `BGEServiceDown` / `BM42ServiceDown`
+
+1. Capture exit reason and last 200 log lines.
+2. If `OOMKilled=true`: raise the relevant memory limit (`BGE_M3_MEMORY_LIMIT` for `bge-m3`) in `compose.dev.yml`, then:
+   ```bash
+   COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml up -d --force-recreate bge-m3
+   ```
+3. If model cache is corrupt: stop the service, prune its named volume, and restart so the model re-downloads.
+
+### `EmbeddingServiceError`
+
+1. Identify which container the errors come from (alert query covers `dev-bge-m3|dev-bm42|dev-user-base`).
+2. Look for repeated patterns: missing model file, CUDA/CPU mismatch, timeouts.
+3. Apply the matching service fix; do **not** restart the bot until embeddings recover, or it will retry-storm.
+
+### `BGEEmbedRetryFromBot`
+
+1. If the underlying service is healthy, this is usually network/DNS jitter.
+2. Confirm `EMBEDDING_BASE_URL` (presence only) points at the in-network service name (`http://bge-m3:8000`), not the host port.
+3. Increase `httpx` retry/backoff in the bot config only if retries are persistently failing.
+
+### `BGEEmbedErrorFromBot`
+
+Critical. Bot embedding calls have exhausted retries and are surfacing failures to users.
+
+1. Pin the bge-m3 health and bot health side-by-side. If both are up, the issue is contractual (URL/keys).
+2. Roll back to the last known-good `bge-m3` image tag if a recent deploy correlates.
+3. Engage on-call before users notice degraded retrieval.
+
+### `VoyageRateLimited`
+
+1. Reduce ingestion concurrency: lower `INGEST_CONCURRENCY` (or the equivalent CocoIndex / unified flow knob).
+2. If Voyage is optional, switch to local BGE-M3 fallback for ingestion.
+3. Coordinate with the API key owner before bumping the Voyage tier.
+
+## Prevention
+
+- Pre-warm the BGE-M3 model on container start so the first request after deploy is not slow.
+- Keep memory limits with ≥ 30% headroom; review after model upgrades.
+- Track `bge_embed_error` and `bge_embed_latency_ms` Langfuse scores; alert thresholds in [`docs/RAG_QUALITY_SCORES.md`](../RAG_QUALITY_SCORES.md).
+- For Voyage, cap ingestion concurrency in `Makefile` / `scripts/ingest_*.sh` to stay under quota.
+
+## See Also
+
+- [`TELEGRAM_BOT_FAILURE.md`](TELEGRAM_BOT_FAILURE.md)
+- [`QDRANT_TROUBLESHOOTING.md`](QDRANT_TROUBLESHOOTING.md)
+- [`vps-gdrive-ingestion-recovery.md`](vps-gdrive-ingestion-recovery.md)
+- [`docs/RAG_QUALITY_SCORES.md`](../RAG_QUALITY_SCORES.md)
+- [`DOCKER.md`](../../DOCKER.md)

--- a/docs/runbooks/LIGHTRAG_FAILURE.md
+++ b/docs/runbooks/LIGHTRAG_FAILURE.md
@@ -1,0 +1,140 @@
+# Runbook: LightRAG Failure
+
+> **Owner:** Graph RAG / Retrieval extensions
+> **Last verified:** 2026-05-22
+> **Verification command:**
+> ```bash
+> COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml ps lightrag
+> ```
+
+Use this runbook when LightRAG alerts fire from `docker/monitoring/rules/extended-services.yaml`. LightRAG provides graph-based retrieval; its outages do not stop the bot's primary RAG path but degrade graph-aware answers.
+
+## Covered Alerts
+
+| Alert | Severity | Source |
+|---|---|---|
+| `LightRAGDown` | critical | [`extended-services.yaml`](../../docker/monitoring/rules/extended-services.yaml) |
+| `LightRAGError` | warning | [`extended-services.yaml`](../../docker/monitoring/rules/extended-services.yaml) |
+| `LightRAGAPIError` | warning | [`extended-services.yaml`](../../docker/monitoring/rules/extended-services.yaml) |
+
+## Service / Container Map
+
+| Compose service | Typical container names |
+|---|---|
+| `lightrag` | `dev-lightrag-1`, `dev_lightrag_1` |
+
+> Endpoints, ports, profiles: [`DOCKER.md`](../../DOCKER.md). Local dev: [`docs/LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md).
+
+## Fast-Path Diagnosis (read-only)
+
+### 1. Container state
+
+```bash
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml ps lightrag
+docker inspect dev-lightrag-1 --format '
+  Name={{.Name}}
+  Status={{.State.Status}}
+  OOMKilled={{.State.OOMKilled}}
+  ExitCode={{.State.ExitCode}}
+  Restarts={{.RestartCount}}
+'
+```
+
+### 2. Bounded log slice
+
+```bash
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml logs lightrag --tail=200
+```
+
+Pattern → alert mapping:
+
+| Pattern (case-insensitive) | Alert |
+|---|---|
+| no logs for 10m | `LightRAGDown` |
+| `error`, `exception`, `failed`, `traceback` (rate based) | `LightRAGError` |
+| `openai.*error`, `api.*error`, `rate.*limit` | `LightRAGAPIError` |
+
+### 3. Health endpoint (if exposed)
+
+```bash
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec lightrag wget -qO- http://localhost:9621/health || true
+```
+
+### 4. Upstream LLM contract
+
+LightRAG depends on an LLM/embedding provider for graph extraction. If `LightRAGAPIError` fires:
+
+```bash
+# Confirm presence of the env vars LightRAG uses (do not print values)
+docker compose exec lightrag sh -lc 'set | grep -E "^(OPENAI_API_KEY|LLM_BASE_URL|EMBEDDING_BASE_URL)=" | sed "s/=.*/=present/"'
+```
+
+If the bot uses LiteLLM as the upstream LLM, cross-check with [`LITEllm_FAILURE.md`](LITEllm_FAILURE.md).
+
+## Service Failure vs App Bug
+
+| Observation | Interpretation | Next step |
+|---|---|---|
+| `LightRAGDown` with `OOMKilled=true` | Service failure (memory) | Raise memory limit in `compose.dev.yml`; recreate |
+| `LightRAGDown` after deploy | Service failure (regression) | Roll back image tag |
+| `LightRAGError` with `traceback` from query path | App bug | Capture sample query; reproduce locally |
+| `LightRAGAPIError` with `429` | Upstream rate limit | Reduce concurrency; verify LiteLLM fallback chain |
+| `LightRAGAPIError` with `connection refused` | Network / dependency outage | Check LiteLLM ([`LITEllm_FAILURE.md`](LITEllm_FAILURE.md)) and embedding service ([`EMBEDDING_SERVICE_FAILURE.md`](EMBEDDING_SERVICE_FAILURE.md)) |
+| `LightRAGError` only on graph-build path | Data issue | Quarantine offending document; re-run graph extraction |
+
+## Source Paths
+
+| Component | Path |
+|---|---|
+| Compose definitions | [`compose.yml`](../../compose.yml), [`compose.dev.yml`](../../compose.dev.yml) |
+| Alert rules | [`docker/monitoring/rules/extended-services.yaml`](../../docker/monitoring/rules/extended-services.yaml) |
+| Bot graph-RAG integration (if any) | search [`telegram_bot/`](../../telegram_bot/) for `lightrag` |
+
+## Logs and Artifacts
+
+| Artifact | Location / command |
+|---|---|
+| Runtime logs | `docker compose logs lightrag --tail=200` |
+| Container metadata | `docker inspect dev-lightrag-1` |
+| Graph store volume | `docker volume inspect dev_lightrag_data` (or hyphen variant) |
+| Model cache | named volume; review with `docker volume inspect` |
+
+## Remediation
+
+> ⚠️ **Caution:** Mutating commands. Run only after fast-path diagnosis confirms the issue.
+
+### `LightRAGDown`
+
+1. Capture exit reason and last 200 log lines.
+2. If `OOMKilled=true`: raise the memory limit in `compose.dev.yml` and recreate.
+3. Otherwise:
+   ```bash
+   COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml up -d --force-recreate lightrag
+   ```
+4. Because LightRAG is a graph-RAG accelerator, the bot can run without it. If the outage is prolonged, disable the LightRAG path in the bot config rather than letting users see degraded answers.
+
+### `LightRAGError`
+
+1. Aggregate the most common error class.
+2. Distinguish data issues (single-document failures) from systemic issues (every request fails).
+3. Apply the matching fix; do not blanket-restart while a single document is the culprit.
+
+### `LightRAGAPIError`
+
+1. If `429`: reduce LightRAG concurrency knobs; coordinate with the upstream LLM owner.
+2. If `connection refused` / `timeout`: confirm LiteLLM and embedding services are up before restarting LightRAG.
+3. If a recent secret rotation: refresh the LightRAG container's env (presence only) and recreate.
+
+## Prevention
+
+- Treat LightRAG as best-effort: feature-flag the graph path so the bot degrades gracefully when LightRAG is down.
+- Keep memory limits with ≥ 30% headroom for graph builds.
+- Pin LightRAG image tags via Renovate; review release notes for prompt / API changes before bumping.
+- Cap graph-build concurrency in ingestion to stay under upstream LLM quotas.
+
+## See Also
+
+- [`LITEllm_FAILURE.md`](LITEllm_FAILURE.md)
+- [`EMBEDDING_SERVICE_FAILURE.md`](EMBEDDING_SERVICE_FAILURE.md)
+- [`QDRANT_TROUBLESHOOTING.md`](QDRANT_TROUBLESHOOTING.md)
+- [`DOCKER.md`](../../DOCKER.md)

--- a/docs/runbooks/MINIO_FAILURE.md
+++ b/docs/runbooks/MINIO_FAILURE.md
@@ -1,0 +1,161 @@
+# Runbook: MinIO Storage Failure
+
+> **Owner:** Langfuse storage / S3-compatible bucket on-call
+> **Last verified:** 2026-05-22
+> **Verification command:**
+> ```bash
+> curl -fsS http://localhost:9000/minio/health/ready
+> ```
+
+Use this runbook when MinIO alerts fire from `docker/monitoring/rules/extended-services.yaml`. MinIO backs Langfuse blob storage; its outages typically appear as Langfuse upload errors first.
+
+## Covered Alerts
+
+| Alert | Severity | Source |
+|---|---|---|
+| `MinioDown` | critical | [`extended-services.yaml`](../../docker/monitoring/rules/extended-services.yaml) |
+| `MinioDiskFull` | critical | [`extended-services.yaml`](../../docker/monitoring/rules/extended-services.yaml) |
+| `MinioCorruption` | critical | [`extended-services.yaml`](../../docker/monitoring/rules/extended-services.yaml) |
+| `MinioHealingFailed` | warning | [`extended-services.yaml`](../../docker/monitoring/rules/extended-services.yaml) |
+| `MinioError` | warning | [`extended-services.yaml`](../../docker/monitoring/rules/extended-services.yaml) |
+
+## Service / Container Map
+
+| Compose service | Typical container names |
+|---|---|
+| `minio` | `dev-minio-1`, `dev_minio_1` |
+
+> Endpoints, ports, profiles: [`DOCKER.md`](../../DOCKER.md). Local dev: [`docs/LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md).
+
+## Fast-Path Diagnosis (read-only)
+
+### 1. Container state
+
+```bash
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml ps minio
+docker inspect dev-minio-1 --format '
+  Name={{.Name}}
+  Status={{.State.Status}}
+  OOMKilled={{.State.OOMKilled}}
+  ExitCode={{.State.ExitCode}}
+  Restarts={{.RestartCount}}
+'
+```
+
+### 2. Health endpoints
+
+```bash
+# Liveness (host-side dev mapping)
+curl -fsS http://localhost:9000/minio/health/live
+# Readiness — must be 200 to accept writes
+curl -fsS http://localhost:9000/minio/health/ready
+```
+
+### 3. Bounded log slice
+
+```bash
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml logs minio --tail=200
+```
+
+Pattern → alert mapping:
+
+| Pattern (case-insensitive) | Alert |
+|---|---|
+| no logs for 5m | `MinioDown` |
+| `disk full`, `no space left`, `drive offline` | `MinioDiskFull` |
+| `corrupt`, `AccessDenied`, `signature mismatch` | `MinioCorruption` |
+| `failed to initialize`, `unable to use drive`, `healing.*failed` | `MinioHealingFailed` |
+| `error`, `exception` (rate based) | `MinioError` |
+
+### 4. Disk usage
+
+```bash
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec minio df -h /data || true
+docker volume inspect dev_minio_data || docker volume inspect dev-minio-data
+```
+
+### 5. Bucket reachability from Langfuse
+
+```bash
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec langfuse-worker wget -qO- http://minio:9000/minio/health/ready
+```
+
+If MinIO is healthy from the host but unreachable from inside the network, treat as a service-mesh / DNS issue.
+
+## Service Failure vs App Bug
+
+| Observation | Interpretation | Next step |
+|---|---|---|
+| `MinioDiskFull` with high object count | Service failure (capacity) | Free space / extend volume; rotate Langfuse blob retention |
+| `MinioCorruption` with `AccessDenied` | Auth contract drift | Check Langfuse `S3_*` env vs MinIO root credentials (presence only) |
+| `MinioCorruption` with `corrupt` keyword | Service failure (data) | Stop service, snapshot volume, run MinIO healing |
+| `MinioHealingFailed` after host disk swap | Service failure | Verify drive mount UID/GID; restart MinIO once mounts are correct |
+| `MinioError` with `slow downloads` | App bug / capacity | Check network throughput; consider node placement |
+| `MinioDown` while host disk is fine | Service failure (process) | `docker compose up -d --force-recreate minio` and capture last 200 log lines first |
+
+## Source Paths
+
+| Component | Path |
+|---|---|
+| Compose definitions | [`compose.yml`](../../compose.yml), [`compose.dev.yml`](../../compose.dev.yml) |
+| Alert rules | [`docker/monitoring/rules/extended-services.yaml`](../../docker/monitoring/rules/extended-services.yaml) |
+| Langfuse storage env contract | env vars `LANGFUSE_S3_*` (see [`compose.dev.yml`](../../compose.dev.yml); never echo values) |
+| Langfuse runbook for downstream effects | [`LANGFUSE_TRACING_GAPS.md`](LANGFUSE_TRACING_GAPS.md) |
+
+## Logs and Artifacts
+
+| Artifact | Location / command |
+|---|---|
+| Runtime logs | `docker compose logs minio --tail=200` |
+| Volume metadata | `docker volume inspect dev_minio_data` |
+| Object counts | MinIO `mc admin info` from a sidecar (do not run mutating commands) |
+| Langfuse worker logs | `docker compose logs langfuse-worker --tail=200` |
+
+## Remediation
+
+> ⚠️ **Caution:** Mutating commands. Run only after fast-path diagnosis confirms the issue.
+
+### `MinioDown`
+
+1. Inspect exit reason and last 200 log lines.
+2. Recreate only the MinIO container:
+   ```bash
+   COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml up -d --force-recreate minio
+   ```
+
+### `MinioDiskFull`
+
+1. Capture object counts per bucket before deletion.
+2. Trim Langfuse blob retention according to product policy; do not bulk-delete buckets blindly.
+3. Extend the volume / move data to a larger disk if growth is organic.
+
+### `MinioCorruption`
+
+1. Halt writes if possible (set Langfuse `S3_*` to read-only mode or stop the worker).
+2. Snapshot the MinIO data volume.
+3. Run MinIO healing per the upstream MinIO runbook (`mc admin heal`).
+4. Restore from snapshot if healing fails.
+
+### `MinioHealingFailed`
+
+1. Inspect mount permissions / disk SMART status.
+2. Re-bind correct UID/GID, restart only after the underlying drive is verified.
+3. Engage storage on-call before touching production data.
+
+### `MinioError`
+
+1. Look for repeated error classes in the last 50 lines.
+2. Apply the matching fix (auth, throughput, network) before restart.
+
+## Prevention
+
+- Cap Langfuse blob retention in production (avoid unbounded growth).
+- Keep MinIO data volume on a disk with ≥ 20% headroom.
+- Pin MinIO image tags via Renovate; verify compatibility before bumping major versions.
+- Watch `MinioError` rate as an early signal before `MinioDown` fires.
+
+## See Also
+
+- [`LANGFUSE_TRACING_GAPS.md`](LANGFUSE_TRACING_GAPS.md)
+- [`POSTGRESQL_WAL_RECOVERY.md`](POSTGRESQL_WAL_RECOVERY.md)
+- [`DOCKER.md`](../../DOCKER.md)

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -14,6 +14,11 @@ Operator entrypoint for container/service investigations and incident response. 
 | LiteLLM / provider failure (Russian: "сломался litellm") | `curl -s http://localhost:4000/health` → [`LITEllm_FAILURE.md`](LITEllm_FAILURE.md) |
 | Compose service health | `make docker-ps` → [`DOCKER.md`](../../DOCKER.md) |
 | Self-hosted runner offline / nightly-heavy queued | `scripts/check_self_hosted_runner.sh` → [`SELF_HOSTED_RUNNER.md`](SELF_HOSTED_RUNNER.md) |
+| Telegram bot is down / restarting / high error rate | `docker compose ps bot` → [`TELEGRAM_BOT_FAILURE.md`](TELEGRAM_BOT_FAILURE.md) |
+| Embedding service (BGE-M3 / BM42 / Voyage) errors | `docker compose ps bge-m3` → [`EMBEDDING_SERVICE_FAILURE.md`](EMBEDDING_SERVICE_FAILURE.md) |
+| Docling document parser down / OOM / conversion errors | `docker compose ps docling` → [`DOCLING_FAILURE.md`](DOCLING_FAILURE.md) |
+| MinIO object storage down / disk full / corruption | `curl -fsS http://localhost:9000/minio/health/ready` → [`MINIO_FAILURE.md`](MINIO_FAILURE.md) |
+| LightRAG graph retrieval down / API errors | `docker compose ps lightrag` → [`LIGHTRAG_FAILURE.md`](LIGHTRAG_FAILURE.md) |
 
 ## Start Here
 
@@ -28,6 +33,11 @@ Operator entrypoint for container/service investigations and incident response. 
 | Postgres WAL recovery or replication issues | [`POSTGRESQL_WAL_RECOVERY.md`](POSTGRESQL_WAL_RECOVERY.md) |
 | VPS / Google Drive ingestion recovery | [`vps-gdrive-ingestion-recovery.md`](vps-gdrive-ingestion-recovery.md) |
 | Self-hosted GitHub Actions runner for `nightly-heavy.yml` is offline | [`SELF_HOSTED_RUNNER.md`](SELF_HOSTED_RUNNER.md) |
+| Telegram bot container, Telegram API, or query-processing alerts | [`TELEGRAM_BOT_FAILURE.md`](TELEGRAM_BOT_FAILURE.md) |
+| Embedding service (BGE-M3, BM42, Voyage) alerts | [`EMBEDDING_SERVICE_FAILURE.md`](EMBEDDING_SERVICE_FAILURE.md) |
+| Docling document parser alerts | [`DOCLING_FAILURE.md`](DOCLING_FAILURE.md) |
+| MinIO storage alerts | [`MINIO_FAILURE.md`](MINIO_FAILURE.md) |
+| LightRAG graph-retrieval alerts | [`LIGHTRAG_FAILURE.md`](LIGHTRAG_FAILURE.md) |
 | Weekly git/pr/issue hygiene workflow | [`GIT_PR_ISSUE_NATIVE.md`](GIT_PR_ISSUE_NATIVE.md) |
 
 ## Container / Service Map

--- a/docs/runbooks/TELEGRAM_BOT_FAILURE.md
+++ b/docs/runbooks/TELEGRAM_BOT_FAILURE.md
@@ -1,0 +1,181 @@
+# Runbook: Telegram Bot Failure
+
+> **Owner:** Bot core / On-call
+> **Last verified:** 2026-05-22
+> **Verification command:**
+> ```bash
+> COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml ps bot
+> ```
+
+Use this runbook when alerts from `docker/monitoring/rules/telegram-bot.yaml` fire or the bot is misbehaving end-to-end.
+
+## Covered Alerts
+
+| Alert | Severity | Source |
+|---|---|---|
+| `BotContainerDown` | critical | [`telegram-bot.yaml`](../../docker/monitoring/rules/telegram-bot.yaml) |
+| `BotHighErrorRate` | warning | [`telegram-bot.yaml`](../../docker/monitoring/rules/telegram-bot.yaml) |
+| `BotCriticalError` | critical | [`telegram-bot.yaml`](../../docker/monitoring/rules/telegram-bot.yaml) |
+| `TelegramAPIError` | warning | [`telegram-bot.yaml`](../../docker/monitoring/rules/telegram-bot.yaml) |
+| `BotRestarted` | info | [`telegram-bot.yaml`](../../docker/monitoring/rules/telegram-bot.yaml) |
+| `QueryProcessingError` | warning | [`telegram-bot.yaml`](../../docker/monitoring/rules/telegram-bot.yaml) |
+| `SlowBotResponse` | warning | [`telegram-bot.yaml`](../../docker/monitoring/rules/telegram-bot.yaml) |
+| `BotMemoryWarning` | warning | [`telegram-bot.yaml`](../../docker/monitoring/rules/telegram-bot.yaml) |
+
+## Service / Container Map
+
+| Compose service | Typical container names |
+|---|---|
+| `bot` | `dev-bot-1`, `dev_bot_1` |
+
+> Service endpoints, ports, and Compose profiles: [`DOCKER.md`](../../DOCKER.md).
+> Local dev workflow: [`docs/LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md).
+
+## Fast-Path Diagnosis (read-only)
+
+### 1. Container state
+
+```bash
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml ps bot
+docker inspect dev-bot-1 --format '
+  Name={{.Name}}
+  Status={{.State.Status}}
+  Restarts={{.RestartCount}}
+  OOMKilled={{.State.OOMKilled}}
+  ExitCode={{.State.ExitCode}}
+'
+```
+
+If `Status` is `restarting` and `RestartCount` keeps climbing, treat as `BotContainerDown`/`BotRestarted` and continue with logs.
+
+### 2. Bounded log slice
+
+```bash
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml logs bot --tail=200
+```
+
+Look for the same patterns that drive the alerts:
+
+| Pattern | Likely alert |
+|---|---|
+| `error`, `exception`, `failed` (rate based) | `BotHighErrorRate` |
+| `critical`, `fatal`, `panic` | `BotCriticalError` |
+| `telegram.*error`, `aiogram.*error` | `TelegramAPIError` |
+| `Starting bot` (more than once in 5m) | `BotRestarted` |
+| `query.*error`, `search.*failed`, `retrieval.*error` | `QueryProcessingError` |
+| `response_time.*5000` (or higher) | `SlowBotResponse` |
+| `memory.*warning`, `memory.*high`, `oom` | `BotMemoryWarning` |
+
+### 3. Health checks for the bot's hard dependencies
+
+If the bot is up but failing every query, the root cause is usually one of its dependencies:
+
+```bash
+# Qdrant
+curl -fsS http://localhost:6333/readyz
+
+# Redis (app cache)
+COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec redis sh -lc 'redis-cli -a "$REDIS_PASSWORD" ping'
+
+# LiteLLM
+curl -fsS http://localhost:4000/health/liveliness
+```
+
+Fan-out to the dedicated runbook for whichever check fails: [`QDRANT_TROUBLESHOOTING.md`](QDRANT_TROUBLESHOOTING.md), [`REDIS_CACHE_DEGRADATION.md`](REDIS_CACHE_DEGRADATION.md), [`LITEllm_FAILURE.md`](LITEllm_FAILURE.md).
+
+### 4. Trace freshness
+
+```bash
+make validate-traces-fast
+```
+
+If traces are stale or missing, see [`LANGFUSE_TRACING_GAPS.md`](LANGFUSE_TRACING_GAPS.md). Langfuse can be healthy while the bot still records `LLM failed: Connection error` spans — that points back at LiteLLM, not Langfuse.
+
+## Service Failure vs App Bug
+
+| Observation | Interpretation | Next step |
+|---|---|---|
+| Container `Exited (137)` or `OOMKilled=true` | Service failure (memory) | Increase memory limit in `compose.dev.yml`; investigate workload |
+| Container `Exited (127)` with bind-mount error in `inspect` | Stale Docker Desktop / WSL bind-mount | Recreate only the bot: `docker compose up -d --force-recreate bot` |
+| `RestartCount` climbing, no log entries | Service failure (startup crash) | `docker compose logs bot --since=10m` and inspect `compose.yml` env contract |
+| Bot is up, alerts only show `TelegramAPIError` | App bug or upstream Telegram outage | Verify `TELEGRAM_BOT_TOKEN` is present (do not print it); check `https://api.telegram.org` reachability |
+| `BotHighErrorRate` with no critical errors | App bug or load spike | Profile slow node from Langfuse; check rate limits |
+| `QueryProcessingError` correlated with Qdrant warnings | Service failure (Qdrant) | [`QDRANT_TROUBLESHOOTING.md`](QDRANT_TROUBLESHOOTING.md) |
+| `SlowBotResponse` only on cache miss | App bug / capacity | Check Redis hit rate; consider preheating |
+| `BotMemoryWarning` rising over hours | Memory leak | Capture `docker stats bot`; restart and compare |
+
+## Source Paths
+
+| Component | Path |
+|---|---|
+| Bot entry point | [`telegram_bot/bot.py`](../../telegram_bot/bot.py) |
+| LangGraph wiring | [`telegram_bot/graph/`](../../telegram_bot/graph/) |
+| Score taxonomy | [`telegram_bot/scoring.py`](../../telegram_bot/scoring.py), [`docs/RAG_QUALITY_SCORES.md`](../RAG_QUALITY_SCORES.md) |
+| Compose service definition | [`compose.yml`](../../compose.yml), [`compose.dev.yml`](../../compose.dev.yml) |
+
+## Logs and Artifacts
+
+| Artifact | Location / command |
+|---|---|
+| Runtime logs | `docker compose logs bot --tail=200` |
+| Health probe | `make test-bot-health` |
+| Langfuse traces | Langfuse UI → filter by `service=bot`; or `make validate-traces-fast` |
+| Container metadata | `docker inspect dev-bot-1` |
+
+## Remediation
+
+> ⚠️ **Caution:** Mutating commands. Run only after fast-path diagnosis confirms the issue.
+
+### `BotContainerDown`
+
+1. Inspect exit reason (see Fast-Path Diagnosis #1).
+2. If `OOMKilled=true`: raise `services.bot.deploy.resources.limits.memory` in `compose.dev.yml` and recreate.
+3. If startup crash: fix the surfaced error, then:
+   ```bash
+   COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml up -d --force-recreate bot
+   ```
+
+### `BotHighErrorRate` / `BotCriticalError` / `QueryProcessingError`
+
+1. Capture the offending stack trace from logs.
+2. Cross-reference with current Langfuse traces.
+3. If a dependency is the culprit, follow that runbook; do not preemptively restart the bot.
+
+### `TelegramAPIError`
+
+1. Confirm `TELEGRAM_BOT_TOKEN` env var is present (presence only, never print).
+2. Check Telegram BotFather status / public Telegram outage page.
+3. If the bot is rate-limited (429), back off retries; do not loop.
+
+### `BotRestarted`
+
+`info`-severity. Confirm the cause: planned deploy, OOM, or crash loop. Treat repeated restarts as `BotContainerDown`.
+
+### `SlowBotResponse`
+
+1. Compare current p50/p95 from Langfuse with baseline.
+2. Check upstream latency (LiteLLM, Qdrant, BGE-M3).
+3. If only cold cache: warm semantic + search caches with synthetic queries.
+
+### `BotMemoryWarning`
+
+1. `docker stats dev-bot-1` for current RSS.
+2. If steady growth: capture heap snapshot via tracemalloc / py-spy attach, then restart.
+3. If transient spike: raise the dev memory limit, file a follow-up to investigate.
+
+## Prevention
+
+- Keep Compose memory limits headroom ≥ 30%.
+- Wire `make pre-push` and `make check` into the local loop.
+- Watch the `bge_embed_error`, `llm_timeout`, and `safe_fallback_used` Langfuse scores — they typically rise before `BotHighErrorRate` fires.
+- Capture restart events in CHANGELOG when caused by deploys.
+
+## See Also
+
+- [`LITEllm_FAILURE.md`](LITEllm_FAILURE.md)
+- [`REDIS_CACHE_DEGRADATION.md`](REDIS_CACHE_DEGRADATION.md)
+- [`QDRANT_TROUBLESHOOTING.md`](QDRANT_TROUBLESHOOTING.md)
+- [`LANGFUSE_TRACING_GAPS.md`](LANGFUSE_TRACING_GAPS.md)
+- [`EMBEDDING_SERVICE_FAILURE.md`](EMBEDDING_SERVICE_FAILURE.md)
+- [`docs/RAG_QUALITY_SCORES.md`](../RAG_QUALITY_SCORES.md)
+- [`DOCKER.md`](../../DOCKER.md)

--- a/tests/contract/test_runbooks_1960_1964_contract.py
+++ b/tests/contract/test_runbooks_1960_1964_contract.py
@@ -1,0 +1,114 @@
+"""Contract: alert-driven runbooks for #1960-#1964 exist and reference every named alert.
+
+Sub-issues #1960-#1964 split out of #1957 require five operational runbooks under
+``docs/runbooks/`` with explicit alert coverage. Each runbook must:
+
+* live under ``docs/runbooks/<NAME>.md`` (canonical filenames below);
+* contain every alert name listed in the issue body so an on-call operator can
+  ``grep`` straight from the alert payload to a remediation section;
+* be linked from ``docs/runbooks/README.md`` so it shows up in the index.
+
+The mapping below is the source of truth used both by this contract and by
+the runbook authors. Update it in lock-step with the runbook bodies.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNBOOKS_DIR = REPO_ROOT / "docs" / "runbooks"
+README = RUNBOOKS_DIR / "README.md"
+
+
+# Issue -> (runbook filename, [alert names that must appear verbatim]).
+RUNBOOKS: dict[int, tuple[str, tuple[str, ...]]] = {
+    1960: (
+        "TELEGRAM_BOT_FAILURE.md",
+        (
+            "BotContainerDown",
+            "BotHighErrorRate",
+            "BotCriticalError",
+            "TelegramAPIError",
+            "BotRestarted",
+            "QueryProcessingError",
+            "SlowBotResponse",
+            "BotMemoryWarning",
+        ),
+    ),
+    1961: (
+        "EMBEDDING_SERVICE_FAILURE.md",
+        (
+            "BGEServiceDown",
+            "BM42ServiceDown",
+            "EmbeddingServiceError",
+            "BGEEmbedRetryFromBot",
+            "BGEEmbedErrorFromBot",
+            "VoyageRateLimited",
+        ),
+    ),
+    1962: (
+        "DOCLING_FAILURE.md",
+        (
+            "DoclingDown",
+            "DoclingOOM",
+            "DoclingConversionFailed",
+            "DoclingError",
+        ),
+    ),
+    1963: (
+        "MINIO_FAILURE.md",
+        (
+            "MinioDown",
+            "MinioDiskFull",
+            "MinioCorruption",
+            "MinioHealingFailed",
+            "MinioError",
+        ),
+    ),
+    1964: (
+        "LIGHTRAG_FAILURE.md",
+        (
+            "LightRAGDown",
+            "LightRAGError",
+            "LightRAGAPIError",
+        ),
+    ),
+}
+
+
+@pytest.mark.parametrize("issue_number", sorted(RUNBOOKS))
+def test_runbook_file_exists(issue_number: int) -> None:
+    filename, _ = RUNBOOKS[issue_number]
+    path = RUNBOOKS_DIR / filename
+    assert path.exists(), (
+        f"#{issue_number}: runbook docs/runbooks/{filename} is missing. "
+        "Sub-issues #1960-#1964 require alert-driven runbooks under this path."
+    )
+
+
+@pytest.mark.parametrize("issue_number", sorted(RUNBOOKS))
+def test_runbook_covers_named_alerts(issue_number: int) -> None:
+    filename, alerts = RUNBOOKS[issue_number]
+    path = RUNBOOKS_DIR / filename
+    if not path.exists():
+        pytest.skip(f"runbook {filename} missing — see test_runbook_file_exists")
+    text = path.read_text(encoding="utf-8")
+    missing = [name for name in alerts if name not in text]
+    assert not missing, (
+        f"#{issue_number}: docs/runbooks/{filename} must mention every alert from the issue "
+        f"verbatim (so operators can grep from an alert payload). Missing names: {missing}"
+    )
+
+
+@pytest.mark.parametrize("issue_number", sorted(RUNBOOKS))
+def test_runbook_indexed_in_readme(issue_number: int) -> None:
+    filename, _ = RUNBOOKS[issue_number]
+    text = README.read_text(encoding="utf-8")
+    assert f"({filename})" in text or f"]({filename})" in text, (
+        f"#{issue_number}: docs/runbooks/README.md must link to {filename} so it appears in "
+        "the operator index."
+    )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes the five sub-issues split out of the operator-docs umbrella #1957:

- #1960 — Runbook: Telegram bot failure
- #1961 — Runbook: Embedding service failure
- #1962 — Runbook: Docling failure
- #1963 — Runbook: MinIO storage failure
- #1964 — Runbook: LightRAG failure

Each runbook follows the existing `docs/runbooks/QDRANT_TROUBLESHOOTING.md` shape: alert table at the top, container map, fast-path read-only diagnosis, service-failure-vs-app-bug decision matrix, source paths, log/artifact inventory, and remediation guarded by mutating-command warnings.

## Files touched

New runbooks:

- `docs/runbooks/TELEGRAM_BOT_FAILURE.md` — BotContainerDown, BotHighErrorRate, BotCriticalError, TelegramAPIError, BotRestarted, QueryProcessingError, SlowBotResponse, BotMemoryWarning
- `docs/runbooks/EMBEDDING_SERVICE_FAILURE.md` — BGEServiceDown, BM42ServiceDown, EmbeddingServiceError, BGEEmbedRetryFromBot, BGEEmbedErrorFromBot, VoyageRateLimited
- `docs/runbooks/DOCLING_FAILURE.md` — DoclingDown, DoclingOOM, DoclingConversionFailed, DoclingError
- `docs/runbooks/MINIO_FAILURE.md` — MinioDown, MinioDiskFull, MinioCorruption, MinioHealingFailed, MinioError
- `docs/runbooks/LIGHTRAG_FAILURE.md` — LightRAGDown, LightRAGError, LightRAGAPIError

Index update:

- `docs/runbooks/README.md` — new rows under both "Quick Access" and "Start Here" so the runbooks are discoverable from the operator entrypoint.

Drift guard:

- `tests/contract/test_runbooks_1960_1964_contract.py` — single source-of-truth `RUNBOOKS` mapping; asserts each file exists, mentions every alert verbatim (so on-call operators can grep an alert payload straight into the runbook), and is linked from the README. Future alert renames will fail this test instead of silently outdating the docs.

## Validation

- [x] `uv run pytest tests/contract/test_runbooks_1960_1964_contract.py -q --no-cov` → 15 passed (5 file-existence × 5 alert-coverage × 5 README-link)
- [x] `python3 scripts/check_markdown_links.py` → `All relative Markdown links OK.`
- [x] `uv run ruff check` + `ruff format --check` on the new contract test file
- [ ] `make check` — skipped, mypy fails on pre-existing unrelated errors
- [ ] `make test-unit` — skipped, full unit suite needs extras and is unrelated

## Runtime Impact

- [x] No runtime impact (docs + new contract test only)

## Reviewer Notes

- Alert names are taken verbatim from `docker/monitoring/rules/{telegram-bot,infrastructure,extended-services,ingestion}.yaml`. If we rename an alert, fix it in both the rule and the runbook; the contract test will block silent drift.
- All runbook commands use `COMPOSE_PROJECT_NAME=dev` + `--env-file tests/fixtures/compose.ci.env` so they work without a local `.env`, matching the pattern in the existing runbooks.
- Mutating sections are explicitly guarded with a "⚠ Caution" note and the diagnosis-before-restart ordering used in `LITEllm_FAILURE.md`.
- Cross-references between the new runbooks and existing ones (LiteLLM, Redis, Qdrant, Langfuse, ingestion recovery) are intentional so on-call can chain runbooks for cascading outages.

Closes #1960, #1961, #1962, #1963, #1964.