### PR TITLE
ci: restore CodeQL workflow for Python security analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main, dev]
+  push:
+    branches: [main, dev]
+  schedule:
+    - cron: "30 3 * * 0"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (Python)
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
+        with:
+          languages: python
+          build-mode: none
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
+        with:
+          category: "/language:python"


### PR DESCRIPTION
## Summary

Restore the CodeQL workflow (`.github/workflows/codeql.yml`) previously present in the repo at commit `c1fcff18`. This workflow was removed at some point and the PR #2011 fixes to the CodeQL alert patterns have been merged, but GitHub still shows 16 stale alerts from the old commit.

## Changes

1 file changed, 41 insertions(+): **`.github/workflows/codeql.yml`**

## Workflow Details

- **Triggers**: PR/push to `main` and `dev`, weekly schedule (Sunday 03:30 UTC), manual dispatch
- **Analysis**: Python with `security-extended` queries, build-mode: none
- **Security**: All actions pinned by commit SHA; least-privilege permissions (`contents: read` + `security-events: write`)
- **Concurrency**: cancel-in-progress enabled

## Validation

- `git diff --check`: clean
- YAML syntax: valid (Python yaml.safe_load)
- No new findings from read-only security review (STRIDE pass)