### PR TITLE
feat(bot): add SDK-native Prometheus /metrics ASGI endpoint (#2057)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -177,6 +177,8 @@ LLM_MODEL=gpt-4o-mini
 
 # Telegram Bot (TELEGRAM_BOT_TOKEN defined above in required section)
 BOT_USERNAME=
+# Prometheus metrics ASGI server port (#2057). Internal-only; not exposed publicly.
+# TELEGRAM_BOT_METRICS_PORT=9091
 SUPERVISOR_MAX_TOKENS=1024
 # TTFT drift warning threshold (ms). Raise for reasoning models behind proxy (#675)
 TTFT_DRIFT_WARN_MS=500

--- a/.env.example
+++ b/.env.example
@@ -177,7 +177,9 @@ LLM_MODEL=gpt-4o-mini
 
 # Telegram Bot (TELEGRAM_BOT_TOKEN defined above in required section)
 BOT_USERNAME=
-# Prometheus metrics ASGI server port (#2057). Internal-only; not exposed publicly.
+# Prometheus metrics ASGI server (#2057). Internal-only; not exposed publicly.
+# Gate: set to 0/false/no to disable. Default 1 (enabled) for production.
+# TELEGRAM_BOT_METRICS_ENABLED=1
 # TELEGRAM_BOT_METRICS_PORT=9091
 SUPERVISOR_MAX_TOKENS=1024
 # TTFT drift warning threshold (ms). Raise for reasoning models behind proxy (#675)

--- a/docs/engineering/sdk-registry.md
+++ b/docs/engineering/sdk-registry.md
@@ -397,6 +397,26 @@ paths: "telegram_bot/**,src/**,mini_app/**,pyproject.toml"
   - НЕ использовать для основной генерации — только через LiteLLM unified routing
   - Прямой вызов Anthropic API = обход трейсинга Langfuse
 
+## prometheus_client
+- **triggers:** prometheus, metrics, histogram, counter, /metrics, make_asgi_app, REGISTRY, scrape
+- **context7_id:** /prometheus/client_python
+- **как_у_нас:**
+  - `src/runtime/services/metrics.py` — canonical SDK-native ``pipeline_latency_seconds`` (Histogram) and ``rag_pipeline_events_total`` (Counter) with default ``prometheus_client.REGISTRY``
+  - `telegram_bot/services/metrics.py` — back-compat re-export shim (#2047)
+  - `telegram_bot/metrics_server.py` — standalone ASGI ``/metrics`` endpoint using ``make_asgi_app()`` (#2057)
+  - `services/bge-m3-api/app.py:588-589` — canonical mount pattern: ``make_asgi_app()`` + ``app.mount("/metrics", metrics_app)``
+  - `telegram_bot/handlers/command_handlers.py::cmd_metrics` — admin ``/metrics`` Telegram command uses ``generate_latest()``
+- **паттерны:**
+  - BСЕГДА использовать package-wide default ``prometheus_client.REGISTRY`` — не создавать кастомный ``CollectorRegistry``
+  - ASGI экспозиция через ``make_asgi_app()`` (SDK-native)
+  - ``generate_latest()`` для текстового дампа (Telegram команда или дебаг)
+  - Метрики зарегистрированы на уровне модуля, а не внутри request-handler
+- **gotchas:**
+  - НЕ создавать кастомный ``CollectorRegistry()`` — ломает скрапинг через ``make_asgi_app``
+  - НЕ писать кастомный HTTP-сервер для метрик — использовать ``make_asgi_app()`` + ``uvicorn``
+  - ``TELEGRAM_BOT_METRICS_PORT`` (default 9091) — internal-only exposure
+  - Контрактный тест: ``tests/contract/test_no_custom_metrics_registry_contract.py``
+
 ---
 
 ## Шаблон для нового SDK

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -528,6 +528,12 @@ class PropertyBot:
         self._polling_lock_consecutive_failures: int = 0
         self._polling_lock_owner: str | None = None
 
+        # Prometheus metrics ASGI server (#2057).
+        # Started in start() alongside the aiogram polling loop and
+        # exposes the default prometheus_client.REGISTRY on
+        # TELEGRAM_BOT_METRICS_PORT (default 9091).
+        self._metrics_server: Any | None = None
+
         # Bounded fan-out for fire-and-forget history persistence (#1600).
         # Without a bound the text path could accumulate unbounded background
         # tasks under burst traffic / slow DB writes. Track every spawned save
@@ -4508,7 +4514,7 @@ class PropertyBot:
                 BotCommand(command="clear", description="Очистить историю диалога"),
                 BotCommand(command="history", description="Поиск по истории диалогов"),
                 BotCommand(command="stats", description="Статистика кеша"),
-                BotCommand(command="metrics", description="Метрики пайплайна (p50/p95)"),
+                BotCommand(command="metrics", description="Метрики пайплайна (Prometheus)"),
                 BotCommand(command="clearcache", description="Очистить кеш Redis"),
             ]
         )
@@ -4570,6 +4576,18 @@ class PropertyBot:
             )
             self._polling_lock_scheduler.start()
 
