### PR TITLE
feat(observability): PII-safe Sentry breadcrumbs for bot/RAG lifecycle (#2062)

### DIFF
--- a/src/observability_sentry.py
+++ b/src/observability_sentry.py
@@ -35,7 +35,14 @@ from src.security.pii_redaction import PIIRedactor
 
 __all__ = [
     "_reset_for_tests",
+    "add_safe_breadcrumb",
+    "error_boundary_breadcrumb",
+    "handler_breadcrumb",
     "initialize_sentry",
+    "lifecycle_breadcrumb",
+    "message_receive_breadcrumb",
+    "rag_breadcrumb",
+    "session_breadcrumb",
 ]
 
 
@@ -45,6 +52,7 @@ logger = logging.getLogger(__name__)
 # global ``sentry_sdk`` module (which other helpers may import).
 _sentry_init = sentry_sdk.init
 _sentry_capture_message = sentry_sdk.capture_message
+_sentry_add_breadcrumb = sentry_sdk.add_breadcrumb
 
 _PII_TRUNCATE_LIMIT = 4000
 
@@ -251,3 +259,119 @@ def _reset_for_tests() -> None:
     global _initialized, _skip_logged
     _initialized = False
     _skip_logged = False
+
+
+# ---------------------------------------------------------------------------
+# PII-safe breadcrumbs (#2062)
+# ---------------------------------------------------------------------------
+
+
+# Allow-list of safe metadata keys that ``message_receive_breadcrumb`` is
+# permitted to forward. Anything outside this set (raw text, tokens, CRM
+# payloads, headers, etc.) is dropped at the source — the ``before_send``
+# scrubber from #2060 acts as a second line of defence.
+_MESSAGE_RECEIVE_SAFE_KEYS: frozenset[str] = frozenset(
+    {
+        "content_type",
+        "text_length",
+        "voice_seconds",
+        "chat_id_hash",
+        "telegram_user_id_hash",
+        "route",
+        "pipeline_mode",
+        "trace_id",
+        "langfuse_trace_id",
+    }
+)
+
+
+def add_safe_breadcrumb(
+    *,
+    category: str,
+    message: str | None = None,
+    data: dict[str, Any] | None = None,
+    level: str = "info",
+) -> None:
+    """Add a Sentry breadcrumb whose ``message`` and ``data`` are PII-redacted.
+
+    Drop-in replacement for ``sentry_sdk.add_breadcrumb`` — runs every
+    string field through :class:`~src.security.pii_redaction.PIIRedactor`
+    (mask + truncate at 4000 chars) before delegating to the SDK. If
+    redaction itself fails, the breadcrumb is silently dropped rather than
+    risking a partially-redacted payload reaching Sentry.
+    """
+    try:
+        safe_message = _redact(message) if message is not None else None
+        safe_data = _redact(data) if data is not None else None
+    except Exception:
+        logger.warning("Sentry breadcrumb PII scrub failed; dropping breadcrumb", exc_info=True)
+        return
+
+    _sentry_add_breadcrumb(
+        category=category,
+        message=safe_message,
+        data=safe_data,
+        level=level,
+    )
+
+
+def lifecycle_breadcrumb(event: str, **data: Any) -> None:
+    """Bot/RAG lifecycle event (startup, shutdown, config reload)."""
+    add_safe_breadcrumb(
+        category="lifecycle",
+        message=event,
+        data=dict(data) if data else None,
+    )
+
+
+def rag_breadcrumb(event: str, *, level: str = "info", **data: Any) -> None:
+    """RAG pipeline lifecycle (rag.start, rag.end, rag.fallback)."""
+    add_safe_breadcrumb(
+        category="rag",
+        message=event,
+        data=dict(data) if data else None,
+        level=level,
+    )
+
+
+def session_breadcrumb(event: str, **data: Any) -> None:
+    """Conversation/session lifecycle (session.create, session.destroy)."""
+    add_safe_breadcrumb(
+        category="session",
+        message=event,
+        data=dict(data) if data else None,
+    )
+
+
+def handler_breadcrumb(event: str, **data: Any) -> None:
+    """Telegram handler dispatch (handler.dispatch, handler.exit)."""
+    add_safe_breadcrumb(
+        category="handler",
+        message=event,
+        data=dict(data) if data else None,
+    )
+
+
+def error_boundary_breadcrumb(event: str, **data: Any) -> None:
+    """Caught-exception boundary marker — emitted at warning level."""
+    add_safe_breadcrumb(
+        category="error_boundary",
+        message=event,
+        data=dict(data) if data else None,
+        level="warning",
+    )
+
+
+def message_receive_breadcrumb(**data: Any) -> None:
+    """Telegram message receipt — strict allow-list, NEVER logs raw text.
+
+    Only the ``_MESSAGE_RECEIVE_SAFE_KEYS`` metadata keys are forwarded to
+    the breadcrumb payload. Raw message text, tokens, CRM payloads, and any
+    other key that might leak PII are dropped at the source.
+    """
+    safe_data = {k: v for k, v in data.items() if k in _MESSAGE_RECEIVE_SAFE_KEYS}
+    add_safe_breadcrumb(
+        category="message_receive",
+        message=None,
+        data=safe_data or None,
+    )

--- a/tests/unit/observability/test_sentry_breadcrumbs.py
+++ b/tests/unit/observability/test_sentry_breadcrumbs.py
@@ -1,0 +1,213 @@
+"""Unit tests for PII-safe Sentry breadcrumb helpers (#2062).
+
+Covers ``add_safe_breadcrumb`` and the project-canonical category wrappers
+(``lifecycle_breadcrumb``, ``rag_breadcrumb``, ``session_breadcrumb``,
+``handler_breadcrumb``, ``error_boundary_breadcrumb``,
+``message_receive_breadcrumb``) in ``src.observability_sentry``.
+
+The tests patch the ``_sentry_add_breadcrumb`` indirection seam so we
+verify the redacted payload that would land in the SDK without poking a
+live transport.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture()
+def helper(monkeypatch):
+    for var in (
+        "SENTRY_DSN",
+        "SENTRY_ENVIRONMENT",
+        "SENTRY_RELEASE",
+        "SENTRY_TRACES_SAMPLE_RATE",
+        "SENTRY_DEBUG",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    sys.modules.pop("src.observability_sentry", None)
+    import src.observability_sentry as m
+
+    yield m
+    sys.modules.pop("src.observability_sentry", None)
+
+
+# ---------------------------------------------------------------------------
+# add_safe_breadcrumb
+# ---------------------------------------------------------------------------
+
+
+def test_add_safe_breadcrumb_redacts_phone_in_message(helper):
+    with patch.object(helper, "_sentry_add_breadcrumb") as spy:
+        helper.add_safe_breadcrumb(category="rag", message="user called +380501234567")
+    kwargs = spy.call_args.kwargs
+    assert "+380501234567" not in kwargs["message"]
+    assert "[PHONE]" in kwargs["message"]
+
+
+def test_add_safe_breadcrumb_redacts_email_in_data(helper):
+    with patch.object(helper, "_sentry_add_breadcrumb") as spy:
+        helper.add_safe_breadcrumb(
+            category="rag", message="agent reply", data={"contact": "agent@example.com"}
+        )
+    data = spy.call_args.kwargs["data"]
+    assert "agent@example.com" not in data["contact"]
+    assert "[EMAIL]" in data["contact"]
+
+
+def test_add_safe_breadcrumb_truncates_long_text(helper):
+    long_text = "A" * 8000
+    with patch.object(helper, "_sentry_add_breadcrumb") as spy:
+        helper.add_safe_breadcrumb(category="rag", message=long_text)
+    msg = spy.call_args.kwargs["message"]
+    assert len(msg) < len(long_text)
+    assert msg.endswith("[TRUNCATED]")
+
+
+def test_add_safe_breadcrumb_handles_none_message(helper):
+    """category-only breadcrumbs (no message) must not crash."""
+    with patch.object(helper, "_sentry_add_breadcrumb") as spy:
+        helper.add_safe_breadcrumb(category="lifecycle")
+    kwargs = spy.call_args.kwargs
+    assert kwargs["category"] == "lifecycle"
+    assert kwargs["message"] is None
+
+
+def test_add_safe_breadcrumb_handles_none_data(helper):
+    with patch.object(helper, "_sentry_add_breadcrumb") as spy:
+        helper.add_safe_breadcrumb(category="rag", message="event")
+    assert spy.call_args.kwargs["data"] is None
+
+
+def test_add_safe_breadcrumb_default_level_is_info(helper):
+    with patch.object(helper, "_sentry_add_breadcrumb") as spy:
+        helper.add_safe_breadcrumb(category="rag", message="event")
+    assert spy.call_args.kwargs["level"] == "info"
+
+
+def test_add_safe_breadcrumb_passes_explicit_level(helper):
+    with patch.object(helper, "_sentry_add_breadcrumb") as spy:
+        helper.add_safe_breadcrumb(category="rag", message="event", level="warning")
+    assert spy.call_args.kwargs["level"] == "warning"
+
+
+def test_add_safe_breadcrumb_passes_through_category(helper):
+    with patch.object(helper, "_sentry_add_breadcrumb") as spy:
+        helper.add_safe_breadcrumb(category="custom_cat", message="event")
+    assert spy.call_args.kwargs["category"] == "custom_cat"
+
+
+def test_add_safe_breadcrumb_does_not_drop_when_redact_raises(helper):
+    """If PII redaction blows up, the breadcrumb is dropped, not the event."""
+    with (
+        patch.object(helper, "_sentry_add_breadcrumb") as spy,
+        patch.object(helper, "_redact", side_effect=RuntimeError("bad")),
+    ):
+        # Must not raise out of the helper
+        helper.add_safe_breadcrumb(category="rag", message="bad payload")
+    spy.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Canonical lifecycle wrappers
+# ---------------------------------------------------------------------------
+
+
+def test_lifecycle_breadcrumb_uses_lifecycle_category(helper):
+    with patch.object(helper, "_sentry_add_breadcrumb") as spy:
+        helper.lifecycle_breadcrumb("bot.startup", version="2.14.0")
+    kwargs = spy.call_args.kwargs
+    assert kwargs["category"] == "lifecycle"
+    assert kwargs["message"] == "bot.startup"
+    assert kwargs["data"] == {"version": "2.14.0"}
+    assert kwargs["level"] == "info"
+
+
+def test_rag_breadcrumb_uses_rag_category(helper):
+    with patch.object(helper, "_sentry_add_breadcrumb") as spy:
+        helper.rag_breadcrumb("rag.start", route="/query")
+    kwargs = spy.call_args.kwargs
+    assert kwargs["category"] == "rag"
+    assert kwargs["message"] == "rag.start"
+    assert kwargs["data"] == {"route": "/query"}
+
+
+def test_rag_breadcrumb_supports_warning_level(helper):
+    with patch.object(helper, "_sentry_add_breadcrumb") as spy:
+        helper.rag_breadcrumb("rag.fallback", level="warning", reason="timeout")
+    assert spy.call_args.kwargs["level"] == "warning"
+    assert spy.call_args.kwargs["data"] == {"reason": "timeout"}
+
+
+def test_session_breadcrumb_uses_session_category(helper):
+    with patch.object(helper, "_sentry_add_breadcrumb") as spy:
+        helper.session_breadcrumb("session.create", thread_id="t-1")
+    kwargs = spy.call_args.kwargs
+    assert kwargs["category"] == "session"
+    assert kwargs["message"] == "session.create"
+    assert kwargs["data"] == {"thread_id": "t-1"}
+
+
+def test_handler_breadcrumb_uses_handler_category(helper):
+    with patch.object(helper, "_sentry_add_breadcrumb") as spy:
+        helper.handler_breadcrumb("handler.dispatch", route="/start")
+    kwargs = spy.call_args.kwargs
+    assert kwargs["category"] == "handler"
+    assert kwargs["data"] == {"route": "/start"}
+
+
+def test_error_boundary_breadcrumb_uses_error_category_and_warning_level(helper):
+    with patch.object(helper, "_sentry_add_breadcrumb") as spy:
+        helper.error_boundary_breadcrumb("rag.failure", reason="timeout")
+    kwargs = spy.call_args.kwargs
+    assert kwargs["category"] == "error_boundary"
+    assert kwargs["level"] == "warning"
+    assert kwargs["data"] == {"reason": "timeout"}
+
+
+# ---------------------------------------------------------------------------
+# message_receive_breadcrumb — must NEVER log raw user text
+# ---------------------------------------------------------------------------
+
+
+def test_message_receive_breadcrumb_does_not_log_raw_text(helper):
+    """message_receive must skip ``text=`` payload and only emit metadata."""
+    with patch.object(helper, "_sentry_add_breadcrumb") as spy:
+        helper.message_receive_breadcrumb(
+            content_type="text",
+            text="secret user message with +380501234567",
+            text_length=42,
+        )
+    kwargs = spy.call_args.kwargs
+    # No raw message text in the breadcrumb message or data
+    serialised = repr(kwargs)
+    assert "secret user message" not in serialised
+    assert "+380501234567" not in serialised
+    # But length and content_type are preserved as safe metadata
+    assert kwargs["category"] == "message_receive"
+    assert kwargs["data"]["content_type"] == "text"
+    assert kwargs["data"]["text_length"] == 42
+
+
+def test_message_receive_breadcrumb_strips_unknown_payload_keys(helper):
+    """Only allow-listed safe metadata keys are forwarded."""
+    with patch.object(helper, "_sentry_add_breadcrumb") as spy:
+        helper.message_receive_breadcrumb(
+            content_type="voice",
+            voice_seconds=12,
+            telegram_user_id_hash="abc",
+            tokens="oauth-secret",
+            crm_payload={"phone": "+380999999999"},
+        )
+    kwargs = spy.call_args.kwargs
+    data = kwargs["data"]
+    # Allow-listed keys
+    assert data["content_type"] == "voice"
+    assert data["voice_seconds"] == 12
+    assert data["telegram_user_id_hash"] == "abc"
+    # Not allow-listed
+    assert "tokens" not in data
+    assert "crm_payload" not in data


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Adds a small PII-safe breadcrumb layer on top of `sentry-sdk` (initialised in [#2060](https://github.com/yastman/rag/issues/2060), tagged in [#2061](https://github.com/yastman/rag/issues/2061)) so bot / RAG lifecycle context lands in Sentry without leaking PII.

### Public surface

- `add_safe_breadcrumb(*, category, message, data, level)` — drop-in for `sentry_sdk.add_breadcrumb`. Runs every string field through `PIIRedactor` (phone / email / passport / РНОКПП IDs masked, strings truncated at 4000 chars). If redaction itself raises, the breadcrumb is dropped rather than risking a partially-redacted payload.
- `lifecycle_breadcrumb(event, **data)` — `category='lifecycle'`, level=info. Bot startup / shutdown / config reload.
- `rag_breadcrumb(event, *, level='info', **data)` — `category='rag'`. `rag.start` / `rag.end` / `rag.fallback`.
- `session_breadcrumb(event, **data)` — `category='session'`. Conversation / session lifecycle.
- `handler_breadcrumb(event, **data)` — `category='handler'`. Telegram handler dispatch.
- `error_boundary_breadcrumb(event, **data)` — `category='error_boundary'`, level=warning. Caught-exception boundary.
- `message_receive_breadcrumb(**data)` — `category='message_receive'`. Strict allow-list around Telegram message receipt: only `content_type`, `text_length`, `voice_seconds`, `chat_id_hash`, `telegram_user_id_hash`, `route`, `pipeline_mode`, `trace_id`, `langfuse_trace_id` are forwarded. Raw text, tokens, and CRM payloads are dropped at the source.

### SDK choice

Follows Sentry SDK pattern from Context7 (`/getsentry/sentry-python`) — uses `sentry_sdk.add_breadcrumb`. Indirection seam `_sentry_add_breadcrumb` mirrors the existing `_sentry_init` / `_sentry_capture_message` pattern so tests can patch the SDK call without touching the live transport.

### PII contract

- `add_safe_breadcrumb` redacts at emit time which is the proper layer.
- The `before_send` hook from [#2060](https://github.com/yastman/rag/issues/2060) already runs over breadcrumbs as a second line of defence.
- `message_receive_breadcrumb` is the only public surface that explicitly handles user-message context — and it never emits the message text, only allow-listed metadata.

## Closes / refs

- Closes #2062
- Refs #1417 #2060

## Validation

- `uv run --frozen pytest tests/unit/observability/test_sentry_breadcrumbs.py -q` → **17 passed**
- `uv run --frozen pytest tests/unit/observability/ -q` → **213 passed** (no regressions on the existing #2060 suite)
- `ruff check`, `ruff format`, `pre-commit run` (incl. gitleaks) — all clean.
