### PR TITLE
feat(observability): Sentry runtime tags + Langfuse trace context (#2061)

### DIFF
--- a/src/observability_sentry.py
+++ b/src/observability_sentry.py
@@ -22,8 +22,11 @@ configuration contract and the umbrella issue
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
+from collections.abc import Iterator
+from contextlib import contextmanager
 from importlib import metadata as _metadata
 from typing import Any
 
@@ -35,7 +38,10 @@ from src.security.pii_redaction import PIIRedactor
 
 __all__ = [
     "_reset_for_tests",
+    "hash_id",
     "initialize_sentry",
+    "runtime_scope",
+    "set_runtime_tags",
 ]
 
 
@@ -45,6 +51,8 @@ logger = logging.getLogger(__name__)
 # global ``sentry_sdk`` module (which other helpers may import).
 _sentry_init = sentry_sdk.init
 _sentry_capture_message = sentry_sdk.capture_message
+_sentry_set_tag = sentry_sdk.set_tag
+_sentry_new_scope = sentry_sdk.new_scope
 
 _PII_TRUNCATE_LIMIT = 4000
 
@@ -251,3 +259,97 @@ def _reset_for_tests() -> None:
     global _initialized, _skip_logged
     _initialized = False
     _skip_logged = False
+
+
+# ---------------------------------------------------------------------------
+# Runtime tags + trace context (#2061)
+# ---------------------------------------------------------------------------
+
+
+_HASH_PREFIX_LEN = 16
+
+
+def hash_id(value: str | int) -> str:
+    """Return a stable, opaque 16-char hex hash of an ID.
+
+    Used for ``chat_id_hash`` / ``telegram_user_id_hash`` Sentry tags so we
+    keep the ability to correlate events for the same user without leaking
+    the raw Telegram identifier. Inputs are normalised to ``str`` so
+    ``hash_id(123)`` and ``hash_id("123")`` collide as expected.
+    """
+    digest = hashlib.sha256(str(value).encode("utf-8")).hexdigest()
+    return digest[:_HASH_PREFIX_LEN]
+
+
+def set_runtime_tags(
+    *,
+    service: str = "telegram-bot",
+    component: str | None = None,
+    pipeline_mode: str | None = None,
+    route: str | None = None,
+    extra_tags: dict[str, str] | None = None,
+) -> None:
+    """Set static service-level tags on the active Sentry isolation scope.
+
+    Intended to be called once at startup (after :func:`initialize_sentry`)
+    so every event picks up the service / component / pipeline_mode / route
+    metadata. ``extra_tags`` is an escape hatch for deployment-specific
+    labels (locale, tenant, etc.).
+    """
+    _sentry_set_tag("service", service)
+    if component is not None:
+        _sentry_set_tag("component", component)
+    if pipeline_mode is not None:
+        _sentry_set_tag("pipeline_mode", pipeline_mode)
+    if route is not None:
+        _sentry_set_tag("route", route)
+    for key, value in (extra_tags or {}).items():
+        _sentry_set_tag(key, value)
+
+
+@contextmanager
+def runtime_scope(
+    *,
+    chat_id: str | int | None = None,
+    telegram_user_id: str | int | None = None,
+    trace_id: str | None = None,
+    langfuse_trace_id: str | None = None,
+    route: str | None = None,
+    pipeline_mode: str | None = None,
+    extra_tags: dict[str, str] | None = None,
+) -> Iterator[Any]:
+    """Push a request-scoped Sentry scope with PII-safe runtime metadata.
+
+    The context manager emits hashed ``chat_id_hash`` and
+    ``telegram_user_id_hash`` tags and a ``trace`` context block that
+    correlates the current Telegram update with its Langfuse / OTEL trace.
+    Raw Telegram identifiers and free-text payloads never reach the SDK.
+
+    All arguments are optional — ``None`` values are silently skipped so
+    callers can call ``runtime_scope(chat_id=update.chat.id, ...)`` without
+    branching on availability.
+    """
+    with _sentry_new_scope() as scope:
+        if chat_id is not None:
+            scope.set_tag("chat_id_hash", hash_id(chat_id))
+        if telegram_user_id is not None:
+            scope.set_tag("telegram_user_id_hash", hash_id(telegram_user_id))
+
+        trace_block: dict[str, str] = {}
+        if trace_id is not None:
+            scope.set_tag("trace_id", trace_id)
+            trace_block["trace_id"] = trace_id
+        if langfuse_trace_id is not None:
+            scope.set_tag("langfuse_trace_id", langfuse_trace_id)
+            trace_block["langfuse_trace_id"] = langfuse_trace_id
+        if trace_block:
+            scope.set_context("trace", trace_block)
+
+        if route is not None:
+            scope.set_tag("route", route)
+        if pipeline_mode is not None:
+            scope.set_tag("pipeline_mode", pipeline_mode)
+        for key, value in (extra_tags or {}).items():
+            scope.set_tag(key, value)
+
+        yield scope

--- a/tests/unit/observability/test_sentry_runtime_tags.py
+++ b/tests/unit/observability/test_sentry_runtime_tags.py
@@ -1,0 +1,233 @@
+"""Unit tests for Sentry runtime tags + trace context (#2061).
+
+Covers the three new helpers in ``src.observability_sentry``:
+
+- ``hash_id`` — stable, short, opaque hash for Telegram chat/user IDs
+- ``set_runtime_tags`` — set static service/component/pipeline tags on the
+  active Sentry scope
+- ``runtime_scope`` — context manager that pushes PII-safe runtime tags
+  (hashed IDs) and Langfuse trace context, and lets them fall off the
+  scope on exit
+
+The tests patch ``sentry_sdk`` indirection seams on
+``src.observability_sentry`` so we never poke a live SDK transport.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def helper(monkeypatch):
+    for var in (
+        "SENTRY_DSN",
+        "SENTRY_ENVIRONMENT",
+        "SENTRY_RELEASE",
+        "SENTRY_TRACES_SAMPLE_RATE",
+        "SENTRY_DEBUG",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    sys.modules.pop("src.observability_sentry", None)
+    import src.observability_sentry as m
+
+    yield m
+    sys.modules.pop("src.observability_sentry", None)
+
+
+# ---------------------------------------------------------------------------
+# hash_id
+# ---------------------------------------------------------------------------
+
+
+def test_hash_id_is_stable_for_same_input(helper):
+    assert helper.hash_id(123456789) == helper.hash_id(123456789)
+    assert helper.hash_id("user-abc") == helper.hash_id("user-abc")
+
+
+def test_hash_id_differs_for_different_inputs(helper):
+    assert helper.hash_id(1) != helper.hash_id(2)
+    assert helper.hash_id("a") != helper.hash_id("b")
+
+
+def test_hash_id_normalizes_int_and_str_to_same_value(helper):
+    """``hash_id(123)`` and ``hash_id("123")`` must be equal so a chat_id
+    hashed at handler entry equals the same id later in the pipeline.
+    """
+    assert helper.hash_id(123456789) == helper.hash_id("123456789")
+
+
+def test_hash_id_returns_short_hex(helper):
+    h = helper.hash_id(987654321)
+    assert isinstance(h, str)
+    assert len(h) == 16
+    assert all(c in "0123456789abcdef" for c in h)
+
+
+def test_hash_id_does_not_leak_raw_value(helper):
+    raw = 123456789
+    h = helper.hash_id(raw)
+    assert str(raw) not in h
+
+
+# ---------------------------------------------------------------------------
+# set_runtime_tags
+# ---------------------------------------------------------------------------
+
+
+def test_set_runtime_tags_sets_service_tag(helper):
+    with patch.object(helper, "_sentry_set_tag") as set_tag:
+        helper.set_runtime_tags(service="telegram-bot")
+    set_tag.assert_any_call("service", "telegram-bot")
+
+
+def test_set_runtime_tags_default_service(helper):
+    with patch.object(helper, "_sentry_set_tag") as set_tag:
+        helper.set_runtime_tags()
+    set_tag.assert_any_call("service", "telegram-bot")
+
+
+def test_set_runtime_tags_omits_none_optional_fields(helper):
+    """When optional fields are None, they must not be emitted as tags."""
+    with patch.object(helper, "_sentry_set_tag") as set_tag:
+        helper.set_runtime_tags(service="rag-api")
+    keys = [call.args[0] for call in set_tag.call_args_list]
+    assert "component" not in keys
+    assert "pipeline_mode" not in keys
+    assert "route" not in keys
+
+
+def test_set_runtime_tags_emits_explicit_fields(helper):
+    with patch.object(helper, "_sentry_set_tag") as set_tag:
+        helper.set_runtime_tags(
+            service="telegram-bot",
+            component="rag_pipeline",
+            pipeline_mode="text",
+            route="/query",
+        )
+    keys = {call.args[0]: call.args[1] for call in set_tag.call_args_list}
+    assert keys["service"] == "telegram-bot"
+    assert keys["component"] == "rag_pipeline"
+    assert keys["pipeline_mode"] == "text"
+    assert keys["route"] == "/query"
+
+
+def test_set_runtime_tags_supports_extra_tags(helper):
+    with patch.object(helper, "_sentry_set_tag") as set_tag:
+        helper.set_runtime_tags(extra_tags={"locale": "uk", "tenant": "demo"})
+    keys = {call.args[0]: call.args[1] for call in set_tag.call_args_list}
+    assert keys["locale"] == "uk"
+    assert keys["tenant"] == "demo"
+
+
+# ---------------------------------------------------------------------------
+# runtime_scope
+# ---------------------------------------------------------------------------
+
+
+def _make_scope_mock():
+    """Returns (scope_mock, context_manager_mock)."""
+    scope = MagicMock()
+    cm = MagicMock()
+    cm.__enter__ = MagicMock(return_value=scope)
+    cm.__exit__ = MagicMock(return_value=False)
+    return scope, cm
+
+
+def test_runtime_scope_hashes_chat_id(helper):
+    scope, cm = _make_scope_mock()
+    expected_hash = helper.hash_id(99887766)
+    with patch.object(helper, "_sentry_new_scope", return_value=cm):
+        with helper.runtime_scope(chat_id=99887766):
+            pass
+    keys = {call.args[0]: call.args[1] for call in scope.set_tag.call_args_list}
+    assert keys["chat_id_hash"] == expected_hash
+
+
+def test_runtime_scope_hashes_telegram_user_id(helper):
+    scope, cm = _make_scope_mock()
+    expected_hash = helper.hash_id(11223344)
+    with patch.object(helper, "_sentry_new_scope", return_value=cm):
+        with helper.runtime_scope(telegram_user_id=11223344):
+            pass
+    keys = {call.args[0]: call.args[1] for call in scope.set_tag.call_args_list}
+    assert keys["telegram_user_id_hash"] == expected_hash
+
+
+def test_runtime_scope_does_not_emit_raw_ids(helper):
+    """No raw chat_id / telegram_user_id ever reaches the scope."""
+    scope, cm = _make_scope_mock()
+    with patch.object(helper, "_sentry_new_scope", return_value=cm):
+        with helper.runtime_scope(chat_id=99887766, telegram_user_id=11223344):
+            pass
+
+    # Aggregate every value that crossed scope.* calls
+    for call in scope.set_tag.call_args_list + scope.set_context.call_args_list:
+        for arg in (*call.args, *call.kwargs.values()):
+            assert "99887766" not in str(arg)
+            assert "11223344" not in str(arg)
+
+
+def test_runtime_scope_attaches_langfuse_trace_id_to_context(helper):
+    scope, cm = _make_scope_mock()
+    with patch.object(helper, "_sentry_new_scope", return_value=cm):
+        with helper.runtime_scope(langfuse_trace_id="lf-trace-abc"):
+            pass
+
+    tag_keys = {call.args[0]: call.args[1] for call in scope.set_tag.call_args_list}
+    assert tag_keys["langfuse_trace_id"] == "lf-trace-abc"
+
+    ctx_calls = {call.args[0]: call.args[1] for call in scope.set_context.call_args_list}
+    assert "trace" in ctx_calls
+    assert ctx_calls["trace"]["langfuse_trace_id"] == "lf-trace-abc"
+
+
+def test_runtime_scope_attaches_trace_id_when_no_langfuse(helper):
+    scope, cm = _make_scope_mock()
+    with patch.object(helper, "_sentry_new_scope", return_value=cm):
+        with helper.runtime_scope(trace_id="otel-trace-xyz"):
+            pass
+    tag_keys = {call.args[0]: call.args[1] for call in scope.set_tag.call_args_list}
+    assert tag_keys["trace_id"] == "otel-trace-xyz"
+    ctx_calls = {call.args[0]: call.args[1] for call in scope.set_context.call_args_list}
+    assert ctx_calls["trace"]["trace_id"] == "otel-trace-xyz"
+
+
+def test_runtime_scope_skips_none_fields(helper):
+    """None-valued args must not produce any tag/context calls."""
+    scope, cm = _make_scope_mock()
+    with patch.object(helper, "_sentry_new_scope", return_value=cm):
+        with helper.runtime_scope():
+            pass
+    scope.set_tag.assert_not_called()
+    scope.set_context.assert_not_called()
+
+
+def test_runtime_scope_supports_route_and_pipeline_mode(helper):
+    scope, cm = _make_scope_mock()
+    with patch.object(helper, "_sentry_new_scope", return_value=cm):
+        with helper.runtime_scope(route="/voice", pipeline_mode="voice"):
+            pass
+    keys = {call.args[0]: call.args[1] for call in scope.set_tag.call_args_list}
+    assert keys["route"] == "/voice"
+    assert keys["pipeline_mode"] == "voice"
+
+
+def test_runtime_scope_supports_extra_tags(helper):
+    scope, cm = _make_scope_mock()
+    with patch.object(helper, "_sentry_new_scope", return_value=cm):
+        with helper.runtime_scope(extra_tags={"locale": "uk"}):
+            pass
+    keys = {call.args[0]: call.args[1] for call in scope.set_tag.call_args_list}
+    assert keys["locale"] == "uk"
+
+
+def test_runtime_scope_yields_scope_handle(helper):
+    """Caller can mutate the underlying scope inside the with-block."""
+    scope, cm = _make_scope_mock()
+    with patch.object(helper, "_sentry_new_scope", return_value=cm):
+        with helper.runtime_scope() as s:
+            assert s is scope


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Adds three SDK-native helpers on top of the `src/observability_sentry` initialization helper from [#2060](https://github.com/yastman/rag/issues/2060) so runtime errors carry useful operational context without PII:

- `hash_id(value)` — stable 16-char SHA256 hex of Telegram `chat_id` / `telegram_user_id`. Normalises `int`/`str` so the same id always hashes to the same tag value.
- `set_runtime_tags(...)` — sets static `service` / `component` / `pipeline_mode` / `route` (plus optional `extra_tags`) on the active Sentry isolation scope. Intended to be called once after `initialize_sentry()`.
- `runtime_scope(...)` — context manager that pushes a new scope per Telegram update with hashed `chat_id_hash` / `telegram_user_id_hash` tags and an OTEL/Langfuse `trace` context block, then lets them fall off cleanly on exit.

## SDK choice

Follows the Sentry SDK pattern from Context7 (`/getsentry/sentry-python`) — uses `sentry_sdk.set_tag`, `sentry_sdk.new_scope`, and the `set_context` block on the scope returned by `new_scope()`. Indirection seams `_sentry_set_tag` and `_sentry_new_scope` mirror the existing `_sentry_init` / `_sentry_capture_message` pattern so tests can patch them without touching the real SDK transport.

## PII contract

- No raw `chat_id`, `telegram_user_id`, message text, tokens, or CRM payloads pass through any of the three helpers.
- `runtime_scope` is hard-asserted to never let a raw int/str id leak through `set_tag` / `set_context` — the test suite enumerates every call's args/kwargs and forbids the raw value substring.
- `send_default_pii=False` and the `before_send` PIIRedactor hook from [#2060](https://github.com/yastman/rag/issues/2060) remain as a second line of defence.

## Closes / refs

- Closes #2061
- Refs #1417 #2060

## Validation

- `uv run --frozen pytest tests/unit/observability/test_sentry_runtime_tags.py -q` → **19 passed**
- `uv run --frozen pytest tests/unit/observability/ -q` → **215 passed** (no regressions on the existing #2060 suite)
- `ruff check`, `ruff format --check`, `pre-commit run` (incl. gitleaks) — all clean.