+        # Start Prometheus metrics ASGI server on TELEGRAM_BOT_METRICS_PORT (#2057).
+        try:
+            from .metrics_server import start_metrics_server as _start_metrics
+
+            self._metrics_server = await _start_metrics()
+        except Exception:
+            logger.warning(
+                "Failed to start Prometheus metrics ASGI server; /metrics HTTP "
+                "endpoint will be unavailable. Check TELEGRAM_BOT_METRICS_PORT.",
+                exc_info=True,
+            )
+
         try:
             await self.dp.start_polling(self.bot)
         finally:
@@ -4612,6 +4630,21 @@ class PropertyBot:
     async def stop(self):
         """Stop bot and cleanup."""
         logger.info("Stopping bot...")
+
+        # Stop Prometheus metrics ASGI server (#2057).
+        if self._metrics_server is not None:
+            try:
+                from .metrics_server import stop_metrics_server
+
+                await stop_metrics_server(self._metrics_server)
+            except Exception:
+                logger.warning(
+                    "Failed to stop metrics server cleanly",
+                    exc_info=True,
+                )
+            finally:
+                self._metrics_server = None
+
         # Drain pending fire-and-forget history saves before tearing services down
         # so in-flight DB writes are not lost on shutdown (#1600). Bounded by
         # _history_save_drain_timeout_s so a stuck DB cannot block shutdown.

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -4577,16 +4577,20 @@ class PropertyBot:
             self._polling_lock_scheduler.start()
 
         # Start Prometheus metrics ASGI server on TELEGRAM_BOT_METRICS_PORT (#2057).
-        try:
-            from .metrics_server import start_metrics_server as _start_metrics
+        # Gated by TELEGRAM_BOT_METRICS_ENABLED so unit tests do not
+        # accidentally bind a real listening port.  The default is "1"
+        # (enabled) for backward-compatible production behaviour.
+        if os.getenv("TELEGRAM_BOT_METRICS_ENABLED", "1") in ("1", "true", "yes"):
+            try:
+                from .metrics_server import start_metrics_server as _start_metrics
 
-            self._metrics_server = await _start_metrics()
-        except Exception:
-            logger.warning(
-                "Failed to start Prometheus metrics ASGI server; /metrics HTTP "
-                "endpoint will be unavailable. Check TELEGRAM_BOT_METRICS_PORT.",
-                exc_info=True,
-            )
+                self._metrics_server = await _start_metrics()
+            except BaseException:
+                logger.warning(
+                    "Failed to start Prometheus metrics ASGI server; /metrics HTTP "
+                    "endpoint will be unavailable. Check TELEGRAM_BOT_METRICS_PORT.",
+                    exc_info=True,
+                )
 
         try:
             await self.dp.start_polling(self.bot)

--- a/telegram_bot/handlers/command_handlers.py
+++ b/telegram_bot/handlers/command_handlers.py
@@ -106,7 +106,8 @@ async def cmd_help(bot: PropertyBot, message: Message) -> None:
         "/clear - Очистить историю диалога\n"
         "/stats - Показать статистику кеша\n"
         "/history <запрос> - Поиск по истории диалогов\n"
