### PR TITLE
fix(observability): stop forwarding langfuse_trace_id from rag_search to rag_pipeline (#2157)

### DIFF
--- a/telegram_bot/agents/rag_tool.py
+++ b/telegram_bot/agents/rag_tool.py
@@ -160,8 +160,6 @@ async def rag_search(
                 result_store.get("semantic_cache_already_checked")
             )
 
-        trace_id = lf.get_current_trace_id() or ""
-
         invoke_start = time.perf_counter()
         # NOTE (#2157): do NOT forward `langfuse_trace_id` to rag_pipeline.
         # Per Langfuse SDK 4 docs (OpenTelemetry-based), @observe and

--- a/telegram_bot/agents/rag_tool.py
+++ b/telegram_bot/agents/rag_tool.py
@@ -163,6 +163,18 @@ async def rag_search(
         trace_id = lf.get_current_trace_id() or ""
 
         invoke_start = time.perf_counter()
+        # NOTE (#2157): do NOT forward `langfuse_trace_id` to rag_pipeline.
+        # Per Langfuse SDK 4 docs (OpenTelemetry-based), @observe and
+        # start_as_current_observation share the same OTEL context-propagation
+        # model and nest automatically across the same async call chain. The
+        # `langfuse_trace_id` kwarg on an @observe-decorated function is the
+        # contract for *external* trace context (e.g., a W3C trace context
+        # arriving over HTTP from another process). Passing it from inside an
+        # already-active OTEL span detaches rag_pipeline's @observe from its
+        # parent (tool-rag-search), drops the rag-pipeline observation, takes
+        # over `trace.name`, and orphans cache-/bge-/classify spans up to
+        # telegram-rag-supervisor. See #1253 for the original (wrong) forward
+        # contract this comment reverts.
         pipeline_kwargs: dict[str, Any] = {
             "user_id": ctx.telegram_user_id if ctx else 0,
             "session_id": ctx.session_id if ctx else "",
@@ -181,8 +193,6 @@ async def rag_search(
             "pre_computed_colbert": pre_computed_colbert,
             "semantic_cache_already_checked": semantic_cache_already_checked,
         }
-        if trace_id:
-            pipeline_kwargs["langfuse_trace_id"] = trace_id
 
         result = await rag_pipeline(query, **pipeline_kwargs)
         pipeline_wall_ms = (time.perf_counter() - invoke_start) * 1000

--- a/tests/unit/agents/test_rag_tool.py
+++ b/tests/unit/agents/test_rag_tool.py
@@ -488,8 +488,28 @@ async def test_rag_search_falls_back_to_query_when_no_original(bot_context):
     assert guard_state["messages"][0]["content"] == "цены на квартиры"
 
 
-async def test_rag_search_forwards_active_trace_id_to_pipeline(bot_context):
-    """rag_search forwards active Langfuse trace id to rag_pipeline (#1253)."""
+async def test_rag_search_does_not_forward_langfuse_trace_id_to_pipeline(bot_context):
+    """rag_search MUST NOT pass langfuse_trace_id to rag_pipeline (#2157).
+
+    Per Langfuse SDK 4 docs (OpenTelemetry-based), @observe and
+    start_as_current_observation share the same OTEL context-propagation model
+    and nest automatically inside the same async call chain. The
+    ``langfuse_trace_id`` kwarg on an @observe-decorated function is the
+    contract for *external* trace context propagation (e.g., a W3C trace
+    context arriving on an HTTP request from another process). Passing it
+    inside an already-active OTEL parent span DETACHES the @observe-decorated
+    function from its parent and turns it into a new trace entrypoint —
+    which:
+
+    * removes the ``rag-pipeline`` observation from the trace tree,
+    * overrides ``trace.name`` to ``rag-pipeline``,
+    * orphans every nested @observe span inside ``rag_pipeline`` (cache-*,
+      bge-m3-*, classify-query) up to ``telegram-rag-supervisor`` instead of
+      keeping them under ``tool-rag-search → rag-pipeline``.
+
+    Reverts the wrong forwarding contract introduced in #1253; see #2157 for
+    the regression evidence and Langfuse SDK 4 reasoning.
+    """
     from telegram_bot.agents.rag_tool import rag_search
 
     mock_lf = MagicMock()
@@ -506,11 +526,20 @@ async def test_rag_search_forwards_active_trace_id_to_pipeline(bot_context):
         await rag_search.ainvoke({"query": "test"}, config=_make_config(bot_context))
 
     assert mock_pipeline.call_count == 1
-    assert mock_pipeline.call_args.kwargs.get("langfuse_trace_id") == "trace-active-123"
+    # The OTEL parent context must remain implicit; we never pass an explicit
+    # langfuse_trace_id to a @observe-decorated function from inside an
+    # active trace.
+    assert "langfuse_trace_id" not in mock_pipeline.call_args.kwargs
 
 
 async def test_rag_search_omits_langfuse_trace_id_when_no_active_trace(bot_context):
-    """rag_search omits langfuse_trace_id kwarg when no active trace (#1253)."""
+    """rag_search omits langfuse_trace_id kwarg when there is no active trace.
+
+    The original #1253 contract (always forward) was reverted in #2157; the
+    new contract is "never forward" regardless of trace presence. This test
+    pins the no-active-trace branch behavior to keep the absence guarantee
+    independent of ``get_current_trace_id`` return value.
+    """
     from telegram_bot.agents.rag_tool import rag_search
 
     mock_lf = MagicMock()


### PR DESCRIPTION
## Summary

Fixes #2157.

Reverts the wrong `langfuse_trace_id` forwarding contract introduced in #1253. After this change, a single Telegram text message produces **one** top-level Langfuse trace named `telegram-message`, with `telegram-rag-query → telegram-rag-supervisor → … → tool-rag-search → rag-pipeline → cache-* / bge-m3-* / classify-query` correctly nested below it.

## Root cause

`telegram_bot/agents/rag_tool.py:rag_search` was passing
`pipeline_kwargs["langfuse_trace_id"] = lf.get_current_trace_id()` to the
`@observe`-decorated `rag_pipeline()`.

Per Langfuse SDK 4 docs (Context7 lookup against `/langfuse/langfuse-python`):

> `@observe` and `start_as_current_observation` share the same OpenTelemetry
> context-propagation model and can be freely mixed within the same trace.

The `langfuse_trace_id` kwarg is documented as the contract for **external**
trace context propagation — for example, a W3C trace context arriving over
HTTP from another process. Passing it from inside an already-active OTEL
parent span detaches the `@observe`-decorated function from that parent and
turns it into a new trace entrypoint.

## Production evidence (#2157)

| | Before fix (May 26 trace `4716835a…`) | After fix (expected) |
|---|---|---|
| `trace.name` | `rag-pipeline` ❌ | `telegram-message` ✅ |
| `rag-pipeline` observation | absent ❌ | nested under `tool-rag-search` ✅ |
| `cache-*` / `bge-m3-*` / `classify-query` parents | float up to `telegram-rag-supervisor` ❌ | nested under `rag-pipeline` ✅ |
| `telegram-message` | only an inner observation, name hijacked ❌ | top-level root ✅ |

The middleware (`telegram_bot/middlewares/langfuse_middleware.py`) was already opening the correct root span — the regression was purely in the in-process child detachment.

The other `rag_pipeline` call sites do not forward `langfuse_trace_id` and were not regressed:
- `telegram_bot/pipelines/client.py:374` (text path through `client-direct-pipeline`)
- `telegram_bot/bot.py:1261` (Mini App path)

## Fix

`telegram_bot/agents/rag_tool.py`:
- Removed the `pipeline_kwargs["langfuse_trace_id"] = trace_id` block.
- Kept `trace_id = lf.get_current_trace_id() or ""` because it is still used by `write_langfuse_scores(lf, result, trace_id=trace_id)` further down.
- Added inline rationale referencing #2157 and #1253.

## TDD

- New failing test (RED before fix, GREEN after):
  `tests/unit/agents/test_rag_tool.py::test_rag_search_does_not_forward_langfuse_trace_id_to_pipeline`
  — asserts the `langfuse_trace_id` kwarg is **never** on the `rag_pipeline` call, even when an active trace exists.
- Replaces `test_rag_search_forwards_active_trace_id_to_pipeline` from #1253 (which pinned the wrong contract).
- `test_rag_search_omits_langfuse_trace_id_when_no_active_trace` retained, docstring updated to rationalize the no-active-trace branch as part of the new "never forward" contract.

## Validation

- `make check` (ruff + mypy strict): clean. Only pre-existing `annotation-unchecked` notes from untouched files.
- `pytest tests/unit/agents/ tests/unit/middlewares/test_langfuse_middleware.py tests/unit/test_langfuse_context_middleware.py tests/unit/observability/ tests/unit/test_bot_query_supervisor.py`: **597 passed, 3 skipped** (livekit not installed in this env — unrelated to the change).

## Out of scope

- Voice path (`telegram-rag-voice`) — does not call `rag_search` with this code path; not affected.
- LiteLLM proxy `litellm-acompletion` flat traces — these come from the proxy's native callback and are documented as expected noise in `docs/runbooks/LANGFUSE_TRACING_GAPS.md`.

## References

- Issue: #2157
- Wrong contract introduced in: #1253
- Runbook: `docs/runbooks/LANGFUSE_TRACING_GAPS.md` ("Trace Interpretation Matrix")
- SDK reference: Langfuse Python SDK 4.x — OTel-based, mixed `@observe` + `start_as_current_observation` is canonical.
