### PR TITLE
fix(streaming): throttle send_message_draft in supervisor astream loop (#2159)

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -3020,6 +3020,16 @@ class PropertyBot:
             accumulated = ""
             stream_messages: list[Any] = []
             latest_state: dict[str, Any] | None = None
+            # Throttle ``send_message_draft`` to at most one call per
+            # ``_AGENT_DRAFT_INTERVAL`` (#2159). The supervisor stream path
+            # was rewired to ``astream(..., stream_mode=['messages', 'values'],
+            # version='v2')`` in #952 and lost the throttle that the sibling
+            # helper ``_stream_agent_to_draft`` still uses. Without it every
+            # text-bearing chunk produces one Telegram Bot API round-trip,
+            # serializing into 3-6 s of tail latency on a 150-200 token
+            # answer. ``time.monotonic`` is the canonical clock for
+            # interval throttling — wall-clock jumps cannot starve drafts.
+            last_draft_at = 0.0
             stream = current_agent.astream(
                 payload,
                 config=config,
@@ -3049,6 +3059,9 @@ class PropertyBot:
                     continue
                 accumulated += text
                 stream_messages.append(message_chunk)
+                now = time.monotonic()
+                if now - last_draft_at < _AGENT_DRAFT_INTERVAL:
+                    continue
                 with contextlib.suppress(Exception):
                     draft_kwargs: dict[str, Any] = {
                         "chat_id": draft_state["chat_id"],
@@ -3058,6 +3071,7 @@ class PropertyBot:
                     if draft_state["thread_id"] is not None:
                         draft_kwargs["message_thread_id"] = draft_state["thread_id"]
                     await self.bot.send_message_draft(**draft_kwargs)
+                last_draft_at = now
 
             if accumulated:
                 # Finalize later in _handle_query_supervisor after feedback/sources assembly.

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -3358,6 +3358,88 @@ class TestStreamingCoordination:
         assert response_text == "Создать"
         assert result["__interrupt__"] == [interrupt_obj]
 
+    async def test_astream_supervisor_throttles_send_message_draft(self, mock_config):
+        """Throttle ``send_message_draft`` to at most one call per ``_AGENT_DRAFT_INTERVAL`` (#2159).
+
+        Regression contract for the supervisor stream path. Each text-bearing
+        chunk previously triggered a fresh ``sendMessageDraft`` HTTP call, so a
+        150-200 token answer produced 50-100 round-trips and added 3-6 seconds
+        of tail latency after the LLM had already finished. The sibling helper
+        ``_stream_agent_to_draft`` already throttles via ``_AGENT_DRAFT_INTERVAL``;
+        this test pins the same contract on ``_astream_supervisor_with_recovery``.
+
+        Strategy: feed 100 single-token chunks through a fake ``astream`` while
+        a controllable ``time.monotonic`` advances by less than the throttle
+        interval per chunk. We expect the final draft count to be **strictly
+        less** than the chunk count (without the fix it would equal the chunk
+        count). We also pin a generous upper bound so a future optimisation that
+        sends two early drafts plus a final drainer still passes.
+        """
+        from langchain_core.messages import AIMessageChunk
+
+        bot, _ = _create_bot(mock_config)
+        bot.bot.send_message_draft = AsyncMock(return_value=True)
+
+        chunk_count = 100
+
+        async def _agent_stream(*args, **kwargs):
+            for idx in range(chunk_count):
+                yield (
+                    AIMessageChunk(content=f"t{idx} "),
+                    {"langgraph_node": "model"},
+                )
+
+        mock_agent = AsyncMock()
+        mock_agent.astream = _agent_stream
+
+        # Fake monotonic clock that advances 0.05s per call — well under the
+        # production ``_AGENT_DRAFT_INTERVAL = 0.2s``. Each chunk consumes two
+        # ``time.monotonic()`` calls (now-comparison + last_draft_at update on
+        # the chosen ones), so we use a generator that ticks unconditionally.
+        clock = [0.0]
+
+        def _fake_monotonic() -> float:
+            value = clock[0]
+            clock[0] += 0.05
+            return value
+
+        with patch("telegram_bot.bot.time.monotonic", side_effect=_fake_monotonic):
+            response_text, _result = await bot._astream_supervisor_with_recovery(
+                agent=mock_agent,
+                tools=[],
+                role="client",
+                user_text="long answer",
+                chat_id=12345,
+                callbacks=[],
+                bot_context=types.SimpleNamespace(
+                    telegram_user_id=12345, session_id="sess-throttle"
+                ),
+                rag_result_store={},
+                forum_thread_id=None,
+                use_streaming=True,
+            )
+
+        # Final accumulated text must contain every chunk — throttle must NOT
+        # truncate the response.
+        assert response_text.startswith("t0 ")
+        assert response_text.endswith(f"t{chunk_count - 1} ")
+
+        # Throttle contract: strictly fewer draft sends than chunks. With
+        # the fix in place we expect at most ~chunk_count * 0.05s / 0.2s = 25
+        # draft sends; a comfortable upper bound of ``chunk_count // 2``
+        # tolerates implementation tweaks.
+        draft_calls = bot.bot.send_message_draft.await_count
+        assert draft_calls < chunk_count, (
+            f"send_message_draft was awaited {draft_calls} times for "
+            f"{chunk_count} chunks — throttle from #2159 regressed; expected "
+            f"< {chunk_count} (ideally ~{chunk_count // 4})"
+        )
+        assert draft_calls <= chunk_count // 2, (
+            f"send_message_draft was awaited {draft_calls} times for "
+            f"{chunk_count} chunks at 0.05s ticks under a 0.2s throttle; "
+            "the throttle window appears to be missing or much shorter"
+        )
+
     @pytest.mark.parametrize(
         ("manager_mode", "should_retry"),
         [(False, True), (True, False)],


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
Fixes #2159.

## Summary

`_astream_supervisor_with_recovery._run_once` in `telegram_bot/bot.py` called `bot.send_message_draft(...)` on **every** text-bearing token chunk with no time-based throttle. For a typical 150–200 token answer this produced 50–100 sequential Telegram Bot API round-trips after the LLM had already finished, adding 3–6 seconds of perceived tail latency.

The sibling helper `_stream_agent_to_draft` already throttles via `_AGENT_DRAFT_INTERVAL = 0.2 s`. The two implementations had drifted when the supervisor path was rewired in #952 to `astream(..., stream_mode=['messages', 'values'], version='v2')`. This PR re-introduces the throttle so both agree.

## Evidence cited in #2159

Langfuse trace `eb45e2b221a367570b35f0bcfe8e7051`:

```
T+3.96s   ChatOpenAI generation done
>>> 6.07 seconds of pure tail latency after LLM finished <<<
T+10.04s  aiogram update handled
```

Direct LiteLLM smoke test against the same Cerebras model showed total latency 0.23–0.93 s — the bottleneck is on the bot side, in the stream consumer loop.

## Fix

`telegram_bot/bot.py::_run_once` now tracks `last_draft_at = time.monotonic()` and skips `send_message_draft` until at least `_AGENT_DRAFT_INTERVAL` (0.2 s) has elapsed since the previous send. The accumulated text continues to grow across all chunks — the throttle only suppresses the intermediate Bot API round-trips. The final message is finalised by `bot.send_message(...)` in `_handle_query_supervisor` after the stream loop, so users always see the complete answer regardless of throttle interval.

`time.monotonic` (already imported at `bot.py:50`) is the canonical clock for interval throttling — wall-clock jumps cannot starve drafts.

## Acceptance criteria

- [x] `bot.send_message_draft` is called at most once per `_AGENT_DRAFT_INTERVAL` per turn — pinned by the new `test_astream_supervisor_throttles_send_message_draft` (feeds 100 chunks at 0.05 s ticks under the 0.2 s throttle, asserts `< chunk_count` draft sends and a generous `<= chunk_count // 2` upper bound for future tweaks).
- [x] Final `bot.send_message` still produces the complete answer (no truncation regression — the new test asserts response starts with the first chunk and ends with the last chunk).
- [x] Existing streaming tests still pass.

## Validation

```
uv run pytest tests/unit/test_bot_handlers.py
              tests/unit/agents/test_streaming.py
              tests/unit/test_bot_query_supervisor.py
              tests/unit/test_agent_streaming.py
              tests/contract/test_bot_streaming_extraction_contract.py
              tests/contract/test_streaming_sdk_native_contract.py
```
**250 passed** locally.

`ruff check` + `ruff format --check` + `mypy --ignore-missing-imports`: clean.

## Out of scope

- Removing the `contextlib.suppress(Exception)` wrapper (separate observability issue: failed drafts should be logged at warning level).
- Pre-agent BGE-M3 embedding reuse inside `rag_search` (#951).
- LiteLLM Cerebras `disable_reasoning` deprecation migration.

## References

- `telegram_bot/bot.py:287–340` — sibling throttled implementation (`_stream_agent_to_draft`, `_AGENT_DRAFT_INTERVAL`)
- `telegram_bot/bot.py:3001–3068` — affected function (`_astream_supervisor_with_recovery._run_once`)
- Original streaming refactor: #952
- Langfuse trace ID for evidence: `eb45e2b221a367570b35f0bcfe8e7051`

Closes #2159.