### PR TITLE
feat(ingestion): public HybridChunker adapter + migration ratchet (#1235)

### DIFF
--- a/src/ingestion/hybrid_chunker.py
+++ b/src/ingestion/hybrid_chunker.py
@@ -1,0 +1,121 @@
+"""Public adapter for ``docling_core.transforms.chunker.HybridChunker`` (#1235).
+
+The legacy :class:`~src.ingestion.chunker.DocumentChunker` exposes
+``FIXED_SIZE`` / ``SLIDING_WINDOW`` strategies that the project itself
+marked deprecated in favour of Docling's HybridChunker (issue #1235).
+This module gives downstream code a stable, tested entry point so the
+follow-up call-site migrations (``cocoindex_flow.py``,
+``core/pipeline.py``) become mechanical edits.
+
+The adapter intentionally does **not** delete the legacy chunker — that
+removal is gated by the contract test
+``tests/contract/test_chunker_migration_1235_contract.py`` which
+allowlists existing call sites and ratchets toward zero.
+
+Verified shape via Context7 (``/docling-project/docling-core``):
+
+* ``HybridChunker(tokenizer=, max_tokens=, merge_peers=)``
+* ``chunker.chunk(doc)`` returns chunks each exposing a ``text`` attribute.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Iterable
+from typing import Any
+
+from src.ingestion.chunker import Chunk
+
+
+__all__ = ["chunks_to_chunk_objects", "make_hybrid_chunker"]
+
+
+def _load_hybrid_chunker_cls() -> type[Any] | None:
+    """Lazy-import ``HybridChunker``; returns ``None`` when ingest extra missing."""
+    try:
+        module = importlib.import_module("docling_core.transforms.chunker")
+    except ImportError:
+        return None
+    return getattr(module, "HybridChunker", None)
+
+
+def make_hybrid_chunker(
+    *,
+    max_tokens: int = 1024,
+    merge_peers: bool = True,
+    tokenizer: Any | None = None,
+) -> Any:
+    """Return a configured ``HybridChunker`` instance.
+
+    Args:
+        max_tokens: Token budget per chunk. Default 1024 matches the BGE-M3
+            embedding window the project ships with.
+        merge_peers: Merge undersized peer chunks that share metadata.
+        tokenizer: Optional tokenizer (transformers ``PreTrainedTokenizer``
+            or HF model name). When ``None`` the SDK's own default factory
+            is used — we deliberately omit the kwarg in that case so the
+            SDK default applies.
+
+    Raises:
+        ImportError: When ``docling_core`` is not installed. Message points
+            operators at ``uv sync --extra ingest``.
+    """
+    HybridChunker = _load_hybrid_chunker_cls()
+    if HybridChunker is None:
+        raise ImportError(
+            "docling_core.transforms.chunker.HybridChunker is unavailable. "
+            "Install the optional ingest extra: `uv sync --extra ingest`."
+        )
+
+    kwargs: dict[str, Any] = {"max_tokens": max_tokens, "merge_peers": merge_peers}
+    if tokenizer is not None:
+        kwargs["tokenizer"] = tokenizer
+    return HybridChunker(**kwargs)
+
+
+def _extract_text(item: Any) -> str:
+    """Best-effort extraction of chunk text from object or dict shapes."""
+    text = getattr(item, "text", None)
+    if text is None and isinstance(item, dict):
+        text = item.get("text", "")
+    return text or ""
+
+
+def chunks_to_chunk_objects(
+    raw_chunks: Iterable[Any],
+    *,
+    document_name: str,
+    article_number: str = "",
+) -> list[Chunk]:
+    """Adapt ``HybridChunker.chunk(doc)`` output to legacy :class:`Chunk` dataclasses.
+
+    Empty-text chunks are dropped. ``chunk_id`` and ``order`` are assigned
+    from the surviving sequence so downstream consumers (indexer,
+    contextual loader) keep their stable identifiers.
+
+    Args:
+        raw_chunks: Iterable produced by ``HybridChunker.chunk(doc)``.
+            Each item may be a Pydantic-style object exposing ``.text`` or
+            a plain dict with a ``"text"`` key.
+        document_name: Stable name attached to every emitted ``Chunk``.
+        article_number: Optional article identifier carried into each
+            ``Chunk`` (used by legal-document ingestion). Defaults to ``""``
+            for generic documents that have no article structure.
+    """
+    out: list[Chunk] = []
+    next_id = 0
+    for item in raw_chunks:
+        text = _extract_text(item).strip()
+        if not text:
+            continue
+        out.append(
+            Chunk(
+                text=text,
+                chunk_id=next_id,
+                document_name=document_name,
+                article_number=article_number,
+                order=next_id,
+            )
+        )
+        next_id += 1
+    return out

--- a/tests/contract/test_chunker_migration_1235_contract.py
+++ b/tests/contract/test_chunker_migration_1235_contract.py
@@ -1,0 +1,148 @@
+"""Contract: ratchet for the legacy ``DocumentChunker`` migration (#1235).
+
+Issue #1235 directs production code away from the deprecated
+``DocumentChunker`` (FIXED_SIZE / SLIDING_WINDOW / SEMANTIC strategies)
+toward Docling's :class:`HybridChunker` exposed via the new public
+adapter :func:`src.ingestion.hybrid_chunker.make_hybrid_chunker`.
+
+The migration is multi-PR (each call site has its own consumers and
+config). This contract is the **ratchet** that keeps the migration
+moving:
+
+* ``CHUNKER_CALL_SITE_ALLOWLIST`` lists every file that constructs
+  ``DocumentChunker(...)`` today.
+* The contract fails when a new file introduces a forbidden constructor
+  call (mirrors the layering ratchet in
+  ``test_layering_no_telegram_bot_imports_contract.py``).
+* The allowlist must shrink over time; never regenerate it to silence a
+  failure.
+
+Re-export entries (``__init__.py`` lines that simply expose
+``DocumentChunker`` for back-compat) are not constructor calls and are
+out of scope.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCAN_DIRS: tuple[Path, ...] = (
+    REPO_ROOT / "src",
+    REPO_ROOT / "telegram_bot",
+    REPO_ROOT / "mini_app",
+    REPO_ROOT / "services",
+    REPO_ROOT / "scripts",
+)
+
+# Files allowed to construct ``DocumentChunker(...)`` today.
+# Frozen baseline — must shrink, never grow. Each entry should map to a
+# tracked follow-up PR removing the call site.
+CHUNKER_CALL_SITE_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # Legacy core RAG pipeline used by the evaluation script
+        # (src/evaluation/ragas_evaluation.py imports RAGPipeline from here).
+        # Migration to make_hybrid_chunker is tracked in #1235 follow-ups.
+        "src/core/pipeline.py",
+    }
+)
+
+
+def _iter_python_files() -> list[Path]:
+    files: list[Path] = []
+    for d in SCAN_DIRS:
+        if not d.exists():
+            continue
+        for p in d.rglob("*.py"):
+            spath = str(p)
+            if "/.venv/" in spath or "/__pycache__/" in spath:
+                continue
+            files.append(p)
+    return files
+
+
+def _parse(path: Path) -> ast.AST | None:
+    try:
+        return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (SyntaxError, UnicodeDecodeError):
+        return None
+
+
+def _find_document_chunker_calls(tree: ast.AST) -> list[int]:
+    """Return line numbers of bare ``DocumentChunker(...)`` constructor calls.
+
+    Matches both ``DocumentChunker(...)`` and ``mod.DocumentChunker(...)``.
+    """
+    found: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if (isinstance(func, ast.Name) and func.id == "DocumentChunker") or (
+            isinstance(func, ast.Attribute) and func.attr == "DocumentChunker"
+        ):
+            found.append(node.lineno)
+    return found
+
+
+def test_no_new_document_chunker_call_sites() -> None:
+    """New code must use ``make_hybrid_chunker`` instead of ``DocumentChunker``."""
+    offenders: list[str] = []
+    for py_file in _iter_python_files():
+        rel = py_file.relative_to(REPO_ROOT).as_posix()
+        if rel in CHUNKER_CALL_SITE_ALLOWLIST:
+            continue
+        # Skip the chunker module itself (defines the class).
+        if rel == "src/ingestion/chunker.py":
+            continue
+        # Adapter module references the class only in docstrings.
+        if rel == "src/ingestion/hybrid_chunker.py":
+            continue
+        tree = _parse(py_file)
+        if tree is None:
+            continue
+        for lineno in _find_document_chunker_calls(tree):
+            offenders.append(f"  {rel}:{lineno}")
+    assert not offenders, (
+        "#1235: new file(s) construct DocumentChunker(...). The legacy chunker "
+        "is being replaced by Docling HybridChunker via "
+        "src.ingestion.hybrid_chunker.make_hybrid_chunker(). Migrate the new "
+        "call site instead of adding it to the allowlist.\nOffenders:\n" + "\n".join(offenders)
+    )
+
+
+def test_chunker_allowlist_paths_exist() -> None:
+    """Allowlist entries must point to real files (catches drift on rename)."""
+    missing = [rel for rel in CHUNKER_CALL_SITE_ALLOWLIST if not (REPO_ROOT / rel).exists()]
+    assert not missing, (
+        "#1235: known_allowlist points to missing files. Update the contract "
+        f"after the migration / rename:\n  {missing}"
+    )
+
+
+def test_chunker_allowlist_entries_actually_use_pattern() -> None:
+    """Stale allowlist entries are rejected — forces shrinkage as call sites
+    are migrated to ``make_hybrid_chunker``."""
+    stale: list[str] = []
+    for rel in CHUNKER_CALL_SITE_ALLOWLIST:
+        path = REPO_ROOT / rel
+        if not path.exists():
+            continue
+        tree = _parse(path)
+        if tree is None:
+            continue
+        if not _find_document_chunker_calls(tree):
+            stale.append(f"  {rel} (no DocumentChunker(...) call remains)")
+    assert not stale, (
+        "#1235: stale allowlist entries — remove them from the contract:\n" + "\n".join(stale)
+    )
+
+
+def test_make_hybrid_chunker_is_publicly_importable() -> None:
+    """The migration target must remain a stable public import."""
+    from src.ingestion.hybrid_chunker import (  # noqa: F401
+        chunks_to_chunk_objects,
+        make_hybrid_chunker,
+    )

