### PR TITLE
feat(observability): mount telegram_bot ASGI /metrics endpoint (#2057)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -231,6 +231,10 @@ LANGFUSE_DOCKER_HOST=http://langfuse:3000
 # Each service sets a default automatically in Compose; override only when needed.
 # OTEL_SERVICE_NAME=telegram-bot
 
+# Prometheus /metrics ASGI port for the Telegram bot (#2057).
+# Default 9091; intentionally distinct from bge-m3-api default 9090 to avoid collision.
+# TELEGRAM_BOT_METRICS_PORT=9091
+
 # Content filter / guard
 # GUARD_MODE=hard                    # hard (block) | soft (flag+continue) | log (log only)
 # CONTENT_FILTER_ENABLED=true

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -100,6 +100,7 @@ from .integrations.polling_lock import RedisPollingLock
 from .keyboards.client_keyboard import (
     parse_menu_button,
 )
+from .metrics_server import MetricsServer
 from .middlewares import setup_error_handler, setup_throttling_middleware
 from .middlewares.fsm_cancel import FSMCancelMiddleware
 from .middlewares.langfuse_middleware import LangfuseContextMiddleware
@@ -544,6 +545,10 @@ class PropertyBot:
         # Track initialization state
         self._cache_initialized = False
         self._pre_agent_filter_extractor: Any | None = None
+
+        # Prometheus /metrics ASGI server (#2057). Bound during start(),
+        # released during stop().
+        self._metrics_server: MetricsServer | None = None
 
         # Setup middlewares (before handlers)
         self._setup_middlewares()
@@ -4007,6 +4012,16 @@ class PropertyBot:
             self._cache_initialized = True
             logger.info("Cache service ready")
 
+        # Bind the Prometheus /metrics ASGI server (#2057). Failure to bind
+        # is non-fatal: the bot keeps running with metrics scraping disabled
+        # and a WARNING is logged.
+        try:
+            self._metrics_server = MetricsServer()
+            await self._metrics_server.start_in_background()
+        except Exception:
+            logger.warning("Failed to start /metrics endpoint", exc_info=True)
+            self._metrics_server = None
+
         # Initialize conversation memory checkpointer (SDK)
         from .integrations.memory import create_fallback_checkpointer, create_redis_checkpointer
 
@@ -4565,6 +4580,16 @@ class PropertyBot:
     async def stop(self):
         """Stop bot and cleanup."""
         logger.info("Stopping bot...")
+        # Release the /metrics endpoint early so the port is freed even if a
+        # later teardown step raises (#2057).
+        if self._metrics_server is not None:
+            try:
+                await self._metrics_server.stop()
+            except Exception:
+                logger.warning("Failed to stop /metrics endpoint cleanly", exc_info=True)
+            finally:
+                self._metrics_server = None
+
         # Drain pending fire-and-forget history saves before tearing services down
         # so in-flight DB writes are not lost on shutdown (#1600). Bounded by
         # _history_save_drain_timeout_s so a stuck DB cannot block shutdown.

--- a/telegram_bot/metrics_server.py
+++ b/telegram_bot/metrics_server.py
@@ -1,0 +1,204 @@
+"""ASGI ``/metrics`` endpoint for the Telegram bot (#2057).
+
+Exposes the canonical Prometheus surface (``pipeline_latency_seconds`` and
+``rag_pipeline_events_total`` from :mod:`src.runtime.services.metrics`) on a
+dedicated port so operator dashboards can scrape the bot without going
+through the bge-m3-api process.
+
+Mirrors the ``services/bge-m3-api/app.py:make_asgi_app() + app.mount('/metrics', ...)``
+pattern recorded in ADR-0015 (SDK-native baseline). The bot has no
+ambient FastAPI app, so the ASGI surface is hosted by a dedicated uvicorn
+server bound to ``TELEGRAM_BOT_METRICS_PORT`` (default ``9091`` —
+intentionally distinct from the bge-m3-api default ``9090`` to avoid the
+documented port collision).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+from typing import Any
+
+from prometheus_client import make_asgi_app
+
+
+__all__ = ["MetricsServer", "make_metrics_app", "resolve_metrics_port"]
+
+
+logger = logging.getLogger(__name__)
+
+# Default avoids the bge-m3-api 9090 collision documented in #2057.
+DEFAULT_METRICS_PORT = 9091
+
+
+def make_metrics_app() -> Any:
+    """Return the SDK-native Prometheus ASGI application.
+
+    A thin wrapper around :func:`prometheus_client.make_asgi_app` so call
+    sites and tests do not need to import the SDK directly. The returned
+    callable is mounted by :class:`MetricsServer` (production) or driven
+    by ``httpx.ASGITransport`` (tests).
+    """
+    return make_asgi_app()
+
+
+def resolve_metrics_port(default: int = DEFAULT_METRICS_PORT) -> int:
+    """Resolve the metrics port from ``TELEGRAM_BOT_METRICS_PORT``.
+
+    Falls back to *default* (``9091``) on missing or invalid values, with a
+    ``WARNING`` log so operators notice misconfiguration without the bot
+    refusing to start.
+    """
+    raw = os.environ.get("TELEGRAM_BOT_METRICS_PORT", "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "TELEGRAM_BOT_METRICS_PORT=%r is not a valid int; falling back to %d",
+            raw,
+            default,
+        )
+        return default
+
+
+class MetricsServer:
+    """Background ``uvicorn`` server hosting the Prometheus ASGI app.
+
+    Designed to be created once at bot startup. ``start_in_background`` is
+    idempotent and ``stop`` is safe to call even if the server was never
+    started (so the bot's ``finally:`` shutdown branch can call it
+    unconditionally).
+
+    The actual ``uvicorn`` import and ``uvicorn.Server`` lifecycle are
+    deferred until ``start_in_background`` is awaited, so ``import``-time
+    errors in environments without the optional ``uvicorn`` extra do not
+    break bot startup outside the metrics endpoint path.
+    """
+
+    def __init__(self, *, port: int | None = None, host: str = "127.0.0.1") -> None:
+        self.host = host
+        self.port = port if port is not None else resolve_metrics_port()
+        self._server: Any | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._started = asyncio.Event()
+
+    @property
+    def bound_port(self) -> int | None:
+        """Return the OS-assigned port when ``port=0`` was used at init time."""
+        if self._server is None:
+            return None
+        servers = getattr(self._server, "servers", None) or []
+        for s in servers:
+            sockets = getattr(s, "sockets", None) or []
+            for sock in sockets:
+                getsockname = getattr(sock, "getsockname", None)
+                if callable(getsockname):
+                    try:
+                        return int(getsockname()[1])
+                    except (IndexError, TypeError, ValueError):
+                        continue
+        return self.port if self.port != 0 else None
+
+    async def start_in_background(self) -> None:
+        """Bind the metrics server and start serving in a background task."""
+        if self._task is not None and not self._task.done():
+            return  # Idempotent: already running.
+
+        try:
+            import uvicorn
+        except ImportError as exc:  # pragma: no cover — uvicorn ships in deps
+            logger.warning("uvicorn is not installed; /metrics endpoint disabled (%s)", exc)
+            return
+
+        # Pre-bind probe so a port collision does not reach uvicorn's
+        # ``sys.exit(1)`` branch (uvicorn aborts the whole process on
+        # OSError otherwise — see uvicorn/server.py:create_server). The
+        # probe is skipped when ``port=0`` because the OS picks a free port
+        # and there is no collision possible there.
+        if self.port != 0:
+            import socket as _socket
+
+            probe = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+            try:
+                probe.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, 1)
+                probe.bind((self.host, self.port))
+            except OSError as exc:
+                logger.warning(
+                    "Cannot bind metrics port %d on %s: %s — /metrics disabled",
+                    self.port,
+                    self.host,
+                    exc,
+                )
+                probe.close()
+                return
+            finally:
+                probe.close()
+
+        config = uvicorn.Config(
+            make_metrics_app(),
+            host=self.host,
+            port=self.port,
+            log_level="warning",
+            lifespan="off",
+            access_log=False,
+        )
+        self._server = uvicorn.Server(config)
+        # Disable signal handler installation (would conflict with the
+        # bot's own asyncio loop signal handlers).
+        self._server.install_signal_handlers = lambda: None  # type: ignore[method-assign]
+
+        self._started.clear()
+
+        async def _serve() -> None:
+            try:
+                await self._server.serve()
+            except SystemExit as exc:
+                # uvicorn calls ``sys.exit(1)`` on bind failure even with
+                # signal handlers disabled. Demote to a warning so the bot
+                # keeps running without /metrics.
+                logger.warning("Metrics server exited (uvicorn SystemExit): %s", exc)
+            except Exception:  # pragma: no cover — defensive
+                logger.exception("Metrics server crashed")
+
+        self._task = asyncio.create_task(_serve(), name="metrics-server")
+
+        # Wait until uvicorn binds before returning so callers can read
+        # ``bound_port`` immediately after ``await server.start_in_background()``.
+        for _ in range(50):  # up to ~5s
+            await asyncio.sleep(0.1)
+            servers = getattr(self._server, "servers", None) or []
+            if servers and any(getattr(s, "sockets", None) for s in servers):
+                self._started.set()
+                logger.info(
+                    "Metrics endpoint listening on http://%s:%d/metrics",
+                    self.host,
+                    self.bound_port or self.port,
+                )
+                return
+
+        logger.warning("Metrics server did not bind within timeout on port %d", self.port)
+
+    async def stop(self) -> None:
+        """Stop the background server. Safe to call even if never started."""
+        if self._server is None and self._task is None:
+            return
+
+        if self._server is not None:
+            self._server.should_exit = True
+
+        if self._task is not None:
+            with contextlib.suppress(asyncio.CancelledError):
+                try:
+                    await asyncio.wait_for(self._task, timeout=5.0)
+                except TimeoutError:
+                    self._task.cancel()
+                    with contextlib.suppress(BaseException):
+                        await self._task
+
+        self._server = None
+        self._task = None
+        self._started.clear()

--- a/tests/unit/test_metrics_server.py
+++ b/tests/unit/test_metrics_server.py
@@ -1,0 +1,218 @@
+"""Unit tests for telegram_bot.metrics_server (#2057).
+
+The bot exposes its Prometheus surface (``pipeline_latency_seconds`` and
+``rag_pipeline_events_total`` from ``src.runtime.services.metrics``) on a
+dedicated ASGI ``/metrics`` endpoint, mirroring the
+``services/bge-m3-api`` pattern.
+
+Verified shape via the Prometheus Python client docs:
+``prometheus_client.make_asgi_app()`` returns a Starlette-compatible ASGI
+callable that serves the registered metrics in text-format on the
+configured registry.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Module surface
+# ---------------------------------------------------------------------------
+
+
+def test_module_exports_expected_public_surface():
+    """The module must export the documented helpers."""
+    from telegram_bot import metrics_server
+
+    for name in ("make_metrics_app", "resolve_metrics_port", "MetricsServer"):
+        assert hasattr(metrics_server, name), (
+            f"telegram_bot.metrics_server must export {name} (#2057)."
+        )
+
+
+def test_make_metrics_app_returns_asgi_callable():
+    """``make_metrics_app()`` returns the prometheus_client ASGI app.
+
+    The test uses ``callable()`` rather than an isinstance check because
+    ``make_asgi_app`` returns a closure rather than a class instance.
+    """
+    from telegram_bot.metrics_server import make_metrics_app
+
+    app = make_metrics_app()
+    assert callable(app)
+
+
+# ---------------------------------------------------------------------------
+# Live ASGI behaviour
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_metrics(app) -> tuple[int, str]:
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://metrics") as client:
+        response = await client.get("/")
+    return response.status_code, response.text
+
+
+async def test_metrics_app_returns_pipeline_latency_seconds():
+    """The exposed surface must include the canonical pipeline latency Histogram."""
+    from src.runtime.services.metrics import pipeline_latency_seconds
+    from telegram_bot.metrics_server import make_metrics_app
+
+    # Force at least one observation so the metric appears in the export.
+    pipeline_latency_seconds.labels(stage="metrics-test").observe(0.001)
+
+    status, body = await _fetch_metrics(make_metrics_app())
+    assert status == 200
+    assert "pipeline_latency_seconds" in body, (
+        "Acceptance criterion: /metrics emits pipeline_latency_seconds (#2057)."
+    )
+
+
+async def test_metrics_app_returns_rag_pipeline_events_total():
+    """The exposed surface must include the canonical RAG events Counter."""
+    from src.runtime.services.metrics import rag_pipeline_events_total
+    from telegram_bot.metrics_server import make_metrics_app
+
+    # Force at least one increment so the counter appears in the export.
+    rag_pipeline_events_total.labels(event="metrics-test").inc()
+
+    status, body = await _fetch_metrics(make_metrics_app())
+    assert status == 200
+    assert "rag_pipeline_events_total" in body, (
+        "Acceptance criterion: /metrics emits rag_pipeline_events_total (#2057)."
+    )
+
+
+async def test_metrics_app_returns_text_format():
+    """Response content type must match the Prometheus text format contract."""
+    from telegram_bot.metrics_server import make_metrics_app
+
+    transport = httpx.ASGITransport(app=make_metrics_app())
+    async with httpx.AsyncClient(transport=transport, base_url="http://metrics") as client:
+        response = await client.get("/")
+
+    assert response.status_code == 200
+    content_type = response.headers.get("content-type", "")
+    assert "text/plain" in content_type, (
+        f"prometheus_client must return text/plain Prometheus exposition format. "
+        f"Got: {content_type!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Port resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_metrics_port_default_is_9091():
+    """Default port avoids the bge-m3-api 9090 collision (#2057 acceptance)."""
+    from telegram_bot.metrics_server import resolve_metrics_port
+
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("TELEGRAM_BOT_METRICS_PORT", None)
+        assert resolve_metrics_port() == 9091
+
+
+def test_resolve_metrics_port_reads_env_var():
+    from telegram_bot.metrics_server import resolve_metrics_port
+
+    with patch.dict(os.environ, {"TELEGRAM_BOT_METRICS_PORT": "9555"}):
+        assert resolve_metrics_port() == 9555
+
+
+def test_resolve_metrics_port_falls_back_on_invalid_value(caplog):
+    """Garbage env values must not crash the bot startup."""
+    from telegram_bot.metrics_server import resolve_metrics_port
+
+    with patch.dict(os.environ, {"TELEGRAM_BOT_METRICS_PORT": "not-a-number"}):
+        with caplog.at_level("WARNING"):
+            assert resolve_metrics_port() == 9091
+        assert any("TELEGRAM_BOT_METRICS_PORT" in r.message for r in caplog.records)
+
+
+def test_resolve_metrics_port_does_not_collide_with_bge_m3_api():
+    """Sanity guard for the documented 9090 vs 9091 split."""
+    from telegram_bot.metrics_server import resolve_metrics_port
+
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("TELEGRAM_BOT_METRICS_PORT", None)
+        # bge-m3-api default is 9090; we must not equal it by default.
+        assert resolve_metrics_port() != 9090
+
+
+# ---------------------------------------------------------------------------
+# MetricsServer lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_server_constructor_records_port():
+    from telegram_bot.metrics_server import MetricsServer
+
+    server = MetricsServer(port=9555)
+    assert server.port == 9555
+
+
+def test_metrics_server_default_port_uses_resolver():
+    """When no port is passed, fall back to ``resolve_metrics_port()``."""
+    from telegram_bot.metrics_server import MetricsServer
+
+    with patch.dict(os.environ, {"TELEGRAM_BOT_METRICS_PORT": "9777"}):
+        server = MetricsServer()
+        assert server.port == 9777
+
+
+async def test_metrics_server_start_in_background_is_idempotent():
+    """Calling ``start_in_background`` twice must not double-bind the port."""
+    from telegram_bot.metrics_server import MetricsServer
+
+    server = MetricsServer(port=0)  # port=0 so the OS picks a free one
+    try:
+        await server.start_in_background()
+        first_task = server._task
+        await server.start_in_background()
+        assert server._task is first_task, (
+            "Idempotency: a second start_in_background must reuse the running task."
+        )
+    finally:
+        await server.stop()
+
+
+async def test_metrics_server_stop_when_not_started_is_noop():
+    """Stopping a never-started server must not raise."""
+    from telegram_bot.metrics_server import MetricsServer
+
+    server = MetricsServer(port=0)
+    # Must not raise.
+    await server.stop()
+
+
+async def test_metrics_server_serves_pipeline_metrics_when_running():
+    """Integration: bind to a free port and curl /metrics for the canonical signals."""
+    pytest.importorskip("uvicorn")
+    from src.runtime.services.metrics import (
+        pipeline_latency_seconds,
+        rag_pipeline_events_total,
+    )
+    from telegram_bot.metrics_server import MetricsServer
+
+    pipeline_latency_seconds.labels(stage="metrics-server-it").observe(0.002)
+    rag_pipeline_events_total.labels(event="metrics-server-it").inc()
+
+    server = MetricsServer(port=0)
+    await server.start_in_background()
+    try:
+        bound_port = server.bound_port
+        assert bound_port is not None and bound_port > 0
+        async with httpx.AsyncClient(base_url=f"http://127.0.0.1:{bound_port}") as client:
+            response = await client.get("/metrics")
+        assert response.status_code == 200
+        assert "pipeline_latency_seconds" in response.text
+        assert "rag_pipeline_events_total" in response.text
+    finally:
+        await server.stop()


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Closes #2057. Slice 4 of #1648 (observability metrics consolidation).

## What this PR adds

`telegram_bot/metrics_server.py`:

| API | Purpose |
|---|---|
| `make_metrics_app()` | Thin wrapper around `prometheus_client.make_asgi_app()` (the SDK-native ASGI surface). |
| `resolve_metrics_port()` | Reads `TELEGRAM_BOT_METRICS_PORT`, defaults to `9091` — intentionally distinct from `bge-m3-api`'s default `9090` per the issue acceptance criterion. Falls back on invalid values with a `WARNING` log. |
| `MetricsServer` | Background `uvicorn` server hosting the ASGI app. Idempotent `start_in_background()`; safe `stop()`; pre-bind probe avoids `uvicorn` `sys.exit(1)` on port collisions; `SystemExit` and `Exception` both handled inside the task. |

Wiring in `telegram_bot/bot.py`:
- `self._metrics_server` lazy-initialised in `__init__`
- `start()` bootstraps the endpoint after cache init, non-fatal on bind failure
- `stop()` releases the port early so a later teardown failure doesn't hold it

`.env.example` documents `TELEGRAM_BOT_METRICS_PORT=9091` (commented out).

Mirrors the `services/bge-m3-api/app.py:make_asgi_app() + app.mount('/metrics', ...)` pattern recorded in ADR-0015.

## Tests (TDD, 14 cases)

`tests/unit/test_metrics_server.py` — written before implementation:

- Module exports public surface (`make_metrics_app`, `resolve_metrics_port`, `MetricsServer`).
- `make_metrics_app()` returns an ASGI callable.
- `/metrics` serves `pipeline_latency_seconds` Histogram.
- `/metrics` serves `rag_pipeline_events_total` Counter.
- `/metrics` returns Prometheus `text/plain` exposition format.
- Port default is `9091` (not `9090`).
- Port reads `TELEGRAM_BOT_METRICS_PORT` env var.
- Port falls back on invalid values with `WARNING` log.
- Port does not collide with `bge-m3-api` default.
- Constructor records explicit port.
- Constructor falls back to `resolve_metrics_port()` when port omitted.
- `start_in_background` is idempotent (second call reuses the running task).
- `stop` is safe to call when the server was never started.
- Integration: real `uvicorn` binding on a free port, `curl /metrics` returns both canonical metrics.

## Acceptance criterion (from #2057)

> `curl http://localhost:${TELEGRAM_BOT_METRICS_PORT:-9091}/metrics | grep -E 'pipeline_latency_seconds|rag_pipeline_events_total'`

Verified through the integration test (`test_metrics_server_serves_pipeline_metrics_when_running`) which binds to a free port via `port=0`, hits `GET /metrics`, and asserts both metric families appear in the response body. The sandbox cannot run the bot end-to-end, so the operator-side `curl` validation lives outside this PR.

## Verification

```
uv run --python 3.12 pytest tests/unit/test_metrics_server.py tests/unit/test_bot_handlers.py -q   # 212 passed
uv run --python 3.12 pytest tests/contract -q -n auto --dist=worksteal                              # 1152 passed, 4 skipped, 3 xfailed
uv run --python 3.12 ruff check ... && ruff format --check ...                                      # clean
```

## Known limitations

- The `bot.py` `start()` wiring catches every exception from `start_in_background()` and continues — failure to expose `/metrics` must never block bot startup. The reverse (a leaked port) is mitigated by the early `stop()` call in `bot.py.stop()`.
- Production exposure (i.e. surfacing the port outside the bot host) stays operator-controlled. Per the issue, exposure should be kept internal/local unless explicitly approved for production.

Refs #2057 #1648.