### PR TITLE
fix(bot): tolerate empty MANAGERS_GROUP_ID in Docker bot config (#2149)

### DIFF
--- a/telegram_bot/config.py
+++ b/telegram_bot/config.py
@@ -28,6 +28,13 @@ def _empty_str_to_false(v: object) -> object:
 EmptyStrBool = Annotated[bool, BeforeValidator(_empty_str_to_false)]
 
 
+def _empty_str_to_none(v: object) -> object:
+    """Convert empty string to None for optional int env vars (#2149)."""
+    if v == "":
+        return None
+    return v
+
+
 def _inject_local_redis_password(
     redis_url: str,
     *,
@@ -600,7 +607,7 @@ class BotConfig(BaseSettings):
         default=False,
         validation_alias=AliasChoices("handoff_enabled", "HANDOFF_ENABLED"),
     )
-    managers_group_id: int | None = Field(
+    managers_group_id: Annotated[int | None, BeforeValidator(_empty_str_to_none)] = Field(
         default=None,
         validation_alias=AliasChoices("managers_group_id", "MANAGERS_GROUP_ID"),
     )

--- a/tests/unit/config/test_bot_config_settings.py
+++ b/tests/unit/config/test_bot_config_settings.py
@@ -159,6 +159,15 @@ class TestBotConfigIsPydanticSettings:
         cfg = BotConfig(_env_file=None)
         assert cfg.handoff_enabled is False
 
+    def test_managers_group_id_empty_string_does_not_crash(self, monkeypatch):
+        """Empty MANAGERS_GROUP_ID should parse as None, not crash (#2149)."""
+        monkeypatch.setenv("MANAGERS_GROUP_ID", "")
+
+        from telegram_bot.config import BotConfig
+
+        cfg = BotConfig(_env_file=None)
+        assert cfg.managers_group_id is None
+
     def test_redis_url_infers_password_loaded_from_env_file(self, monkeypatch, tmp_path):
         """REDIS_PASSWORD loaded from dotenv should drive the native local default URL."""
         monkeypatch.delenv("REDIS_URL", raising=False)


### PR DESCRIPTION
## Problem

When `MANAGERS_GROUP_ID` is unset in the host environment, Compose's `${MANAGERS_GROUP_ID:-}` substitution provides an empty string to the bot container. Pydantic's `int | None` field cannot parse an empty string, causing a `ValidationError` crash on container startup.

Fixes #2149. Relates to #2126 (handoff config).

## Root Cause

`telegram_bot/config.py:603` declared `managers_group_id: int | None` without a `BeforeValidator` to handle empty strings. The existing `_empty_str_to_false` / `EmptyStrBool` pattern for boolean fields showed the correct approach.

## Fix

- Added `_empty_str_to_none` validator that converts empty string to `None` (matching the `_empty_str_to_false` pattern)
- Changed `managers_group_id` from `int | None` to `Annotated[int | None, BeforeValidator(_empty_str_to_none)]`
- Regression test: `test_managers_group_id_empty_string_does_not_crash`

## Verification

```
uv run pytest tests/unit/config/test_bot_config_settings.py -q       # 19 passed
uv run pytest tests/unit/security/test_secret_hygiene.py -q          # 6 passed
COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --profile bot --env-file tests/fixtures/compose.ci.env config --quiet  # clean
git diff --check                                                        # clean
```