### PR TITLE
fix(observability): explicit Langfuse init in mini-app FastAPI lifespan (#2161)

### DIFF
--- a/mini_app/api.py
+++ b/mini_app/api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -17,7 +18,7 @@ from pydantic import BaseModel, Field, field_validator
 from mini_app.auth import validate_init_data
 from mini_app.expert_start import StartExpertRequest, StartExpertResponse
 from mini_app.phone import PhoneRequest, submit_phone
-from src.observability import get_client, observe, propagate_attributes
+from src.observability import get_client, initialize_langfuse, observe, propagate_attributes
 from src.observability_sentry import initialize_sentry, set_runtime_tags
 from src.services.content_loader import load_mini_app_config
 
@@ -43,12 +44,42 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     the connection lifecycle here (instead of a module-level lazy
     global) ensures graceful close on process shutdown and matches the
     FastAPI-native pattern (#1645).
+
+    Langfuse tracing is initialized explicitly here as well (#2161). The
+    Mini App process owns its own ``Langfuse()`` client built via
+    :func:`src.observability.initialize_langfuse` so ``@observe``-
+    decorated endpoints (``miniapp-start-expert``, ``miniapp-submit-phone``,
+    ``miniapp-kommo-create-lead``) actually emit traces. Without an
+    explicit init the Langfuse SDK lazy-builds a singleton on first
+    ``get_client()`` call; if env wasn't fully loaded by then (or if
+    ``auth_check`` would have failed) the singleton stays disabled
+    silently for the remainder of the process. Initializing in lifespan
+    surfaces credential / connectivity errors loudly at startup and
+    flushes pending spans on graceful shutdown.
     """
     # Initialize Sentry FIRST so any subsequent startup error (Redis,
     # config) is captured. No-op when SENTRY_DSN is unset (#1417).
     if initialize_sentry():
         set_runtime_tags(service="mini-app")
         logger.info("Sentry error tracking enabled with PII redaction")
+
+    # Initialize Langfuse explicitly (#2161). ``initialize_langfuse``
+    # logs the reason for any disable (missing keys, unreachable host,
+    # SDK import failure) at INFO/WARNING and never raises, so the API
+    # boots cleanly even when Langfuse is not configured. Stash the
+    # client on ``app.state.langfuse`` so it can be shut down on exit
+    # alongside Redis.
+    langfuse_client = initialize_langfuse()
+    if langfuse_client is not None:
+        try:
+            langfuse_client.auth_check()
+            logger.info("Langfuse initialized for mini-app-api")
+        except Exception:
+            logger.exception("Langfuse auth_check failed; tracing disabled for mini-app-api")
+            with contextlib.suppress(Exception):
+                langfuse_client.shutdown()
+            langfuse_client = None
+    app.state.langfuse = langfuse_client
 
     import redis.asyncio as aioredis
 
@@ -65,6 +96,13 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             result = close()
             if hasattr(result, "__await__"):
                 await result
+        # Flush + close Langfuse so pending spans land in the backend
+        # before the process exits (#2161). ``shutdown`` is idempotent
+        # and safe to call even when ``initialize_langfuse`` returned
+        # ``None`` (suppressed below).
+        if app.state.langfuse is not None:
+            with contextlib.suppress(Exception):
+                app.state.langfuse.shutdown()
 
 
 async def get_redis(request: Request) -> Any:

--- a/tests/unit/mini_app/test_api_lifespan.py
+++ b/tests/unit/mini_app/test_api_lifespan.py
@@ -140,3 +140,80 @@ def test_start_expert_handler_uses_depends_get_redis() -> None:
         "start_expert must declare a Redis parameter via Depends(get_redis) "
         "for FastAPI-native dependency injection (#1645)"
     )
+
+
+# ---------------------------------------------------------------------------
+# #2161 — explicit Langfuse init in mini-app FastAPI lifespan
+# ---------------------------------------------------------------------------
+
+
+async def test_lifespan_initializes_langfuse_when_credentials_present() -> None:
+    """Lifespan must explicitly call ``initialize_langfuse`` + ``auth_check``.
+
+    Without an explicit init the SDK lazy-builds a singleton on the first
+    ``get_client()`` call. If env wasn't fully loaded by then (or the host is
+    unreachable) the singleton stays disabled silently for the rest of the
+    process and zero traces materialize for ``@observe``-decorated endpoints
+    (``miniapp-start-expert``, ``miniapp-submit-phone``,
+    ``miniapp-kommo-create-lead``). Closes #2161.
+    """
+    from mini_app import api as mod
+
+    fake_redis = MagicMock()
+    fake_redis.aclose = AsyncMock()
+
+    fake_lf_client = MagicMock(name="langfuse-client")
+    fake_lf_client.auth_check = MagicMock(return_value=True)
+    fake_lf_client.shutdown = MagicMock()
+
+    with (
+        patch("redis.asyncio.from_url", return_value=fake_redis),
+        patch("mini_app.api.initialize_langfuse", return_value=fake_lf_client) as init_lf,
+    ):
+        async with mod.lifespan(mod.app):
+            # Client is stashed on app state so it can be reused/shut down.
+            assert mod.app.state.langfuse is fake_lf_client
+            init_lf.assert_called_once()
+            fake_lf_client.auth_check.assert_called_once()
+
+        # Lifespan exit must flush+close the Langfuse client exactly once.
+        fake_lf_client.shutdown.assert_called_once()
+
+
+async def test_lifespan_disables_langfuse_when_credentials_missing() -> None:
+    """Missing/invalid credentials must gracefully disable tracing — never crash."""
+    from mini_app import api as mod
+
+    fake_redis = MagicMock()
+    fake_redis.aclose = AsyncMock()
+
+    with (
+        patch("redis.asyncio.from_url", return_value=fake_redis),
+        patch("mini_app.api.initialize_langfuse", return_value=None) as init_lf,
+    ):
+        async with mod.lifespan(mod.app):
+            assert mod.app.state.langfuse is None
+            init_lf.assert_called_once()
+
+
+async def test_lifespan_handles_auth_check_failure_gracefully() -> None:
+    """If ``auth_check`` raises, tracing is disabled but the API still boots."""
+    from mini_app import api as mod
+
+    fake_redis = MagicMock()
+    fake_redis.aclose = AsyncMock()
+
+    fake_lf_client = MagicMock(name="langfuse-client")
+    fake_lf_client.auth_check = MagicMock(side_effect=RuntimeError("bad credentials"))
+    fake_lf_client.shutdown = MagicMock()
+
+    with (
+        patch("redis.asyncio.from_url", return_value=fake_redis),
+        patch("mini_app.api.initialize_langfuse", return_value=fake_lf_client),
+    ):
+        async with mod.lifespan(mod.app):
+            # Auth failed — client must be reset to None so handlers no-op.
+            assert mod.app.state.langfuse is None
+            fake_lf_client.auth_check.assert_called_once()
+            # The failed client must be shut down on auth failure to release threads.
+            fake_lf_client.shutdown.assert_called_once()


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Fixes #2161.

## Summary

The Mini App FastAPI process exposes three `@observe`-decorated endpoints (`miniapp-start-expert`, `miniapp-submit-phone`, `miniapp-kommo-create-lead`) but produces **zero Langfuse traces** in practice (`totalItems = 0` for every name). Without an explicit init the SDK lazy-builds a singleton on the first `get_client()` call; if env wasn't fully loaded by then (or the host is unreachable) the singleton stays disabled silently for the rest of the process.

Compose env wiring for the `mini-app-api` service was already correct — `LANGFUSE_DOCKER_HOST` resolves into `LANGFUSE_HOST` inside the container, and `OTEL_SERVICE_NAME=mini-app-api` is set. **The fix is purely in the FastAPI lifespan.**

## SDK-native fix

Per Langfuse Python SDK 4 docs (Context7 lookup against `/langfuse/langfuse-python`), the canonical bootstrap is a `Langfuse()` constructor call followed by a synchronous `auth_check()` so credential / connectivity errors surface loudly at startup instead of silently disabling traces, plus a `shutdown()` on graceful exit so pending spans flush before the process exits.

```python
async with mod.lifespan(mod.app):
    # initialize_langfuse() + auth_check() ran; client on app.state.langfuse
    ...
# shutdown() called automatically on lifespan exit
```

## Changes

- `mini_app/api.py:lifespan` now calls `src.observability.initialize_langfuse` (the same shared bootstrap used by the bot and voice runtimes), runs `auth_check`, stashes the client on `app.state.langfuse`, and calls `shutdown()` on exit so pending spans flush before process exit.
- Failure modes (missing keys, `auth_check` raising, host unreachable) are logged and gracefully disable tracing — never crash the API.
- New regression tests pin the contract:
  - `test_lifespan_initializes_langfuse_when_credentials_present`
  - `test_lifespan_disables_langfuse_when_credentials_missing`
  - `test_lifespan_handles_auth_check_failure_gracefully`

## Validation

- `pytest tests/unit/mini_app/`: **67 passed** (64 existing + 3 new) in 2.86s.
- Lint (ruff), format (ruff format), type-check (mypy --ignore-missing-imports): clean.

## Acceptance criteria coverage

- [x] `mini_app/api.py:lifespan` performs an explicit `Langfuse()` + `auth_check()` on startup, stores the client on `app.state.langfuse`, and calls `shutdown()` on exit.
- [x] Missing or invalid credentials log a single warning and gracefully disable tracing — never crash the API.
- [x] Compose env wiring already honors `LANGFUSE_DOCKER_HOST` inside the container (no change needed).
- [x] Regression tests added.
- [x] PII protection unchanged — curated input/output dicts in `@observe`-decorated endpoints already in place per #1658.

## Out of scope

- Browser-side OTEL instrumentation in the Mini App frontend.
- Langfuse cloud vs self-hosted resolution — left to env config.

Closes #2161.