--- a/tests/unit/ingestion/test_hybrid_chunker.py
+++ b/tests/unit/ingestion/test_hybrid_chunker.py
@@ -1,0 +1,206 @@
+"""Unit tests for the public HybridChunker adapter (#1235).
+
+The legacy ``DocumentChunker`` (FIXED_SIZE / SLIDING_WINDOW / SEMANTIC) is
+self-deprecated. Issue #1235 directs production code to migrate to
+``docling_core.transforms.chunker.HybridChunker``.
+
+This PR introduces a tested public adapter so follow-up call-site
+migrations (cocoindex_flow, core/pipeline) are mechanical:
+
+* ``make_hybrid_chunker`` — thin factory that lazily imports
+  ``HybridChunker`` and surfaces a clear ImportError when the optional
+  ``ingest`` extra is not installed.
+* ``chunks_to_chunk_objects`` — converts ``HybridChunker.chunk(doc)`` output
+  into the legacy ``src.ingestion.chunker.Chunk`` dataclass so existing
+  consumers (indexer, contextual loader) keep working.
+
+Verified shape via Context7 (``/docling-project/docling-core``):
+``HybridChunker(max_tokens=, merge_peers=, tokenizer=)``; ``chunk(doc)``
+returns chunks exposing a ``text`` attribute.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# make_hybrid_chunker
+# ---------------------------------------------------------------------------
+
+
+def test_make_hybrid_chunker_returns_configured_instance():
+    """Forwards max_tokens / merge_peers to the underlying HybridChunker."""
+    from src.ingestion import hybrid_chunker as mod
+
+    fake_cls = MagicMock()
+    fake_cls.return_value = MagicMock(name="hybrid")
+
+    with patch.object(mod, "_load_hybrid_chunker_cls", return_value=fake_cls):
+        instance = mod.make_hybrid_chunker(max_tokens=256, merge_peers=False)
+
+    fake_cls.assert_called_once_with(max_tokens=256, merge_peers=False)
+    assert instance is fake_cls.return_value
+
+
+def test_make_hybrid_chunker_forwards_tokenizer_when_provided():
+    from src.ingestion import hybrid_chunker as mod
+
+    fake_cls = MagicMock()
+    sentinel_tokenizer = object()
+
+    with patch.object(mod, "_load_hybrid_chunker_cls", return_value=fake_cls):
+        mod.make_hybrid_chunker(tokenizer=sentinel_tokenizer)
+
+    call_kwargs = fake_cls.call_args.kwargs
+    assert call_kwargs.get("tokenizer") is sentinel_tokenizer
+
+
+def test_make_hybrid_chunker_omits_tokenizer_kwarg_when_none():
+    """When tokenizer is None, the SDK falls back to its own default — we
+    must not pass ``tokenizer=None`` because that would override the SDK's
+    default factory with a literal None."""
+    from src.ingestion import hybrid_chunker as mod
+
+    fake_cls = MagicMock()
+
+    with patch.object(mod, "_load_hybrid_chunker_cls", return_value=fake_cls):
+        mod.make_hybrid_chunker()
+
+    assert "tokenizer" not in fake_cls.call_args.kwargs
+
+
+def test_make_hybrid_chunker_raises_clear_import_error_when_unavailable():
+    from src.ingestion import hybrid_chunker as mod
+
+    with patch.object(mod, "_load_hybrid_chunker_cls", return_value=None):
+        with pytest.raises(ImportError) as ei:
+            mod.make_hybrid_chunker()
+
+    msg = str(ei.value)
+    assert "HybridChunker" in msg
+    assert "ingest" in msg, "Error message must point operators at the optional extra."
+
+
+def test_make_hybrid_chunker_uses_documented_defaults():
+    """Defaults match the project chunking contract (max_tokens=1024, merge_peers=True)."""
+    from src.ingestion import hybrid_chunker as mod
+
+    fake_cls = MagicMock()
+    with patch.object(mod, "_load_hybrid_chunker_cls", return_value=fake_cls):
+        mod.make_hybrid_chunker()
+
+    kwargs = fake_cls.call_args.kwargs
+    assert kwargs.get("max_tokens") == 1024
+    assert kwargs.get("merge_peers") is True
+
+
+# ---------------------------------------------------------------------------
+# chunks_to_chunk_objects
+# ---------------------------------------------------------------------------
+
+
+def test_chunks_to_chunk_objects_handles_attribute_text():
+    from src.ingestion.chunker import Chunk
+    from src.ingestion.hybrid_chunker import chunks_to_chunk_objects
+
+    raw = [
+        SimpleNamespace(text="первый чанк"),
+        SimpleNamespace(text="второй чанк"),
+    ]
+    out = chunks_to_chunk_objects(raw, document_name="doc.md", article_number="art-1")
+    assert len(out) == 2
+    assert all(isinstance(c, Chunk) for c in out)
+    assert out[0].text == "первый чанк"
+    assert out[0].document_name == "doc.md"
+    assert out[0].article_number == "art-1"
+    assert out[0].chunk_id == 0
+    assert out[1].chunk_id == 1
+
+
+def test_chunks_to_chunk_objects_handles_dict_text():
+    from src.ingestion.hybrid_chunker import chunks_to_chunk_objects
+
+    raw = [{"text": "dict chunk"}]
+    out = chunks_to_chunk_objects(raw, document_name="d.md")
+    assert len(out) == 1
+    assert out[0].text == "dict chunk"
+
+
+def test_chunks_to_chunk_objects_skips_empty_text():
+    from src.ingestion.hybrid_chunker import chunks_to_chunk_objects
+
+    raw = [
+        SimpleNamespace(text="kept"),
+        SimpleNamespace(text=""),
+        SimpleNamespace(text=None),
+        {"text": ""},
+        SimpleNamespace(),  # no text attr
+        SimpleNamespace(text="kept again"),
+    ]
+    out = chunks_to_chunk_objects(raw, document_name="d.md")
+    assert [c.text for c in out] == ["kept", "kept again"]
+
+
+def test_chunks_to_chunk_objects_preserves_order_indices():
+    from src.ingestion.hybrid_chunker import chunks_to_chunk_objects
+
+    raw = [SimpleNamespace(text=f"chunk-{i}") for i in range(5)]
+    out = chunks_to_chunk_objects(raw, document_name="d.md")
+    assert [c.chunk_id for c in out] == [0, 1, 2, 3, 4]
+    assert [c.order for c in out] == [0, 1, 2, 3, 4]
+
+
+def test_chunks_to_chunk_objects_returns_empty_for_empty_iter():
+    from src.ingestion.hybrid_chunker import chunks_to_chunk_objects
+
+    assert chunks_to_chunk_objects([], document_name="d.md") == []
+
+
+def test_chunks_to_chunk_objects_default_article_number_is_empty_string():
+    """The legacy Chunk dataclass requires article_number; the adapter must
+    supply a stable default ('') so callers that do not track article numbers
+    (markdown notes, generic web pages) still get a valid Chunk."""
+    from src.ingestion.hybrid_chunker import chunks_to_chunk_objects
+
+    out = chunks_to_chunk_objects([SimpleNamespace(text="x")], document_name="d.md")
+    assert out[0].article_number == ""
+
+
+# ---------------------------------------------------------------------------
+# Integration: full round-trip with real HybridChunker on a tiny document
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_with_real_hybrid_chunker_on_tiny_doc():
+    """Smoke test against the actual HybridChunker, when ingest extra is installed.
+
+    Confirms the adapter accepts the SDK's chunk objects unchanged and
+    produces non-empty Chunk dataclasses.
+    """
+    pytest.importorskip("docling_core")
+    from docling_core.types.doc import DocItemLabel, DoclingDocument
+
+    from src.ingestion.hybrid_chunker import (
+        chunks_to_chunk_objects,
+        make_hybrid_chunker,
+    )
+
+    doc = DoclingDocument(name="ingest-1235-test")
+    doc.add_title(text="Title")
+    doc.add_heading(text="Section A", level=1)
+    doc.add_text(label=DocItemLabel.PARAGRAPH, text="Lorem ipsum dolor sit amet. " * 8)
+
+    chunker = make_hybrid_chunker(max_tokens=64, merge_peers=True)
+    raw_chunks = list(chunker.chunk(doc))
+    assert raw_chunks, "HybridChunker must emit at least one chunk for non-empty doc"
+
+    out = chunks_to_chunk_objects(raw_chunks, document_name="ingest-1235-test", article_number="t")
+    assert out, "Adapter must yield at least one Chunk for a non-empty input"
+    for c in out:
+        assert c.text.strip()
+        assert c.document_name == "ingest-1235-test"
+        assert c.article_number == "t"


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Closes #1235.

## Problem

`DocumentChunker` (`FIXED_SIZE` / `SLIDING_WINDOW` / `SEMANTIC` strategies in `src/ingestion/chunker.py`) was self-marked deprecated in favour of Docling `HybridChunker`. The naive markdown chunker pair (`_chunk_markdown` / `_split_text` in `NativeDoclingAdapter`) was already removed in a prior PR; the remaining work is migrating the rest of the call sites.

The migration is multi-PR — each call site has its own consumers and config — so this PR delivers the **public migration target** plus a **contract ratchet** so the migration moves only one direction.

## Change

### Public adapter

`src/ingestion/hybrid_chunker.py`:

| API | Purpose |
|---|---|
| `make_hybrid_chunker(*, max_tokens=1024, merge_peers=True, tokenizer=None)` | Thin factory that lazily imports `docling_core.transforms.chunker.HybridChunker` and forwards kwargs. Raises `ImportError` pointing operators at `uv sync --extra ingest` when the optional extra is missing. Defaults match the project's BGE-M3 token window. Omits `tokenizer=None` from the kwargs so the SDK's own default factory still applies. |
| `chunks_to_chunk_objects(raw_chunks, *, document_name, article_number="")` | Adapts `HybridChunker.chunk(doc)` output to the legacy `src.ingestion.chunker.Chunk` dataclass so existing consumers (indexer, contextual loader) keep working unchanged. Skips empty-text chunks; preserves order indices. |

Shape verified via Context7 (`/docling-project/docling-core`): `HybridChunker(tokenizer=, max_tokens=, merge_peers=)`; `chunker.chunk(doc)` returns chunks each exposing `.text`.

### Contract ratchet

`tests/contract/test_chunker_migration_1235_contract.py`:

- Allowlists the **single** remaining `DocumentChunker(...)` constructor site: `src/core/pipeline.py` (used only by `src/evaluation/ragas_evaluation.py`).
- New code outside the allowlist that constructs `DocumentChunker` fails the contract.
- Stale allowlist entries are detected and rejected — forces the allowlist to shrink as call sites migrate.
- Mirrors the layering ratchet from #1948 / #2049.

## What this PR does NOT touch

- The legacy `DocumentChunker` class — still has `FIXED_SIZE` / `SLIDING_WINDOW` paths that emit `DeprecationWarning` (covered by `tests/unit/test_dead_code_cleanup.py`).
- `chunk_csv_by_rows` — migration changes ingestion semantics for `apartments.csv` and needs runtime verification against the indexed dataset.
- `cocoindex_flow.py:SplitRecursively` — same risk profile.
- `document_parser._parse_pdf` PyMuPDF path — explicitly out of scope per issue (different priority).

These are tracked as the next steps in the migration ladder; each will land as a separate PR with runtime verification.

## Tests (TDD, 12 unit + 4 contract)

`tests/unit/ingestion/test_hybrid_chunker.py`:

- `test_make_hybrid_chunker_returns_configured_instance`
- `test_make_hybrid_chunker_forwards_tokenizer_when_provided`
- `test_make_hybrid_chunker_omits_tokenizer_kwarg_when_none`
- `test_make_hybrid_chunker_raises_clear_import_error_when_unavailable`
- `test_make_hybrid_chunker_uses_documented_defaults`
- `test_chunks_to_chunk_objects_handles_attribute_text`
- `test_chunks_to_chunk_objects_handles_dict_text`
- `test_chunks_to_chunk_objects_skips_empty_text`
- `test_chunks_to_chunk_objects_preserves_order_indices`
- `test_chunks_to_chunk_objects_returns_empty_for_empty_iter`
- `test_chunks_to_chunk_objects_default_article_number_is_empty_string`
- `test_round_trip_with_real_hybrid_chunker_on_tiny_doc` — integration smoke against real `HybridChunker` on a tiny `DoclingDocument`; auto-skipped when ingest extra isn't installed.

`tests/contract/test_chunker_migration_1235_contract.py`:

- `test_no_new_document_chunker_call_sites`
- `test_chunker_allowlist_paths_exist`
- `test_chunker_allowlist_entries_actually_use_pattern` — stale-entry detector.
- `test_make_hybrid_chunker_is_publicly_importable` — public surface guard.

## Verification

```
uv sync --extra ingest --python 3.12
uv run --python 3.12 pytest tests/unit/ingestion -q              # 338 passed
uv run --python 3.12 pytest tests/contract -q -n auto             # 1161 passed, 3 xfailed
uv run --python 3.12 ruff check ... && ruff format --check ...    # clean
```

## Known limitations

- The integration test exercises a tiny synthetic `DoclingDocument`; large-document and PDF pipelines are validated by separate runtime tests not included in this PR.
- `HybridChunker` SDK currently warns about deprecated init parameter types; the adapter passes only the documented kwargs (`max_tokens`, `merge_peers`, optional `tokenizer`) so the warning is the SDK's own — not introduced here.