### PR TITLE
docs(bot-decomp): publish #1265 Slice 2 decomposition plan

### DIFF
--- a/docs/engineering/bot-decomposition-plan-2026-05-27.md
+++ b/docs/engineering/bot-decomposition-plan-2026-05-27.md
@@ -63,41 +63,68 @@ guiding rule from Slice 1 still holds: every PR must be byte-for-byte
 behaviour-preserving and pinned by a new contract test under
 `tests/contract/`.
 
-### PR-8 — Lifecycle extraction (tracked by [#2048](https://github.com/yastman/rag/issues/2048))
+### PR-8 — Lifecycle helper extraction (tracked by [#2048](https://github.com/yastman/rag/issues/2048))
 
 **Move target:** `telegram_bot/_bot_lifecycle.py`
 
 **Methods extracted from `PropertyBot`:**
 
-- `start` (lines 3873–4447, ~575 LOC)
 - `_warmup_bge` (4448–4455, ~8 LOC)
 - `_polling_lock_heartbeat_tick` (4456–4479, ~24 LOC)
+
+**Approach:**
+
+- Lift `_warmup_bge` and `_polling_lock_heartbeat_tick` to module-level
+  helpers that receive their narrow collaborators explicitly.
+- Keep `PropertyBot._warmup_bge` and
+  `PropertyBot._polling_lock_heartbeat_tick` as thin async delegates so
+  existing call sites and tests do not change.
+- Leave `start` / `stop` in `bot.py` for a follow-up PR: those methods
+  are much larger, mix runtime wiring concerns, and deserve their own
+  characterization tests before moving.
+
+**Acceptance:**
+
+- `_bot_lifecycle.py` owns the two warmup/heartbeat helpers and
+  `bot.py` delegates to them without changing method signatures.
+- `_bot_lifecycle.py` has no `aiogram` / `langgraph` import at module
+  scope (lazy imports allowed inside function bodies).
+- New `tests/contract/test_bot_lifecycle_extraction_contract.py`
+  asserts the lifecycle helpers exist, are async, the class methods
+  delegate to them, and the import graph is clean.
+- Existing tests under `tests/unit/test_bot_handlers.py` and
+  `tests/unit/test_bot_scores.py` keep passing without changes.
+
+### PR-9 — Start/stop lifecycle extraction (proposed new child issue)
+
+**Move target:** `telegram_bot/_bot_lifecycle.py`
+
+**Methods extracted:**
+
+- `start` (lines 3873–4447, ~575 LOC)
 - `stop` (4480–end, ~100 LOC)
 
 **Approach:**
 
 - Convert `start`/`stop` into module-level functions that take
   `(self) -> Awaitable[None]` so tests can mock the wiring without
-  instantiating `PropertyBot`. (Or keep them as bound methods and
-  delegate to module-level helpers — pick whichever passes the
-  characterization test with the smallest call-site delta.)
-- Lift `_warmup_bge` and `_polling_lock_heartbeat_tick` to module level
-  with `(config, logger)` signatures.
+  instantiating `PropertyBot`.
 - Keep the `PropertyBot.start`/`stop` methods on the class as thin
-  wrappers (`return await _bot_lifecycle.start(self)`).
+  wrappers (`return await _bot_lifecycle.start_property_bot(self)` or
+  equivalent).
+- Preserve local imports inside the moved functions when they prevent
+  heavy module-scope dependencies.
 
 **Acceptance:**
 
-- `bot.py` shrinks by ~700 lines.
-- `_bot_lifecycle.py` has no `aiogram` / `langgraph` import at module
-  scope (lazy imports allowed inside function bodies).
-- New `tests/contract/test_bot_lifecycle_extraction_contract.py`
-  asserts `bot.start is _bot_lifecycle.start_property_bot` (or the
-  thin-wrapper equivalent) and that the import graph is clean.
-- Existing tests under `tests/unit/test_bot_handlers.py` and
-  `tests/unit/test_bot_scores.py` keep passing without changes.
+- `bot.py` shrinks by ~675 lines.
+- `_bot_lifecycle.py` still has no `aiogram` / `langgraph` import at
+  module scope.
+- Contract tests pin the thin-wrapper delegation and import graph.
+- Existing bot lifecycle, startup/import, and handler tests keep
+  passing without signature changes.
 
-### PR-9 — Handlers extraction (proposed new child issue)
+### PR-10 — Handlers extraction (proposed new child issue)
 
 **Move target:** `telegram_bot/_bot_handlers.py`
 
