### PR TITLE
fix: allow local postgres startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -704,7 +704,7 @@ qa: all-checks test ## Full quality assurance
 # =============================================================================
 
 .PHONY: local-up local-up-ingest local-down local-logs local-ps local-build local-redis-recreate run-bot bot
-LOCAL_SERVICES := redis qdrant bge-m3 litellm
+LOCAL_SERVICES := postgres redis qdrant bge-m3 litellm
 LOCAL_INGEST_SERVICES := docling
 LOCAL_ALL_SERVICES := $(LOCAL_SERVICES) $(LOCAL_INGEST_SERVICES)
 

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -7,6 +7,14 @@
 
 services:
   postgres:
+    # Local pgvector startup needs these while initializing/fixing ownership on
+    # the mounted data and runtime directories. Keep this scoped to dev only.
+    cap_add:
+      - CHOWN
+      - FOWNER
+      - DAC_OVERRIDE
+      - SETGID
+      - SETUID
     ports:
       - "127.0.0.1:5432:5432"
     environment:

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -266,6 +266,11 @@ make local-ps
 make local-down
 ```
 
+`make local-up` starts the native bot dependencies needed for the local loop:
+Postgres, Redis, Qdrant, BGE-M3, and LiteLLM. Postgres is included so
+favorites backed by `realestate.public.user_favorites` are available during
+native bot runs.
+
 If you changed `.env` `REDIS_PASSWORD`, recreate local Redis before retrying bot health:
 
 ```bash

--- a/tests/unit/test_compose.py
+++ b/tests/unit/test_compose.py
@@ -100,6 +100,19 @@ def test_compose_dev_has_ports_for_core_services():
         )
 
 
+def test_compose_dev_postgres_has_minimal_startup_capabilities():
+    """Dev Postgres must be able to initialize its mounted data directory."""
+    data = load_yaml("compose.dev.yml")
+    postgres = data["services"]["postgres"]
+    assert set(postgres["cap_add"]) == {
+        "CHOWN",
+        "FOWNER",
+        "DAC_OVERRIDE",
+        "SETGID",
+        "SETUID",
+    }
+
+
 def test_compose_dev_redis_disables_rdb_snapshots():
     """Dev Redis must not block writes when local RDB persistence cannot save."""
     data = load_yaml("compose.dev.yml")

--- a/tests/unit/test_docker_static_validation.py
+++ b/tests/unit/test_docker_static_validation.py
@@ -118,6 +118,38 @@ def test_compose_ci_telegram_token_is_sdk_valid() -> None:
     validate_token(values["TELEGRAM_BOT_TOKEN"])
 
 
+def test_compose_dev_postgres_renders_with_dev_only_capabilities() -> None:
+    """Dev Postgres keeps base cap_drop while adding only startup capabilities."""
+    result = _run_docker_command(
+        [
+            "docker",
+            "compose",
+            "--env-file",
+            str(COMPOSE_CI_ENV),
+            "-f",
+            "compose.yml",
+            "-f",
+            "compose.dev.yml",
+            "config",
+            "postgres",
+        ],
+    )
+    assert result.returncode == 0, f"Compose postgres config failed:\n{result.stderr}"
+
+    import yaml
+
+    rendered = yaml.safe_load(result.stdout)
+    postgres = rendered["services"]["postgres"]
+    assert postgres["cap_drop"] == ["ALL"]
+    assert set(postgres["cap_add"]) == {
+        "CHOWN",
+        "FOWNER",
+        "DAC_OVERRIDE",
+        "SETGID",
+        "SETUID",
+    }
+
+
 @pytest.mark.parametrize("dockerfile", _LANGFUSE_RUNTIME_DOCKERFILES)
 def test_langfuse_dockerfile_does_not_use_python314(dockerfile: str) -> None:
     """Langfuse SDK uses Pydantic v1 compatibility that crashes under Python 3.14.

--- a/tests/unit/test_makefile_contract.py
+++ b/tests/unit/test_makefile_contract.py
@@ -48,6 +48,17 @@ def test_local_services_excludes_docling() -> None:
     assert "docling" not in services, f"docling must not be in LOCAL_SERVICES (found {services!r})"
 
 
+def test_local_services_includes_postgres_for_native_bot_favorites() -> None:
+    text = _makefile_text()
+    match = re.search(r"^LOCAL_SERVICES\s*:=\s*(.+)$", text, re.MULTILINE)
+    assert match, "LOCAL_SERVICES not found in Makefile"
+    services = match.group(1).strip().split()
+    assert "postgres" in services, (
+        "LOCAL_SERVICES must include postgres so native bot favorites backed by "
+        "realestate.public.user_favorites are available in the local loop"
+    )
+
+
 def test_local_ingest_services_includes_docling() -> None:
     text = _makefile_text()
     match = re.search(r"^LOCAL_INGEST_SERVICES\s*:=\s*(.+)$", text, re.MULTILINE)


### PR DESCRIPTION
## Summary

Closes #2103.

- add dev-only Postgres startup capabilities in compose.dev.yml while preserving base cap_drop: ALL
- include postgres in make local-up so native bot favorites have the realestate DB available
- document the local loop dependency and add compose/Makefile regression coverage

## Verification

- uv run pytest tests/unit/test_compose.py tests/unit/test_docker_static_validation.py tests/unit/test_makefile_contract.py -q
  - 77 passed, 30 warnings
- COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility --env-file tests/fixtures/compose.ci.env config postgres
  - rendered cap_drop: ALL plus cap_add: CHOWN, FOWNER, DAC_OVERRIDE, SETGID, SETUID
- Isolated runtime check with COMPOSE_PROJECT_NAME=codex2103 and host ports reset:
  - postgres health: healthy
  - realestate.public.user_favorites exists
  - rollback write probe returned 1

Note: an existing dev_postgres_1 was already healthy on localhost:5432, so the live startup check used an isolated Compose project to avoid touching local dev state.