### PR TITLE
fix(observability): propagate contextvars across all run_in_executor hops in RAGPipeline.search (#2167)

### DIFF
--- a/docs/runbooks/LANGFUSE_TRACING_GAPS.md
+++ b/docs/runbooks/LANGFUSE_TRACING_GAPS.md
@@ -214,18 +214,12 @@ write_langfuse_scores(lf, result, trace_id=trace_id)
 
 ### Embedding Span Missing or Orphaned (`core-pipeline-query-embedding`)
 
-**Cause:** The core RAG pipeline runs query embedding inside a thread-pool via `run_in_executor`. Langfuse spans rely on `contextvars` for parent-trace linkage; standard `run_in_executor` drops that context, so the span becomes orphaned or invisible.
+**Cause:** The core RAG pipeline runs query embedding and sync search calls inside worker threads. Langfuse spans rely on `contextvars` for parent-trace linkage; raw `run_in_executor` drops that context, so the span becomes orphaned or invisible.
 
-**Fix:** Wrap the observed call with `contextvars.copy_context()` and `Context.run()`:
+**Fix:** Use `asyncio.to_thread(...)` for observed sync calls; it propagates the current `contextvars.Context` into the worker thread:
 
 ```python
-import contextvars
-
-loop = asyncio.get_event_loop()
-ctx = contextvars.copy_context()
-query_embedding = await loop.run_in_executor(
-    None, lambda: ctx.run(self._encode_query, query)
-)
+query_embedding = await asyncio.to_thread(self._encode_query, query)
 ```
 
 Where `_encode_query` is decorated as:
@@ -243,7 +237,7 @@ def _encode_query(self, query: str):
 
 **Prevention:** All embedding spans (including `bge-m3-*`, `search-engine-*`, and pipeline spans) must keep `capture_input=False` and `capture_output=False` to avoid leaking raw vectors or query text into Langfuse.
 
-**Coverage of `RAGPipeline.search` (post #2167):** every `loop.run_in_executor(...)` hop inside `src/core/pipeline.py:RAGPipeline.search` — the encode-query path *and* both `search_engine.search(...)` paths (hybrid and non-hybrid) — must dispatch through `contextvars.copy_context().run(...)`. The `search_engine.search` methods are themselves `@observe`-decorated (`hybrid-rrf-search`, `hybrid-rrf-colbert-search`, etc.), so an executor hop without `ctx.run` would emit a top-level orphan trace instead of nesting under the active `rag-pipeline` / `telegram-message` parent. The contract is pinned by `tests/unit/core/test_pipeline.py::TestRAGPipelineExecutorContextPropagation`.
+**Coverage of `RAGPipeline.search` (post #2167):** every worker-thread hop inside `src/core/pipeline.py:RAGPipeline.search` — the encode-query path *and* both `search_engine.search(...)` paths (hybrid and non-hybrid) — must dispatch through `asyncio.to_thread(...)`. The `search_engine.search` methods are themselves `@observe`-decorated (`hybrid-rrf-search`, `hybrid-rrf-colbert-search`, etc.), so a raw executor hop without context propagation would emit a top-level orphan trace instead of nesting under the active `rag-pipeline` / `telegram-message` parent. The contract is pinned by `tests/unit/core/test_pipeline.py::TestRAGPipelineExecutorContextPropagation`.
 
 ### Flat `litellm-acompletion` Traces Everywhere
 

--- a/docs/runbooks/LANGFUSE_TRACING_GAPS.md
+++ b/docs/runbooks/LANGFUSE_TRACING_GAPS.md
@@ -243,6 +243,8 @@ def _encode_query(self, query: str):
 
 **Prevention:** All embedding spans (including `bge-m3-*`, `search-engine-*`, and pipeline spans) must keep `capture_input=False` and `capture_output=False` to avoid leaking raw vectors or query text into Langfuse.
 
+**Coverage of `RAGPipeline.search` (post #2167):** every `loop.run_in_executor(...)` hop inside `src/core/pipeline.py:RAGPipeline.search` — the encode-query path *and* both `search_engine.search(...)` paths (hybrid and non-hybrid) — must dispatch through `contextvars.copy_context().run(...)`. The `search_engine.search` methods are themselves `@observe`-decorated (`hybrid-rrf-search`, `hybrid-rrf-colbert-search`, etc.), so an executor hop without `ctx.run` would emit a top-level orphan trace instead of nesting under the active `rag-pipeline` / `telegram-message` parent. The contract is pinned by `tests/unit/core/test_pipeline.py::TestRAGPipelineExecutorContextPropagation`.
+
 ### Flat `litellm-acompletion` Traces Everywhere
 
 **Cause:** LiteLLM proxy is logging every LLM call as a standalone trace via its native Langfuse callback. This is expected behavior, but it produces flat traces with no pipeline context.

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -1,7 +1,6 @@
 """Main RAG pipeline orchestrator."""
 
 import asyncio
-import contextvars
 from dataclasses import dataclass
 from typing import Any
 
@@ -117,47 +116,30 @@ class RAGPipeline:
         if isinstance(self.search_engine, (HybridRRFSearchEngine, HybridRRFColBERTSearchEngine)):
             # Pass query string directly for hybrid search (async handled inside).
             #
-            # We MUST hop through ``contextvars.copy_context()`` here because
-            # ``self.search_engine.search`` is ``@observe``-decorated. Without
-            # the copy the worker thread sees an empty OTEL context and emits a
-            # new top-level trace instead of nesting under whatever parent
-            # opened the surrounding ``rag-pipeline`` / ``telegram-message``
-            # span (#2167 follow-up to #2157).
-            loop = asyncio.get_running_loop()
-            ctx = contextvars.copy_context()
-            search_results = await loop.run_in_executor(
-                None,
-                lambda: ctx.run(
-                    self.search_engine.search,
-                    query_embedding=query,
-                    top_k=top_k,
-                    score_threshold=self.settings.score_threshold,
-                ),
+            # ``self.search_engine.search`` is ``@observe``-decorated.
+            # ``asyncio.to_thread`` preserves the current contextvars.Context,
+            # keeping the worker span nested under the active Langfuse parent
+            # instead of emitting a top-level orphan trace (#2167).
+            search_results = await asyncio.to_thread(
+                self.search_engine.search,
+                query_embedding=query,
+                top_k=top_k,
+                score_threshold=self.settings.score_threshold,
             )
         else:
             # For other engines, generate dense embedding (async).
             #
             # Both inner calls (``_encode_query`` and ``search_engine.search``)
-            # are ``@observe``-decorated, so both have to ride through the same
-            # captured ``contextvars`` snapshot. A single ``copy_context()``
-            # per executor hop is sufficient — each ``ctx.run(...)`` call uses
-            # the snapshot independently (#2167).
-            loop = asyncio.get_running_loop()
-            ctx = contextvars.copy_context()
-            query_embedding = await loop.run_in_executor(
-                None, lambda: ctx.run(self._encode_query, query)
-            )
+            # are ``@observe``-decorated, so both thread hops use
+            # ``asyncio.to_thread`` to preserve the active Langfuse context.
+            query_embedding = await asyncio.to_thread(self._encode_query, query)
 
             # Step 2: Search using configured search engine (async)
-            ctx = contextvars.copy_context()
-            search_results = await loop.run_in_executor(
-                None,
-                lambda: ctx.run(
-                    self.search_engine.search,
-                    query_embedding=query_embedding,
-                    top_k=top_k,
-                    score_threshold=self.settings.score_threshold,
-                ),
+            search_results = await asyncio.to_thread(
+                self.search_engine.search,
+                query_embedding=query_embedding,
+                top_k=top_k,
+                score_threshold=self.settings.score_threshold,
             )
 
         # Step 3: Optional contextualization

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -115,18 +115,33 @@ class RAGPipeline:
         from src.retrieval import HybridRRFColBERTSearchEngine, HybridRRFSearchEngine
 
         if isinstance(self.search_engine, (HybridRRFSearchEngine, HybridRRFColBERTSearchEngine)):
-            # Pass query string directly for hybrid search (async handled inside)
+            # Pass query string directly for hybrid search (async handled inside).
+            #
+            # We MUST hop through ``contextvars.copy_context()`` here because
+            # ``self.search_engine.search`` is ``@observe``-decorated. Without
+            # the copy the worker thread sees an empty OTEL context and emits a
+            # new top-level trace instead of nesting under whatever parent
+            # opened the surrounding ``rag-pipeline`` / ``telegram-message``
+            # span (#2167 follow-up to #2157).
             loop = asyncio.get_running_loop()
+            ctx = contextvars.copy_context()
             search_results = await loop.run_in_executor(
                 None,
-                lambda: self.search_engine.search(
+                lambda: ctx.run(
+                    self.search_engine.search,
                     query_embedding=query,
                     top_k=top_k,
                     score_threshold=self.settings.score_threshold,
                 ),
             )
         else:
-            # For other engines, generate dense embedding (async)
+            # For other engines, generate dense embedding (async).
+            #
+            # Both inner calls (``_encode_query`` and ``search_engine.search``)
+            # are ``@observe``-decorated, so both have to ride through the same
+            # captured ``contextvars`` snapshot. A single ``copy_context()``
+            # per executor hop is sufficient — each ``ctx.run(...)`` call uses
+            # the snapshot independently (#2167).
             loop = asyncio.get_running_loop()
             ctx = contextvars.copy_context()
             query_embedding = await loop.run_in_executor(
@@ -134,9 +149,11 @@ class RAGPipeline:
             )
 
             # Step 2: Search using configured search engine (async)
+            ctx = contextvars.copy_context()
             search_results = await loop.run_in_executor(
                 None,
-                lambda: self.search_engine.search(
+                lambda: ctx.run(
+                    self.search_engine.search,
                     query_embedding=query_embedding,
                     top_k=top_k,
                     score_threshold=self.settings.score_threshold,

--- a/tests/unit/core/test_pipeline.py
+++ b/tests/unit/core/test_pipeline.py
@@ -241,6 +241,61 @@ class TestRAGPipelineSearch:
         assert callable(mock_pipeline._encode_query)
 
 
+class TestRAGPipelineExecutorContextPropagation:
+    """Pin the contract that every executor hop in ``search`` propagates context.
+
+    Closes #2167 (follow-up to #2157). ``self.search_engine.search`` and
+    ``self._encode_query`` are both ``@observe``-decorated. When they run
+    inside a ``loop.run_in_executor`` worker thread without
+    ``contextvars.copy_context().run(...)``, the worker sees an empty OTEL
+    context and emits a top-level orphan trace (e.g. ``bge-m3-hybrid-embed``,
+    ``hybrid-rrf-search``) instead of nesting under whatever parent opened
+    the surrounding ``rag-pipeline`` / ``telegram-message`` span.
+    """
+
+    def test_every_run_in_executor_call_uses_ctx_run(self) -> None:
+        """AST contract: every ``run_in_executor(...)`` in ``RAGPipeline.search`` runs via ``ctx.run``."""
+        import ast
+        import inspect
+        import textwrap
+
+        from src.core.pipeline import RAGPipeline
+
+        src = textwrap.dedent(inspect.getsource(RAGPipeline.search))
+        tree = ast.parse(src)
+
+        executor_calls: list[ast.Call] = []
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "run_in_executor"
+            ):
+                executor_calls.append(node)
+
+        assert executor_calls, (
+            "RAGPipeline.search must dispatch sync work through "
+            "loop.run_in_executor — no executor call found in source"
+        )
+
+        for call in executor_calls:
+            call_src = ast.unparse(call)
+            assert "ctx.run(" in call_src, (
+                "Every loop.run_in_executor(...) inside RAGPipeline.search must "
+                "wrap the callable with ``contextvars.copy_context().run(...)`` "
+                "so that @observe-decorated callees nest under the active OTEL "
+                "parent (#2167). Offending call:\n" + call_src
+            )
+
+    def test_search_module_imports_contextvars(self) -> None:
+        """``src.core.pipeline`` must import ``contextvars`` for the executor hops."""
+        import src.core.pipeline as pipeline_module
+
+        assert hasattr(pipeline_module, "contextvars"), (
+            "src.core.pipeline must import contextvars at module level"
+        )
+
+
 class TestRAGPipelineStats:
     """Tests for pipeline statistics methods."""
 

--- a/tests/unit/core/test_pipeline.py
+++ b/tests/unit/core/test_pipeline.py
@@ -1,5 +1,6 @@
 """Tests for RAG pipeline."""
 
+import asyncio
 import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -219,20 +220,23 @@ class TestRAGPipelineSearch:
         )
         assert isinstance(result, RAGResult)
 
-    async def test_search_propagates_context_to_encode_query(self, mock_pipeline):
-        """Test search uses contextvars.copy_context/ctx.run to preserve observe span hierarchy."""
-        import contextvars as cv
-
+    async def test_search_uses_to_thread_for_encode_query(self, mock_pipeline):
+        """Test search uses asyncio.to_thread so contextvars propagate to worker threads."""
         mock_pipeline.embedding_model.encode.return_value = MagicMock(
             tolist=lambda: [0.1, 0.2, 0.3]
         )
 
-        with patch.object(cv, "copy_context", wraps=cv.copy_context) as spy_copy_ctx:
+        original_to_thread = asyncio.to_thread
+        calls = []
+
+        async def recording_to_thread(func, *args, **kwargs):
+            calls.append((func, args, kwargs))
+            return await original_to_thread(func, *args, **kwargs)
+
+        with patch("src.core.pipeline.asyncio.to_thread", new=recording_to_thread):
             result = await mock_pipeline.search("test query")
 
-            # pytest-asyncio also calls copy_context for test runner setup.
-            # We verify our code path exercises it at least once.
-            assert spy_copy_ctx.call_count > 0
+            assert len(calls) == 2
             assert isinstance(result, RAGResult)
 
     def test_encode_query_method_exists(self, mock_pipeline):
@@ -242,19 +246,20 @@ class TestRAGPipelineSearch:
 
 
 class TestRAGPipelineExecutorContextPropagation:
-    """Pin the contract that every executor hop in ``search`` propagates context.
+    """Pin the contract that every thread hop in ``search`` propagates context.
 
     Closes #2167 (follow-up to #2157). ``self.search_engine.search`` and
     ``self._encode_query`` are both ``@observe``-decorated. When they run
-    inside a ``loop.run_in_executor`` worker thread without
-    ``contextvars.copy_context().run(...)``, the worker sees an empty OTEL
-    context and emits a top-level orphan trace (e.g. ``bge-m3-hybrid-embed``,
-    ``hybrid-rrf-search``) instead of nesting under whatever parent opened
-    the surrounding ``rag-pipeline`` / ``telegram-message`` span.
+    in a worker thread without context propagation, the worker sees an empty
+    OTEL context and emits a top-level orphan trace (e.g.
+    ``bge-m3-hybrid-embed``, ``hybrid-rrf-search``) instead of nesting under
+    whatever parent opened the surrounding ``rag-pipeline`` /
+    ``telegram-message`` span. ``asyncio.to_thread`` is the stdlib-native
+    thread hop here because it propagates the current ``contextvars.Context``.
     """
 
-    def test_every_run_in_executor_call_uses_ctx_run(self) -> None:
-        """AST contract: every ``run_in_executor(...)`` in ``RAGPipeline.search`` runs via ``ctx.run``."""
+    def test_search_uses_to_thread_instead_of_raw_executor_hops(self) -> None:
+        """AST contract: ``RAGPipeline.search`` uses context-propagating ``to_thread``."""
         import ast
         import inspect
         import textwrap
@@ -264,35 +269,30 @@ class TestRAGPipelineExecutorContextPropagation:
         src = textwrap.dedent(inspect.getsource(RAGPipeline.search))
         tree = ast.parse(src)
 
-        executor_calls: list[ast.Call] = []
+        to_thread_calls: list[ast.Call] = []
+        run_in_executor_calls: list[ast.Call] = []
         for node in ast.walk(tree):
             if (
                 isinstance(node, ast.Call)
                 and isinstance(node.func, ast.Attribute)
                 and node.func.attr == "run_in_executor"
             ):
-                executor_calls.append(node)
+                run_in_executor_calls.append(node)
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "to_thread"
+            ):
+                to_thread_calls.append(node)
 
-        assert executor_calls, (
-            "RAGPipeline.search must dispatch sync work through "
-            "loop.run_in_executor — no executor call found in source"
+        assert not run_in_executor_calls, (
+            "RAGPipeline.search must not use raw loop.run_in_executor; use "
+            "asyncio.to_thread so contextvars propagate into @observe-decorated "
+            "worker calls (#2167)."
         )
-
-        for call in executor_calls:
-            call_src = ast.unparse(call)
-            assert "ctx.run(" in call_src, (
-                "Every loop.run_in_executor(...) inside RAGPipeline.search must "
-                "wrap the callable with ``contextvars.copy_context().run(...)`` "
-                "so that @observe-decorated callees nest under the active OTEL "
-                "parent (#2167). Offending call:\n" + call_src
-            )
-
-    def test_search_module_imports_contextvars(self) -> None:
-        """``src.core.pipeline`` must import ``contextvars`` for the executor hops."""
-        import src.core.pipeline as pipeline_module
-
-        assert hasattr(pipeline_module, "contextvars"), (
-            "src.core.pipeline must import contextvars at module level"
+        assert len(to_thread_calls) == 3, (
+            "RAGPipeline.search must dispatch every sync worker call through "
+            "asyncio.to_thread: hybrid search, dense embedding, and dense search."
         )
 
 


### PR DESCRIPTION
Fixes #2167 — follow-up to #2157 / PR #2158.

## Summary

PR #2158 fixed the first known `telegram-message` ↔ `rag-pipeline` trace-fragmentation path. This PR fixes the remaining executor/thread boundary in `src/core/pipeline.py::RAGPipeline.search`: observed sync calls (`_encode_query` and `search_engine.search`) must keep the active Langfuse/OpenTelemetry context when they run off the event loop.

## SDK-native fix

Langfuse `@observe` nests spans through the current OpenTelemetry/contextvars context. Python's stdlib `asyncio.to_thread(...)` propagates the current `contextvars.Context` into the worker thread, so the final patch uses that native API instead of manual `contextvars.copy_context().run(...)` wrappers.

## Changes

- `src/core/pipeline.py`: all three sync worker hops in `RAGPipeline.search` now use `asyncio.to_thread(...)`.
- `tests/unit/core/test_pipeline.py`: regression coverage pins that `RAGPipeline.search` uses `asyncio.to_thread` and no raw `run_in_executor` calls.
- `docs/runbooks/LANGFUSE_TRACING_GAPS.md`: runbook guidance now points to `asyncio.to_thread` as the preferred fix.

## Validation

Local:

- `uv run pytest tests/unit/core/test_pipeline.py -q` → 28 passed.
- `uv run pytest tests/contract/test_no_get_event_loop.py tests/unit/core/test_pipeline.py -q` → 31 passed.
- `uv run ruff check src/core/pipeline.py tests/unit/core/test_pipeline.py` → passed.
- `uv run ruff format --check src/core/pipeline.py tests/unit/core/test_pipeline.py` → passed.
- `make check` → passed.

GitHub checks are expected to rerun after the autofix push.

## Out of scope

- LiteLLM proxy callback behavior.
- Voice / mini-app trace materialization.
- Runtime Langfuse validation against a live local stack.

Closes #2167.
