### PR TITLE
refactor(qdrant): extract _colbert_fallback_to_rrf helper (#1542 DRY)

### DIFF
--- a/src/runtime/services/qdrant.py
+++ b/src/runtime/services/qdrant.py
@@ -565,6 +565,69 @@ class QdrantService:
                 }
             return []
 
+    async def _colbert_fallback_to_rrf(
+        self,
+        *,
+        dense_vector: list[float],
+        sparse_vector: dict | None,
+        filters: dict | None,
+        top_k: int,
+        dense_weight: float,
+        sparse_weight: float,
+        rrf_k: int,
+        return_meta: bool,
+        fallback_reason: str,
+    ) -> tuple[Any, list[dict]]:
+        """Run RRF as a fallback for ColBERT search and emit the standard span output.
+
+        Extracted from ``hybrid_search_rrf_colbert`` (#1542) where the same
+        ~17-line block was inlined four times — once for each fallback
+        cause: ``colbert_unavailable``, ``empty_colbert_query``,
+        ``colbert_empty`` (post-query empty result), and
+        ``colbert_error:<ExcType>``.
+
+        Args:
+            dense_vector / sparse_vector / filters / top_k / dense_weight /
+            sparse_weight / rrf_k / return_meta: forwarded verbatim to
+                :meth:`hybrid_search_rrf`.
+            fallback_reason: human-readable cause used as the
+                ``fallback_reason`` field in the Langfuse span output.
+                Caller-controlled so the four sites stay observably
+                distinct in traces.
+
+        Returns:
+            ``(fallback, fallback_results)`` — ``fallback`` preserves the
+            shape :meth:`hybrid_search_rrf` returned (list or
+            ``(list, meta)`` tuple, mirroring ``return_meta``);
+            ``fallback_results`` is the flat list, already unwrapped, so
+            the caller can run post-fallback hooks (e.g., disabling
+            ColBERT for the collection on a non-empty fallback) without
+            re-doing the ``isinstance`` dance.
+        """
+        fallback = await self.hybrid_search_rrf(
+            dense_vector=dense_vector,
+            sparse_vector=sparse_vector,
+            filters=filters,
+            top_k=top_k,
+            dense_weight=dense_weight,
+            sparse_weight=sparse_weight,
+            rrf_k=rrf_k,
+            return_meta=return_meta,
+        )
+        fallback_results = fallback[0] if isinstance(fallback, tuple) else fallback
+        get_client().update_current_span(
+            output={
+                "fallback_reason": fallback_reason,
+                "results_count": len(fallback_results),
+                "top_score": fallback_results[0]["score"] if fallback_results else None,
+            },
+            metadata={
+                "collection": self._collection_name,
+                "quantization_mode": self._quantization_mode,
+            },
+        )
+        return fallback, fallback_results
+
     @observe(
         name="qdrant-hybrid-search-rrf-colbert",
         as_type="retriever",
@@ -628,7 +691,7 @@ class QdrantService:
                 "Qdrant ColBERT skipped: vector unavailable in collection %s; using RRF",
                 self._collection_name,
             )
