### PR TITLE
chore: prune dead linter/test config (legacy/, _old.py, _backup.py paths) (#1947)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,14 +55,12 @@ repos:
           - --fix           # Auto-fix issues when possible
           - --exit-non-zero-on-fix  # Fail if fixes were applied (to review changes)
         types_or: [python, pyi]
-        exclude: ^legacy/
         stages: [pre-commit]
 
       # Step 2: Formatter - formats code (runs AFTER linting)
       - id: ruff-format
         name: Ruff Formatter
         types_or: [python, pyi]
-        exclude: ^legacy/
         stages: [pre-commit]
 
   # Standard pre-commit hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,7 +272,6 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 "evaluation/*.py" = ["T201"]      # Allow print() in evaluation scripts
 "test_*.py" = ["E402", "T201", "SIM117"]  # Allow late imports, print(), nested with in tests
 "tests/**/*.py" = ["E402", "T201", "SIM117"]  # Same for tests/ directory
-"legacy/*.py" = ["ASYNC210"]      # Allow blocking HTTP calls in async functions (legacy code)
 # Per-file ASYNC240 ignores for src/ingestion/docling_client.py and
 # src/ingestion/service.py removed in #1532: ASYNC240 is already in the
 # global ignore list above, so the per-file entries were redundant. The
@@ -340,7 +339,7 @@ disallow_untyped_defs = true
 # Run: bandit -r . -c pyproject.toml
 
 [tool.bandit]
-exclude_dirs = [".venv", "tests", "evaluation", "legacy", "scripts/archive", "__pycache__"]
+exclude_dirs = [".venv", "tests", "evaluation", "scripts/archive", "__pycache__"]
 skips = ["B101"]  # Skip assert_used (common in tests)
 
 # =============================================================================
@@ -353,8 +352,7 @@ skips = ["B101"]  # Skip assert_used (common in tests)
 py-version = "3.13"
 
 # Files/directories to exclude
-ignore = ["legacy", "tests", ".venv", "__pycache__"]
-ignore-patterns = [".*_old\\.py$", ".*_backup\\.py$"]
+ignore = ["tests", ".venv", "__pycache__"]
 
 [tool.pylint.messages_control]
 # Disable specific checks
@@ -396,7 +394,6 @@ addopts = """
 testpaths = ["tests"]
 pythonpath = ["."]
 asyncio_mode = "auto"
-norecursedirs = ["tests/legacy"]
 timeout = 30
 markers = [
     "unit: Unit tests with mocks (fast, no external deps)",
@@ -431,7 +428,6 @@ source = ["src", "telegram_bot"]
 branch = true
 omit = [
     "*/tests/*",
-    "*/legacy/*",
     "*/__pycache__/*",
     "*/.venv/*",
     "telegram_bot/.venv/*",

--- a/tests/contract/test_config_paths_exist_contract.py
+++ b/tests/contract/test_config_paths_exist_contract.py
@@ -1,0 +1,129 @@
+"""Contract test for issue #1947 — config files must not reference dead paths.
+
+Several configs historically carried "if-it-ever-comes-back" guards for
+`legacy/`, `tests/legacy/`, `*_old.py`, and `*_backup.py`. None of these
+paths or patterns currently exist in the repo. The dead rules quietly mask
+the fact that the cleanup is already complete.
+
+This test asserts:
+
+1. `legacy/` and `tests/legacy/` directories are absent.
+2. No file matching `*_old.py` or `*_backup.py` exists outside `.git`/`.venv`.
+3. `pyproject.toml` does not reference these dead paths in:
+     - `[tool.ruff.lint.per-file-ignores]`
+     - `[tool.bandit].exclude_dirs`
+     - `[tool.pylint.main].ignore`
+     - `[tool.pylint.main].ignore-patterns`
+     - `[tool.pytest.ini_options].norecursedirs`
+     - `[tool.coverage.run].omit`
+4. `.pre-commit-config.yaml` does not exclude `^legacy/` from any hook.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover
+    import tomli as tomllib  # type: ignore[no-redef]
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _all_python_files(root: Path) -> list[Path]:
+    skip = {".git", ".venv", "venv", "node_modules", ".pytest_cache", ".mypy_cache"}
+    out: list[Path] = []
+    for p in root.rglob("*.py"):
+        if any(part in skip for part in p.parts):
+            continue
+        out.append(p)
+    return out
+
+
+def test_legacy_directories_do_not_exist() -> None:
+    assert not (REPO / "legacy").exists(), (
+        "legacy/ does not exist; remove guard rules that reference it"
+    )
+    assert not (REPO / "tests" / "legacy").exists(), (
+        "tests/legacy/ does not exist; remove guard rules that reference it"
+    )
+
+
+def test_no_old_or_backup_python_files() -> None:
+    offenders = [
+        p
+        for p in _all_python_files(REPO)
+        if p.name.endswith(("_old.py", "_backup.py"))
+    ]
+    assert offenders == [], (
+        f"Found *_old.py / *_backup.py files; either remove them or "
+        f"re-justify the pylint ignore-patterns rule: {offenders}"
+    )
+
+
+def _pyproject() -> dict:
+    with (REPO / "pyproject.toml").open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def test_pyproject_ruff_per_file_ignores_no_legacy() -> None:
+    cfg = _pyproject()
+    per_file = cfg["tool"]["ruff"]["lint"].get("per-file-ignores", {})
+    for key in per_file:
+        assert "legacy" not in key, (
+            f"ruff per-file-ignores still references dead legacy path: {key!r}"
+        )
+
+
+def test_pyproject_bandit_exclude_dirs_no_legacy() -> None:
+    cfg = _pyproject()
+    excludes = cfg["tool"]["bandit"].get("exclude_dirs", [])
+    assert "legacy" not in excludes, (
+        "bandit.exclude_dirs still includes dead 'legacy' entry"
+    )
+
+
+def test_pyproject_pylint_ignore_no_legacy_and_no_old_backup_patterns() -> None:
+    cfg = _pyproject()
+    pylint_main = cfg["tool"]["pylint"]["main"]
+    assert "legacy" not in pylint_main.get("ignore", []), (
+        "pylint.ignore still includes dead 'legacy' entry"
+    )
+    assert "ignore-patterns" not in pylint_main, (
+        "pylint.ignore-patterns is dead (no *_old.py/*_backup.py files exist) "
+        "and must be removed"
+    )
+
+
+def test_pyproject_pytest_norecursedirs_no_legacy() -> None:
+    cfg = _pyproject()
+    norec = cfg["tool"]["pytest"]["ini_options"].get("norecursedirs", [])
+    assert "tests/legacy" not in norec, (
+        "pytest norecursedirs still references non-existent tests/legacy"
+    )
+
+
+def test_pyproject_coverage_omit_no_legacy() -> None:
+    cfg = _pyproject()
+    omit = cfg["tool"]["coverage"]["run"].get("omit", [])
+    assert "*/legacy/*" not in omit, (
+        "coverage.run.omit still references dead */legacy/* glob"
+    )
+
+
+def test_precommit_hooks_no_legacy_exclude() -> None:
+    with (REPO / ".pre-commit-config.yaml").open(encoding="utf-8") as fh:
+        cfg = yaml.safe_load(fh)
+    for repo in cfg.get("repos", []):
+        for hook in repo.get("hooks", []):
+            exclude = hook.get("exclude")
+            if not exclude:
+                continue
+            assert "legacy" not in exclude, (
+                f"pre-commit hook {hook.get('id')!r} still excludes "
+                f"dead path: {exclude!r}"
+            )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

The repo no longer ships any `legacy/`, `tests/legacy/`, `*_old.py`, or `*_backup.py` files, but six configs still carried "if-it-ever-comes-back" guards for them. The dead rules were quietly inert and created false impressions about what the linters/tests were actually enforcing.

## Changes

- `pyproject.toml`:
  - Drop `"legacy/*.py" = ["ASYNC210"]` from `[tool.ruff.lint.per-file-ignores]`.
  - Drop `"legacy"` from `[tool.bandit].exclude_dirs`.
  - Drop `"legacy"` from `[tool.pylint.main].ignore`.
  - Drop `[tool.pylint.main].ignore-patterns` (was `[".*_old\\.py$", ".*_backup\\.py$"]`) entirely.
  - Drop `["tests/legacy"]` from `[tool.pytest.ini_options].norecursedirs`.
  - Drop `"*/legacy/*"` from `[tool.coverage.run].omit`.
- `.pre-commit-config.yaml`:
  - Remove `exclude: ^legacy/` from both `ruff-check` and `ruff-format` hooks.
- New `tests/contract/test_config_paths_exist_contract.py` (8 tests):
  - Asserts `legacy/` and `tests/legacy/` are absent.
  - Asserts no `*_old.py` / `*_backup.py` files anywhere in the tree.
  - Asserts every dead-path key removed above never reappears in either config.

The pylint marker `legacy_api` and the `tests/contract/test_legacy_ingestion_removed_contract.py` reference are left untouched — they describe distinct concerns (test marker name; live-callers audit for `src/ingestion/{docling_client,service}.py`).

## Verification

```
$ uv run pytest tests/contract/test_config_paths_exist_contract.py -q
8 passed in 0.10s
$ uv run ruff check src/ telegram_bot/
All checks passed!
$ python -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"
OK
```

## Limitations

None. This PR only removes dead config entries that point at paths that already do not exist; it does not change any active linter behaviour.

Closes #1947