### PR TITLE
refactor(voice): delegate Langfuse OTEL bootstrap to src.observability (#2059)

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -440,8 +440,8 @@ services:
     stop_grace_period: 30s
     logging: *default-logging
     environment:
-      - LANGFUSE_PUBLIC_KEY=[REDACTED-LANGFUSE-KEY]
-      - LANGFUSE_SECRET_KEY=[REDACTED-LANGFUSE-KEY]
+      - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-}
+      - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY:-}
       - LANGFUSE_HOST=${LANGFUSE_DOCKER_HOST:-http://langfuse:3000}
       - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-ingestion}
       - GDRIVE_SYNC_DIR=/data/drive-sync

--- a/src/voice/agent.py
+++ b/src/voice/agent.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import contextlib
 import functools
 import json
@@ -17,7 +16,9 @@ from typing import Any, cast
 
 import httpx
 from dotenv import load_dotenv
+from opentelemetry import trace
 
+from src.observability import initialize_langfuse
 from src.observability_sentry import initialize_sentry, set_runtime_tags
 from src.voice.observability import trace_voice_session, update_voice_trace, voice_session_id
 from src.voice.rag_api_client import RagApiClient, RagApiClientError, RagQueryRequest
@@ -256,44 +257,39 @@ def _setup_sentry() -> None:
 
 
 def _setup_langfuse() -> None:
-    """Configure Langfuse tracing via OpenTelemetry."""
-    public_key = os.getenv("LANGFUSE_PUBLIC_KEY", "")
-    secret_key = os.getenv("LANGFUSE_SECRET_KEY", "")
-    host = os.getenv("LANGFUSE_HOST", "")
+    """Configure Langfuse tracing and forward the active provider to LiveKit.
 
-    if not public_key or not secret_key or not host:
-        logger.info("Langfuse not configured, skipping OTEL setup")
+    Delegates to :func:`src.observability.initialize_langfuse`, which is the
+    single source of truth for credentials, endpoint reachability checks and
+    PII masking (see issue #2059). The bootstrap registers a global
+    OpenTelemetry ``TracerProvider`` for us; the voice agent only needs to
+    forward that provider to LiveKit's telemetry helper so LiveKit-emitted
+    spans land on the same exporter as the rest of the runtime.
+
+    No-op when ``initialize_langfuse`` returns ``None`` (missing credentials,
+    unreachable Langfuse host, or SDK unavailable). LiveKit telemetry wiring
+    is skipped in that case to avoid registering an unconfigured provider.
+    """
+    client = initialize_langfuse()
+    if client is None:
+        # initialize_langfuse already logged the reason at INFO/WARNING.
+        return
+
+    provider = trace.get_tracer_provider()
+
+    try:
+        from livekit.agents.telemetry import set_tracer_provider
+    except ImportError:
+        # Older LiveKit versions or partial installs: spans still flow via the
+        # global provider that initialize_langfuse() registered.
+        logger.debug("livekit.agents.telemetry unavailable; relying on global provider")
         return
 
     try:
-        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-        from opentelemetry.sdk.trace import TracerProvider
-        from opentelemetry.sdk.trace.export import BatchSpanProcessor
-
-        auth = base64.b64encode(f"{public_key}:{secret_key}".encode()).decode()
-        exporter = OTLPSpanExporter(
-            endpoint=f"{host.rstrip('/')}/api/public/otel",
-            headers={
-                "Authorization": f"Basic {auth}",
-                "x-langfuse-ingestion-version": "4",
-            },
-        )
-        provider = TracerProvider()
-        provider.add_span_processor(BatchSpanProcessor(exporter))
-
-        # Try livekit's telemetry helper, fall back to global OTEL
-        try:
-            from livekit.agents.telemetry import set_tracer_provider
-
-            set_tracer_provider(provider)
-        except ImportError:
-            from opentelemetry import trace
-
-            trace.set_tracer_provider(provider)
-
-        logger.info("Langfuse OTEL tracing configured")
+        set_tracer_provider(provider)
+        logger.info("Langfuse OTEL tracing configured (LiveKit telemetry wired)")
     except Exception:
