### PR TITLE
security(deps): upgrade transformers 5.5.4 → 5.9.0 (Dependabot batch)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -7682,7 +7682,7 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "5.5.4"
+version = "5.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -7695,9 +7695,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/1e/1e244ab2ab50a863e6b52cc55761910567fa532b69a6740f6e99c5fdbd98/transformers-5.5.4.tar.gz", hash = "sha256:2e67cadba81fc7608cc07c4dd54f524820bc3d95b1cabd0ef3db7733c4f8b82e", size = 8227649, upload-time = "2026-04-13T16:55:55.181Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/58/7f843608f2e8421f86bb97060b54649be6239ec612b82bf9d41e65c26c00/transformers-5.9.0.tar.gz", hash = "sha256:25997cb8fa6053533171634b6162d7df54346530ec2aa9b42bb834e63668c842", size = 8642240, upload-time = "2026-05-20T14:50:49.278Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/fb/162a66789c65e5afa3b051309240c26bf37fbc8fea285b4546ae747995a2/transformers-5.5.4-py3-none-any.whl", hash = "sha256:0bd6281b82966fe5a7a16f553ea517a9db1dee6284d7cb224dfd88fc0dd1c167", size = 10236696, upload-time = "2026-04-13T16:55:51.497Z" },
+    { url = "https://files.pythonhosted.org/packages/02/ca/2eaa5359f2ccb8c2e1656bc26305ad0cf438aa392ce4b29ae67a315c186e/transformers-5.9.0-py3-none-any.whl", hash = "sha256:1d19509bcff7028ebc6b277d71caa712e8353778463d38764237d14b42b52788", size = 10787648, upload-time = "2026-05-20T14:50:45.337Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Dependency Security Batch — 2026-05-22

### Completed Upgrade
- **transformers**: 5.5.4 → **5.9.0** (latest 5.x, released 2026-05-20)

### Blocked Upgrades (documented for triage)
- **pillow** (11.3.0): blocked by `gradio 5.x ≤ pillow<12.0`. Gradio cannot be upgraded to 6.x because `docling-serve[ui]` pins `gradio<6.0.0`. docling-serve itself cannot be upgraded to 1.10+ because `opentelemetry-instrumentation-fastapi==0.57b0` (transitive via docling-serve) requires `opentelemetry-api==1.36.0`, which is incompatible with `livekit-agents` requiring `opentelemetry-api≥1.39.0`. This cross-dependency conflict requires upstream releases.
- **gradio** (5.50.0): same blocker chain as pillow.

### Already at Latest
- **diskcache**: 5.6.3 is the latest PyPI release; no upgrade available.
- **ragas**: 0.4.3 is the latest PyPI release; no upgrade available.

### Verification
- `uv lock --check`: exit 0, consistent
- `git diff --check`: clean
- `pytest tests/ -m unit -x --ignore=tests/baseline`: **7113 passed**, 38 skipped, 0 failed
- `import transformers; print(transformers.__version__)`: 5.9.0 OK
- pre-commit hooks: all passed