### PR TITLE
fix: remove hardcoded password fallbacks from compose.dev.yml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,8 +63,8 @@ OMP_NUM_THREADS=4
 # ==============================================================================
 # DATABASE CREDENTIALS (compose services)
 # ==============================================================================
-POSTGRES_PASSWORD=<change-me>  # Change in production!
-REDIS_PASSWORD=<change-me>  # Change in production!
+POSTGRES_PASSWORD=<change-me>  # Change before running Docker services.
+REDIS_PASSWORD=<change-me>  # Change before running Docker services.
 # If you change REDIS_PASSWORD locally, run: make local-redis-recreate
 # Optional native-run override. When unset, the bot derives:
 # REDIS_URL=redis://:${REDIS_PASSWORD}@localhost:6379
@@ -82,9 +82,10 @@ ENCRYPTION_KEY=    # generate: openssl rand -hex 32
 # ==============================================================================
 # DEV INFRASTRUCTURE (optional overrides, defaults work out of the box)
 # ==============================================================================
-# Required in VPS/prod; dev override has local defaults.
-CLICKHOUSE_PASSWORD=
-MINIO_ROOT_PASSWORD=
+# Required for local ML/full Compose profiles and VPS/prod.
+CLICKHOUSE_PASSWORD=<change-me>
+MINIO_ROOT_PASSWORD=<change-me>
+LANGFUSE_REDIS_PASSWORD=<change-me>
 
 # ==============================================================================
 # LLM PROVIDERS (at least one required for bot profile)
@@ -291,7 +292,7 @@ TELEGRAM_ALERTING_CHAT_ID=-1001234567890
 ELEVENLABS_API_KEY=
 LIVEKIT_URL=ws://livekit-server:7880
 LIVEKIT_API_KEY=devkey
-LIVEKIT_API_SECRET=secret
+LIVEKIT_API_SECRET=<change-me>
 LIFECELL_SIP_USER=
 LIFECELL_SIP_PASS=
 RAG_API_URL=http://rag-api:8080

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -89,6 +89,17 @@ For local development, the canonical local env file is `.env` in the repo root. 
 
 Local `make` targets that use `$(LOCAL_COMPOSE_CMD)` automatically fall back to `tests/fixtures/compose.ci.env` when `.env` is absent. This lets commands like `make docker-ps` and profile-gated `up` targets render Compose config without real secrets.
 
+When `.env` is present, Docker credentials must be set there. `compose.dev.yml`
+does not provide built-in password defaults for stateful services; local values
+still need to be throwaway/dev-only:
+
+- `POSTGRES_PASSWORD`
+- `REDIS_PASSWORD`
+- `CLICKHOUSE_PASSWORD`
+- `MINIO_ROOT_PASSWORD`
+- `LANGFUSE_REDIS_PASSWORD`
+- `LIVEKIT_API_SECRET` when using the `voice` profile
+
 ## Service Endpoints (Host)
 
 | Service | URL/Port |
@@ -177,9 +188,10 @@ match the traced service defaults:
 | `LANGFUSE_INIT_PROJECT_PUBLIC_KEY` | `[REDACTED-LANGFUSE-KEY] |
 | `LANGFUSE_INIT_PROJECT_SECRET_KEY` | `[REDACTED-LANGFUSE-KEY] |
 
-These defaults are local-only. Override them from `.env` when a dev stack should
-use a different local Langfuse project. Production and VPS environments must
-provide real Langfuse keys and must not rely on the dev defaults.
+These non-password defaults are local-only. Override them from `.env` when a dev
+stack should use a different local Langfuse project. Production and VPS
+environments must provide real Langfuse keys and must not rely on the dev
+defaults.
 
 If `bot` logs show OTLP `401` or Langfuse logs show `No key found for public
 key`, the local Langfuse database likely lacks the project key currently

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,9 +1,8 @@
-# compose.dev.yml — Development overrides: ports, colbert reranking, relaxed defaults, ML profile-gating.
+# compose.dev.yml — Development overrides: ports, colbert reranking, ML profile-gating.
 # Usage: COMPOSE_FILE=compose.yml:compose.dev.yml docker compose up -d
 #