-        "/metrics - Метрики пайплайна (p50/p95)\n"
+        "/metrics - Метрики пайплайна (Prometheus)\n"
+        "HTTP: http://localhost:9091/metrics (Prometheus scrape endpoint)\n"
         "/clearcache - Очистить кеш Redis\n"
     )
 

--- a/telegram_bot/metrics_server.py
+++ b/telegram_bot/metrics_server.py
@@ -1,0 +1,136 @@
+"""Standalone Prometheus metrics ASGI server for the Telegram bot.
+
+Issue #2057: expose the SDK-native ``prometheus_client`` default registry
+via a lightweight ASGI ``/metrics`` endpoint using
+:func:`prometheus_client.make_asgi_app`.  The server runs on
+``TELEGRAM_BOT_METRICS_PORT`` (default 9091) alongside the aiogram
+polling loop and is exposed only on localhost / internal networking.
+
+Context7 baseline (``/prometheus/client_python``):
+    ``make_asgi_app()`` returns an ASGI application that exposes the
+    default ``prometheus_client.REGISTRY``.  The canonical FastAPI/Starlette
+    mounting pattern is ``app.mount("/metrics", make_asgi_app())``.
+
+The local pattern in ``services/bge-m3-api/app.py:588-589`` confirms the
+same approach is used across the repository:
+
+    .. code-block:: python
+
+        from prometheus_client import make_asgi_app
+
+        metrics_app = make_asgi_app()
+        app.mount("/metrics", metrics_app)
+
+For the bot the ASGI app is served standalone (no FastAPI parent) because
+the bot runtime is aiogram-based, not ASGI-based.
+
+Refs #2057.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import uvicorn
+from prometheus_client import make_asgi_app
+
+
+logger = logging.getLogger(__name__)
+
+# Default port for the metrics endpoint.  Override with
+# TELEGRAM_BOT_METRICS_PORT environment variable.
+DEFAULT_METRICS_PORT: int = int(os.getenv("TELEGRAM_BOT_METRICS_PORT", "9091"))
+
+
+def create_metrics_app() -> Any:
+    """Create an ASGI application that exposes Prometheus metrics.
+
+    Uses :func:`prometheus_client.make_asgi_app` with the package-wide
+    default ``prometheus_client.REGISTRY``.  No custom
+    ``CollectorRegistry`` is used.
+
+    Returns:
+        An ASGI application callable serving the Prometheus text format
+        at its root path (``/``).
+    """
+    return make_asgi_app()
+
+
+async def start_metrics_server(
+    *,
+    host: str = "127.0.0.1",
+    port: int | None = None,
+    log_level: str | None = None,
+) -> uvicorn.Server:
+    """Start a uvicorn ASGI server for the Prometheus ``/metrics`` endpoint.
+
+    The server runs as an asyncio background task so the aiogram polling
+    loop is not blocked.  Call :func:`stop_metrics_server` to shut it down
+    gracefully.
+
+    Args:
+        host: Bind address (default ``"127.0.0.1"`` — internal only).
+        port: Port to listen on (default ``TELEGRAM_BOT_METRICS_PORT``
+            env or ``9091``).
+        log_level: Uvicorn log level (default ``"info"``).
+
+    Returns:
+        A ``uvicorn.Server`` instance whose shutdown is controlled by
+        ``stop_metrics_server``.
+    """
+    if port is None:
+        port = DEFAULT_METRICS_PORT
+    if log_level is None:
+        log_level = "info"
+
+    app = create_metrics_app()
+    config = uvicorn.Config(
+        app=app,
+        host=host,
+        port=port,
+        log_level=log_level,
+        # The bot owns its own event loop (aiogram polling); avoid
+        # uvicorn trying to install its own signal handlers or manage
+        # event-loop lifecycle.
+        loop="asyncio",
+    )
+    server = uvicorn.Server(config)
+
+    logger.info(
+        "Starting Prometheus metrics ASGI server on %s:%s",
+        host,
+        port,
+    )
+
+    # Run the server as a concurrent task so the bot polling loop is not
+    # blocked.
+    import asyncio
+
+    __metrics_server_task = asyncio.create_task(server.serve(), name="metrics-server")
+    # Store a reference on the server object so the task is not garbage-
+    # collected; the dunder prefix signals "internal — do not touch".
+    server._metrics_task = __metrics_server_task  # type: ignore[attr-defined]
+
+    # Let the server bind its socket before returning.
+    await asyncio.sleep(0.1)
+
+    return server
+
+
+async def stop_metrics_server(server: uvicorn.Server) -> None:
+    """Stop a running uvicorn metrics server gracefully.
+
+    Args:
+        server: The ``uvicorn.Server`` instance returned by
+            :func:`start_metrics_server`.
+    """
+    if server is None:
+        return
+    logger.info("Stopping Prometheus metrics ASGI server")
+    server.should_exit = True
+    # Give the server a moment to drain
+    import asyncio
+
+    await asyncio.sleep(0.1)

--- a/telegram_bot/metrics_server.py
+++ b/telegram_bot/metrics_server.py
@@ -103,7 +103,7 @@ async def start_metrics_server(
         access_log=False,
     )
     server = uvicorn.Server(config)
-    server.install_signal_handlers = lambda: None  # type: ignore[method-assign]
+    server.install_signal_handlers = lambda: None  # type: ignore[attr-defined,method-assign]
 
     if not _port_can_bind(host, port):
         server.should_exit = True

--- a/telegram_bot/metrics_server.py
+++ b/telegram_bot/metrics_server.py
@@ -11,16 +11,6 @@ Context7 baseline (``/prometheus/client_python``):
     default ``prometheus_client.REGISTRY``.  The canonical FastAPI/Starlette
     mounting pattern is ``app.mount("/metrics", make_asgi_app())``.
 
-The local pattern in ``services/bge-m3-api/app.py:588-589`` confirms the
-same approach is used across the repository:
-
-    .. code-block:: python
-
-        from prometheus_client import make_asgi_app
-
-        metrics_app = make_asgi_app()
-        app.mount("/metrics", metrics_app)
-
 For the bot the ASGI app is served standalone (no FastAPI parent) because
 the bot runtime is aiogram-based, not ASGI-based.
 
@@ -29,8 +19,11 @@ Refs #2057.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import logging
 import os
+import socket
 from typing import Any
 
 import uvicorn
@@ -39,23 +32,49 @@ from prometheus_client import make_asgi_app
 
 logger = logging.getLogger(__name__)
 
-# Default port for the metrics endpoint.  Override with
-# TELEGRAM_BOT_METRICS_PORT environment variable.
-DEFAULT_METRICS_PORT: int = int(os.getenv("TELEGRAM_BOT_METRICS_PORT", "9091"))
+DEFAULT_METRICS_PORT = 9091
+
+
+def resolve_metrics_port(default: int = DEFAULT_METRICS_PORT) -> int:
+    """Resolve ``TELEGRAM_BOT_METRICS_PORT`` without import-time crashes."""
+    raw = os.getenv("TELEGRAM_BOT_METRICS_PORT", "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "TELEGRAM_BOT_METRICS_PORT=%r is not a valid integer; falling back to %d",
+            raw,
+            default,
+        )
+        return default
 
 
 def create_metrics_app() -> Any:
-    """Create an ASGI application that exposes Prometheus metrics.
-
-    Uses :func:`prometheus_client.make_asgi_app` with the package-wide
-    default ``prometheus_client.REGISTRY``.  No custom
-    ``CollectorRegistry`` is used.
-
-    Returns:
-        An ASGI application callable serving the Prometheus text format
-        at its root path (``/``).
-    """
+    """Create an ASGI application that exposes the default Prometheus registry."""
     return make_asgi_app()
+
+
+def _port_can_bind(host: str, port: int) -> bool:
+    """Return False when the configured metrics port is already occupied."""
+    if port == 0:
+        return True
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        probe.bind((host, port))
+    except OSError as exc:
+        logger.warning(
+            "Cannot bind Prometheus metrics server on %s:%d: %s; /metrics disabled",
+            host,
+            port,
+            exc,
+        )
+        return False
+    finally:
+        probe.close()
+    return True
 
 
 async def start_metrics_server(
@@ -64,73 +83,71 @@ async def start_metrics_server(
     port: int | None = None,
     log_level: str | None = None,
 ) -> uvicorn.Server:
-    """Start a uvicorn ASGI server for the Prometheus ``/metrics`` endpoint.
+    """Start a background uvicorn server for Prometheus metrics.
 
-    The server runs as an asyncio background task so the aiogram polling
-    loop is not blocked.  Call :func:`stop_metrics_server` to shut it down
-    gracefully.
-
-    Args:
-        host: Bind address (default ``"127.0.0.1"`` — internal only).
-        port: Port to listen on (default ``TELEGRAM_BOT_METRICS_PORT``
-            env or ``9091``).
-        log_level: Uvicorn log level (default ``"info"``).
-
-    Returns:
-        A ``uvicorn.Server`` instance whose shutdown is controlled by
-        ``stop_metrics_server``.
+    The bot must keep polling even when metrics cannot bind, so bind
+    failures and uvicorn ``SystemExit`` are downgraded to warnings.
     """
     if port is None:
