### PR TITLE
fix: restore docker unit test gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,7 +378,8 @@ test-redis: ## Verify Redis Query Engine is available
 
 test-bot-health: ## Preflight: verify local native-bot prerequisites (Redis/Qdrant/LiteLLM + optional Postgres note)
 	@echo "$(BLUE)Running bot health preflight...$(NC)"
-	@./scripts/probe/bot_health.sh
+	@set -a; if [ -f .env ]; then . ./.env; else . tests/fixtures/compose.ci.env; fi; set +a; \
+	./scripts/probe/bot_health.sh
 	@echo "$(GREEN)✓ Bot health preflight passed$(NC)"
 
 test-bot-health-vps: ## Preflight: verify Qdrant + LLM from inside Docker network (VPS)

--- a/scripts/probe/bot_health.sh
+++ b/scripts/probe/bot_health.sh
@@ -12,6 +12,21 @@ strip_trailing_slash() {
   printf '%s' "${1%/}"
 }
 
+# Load runtime env: .env first (user override), then safe local fallback.
+# Docker Compose uses the same tests/fixtures/compose.ci.env fallback.
+# This bridge prevents BotConfig() from missing REDIS_PASSWORD when .env is absent.
+if [ -f .env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . ./.env
+  set +a
+elif [ -f tests/fixtures/compose.ci.env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . tests/fixtures/compose.ci.env
+  set +a
+fi
+
 if ! command -v curl >/dev/null 2>&1; then
   fail "curl is required"
 fi

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -3386,7 +3386,7 @@ class PropertyBot:
                     # into a ContextVar bucket while this capture is active.
                     # Falls back to the proxy when the checkpointer is not
                     # instrumented (e.g. MemorySaver in tests).
-                    overhead_bucket = begin_checkpoint_overhead_capture()
+                    overhead_bucket: dict[str, float] | None = begin_checkpoint_overhead_capture()
                     try:
                         result = await graph.ainvoke(state, config=invoke_config)
                     finally:

--- a/tests/unit/api/test_rag_api_runtime.py
+++ b/tests/unit/api/test_rag_api_runtime.py
@@ -15,6 +15,7 @@ import pytest
 # installing a partial fake module into ``sys.modules`` that could leak into
 # later tests calling ``pytest.importorskip("fastapi")`` (#2009 evidence).
 pytest.importorskip("fastapi", reason="src.api.main needs FastAPI; install --extra api")
+pytestmark = pytest.mark.requires_extras
 
 from src.api.main import app, generic_error_handler, lifespan, query
 from src.api.schemas import QueryRequest, QueryResponse
@@ -50,8 +51,8 @@ async def test_query_applies_max_rewrite_attempts_from_app_state() -> None:
     lf.update_current_span = MagicMock()
 
     with (
-        patch("telegram_bot.observability.propagate_attributes", return_value=nullcontext()),
-        patch("telegram_bot.observability.get_client", return_value=lf),
+        patch("src.observability.propagate_attributes", return_value=nullcontext()),
+        patch("src.observability.get_client", return_value=lf),
     ):
         await query(QueryRequest(query="test", user_id=1))
 
@@ -70,8 +71,8 @@ async def test_query_writes_langfuse_scores() -> None:
     lf.score_current_trace = MagicMock()
 
     with (
-        patch("telegram_bot.observability.propagate_attributes", return_value=nullcontext()),
-        patch("telegram_bot.observability.get_client", return_value=lf),
+        patch("src.observability.propagate_attributes", return_value=nullcontext()),
+        patch("src.observability.get_client", return_value=lf),
         patch("src.scoring.write_langfuse_scores") as mock_write_scores,
     ):
         await query(QueryRequest(query="test", user_id=1))
@@ -94,9 +95,9 @@ async def test_query_updates_current_observation_and_propagates_api_attributes()
 
     with (
         patch(
-            "telegram_bot.observability.propagate_attributes", return_value=nullcontext()
+            "src.observability.propagate_attributes", return_value=nullcontext()
         ) as mock_propagate,
-        patch("telegram_bot.observability.get_client", return_value=lf),
+        patch("src.observability.get_client", return_value=lf),
     ):
         await query(QueryRequest(query="test", user_id=42, session_id="sess-1", channel="voice"))
 
@@ -135,7 +136,7 @@ async def test_query_propagates_explicit_langfuse_trace_id() -> None:
     lf.start_as_current_observation.return_value = nullcontext()
 
     with (
-        patch("telegram_bot.observability.get_client", return_value=lf),
+        patch("src.observability.get_client", return_value=lf),
         patch(
             "src.api.main._execute_query",
             new=AsyncMock(return_value=SimpleNamespace()),
@@ -265,7 +266,7 @@ async def test_lifespan_unknown_rerank_provider_logs_and_closes_embeddings() -> 
 async def test_generic_error_handler_returns_structured_payload() -> None:
     """Unhandled exceptions must return a stable structured error with trace id."""
     with (
-        patch("telegram_bot.observability.get_client", return_value=None),
+        patch("src.observability.get_client", return_value=None),
         patch("src.api.main.uuid.uuid4", return_value=SimpleNamespace(hex="fallback-trace-id")),
         patch("src.api.main.logger") as mock_logger,
     ):
@@ -288,7 +289,7 @@ async def test_generic_error_handler_uses_langfuse_trace_id_when_available() -> 
     mock_lf.get_current_trace_id.return_value = "trace-abc-123"
 
     with (
-        patch("telegram_bot.observability.get_client", return_value=mock_lf),
+        patch("src.observability.get_client", return_value=mock_lf),
         patch("src.api.main.logger") as mock_logger,
     ):
         response = await generic_error_handler(None, ValueError("bad input"))
@@ -314,8 +315,8 @@ async def test_query_returns_fallback_on_graph_recursion_error() -> None:
     lf.update_current_span = MagicMock()
 
     with (
-        patch("telegram_bot.observability.propagate_attributes", return_value=nullcontext()),
-        patch("telegram_bot.observability.get_client", return_value=lf),
+        patch("src.observability.propagate_attributes", return_value=nullcontext()),
+        patch("src.observability.get_client", return_value=lf),
         patch("src.scoring.write_langfuse_scores") as mock_write_scores,
     ):
         response = await query(QueryRequest(query="test", user_id=1))
@@ -345,8 +346,8 @@ async def test_query_graph_recursion_error_preserves_trace_context() -> None:
     lf.update_current_span = MagicMock()
 
     with (
-        patch("telegram_bot.observability.propagate_attributes", return_value=nullcontext()),
-        patch("telegram_bot.observability.get_client", return_value=lf),
+        patch("src.observability.propagate_attributes", return_value=nullcontext()),
+        patch("src.observability.get_client", return_value=lf),
     ):
         await query(QueryRequest(query="complex", user_id=42, session_id="sess-1"))
 
@@ -383,8 +384,8 @@ async def test_query_graph_recursion_error_works_when_langfuse_disabled() -> Non
     app.state.max_rewrite_attempts = 1
 
     with (
-        patch("telegram_bot.observability.propagate_attributes", return_value=nullcontext()),
-        patch("telegram_bot.observability.get_client", return_value=None),
+        patch("src.observability.propagate_attributes", return_value=nullcontext()),
+        patch("src.observability.get_client", return_value=None),
         patch("src.scoring.write_langfuse_scores") as mock_write_scores,
     ):
         response = await query(QueryRequest(query="test", user_id=1))

--- a/tests/unit/dialogs/test_dialogs_fsm_coverage.py
+++ b/tests/unit/dialogs/test_dialogs_fsm_coverage.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import inspect
 import re
+import sys
 from pathlib import Path
 
 import pytest
@@ -30,6 +31,19 @@ from telegram_bot.dialogs import states as states_module
 
 
 DIALOGS_DIR = Path(__file__).resolve().parents[3] / "telegram_bot" / "dialogs"
+_NOISE_PARTS: frozenset[str] = frozenset(
+    {
+        ".venv",
+        "venv",
+        "__pycache__",
+        ".tox",
+        "node_modules",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".worktrees",
+    }
+)
 
 
 # ---------------------------------------------------------------------------
@@ -210,9 +224,10 @@ def _all_production_files() -> list[Path]:
     dep source into the regex search and time the test out.
     """
     root = DIALOGS_DIR.parent  # telegram_bot/
-    skip_parts = {".venv", "venv", "__pycache__", ".tox", "node_modules", ".mypy_cache"}
     return sorted(
-        p for p in root.rglob("*.py") if p.name != "states.py" and skip_parts.isdisjoint(p.parts)
+        p
+        for p in root.rglob("*.py")
+        if p.name != "states.py" and _NOISE_PARTS.isdisjoint(p.relative_to(root).parts)
     )
 
 
@@ -260,6 +275,24 @@ def test_every_declared_state_is_referenced_by_a_dialog() -> None:
         "by any production module under telegram_bot/. Either wire them into "
         f"a dialog/handler or remove them.\n  Orphans: {orphaned!r}"
     )
+
+
+def test_all_production_files_excludes_noise_dirs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "telegram_bot"
+    dialogs = root / "dialogs"
+    dialogs.mkdir(parents=True)
+    real_file = root / "handlers.py"
+    real_file.write_text("# production\n", encoding="utf-8")
+    for part in _NOISE_PARTS:
+        noise_file = root / part / "noise.py"
+        noise_file.parent.mkdir(parents=True, exist_ok=True)
+        noise_file.write_text("# ignored\n", encoding="utf-8")
+
+    monkeypatch.setattr(sys.modules[__name__], "DIALOGS_DIR", dialogs)
+
+    assert _all_production_files() == [real_file]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mini_app/test_api_config.py
+++ b/tests/unit/mini_app/test_api_config.py
@@ -4,6 +4,7 @@ import pytest
 
 
 pytest.importorskip("fastapi")
+pytestmark = pytest.mark.requires_extras
 
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/unit/mini_app/test_api_lifespan.py
+++ b/tests/unit/mini_app/test_api_lifespan.py
@@ -33,6 +33,7 @@ import pytest
 
 
 pytest.importorskip("fastapi")
+pytestmark = pytest.mark.requires_extras
 
 
 def test_module_no_longer_exposes_module_level_redis_global() -> None:

--- a/tests/unit/mini_app/test_chat.py
+++ b/tests/unit/mini_app/test_chat.py
@@ -7,6 +7,7 @@ import pytest
 
 
 pytest.importorskip("fastapi")
+pytestmark = pytest.mark.requires_extras
 
 from httpx import ASGITransport, AsyncClient
 

--- a/tests/unit/mini_app/test_langfuse_tracing.py
+++ b/tests/unit/mini_app/test_langfuse_tracing.py
@@ -27,6 +27,7 @@ import pytest
 
 
 pytest.importorskip("fastapi")
+pytestmark = pytest.mark.requires_extras
 
 from httpx import ASGITransport, AsyncClient
 

--- a/tests/unit/mini_app/test_mini_app_auth_enforcement.py
+++ b/tests/unit/mini_app/test_mini_app_auth_enforcement.py
@@ -28,6 +28,7 @@ import pytest
 
 
 pytest.importorskip("fastapi")
+pytestmark = pytest.mark.requires_extras
 
 from httpx import ASGITransport, AsyncClient
 

--- a/tests/unit/mini_app/test_mini_app_log_security.py
+++ b/tests/unit/mini_app/test_mini_app_log_security.py
@@ -14,6 +14,7 @@ import pytest
 
 
 pytest.importorskip("fastapi")
+pytestmark = pytest.mark.requires_extras
 
 from httpx import ASGITransport, AsyncClient
 

--- a/tests/unit/mini_app/test_phone.py
+++ b/tests/unit/mini_app/test_phone.py
@@ -4,6 +4,7 @@ import pytest
 
 
 pytest.importorskip("fastapi")
+pytestmark = pytest.mark.requires_extras
 
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/unit/scripts/test_bot_health_script.py
+++ b/tests/unit/scripts/test_bot_health_script.py
@@ -43,3 +43,20 @@ def test_bot_health_reports_redis_password_drift_remediation() -> None:
 def test_bot_health_redacts_redis_and_rediss_credentials() -> None:
     text = SCRIPT.read_text(encoding="utf-8")
     assert r"(rediss?://)([^@\s]+)@" in text
+
+
+def test_bot_health_script_sources_env_file_with_fallback() -> None:
+    """The script must load runtime env vars (.env first, fallback fixture second)."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "tests/fixtures/compose.ci.env" in text, (
+        "script must reference tests/fixtures/compose.ci.env as the safe local env fallback"
+    )
+    assert "-f .env" in text, "script must check for .env file existence before using fallback"
+
+
+def test_bot_health_script_exports_env_vars_via_set_a() -> None:
+    """The script must auto-export sourced env vars to uv subprocesses."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "set -a" in text, (
+        "script must use 'set -a' so BotConfig() in uv subprocesses can read REDIS_PASSWORD"
+    )

--- a/tests/unit/services/test_draft_streamer_removed.py
+++ b/tests/unit/services/test_draft_streamer_removed.py
@@ -21,12 +21,26 @@ These tests pin the post-deletion state:
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+_NOISE_PARTS: frozenset[str] = frozenset(
+    {
+        ".venv",
+        "venv",
+        "__pycache__",
+        ".tox",
+        "node_modules",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".worktrees",
+    }
+)
 
 
 def test_draft_streamer_module_file_is_gone() -> None:
@@ -78,6 +92,8 @@ def test_no_production_references_to_draft_streamer_module() -> None:
     for py_file in REPO_ROOT.rglob("*.py"):
         rel = py_file.relative_to(REPO_ROOT)
         rel_str = str(rel)
+        if any(part in _NOISE_PARTS for part in rel.parts):
+            continue
         if rel_str.startswith(("tests/", ".venv/", "scripts/")):
             continue
         if rel.name in {"test_draft_streamer.py", "test_draft_streamer_removed.py"}:
@@ -95,6 +111,21 @@ def test_no_production_references_to_draft_streamer_module() -> None:
     assert not bad_files, (
         f"Production code still references the deleted draft_streamer module: {bad_files}"
     )
+
+
+def test_production_reference_scanner_excludes_noise_dirs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "telegram_bot").mkdir()
+    (tmp_path / "telegram_bot" / "bot.py").write_text("# clean production\n", encoding="utf-8")
+    for part in _NOISE_PARTS:
+        noise_file = tmp_path / part / "stale.py"
+        noise_file.parent.mkdir(parents=True, exist_ok=True)
+        noise_file.write_text("import telegram_bot.services.draft_streamer\n", encoding="utf-8")
+
+    monkeypatch.setattr(sys.modules[__name__], "REPO_ROOT", tmp_path)
+
+    test_no_production_references_to_draft_streamer_module()
 
 
 def test_streaming_path_still_uses_send_message_draft_directly() -> None:

--- a/tests/unit/test_makefile_contract.py
+++ b/tests/unit/test_makefile_contract.py
@@ -310,6 +310,38 @@ def test_runtime_env_file_has_safe_fallback() -> None:
 # --- Local all-test entrypoint contract tests ---
 
 
+def test_test_bot_health_target_sources_env_file() -> None:
+    """The test-bot-health target must source an env file before running the script."""
+    text = _makefile_text()
+    block_match = re.search(
+        r"^test-bot-health:.*?(?=^[A-Za-z0-9_.-]+:|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert block_match, "test-bot-health target not found in Makefile"
+    block = block_match.group(0)
+    assert "tests/fixtures/compose.ci.env" in block, (
+        "test-bot-health target must reference tests/fixtures/compose.ci.env "
+        "as the safe local env fallback when .env is absent"
+    )
+
+
+def test_test_bot_health_target_env_precedence() -> None:
+    """The test-bot-health target must prefer .env over the fixture when .env exists."""
+    text = _makefile_text()
+    block_match = re.search(
+        r"^test-bot-health:.*?(?=^[A-Za-z0-9_.-]+:|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert block_match, "test-bot-health target not found in Makefile"
+    block = block_match.group(0)
+    assert "-f .env" in block, (
+        "test-bot-health target must check for .env existence first, "
+        "preserving user .env precedence over the compose.ci.env fallback"
+    )
+
+
 def test_frontend_test_target_runs_vitest() -> None:
     """The local test inventory includes Vitest tests outside pytest's testpaths."""
     text = _makefile_text()
@@ -359,9 +391,7 @@ def test_test_full_uses_bounded_parallelism_by_default() -> None:
     text = _makefile_text()
 
     # 1. PYTEST_FULL_PARALLEL_ARGS must be defined
-    var_match = re.search(
-        r"^PYTEST_FULL_PARALLEL_ARGS\s*\?=\s*(.+)$", text, re.MULTILINE
-    )
+    var_match = re.search(r"^PYTEST_FULL_PARALLEL_ARGS\s*\?=\s*(.+)$", text, re.MULTILINE)
     assert var_match, "PYTEST_FULL_PARALLEL_ARGS not found in Makefile"
 
     # 2. Its default must NOT be unbounded -n auto


### PR DESCRIPTION
## Summary

Restores the local Docker/unit recovery gate on current `origin/dev`:

- load the local compose fixture env for bare `make test-bot-health`, `make run-bot`, and `make bot` when `.env` is absent
- preserve `make bot` failures through the tee pipeline instead of masking them behind `[COMPLETE]`
- make the fallback Telegram token syntactically valid for aiogram startup checks
- disable local dev Redis RDB snapshots so Redis writes/checkpointers are not blocked by host volume permission issues
- gate optional FastAPI/API/Mini App tests with `requires_extras`
- patch API observability mocks to match current `src.observability` imports
- exclude local noise dirs from production scan helper tests
- preserve ingestion CLI return-code expectations already present on current dev
- fix the remaining bot checkpointer-overhead mypy annotation

## Verification

Passed on branch `fix/docker-test-gate-current-dev` after rebasing on latest `origin/dev`:

- `make test-bot-health`
- `docker exec dev_redis_1 redis-cli -a test-redis-password SET __codex_write_probe ok EX 30`: `OK`
- focused Docker/bot/compose suite: `82 passed`
- focused recovery suite: `110 passed, 1 warning`
- `uv run --python 3.12 mypy src/ telegram_bot/ --ignore-missing-imports --no-error-summary`
- `make test-unit`: `7098 passed, 3 skipped, 192 warnings`
- push hooks passed, including shellcheck

`timeout 35s make bot` was also run without `.env`: it now gets past env loading, Redis cache/checkpointer init, Qdrant, BGE-M3, and LiteLLM preflight. It exits nonzero at Telegram with `TelegramUnauthorizedError` because the fallback fixture token is intentionally not a real bot token; this is expected and no longer hidden by the Makefile pipeline.

## Caveat

`make check` on current `origin/dev` now type-checks additional areas (`scripts/`, `mini_app/`, `services/`) and fails on existing mypy errors outside this PR's touched scope. The scoped mypy check for `src/ telegram_bot/` is green.

Heavy/e2e/full-extra tiers were not run.
