### PR TITLE
fix(#1408): reduce noisy full tracebacks for LLM connection failures

### DIFF
--- a/telegram_bot/services/generate_response.py
+++ b/telegram_bot/services/generate_response.py
@@ -40,6 +40,46 @@ from telegram_bot.services.telegram_formatting import (
 logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Connection-error detection (#1408)
+# ---------------------------------------------------------------------------
+
+_CONNECTION_ERROR_TYPES: tuple[type[BaseException], ...]
+try:
+    from httpx import ConnectError
+
+    _HTTPX_CONNECT_ERROR = ConnectError
+except ImportError:  # pragma: no cover
+    _HTTPX_CONNECT_ERROR = None  # type: ignore[assignment]
+
+try:
+    from openai import APIConnectionError
+
+    _OPENAI_API_CONNECTION_ERROR = APIConnectionError
+except ImportError:  # pragma: no cover
+    _OPENAI_API_CONNECTION_ERROR = None  # type: ignore[assignment]
+
+_conn_errors: list[type[BaseException]] = []
+if _HTTPX_CONNECT_ERROR is not None:
+    _conn_errors.append(_HTTPX_CONNECT_ERROR)
+if _OPENAI_API_CONNECTION_ERROR is not None:
+    _conn_errors.append(_OPENAI_API_CONNECTION_ERROR)
+_CONNECTION_ERROR_TYPES = tuple(_conn_errors)
+
+
+def _is_connection_error(exc: BaseException) -> bool:
+    """Return True when *exc* is a known LLM connection failure (#1408).
+
+    Connection failures (httpx.ConnectError, openai.APIConnectionError) are
+    routine infrastructure noise — full tracebacks add no diagnostic value
+    and flood logs with repeated stack frames.
+
+    """
+    if not _CONNECTION_ERROR_TYPES:
+        return False
+    return isinstance(exc, _CONNECTION_ERROR_TYPES)
+
+
 class StreamingPartialDeliveryError(Exception):
     """Raised when streaming delivered partial content to user then failed."""
 
@@ -838,12 +878,21 @@ async def generate_response(
                 response_sent = sent_msg is not None
             except Exception as stream_exc:
                 if hasattr(stream_exc, "sent_msg") and hasattr(stream_exc, "partial_text"):
-                    logger.warning(
-                        "Streaming failed after partial delivery (%d chars), "
-                        "falling back to non-streaming with edit",
-                        len(getattr(stream_exc, "partial_text", "")),
-                        exc_info=True,
-                    )
+                    _partial_len = len(getattr(stream_exc, "partial_text", ""))
+                    if _is_connection_error(stream_exc.__cause__ or stream_exc):
+                        logger.warning(
+                            "Streaming failed after partial delivery (%d chars) "
+                            "due to connection error (%s), falling back to non-streaming",
+                            _partial_len,
+                            type(stream_exc.__cause__ or stream_exc).__name__,
+                        )
+                    else:
+                        logger.warning(
+                            "Streaming failed after partial delivery (%d chars), "
+                            "falling back to non-streaming with edit",
+                            _partial_len,
+                            exc_info=True,
+                        )
                     sent_msg = getattr(stream_exc, "sent_msg", None)
                     t_llm_start = time.monotonic()
                     create_kwargs: dict[str, Any] = {
@@ -912,7 +961,17 @@ async def generate_response(
                                 )
                     response_sent = delivered
                 else:
-                    logger.warning("Streaming failed, falling back to non-streaming", exc_info=True)
+                    if _is_connection_error(stream_exc):
+                        logger.warning(
+                            "Streaming failed due to connection error (%s), "
+                            "falling back to non-streaming",
+                            type(stream_exc).__name__,
+                        )
+                    else:
+                        logger.warning(
+                            "Streaming failed, falling back to non-streaming",
+                            exc_info=True,
+                        )
                     # Recovery path succeeded below; keep normal-success span level.
                     # Degraded mode is tracked via llm_stream_recovery=True.
                     t_llm_start = time.monotonic()
@@ -975,7 +1034,13 @@ async def generate_response(
                     getattr(usage, "completion_tokens", None)
                 )
     except Exception as e:
-        logger.exception("generate_response: LLM call failed, using fallback")
+        if _is_connection_error(e):
+            logger.warning(
+                "generate_response: LLM connection failed (%s), using fallback",
+                type(e).__name__,
+            )
+        else:
+            logger.exception("generate_response: LLM call failed, using fallback")
         _update_current_span(
             lf_client,
             level="ERROR",

--- a/tests/unit/services/test_generate_response.py
+++ b/tests/unit/services/test_generate_response.py
@@ -1287,3 +1287,248 @@ async def test_generate_response_works_when_langfuse_client_unavailable() -> Non
 
     assert result["response"] == "Ответ без tracing"
     client.chat.completions.create.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# #1408 — reduce noisy tracebacks for LLM connection failures
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connection_error_uses_logger_warning_not_exception() -> None:
+    """httpx.ConnectError must log via logger.warning() without a full traceback."""
+    from httpx import ConnectError
+
+    config, _ = _make_non_streaming_config()
+    config.create_llm.side_effect = ConnectError("connection refused")
+    lf = MagicMock()
+
+    with (
+        patch("telegram_bot.services.generate_response.get_client", return_value=lf),
+        patch("telegram_bot.services.generate_response.logger") as mock_logger,
+    ):
+        result = await generate_response(
+            query="Запрос",
+            documents=[],
+            config=config,
+            lf_client=lf,
+        )
+
+    assert "временно недоступен" in result["response"]
+    assert result["fallback_used"] is True
+    assert result["llm_provider_model"] == "fallback"
+
+    mock_logger.exception.assert_not_called()
+    mock_logger.warning.assert_called()
+    warning_msg = mock_logger.warning.call_args[0][0]
+    assert "LLM connection" in warning_msg or "connection" in warning_msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_openai_connection_error_uses_logger_warning_not_exception() -> None:
+    """openai.APIConnectionError must log via logger.warning() without a full traceback."""
+    from openai import APIConnectionError
+
+    config, _ = _make_non_streaming_config()
+    config.create_llm.side_effect = APIConnectionError(
+        message="connection error", request=MagicMock()
+    )
+    lf = MagicMock()
+
+    with (
+        patch("telegram_bot.services.generate_response.get_client", return_value=lf),
+        patch("telegram_bot.services.generate_response.logger") as mock_logger,
+    ):
+        result = await generate_response(
+            query="Запрос",
+            documents=[],
+            config=config,
+            lf_client=lf,
+        )
+
+    assert "временно недоступен" in result["response"]
+    assert result["fallback_used"] is True
+    assert result["llm_provider_model"] == "fallback"
+
+    mock_logger.exception.assert_not_called()
+    mock_logger.warning.assert_called()
+    warning_msg = mock_logger.warning.call_args[0][0]
+    assert "LLM connection" in warning_msg or "connection" in warning_msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_unexpected_error_still_uses_logger_exception() -> None:
+    """Non-connection exceptions (e.g. RuntimeError) must still log via logger.exception()."""
+    config, _ = _make_non_streaming_config()
+    config.create_llm.side_effect = RuntimeError("unexpected failure")
+    lf = MagicMock()
+
+    with (
+        patch("telegram_bot.services.generate_response.get_client", return_value=lf),
+        patch("telegram_bot.services.generate_response.logger") as mock_logger,
+    ):
+        result = await generate_response(
+            query="Запрос",
+            documents=[],
+            config=config,
+            lf_client=lf,
+        )
+
+    assert "временно недоступен" in result["response"]
+    assert result["fallback_used"] is True
+    assert result["llm_provider_model"] == "fallback"
+
+    mock_logger.exception.assert_called()
+    exception_msg = mock_logger.exception.call_args[0][0]
+    assert "LLM call failed" in exception_msg
+
+
+@pytest.mark.asyncio
+async def test_fallback_behavior_preserved_for_connection_error() -> None:
+    """Fallback response must still be generated when connection error occurs."""
+    from httpx import ConnectError
+
+    config, _ = _make_non_streaming_config()
+    config.create_llm.side_effect = ConnectError("connection refused")
+    lf = MagicMock()
+
+    with patch("telegram_bot.services.generate_response.get_client", return_value=lf):
+        result = await generate_response(
+            query="Запрос",
+            documents=[],
+            config=config,
+            lf_client=lf,
+        )
+
+    assert result["response"] == (
+        "⚠️ Извините, сервис временно недоступен.\n\nПопробуйте повторить запрос позже."
+    )
+    assert result["fallback_used"] is True
+    assert result["safe_fallback_used"] is False
+    assert result["llm_provider_model"] == "fallback"
+    assert result["llm_timeout"] is True
+
+
+@pytest.mark.asyncio
+async def test_fallback_with_documents_preserved_for_connection_error() -> None:
+    """Fallback with documents must still work when connection error occurs."""
+    from httpx import ConnectError
+
+    config, _ = _make_non_streaming_config()
+    config.create_llm.side_effect = ConnectError("connection refused")
+    lf = MagicMock()
+
+    with patch("telegram_bot.services.generate_response.get_client", return_value=lf):
+        result = await generate_response(
+            query="Запрос",
+            documents=[{"text": "Док", "score": 0.9, "metadata": {"title": "Тест"}}],
+            config=config,
+            lf_client=lf,
+        )
+
+    assert result["fallback_used"] is True
+    assert "Тест" in result["response"]
+    assert "Найденные результаты" in result["response"]
+
+
+@pytest.mark.asyncio
+async def test_connection_error_fallback_preserves_usage_and_timing_structure() -> None:
+    """Result dict structure (latency_stages, llm_call_count, etc.) preserved on connection error."""
+    from httpx import ConnectError
+
+    config, _ = _make_non_streaming_config()
+    config.create_llm.side_effect = ConnectError("connection refused")
+    lf = MagicMock()
+
+    with patch("telegram_bot.services.generate_response.get_client", return_value=lf):
+        result = await generate_response(
+            query="Запрос",
+            documents=[],
+            config=config,
+            lf_client=lf,
+            llm_call_count=3,
+            latency_stages={"retrieve": 0.5},
+        )
+
+    assert result["fallback_used"] is True
+    assert result["llm_call_count"] == 4  # input count (3) + 1
+    assert "generate" in result["latency_stages"]
+    assert "retrieve" in result["latency_stages"]
+    assert result["response_sent"] is False
+    assert result["sent_message"] is None
+    assert result["llm_ttft_ms"] == 0.0
+    assert result["grounding_mode"] == "normal"
+
+
+@pytest.mark.asyncio
+async def test_streaming_connection_error_logs_concise_warning() -> None:
+    """Streaming path connection error must log via logger.warning() without full traceback."""
+    from httpx import ConnectError
+
+    config, client = _make_non_streaming_config()
+    config.streaming_enabled = True
+    client.chat.completions.create = AsyncMock(side_effect=ConnectError("connection refused"))
+    config.create_llm.return_value = client
+
+    lf = MagicMock()
+    bot = AsyncMock()
+    bot.send_message_draft = AsyncMock(return_value=True)
+    message = AsyncMock()
+    message.chat = MagicMock(id=1)
+    message.bot = bot
+    message.answer = AsyncMock(return_value=None)
+
+    with (
+        patch("telegram_bot.services.generate_response.get_client", return_value=lf),
+        patch("telegram_bot.services.generate_response.logger") as mock_logger,
+    ):
+        result = await generate_response(
+            query="Запрос",
+            documents=[],
+            config=config,
+            lf_client=lf,
+            message=message,
+            raw_messages=[{"role": "user", "content": "Запрос"}],
+        )
+
+    assert result["fallback_used"] is True
+    assert result["llm_provider_model"] == "fallback"
+
+    mock_logger.exception.assert_not_called()
+    mock_logger.warning.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_streaming_non_connection_error_still_uses_exception() -> None:
+    """Streaming path unexpected error must still log via logger.exception() with full traceback."""
+    config, client = _make_non_streaming_config()
+    config.streaming_enabled = True
+    client.chat.completions.create = AsyncMock(side_effect=ValueError("invalid model"))
+    config.create_llm.return_value = client
+
+    lf = MagicMock()
+    bot = AsyncMock()
+    bot.send_message_draft = AsyncMock(return_value=True)
+    message = AsyncMock()
+    message.chat = MagicMock(id=1)
+    message.bot = bot
+    message.answer = AsyncMock(return_value=None)
+
+    with (
+        patch("telegram_bot.services.generate_response.get_client", return_value=lf),
+        patch("telegram_bot.services.generate_response.logger") as mock_logger,
+    ):
+        result = await generate_response(
+            query="Запрос",
+            documents=[],
+            config=config,
+            lf_client=lf,
+            message=message,
+            raw_messages=[{"role": "user", "content": "Запрос"}],
+        )
+
+    assert result["fallback_used"] is True
+
+    mock_logger.exception.assert_called()
+    exception_msg = mock_logger.exception.call_args[0][0]
+    assert "LLM call failed" in exception_msg


### PR DESCRIPTION
## Summary

Reduce noisy repeated full tracebacks for LLM connection failures in `generate_response.py` while preserving useful diagnostic information and safe fallback behavior.

## Changes

### `telegram_bot/services/generate_response.py`
- Add `_is_connection_error()` helper that detects `httpx.ConnectError` and `openai.APIConnectionError` as routine infrastructure noise.
- Main except block: connection errors log via `logger.warning()` with concise message (no full traceback). Non-connection/unexpected exceptions still use `logger.exception()` with full traceback.
- Streaming recovery paths: same pattern applied — connection errors get concise warning, other errors keep `exc_info=True`.
- Fallback response behavior unchanged for all error types.

### `tests/unit/services/test_generate_response.py`
- 8 new tests covering:
  - `httpx.ConnectError` → `logger.warning()`, no `exception()`
  - `openai.APIConnectionError` → `logger.warning()`, no `exception()`
  - `RuntimeError` (non-connection) → `logger.exception()` preserved
  - Fallback response text preserved for connection errors
  - Fallback with documents preserved for connection errors
  - Result dict structure preserved (latency_stages, llm_call_count, etc.)
  - Streaming path connection error → concise warning
  - Streaming path unexpected error → full traceback preserved

## Verification
- All 47 tests pass (39 existing + 8 new)
- Ruff lint and format clean
- Git diff --check clean

## Linked Issue
Closes #1408 (Slice 3)