-        port = DEFAULT_METRICS_PORT
+        port = resolve_metrics_port()
     if log_level is None:
-        log_level = "info"
+        log_level = "warning"
 
-    app = create_metrics_app()
     config = uvicorn.Config(
-        app=app,
+        app=create_metrics_app(),
         host=host,
         port=port,
         log_level=log_level,
-        # The bot owns its own event loop (aiogram polling); avoid
-        # uvicorn trying to install its own signal handlers or manage
-        # event-loop lifecycle.
         loop="asyncio",
+        lifespan="off",
+        access_log=False,
     )
     server = uvicorn.Server(config)
+    server.install_signal_handlers = lambda: None  # type: ignore[method-assign]
 
-    logger.info(
-        "Starting Prometheus metrics ASGI server on %s:%s",
-        host,
-        port,
-    )
+    if not _port_can_bind(host, port):
+        server.should_exit = True
+        return server
 
-    # Run the server as a concurrent task so the bot polling loop is not
-    # blocked.
-    import asyncio
+    logger.info("Starting Prometheus metrics ASGI server on %s:%s", host, port)
 
-    __metrics_server_task = asyncio.create_task(server.serve(), name="metrics-server")
-    # Store a reference on the server object so the task is not garbage-
-    # collected; the dunder prefix signals "internal — do not touch".
-    server._metrics_task = __metrics_server_task  # type: ignore[attr-defined]
+    async def _serve() -> None:
+        try:
+            await server.serve()
+        except SystemExit as exc:
+            logger.warning("Prometheus metrics server exited during startup: %s", exc)
+        except Exception:
+            logger.warning("Prometheus metrics server stopped unexpectedly", exc_info=True)
 
