### PR TITLE
fix(observability): instrument rag_core orchestration helpers with @observe (#2162)

### DIFF
--- a/telegram_bot/services/rag_core.py
+++ b/telegram_bot/services/rag_core.py
@@ -6,14 +6,25 @@ Extracted to avoid ~300 LOC duplication between:
 
 Core functions are pure computation (no Langfuse spans, no PipelineMetrics).
 Adapters (pipeline / nodes) handle span tracking, metrics, and state wrapping.
+
+Observability (#2162):
+    Each orchestration helper carries an ``@observe`` decorator with
+    ``capture_input=False`` and ``capture_output=False`` so that the trace tree
+    contains a stable ``rag-core-*`` span for every helper without leaking raw
+    user query text, embedding vectors, or document text. Curated
+    high-signal metadata (cache hit, query type, top-k, vector dim) is added
+    inside each function via ``update_current_span(input=..., output=...)`` so
+    the Langfuse UI shows useful summary fields.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from typing import Any
 
+from telegram_bot.observability import get_client, observe
 from telegram_bot.services.bge_m3_query_bundle import BgeM3QueryVectorBundle
 from telegram_bot.services.cache_policy import is_contextual_query
 
@@ -34,6 +45,14 @@ _REWRITE_PROMPT = (
 )
 
 
+def _update_current_span(**kwargs: Any) -> None:
+    """Best-effort ``update_current_span`` wrapper; no-op when no client."""
+    lf = get_client()
+    if lf is not None:
+        with contextlib.suppress(Exception):
+            lf.update_current_span(**kwargs)
+
+
 def _is_deprecated_colbert_reranker(reranker: Any) -> bool:
     """Return True when caller passed the deprecated client-side ColBERT service."""
     if reranker is None:
@@ -52,6 +71,7 @@ def _is_deprecated_colbert_reranker(reranker: Any) -> bool:
 # ---------------------------------------------------------------------------
 
 
+@observe(name="rag-core-build-context", capture_input=False, capture_output=False)
 def build_retrieved_context(
     results: list[dict[str, Any]],
     limit: int = 5,
@@ -74,6 +94,10 @@ def build_retrieved_context(
                 "chunk_location": meta.get("chunk_location", ""),
             }
         )
+    _update_current_span(
+        input={"docs_in": len(results), "limit": limit},
+        output={"snippets_out": len(ctx), "snippet_chars_max": _MAX_CONTEXT_SNIPPET},
+    )
     return ctx
 
 
@@ -82,6 +106,7 @@ def build_retrieved_context(
 # ---------------------------------------------------------------------------
 
 
+@observe(name="rag-core-rewrite-query", capture_input=False, capture_output=False)
 async def rewrite_query_via_llm(
     query: str,
     *,
@@ -117,7 +142,19 @@ async def rewrite_query_via_llm(
     actual_model = getattr(response, "model", config.rewrite_model) or config.rewrite_model
 
     if not rewritten or rewritten == query:
+        _update_current_span(
+            input={"query_chars": len(query), "rewrite_model": config.rewrite_model},
+            output={"effective": False, "model": actual_model},
+        )
         return (query, False, actual_model)
+    _update_current_span(
+        input={"query_chars": len(query), "rewrite_model": config.rewrite_model},
+        output={
+            "effective": True,
+            "model": actual_model,
+            "rewritten_chars": len(rewritten),
+        },
+    )
     return (rewritten, True, actual_model)
 
 
@@ -126,6 +163,7 @@ async def rewrite_query_via_llm(
 # ---------------------------------------------------------------------------
 
 
+@observe(name="rag-core-perform-rerank", capture_input=False, capture_output=False)
 async def perform_rerank(
     query: str,
     documents: list[dict[str, Any]],
@@ -157,6 +195,10 @@ async def perform_rerank(
         Callers should sort/trim on the no-reranker path if needed.
     """
     if not documents:
+        _update_current_span(
+            input={"docs_in": 0, "top_k": top_k},
+            output={"docs_out": 0, "rerank_applied": False, "rerank_cache_hit": False},
+        )
         return ([], False, False)
 
     if _is_deprecated_colbert_reranker(reranker):
@@ -175,6 +217,14 @@ async def perform_rerank(
         if _has_get_rerank and _cache_get is not None:
             cached_reranked = await _cache_get(query, documents, top_k)
             if cached_reranked is not None:
+                _update_current_span(
+                    input={"docs_in": len(documents), "top_k": top_k},
+                    output={
+                        "docs_out": len(cached_reranked),
+                        "rerank_applied": True,
+                        "rerank_cache_hit": True,
+                    },
+                )
                 return (cached_reranked, True, True)
 
         # May raise — callers handle error + fallback sort
@@ -191,9 +241,25 @@ async def perform_rerank(
         if _has_store_rerank and _cache_store is not None:
             await _cache_store(query, documents, top_k, reranked)
 
+        _update_current_span(
+            input={"docs_in": len(documents), "top_k": top_k},
+            output={
+                "docs_out": len(reranked),
+                "rerank_applied": True,
+                "rerank_cache_hit": False,
+            },
+        )
         return (reranked, True, False)
 
     # No reranker — return documents as-is; callers sort/trim as needed
+    _update_current_span(
+        input={"docs_in": len(documents), "top_k": top_k},
+        output={
+            "docs_out": len(documents),
+            "rerank_applied": False,
+            "rerank_cache_hit": False,
+        },
+    )
     return (documents, False, False)
 
 
@@ -202,6 +268,7 @@ async def perform_rerank(
 # ---------------------------------------------------------------------------
 
 
+@observe(name="rag-core-compute-query-embedding", capture_input=False, capture_output=False)
 async def compute_query_embedding(
     query: str,
     *,
@@ -241,6 +308,15 @@ async def compute_query_embedding(
     """
     # Path 1: caller already has pre-computed vectors
     if pre_computed is not None:
+        _update_current_span(
+            input={"query_chars": len(query), "source": "pre_computed"},
+            output={
+                "dense_dim": len(pre_computed),
+                "has_sparse": pre_computed_sparse is not None,
+                "has_colbert": pre_computed_colbert is not None,
+                "from_cache": False,
+            },
+        )
         return (pre_computed, pre_computed_sparse, pre_computed_colbert, False)
 
     # Determine capabilities
@@ -259,6 +335,15 @@ async def compute_query_embedding(
     if _has_bundle_get:
         bundle = await cache.get_bge_m3_query_bundle(query)
         if isinstance(bundle, BgeM3QueryVectorBundle) and bundle.is_complete():
+            _update_current_span(
+                input={"query_chars": len(query), "source": "bundle_cache"},
+                output={
+                    "dense_dim": len(bundle.dense),
+                    "has_sparse": bundle.sparse is not None,
+                    "has_colbert": bundle.colbert is not None,
+                    "from_cache": True,
+                },
+            )
             return (bundle.dense, bundle.sparse, bundle.colbert, True)
 
     # Path 3: full bundle compute (cache miss + aembed_hybrid_with_colbert available)
@@ -289,6 +374,15 @@ async def compute_query_embedding(
             except Exception:
                 logger.debug("Legacy embedding store failed (non-critical), skipping")
 
+            _update_current_span(
+                input={"query_chars": len(query), "source": "bundle_compute"},
+                output={
+                    "dense_dim": len(dense),
+                    "has_sparse": sparse is not None,
+                    "has_colbert": colbert is not None,
+                    "from_cache": False,
+                },
+            )
             return (dense, sparse, colbert, False)
 
     # Path 4: legacy dense cache
@@ -296,6 +390,15 @@ async def compute_query_embedding(
     from_cache = dense is not None
 
     if dense is not None:
+        _update_current_span(
+            input={"query_chars": len(query), "source": "legacy_dense_cache"},
+            output={
+                "dense_dim": len(dense),
+                "has_sparse": False,
+                "has_colbert": False,
+                "from_cache": True,
+            },
+        )
         return (dense, None, None, from_cache)
 
     # Path 5: legacy model compute
@@ -312,9 +415,19 @@ async def compute_query_embedding(
         await cache.store_embedding(query, dense)
         sparse = None
 
+    _update_current_span(
+        input={"query_chars": len(query), "source": "legacy_compute"},
+        output={
+            "dense_dim": len(dense),
+            "has_sparse": sparse is not None,
+            "has_colbert": False,
+            "from_cache": False,
+        },
+    )
     return (dense, sparse, None, False)
 
 
+@observe(name="rag-core-check-semantic-cache", capture_input=False, capture_output=False)
 async def check_semantic_cache(
     query: str,
     vector: list[float],
@@ -341,8 +454,24 @@ async def check_semantic_cache(
         - response: The cached response string, or None on miss
     """
     if query_type not in CACHEABLE_QUERY_TYPES:
+        _update_current_span(
+            input={
+                "query_type": query_type,
+                "query_chars": len(query),
+                "vector_dim": len(vector),
+            },
+            output={"cache_hit": False, "skipped_reason": "non_cacheable_query_type"},
+        )
         return (False, None)
     if is_contextual_query(query):
+        _update_current_span(
+            input={
+                "query_type": query_type,
+                "query_chars": len(query),
+                "vector_dim": len(vector),
+            },
+            output={"cache_hit": False, "skipped_reason": "contextual_query"},
+        )
         return (False, None)
 
     cached = await cache.check_semantic(
@@ -352,6 +481,17 @@ async def check_semantic_cache(
         cache_scope="rag",
         agent_role=agent_role,
         filter_signature=filter_signature,
+    )
+
+    _update_current_span(
+        input={
+            "query_type": query_type,
+            "query_chars": len(query),
+            "vector_dim": len(vector),
+            "agent_role": agent_role,
+            "has_filter_signature": filter_signature is not None,
+        },
+        output={"cache_hit": bool(cached)},
     )
 
     if cached:

--- a/tests/observability/trace_contract.yaml
+++ b/tests/observability/trace_contract.yaml
@@ -52,6 +52,13 @@ spans:
     - query-rewrite
     - cache-store
 
+  rag_core:
+    - rag-core-build-context
+    - rag-core-rewrite-query
+    - rag-core-perform-rerank
+    - rag-core-compute-query-embedding
+    - rag-core-check-semantic-cache
+
   agent_tools:
     - tool-rag-search
     - tool-history-search
@@ -307,6 +314,12 @@ sensitive_spans:
   - retrieval.initial
   - retrieval.relax
   - cache-store
+  # rag_core (raw query text, document chunks, vectors, cache payloads)
+  - rag-core-build-context
+  - rag-core-rewrite-query
+  - rag-core-perform-rerank
+  - rag-core-compute-query-embedding
+  - rag-core-check-semantic-cache
   # agent_tools
   - tool-rag-search
   - tool-history-search

--- a/tests/unit/services/test_rag_core.py
+++ b/tests/unit/services/test_rag_core.py
@@ -459,3 +459,121 @@ class TestCheckSemanticCache:
         assert "GENERAL" in CACHEABLE_QUERY_TYPES
         # Non-cacheable types not included
         assert "APARTMENT" not in CACHEABLE_QUERY_TYPES
+
+
+# ---------------------------------------------------------------------------
+# #2162: @observe instrumentation contract
+# ---------------------------------------------------------------------------
+
+
+class TestRagCoreObserveContract:
+    """Verifies all five orchestration helpers carry @observe instrumentation.
+
+    Each helper must:
+      - emit exactly one Langfuse span with the documented ``rag-core-*`` name
+      - opt out of automatic input/output capture (PII protection)
+      - write curated metadata via ``update_current_span`` (no raw query text,
+        no embedding vectors, no document text)
+
+    Closes #2162.
+    """
+
+    EXPECTED_SPAN_NAMES = {
+        "build_retrieved_context": "rag-core-build-context",
+        "rewrite_query_via_llm": "rag-core-rewrite-query",
+        "perform_rerank": "rag-core-perform-rerank",
+        "compute_query_embedding": "rag-core-compute-query-embedding",
+        "check_semantic_cache": "rag-core-check-semantic-cache",
+    }
+
+    @pytest.mark.parametrize(
+        "func_name,expected_span_name",
+        list(EXPECTED_SPAN_NAMES.items()),
+    )
+    def test_each_helper_is_observe_decorated(
+        self, func_name: str, expected_span_name: str, monkeypatch
+    ) -> None:
+        """The decorated helper must call ``observe(name=...)`` at import time."""
+        captured: list[dict] = []
+
+        # Source-level assertion — survives any wrapper transparency tricks
+        # introduced by the langfuse SDK in future versions.
+        import inspect
+        import textwrap
+
+        from telegram_bot.services import rag_core as rag_core_mod
+
+        src = textwrap.dedent(inspect.getsource(getattr(rag_core_mod, func_name)))
+        # The decorator line MUST appear in the source above the def line.
+        assert f'@observe(name="{expected_span_name}"' in src, (
+            f'{func_name} must be wrapped with @observe(name="{expected_span_name}", ...)'
+        )
+        assert "capture_input=False" in src, (
+            f"{func_name} must opt out of automatic input capture (PII protection)"
+        )
+        assert "capture_output=False" in src, (
+            f"{func_name} must opt out of automatic output capture"
+        )
+
+        # Suppress unused warning while still keeping the parameter for future use.
+        del captured, monkeypatch
+
+    def test_build_retrieved_context_emits_span_with_curated_metadata(self) -> None:
+        """``build_retrieved_context`` must call update_current_span with curated keys.
+
+        We patch ``_update_current_span`` (the module-level helper) so we can
+        observe the curated metadata payload without a live Langfuse client.
+        """
+        from unittest.mock import patch
+
+        from telegram_bot.services import rag_core as rag_core_mod
+
+        with patch.object(rag_core_mod, "_update_current_span") as mock_update:
+            rag_core_mod.build_retrieved_context(
+                [
+                    {"text": "hello", "score": 0.5, "metadata": {}},
+                    {"text": "world", "score": 0.4, "metadata": {}},
+                ],
+                limit=5,
+            )
+
+        assert mock_update.call_count >= 1
+        call_kwargs = mock_update.call_args.kwargs
+        # Curated input fields only — no raw doc text.
+        assert "input" in call_kwargs
+        assert call_kwargs["input"] == {"docs_in": 2, "limit": 5}
+        # Curated output — no raw doc text.
+        assert "output" in call_kwargs
+        assert call_kwargs["output"]["snippets_out"] == 2
+
+    async def test_check_semantic_cache_curated_metadata_no_raw_query(self) -> None:
+        """``check_semantic_cache`` must NOT include the raw query in span metadata."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from telegram_bot.services import rag_core as rag_core_mod
+
+        cache = MagicMock()
+        cache.check_semantic = AsyncMock(return_value=None)
+
+        with patch.object(rag_core_mod, "_update_current_span") as mock_update:
+            await rag_core_mod.check_semantic_cache(
+                "очень секретный текст пользователя",
+                [0.1, 0.2, 0.3],
+                "FAQ",
+                cache=cache,
+            )
+
+        assert mock_update.call_count >= 1
+        all_payloads = [c.kwargs for c in mock_update.call_args_list]
+        # Concatenate every payload to a single string and assert raw query
+        # text is not present anywhere — neither in input nor output.
+        flattened = repr(all_payloads)
+        assert "очень секретный текст" not in flattened
+        # But query length is OK to expose.
+        assert any(
+            p.get("input", {}).get("query_chars") == len("очень секретный текст пользователя")
+            for p in all_payloads
+        )
+        # Vector dim too — but never the vector values.
+        assert any(p.get("input", {}).get("vector_dim") == 3 for p in all_payloads)
+        assert "0.1" not in flattened or "0.2" not in flattened or "0.3" not in flattened


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Fixes #2162.

## Summary

Adds `@observe` decorators with `capture_input=False` / `capture_output=False` to the **five orchestration helpers** in `telegram_bot/services/rag_core.py`. Closes the last meaningful instrumentation hole inside the RAG hot path so the trace tree contains a stable `rag-core-*` span for every helper without leaking raw user query text, embedding vectors, or document text.

## Decorated functions and span names

| Function | Span name | as_type |
|---|---|---|
| `build_retrieved_context` | `rag-core-build-context` | span (sync) |
| `rewrite_query_via_llm` | `rag-core-rewrite-query` | span |
| `perform_rerank` | `rag-core-perform-rerank` | span |
| `compute_query_embedding` | `rag-core-compute-query-embedding` | span |
| `check_semantic_cache` | `rag-core-check-semantic-cache` | span |

## SDK-native pattern

Per Langfuse Python SDK 4 docs (Context7 lookup against `/langfuse/langfuse-python`), the canonical orchestration-helper pattern is `@observe(name=..., capture_input=False, capture_output=False)` plus curated `update_current_span(input=..., output=...)` calls inside the function body for cheap-to-read summary fields. PII protection is mandatory because:

- `compute_query_embedding` returns a 1024-dim BGE-M3 dense vector — large and useless in Langfuse UI.
- `check_semantic_cache` input is the raw user query (PII-sensitive).
- `rewrite_query_via_llm` rewrites the raw query — both input and output are user content.
- `perform_rerank` input is a list of document chunks; large and noisy.
- `build_retrieved_context` input is the full retrieved chunk list.

Curated metadata captures only high-signal fields: `query_type`, `cache_hit`, `rerank_top_k`, `vector_dim`, `query_chars`, `dense_dim`, `from_cache`, etc. — never the values themselves.

## Validation

- `make check` (ruff + mypy on touched files): clean.
- `pytest tests/unit/services/test_rag_core.py tests/unit/services/test_rag_core_embedding_bundle.py tests/unit/agents/ tests/unit/graph/`: **908 passed** in 19.78s.
- New regression test class `TestRagCoreObserveContract` (7 tests) pins the decorator + curated-output contract with a parametrized source-level assertion that survives any future SDK wrapper-transparency changes.

## Tested

- Local unit suite (touched surface)
- Lint (ruff), format (ruff format), type-check (mypy --ignore-missing-imports)

## Out of scope

- Tightening `capture_input` on existing decorators in `rag_pipeline.py`, `cache.py`, `embeddings.py` — already use `capture_input=False` consistently.
- Trace-quality scores from inside these functions — handled by `write_langfuse_scores` at the `rag_search` boundary.
- The `run_in_executor` embedding span fix — already in place per the runbook.

Closes #2162.