-# WARNING: This file contains hardcoded dev-only passwords (miniosecret, clickhouse, etc.).
-#          These defaults are safe for local development only. Do NOT reuse this file
-#          for any internet-facing or shared environment.
+# Docker credentials must come from .env or an explicit --env-file. The make
+# targets fall back to tests/fixtures/compose.ci.env when .env is absent.
 
 services:
   postgres:
@@ -18,7 +17,7 @@ services:
     ports:
       - "127.0.0.1:5432:5432"
     environment:
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s
@@ -30,10 +29,10 @@ services:
     ports:
       - "127.0.0.1:6379:6379"
     environment:
-      REDIS_PASSWORD: ${REDIS_PASSWORD:-dev_redis_pass}
+      REDIS_PASSWORD: ${REDIS_PASSWORD:?REDIS_PASSWORD is required}
     command: >
       redis-server
-      --requirepass ${REDIS_PASSWORD:-dev_redis_pass}
+      --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD is required}
       --maxmemory ${REDIS_MAXMEMORY:-512mb}
       --maxmemory-policy volatile-lfu
       --maxmemory-samples 10
@@ -90,7 +89,7 @@ services:
       - "127.0.0.1:8123:8123"
       - "127.0.0.1:9009:9000"
     environment:
-      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-clickhouse}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:?CLICKHOUSE_PASSWORD is required}
 
   minio:
     profiles: ["ml", "full"]
@@ -99,15 +98,15 @@ services:
       - "127.0.0.1:9091:9001"
     command: -c 'mkdir -p /data/langfuse && minio server --address ":9000" --console-address ":9001" /data'
     environment:
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-miniosecret}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
 
   redis-langfuse:
     profiles: ["ml", "full"]
     ports:
       - "127.0.0.1:6380:6379"
-    command: redis-server --requirepass ${LANGFUSE_REDIS_PASSWORD:-langfuseredis}
+    command: redis-server --requirepass ${LANGFUSE_REDIS_PASSWORD:?LANGFUSE_REDIS_PASSWORD is required}
     healthcheck:
-      test: ["CMD", "redis-cli", "-a", "${LANGFUSE_REDIS_PASSWORD:-langfuseredis}", "ping"]
+      test: ["CMD", "redis-cli", "-a", "${LANGFUSE_REDIS_PASSWORD:?LANGFUSE_REDIS_PASSWORD is required}", "ping"]
       interval: 5s
       timeout: 5s
       retries: 3
@@ -115,10 +114,10 @@ services:
   langfuse-worker:
     profiles: ["ml", "full"]
     environment:
-      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-clickhouse}
-      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-miniosecret}
-      LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-miniosecret}
-      REDIS_AUTH: ${LANGFUSE_REDIS_PASSWORD:-langfuseredis}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:?CLICKHOUSE_PASSWORD is required}
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
+      LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
+      REDIS_AUTH: ${LANGFUSE_REDIS_PASSWORD:?LANGFUSE_REDIS_PASSWORD is required}
 
   langfuse:
     profiles: ["ml", "full"]
@@ -131,10 +130,10 @@ services:
       LANGFUSE_INIT_PROJECT_NAME: ${LANGFUSE_INIT_PROJECT_NAME:-Local Dev}
       LANGFUSE_INIT_PROJECT_PUBLIC_KEY: ${LANGFUSE_INIT_PROJECT_PUBLIC_KEY:-pk-lf-dev}
       LANGFUSE_INIT_PROJECT_SECRET_KEY: ${LANGFUSE_INIT_PROJECT_SECRET_KEY:-sk-lf-dev}
-      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-clickhouse}
-      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-miniosecret}
-      LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-miniosecret}
-      REDIS_AUTH: ${LANGFUSE_REDIS_PASSWORD:-langfuseredis}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:?CLICKHOUSE_PASSWORD is required}
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
+      LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
+      REDIS_AUTH: ${LANGFUSE_REDIS_PASSWORD:?LANGFUSE_REDIS_PASSWORD is required}
     deploy:
       resources:
         limits:
@@ -170,7 +169,7 @@ services:
       - "127.0.0.1:50000-50100:50000-50100/udp"
     environment:
       LIVEKIT_API_KEY: ${LIVEKIT_API_KEY:-devkey}
-      LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET:-secret}
+      LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET:?LIVEKIT_API_SECRET is required}
 
   livekit-sip:
     ports:
