### PR TITLE
feat(observability): wire Sentry init into bot/voice/mini_app entry points (#1417)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -220,6 +220,10 @@ LANGFUSE_DOCKER_HOST=http://langfuse:3000
 # LANGFUSE_PROMPT_LABEL=production
 
 # Sentry-compatible error tracking (optional; see docs/observability/bugsink-setup.md).
+# When SENTRY_DSN is unset/blank the bot starts cleanly with Sentry disabled.
+# SENTRY_DSN=https://<public-key>@bugsink.example.com/1
+# SENTRY_ENVIRONMENT=local             # production | staging | local. Default: local.
+# SENTRY_RELEASE=                      # Override; default falls back to contextual-rag@<pkg-version>.
 # SENTRY_TRACES_SAMPLE_RATE=0.0       # 0.0 = errors only; raise cautiously after storage review.
 # SENTRY_DEBUG=false                  # Enable sentry-sdk debug logging for local troubleshooting.
 

--- a/compose.yml
+++ b/compose.yml
@@ -281,6 +281,12 @@ services:
       LANGFUSE_FLUSH_INTERVAL: "${LANGFUSE_FLUSH_INTERVAL:-5.0}"
       LANGFUSE_PROMPT_LABEL: "${LANGFUSE_PROMPT_LABEL:-production}"
       OTEL_SERVICE_NAME: "${OTEL_SERVICE_NAME:-telegram-bot}"
+      # Sentry-compatible error tracking (optional; disabled when DSN is blank)
+      SENTRY_DSN: "${SENTRY_DSN:-}"
+      SENTRY_ENVIRONMENT: "${SENTRY_ENVIRONMENT:-local}"
+      SENTRY_RELEASE: "${SENTRY_RELEASE:-}"
+      SENTRY_TRACES_SAMPLE_RATE: "${SENTRY_TRACES_SAMPLE_RATE:-0.0}"
+      SENTRY_DEBUG: "${SENTRY_DEBUG:-false}"
       # CRM — Kommo integration
       KOMMO_ENABLED: "${KOMMO_ENABLED:-false}"
       KOMMO_SUBDOMAIN: "${KOMMO_SUBDOMAIN:-}"
@@ -361,6 +367,11 @@ services:
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
       LANGFUSE_HOST: ${LANGFUSE_DOCKER_HOST:-http://langfuse:3000}
       OTEL_SERVICE_NAME: "${OTEL_SERVICE_NAME:-mini-app-api}"
+      SENTRY_DSN: "${SENTRY_DSN:-}"
+      SENTRY_ENVIRONMENT: "${SENTRY_ENVIRONMENT:-local}"
+      SENTRY_RELEASE: "${SENTRY_RELEASE:-}"
+      SENTRY_TRACES_SAMPLE_RATE: "${SENTRY_TRACES_SAMPLE_RATE:-0.0}"
+      SENTRY_DEBUG: "${SENTRY_DEBUG:-false}"
       REALESTATE_DATABASE_URL: "postgresql://postgres:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/realestate"
       KOMMO_ENABLED: "${KOMMO_ENABLED:-false}"
       KOMMO_SUBDOMAIN: "${KOMMO_SUBDOMAIN:-}"
@@ -896,6 +907,11 @@ services:
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
       LANGFUSE_HOST: ${LANGFUSE_DOCKER_HOST:-http://langfuse:3000}
       OTEL_SERVICE_NAME: "${OTEL_SERVICE_NAME:-voice-agent}"
+      SENTRY_DSN: "${SENTRY_DSN:-}"
+      SENTRY_ENVIRONMENT: "${SENTRY_ENVIRONMENT:-local}"
+      SENTRY_RELEASE: "${SENTRY_RELEASE:-}"
+      SENTRY_TRACES_SAMPLE_RATE: "${SENTRY_TRACES_SAMPLE_RATE:-0.0}"
+      SENTRY_DEBUG: "${SENTRY_DEBUG:-false}"
     healthcheck:
       test: ["CMD", "python", "-m", "src.voice.healthcheck"]
       interval: 15s

--- a/mini_app/api.py
+++ b/mini_app/api.py
@@ -18,6 +18,7 @@ from mini_app.auth import validate_init_data
 from mini_app.expert_start import StartExpertRequest, StartExpertResponse
 from mini_app.phone import PhoneRequest, submit_phone
 from src.observability import get_client, observe, propagate_attributes
+from src.observability_sentry import initialize_sentry, set_runtime_tags
 from src.services.content_loader import load_mini_app_config
 
 
@@ -43,6 +44,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     global) ensures graceful close on process shutdown and matches the
     FastAPI-native pattern (#1645).
     """
+    # Initialize Sentry FIRST so any subsequent startup error (Redis,
+    # config) is captured. No-op when SENTRY_DSN is unset (#1417).
+    if initialize_sentry():
+        set_runtime_tags(service="mini-app")
+        logger.info("Sentry error tracking enabled with PII redaction")
+
     import redis.asyncio as aioredis
 
     redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379")

--- a/src/observability_sentry.py
+++ b/src/observability_sentry.py
@@ -104,7 +104,9 @@ def _resolve(value: str | None, env_name: str, default: str | None = None) -> st
 
 def _resolve_dsn(explicit: str | None) -> str | None:
     """Return a non-blank DSN or ``None``."""
-    return _resolve(explicit, "SENTRY_DSN")
+    candidate = explicit if explicit is not None else os.getenv("SENTRY_DSN", "")
+    candidate = (candidate or "").strip()
+    return candidate or None
 
 
 def _resolve_traces_sample_rate(explicit: float | None) -> float:
@@ -121,15 +123,22 @@ def _resolve_traces_sample_rate(explicit: float | None) -> float:
 
 
 def _resolve_release(explicit: str | None) -> str:
-    explicit_value = _resolve(explicit, "SENTRY_RELEASE")
-    if explicit_value:
-        return explicit_value
+    candidate = explicit if explicit is not None else os.getenv("SENTRY_RELEASE", "")
+    candidate = (candidate or "").strip()
+    if candidate:
+        return candidate
     # Fall back to the installed package version so Bugsink/Sentry can group
     # events by release without operator-side configuration.
     try:
         return f"contextual-rag@{_metadata.version('contextual-rag')}"
     except _metadata.PackageNotFoundError:
         return "contextual-rag@unknown"
+
+
+def _resolve_environment(explicit: str | None) -> str:
+    candidate = explicit if explicit is not None else os.getenv("SENTRY_ENVIRONMENT", "")
+    candidate = (candidate or "").strip()
+    return candidate or "local"
 
 
 def _resolve_debug(explicit: bool | None) -> bool:
@@ -235,7 +244,7 @@ def initialize_sentry(
 
     init_kwargs: dict[str, Any] = {
         "dsn": resolved_dsn,
-        "environment": _resolve(environment, "SENTRY_ENVIRONMENT", default="local"),
+        "environment": _resolve_environment(environment),
         "release": _resolve_release(release),
         "traces_sample_rate": _resolve_traces_sample_rate(traces_sample_rate),
         # Hard-coded safety knobs:

--- a/src/voice/agent.py
+++ b/src/voice/agent.py
@@ -18,6 +18,7 @@ from typing import Any, cast
 import httpx
 from dotenv import load_dotenv
 
+from src.observability_sentry import initialize_sentry, set_runtime_tags
 from src.voice.observability import trace_voice_session, update_voice_trace, voice_session_id
 from src.voice.rag_api_client import RagApiClient, RagApiClientError, RagQueryRequest
 from src.voice.schemas import CallStatus
@@ -241,6 +242,17 @@ async def _get_transcript_store() -> TranscriptStore | None:
         _transcript_store = TranscriptStore(database_url=DATABASE_URL)
         await _transcript_store.initialize()
     return _transcript_store
+
+
+def _setup_sentry() -> None:
+    """Boot Sentry error tracking for the LiveKit voice process (#1417).
+
+    No-op when ``SENTRY_DSN`` is unset. Tags ``service=voice-agent`` so events
+    can be filtered separately from the Telegram bot runtime.
+    """
+    if initialize_sentry():
+        set_runtime_tags(service="voice-agent")
+        logger.info("Sentry error tracking enabled with PII redaction")
 
 
 def _setup_langfuse() -> None:
@@ -524,6 +536,8 @@ def _start_health_server() -> None:
     threading.Thread(target=_run, daemon=True).start()
 
 
+# Setup Sentry (no-op without SENTRY_DSN) before Langfuse so init errors are captured.
+_setup_sentry()
 # Setup Langfuse before starting
 _setup_langfuse()
 

--- a/telegram_bot/main.py
+++ b/telegram_bot/main.py
@@ -19,6 +19,8 @@ from tenacity import (
     wait_exponential,
 )
 
+from src.observability_sentry import initialize_sentry, set_runtime_tags
+
 from .bot import PropertyBot
 from .config import BotConfig
 from .integrations.polling_lock import PollingLockBusy
@@ -80,6 +82,15 @@ async def main():
 
     # Load config
     config = BotConfig()
+
+    # Initialize Sentry FIRST so it captures any subsequent init failures
+    # (Langfuse, Postgres, Redis, etc.). No-op when SENTRY_DSN is unset
+    # (#1417). Verified via Context7 — sentry_sdk.init must run before any
+    # other SDK call.
+    sentry_enabled = initialize_sentry()
+    set_runtime_tags(service="telegram-bot")
+    if sentry_enabled:
+        logger.info("Sentry error tracking enabled with PII redaction")
 
     # Initialize Langfuse after BotConfig loaded .env / env vars
     _langfuse = initialize_langfuse(

--- a/telegram_bot/pyproject.toml
+++ b/telegram_bot/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "apscheduler>=3.11.2,<4.0",
     "phonenumbers>=9.0.25",
     "prometheus-client>=0.20.0,<1.0",
+    "sentry-sdk>=2.0,<3.0",
 ]
 
 [project.optional-dependencies]

--- a/telegram_bot/uv.lock
+++ b/telegram_bot/uv.lock
@@ -2083,6 +2083,7 @@ dependencies = [
     { name = "qdrant-client" },
     { name = "redis" },
     { name = "redisvl" },
+    { name = "sentry-sdk" },
     { name = "tenacity" },
 ]
 
@@ -2122,6 +2123,7 @@ requires-dist = [
     { name = "rag-telegram-bot", extras = ["voyage"], marker = "extra == 'all'" },
     { name = "redis", specifier = ">=5.0.0" },
     { name = "redisvl", specifier = ">=0.3.0" },
+    { name = "sentry-sdk", specifier = ">=2.0,<3.0" },
     { name = "tenacity", specifier = ">=8.2.0" },
     { name = "voyageai", marker = "extra == 'voyage'", specifier = ">=0.3.0" },
 ]
@@ -2281,6 +2283,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.60.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/a2/2e6c090db384cc515069f4f85542bd5baf6786852073020ea73d4a76d3ea/sentry_sdk-2.60.0.tar.gz", hash = "sha256:0bd25e54e78ca02d0be512529fa644bbbf9e8470d7b26371294012d4ca93c978", size = 452946, upload-time = "2026-05-13T13:34:52.516Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/41/f2b800b7f12a05dd48c2a6280d4dd812d1425fc66ed3fe3fd99420c41d1a/sentry_sdk-2.60.0-py3-none-any.whl", hash = "sha256:28a536c03291c8bcb363cf35c611b32738ec118ff64d8d6383b096448ac4c803", size = 475616, upload-time = "2026-05-13T13:34:50.259Z" },
 ]
 
 [[package]]

--- a/tests/unit/observability/test_sentry_wiring.py
+++ b/tests/unit/observability/test_sentry_wiring.py
@@ -1,0 +1,285 @@
+"""Wiring tests: Sentry must be initialized at every entry point (#1417).
+
+Acceptance for #1417 closes the gap that ``initialize_sentry`` was implemented
+(child issues #2060, #2061, #2062) but never wired into the runtime entry
+points. Without these calls the helper is a dead module and a configured
+``SENTRY_DSN`` does nothing.
+
+Verified via Context7 (/getsentry/sentry-python): the SDK requires
+``sentry_sdk.init()`` to be called **before any other SDK call**, typically
+at application startup. We assert call order against ``initialize_langfuse``
+so Sentry catches even Langfuse-init failures.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_main_module():
+    """Drop ``telegram_bot.main`` so each test re-imports a fresh module."""
+    tracked = (
+        "telegram_bot.main",
+        "telegram_bot.bot",
+        "telegram_bot.config",
+        "telegram_bot.logging_config",
+    )
+    originals = {name: sys.modules.get(name) for name in tracked}
+    pkg = sys.modules.get("telegram_bot")
+    had_main_attr = pkg is not None and hasattr(pkg, "main")
+    original_main_attr = getattr(pkg, "main", None) if had_main_attr else None
+    for name in tracked:
+        sys.modules.pop(name, None)
+    if pkg is not None and hasattr(pkg, "main"):
+        delattr(pkg, "main")
+    yield
+    for name, module in originals.items():
+        if module is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module
+    if pkg is not None:
+        if had_main_attr:
+            pkg.main = original_main_attr
+        elif hasattr(pkg, "main"):
+            delattr(pkg, "main")
+
+
+def _patch_aiogram_imports():
+    """Provide minimal stand-ins for aiogram exception types main.py imports."""
+    fake = MagicMock()
+    fake.exceptions.TelegramConflictError = type("TelegramConflictError", (Exception,), {})
+    fake.exceptions.TelegramNetworkError = type("TelegramNetworkError", (Exception,), {})
+    fake.exceptions.TelegramRetryAfter = type("TelegramRetryAfter", (Exception,), {})
+    fake.exceptions.TelegramServerError = type("TelegramServerError", (Exception,), {})
+    fake.exceptions.TelegramUnauthorizedError = type("TelegramUnauthorizedError", (Exception,), {})
+    return fake
+
+
+async def test_main_calls_initialize_sentry_before_initialize_langfuse():
+    """Sentry must be booted FIRST so it captures Langfuse-init exceptions."""
+    mock_property_bot_instance = AsyncMock()
+    mock_property_bot = MagicMock(return_value=mock_property_bot_instance)
+    mock_bot_config = MagicMock()
+    mock_setup_logging = MagicMock()
+
+    mock_bot_mod = MagicMock()
+    mock_bot_mod.PropertyBot = mock_property_bot
+    mock_config_mod = MagicMock()
+    mock_config_mod.BotConfig = mock_bot_config
+    mock_logging_mod = MagicMock()
+    mock_logging_mod.setup_logging = mock_setup_logging
+
+    call_order: list[str] = []
+
+    def _record_sentry(*args, **kwargs):
+        call_order.append("sentry")
+        return True
+
+    def _record_set_tags(*args, **kwargs):
+        call_order.append("sentry_tags")
+        return
+
+    def _record_langfuse(*args, **kwargs):
+        call_order.append("langfuse")
+        return MagicMock()
+
+    with patch.dict(
+        sys.modules,
+        {
+            "telegram_bot.bot": mock_bot_mod,
+            "telegram_bot.config": mock_config_mod,
+            "telegram_bot.logging_config": mock_logging_mod,
+        },
+    ):
+        from telegram_bot import main as main_mod
+
+        with (
+            patch.object(main_mod, "initialize_langfuse", side_effect=_record_langfuse),
+            patch.object(main_mod, "initialize_sentry", side_effect=_record_sentry, create=True),
+            patch.object(main_mod, "set_runtime_tags", side_effect=_record_set_tags, create=True),
+        ):
+            await main_mod.main()
+
+    # Sentry must come first; tags after init; Langfuse last.
+    assert call_order[:3] == ["sentry", "sentry_tags", "langfuse"], (
+        f"Sentry must be initialized before Langfuse (#1417). Order={call_order}"
+    )
+
+
+async def test_main_does_not_fail_when_sentry_dsn_unset():
+    """When SENTRY_DSN is unset, initialize_sentry returns False and main proceeds."""
+    mock_property_bot_instance = AsyncMock()
+    mock_property_bot = MagicMock(return_value=mock_property_bot_instance)
+    mock_bot_config = MagicMock()
+
+    mock_bot_mod = MagicMock()
+    mock_bot_mod.PropertyBot = mock_property_bot
+    mock_config_mod = MagicMock()
+    mock_config_mod.BotConfig = mock_bot_config
+    mock_logging_mod = MagicMock()
+    mock_logging_mod.setup_logging = MagicMock()
+
+    with patch.dict(
+        sys.modules,
+        {
+            "telegram_bot.bot": mock_bot_mod,
+            "telegram_bot.config": mock_config_mod,
+            "telegram_bot.logging_config": mock_logging_mod,
+        },
+    ):
+        from telegram_bot import main as main_mod
+
+        with (
+            patch.object(main_mod, "initialize_langfuse", return_value=MagicMock()),
+            patch.object(main_mod, "initialize_sentry", return_value=False, create=True),
+            patch.object(main_mod, "set_runtime_tags", create=True),
+        ):
+            # Must not raise; Sentry returning False is the documented disabled path.
+            await main_mod.main()
+
+        mock_property_bot_instance.start.assert_awaited()
+
+
+async def test_main_set_runtime_tags_called_with_telegram_bot_service():
+    """set_runtime_tags must label the service so Sentry events tag service=telegram-bot."""
+    mock_property_bot_instance = AsyncMock()
+    mock_property_bot = MagicMock(return_value=mock_property_bot_instance)
+    mock_bot_config = MagicMock()
+
+    mock_bot_mod = MagicMock()
+    mock_bot_mod.PropertyBot = mock_property_bot
+    mock_config_mod = MagicMock()
+    mock_config_mod.BotConfig = mock_bot_config
+    mock_logging_mod = MagicMock()
+    mock_logging_mod.setup_logging = MagicMock()
+
+    captured_kwargs: dict = {}
+
+    def _capture(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+
+    with patch.dict(
+        sys.modules,
+        {
+            "telegram_bot.bot": mock_bot_mod,
+            "telegram_bot.config": mock_config_mod,
+            "telegram_bot.logging_config": mock_logging_mod,
+        },
+    ):
+        from telegram_bot import main as main_mod
+
+        with (
+            patch.object(main_mod, "initialize_langfuse", return_value=MagicMock()),
+            patch.object(main_mod, "initialize_sentry", return_value=True, create=True),
+            patch.object(main_mod, "set_runtime_tags", side_effect=_capture, create=True),
+        ):
+            await main_mod.main()
+
+    assert captured_kwargs.get("service") == "telegram-bot", (
+        f"set_runtime_tags must label service='telegram-bot'. Got {captured_kwargs}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Voice agent wiring
+# ---------------------------------------------------------------------------
+
+
+def test_voice_agent_has_setup_sentry_helper():
+    """src.voice.agent must expose _setup_sentry() (#1417)."""
+    pytest.importorskip("livekit")
+    import src.voice.agent as mod
+
+    assert hasattr(mod, "_setup_sentry"), (
+        "src/voice/agent.py must expose _setup_sentry() so the LiveKit voice "
+        "process initializes Sentry on startup (#1417)."
+    )
+    assert callable(mod._setup_sentry)
+
+
+def test_voice_setup_sentry_initializes_sentry_with_service_tag():
+    """_setup_sentry() boots Sentry and tags the voice-agent service."""
+    pytest.importorskip("livekit")
+    import src.voice.agent as mod
+
+    captured_kwargs: dict = {}
+
+    def _capture(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+
+    with (
+        patch.object(mod, "initialize_sentry", return_value=True) as init_mock,
+        patch.object(mod, "set_runtime_tags", side_effect=_capture),
+    ):
+        mod._setup_sentry()
+
+    init_mock.assert_called_once_with()
+    assert captured_kwargs.get("service") == "voice-agent", (
+        f"voice _setup_sentry must tag service='voice-agent'. Got {captured_kwargs}"
+    )
+
+
+def test_voice_setup_sentry_skips_runtime_tags_when_disabled():
+    """When SENTRY_DSN is unset, do not push runtime tags into the SDK."""
+    pytest.importorskip("livekit")
+    import src.voice.agent as mod
+
+    with (
+        patch.object(mod, "initialize_sentry", return_value=False),
+        patch.object(mod, "set_runtime_tags") as tags_mock,
+    ):
+        mod._setup_sentry()
+
+    tags_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Mini App wiring
+# ---------------------------------------------------------------------------
+
+
+async def test_mini_app_lifespan_initializes_sentry_before_redis():
+    """mini_app lifespan boots Sentry before opening Redis (#1417)."""
+    pytest.importorskip("fastapi")
+    from fastapi import FastAPI
+
+    from mini_app import api as mini_api
+
+    call_order: list[str] = []
+
+    def _record_sentry(*args, **kwargs):
+        call_order.append("sentry")
+        return True
+
+    def _record_set_tags(*args, **kwargs):
+        call_order.append("sentry_tags")
+
+    fake_aioredis = MagicMock()
+    fake_redis_client = MagicMock()
+    fake_redis_client.aclose = AsyncMock()
+
+    def _fake_from_url(*args, **kwargs):
+        call_order.append("redis_from_url")
+        return fake_redis_client
+
+    fake_aioredis.from_url = _fake_from_url
+
+    fake_redis_module = MagicMock()
+    fake_redis_module.asyncio = fake_aioredis
+
+    app = FastAPI()
+    with (
+        patch.object(mini_api, "initialize_sentry", side_effect=_record_sentry, create=True),
+        patch.object(mini_api, "set_runtime_tags", side_effect=_record_set_tags, create=True),
+        patch.dict(sys.modules, {"redis": fake_redis_module, "redis.asyncio": fake_aioredis}),
+    ):
+        async with mini_api.lifespan(app):
+            assert call_order[:2] == ["sentry", "sentry_tags"], (
+                f"Sentry must boot before Redis in mini_app lifespan. Order={call_order}"
+            )
+            assert "redis_from_url" in call_order


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Closes #1417 (umbrella). Companion to #2060 / #2061 / #2062.

## Problem

The Sentry helper (`src/observability_sentry.py` — `initialize_sentry`, `set_runtime_tags`, `runtime_scope`, breadcrumb helpers) was implemented by the child issues, complete with EventScrubber, project denylist, PII redaction in `before_send`, and full unit-test coverage. It was, however, **never called from any runtime entry point**. A configured `SENTRY_DSN` did nothing.

This PR closes that gap.

## Change

Wire `initialize_sentry()` **first** at every entry point — verified via Context7 (`/getsentry/sentry-python`): _"sentry_sdk.init must be called once before any other SDK call, typically at application startup"_. On success the service tag is set so events can be filtered by component.

| Entry point | Service tag | Order |
|---|---|---|
| `telegram_bot/main.py` | `telegram-bot` | before `initialize_langfuse` |
| `src/voice/agent.py` (`_setup_sentry`) | `voice-agent` | before `_setup_langfuse` |
| `mini_app/api.py` (`lifespan`) | `mini-app` | before Redis open |

All wiring is no-op when `SENTRY_DSN` is unset / blank.

### Contract: env_example_completeness

The contract scanner only sees env vars referenced via literal `os.getenv("KEY", ...)` / `os.environ["KEY"]`. Sentry's helpers piped names through `_resolve(...)` indirection, so `SENTRY_DSN` / `SENTRY_ENVIRONMENT` / `SENTRY_RELEASE` were invisible to the scanner. Inlined `os.getenv(literal, "")` in `_resolve_dsn`, `_resolve_release` and a new `_resolve_environment` so the contract passes after the `.env.example` rows are documented.

### `.env.example`

Adds commented placeholders under the existing Sentry block:
```
# SENTRY_DSN=https://<public-key>@bugsink.example.com/1
# SENTRY_ENVIRONMENT=local
# SENTRY_RELEASE=
```

## Tests (TDD)

`tests/unit/observability/test_sentry_wiring.py` — added before implementation:

- `test_main_calls_initialize_sentry_before_initialize_langfuse` — call order in `telegram_bot.main`.
- `test_main_does_not_fail_when_sentry_dsn_unset` — disabled path.
- `test_main_set_runtime_tags_called_with_telegram_bot_service` — service tag.
- `test_voice_agent_has_setup_sentry_helper` — voice exposes the function (skipped when `livekit` extra is missing).
- `test_voice_setup_sentry_initializes_sentry_with_service_tag` — voice wiring.
- `test_voice_setup_sentry_skips_runtime_tags_when_disabled` — disabled path.
- `test_mini_app_lifespan_initializes_sentry_before_redis` — lifespan order.

## Verification

```
uv run --python 3.12 pytest tests/contract -q -n auto --dist=worksteal     # 1151 passed, 4 skipped, 3 xfailed
uv run --python 3.12 pytest tests/unit/observability tests/unit/voice tests/unit/mini_app tests/unit/test_main.py -q   # 354 passed
uv run --python 3.12 ruff check src/observability_sentry.py src/voice/agent.py mini_app/api.py telegram_bot/main.py tests/unit/observability/test_sentry_wiring.py   # clean
uv run --python 3.12 ruff format --check ...                                # all formatted
```

## Known limitations

- E2E synthetic-exception verification with a live Bugsink/Sentry endpoint is out of scope here — that is exactly the work tracked by **#2064**. This PR is the prerequisite.
- `traces_sample_rate` defaults to `0.0` (errors only). Operators can raise it via env var after storage review.
- This PR does not touch the existing Sentry helper internals or the breadcrumb helpers — it is wiring only.