### PR TITLE
fix(test): #2009 — docker compose plugin skip guard for fast lane

### DIFF
--- a/tests/unit/test_docker_static_validation.py
+++ b/tests/unit/test_docker_static_validation.py
@@ -45,20 +45,47 @@ QDRANT_STACK_DOC = Path("docs/QDRANT_STACK.md")
 
 
 def _docker_available() -> bool:
-    return shutil.which("docker") is not None
+    """Return True only when both ``docker`` and the Compose v2 plugin are usable.
+
+    On hosts that ship the engine without the Compose plugin
+    (lightweight CI sandboxes, default Amazon Linux 2023, etc.)
+    ``shutil.which("docker")`` returns truthy but ``docker compose ...``
+    exits 125 ("looking up compose provider failed"). Probing the plugin
+    here lets the static-validation tests skip gracefully instead of
+    asserting on the plugin error message. Tracked under #2009.
+    """
+    if shutil.which("docker") is None:
+        return False
+    try:
+        probe = subprocess.run(
+            ["docker", "compose", "version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    return probe.returncode == 0
 
 
 def _run_docker_command(args: list[str]) -> subprocess.CompletedProcess[str]:
     if not _docker_available():
-        pytest.skip("Docker not available")
+        pytest.skip("Docker / Compose plugin not available")
     try:
-        return subprocess.run(
+        result = subprocess.run(
             args,
             capture_output=True,
             text=True,
         )
     except FileNotFoundError:
-        pytest.skip("Docker not available")
+        pytest.skip("Docker / Compose plugin not available")
+    # Defensive: if the Compose plugin disappeared between the probe and
+    # this call (or the host emits the same "compose provider failed"
+    # error from a different path), downgrade to skip so we never flip a
+    # missing-runtime condition into a hard FAIL.
+    if result.returncode == 125 and "compose provider failed" in (result.stderr or ""):
+        pytest.skip("Docker Compose plugin missing at runtime")
+    return result
 
 
 @pytest.mark.parametrize("dockerfile", DOCKERFILES)

--- a/tests/unit/test_docker_static_validation_runtime_guard.py
+++ b/tests/unit/test_docker_static_validation_runtime_guard.py
@@ -1,0 +1,113 @@
+"""Runtime-guard regression tests for ``tests/unit/test_docker_static_validation.py`` (#2009).
+
+#2009 calls out runtime gates that rely on ambient env / runtime
+availability. ``test_docker_static_validation`` declares "Docker
+availability is checked at runtime; tests skip gracefully when absent",
+but the original ``_docker_available`` only probed for the ``docker``
+binary. On hosts that have the engine without the Compose v2 plugin
+(common in lightweight CI sandboxes and a default RHEL/Amazon Linux
+2023 box), ``shutil.which("docker")`` returns truthy yet
+``docker compose ...`` exits with status 125 ("looking up compose
+provider failed") and the assertion ``result.returncode == 0`` flips a
+skip into a hard FAIL.
+
+This test file pins the corrected guard:
+
+* ``_docker_available`` accepts a callable for compose-plugin probing
+  so we can inject deterministic outcomes.
+* ``_run_docker_command`` calls ``pytest.skip`` (not asserts) when the
+  Compose plugin probe returns ``False``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+import tests.unit.test_docker_static_validation as docker_module
+
+
+def test_docker_available_returns_false_when_binary_missing() -> None:
+    with patch.object(docker_module.shutil, "which", return_value=None):
+        assert docker_module._docker_available() is False
+
+
+def test_docker_available_returns_false_when_compose_plugin_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``docker`` binary present, but ``docker compose version`` exits
+    non-zero (the plugin is not installed). ``_docker_available`` must
+    report False so the test skips instead of asserting against a
+    runtime that cannot honour the call.
+    """
+    monkeypatch.setattr(docker_module.shutil, "which", lambda _: "/usr/bin/docker")
+
+    def _fake_run(args, **kwargs):
+        # Mirrors the real `docker compose version` failure shape on
+        # hosts with no Compose v2 plugin.
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=125,
+            stdout="",
+            stderr=(
+                "Error: looking up compose provider failed\n"
+                'exec: "docker-compose": executable file not found in $PATH\n'
+            ),
+        )
+
+    monkeypatch.setattr(docker_module.subprocess, "run", _fake_run)
+    assert docker_module._docker_available() is False
+
+
+def test_docker_available_returns_true_when_compose_plugin_works(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(docker_module.shutil, "which", lambda _: "/usr/bin/docker")
+
+    def _fake_run(args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout="Docker Compose version v2.30.0\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(docker_module.subprocess, "run", _fake_run)
+    assert docker_module._docker_available() is True
+
+
+def test_run_docker_command_skips_when_compose_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(docker_module, "_docker_available", lambda: False)
+
+    with pytest.raises(pytest.skip.Exception) as excinfo:
+        docker_module._run_docker_command(["docker", "compose", "config", "--quiet"])
+
+    assert "Docker" in str(excinfo.value) or "Compose" in str(excinfo.value)
+
+
+def test_run_docker_command_skips_when_compose_provider_failure_leaks_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defensive: if the host adds the Compose plugin AFTER ``_docker_available``
+    samples it (race) or returns 125 from the actual command, the wrapper
+    must downgrade the failure to a skip rather than letting an assertion
+    fail. This pins the secondary guard.
+    """
+    monkeypatch.setattr(docker_module, "_docker_available", lambda: True)
+
+    def _fake_run(args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=125,
+            stdout="",
+            stderr="Error: looking up compose provider failed\n",
+        )
+
+    monkeypatch.setattr(docker_module.subprocess, "run", _fake_run)
+
+    with pytest.raises(pytest.skip.Exception):
+        docker_module._run_docker_command(["docker", "compose", "config", "--quiet"])


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Refs #2009. Closes the runtime-gate part of the audit ("runtime env gates rely on ambient env in places").

## Problem

`tests/unit/test_docker_static_validation.py` claims:

> Docker availability is checked at runtime; tests skip gracefully when absent.

The original `_docker_available()` only probed `shutil.which("docker")`. On hosts that ship the engine without the Compose v2 plugin (lightweight CI sandboxes, default Amazon Linux 2023), the docker binary is present but `docker compose ...` exits with status `125` and stderr `looking up compose provider failed`. The assertion `result.returncode == 0` then flipped a skip into a hard **FAIL**.

Reproduces in the canonical fast lane on this sandbox:

```
uv run --python 3.12 pytest tests/unit/ tests/integration/test_graph_paths.py \
  --ignore=... -m "not legacy_api and not requires_extras and not slow"
# Before this PR: 3 failed (test_compose_dev_config_renders,
#                            test_compose_dev_config_renders_with_full_profile,
#                            test_compose_dev_postgres_renders_with_dev_only_capabilities),
#                 6944 passed
```

## Fix

Two layers:

1. **Probe** — `_docker_available()` now runs `docker compose version` (5s timeout) and returns `False` on non-zero exit / `FileNotFoundError` / `TimeoutExpired`. Both the binary AND the plugin must be usable.
2. **Defensive secondary guard** in `_run_docker_command`: if a real call returns `125` with `compose provider failed` in stderr (race / late plugin removal), downgrade to `pytest.skip` instead of returning the broken result. This way the runtime gate cannot flip into an assertion failure even when the probe and the call observe different states.

## TDD

`tests/unit/test_docker_static_validation_runtime_guard.py` — 5 cases, written first:

1. `_docker_available()` is `False` when the docker binary is missing.
2. `_docker_available()` is `False` when `docker compose version` exits `125`.
3. `_docker_available()` is `True` when the plugin probe exits `0`.
4. `_run_docker_command(...)` raises `pytest.skip.Exception` when `_docker_available()` is `False`.
5. `_run_docker_command(...)` raises `pytest.skip.Exception` on a `125` + `compose provider failed` result (defensive secondary guard).

## Validation

```
uv run --python 3.12 pytest tests/unit/test_docker_static_validation.py \
  tests/unit/test_docker_static_validation_runtime_guard.py
# 33 passed, 3 skipped (the three previously failing compose-config
# tests now skip gracefully on this sandbox)

uv run --python 3.12 pytest tests/unit/ tests/integration/test_graph_paths.py \
  --ignore=... -m "not legacy_api and not requires_extras and not slow"
# Before: 3 failed, 6944 passed
# After : 0 failed, 6967 passed, 60 skipped

uv run ruff check / format --check
# clean
```

## Scope note

This PR addresses one row of the #2009 acceptance list — the runtime-gate one. Other items (`uv sync` -> fast-lane FastAPI guard, CI workflow pytest wiring, nightly heavy lane coverage, compose project name guard) are already addressed on `dev`:

- `.github/workflows/ci.yml` runs pytest (line 66+).
- `.github/workflows/nightly-heavy.yml` covers integration / smoke / baseline plus the heavy tier.
- `BOT_TOKEN` and `MINI_APP_ALLOWED_ORIGIN` are present in `.env.example`.
- `test_injection_hard_mode_blocks` is no longer duplicated.
- `tests/contract/` passes (1169 passed).

Refs #2009.