-    # Let the server bind its socket before returning.
-    await asyncio.sleep(0.1)
+    task = asyncio.create_task(_serve(), name="metrics-server")
+    server._metrics_task = task  # type: ignore[attr-defined]
 
+    # Wait briefly for the socket to bind so startup races are visible in logs.
+    for _ in range(50):
+        await asyncio.sleep(0.1)
+        servers = getattr(server, "servers", None) or []
+        if servers and any(getattr(s, "sockets", None) for s in servers):
+            return server
+        if task.done():
+            return server
+
+    logger.warning("Prometheus metrics server did not bind within timeout on %s:%s", host, port)
     return server
 
 
 async def stop_metrics_server(server: uvicorn.Server) -> None:
-    """Stop a running uvicorn metrics server gracefully.
-
-    Args:
-        server: The ``uvicorn.Server`` instance returned by
-            :func:`start_metrics_server`.
-    """
+    """Stop a running uvicorn metrics server gracefully."""
     if server is None:
         return
     logger.info("Stopping Prometheus metrics ASGI server")
     server.should_exit = True
-    # Give the server a moment to drain
-    import asyncio
-
-    await asyncio.sleep(0.1)
+    task = getattr(server, "_metrics_task", None)
+    if task is None:
+        return
+    with contextlib.suppress(asyncio.CancelledError):
+        try:
+            await asyncio.wait_for(task, timeout=5.0)
+        except TimeoutError:
+            task.cancel()
+            with contextlib.suppress(BaseException):
+                await task

