### PR TITLE
test(audit): #1515 D5 — remove 6 redundant get_client patches + ratchet

### DIFF
--- a/tests/contract/test_no_redundant_get_client_patches_contract.py
+++ b/tests/contract/test_no_redundant_get_client_patches_contract.py
@@ -1,0 +1,82 @@
+"""Contract: no anonymous ``patch("telegram_bot.bot.get_client", return_value=MagicMock())``.
+
+Issue #1515 audit, **D5** — `tests/unit/test_bot_handlers.py` accumulated
+65+ near-identical ``patch("telegram_bot.bot.get_client", ...)`` calls.
+``tests/unit/conftest.py`` already provides an ``autouse=True``
+``mock_get_client`` fixture that patches ``telegram_bot.bot.get_client``
+with a ``MagicMock()`` whenever ``telegram_bot.bot`` is in ``sys.modules``.
+Tests that use the **anonymous** variant — i.e., they do not capture the
+patch result and do not need a specific mock instance — are redundant
+with the autouse fixture and should rely on it.
+
+This contract test pins that no test file (re)introduces the anonymous
+shape ``patch("telegram_bot.bot.get_client", return_value=MagicMock())``
+inside a ``with`` / ``patch`` stack. Tests that need to inspect the
+returned client (``return_value=mock_lf``, ``return_value=lf``, …) are
+**not** flagged: those are legitimate per-test overrides.
+
+The match is a literal substring scan to keep the rule unambiguous and
+trivially explainable in PR review. If you genuinely need an anonymous
+``MagicMock()`` override, the autouse fixture already gives you one —
+remove the inline ``patch`` and let the fixture handle it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TESTS_ROOT = REPO_ROOT / "tests"
+# The autouse ``mock_get_client`` fixture is defined in
+# ``tests/unit/conftest.py``. Only test files under ``tests/unit/`` get
+# the fixture, so the redundancy claim is scoped to that subtree.
+# Integration / smoke / e2e tests must keep their own explicit patch.
+GUARDED_ROOT = TESTS_ROOT / "unit"
+
+# Match the redundant pattern: a literal anonymous MagicMock() / Mock()
+# return_value on the bot.get_client patch. Tolerates whitespace around
+# the comma but not aliased variables.
+REDUNDANT_PATTERN = re.compile(
+    r'patch\(\s*["\']telegram_bot\.bot\.get_client["\']\s*,\s*'
+    r"return_value\s*=\s*(?:Magic)?Mock\(\)\s*\)"
+)
+
+
+def _python_test_files() -> list[Path]:
+    skip = {".git", ".venv", "venv", "__pycache__", ".pytest_cache"}
+    out: list[Path] = []
+    for path in GUARDED_ROOT.rglob("*.py"):
+        # Only inspect path segments BELOW tests/unit/ — outer worktree
+        # paths like ``.worktrees/<branch>/`` are not relevant to the
+        # rule and would otherwise cause the entire tree to be skipped
+        # under a ``git worktree add`` checkout.
+        rel_parts = path.relative_to(GUARDED_ROOT).parts
+        if any(part in skip for part in rel_parts):
+            continue
+        if path.name == Path(__file__).name:  # don't scan ourselves
+            continue
+        out.append(path)
+    return out
+
+
+def test_no_redundant_anonymous_get_client_patches() -> None:
+    offenders: dict[str, int] = {}
+    for path in _python_test_files():
+        text = path.read_text(encoding="utf-8")
+        matches = REDUNDANT_PATTERN.findall(text)
+        if matches:
+            offenders[str(path.relative_to(REPO_ROOT))] = len(matches)
+
+    if offenders:
+        details = "\n  ".join(f"{p}: {n}" for p, n in sorted(offenders.items()))
+        raise AssertionError(
+            "Anonymous patch('telegram_bot.bot.get_client', "
+            "return_value=MagicMock()) calls are redundant with the "
+            "autouse mock_get_client fixture in tests/unit/conftest.py "
+            "(#1515 audit D5). Drop the inline patch and let the fixture "
+            "handle it; if you actually need a specific mock, capture it "
+            "into a variable (return_value=mock_lf) so reviewers can see "
+            "the dependency.\n  " + details
+        )

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -4569,7 +4569,6 @@ class TestPreAgentCacheCheck:
 
         with (
             patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
-            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
             patch("telegram_bot.bot.propagate_attributes"),
             patch("telegram_bot.bot.create_callback_handler", return_value=None),
             patch("telegram_bot.bot.classify_query", return_value="FAQ"),
@@ -4607,7 +4606,6 @@ class TestPreAgentCacheCheck:
 
         with (
             patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
-            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
             patch("telegram_bot.bot.propagate_attributes"),
             patch("telegram_bot.bot.create_callback_handler", return_value=None),
             patch("telegram_bot.bot.classify_query", return_value="FAQ"),
@@ -4655,7 +4653,6 @@ class TestPreAgentCacheCheck:
 
         with (
             patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
-            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
             patch("telegram_bot.bot.propagate_attributes"),
             patch("telegram_bot.bot.create_callback_handler", return_value=None),
             patch("telegram_bot.bot.classify_query", return_value="FAQ"),
@@ -5033,7 +5030,6 @@ class TestPreAgentCacheCheck:
 
         with (
             patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
-            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
             patch("telegram_bot.bot.propagate_attributes"),
             patch("telegram_bot.bot.create_callback_handler", return_value=None),
             patch("telegram_bot.bot.classify_query", return_value="FAQ"),

--- a/tests/unit/test_bot_handlers_query.py
+++ b/tests/unit/test_bot_handlers_query.py
@@ -90,7 +90,6 @@ class TestHandleVoiceRecursionLimit:
 
         with (
             patch("telegram_bot.bot.build_graph", return_value=mock_graph),
-            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
             patch("telegram_bot.bot.write_langfuse_scores") as mock_write_scores,
             patch("telegram_bot.bot.propagate_attributes"),
             patch("telegram_bot.bot._write_voice_error_scores") as mock_error_scores,
@@ -129,7 +128,6 @@ class TestHandleVoiceRecursionLimit:
         caplog.set_level("INFO")
         with (
             patch("telegram_bot.bot.build_graph", return_value=mock_graph),
-            patch("telegram_bot.bot.get_client", return_value=MagicMock()),
             patch("telegram_bot.bot.propagate_attributes"),
             patch("telegram_bot.bot._write_voice_error_scores"),
         ):


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Refs #1515. Closes audit item **D5** (anonymous `get_client` patches).

## Problem

`tests/unit/test_bot_handlers.py` accumulated 65+ near-identical `patch("telegram_bot.bot.get_client", ...)` calls (D5 in the audit). `tests/unit/conftest.py` already provides an `autouse=True` `mock_get_client` fixture that does exactly:

```python
mock = MagicMock()
with patch("telegram_bot.bot.get_client", return_value=mock, create=True):
    yield mock
```

Any inline `patch("telegram_bot.bot.get_client", return_value=MagicMock())` with an **anonymous** `MagicMock()` is therefore redundant with the fixture — same patch target, same return shape, same lifetime (one-shot per test).

## Fix

Remove the 6 redundant inline patches and pin the absence with a contract test.

| File | Removed |
|---|---|
| `tests/unit/test_bot_handlers.py` | 4 |
| `tests/unit/test_bot_handlers_query.py` | 2 |

Tests that bind the mock into a named variable (`return_value=mock_lf` or `return_value=lf`) **stay** — they need a specific reference to assert against, which the autouse fixture cannot provide. 27 such legitimate sites remain.

## TDD / ratchet

`tests/contract/test_no_redundant_get_client_patches_contract.py` — written first (failed with 6 offenders), passes after the cleanup.

Scoped to `tests/unit/` because the autouse fixture only lives there. Integration / smoke / e2e tests must keep their own explicit patch (no fixture available). One worktree-specific subtlety baked in: `path.parts` is checked against the path **relative to** `tests/unit/` so checkouts under `.worktrees/<branch>/` are not silently skipped.

## Validation

```
uv run --python 3.12 pytest tests/contract/ -q --timeout=30 -n auto --dist=worksteal
# 1171 passed, 4 skipped (cocoindex), 3 xfailed (#1532, unrelated)

uv run --python 3.12 pytest tests/unit/test_bot_handlers.py tests/unit/test_bot_handlers_query.py -q
# 201 passed — no behaviour change from the fixture takeover

uv run ruff check / format --check
# clean
```

## Scope note

This PR addresses exactly one item from #1515 (D5). A follow-up close-out comment with the full audit phase status will land separately. The remaining tractable items (D1 `sample_context_chunks` dupe, A2 conftest split, A4 empty `src/governance/`, A6 empty `tests/eval/`, S5 long test names, S7 `src/api/schemas.py` direct tests) are independent and would each warrant its own PR.

Refs #1515.