### PR TITLE
test: dedup smoke fixtures + register shared config plugin (#2066)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,12 @@ import pytest
 from dotenv import load_dotenv
 
 
+# Register shared URL/collection fixtures (issue #2066). Smoke and integration
+# tiers consume `redis_url`, `qdrant_url`, `qdrant_api_key`,
+# `qdrant_collection`, `bge_m3_url`, `openai_api_key` from a single source.
+pytest_plugins = ["tests.fixtures.config"]
+
+
 # Set testing flag to prevent heavy imports in src/__init__.py
 os.environ["RAG_TESTING"] = "true"
 

--- a/tests/contract/test_smoke_fixtures_dedup_contract.py
+++ b/tests/contract/test_smoke_fixtures_dedup_contract.py
@@ -1,0 +1,102 @@
+"""Contract test for issue #2066 — smoke fixtures must use shared config.
+
+Issue #1515 audit D3+D4 flagged that ``tests/smoke/conftest.py`` had its
+own ``redis_url`` and Qdrant URL/collection fixtures that duplicated the
+shared definitions in ``tests/fixtures/config.py`` (with subtly different
+default values — the smoke copy used the production collection
+``gdrive_documents_bge`` while the shared copy used ``test_documents``).
+
+This contract locks in three invariants after the dedup:
+
+1. ``tests/fixtures/config.py`` is registered as a pytest plugin from
+   ``tests/conftest.py`` so its fixtures are visible repo-wide.
+2. ``tests/fixtures/config.py::qdrant_collection`` defaults to the
+   production contract value ``gdrive_documents_bge``, matching
+   ``telegram_bot/config.py`` and ``compose.yml``.
+3. ``tests/smoke/conftest.py`` does not redefine ``redis_url`` /
+   ``qdrant_url`` / ``qdrant_api_key`` / ``qdrant_collection``. It may
+   *consume* them from the shared plugin, but it must not redeclare them.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+SHARED_FIXTURES = REPO / "tests" / "fixtures" / "config.py"
+ROOT_CONFTEST = REPO / "tests" / "conftest.py"
+SMOKE_CONFTEST = REPO / "tests" / "smoke" / "conftest.py"
+
+SHARED_FIXTURE_NAMES = (
+    "redis_url",
+    "qdrant_url",
+    "qdrant_api_key",
+    "qdrant_collection",
+)
+
+
+def test_shared_config_fixtures_registered_in_root_conftest() -> None:
+    text = ROOT_CONFTEST.read_text(encoding="utf-8")
+    assert "tests.fixtures.config" in text, (
+        "tests/conftest.py must register `tests.fixtures.config` as a "
+        "pytest plugin so its session-scoped URL/collection fixtures are "
+        "available to every test tier (issue #2066)."
+    )
+
+
+def test_qdrant_collection_default_matches_production_contract() -> None:
+    text = SHARED_FIXTURES.read_text(encoding="utf-8")
+    match = re.search(
+        r"def qdrant_collection\([^)]*\):.*?return os\.getenv\(\s*\"QDRANT_COLLECTION\"\s*,\s*\"([^\"]+)\"\s*\)",
+        text,
+        re.DOTALL,
+    )
+    assert match, "qdrant_collection fixture not found in tests/fixtures/config.py"
+    assert match.group(1) == "gdrive_documents_bge", (
+        f"qdrant_collection default is {match.group(1)!r}; must be "
+        "'gdrive_documents_bge' to match telegram_bot/config.py and "
+        "compose.yml (issue #2066)."
+    )
+
+
+def test_smoke_conftest_does_not_redefine_shared_fixtures() -> None:
+    text = SMOKE_CONFTEST.read_text(encoding="utf-8")
+    # Strip docstrings and comments so we don't false-match prose.
+    code_only_lines: list[str] = []
+    in_string = False
+    string_delim = ""
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if not in_string:
+            if stripped.startswith(("#",)):
+                continue
+            triple = '"""' if '"""' in stripped else ("'''" if "'''" in stripped else "")
+            if triple and stripped.count(triple) % 2 == 1:
+                in_string = True
+                string_delim = triple
+                continue
+        else:
+            if string_delim in line:
+                in_string = False
+            continue
+        code_only_lines.append(line)
+    code = "\n".join(code_only_lines)
+
+    redefined: list[str] = []
+    for name in SHARED_FIXTURE_NAMES:
+        # Match `def <name>(` only when preceded by a fixture decorator marker
+        # (look back ~80 chars for `@pytest.fixture`).
+        for m in re.finditer(rf"\bdef\s+{re.escape(name)}\s*\(", code):
+            window = code[max(0, m.start() - 100) : m.start()]
+            if "pytest.fixture" in window or "@fixture" in window:
+                redefined.append(name)
+                break
+
+    assert redefined == [], (
+        "tests/smoke/conftest.py redefines fixture(s) that are owned by "
+        "tests/fixtures/config.py: "
+        f"{redefined}. Drop the local copies and consume the shared "
+        "session-scoped fixtures (issue #2066)."
+    )

--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -19,8 +19,14 @@ def qdrant_api_key():
 
 @pytest.fixture(scope="session")
 def qdrant_collection():
-    """Qdrant collection name for tests."""
-    return os.getenv("QDRANT_COLLECTION", "test_documents")
+    """Qdrant collection name for tests.
+
+    Defaults to the production contract value ``gdrive_documents_bge``
+    (matches ``telegram_bot/config.py`` and ``compose.yml``) so smoke
+    tests run against the same collection naming the bot uses
+    end-to-end. Override per-environment via ``QDRANT_COLLECTION``.
+    """
+    return os.getenv("QDRANT_COLLECTION", "gdrive_documents_bge")
 
 
 @pytest.fixture(scope="session")

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -1,5 +1,12 @@
 # tests/smoke/conftest.py
-"""Smoke test fixtures - require live Qdrant and Redis."""
+"""Smoke test fixtures - require live Qdrant and Redis.
+
+URL/credential fixtures (``redis_url``, ``qdrant_url``, ``qdrant_api_key``,
+``qdrant_collection``) are owned by ``tests/fixtures/config.py`` and
+registered globally in ``tests/conftest.py`` (issue #2066). This module
+only declares smoke-tier-specific fixtures (live-service guard, service
+clients).
+"""
 
 import asyncio
 import os
@@ -10,20 +17,6 @@ import redis.asyncio as redis
 
 from telegram_bot.integrations.cache import CacheLayerManager
 from telegram_bot.services.qdrant import QdrantService
-
-
-@pytest.fixture(scope="module")
-def redis_url() -> str:
-    """Redis URL for smoke tests, with REDIS_PASSWORD injected if not embedded.
-
-    Mirrors `scripts/validate_traces.py::_build_redis_url` so smoke tests work
-    against Compose dev defaults (auth-required Redis) without per-test plumbing.
-    """
-    base = os.getenv("REDIS_URL", "redis://localhost:6379")
-    password = os.getenv("REDIS_PASSWORD", "")
-    if password and "@" not in base:
-        base = base.replace("redis://", f"redis://:{password}@", 1)
-    return base
 
 
 @pytest.fixture(scope="module")

--- a/uv.lock
+++ b/uv.lock
@@ -23,9 +23,6 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'",
 ]
 
-[options]
-prerelease-mode = "allow"
-
 [manifest]
 overrides = [{ name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.58b0" }]
 


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Parent: #1515 (test audit), categories D3 + D4.

#2066 calls out three issues with smoke test fixtures:
- **D3**: `tests/smoke/conftest.py` declared its own `redis_url`, duplicating `tests/fixtures/config.py::redis_url` with a different scope.
- **D4**: `tests/smoke/conftest.py` read `QDRANT_URL`/`QDRANT_COLLECTION` env vars directly, with `QDRANT_COLLECTION` default `gdrive_documents_bge` diverging from `tests/fixtures/config.py` default `test_documents`.

**Root cause:** `tests/fixtures/config.py` existed as a "shared fixtures" file but was never registered with pytest, so its session-scoped fixtures were not actually visible to any test tier. Each tier rolled its own.

## Fix

1. `tests/conftest.py` — declare
   ```python
   pytest_plugins = ["tests.fixtures.config"]
   ```
   so the shared fixtures resolve repo-wide.

2. `tests/fixtures/config.py` — change `qdrant_collection` default from `"test_documents"` to `"gdrive_documents_bge"` to match `telegram_bot/config.py` and `compose.yml`. Smoke tests against the default config now hit the same collection name the bot uses end-to-end.

3. `tests/smoke/conftest.py` — drop the local `redis_url` fixture; the shared session-scoped one now resolves automatically. The `require_live_services` / `qdrant_service` / `cache_service` / `voyage_service` fixtures continue to work; they consumed `redis_url` via `request.getfixturevalue()`, which keeps working.

## Contract test

`tests/contract/test_smoke_fixtures_dedup_contract.py` with three invariants:
- shared plugin is registered from root conftest;
- `qdrant_collection` default == production contract value;
- `tests/smoke/conftest.py` does not redefine any shared fixture.

## Verification

```
uv run pytest tests/contract/test_smoke_fixtures_dedup_contract.py -v
  3 passed

uv run pytest tests/smoke/ --collect-only -q
  73 tests collected (no fixture-resolution errors)
```

Closes #2066.