### PR TITLE
arch: add src/runtime scaffold + migration runbook (#2044)

### DIFF
--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -1,0 +1,70 @@
+# `src/runtime` — shared runtime kernel scaffold
+
+Migration target for [#1948](https://github.com/yastman/rag/issues/1948)
+("reverse layering: `src/api` and `mini_app` import from `telegram_bot`")
+and the parallel decomposition slice in
+[#1265](https://github.com/yastman/rag/issues/1265).
+
+## Why this directory exists
+
+`src/api/main.py` currently imports from `telegram_bot.graph.*`,
+`telegram_bot.integrations.cache`, `telegram_bot.services.qdrant`, and
+`telegram_bot.scoring`. The current violation list lives in
+[`tests/data/known_layering_violations.json`](../../tests/data/known_layering_violations.json)
+and is locked by
+[`tests/contract/test_layering_no_telegram_bot_imports_contract.py`](../../tests/contract/test_layering_no_telegram_bot_imports_contract.py).
+
+The plan in #1948 is to relocate the truly shared kernel modules to
+`src/runtime/` so `src/api`, `mini_app`, and `telegram_bot` all import
+from a single home, and the dependency arrows finally point in the
+direction the README/`pyproject` advertise.
+
+## Migration plan (one PR per row)
+
+| Phase | Issue | Modules to move | Drops from allowlist |
+|---|---|---|---|
+| Phase 1 — pure | [#2045](https://github.com/yastman/rag/issues/2045) | `phone_utils`, `scoring`, `observability`, `content_loader`, `kommo_client` (no graph/cache/qdrant deps) | partial: `telegram_bot.scoring` and any other pure-module entries |
+| Phase 3 — coupled | [#2047](https://github.com/yastman/rag/issues/2047) | `graph/`, `integrations/cache.py`, `services/qdrant.py` | `telegram_bot.graph.*`, `telegram_bot.integrations.cache`, `telegram_bot.services.qdrant` |
+| Cleanup | [#2049](https://github.com/yastman/rag/issues/2049) | nothing — drop the allowlist file | the JSON itself |
+
+Phase 2 is the parallel `telegram_bot/bot.py` decomposition slice
+([#2046](https://github.com/yastman/rag/issues/2046),
+[#2048](https://github.com/yastman/rag/issues/2048) — #1265).
+
+## Per-slice procedure
+
+For each module relocated into `src/runtime/`:
+
+1. `git mv telegram_bot/<path>.py src/runtime/<path>.py`.
+2. Update internal `telegram_bot/` callers to
+   `from src.runtime.<path> import ...`.
+3. Add a thin compat shim back at the original path that re-exports
+   from `src.runtime` (preserves any external dependents while we
+   migrate Docker images and k8s manifests). The shim should be
+   marked `# Deprecated: re-export shim, drop after #2049.`
+4. Update `src/api/main.py` and any `mini_app/` callers to import
+   from `src.runtime.<path>`.
+5. Remove the corresponding entry from
+   `tests/data/known_layering_violations.json`. The contract test
+   refuses to leave stale entries, so a missed step here fails CI.
+6. Run the existing contract suite + any tests that touch the moved
+   surface.
+
+## What this scaffold PR does NOT do
+
+- It does **not** move any module — that is the work of #2045/#2047.
+- It does **not** change runtime behaviour. Importing
+  `src.runtime` succeeds and yields an empty namespace until the first
+  migration slice lands.
+- It does **not** modify the existing ratchet contract or the
+  allowlist JSON — both already enforce "no new violations" on `dev`.
+
+## Verification
+
+The ratchet contract has been on `dev` since 2026-05-22 (PR landing
+the migration scaffolding for #1948). Running it against this scaffold
+shows zero changes:
+
+```bash
+uv run pytest tests/contract/test_layering_no_telegram_bot_imports_contract.py -q
+```

--- a/src/runtime/__init__.py
+++ b/src/runtime/__init__.py
@@ -1,0 +1,47 @@
+"""Shared runtime kernel — destination package for the reverse-layering fix.
+
+This package is the migration target for #1948 (and the related slice in
+#1265). The repository's stated layering is::
+
+    src/*           — reusable RAG library, no application coupling
+    telegram_bot/*  — bot application, consumer of src/*
+    mini_app/*      — Mini App backend, consumer of src/*
+
+Reality on `dev` still has ``src/api/main.py`` importing
+``telegram_bot.graph.*``, ``telegram_bot.integrations.cache``,
+``telegram_bot.services.qdrant``, and ``telegram_bot.scoring`` — see
+``tests/data/known_layering_violations.json`` for the explicit ratchet
+allowlist.
+
+The intent of ``src.runtime`` is to host the truly shared kernel
+modules that today live under ``telegram_bot/``::
+
+    src/runtime/graph/             ← from telegram_bot/graph/
+    src/runtime/integrations/cache  ← from telegram_bot/integrations/cache.py
+    src/runtime/services/qdrant     ← from telegram_bot/services/qdrant.py
+    src/runtime/observability/      ← from telegram_bot/observability.py
+    src/runtime/services/content_loader  ← ...
+    src/runtime/services/kommo_client     ← ...
+    src/runtime/phone_utils.py            ← ...
+    src/runtime/scoring/                  ← ...
+
+After each migration slice:
+
+* ``telegram_bot/`` re-exports the moved symbol from ``src.runtime`` for
+  backward compatibility, then is itself updated to import from the new
+  location;
+* ``src/api/main.py`` and ``mini_app/*`` are switched to
+  ``from src.runtime.* import ...`` for the same symbol;
+* the corresponding row in ``tests/data/known_layering_violations.json``
+  is removed.
+
+The migration slices are tracked as #2045 (phase 1: pure modules),
+#2047 (phase 3: coupled modules), and #2049 (cleanup: drop the
+allowlist and verify Mini App separability). #2046 / #2048 cover the
+parallel ``telegram_bot/bot.py`` decomposition (#1265).
+
+Until those slices land, this package exposes nothing — importing it
+just makes the destination directory exist as a Python package so
+future ``git mv`` operations can land without dance. See
+``src/runtime/README.md`` for the migration runbook.
+"""


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Parent: #1948 (reverse layering). Related: #1265.

The ratchet contract test for #1948 is already on `dev`:

- `tests/contract/test_layering_no_telegram_bot_imports_contract.py`
- `tests/data/known_layering_violations.json` (5 entries, all in `src/api/main.py`)

What is missing is the destination package the migration slices (#2045 phase 1, #2047 phase 3, #2049 cleanup) need to land into. This PR adds the scaffold so each follow-up slice can do a single `git mv` without also creating the package on its first PR.

## Changes

- `src/runtime/__init__.py` — module docstring explaining the package role: this is the destination kernel. Imports as a working empty namespace; future slices fill it via `git mv`.
- `src/runtime/README.md` — migration runbook with the per-phase plan (#2045 / #2047 / #2049), the per-slice procedure (`git mv` → update callers → add compat shim → drop allowlist row → run contract), and an explicit list of what this scaffold PR does **not** do.

## What this PR does NOT do

- No module relocation — that's #2045 / #2047.
- No behaviour change — `src.runtime` imports as an empty namespace.
- No contract / allowlist change — `tests/data/known_layering_violations.json` and the ratchet test are untouched.

## Verification

```
uv run pytest tests/contract/test_layering_no_telegram_bot_imports_contract.py -q   # 4 passed
uv run pytest tests/contract/ -q                                                     # 1095 passed
uv run python -c 'import src.runtime'                                                # OK
uv run python scripts/check_markdown_links.py                                        # OK
uvx ruff check src/runtime/                                                          # OK
```

Closes #2044