-        logger.exception("Failed to setup Langfuse OTEL")
+        logger.exception("Failed to wire LiveKit telemetry to Langfuse provider")
 
 
 class VoiceBot(Agent):

--- a/tests/contract/test_langfuse_sdk_native_contract.py
+++ b/tests/contract/test_langfuse_sdk_native_contract.py
@@ -53,10 +53,6 @@ SCAN_DIRS: tuple[Path, ...] = (
 # ``opentelemetry.sdk.trace``. Frozen baseline — must shrink, never grow.
 OTEL_BOOTSTRAP_ALLOWLIST: frozenset[str] = frozenset(
     {
-        # LiveKit's set_tracer_provider helper requires an explicit
-        # SDK TracerProvider; this is the only legitimate manual OTEL
-        # bootstrap in the production runtime.
-        "src/voice/agent.py",
         # isinstance check on the active provider during graceful
         # shutdown — imports the symbol but never constructs it.
         # Lives in src/ since the observability bootstrap was unified there;

--- a/tests/unit/voice/test_voice_agent.py
+++ b/tests/unit/voice/test_voice_agent.py
@@ -87,37 +87,71 @@ def test_voice_bot_stores_trace_session_id():
     assert agent._session_id == "voice-call-xyz"
 
 
-def test_setup_langfuse_configures_langfuse_otel_headers(monkeypatch):
-    """Voice OTEL exporter uses Langfuse's current OTLP ingestion headers."""
+def test_setup_langfuse_delegates_to_canonical_initialize(monkeypatch):
+    """Voice OTEL setup reuses src.observability.initialize_langfuse instead of
+    building a parallel OTLP/TracerProvider/BatchSpanProcessor pipeline (#2059).
+
+    The canonical bootstrap already configures Langfuse with PII masking and
+    registers the global TracerProvider. The voice agent only needs to wire the
+    resulting provider into LiveKit's telemetry helper.
+    """
     import src.voice.agent as mod
 
-    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
-    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
-    monkeypatch.setenv("LANGFUSE_HOST", "https://cloud.langfuse.com/")
+    fake_provider = object()
+    fake_client = object()
 
     with (
-        patch("src.voice.agent.logger"),
-        patch(
-            "opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter"
-        ) as exporter_cls,
-        patch("opentelemetry.sdk.trace.TracerProvider") as provider_cls,
-        patch("opentelemetry.sdk.trace.export.BatchSpanProcessor") as processor_cls,
+        patch("src.voice.agent.initialize_langfuse", return_value=fake_client) as init_mock,
+        patch("src.voice.agent.trace.get_tracer_provider", return_value=fake_provider),
         patch("livekit.agents.telemetry.set_tracer_provider") as set_provider,
     ):
-        provider = provider_cls.return_value
-
         mod._setup_langfuse()
 
-    exporter_cls.assert_called_once_with(
-        endpoint="https://cloud.langfuse.com/api/public/otel",
-        headers={
-            "Authorization": "Basic cGstdGVzdDpzay10ZXN0",
-            "x-langfuse-ingestion-version": "4",
-        },
-    )
-    processor_cls.assert_called_once_with(exporter_cls.return_value)
-    provider.add_span_processor.assert_called_once_with(processor_cls.return_value)
-    set_provider.assert_called_once_with(provider)
+    init_mock.assert_called_once_with()
+    set_provider.assert_called_once_with(fake_provider)
+
+
+def test_setup_langfuse_skips_livekit_wiring_when_disabled(monkeypatch):
+    """When initialize_langfuse() returns None (missing creds, unreachable host,
+    SDK unavailable), the voice agent must NOT register a tracer provider with
+    LiveKit. This avoids wiring an unconfigured provider into the agent runtime.
+    """
+    import src.voice.agent as mod
+
+    with (
+        patch("src.voice.agent.initialize_langfuse", return_value=None) as init_mock,
+        patch("livekit.agents.telemetry.set_tracer_provider") as set_provider,
+    ):
+        mod._setup_langfuse()
+
+    init_mock.assert_called_once_with()
+    set_provider.assert_not_called()
+
+
+def test_setup_langfuse_swallows_livekit_telemetry_import_error(monkeypatch):
+    """If livekit.agents.telemetry is unavailable (older LiveKit version), the
+    setup must still succeed silently. Langfuse spans continue to flow via the
+    global TracerProvider that initialize_langfuse() registered.
+    """
+    import sys
+
+    import src.voice.agent as mod
+
+    fake_client = object()
+    fake_provider = object()
+
+    saved = sys.modules.pop("livekit.agents.telemetry", None)
+    try:
+        with (
+            patch("src.voice.agent.initialize_langfuse", return_value=fake_client),
+            patch("src.voice.agent.trace.get_tracer_provider", return_value=fake_provider),
+            patch.dict(sys.modules, {"livekit.agents.telemetry": None}),
+        ):
+            # Should not raise even though the import fails.
+            mod._setup_langfuse()
+    finally:
+        if saved is not None:
+            sys.modules["livekit.agents.telemetry"] = saved
 
 
 async def test_voice_tool_propagates_langfuse_trace_id_to_api_payload():


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Closes #2059. Part of umbrella #1648 (Langfuse v4 SDK-native usage).

## Problem

`src/voice/agent.py` maintained a parallel OTEL pipeline (`OTLPSpanExporter` + `TracerProvider` + `BatchSpanProcessor` + manual basic-auth header) that duplicated everything `src.observability.initialize_langfuse` already does, **without** the canonical PII masking, endpoint reachability check or model-definitions sync.

## Change

`_setup_langfuse()` now:

1. Calls `src.observability.initialize_langfuse()` — single source of truth (PII mask, env resolution, endpoint probe, model sync, atexit shutdown).
2. Forwards `opentelemetry.trace.get_tracer_provider()` to `livekit.agents.telemetry.set_tracer_provider` so LiveKit-emitted spans land on the same exporter.
3. Skips LiveKit wiring when `initialize_langfuse()` returns `None` (no creds / unreachable / SDK absent).
4. Tolerates `livekit.agents.telemetry` ImportError (older LiveKit) — spans still flow via the global provider.

Drops `base64` import and the manual auth header construction.

## Tests (TDD)

Added before implementation, all in `tests/unit/voice/test_voice_agent.py`:

- `test_setup_langfuse_delegates_to_canonical_initialize` — asserts the new wiring.
- `test_setup_langfuse_skips_livekit_wiring_when_disabled` — no provider registration when initialize returns None.
- `test_setup_langfuse_swallows_livekit_telemetry_import_error` — graceful fallback.

Replaces the legacy `test_setup_langfuse_configures_langfuse_otel_headers` which encoded the manual OTLP path that no longer exists.

## Contract ratchet

`tests/contract/test_langfuse_sdk_native_contract.py:OTEL_BOOTSTRAP_ALLOWLIST` shrinks by one entry (`src/voice/agent.py` removed). The contract's stale-entry detector (`test_allowlist_entries_actually_use_pattern`) enforces this shrink — re-adding manual OTEL bootstrap to voice would require explicit allowlist re-entry.

## Verification

```
uv run --python 3.12 pytest tests/unit/voice -q          # 48 passed
uv run --python 3.12 pytest tests/contract -q             # 1151 passed, 4 skipped, 3 xfailed
uv run --python 3.12 ruff check src/voice/agent.py tests/unit/voice/test_voice_agent.py tests/contract/test_langfuse_sdk_native_contract.py   # clean
uv run --python 3.12 ruff format --check ...              # all formatted
```

## Known limitations

- Runtime trace validation against a live Langfuse instance is out of scope here (covered by #1507).
- LiveKit telemetry semantics with the Langfuse-managed provider should be validated against a non-prod LiveKit session before relying on it for production-grade voice traces.