-            fallback = await self.hybrid_search_rrf(
+            fallback, _ = await self._colbert_fallback_to_rrf(
                 dense_vector=dense_vector,
                 sparse_vector=sparse_vector,
                 filters=filters,
@@ -637,18 +700,7 @@ class QdrantService:
                 sparse_weight=sparse_weight,
                 rrf_k=rrf_k,
                 return_meta=return_meta,
-            )
-            fallback_results = fallback[0] if isinstance(fallback, tuple) else fallback
-            lf.update_current_span(
-                output={
-                    "fallback_reason": "colbert_unavailable",
-                    "results_count": len(fallback_results),
-                    "top_score": fallback_results[0]["score"] if fallback_results else None,
-                },
-                metadata={
-                    "collection": self._collection_name,
-                    "quantization_mode": self._quantization_mode,
-                },
+                fallback_reason="colbert_unavailable",
             )
             return fallback
 
@@ -656,7 +708,7 @@ class QdrantService:
             logger.warning(
                 "Qdrant ColBERT search skipped: empty query vectors, falling back to RRF"
             )
-            fallback = await self.hybrid_search_rrf(
+            fallback, _ = await self._colbert_fallback_to_rrf(
                 dense_vector=dense_vector,
                 sparse_vector=sparse_vector,
                 filters=filters,
@@ -665,18 +717,7 @@ class QdrantService:
                 sparse_weight=sparse_weight,
                 rrf_k=rrf_k,
                 return_meta=return_meta,
-            )
-            fallback_results = fallback[0] if isinstance(fallback, tuple) else fallback
-            lf.update_current_span(
-                output={
-                    "fallback_reason": "empty_colbert_query",
-                    "results_count": len(fallback_results),
-                    "top_score": fallback_results[0]["score"] if fallback_results else None,
-                },
-                metadata={
-                    "collection": self._collection_name,
-                    "quantization_mode": self._quantization_mode,
-                },
+                fallback_reason="empty_colbert_query",
             )
             return fallback
 
@@ -742,7 +783,7 @@ class QdrantService:
                     self._collection_name,
                 )
                 record_pipeline_event("colbert_fallback_to_rrf")
-                fallback = await self.hybrid_search_rrf(
+                fallback, fallback_results = await self._colbert_fallback_to_rrf(
                     dense_vector=dense_vector,
                     sparse_vector=sparse_vector,
                     filters=filters,
@@ -751,18 +792,7 @@ class QdrantService:
                     sparse_weight=sparse_weight,
                     rrf_k=rrf_k,
                     return_meta=return_meta,
-                )
-                fallback_results = fallback[0] if isinstance(fallback, tuple) else fallback
-                lf.update_current_span(
-                    output={
-                        "fallback_reason": "colbert_empty",
-                        "results_count": len(fallback_results),
-                        "top_score": fallback_results[0]["score"] if fallback_results else None,
-                    },
-                    metadata={
-                        "collection": self._collection_name,
-                        "quantization_mode": self._quantization_mode,
-                    },
+                    fallback_reason="colbert_empty",
                 )
                 if fallback_results:
                     self._colbert_available = False
@@ -808,7 +838,7 @@ class QdrantService:
                     "quantization_mode": self._quantization_mode,
                 },
             )
