### PR TITLE
fix(security): resolve CodeQL #17 log-injection by using constant-mapped level name

### DIFF
--- a/mini_app/api.py
+++ b/mini_app/api.py
@@ -325,10 +325,18 @@ async def remote_log(
     as structured fields.
     """
     lvl = _LEVEL_MAP.get(request.level, logging.INFO)
+    # Reconstruct a validated level name from the mapped integer so that
+    # CodeQL cannot trace the string back to user-controlled ``request.level``.
+    level_name: str = {
+        logging.DEBUG: "debug",
+        logging.INFO: "info",
+        logging.WARNING: "warn",
+        logging.ERROR: "error",
+    }.get(lvl, "info")
     logger.log(
         lvl,
         "[REMOTE:%s] frontend log received message_len=%d %s",
-        request.level,
+        level_name,
         len(request.message),
         _remote_log_data_shape(request.data),
     )

--- a/tests/unit/security/test_codeql_regressions.py
+++ b/tests/unit/security/test_codeql_regressions.py
@@ -72,3 +72,47 @@ async def test_remote_log_does_not_emit_raw_user_payload(caplog: pytest.LogCaptu
     rendered_logs = "\n".join(record.getMessage() for record in caplog.records)
     assert raw_message not in rendered_logs
     assert "+380501234567" not in rendered_logs
+
+
+def test_remote_log_handler_level_is_not_raw_user_controlled() -> None:
+    """CodeQL #17: request.level must not be passed as a log format argument.
+
+    The remote_log handler maps ``request.level`` through a validated
+    constant lookup (_LEVEL_MAP).  The mapped integer level (e.g. ``lvl``)
+    is safe, but CodeQL still flags the raw ``request.level`` string when
+    it appears as a positional argument inside the ``logger.log`` call.
+    This regression guard asserts that the ``logger.log`` call-site does
+    not contain ``request.level``.
+    """
+    source = _read("mini_app/api.py")
+
+    # Locate the logger call that contains the [REMOTE:] format tag
+    fmt_idx = source.find("[REMOTE:")
+    assert fmt_idx != -1, "Format string [REMOTE:] not found"
+
+    # Find the enclosing logger.log(...) call
+    log_start = source.rfind("logger.log", 0, fmt_idx)
+    assert log_start != -1, "logger.log call before [REMOTE:] not found"
+
+    paren_start = source.find("(", log_start)
+    assert paren_start != -1, "Opening paren after logger.log not found"
+
+    # Match the closing paren of logger.log(...)
+    depth = 0
+    paren_end = paren_start
+    for j in range(paren_start, len(source)):
+        if source[j] == "(":
+            depth += 1
+        elif source[j] == ")":
+            depth -= 1
+            if depth == 0:
+                paren_end = j
+                break
+
+    # Arguments of the logger.log call
+    log_call_body = source[paren_start + 1 : paren_end]
+
+    assert "request.level" not in log_call_body, (
+        "request.level must not be a log format argument inside logger.log (CodeQL #17). "
+        "Use a constant-mapped level name derived from _LEVEL_MAP instead."
+    )


### PR DESCRIPTION
## Problem

CodeQL alert #17 (`py/log-injection`) at `mini_app/api.py:331` flags the `remote_log` handler because `request.level` is passed as a positional format argument to `logger.log()`. PR #2011 already removed raw message/data from the log, but `request.level` remained in the logger call.

## Fix

Replace raw `request.level` in the `logger.log` format args with `level_name` derived from a **hardcoded constant dict** lookup of the already-validated `lvl` integer. CodeQL can no longer trace the format argument string back to user-controlled `request.level`.

Same log output, same metadata — all four frontend level names (`debug`, `info`, `warn`, `error`) are preserved exactly.

## Changes

- `mini_app/api.py`: replace `request.level` with constant-mapped `level_name` in `remote_log` handler
- `tests/unit/security/test_codeql_regressions.py`: add source-level regression guard that asserts `request.level` does NOT appear inside the `logger.log()` call-site

## Validation

- `uv run --extra mini-app pytest tests/unit/security/test_codeql_regressions.py -q` → 5 passed
- `uv run ruff check mini_app/api.py tests/unit/security/test_codeql_regressions.py` → All checks passed
- `git diff --check` → clean

## TDD

- RED: wrote failing source-code regression test confirming `request.level` inside `logger.log()`
- GREEN: implemented fix → test passes
- Existing `test_remote_log_does_not_emit_raw_user_payload` still passes