### PR TITLE
docs(bot): document slice-1 module-helper extraction map (#2046)

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -1,4 +1,41 @@
-"""Main Telegram bot logic — LangGraph pipeline."""
+"""Main Telegram bot logic — LangGraph pipeline.
+
+Module-level helpers were extracted to focused submodules in slice 1 of
+the ``PropertyBot`` decomposition (issue #1265 / #2046). The thin
+wrappers below preserve the historical ``from telegram_bot.bot import X``
+import surface for tests that ``patch("telegram_bot.bot.X", ...)``.
+
+Slice 1 extraction map:
+
+* ``_bot_state_helpers`` (#1265 PR-1) — apartment-list and catalog-control
+  message-id reads (``_state_apartment_results``,
+  ``_state_control_message_id``, ``_extract_current_turn``).
+* ``_bot_observability`` (#1265 PR-2) — Langfuse trace metadata builder
+  and voice error-score writer (``_build_trace_metadata``,
+  ``_write_voice_error_scores``).
+* ``_bot_error_classification`` (#1265 PR-3) — post-pipeline cleanup and
+  checkpointer error guards (``_is_post_pipeline_cleanup_error``,
+  ``_is_checkpointer_runtime_error``).
+* ``_bot_streaming`` (#1265 PR-4) — agent streaming draft helpers
+  (``_new_draft_id``, ``_extract_stream_chunk_text``,
+  ``_stream_agent_to_draft``, ``_AGENT_DRAFT_INTERVAL``).
+* ``_bot_pre_agent`` (#1265 PR-5) — pre-agent state contract, dense
+  vector caching, retrieval-vector preparation
+  (``_build_pre_agent_state_contract``, ``_has_async_method``,
+  ``_get_or_compute_pre_agent_dense``,
+  ``_prepare_pre_agent_retrieval_vectors``).
+* ``_bot_kommo`` (#1265 PR-6) — Kommo CRM startup token seeder
+  (``_seed_kommo_access_token``).
+
+Each extraction is enforced by a contract test under
+``tests/contract/test_bot_*_extraction_contract.py``: byte-for-byte
+parity with the previous module-level implementation, plus a
+``from telegram_bot.bot import …`` import surface guard.
+
+The remaining lifecycle method extraction (``PropertyBot`` instance
+methods → focused modules) is tracked separately as #2048 and is
+blocked on the runtime migration in #1948 / #2045 / #2047.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary
- Issue #2046 (phase-1 of `bot.py` decomposition under #1265) was already delivered across six earlier PRs (`#1265 slice-1 PR-1` … `PR-6`) which extracted every module-level helper out of `telegram_bot/bot.py` into focused `_bot_*.py` modules. Each extraction is locked in by a contract test under `tests/contract/test_bot_*_extraction_contract.py` (**89 passed** on `dev`).
- This PR formalises the closeout by lifting the slice-1 extraction map into the top-of-file docstring of `telegram_bot/bot.py`, so a new reader can navigate from "where does `_build_trace_metadata` live?" to `_bot_observability` without grepping for the helper name across the 4615-line module.

## Why keep the wrappers
The thin wrappers in `bot.py` are preserved by design — they keep the `from telegram_bot.bot import X` import surface that existing tests rely on for mocking (`patch("telegram_bot.bot.X", ...)`). The contract tests refuse to let the wrappers drift away from the extracted implementations.

## Slice-1 extraction map (now in `bot.py` docstring)

| Helper | Module |
|---|---|
| `_state_apartment_results`, `_state_control_message_id`, `_extract_current_turn` | `_bot_state_helpers` (#1265 PR-1) |
| `_build_trace_metadata`, `_write_voice_error_scores` | `_bot_observability` (#1265 PR-2) |
| `_is_post_pipeline_cleanup_error`, `_is_checkpointer_runtime_error` | `_bot_error_classification` (#1265 PR-3) |
| `_new_draft_id`, `_extract_stream_chunk_text`, `_stream_agent_to_draft`, `_AGENT_DRAFT_INTERVAL` | `_bot_streaming` (#1265 PR-4) |
| `_build_pre_agent_state_contract`, `_has_async_method`, `_get_or_compute_pre_agent_dense`, `_prepare_pre_agent_retrieval_vectors` | `_bot_pre_agent` (#1265 PR-5) |
| `_seed_kommo_access_token` | `_bot_kommo` (#1265 PR-6) |

## Scope
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation / portfolio cleanup
- [ ] Infrastructure / deploy

## Files touched
- `telegram_bot/bot.py` — module docstring extended with the slice-1 extraction map (no behavior change, no wrapper removal).

## Validation
- [x] `uv run --frozen pytest tests/contract/test_bot_*_extraction*.py -q` → **89 passed**
- [x] `ruff check` + `ruff format --check` clean
- [ ] `make check` / `make test` skipped (sandbox has no docker compose / external services).

## Runtime Impact
- [x] No runtime impact — docstring only.

## Reviewer notes
- The remaining `PropertyBot` instance-method (lifecycle) extraction is tracked separately as **#2048** and is blocked on the runtime migration in #1948 / #2045 / #2047.

Closes #2046
Refs #1265 #2048