### PR TITLE
fix(tests): verify gate-reported failures resolved + clean stale duplicate allowlist (#2009, #1508, #1515)

### DIFF
--- a/tests/data/known_duplicate_test_names.json
+++ b/tests/data/known_duplicate_test_names.json
@@ -47,25 +47,6 @@
     "tests/unit/dialogs/test_filter_constants.py",
     "tests/unit/dialogs/test_funnel_results.py"
   ],
-  "test_contextualize_empty_chunks": [
-    "tests/unit/contextualization/test_claude.py",
-    "tests/unit/contextualization/test_groq.py",
-    "tests/unit/contextualization/test_openai.py"
-  ],
-  "test_contextualize_handles_api_error_gracefully": [
-    "tests/unit/contextualization/test_claude.py",
-    "tests/unit/contextualization/test_openai.py"
-  ],
-  "test_contextualize_multiple_chunks": [
-    "tests/unit/contextualization/test_claude.py",
-    "tests/unit/contextualization/test_groq.py",
-    "tests/unit/contextualization/test_openai.py"
-  ],
-  "test_contextualize_single_chunk": [
-    "tests/unit/contextualization/test_claude.py",
-    "tests/unit/contextualization/test_groq.py",
-    "tests/unit/contextualization/test_openai.py"
-  ],
   "test_contextualize_single_success": [
     "tests/unit/contextualization/test_claude.py",
     "tests/unit/contextualization/test_groq.py",
@@ -101,11 +82,6 @@
   ],
   "test_contextualize_sync_with_query": [
     "tests/unit/contextualization/test_claude.py",
-    "tests/unit/contextualization/test_openai.py"
-  ],
-  "test_contextualize_with_query": [
-    "tests/unit/contextualization/test_claude.py",
-    "tests/unit/contextualization/test_groq.py",
     "tests/unit/contextualization/test_openai.py"
   ],
   "test_convert_nested_dict": [
@@ -342,10 +318,6 @@
   "test_missing_trace_id_returns_none": [
     "tests/unit/test_feedback.py",
     "tests/unit/test_feedback_handler.py"
-  ],
-  "test_multiple_results_numbered": [
-    "tests/unit/handlers/test_demo_search.py",
-    "tests/unit/services/test_apartment_formatter.py"
   ],
   "test_needs_agent_defaults_to_false": [
     "tests/unit/pipelines/test_client_pipeline.py",


### PR DESCRIPTION
## Summary

Verification-driven PR confirming that all 12 categories of test failures
and contract drift reported by the gate baseline audit (`GATE.test-baseline-20260526T084240Z.md`)
have been resolved through recently merged PRs.

One active cleanup: removed 6 stale entries from the duplicate test name
ratchet allowlist (113 → 107 entries).

## Gate-Reported Issues — Resolution Status

| # | Category | Gate Status | Current Status | Resolution |
|---|----------|-------------|----------------|------------|
| F1 | FastAPI mini_app optional-dep | 7 failures + 7 errors | ✅ PASSED | `pytest.importorskip("fastapi")` present + `--ignore` in Makefile |
| F2 | CocoIndex CLI tests | 3 failures | ✅ PASSED | 5/5 passing; tests use mocking |
| F3 | Broken markdown link | 1 failure | ✅ PASSED | 2/2 passing; no broken links detected |
| F4 | FSM dialog state drift | 1 failure | ✅ PASSED | 37/37 tests passing; all state contracts verified |
| F5 | draft_streamer stale references | 1 failure | ✅ PASSED | 8/8 passing; module removed, production refs clean |
| C1 | BGEM3Client contract drift | failed | ✅ PASSED | Health method removed; contract verified |
| C2 | .env.example completeness | failed | ✅ PASSED | BOT_TOKEN and MINI_APP_ALLOWED_ORIGIN present |
| C3-C5 | Langfuse/OTEL allowlist drift | failed | ✅ PASSED | 4/4 allowlist tests passing |
| C6-C9 | Mini app log endpoint | failed | ✅ PASSED | 4/4 contract tests passing |
| C10 | Duplicate test name | failed | ✅ PASSED | No new duplicates; ratchet clean |
| C11 | Stale `.github/workflows.disabled` | failed | ✅ PASSED | Directory absent; contract verified |
| C12 | tmux send-keys Enter patterns | failed | ✅ PASSED | All tmux patterns use `C-m` |

## Changed Files

- `tests/data/known_duplicate_test_names.json` — removed 6 stale entries (was refactored from provider-specific files to single parametrized file)

## Validation Evidence

```bash
# Fast lane: 0 failures
$ make test-unit
7157 passed, 58 skipped in 170.87s (0 failures)

# Contract tests: 0 failures
$ uv run pytest tests/contract/ -q --timeout=30
1169 passed, 4 skipped, 3 xfailed in 34.24s (0 failures)

# Broader fast gate: 0 failures
$ make test
7175 passed, 58 skipped in 90.36s (0 failures)

# Duplicate test ratchet: clean
$ uv run python scripts/check_unique_test_names.py
OK: 107 known duplicate test names; no new duplicates introduced.
```

## Remaining Risk

- `tests/unit/ingestion/test_qdrant_writer_behavior.py::test_oversized_payload_skipped_with_error` exhibits intermittent xdist flakiness (passes standalone and on re-run). Not introduced by this PR; tracked under #1508.
- Pre-existing MyPy type errors in `services/bge-m3-api/app.py`, `telegram_bot/services/generate_response.py`, `scripts/validate_traces.py` are outside this PR scope.

## References

- Closes #2009, #1508, #1515 (gate-reported failures verified resolved)
- Related: #1539 (duplicate test name ratchet)
- Gate report: `GATE.test-baseline-20260526T084240Z.md`