--- a/telegram_bot/pyproject.toml
+++ b/telegram_bot/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "phonenumbers>=9.0.25",
     "prometheus-client>=0.20.0,<1.0",
     "sentry-sdk>=2.0,<3.0",
+    "uvicorn>=0.30.0",
 ]
 
 [project.optional-dependencies]

--- a/telegram_bot/uv.lock
+++ b/telegram_bot/uv.lock
@@ -2085,6 +2085,7 @@ dependencies = [
     { name = "redisvl" },
     { name = "sentry-sdk" },
     { name = "tenacity" },
+    { name = "uvicorn" },
 ]
 
 [package.optional-dependencies]
@@ -2125,6 +2126,7 @@ requires-dist = [
     { name = "redisvl", specifier = ">=0.3.0" },
     { name = "sentry-sdk", specifier = ">=2.0,<3.0" },
     { name = "tenacity", specifier = ">=8.2.0" },
+    { name = "uvicorn", specifier = ">=0.30.0" },
     { name = "voyageai", marker = "extra == 'voyage'", specifier = ">=0.3.0" },
 ]
 provides-extras = ["voyage", "all"]
@@ -2567,6 +2569,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/22/14dbedb6b61f492d5524077fd10bbfb137583b0f0aafa6cd870ccb43f39a/uuid_utils-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:756575d082ea4cb7d2f923d5b640c0efe7c82573aab49220c4e09b62d13737ff", size = 169358, upload-time = "2026-05-19T07:45:05.146Z" },
     { url = "https://files.pythonhosted.org/packages/25/f4/a636806c98401a1108f2456e9cc3fa39a618145bfb1d0860c57203159cfe/uuid_utils-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:aa50261a83991dbb570a00573741455bd8f3249444f7329e5bdcd494799d1504", size = 174813, upload-time = "2026-05-19T07:45:59.579Z" },
     { url = "https://files.pythonhosted.org/packages/75/12/3823742459d87a100deb24bb6b41692aa961b267abd130fa7739cdf7d409/uuid_utils-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:22a17e93a371d850ffce8fcdbacc2239f890efe73aa3262b6170c1febc08afe1", size = 171733, upload-time = "2026-05-19T07:45:29.283Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
 ]
 
 [[package]]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -152,6 +152,11 @@ def isolate_otel_langfuse(monkeypatch):
     monkeypatch.setenv("LANGFUSE_HOST", "")
     monkeypatch.setenv("LANGFUSE_TRACING_ENABLED", "false")
     monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+    # Disable the uvicorn-based metrics server in unit tests (#2139).
+    # bot.start() would otherwise try to bind a real listening port
+    # (TELEGRAM_BOT_METRICS_PORT / 9091), causing SystemExit when the
+    # port is unavailable (e.g. in CI with concurrent workers).
+    monkeypatch.setenv("TELEGRAM_BOT_METRICS_ENABLED", "0")
 
     # Create no-op mocks
     mock_noop = MagicMock()

--- a/tests/unit/test_metrics_server.py
+++ b/tests/unit/test_metrics_server.py
@@ -7,6 +7,7 @@ metrics endpoint served via uvicorn as a lightweight ASGI app.
 from __future__ import annotations
 
 import asyncio
+import importlib
 import socket
 from contextlib import closing
 
@@ -16,6 +17,7 @@ from prometheus_client import REGISTRY, Histogram
 
 from telegram_bot.metrics_server import (
     create_metrics_app,
+    resolve_metrics_port,
     start_metrics_server,
     stop_metrics_server,
 )
@@ -80,6 +82,25 @@ class TestCreateMetricsApp:
             REGISTRY.unregister(test_histogram)
 
 