@@ -133,7 +160,7 @@ sub-PRs: callbacks + menu first, query/voice last.
   `tests/unit/test_bot_handlers.py` (the largest single test file in
   the repo) keep passing without signature changes.
 
-### PR-10 — Supervisor recovery extraction (proposed)
+### PR-11 — Supervisor recovery extraction (proposed)
 
 **Move target:** `telegram_bot/_bot_supervisor_recovery.py`
 
@@ -154,12 +181,12 @@ sub-PRs: callbacks + menu first, query/voice last.
 - `bot.py` shrinks by ~225 lines.
 - Contract test pins both helpers as module-level callables.
 
-### PR-11 — Optional: scoring/Langfuse glue (low priority)
+### PR-12 — Optional: scoring/Langfuse glue (low priority)
 
 The `bot_scoring.py` mentioned in #1265's target decomposition already
 exists outside `bot.py` as `telegram_bot/scoring.py` (31 LOC). Only the
 `PropertyBot._spawn_history_save` and a handful of inline score writes
-remain inside `bot.py`. Defer until PR-8 / PR-9 / PR-10 land — the
+remain inside `bot.py`. Defer until PR-8 / PR-9 / PR-10 / PR-11 land — the
 remaining glue may end up small enough to leave in place.
 
 ## Testing strategy — TDD characterization
@@ -198,10 +225,11 @@ uv run --python 3.12 pytest \
 
 ## Sequencing
 
