### PR TITLE
docs: justify phone_collector as aiogram-dialog migration exception (#2055)

### DIFF
--- a/docs/engineering/sdk-registry.md
+++ b/docs/engineering/sdk-registry.md
@@ -52,6 +52,7 @@ paths: "telegram_bot/**,src/**,mini_app/**,pyproject.toml"
   - НЕ писать кастомные InlineKeyboard для навигации — использовать Select/Button/SwitchTo
   - States определяются ТОЛЬКО в states.py (централизованно)
   - setup_dialogs(dp) вызывается ПОСЛЕДНИМ после всех include_router
+  - **Документированное исключение (#1232 / #2055):** `telegram_bot/handlers/phone_collector.py` остаётся на raw aiogram Router + FSMContext. Причина: lead capture использует `KeyboardButton(request_contact=True)` через `ReplyKeyboardMarkup`, а aiogram-dialog не предоставляет эквивалентного widget'а для one-tap contact share. Принудительный переход на inline `Select`/`Button` ухудшит UX (ручной ввод вместо одного тапа) и снизит opt-in rate. CRM quick actions и demo handler мигрируют (см. #2053, #2054), phone collector остаётся exception'ом до тех пор, пока продукт не примет более слабый UX или aiogram-dialog не добавит contact-share widget.
 
 ## langgraph
 - **triggers:** graph, pipeline, node, edge, state, checkpoint, memory, agent, tool, RAG pipeline, voice

--- a/telegram_bot/handlers/phone_collector.py
+++ b/telegram_bot/handlers/phone_collector.py
@@ -1,5 +1,37 @@
 # telegram_bot/handlers/phone_collector.py
-"""Phone collection FSM for lead capture (#628)."""
+"""Phone collection FSM for lead capture (#628).
+
+## Design exception: justified non-aiogram-dialog FSM (#1232 / #2055)
+
+Telegram lead capture relies on a one-tap *contact share* button
+(`KeyboardButton(request_contact=True)` rendered via
+`ReplyKeyboardMarkup`). The native UX is:
+
+  * the user sees a single big "Поделиться номером" button at the bottom
+    of the chat,
+  * one tap sends a `Contact` payload (verified phone, no manual typing),
+  * fallback path accepts free-text phone input from users on clients
+    that hide the keyboard or refuse contact share.
+
+aiogram-dialog renders inline-keyboard `Select`/`Button` widgets above
+the message and does **not** provide a `request_contact` widget.
+Replacing the reply-keyboard contact share with an inline button would
+force users to type their phone manually, which measurably reduces
+opt-in rate for lead capture.
+
+This module therefore stays as a raw aiogram `Router` + `StatesGroup`
+implementation. The SDK registry calls this out at the bottom of the
+aiogram-dialog gotchas section: it is the **single** intentional
+exception to the "no custom FSM" rule. CRM quick actions (#2053) and
+the demo handler (#2054) migrate to aiogram-dialog as scheduled; this
+file does not.
+
+If a future product decision accepts a weaker UX (no contact share),
+or aiogram-dialog gains a native contact-share widget, drop this
+exception and migrate. Until then, do not "consistency-refactor" this
+file into aiogram-dialog. See #1232 (parent) and #2055 (this design
+note).
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Per the issue body, CRM quick actions (#2053) and the demo handler (#2054) are migrating to aiogram-dialog, but `phone_collector` should stay on raw aiogram `Router` + `FSMContext`. Reason:

- Telegram lead capture uses `KeyboardButton(request_contact=True)` inside `ReplyKeyboardMarkup`. One tap sends a verified `Contact` payload.
- aiogram-dialog renders **inline-keyboard** `Select`/`Button` widgets and does **not** provide a `request_contact` widget.
- A forced migration would replace one-tap contact share with manual phone typing, measurably reducing opt-in rate for lead capture.

This PR makes the exception explicit in two places, so a future reader doing a "consistency refactor" doesn't accidentally weaken the UX.

## Changes

- `telegram_bot/handlers/phone_collector.py` — module docstring expanded from a single-line `#628` note into a full design-exception block referencing #1232 and #2055, with the explicit trade-off and a "drop this exception when..." condition.
- `docs/engineering/sdk-registry.md` — new bullet at the end of the aiogram-dialog gotchas section calling out `phone_collector` as the **single** intentional exception, with cross-references to #2053 and #2054.

This is a docs-only PR — no behaviour change in `phone_collector.py`.

## Verification

```
uv run python -c 'from telegram_bot.handlers import phone_collector'
  → OK
uv run pytest tests/unit/handlers/test_phone_collector.py \
              tests/unit/handlers/test_phone_crm_integration.py -q
  → 47 passed
uv run python scripts/check_markdown_links.py
  → All relative Markdown links OK.
uvx ruff check telegram_bot/handlers/phone_collector.py
  → All checks passed!
```

Closes #2055
Parent: #1232