### PR TITLE
feat(docker): add preflight-bot guard for make bot / docker-bot-up (#2123, #2126)

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -213,6 +213,67 @@ For native bot startup it also resolves Redis in this order:
 2. `.env` value (`REDIS_URL=...`)
 3. derived local default from `REDIS_PASSWORD` as `redis://:REDIS_PASSWORD@localhost:6379`
 
+### Bot Runtime Environment Preflight
+
+```bash
+make preflight-bot
+```
+
+This target runs `scripts/probe/check_bot_runtime_env.py` and checks:
+
+* `.env` is present (otherwise the CI fallback `tests/fixtures/compose.ci.env`
+  is used — it contains **placeholder** credentials that are **not** valid for
+  real bot operation).
+* `TELEGRAM_BOT_TOKEN` is not the CI fallback value `123456789:ABC...fghi`.
+  Bot startup with this value will crash-loop with `TokenValidationError`.
+* LiteLLM port `4000` is published on the Docker host (if Docker is available).
+  A missing port binding is most often caused by a **stray third compose file**
+  that sets `litellm: {ports: []}`, overriding the `compose.dev.yml` mapping
+  of `"127.0.0.1:4000:4000"`.
+
+If issues are found `preflight-bot` exits non-zero, which blocks the
+`docker-bot-up` and `bot` targets. To run checks without blocking (e.g. in CI):
+
+```bash
+PREFLIGHT_BOT_FLAGS='--no-fail' make preflight-bot
+```
+
+The preflight is a **guardrail** — it explains what is wrong and how to fix
+it, but it cannot supply real credentials. You must provide a valid
+`TELEGRAM_BOT_TOKEN`, `LITELLM_MASTER_KEY`, and at least one provider key
+in `.env`.
+
+### Common `make bot` and `make docker-bot-up` failures
+
+| Symptom                                         | Likely cause                                    | Fix                                                                              |
+|-------------------------------------------------|-------------------------------------------------|----------------------------------------------------------------------------------|
+| Bot crash-loop, `TokenValidationError`          | `.env` is missing and CI fallback token is used | `cp .env.example .env` then set `TELEGRAM_BOT_TOKEN`, `LITELLM_MASTER_KEY`, and a provider key |
+| `curl localhost:4000` Connection Refused        | LiteLLM port not published; stray compose file  | Remove any stray compose files (e.g. `/tmp/compose.postgres-root.yml`) that override `litellm` ports, then `make docker-bot-up` |
+| Redis auth `WRONGPASS` / `NOAUTH` after `.env` change | `REDIS_PASSWORD` differs between `.env` and running container | `make local-redis-recreate` then `make test-bot-health` |
+| `make docker-bot-up` exits before starting      | `preflight-bot` detected issues (see #2123, #2126) | `make preflight-bot` for details, or `PREFLIGHT_BOT_FLAGS='--no-fail' make docker-bot-up` to bypass |
+| `make bot` exits before starting                | `preflight-bot` detected issues (see #2123, #2126) | `make preflight-bot` for details, or `PREFLIGHT_BOT_FLAGS='--no-fail' make bot` to bypass |
+
+### LiteLLM port recovery (stray compose file)
+
+A stray Compose file at `/tmp/compose.postgres-root.yml` was observed to clear
+`litellm` host ports (`ports: []`), overriding the `compose.dev.yml` mapping.
+This blocks LLM-dependent commands (`make bot`, `make test-bot-health`).
+
+Recovery:
+
+```bash
+# 1. Remove the stray compose file
+rm /tmp/compose.postgres-root.yml
+
+# 2. Restart litellm without the stray file
+COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility \
+  --env-file tests/fixtures/compose.ci.env \
+  --profile bot up -d --force-recreate litellm
+
+# 3. Verify the port
+curl -fsS http://localhost:4000/health/liveliness
+```
+
 ## Local Release Gate
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@
 	git-hygiene git-hygiene-fix pr-hygiene issue-hygiene repo-cleanup repo-cleanup-force \
 	docker-clean docker-clean-aggressive
 	test-contract \
+	preflight-bot \
 	docs-check \
 	remote-docker-status remote-compose-config remote-docker-ps remote-env-sync remote-env-check \
 	remote-active-up remote-core-up remote-core-ps remote-core-logs remote-core-health remote-core-env-check \
@@ -374,7 +375,12 @@ test-redis: ## Verify Redis Query Engine is available
 	fi
 	@echo "$(GREEN)✓ Redis capabilities verified$(NC)"
 
-.PHONY: test-bot-health test-bot-health-vps
+.PHONY: test-bot-health test-bot-health-vps preflight-bot
+
+PREFLIGHT_BOT_FLAGS ?=
+
+preflight-bot: ## Check bot runtime env before starting (missing .env, invalid token, port issues)
+	@uv run python scripts/probe/check_bot_runtime_env.py $(PREFLIGHT_BOT_FLAGS)
 
 test-bot-health: ## Preflight: verify local native-bot prerequisites (Redis/Qdrant/LiteLLM + optional Postgres note)
 	@echo "$(BLUE)Running bot health preflight...$(NC)"
@@ -599,7 +605,7 @@ docker-core-up: ## Start default local compose stack (unprofiled services)
 	$(LOCAL_COMPOSE_CMD) up -d
 	@echo "$(GREEN)✓ Core services started$(NC)"
 
-docker-bot-up: ## Start core + bot services (litellm, bot)
+docker-bot-up: preflight-bot ## Start core + bot services (litellm, bot)
 	@echo "$(BLUE)Starting bot services...$(NC)"
 	$(LOCAL_COMPOSE_CMD) --profile bot up -d
 	@echo "$(GREEN)✓ Bot services started$(NC)"
@@ -719,7 +725,7 @@ local-up-ingest:  ## Start local services + docling for ingestion workflows
 run-bot:  ## Run bot locally (requires: make local-up)
 	uv run --env-file "$$RAG_RUNTIME_ENV_FILE" python -m telegram_bot.main
 
-bot:  ## Alias: run bot and tee output to logs/bot-run.log
+bot: preflight-bot ## Alias: run bot and tee output to logs/bot-run.log
 	@mkdir -p logs
 	@bash -o pipefail -c 'uv run --env-file "$$RAG_RUNTIME_ENV_FILE" python -m telegram_bot.main 2>&1 | tee logs/bot-run.log'; \
 	status=$$?; echo '[COMPLETE]'; exit $$status

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -82,6 +82,12 @@ curl -fsS http://localhost:8000/health
 curl -fsS http://localhost:5001/health
 ```
 
+Bot environment preflight (checks .env, token validity, port binding):
+
+```bash
+make preflight-bot
+```
+
 Bot preflight:
 
 ```bash
@@ -337,7 +343,10 @@ Swarm worktrees start from a fresh `origin/dev` checkout and do not contain the 
 
 ## 11. Common Issues
 
-- `docker-bot-up` fails immediately: missing required env variables in `.env`.
+- `docker-bot-up` fails immediately: missing required env variables in `.env`. Run `make preflight-bot` for a diagnostic report.
+- Bot crash-loops with `TokenValidationError`: `.env` is missing and the CI fallback `TELEGRAM_BOT_TOKEN=123456789:ABC...fghi` is not a valid Telegram token. `cp .env.example .env` then set real `TELEGRAM_BOT_TOKEN`, `LITELLM_MASTER_KEY`, and a provider key.
+- `curl localhost:4000` Connection Refused: LiteLLM port not published on host. See [`../DOCKER.md`](../DOCKER.md) "LiteLLM port recovery" — most often caused by a stray compose file at `/tmp/compose.postgres-root.yml` overriding the dev port mapping.
 - Slow first startup: BGE-M3 and Docling warm up and cache models.
 - Ingestion status empty: verify `GDRIVE_SYNC_DIR` and collection bootstrap.
 - Redis auth error (`WRONGPASS` / `NOAUTH`) after changing `.env` `REDIS_PASSWORD`: run `make local-redis-recreate`, then `make test-bot-health`.
+- `make docker-bot-up` or `make bot` exits before starting with no clear error: run `make preflight-bot` to see exactly what is missing. Use `PREFLIGHT_BOT_FLAGS='--no-fail'` to bypass the guardrail if you only need to start infrastructure.

--- a/scripts/probe/check_bot_runtime_env.py
+++ b/scripts/probe/check_bot_runtime_env.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import argparse
 import shutil
-import subprocess
+import subprocess  # nosec B404
 import sys
 from pathlib import Path
 from typing import NoReturn
@@ -41,12 +41,12 @@ from typing import NoReturn
 # Well-known CI fallback values that are NEVER valid for real bot operation
 # ---------------------------------------------------------------------------
 
-_CI_TELEGRAM_BOT_TOKEN = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi"
+_CI_TELEGRAM_BOT_TOKEN = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi"  # nosec B105
 
 # Regex-based format check:  <bot_id>:<bot_token>
 # aiogram.aiogram.utils.token.TokenValidationError is the authoritative check,
 # but we also want to catch the exact CI placeholder value before any SDK call.
-_TOKEN_PATTERN = r"^\d+:[A-Za-z\d_-]{35,}$"
+_TOKEN_PATTERN = r"^\d+:[A-Za-z\d_-]{35,}$"  # nosec B105
 
 # ---------------------------------------------------------------------------
 # Env file resolution (mirrors Makefile LOCAL_COMPOSE_CMD / RUNTIME_ENV_FILE)
@@ -143,7 +143,8 @@ def _check_litellm_port() -> list[str]:
         return issues
 
     try:
-        cp = subprocess.run(
+        # nosec B603 B607: fixed docker subcommand with no shell expansion.
+        cp = subprocess.run(  # nosec B603
             [
                 "docker",
                 "inspect",

--- a/scripts/probe/check_bot_runtime_env.py
+++ b/scripts/probe/check_bot_runtime_env.py
@@ -143,8 +143,8 @@ def _check_litellm_port() -> list[str]:
         return issues
 
     try:
-        # nosec B603 B607: fixed docker subcommand with no shell expansion.
-        cp = subprocess.run(  # nosec B603
+        # fixed docker subcommand with no shell expansion.
+        cp = subprocess.run(  # nosec B603 B607
             [
                 "docker",
                 "inspect",

--- a/scripts/probe/check_bot_runtime_env.py
+++ b/scripts/probe/check_bot_runtime_env.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Preflight guard for ``make bot`` / ``make docker-bot-up`` runtime environment.
+
+Detects and explains:
+
+* missing ``.env`` file (CI fallback is used instead)
+* invalid/placeholder ``TELEGRAM_BOT_TOKEN`` that will crash the bot
+* ``LiteLLM`` ``localhost:4000`` not published (common stray-compose-file issue)
+
+Usage::
+
+    # Default: check the effective env file for local development
+    python scripts/probe/check_bot_runtime_env.py
+
+    # Explicit env file
+    python scripts/probe/check_bot_runtime_env.py --env-file .env
+
+    # Warn-only (exit 0 even when issues found — use in CI)
+    python scripts/probe/check_bot_runtime_env.py --no-fail
+
+Exit codes
+    0  all clear, or ``--no-fail`` was given
+    1  critical issues found — expect ``make bot`` / ``make docker-bot-up`` to fail
+    2  Docker not available (LiteLLM port check skipped, non-fatal)
+
+Related issues: `#2123 <https://github.com/yastman/rag/issues/2123>`_,
+`#2126 <https://github.com/yastman/rag/issues/2126>`_.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import NoReturn
+
+
+# ---------------------------------------------------------------------------
+# Well-known CI fallback values that are NEVER valid for real bot operation
+# ---------------------------------------------------------------------------
+
+_CI_TELEGRAM_BOT_TOKEN = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi"
+
+# Regex-based format check:  <bot_id>:<bot_token>
+# aiogram.aiogram.utils.token.TokenValidationError is the authoritative check,
+# but we also want to catch the exact CI placeholder value before any SDK call.
+_TOKEN_PATTERN = r"^\d+:[A-Za-z\d_-]{35,}$"
+
+# ---------------------------------------------------------------------------
+# Env file resolution (mirrors Makefile LOCAL_COMPOSE_CMD / RUNTIME_ENV_FILE)
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CI_ENV_FILE = _REPO_ROOT / "tests" / "fixtures" / "compose.ci.env"
+_ENV_EXAMPLE = _REPO_ROOT / ".env.example"
+_DOTENV = _REPO_ROOT / ".env"
+
+
+def _resolve_env_file(explicit: str | None) -> tuple[Path, bool]:
+    """Resolve the effective env file and whether .env was found.
+
+    Returns ``(env_file_path, dotenv_found)``.
+    """
+    if explicit:
+        p = Path(explicit)
+        return p.resolve(), p.name == ".env" and p.exists()
+    if _DOTENV.is_file():
+        return _DOTENV, True
+    return _CI_ENV_FILE, False
+
+
+# ---------------------------------------------------------------------------
+# Checks
+# ---------------------------------------------------------------------------
+
+
+def _check_env_presence(dotenv_found: bool) -> list[str]:
+    """Report whether .env is present or the CI fallback is active."""
+    issues: list[str] = []
+
+    if dotenv_found:
+        issues.append("  .env: found  ✓")
+    else:
+        issues.append("  .env: MISSING  ✗")
+        issues.append("    CI fallback env is active: tests/fixtures/compose.ci.env")
+        issues.append(
+            "    The CI fallback contains placeholder credentials that are "
+            "NOT valid for real bot operation."
+        )
+        issues.append("    Remediation:   cp .env.example .env   then fill real credentials.")
+    return issues
+
+
+def _check_telegram_token(env_file: Path) -> list[str]:
+    """Validate TELEGRAM_BOT_TOKEN from the effective env file."""
+    import re
+
+    issues: list[str] = []
+    token_value = _read_env_var(env_file, "TELEGRAM_BOT_TOKEN")
+
+    if token_value is None:
+        issues.append("  TELEGRAM_BOT_TOKEN: MISSING  ✗")
+        issues.append("    The bot will fail to start without a Telegram bot token.")
+        issues.append("    Remediation: set TELEGRAM_BOT_TOKEN in .env from @BotFather.")
+        return issues
+
+    # Exact match to the well-known CI fallback
+    if token_value == _CI_TELEGRAM_BOT_TOKEN:
+        issues.append("  TELEGRAM_BOT_TOKEN: CI placeholder  ✗")
+        issues.append(
+            "    Value is the CI-only fallback '123456789:ABC...fghi'. "
+            "This is NOT a real Telegram token."
+        )
+        issues.append("    Effect: the bot will crash-loop with TokenValidationError (see #2126).")
+        issues.append("    Remediation: set a real TELEGRAM_BOT_TOKEN in .env from @BotFather.")
+        return issues
+
+    if not re.match(_TOKEN_PATTERN, token_value):
+        issues.append("  TELEGRAM_BOT_TOKEN: possibly invalid format  ✗")
+        issues.append("    The token does not match the expected '<bot_id>:<token>' format.")
+        issues.append("    Effect: the bot will fail with TokenValidationError at startup.")
+        issues.append("    Remediation: verify your TELEGRAM_BOT_TOKEN in .env.")
+        return issues
+
+    issues.append("  TELEGRAM_BOT_TOKEN: present (real value)  ✓")
+    return issues
+
+
+def _check_litellm_port() -> list[str]:
+    """Check whether LiteLLM port 4000 is published on the Docker host.
+
+    This only runs when Docker is available.  A missing port binding is
+    most commonly caused by a stray third compose file
+    (e.g. ``/tmp/compose.postgres-root.yml``) that sets ``ports: []``,
+    overriding the ``compose.dev.yml`` ``"127.0.0.1:4000:4000"`` mapping.
+    """
+    issues: list[str] = []
+
+    if not shutil.which("docker"):
+        issues.append("  LiteLLM port: Docker not available (skipped)")
+        return issues
+
+    try:
+        cp = subprocess.run(
+            [
+                "docker",
+                "inspect",
+                "dev-litellm-1",
+                "--format",
+                "{{json .HostConfig.PortBindings}}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        issues.append("  LiteLLM port: Docker unreachable (skipped)")
+        return issues
+
+    if cp.returncode != 0:
+        issues.append("  LiteLLM port: container dev-litellm-1 not found (skipped)")
+        return issues
+
+    import json
+
+    try:
+        bindings = json.loads(cp.stdout.strip())
+    except json.JSONDecodeError:
+        issues.append("  LiteLLM port: could not parse Docker output (skipped)")
+        return issues
+
+    # When PortBindings is empty/null, no host ports are published.
+    if not bindings:
+        issues.append("  LiteLLM port 4000: NOT published on host  ✗")
+        issues.append("    dev-litellm-1 container is running but no host port mapping exists.")
+        issues.append(
+            "    Effect: LLM-dependent features (make bot, test-bot-health) "
+            "will fail with Connection Refused."
+        )
+        issues.append(
+            "    Common cause: a stray compose file (e.g. "
+            "/tmp/compose.postgres-root.yml) overrides the litellm port "
+            "binding from compose.dev.yml ('127.0.0.1:4000:4000')."
+        )
+        issues.append(
+            "    Remediation: remove any stray compose files overriding litellm "
+            "ports, then run: make docker-bot-up"
+        )
+    else:
+        issues.append("  LiteLLM port 4000: published  ✓")
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_env_var(env_file: Path, key: str) -> str | None:
+    """Read a single KEY=VALUE from a simple dotenv file (no shell syntax)."""
+    try:
+        text = env_file.read_text(encoding="utf-8")
+    except (FileNotFoundError, PermissionError):
+        return None
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        if k.strip() == key:
+            return v.strip()
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Preflight guard for make bot / make docker-bot-up.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=("Related: #2123 (restore Docker stack), #2126 (bot profile runtime).\n"),
+    )
+    p.add_argument(
+        "--env-file",
+        default=None,
+        help="Path to the effective env file (default: .env if present, else CI fixture)",
+    )
+    p.add_argument(
+        "--no-fail",
+        action="store_true",
+        help="Print issues but always exit 0 (e.g. in CI).",
+    )
+    p.add_argument(
+        "--skip-docker",
+        action="store_true",
+        help="Skip Docker/LiteLLM port checks.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> NoReturn:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    all_issues: list[str] = []
+    exit_code = 0
+
+    # Resolve effective env file
+    env_file, dotenv_found = _resolve_env_file(args.env_file)
+    all_issues.append("Bot runtime environment preflight")
+    all_issues.append(f"  Effective env file: {env_file}")
+    all_issues.append("")
+
+    # .env presence
+    all_issues.extend(_check_env_presence(dotenv_found))
+
+    # Empty separator
+    all_issues.append("")
+
+    # TELEGRAM_BOT_TOKEN
+    all_issues.extend(_check_telegram_token(env_file))
+
+    all_issues.append("")
+
+    # LiteLLM port (skip if requested or Docker not available)
+    if args.skip_docker:
+        all_issues.append("  LiteLLM port: skipped (--skip-docker)")
+    else:
+        all_issues.extend(_check_litellm_port())
+
+    all_issues.append("")
+
+    # Determine overall status
+    severity = _classify(all_issues)
+
+    if severity == "ok":
+        all_issues.append("All bot runtime preflight checks passed.")
+        exit_code = 0
+    else:
+        all_issues.append("One or more issues found. The bot may fail to start or operate.")
+        all_issues.append(
+            "Affected targets:   make bot   make docker-bot-up   make test-bot-health"
+        )
+        all_issues.append(
+            "For safe local development:   cp .env.example .env   "
+            "then fill TELEGRAM_BOT_TOKEN and a provider key."
+        )
+        exit_code = 1 if not args.no_fail else 0
+
+    out = "\n".join(all_issues) + "\n"
+    sys.stdout.write(out)
+    sys.exit(exit_code)
+
+
+def _classify(lines: list[str]) -> str:
+    """Return 'ok' if no ✗ markers, otherwise 'issues'."""
+    for line in lines:
+        if "✗" in line:
+            return "issues"
+    return "ok"
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/scripts/test_check_bot_runtime_env.py
+++ b/tests/unit/scripts/test_check_bot_runtime_env.py
@@ -1,0 +1,265 @@
+"""Tests for scripts/probe/check_bot_runtime_env.py — preflight guard for make bot / docker-bot-up."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path("scripts/probe/check_bot_runtime_env.py")
+
+CI_ENV_CONTENT = """\
+COMPOSE_PROJECT_NAME=dev
+TELEGRAM_BOT_TOKEN=123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi
+LITELLM_MASTER_KEY=test-litellm-master-key
+REDIS_PASSWORD=test-redis-password
+POSTGRES_PASSWORD=postgres
+"""
+
+VALID_ENV_CONTENT = """\
+COMPOSE_PROJECT_NAME=dev
+TELEGRAM_BOT_TOKEN=1234567890:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl
+LITELLM_MASTER_KEY=sk-real-master-key
+REDIS_PASSWORD=test-redis-password
+POSTGRES_PASSWORD=postgres
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helper: run the script with a specific env file
+# ---------------------------------------------------------------------------
+
+
+def _run_script(
+    env_file: Path | None = None,
+    no_fail: bool = False,
+    check_docker: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    args = [sys.executable, str(SCRIPT.resolve())]
+    if env_file:
+        args.extend(["--env-file", str(env_file)])
+    if no_fail:
+        args.append("--no-fail")
+    if not check_docker:
+        args.append("--skip-docker")
+    return subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        cwd=SCRIPT.parents[2],
+    )
+
+
+# ---------------------------------------------------------------------------
+# .env presence checks
+# ---------------------------------------------------------------------------
+
+
+def test_script_detects_missing_dotenv(tmp_path: Path) -> None:
+    """When the effective env file is the CI fallback, the script must warn
+    about the missing .env and explain the fallback behaviour."""
+    env_file = tmp_path / "compose.ci.env"
+    env_file.write_text(CI_ENV_CONTENT)
+
+    cp = _run_script(env_file=env_file)
+
+    combined = cp.stdout + cp.stderr
+    assert "missing" in combined.lower() or ".env not found" in combined.lower(), (
+        f"script must note .env is missing when using CI fallback; got:\n{combined}"
+    )
+    assert (
+        "ci fallback" in combined.lower()
+        or "fixture" in combined.lower()
+        or "compose.ci.env" in combined.lower()
+    ), f"script must explain CI fallback behaviour; got:\n{combined}"
+
+
+def test_script_detects_dotenv_present(tmp_path: Path) -> None:
+    """When the env file is .env, the script should not warn about missing .env."""
+    env_file = tmp_path / ".env"
+    env_file.write_text(VALID_ENV_CONTENT)
+
+    cp = _run_script(env_file=env_file)
+
+    combined = cp.stdout + cp.stderr
+    # Should NOT report .env as missing
+    assert "missing" not in combined.lower() or ".env not found" not in combined.lower(), (
+        f"script should not report .env missing when .env is used; got:\n{combined}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# TELEGRAM_BOT_TOKEN validation
+# ---------------------------------------------------------------------------
+
+
+def test_script_warns_on_ci_fallback_token(tmp_path: Path) -> None:
+    """When TELEGRAM_BOT_TOKEN matches the CI fallback value
+    (123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi), the script must warn
+    that this token is invalid and explain the bot will fail."""
+    env_file = tmp_path / "compose.ci.env"
+    env_file.write_text(CI_ENV_CONTENT)
+
+    cp = _run_script(env_file=env_file)
+
+    combined = cp.stdout + cp.stderr
+    assert "TELEGRAM_BOT_TOKEN" in combined, (
+        f"script must mention TELEGRAM_BOT_TOKEN; got:\n{combined}"
+    )
+    assert (
+        "invalid" in combined.lower()
+        or "placeholder" in combined.lower()
+        or "ci" in combined.lower()
+    ), f"script must indicate the token is a CI placeholder/invalid; got:\n{combined}"
+
+
+def test_script_reports_remediation_for_missing_env(tmp_path: Path) -> None:
+    """When .env is missing, the script must suggest creating one from
+    .env.example and filling credentials."""
+    env_file = tmp_path / "compose.ci.env"
+    env_file.write_text(CI_ENV_CONTENT)
+
+    cp = _run_script(env_file=env_file)
+
+    combined = cp.stdout + cp.stderr
+    assert ".env.example" in combined or "cp .env.example" in combined, (
+        f"script must reference .env.example as remediation; got:\n{combined}"
+    )
+
+
+def test_script_explains_token_validation_failure(tmp_path: Path) -> None:
+    """When TELEGRAM_BOT_TOKEN will cause a TokenValidationError, the script
+    must explain the crash behaviour (bot will restart/loop)."""
+    env_file = tmp_path / "compose.ci.env"
+    env_file.write_text(CI_ENV_CONTENT)
+
+    cp = _run_script(env_file=env_file)
+
+    combined = cp.stdout + cp.stderr
+    assert (
+        "crash" in combined.lower()
+        or "restart" in combined.lower()
+        or "fail" in combined.lower()
+        or "token" in combined.lower()
+    ), f"script must explain bot crash behaviour with placeholder token; got:\n{combined}"
+
+
+# ---------------------------------------------------------------------------
+# LiteLLM port binding warnings
+# ---------------------------------------------------------------------------
+
+
+def test_script_skips_docker_check_when_requested(tmp_path: Path) -> None:
+    """When --skip-docker is passed, LiteLLM port check must be skipped."""
+    env_file = tmp_path / "compose.ci.env"
+    env_file.write_text(CI_ENV_CONTENT)
+
+    cp = _run_script(env_file=env_file, check_docker=False)
+
+    combined = cp.stdout + cp.stderr
+    assert "skip" in combined.lower() or "docker" in combined.lower(), (
+        f"script must acknowledge Docker check is skipped; got:\n{combined}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Exit code behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_script_exits_nonzero_on_ci_fallback_env(tmp_path: Path) -> None:
+    """The script must fail fast (exit non-zero) when critical issues are found,
+    so Makefile targets can depend on it."""
+    env_file = tmp_path / "compose.ci.env"
+    env_file.write_text(CI_ENV_CONTENT)
+
+    cp = _run_script(env_file=env_file)
+
+    assert cp.returncode != 0, (
+        f"script must exit non-zero when .env is missing and CI fallback is used; "
+        f"got exit code {cp.returncode}"
+    )
+
+
+def test_script_exits_zero_with_no_fail_flag(tmp_path: Path) -> None:
+    """The --no-fail flag must suppress the non-zero exit so CI can still proceed."""
+    env_file = tmp_path / "compose.ci.env"
+    env_file.write_text(CI_ENV_CONTENT)
+
+    cp = _run_script(env_file=env_file, no_fail=True)
+
+    assert cp.returncode == 0, (
+        f"script must exit 0 with --no-fail, got {cp.returncode}\n"
+        f"stdout: {cp.stdout}\nstderr: {cp.stderr}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Script structure / contract checks
+# ---------------------------------------------------------------------------
+
+
+def test_script_exists_and_is_python() -> None:
+    """The script file must exist and be a Python script."""
+    assert SCRIPT.is_file(), f"{SCRIPT} not found"
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "python" in text.lower() or text.startswith("#!"), f"{SCRIPT} must be a Python script"
+
+
+def test_script_has_shebang_and_main_guard() -> None:
+    """The script must have proper shebang and __main__ guard for standalone use."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "#!/usr/bin/env python" in text, f"{SCRIPT} must have a Python shebang"
+    assert 'if __name__ == "__main__"' in text, (
+        f"{SCRIPT} must have a __main__ guard to allow import testing"
+    )
+
+
+def test_script_provides_help() -> None:
+    """The script must support --help for operator documentation."""
+    cp = subprocess.run(
+        [sys.executable, str(SCRIPT.resolve()), "--help"],
+        capture_output=True,
+        text=True,
+        cwd=SCRIPT.parents[2],
+    )
+    assert cp.returncode == 0, f"--help must exit 0, got {cp.returncode}"
+    assert "usage" in (cp.stdout + cp.stderr).lower(), (
+        f"--help must show usage; got:\n{cp.stdout}{cp.stderr}"
+    )
+
+
+def test_script_lists_affected_make_targets_in_help_or_output(tmp_path: Path) -> None:
+    """The script must mention affected make targets so operators know what
+    this preflight gates."""
+    env_file = tmp_path / "compose.ci.env"
+    env_file.write_text(CI_ENV_CONTENT)
+
+    cp = _run_script(env_file=env_file)
+
+    combined = cp.stdout + cp.stderr
+    assert (
+        "make bot" in combined.lower()
+        or "make docker-bot-up" in combined.lower()
+        or "docker-bot-up" in combined.lower()
+    ), f"script must reference affected make targets; got:\n{combined}"
+
+
+def test_script_does_not_print_secret_values(tmp_path: Path) -> None:
+    """The script must never print actual secret values from the env file."""
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "TELEGRAM_BOT_TOKEN=1234567890:REALsecretKEY1234567890abcdef\n"
+        "LITELLM_MASTER_KEY=sk-real-master-key-12345\n"
+        "REDIS_PASSWORD=supersecretredis123\n"
+    )
+
+    cp = _run_script(env_file=env_file)
+
+    combined = cp.stdout + cp.stderr
+    assert "REALsecretKEY" not in combined, "script must not print real TELEGRAM_BOT_TOKEN value"
+    assert "sk-real-master-key-12345" not in combined, (
+        "script must not print real LITELLM_MASTER_KEY value"
+    )
+    assert "supersecretredis123" not in combined, "script must not print real REDIS_PASSWORD value"

--- a/tests/unit/test_makefile_contract.py
+++ b/tests/unit/test_makefile_contract.py
@@ -482,3 +482,87 @@ def test_test_full_uses_bounded_parallelism_by_default() -> None:
         "test-full must NOT use $(PYTEST_PARALLEL_ARGS) (unbounded -n auto); "
         "use $(PYTEST_FULL_PARALLEL_ARGS) instead"
     )
+
+
+# --- #2123 / #2126 preflight-bot guardrail contract tests ---
+
+
+def test_preflight_bot_target_exists() -> None:
+    """`preflight-bot` must exist as a standalone Makefile target."""
+    text = _makefile_text()
+    assert re.search(r"^preflight-bot:", text, re.MULTILINE), (
+        "preflight-bot target must exist in Makefile"
+    )
+
+
+def test_preflight_bot_is_phony() -> None:
+    """`preflight-bot` must be declared .PHONY."""
+    text = _makefile_text()
+    phony_blocks = re.findall(r"^\.PHONY:.*(?:\\\n.*)*", text, re.MULTILINE)
+    combined = " ".join(phony_blocks)
+    assert "preflight-bot" in combined, "preflight-bot must be declared in .PHONY"
+
+
+def test_preflight_bot_runs_python_script() -> None:
+    """`preflight-bot` must invoke the check_bot_runtime_env.py script."""
+    text = _makefile_text()
+    block_match = re.search(
+        r"^preflight-bot:.*?(?=^[A-Za-z0-9_.-]+:|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert block_match, "preflight-bot target not found in Makefile"
+    block = block_match.group(0)
+    assert "scripts/probe/check_bot_runtime_env.py" in block, (
+        "preflight-bot must invoke scripts/probe/check_bot_runtime_env.py"
+    )
+
+
+def test_preflight_bot_has_flag_override() -> None:
+    """`PREFLIGHT_BOT_FLAGS` must be a ?= variable so CI can pass `--no-fail`."""
+    text = _makefile_text()
+    match = re.search(r"^PREFLIGHT_BOT_FLAGS\s*\?=", text, re.MULTILINE)
+    assert match, "PREFLIGHT_BOT_FLAGS must use ?= so CI can override with --no-fail"
+
+
+def test_docker_bot_up_depends_on_preflight_bot() -> None:
+    """`docker-bot-up` must depend on `preflight-bot` so the env check
+    runs before starting the bot containers."""
+    text = _makefile_text()
+    block_match = re.search(
+        r"^docker-bot-up:.*?(?=^[A-Za-z0-9_.-]+:|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert block_match, "docker-bot-up target not found in Makefile"
+    # The dependency line (first line of the target block).
+    first_line = block_match.group(0).split("\n")[0]
+    assert "preflight-bot" in first_line, (
+        "docker-bot-up must list preflight-bot as a dependency so the env "
+        f"check runs first. Found: {first_line!r}"
+    )
+
+
+def test_bot_target_depends_on_preflight_bot() -> None:
+    """`make bot` (native) must also depend on `preflight-bot` since
+    native bot startup requires real credentials."""
+    text = _makefile_text()
+    block_match = re.search(
+        r"^bot:.*?(?=^[A-Za-z0-9_.-]+:|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert block_match, "bot target not found in Makefile"
+    first_line = block_match.group(0).split("\n")[0]
+    assert "preflight-bot" in first_line, (
+        "bot target must list preflight-bot as a dependency so native bot "
+        f"launch fails fast when .env is missing. Found: {first_line!r}"
+    )
+
+
+def test_preflight_bot_script_exists() -> None:
+    """The script referenced by preflight-bot must actually exist."""
+    script = Path("scripts/probe/check_bot_runtime_env.py")
+    assert script.is_file(), (
+        f"{script} not found — preflight-bot target references a missing script"
+    )


### PR DESCRIPTION
## Summary

Adds a `preflight-bot` guardrail that fails fast and explains common `make bot` / `make docker-bot-up` failures, addressing #2123 (Docker stack restore) and #2126 (bot profile runtime).

## What it checks

- **Missing `.env`**: when `.env` is absent, the CI fallback `tests/fixtures/compose.ci.env` is used — which contains placeholder credentials. The preflight warns and explains remediation (`cp .env.example .env`).
- **Invalid `TELEGRAM_BOT_TOKEN`**: the CI fallback token `123456789:ABC...fghi` causes `TokenValidationError` at bot startup. The preflight catches this before launch and explains the crash-loop behaviour.
- **LiteLLM `localhost:4000` not published**: common stray-compose-file issue (e.g. `/tmp/compose.postgres-root.yml` overriding dev port mappings). The preflight checks Docker `PortBindings` and suggests recovery steps.

## Changes

| File | Change |
|------|--------|
| `scripts/probe/check_bot_runtime_env.py` | **New** — diagnostic script with --no-fail (CI), --skip-docker support |
| `Makefile` | `preflight-bot` target, wired as dependency on `docker-bot-up` and `bot`; `PREFLIGHT_BOT_FLAGS ?=` for CI override |
| `DOCKER.md` | Preflight section, common failures table, LiteLLM port recovery instructions |
| `docs/LOCAL-DEVELOPMENT.md` | Preflight in validation ladder, expanded common issues |
| `tests/unit/scripts/test_check_bot_runtime_env.py` | **New** — 13 tests for the diagnostic script |
| `tests/unit/test_makefile_contract.py` | **New** — 8 contract tests for make targets |

## Tests

```bash
# 93 focused tests (all pass):
uv run pytest tests/unit/test_makefile_contract.py \
  tests/unit/scripts/test_check_bot_runtime_env.py \
  tests/unit/scripts/test_bot_health_script.py \
  tests/unit/test_docker_static_validation.py \
  tests/unit/test_release_gate_contract.py -q

# Compose config renders cleanly:
docker compose --env-file tests/fixtures/compose.ci.env \
  -f compose.yml -f compose.dev.yml config --quiet  # exit 0

# Lint clean:
uv run ruff check scripts/probe/check_bot_runtime_env.py \
  tests/unit/scripts/test_check_bot_runtime_env.py  # all checks passed
```

## Manual gates (real credentials)

This PR provides repo-side guardrails only. The following require **real non-production credentials in `.env`**:

- `TELEGRAM_BOT_TOKEN` — from @BotFather
- `LITELLM_MASTER_KEY` — LiteLLM proxy master key
- At least one provider key: `CEREBRAS_API_KEY`, `GROQ_API_KEY`, or `OPENAI_API_KEY`

Without these, `make bot` and `make docker-bot-up` will fail at runtime regardless of the preflight guard.

## CI bypass

```bash
PREFLIGHT_BOT_FLAGS=--no-fail make docker-bot-up
PREFLIGHT_BOT_FLAGS=--no-fail make bot
```