### PR TITLE
arch(#1948): land layering ratchet + phone_utils slice (src/ canonical home)

### DIFF
--- a/mini_app/phone.py
+++ b/mini_app/phone.py
@@ -6,8 +6,8 @@ import logging
 
 from pydantic import BaseModel, field_validator
 
+from src.phone_utils import normalize_phone
 from telegram_bot.observability import get_client, observe
-from telegram_bot.phone_utils import normalize_phone
 
 
 logger = logging.getLogger(__name__)

--- a/src/phone_utils.py
+++ b/src/phone_utils.py
@@ -1,0 +1,65 @@
+"""Shared phone-normalization helpers (canonical home, #1948).
+
+Single source of truth for phone validation/normalization. Used by:
+
+- ``telegram_bot/keyboards/phone_keyboard.py`` (bot reply-keyboard flow)
+- ``mini_app/phone.py`` (Mini App ``/api/phone`` Pydantic validator)
+- any future ``src/api`` consumer
+
+Closes the duplication called out in #1614 — Mini App previously redeclared a
+``_PHONE_RE = ^\\+?\\d{7,15}$`` regex that accepted impossible numbers like
+``+11111111111`` and never normalized to E.164. This module routes both
+consumers through ``phonenumbers.is_valid_number`` and E.164 formatting.
+
+This module is intentionally UI-free (no aiogram / no FastAPI) so it can be
+imported from any context without side-effects. The original location at
+``telegram_bot/phone_utils.py`` is kept as a thin re-export shim for back
+compatibility with existing bot internal callers (see #1948).
+"""
+
+from __future__ import annotations
+
+import re
+
+import phonenumbers
+
+
+_SEPARATORS_RE = re.compile(r"[\s\-\(\)]")
+
+
+def _strip_separators(raw: str) -> str:
+    """Remove whitespace, dashes, and parentheses commonly typed by users."""
+    return _SEPARATORS_RE.sub("", raw)
+
+
+def normalize_phone(raw: str, default_region: str = "BG") -> str | None:
+    """Parse and normalize ``raw`` to E.164 format.
+
+    Tries the supplied ``default_region`` first (Bulgaria, the primary user
+    base) and then attempts a region-less parse (which works when the input
+    is already in international ``+CC...`` form).
+
+    Returns
+    -------
+    str | None
+        E.164 string (e.g. ``"+359888123456"``) on a valid number, ``None``
+        otherwise.
+    """
+    cleaned = _strip_separators(raw)
+    for region in (default_region, None):
+        try:
+            parsed = phonenumbers.parse(cleaned, region)
+        except phonenumbers.NumberParseException:
+            continue
+        if phonenumbers.is_valid_number(parsed):
+            return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164)
+    return None
+
+
+def validate_phone(text: str, default_region: str = "BG") -> bool:
+    """Return ``True`` iff ``text`` parses to a valid phone number.
+
+    Backed by :func:`normalize_phone`, so impossible-but-digit-count-valid
+    inputs like ``+11111111111`` correctly return ``False``.
+    """
+    return normalize_phone(text, default_region=default_region) is not None

