### PR TITLE
docs(#1955): refresh pipeline routing docs to reflect dual-path architecture

### DIFF
--- a/docs/CLIENT_PIPELINE.md
+++ b/docs/CLIENT_PIPELINE.md
@@ -1,6 +1,19 @@
 # Client Pipeline: Dual-Path Architecture
 
-The Telegram bot uses a **dual-path architecture** to route queries efficiently based on role and query complexity.
+> **Canonical home for the dual-path split.** This doc describes the runtime asymmetry between the text and voice RAG flows.
+>
+> See also: [`PIPELINE_OVERVIEW.md`](PIPELINE_OVERVIEW.md) for the operational overview of all flows (ingestion / query / voice) and [`PIPELINE_ROUTING.md`](PIPELINE_ROUTING.md) for the StateGraph routing rules used by the voice path and the text-path `rag_search` tool.
+>
+> Migration plan and SDK context: [`docs/adr/0010-voice-path-create-agent-migration-plan.md`](adr/0010-voice-path-create-agent-migration-plan.md), SDK-native audit issue [#1538](https://github.com/yastman/rag/issues/1538), voice migration tracker [#1535](https://github.com/yastman/rag/issues/1535).
+
+The Telegram bot uses a **dual-path architecture** to route queries efficiently based on role and query complexity. The two paths use **different orchestrators**:
+
+| Path | Orchestrator | Source | Status |
+|---|---|---|---|
+| Text (text + agent intent) | `langchain.agents.create_agent` (LangChain 1.x) | [`telegram_bot/agents/agent.py`](../telegram_bot/agents/agent.py) | SDK-native |
+| Voice | Custom `StateGraph` from `build_graph()` | [`telegram_bot/graph/graph.py`](../telegram_bot/graph/graph.py) | Pending migration ([ADR-0010](adr/0010-voice-path-create-agent-migration-plan.md), #1535) |
+
+The voice path's `StateGraph` is reused (read-only) by the text path's `rag_search` tool, so the routing rules in `PIPELINE_ROUTING.md` apply to both paths' retrieve→grade→rerank inner loop.
 
 ## Architecture Overview
 
@@ -17,9 +30,9 @@ PropertyBot.handle_query()
     │                                          │
     │                                    rag_pipeline() → generate_response()
     │                                          │
-    └─── [Manager role OR complex query] ──→ SDK Agent Pipeline
+    └─── [Manager role OR complex query] ──→ SDK Agent Pipeline (create_agent)
                                                │
-                                         Full LangGraph agent
+                                         langchain.agents.create_agent
                                                │
                                     create_bot_agent() → tools
 ```
@@ -77,7 +90,7 @@ Client pipeline uses store guards:
 ### Characteristics
 
 - **1-N LLM calls** (agent loop + generation)
-- **Full LangGraph** with checkpointer
+- **Orchestrator:** `langchain.agents.create_agent` (LangChain 1.x SDK) — not a raw `StateGraph`. Voice path still uses `StateGraph` pending [ADR-0010](adr/0010-voice-path-create-agent-migration-plan.md) / #1535.
 - **Tools available:** RAG search, history, CRM operations
 - **Higher latency** but more capable
 

--- a/docs/PIPELINE_OVERVIEW.md
+++ b/docs/PIPELINE_OVERVIEW.md
@@ -1,10 +1,17 @@
 # Pipeline Overview
 
+> Operational overview of ingestion, query, and voice flows. The query path is split across two orchestrators (text=`create_agent`, voice=`StateGraph`); see [`CLIENT_PIPELINE.md`](CLIENT_PIPELINE.md) for the canonical dual-path explanation, [`PIPELINE_ROUTING.md`](PIPELINE_ROUTING.md) for the StateGraph routing rules, and [`docs/adr/0010-voice-path-create-agent-migration-plan.md`](adr/0010-voice-path-create-agent-migration-plan.md) plus SDK-native audit issue [#1538](https://github.com/yastman/rag/issues/1538) for the migration context.
+
 Operational overview of ingestion, query, and voice flows.
 
 ## 1) Query Pipeline (Telegram Bot / API)
 
-`telegram_bot/graph/graph.py` builds a LangGraph state machine.
+The bot has **two orchestrators** for queries (see [`CLIENT_PIPELINE.md`](CLIENT_PIPELINE.md) for full details):
+
+- **Text path** uses `langchain.agents.create_agent` ([`telegram_bot/agents/agent.py`](../telegram_bot/agents/agent.py)). The agent calls a `rag_search` tool that internally drives the retrieve→grade→rerank loop, plus other tools (history, CRM).
+- **Voice path** uses a custom `StateGraph` built by `build_graph()` ([`telegram_bot/graph/graph.py`](../telegram_bot/graph/graph.py)). Migration to `create_agent` is tracked in [ADR-0010](adr/0010-voice-path-create-agent-migration-plan.md) and #1535 / #1538.
+
+The node list below describes the **voice-path StateGraph** and the inner stages reused by the text path's `rag_search` tool. Routing rules and conditional edges between these nodes live in [`PIPELINE_ROUTING.md`](PIPELINE_ROUTING.md).
 
 Main nodes:
 - `transcribe` (voice input only)

--- a/docs/PIPELINE_ROUTING.md
+++ b/docs/PIPELINE_ROUTING.md
@@ -1,5 +1,7 @@
 # Pipeline Routing
 
+> Routing rules and conditional edges of the LangGraph `StateGraph` built by `build_graph()` in [`telegram_bot/graph/graph.py`](../telegram_bot/graph/graph.py). This graph drives the **voice path** end-to-end and is reused by the **text path** through the `rag_search` tool's internal retrieve→grade→rerank loop. The dual-path split itself is documented in [`CLIENT_PIPELINE.md`](CLIENT_PIPELINE.md); the operational overview of ingestion / query / voice flows lives in [`PIPELINE_OVERVIEW.md`](PIPELINE_OVERVIEW.md). Voice migration plan: [`docs/adr/0010-voice-path-create-agent-migration-plan.md`](adr/0010-voice-path-create-agent-migration-plan.md), tracked under #1535 and the SDK-native audit issue [#1538](https://github.com/yastman/rag/issues/1538).
+
 Query routing logic through the LangGraph pipeline.
 
 ## Routing Flow

--- a/tests/contract/test_pipeline_docs_dual_path_contract.py
+++ b/tests/contract/test_pipeline_docs_dual_path_contract.py
@@ -1,0 +1,117 @@
+"""Contract: pipeline docs reflect the current dual-path architecture (#1955).
+
+The bot has two RAG entrypoints with divergent orchestrators (see
+ADR-0010 and #1538):
+
+* Text path uses ``langchain.agents.create_agent`` in
+  ``telegram_bot/agents/agent.py``.
+* Voice path uses a custom ``StateGraph`` in
+  ``telegram_bot/graph/graph.py``.
+
+Three docs describe slices of this architecture:
+
+* ``docs/PIPELINE_OVERVIEW.md`` — operational view of all flows
+  (ingestion / query / voice).
+* ``docs/PIPELINE_ROUTING.md`` — StateGraph routing rules; remains the
+  source of truth for the voice path and the ``rag_search`` tool reused
+  by the text path.
+* ``docs/CLIENT_PIPELINE.md`` — canonical description of the
+  dual-path split.
+
+This contract pins three drift-prone properties:
+
+1. Each doc carries a short header pointing at the other two so readers
+   land on the right place.
+2. ``CLIENT_PIPELINE.md`` is the single canonical dual-path home; the
+   other two link to it.
+3. Each doc references ADR-0010 and the SDK-native audit issue #1538
+   so the migration plan is one click away.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+PIPELINE_OVERVIEW = REPO_ROOT / "docs" / "PIPELINE_OVERVIEW.md"
+PIPELINE_ROUTING = REPO_ROOT / "docs" / "PIPELINE_ROUTING.md"
+CLIENT_PIPELINE = REPO_ROOT / "docs" / "CLIENT_PIPELINE.md"
+
+ALL_DOCS = (PIPELINE_OVERVIEW, PIPELINE_ROUTING, CLIENT_PIPELINE)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _header_block(text: str, lines: int = 12) -> str:
+    return "\n".join(text.splitlines()[:lines])
+
+
+@pytest.mark.parametrize("path", ALL_DOCS, ids=lambda p: p.name)
+def test_doc_header_links_to_other_two(path: Path) -> None:
+    """Each doc's first ~12 lines must point at the other two pipeline docs."""
+    text = _header_block(_read(path))
+    others = [d.name for d in ALL_DOCS if d != path]
+    missing = [name for name in others if name not in text]
+    assert not missing, (
+        f"#{1955}: {path.name} header must reference both other pipeline docs so "
+        f"readers can pivot to the right surface. Missing references: {missing}. "
+        "Add a 'see also' line within the first ~12 lines."
+    )
+
+
+@pytest.mark.parametrize("path", (PIPELINE_OVERVIEW, PIPELINE_ROUTING), ids=lambda p: p.name)
+def test_secondary_docs_point_at_canonical_dual_path(path: Path) -> None:
+    """PIPELINE_OVERVIEW and PIPELINE_ROUTING must defer dual-path detail to CLIENT_PIPELINE.md."""
+    text = _read(path)
+    assert "CLIENT_PIPELINE.md" in text, (
+        f"#{1955}: {path.name} must link to CLIENT_PIPELINE.md, the canonical home for the "
+        "dual-path (text=create_agent / voice=StateGraph) architecture."
+    )
+
+
+@pytest.mark.parametrize("path", ALL_DOCS, ids=lambda p: p.name)
+def test_doc_references_adr_0010_and_sdk_audit(path: Path) -> None:
+    """Each doc must point at ADR-0010 (voice migration plan) and the SDK-native audit (#1538)."""
+    text = _read(path)
+    assert "0010" in text, (
+        f"#{1955}: {path.name} must reference ADR-0010 (voice path migration). "
+        "Link to docs/adr/0010-voice-path-create-agent-migration-plan.md."
+    )
+    assert "#1538" in text or "1538" in text, (
+        f"#{1955}: {path.name} must reference the SDK-native audit issue "
+        "(#1538) so the dual-path context is discoverable."
+    )
+
+
+def test_canonical_dual_path_doc_names_both_orchestrators() -> None:
+    """CLIENT_PIPELINE.md must explicitly name both orchestrators."""
+    text = _read(CLIENT_PIPELINE)
+    assert "create_agent" in text, (
+        "#1955: CLIENT_PIPELINE.md must name the create_agent SDK explicitly for the text path."
+    )
+    assert "StateGraph" in text or "build_graph" in text, (
+        "#1955: CLIENT_PIPELINE.md must name the StateGraph orchestrator explicitly "
+        "for the voice path so the asymmetry is documented."
+    )
+
+
+def test_pipeline_overview_does_not_misattribute_text_path_to_stategraph() -> None:
+    """Stale claim guard: PIPELINE_OVERVIEW must not say the bot's main entry uses StateGraph alone.
+
+    The pre-#1955 text said 'telegram_bot/graph/graph.py builds a LangGraph state machine'
+    without mentioning that the text path uses create_agent. After #1955, that line either
+    must be removed or qualified so readers don't conclude the entire bot runs on StateGraph.
+    """
+    text = _read(PIPELINE_OVERVIEW)
+    if "telegram_bot/graph/graph.py builds a LangGraph state machine" in text:
+        pytest.fail(
+            "#1955: PIPELINE_OVERVIEW.md still claims 'telegram_bot/graph/graph.py builds a "
+            "LangGraph state machine' without mentioning the create_agent text path. Qualify "
+            "the statement (voice path) or remove it."
+        )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Sub-issue split out of the operator-docs umbrella #1193. Refreshes the three pipeline docs so they accurately reflect the **dual-path orchestration** that the SDK-native audit (#1538) and ADR-0010 already document at the code level.

The pre-PR docs implied the entire query path runs on a custom `StateGraph`, but only the **voice** path does. The **text** path uses `langchain.agents.create_agent` and reuses the StateGraph nodes only via the `rag_search` tool's inner loop.

## Files touched

- `docs/PIPELINE_OVERVIEW.md` — header + Section 1 rewrite naming both orchestrators; defers dual-path detail to `CLIENT_PIPELINE.md`.
- `docs/PIPELINE_ROUTING.md` — header clarifying that routing rules apply to the voice-path StateGraph and the text-path `rag_search` inner loop.
- `docs/CLIENT_PIPELINE.md` — header positioning it as the canonical dual-path home; orchestrator table; Path 2 description updated from "Full LangGraph agent" to `langchain.agents.create_agent` with explicit cross-references to ADR-0010, #1535, and #1538.
- `tests/contract/test_pipeline_docs_dual_path_contract.py` — new contract pinning header cross-links, the canonical-doc role, ADR/issue references, and a regression guard against the stale "telegram_bot/graph/graph.py builds a LangGraph state machine" claim.

## Acceptance criteria from #1955

- [x] Each of the 3 docs has a one-sentence "this doc covers X, see Y for Z" header (`> Operational overview…`, `> Routing rules…`, `> Canonical home for the dual-path split.`).
- [x] Dual-path is described in **one** canonical place — `CLIENT_PIPELINE.md`; the other two link to it.
- [x] Reference SDK-native audit #1538 and ADR-0010 — present in all three docs (verified by contract test).
- [x] No code-level claim contradicts `telegram_bot/agents/agent.py` or `telegram_bot/graph/graph.py` — `agent.py` uses `langchain.agents.create_agent`, `graph.py` builds `StateGraph`; both are now named verbatim where they apply.
- [x] `scripts/check_markdown_links.py` clean.

## Validation

- [x] `uv run pytest tests/contract/test_pipeline_docs_dual_path_contract.py -q --no-cov` → 10 passed
- [x] `python3 scripts/check_markdown_links.py` → `All relative Markdown links OK.`
- [x] `uv run ruff check` + `ruff format --check` on the new contract test file
- [ ] `make check` — skipped, mypy fails on pre-existing unrelated errors
- [ ] `make test-unit` — skipped, full unit suite needs extras and is unrelated

## Runtime Impact

- [x] No runtime impact (docs + new contract test only)

## Reviewer Notes

- The contract test does not enforce specific wording — it only asserts cross-links, orchestrator naming, and reference presence — so the docs can be polished further without churning the test.
- The PIPELINE_ROUTING.md content (StateGraph routing rules) is still accurate and was kept; it was missing only a header explaining that the rules apply to the voice path and the text-path `rag_search` inner loop.
- No new ADRs added; ADR-0010 is the design-first migration plan and is referenced from all three docs.

Closes #1955.