### PR TITLE
feat(voice-migration): ClassifyMiddleware (#2051 Slice 2.5)

### DIFF
--- a/telegram_bot/graph/middleware/__init__.py
+++ b/telegram_bot/graph/middleware/__init__.py
@@ -5,7 +5,8 @@ migrate from the bespoke StateGraph to ``create_agent`` (umbrella #1535).
 The legacy node modules stay in place; new code lives here.
 """
 
+from telegram_bot.graph.middleware.classify import ClassifyMiddleware
 from telegram_bot.graph.middleware.guard import GuardMiddleware
 
 
-__all__ = ["GuardMiddleware"]
+__all__ = ["ClassifyMiddleware", "GuardMiddleware"]

--- a/telegram_bot/graph/middleware/classify.py
+++ b/telegram_bot/graph/middleware/classify.py
@@ -1,0 +1,144 @@
+"""ClassifyMiddleware — SDK-native ``before_agent`` hook for query classification.
+
+This is the ``create_agent``-compatible counterpart of
+:func:`telegram_bot.graph.nodes.classify.classify_node`. Slice 2.5 of the
+voice-path migration plan in ADR-0010 (parent #1535 / #2051).
+
+Behaviour
+---------
+
+Runs once at the start of an agent invocation:
+
+* Reads the latest human message text and feeds it to
+  :func:`~telegram_bot.graph.nodes.classify.classify_query` (regex-only,
+  ~0 ms — no LLM).
+* For ``CHITCHAT`` and ``OFF_TOPIC`` query types: returns
+  ``{"messages": [AIMessage(canned)], "jump_to": "end", "query_type": ...}``
+  so the SDK skips both the model loop and the cache hooks. This
+  matches the legacy router in ``graph.py`` which sends those types
+  straight to ``respond`` without touching ``cache_check``.
+* For all other types: returns ``{"query_type": ...}`` so downstream
+  middleware (cache_check) and tools see the classification without
+  rerunning the regex.
+
+The middleware is intentionally tiny — it owns no embeddings, no Redis,
+no LLM. It exists purely to lift the legacy classify routing into the
+``create_agent`` lifecycle.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, NotRequired
+
+from langchain.agents.middleware import AgentMiddleware, AgentState, hook_config
+from langchain.messages import AIMessage
+from langgraph.runtime import Runtime
+
+from telegram_bot.graph.nodes.classify import (
+    CHITCHAT,
+    OFF_TOPIC,
+    _get_chitchat_response,
+    classify_query,
+)
+from telegram_bot.observability import get_client
+
+
+logger = logging.getLogger(__name__)
+
+
+class _ClassifyAwareState(AgentState):
+    """Adds the classification slot to the agent state."""
+
+    query_type: NotRequired[str]
+    response: NotRequired[str]
+    latency_stages: NotRequired[dict[str, float]]
+
+
+def _extract_query_text(state: AgentState | dict[str, Any]) -> str:
+    messages = state.get("messages") or []
+    if not messages:
+        return ""
+    last = messages[-1]
+    content = getattr(last, "content", None)
+    if content is None and isinstance(last, dict):
+        content = last.get("content", "")
+    return content or ""
+
+
+def _canned_response(query: str, query_type: str) -> str:
+    """Return the canned response the legacy node would have emitted."""
+    if query_type == CHITCHAT:
+        return _get_chitchat_response(query)
+    if query_type == OFF_TOPIC:
+        # Reuse the same off-topic response set the graph node uses, via a
+        # local import so the module-scope import surface stays narrow.
+        from random import choice
+
+        from telegram_bot.graph.nodes.classify import OFF_TOPIC_RESPONSES
+
+        return choice(OFF_TOPIC_RESPONSES)
+    return ""
+
+
+class ClassifyMiddleware(AgentMiddleware):
+    """Classify the user query and short-circuit on CHITCHAT/OFF_TOPIC.
+
+    Reuses ``classify_query`` (regex-only, ~0 ms) so detection is byte-for-byte
+    aligned with the legacy graph until Slice 5 deletes ``classify_node``.
+
+    Args:
+        skip_canned_response: When ``True`` the middleware sets
+            ``query_type`` but does not emit a canned reply for
+            CHITCHAT/OFF_TOPIC. Useful for tests and for callers that
+            want to render those messages with custom keyboards. Default
+            ``False`` (matches legacy behaviour).
+    """
+
+    state_schema = _ClassifyAwareState
+
+    def __init__(self, *, skip_canned_response: bool = False) -> None:
+        super().__init__()
+        self.skip_canned_response = skip_canned_response
+
+    @hook_config(can_jump_to=["end"])
+    def before_agent(
+        self,
+        state: _ClassifyAwareState,
+        runtime: Runtime,
+    ) -> dict[str, Any] | None:
+        query = _extract_query_text(state)
+        if not query:
+            return None
+
+        t0 = time.perf_counter()
+        query_type = classify_query(query)
+        latency = time.perf_counter() - t0
+
+        try:
+            get_client().update_current_span(
+                output={"query_type": query_type, "duration_ms": round(latency * 1000, 2)}
+            )
+        except Exception:  # pragma: no cover — observability must never raise
+            logger.debug("classify update_current_span failed", exc_info=True)
+
+        latency_stages = {**(state.get("latency_stages") or {}), "classify": latency}
+
+        if query_type in {CHITCHAT, OFF_TOPIC}:
+            if self.skip_canned_response:
+                # Caller wants to render the canned message itself.
+                return {"query_type": query_type, "latency_stages": latency_stages}
+            canned = _canned_response(query, query_type)
+            return {
+                "messages": [AIMessage(content=canned)],
+                "jump_to": "end",
+                "query_type": query_type,
+                "response": canned,
+                "latency_stages": latency_stages,
+            }
+
+        return {"query_type": query_type, "latency_stages": latency_stages}
+
+
+__all__ = ("ClassifyMiddleware", "_ClassifyAwareState")

--- a/tests/contract/test_voice_classify_middleware_contract.py
+++ b/tests/contract/test_voice_classify_middleware_contract.py
@@ -1,0 +1,126 @@
+"""Contract: ClassifyMiddleware lives in ``telegram_bot/graph/middleware/classify.py``.
+
+Slice 2.5 of the voice-path migration to ``create_agent`` (ADR-0010,
+parent #1535 / #2051). The middleware is the SDK-native counterpart of
+:func:`telegram_bot.graph.nodes.classify.classify_node`. It runs once
+at the start of the agent invocation, classifies the user query and
+short-circuits the agent loop for ``CHITCHAT`` / ``OFF_TOPIC`` types
+with a canned response — exactly as the legacy ``classify_node``
+routes those types past ``cache_check`` straight to ``respond``.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_NAME = "telegram_bot.graph.middleware.classify"
+MODULE_PATH = REPO_ROOT / "telegram_bot" / "graph" / "middleware" / "classify.py"
+PKG_INIT_PATH = REPO_ROOT / "telegram_bot" / "graph" / "middleware" / "__init__.py"
+
+FORBIDDEN_TOP_IMPORTS = {
+    "aiogram",
+    "qdrant_client",
+    "fastapi",
+}
+ALLOWED_LANGGRAPH_SUBPACKAGES = {"langgraph.runtime"}
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def test_module_exists_and_exports_required_symbols() -> None:
+    assert MODULE_PATH.is_file(), (
+        f"{MODULE_PATH.relative_to(REPO_ROOT)} must exist (#2051 Slice 2.5)."
+    )
+    module = importlib.import_module(MODULE_NAME)
+    for name in ("ClassifyMiddleware", "_ClassifyAwareState"):
+        assert hasattr(module, name), f"{MODULE_NAME} must export {name}."
+
+
+def test_middleware_subclasses_AgentMiddleware() -> None:
+    from langchain.agents.middleware import AgentMiddleware
+
+    module = importlib.import_module(MODULE_NAME)
+    cls = module.ClassifyMiddleware
+    assert inspect.isclass(cls)
+    assert issubclass(cls, AgentMiddleware)
+
+
+def test_middleware_declares_before_agent_hook() -> None:
+    module = importlib.import_module(MODULE_NAME)
+    cls = module.ClassifyMiddleware
+    member = inspect.getattr_static(cls, "before_agent", None)
+    assert member is not None, (
+        "ClassifyMiddleware must define before_agent (Slice 2.5 single-shot classify)."
+    )
+
+
+def test_before_agent_is_hook_config_with_jump_to_end() -> None:
+    """`@hook_config(can_jump_to=['end'])` is required so the SDK
+    permits the canned-response short-circuit."""
+    tree = _parse(MODULE_PATH)
+    found = False
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+            and node.name == "before_agent"
+        ):
+            continue
+        for deco in node.decorator_list:
+            if not (isinstance(deco, ast.Call) and isinstance(deco.func, ast.Name)):
+                continue
+            if deco.func.id != "hook_config":
+                continue
+            for kw in deco.keywords:
+                if kw.arg != "can_jump_to":
+                    continue
+                if isinstance(kw.value, ast.List) and any(
+                    isinstance(elt, ast.Constant) and elt.value == "end" for elt in kw.value.elts
+                ):
+                    found = True
+    assert found, (
+        "ClassifyMiddleware.before_agent must be decorated with "
+        "@hook_config(can_jump_to=['end']) — the canned-response path needs jump_to='end'."
+    )
+
+
+def test_module_has_no_forbidden_top_imports() -> None:
+    tree = _parse(MODULE_PATH)
+    offenders: list[str] = []
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                top = alias.name.split(".", 1)[0]
+                if top in FORBIDDEN_TOP_IMPORTS:
+                    offenders.append(alias.name)
+                if top == "langgraph" and alias.name not in ALLOWED_LANGGRAPH_SUBPACKAGES:
+                    offenders.append(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            top = module.split(".", 1)[0]
+            if top in FORBIDDEN_TOP_IMPORTS:
+                offenders.append(module)
+            if top == "langgraph" and module not in ALLOWED_LANGGRAPH_SUBPACKAGES:
+                offenders.append(module)
+    assert not offenders, (
+        f"{MODULE_PATH.relative_to(REPO_ROOT)} forbidden module-scope imports: {offenders}."
+    )
+
+
+def test_package_init_re_exports_middleware() -> None:
+    init_text = PKG_INIT_PATH.read_text(encoding="utf-8")
+    assert "ClassifyMiddleware" in init_text, (
+        "telegram_bot/graph/middleware/__init__.py must re-export ClassifyMiddleware."
+    )
+
+
+def test_state_schema_has_query_type_field() -> None:
+    module = importlib.import_module(MODULE_NAME)
+    schema = module._ClassifyAwareState
+    assert "query_type" in getattr(schema, "__annotations__", {})

--- a/tests/unit/agents/middleware/test_classify_middleware.py
+++ b/tests/unit/agents/middleware/test_classify_middleware.py
@@ -1,0 +1,135 @@
+"""Behaviour parity tests for ``ClassifyMiddleware`` (Slice 2.5 / #2051).
+
+Pin the routing the legacy ``classify_node`` provides today:
+
+* CHITCHAT / OFF_TOPIC → emit canned response + ``jump_to=end``.
+* All other types → annotate ``query_type`` and return without jumping.
+* Empty messages → no-op (``None``).
+* ``skip_canned_response=True`` → set ``query_type`` even on
+  CHITCHAT/OFF_TOPIC but leave message emission to the caller.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from langchain.messages import AIMessage, HumanMessage
+
+from telegram_bot.graph.middleware.classify import (
+    ClassifyMiddleware,
+    _ClassifyAwareState,
+)
+
+
+def _state(text: str = "") -> dict:
+    if not text:
+        return {"messages": []}
+    return {"messages": [HumanMessage(content=text)]}
+
+
+def _runtime() -> MagicMock:
+    rt = MagicMock()
+    rt.context = {}
+    return rt
+
+
+@pytest.fixture(autouse=True)
+def _stub_observability(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = MagicMock()
+    fake.update_current_span = MagicMock()
+    monkeypatch.setattr("telegram_bot.graph.middleware.classify.get_client", lambda: fake)
+
+
+@pytest.fixture
+def middleware() -> ClassifyMiddleware:
+    return ClassifyMiddleware()
+
+
+def test_returns_none_for_empty_messages(middleware: ClassifyMiddleware) -> None:
+    assert middleware.before_agent(_state(""), _runtime()) is None
+
+
+def test_chitchat_short_circuits_with_canned_response(
+    middleware: ClassifyMiddleware,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "telegram_bot.graph.middleware.classify.classify_query", lambda _q: "CHITCHAT"
+    )
+    monkeypatch.setattr(
+        "telegram_bot.graph.middleware.classify._get_chitchat_response",
+        lambda _q: "Привет! Чем могу помочь?",
+    )
+
+    result = middleware.before_agent(_state("привет"), _runtime())
+
+    assert result is not None
+    assert result["jump_to"] == "end"
+    assert result["query_type"] == "CHITCHAT"
+    assert result["response"] == "Привет! Чем могу помочь?"
+    [msg] = result["messages"]
+    assert isinstance(msg, AIMessage)
+    assert msg.content == "Привет! Чем могу помочь?"
+
+
+def test_off_topic_short_circuits_with_canned_response(
+    middleware: ClassifyMiddleware,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "telegram_bot.graph.middleware.classify.classify_query", lambda _q: "OFF_TOPIC"
+    )
+    # Neutralise random.choice so the test is deterministic.
+    monkeypatch.setattr(
+        "telegram_bot.graph.nodes.classify.OFF_TOPIC_RESPONSES",
+        ["Я отвечаю только по недвижимости."],
+    )
+
+    result = middleware.before_agent(_state("сколько весит марс"), _runtime())
+
+    assert result is not None
+    assert result["jump_to"] == "end"
+    assert result["query_type"] == "OFF_TOPIC"
+    [msg] = result["messages"]
+    assert isinstance(msg, AIMessage)
+
+
+@pytest.mark.parametrize("classified_type", ["FAQ", "ENTITY", "STRUCTURED", "GENERAL"])
+def test_cacheable_types_pass_through(
+    middleware: ClassifyMiddleware,
+    monkeypatch: pytest.MonkeyPatch,
+    classified_type: str,
+) -> None:
+    monkeypatch.setattr(
+        "telegram_bot.graph.middleware.classify.classify_query", lambda _q: classified_type
+    )
+
+    result = middleware.before_agent(_state("сколько стоит ВНЖ"), _runtime())
+
+    assert result is not None
+    assert "jump_to" not in result
+    assert result["query_type"] == classified_type
+    # No canned messages on the cacheable paths.
+    assert "messages" not in result
+
+
+def test_skip_canned_response_flag_keeps_query_type_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "telegram_bot.graph.middleware.classify.classify_query", lambda _q: "CHITCHAT"
+    )
+    middleware = ClassifyMiddleware(skip_canned_response=True)
+
+    result = middleware.before_agent(_state("привет"), _runtime())
+
+    assert result is not None
+    assert "jump_to" not in result
+    assert result["query_type"] == "CHITCHAT"
+    assert "messages" not in result
+
+
+def test_state_schema_carries_query_type() -> None:
+    annotations = _ClassifyAwareState.__annotations__
+    assert "query_type" in annotations


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Slice 2.5 of the voice-path migration to `create_agent` (ADR-0010, parent #1535 / #2051). Lifts the legacy `classify_node` routing into an SDK middleware so the upcoming `create_voice_agent` factory (Slice 3) keeps the CHITCHAT/OFF_TOPIC short-circuit the bespoke graph provides today.

## What landed

- **`telegram_bot/graph/middleware/classify.py`** — `ClassifyMiddleware(AgentMiddleware)`:
  - `before_agent` decorated with `@hook_config(can_jump_to=["end"])`
  - On `CHITCHAT` / `OFF_TOPIC`: returns `{messages: [AIMessage(canned)], jump_to: "end", query_type: ..., response: ...}`
  - On all other types: returns `{query_type: ...}` so downstream middleware (cache_check) sees the classification without re-running regex
  - `skip_canned_response` constructor flag for callers that prefer to emit the canned message themselves with custom keyboards
  - Reuses `classify_query` (regex-only, ~0 ms, no LLM) and the existing canned-response pickers verbatim — byte-for-byte aligned with `classify_node` until Slice 5 deletes the legacy node
  - `_ClassifyAwareState(AgentState)` adds `NotRequired` `query_type` / `response` / `latency_stages`

- **`tests/contract/test_voice_classify_middleware_contract.py`** (7 tests) — pins module + state-schema + `__init__.py` re-export + subclass + `before_agent` presence + `@hook_config(can_jump_to=["end"])` + module-scope import allow-list.

- **`tests/unit/agents/middleware/test_classify_middleware.py`** (9 tests) — behaviour parity:
  - empty messages → no-op
  - CHITCHAT / OFF_TOPIC → canned response + `jump_to=end`
  - FAQ / ENTITY / STRUCTURED / GENERAL (parametrised) → pass-through, no jump
  - `skip_canned_response=True` → query_type set, no `messages` emitted
  - state schema carries `query_type`

## Verification

```
uv run --python 3.12 pytest \
  tests/unit/graph/ tests/unit/agents/middleware/ \
  tests/contract/test_voice_classify_middleware_contract.py \
  tests/unit/test_bot_handlers.py \
  -q --timeout=30 -n auto --dist=worksteal
```
→ **749 passed in 28.08s**; ruff clean.

## Out of scope

`handle_voice` rewire (issue #2051) still requires Slice 3 (`VoiceAgentState` + `create_voice_agent` factory) and Slice 4 (gold-set parity). See `docs/engineering/voice-create-agent-2026-05-27-status.md` for the full sequence.

Refs #2051, refs #1535, refs ADR-0010