+class TestMetricsPortResolution:
+    def test_default_port_is_9091(self):
+        assert resolve_metrics_port() == 9091
+
+    def test_invalid_env_value_falls_back_without_import_crash(self, monkeypatch, caplog):
+        monkeypatch.setenv("TELEGRAM_BOT_METRICS_PORT", "not-an-int")
+        with caplog.at_level("WARNING"):
+            assert resolve_metrics_port() == 9091
+        assert "TELEGRAM_BOT_METRICS_PORT" in caplog.text
+
+        # Regression: this used to evaluate int(os.getenv(...)) at import time.
+        import telegram_bot.metrics_server as metrics_server
+
+        importlib.reload(metrics_server)
+        assert metrics_server.resolve_metrics_port() == 9091
+        monkeypatch.delenv("TELEGRAM_BOT_METRICS_PORT", raising=False)
+        importlib.reload(metrics_server)
+
+
 class TestMetricsServerLifecycle:
     """The uvicorn-based metrics server starts and stops cleanly."""
 
@@ -107,6 +128,24 @@ class TestMetricsServerLifecycle:
 
         # After stop, the port should be free again (give it a moment)
         await asyncio.sleep(0.3)
+
+    @pytest.mark.timeout(10)
+    async def test_occupied_port_does_not_raise_or_exit_process(self):
+        """A metrics port collision must disable /metrics, not kill the bot."""
+        port = _find_free_port()
+        blocker = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        blocker.bind(("127.0.0.1", port))
+        blocker.listen(1)
+        try:
+            server = await start_metrics_server(
+                host="127.0.0.1",
+                port=port,
+                log_level="error",
+            )
+            assert server.should_exit is True
+            assert getattr(server, "_metrics_task", None) is None
+        finally:
+            blocker.close()
 
     @pytest.mark.timeout(10)
     async def test_custom_port(self):

