### PR TITLE
security(deps): isolate ragas/diskcache no-patch alerts + audit doc (#2043)

### DIFF
--- a/docs/security/dependabot-no-patch-audit-2026-05-22.md
+++ b/docs/security/dependabot-no-patch-audit-2026-05-22.md
@@ -1,0 +1,145 @@
+# Dependabot no-patch alerts — exposure audit
+
+> Tracks issue [#2043](https://github.com/yastman/rag/issues/2043).
+> Audit date: 2026-05-22. Audit scope: post-merge security audit on `dev`
+> after PRs #2028, #2031, #2035, #2037 closed all fixable Dependabot
+> alerts.
+
+## Alerts in scope
+
+After the patched fixes landed, two open Dependabot alerts remain with
+**no upstream patched version**:
+
+| Package | CVE | Severity | Current | Vulnerable range | Patched version |
+|---|---|---|---|---|---|
+| `diskcache` | CVE-2025-69872 | medium | `5.6.3` | `<=5.6.3` | none |
+| `ragas` | CVE-2026-6587 | low | `0.4.3` | `>=0.2.3, <=0.4.3` | none |
+
+## Repository exposure
+
+### `ragas` — confined to evaluation pipeline
+
+`ragas` appears as a **direct dependency in exactly one place**:
+
+```toml
+# pyproject.toml
+[project.optional-dependencies]
+eval = [
+    "ragas>=0.4.3",
+    "datasets>=3.0.0",
+    "pandas>=2.0.0",
+]
+```
+
+It is **not** in `[project].dependencies` (the production install set).
+Subpackage `pyproject.toml` files (`telegram_bot/`, `mini_app/`,
+`services/bge-m3-api/`, `services/user-base/`, `services/docling/`) do
+not depend on `ragas`.
+
+First-party imports — verified by `grep -rn -E "(import ragas|from ragas)"`:
+
+| File | Purpose |
+|---|---|
+| `src/evaluation/ragas_evaluation.py` | The only production-style import. Builds a `Dataset` locally from `tests/eval/ground_truth.json` and calls `evaluate(dataset, metrics=...)`. Never receives external/user input. |
+| `tests/conftest.py` | Two log-level overrides (`logging.getLogger("ragas")`) — no SDK call. |
+| `tests/unit/evaluation/test_evaluate_with_ragas.py` | Mocks `ragas.dataset_schema`, `ragas.llms`, `ragas.metrics`, `ragas.metrics.collections` via `MagicMock`. The actual `ragas` package is never imported in the test path. |
+
+Runtime entrypoints — verified by `grep -nE "^eval-rag" Makefile`:
+
+```
+Makefile:942: eval-rag: ## Run RAG evaluation with RAGAS metrics
+Makefile:950: eval-rag-quick: ## Quick RAG evaluation (10 samples)
+Makefile:956: eval-rag-full: ## Full RAG evaluation with all metrics
+```
+
+`make eval-rag*` is the only path that actually loads `ragas`. None of
+the bot/API/Mini-App/voice runtimes import `src.evaluation.ragas_evaluation`.
+
+**Net exposure:** `ragas` runs only when an operator manually invokes
+`make eval-rag` (or one of its variants). Input to `ragas.evaluate(...)`
+comes from a **locally curated ground-truth dataset** under `tests/eval/`,
+not from user-facing channels (Telegram messages, Mini App requests,
+voice transcriptions, ingestion documents). The CVE-2026-6587 attack
+surface — whatever it requires — is not reachable from any production
+runtime path.
+
+### `diskcache` — transitive-only via `ragas`
+
+`diskcache` is **not declared anywhere** in this repository:
+
+```bash
+$ grep -i diskcache pyproject.toml services/*/pyproject.toml telegram_bot/pyproject.toml
+(no output)
+
+$ grep -rn -E "(import diskcache|from diskcache)" \
+       src/ telegram_bot/ mini_app/ services/ scripts/ tests/
+(no output)
+```
+
+`uv.lock` resolves it as a transitive dependency of `ragas`:
+
+```
+[[package]]
+name = "ragas"
+...
+dependencies = [
+    ...
+    { name = "diskcache" },
+    ...
+]
+```
+
+The `eval` optional extra is the only install path that pulls
+`diskcache` into the venv. The bot, Mini App, ingestion, and voice
+images do not install the `eval` extra; their Dockerfiles pin the base
+runtime install set explicitly.
+
+**Net exposure:** identical to `ragas` — the package is loaded only when
+a developer or operator runs the evaluation pipeline locally with `uv
+sync --extra eval` followed by `make eval-rag*`. CVE-2025-69872 is not
+reachable from production deployments.
+
+## Mitigation
+
+The audit decision is **monitor-and-isolate**, not "patch-or-replace":
+
+1. **No production code change.** Both packages already sit outside the
+   production install set; no further isolation is achievable without
+   removing the `eval` extra altogether.
+2. **Lock the seam with a contract test.** New test
+   `tests/contract/test_dependabot_no_patch_isolation_contract.py`
+   asserts the four invariants:
+   - `ragas` stays in `[project.optional-dependencies].eval` (and only there).
+   - `ragas` does not leak into any subpackage `pyproject.toml`.
+   - `diskcache` is not declared as a direct dependency anywhere.
+   - First-party Python source does not `import diskcache`, and `import
+     ragas` is only in `src/evaluation/`.
+3. **Track upstream.** Watch the
+   [`ragas`](https://github.com/explodinggradients/ragas) and
+   [`diskcache`](https://github.com/grantjenks/python-diskcache)
+   repositories for a patched release. Reopen #2043 (or its successor)
+   if a fix is shipped so we can bump and remove the suppression.
+4. **Do not blanket-dismiss the alerts.** Per the issue body: *"Do not
+   dismiss these alerts without explicit risk acceptance."* The
+   contract test plus this document are that explicit acceptance.
+
+## Verification commands
+
+```bash
+# Confirm ragas is only in the eval extra
+python -c "import tomllib; cfg = tomllib.load(open('pyproject.toml','rb')); \
+  print({k: 'ragas' in [d.split('>=')[0].split('==')[0] for d in v] \
+         for k, v in cfg['project']['optional-dependencies'].items()})"
+
+# Confirm no first-party imports of diskcache
+grep -rn -E "(import diskcache|from diskcache)" src/ telegram_bot/ mini_app/ services/ scripts/ tests/
+
+# Confirm ragas imports stay under src/evaluation/
+grep -rn -E "(import ragas|from ragas)" src/ telegram_bot/ mini_app/ services/ scripts/ \
+  | grep -v ^src/evaluation/
+
+# Run the contract test
+uv run pytest tests/contract/test_dependabot_no_patch_isolation_contract.py -q
+```
+
+All four commands return clean results on `dev` at the time of this audit.

--- a/tests/contract/test_dependabot_no_patch_isolation_contract.py
+++ b/tests/contract/test_dependabot_no_patch_isolation_contract.py
@@ -1,0 +1,208 @@
+"""Contract test for issue #2043 — keep no-patch Dependabot deps isolated.
+
+Tracks the post-merge security audit on 2026-05-22 which surfaced two open
+Dependabot alerts with no upstream patched version:
+
+- ``diskcache`` CVE-2025-69872 (medium) — vulnerable range ``<=5.6.3``,
+  patched version: none.
+- ``ragas`` CVE-2026-6587 (low) — vulnerable range ``>=0.2.3, <=0.4.3``,
+  patched version: none.
+
+The audit decision (see
+``docs/security/dependabot-no-patch-audit-2026-05-22.md``) is to keep both
+packages confined to the optional ``eval`` extra and the
+``src/evaluation/`` evaluation pipeline so the production bot/API runtime
+is not exposed.
+
+This test prevents accidental drift back into production code or the
+default install. The four invariants are:
+
+1. ``ragas`` lives ONLY under ``[project.optional-dependencies].eval`` —
+   it must not appear in ``[project].dependencies`` or in any other
+   pyproject (telegram_bot, mini_app, services).
+2. ``diskcache`` is transitive-only — it must not appear in any
+   ``[project]`` or ``[project.optional-dependencies]`` block in any
+   pyproject.
+3. ``import ragas`` / ``from ragas`` is restricted to
+   ``src/evaluation/`` and ``tests/`` (mocks).
+4. ``import diskcache`` / ``from diskcache`` does not appear anywhere in
+   first-party code or tests (we only consume it transitively).
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+
+PYPROJECTS = [
+    REPO / "pyproject.toml",
+    REPO / "telegram_bot" / "pyproject.toml",
+    REPO / "mini_app" / "pyproject.toml",
+    REPO / "services" / "bge-m3-api" / "pyproject.toml",
+    REPO / "services" / "user-base" / "pyproject.toml",
+    REPO / "services" / "docling" / "pyproject.toml",
+]
+
+# Directories scanned for first-party imports.
+FIRST_PARTY_ROOTS = ("src", "telegram_bot", "mini_app", "services", "scripts")
+
+
+def _load_pyproject(path: Path) -> dict:
+    with path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def _project_dep_strings(cfg: dict) -> list[str]:
+    """All `[project].dependencies` strings (PEP 621)."""
+    return list((cfg.get("project") or {}).get("dependencies", []) or [])
+
+
+def _project_optional_dep_strings(cfg: dict) -> dict[str, list[str]]:
+    """All `[project.optional-dependencies].<extra>` mappings."""
+    return dict((cfg.get("project") or {}).get("optional-dependencies", {}) or {})
+
+
+def _dep_name(spec: str) -> str:
+    """Strip version specifiers/extras to the bare PEP 503 distribution name."""
+    return re.split(r"[\s<>=!~\[]", spec, maxsplit=1)[0].strip().lower()
+
+
+# ── ragas isolation ────────────────────────────────────────────────────
+
+
+def test_ragas_not_in_root_pyproject_dependencies() -> None:
+    cfg = _load_pyproject(REPO / "pyproject.toml")
+    names = {_dep_name(s) for s in _project_dep_strings(cfg)}
+    assert "ragas" not in names, (
+        "ragas is a no-patch Dependabot alert (CVE-2026-6587) with limited "
+        "exposure scope; it must remain in [project.optional-dependencies].eval"
+        " and not be promoted to [project].dependencies (issue #2043)."
+    )
+
+
+def test_ragas_only_in_eval_extra() -> None:
+    cfg = _load_pyproject(REPO / "pyproject.toml")
+    extras = _project_optional_dep_strings(cfg)
+    where_ragas_appears = sorted(
+        name for name, deps in extras.items() if any(_dep_name(s) == "ragas" for s in deps)
+    )
+    assert where_ragas_appears == ["eval"], (
+        f"ragas must appear in exactly one optional extra ('eval'), but found "
+        f"in: {where_ragas_appears}. See issue #2043."
+    )
+
+
+def test_ragas_absent_from_subpackage_pyprojects() -> None:
+    """ragas must not leak into bot/mini-app/service pyprojects."""
+    for path in PYPROJECTS:
+        if not path.exists() or (path.name == "pyproject.toml" and path.parent == REPO):
+            # Skip the root pyproject — that one is asserted by the two tests
+            # above.
+            if path == REPO / "pyproject.toml":
+                continue
+            if not path.exists():
+                continue
+        cfg = _load_pyproject(path)
+        names = {_dep_name(s) for s in _project_dep_strings(cfg)}
+        names |= {
+            _dep_name(s) for deps in _project_optional_dep_strings(cfg).values() for s in deps
+        }
+        assert "ragas" not in names, (
+            f"{path.relative_to(REPO)} must not depend on ragas (issue #2043)."
+        )
+
+
+# ── diskcache isolation ────────────────────────────────────────────────
+
+
+def test_diskcache_is_transitive_only() -> None:
+    """diskcache must not appear as a direct dependency in any pyproject.
+
+    It is allowed to land in ``uv.lock`` because ``ragas`` pulls it in
+    transitively when the optional ``eval`` extra is installed.
+    """
+    for path in PYPROJECTS:
+        if not path.exists():
+            continue
+        cfg = _load_pyproject(path)
+        direct = {_dep_name(s) for s in _project_dep_strings(cfg)}
+        optional = {
+            _dep_name(s) for deps in _project_optional_dep_strings(cfg).values() for s in deps
+        }
+        for bucket_name, bucket in (("dependencies", direct), ("optional", optional)):
+            assert "diskcache" not in bucket, (
+                f"{path.relative_to(REPO)} declares diskcache as a {bucket_name} "
+                f"dependency; CVE-2025-69872 has no upstream patch and the "
+                f"agreed mitigation in issue #2043 is to keep diskcache "
+                "transitive-only via ragas."
+            )
+
+
+# ── First-party import isolation ───────────────────────────────────────
+
+
+def _python_files() -> list[Path]:
+    skip_parts = {
+        ".git",
+        ".venv",
+        "venv",
+        "__pycache__",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".ruff_cache",
+        "node_modules",
+        "dist",
+        "build",
+    }
+    files: list[Path] = []
+    for root_name in FIRST_PARTY_ROOTS:
+        root = REPO / root_name
+        if not root.exists():
+            continue
+        for py in root.rglob("*.py"):
+            if any(part in skip_parts for part in py.parts):
+                continue
+            files.append(py)
+    return files
+
+
+def _imports(text: str, package: str) -> bool:
+    pattern = re.compile(
+        rf"^\s*(?:import\s+{re.escape(package)}\b|from\s+{re.escape(package)}(?:\.|\s+import))",
+        re.MULTILINE,
+    )
+    return bool(pattern.search(text))
+
+
+def test_diskcache_not_imported_in_first_party_code() -> None:
+    offenders: list[str] = []
+    for path in _python_files():
+        if _imports(path.read_text(encoding="utf-8"), "diskcache"):
+            offenders.append(str(path.relative_to(REPO)))
+    assert offenders == [], (
+        "diskcache must remain a transitive-only dependency (issue #2043). "
+        f"Direct imports found in: {offenders}. If a real need arises, raise "
+        "the exposure decision in #2043 first."
+    )
+
+
+def test_ragas_only_imported_under_src_evaluation() -> None:
+    """All first-party ragas imports must be under src/evaluation/."""
+    allowed_prefix = REPO / "src" / "evaluation"
+    offenders: list[str] = []
+    for path in _python_files():
+        text = path.read_text(encoding="utf-8")
+        if not _imports(text, "ragas"):
+            continue
+        try:
+            path.relative_to(allowed_prefix)
+        except ValueError:
+            offenders.append(str(path.relative_to(REPO)))
+    assert offenders == [], (
+        "ragas imports must be confined to src/evaluation/ (issue #2043). "
+        f"Found ragas imports outside that directory in: {offenders}."
+    )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Two open Dependabot alerts have **no upstream patched version**:

| Package | CVE | Severity | Vulnerable range |
|---|---|---|---|
| `diskcache` | CVE-2025-69872 | medium | `<=5.6.3` |
| `ragas` | CVE-2026-6587 | low | `>=0.2.3, <=0.4.3` |

This PR documents the audit decision (monitor-and-isolate, not "patch-or-replace") and locks the isolation with a contract test.

## Audit findings

- **`ragas`** is declared only in `[project.optional-dependencies].eval`. Imported only in `src/evaluation/ragas_evaluation.py` (the RAGAS metric pipeline). Reached only by `make eval-rag*` targets. The bot, API, Mini App, voice, and ingestion runtimes do not import `src.evaluation.*` and do not install the `eval` extra.
- **`diskcache`** is **not** declared anywhere in this repo. It lands in `uv.lock` only as a transitive dependency of `ragas`, so the same install gate applies.

## Changes

- `docs/security/dependabot-no-patch-audit-2026-05-22.md` — explicit risk acceptance with verification commands and upstream-tracking notes.
- `tests/contract/test_dependabot_no_patch_isolation_contract.py` — 6 invariants that fail loudly if either package leaks into production deps or first-party imports.

## Verification

```
uv run pytest tests/contract/test_dependabot_no_patch_isolation_contract.py -q  # 6 passed
uv run pytest tests/contract/test_*_contract.py -q (subset)                       # 70 passed
uv run python scripts/check_markdown_links.py                                     # OK
uvx ruff check tests/contract/test_dependabot_no_patch_isolation_contract.py      # OK
```

Closes #2043