### PR TITLE
observability: migrate record_counter_metric call-sites to record_pipeline_event (#2056)

### DIFF
--- a/telegram_bot/agents/rag_pipeline.py
+++ b/telegram_bot/agents/rag_pipeline.py
@@ -32,7 +32,7 @@ from telegram_bot.services.cache_policy import (
     maybe_store_semantic_response,
     resolve_semantic_cache_signature,
 )
-from telegram_bot.services.metrics import record_counter_metric
+from telegram_bot.services.metrics import record_pipeline_event
 from telegram_bot.services.query_filter_signal import detect_filter_sensitive_query
 from telegram_bot.services.query_preprocessor import QueryPreprocessor, expand_short_query
 from telegram_bot.services.rag_core import (
@@ -558,7 +558,7 @@ async def _hybrid_retrieve(
 
     # Step 4: Hybrid search via Qdrant SDK (RRF fusion or ColBERT server-side rerank)
     if colbert_query and callable(getattr(qdrant, "hybrid_search_rrf_colbert", None)):
-        record_counter_metric("colbert_rerank_attempted")
+        record_pipeline_event("colbert_rerank_attempted")
     results, search_meta, colbert_used = await _run_initial_retrieval(
         qdrant=qdrant,
         dense_vector=dense_vector,
@@ -574,7 +574,7 @@ async def _hybrid_retrieve(
     initial_results_count = len(results)
 
     if active_filters and len(results) < 3 and active_filters != relaxed_filters:
-        record_counter_metric("topic_filter_fallback")
+        record_pipeline_event("topic_filter_fallback")
         retrieval_relaxed_from_topic_filter = True
         fallback_filters = relaxed_filters if relaxed_filters is not None else None
         if prefer_faq_doc_type:
@@ -618,7 +618,7 @@ async def _hybrid_retrieve(
         final_filters = dict(base_filters) if isinstance(base_filters, dict) else None
 
     if not results:
-        record_counter_metric("retrieval_zero_docs")
+        record_pipeline_event("retrieval_zero_docs")
 
     # Step 5: Cache results
     if results and not search_meta.get("backend_error", False):
@@ -746,7 +746,7 @@ async def _grade_documents(
         len(documents),
         elapsed,
     )
-    record_counter_metric("score_gap_confident", 1 if score_gap["confident"] else 0)
+    record_pipeline_event("score_gap_confident", 1 if score_gap["confident"] else 0)
 
     return {
         "documents_relevant": relevant,

--- a/telegram_bot/services/qdrant.py
+++ b/telegram_bot/services/qdrant.py
@@ -12,7 +12,7 @@ from qdrant_client import AsyncQdrantClient, models
 
 from src.config.qdrant_policy import resolve_collection_name
 from telegram_bot.observability import get_client, observe
-from telegram_bot.services.metrics import record_counter_metric
+from telegram_bot.services.metrics import record_pipeline_event
 
 
 logger = logging.getLogger(__name__)
@@ -730,12 +730,12 @@ class QdrantService:
             )
             results = self._format_results(result.points)
             if not results:
-                record_counter_metric("colbert_rerank_empty")
+                record_pipeline_event("colbert_rerank_empty")
                 logger.warning(
                     "Qdrant ColBERT returned 0 docs for collection %s, falling back to RRF",
                     self._collection_name,
                 )
-                record_counter_metric("colbert_fallback_to_rrf")
+                record_pipeline_event("colbert_fallback_to_rrf")
                 fallback = await self.hybrid_search_rrf(
                     dense_vector=dense_vector,
                     sparse_vector=sparse_vector,

--- a/tests/contract/test_record_counter_metric_migration_contract.py
+++ b/tests/contract/test_record_counter_metric_migration_contract.py
@@ -1,0 +1,93 @@
+"""Contract test for issue #2056 — log/record_counter_metric → record_pipeline_event.
+
+Issue #1648 slice 3/4 (#2056) replaces the legacy
+``record_counter_metric(name)`` shim with the SDK-native
+``record_pipeline_event(event)`` Counter API exported by
+``telegram_bot.services.metrics``.
+
+The legacy ``record_counter_metric`` function is intentionally kept inside
+``telegram_bot/services/metrics.py`` as a thin compatibility wrapper —
+removing it is scoped to #2058 (slice 4/4 cleanup), not this issue. So
+this contract enforces a directional rule:
+
+* ``record_counter_metric`` may only be **defined** in
+  ``telegram_bot/services/metrics.py``.
+* ``record_counter_metric`` may not be **imported** or **called** from
+  any first-party module under ``telegram_bot/``, ``src/``, ``mini_app/``,
+  or ``services/``.
+* All event-counter call-sites must use ``record_pipeline_event``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+METRICS_OWNER = REPO / "telegram_bot" / "services" / "metrics.py"
+
+FIRST_PARTY_ROOTS = ("src", "telegram_bot", "mini_app", "services")
+
+IMPORT_RE = re.compile(
+    r"^\s*from\s+telegram_bot\.services\.metrics\s+import\s+[^#\n]*\brecord_counter_metric\b",
+    re.MULTILINE,
+)
+CALL_RE = re.compile(r"\brecord_counter_metric\s*\(")
+
+
+def _python_files() -> list[Path]:
+    skip = {".git", ".venv", "venv", "__pycache__", ".pytest_cache"}
+    out: list[Path] = []
+    for root_name in FIRST_PARTY_ROOTS:
+        root = REPO / root_name
+        if not root.exists():
+            continue
+        for py in root.rglob("*.py"):
+            if any(part in skip for part in py.parts):
+                continue
+            out.append(py)
+    return out
+
+
+def test_record_counter_metric_not_imported_outside_metrics_module() -> None:
+    offenders: list[str] = []
+    for path in _python_files():
+        if path == METRICS_OWNER:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if IMPORT_RE.search(text):
+            offenders.append(str(path.relative_to(REPO)))
+    assert offenders == [], (
+        "record_counter_metric is a legacy compatibility shim (issue #2056). "
+        "First-party code must import record_pipeline_event from "
+        "telegram_bot.services.metrics instead. "
+        f"Offending imports: {offenders}"
+    )
+
+
+def test_record_counter_metric_not_called_outside_metrics_module() -> None:
+    offenders: list[str] = []
+    for path in _python_files():
+        if path == METRICS_OWNER:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if CALL_RE.search(text):
+            offenders.append(str(path.relative_to(REPO)))
+    assert offenders == [], (
+        "record_counter_metric() is a legacy compatibility shim (issue #2056). "
+        "First-party call-sites must use record_pipeline_event(event, amount). "
+        f"Offending callers: {offenders}"
+    )
+
+
+def test_record_pipeline_event_remains_the_canonical_counter_api() -> None:
+    """Sanity guard: the new SDK-native helper still exists and is exported."""
+    text = METRICS_OWNER.read_text(encoding="utf-8")
+    assert "def record_pipeline_event(" in text, (
+        "record_pipeline_event() must remain the canonical Counter API in "
+        "telegram_bot/services/metrics.py (issue #2056)."
+    )
+    assert '"record_pipeline_event"' in text or "'record_pipeline_event'" in text, (
+        "record_pipeline_event must be in the module __all__ export list."
+    )

--- a/tests/unit/agents/test_rag_pipeline.py
+++ b/tests/unit/agents/test_rag_pipeline.py
@@ -699,16 +699,27 @@ async def test_grade_documents_includes_score_gap_confident():
 
 
 async def test_grade_documents_records_score_gap_counter():
-    from telegram_bot.agents.rag_pipeline import _grade_documents
-    from telegram_bot.services.metrics import PipelineMetrics
+    from prometheus_client import REGISTRY
 
-    PipelineMetrics.reset()
+    from telegram_bot.agents.rag_pipeline import _grade_documents
+
+    before = (
+        REGISTRY.get_sample_value(
+            "rag_pipeline_events_total", labels={"event": "score_gap_confident"}
+        )
+        or 0.0
+    )
     docs = [{"score": 0.020}, {"score": 0.010}, {"score": 0.005}]
 
     await _grade_documents(docs, 0.0, latency_stages={})
 
-    stats = PipelineMetrics.get().get_stats()
-    assert stats["counters"]["score_gap_confident"] == 1
+    after = (
+        REGISTRY.get_sample_value(
+            "rag_pipeline_events_total", labels={"event": "score_gap_confident"}
+        )
+        or 0.0
+    )
+    assert after - before == 1.0
 
 
 # ---------------------------------------------------------------------------
@@ -1965,10 +1976,16 @@ async def test_hybrid_retrieve_uses_pre_computed_sparse(mock_cache, mock_sparse,
 
 async def test_hybrid_retrieve_counts_colbert_rerank_attempted(mock_cache, mock_sparse):
     """_hybrid_retrieve counts colbert_rerank_attempted when ColBERT path is taken."""
-    from telegram_bot.agents.rag_pipeline import _hybrid_retrieve
-    from telegram_bot.services.metrics import PipelineMetrics
+    from prometheus_client import REGISTRY
 
-    PipelineMetrics.reset()
+    from telegram_bot.agents.rag_pipeline import _hybrid_retrieve
+
+    before = (
+        REGISTRY.get_sample_value(
+            "rag_pipeline_events_total", labels={"event": "colbert_rerank_attempted"}
+        )
+        or 0.0
+    )
 
     mock_qdrant = AsyncMock()
     mock_qdrant.hybrid_search_rrf_colbert = AsyncMock(
@@ -1988,16 +2005,27 @@ async def test_hybrid_retrieve_counts_colbert_rerank_attempted(mock_cache, mock_
         latency_stages={},
     )
 
-    stats = PipelineMetrics.get().get_stats()
-    assert stats["counters"]["colbert_rerank_attempted"] == 1
+    after = (
+        REGISTRY.get_sample_value(
+            "rag_pipeline_events_total", labels={"event": "colbert_rerank_attempted"}
+        )
+        or 0.0
+    )
+    assert after - before == 1.0
 
 
 async def test_hybrid_retrieve_counts_retrieval_zero_docs(mock_cache, mock_sparse):
     """_hybrid_retrieve counts retrieval_zero_docs when search returns empty list."""
-    from telegram_bot.agents.rag_pipeline import _hybrid_retrieve
-    from telegram_bot.services.metrics import PipelineMetrics
+    from prometheus_client import REGISTRY
 
-    PipelineMetrics.reset()
+    from telegram_bot.agents.rag_pipeline import _hybrid_retrieve
+
+    before = (
+        REGISTRY.get_sample_value(
+            "rag_pipeline_events_total", labels={"event": "retrieval_zero_docs"}
+        )
+        or 0.0
+    )
 
     mock_qdrant_empty = AsyncMock()
     mock_qdrant_empty.hybrid_search_rrf = AsyncMock(
@@ -2017,8 +2045,13 @@ async def test_hybrid_retrieve_counts_retrieval_zero_docs(mock_cache, mock_spars
         latency_stages={},
     )
 
-    stats = PipelineMetrics.get().get_stats()
-    assert stats["counters"]["retrieval_zero_docs"] == 1
+    after = (
+        REGISTRY.get_sample_value(
+            "rag_pipeline_events_total", labels={"event": "retrieval_zero_docs"}
+        )
+        or 0.0
+    )
+    assert after - before == 1.0
 
 
 async def test_rag_pipeline_passes_pre_computed_sparse_to_retrieve(mock_cache, mock_sparse):

--- a/tests/unit/test_qdrant_service.py
+++ b/tests/unit/test_qdrant_service.py
@@ -736,10 +736,22 @@ class TestQdrantServiceHybridSearchColbert:
         service.hybrid_search_rrf.assert_awaited_once()
 
     async def test_colbert_empty_results_counts_rerank_empty_metric(self, service):
-        """Empty ColBERT results count rerank-empty and fallback metrics."""
-        from telegram_bot.services.metrics import PipelineMetrics
+        """Empty ColBERT results count rerank-empty and fallback metrics (#2056)."""
+        from prometheus_client import REGISTRY
 
-        PipelineMetrics.reset()
+        before_empty = (
+            REGISTRY.get_sample_value(
+                "rag_pipeline_events_total", labels={"event": "colbert_rerank_empty"}
+            )
+            or 0.0
+        )
+        before_fallback = (
+            REGISTRY.get_sample_value(
+                "rag_pipeline_events_total", labels={"event": "colbert_fallback_to_rrf"}
+            )
+            or 0.0
+        )
+
         service._client.query_points = AsyncMock(return_value=MagicMock(points=[]))
         service.hybrid_search_rrf = AsyncMock(
             return_value=[{"id": "fallback_1", "score": 0.9, "text": "fallback", "metadata": {}}]
@@ -751,9 +763,20 @@ class TestQdrantServiceHybridSearchColbert:
             top_k=5,
         )
 
-        stats = PipelineMetrics.get().get_stats()
-        assert stats["counters"]["colbert_rerank_empty"] == 1
-        assert stats["counters"]["colbert_fallback_to_rrf"] == 1
+        after_empty = (
+            REGISTRY.get_sample_value(
+                "rag_pipeline_events_total", labels={"event": "colbert_rerank_empty"}
+            )
+            or 0.0
+        )
+        after_fallback = (
+            REGISTRY.get_sample_value(
+                "rag_pipeline_events_total", labels={"event": "colbert_fallback_to_rrf"}
+            )
+            or 0.0
+        )
+        assert after_empty - before_empty == 1.0
+        assert after_fallback - before_fallback == 1.0
 
     async def test_colbert_search_with_filters(self, service, mock_point):
         """Filters are passed through to query_points."""

--- a/uv.lock
+++ b/uv.lock
@@ -23,9 +23,6 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'",
 ]
 
-[options]
-prerelease-mode = "allow"
-
 [manifest]
 overrides = [{ name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.58b0" }]
 


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Parent: #1648 (slice 3/4).

The SDK-native `rag_pipeline_events_total` Counter and the `record_pipeline_event()` helper landed earlier in #1648 slice 3/4. Six call-sites in production code still used the legacy `record_counter_metric()` compat shim:

| File | Event |
|---|---|
| `telegram_bot/agents/rag_pipeline.py` | `colbert_rerank_attempted` |
| `telegram_bot/agents/rag_pipeline.py` | `topic_filter_fallback` |
| `telegram_bot/agents/rag_pipeline.py` | `retrieval_zero_docs` |
| `telegram_bot/agents/rag_pipeline.py` | `score_gap_confident` |
| `telegram_bot/services/qdrant.py` | `colbert_rerank_empty` |
| `telegram_bot/services/qdrant.py` | `colbert_fallback_to_rrf` |

This PR migrates all six to `record_pipeline_event(name)` directly, removing the indirection through `PipelineMetrics.get().inc()` while preserving the exact event labels (so existing dashboards/alerts on `rag_pipeline_events_total{event=...}` continue to work).

The legacy `record_counter_metric()` function stays in `telegram_bot/services/metrics.py` — its removal is scoped to **#2058** (slice 4/4 cleanup), not this PR.

## Test migration (commit 2 of 2)

Three tests in `tests/unit/agents/test_rag_pipeline.py` still asserted on the legacy `PipelineMetrics.get().get_stats()["counters"]` surface, which `record_pipeline_event()` no longer touches. They are migrated to read from the Prometheus default `REGISTRY` instead — using a delta-based assertion that is xdist-safe and matches the style in `tests/unit/services/test_pipeline_counters_prometheus.py`:

```python
before = REGISTRY.get_sample_value(
    "rag_pipeline_events_total", labels={"event": "<event>"}
) or 0.0
...
after - before == 1.0
```

## New contract test

`tests/contract/test_record_counter_metric_migration_contract.py` with three invariants:
- `record_counter_metric` is not imported anywhere outside `metrics.py`;
- `record_counter_metric()` is not called anywhere outside `metrics.py`;
- `record_pipeline_event()` remains the canonical Counter API.

## Verification

```
uv run pytest tests/unit/agents/test_rag_pipeline.py
              tests/contract/test_record_counter_metric_migration_contract.py
              tests/unit/services/test_pipeline_counters_prometheus.py
              tests/contract/test_no_custom_metrics_registry_contract.py -q
  98 passed

uvx ruff check telegram_bot/agents/rag_pipeline.py
               telegram_bot/services/qdrant.py
               tests/contract/test_record_counter_metric_migration_contract.py
  All checks passed!
```

Default REGISTRY unchanged — no custom `CollectorRegistry` is added, matching the issue's explicit constraint and the existing `test_no_custom_metrics_registry_contract.py` guard.

Closes #2056.