@@ -179,12 +178,12 @@ services:
       - "127.0.0.1:10000-10100:10000-10100/udp"
     environment:
       LIVEKIT_API_KEY: ${LIVEKIT_API_KEY:-devkey}
-      LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET:-secret}
+      LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET:?LIVEKIT_API_SECRET is required}
 
   voice-agent:
     environment:
       LIVEKIT_API_KEY: ${LIVEKIT_API_KEY:-devkey}
-      LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET:-secret}
+      LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET:?LIVEKIT_API_SECRET is required}
       LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-sk-lf-dev}
 

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -47,7 +47,13 @@ The canonical local Compose project name is `dev`. `COMPOSE_PROJECT_NAME=dev` is
 
 Secret model by compose file:
 - `compose.yml` is the secure baseline: no predictable built-in secret defaults.
-- `compose.dev.yml` may provide local-only defaults for development convenience (`[REDACTED-LANGFUSE-KEY] `[REDACTED-LANGFUSE-KEY] `clickhouse`, `miniosecret`, `langfuseredis`, `devkey`).
+  Stateful passwords use `${VAR:?VAR is required}` — they must come from `.env`
+  or an explicit `--env-file`.
+- `compose.dev.yml` overrides stateful password variables with the same required
+  pattern and provides local-only non-password defaults for Langfuse headless
+  init (`LANGFUSE_INIT_*`) and traced-service keys (`LANGFUSE_PUBLIC_KEY`,
+  `LANGFUSE_SECRET_KEY`). `LIVEKIT_API_KEY` defaults to `devkey` as a documented
+  dev identifier.
 - Production/VPS stacks must set real secret values via environment management or file-backed secret patterns (`*_FILE` / `secrets:`) when available.
 
 Langfuse local development:

--- a/tests/fixtures/compose.ci.env
+++ b/tests/fixtures/compose.ci.env
@@ -14,4 +14,6 @@ NEXTAUTH_SECRET=test-nextauth-secret-placeholder-for-local-dev-ci-only
 POSTGRES_PASSWORD=postgres
 REDIS_PASSWORD=test-redis-password
 SALT=test-salt-placeholder-for-local-dev-ci-only
+LIVEKIT_API_KEY=test-livekit-api-key
+LIVEKIT_API_SECRET=test-livekit-api-secret
 TELEGRAM_BOT_TOKEN=123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi

--- a/tests/unit/security/test_secret_hygiene.py
+++ b/tests/unit/security/test_secret_hygiene.py
@@ -89,6 +89,85 @@ def test_stack_doc_mentions_redis_auth_requirement():
 
 
 @pytest.mark.timeout(0)
+def test_compose_dev_yml_has_no_hardcoded_password_fallbacks():
+    """compose.dev.yml must not provide hardcoded fallback values for stateful passwords."""
+    import re
+    from pathlib import Path
+
+    project_root = Path(__file__).parent.parent.parent.parent
+    compose_dev = project_root / "compose.dev.yml"
+
+    content = compose_dev.read_text()
+
+    # Password variables that must use :? (required) pattern, not :- (fallback).
+    # These map to stateful/runtime credentials: Postgres, Redis, ClickHouse,
+    # MinIO, Langfuse Redis, and LiveKit API secret.
+    password_vars = [
+        "POSTGRES_PASSWORD",
+        "REDIS_PASSWORD",
+        "CLICKHOUSE_PASSWORD",
+        "MINIO_ROOT_PASSWORD",
+        "LANGFUSE_REDIS_PASSWORD",
+        "LIVEKIT_API_SECRET",
+    ]
+
+    errors = []
+    for var in password_vars:
+        # Check for :- fallback pattern on the exact variable
+        fallback_pattern = rf"\$\{{{re.escape(var)}:-"
+        if re.search(fallback_pattern, content):
+            errors.append(
+                f"compose.dev.yml: {var} uses ':-' fallback (hardcoded default). "
+                f"Must use ':?' (required) instead."
+            )
+
+        # Verify :? pattern is present (must be a required variable)
+        required_pattern = rf"\$\{{{re.escape(var)}:\?"
+        if not re.search(required_pattern, content):
+            errors.append(
+                f"compose.dev.yml: {var} missing ':?' required pattern. "
+                f"Must use '${{{var}:?{var} is required}}'."
+            )
+
+    assert not errors, (
+        "compose.dev.yml must not contain hardcoded password fallbacks:\n"
+        + "\n".join(f"  - {err}" for err in errors)
+    )
+
+
+@pytest.mark.timeout(0)
+def test_compose_ci_env_has_all_required_password_vars():
+    """tests/fixtures/compose.ci.env must declare every required password var."""
+    import re
+    from pathlib import Path
+
+    project_root = Path(__file__).parent.parent.parent.parent
+    ci_env = project_root / "tests" / "fixtures" / "compose.ci.env"
+    compose_dev = project_root / "compose.dev.yml"
+
+    ci_env_content = ci_env.read_text()
+    compose_dev_content = compose_dev.read_text()
+
+    # Collect all :? required vars from compose.dev.yml
+    required_vars = set()
+    for match in re.finditer(r"\$\{([A-Z_]+):\?", compose_dev_content):
+        required_vars.add(match.group(1))
+
+    errors = []
+    for var in sorted(required_vars):
+        if not re.search(rf"^{var}=", ci_env_content, re.MULTILINE):
+            errors.append(
+                f"compose.ci.env missing '{var}' — required by compose.dev.yml "
+                f"for config rendering. Add a CI-safe test value."
+            )
+
+    assert not errors, (
+        "tests/fixtures/compose.ci.env is missing required password variables:\n"
+        + "\n".join(f"  - {err}" for err in errors)
+    )
+
+
+@pytest.mark.timeout(0)
 def test_k8s_bot_redis_password_declared_before_redis_url():
     """K8s expands $(VAR) only from previously declared env vars in the same list."""
     from pathlib import Path


