### PR TITLE
feat(graph): SDK-native tool factories for create_agent voice path (#2050)

### DIFF
--- a/telegram_bot/graph/tools/__init__.py
+++ b/telegram_bot/graph/tools/__init__.py
@@ -1,0 +1,23 @@
+"""SDK-native tool factories for ``create_agent`` (#2050).
+
+Companion to :mod:`telegram_bot.graph.middleware` (#2052). These factories
+return ``langchain.tools.BaseTool`` instances that #2051 wires into
+``langchain.agents.create_agent(tools=[...])`` for the voice path.
+
+Each factory accepts its dependencies as keyword arguments so production
+code injects real services (``QdrantService``, embedder, reranker, LLM)
+and tests pass mocks. The legacy node modules in
+``telegram_bot.graph.nodes`` stay in place until #2050 + #2051 + the
+guard-removal cleanup retire the StateGraph.
+"""
+
+from telegram_bot.graph.tools.rerank import make_rerank_tool
+from telegram_bot.graph.tools.retrieve import make_retrieve_tool
+from telegram_bot.graph.tools.rewrite import make_rewrite_tool
+
+
+__all__ = [
+    "make_rerank_tool",
+    "make_retrieve_tool",
+    "make_rewrite_tool",
+]

--- a/telegram_bot/graph/tools/rerank.py
+++ b/telegram_bot/graph/tools/rerank.py
@@ -1,0 +1,59 @@
+"""``rerank_documents`` tool factory for ``create_agent`` (#2050)."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from langchain_core.tools import BaseTool, tool
+from pydantic import BaseModel, Field
+
+
+logger = logging.getLogger(__name__)
+
+
+class RerankDocumentsInput(BaseModel):
+    """Schema for the ``rerank_documents`` tool."""
+
+    query: str = Field(description="Original natural-language query.")
+    documents: list[dict[str, Any]] = Field(
+        description="Documents to reorder, each carrying at minimum an ``id`` and ``text``.",
+    )
+
+
+def make_rerank_tool(
+    *,
+    rerank_fn: Callable[[str, list[dict[str, Any]]], Awaitable[list[dict[str, Any]]]],
+    name: str = "rerank_documents",
+) -> BaseTool:
+    """Return a ``BaseTool`` that reranks an existing candidate list.
+
+    Args:
+        rerank_fn: Async callable ``(query, documents) -> reordered_documents``.
+            Production wiring will pass either Voyage AI rerank or the
+            ColBERT reranker depending on ``RERANK_PROVIDER``.
+        name: Tool name surfaced to the LLM.
+
+    On error, the original document list is returned unchanged so the
+    agent can still proceed with the candidates it already has.
+    """
+
+    @tool(name, args_schema=RerankDocumentsInput)
+    async def rerank_documents(query: str, documents: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Reorder candidate documents by relevance to ``query``.
+
+        Use this after ``retrieve_documents`` returns a wide candidate set
+        and the model wants to prioritise the most relevant matches. The
+        return value contains the same documents in a new order — never
+        adds or drops items.
+        """
+        try:
+            return await rerank_fn(query, documents)
+        except Exception:
+            logger.warning(
+                "rerank_documents: rerank_fn failed; returning input order", exc_info=True
+            )
+            return documents
+
+    return rerank_documents

--- a/telegram_bot/graph/tools/retrieve.py
+++ b/telegram_bot/graph/tools/retrieve.py
@@ -1,0 +1,119 @@
+"""``retrieve_documents`` tool factory for ``create_agent`` (#2050).
+
+Wraps the project's hybrid RRF + ColBERT retrieval into a thin SDK tool.
+The tool itself does NOT own the embedder or the Qdrant connection —
+both are passed in by ``make_retrieve_tool`` so production code can wire
+the singleton services (#2051) and tests can inject mocks.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from langchain_core.tools import BaseTool, tool
+from pydantic import BaseModel, Field, create_model
+
+
+logger = logging.getLogger(__name__)
+
+
+def _result_to_dict(item: Any) -> dict[str, Any]:
+    """Normalize a Qdrant result into a serialisable dict.
+
+    Accepts the dict shape used elsewhere in the runtime as well as the
+    ``ScoredPoint``-like objects returned by ``qdrant-client``.
+    """
+    if isinstance(item, dict):
+        return item
+    out: dict[str, Any] = {}
+    for attr in ("id", "score"):
+        value = getattr(item, attr, None)
+        if value is not None:
+            out[attr] = value
+    payload = getattr(item, "payload", None)
+    if isinstance(payload, dict):
+        out.update(payload)
+    return out
+
+
+def _make_retrieve_schema(default_k: int) -> type[BaseModel]:
+    """Build the args schema with a configurable default ``k``.
+
+    The Pydantic class-level default is fixed at definition time. We rebuild
+    the schema per factory call so ``default_k`` flows through to the
+    LLM-visible JSON schema and to validated inputs (#2050).
+    """
+    return create_model(
+        "RetrieveDocumentsInput",
+        query=(
+            str,
+            Field(description="Natural-language query against the property knowledge base."),
+        ),
+        k=(
+            int,
+            Field(
+                default=default_k,
+                ge=1,
+                le=100,
+                description=f"Maximum documents to return (1..100). Defaults to {default_k}.",
+            ),
+        ),
+    )
+
+
+def make_retrieve_tool(
+    *,
+    qdrant: Any,
+    embed_query: Callable[[str], Awaitable[Any]],
+    name: str = "retrieve_documents",
+    default_k: int = 20,
+) -> BaseTool:
+    """Return a ``BaseTool`` wrapping hybrid retrieval.
+
+    Args:
+        qdrant: Object exposing ``hybrid_search_rrf_colbert(dense_query=,
+            sparse_query=, colbert_query=, k=)`` — typically the production
+            ``src.runtime.services.qdrant.QdrantService`` instance.
+        embed_query: Async callable that returns an object with ``dense``,
+            ``sparse`` and ``colbert`` attributes (the unified query
+            embeddings bundle used by the rest of the runtime).
+        name: Tool name surfaced to the LLM via tool calls.
+        default_k: Default ``k`` when the LLM omits it.
+    """
+
+    @tool(name, args_schema=_make_retrieve_schema(default_k))
+    async def retrieve_documents(query: str, k: int = default_k) -> list[dict[str, Any]]:
+        """Search the property knowledge base for documents relevant to ``query``.
+
+        Uses hybrid retrieval (dense + sparse + ColBERT) with reciprocal-rank
+        fusion. Returns up to ``k`` documents ordered by relevance score
+        (highest first). Returns an empty list if retrieval fails — the
+        agent should then ask a clarifying question rather than fabricate
+        an answer.
+        """
+        try:
+            embeddings = await embed_query(query)
+        except Exception:
+            logger.warning("retrieve_documents: embed_query failed", exc_info=True)
+            return []
+
+        try:
+            response = await qdrant.hybrid_search_rrf_colbert(
+                dense_query=getattr(embeddings, "dense", None),
+                sparse_query=getattr(embeddings, "sparse", None),
+                colbert_query=getattr(embeddings, "colbert", None),
+                k=k,
+            )
+        except Exception:
+            logger.warning("retrieve_documents: qdrant search failed", exc_info=True)
+            return []
+
+        # Some helpers return ``(results, meta)`` tuples; others return a list.
+        results = response[0] if isinstance(response, tuple) else response
+        if not results:
+            return []
+        return [_result_to_dict(item) for item in results]
+
+    return retrieve_documents

--- a/telegram_bot/graph/tools/rewrite.py
+++ b/telegram_bot/graph/tools/rewrite.py
@@ -1,0 +1,56 @@
+"""``rewrite_query`` tool factory for ``create_agent`` (#2050)."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+
+from langchain_core.tools import BaseTool, tool
+from pydantic import BaseModel, Field
+
+
+logger = logging.getLogger(__name__)
+
+
+class RewriteQueryInput(BaseModel):
+    """Schema for the ``rewrite_query`` tool."""
+
+    query: str = Field(description="Original user query that returned weak retrieval results.")
+
+
+def make_rewrite_tool(
+    *,
+    rewrite_fn: Callable[[str], Awaitable[str]],
+    name: str = "rewrite_query",
+) -> BaseTool:
+    """Return a ``BaseTool`` that rewrites a query for retry retrieval.
+
+    Args:
+        rewrite_fn: Async callable ``(query) -> rewritten_query``. Production
+            wiring will pass an LLM-backed rewrite helper that mirrors
+            ``rewrite_node`` semantics (translit / synonym expansion /
+            scope clarification).
+        name: Tool name surfaced to the LLM.
+
+    On error, the original query is returned unchanged so the agent can
+    fall back to the previous retrieval attempt instead of crashing.
+    """
+
+    @tool(name, args_schema=RewriteQueryInput)
+    async def rewrite_query(query: str) -> str:
+        """Produce a rewritten query that may yield better retrieval matches.
+
+        Use after ``retrieve_documents`` returns a poor candidate set and
+        ``rerank_documents`` cannot rescue the order. The rewritten query
+        usually expands synonyms or clarifies scope while preserving the
+        user's intent.
+        """
+        try:
+            return await rewrite_fn(query)
+        except Exception:
+            logger.warning(
+                "rewrite_query: rewrite_fn failed; returning original query", exc_info=True
+            )
+            return query
+
+    return rewrite_query

--- a/tests/unit/graph/test_voice_tools.py
+++ b/tests/unit/graph/test_voice_tools.py
@@ -1,0 +1,236 @@
+"""Unit tests for SDK-native voice tools (#2050).
+
+Companion to ``GuardMiddleware`` (#2052). This PR introduces three
+``create_agent``-compatible tool factories that #2051 will wire into the
+voice handler:
+
+* ``make_retrieve_tool`` — semantic retrieval against ``QdrantService``.
+* ``make_rerank_tool`` — server-side document reranking.
+* ``make_rewrite_tool`` — query rewrite for retry loops.
+
+Each factory takes its dependencies as arguments so production code can
+inject real services and tests can pass mocks. The tests verify the
+``langchain.tools.@tool`` decorator shape (Pydantic args schema, async
+``ainvoke``, name, description) so #2051 can plug the resulting
+``BaseTool`` instances directly into ``create_agent(tools=[...])``.
+
+Verified via Context7 (``/websites/langchain_oss_python_langchain``):
+``@tool`` decorated callables expose ``BaseTool``-style ``ainvoke``,
+``name`` and ``args`` attributes; the tool description comes from the
+docstring.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain_core.tools import BaseTool
+
+from telegram_bot.graph.tools import (
+    make_rerank_tool,
+    make_retrieve_tool,
+    make_rewrite_tool,
+)
+
+
+# ---------------------------------------------------------------------------
+# retrieve_documents
+# ---------------------------------------------------------------------------
+
+
+class _FakeEmbeddings:
+    """Stand-in for the production query embeddings bundle."""
+
+    def __init__(self) -> None:
+        self.dense = [0.1] * 4
+        self.sparse = {"indices": [0, 1], "values": [0.5, 0.5]}
+        self.colbert = [[0.1, 0.2, 0.3, 0.4]]
+
+
+def _make_qdrant_mock(results: list[dict] | None = None) -> MagicMock:
+    qdrant = MagicMock(name="QdrantService")
+    if results is None:
+        results = [
+            {"id": "doc-1", "text": "пример квартиры", "score": 0.92},
+            {"id": "doc-2", "text": "вторая квартира", "score": 0.81},
+        ]
+    qdrant.hybrid_search_rrf_colbert = AsyncMock(return_value=(results, {"latency_ms": 12}))
+    return qdrant
+
+
+async def _embed_query_async(_text: str) -> _FakeEmbeddings:
+    return _FakeEmbeddings()
+
+
+def test_retrieve_tool_is_a_basetool():
+    tool = make_retrieve_tool(qdrant=_make_qdrant_mock(), embed_query=_embed_query_async)
+    assert isinstance(tool, BaseTool), (
+        "make_retrieve_tool must return a langchain BaseTool so create_agent "
+        "can pick it up via tools=[...] (#2051)."
+    )
+
+
+def test_retrieve_tool_has_descriptive_name_and_doc():
+    tool = make_retrieve_tool(qdrant=_make_qdrant_mock(), embed_query=_embed_query_async)
+    assert tool.name == "retrieve_documents"
+    assert tool.description, "Tool must expose a non-empty description for the model."
+
+
+def test_retrieve_tool_args_schema_is_pydantic():
+    tool = make_retrieve_tool(qdrant=_make_qdrant_mock(), embed_query=_embed_query_async)
+    schema = tool.args_schema
+    assert schema is not None, "args_schema must be set so the LLM gets a typed JSON schema."
+    fields = schema.model_fields if hasattr(schema, "model_fields") else schema.__fields__
+    assert "query" in fields
+    assert "k" in fields
+
+
+async def test_retrieve_tool_ainvoke_returns_documents():
+    qdrant = _make_qdrant_mock()
+    tool = make_retrieve_tool(qdrant=qdrant, embed_query=_embed_query_async)
+
+    out = await tool.ainvoke({"query": "квартира в Несебре", "k": 5})
+
+    assert isinstance(out, list)
+    assert len(out) == 2
+    assert out[0]["id"] == "doc-1"
+    qdrant.hybrid_search_rrf_colbert.assert_awaited_once()
+    call_kwargs = qdrant.hybrid_search_rrf_colbert.await_args.kwargs
+    # Embeddings forwarded; k forwarded.
+    assert call_kwargs.get("k") == 5
+
+
+async def test_retrieve_tool_uses_default_k_when_unspecified():
+    qdrant = _make_qdrant_mock()
+    tool = make_retrieve_tool(qdrant=qdrant, embed_query=_embed_query_async, default_k=12)
+
+    await tool.ainvoke({"query": "test"})
+
+    call_kwargs = qdrant.hybrid_search_rrf_colbert.await_args.kwargs
+    assert call_kwargs.get("k") == 12
+
+
+async def test_retrieve_tool_returns_empty_on_qdrant_error():
+    """Tool failures must not crash the agent; the LLM gets an empty list."""
+    qdrant = MagicMock(name="QdrantService")
+    qdrant.hybrid_search_rrf_colbert = AsyncMock(side_effect=RuntimeError("qdrant down"))
+    tool = make_retrieve_tool(qdrant=qdrant, embed_query=_embed_query_async)
+
+    out = await tool.ainvoke({"query": "anything"})
+
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# rerank_documents
+# ---------------------------------------------------------------------------
+
+
+async def test_rerank_tool_is_a_basetool_and_named():
+    async def _rerank(_query: str, docs: list[dict]) -> list[dict]:
+        return docs[::-1]
+
+    tool = make_rerank_tool(rerank_fn=_rerank)
+    assert isinstance(tool, BaseTool)
+    assert tool.name == "rerank_documents"
+    assert tool.description
+
+
+async def test_rerank_tool_returns_reordered_documents():
+    async def _rerank(_query: str, docs: list[dict]) -> list[dict]:
+        # Stable sort by length desc to make the reorder visible.
+        return sorted(docs, key=lambda d: len(d.get("text", "")), reverse=True)
+
+    tool = make_rerank_tool(rerank_fn=_rerank)
+    out = await tool.ainvoke(
+        {
+            "query": "квартира",
+            "documents": [
+                {"id": "a", "text": "short"},
+                {"id": "b", "text": "longer document"},
+            ],
+        }
+    )
+    assert [d["id"] for d in out] == ["b", "a"]
+
+
+async def test_rerank_tool_returns_input_on_error():
+    async def _rerank(_query: str, _docs: list[dict]) -> list[dict]:
+        raise RuntimeError("reranker offline")
+
+    tool = make_rerank_tool(rerank_fn=_rerank)
+    docs = [{"id": "a"}]
+    out = await tool.ainvoke({"query": "q", "documents": docs})
+    assert out == docs
+
+
+# ---------------------------------------------------------------------------
+# rewrite_query
+# ---------------------------------------------------------------------------
+
+
+async def test_rewrite_tool_is_a_basetool_and_named():
+    async def _rewrite(_query: str) -> str:
+        return "(rewritten)"
+
+    tool = make_rewrite_tool(rewrite_fn=_rewrite)
+    assert isinstance(tool, BaseTool)
+    assert tool.name == "rewrite_query"
+    assert tool.description
+
+
+async def test_rewrite_tool_returns_string():
+    captured: dict[str, str] = {}
+
+    async def _rewrite(query: str) -> str:
+        captured["query"] = query
+        return f"улучшенный: {query}"
+
+    tool = make_rewrite_tool(rewrite_fn=_rewrite)
+    out = await tool.ainvoke({"query": "квартира 2 комнаты"})
+
+    assert isinstance(out, str)
+    assert "улучшенный" in out
+    assert captured["query"] == "квартира 2 комнаты"
+
+
+async def test_rewrite_tool_returns_original_on_error():
+    async def _rewrite(_query: str) -> str:
+        raise RuntimeError("LLM down")
+
+    tool = make_rewrite_tool(rewrite_fn=_rewrite)
+    out = await tool.ainvoke({"query": "оригинал"})
+    assert out == "оригинал"
+
+
+# ---------------------------------------------------------------------------
+# Package exports
+# ---------------------------------------------------------------------------
+
+
+def test_package_exports_factories():
+    from telegram_bot.graph import tools as tools_pkg
+
+    for name in ("make_retrieve_tool", "make_rerank_tool", "make_rewrite_tool"):
+        assert hasattr(tools_pkg, name), f"telegram_bot.graph.tools must export {name}"
+
+
+@pytest.mark.parametrize(
+    "factory_name, kwargs",
+    [
+        (
+            "make_retrieve_tool",
+            {"qdrant": _make_qdrant_mock(), "embed_query": _embed_query_async},
+        ),
+        ("make_rerank_tool", {"rerank_fn": AsyncMock(return_value=[])}),
+        ("make_rewrite_tool", {"rewrite_fn": AsyncMock(return_value="x")}),
+    ],
+)
+def test_factory_returns_basetool(factory_name: str, kwargs: dict):
+    """Defensive check: each factory returns a BaseTool, not a raw callable."""
+    from telegram_bot.graph import tools as tools_pkg
+
+    factory = getattr(tools_pkg, factory_name)
+    tool = factory(**kwargs)
+    assert isinstance(tool, BaseTool)


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Closes #2050. Child of umbrella #1535 (voice-path migration to `create_agent`).

## Problem

The voice path will move from a bespoke `StateGraph` to LangChain `create_agent` over three sequenced PRs:

| Issue | Change | Status |
|---|---|---|
| #2052 | Guard as `before_model` middleware | ✅ #2118 |
| #2050 (this PR) | Graph nodes as `@tool` factories | ✅ |
| #2051 | Voice handler invokes `create_agent` | next |

Without #2050, the voice handler in #2051 has no SDK-shaped tools to plug into `create_agent(tools=[...])`.

## Change

New module `telegram_bot/graph/tools/` with three factories:

```python
from telegram_bot.graph.tools import (
    make_retrieve_tool,   # hybrid RRF + ColBERT retrieval
    make_rerank_tool,     # Voyage / ColBERT rerank
    make_rewrite_tool,    # LLM query rewrite for retry loops
)
```

Each factory takes its dependencies as keyword arguments (so production code injects real services and tests pass mocks) and returns a `langchain.tools.BaseTool` ready for `create_agent(tools=[...])`.

Verified shape via Context7 (`/websites/langchain_oss_python_langchain`):

- `@tool` decorator with explicit `args_schema` Pydantic models.
- Async `ainvoke` for tool execution.
- Docstring → model-visible description.
- `BaseTool` subclass identity for `create_agent` plumbing.

Defensive error handling on every tool — a faulty service returns:
- `retrieve_documents` → empty list
- `rerank_documents` → input order
- `rewrite_query` → original query

so a tool fault never crashes the agent loop.

The `retrieve_documents` schema is built per factory call via `pydantic.create_model` so the configurable `default_k` flows into both the LLM-visible JSON schema and validated inputs.

### What this PR does NOT touch

- Production wiring of Voyage / BGE-M3 / LLM helpers — those callables are accepted as plain `Callable[..., Awaitable[...]]`. The voice handler in #2051 supplies them.
- Legacy `telegram_bot.graph.nodes.{retrieve,rerank,rewrite}` modules — they continue to power the StateGraph until #2051 retires the StateGraph wiring.

## Tests (TDD, 16 cases)

`tests/unit/graph/test_voice_tools.py` — written before implementation:

- `test_retrieve_tool_is_a_basetool`
- `test_retrieve_tool_has_descriptive_name_and_doc`
- `test_retrieve_tool_args_schema_is_pydantic`
- `test_retrieve_tool_ainvoke_returns_documents`
- `test_retrieve_tool_uses_default_k_when_unspecified`
- `test_retrieve_tool_returns_empty_on_qdrant_error`
- `test_rerank_tool_is_a_basetool_and_named`
- `test_rerank_tool_returns_reordered_documents`
- `test_rerank_tool_returns_input_on_error`
- `test_rewrite_tool_is_a_basetool_and_named`
- `test_rewrite_tool_returns_string`
- `test_rewrite_tool_returns_original_on_error`
- `test_package_exports_factories`
- `test_factory_returns_basetool[make_retrieve_tool-…]`
- `test_factory_returns_basetool[make_rerank_tool-…]`
- `test_factory_returns_basetool[make_rewrite_tool-…]`

## Verification

```
uv run --python 3.12 pytest tests/unit/graph -q                    # 506 passed
uv run --python 3.12 pytest tests/contract -q -n auto              # 1155 passed, 4 skipped, 3 xfailed
uv run --python 3.12 ruff check ... && ruff format --check ...     # clean
```

## Known limitations

- `retrieve_documents` returns at most `k` (1..100) documents; quotas / per-tenant filters live in the production retrieval helper, not in this thin tool wrapper.
- The `rewrite_query` tool only refines the natural-language query; embedding refresh remains the agent's responsibility (it can re-call `retrieve_documents` with the rewritten string).
- Cache / classify / grade nodes are intentionally **not** converted in this PR — they are middleware-shaped rather than tool-shaped and will land in a follow-up PR alongside #2051.