--- a/tests/unit/test_metrics_server.py
+++ b/tests/unit/test_metrics_server.py
@@ -1,0 +1,137 @@
+"""Smoke tests for the Prometheus metrics ASGI server (#2057).
+
+Validates the SDK-native ``prometheus_client.make_asgi_app()``
+metrics endpoint served via uvicorn as a lightweight ASGI app.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from contextlib import closing
+
+import httpx
+import pytest
+from prometheus_client import REGISTRY, Histogram
+
+from telegram_bot.metrics_server import (
+    create_metrics_app,
+    start_metrics_server,
+    stop_metrics_server,
+)
+
+
+def _find_free_port() -> int:
+    """Return a free port for testing."""
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("127.0.0.1", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]
+
+
+class TestCreateMetricsApp:
+    """The ASGI app created by create_metrics_app() serves Prometheus
+    exposition at the root path.
+    """
+
+    def test_app_is_asgi_app(self):
+        """create_metrics_app() returns a callable ASGI app."""
+        app = create_metrics_app()
+        assert callable(app), "must return a callable ASGI application"
+
+    async def test_metrics_endpoint_returns_prometheus_text(self):
+        """The ASGI app root returns valid Prometheus text format."""
+        app = create_metrics_app()
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/")
+            assert resp.status_code == 200
+            body = resp.text
+            # The default prometheus_client.REGISTRY always exposes at
+            # least process-level and Python GC metrics, so the output
+            # should be non-empty Prometheus text format.
+            assert body, "Response body must not be empty"
+            assert "HELP " in body or "# HELP " in body, "Body must contain Prometheus HELP lines"
+
+    async def test_metrics_endpoint_includes_registered_metric(self):
+        """A metric registered with the default REGISTRY appears in output."""
+        # Register a temporary test metric to verify integration
+        test_histogram = Histogram(
+            "test_metrics_server_smoke_seconds",
+            "Smoke-test metric for ASGI metrics endpoint.",
+            labelnames=("label",),
+        )
+        try:
+            test_histogram.labels(label="smoke").observe(0.42)
+            app = create_metrics_app()
+
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.get("/")
+                assert resp.status_code == 200
+                body = resp.text
+                assert "test_metrics_server_smoke_seconds" in body, (
+                    "Registered metric must appear in /metrics output"
+                )
+        finally:
+            REGISTRY.unregister(test_histogram)
+
+
+class TestMetricsServerLifecycle:
+    """The uvicorn-based metrics server starts and stops cleanly."""
+
+    @pytest.mark.timeout(10)
+    async def test_start_and_stop_server(self):
+        """A uvicorn server starts on the given port and can be stopped."""
+        port = _find_free_port()
+
+        server = await start_metrics_server(
+            host="127.0.0.1",
+            port=port,
+            log_level="error",
+        )
+
+        # Give uvicorn a moment to bind the port
+        await asyncio.sleep(0.3)
+
+        # Verify the server is actually listening
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(f"http://127.0.0.1:{port}/", timeout=3.0)
+                assert resp.status_code == 200
+        finally:
+            await stop_metrics_server(server)
+
+        # After stop, the port should be free again (give it a moment)
+        await asyncio.sleep(0.3)
+
+    @pytest.mark.timeout(10)
+    async def test_custom_port(self):
+        """Server respects the configured port."""
+        port = _find_free_port()
+
+        server = await start_metrics_server(
+            host="127.0.0.1",
+            port=port,
+            log_level="error",
+        )
+
+        await asyncio.sleep(0.3)
+
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(f"http://127.0.0.1:{port}/", timeout=3.0)
+                assert resp.status_code == 200
+
+                # Verify another port is NOT serving
+                other_port = _find_free_port()
+                if other_port != port:
+                    with pytest.raises(
+                        (httpx.ConnectError, httpx.ConnectTimeout),
+                    ):
+                        await client.get(f"http://127.0.0.1:{other_port}/", timeout=1.0)
+        finally:
+            await stop_metrics_server(server)


### PR DESCRIPTION
## Summary

Closes #2057 — expose the telegram_bot Prometheus metrics through an SDK-native ASGI `/metrics` endpoint using `prometheus_client.make_asgi_app()`.

## Context7 / SDK Evidence

- **Context7 `/prometheus/client_python`** confirms `make_asgi_app()` is the standard FastAPI/ASGI pattern for exposing the default registry.
- **Local pattern:** `services/bge-m3-api/app.py:588-589` — `metrics_app = make_asgi_app(); app.mount(/metrics, metrics_app)`
- **SDK registry:** `prometheus_client` section added to `docs/engineering/sdk-registry.md`

## Changes

| File | Change |
|------|--------|
| `telegram_bot/metrics_server.py` | **NEW** — ASGI app using `make_asgi_app()` + uvicorn lifecycle |
| `telegram_bot/bot.py` | Hook metrics server into `PropertyBot.start()` / `stop()` |
| `telegram_bot/pyproject.toml` | Add `uvicorn>=0.30.0` dependency |
| `telegram_bot/uv.lock` | Updated lock (uvicorn v0.48.0) |
| `telegram_bot/handlers/command_handlers.py` | Update `/help` text with HTTP endpoint info |
| `.env.example` | Add `TELEGRAM_BOT_METRICS_PORT=9091` |
| `docs/engineering/sdk-registry.md` | Add `prometheus_client` section |
| `tests/unit/test_metrics_server.py` | **NEW** — 5 smoke/lifecycle tests |

## Design

- Uses `prometheus_client.make_asgi_app()` with the **default `REGISTRY`** — no custom `CollectorRegistry`.
- Server runs as a **separate asyncio background task** alongside the aiogram polling loop.
- Default port: `TELEGRAM_BOT_METRICS_PORT=9091` (internal-only, bind to `127.0.0.1`).
- Startup is fail-safe: if the metrics server cannot start, the bot continues with a logged warning.
- Follows the same pattern as `services/bge-m3-api/app.py`.

## Tests

```
uv run pytest tests/contract/test_no_custom_metrics_registry_contract.py -q   # 4 passed
uv run pytest tests/contract/test_admin_metrics_uses_prometheus_contract.py -q # 2 passed
uv run pytest tests/unit/graph/test_metrics_instrumentation.py -q             # 9 passed
uv run pytest tests/unit/test_metrics_server.py -q                            # 5 passed
```

All 20 tests pass. Static analysis (Ruff) clean.