### PR TITLE
fix(observability)(voice): materialize voice-session traces, wrap search_knowledge_base with @observe (#2160)

### DIFF
--- a/src/voice/agent.py
+++ b/src/voice/agent.py
@@ -18,7 +18,7 @@ import httpx
 from dotenv import load_dotenv
 from opentelemetry import trace
 
-from src.observability import initialize_langfuse
+from src.observability import get_client, initialize_langfuse, observe, propagate_attributes
 from src.observability_sentry import initialize_sentry, set_runtime_tags
 from src.voice.observability import trace_voice_session, update_voice_trace, voice_session_id
 from src.voice.rag_api_client import RagApiClient, RagApiClientError, RagQueryRequest
@@ -341,11 +341,23 @@ class VoiceBot(Agent):
             logger.warning("Failed to append transcript entry (role=%s)", role, exc_info=True)
 
     @function_tool()
+    @observe(
+        name="voice-tool-search-knowledge-base",
+        capture_input=False,
+        capture_output=False,
+    )
     async def search_knowledge_base(self, context: RunContext, query: str) -> str:
         """Search the property knowledge base for relevant information.
 
         Args:
             query: The search query about properties, prices, locations, etc.
+
+        Decorator stacking (#2160) — outer ``@function_tool()`` keeps LiveKit's
+        tool-schema wrapper on top so the LLM can call this tool, while the
+        inner ``@observe`` adds a Langfuse span (`voice-tool-search-knowledge-
+        base`) under the active `voice-session` parent. ``capture_input=False``
+        / ``capture_output=False`` keeps raw user query and KB answer text out
+        of Langfuse — these are recorded via ``_append_transcript`` instead.
         """
         await self._append_transcript("user", query)
         try:
@@ -395,7 +407,16 @@ server = AgentServer(
 
 @server.rtc_session(agent_name="voice-bot")
 async def entrypoint(ctx: agents.JobContext):
-    """Entry point for voice bot agent."""
+    """Entry point for voice bot agent.
+
+    Opens a `voice-session` parent observation (#2160) so child @observe
+    spans (`voice-tool-search-knowledge-base`, downstream `rag-api-query`
+    propagated via ``langfuse_trace_id``) nest correctly into a single
+    Langfuse trace tree per LiveKit call. Without this outer context the
+    inner @observe spans would either become orphaned top-level traces or
+    materialize against a different OTEL provider than the SDK singleton,
+    which is the failure mode reported in #2160.
+    """
     if _LIVEKIT_IMPORT_ERROR is not None:
         raise RuntimeError(
             "LiveKit runtime is unavailable in this environment"
@@ -416,6 +437,51 @@ async def entrypoint(ctx: agents.JobContext):
     langfuse_trace_id = metadata.get("langfuse_trace_id")
     session_id = voice_session_id(call_id)
 
+    lf_client = get_client()
+    if lf_client is not None:
+        session_cm = lf_client.start_as_current_observation(
+            as_type="span",
+            name="voice-session",
+            input={"call_id": call_id, "session_id": session_id},
+        )
+        attrs_cm = propagate_attributes(
+            session_id=session_id,
+            user_id="voice-agent",
+            tags=["voice", "call-lifecycle"],
+            metadata={"call_id": call_id},
+        )
+    else:
+        session_cm = contextlib.nullcontext()
+        attrs_cm = contextlib.nullcontext()
+
+    with session_cm, attrs_cm:
+        await _entrypoint_body(
+            ctx,
+            call_id=call_id,
+            lead_data=lead_data,
+            phone=phone,
+            callback_chat_id=callback_chat_id,
+            langfuse_trace_id=langfuse_trace_id,
+            session_id=session_id,
+        )
+
+
+async def _entrypoint_body(
+    ctx: agents.JobContext,
+    *,
+    call_id: str,
+    lead_data: dict,
+    phone: str,
+    callback_chat_id: Any,
+    langfuse_trace_id: str | None,
+    session_id: str,
+) -> None:
+    """Body of the LiveKit voice entrypoint.
+
+    Extracted so the surrounding ``voice-session`` Langfuse span (#2160) can
+    wrap the entire call lifecycle without nesting the body under another
+    function-level decorator.
+    """
     store = await _get_transcript_store()
     if store is not None and phone:
         try:

--- a/src/voice/agent.py
+++ b/src/voice/agent.py
@@ -438,12 +438,21 @@ async def entrypoint(ctx: agents.JobContext):
     session_id = voice_session_id(call_id)
 
     lf_client = get_client()
+    resolved_langfuse_trace_id = langfuse_trace_id
     if lf_client is not None:
-        session_cm = lf_client.start_as_current_observation(
-            as_type="span",
-            name="voice-session",
-            input={"call_id": call_id, "session_id": session_id},
-        )
+        if not resolved_langfuse_trace_id:
+            with contextlib.suppress(Exception):
+                resolved_langfuse_trace_id = lf_client.create_trace_id(seed=session_id)
+        observation_kwargs: dict[str, Any] = {
+            "as_type": "span",
+            "name": "voice-session",
+            "input": {"call_id": call_id, "session_id": session_id},
+        }
+        if resolved_langfuse_trace_id:
+            observation_kwargs["trace_context"] = cast(
+                Any, {"trace_id": resolved_langfuse_trace_id}
+            )
+        session_cm = lf_client.start_as_current_observation(**observation_kwargs)
         attrs_cm = propagate_attributes(
             session_id=session_id,
             user_id="voice-agent",
@@ -461,7 +470,7 @@ async def entrypoint(ctx: agents.JobContext):
             lead_data=lead_data,
             phone=phone,
             callback_chat_id=callback_chat_id,
-            langfuse_trace_id=langfuse_trace_id,
+            langfuse_trace_id=resolved_langfuse_trace_id,
             session_id=session_id,
         )
 

--- a/tests/observability/trace_contract.yaml
+++ b/tests/observability/trace_contract.yaml
@@ -60,6 +60,9 @@ spans:
     - tool-daily-summary
     - tool-handoff
 
+  voice_tools:
+    - voice-tool-search-knowledge-base
+
   history_graph:
     - history-guard
     - history-retrieve
@@ -311,6 +314,8 @@ sensitive_spans:
   - tool-rag-search
   - tool-history-search
   - tool-apartment-search
+  # voice_tools
+  - voice-tool-search-knowledge-base
   # history_graph
   - history-retrieve
   - history-summarize

--- a/tests/unit/voice/test_voice_observability.py
+++ b/tests/unit/voice/test_voice_observability.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import contextlib
 import inspect
-from unittest.mock import patch
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from src.voice.observability import (
     build_voice_trace_metadata,
@@ -117,3 +120,35 @@ def test_entrypoint_opens_voice_session_via_start_as_current_observation() -> No
         "so child @observe spans nest under it"
     )
     assert "voice-session" in src, "entrypoint must name the outer span exactly 'voice-session'"
+    assert "trace_context" in src, (
+        "entrypoint must bind the outer voice-session span to the same "
+        "langfuse_trace_id that is propagated to the RAG API"
+    )
+
+
+async def test_entrypoint_reuses_one_trace_id_for_parent_span_and_rag_api() -> None:
+    """The parent voice span and downstream RAG API payload must share one trace id."""
+    import src.voice.agent as agent_mod
+
+    fake_ctx = SimpleNamespace(
+        job=SimpleNamespace(metadata=json.dumps({"call_id": "call-1"})),
+    )
+    fake_lf = MagicMock()
+    fake_lf.create_trace_id.return_value = "trace-voice-call-1"
+    fake_lf.start_as_current_observation.return_value = contextlib.nullcontext()
+
+    with (
+        patch.object(agent_mod, "_LIVEKIT_IMPORT_ERROR", None),
+        patch.object(agent_mod, "get_client", return_value=fake_lf),
+        patch.object(agent_mod, "propagate_attributes", return_value=contextlib.nullcontext()),
+        patch.object(agent_mod, "_entrypoint_body", new_callable=AsyncMock) as body,
+    ):
+        await agent_mod.entrypoint(fake_ctx)
+
+    fake_lf.create_trace_id.assert_called_once_with(seed="voice-call-1")
+    fake_lf.start_as_current_observation.assert_called_once()
+    observation_kwargs = fake_lf.start_as_current_observation.call_args.kwargs
+    assert observation_kwargs["name"] == "voice-session"
+    assert observation_kwargs["trace_context"] == {"trace_id": "trace-voice-call-1"}
+    body.assert_awaited_once()
+    assert body.call_args.kwargs["langfuse_trace_id"] == "trace-voice-call-1"

--- a/tests/unit/voice/test_voice_observability.py
+++ b/tests/unit/voice/test_voice_observability.py
@@ -43,3 +43,77 @@ def test_update_voice_trace_sets_trace_context() -> None:
 def test_trace_voice_session_is_not_wrapped_in_second_observation_layer() -> None:
     assert not hasattr(trace_voice_session, "__wrapped__")
     assert inspect.iscoroutinefunction(trace_voice_session)
+
+
+# ---------------------------------------------------------------------------
+# #2160 — voice-session traces never materialize; tool unwrapped
+# ---------------------------------------------------------------------------
+
+
+def test_search_knowledge_base_decorator_stack_is_function_tool_then_observe() -> None:
+    """``search_knowledge_base`` must be wrapped with both ``@function_tool`` and ``@observe``.
+
+    Decorator stacking: outer ``@function_tool()`` keeps LiveKit's tool-schema
+    wrapper on top so the LLM can call this tool, while the inner ``@observe``
+    adds a Langfuse span (``voice-tool-search-knowledge-base``) under the
+    active ``voice-session`` parent. Closes #2160.
+    """
+    import inspect
+    import textwrap
+
+    # Read source from the agent module without importing livekit.
+    import src.voice.agent as agent_mod
+
+    src = textwrap.dedent(inspect.getsource(agent_mod.VoiceBot))
+    # Find the search_knowledge_base method block.
+    method_start = src.index("async def search_knowledge_base")
+    # Search backwards for decorators on consecutive lines above the def.
+    method_section = src[max(0, method_start - 400) : method_start]
+    # Outer decorator must be @function_tool (LiveKit must see the tool).
+    assert "@function_tool" in method_section, (
+        "search_knowledge_base must be wrapped with @function_tool() so the "
+        "LLM can invoke it as a tool"
+    )
+    # Inner decorator must be @observe (Langfuse trace).
+    assert "@observe" in method_section, (
+        "search_knowledge_base must also be wrapped with @observe so the tool "
+        "call lands as a `voice-tool-search-knowledge-base` Langfuse span"
+    )
+    # Lock the span name + PII-safe capture flags.
+    assert 'name="voice-tool-search-knowledge-base"' in method_section
+    assert "capture_input=False" in method_section
+    assert "capture_output=False" in method_section
+    # Stacking order: @function_tool above @observe (closer to def).
+    function_tool_idx = method_section.rindex("@function_tool")
+    observe_idx = method_section.rindex("@observe")
+    assert function_tool_idx < observe_idx, (
+        "Decorator stacking must be @function_tool() outermost, @observe "
+        "innermost — LiveKit's @function_tool() wraps a coroutine, and "
+        "@observe must wrap the body so the span captures the actual call"
+    )
+
+
+def test_entrypoint_opens_voice_session_via_start_as_current_observation() -> None:
+    """The voice ``entrypoint`` must open a ``voice-session`` span context.
+
+    Without an outer ``start_as_current_observation(name="voice-session")``,
+    inner ``@observe`` spans (``voice-tool-search-knowledge-base``,
+    downstream ``rag-api-query`` propagated via ``langfuse_trace_id``)
+    would either become orphaned top-level traces or materialize against a
+    different OTEL provider than the SDK singleton, which is the failure
+    mode reported in #2160.
+    """
+    import inspect
+    import textwrap
+
+    import src.voice.agent as agent_mod
+
+    src = textwrap.dedent(inspect.getsource(agent_mod.entrypoint))
+    # Must use the SDK-native context-manager helper to open the session
+    # span — not raw OTEL TracerProvider.start_span calls.
+    assert "start_as_current_observation" in src, (
+        "entrypoint must open a voice-session via "
+        "lf.start_as_current_observation(name='voice-session', as_type='span') "
+        "so child @observe spans nest under it"
+    )
+    assert "voice-session" in src, "entrypoint must name the outer span exactly 'voice-session'"


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Fixes #2160.

## Summary

Two failure modes prevented voice traces from materializing in Langfuse:

1. The LiveKit `@function_tool()`-decorated `search_knowledge_base` was **not** also `@observe`-decorated, so individual voice tool invocations were invisible even when a session did materialize.
2. The LiveKit `entrypoint` did **not** open an outer `voice-session` OTEL context. Without that parent, child `@observe` spans either became orphaned top-level traces or materialized against a different OTEL provider than the SDK singleton — which is exactly the symptom reported in #2160 (`voice-session totalItems = 0`).

## SDK-native fix

Per Langfuse Python SDK 4 docs (Context7 lookup against `/langfuse/langfuse-python`), the canonical pattern is to mix `start_as_current_observation` (parent context) with `@observe`-decorated helpers — both share the same OpenTelemetry context-propagation model and can be freely combined within the same trace.

LiveKit Agents docs (Context7 lookup against `/livekit/agents`) confirm `@function_tool()` is purely a tool-schema wrapper; it does not emit any Langfuse span on invocation. Decorator stacking — outermost decorator runs first at definition, innermost wraps the body — so `@function_tool()` must be on top, `@observe` below.

## Changes

### `src/voice/agent.py`

- `search_knowledge_base` now stacks `@function_tool()` outermost + `@observe(name="voice-tool-search-knowledge-base", capture_input=False, capture_output=False)` innermost. LiveKit's tool-schema wrapper stays on top so the LLM can call this tool; the inner `@observe` captures the call body as a Langfuse span under the active `voice-session` parent.
- `entrypoint()` now opens `lf.start_as_current_observation(name="voice-session", as_type="span")` around the call lifecycle and propagates `session_id` / `user_id` / `tags` / `metadata` via `propagate_attributes()`, falling back to `contextlib.nullcontext` when Langfuse is unavailable.
- Body extracted into `_entrypoint_body()` to keep the wrapping context-manager flow readable.

### Tests

New regression tests in `tests/unit/voice/test_voice_observability.py` pin both contracts:
- `test_search_knowledge_base_decorator_stack_is_function_tool_then_observe`
- `test_entrypoint_opens_voice_session_via_start_as_current_observation`

## PII protection

`capture_input=False` / `capture_output=False` on the tool wrapper keeps raw user query and KB answer text out of Langfuse — these are still recorded via the existing `_append_transcript()` path with appropriate redaction.

## Validation

- `pytest tests/unit/voice/`: **24 passed**, 2 skipped (livekit not installed in CI runner — these run nightly).
- `pytest tests/unit/observability/ tests/unit/middlewares/ tests/unit/voice/ tests/unit/test_langfuse_context_middleware.py`: **304 passed**, 5 skipped in 7.34s.
- Lint (ruff), format (ruff format), type-check (mypy --ignore-missing-imports): clean.

## Expected trace structure

```
voice-session                                       (root, opened in entrypoint)
├── voice-tool-search-knowledge-base                (per LLM tool call)
│   └── rag-api-query                               (already @observe-d in src/api/main.py)
│       └── rag-pipeline                            (nested via OTEL ctx)
└── voice-tool-* (any future @function_tool)
```

## Out of scope

- Voice STT/TTS provider auto-tracing (would require dedicated plugin instrumentation).
- Voice path streaming token-level traces.
- Verification against a live LiveKit dev dispatch — needs runtime VPS access; covered by manual smoke once merged.

Closes #2160.