-1. PR-8 (lifecycle, #2048) — first, smallest delta, sets the pattern for `_bot_*.py` extraction with `self` argument.
-2. PR-9 (handlers, new child) — split into PR-9a (callbacks/menu/feedback/HITL) and PR-9b (query/voice). PR-9b is the biggest piece of work in the plan.
-3. PR-10 (supervisor recovery) — independent of the others; can land in parallel once the lifecycle pattern is set.
-4. PR-11 (scoring glue) — only if the residual `bot.py` size still merits it.
+1. PR-8 (lifecycle helpers, #2048) — first, smallest delta, sets the pattern for `_bot_*.py` extraction with explicit collaborators.
+2. PR-9 (start/stop lifecycle, new child) — larger runtime-wiring move, after PR-8 proves the lifecycle module pattern.
+3. PR-10 (handlers, new child) — split into PR-10a (callbacks/menu/feedback/HITL) and PR-10b (query/voice). PR-10b is the biggest piece of work in the plan.
+4. PR-11 (supervisor recovery) — independent of the others; can land in parallel once the lifecycle pattern is set.
+5. PR-12 (scoring glue) — only if the residual `bot.py` size still merits it.
 
 ## Out of scope
 
@@ -211,11 +239,11 @@ uv run --python 3.12 pytest \
 - Splitting `bot.py` into a package directory. That is a larger
   follow-up that should only be considered after Slice 2 lands.
 - Voice path migration to `create_agent` — tracked separately by #2051
-  on top of PR-9b.
+  on top of PR-10b.
 
 ## Decision
 
 Adopt this plan. Execute PR-8 under #2048, then file follow-up child
-issues for PR-9 / PR-10 / PR-11. Keep #1265 open as the umbrella for
-the decomposition and close it only after the residual `bot.py` is at
-or below 1500 lines.
+issues for PR-9 / PR-10 / PR-11 / PR-12. Keep #1265 open as the
+umbrella for the decomposition and close it only after the residual
+`bot.py` is at or below 1500 lines.

--- a/docs/engineering/bot-decomposition-plan-2026-05-27.md
+++ b/docs/engineering/bot-decomposition-plan-2026-05-27.md
@@ -1,0 +1,221 @@
+# `telegram_bot/bot.py` decomposition plan — 2026-05-27
+
+**Issue:** [#1265 — refactor: decompose bot.py god-object after current PropertyBot audit](https://github.com/yastman/rag/issues/1265)
+**Lane:** `lane:design-first`
+**Verify:** `verify:repo-only`
+**Status of this document:** Slice 2 plan. Slice 1 already shipped across PR-1…PR-7 referenced inside each `_bot_*.py` module.
+
+This document is the design-first deliverable required by `lane:design-first`.
+It captures (a) the post-Slice-1 inventory of `telegram_bot/bot.py`, (b) the
+atomic-PR sequence proposed for Slice 2, and (c) the testing rules each PR
+must satisfy. It is intentionally a plan, not an implementation — execution
+is tracked under the child issues listed below.
+
+## Slice 1 — done
+
+Seven byte-for-byte extractions landed under #1265 and shrank `bot.py` from
+~5099 → 4582 lines (–10 %). Each module is referenced from `bot.py` via thin
+wrappers and is pinned by a contract test in `tests/contract/`.
+
+| PR | Module | LOC | Concern |
+|----|--------|-----|---------|
+| PR-1 | `telegram_bot/_bot_state_helpers.py` | 77 | `_state_apartment_results`, `_state_control_message_id`, `_extract_current_turn` |
+| PR-2 | `telegram_bot/_bot_observability.py` | 97 | `_build_trace_metadata`, `_write_voice_error_scores` |
+| PR-3 | `telegram_bot/_bot_error_classification.py` | 86 | `_is_post_pipeline_cleanup_error`, `_is_checkpointer_runtime_error` |
+| PR-4 | `telegram_bot/_bot_streaming.py` | 132 | `_new_draft_id`, `_stream_agent_to_draft`, `_extract_stream_chunk_text` |
+| PR-5 | `telegram_bot/_bot_pre_agent.py` | 163 | `_build_pre_agent_state_contract`, `_has_async_method`, `_get_or_compute_pre_agent_dense`, `_prepare_pre_agent_retrieval_vectors` |
+| PR-6 | `telegram_bot/_bot_kommo.py` | 57 | `_seed_kommo_access_token` |
+| PR-7 | `telegram_bot/_bot_postgres_bootstrap.py` | 285 | `_extract_database_name`, `_ensure_postgres_database_exists`, `_ensure_realestate_schema` |
+| **total** |  | **897** |  |
+
+Slice-1 invariants (preserved by the contract tests):
+
+- Module-level imports stay within stdlib + the helper's narrow third-party need.
+- No `aiogram`, `langgraph`, `qdrant_client`, `langchain` or `fastapi` imports at module scope of an `_bot_*.py` file — keeps unit tests cheap.
+- The `bot.py` thin wrappers preserve `from telegram_bot.bot import _xxx` resolution so existing tests keep working.
+
+## Post-Slice-1 inventory
+
+`bot.py` (4582 lines) breaks down roughly as:
+
+| Concern | Approximate LOC | Representative methods |
+|---------|-----------------|------------------------|
+| Module preamble + free helpers (compat shims `create_bot_agent`, `build_graph`, `classify_query`, `detect_injection`) | 1–356 | top-of-file shims |
+| `PropertyBot.__init__` | 370–557 | `__init__` |
+| Misc instance helpers, history save bridge | 558–730 | `_spawn_history_save`, `_get_pre_agent_filter_extractor`, `_setup_middlewares`, `_register_handlers`, `_resolve_user_role` |
+| Mini-app entry & deeplink | 749–973 | `_handle_deeplink_start`, `_process_miniapp_start`, `_run_miniapp_rag`, `_miniapp_subscriber_loop`, `_is_admin` |
+| Menu / navigation / favourites callbacks | 979–1922 | `handle_menu_button`, `_handle_search`, `_handle_services`, `_handle_viewing`, `_handle_bookmarks`, `_handle_ask`, `handle_*_callback`, `handle_fav_*` |
+| Free-form text query path (text agent) | 1922–2202 | `handle_query`, `_send_markdown_chunks`, `_handle_apartment_fast_path`, `_handle_client_direct_pipeline` |
+| Supervisor query path (LangGraph) | 2202–2972 | `_handle_query_supervisor` (~750 LOC, the largest single method) |
+| Streaming/sync supervisor recovery | 2973–3201 | `_astream_supervisor_with_recovery`, `_ainvoke_supervisor_with_recovery` |
+| Voice path | 3201–3441 | `handle_voice` (#2051 child) |
+| HITL flow | 3442–3570 | `_send_hitl_confirmation`, `handle_hitl_callback` |
+| Feedback flow | 3571–3730 | `handle_feedback`, `handle_feedback_reason`, `_clear_feedback_confirmation_later` |
+| Cache management callbacks | 3731–3873 | `handle_clearcache_callback`, `handle_menu_action` |
+| Lifecycle (`start`/`stop`, warmup, polling lock heartbeat) | 3873–end | `start`, `_warmup_bge`, `_polling_lock_heartbeat_tick`, `stop` |
+
+19 public `handle_*` methods and 12 private `_handle_*` dispatchers remain.
+
+## Slice 2 — proposed extractions
+
+Slice 2 targets the remaining ~3500 lines that are not pure helpers. The
+guiding rule from Slice 1 still holds: every PR must be byte-for-byte
+behaviour-preserving and pinned by a new contract test under
+`tests/contract/`.
+
+### PR-8 — Lifecycle extraction (tracked by [#2048](https://github.com/yastman/rag/issues/2048))
+
+**Move target:** `telegram_bot/_bot_lifecycle.py`
+
+**Methods extracted from `PropertyBot`:**
+
+- `start` (lines 3873–4447, ~575 LOC)
+- `_warmup_bge` (4448–4455, ~8 LOC)
+- `_polling_lock_heartbeat_tick` (4456–4479, ~24 LOC)
+- `stop` (4480–end, ~100 LOC)
+
+**Approach:**
+
+- Convert `start`/`stop` into module-level functions that take
+  `(self) -> Awaitable[None]` so tests can mock the wiring without
+  instantiating `PropertyBot`. (Or keep them as bound methods and
+  delegate to module-level helpers — pick whichever passes the
+  characterization test with the smallest call-site delta.)
+- Lift `_warmup_bge` and `_polling_lock_heartbeat_tick` to module level
+  with `(config, logger)` signatures.
+- Keep the `PropertyBot.start`/`stop` methods on the class as thin
+  wrappers (`return await _bot_lifecycle.start(self)`).
+
+**Acceptance:**
+
+- `bot.py` shrinks by ~700 lines.
+- `_bot_lifecycle.py` has no `aiogram` / `langgraph` import at module
+  scope (lazy imports allowed inside function bodies).
+- New `tests/contract/test_bot_lifecycle_extraction_contract.py`
+  asserts `bot.start is _bot_lifecycle.start_property_bot` (or the
+  thin-wrapper equivalent) and that the import graph is clean.
+- Existing tests under `tests/unit/test_bot_handlers.py` and
+  `tests/unit/test_bot_scores.py` keep passing without changes.
+
+### PR-9 — Handlers extraction (proposed new child issue)
+
+**Move target:** `telegram_bot/_bot_handlers.py`
+
+**Methods extracted:**
+
+- All 19 public `handle_*` methods (menu, callbacks, query, voice, HITL, feedback, clearcache).
+- The 12 private `_handle_*` dispatchers (search, services, viewing, bookmarks, ask, manager, group_message, apartment_fast_path, client_direct_pipeline, query_supervisor, demo, complete_handoff, close_handoff).
+
+**Approach:**
+
+- Each handler becomes a module-level `async def` that takes `(self, …)`
+  as its first argument. The `PropertyBot` class keeps `handle_*` /
+  `_handle_*` methods as thin delegates.
+- Note that `_handle_query_supervisor` is ~750 LOC on its own — it
+  splits naturally into:
+  - state-prep section,
+  - graph-invoke section (the `_astream_supervisor_with_recovery` /
+    `_ainvoke_supervisor_with_recovery` pair already lives lower in the
+    file and can move with the handler),
+  - response-emit section.
+  Each section becomes a private function inside `_bot_handlers.py`.
+
+**Risk:** highest in the plan — `handle_query` and
+`_handle_query_supervisor` are the hottest call sites. Land in two
+sub-PRs: callbacks + menu first, query/voice last.
+
+**Acceptance:**
+
+- `bot.py` shrinks by ~2000 lines.
+- New contract test pins `bot.handle_X is _bot_handlers.X` for every
+  handler.
+- The existing characterization tests under
+  `tests/unit/test_bot_handlers.py` (the largest single test file in
+  the repo) keep passing without signature changes.
+
+### PR-10 — Supervisor recovery extraction (proposed)
+
+**Move target:** `telegram_bot/_bot_supervisor_recovery.py`
+
+**Methods extracted:**
+
+- `_astream_supervisor_with_recovery` (~140 LOC)
+- `_ainvoke_supervisor_with_recovery` (~85 LOC)
+
+**Approach:**
+
+- Lift to module-level functions taking `(self, agent, …)`. The
+  `_run_once` inner closure stays inside the function body; nothing in
+  the body touches `self` after the first line, so the recovery loop is
+  effectively pure.
+
+**Acceptance:**
+
+- `bot.py` shrinks by ~225 lines.
+- Contract test pins both helpers as module-level callables.
+
+### PR-11 — Optional: scoring/Langfuse glue (low priority)
+
+The `bot_scoring.py` mentioned in #1265's target decomposition already
+exists outside `bot.py` as `telegram_bot/scoring.py` (31 LOC). Only the
+`PropertyBot._spawn_history_save` and a handful of inline score writes
+remain inside `bot.py`. Defer until PR-8 / PR-9 / PR-10 land — the
+remaining glue may end up small enough to leave in place.
+
+## Testing strategy — TDD characterization
+
+Every Slice 2 PR follows the same characterization-first loop, mirroring
+Slice 1:
+
+1. **Capture current behaviour.** Before moving anything, add a new
+   contract test under `tests/contract/` that asserts the bound-method
+   identity (`PropertyBot.X is _bot_module.X` or thin-wrapper
+   equivalent) and the import-graph rules. The contract test passes
+   only after the extraction.
+2. **Add narrow unit coverage if missing.** If the moved method is not
+   already exercised by `tests/unit/test_bot_handlers.py` /
+   `tests/unit/test_bot_scores.py`, write a targeted unit test that
+   pins the observable behaviour (return value, side effects on
+   `self`, calls to mocked dependencies) before the move.
+3. **Cut the slice.** Move the body to the new module, leave a thin
+   wrapper on the class, run `make test-unit`. Both the new contract
+   test and the existing unit tests must stay green.
+4. **Lint the import graph.** `_bot_*.py` files MUST NOT import
+   `aiogram`, `langgraph`, `qdrant_client` or `fastapi` at module
+   scope. Catch this in the contract test.
+
+## Verification command
+
+For every Slice 2 PR (matching the issue body's `Validation` line):
+
+```
+uv run --python 3.12 pytest \
+  tests/unit/test_bot_handlers.py \
+  tests/unit/test_bot_scores.py \
+  tests/contract/test_bot_*_extraction_contract.py \
+  -q --timeout=30
+```
+
+## Sequencing
+
+1. PR-8 (lifecycle, #2048) — first, smallest delta, sets the pattern for `_bot_*.py` extraction with `self` argument.
+2. PR-9 (handlers, new child) — split into PR-9a (callbacks/menu/feedback/HITL) and PR-9b (query/voice). PR-9b is the biggest piece of work in the plan.
+3. PR-10 (supervisor recovery) — independent of the others; can land in parallel once the lifecycle pattern is set.
+4. PR-11 (scoring glue) — only if the residual `bot.py` size still merits it.
+
+## Out of scope
+
+- Re-naming `_bot_*.py` to `bot_*.py`. The leading-underscore convention
+  signals "internal helpers re-exported by the `bot.py` facade" and
+  should be kept until the entire god-object is dissolved.
+- Splitting `bot.py` into a package directory. That is a larger
+  follow-up that should only be considered after Slice 2 lands.
+- Voice path migration to `create_agent` — tracked separately by #2051
+  on top of PR-9b.
+
+## Decision
+
+Adopt this plan. Execute PR-8 under #2048, then file follow-up child
+issues for PR-9 / PR-10 / PR-11. Keep #1265 open as the umbrella for
+the decomposition and close it only after the residual `bot.py` is at
+or below 1500 lines.


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Refs #1265 (umbrella) and #2048 (PR-8 child).

`lane:design-first` deliverable for the `telegram_bot/bot.py` god-object decomposition. Slice 1 already shipped across PR-1…PR-7 (referenced inside each `_bot_*.py` module) and pulled 897 LOC of pure helpers out of `bot.py`. This PR adds the companion Slice 2 plan that:

- inventories Slice 1 (PR table with module / LOC / concern),
- breaks down the remaining 4582-line `bot.py` by concern,
- proposes the atomic-PR sequence for Slice 2 (lifecycle / handlers / supervisor recovery / scoring),
- pins the TDD characterization rules and import-graph invariants every Slice 2 PR must satisfy.

Slice 2 starts with PR-8 (lifecycle), tracked by #2048.

## What changed

- `docs/engineering/bot-decomposition-plan-2026-05-27.md` — 221-line design doc.

No code, config or test changes. This is the design-first artefact.

## Highlights

- **Slice 1 totals** — 897 LOC extracted, `bot.py` shrank ~5099 → 4582 (–10 %).
- **Remaining hot spot** — `_handle_query_supervisor` is ~750 LOC by itself; PR-9 splits it into state-prep / graph-invoke / response-emit.
- **Sequencing** — PR-8 (lifecycle) first, PR-9 (handlers) split into PR-9a / PR-9b, PR-10 (supervisor recovery) independent, PR-11 (scoring glue) only if residual `bot.py` size still merits it.
- **Close criterion for #1265** — residual `bot.py` ≤ 1500 lines.

## Verification

Docs-only PR. The verification command for each Slice 2 PR is recorded in the plan:

```
uv run --python 3.12 pytest \
  tests/unit/test_bot_handlers.py \
  tests/unit/test_bot_scores.py \
  tests/contract/test_bot_*_extraction_contract.py \
  -q --timeout=30
```

## Follow-up

- #2048 — PR-8 lifecycle extraction, ready to execute against this plan.
- New child issues to be filed for PR-9, PR-10, PR-11.