### PR TITLE
feat(voice-migration): SemanticCacheMiddleware (#2051 Slice 2)

### DIFF
--- a/telegram_bot/graph/middleware/__init__.py
+++ b/telegram_bot/graph/middleware/__init__.py
@@ -5,7 +5,8 @@ migrate from the bespoke StateGraph to ``create_agent`` (umbrella #1535).
 The legacy node modules stay in place; new code lives here.
 """
 
+from telegram_bot.graph.middleware.cache import SemanticCacheMiddleware
 from telegram_bot.graph.middleware.guard import GuardMiddleware
 
 
-__all__ = ["GuardMiddleware"]
+__all__ = ["GuardMiddleware", "SemanticCacheMiddleware"]

--- a/telegram_bot/graph/middleware/cache.py
+++ b/telegram_bot/graph/middleware/cache.py
@@ -1,0 +1,432 @@
+"""SemanticCacheMiddleware — SDK-native cache_check + cache_store hooks.
+
+This is the ``create_agent``-compatible counterpart of the legacy graph
+nodes :func:`telegram_bot.graph.nodes.cache.cache_check_node` and
+:func:`telegram_bot.graph.nodes.cache.cache_store_node`. Slice 2 of the
+voice-path migration plan in ADR-0010 (parent #1535 / #2051).
+
+Behaviour
+---------
+
+* :py:meth:`before_agent` — runs once at the start of an agent invocation:
+    1. Reads the latest human message text.
+    2. If ``query_type`` is in :data:`~telegram_bot.services.rag_core.CACHEABLE_QUERY_TYPES`,
+       computes (or reuses) the dense embedding via
+       :func:`~telegram_bot.services.rag_core.compute_query_embedding`.
+    3. Skips the lookup for contextual queries and for filter-sensitive
+       queries that arrive without a resolved ``filter_signature``
+       (matches the safety carve-out from ``cache_check_node``).
+    4. Otherwise calls
+       :func:`~telegram_bot.services.rag_core.check_semantic_cache`.
+       On HIT, returns ``{"messages": [AIMessage(cached)], "jump_to": "end",
+       "cache_hit": True, ...}`` so the SDK skips the model + tools loop
+       entirely.
+    5. On MISS, returns the fresh embedding / ColBERT vectors so
+       downstream tools can reuse them without recomputation.
+
+* :py:meth:`after_agent` — runs once after the agent finishes:
+    1. Reads the final assistant response from
+       ``state["messages"][-1].content``.
+    2. Builds the same cacheability decision as
+       :func:`cache_store_node` via
+       :func:`telegram_bot.services.cache_policy.build_cacheability_decision`.
+    3. Calls
+       :func:`telegram_bot.services.cache_policy.maybe_store_semantic_response`
+       to persist the response when the decision is favourable.
+
+Dependency injection
+--------------------
+
+``cache`` and ``embeddings`` are passed via the constructor rather than
+read from ``runtime.context``. The legacy node reads
+``runtime.context["cache"]`` / ``runtime.context["embeddings"]``; the
+middleware-shaped equivalent decouples the two so the class is unit
+testable in isolation. Slice 3's ``create_voice_agent`` factory wires
+the dependencies in at construction time.
+
+Module-scope imports are constrained by
+``tests/contract/test_voice_cache_middleware_contract.py``: stdlib +
+``langchain.agents.middleware`` + ``langchain.messages`` +
+``langgraph.runtime``. Heavy services
+(``telegram_bot.services.rag_core`` etc.) are imported at module scope
+because they are pure Python with no aiogram / qdrant_client / fastapi
+imports themselves.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from typing import Any, NotRequired
+
+from langchain.agents.middleware import AgentMiddleware, AgentState, hook_config
+from langchain.messages import AIMessage
+from langgraph.runtime import Runtime
+
+from telegram_bot.observability import get_client
+from telegram_bot.services.cache_policy import (
+    SEMANTIC_CACHE_SCHEMA_VERSION,
+    build_cacheability_decision,
+    is_contextual_query,
+    maybe_store_semantic_response,
+    resolve_semantic_cache_signature,
+)
+from telegram_bot.services.query_filter_signal import detect_filter_sensitive_query
+from telegram_bot.services.rag_core import (
+    CACHEABLE_QUERY_TYPES,
+    check_semantic_cache,
+    compute_query_embedding,
+)
+
+
+logger = logging.getLogger(__name__)
+
+# Default query type when the agent state has not been classified yet. Mirrors
+# the fallback in cache_check_node so HIT/MISS semantics are identical.
+_DEFAULT_QUERY_TYPE = "GENERAL"
+
+
+class _CacheAwareState(AgentState):
+    """``AgentState`` extension covering the cache fields the hooks read/write.
+
+    All fields are :class:`typing_extensions.NotRequired` so old
+    checkpoints that pre-date the cache middleware still validate. The
+    schema is intentionally narrower than the eventual ``VoiceAgentState``
+    (Slice 3) — Slice 2 only ships what the cache middleware itself
+    exchanges with downstream middleware/tools.
+    """
+
+    query_type: NotRequired[str]
+    cache_hit: NotRequired[bool]
+    cached_response: NotRequired[str | None]
+    query_embedding: NotRequired[list[float] | None]
+    embeddings_cache_hit: NotRequired[bool]
+    embedding_error: NotRequired[bool]
+    embedding_error_type: NotRequired[str | None]
+    colbert_query: NotRequired[list[list[float]] | None]
+    filters: NotRequired[dict[str, Any]]
+    semantic_cache_filter_signature: NotRequired[str | None]
+    grounding_mode: NotRequired[str]
+    grade_confidence: NotRequired[float]
+    documents: NotRequired[list[Any]]
+    search_results_count: NotRequired[int]
+    response: NotRequired[str]
+    latency_stages: NotRequired[dict[str, float]]
+
+
+def _extract_query_text(state: AgentState | dict[str, Any]) -> str:
+    """Return the latest human message content; tolerant of dict/AIMessage."""
+    messages = state.get("messages") or []
+    if not messages:
+        return ""
+    last = messages[-1]
+    content = getattr(last, "content", None)
+    if content is None and isinstance(last, dict):
+        content = last.get("content", "")
+    return content or ""
+
+
+def _resolve_filter_signature(
+    state: dict[str, Any] | AgentState, query: str
+) -> tuple[bool, str | None]:
+    """Mirror ``_resolve_graph_filter_signature`` from the legacy node."""
+    filter_sensitive = detect_filter_sensitive_query(query).is_filter_sensitive
+    filter_signature = resolve_semantic_cache_signature(
+        filters=state.get("filters"),
+        explicit_signature=state.get("semantic_cache_filter_signature"),
+    )
+    return filter_sensitive, filter_signature
+
+
+def _final_response_text(state: AgentState | dict[str, Any]) -> str:
+    """Return the latest assistant message content, falling back to ``response``."""
+    messages = state.get("messages") or []
+    for message in reversed(messages):
+        message_type = getattr(message, "type", None) or (
+            message.get("role") if isinstance(message, dict) else None
+        )
+        if message_type in {"ai", "assistant"}:
+            content = getattr(message, "content", None)
+            if content is None and isinstance(message, dict):
+                content = message.get("content", "")
+            if content:
+                return content
+    fallback = state.get("response") if isinstance(state, dict) else None
+    return fallback or ""
+
+
+class SemanticCacheMiddleware(AgentMiddleware):
+    """Skip the agent loop on semantic-cache HIT and persist on MISS.
+
+    Args:
+        cache: Cache layer manager exposing ``check_semantic`` (and the
+            shape :func:`check_semantic_cache` expects).
+        embeddings: Embedder exposing ``aembed_query`` (and optionally
+            ``aembed_colbert_query`` for ColBERT prep on MISS).
+        cache_scope: Cache namespace; ``"rag"`` matches the voice graph.
+        agent_role: Role tag for cache key isolation. Voice path historically
+            shares responses across roles, so the default is ``None``.
+    """
+
+    state_schema = _CacheAwareState
+
+    def __init__(
+        self,
+        *,
+        cache: Any,
+        embeddings: Any,
+        cache_scope: str = "rag",
+        agent_role: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.cache = cache
+        self.embeddings = embeddings
+        self.cache_scope = cache_scope
+        self.agent_role = agent_role
+
+    @hook_config(can_jump_to=["end"])
+    async def before_agent(
+        self,
+        state: _CacheAwareState,
+        runtime: Runtime,
+    ) -> dict[str, Any] | None:
+        """Cache-check hook; short-circuits the agent loop on HIT."""
+        query = _extract_query_text(state)
+        if not query:
+            return None
+        query_type = state.get("query_type") or _DEFAULT_QUERY_TYPE
+        if query_type not in CACHEABLE_QUERY_TYPES:
+            # Non-cacheable query types skip the cache layer entirely so we do
+            # not pay the embedding cost on chit-chat / off-topic flows. This
+            # matches the ``cache_check_node`` behaviour where the legacy
+            # graph routes those types past cache_check via classify_node.
+            return None
+
+        lf = get_client()
+        try:
+            lf.update_current_span(
+                input={
+                    "query_preview": query[:120],
+                    "query_len": len(query),
+                    "query_hash": hashlib.sha256(query.encode()).hexdigest()[:8],
+                    "query_type": query_type,
+                }
+            )
+        except Exception:  # pragma: no cover — observability must never raise
+            logger.debug("update_current_span (cache before) failed", exc_info=True)
+
+        start = time.perf_counter()
+
+        try:
+            embedding, _sparse, colbert_query, embeddings_cache_hit = await compute_query_embedding(
+                query, cache=self.cache, embeddings=self.embeddings
+            )
+        except Exception as exc:
+            embedding_error_type = type(exc).__name__
+            logger.error("Cache middleware embedding failed: %s: %s", embedding_error_type, exc)
+            latency = time.perf_counter() - start
+            try:
+                lf.update_current_span(
+                    level="ERROR",
+                    output={
+                        "embedding_error": True,
+                        "embedding_error_type": embedding_error_type,
+                        "duration_ms": round(latency * 1000, 1),
+                    },
+                )
+            except Exception:  # pragma: no cover
+                logger.debug("update_current_span (cache embed-error) failed", exc_info=True)
+            # On embedding failure we surface the graceful fallback message
+            # the legacy node returned and still short-circuit, so no half
+            # answer leaks through. Mirrors lines 89–106 of cache.py.
+            return {
+                "messages": [
+                    AIMessage(
+                        content="Сервис временно недоступен. Пожалуйста, повторите через минуту."
+                    )
+                ],
+                "jump_to": "end",
+                "cache_hit": False,
+                "cached_response": None,
+                "query_embedding": None,
+                "embeddings_cache_hit": False,
+                "embedding_error": True,
+                "embedding_error_type": embedding_error_type,
+                "latency_stages": {
+                    **(state.get("latency_stages") or {}),
+                    "cache_check": latency,
+                },
+            }
+
+        filter_sensitive, filter_signature = _resolve_filter_signature(state, query)
+        contextual_query = is_contextual_query(query)
+        if contextual_query or (filter_sensitive and filter_signature is None):
+            hit, cached = False, None
+        else:
+            hit, cached = await check_semantic_cache(
+                query,
+                embedding,
+                query_type,
+                cache=self.cache,
+                agent_role=self.agent_role,
+                filter_signature=filter_signature,
+            )
+
+        latency = time.perf_counter() - start
+
+        if hit:
+            logger.info("cache_middleware HIT (%.3fs, type=%s)", latency, query_type)
+            try:
+                lf.update_current_span(
+                    output={
+                        "cache_hit": True,
+                        "embeddings_cache_hit": embeddings_cache_hit,
+                        "hit_layer": "semantic",
+                        "duration_ms": round(latency * 1000, 1),
+                    }
+                )
+            except Exception:  # pragma: no cover
+                logger.debug("update_current_span (cache HIT) failed", exc_info=True)
+            return {
+                "messages": [AIMessage(content=cached or "")],
+                "jump_to": "end",
+                "cache_hit": True,
+                "cached_response": cached,
+                "query_embedding": embedding,
+                "embeddings_cache_hit": embeddings_cache_hit,
+                "embedding_error": False,
+                "embedding_error_type": None,
+                "colbert_query": None,
+                "response": cached or "",
+                "latency_stages": {
+                    **(state.get("latency_stages") or {}),
+                    "cache_check": latency,
+                },
+            }
+
+        # MISS: surface vectors so downstream tools reuse them. Match the
+        # legacy ``cache_check_node`` MISS shape, including the ColBERT
+        # fallback for embedders that expose ``aembed_colbert_query`` as a
+        # standalone async method (older bundle implementations).
+        if colbert_query is None:
+            colbert_only = getattr(self.embeddings, "aembed_colbert_query", None)
+            if callable(colbert_only):
+                try:
+                    colbert_query = await colbert_only(query)
+                except Exception:
+                    logger.debug(
+                        "ColBERT query encode failed (non-critical), skipping",
+                        exc_info=True,
+                    )
+
+        logger.info("cache_middleware MISS (%.3fs, type=%s)", latency, query_type)
+        try:
+            lf.update_current_span(
+                output={
+                    "cache_hit": False,
+                    "embeddings_cache_hit": embeddings_cache_hit,
+                    "hit_layer": "none",
+                    "duration_ms": round(latency * 1000, 1),
+                }
+            )
+        except Exception:  # pragma: no cover
+            logger.debug("update_current_span (cache MISS) failed", exc_info=True)
+        return {
+            "cache_hit": False,
+            "cached_response": None,
+            "query_embedding": embedding,
+            "embeddings_cache_hit": embeddings_cache_hit,
+            "embedding_error": False,
+            "embedding_error_type": None,
+            "colbert_query": colbert_query,
+            "latency_stages": {
+                **(state.get("latency_stages") or {}),
+                "cache_check": latency,
+            },
+        }
+
+    async def after_agent(
+        self,
+        state: _CacheAwareState,
+        runtime: Runtime,
+    ) -> dict[str, Any] | None:
+        """Persist the agent's final response into the semantic cache."""
+        # Cache HITs already routed through before_agent's jump_to=end and
+        # left the response in place; we must not store the cached response
+        # back as a fresh entry (would race with TTL bookkeeping).
+        if state.get("cache_hit"):
+            return None
+
+        query = _extract_query_text(state)
+        if not query:
+            return None
+        response = _final_response_text(state)
+        if not response:
+            return None
+        embedding = state.get("query_embedding")
+        if not embedding:
+            return None
+        query_type = state.get("query_type") or _DEFAULT_QUERY_TYPE
+        if query_type not in CACHEABLE_QUERY_TYPES:
+            return None
+
+        filter_sensitive, filter_signature = _resolve_filter_signature(state, query)
+        if filter_sensitive and filter_signature is None:
+            # Filter-sensitive query without a resolved signature: storing
+            # would cross-contaminate filter buckets. Skip just like the
+            # legacy ``cache_store_node``.
+            return None
+
+        decision = build_cacheability_decision(
+            result=dict(state),
+            query_type=query_type,
+            grounding_mode=str(state.get("grounding_mode") or "normal"),
+            documents=state.get("documents") or [],
+            cache_hit=False,
+            contextual=is_contextual_query(query),
+            grade_confidence=float(state.get("grade_confidence") or 0.0),
+            confidence_threshold=0.0,
+            schema_version=SEMANTIC_CACHE_SCHEMA_VERSION,
+        )
+
+        stored = False
+        try:
+            stored = await maybe_store_semantic_response(
+                cache=self.cache,
+                query=query,
+                response=response,
+                vector=embedding,
+                query_type=query_type,
+                cache_scope=self.cache_scope,
+                decision=decision,
+                agent_role=self.agent_role,
+                filter_signature=filter_signature,
+            )
+        except Exception as exc:
+            # Match the legacy node: a cache-store failure must never
+            # destroy the response. Log + swallow + continue.
+            logger.warning(
+                "cache_middleware: semantic store failed, response preserved: %s: %s",
+                type(exc).__name__,
+                exc,
+            )
+
+        try:
+            get_client().update_current_span(output={"stored": stored, "stored_semantic": stored})
+        except Exception:  # pragma: no cover
+            logger.debug("update_current_span (cache_store) failed", exc_info=True)
+
+        # Surface the same observability fields the legacy node wrote into
+        # the state so ``_handle_query_supervisor``'s post-processing block
+        # keeps working unchanged.
+        return {
+            "response": response,
+            "response_state": decision.response_state,
+            "degraded_reason": decision.degraded_reason,
+            "cache_eligible": decision.cache_eligible,
+            "store_reason": decision.store_reason,
+        }
+
+
+__all__ = ("SemanticCacheMiddleware", "_CacheAwareState")

--- a/tests/contract/test_error_contract.py
+++ b/tests/contract/test_error_contract.py
@@ -26,6 +26,10 @@ ERROR_SPAN_ALLOWLIST: dict[str, list[str]] = {
     "telegram_bot/graph/nodes/rerank.py": ["ERROR"],
     "telegram_bot/graph/nodes/respond.py": ["ERROR"],
     "telegram_bot/graph/nodes/cache.py": ["ERROR"],
+    # SDK-native counterpart of cache_check_node — records ERROR on the
+    # embedding-failure path before short-circuiting the agent loop with
+    # a graceful fallback message (#2051 Slice 2).
+    "telegram_bot/graph/middleware/cache.py": ["ERROR"],
     # Voice transcription error path (Whisper / LiteLLM failure) — span is
     # re-raised so the outer voice-session trace records the failure (#1810).
     "telegram_bot/graph/nodes/transcribe.py": ["ERROR"],

--- a/tests/contract/test_voice_cache_middleware_contract.py
+++ b/tests/contract/test_voice_cache_middleware_contract.py
@@ -1,0 +1,178 @@
+"""Contract: SemanticCacheMiddleware lives in ``telegram_bot/graph/middleware/cache.py``.
+
+Slice 2 of the voice-path migration to ``create_agent`` (ADR-0010, parent
+#1535 / #2051). The middleware is the SDK-native counterpart of
+:func:`telegram_bot.graph.nodes.cache.cache_check_node` and
+:func:`telegram_bot.graph.nodes.cache.cache_store_node`.
+
+The contract pins:
+
+1. ``telegram_bot.graph.middleware.cache`` exposes
+   ``SemanticCacheMiddleware`` and the local state schema
+   ``_CacheAwareState`` it ships with.
+2. ``SemanticCacheMiddleware`` is a subclass of
+   :class:`langchain.agents.middleware.AgentMiddleware`.
+3. The class declares the two SDK-native hooks required for the
+   cache-hit short-circuit: ``before_agent`` (runs once at the start;
+   may ``jump_to=end`` on cache HIT) and ``after_agent`` (runs once at
+   the end; persists the agent's final response).
+4. ``before_agent`` is decorated with ``@hook_config(can_jump_to=["end"])``
+   so the SDK knows the hook may short-circuit.
+5. The constructor takes ``cache`` and ``embeddings`` keyword-only — no
+   reading from ``runtime.context`` for these heavy collaborators, so
+   the middleware stays unit-testable in isolation.
+6. The module does not import aiogram / langgraph (beyond
+   ``langgraph.runtime``) / qdrant_client / fastapi at module scope.
+   Heavy imports must stay inside function bodies if needed.
+7. ``__init__.py`` re-exports ``SemanticCacheMiddleware`` so callers
+   can ``from telegram_bot.graph.middleware import SemanticCacheMiddleware``.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_NAME = "telegram_bot.graph.middleware.cache"
+MODULE_PATH = REPO_ROOT / "telegram_bot" / "graph" / "middleware" / "cache.py"
+PKG_INIT_PATH = REPO_ROOT / "telegram_bot" / "graph" / "middleware" / "__init__.py"
+
+FORBIDDEN_TOP_IMPORTS = {
+    "aiogram",
+    "qdrant_client",
+    "fastapi",
+}
+# ``langgraph.runtime`` is allowed (Runtime is the SDK type-hint), but other
+# langgraph subpackages should stay out of module scope.
+ALLOWED_LANGGRAPH_SUBPACKAGES = {"langgraph.runtime"}
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def test_module_exists_and_exports_required_symbols() -> None:
+    assert MODULE_PATH.is_file(), (
+        f"{MODULE_PATH.relative_to(REPO_ROOT)} must exist (#2051 Slice 2)."
+    )
+    module = importlib.import_module(MODULE_NAME)
+    for name in ("SemanticCacheMiddleware", "_CacheAwareState"):
+        assert hasattr(module, name), f"{MODULE_NAME} must export {name}."
+
+
+def test_middleware_subclasses_AgentMiddleware() -> None:
+    from langchain.agents.middleware import AgentMiddleware
+
+    module = importlib.import_module(MODULE_NAME)
+    cls = module.SemanticCacheMiddleware
+    assert inspect.isclass(cls)
+    assert issubclass(cls, AgentMiddleware), (
+        "SemanticCacheMiddleware must subclass langchain.agents.middleware.AgentMiddleware"
+    )
+
+
+def test_middleware_declares_required_hooks() -> None:
+    module = importlib.import_module(MODULE_NAME)
+    cls = module.SemanticCacheMiddleware
+    for hook in ("before_agent", "after_agent"):
+        member = inspect.getattr_static(cls, hook, None)
+        assert member is not None, (
+            f"SemanticCacheMiddleware must define {hook} (Slice 2 cache lifecycle)."
+        )
+
+
+def test_before_agent_is_hook_config_with_jump_to_end() -> None:
+    """``@hook_config(can_jump_to=['end'])`` is required so the SDK
+    permits the cache-hit short-circuit. Detect via AST so the test
+    does not depend on runtime decorator metadata."""
+    tree = _parse(MODULE_PATH)
+    found = False
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+            and node.name == "before_agent"
+        ):
+            continue
+        for deco in node.decorator_list:
+            if not (isinstance(deco, ast.Call) and isinstance(deco.func, ast.Name)):
+                continue
+            if deco.func.id != "hook_config":
+                continue
+            for kw in deco.keywords:
+                if kw.arg != "can_jump_to":
+                    continue
+                if isinstance(kw.value, ast.List) and any(
+                    isinstance(elt, ast.Constant) and elt.value == "end"
+                    for elt in kw.value.elts
+                ):
+                    found = True
+    assert found, (
+        "SemanticCacheMiddleware.before_agent must be decorated with "
+        "@hook_config(can_jump_to=['end']) so the SDK allows jump_to='end' on cache HIT."
+    )
+
+
+def test_constructor_takes_cache_and_embeddings_keyword_only() -> None:
+    module = importlib.import_module(MODULE_NAME)
+    cls = module.SemanticCacheMiddleware
+    sig = inspect.signature(cls.__init__)
+    params = sig.parameters
+    for name in ("cache", "embeddings"):
+        assert name in params, (
+            f"SemanticCacheMiddleware.__init__ must accept '{name}' (keyword-only)"
+        )
+        assert params[name].kind == inspect.Parameter.KEYWORD_ONLY, (
+            f"'{name}' must be KEYWORD_ONLY for explicit dependency injection"
+        )
+
+
+def test_module_has_no_forbidden_top_imports() -> None:
+    tree = _parse(MODULE_PATH)
+    offenders: list[str] = []
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                top = alias.name.split(".", 1)[0]
+                if top in FORBIDDEN_TOP_IMPORTS:
+                    offenders.append(alias.name)
+                if top == "langgraph" and alias.name not in ALLOWED_LANGGRAPH_SUBPACKAGES:
+                    offenders.append(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            top = module.split(".", 1)[0]
+            if top in FORBIDDEN_TOP_IMPORTS:
+                offenders.append(module)
+            if top == "langgraph" and module not in ALLOWED_LANGGRAPH_SUBPACKAGES:
+                offenders.append(module)
+    assert not offenders, (
+        f"{MODULE_PATH.relative_to(REPO_ROOT)} has forbidden module-scope imports: "
+        f"{offenders}. Lazy-import inside function bodies if needed."
+    )
+
+
+def test_package_init_re_exports_middleware() -> None:
+    init_text = PKG_INIT_PATH.read_text(encoding="utf-8")
+    assert "SemanticCacheMiddleware" in init_text, (
+        "telegram_bot/graph/middleware/__init__.py must re-export "
+        "SemanticCacheMiddleware so callers can do "
+        "`from telegram_bot.graph.middleware import SemanticCacheMiddleware`."
+    )
+
+
+def test_state_schema_has_required_fields() -> None:
+    """``_CacheAwareState`` must declare the cache fields the hooks
+    write so the SDK's state-merge layer accepts them. NotRequired
+    keeps backward-compatibility with checkpoints lacking these fields.
+    """
+    module = importlib.import_module(MODULE_NAME)
+    schema = module._CacheAwareState
+    annotations = getattr(schema, "__annotations__", {})
+    for field in ("query_type", "cache_hit", "cached_response", "query_embedding"):
+        assert field in annotations, (
+            f"_CacheAwareState must annotate field '{field}' "
+            f"(declared annotations: {sorted(annotations)})"
+        )

--- a/tests/unit/agents/middleware/test_semantic_cache_middleware.py
+++ b/tests/unit/agents/middleware/test_semantic_cache_middleware.py
@@ -1,0 +1,380 @@
+"""Behaviour parity tests for ``SemanticCacheMiddleware`` (Slice 2 / #2051).
+
+The middleware replaces the legacy graph nodes
+:func:`telegram_bot.graph.nodes.cache.cache_check_node` and
+:func:`telegram_bot.graph.nodes.cache.cache_store_node`. These tests pin
+the behaviour the legacy nodes ship today so that the middleware shape
+can be wired into ``create_voice_agent`` (Slice 3) without surprising
+the graph-side regression suite.
+
+Every test stubs ``rag_core``/``cache_policy`` collaborators so the
+middleware is exercised in isolation — no Redis, no embedding service,
+no Langfuse client.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain.messages import AIMessage, HumanMessage
+
+from telegram_bot.graph.middleware.cache import (
+    SemanticCacheMiddleware,
+    _CacheAwareState,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def _state(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "messages": [HumanMessage(content="что такое прописка в Болгарии")],
+        "query_type": "FAQ",
+    }
+    base.update(overrides)
+    return base
+
+
+def _runtime_stub() -> Any:
+    runtime = MagicMock()
+    runtime.context = {}
+    return runtime
+
+
+@pytest.fixture
+def cache() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def embeddings() -> AsyncMock:
+    embeddings = AsyncMock()
+    embeddings.aembed_query.return_value = [0.1] * 8
+    return embeddings
+
+
+@pytest.fixture
+def middleware(cache: AsyncMock, embeddings: AsyncMock) -> SemanticCacheMiddleware:
+    return SemanticCacheMiddleware(cache=cache, embeddings=embeddings)
+
+
+@pytest.fixture(autouse=True)
+def _stub_observability(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Silence observability so tests do not depend on Langfuse internals."""
+    fake_client = MagicMock()
+    fake_client.update_current_span = MagicMock()
+    monkeypatch.setattr("telegram_bot.graph.middleware.cache.get_client", lambda: fake_client)
+
+
+@pytest.fixture
+def patched_rag_core(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Replace ``compute_query_embedding`` and ``check_semantic_cache``.
+
+    Default behaviour: embedding succeeds, cache MISS, ColBERT vectors
+    None. Individual tests override return values via the returned dict.
+    """
+    embedding = [0.1] * 8
+    state: dict[str, Any] = {
+        "compute": AsyncMock(return_value=(embedding, None, None, False)),
+        "check": AsyncMock(return_value=(False, None)),
+        "embedding": embedding,
+    }
+    monkeypatch.setattr(
+        "telegram_bot.graph.middleware.cache.compute_query_embedding", state["compute"]
+    )
+    monkeypatch.setattr("telegram_bot.graph.middleware.cache.check_semantic_cache", state["check"])
+    return state
+
+
+@pytest.fixture
+def patched_store(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    fake = AsyncMock(return_value=True)
+    monkeypatch.setattr("telegram_bot.graph.middleware.cache.maybe_store_semantic_response", fake)
+    return fake
+
+
+# --------------------------------------------------------------------------- #
+# before_agent — cache check                                                    #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_before_agent_returns_none_for_empty_messages(
+    middleware: SemanticCacheMiddleware,
+) -> None:
+    """No human message → middleware is a no-op (no embedding, no jump)."""
+    result = await middleware.before_agent({"messages": []}, _runtime_stub())
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_before_agent_skips_cache_for_non_cacheable_query_type(
+    middleware: SemanticCacheMiddleware,
+    patched_rag_core: dict[str, Any],
+) -> None:
+    """CHITCHAT / OFF_TOPIC bypass cache (matches legacy classify routing)."""
+    state = _state(query_type="CHITCHAT")
+    result = await middleware.before_agent(state, _runtime_stub())
+    assert result is None
+    patched_rag_core["compute"].assert_not_called()
+    patched_rag_core["check"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_before_agent_short_circuits_on_cache_hit(
+    middleware: SemanticCacheMiddleware,
+    patched_rag_core: dict[str, Any],
+) -> None:
+    """Cache HIT must return jump_to=end + AIMessage(cached) so the SDK
+    skips both the model call and the after_agent cache_store path."""
+    cached_response = "ВНЖ оформляется в течение 30 рабочих дней."
+    patched_rag_core["check"].return_value = (True, cached_response)
+
+    result = await middleware.before_agent(_state(), _runtime_stub())
+
+    assert result is not None
+    assert result["jump_to"] == "end"
+    assert result["cache_hit"] is True
+    assert result["cached_response"] == cached_response
+    assert result["query_embedding"] == patched_rag_core["embedding"]
+    # Final-message slot carries the cached AI response so handle_voice
+    # / handle_query can read it from state["messages"][-1].
+    [message] = result["messages"]
+    assert isinstance(message, AIMessage)
+    assert message.content == cached_response
+
+
+@pytest.mark.asyncio
+async def test_before_agent_returns_embedding_on_cache_miss(
+    middleware: SemanticCacheMiddleware,
+    patched_rag_core: dict[str, Any],
+) -> None:
+    """Cache MISS must surface the freshly-computed embedding so downstream
+    tools (rag_search) reuse it rather than recomputing."""
+    result = await middleware.before_agent(_state(), _runtime_stub())
+
+    assert result is not None
+    assert "jump_to" not in result
+    assert result["cache_hit"] is False
+    assert result["query_embedding"] == patched_rag_core["embedding"]
+    assert result["cached_response"] is None
+
+
+@pytest.mark.asyncio
+async def test_before_agent_skips_cache_for_contextual_query(
+    middleware: SemanticCacheMiddleware,
+    patched_rag_core: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``is_contextual_query`` short-circuits the lookup (legacy parity).
+
+    The embedding is still computed because downstream tools need it on
+    the no-hit branch; only the ``check_semantic_cache`` call is gated.
+    """
+    monkeypatch.setattr("telegram_bot.graph.middleware.cache.is_contextual_query", lambda _q: True)
+    result = await middleware.before_agent(_state(), _runtime_stub())
+
+    assert result is not None
+    assert result["cache_hit"] is False
+    patched_rag_core["compute"].assert_awaited_once()
+    patched_rag_core["check"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_before_agent_skips_cache_when_filter_sensitive_without_signature(
+    middleware: SemanticCacheMiddleware,
+    patched_rag_core: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Filter-sensitive queries with no resolved filter_signature must NOT
+    hit the shared cache bucket; matches the carve-out in cache_check_node."""
+
+    fake_signal = MagicMock()
+    fake_signal.is_filter_sensitive = True
+    monkeypatch.setattr(
+        "telegram_bot.graph.middleware.cache.detect_filter_sensitive_query",
+        lambda _q: fake_signal,
+    )
+    monkeypatch.setattr(
+        "telegram_bot.graph.middleware.cache.resolve_semantic_cache_signature",
+        lambda **_: None,
+    )
+
+    result = await middleware.before_agent(_state(), _runtime_stub())
+
+    assert result is not None
+    assert result["cache_hit"] is False
+    patched_rag_core["check"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_before_agent_short_circuits_on_embedding_failure(
+    middleware: SemanticCacheMiddleware,
+    patched_rag_core: dict[str, Any],
+) -> None:
+    """Embedding failure surfaces the graceful-fallback response and stops
+    the agent loop (matches the early-return shape of cache_check_node)."""
+    patched_rag_core["compute"].side_effect = TimeoutError("BGE timeout")
+
+    result = await middleware.before_agent(_state(), _runtime_stub())
+
+    assert result is not None
+    assert result["jump_to"] == "end"
+    assert result["embedding_error"] is True
+    assert result["embedding_error_type"] == "TimeoutError"
+    [message] = result["messages"]
+    assert "временно недоступен" in message.content
+
+
+# --------------------------------------------------------------------------- #
+# after_agent — cache store                                                     #
+# --------------------------------------------------------------------------- #
+
+
+@dataclasses.dataclass
+class _FakeDecision:
+    response_state: str = "ok"
+    degraded_reason: str | None = None
+    cache_eligible: bool = True
+    store_reason: str = "ok"
+
+
+@pytest.fixture
+def patched_decision(monkeypatch: pytest.MonkeyPatch) -> _FakeDecision:
+    decision = _FakeDecision()
+    monkeypatch.setattr(
+        "telegram_bot.graph.middleware.cache.build_cacheability_decision",
+        lambda **_: decision,
+    )
+    return decision
+
+
+@pytest.mark.asyncio
+async def test_after_agent_persists_response_for_cacheable_query(
+    middleware: SemanticCacheMiddleware,
+    patched_store: AsyncMock,
+    patched_decision: _FakeDecision,
+) -> None:
+    state = _state(
+        messages=[
+            HumanMessage(content="как получить ВНЖ?"),
+            AIMessage(content="ВНЖ оформляется около 30 дней."),
+        ],
+        query_embedding=[0.1] * 8,
+        cache_hit=False,
+    )
+
+    update = await middleware.after_agent(state, _runtime_stub())
+
+    patched_store.assert_awaited_once()
+    kwargs = patched_store.await_args.kwargs
+    assert kwargs["query_type"] == "FAQ"
+    assert kwargs["response"] == "ВНЖ оформляется около 30 дней."
+    assert kwargs["vector"] == [0.1] * 8
+    assert kwargs["decision"] is patched_decision
+    assert update is not None
+    assert update["response"] == "ВНЖ оформляется около 30 дней."
+    assert update["cache_eligible"] is True
+
+
+@pytest.mark.asyncio
+async def test_after_agent_noop_on_cache_hit(
+    middleware: SemanticCacheMiddleware,
+    patched_store: AsyncMock,
+) -> None:
+    """On HIT, before_agent already stored nothing fresh; after_agent
+    must not re-write the cached response back into Redis."""
+    state = _state(
+        messages=[HumanMessage(content="x"), AIMessage(content="cached")],
+        query_embedding=[0.1] * 8,
+        cache_hit=True,
+    )
+    result = await middleware.after_agent(state, _runtime_stub())
+    assert result is None
+    patched_store.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_after_agent_skips_when_response_missing(
+    middleware: SemanticCacheMiddleware,
+    patched_store: AsyncMock,
+) -> None:
+    """No assistant message → nothing to store."""
+    state = _state(messages=[HumanMessage(content="x")], query_embedding=[0.1] * 8)
+    result = await middleware.after_agent(state, _runtime_stub())
+    assert result is None
+    patched_store.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_after_agent_skips_when_embedding_missing(
+    middleware: SemanticCacheMiddleware,
+    patched_store: AsyncMock,
+) -> None:
+    state = _state(
+        messages=[HumanMessage(content="x"), AIMessage(content="hi")],
+        query_embedding=None,
+    )
+    result = await middleware.after_agent(state, _runtime_stub())
+    assert result is None
+    patched_store.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_after_agent_skips_for_non_cacheable_query_type(
+    middleware: SemanticCacheMiddleware,
+    patched_store: AsyncMock,
+) -> None:
+    """OFF_TOPIC must not be persisted — matches CACHEABLE_QUERY_TYPES gate."""
+    state = _state(
+        query_type="OFF_TOPIC",
+        messages=[HumanMessage(content="x"), AIMessage(content="off-topic answer")],
+        query_embedding=[0.1] * 8,
+    )
+    result = await middleware.after_agent(state, _runtime_stub())
+    assert result is None
+    patched_store.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_after_agent_swallows_store_failure(
+    middleware: SemanticCacheMiddleware,
+    patched_store: AsyncMock,
+    patched_decision: _FakeDecision,
+) -> None:
+    """A cache-store error must never destroy the response (legacy invariant)."""
+    patched_store.side_effect = RuntimeError("redisvl exploded")
+
+    state = _state(
+        messages=[HumanMessage(content="x"), AIMessage(content="answer")],
+        query_embedding=[0.1] * 8,
+    )
+
+    update = await middleware.after_agent(state, _runtime_stub())
+
+    # Response is preserved despite the store crash.
+    assert update is not None
+    assert update["response"] == "answer"
+
+
+# --------------------------------------------------------------------------- #
+# State schema                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_cache_aware_state_extends_agent_state() -> None:
+    """``_CacheAwareState`` must compose with ``AgentState``'s ``messages``
+    field so the SDK's state-merge accepts middleware updates."""
+    annotations = dict(_CacheAwareState.__annotations__)
+    # Inherited annotations should still be reachable via ``__annotations__``
+    # at runtime — fall back to ``getattr`` for safety on older typing
+    # backends. The presence of the cache-specific fields is sufficient
+    # contract evidence.
+    assert "cache_hit" in annotations
+    assert "query_embedding" in annotations


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Slice 2 of the voice-path migration to `create_agent` (ADR-0010, parent #1535 / #2051). Ships the SDK-native counterpart of `cache_check_node` + `cache_store_node` so the upcoming `create_voice_agent` factory (Slice 3) can drop into `create_agent` without losing the semantic-cache short-circuit the legacy graph provides today.

## What landed

- **`telegram_bot/graph/middleware/cache.py`** — `SemanticCacheMiddleware(AgentMiddleware)`:
  - `before_agent` decorated with `@hook_config(can_jump_to=["end"])` — Context7-verified shape; on cache HIT returns `{messages: [AIMessage(cached)], jump_to: "end", cache_hit: True, ...}`
  - `after_agent` persists the agent's final response via the existing `cache_policy.maybe_store_semantic_response`
  - `_CacheAwareState(AgentState)` — narrow set of `NotRequired` fields the hooks read/write; sized for Slice 2 only, broader `VoiceAgentState` ships in Slice 3
  - `cache` and `embeddings` injected via constructor (mirrors `GuardMiddleware`); class is unit testable in isolation
  - Re-uses `rag_core.compute_query_embedding`, `rag_core.check_semantic_cache`, `cache_policy.maybe_store_semantic_response` verbatim — no logic duplication

- **`tests/contract/test_voice_cache_middleware_contract.py`** (8 tests) — pins:
  - module + state schema + `__init__.py` re-export presence
  - subclass relationship with `langchain.agents.middleware.AgentMiddleware`
  - `before_agent` / `after_agent` hook presence
  - `@hook_config(can_jump_to=["end"])` decoration on `before_agent`
  - keyword-only `cache` + `embeddings` constructor params
  - no aiogram / qdrant_client / fastapi / non-runtime langgraph imports at module scope

- **`tests/unit/agents/middleware/test_semantic_cache_middleware.py`** (14 tests) — behaviour parity with the legacy nodes:
  - `before_agent`: empty messages, non-cacheable query type, cache HIT, cache MISS surfaces embedding, contextual-query carve-out, filter-sensitive without signature, embedding-failure graceful exit
  - `after_agent`: cacheable response stored, no-op on `cache_hit=True`, no-op without response/embedding, OFF_TOPIC skip, store-exception swallowed (response preserved invariant)
  - `_CacheAwareState` extends `AgentState`

## Verification

```
uv run --python 3.12 pytest \
  tests/unit/graph/test_cache_nodes.py \
  tests/unit/agents/middleware/ \
  tests/contract/test_voice_cache_middleware_contract.py \
  tests/unit/test_bot_handlers.py \
  tests/unit/graph/ \
  -q --timeout=30 -n auto --dist=worksteal
```
→ **755 passed in 28.75s**; ruff clean.

## Out of scope

This PR does **not** rewire `handle_voice` (issue #2051's final acceptance). Slices remaining per ADR-0010:

- **Slice 2.5** — `ClassifyMiddleware` (CHITCHAT/OFF_TOPIC short-circuit)
- **Slice 3** — `VoiceAgentState` + `create_voice_agent` factory
- **Slice 4** — gold-set parity check (`graph` vs `agent` backend)
- **Slice 5** — actual `handle_voice` rewire under feature flag

See `docs/engineering/voice-create-agent-2026-05-27-status.md` for the full sequencing.

Refs #2051, refs #1535, refs ADR-0010