### PR TITLE
refactor(tests): finish #1515 Phase 2/4 — smoke fixtures, async-without-await, midnight UTC flake

### DIFF
--- a/tests/contract/test_async_tests_have_await_contract.py
+++ b/tests/contract/test_async_tests_have_await_contract.py
@@ -1,4 +1,4 @@
-"""Contract: ``async def test_*`` functions must contain at least one ``await`` (#1515 S2).
+"""Contract: ``async def test_*`` functions must use at least one async feature (#1515 S2).
 
 Background
 ----------
@@ -14,9 +14,20 @@ This contract is a **ratchet**:
 * ``ALLOWLIST`` records every existing offender at the time #1515 Phase 4
   landed. The list must shrink — never grow — as offenders are migrated
   to plain ``def test_*``.
-* New ``async def test_*`` functions that lack ``await`` fail the
+* New ``async def test_*`` functions that lack any async usage fail the
   contract immediately, prompting the author to either remove ``async``
-  or add the missing ``await``.
+  or add the missing async usage.
+
+The detection accepts any of:
+
+* ``await EXPR`` (``ast.Await``)
+* ``async with CTX`` (``ast.AsyncWith``)
+* ``async for X in IT`` (``ast.AsyncFor``)
+* ``yield`` inside an async function (async generator)
+
+If a test legitimately exercises an async context manager via ``async
+with`` (e.g. FastAPI ``lifespan``), it is *not* an offender — keeping
+``async def`` is the only way to consume it.
 
 The shape mirrors the layering ratchet
 (``test_layering_no_telegram_bot_imports_contract.py``) and the chunker
@@ -37,38 +48,15 @@ SCAN_ROOT = REPO_ROOT / "tests" / "unit"
 # ``relative/path/to/file.py::test_function_name`` identifier.
 # This list MUST shrink as the offenders are migrated to plain
 # ``def test_*``. Never regenerate it to silence a failure.
-ALLOWLIST: frozenset[str] = frozenset(
-    {
-        "tests/unit/agents/test_bot_agent_integration.py::test_handle_query_supervisor_imports_available",
-        "tests/unit/agents/test_bot_agent_integration.py::test_bot_context_has_required_fields",
-        "tests/unit/agents/test_bot_agent_integration.py::test_get_crm_tools_returns_list",
-        "tests/unit/agents/test_crm_tools.py::test_get_crm_tools_count",
-        "tests/unit/agents/test_history_graph_integration.py::test_graph_compiles",
-        "tests/unit/agents/test_nurturing_analytics_tools.py::test_manager_tools_hidden_for_client_role",
-        "tests/unit/api/test_rag_api_runtime.py::test_lifespan_respects_rerank_provider_none",
-        "tests/unit/api/test_rag_api_runtime.py::test_lifespan_keeps_colbert_runtime_server_side",
-        "tests/unit/api/test_rag_api_runtime.py::test_lifespan_unknown_rerank_provider_logs_and_closes_embeddings",
-        "tests/unit/contextualization/test_base.py::test_inheritance_preserves_static_methods",
-        "tests/unit/dialogs/test_crm_foundation.py::test_kommo_client_has_update_task",
-        "tests/unit/dialogs/test_crm_foundation.py::test_kommo_client_has_complete_task",
-        "tests/unit/mini_app/test_api_lifespan.py::test_lifespan_opens_and_closes_redis",
-        "tests/unit/observability/test_sentry_wiring.py::test_mini_app_lifespan_initializes_sentry_before_redis",
-        "tests/unit/services/test_nurturing_scheduler.py::test_scheduler_has_no_jobs_before_start",
-        "tests/unit/services/test_rag_core.py::test_all_cacheable_types_are_checked",
-        "tests/unit/services/test_session_summary_worker.py::test_cap_default_is_50",
-        "tests/unit/services/test_session_summary_worker.py::test_cap_clamps_at_minimum_one",
-        "tests/unit/test_agent_streaming.py::test_stream_agent_to_draft_is_importable",
-        "tests/unit/test_bot_handlers.py::test_no_handle_promotions_method",
-        "tests/unit/test_perf_fixes.py::test_start_calls_warmup_bge",
-        "tests/unit/test_preflight.py::test_postgres_in_dep_classification_as_optional",
-        "tests/unit/test_topic_service_init.py::test_bot_has_topic_service_attr",
-    }
-)
+ALLOWLIST: frozenset[str] = frozenset()
 
 
 def _collect_offenders() -> set[str]:
     """Return the set of ``relative_path::function_name`` for every async test
-    under ``tests/unit/`` whose body does not contain ``await``.
+    under ``tests/unit/`` whose body does not use any async feature.
+
+    "Async feature" means at least one of: ``await``, ``async with``,
+    ``async for``, or ``yield`` (async generator).
     """
     offenders: set[str] = set()
     if not SCAN_ROOT.exists():
@@ -86,24 +74,32 @@ def _collect_offenders() -> set[str]:
                 continue
             if not node.name.startswith("test_"):
                 continue
-            has_await = any(isinstance(child, ast.Await) for child in ast.walk(node))
-            if not has_await:
+            has_async_use = any(
+                isinstance(
+                    child,
+                    (ast.Await, ast.AsyncWith, ast.AsyncFor, ast.Yield, ast.YieldFrom),
+                )
+                for child in ast.walk(node)
+            )
+            if not has_async_use:
                 rel = path.relative_to(REPO_ROOT).as_posix()
                 offenders.add(f"{rel}::{node.name}")
     return offenders
 
 
 def test_no_new_async_tests_without_await() -> None:
-    """New ``async def test_*`` functions must contain at least one ``await``.
+    """New ``async def test_*`` functions must use at least one async feature.
 
-    Either drop ``async`` (the test is sync) or add the missing ``await``.
+    Either drop ``async`` (the test is sync) or add the missing async
+    usage (``await``, ``async with``, ``async for``, or ``yield``).
     """
     offenders = _collect_offenders()
     new_offenders = sorted(offenders - ALLOWLIST)
     assert not new_offenders, (
-        "#1515 S2: new async test(s) without `await` detected. "
+        "#1515 S2: new async test(s) without any async usage detected. "
         "Convert to a plain `def test_*` if the body is sync, or add the "
-        "missing `await` if it should genuinely exercise async code.\n"
+        "missing `await` / `async with` / `async for` if it should "
+        "genuinely exercise async code.\n"
         "New offenders:\n  - " + "\n  - ".join(new_offenders)
     )
 

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -3,9 +3,9 @@
 
 URL/credential fixtures (``redis_url``, ``qdrant_url``, ``qdrant_api_key``,
 ``qdrant_collection``) are owned by ``tests/fixtures/config.py`` and
-registered globally in ``tests/conftest.py`` (issue #2066). This module
-only declares smoke-tier-specific fixtures (live-service guard, service
-clients).
+registered globally in ``tests/conftest.py`` (issues #2066, #1515 D4).
+This module only declares smoke-tier-specific fixtures (live-service
+guard, service clients).
 """
 
 import asyncio
@@ -20,11 +20,8 @@ from telegram_bot.services.qdrant import QdrantService
 
 
 @pytest.fixture(scope="module")
-def require_live_services(request):
+def require_live_services(qdrant_url, redis_url):
     """Skip if live services not available. Checks BOTH Qdrant AND Redis."""
-    qdrant_url = os.getenv("QDRANT_URL", "http://localhost:6333")
-    redis_url = request.getfixturevalue("redis_url")
-
     # Check Qdrant
     try:
         resp = httpx.get(f"{qdrant_url}/collections", timeout=2)
@@ -59,25 +56,24 @@ async def voyage_service():
 
 
 @pytest.fixture(scope="module")
-async def qdrant_service():
-    """QdrantService for search."""
-    url = os.getenv("QDRANT_URL", "http://localhost:6333")
-    api_key = os.getenv("QDRANT_API_KEY", "")
-    collection = os.getenv("QDRANT_COLLECTION", "gdrive_documents_bge")
+async def qdrant_service(qdrant_url, qdrant_api_key, qdrant_collection):
+    """QdrantService for search.
 
+    Reuses the root URL / credential / collection fixtures from
+    ``tests/fixtures/config.py`` (issue #1515 D4).
+    """
     service = QdrantService(
-        url=url,
-        api_key=api_key or None,
-        collection_name=collection,
+        url=qdrant_url,
+        api_key=qdrant_api_key or None,
+        collection_name=qdrant_collection,
     )
     yield service
     await service.close()
 
 
 @pytest.fixture(scope="module")
-async def cache_service(request):
+async def cache_service(redis_url):
     """CacheLayerManager for caching."""
-    redis_url = request.getfixturevalue("redis_url")
     service = CacheLayerManager(redis_url=redis_url)
     await service.initialize()
     yield service

--- a/tests/unit/agents/test_bot_agent_integration.py
+++ b/tests/unit/agents/test_bot_agent_integration.py
@@ -23,7 +23,7 @@ def mock_message():
     return msg
 
 
-async def test_handle_query_supervisor_imports_available():
+def test_handle_query_supervisor_imports_available():
     """Verify new imports are available in bot module."""
     from telegram_bot.agents.agent import create_bot_agent
     from telegram_bot.agents.context import BotContext
@@ -40,7 +40,7 @@ async def test_handle_query_supervisor_imports_available():
     assert BotContext is not None
 
 
-async def test_bot_context_has_required_fields():
+def test_bot_context_has_required_fields():
     """BotContext has all fields needed by _handle_query_supervisor."""
     from telegram_bot.agents.context import BotContext
 
@@ -63,7 +63,7 @@ async def test_bot_context_has_required_fields():
     assert ctx.language == "ru"
 
 
-async def test_get_crm_tools_returns_list():
+def test_get_crm_tools_returns_list():
     """get_crm_tools returns list of tool objects."""
     from telegram_bot.agents.crm_tools import get_crm_tools
 

--- a/tests/unit/agents/test_crm_tools.py
+++ b/tests/unit/agents/test_crm_tools.py
@@ -561,7 +561,7 @@ async def test_crm_update_contact_no_kommo():
     assert "недоступен" in result.lower()
 
 
-async def test_get_crm_tools_count():
+def test_get_crm_tools_count():
     """get_crm_tools returns exactly 12 tools."""
     from telegram_bot.agents.crm_tools import get_crm_tools
 

--- a/tests/unit/agents/test_history_graph_integration.py
+++ b/tests/unit/agents/test_history_graph_integration.py
@@ -21,7 +21,7 @@ def _patch_observe():
             yield mock_lf
 
 
-async def test_graph_compiles(_patch_observe):
+def test_graph_compiles(_patch_observe):
     """build_history_graph() returns a compiled graph."""
     from telegram_bot.agents.history_graph.graph import build_history_graph
 

--- a/tests/unit/agents/test_nurturing_analytics_tools.py
+++ b/tests/unit/agents/test_nurturing_analytics_tools.py
@@ -16,7 +16,7 @@ async def base_tool(message: str) -> str:
     return message
 
 
-async def test_manager_tools_hidden_for_client_role():
+def test_manager_tools_hidden_for_client_role():
     nurturing_tools = create_manager_nurturing_tools(
         analytics_service=AsyncMock(),
         nurturing_service=AsyncMock(),

--- a/tests/unit/contextualization/test_base.py
+++ b/tests/unit/contextualization/test_base.py
@@ -594,7 +594,7 @@ class TestContextualizeProviderImplementation:
         result = await mock_provider.contextualize([])
         assert result == []
 
-    async def test_inheritance_preserves_static_methods(self, mock_provider):
+    def test_inheritance_preserves_static_methods(self, mock_provider):
         """Test that static methods are inherited correctly."""
         # Should be accessible on instance
         system_prompt = mock_provider.get_system_prompt()

--- a/tests/unit/dialogs/test_crm_foundation.py
+++ b/tests/unit/dialogs/test_crm_foundation.py
@@ -195,7 +195,7 @@ def test_build_pagination_buttons_single_page():
 # --- KommoClient new methods ---
 
 
-async def test_kommo_client_has_update_task():
+def test_kommo_client_has_update_task():
     """KommoClient exposes update_task method."""
     from telegram_bot.services.kommo_client import KommoClient
 
@@ -203,7 +203,7 @@ async def test_kommo_client_has_update_task():
     assert callable(KommoClient.update_task)
 
 
-async def test_kommo_client_has_complete_task():
+def test_kommo_client_has_complete_task():
     """KommoClient exposes complete_task method."""
     from telegram_bot.services.kommo_client import KommoClient
 

--- a/tests/unit/dialogs/test_crm_tasks.py
+++ b/tests/unit/dialogs/test_crm_tasks.py
@@ -4,8 +4,38 @@ from __future__ import annotations
 
 import datetime
 import time
+import types
 
 import pytest
+
+
+def _freeze_crm_tasks_now(monkeypatch: pytest.MonkeyPatch, fixed_now: datetime.datetime) -> None:
+    """Freeze ``datetime.datetime.now`` inside ``telegram_bot.dialogs.crm_tasks``.
+
+    ``filter_tasks_today`` calls ``datetime.datetime.now(tz=UTC)`` to compute
+    today's window. If the test runs across midnight UTC, the test's
+    ``today_ts`` (computed from a separate ``datetime.now()``) lands on a
+    different date than the production's ``today_start``/``today_end``,
+    causing a flake (#1515 S4). This helper replaces the ``datetime`` module
+    binding inside ``crm_tasks`` with a fake namespace whose ``datetime``
+    class returns ``fixed_now`` from ``now()``, so both the test setup and
+    production code see the same instant. ``freezegun`` is intentionally not
+    introduced as a new dep.
+    """
+    from telegram_bot.dialogs import crm_tasks as crm_tasks_mod
+
+    class _FrozenDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            return fixed_now if tz is None else fixed_now.astimezone(tz)
+
+    fake_dt_module = types.SimpleNamespace(
+        datetime=_FrozenDatetime,
+        UTC=datetime.UTC,
+        timezone=datetime.timezone,
+        timedelta=datetime.timedelta,
+    )
+    monkeypatch.setattr(crm_tasks_mod, "datetime", fake_dt_module)
 
 
 # --- MyTasksSG states ---
@@ -79,13 +109,18 @@ def test_parse_due_date_past_raises():
 # --- filter_tasks helpers ---
 
 
-def test_filter_tasks_today_returns_only_todays_tasks():
+def test_filter_tasks_today_returns_only_todays_tasks(monkeypatch):
     """filter_tasks_today returns only tasks due today."""
     from telegram_bot.dialogs.crm_tasks import filter_tasks_today
     from telegram_bot.services.kommo_models import Task
 
-    now = datetime.datetime.now(tz=datetime.UTC)
-    today_ts = int(now.replace(hour=12, minute=0, second=0, microsecond=0).timestamp())
+    # Freeze production's "now" to a deterministic UTC noon so the test's
+    # today_ts/tomorrow_ts/yesterday_ts and the production's today_start/end
+    # observe the same date even if the test runs across midnight UTC.
+    fixed_now = datetime.datetime(2026, 6, 15, 12, 0, 0, tzinfo=datetime.UTC)
+    _freeze_crm_tasks_now(monkeypatch, fixed_now)
+
+    today_ts = int(fixed_now.timestamp())
     tomorrow_ts = today_ts + 86400
     yesterday_ts = today_ts - 86400
 
@@ -120,13 +155,15 @@ def test_filter_tasks_overdue_returns_only_overdue():
     assert result[0].id == 1
 
 
-def test_filter_tasks_today_skips_completed():
+def test_filter_tasks_today_skips_completed(monkeypatch):
     """filter_tasks_today skips completed tasks."""
     from telegram_bot.dialogs.crm_tasks import filter_tasks_today
     from telegram_bot.services.kommo_models import Task
 
-    now = datetime.datetime.now(tz=datetime.UTC)
-    today_ts = int(now.replace(hour=12, minute=0, second=0, microsecond=0).timestamp())
+    fixed_now = datetime.datetime(2026, 6, 15, 12, 0, 0, tzinfo=datetime.UTC)
+    _freeze_crm_tasks_now(monkeypatch, fixed_now)
+
+    today_ts = int(fixed_now.timestamp())
 
     tasks = [
         Task(id=1, text="Done today", complete_till=today_ts, is_completed=True),

--- a/tests/unit/services/test_nurturing_scheduler.py
+++ b/tests/unit/services/test_nurturing_scheduler.py
@@ -34,8 +34,7 @@ async def test_scheduler_configures_single_instance_coalesced_jobs(fake_services
     await scheduler.stop()
 
 
-@pytest.mark.asyncio
-async def test_scheduler_has_no_jobs_before_start(fake_services):
+def test_scheduler_has_no_jobs_before_start(fake_services):
     scheduler = NurturingScheduler(**fake_services)
 
     assert not scheduler.has_job("nurturing-batch")

--- a/tests/unit/services/test_rag_core.py
+++ b/tests/unit/services/test_rag_core.py
@@ -451,7 +451,7 @@ class TestCheckSemanticCache:
         call_kwargs = cache.check_semantic.call_args.kwargs
         assert call_kwargs.get("agent_role") == "sales"
 
-    async def test_all_cacheable_types_are_checked(self):
+    def test_all_cacheable_types_are_checked(self):
         """CACHEABLE_QUERY_TYPES includes expected types."""
         assert "FAQ" in CACHEABLE_QUERY_TYPES
         assert "ENTITY" in CACHEABLE_QUERY_TYPES

--- a/tests/unit/services/test_session_summary_worker.py
+++ b/tests/unit/services/test_session_summary_worker.py
@@ -639,14 +639,14 @@ class TestPerCycleCap:
         ]
         assert not cap_calls
 
-    async def test_cap_default_is_50(self):
+    def test_cap_default_is_50(self):
         """Default ``max_sessions_per_cycle`` keeps current behavior bounded."""
         from telegram_bot.services.session_summary_worker import SessionSummaryWorker
 
         worker = SessionSummaryWorker(redis=AsyncMock(), llm=AsyncMock())
         assert worker._max_sessions_per_cycle == 50
 
-    async def test_cap_clamps_at_minimum_one(self):
+    def test_cap_clamps_at_minimum_one(self):
         """A non-positive cap is normalized to 1 (must process at least one)."""
         from telegram_bot.services.session_summary_worker import SessionSummaryWorker
 

--- a/tests/unit/test_agent_streaming.py
+++ b/tests/unit/test_agent_streaming.py
@@ -58,7 +58,7 @@ def _make_bot() -> AsyncMock:
 # ---------------------------------------------------------------------------
 
 
-async def test_stream_agent_to_draft_is_importable():
+def test_stream_agent_to_draft_is_importable():
     """_stream_agent_to_draft must be importable from telegram_bot.bot."""
     from telegram_bot.bot import _stream_agent_to_draft
 

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -320,7 +320,7 @@ class TestCommandHandlers:
         for cmd in ["/history", "/metrics", "/clearcache"]:
             assert cmd in call_args, f"{cmd} missing from /help text"
 
-    async def test_no_handle_promotions_method(self, mock_config):
+    def test_no_handle_promotions_method(self, mock_config):
         """_handle_promotions removed as dead code (#863)."""
         bot, _ = _create_bot(mock_config)
         assert not hasattr(bot, "_handle_promotions")

--- a/tests/unit/test_perf_fixes.py
+++ b/tests/unit/test_perf_fixes.py
@@ -197,7 +197,7 @@ async def test_warmup_bge_failure_nonfatal():
             sys.modules.pop(mod, None)
 
 
-async def test_start_calls_warmup_bge():
+def test_start_calls_warmup_bge():
     """#953: PropertyBot.start() invokes _warmup_bge()."""
     import ast
     from pathlib import Path

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -852,7 +852,7 @@ class TestPostgresPreflight:
             assert result is True
             assert "auto-create" in caplog.text.lower()
 
-    async def test_postgres_in_dep_classification_as_optional(self):
+    def test_postgres_in_dep_classification_as_optional(self):
         """Postgres is OPTIONAL — bot degrades without it."""
         from telegram_bot.preflight import DEP_CLASSIFICATION, DepLevel
 

--- a/tests/unit/test_topic_service_init.py
+++ b/tests/unit/test_topic_service_init.py
@@ -2,11 +2,8 @@
 
 from unittest.mock import patch
 
-import pytest
 
-
-@pytest.mark.asyncio
-async def test_bot_has_topic_service_attr(monkeypatch):
+def test_bot_has_topic_service_attr(monkeypatch):
     """PropertyBot should have _topic_service after init."""
     monkeypatch.delenv("CLIENT_DIRECT_PIPELINE_ENABLED", raising=False)
     monkeypatch.delenv("KOMMO_ACCESS_TOKEN", raising=False)


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes the actionable scope of **#1515** (test-suite duplication & code-smell audit). Most items landed on `dev` via prior PRs since the issue was filed; this PR finishes the remaining three:

- **D4** — `tests/smoke/conftest.py` now consumes the shared `qdrant_url` / `qdrant_api_key` / `qdrant_collection` / `redis_url` fixtures from `tests/fixtures/` instead of re-reading env vars with a different default collection name.
- **S2** — emptied the 23-entry frozen ALLOWLIST in `tests/contract/test_async_tests_have_await_contract.py`; converted 13 sync-bodied `async def test_*` to plain `def test_*`; taught the contract scanner to recognize `async with` / `async for` / `yield` as legitimate async work.
- **S4** — fixed the 2 midnight-UTC flake-prone tests in `tests/unit/dialogs/test_crm_tasks.py` via a `monkeypatch`-only helper that freezes `datetime.datetime` inside the production module. **No new dependency** (`freezegun` not added per the issue's constraint).

## Per-item table

| Item | Status |
|---|---|
| D1 sample_context_chunks dup | ✅ already on dev (`tests/fixtures/data.py`) |
| D2 pytest_collection_modifyitems × 6 | ✅ already on dev |
| D3 Redis URL × 3 impls | ✅ already on dev (`tests/fixtures/config.py`) |
| **D4 Qdrant smoke hardcoded** | **DONE** |
| D5 65 `patch("get_client")` | ✅ already on dev (autouse + contract test) |
| D6 BotConfig 4 byte-identical | ✅ already on dev |
| D7 Contextualization 3× | ✅ already on dev (parametrized) |
| D8 Qdrant connection 2 files | ✅ already on dev (deleted) |
| D9 format_context dup | ✅ already on dev |
| S1 `call_count == 0` | ✅ already on dev |
| **S2 async without await** | **DONE** (allowlist → 0) |
| S3 `random.seed()` in tests | ✅ already on dev |
| **S4 midnight UTC flakes** | **DONE** (worst 2 tests) |
| S5 long test names | skipped (descriptive on purpose) |
| S6 `uuid4()` module-level | ✅ already on dev |
| S7 `src/api/schemas.py` no tests | ✅ already on dev |

## Tests

```
uv run pytest tests/unit tests/contract -q --timeout=120 \
  -m 'not legacy_api and not requires_extras and not slow'
→ 8463 passed, 77 skipped (optional extras), 160 deselected, 3 xfailed in 150s
```

`uv run ruff check tests/` clean on all 17 touched files.

## Files changed

```
17 files changed, 107 insertions(+), 82 deletions(-)
```

## Why I deviated from the issue's S4 plan

The issue says "12+ tests use real time and risk midnight/timezone flakes". After auditing all 51 hits, only the two `filter_tasks_today` tests have a true flake window: production calls `datetime.now(UTC)` independently of the test's pre-computed `now`, with no buffer between the two reads. The other 49 sites pass `now_ts` explicitly into production helpers with ≥1-day buffers and are stable. Patching them blindly would have been busywork without a behavioural justification, so I scoped the fix to the 2 genuinely flaky tests.

## Why I tightened the existing S2 contract instead of adding a new file

The issue says "Add a contract test: `tests/contract/test_async_test_must_await.py`". An equivalent contract already exists at `tests/contract/test_async_tests_have_await_contract.py`. Rather than introduce a parallel file, I:
- emptied the 23-entry frozen `ALLOWLIST` (after converting the offenders);
- taught the AST scanner to also recognize `async with`, `async for`, and `yield` as legitimate async work — without that, FastAPI-lifespan tests like `test_lifespan_opens_and_closes_redis` would have to be allowlisted or rewritten unnecessarily.