-            fallback = await self.hybrid_search_rrf(
+            fallback, _ = await self._colbert_fallback_to_rrf(
                 dense_vector=dense_vector,
                 sparse_vector=sparse_vector,
                 filters=filters,
@@ -817,18 +847,7 @@ class QdrantService:
                 sparse_weight=sparse_weight,
                 rrf_k=rrf_k,
                 return_meta=return_meta,
-            )
-            fallback_results = fallback[0] if isinstance(fallback, tuple) else fallback
-            lf.update_current_span(
-                output={
-                    "fallback_reason": f"colbert_error:{type(e).__name__}",
-                    "results_count": len(fallback_results),
-                    "top_score": fallback_results[0]["score"] if fallback_results else None,
-                },
-                metadata={
-                    "collection": self._collection_name,
-                    "quantization_mode": self._quantization_mode,
-                },
+                fallback_reason=f"colbert_error:{type(e).__name__}",
             )
             return fallback
 

--- a/src/runtime/services/qdrant.py
+++ b/src/runtime/services/qdrant.py
@@ -23,6 +23,9 @@ from src.runtime.services.metrics import record_pipeline_event
 
 logger = logging.getLogger(__name__)
 
+SearchResults = list[dict[Any, Any]]
+SearchReturn = SearchResults | tuple[SearchResults, dict[str, Any]]
+
 
 class QdrantService:
     """Smart Gateway for Qdrant with advanced search features.
@@ -577,7 +580,7 @@ class QdrantService:
         rrf_k: int,
         return_meta: bool,
         fallback_reason: str,
-    ) -> tuple[Any, list[dict]]:
+    ) -> tuple[SearchReturn, SearchResults]:
         """Run RRF as a fallback for ColBERT search and emit the standard span output.
 
         Extracted from ``hybrid_search_rrf_colbert`` (#1542) where the same
@@ -604,7 +607,7 @@ class QdrantService:
             ColBERT for the collection on a non-empty fallback) without
             re-doing the ``isinstance`` dance.
         """
-        fallback = await self.hybrid_search_rrf(
+        fallback: SearchReturn = await self.hybrid_search_rrf(
             dense_vector=dense_vector,
             sparse_vector=sparse_vector,
             filters=filters,

--- a/tests/unit/runtime/services/test_qdrant_colbert_fallback.py
+++ b/tests/unit/runtime/services/test_qdrant_colbert_fallback.py
@@ -1,0 +1,216 @@
+"""Unit tests for ``QdrantService._colbert_fallback_to_rrf`` (#1542 DRY fix).
+
+Issue #1542 flagged a ColBERT->RRF fallback pattern repeated 4 times inside
+``hybrid_search_rrf_colbert`` (qdrant.py). After the layering migration
+(#1948 / #2049) the file moved to ``src.runtime.services.qdrant`` but the
+duplication came along with it — line 631, 659, 744, 811 each contain the
+same ~17-line block:
+
+* call ``hybrid_search_rrf`` with the saved kwargs;
+* unwrap the optional ``(results, meta)`` tuple;
+* update the current Langfuse span with ``fallback_reason``,
+  ``results_count``, ``top_score`` and the standard collection metadata.
+
+This PR extracts the block into ``QdrantService._colbert_fallback_to_rrf``.
+The 4 call sites become a single line each. The test below pins:
+
+* the helper forwards every search kwarg to ``hybrid_search_rrf`` unchanged;
+* the helper unwraps both ``return_meta`` shapes (list and ``(list, meta)``);
+* the span output payload contains the expected ``fallback_reason``,
+  ``results_count`` and ``top_score`` fields, plus the standard collection
+  metadata;
+* the helper returns ``(raw_fallback, flat_results)`` so the caller can
+  preserve its return shape AND inspect the flat list (the existing
+  ``colbert_empty`` post-hook needs that to disable ColBERT).
+
+We avoid touching the integration tests around ``hybrid_search_rrf_colbert``
+itself (those are covered by ``tests/integration/test_colbert_backfill.py``
+and ``tests/unit/agents/test_rag_pipeline.py``) — this file targets the
+extracted seam only.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.runtime.services.qdrant import QdrantService
+
+
+def _make_service() -> QdrantService:
+    """Build a service shell with just the attributes the helper reads."""
+    service = QdrantService.__new__(QdrantService)
+    service._collection_name = "unit-collection"
+    service._quantization_mode = "binary"
+    return service
+
+
+@pytest.mark.asyncio
+async def test_colbert_fallback_forwards_search_kwargs(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _make_service()
+    expected_results = [{"id": "doc-1", "score": 0.91, "text": "hit"}]
+    service.hybrid_search_rrf = AsyncMock(return_value=expected_results)
+    fake_lf = MagicMock()
+    monkeypatch.setattr(
+        "src.runtime.services.qdrant.get_client",
+        lambda: fake_lf,
+    )
+
+    fallback, flat = await service._colbert_fallback_to_rrf(
+        dense_vector=[0.1, 0.2],
+        sparse_vector={"indices": [1], "values": [0.5]},
+        filters={"city": "Tashkent"},
+        top_k=7,
+        dense_weight=0.5,
+        sparse_weight=0.5,
+        rrf_k=60,
+        return_meta=False,
+        fallback_reason="colbert_unavailable",
+    )
+
+    service.hybrid_search_rrf.assert_awaited_once_with(
+        dense_vector=[0.1, 0.2],
+        sparse_vector={"indices": [1], "values": [0.5]},
+        filters={"city": "Tashkent"},
+        top_k=7,
+        dense_weight=0.5,
+        sparse_weight=0.5,
+        rrf_k=60,
+        return_meta=False,
+    )
+    assert fallback is expected_results
+    assert flat is expected_results
+
+
+@pytest.mark.asyncio
+async def test_colbert_fallback_unwraps_return_meta_tuple(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _make_service()
+    flat_results = [{"id": "doc-1", "score": 0.5}]
+    raw_meta = {"backend_error": False}
+    service.hybrid_search_rrf = AsyncMock(return_value=(flat_results, raw_meta))
+    monkeypatch.setattr(
+        "src.runtime.services.qdrant.get_client",
+        lambda: MagicMock(),
+    )
+
+    fallback, flat = await service._colbert_fallback_to_rrf(
+        dense_vector=[0.0],
+        sparse_vector=None,
+        filters=None,
+        top_k=5,
+        dense_weight=0.6,
+        sparse_weight=0.4,
+        rrf_k=60,
+        return_meta=True,
+        fallback_reason="empty_colbert_query",
+    )
+
+    assert fallback == (flat_results, raw_meta)
+    assert flat is flat_results
+
+
+@pytest.mark.asyncio
+async def test_colbert_fallback_emits_canonical_span_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _make_service()
+    flat_results = [{"id": "a", "score": 0.7}, {"id": "b", "score": 0.3}]
+    service.hybrid_search_rrf = AsyncMock(return_value=flat_results)
+    fake_lf = MagicMock()
+    monkeypatch.setattr(
+        "src.runtime.services.qdrant.get_client",
+        lambda: fake_lf,
+    )
+
+    await service._colbert_fallback_to_rrf(
+        dense_vector=[],
+        sparse_vector=None,
+        filters=None,
+        top_k=5,
+        dense_weight=0.6,
+        sparse_weight=0.4,
+        rrf_k=60,
+        return_meta=False,
+        fallback_reason="colbert_error:RuntimeError",
+    )
+
+    fake_lf.update_current_span.assert_called_once()
+    payload = fake_lf.update_current_span.call_args.kwargs
+    assert payload["output"] == {
+        "fallback_reason": "colbert_error:RuntimeError",
+        "results_count": 2,
+        "top_score": 0.7,
+    }
+    assert payload["metadata"] == {
+        "collection": "unit-collection",
+        "quantization_mode": "binary",
+    }
+
+
+@pytest.mark.asyncio
+async def test_colbert_fallback_handles_empty_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``top_score`` must be ``None`` when fallback returns no docs — the
+    existing call sites all rely on this exact shape, so we pin it here.
+    """
+    service = _make_service()
+    service.hybrid_search_rrf = AsyncMock(return_value=[])
+    fake_lf = MagicMock()
+    monkeypatch.setattr(
+        "src.runtime.services.qdrant.get_client",
+        lambda: fake_lf,
+    )
+
+    await service._colbert_fallback_to_rrf(
+        dense_vector=[],
+        sparse_vector=None,
+        filters=None,
+        top_k=5,
+        dense_weight=0.6,
+        sparse_weight=0.4,
+        rrf_k=60,
+        return_meta=False,
+        fallback_reason="colbert_empty",
+    )
+
+    payload = fake_lf.update_current_span.call_args.kwargs
+    assert payload["output"]["results_count"] == 0
+    assert payload["output"]["top_score"] is None
+
+
+def test_colbert_fallback_pattern_is_extracted_from_inline_callsites() -> None:
+    """Source-level guard: the four inline 'fallback = await self.hybrid_search_rrf(...)
+    + unwrap + update_current_span(output={fallback_reason: "<literal>"})' blocks inside
+    ``hybrid_search_rrf_colbert`` must collapse after the extraction.
+
+    The check counts span outputs whose ``fallback_reason`` is a non-None
+    string literal — those are exactly the four fallback emit sites the
+    helper now owns. The success path (which emits
+    ``"fallback_reason": None`` after a non-empty ColBERT result) and any
+    f-string variant inside the helper itself are intentionally not
+    flagged.
+
+    Allows future re-introduction (e.g., a 5th distinct fallback path)
+    without forbidding the helper itself, but flags any silent regression.
+    """
+    import inspect
+    import re
+
+    from src.runtime.services import qdrant as qdrant_module
+
+    source = inspect.getsource(qdrant_module)
+
+    # Match an inline span emit pattern with a string literal fallback_reason
+    # (single or double quoted), but NOT ``None``. The helper's own emit uses
+    # the parameter name (``"fallback_reason": fallback_reason``) which does
+    # not match the literal pattern.
+    inline_string_literal_emits = re.findall(
+        r'"fallback_reason":\s*[\'"][^\'\"]+[\'"]',
+        source,
+    )
+    assert len(inline_string_literal_emits) == 0, (
+        f"Found {len(inline_string_literal_emits)} inline ColBERT fallback "
+        f"span emit(s) with a string-literal fallback_reason. Route those "
+        f"through _colbert_fallback_to_rrf(...,fallback_reason='<reason>') "
+        f"instead. Offending matches: {inline_string_literal_emits!r}"
+    )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Refs #1542. Closes the ColBERT->RRF fallback DRY violation flagged in the issue table (row 1).

## Problem

`hybrid_search_rrf_colbert` had **four** copies of the same ~17-line ColBERT->RRF fallback block:

| Line (post-#1948) | Cause | Side-effect after fallback |
|---|---|---|
| 631 | `colbert_unavailable` (cached signal) | none |
| 659 | `empty_colbert_query` (no query vectors) | none |
| 744 | `colbert_empty` (rerank returned 0 docs) | sets `_colbert_available = False` |
| 811 | `colbert_error:<ExcType>` (in `except`) | none |

Each block called `hybrid_search_rrf(**eight kwargs)`, unwrapped the optional `(results, meta)` tuple, and emitted a `lf.update_current_span(output={fallback_reason, results_count, top_score}, metadata={collection, quantization_mode})`. The block was re-introduced verbatim at every site.

## Fix

Extract `QdrantService._colbert_fallback_to_rrf(*, ..., fallback_reason)` returning `(fallback, fallback_results)`:

- `fallback` preserves the caller's return shape (list or `(list, meta)` tuple).
- `fallback_results` is the flat list, already unwrapped, so the existing `colbert_empty` post-hook can disable ColBERT without redoing the `isinstance` dance.

Each callsite shrinks to ~10 lines (down from ~20), with the post-hook only on the `colbert_empty` path.

## TDD

`tests/unit/runtime/services/test_qdrant_colbert_fallback.py` — 5 cases, written **before** the implementation:

1. Helper forwards every search kwarg to `hybrid_search_rrf` verbatim.
2. Helper unwraps the `(list, meta)` tuple when `return_meta=True`.
3. Helper emits the canonical span output payload (`fallback_reason`, `results_count`, `top_score`) plus collection metadata.
4. Helper handles empty fallback results (`top_score=None`).
5. **Source-level ratchet**: zero inline `'"fallback_reason": "<string-literal>"'` emits remain in `qdrant.py`. The success path (which emits `'"fallback_reason": None'`) and the helper's parameter-driven emit (`'"fallback_reason": fallback_reason'`) are intentionally not flagged. Future fallback paths must route through the helper.

## Validation

```
uv run --python 3.12 pytest tests/unit/runtime/services/test_qdrant_colbert_fallback.py -q
# 5 passed

uv run --python 3.12 pytest tests/contract/ tests/unit/runtime/ tests/unit/agents/test_rag_pipeline.py -q -n auto --dist=worksteal
# 1254 passed, 4 skipped (cocoindex), 3 xfailed (#1532 legacy ingestion, unrelated)

uv run ruff check src/runtime/services/qdrant.py tests/unit/runtime/services/test_qdrant_colbert_fallback.py
# All checks passed!
```

## Scope note

This PR addresses the **first** row of #1542's DRY table (ColBERT fallback ×4). The remaining items (`_state_apartment_results` ×2 already done; `generate_response` 562->1201 lines, `on_pref_*_selected` 8->16 handlers, BGE-M3 encode boilerplate) are independent refactors and would each warrant their own PR. I'm leaving #1542 open until the rest of the table is addressed.

Refs #1542 #2049.