### PR DESCRIPTION
## Summary

Remove hardcoded password defaults from `compose.dev.yml` and require Docker
credentials to come from `.env` or an explicit `--env-file`.

## What changed

- **`compose.dev.yml`**: All stateful/runtime password variables now use
  `${VAR:?VAR is required}` instead of `${VAR:-hardcoded_default}`:
  `POSTGRES_PASSWORD`, `REDIS_PASSWORD`, `CLICKHOUSE_PASSWORD`,
  `MINIO_ROOT_PASSWORD`, `LANGFUSE_REDIS_PASSWORD`, `LIVEKIT_API_SECRET`.

- **Non-password dev identifiers** (`LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`,
  `LANGFUSE_INIT_*`, `LIVEKIT_API_KEY`) keep their documented fallback defaults
  because tests/docs rely on them.

- **`.env.example`**: Updated comments, added `LANGFUSE_REDIS_PASSWORD` and
  `LIVEKIT_API_SECRET` placeholders, changed empty `CLICKHOUSE_PASSWORD` /
  `MINIO_ROOT_PASSWORD` to `<change-me>`.

- **`DOCKER.md`**: Documented the new required-password contract; compile a list
  of required credential vars for local developers.

- **`docs/LOCAL-DEVELOPMENT.md`**: Updated secret model text to reflect the
  new required-pattern posture.

- **`tests/fixtures/compose.ci.env`**: Added `LIVEKIT_API_KEY` and
  `LIVEKIT_API_SECRET` CI-safe values so `--profile voice` config renders.

- **`tests/unit/security/test_secret_hygiene.py`**: Two new tests:
  - `test_compose_dev_yml_has_no_hardcoded_password_fallbacks` — verifies
    all password vars use `:?` not `:-`
  - `test_compose_ci_env_has_all_required_password_vars` — verifies CI env
    contains every required var for config rendering

## Verification

```bash
# Compose config renders cleanly
COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --env-file tests/fixtures/compose.ci.env config --quiet
COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --profile voice --env-file tests/fixtures/compose.ci.env config --quiet

# All tests pass (68 passed, 51 skipped)
uv run pytest tests/unit/security/test_secret_hygiene.py tests/unit/test_compose_langfuse.py tests/unit/test_compose_config.py -q

# Secret scanner clean (gitleaks)
```

## Related issues

- #2123 — `env.example` discovery and preflight hardening
- #2126 — Compose service credential removal

This PR does NOT fully resolve either issue. It removes the hardcoded
fallbacks so Docker Compose rejects startup with missing/incomplete `.env`,
but additional preflight guardrails and env.example discovery improvements
are still needed.