### PR TITLE
fix(contract): allowlist LANGFUSE_REDIS_PASSWORD as compose-only env var

### DIFF
--- a/tests/contract/test_env_example_completeness_contract.py
+++ b/tests/contract/test_env_example_completeness_contract.py
@@ -218,6 +218,10 @@ ALLOWLIST_NOT_IN_CODE: dict[str, str] = {
     "SALT": "Read by Langfuse server image",
     "ENCRYPTION_KEY": "Read by Langfuse server image",
     "LANGFUSE_DOCKER_HOST": "Container-network alias for langfuse; consumed by compose env_file",
+    "LANGFUSE_REDIS_PASSWORD": (
+        "Read by redis-langfuse / langfuse / langfuse-worker compose services "
+        "(REDIS_AUTH + redis-server --requirepass); not consumed by any Python code"
+    ),
     # --- Misc ops vars -----------------------------------------------------
     "MLFLOW_TRACKING_URI": "Read by mlflow CLI tooling, not the bot",
 }


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Problem

`make check`'s **Fast Tests** stage was failing on `dev` for every open PR because of one stale entry in `.env.example`:

```
FAILED tests/contract/test_env_example_completeness_contract.py::test_no_env_vars_in_env_example_unused_by_code
  - LANGFUSE_REDIS_PASSWORD
```

This was blocking CI on PRs #2151, #2152, #2153 even though their actual code is correct.

## Root cause

`LANGFUSE_REDIS_PASSWORD` is documented in `.env.example` but no Python code reads it — it is consumed **only** by compose:

- `compose.yml`: `redis-server --requirepass "$LANGFUSE_REDIS_PASSWORD"` and the matching healthcheck
- `compose.yml`: `langfuse` / `langfuse-worker` services pass it as `REDIS_AUTH`
- `compose.dev.yml`: same pattern

This is the exact same shape as the already-allowlisted `CLICKHOUSE_PASSWORD` and `MINIO_ROOT_PASSWORD` (also Compose-only secrets).

## Fix

Add `LANGFUSE_REDIS_PASSWORD` to `ALLOWLIST_NOT_IN_CODE` in `tests/contract/test_env_example_completeness_contract.py` with the standard "consumed by compose" justification. Mirrors the existing entries.

## Validation

```
uv run pytest tests/contract/test_env_example_completeness_contract.py -q --timeout=30
....                                                                     [100%]
4 passed in 1.65s
```

No production code touched. No `.env.example` change. Reproduces and is fixed cleanly on `dev`.

Unblocks CI for #2151, #2152, #2153.