### PR TITLE
refactor(bot): extract lifecycle helpers to _bot_lifecycle.py (#2048 PR-8)

### DIFF
--- a/telegram_bot/_bot_lifecycle.py
+++ b/telegram_bot/_bot_lifecycle.py
@@ -1,0 +1,136 @@
+"""Lifecycle helpers extracted from ``telegram_bot/bot.py`` (#2048).
+
+PR-8 of the Slice 2 decomposition plan
+(``docs/engineering/bot-decomposition-plan-2026-05-27.md``). Owns the
+two pure-ish lifecycle helpers that ``PropertyBot.start`` /
+``PropertyBot.stop`` invoke, so they can be tested without
+instantiating the full bot stack.
+
+Module-level imports are stdlib only; the helpers receive their
+collaborators (the hybrid embedder, the polling-lock state holder) as
+arguments instead of reading ``self`` directly. This keeps the import
+graph narrow — no ``aiogram`` / ``langgraph`` / ``qdrant_client`` /
+``fastapi`` at module scope, pinned by
+``tests/contract/test_bot_lifecycle_extraction_contract.py``.
+
+Owned helpers (verbatim, byte-for-byte semantics with the pre-extract
+``bot.py`` definitions):
+
+  - :func:`warmup_bge_pool` — warm BGE-M3 connection pool (#953).
+  - :func:`polling_lock_heartbeat_tick` — single Redis polling-lock
+    heartbeat tick with bounded retry/give-up behaviour.
+
+The class methods on ``PropertyBot`` (``_warmup_bge`` and
+``_polling_lock_heartbeat_tick``) become thin delegates: they exist so
+the existing ``await bot._warmup_bge()`` / ``await
+bot._polling_lock_heartbeat_tick()`` call sites and their unit tests
+keep working without touching their signatures.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from typing import TYPE_CHECKING, Any, Protocol
+
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only
+    from logging import Logger
+
+
+__all__ = ("polling_lock_heartbeat_tick", "warmup_bge_pool")
+
+
+# Maximum consecutive Redis polling-lock heartbeat failures tolerated before we
+# stop polling. Mirrors ``telegram_bot.bot._POLLING_LOCK_MAX_REFRESH_FAILURES``;
+# kept here so the helper is self-contained and the contract test does not
+# have to reach back into ``bot.py`` for a constant.
+POLLING_LOCK_MAX_REFRESH_FAILURES = 2
+
+
+class _HasAembedQuery(Protocol):
+    async def aembed_query(self, text: str) -> Any: ...  # pragma: no cover
+
+
+class _PollingLockState(Protocol):
+    """Minimal protocol the heartbeat helper needs.
+
+    The protocol exists for documentation only — ``PropertyBot`` instances
+    satisfy it structurally; tests can pass any object exposing the same
+    attributes/methods.
+    """
+
+    _polling_lock: Any
+    _polling_lock_consecutive_failures: int
+    dp: Any  # aiogram Dispatcher with ``stop_polling`` (awaited under the hood)
+
+
+async def warmup_bge_pool(
+    hybrid: _HasAembedQuery,
+    *,
+    log: Logger | None = None,
+) -> None:
+    """Warm up the BGE-M3 connection pool (#953).
+
+    Issues a single ``aembed_query("warmup")`` against the supplied
+    hybrid embedder. Failures are non-fatal: they are logged at
+    ``WARNING`` and the helper returns normally so that bot startup is
+    not blocked when BGE-M3 is briefly unavailable.
+
+    Parameters
+    ----------
+    hybrid:
+        Object exposing the async ``aembed_query`` method
+        (typically the ``HybridEmbedder`` wired into ``PropertyBot``).
+    log:
+        Optional logger override. Defaults to the lifecycle module's
+        own logger so the message origin is unambiguous.
+    """
+    log = log or logging.getLogger(__name__)
+    try:
+        await hybrid.aembed_query("warmup")
+        log.info("BGE-M3 warmup complete")
+    except Exception:
+        log.warning("BGE-M3 warmup failed (will retry on first query)", exc_info=True)
+
+
+async def polling_lock_heartbeat_tick(
+    bot: Any,
+    *,
+    log: Logger | None = None,
+    max_refresh_failures: int = POLLING_LOCK_MAX_REFRESH_FAILURES,
+) -> None:
+    """Single Redis polling-lock heartbeat tick.
+
+    Refreshes the polling lock if one is held. On transient failure the
+    consecutive-failure counter is incremented and the next tick will
+    retry; once ``max_refresh_failures`` is reached the helper stops
+    polling on the bot's dispatcher so the lease can't silently expire.
+
+    The helper mutates ``bot._polling_lock_consecutive_failures`` in
+    place (matching the legacy method). Pass any object satisfying the
+    :class:`_PollingLockState` protocol — the tests use a plain
+    ``MagicMock`` standing in for ``PropertyBot``.
+    """
+    log = log or logging.getLogger(__name__)
+    if bot._polling_lock is None:
+        return
+    try:
+        await bot._polling_lock.refresh()
+        bot._polling_lock_consecutive_failures = 0
+    except Exception:
+        bot._polling_lock_consecutive_failures += 1
+        if bot._polling_lock_consecutive_failures < max_refresh_failures:
+            log.warning(
+                "Polling lock heartbeat refresh failed (%d/%d); retrying",
+                bot._polling_lock_consecutive_failures,
+                max_refresh_failures,
+                exc_info=True,
+            )
+            return
+        log.exception(
+            "Polling lock heartbeat failed %d times; stopping polling",
+            max_refresh_failures,
+        )
+        with contextlib.suppress(Exception):
+            await bot.dp.stop_polling()

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -72,6 +72,7 @@ from src.retrieval.topic_classifier import get_query_topic_hint
 from . import (
     _bot_error_classification,  # #1265 Slice 1 PR-3: extracted error-classification helpers
     _bot_kommo,  # #1265 Slice 1 PR-6: extracted Kommo startup helpers
+    _bot_lifecycle,  # #1265 Slice 2 PR-8 / #2048: extracted lifecycle helpers
     _bot_observability,  # #1265 Slice 1 PR-2: extracted observability helpers
     _bot_pre_agent,  # #1265 Slice 1 PR-5: extracted pre-agent helpers
     _bot_state_helpers,  # #1265 Slice 1 PR-1: extracted state-shape helpers
@@ -4446,36 +4447,27 @@ class PropertyBot:
                 self._polling_lock_scheduler = None
 
     async def _warmup_bge(self) -> None:
-        """Warm up BGE-M3 connection pool (#953)."""
-        try:
-            await self._hybrid.aembed_query("warmup")
-            logger.info("BGE-M3 warmup complete")
-        except Exception:
-            logger.warning("BGE-M3 warmup failed (will retry on first query)", exc_info=True)
+        """Warm up BGE-M3 connection pool (#953).
+
+        Thin delegate to :func:`telegram_bot._bot_lifecycle.warmup_bge_pool`
+        — see ``docs/engineering/bot-decomposition-plan-2026-05-27.md``
+        (#1265 / #2048 PR-8).
+        """
+        await _bot_lifecycle.warmup_bge_pool(self._hybrid, log=logger)
 
     async def _polling_lock_heartbeat_tick(self) -> None:
-        """Single heartbeat tick: refresh the Redis polling lock."""
-        if self._polling_lock is None:
-            return
-        try:
-            await self._polling_lock.refresh()
-            self._polling_lock_consecutive_failures = 0
-        except Exception:
-            self._polling_lock_consecutive_failures += 1
-            if self._polling_lock_consecutive_failures < _POLLING_LOCK_MAX_REFRESH_FAILURES:
-                logger.warning(
-                    "Polling lock heartbeat refresh failed (%d/%d); retrying",
-                    self._polling_lock_consecutive_failures,
-                    _POLLING_LOCK_MAX_REFRESH_FAILURES,
-                    exc_info=True,
-                )
-                return
-            logger.exception(
-                "Polling lock heartbeat failed %d times; stopping polling",
-                _POLLING_LOCK_MAX_REFRESH_FAILURES,
-            )
-            with contextlib.suppress(Exception):
-                await self.dp.stop_polling()
+        """Single heartbeat tick: refresh the Redis polling lock.
+
+        Thin delegate to
+        :func:`telegram_bot._bot_lifecycle.polling_lock_heartbeat_tick` —
+        see ``docs/engineering/bot-decomposition-plan-2026-05-27.md``
+        (#1265 / #2048 PR-8).
+        """
+        await _bot_lifecycle.polling_lock_heartbeat_tick(
+            self,
+            log=logger,
+            max_refresh_failures=_POLLING_LOCK_MAX_REFRESH_FAILURES,
+        )
 
     async def stop(self):
         """Stop bot and cleanup."""

--- a/tests/contract/test_bot_lifecycle_extraction_contract.py
+++ b/tests/contract/test_bot_lifecycle_extraction_contract.py
@@ -1,0 +1,145 @@
+"""Contract: lifecycle helpers live in ``telegram_bot/_bot_lifecycle.py`` (#2048).
+
+PR-8 of the Slice 2 decomposition plan
+(``docs/engineering/bot-decomposition-plan-2026-05-27.md``) extracts the
+``_warmup_bge`` and ``_polling_lock_heartbeat_tick`` helpers out of
+``PropertyBot`` so that:
+
+* their bodies can be imported and unit-tested without instantiating the
+  full bot (no aiogram / langgraph / qdrant_client cost),
+* ``telegram_bot/bot.py`` shrinks toward a thin facade,
+* the import-graph invariants from Slice 1 (no aiogram / langgraph /
+  qdrant_client / fastapi at module scope of an ``_bot_*.py`` file) are
+  preserved.
+
+The contract pins three things:
+
+1. ``telegram_bot._bot_lifecycle`` exposes the module-level helpers
+   ``warmup_bge_pool`` and ``polling_lock_heartbeat_tick``.
+2. ``PropertyBot._warmup_bge`` and ``PropertyBot._polling_lock_heartbeat_tick``
+   delegate to those helpers (verified statically — the method body must
+   ``await`` the module-level helper).
+3. ``telegram_bot/_bot_lifecycle.py`` does not import aiogram, langgraph,
+   langchain, qdrant_client or fastapi at module scope.
+
+Re-introducing inline lifecycle code on ``PropertyBot`` (or pulling a
+heavy import into ``_bot_lifecycle.py``) trips this contract at CI time.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIFECYCLE_MODULE = "telegram_bot._bot_lifecycle"
+LIFECYCLE_PATH = REPO_ROOT / "telegram_bot" / "_bot_lifecycle.py"
+BOT_PATH = REPO_ROOT / "telegram_bot" / "bot.py"
+
+# Forbidden module-scope imports — these belong to the heavy bot stack and
+# must not creep into a pure helper module.
+FORBIDDEN_TOP_IMPORTS = {
+    "aiogram",
+    "langgraph",
+    "langchain",
+    "qdrant_client",
+    "fastapi",
+}
+
+# Public surface the module must export.
+REQUIRED_HELPERS = ("warmup_bge_pool", "polling_lock_heartbeat_tick")
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def test_lifecycle_module_exists_and_exports_helpers() -> None:
+    assert LIFECYCLE_PATH.is_file(), (
+        f"{LIFECYCLE_PATH.relative_to(REPO_ROOT)} must exist (#2048 PR-8)."
+    )
+    module = importlib.import_module(LIFECYCLE_MODULE)
+    missing = [name for name in REQUIRED_HELPERS if not hasattr(module, name)]
+    assert not missing, (
+        f"{LIFECYCLE_MODULE} must export {REQUIRED_HELPERS}; "
+        f"missing: {missing}"
+    )
+    for name in REQUIRED_HELPERS:
+        assert inspect.iscoroutinefunction(getattr(module, name)), (
+            f"{LIFECYCLE_MODULE}.{name} must be async (`async def`)."
+        )
+
+
+def test_lifecycle_module_has_no_heavy_imports() -> None:
+    tree = _parse(LIFECYCLE_PATH)
+    offenders: list[str] = []
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                top = alias.name.split(".", 1)[0]
+                if top in FORBIDDEN_TOP_IMPORTS:
+                    offenders.append(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            module = (node.module or "").split(".", 1)[0]
+            if module in FORBIDDEN_TOP_IMPORTS:
+                offenders.append(node.module or "")
+    assert not offenders, (
+        f"{LIFECYCLE_PATH.relative_to(REPO_ROOT)} has forbidden module-scope "
+        f"imports: {offenders}. Move them into function bodies (lazy import) "
+        f"or keep the helpers stdlib-only."
+    )
+
+
+def _find_class_method(tree: ast.Module, class_name: str, method_name: str) -> ast.AsyncFunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for item in node.body:
+                if isinstance(item, ast.AsyncFunctionDef) and item.name == method_name:
+                    return item
+    raise AssertionError(f"PropertyBot.{method_name} not found in bot.py")
+
+
+def _method_awaits_lifecycle_helper(method: ast.AsyncFunctionDef, helper_name: str) -> bool:
+    """Return True iff the method body awaits a call to the named helper.
+
+    Accepted shapes:
+      * ``await _bot_lifecycle.HELPER(...)`` — preferred form.
+      * ``await HELPER(...)`` — when the helper was imported by name.
+    """
+    for node in ast.walk(method):
+        if not isinstance(node, ast.Await):
+            continue
+        call = node.value
+        if not isinstance(call, ast.Call):
+            continue
+        func = call.func
+        # Bare-name import: ``await polling_lock_heartbeat_tick(...)``.
+        if isinstance(func, ast.Name) and func.id == helper_name:
+            return True
+        # Attribute access: ``await _bot_lifecycle.polling_lock_heartbeat_tick(...)``.
+        if isinstance(func, ast.Attribute) and func.attr == helper_name:
+            return True
+    return False
+
+
+def test_warmup_bge_method_delegates_to_helper() -> None:
+    tree = _parse(BOT_PATH)
+    method = _find_class_method(tree, "PropertyBot", "_warmup_bge")
+    assert _method_awaits_lifecycle_helper(method, "warmup_bge_pool"), (
+        "PropertyBot._warmup_bge must delegate to "
+        "telegram_bot._bot_lifecycle.warmup_bge_pool. Move the body into the "
+        "module-level helper and have the method await it."
+    )
+
+
+def test_polling_lock_heartbeat_method_delegates_to_helper() -> None:
+    tree = _parse(BOT_PATH)
+    method = _find_class_method(tree, "PropertyBot", "_polling_lock_heartbeat_tick")
+    assert _method_awaits_lifecycle_helper(method, "polling_lock_heartbeat_tick"), (
+        "PropertyBot._polling_lock_heartbeat_tick must delegate to "
+        "telegram_bot._bot_lifecycle.polling_lock_heartbeat_tick. Move the "
+        "body into the module-level helper and have the method await it."
+    )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Refs #2048 (umbrella) and #1265 (decomposition plan).

PR-8 of the Slice 2 decomposition plan published in
[`docs/engineering/bot-decomposition-plan-2026-05-27.md`](https://github.com/yastman/rag/pull/2174). Extracts the two pure-ish lifecycle helpers off the `PropertyBot` god-object into a new `telegram_bot/_bot_lifecycle.py` module so they can be unit-tested without instantiating the full bot stack.

`_bot_lifecycle.py` follows the Slice 1 convention from the other `_bot_*.py` helpers (state, observability, error_classification, streaming, pre_agent, kommo, postgres_bootstrap): stdlib-only at module scope, no `aiogram` / `langgraph` / `qdrant_client` / `fastapi` import. The class methods on `PropertyBot` are preserved as thin delegates so the existing call sites and tests keep working without signature changes.

This intentionally does **not** touch `start()` / `stop()` themselves — those are 575 + 100 LOC and earned their own follow-up PR-9 / PR-10 in the plan. PR-8 focuses on the small atomic move that establishes the `_bot_lifecycle` namespace.

## What changed

| Path | Change |
|------|--------|
| `telegram_bot/_bot_lifecycle.py` | **new** — module-level `warmup_bge_pool(hybrid, *, log)` and `polling_lock_heartbeat_tick(bot, *, log, max_refresh_failures)` helpers |
| `telegram_bot/bot.py` | `_warmup_bge` and `_polling_lock_heartbeat_tick` reduced to 6-line delegates that `await` the new helpers |
| `tests/contract/test_bot_lifecycle_extraction_contract.py` | **new** — 4 contract tests pinning the extraction (module exists with required exports, helpers are async, no forbidden top-level imports, methods statically delegate via AST scan) |

`bot.py` shrinks from 4582 → 4574 lines (–8). The bigger reduction comes with PR-9 (handlers); PR-8's value is establishing the `_bot_lifecycle` module + contract pattern that PR-9 / PR-10 will reuse.

## Test plan / verification

Local run on `refactor/2048-propertybot-lifecycle-slices`:

```
uv run --python 3.12 pytest \
  tests/unit/test_bot_handlers.py \
  tests/unit/test_bot_scores.py \
  tests/unit/test_bot_observability.py \
  tests/unit/test_bot_initialization.py \
  tests/unit/test_perf_fixes.py \
  tests/contract/test_bot_lifecycle_extraction_contract.py \
  -q --timeout=30 -n auto --dist=worksteal
```

Result: **293 passed in 29.31s**.

`ruff check` clean on the touched files.

The pre-existing AST contract `tests/unit/test_perf_fixes.py::test_start_calls_warmup_bge` (which scans `PropertyBot.start` body for `await self._warmup_bge()`) keeps passing because `start()` itself is untouched — it still calls `self._warmup_bge()`, which now delegates to the helper.

## Risk

Low. The two helpers are byte-for-byte equivalent; only the call edge moves. Behavioural surface is pinned by:

- existing unit tests for both helpers (`test_warmup_bge_calls_hybrid_embed`, `test_warmup_bge_failure_nonfatal`, `test_polling_lock_heartbeat_retries_transient_failures`, `test_polling_lock_heartbeat_stops_before_lease_can_expire`),
- the new contract test (re-introduction of inline lifecycle code on the class trips it).

## Follow-up

This PR does not close #2048. Per the plan it covers PR-8 only; the
remaining lifecycle work (full `start` / `stop` extraction) is part of
PR-9 (handlers) and PR-10 (supervisor recovery). #2048 should remain
open until residual `bot.py` is at or below 1500 lines (the close
criterion documented in #1265 plan).