### PR TITLE
test(#2009): replace fragile FastAPI shim with pytest.importorskip

### DIFF
--- a/tests/contract/test_no_partial_fastapi_shim_contract.py
+++ b/tests/contract/test_no_partial_fastapi_shim_contract.py
@@ -37,18 +37,6 @@ SCAN_ROOTS = (
     REPO_ROOT / "tests" / "contract",
 )
 
-# Patterns that indicate a partial fake-module install. The literal
-# ``sys.modules["fastapi"] =`` assignment is the smoking gun; ``_FakeFastAPI``
-# / ``_FakeJSONResponse`` were the specific class names from the regression.
-FORBIDDEN_PATTERNS = (
-    'sys.modules["fastapi"] =',
-    "sys.modules['fastapi'] =",
-    'sys.modules["fastapi.responses"] =',
-    "sys.modules['fastapi.responses'] =",
-    "_FakeFastAPI",
-    "_FakeJSONResponse",
-)
-
 
 def _python_test_files() -> list[Path]:
     files: list[Path] = []
@@ -64,8 +52,28 @@ def _python_test_files() -> list[Path]:
 
 @pytest.mark.parametrize("test_path", _python_test_files(), ids=lambda p: p.name)
 def test_no_partial_fastapi_shim_in_sys_modules(test_path: Path) -> None:
+    # Patterns that indicate a partial fake-module install. The literal
+    # ``sys.modules["fastapi"] =`` assignment is the smoking gun; the
+    # ``_FakeFastAPI`` / ``_FakeJSONResponse`` class names came from the
+    # regression in tests/unit/api/test_rag_api_runtime.py before #2009.
+    #
+    # NOTE: keep this tuple inside the test function body. The sibling
+    # ``tests/unit/test_module_pollution.py::test_no_module_level_sys_modules_assignment``
+    # AST guard scans only top-level statements for the literal
+    # ``sys.modules[`` + ``=`` substring, so a module-level constant here
+    # would self-trip that guard. Building the tuple inside the function
+    # keeps both contracts honest without a guard exemption.
+    forbidden_patterns = (
+        'sys.modules["fastapi"] =',
+        "sys.modules['fastapi'] =",
+        'sys.modules["fastapi.responses"] =',
+        "sys.modules['fastapi.responses'] =",
+        "_FakeFastAPI",
+        "_FakeJSONResponse",
+    )
+
     text = test_path.read_text(encoding="utf-8")
-    found = [pat for pat in FORBIDDEN_PATTERNS if pat in text]
+    found = [pat for pat in forbidden_patterns if pat in text]
     assert not found, (
         f"#2009: {test_path.relative_to(REPO_ROOT)} installs a partial fake fastapi module "
         f"({found}). Use pytest.importorskip('fastapi', reason=...) at module top instead so "

--- a/tests/contract/test_no_partial_fastapi_shim_contract.py
+++ b/tests/contract/test_no_partial_fastapi_shim_contract.py
@@ -1,0 +1,83 @@
+"""Contract: no test installs a partial fake ``fastapi`` module into ``sys.modules`` (#2009).
+
+Issue #2009 documented a fast-lane regression where
+``tests/unit/api/test_rag_api_runtime.py`` installed an incomplete
+``_FakeFastAPI`` / ``_FakeJSONResponse`` shim into ``sys.modules`` so it
+could import ``src.api.main`` without the optional FastAPI dependency.
+
+Two ways the shim caused trouble:
+
+* If the import after the shim install raised, the cleanup pop never ran
+  and the partial module leaked into the rest of the worker, turning
+  ``pytest.importorskip("fastapi")`` calls in Mini App tests into
+  ``ImportError: cannot import name 'Depends' from 'fastapi'``.
+* Even when cleanup ran, the bound classes inside ``src.api.main`` kept
+  references to the shim, so any test that re-imported the module later
+  in the same worker saw a chimera.
+
+The supported pattern is ``pytest.importorskip("fastapi")`` at module
+top, which skips cleanly when the optional dep is missing. This contract
+test forbids the pattern that caused the regression so the fast lane
+stays deterministic after a plain ``uv sync``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Guard scope: any test that touches FastAPI lives in one of these subtrees.
+SCAN_ROOTS = (
+    REPO_ROOT / "tests" / "unit" / "api",
+    REPO_ROOT / "tests" / "unit" / "mini_app",
+    REPO_ROOT / "tests" / "contract",
+)
+
+# Patterns that indicate a partial fake-module install. The literal
+# ``sys.modules["fastapi"] =`` assignment is the smoking gun; ``_FakeFastAPI``
+# / ``_FakeJSONResponse`` were the specific class names from the regression.
+FORBIDDEN_PATTERNS = (
+    'sys.modules["fastapi"] =',
+    "sys.modules['fastapi'] =",
+    'sys.modules["fastapi.responses"] =',
+    "sys.modules['fastapi.responses'] =",
+    "_FakeFastAPI",
+    "_FakeJSONResponse",
+)
+
+
+def _python_test_files() -> list[Path]:
+    files: list[Path] = []
+    for root in SCAN_ROOTS:
+        if not root.exists():
+            continue
+        files.extend(sorted(root.rglob("test_*.py")))
+    # Exclude this contract test itself; it intentionally documents the
+    # forbidden patterns.
+    self_path = Path(__file__).resolve()
+    return [p for p in files if p.resolve() != self_path]
+
+
+@pytest.mark.parametrize("test_path", _python_test_files(), ids=lambda p: p.name)
+def test_no_partial_fastapi_shim_in_sys_modules(test_path: Path) -> None:
+    text = test_path.read_text(encoding="utf-8")
+    found = [pat for pat in FORBIDDEN_PATTERNS if pat in text]
+    assert not found, (
+        f"#2009: {test_path.relative_to(REPO_ROOT)} installs a partial fake fastapi module "
+        f"({found}). Use pytest.importorskip('fastapi', reason=...) at module top instead so "
+        "the fast lane skips cleanly when the optional dep is absent."
+    )
+
+
+def test_rag_api_runtime_uses_importorskip() -> None:
+    target = REPO_ROOT / "tests" / "unit" / "api" / "test_rag_api_runtime.py"
+    assert target.exists(), "expected tests/unit/api/test_rag_api_runtime.py to exist"
+    text = target.read_text(encoding="utf-8")
+    assert 'pytest.importorskip("fastapi"' in text or "pytest.importorskip('fastapi'" in text, (
+        "#2009: tests/unit/api/test_rag_api_runtime.py must use pytest.importorskip('fastapi') "
+        "at module top to opt out cleanly when FastAPI is not installed (canonical fast lane)."
+    )

--- a/tests/unit/api/test_rag_api_runtime.py
+++ b/tests/unit/api/test_rag_api_runtime.py
@@ -2,60 +2,22 @@
 
 from __future__ import annotations
 
-import importlib.util
 import json
-import sys
 from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
-_FASTAPI_SHIM_ACTIVE = False
-if importlib.util.find_spec("fastapi") is None:
-    # Minimal shim so src.api.main can be imported in core unit CI.
-    class _FakeJSONResponse:
-        def __init__(self, *, status_code: int, content: dict) -> None:
-            self.status_code = status_code
-            self.content = content
 
-    class _FakeFastAPI:
-        def __init__(self, *args, **kwargs) -> None:
-            self.state = SimpleNamespace()
-
-        def exception_handler(self, *_args, **_kwargs):
-            def _decorator(func):
-                return func
-
-            return _decorator
-
-        def get(self, *_args, **_kwargs):
-            def _decorator(func):
-                return func
-
-            return _decorator
-
-        def post(self, *_args, **_kwargs):
-            def _decorator(func):
-                return func
-
-            return _decorator
-
-    fake_fastapi = type(sys)("fastapi")
-    fake_fastapi.FastAPI = _FakeFastAPI
-    fake_fastapi_responses = type(sys)("fastapi.responses")
-    fake_fastapi_responses.JSONResponse = _FakeJSONResponse
-    sys.modules["fastapi"] = fake_fastapi
-    sys.modules["fastapi.responses"] = fake_fastapi_responses
-    _FASTAPI_SHIM_ACTIVE = True
+# FastAPI is an optional dep; the canonical fast lane (`make test-unit` after
+# `uv sync` without extras) does not install it. Skip cleanly instead of
+# installing a partial fake module into ``sys.modules`` that could leak into
+# later tests calling ``pytest.importorskip("fastapi")`` (#2009 evidence).
+pytest.importorskip("fastapi", reason="src.api.main needs FastAPI; install --extra api")
 
 from src.api.main import app, generic_error_handler, lifespan, query
 from src.api.schemas import QueryRequest, QueryResponse
-
-
-if _FASTAPI_SHIM_ACTIVE:
-    # Prevent leaking shim into other tests that intentionally importorskip fastapi.
-    sys.modules.pop("fastapi.responses", None)
-    sys.modules.pop("fastapi", None)
 
 
 def _response_content(response) -> dict:


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Addresses the highest-leverage finding from #2009: the canonical fast lane (`make test-unit` after `uv sync`) is non-deterministic because `tests/unit/api/test_rag_api_runtime.py` installs a partial fake `fastapi` module into `sys.modules`. The shim leaks into other workers when the post-shim import raises (cleanup pop never runs), turning every downstream `pytest.importorskip("fastapi")` into `ImportError: cannot import name 'Depends'` instead of a clean skip.

## Files touched

- `tests/unit/api/test_rag_api_runtime.py` — replaced the ~50-line `_FakeFastAPI` / `_FakeJSONResponse` shim with the canonical pattern already used by every `tests/unit/mini_app/*.py` file:

  ```python
  pytest.importorskip("fastapi", reason="src.api.main needs FastAPI; install --extra api")
  ```

  No fake module is installed; the file skips cleanly when the optional dep is absent and runs unchanged when FastAPI is present.

- `tests/contract/test_no_partial_fastapi_shim_contract.py` — new contract pinning the fix:
  - scans `tests/unit/api`, `tests/unit/mini_app`, and `tests/contract` for the forbidden patterns (`sys.modules["fastapi"] = …`, `_FakeFastAPI`, `_FakeJSONResponse`);
  - asserts `tests/unit/api/test_rag_api_runtime.py` uses `pytest.importorskip("fastapi")` at module top.

## Scope vs #2009 acceptance criteria

| AC | Status |
|---|---|
| #1 — `uv sync` + `make test-unit` works clean | **Fixed by this PR** (no shim → no leak → mini_app tests skip instead of erroring) |
| #2 — FastAPI-dependent tests use proper isolation | **Fixed by this PR** (`importorskip` matches the established pattern) |
| #3 — No test leaves partial fake modules in `sys.modules` | **Fixed by this PR** + enforced going forward via the new contract test |
| #4 — CI runs the canonical fast gate | **Already on dev** — `.github/workflows/ci.yml` `fast-tests` job runs `tests/unit + tests/contract + tests/integration/test_graph_paths.py` with the same ignore list as `make test-unit` |
| #5/6 — Nightly coverage / bounded parallelism | **Already on dev** — `nightly-heavy.yml` has `nightly-full` (integration + smoke + baseline, `-n auto --dist=worksteal`) and `heavy-tier` (`requires_extras or load or chaos or e2e or benchmark`) |
| #7/8 — Runtime env gates / Compose project name | **Out of scope** for this PR; needs runtime evidence and is best handled in a dedicated follow-up |
| #9 — `make test-contract` clean | **Already on dev** — most §6 contract drift items already fixed (`workflows.disabled` removed, `BOT_TOKEN`/`MINI_APP_ALLOWED_ORIGIN` already present in `.env.example`, `test_injection_hard_mode_blocks` deduped — closed in #1996/PR #2013) |

So this PR closes the high-priority shim issue and the §1–§3 ACs. Remaining items are tracked in the issue body but are best handled as separate, evidence-gathering PRs.

## Validation

- [x] `uv run pytest tests/contract/test_no_partial_fastapi_shim_contract.py -q --no-cov` → **65 passed** (64 file-scan parametrizations + 1 importorskip assertion)
- [x] `uv run pytest tests/unit/api/test_rag_api_runtime.py -q --no-cov` (no FastAPI) → all 12 tests **skipped cleanly** with reason
- [x] `uv run pytest tests/unit/api/test_rag_api_runtime.py -q --no-cov` (with FastAPI + httpx) → 5 passed, 7 failed — **same as `dev` tip without this change**, so the 7 failures are pre-existing Langfuse-mock contract issues unrelated to the shim.
- [x] `uv run ruff check` + `ruff format --check` on touched files
- [ ] `make check` — skipped, mypy fails on pre-existing unrelated errors
- [ ] `make test-unit` — skipped locally; CI fast-tests job will run the same lane

## Runtime Impact

- [x] No runtime impact (test files only)

## Reviewer Notes

- The 7 still-failing tests in `test_rag_api_runtime.py` are not introduced by this PR. I verified by running the same command against `dev` HEAD (cb2a8a1) without my patch — identical 7 failures. Those need their own PR with deeper Langfuse mocking work.
- The contract test deliberately scopes the scan to test directories so that legitimate uses of `sys.modules["fastapi"]` in production code (none today) are not blocked.
- Pattern parity: every `tests/unit/mini_app/*.py` already uses `pytest.importorskip("fastapi")`. This PR aligns the api lane with that convention.

Refs #2009.