--- a/telegram_bot/phone_utils.py
+++ b/telegram_bot/phone_utils.py
@@ -1,61 +1,19 @@
-"""Shared phone-normalization helpers.
+"""Re-export shim for ``src.phone_utils`` (#1948 layering fix).
 
-Single source of truth for phone validation/normalization. Used by:
-- ``telegram_bot/keyboards/phone_keyboard.py`` (bot reply-keyboard flow)
-- ``mini_app/phone.py`` (Mini App ``/api/phone`` Pydantic validator)
+The canonical home of the shared phone-normalization helpers is now
+``src/phone_utils.py`` so ``mini_app/`` and ``src/api/`` can import them
+without taking a dependency on ``telegram_bot.*`` (see #1948 layering
+contract).
 
-Closes the duplication called out in #1614 — Mini App previously redeclared a
-``_PHONE_RE = ^\\+?\\d{7,15}$`` regex that accepted impossible numbers like
-``+11111111111`` and never normalized to E.164. This module routes both
-consumers through ``phonenumbers.is_valid_number`` and E.164 formatting.
-
-This module is intentionally UI-free (no aiogram / no FastAPI) so it can be
-imported from either context without side-effects.
+This shim keeps existing bot internal callers
+(``telegram_bot/keyboards/phone_keyboard.py``) working unchanged; new code
+should import from ``src.phone_utils`` directly. The shim has no behavior
+of its own and cannot drift from the canonical implementation.
 """
 
 from __future__ import annotations
 
-import re
-
-import phonenumbers
+from src.phone_utils import normalize_phone, validate_phone
 
 
-_SEPARATORS_RE = re.compile(r"[\s\-\(\)]")
-
-
-def _strip_separators(raw: str) -> str:
-    """Remove whitespace, dashes, and parentheses commonly typed by users."""
-    return _SEPARATORS_RE.sub("", raw)
-
-
-def normalize_phone(raw: str, default_region: str = "BG") -> str | None:
-    """Parse and normalize ``raw`` to E.164 format.
-
-    Tries the supplied ``default_region`` first (Bulgaria, the primary user
-    base) and then attempts a region-less parse (which works when the input
-    is already in international ``+CC...`` form).
-
-    Returns
-    -------
-    str | None
-        E.164 string (e.g. ``"+359888123456"``) on a valid number, ``None``
-        otherwise.
-    """
-    cleaned = _strip_separators(raw)
-    for region in (default_region, None):
-        try:
-            parsed = phonenumbers.parse(cleaned, region)
-        except phonenumbers.NumberParseException:
-            continue
-        if phonenumbers.is_valid_number(parsed):
-            return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164)
-    return None
-
-
-def validate_phone(text: str, default_region: str = "BG") -> bool:
-    """Return ``True`` iff ``text`` parses to a valid phone number.
-
-    Backed by :func:`normalize_phone`, so impossible-but-digit-count-valid
-    inputs like ``+11111111111`` correctly return ``False``.
-    """
-    return normalize_phone(text, default_region=default_region) is not None
+__all__ = ["normalize_phone", "validate_phone"]

--- a/tests/contract/test_layering_no_telegram_bot_imports_contract.py
+++ b/tests/contract/test_layering_no_telegram_bot_imports_contract.py
@@ -1,0 +1,142 @@
+"""Contract: ratchet allowlist for ``src/`` and ``mini_app/`` imports of ``telegram_bot`` (#1948).
+
+Project layout intent (`README`, `pyproject.toml`):
+
+* ``src/*`` — reusable RAG library, **must not import** ``telegram_bot``.
+* ``mini_app/*`` — Telegram Mini App backend (separate Docker image), **must
+  not import** ``telegram_bot``.
+* ``telegram_bot/*`` — the bot application, **may** import from ``src/*``.
+
+Reality (issue #1948): ``src/api/main.py`` and ``mini_app/{api,phone}.py``
+import from ``telegram_bot.*`` and the Dockerfiles for both services copy
+``telegram_bot/`` into the image to make the imports resolve.
+
+The full migration is multi-PR (each shared module has to be relocated and
+re-exported with care). This contract is the **ratchet** that lets the
+migration land incrementally:
+
+* ``tests/data/known_layering_violations.json`` lists every file with its
+  current set of ``telegram_bot.*`` imports.
+* This test fails when **a new file** introduces a forbidden import or
+  **an existing file gains** a new import path that is not already in the
+  allowlist.
+* The allowlist must shrink over time; never regenerate it to silence a
+  failure (mirror of the duplicate-test-name guard in #1539).
+
+When you fix a violation, remove the corresponding entry from the JSON
+file. The test enforces the smaller surface immediately.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ALLOWLIST_PATH = REPO_ROOT / "tests" / "data" / "known_layering_violations.json"
+
+# Subtrees that must not depend on telegram_bot.
+GUARDED_ROOTS = ("src", "mini_app")
+
+
+def _collect_violations() -> dict[str, list[str]]:
+    """Return ``{relative_file_path: sorted([forbidden_module, ...])}``."""
+    out: dict[str, list[str]] = {}
+    for root_name in GUARDED_ROOTS:
+        root = REPO_ROOT / root_name
+        if not root.exists():
+            continue
+        for path in sorted(root.rglob("*.py")):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except SyntaxError:
+                continue
+            forbidden: set[str] = set()
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ImportFrom):
+                    mod = node.module or ""
+                    if mod == "telegram_bot" or mod.startswith("telegram_bot."):
+                        forbidden.add(mod)
+                elif isinstance(node, ast.Import):
+                    for alias in node.names:
+                        name = alias.name
+                        if name == "telegram_bot" or name.startswith("telegram_bot."):
+                            forbidden.add(name)
+            if forbidden:
+                out[path.relative_to(REPO_ROOT).as_posix()] = sorted(forbidden)
+    return out
+
+
+def _load_allowlist() -> dict[str, list[str]]:
+    if not ALLOWLIST_PATH.exists():
+        return {}
+    payload = json.loads(ALLOWLIST_PATH.read_text(encoding="utf-8"))
+    return {k: sorted(v) for k, v in payload.items()}
+
+
+def test_no_new_files_import_telegram_bot_under_src_or_mini_app() -> None:
+    current = _collect_violations()
+    allowlist = _load_allowlist()
+    new_files = sorted(set(current) - set(allowlist))
+    assert not new_files, (
+        "#1948: new file(s) under src/ or mini_app/ import from telegram_bot. The "
+        "package boundary forbids reverse layering. Fix the import (move the shared "
+        "module under src/ or factor the surface) before merging. New files: "
+        f"{new_files}"
+    )
+
+
+def test_existing_violation_files_do_not_grow() -> None:
+    current = _collect_violations()
+    allowlist = _load_allowlist()
+    grown: dict[str, list[str]] = {}
+    for path, allowed in allowlist.items():
+        if path not in current:
+            # File became compliant; the dedicated test below catches stale
+            # allowlist entries.
+            continue
+        added = sorted(set(current[path]) - set(allowed))
+        if added:
+            grown[path] = added
+    assert not grown, (
+        "#1948: existing file(s) under src/ or mini_app/ added a NEW telegram_bot "
+        "import that is not in the allowlist. Either remove the new import or, if "
+        "the migration legitimately requires it, document why and update the JSON "
+        f"explicitly. Grown: {grown}"
+    )
+
+
+def test_allowlist_does_not_list_already_compliant_files() -> None:
+    current = _collect_violations()
+    allowlist = _load_allowlist()
+    stale = sorted(set(allowlist) - set(current))
+    assert not stale, (
+        "#1948: known_layering_violations.json lists files that no longer import "
+        "telegram_bot. Remove these stale entries to keep the ratchet honest: "
+        f"{stale}"
+    )
+
+
+def test_allowlist_modules_match_current_for_unchanged_files() -> None:
+    """For files in the allowlist that still violate, the listed modules must match
+    exactly. This catches accidental allowlist drift where a module was renamed in
+    the allowlist but not removed from the actual import."""
+    current = _collect_violations()
+    allowlist = _load_allowlist()
+    drift: dict[str, dict[str, list[str]]] = {}
+    for path, allowed in allowlist.items():
+        if path not in current:
+            continue
+        current_set = set(current[path])
+        allowed_set = set(allowed)
+        if current_set != allowed_set:
+            drift[path] = {
+                "extra_in_allowlist": sorted(allowed_set - current_set),
+                "missing_from_allowlist": sorted(current_set - allowed_set),
+            }
+    assert not drift, (
+        "#1948: known_layering_violations.json drift detected. Update the entry to "
+        f"match the current import set exactly: {drift}"
+    )

--- a/tests/contract/test_shared_phone_normalization_contract.py
+++ b/tests/contract/test_shared_phone_normalization_contract.py
@@ -27,7 +27,11 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MINI_APP_PHONE_PATH = REPO_ROOT / "mini_app" / "phone.py"
 PHONE_KEYBOARD_PATH = REPO_ROOT / "telegram_bot" / "keyboards" / "phone_keyboard.py"
-PHONE_UTILS_PATH = REPO_ROOT / "telegram_bot" / "phone_utils.py"
+# Canonical home moved to src/phone_utils.py in #1948 to break the reverse
+# layering between mini_app and telegram_bot. telegram_bot/phone_utils.py is
+# kept as a thin re-export shim for bot internal callers.
+PHONE_UTILS_PATH = REPO_ROOT / "src" / "phone_utils.py"
+PHONE_UTILS_SHIM_PATH = REPO_ROOT / "telegram_bot" / "phone_utils.py"
 
 
 def test_shared_phone_utils_module_exists() -> None:
@@ -37,13 +41,22 @@ def test_shared_phone_utils_module_exists() -> None:
         "non-UI module so Mini App and bot can share it without dragging in "
         "aiogram keyboard imports."
     )
+    assert PHONE_UTILS_SHIM_PATH.exists(), (
+        f"missing {PHONE_UTILS_SHIM_PATH} — the re-export shim under "
+        "telegram_bot/ keeps existing bot internal callers working after the "
+        "canonical home moved to src/phone_utils.py (#1948)."
+    )
 
 
 def test_shared_phone_utils_exports_normalize_and_validate() -> None:
     """The shared module must expose both ``normalize_phone`` and ``validate_phone``."""
-    module = importlib.import_module("telegram_bot.phone_utils")
-    assert hasattr(module, "normalize_phone")
-    assert hasattr(module, "validate_phone")
+    canonical = importlib.import_module("src.phone_utils")
+    assert hasattr(canonical, "normalize_phone")
+    assert hasattr(canonical, "validate_phone")
+    # Back-compat shim must re-export the same callables.
+    shim = importlib.import_module("telegram_bot.phone_utils")
+    assert shim.normalize_phone is canonical.normalize_phone
+    assert shim.validate_phone is canonical.validate_phone
 
 
 def test_shared_phone_utils_does_not_import_aiogram() -> None:
@@ -55,13 +68,13 @@ def test_shared_phone_utils_does_not_import_aiogram() -> None:
         if isinstance(node, ast.Import):
             for alias in node.names:
                 assert not alias.name.startswith("aiogram"), (
-                    f"telegram_bot/phone_utils.py imports {alias.name}; "
+                    f"src/phone_utils.py imports {alias.name}; "
                     "shared phone normalization must stay UI-free."
                 )
         elif isinstance(node, ast.ImportFrom):
             mod = node.module or ""
             assert not mod.startswith("aiogram"), (
-                f"telegram_bot/phone_utils.py imports from {mod}; "
+                f"src/phone_utils.py imports from {mod}; "
                 "shared phone normalization must stay UI-free."
             )
 
@@ -81,20 +94,22 @@ def test_mini_app_phone_no_local_regex_validator() -> None:
 
 
 def test_mini_app_phone_imports_shared_normalizer() -> None:
-    """``mini_app/phone.py`` must import the shared ``normalize_phone``."""
+    """``mini_app/phone.py`` must import the shared ``normalize_phone`` from the
+    canonical ``src.phone_utils`` home (#1948 forbids ``mini_app -> telegram_bot``)."""
     tree = ast.parse(MINI_APP_PHONE_PATH.read_text(encoding="utf-8"))
     imported_normalize = False
     for node in ast.walk(tree):
         if (
             isinstance(node, ast.ImportFrom)
-            and node.module == "telegram_bot.phone_utils"
+            and node.module == "src.phone_utils"
             and any(alias.name == "normalize_phone" for alias in node.names)
         ):
             imported_normalize = True
             break
     assert imported_normalize, (
-        "mini_app/phone.py must import normalize_phone from "
-        "telegram_bot.phone_utils."
+        "mini_app/phone.py must import normalize_phone from src.phone_utils "
+        "(#1948 layering fix). Importing from telegram_bot.phone_utils now "
+        "triggers the layering ratchet test."
     )
 
 

--- a/tests/data/known_layering_violations.json
+++ b/tests/data/known_layering_violations.json
@@ -1,0 +1,18 @@
+{
+  "mini_app/api.py": [
+    "telegram_bot.observability",
+    "telegram_bot.services.content_loader"
+  ],
+  "mini_app/phone.py": [
+    "telegram_bot.observability",
+    "telegram_bot.services.kommo_client"
+  ],
+  "src/api/main.py": [
+    "telegram_bot.graph.config",
+    "telegram_bot.graph.graph",
+    "telegram_bot.graph.state",
+    "telegram_bot.integrations.cache",
+    "telegram_bot.scoring",
+    "telegram_bot.services.qdrant"
+  ]
+}


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Lands the **layering ratchet** from #1948 plus the **first concrete migration slice** (`phone_utils` → `src/`).

`#1948` flagged that `src/api` and `mini_app` import from `telegram_bot`, breaking the documented package boundary. The full migration of every shared module is multi-PR; this PR establishes the enforcement mechanism and converts the lowest-risk module so the pattern is in place.

## Files touched

**Slice (one violation removed):**

- `src/phone_utils.py` — new canonical home for shared phone-normalization helpers (61 lines, UI-free, no `aiogram` / no `fastapi`).
- `telegram_bot/phone_utils.py` — replaced full implementation with a thin re-export shim (`from src.phone_utils import normalize_phone, validate_phone`). Existing bot internal callers (`telegram_bot/keyboards/phone_keyboard.py`) keep working unchanged.
- `mini_app/phone.py` — import switches from `telegram_bot.phone_utils` to `src.phone_utils`. This drops one of the file's three forbidden imports.

**Ratchet (enforcement going forward):**

- `tests/contract/test_layering_no_telegram_bot_imports_contract.py` — AST-walks `src/` and `mini_app/`, diffs the `telegram_bot.*` imports against an allowlist, and fails on:
  1. Any **new file** under `src/` or `mini_app/` adding a forbidden import.
  2. Any **existing file** gaining a new `telegram_bot.*` import path not in the allowlist.
  3. Stale allowlist entries for files that have become compliant.
  4. Any drift between the listed modules and the file's actual import set.
- `tests/data/known_layering_violations.json` — current snapshot (10 remaining violations across 3 files):
  - `src/api/main.py` (6): `graph.config`, `graph.graph`, `graph.state`, `integrations.cache`, `scoring`, `services.qdrant`
  - `mini_app/api.py` (2): `observability`, `services.content_loader`
  - `mini_app/phone.py` (2): `observability`, `services.kommo_client`

The pattern mirrors the proven `tests/data/known_duplicate_test_names.json` ratchet from #1539 / #1996. The list must shrink over time; never regenerate it to silence a failure.

**Existing #1614 contract refreshed:**

- `tests/contract/test_shared_phone_normalization_contract.py` — `PHONE_UTILS_PATH` now points at `src/phone_utils.py`; `test_shared_phone_utils_module_exists` also asserts the shim under `telegram_bot/`; `test_shared_phone_utils_exports_normalize_and_validate` asserts the shim re-exports the same callables (`is canonical.normalize_phone`); `test_mini_app_phone_imports_shared_normalizer` requires `from src.phone_utils import normalize_phone` so the layering ratchet is not re-triggered.

## Acceptance criteria from #1948

| AC | Status |
|---|---|
| No `src/**/*.py` imports `telegram_bot` | **Partial** — 1 of 6 import sites still violate (full migration of `graph/`, `integrations/`, `services/qdrant`, `scoring` requires multi-PR planning per #1538/ADR-0010) |
| No `mini_app/**/*.py` imports `telegram_bot` | **Partial** — `phone_utils` slice removes 1 of 5 violations |
| Contract test enforces the rule | **Done** — ratchet under `tests/contract/test_layering_no_telegram_bot_imports_contract.py` |
| Mini App Docker image can be built without `telegram_bot/` mounted | **Not yet** — tracked for a follow-up PR after `observability` and `services/kommo_client` migrate |

This PR explicitly does not claim full closure. It lays the foundation so subsequent migration PRs can ship one shared module at a time, each removing entries from the allowlist.

## Validation

- [x] `uv run pytest tests/contract/test_layering_no_telegram_bot_imports_contract.py tests/contract/test_shared_phone_normalization_contract.py tests/unit/keyboards/test_phone_keyboard.py -q --no-cov` → 38 passed
- [x] `uv run ruff check` + `ruff format --check` on touched files
- [x] Manual import smoke: `python -c "from telegram_bot.phone_utils import normalize_phone, validate_phone"` works (shim) and `python -c "from src.phone_utils import normalize_phone"` works (canonical).
- [ ] `make check` — skipped, mypy fails on pre-existing unrelated errors
- [ ] `make test-unit` — skipped, broader suite needs full extras and is unrelated to this slice

## Runtime Impact

- [x] No runtime impact — the shim preserves identity (`is`-equality) of the public callables; `mini_app/phone.py` still gets the same `normalize_phone` function, just from the canonical home.

## Reviewer Notes

- The shim guarantees byte-for-byte runtime parity: `telegram_bot.phone_utils.normalize_phone is src.phone_utils.normalize_phone` is `True` after this PR (asserted in the refreshed contract test).
- Suggested follow-up PR order to drain the allowlist:
  1. Move `telegram_bot/observability.py` → `src/observability.py` (kills the `mini_app/api.py` and `mini_app/phone.py` observability imports plus part of `src/api/main.py`).
  2. Move `telegram_bot/services/content_loader.py` → `src/services/content_loader.py`.
  3. Move `telegram_bot/services/kommo_client.py` → `src/services/kommo_client.py`.
  4. After observability + services migrate, the Mini App Dockerfile can stop copying `telegram_bot/`.
  5. Plan-needed migration of `graph/`, `integrations/cache`, `services/qdrant`, `scoring` (overlaps with #1538 / ADR-0010 voice-path migration).

Refs #1948.