### PR TITLE
docs(engineering): voice create_agent migration sequencing (#1535/#2048/#2051)

### DIFF
--- a/docs/adr/0010-voice-path-create-agent-migration-plan.md
+++ b/docs/adr/0010-voice-path-create-agent-migration-plan.md
@@ -134,6 +134,7 @@ Snippets above are paraphrased summaries (≤ 30 consecutive words from any sing
 - Issue [#1535](https://github.com/yastman/rag/issues/1535) — dual pipeline maintenance.
 - Issue [#1533](https://github.com/yastman/rag/issues/1533) — contextualisation duplication (same pattern).
 - ADR-0003 — voice/text split (will be superseded by this ADR upon Acceptance).
+- [`docs/engineering/voice-create-agent-migration-sequence.md`](../engineering/voice-create-agent-migration-sequence.md) — per-slice sequencing across #1535 / #2050 / #2051 / #2048; the canonical "what to do next" pointer for contributors picking up a child issue.
 - `telegram_bot/agents/agent.py` — current `create_agent` factory (text path).
 - `telegram_bot/agents/rag_pipeline.py` — shared RAG core invoked from `rag_search` tool.
 - `telegram_bot/graph/graph.py` — legacy 11-node `StateGraph` (voice path).

--- a/docs/engineering/voice-create-agent-migration-sequence.md
+++ b/docs/engineering/voice-create-agent-migration-sequence.md
@@ -1,0 +1,77 @@
+# Voice Path → `create_agent` Migration — Sequencing
+
+Single source of truth for the per-slice ordering of the voice-path
+migration epic. Pairs with [ADR-0010](../adr/0010-voice-path-create-agent-migration-plan.md)
+which captures the *why*; this document captures the *what to do next*.
+
+## Status
+
+**In progress.**
+
+* [ADR-0010](../adr/0010-voice-path-create-agent-migration-plan.md) — design plan, **Proposed**.
+* [#1535](https://github.com/yastman/rag/issues/1535) — parent epic, open, `lane:design-first`.
+* [#2050](https://github.com/yastman/rag/issues/2050) — convert voice graph nodes into `create_agent` tools, **closed (done)** on 2026-05-26.
+* [#2051](https://github.com/yastman/rag/issues/2051) — rewire voice handler to `create_agent`, open, `lane:plan-needed`.
+* [#2048](https://github.com/yastman/rag/issues/2048) — extract `PropertyBot` lifecycle method slices, open, `lane:architecture-heavy`. **Was blocked on #1948; unblocked by [PR #2135](https://github.com/yastman/rag/pull/2135).**
+* [#1948](https://github.com/yastman/rag/issues/1948) — reverse-layering closure, **closed by PR #2135**.
+
+The sequencing doc flips its `Status` line from `In progress` to `Done`
+in the same PR that flips ADR-0010 from `Proposed` to `Accepted` — i.e.
+the PR that removes `telegram_bot/graph/graph.py::build_graph`.
+
+## Sequence
+
+Order of execution follows the dependency arrows below. Do **not** start a
+later slice before its predecessors land — each one assumes the previous
+slice's invariants.
+
+```
+#1535 (ADR-0010)        ─┐
+                         ├──► #2050 (tools)  ──►  #2051 (rewire)  ──►  ADR-0010 → Accepted
+#1948 (layering)  ──────┘                                                    │
+                                                                             ▼
+                                                                        #2048 (lifecycle)
+```
+
+| Step | Issue | Status | Notes |
+|---|---|---|---|
+| 1 | [#1535](https://github.com/yastman/rag/issues/1535) — design plan | open / `Proposed` | ADR-0010 lives at [docs/adr/0010-voice-path-create-agent-migration-plan.md](../adr/0010-voice-path-create-agent-migration-plan.md). Stays Proposed until the rewire lands and the legacy graph file is removed. |
+| 2 | [#2050](https://github.com/yastman/rag/issues/2050) — convert nodes to tools | **closed** (done) | Voice graph nodes (`guard`, `classify`, `retrieve`, `rerank`, `rewrite`, `grade`, cache) are now `create_agent`-compatible callables in `telegram_bot/graph/tools/`. |
+| 3 | [#2051](https://github.com/yastman/rag/issues/2051) — rewire voice handler | open | Replace `Bot.handle_voice`'s `build_graph(...).ainvoke(...)` with the same `create_bot_agent`-driven path the text supervisor already uses. Pre-agent transcription stays. Preserves checkpointer namespace + `trace_id` injection. |
+| 4 | [#2048](https://github.com/yastman/rag/issues/2048) — extract `PropertyBot` lifecycle | open, **unblocked** | Was waiting on #1948's `src.runtime` migration so the extracted lifecycle module would not need `from telegram_bot.*` back-imports. PR [#2135](https://github.com/yastman/rag/pull/2135) closed the last allowlist entry, so #2048 can now extract `_warmup_bge`, `_polling_lock_heartbeat_tick`, `_postgres_pool_init`, `_kommo_seed`, `_register_handlers`, etc. into a thin `bot_lifecycle.py` module while keeping `bot.py` as a facade. |
+| 5 | ADR-0010 → Accepted | follow-up PR | Same PR removes `telegram_bot/graph/graph.py`, deletes the StateGraph-only nodes, and updates this doc's `Status` to `Done`. |
+
+## Next executable slice
+
+For a contributor picking up the next move:
+
+* **#2051 — rewire voice handler.** This is the highest-value next slice and
+  is the one that lets ADR-0010 flip to Accepted. The work is bounded:
+    1. Build the voice variant of the agent inside
+       `Bot.handle_voice` (mirror `_handle_query_supervisor`).
+    2. Move the pre-agent transcription stage so it runs before
+       `create_bot_agent.ainvoke(...)`.
+    3. Swap `build_graph(...).ainvoke(...)` for the agent invocation.
+    4. Run `python -m pytest tests/unit/graph/ tests/unit/test_bot_handlers.py -q`
+       (per the issue's `Validation` block).
+* **#2048 — extract `PropertyBot` lifecycle.** Independent of #2051.
+  Now unblocked. Recommended sub-slices:
+    - 4a. lifecycle (`start`, `stop`, `_warmup_bge`,
+      `_polling_lock_heartbeat_tick`);
+    - 4b. handlers registration (`_register_handlers` + the FSM
+      handlers that hang off it);
+    - 4c. pre-agent (`_handle_apartment_fast_path`,
+      `_extract_pre_agent_filters`, `_get_pre_agent_filter_extractor`);
+    - 4d. streaming + scoring (`_astream_supervisor_with_recovery`,
+      `_ainvoke_supervisor_with_recovery`).
+  Each sub-slice mirrors the [#1265](https://github.com/yastman/rag/issues/1265) `_bot_<topic>.py`
+  pattern (PR-1..PR-7); each one ratchets the `bot.py` line-count
+  ceiling down further.
+
+## Cross-references
+
+* [ADR-0010 — voice path migration plan](../adr/0010-voice-path-create-agent-migration-plan.md) — the *why*.
+* [`tests/contract/test_voice_create_agent_migration_plan_contract.py`](../../tests/contract/test_voice_create_agent_migration_plan_contract.py) — pins ADR-0010 status + structure.
+* [`tests/contract/test_voice_migration_sequence_doc_contract.py`](../../tests/contract/test_voice_migration_sequence_doc_contract.py) — pins this document.
+* [`tests/contract/test_layering_no_telegram_bot_imports_contract.py`](../../tests/contract/test_layering_no_telegram_bot_imports_contract.py) — guards the `src/` ↔ `telegram_bot/` boundary that #2048 must respect when extracting lifecycle.
+* [#1265](https://github.com/yastman/rag/issues/1265) — bot.py decomposition track that #2048 piggy-backs on.

--- a/tests/contract/test_voice_migration_sequence_doc_contract.py
+++ b/tests/contract/test_voice_migration_sequence_doc_contract.py
@@ -1,0 +1,111 @@
+"""Contract: ``docs/engineering/voice-create-agent-migration-sequence.md`` exists
+and pins the cross-issue sequencing for the voice path migration epic.
+
+The voice-path migration to ``create_agent`` is split across four GitHub
+issues (#1535 parent, #2050 tools, #2051 rewire, #2048 lifecycle
+extraction). ADR-0010 documents the *plan*, but contributors picking up
+a follow-up issue need to know:
+
+* which sibling issues are already done;
+* which issues block which (and which were just unblocked);
+* what the next executable slice is per issue.
+
+The sequencing document is the single source of truth for that
+ordering. It lives under ``docs/engineering/`` (per the existing pattern
+of ``script-native-migration-matrix.md``) and is referenced from
+ADR-0010 plus from each open child issue. This contract pins the
+document's existence and minimum content.
+
+When the epic completes, the ``Status`` line flips from ``In progress``
+to ``Done`` and that flip is the only expected breaking change to this
+contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOC_PATH = (
+    REPO_ROOT
+    / "docs"
+    / "engineering"
+    / "voice-create-agent-migration-sequence.md"
+)
+
+
+REQUIRED_ISSUE_REFS: tuple[str, ...] = (
+    "#1535",  # parent — ADR-0010 plan
+    "#2050",  # tools (closed)
+    "#2051",  # rewire voice handler to create_agent
+    "#2048",  # extract PropertyBot lifecycle method slices
+    "#1948",  # layering closure that unblocks #2048
+)
+
+REQUIRED_HEADINGS: tuple[str, ...] = (
+    "Status",
+    "Sequence",
+    "Next executable slice",
+    "Cross-references",
+)
+
+
+def test_sequence_doc_exists() -> None:
+    assert DOC_PATH.is_file(), (
+        f"Voice migration sequencing doc not found at "
+        f"{DOC_PATH.relative_to(REPO_ROOT)}. The doc is the single "
+        "source of truth for #1535/#2050/#2051/#2048 ordering and is "
+        "referenced from ADR-0010 plus each open child issue."
+    )
+
+
+@pytest.mark.parametrize("issue_ref", REQUIRED_ISSUE_REFS)
+def test_sequence_doc_references_each_issue(issue_ref: str) -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    assert issue_ref in text, (
+        f"voice-create-agent-migration-sequence.md must mention "
+        f"{issue_ref} so contributors discover the cross-issue ordering."
+    )
+
+
+@pytest.mark.parametrize("heading", REQUIRED_HEADINGS)
+def test_sequence_doc_has_required_heading(heading: str) -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    assert (f"## {heading}" in text) or (f"### {heading}" in text), (
+        f"voice-create-agent-migration-sequence.md missing required "
+        f"heading: {heading!r}. The minimum structure is "
+        f"{REQUIRED_HEADINGS}."
+    )
+
+
+def test_sequence_doc_records_2050_as_done_and_2048_as_unblocked() -> None:
+    """Pins the two facts that motivate this doc landing now:
+    #2050 (tools) was closed on 2026-05-26, and #1948 final closure
+    (PR #2135) unblocked #2048. Both facts must be visible in the doc
+    so a contributor reading it immediately knows what is actionable.
+    """
+    text = DOC_PATH.read_text(encoding="utf-8").lower()
+    assert "closed" in text or "done" in text, (
+        "Sequencing doc must mark sibling issues as closed/done so the "
+        "reader can see what is left."
+    )
+    assert "unblock" in text or "unblocks" in text, (
+        "Sequencing doc must call out that #1948 unblocks #2048 — "
+        "without this the reader assumes #2048 is still gated."
+    )
+
+
+def test_adr_0010_links_sequence_doc() -> None:
+    """ADR-0010 stays the design plan, but it must point readers at the
+    sequencing doc so they don't lose the cross-issue context.
+    """
+    adr = REPO_ROOT / "docs" / "adr" / "0010-voice-path-create-agent-migration-plan.md"
+    text = adr.read_text(encoding="utf-8")
+    assert "voice-create-agent-migration-sequence.md" in text, (
+        "ADR-0010 must link to docs/engineering/voice-create-agent-"
+        "migration-sequence.md so readers can find the per-slice "
+        "sequencing without re-deriving it from issue comments."
+    )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Refs #1535 / #2048 / #2051 / #1948.

## What lands

A single sequencing doc at `docs/engineering/voice-create-agent-migration-sequence.md` that tells a contributor picking up any one of the open child issues:

* which sibling issues are already done (#2050 closed 2026-05-26);
* which dependencies just cleared (#1948 / PR #2135 unblocks #2048);
* the bounded next executable slice per remaining issue (#2051 rewire, #2048 lifecycle).

ADR-0010 stays the design plan (the *why*); this doc is the *what to do next*. ADR-0010's References section now links to the sequencing doc so neither artifact is silently the one source of truth.

## Why now

#2050 closed yesterday and PR #2135 (my close-out for #1948) empties the layering allowlist — that combination unblocks #2048 and means #2051 is the only thing standing between the project and ADR-0010 flipping to **Accepted**. Without an explicit sequencing artifact, a contributor opening #2048 still sees `lane:architecture-heavy` + `blocks on #1948 coupled runtime migration` in the issue body and walks away.

## TDD

`tests/contract/test_voice_migration_sequence_doc_contract.py` — 12 cases written first, all red, all green after the doc lands:

| Test | Pins |
|---|---|
| `test_sequence_doc_exists` | Doc at the canonical `docs/engineering/` path. |
| `test_sequence_doc_references_each_issue[#1535/#2050/#2051/#2048/#1948]` (×5) | Cross-issue mentions stay discoverable. |
| `test_sequence_doc_has_required_heading[Status/Sequence/Next executable slice/Cross-references]` (×4) | Minimum structure. |
| `test_sequence_doc_records_2050_as_done_and_2048_as_unblocked` | The two facts that motivate this PR. |
| `test_adr_0010_links_sequence_doc` | ADR-0010 cannot drift away from the sequence doc. |

When the epic completes, the doc's `Status` line flips from `In progress` to `Done` in the same PR that flips ADR-0010 from `Proposed` to `Accepted` (i.e., the PR that removes `telegram_bot/graph/graph.py::build_graph`).

## Validation

```
uv run --python 3.12 pytest tests/contract/ -q --timeout=30 -n auto --dist=worksteal
# 1182 passed (was 1169; +12 new contract tests, +1 ADR link),
# 4 skipped (cocoindex), 3 xfailed (#1532, unrelated).
```

## Scope note

This PR is the **planning artifact** for the three blocked / open child issues, not the migration itself. The actual code landings (#2051 rewire, #2048 lifecycle extraction) are independent follow-ups. Each one ratchets bot.py line count down further (mirrors the `#1265` `_bot_<topic>.py` pattern).

Refs #1535 #2048 #2051 #1948.