### PR TITLE
fix: harden non-destructive security cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,9 @@ evaluation/results/
 evaluation/evaluation/
 *.tar.gz
 *.backup
+*.bak
+opencode.json
+Thumbs.db
 
 # Sensitive files
 .env
@@ -285,7 +288,6 @@ rag-small-to-big-research.md
 .swarm/
 .opencode/
 .opencode/node_modules/
-opencode.json
 projects/
 tmp.*
 
@@ -320,14 +322,3 @@ scripts/qdrant_restore.sh
 **/coverage/
 **/.nyc_output/
 **/.vite/
-
-# OS files
-.DS_Store
-Thumbs.db
-
-# Editor swap/backup files
-*.swp
-*.swo
-*~
-*.bak
-*.backup

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Pre-commit hooks configuration for contextual_rag project
+# Pre-commit hooks configuration for rag-fresh
 # Install: uv add pre-commit --dev && uv run pre-commit install
 # Setup pre-push: uv run pre-commit install --hook-type pre-push
 # Run manually: uv run pre-commit run --all-files

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -31,8 +31,8 @@ Reusable base manifests. These are environment-agnostic and should not contain h
 - **`redis/`** — PVC, Deployment, Service.
 - **`qdrant/`** — PVC, Deployment, Service.
 - **`docling/`** — PVC, Deployment, Service.
-- **`bge-m3/`** — Deployment, Service.
-- **`user-base/`** — Deployment, Service.
+- **`bge-m3/`** — PVC, Deployment, Service.
+- **`user-base/`** — PVC, Deployment, Service.
 - **`litellm/`** — Deployment, Service.
 - **`bot/`** — Deployment.
 - **`ingestion/`** — Deployment.

--- a/k8s/base/bge-m3/deployment.yaml
+++ b/k8s/base/bge-m3/deployment.yaml
@@ -67,6 +67,5 @@ spec:
             failureThreshold: 3
       volumes:
         - name: hf-cache
-          hostPath:
-            path: /opt/k3s-data/hf-cache
-            type: DirectoryOrCreate
+          persistentVolumeClaim:
+            claimName: bge-m3-model-cache

--- a/k8s/base/bge-m3/pvc.yaml
+++ b/k8s/base/bge-m3/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bge-m3-model-cache
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 10Gi

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -22,8 +22,10 @@ resources:
   - docling/pvc.yaml
   - docling/deployment.yaml
   - docling/service.yaml
+  - bge-m3/pvc.yaml
   - bge-m3/deployment.yaml
   - bge-m3/service.yaml
+  - user-base/pvc.yaml
   - user-base/deployment.yaml
   - user-base/service.yaml
   # Application

--- a/k8s/base/user-base/deployment.yaml
+++ b/k8s/base/user-base/deployment.yaml
@@ -65,6 +65,5 @@ spec:
             failureThreshold: 3
       volumes:
         - name: hf-cache
-          hostPath:
-            path: /opt/k3s-data/hf-cache
-            type: DirectoryOrCreate
+          persistentVolumeClaim:
+            claimName: user-base-model-cache

--- a/k8s/base/user-base/pvc.yaml
+++ b/k8s/base/user-base/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: user-base-model-cache
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 5Gi


### PR DESCRIPTION
## Summary
- replace reusable k8s base `hostPath` model caches with PVC-backed volumes for bge-m3 and user-base
- clean stale internal project codename reference and deduplicate ignore patterns for local/agent/backup artifacts
- update k8s documentation and base kustomization for the new PVC resources

## Validation
- `git grep` for known leaked resource patterns: no matches
- `git grep hostPath -- k8s`: no matches
- `git diff --check`
- `kubectl kustomize k8s/overlays/full >/tmp/rag-kustomize-full.yaml`
- `uv run pre-commit run check-yaml --files .pre-commit-config.yaml k8s/base/kustomization.yaml k8s/base/bge-m3/deployment.yaml k8s/base/bge-m3/pvc.yaml k8s/base/user-base/deployment.yaml k8s/base/user-base/pvc.yaml`
- `uv run pre-commit run gitleaks --all-files`
