### PR TITLE
feat(voice-migration): VoiceAgentState + create_voice_agent factory (#2051 Slice 3) [stacked on #2177, #2178]

### DIFF
--- a/telegram_bot/agents/voice_agent.py
+++ b/telegram_bot/agents/voice_agent.py
@@ -1,0 +1,219 @@
+"""Voice-flavoured ``create_agent`` factory.
+
+Slice 3 of the voice-path migration to ``create_agent`` (ADR-0010,
+parent #1535 / #2051). Builds a compiled agent that mirrors the legacy
+voice graph topology (``transcribe`` → ``guard`` → ``classify`` →
+``cache_check`` → ``rag_search`` → ``cache_store``) while staying
+inside the SDK's ``before_agent`` / ``before_model`` / ``after_agent``
+hook system.
+
+Wiring
+------
+
+The factory layers three middleware in deterministic order:
+
+1. :class:`~telegram_bot.graph.middleware.GuardMiddleware` —
+   ``before_model`` injection guard. Already on ``dev`` (#2052).
+2. :class:`~telegram_bot.graph.middleware.ClassifyMiddleware` —
+   ``before_agent`` query classifier; short-circuits CHITCHAT /
+   OFF_TOPIC with the legacy canned response.
+3. :class:`~telegram_bot.graph.middleware.SemanticCacheMiddleware` —
+   ``before_agent`` cache lookup + ``after_agent`` cache store. Skips
+   the model loop entirely on a cache HIT.
+
+Tools default to the existing ``rag_search`` (the same one the text
+``create_bot_agent`` already wires); the factory accepts an explicit
+``tools`` argument for tests / future extensions.
+
+Pre-agent ``transcribe`` and post-agent ``respond`` stay outside the
+factory — they live in ``handle_voice`` because they need aiogram /
+Telegram-side concerns the agent itself does not know about. This
+matches ADR-0010's split between the SDK middleware lifecycle and the
+Telegram-side I/O.
+
+Module imports stay narrow (no aiogram / fastapi / qdrant_client at
+module scope) so the factory is unit testable in isolation.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, NotRequired
+
+from langchain.agents import create_agent
+from langchain.agents.middleware import AgentMiddleware, AgentState
+from langchain_openai import ChatOpenAI
+
+from telegram_bot.agents.context import BotContext
+from telegram_bot.agents.rag_tool import rag_search
+from telegram_bot.graph.middleware.cache import SemanticCacheMiddleware
+from telegram_bot.graph.middleware.classify import ClassifyMiddleware
+from telegram_bot.graph.middleware.guard import GuardMiddleware
+
+
+logger = logging.getLogger(__name__)
+
+
+# Default voice-tuned system prompt. Kept inline (not via prompt registry) so
+# the factory has no extra Redis dependency at construction time. Matches the
+# tone of the legacy voice respond_node — short, conversational, source-aware.
+_VOICE_SYSTEM_PROMPT = (
+    "Ты голосовой ассистент по недвижимости. Отвечай кратко (60–100 слов), "
+    "ясно и вслух — без эмодзи и Markdown. Если в контексте нет ответа, "
+    "скажи об этом прямо одним предложением и предложи переформулировать "
+    "вопрос. Цены — в евро. Расстояния — в метрах. Если вопрос за пределами "
+    "недвижимости — вежливо откажись и предложи задать вопрос по теме."
+)
+
+
+class VoiceAgentState(AgentState):
+    """Custom ``AgentState`` for the voice-path agent.
+
+    All fields are :class:`typing_extensions.NotRequired` so old
+    checkpoints still validate (per ADR-0010 §"Custom State Schema").
+    The schema is the union of:
+
+    * voice-only inputs the handler writes before invoking the agent
+      (``voice_audio``, ``voice_duration_s``, ``stt_text``,
+      ``input_type``, ``trace_id``);
+    * cache fields the middleware stack writes
+      (``query_type``, ``cache_hit``, ``cached_response``,
+      ``query_embedding``, ``colbert_query``, ``embeddings_cache_hit``,
+      ``embedding_error``, ``embedding_error_type``);
+    * shared observability slots (``response``, ``sources_count``,
+      ``show_sources``, ``latency_stages``).
+    """
+
+    # Voice-only inputs
+    voice_audio: NotRequired[bytes]
+    voice_duration_s: NotRequired[float]
+    stt_text: NotRequired[str]
+    stt_duration_ms: NotRequired[float]
+    input_type: NotRequired[str]
+    trace_id: NotRequired[str]
+
+    # Classification + cache (aligned with _ClassifyAwareState / _CacheAwareState)
+    query_type: NotRequired[str]
+    cache_hit: NotRequired[bool]
+    cached_response: NotRequired[str | None]
+    query_embedding: NotRequired[list[float] | None]
+    colbert_query: NotRequired[list[list[float]] | None]
+    embeddings_cache_hit: NotRequired[bool]
+    embedding_error: NotRequired[bool]
+    embedding_error_type: NotRequired[str | None]
+
+    # Shared observability + response surface
+    response: NotRequired[str]
+    response_state: NotRequired[str]
+    degraded_reason: NotRequired[str | None]
+    cache_eligible: NotRequired[bool]
+    store_reason: NotRequired[str]
+    sources_count: NotRequired[int]
+    show_sources: NotRequired[bool]
+    grounding_mode: NotRequired[str]
+    grade_confidence: NotRequired[float]
+    documents: NotRequired[list[Any]]
+    latency_stages: NotRequired[dict[str, float]]
+    filters: NotRequired[dict[str, Any]]
+    semantic_cache_filter_signature: NotRequired[str | None]
+    search_results_count: NotRequired[int]
+
+
+def _build_default_tools() -> list[Any]:
+    """Default tool set for the voice agent — currently the shared ``rag_search``."""
+    return [rag_search]
+
+
+def create_voice_agent(
+    *,
+    cache: Any,
+    embeddings: Any,
+    model: str,
+    tools: list[Any] | None = None,
+    extra_middleware: list[AgentMiddleware] | None = None,
+    checkpointer: Any | None = None,
+    system_prompt: str | None = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+    cache_scope: str = "rag",
+    agent_role: str | None = None,
+    guard_mode: str = "hard",
+    skip_classify_canned_response: bool = False,
+    max_tokens: int | None = None,
+) -> Any:
+    """Compile a voice-flavoured ``create_agent`` instance.
+
+    The factory wires the three voice middleware (guard, classify,
+    cache) on top of a configurable tool set and returns the compiled
+    agent ready for ``await agent.ainvoke({"messages": [...]}, config)``.
+
+    Args:
+        cache: Cache layer manager passed to ``SemanticCacheMiddleware``.
+        embeddings: Embedder passed to ``SemanticCacheMiddleware``.
+        model: LLM model name (e.g. ``"openai/gpt-oss-120b"``). Routed
+            through LiteLLM proxy when ``base_url`` is supplied.
+        tools: Override the default tool set. Defaults to
+            ``[rag_search]``.
+        extra_middleware: Additional middleware appended after the
+            three voice ones. Useful for tests that want to attach a
+            spy or for production callers that want a custom logger.
+        checkpointer: Optional ``langgraph`` checkpointer (Redis or
+            ``MemorySaver``). When ``None`` the agent runs stateless.
+        system_prompt: Override the built-in voice prompt.
+        base_url: OpenAI-compatible API base URL (e.g. LiteLLM proxy).
+        api_key: API key for the LLM provider. Defaults to a sentinel
+            so LiteLLM proxy works without a real OpenAI key.
+        cache_scope: Cache namespace for the cache middleware.
+        agent_role: Optional role tag for cache key isolation.
+        guard_mode: ``"hard"`` / ``"soft"`` / ``"log"`` — forwarded to
+            :class:`~telegram_bot.graph.middleware.GuardMiddleware`.
+        skip_classify_canned_response: Pass-through to
+            :class:`~telegram_bot.graph.middleware.ClassifyMiddleware`.
+        max_tokens: Optional cap on completion tokens.
+
+    Returns:
+        Compiled agent graph ready for ``ainvoke`` / ``astream``.
+    """
+    model_kwargs: dict[str, Any] = {"model": model}
+    if base_url:
+        model_kwargs["base_url"] = base_url
+    model_kwargs["api_key"] = api_key or "sk-not-needed"
+    if max_tokens:
+        model_kwargs["max_tokens"] = max_tokens
+    llm = ChatOpenAI(**model_kwargs)
+
+    middleware: list[AgentMiddleware] = [
+        GuardMiddleware(guard_mode=guard_mode),
+        ClassifyMiddleware(skip_canned_response=skip_classify_canned_response),
+        SemanticCacheMiddleware(
+            cache=cache,
+            embeddings=embeddings,
+            cache_scope=cache_scope,
+            agent_role=agent_role,
+        ),
+    ]
+    if extra_middleware:
+        middleware.extend(extra_middleware)
+
+    agent = create_agent(
+        model=llm,
+        tools=tools if tools is not None else _build_default_tools(),
+        system_prompt=system_prompt or _VOICE_SYSTEM_PROMPT,
+        state_schema=VoiceAgentState,
+        context_schema=BotContext,
+        checkpointer=checkpointer,
+        middleware=middleware,
+    )
+
+    logger.info(
+        "Created voice agent: model=%s base_url=%s tools=%d middleware=%d checkpointer=%s",
+        model,
+        base_url or "default",
+        len(tools) if tools is not None else len(_build_default_tools()),
+        len(middleware),
+        type(checkpointer).__name__ if checkpointer is not None else "None",
+    )
+    return agent
+
+
+__all__ = ("VoiceAgentState", "create_voice_agent")

--- a/telegram_bot/graph/middleware/__init__.py
+++ b/telegram_bot/graph/middleware/__init__.py
@@ -6,7 +6,8 @@ The legacy node modules stay in place; new code lives here.
 """
 
 from telegram_bot.graph.middleware.cache import SemanticCacheMiddleware
+from telegram_bot.graph.middleware.classify import ClassifyMiddleware
 from telegram_bot.graph.middleware.guard import GuardMiddleware
 
 
-__all__ = ["GuardMiddleware", "SemanticCacheMiddleware"]
+__all__ = ["ClassifyMiddleware", "GuardMiddleware", "SemanticCacheMiddleware"]

--- a/telegram_bot/graph/middleware/__init__.py
+++ b/telegram_bot/graph/middleware/__init__.py
@@ -5,7 +5,8 @@ migrate from the bespoke StateGraph to ``create_agent`` (umbrella #1535).
 The legacy node modules stay in place; new code lives here.
 """
 
+from telegram_bot.graph.middleware.cache import SemanticCacheMiddleware
 from telegram_bot.graph.middleware.guard import GuardMiddleware
 
 
-__all__ = ["GuardMiddleware"]
+__all__ = ["GuardMiddleware", "SemanticCacheMiddleware"]

--- a/telegram_bot/graph/middleware/cache.py
+++ b/telegram_bot/graph/middleware/cache.py
@@ -1,0 +1,432 @@
+"""SemanticCacheMiddleware — SDK-native cache_check + cache_store hooks.
+
+This is the ``create_agent``-compatible counterpart of the legacy graph
+nodes :func:`telegram_bot.graph.nodes.cache.cache_check_node` and
+:func:`telegram_bot.graph.nodes.cache.cache_store_node`. Slice 2 of the
+voice-path migration plan in ADR-0010 (parent #1535 / #2051).
+
+Behaviour
+---------
+
+* :py:meth:`before_agent` — runs once at the start of an agent invocation:
+    1. Reads the latest human message text.
+    2. If ``query_type`` is in :data:`~telegram_bot.services.rag_core.CACHEABLE_QUERY_TYPES`,
+       computes (or reuses) the dense embedding via
+       :func:`~telegram_bot.services.rag_core.compute_query_embedding`.
+    3. Skips the lookup for contextual queries and for filter-sensitive
+       queries that arrive without a resolved ``filter_signature``
+       (matches the safety carve-out from ``cache_check_node``).
+    4. Otherwise calls
+       :func:`~telegram_bot.services.rag_core.check_semantic_cache`.
+       On HIT, returns ``{"messages": [AIMessage(cached)], "jump_to": "end",
+       "cache_hit": True, ...}`` so the SDK skips the model + tools loop
+       entirely.
+    5. On MISS, returns the fresh embedding / ColBERT vectors so
+       downstream tools can reuse them without recomputation.
+
+* :py:meth:`after_agent` — runs once after the agent finishes:
+    1. Reads the final assistant response from
+       ``state["messages"][-1].content``.
+    2. Builds the same cacheability decision as
+       :func:`cache_store_node` via
+       :func:`telegram_bot.services.cache_policy.build_cacheability_decision`.
+    3. Calls
+       :func:`telegram_bot.services.cache_policy.maybe_store_semantic_response`
+       to persist the response when the decision is favourable.
+
+Dependency injection
+--------------------
+
+``cache`` and ``embeddings`` are passed via the constructor rather than
+read from ``runtime.context``. The legacy node reads
+``runtime.context["cache"]`` / ``runtime.context["embeddings"]``; the
+middleware-shaped equivalent decouples the two so the class is unit
+testable in isolation. Slice 3's ``create_voice_agent`` factory wires
+the dependencies in at construction time.
+
+Module-scope imports are constrained by
+``tests/contract/test_voice_cache_middleware_contract.py``: stdlib +
+``langchain.agents.middleware`` + ``langchain.messages`` +
+``langgraph.runtime``. Heavy services
+(``telegram_bot.services.rag_core`` etc.) are imported at module scope
+because they are pure Python with no aiogram / qdrant_client / fastapi
+imports themselves.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from typing import Any, NotRequired
+
+from langchain.agents.middleware import AgentMiddleware, AgentState, hook_config
+from langchain.messages import AIMessage
+from langgraph.runtime import Runtime
+
+from telegram_bot.observability import get_client
+from telegram_bot.services.cache_policy import (
+    SEMANTIC_CACHE_SCHEMA_VERSION,
+    build_cacheability_decision,
+    is_contextual_query,
+    maybe_store_semantic_response,
+    resolve_semantic_cache_signature,
+)
+from telegram_bot.services.query_filter_signal import detect_filter_sensitive_query
+from telegram_bot.services.rag_core import (
+    CACHEABLE_QUERY_TYPES,
+    check_semantic_cache,
+    compute_query_embedding,
+)
+
+
+logger = logging.getLogger(__name__)
+
+# Default query type when the agent state has not been classified yet. Mirrors
+# the fallback in cache_check_node so HIT/MISS semantics are identical.
+_DEFAULT_QUERY_TYPE = "GENERAL"
+
+
+class _CacheAwareState(AgentState):
+    """``AgentState`` extension covering the cache fields the hooks read/write.
+
+    All fields are :class:`typing_extensions.NotRequired` so old
+    checkpoints that pre-date the cache middleware still validate. The
+    schema is intentionally narrower than the eventual ``VoiceAgentState``
+    (Slice 3) — Slice 2 only ships what the cache middleware itself
+    exchanges with downstream middleware/tools.
+    """
+
+    query_type: NotRequired[str]
+    cache_hit: NotRequired[bool]
+    cached_response: NotRequired[str | None]
+    query_embedding: NotRequired[list[float] | None]
+    embeddings_cache_hit: NotRequired[bool]
+    embedding_error: NotRequired[bool]
+    embedding_error_type: NotRequired[str | None]
+    colbert_query: NotRequired[list[list[float]] | None]
+    filters: NotRequired[dict[str, Any]]
+    semantic_cache_filter_signature: NotRequired[str | None]
+    grounding_mode: NotRequired[str]
+    grade_confidence: NotRequired[float]
+    documents: NotRequired[list[Any]]
+    search_results_count: NotRequired[int]
+    response: NotRequired[str]
+    latency_stages: NotRequired[dict[str, float]]
+
+
+def _extract_query_text(state: AgentState | dict[str, Any]) -> str:
+    """Return the latest human message content; tolerant of dict/AIMessage."""
+    messages = state.get("messages") or []
+    if not messages:
+        return ""
+    last = messages[-1]
+    content = getattr(last, "content", None)
+    if content is None and isinstance(last, dict):
+        content = last.get("content", "")
+    return content or ""
+
+
+def _resolve_filter_signature(
+    state: dict[str, Any] | AgentState, query: str
+) -> tuple[bool, str | None]:
+    """Mirror ``_resolve_graph_filter_signature`` from the legacy node."""
+    filter_sensitive = detect_filter_sensitive_query(query).is_filter_sensitive
+    filter_signature = resolve_semantic_cache_signature(
+        filters=state.get("filters"),
+        explicit_signature=state.get("semantic_cache_filter_signature"),
+    )
+    return filter_sensitive, filter_signature
+
+
+def _final_response_text(state: AgentState | dict[str, Any]) -> str:
+    """Return the latest assistant message content, falling back to ``response``."""
+    messages = state.get("messages") or []
+    for message in reversed(messages):
+        message_type = getattr(message, "type", None) or (
+            message.get("role") if isinstance(message, dict) else None
+        )
+        if message_type in {"ai", "assistant"}:
+            content = getattr(message, "content", None)
+            if content is None and isinstance(message, dict):
+                content = message.get("content", "")
+            if content:
+                return content
+    fallback = state.get("response") if isinstance(state, dict) else None
+    return fallback or ""
+
+
+class SemanticCacheMiddleware(AgentMiddleware):
+    """Skip the agent loop on semantic-cache HIT and persist on MISS.
+
+    Args:
+        cache: Cache layer manager exposing ``check_semantic`` (and the
+            shape :func:`check_semantic_cache` expects).
+        embeddings: Embedder exposing ``aembed_query`` (and optionally
+            ``aembed_colbert_query`` for ColBERT prep on MISS).
+        cache_scope: Cache namespace; ``"rag"`` matches the voice graph.
+        agent_role: Role tag for cache key isolation. Voice path historically
+            shares responses across roles, so the default is ``None``.
+    """
+
+    state_schema = _CacheAwareState
+
+    def __init__(
+        self,
+        *,
+        cache: Any,
+        embeddings: Any,
+        cache_scope: str = "rag",
+        agent_role: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.cache = cache
+        self.embeddings = embeddings
+        self.cache_scope = cache_scope
+        self.agent_role = agent_role
+
+    @hook_config(can_jump_to=["end"])
+    async def before_agent(
+        self,
+        state: _CacheAwareState,
+        runtime: Runtime,
+    ) -> dict[str, Any] | None:
+        """Cache-check hook; short-circuits the agent loop on HIT."""
+        query = _extract_query_text(state)
+        if not query:
+            return None
+        query_type = state.get("query_type") or _DEFAULT_QUERY_TYPE
+        if query_type not in CACHEABLE_QUERY_TYPES:
+            # Non-cacheable query types skip the cache layer entirely so we do
+            # not pay the embedding cost on chit-chat / off-topic flows. This
+            # matches the ``cache_check_node`` behaviour where the legacy
+            # graph routes those types past cache_check via classify_node.
+            return None
+
+        lf = get_client()
+        try:
+            lf.update_current_span(
+                input={
+                    "query_preview": query[:120],
+                    "query_len": len(query),
+                    "query_hash": hashlib.sha256(query.encode()).hexdigest()[:8],
+                    "query_type": query_type,
+                }
+            )
+        except Exception:  # pragma: no cover — observability must never raise
+            logger.debug("update_current_span (cache before) failed", exc_info=True)
+
+        start = time.perf_counter()
+
+        try:
+            embedding, _sparse, colbert_query, embeddings_cache_hit = await compute_query_embedding(
+                query, cache=self.cache, embeddings=self.embeddings
+            )
+        except Exception as exc:
+            embedding_error_type = type(exc).__name__
+            logger.error("Cache middleware embedding failed: %s: %s", embedding_error_type, exc)
+            latency = time.perf_counter() - start
+            try:
+                lf.update_current_span(
+                    level="ERROR",
+                    output={
+                        "embedding_error": True,
+                        "embedding_error_type": embedding_error_type,
+                        "duration_ms": round(latency * 1000, 1),
+                    },
+                )
+            except Exception:  # pragma: no cover
+                logger.debug("update_current_span (cache embed-error) failed", exc_info=True)
+            # On embedding failure we surface the graceful fallback message
+            # the legacy node returned and still short-circuit, so no half
+            # answer leaks through. Mirrors lines 89–106 of cache.py.
+            return {
+                "messages": [
+                    AIMessage(
+                        content="Сервис временно недоступен. Пожалуйста, повторите через минуту."
+                    )
+                ],
+                "jump_to": "end",
+                "cache_hit": False,
+                "cached_response": None,
+                "query_embedding": None,
+                "embeddings_cache_hit": False,
+                "embedding_error": True,
+                "embedding_error_type": embedding_error_type,
+                "latency_stages": {
+                    **(state.get("latency_stages") or {}),
+                    "cache_check": latency,
+                },
+            }
+
+        filter_sensitive, filter_signature = _resolve_filter_signature(state, query)
+        contextual_query = is_contextual_query(query)
+        if contextual_query or (filter_sensitive and filter_signature is None):
+            hit, cached = False, None
+        else:
+            hit, cached = await check_semantic_cache(
+                query,
+                embedding,
+                query_type,
+                cache=self.cache,
+                agent_role=self.agent_role,
+                filter_signature=filter_signature,
+            )
+
+        latency = time.perf_counter() - start
+
+        if hit:
+            logger.info("cache_middleware HIT (%.3fs, type=%s)", latency, query_type)
+            try:
+                lf.update_current_span(
+                    output={
+                        "cache_hit": True,
+                        "embeddings_cache_hit": embeddings_cache_hit,
+                        "hit_layer": "semantic",
+                        "duration_ms": round(latency * 1000, 1),
+                    }
+                )
+            except Exception:  # pragma: no cover
+                logger.debug("update_current_span (cache HIT) failed", exc_info=True)
+            return {
+                "messages": [AIMessage(content=cached or "")],
+                "jump_to": "end",
+                "cache_hit": True,
+                "cached_response": cached,
+                "query_embedding": embedding,
+                "embeddings_cache_hit": embeddings_cache_hit,
+                "embedding_error": False,
+                "embedding_error_type": None,
+                "colbert_query": None,
+                "response": cached or "",
+                "latency_stages": {
+                    **(state.get("latency_stages") or {}),
+                    "cache_check": latency,
+                },
+            }
+
+        # MISS: surface vectors so downstream tools reuse them. Match the
+        # legacy ``cache_check_node`` MISS shape, including the ColBERT
+        # fallback for embedders that expose ``aembed_colbert_query`` as a
+        # standalone async method (older bundle implementations).
+        if colbert_query is None:
+            colbert_only = getattr(self.embeddings, "aembed_colbert_query", None)
+            if callable(colbert_only):
+                try:
+                    colbert_query = await colbert_only(query)
+                except Exception:
+                    logger.debug(
+                        "ColBERT query encode failed (non-critical), skipping",
+                        exc_info=True,
+                    )
+
+        logger.info("cache_middleware MISS (%.3fs, type=%s)", latency, query_type)
+        try:
+            lf.update_current_span(
+                output={
+                    "cache_hit": False,
+                    "embeddings_cache_hit": embeddings_cache_hit,
+                    "hit_layer": "none",
+                    "duration_ms": round(latency * 1000, 1),
+                }
+            )
+        except Exception:  # pragma: no cover
+            logger.debug("update_current_span (cache MISS) failed", exc_info=True)
+        return {
+            "cache_hit": False,
+            "cached_response": None,
+            "query_embedding": embedding,
+            "embeddings_cache_hit": embeddings_cache_hit,
+            "embedding_error": False,
+            "embedding_error_type": None,
+            "colbert_query": colbert_query,
+            "latency_stages": {
+                **(state.get("latency_stages") or {}),
+                "cache_check": latency,
+            },
+        }
+
+    async def after_agent(
+        self,
+        state: _CacheAwareState,
+        runtime: Runtime,
+    ) -> dict[str, Any] | None:
+        """Persist the agent's final response into the semantic cache."""
+        # Cache HITs already routed through before_agent's jump_to=end and
+        # left the response in place; we must not store the cached response
+        # back as a fresh entry (would race with TTL bookkeeping).
+        if state.get("cache_hit"):
+            return None
+
+        query = _extract_query_text(state)
+        if not query:
+            return None
+        response = _final_response_text(state)
+        if not response:
+            return None
+        embedding = state.get("query_embedding")
+        if not embedding:
+            return None
+        query_type = state.get("query_type") or _DEFAULT_QUERY_TYPE
+        if query_type not in CACHEABLE_QUERY_TYPES:
+            return None
+
+        filter_sensitive, filter_signature = _resolve_filter_signature(state, query)
+        if filter_sensitive and filter_signature is None:
+            # Filter-sensitive query without a resolved signature: storing
+            # would cross-contaminate filter buckets. Skip just like the
+            # legacy ``cache_store_node``.
+            return None
+
+        decision = build_cacheability_decision(
+            result=dict(state),
+            query_type=query_type,
+            grounding_mode=str(state.get("grounding_mode") or "normal"),
+            documents=state.get("documents") or [],
+            cache_hit=False,
+            contextual=is_contextual_query(query),
+            grade_confidence=float(state.get("grade_confidence") or 0.0),
+            confidence_threshold=0.0,
+            schema_version=SEMANTIC_CACHE_SCHEMA_VERSION,
+        )
+
+        stored = False
+        try:
+            stored = await maybe_store_semantic_response(
+                cache=self.cache,
+                query=query,
+                response=response,
+                vector=embedding,
+                query_type=query_type,
+                cache_scope=self.cache_scope,
+                decision=decision,
+                agent_role=self.agent_role,
+                filter_signature=filter_signature,
+            )
+        except Exception as exc:
+            # Match the legacy node: a cache-store failure must never
+            # destroy the response. Log + swallow + continue.
+            logger.warning(
+                "cache_middleware: semantic store failed, response preserved: %s: %s",
+                type(exc).__name__,
+                exc,
+            )
+
+        try:
+            get_client().update_current_span(output={"stored": stored, "stored_semantic": stored})
+        except Exception:  # pragma: no cover
+            logger.debug("update_current_span (cache_store) failed", exc_info=True)
+
+        # Surface the same observability fields the legacy node wrote into
+        # the state so ``_handle_query_supervisor``'s post-processing block
+        # keeps working unchanged.
+        return {
+            "response": response,
+            "response_state": decision.response_state,
+            "degraded_reason": decision.degraded_reason,
+            "cache_eligible": decision.cache_eligible,
+            "store_reason": decision.store_reason,
+        }
+
+
+__all__ = ("SemanticCacheMiddleware", "_CacheAwareState")

--- a/telegram_bot/graph/middleware/cache.py
+++ b/telegram_bot/graph/middleware/cache.py
@@ -186,7 +186,7 @@ class SemanticCacheMiddleware(AgentMiddleware):
         self.agent_role = agent_role
 
     @hook_config(can_jump_to=["end"])
-    async def before_agent(
+    async def abefore_agent(
         self,
         state: _CacheAwareState,
         runtime: Runtime,
@@ -346,13 +346,13 @@ class SemanticCacheMiddleware(AgentMiddleware):
             },
         }
 
-    async def after_agent(
+    async def aafter_agent(
         self,
         state: _CacheAwareState,
         runtime: Runtime,
     ) -> dict[str, Any] | None:
         """Persist the agent's final response into the semantic cache."""
-        # Cache HITs already routed through before_agent's jump_to=end and
+        # Cache HITs already routed through abefore_agent's jump_to=end and
         # left the response in place; we must not store the cached response
         # back as a fresh entry (would race with TTL bookkeeping).
         if state.get("cache_hit"):

--- a/telegram_bot/graph/middleware/classify.py
+++ b/telegram_bot/graph/middleware/classify.py
@@ -1,0 +1,144 @@
+"""ClassifyMiddleware — SDK-native ``before_agent`` hook for query classification.
+
+This is the ``create_agent``-compatible counterpart of
+:func:`telegram_bot.graph.nodes.classify.classify_node`. Slice 2.5 of the
+voice-path migration plan in ADR-0010 (parent #1535 / #2051).
+
+Behaviour
+---------
+
+Runs once at the start of an agent invocation:
+
+* Reads the latest human message text and feeds it to
+  :func:`~telegram_bot.graph.nodes.classify.classify_query` (regex-only,
+  ~0 ms — no LLM).
+* For ``CHITCHAT`` and ``OFF_TOPIC`` query types: returns
+  ``{"messages": [AIMessage(canned)], "jump_to": "end", "query_type": ...}``
+  so the SDK skips both the model loop and the cache hooks. This
+  matches the legacy router in ``graph.py`` which sends those types
+  straight to ``respond`` without touching ``cache_check``.
+* For all other types: returns ``{"query_type": ...}`` so downstream
+  middleware (cache_check) and tools see the classification without
+  rerunning the regex.
+
+The middleware is intentionally tiny — it owns no embeddings, no Redis,
+no LLM. It exists purely to lift the legacy classify routing into the
+``create_agent`` lifecycle.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, NotRequired
+
+from langchain.agents.middleware import AgentMiddleware, AgentState, hook_config
+from langchain.messages import AIMessage
+from langgraph.runtime import Runtime
+
+from telegram_bot.graph.nodes.classify import (
+    CHITCHAT,
+    OFF_TOPIC,
+    _get_chitchat_response,
+    classify_query,
+)
+from telegram_bot.observability import get_client
+
+
+logger = logging.getLogger(__name__)
+
+
+class _ClassifyAwareState(AgentState):
+    """Adds the classification slot to the agent state."""
+
+    query_type: NotRequired[str]
+    response: NotRequired[str]
+    latency_stages: NotRequired[dict[str, float]]
+
+
+def _extract_query_text(state: AgentState | dict[str, Any]) -> str:
+    messages = state.get("messages") or []
+    if not messages:
+        return ""
+    last = messages[-1]
+    content = getattr(last, "content", None)
+    if content is None and isinstance(last, dict):
+        content = last.get("content", "")
+    return content or ""
+
+
+def _canned_response(query: str, query_type: str) -> str:
+    """Return the canned response the legacy node would have emitted."""
+    if query_type == CHITCHAT:
+        return _get_chitchat_response(query)
+    if query_type == OFF_TOPIC:
+        # Reuse the same off-topic response set the graph node uses, via a
+        # local import so the module-scope import surface stays narrow.
+        from random import choice
+
+        from telegram_bot.graph.nodes.classify import OFF_TOPIC_RESPONSES
+
+        return choice(OFF_TOPIC_RESPONSES)
+    return ""
+
+
+class ClassifyMiddleware(AgentMiddleware):
+    """Classify the user query and short-circuit on CHITCHAT/OFF_TOPIC.
+
+    Reuses ``classify_query`` (regex-only, ~0 ms) so detection is byte-for-byte
+    aligned with the legacy graph until Slice 5 deletes ``classify_node``.
+
+    Args:
+        skip_canned_response: When ``True`` the middleware sets
+            ``query_type`` but does not emit a canned reply for
+            CHITCHAT/OFF_TOPIC. Useful for tests and for callers that
+            want to render those messages with custom keyboards. Default
+            ``False`` (matches legacy behaviour).
+    """
+
+    state_schema = _ClassifyAwareState
+
+    def __init__(self, *, skip_canned_response: bool = False) -> None:
+        super().__init__()
+        self.skip_canned_response = skip_canned_response
+
+    @hook_config(can_jump_to=["end"])
+    def before_agent(
+        self,
+        state: _ClassifyAwareState,
+        runtime: Runtime,
+    ) -> dict[str, Any] | None:
+        query = _extract_query_text(state)
+        if not query:
+            return None
+
+        t0 = time.perf_counter()
+        query_type = classify_query(query)
+        latency = time.perf_counter() - t0
+
+        try:
+            get_client().update_current_span(
+                output={"query_type": query_type, "duration_ms": round(latency * 1000, 2)}
+            )
+        except Exception:  # pragma: no cover — observability must never raise
+            logger.debug("classify update_current_span failed", exc_info=True)
+
+        latency_stages = {**(state.get("latency_stages") or {}), "classify": latency}
+
+        if query_type in {CHITCHAT, OFF_TOPIC}:
+            if self.skip_canned_response:
+                # Caller wants to render the canned message itself.
+                return {"query_type": query_type, "latency_stages": latency_stages}
+            canned = _canned_response(query, query_type)
+            return {
+                "messages": [AIMessage(content=canned)],
+                "jump_to": "end",
+                "query_type": query_type,
+                "response": canned,
+                "latency_stages": latency_stages,
+            }
+
+        return {"query_type": query_type, "latency_stages": latency_stages}
+
+
+__all__ = ("ClassifyMiddleware", "_ClassifyAwareState")

--- a/tests/contract/test_error_contract.py
+++ b/tests/contract/test_error_contract.py
@@ -26,6 +26,10 @@ ERROR_SPAN_ALLOWLIST: dict[str, list[str]] = {
     "telegram_bot/graph/nodes/rerank.py": ["ERROR"],
     "telegram_bot/graph/nodes/respond.py": ["ERROR"],
     "telegram_bot/graph/nodes/cache.py": ["ERROR"],
+    # SDK-native counterpart of cache_check_node — records ERROR on the
+    # embedding-failure path before short-circuiting the agent loop with
+    # a graceful fallback message (#2051 Slice 2).
+    "telegram_bot/graph/middleware/cache.py": ["ERROR"],
     # Voice transcription error path (Whisper / LiteLLM failure) — span is
     # re-raised so the outer voice-session trace records the failure (#1810).
     "telegram_bot/graph/nodes/transcribe.py": ["ERROR"],

--- a/tests/contract/test_voice_agent_factory_contract.py
+++ b/tests/contract/test_voice_agent_factory_contract.py
@@ -99,7 +99,7 @@ def test_create_voice_agent_signature_takes_cache_and_embeddings() -> None:
         assert params[name].kind == inspect.Parameter.KEYWORD_ONLY
 
 
-def test_module_has_no_forbidden_top_imports() -> None:
+def test_voice_agent_module_has_no_forbidden_top_imports() -> None:
     tree = _parse(MODULE_PATH)
     offenders: list[str] = []
     for node in ast.iter_child_nodes(tree):

--- a/tests/contract/test_voice_agent_factory_contract.py
+++ b/tests/contract/test_voice_agent_factory_contract.py
@@ -1,0 +1,122 @@
+"""Contract: ``create_voice_agent`` lives in ``telegram_bot/agents/voice_agent.py``.
+
+Slice 3 of the voice-path migration to ``create_agent`` (ADR-0010,
+parent #1535 / #2051). This module assembles the
+``GuardMiddleware`` (#2052), ``ClassifyMiddleware`` (Slice 2.5) and
+``SemanticCacheMiddleware`` (Slice 2) on top of the existing
+``rag_search`` tool, returning a compiled agent ready for
+``handle_voice``'s rewire (Slice 5).
+
+The contract pins:
+
+1. ``telegram_bot.agents.voice_agent`` exposes ``VoiceAgentState``
+   (custom ``AgentState`` with the voice-specific NotRequired fields
+   listed in ADR-0010) and ``create_voice_agent`` (factory).
+2. ``create_voice_agent`` is a callable accepting
+   ``cache`` / ``embeddings`` / ``model`` keyword arguments — the
+   minimum dependency surface needed to wire the middleware stack.
+3. The module does not import aiogram / fastapi / qdrant_client at
+   module scope, so the factory is unit testable in isolation.
+4. ``VoiceAgentState`` declares the voice-specific fields the legacy
+   graph state tracks today (input_type, voice_audio, voice_duration_s,
+   stt_text, trace_id) plus the cache fields the middleware writes.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_NAME = "telegram_bot.agents.voice_agent"
+MODULE_PATH = REPO_ROOT / "telegram_bot" / "agents" / "voice_agent.py"
+
+FORBIDDEN_TOP_IMPORTS = {"aiogram", "fastapi", "qdrant_client"}
+ALLOWED_LANGGRAPH_SUBPACKAGES = {"langgraph.runtime"}
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def test_module_exposes_factory_and_state_schema() -> None:
+    assert MODULE_PATH.is_file(), (
+        f"{MODULE_PATH.relative_to(REPO_ROOT)} must exist (#2051 Slice 3)."
+    )
+    module = importlib.import_module(MODULE_NAME)
+    for name in ("create_voice_agent", "VoiceAgentState"):
+        assert hasattr(module, name), f"{MODULE_NAME} must export {name}."
+
+
+def test_voice_agent_state_subclasses_AgentState() -> None:
+
+    module = importlib.import_module(MODULE_NAME)
+    schema = module.VoiceAgentState
+    assert inspect.isclass(schema)
+    # ``AgentState`` is a TypedDict; subclass relationship is not via issubclass
+    # — instead check the inheritance chain via __orig_bases__.
+    bases = getattr(schema, "__orig_bases__", ())
+    base_names = {getattr(b, "__name__", "") for b in bases}
+    assert "AgentState" in base_names, (
+        f"VoiceAgentState must subclass AgentState (got bases: {base_names})"
+    )
+
+
+def test_voice_agent_state_has_voice_specific_fields() -> None:
+    """Voice fields the legacy graph state carries today + cache fields
+    the middleware stack writes."""
+    module = importlib.import_module(MODULE_NAME)
+    annotations = getattr(module.VoiceAgentState, "__annotations__", {})
+    expected = {
+        # voice-only inputs the handler will write before invoking the agent
+        "voice_audio",
+        "voice_duration_s",
+        "stt_text",
+        "input_type",
+        "trace_id",
+        # shared with text path / written by middleware
+        "query_type",
+        "cache_hit",
+        "query_embedding",
+    }
+    missing = expected - set(annotations)
+    assert not missing, (
+        f"VoiceAgentState must annotate {sorted(expected)} fields. Missing: {sorted(missing)}"
+    )
+
+
+def test_create_voice_agent_signature_takes_cache_and_embeddings() -> None:
+    module = importlib.import_module(MODULE_NAME)
+    factory = module.create_voice_agent
+    assert callable(factory)
+    sig = inspect.signature(factory)
+    params = sig.parameters
+    for name in ("cache", "embeddings", "model"):
+        assert name in params, f"create_voice_agent must accept '{name}' (kw-only)"
+        assert params[name].kind == inspect.Parameter.KEYWORD_ONLY
+
+
+def test_module_has_no_forbidden_top_imports() -> None:
+    tree = _parse(MODULE_PATH)
+    offenders: list[str] = []
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                top = alias.name.split(".", 1)[0]
+                if top in FORBIDDEN_TOP_IMPORTS:
+                    offenders.append(alias.name)
+                if top == "langgraph" and alias.name not in ALLOWED_LANGGRAPH_SUBPACKAGES:
+                    offenders.append(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            top = module.split(".", 1)[0]
+            if top in FORBIDDEN_TOP_IMPORTS:
+                offenders.append(module)
+            if top == "langgraph" and module not in ALLOWED_LANGGRAPH_SUBPACKAGES:
+                offenders.append(module)
+    assert not offenders, (
+        f"{MODULE_PATH.relative_to(REPO_ROOT)} forbidden module-scope imports: {offenders}."
+    )

--- a/tests/contract/test_voice_cache_middleware_contract.py
+++ b/tests/contract/test_voice_cache_middleware_contract.py
@@ -55,7 +55,7 @@ def _parse(path: Path) -> ast.Module:
     return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
 
 
-def test_module_exists_and_exports_required_symbols() -> None:
+def test_cache_middleware_module_exists_and_exports_required_symbols() -> None:
     assert MODULE_PATH.is_file(), (
         f"{MODULE_PATH.relative_to(REPO_ROOT)} must exist (#2051 Slice 2)."
     )
@@ -64,7 +64,7 @@ def test_module_exists_and_exports_required_symbols() -> None:
         assert hasattr(module, name), f"{MODULE_NAME} must export {name}."
 
 
-def test_middleware_subclasses_AgentMiddleware() -> None:
+def test_cache_middleware_subclasses_AgentMiddleware() -> None:
     from langchain.agents.middleware import AgentMiddleware
 
     module = importlib.import_module(MODULE_NAME)
@@ -130,7 +130,7 @@ def test_constructor_takes_cache_and_embeddings_keyword_only() -> None:
         )
 
 
-def test_module_has_no_forbidden_top_imports() -> None:
+def test_cache_module_has_no_forbidden_top_imports() -> None:
     tree = _parse(MODULE_PATH)
     offenders: list[str] = []
     for node in ast.iter_child_nodes(tree):
@@ -154,7 +154,7 @@ def test_module_has_no_forbidden_top_imports() -> None:
     )
 
 
-def test_package_init_re_exports_middleware() -> None:
+def test_package_init_re_exports_cache_middleware() -> None:
     init_text = PKG_INIT_PATH.read_text(encoding="utf-8")
     assert "SemanticCacheMiddleware" in init_text, (
         "telegram_bot/graph/middleware/__init__.py must re-export "

--- a/tests/contract/test_voice_cache_middleware_contract.py
+++ b/tests/contract/test_voice_cache_middleware_contract.py
@@ -13,10 +13,10 @@ The contract pins:
 2. ``SemanticCacheMiddleware`` is a subclass of
    :class:`langchain.agents.middleware.AgentMiddleware`.
 3. The class declares the two SDK-native hooks required for the
-   cache-hit short-circuit: ``before_agent`` (runs once at the start;
-   may ``jump_to=end`` on cache HIT) and ``after_agent`` (runs once at
+   cache-hit short-circuit: ``abefore_agent`` (runs once at the start;
+   may ``jump_to=end`` on cache HIT) and ``aafter_agent`` (runs once at
    the end; persists the agent's final response).
-4. ``before_agent`` is decorated with ``@hook_config(can_jump_to=["end"])``
+4. ``abefore_agent`` is decorated with ``@hook_config(can_jump_to=["end"])``
    so the SDK knows the hook may short-circuit.
 5. The constructor takes ``cache`` and ``embeddings`` keyword-only — no
    reading from ``runtime.context`` for these heavy collaborators, so
@@ -78,14 +78,14 @@ def test_middleware_subclasses_AgentMiddleware() -> None:
 def test_middleware_declares_required_hooks() -> None:
     module = importlib.import_module(MODULE_NAME)
     cls = module.SemanticCacheMiddleware
-    for hook in ("before_agent", "after_agent"):
+    for hook in ("abefore_agent", "aafter_agent"):
         member = inspect.getattr_static(cls, hook, None)
         assert member is not None, (
             f"SemanticCacheMiddleware must define {hook} (Slice 2 cache lifecycle)."
         )
 
 
-def test_before_agent_is_hook_config_with_jump_to_end() -> None:
+def test_abefore_agent_is_hook_config_with_jump_to_end() -> None:
     """``@hook_config(can_jump_to=['end'])`` is required so the SDK
     permits the cache-hit short-circuit. Detect via AST so the test
     does not depend on runtime decorator metadata."""
@@ -94,7 +94,7 @@ def test_before_agent_is_hook_config_with_jump_to_end() -> None:
     for node in ast.walk(tree):
         if not (
             isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
-            and node.name == "before_agent"
+            and node.name == "abefore_agent"
         ):
             continue
         for deco in node.decorator_list:
@@ -111,7 +111,7 @@ def test_before_agent_is_hook_config_with_jump_to_end() -> None:
                 ):
                     found = True
     assert found, (
-        "SemanticCacheMiddleware.before_agent must be decorated with "
+        "SemanticCacheMiddleware.abefore_agent must be decorated with "
         "@hook_config(can_jump_to=['end']) so the SDK allows jump_to='end' on cache HIT."
     )
 

--- a/tests/contract/test_voice_cache_middleware_contract.py
+++ b/tests/contract/test_voice_cache_middleware_contract.py
@@ -1,0 +1,178 @@
+"""Contract: SemanticCacheMiddleware lives in ``telegram_bot/graph/middleware/cache.py``.
+
+Slice 2 of the voice-path migration to ``create_agent`` (ADR-0010, parent
+#1535 / #2051). The middleware is the SDK-native counterpart of
+:func:`telegram_bot.graph.nodes.cache.cache_check_node` and
+:func:`telegram_bot.graph.nodes.cache.cache_store_node`.
+
+The contract pins:
+
+1. ``telegram_bot.graph.middleware.cache`` exposes
+   ``SemanticCacheMiddleware`` and the local state schema
+   ``_CacheAwareState`` it ships with.
+2. ``SemanticCacheMiddleware`` is a subclass of
+   :class:`langchain.agents.middleware.AgentMiddleware`.
+3. The class declares the two SDK-native hooks required for the
+   cache-hit short-circuit: ``before_agent`` (runs once at the start;
+   may ``jump_to=end`` on cache HIT) and ``after_agent`` (runs once at
+   the end; persists the agent's final response).
+4. ``before_agent`` is decorated with ``@hook_config(can_jump_to=["end"])``
+   so the SDK knows the hook may short-circuit.
+5. The constructor takes ``cache`` and ``embeddings`` keyword-only — no
+   reading from ``runtime.context`` for these heavy collaborators, so
+   the middleware stays unit-testable in isolation.
+6. The module does not import aiogram / langgraph (beyond
+   ``langgraph.runtime``) / qdrant_client / fastapi at module scope.
+   Heavy imports must stay inside function bodies if needed.
+7. ``__init__.py`` re-exports ``SemanticCacheMiddleware`` so callers
+   can ``from telegram_bot.graph.middleware import SemanticCacheMiddleware``.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_NAME = "telegram_bot.graph.middleware.cache"
+MODULE_PATH = REPO_ROOT / "telegram_bot" / "graph" / "middleware" / "cache.py"
+PKG_INIT_PATH = REPO_ROOT / "telegram_bot" / "graph" / "middleware" / "__init__.py"
+
+FORBIDDEN_TOP_IMPORTS = {
+    "aiogram",
+    "qdrant_client",
+    "fastapi",
+}
+# ``langgraph.runtime`` is allowed (Runtime is the SDK type-hint), but other
+# langgraph subpackages should stay out of module scope.
+ALLOWED_LANGGRAPH_SUBPACKAGES = {"langgraph.runtime"}
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def test_module_exists_and_exports_required_symbols() -> None:
+    assert MODULE_PATH.is_file(), (
+        f"{MODULE_PATH.relative_to(REPO_ROOT)} must exist (#2051 Slice 2)."
+    )
+    module = importlib.import_module(MODULE_NAME)
+    for name in ("SemanticCacheMiddleware", "_CacheAwareState"):
+        assert hasattr(module, name), f"{MODULE_NAME} must export {name}."
+
+
+def test_middleware_subclasses_AgentMiddleware() -> None:
+    from langchain.agents.middleware import AgentMiddleware
+
+    module = importlib.import_module(MODULE_NAME)
+    cls = module.SemanticCacheMiddleware
+    assert inspect.isclass(cls)
+    assert issubclass(cls, AgentMiddleware), (
+        "SemanticCacheMiddleware must subclass langchain.agents.middleware.AgentMiddleware"
+    )
+
+
+def test_middleware_declares_required_hooks() -> None:
+    module = importlib.import_module(MODULE_NAME)
+    cls = module.SemanticCacheMiddleware
+    for hook in ("before_agent", "after_agent"):
+        member = inspect.getattr_static(cls, hook, None)
+        assert member is not None, (
+            f"SemanticCacheMiddleware must define {hook} (Slice 2 cache lifecycle)."
+        )
+
+
+def test_before_agent_is_hook_config_with_jump_to_end() -> None:
+    """``@hook_config(can_jump_to=['end'])`` is required so the SDK
+    permits the cache-hit short-circuit. Detect via AST so the test
+    does not depend on runtime decorator metadata."""
+    tree = _parse(MODULE_PATH)
+    found = False
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+            and node.name == "before_agent"
+        ):
+            continue
+        for deco in node.decorator_list:
+            if not (isinstance(deco, ast.Call) and isinstance(deco.func, ast.Name)):
+                continue
+            if deco.func.id != "hook_config":
+                continue
+            for kw in deco.keywords:
+                if kw.arg != "can_jump_to":
+                    continue
+                if isinstance(kw.value, ast.List) and any(
+                    isinstance(elt, ast.Constant) and elt.value == "end"
+                    for elt in kw.value.elts
+                ):
+                    found = True
+    assert found, (
+        "SemanticCacheMiddleware.before_agent must be decorated with "
+        "@hook_config(can_jump_to=['end']) so the SDK allows jump_to='end' on cache HIT."
+    )
+
+
+def test_constructor_takes_cache_and_embeddings_keyword_only() -> None:
+    module = importlib.import_module(MODULE_NAME)
+    cls = module.SemanticCacheMiddleware
+    sig = inspect.signature(cls.__init__)
+    params = sig.parameters
+    for name in ("cache", "embeddings"):
+        assert name in params, (
+            f"SemanticCacheMiddleware.__init__ must accept '{name}' (keyword-only)"
+        )
+        assert params[name].kind == inspect.Parameter.KEYWORD_ONLY, (
+            f"'{name}' must be KEYWORD_ONLY for explicit dependency injection"
+        )
+
+
+def test_module_has_no_forbidden_top_imports() -> None:
+    tree = _parse(MODULE_PATH)
+    offenders: list[str] = []
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                top = alias.name.split(".", 1)[0]
+                if top in FORBIDDEN_TOP_IMPORTS:
+                    offenders.append(alias.name)
+                if top == "langgraph" and alias.name not in ALLOWED_LANGGRAPH_SUBPACKAGES:
+                    offenders.append(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            top = module.split(".", 1)[0]
+            if top in FORBIDDEN_TOP_IMPORTS:
+                offenders.append(module)
+            if top == "langgraph" and module not in ALLOWED_LANGGRAPH_SUBPACKAGES:
+                offenders.append(module)
+    assert not offenders, (
+        f"{MODULE_PATH.relative_to(REPO_ROOT)} has forbidden module-scope imports: "
+        f"{offenders}. Lazy-import inside function bodies if needed."
+    )
+
+
+def test_package_init_re_exports_middleware() -> None:
+    init_text = PKG_INIT_PATH.read_text(encoding="utf-8")
+    assert "SemanticCacheMiddleware" in init_text, (
+        "telegram_bot/graph/middleware/__init__.py must re-export "
+        "SemanticCacheMiddleware so callers can do "
+        "`from telegram_bot.graph.middleware import SemanticCacheMiddleware`."
+    )
+
+
+def test_state_schema_has_required_fields() -> None:
+    """``_CacheAwareState`` must declare the cache fields the hooks
+    write so the SDK's state-merge layer accepts them. NotRequired
+    keeps backward-compatibility with checkpoints lacking these fields.
+    """
+    module = importlib.import_module(MODULE_NAME)
+    schema = module._CacheAwareState
+    annotations = getattr(schema, "__annotations__", {})
+    for field in ("query_type", "cache_hit", "cached_response", "query_embedding"):
+        assert field in annotations, (
+            f"_CacheAwareState must annotate field '{field}' "
+            f"(declared annotations: {sorted(annotations)})"
+        )

--- a/tests/contract/test_voice_classify_middleware_contract.py
+++ b/tests/contract/test_voice_classify_middleware_contract.py
@@ -1,0 +1,126 @@
+"""Contract: ClassifyMiddleware lives in ``telegram_bot/graph/middleware/classify.py``.
+
+Slice 2.5 of the voice-path migration to ``create_agent`` (ADR-0010,
+parent #1535 / #2051). The middleware is the SDK-native counterpart of
+:func:`telegram_bot.graph.nodes.classify.classify_node`. It runs once
+at the start of the agent invocation, classifies the user query and
+short-circuits the agent loop for ``CHITCHAT`` / ``OFF_TOPIC`` types
+with a canned response — exactly as the legacy ``classify_node``
+routes those types past ``cache_check`` straight to ``respond``.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_NAME = "telegram_bot.graph.middleware.classify"
+MODULE_PATH = REPO_ROOT / "telegram_bot" / "graph" / "middleware" / "classify.py"
+PKG_INIT_PATH = REPO_ROOT / "telegram_bot" / "graph" / "middleware" / "__init__.py"
+
+FORBIDDEN_TOP_IMPORTS = {
+    "aiogram",
+    "qdrant_client",
+    "fastapi",
+}
+ALLOWED_LANGGRAPH_SUBPACKAGES = {"langgraph.runtime"}
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def test_module_exists_and_exports_required_symbols() -> None:
+    assert MODULE_PATH.is_file(), (
+        f"{MODULE_PATH.relative_to(REPO_ROOT)} must exist (#2051 Slice 2.5)."
+    )
+    module = importlib.import_module(MODULE_NAME)
+    for name in ("ClassifyMiddleware", "_ClassifyAwareState"):
+        assert hasattr(module, name), f"{MODULE_NAME} must export {name}."
+
+
+def test_middleware_subclasses_AgentMiddleware() -> None:
+    from langchain.agents.middleware import AgentMiddleware
+
+    module = importlib.import_module(MODULE_NAME)
+    cls = module.ClassifyMiddleware
+    assert inspect.isclass(cls)
+    assert issubclass(cls, AgentMiddleware)
+
+
+def test_middleware_declares_before_agent_hook() -> None:
+    module = importlib.import_module(MODULE_NAME)
+    cls = module.ClassifyMiddleware
+    member = inspect.getattr_static(cls, "before_agent", None)
+    assert member is not None, (
+        "ClassifyMiddleware must define before_agent (Slice 2.5 single-shot classify)."
+    )
+
+
+def test_before_agent_is_hook_config_with_jump_to_end() -> None:
+    """`@hook_config(can_jump_to=['end'])` is required so the SDK
+    permits the canned-response short-circuit."""
+    tree = _parse(MODULE_PATH)
+    found = False
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+            and node.name == "before_agent"
+        ):
+            continue
+        for deco in node.decorator_list:
+            if not (isinstance(deco, ast.Call) and isinstance(deco.func, ast.Name)):
+                continue
+            if deco.func.id != "hook_config":
+                continue
+            for kw in deco.keywords:
+                if kw.arg != "can_jump_to":
+                    continue
+                if isinstance(kw.value, ast.List) and any(
+                    isinstance(elt, ast.Constant) and elt.value == "end" for elt in kw.value.elts
+                ):
+                    found = True
+    assert found, (
+        "ClassifyMiddleware.before_agent must be decorated with "
+        "@hook_config(can_jump_to=['end']) — the canned-response path needs jump_to='end'."
+    )
+
+
+def test_module_has_no_forbidden_top_imports() -> None:
+    tree = _parse(MODULE_PATH)
+    offenders: list[str] = []
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                top = alias.name.split(".", 1)[0]
+                if top in FORBIDDEN_TOP_IMPORTS:
+                    offenders.append(alias.name)
+                if top == "langgraph" and alias.name not in ALLOWED_LANGGRAPH_SUBPACKAGES:
+                    offenders.append(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            top = module.split(".", 1)[0]
+            if top in FORBIDDEN_TOP_IMPORTS:
+                offenders.append(module)
+            if top == "langgraph" and module not in ALLOWED_LANGGRAPH_SUBPACKAGES:
+                offenders.append(module)
+    assert not offenders, (
+        f"{MODULE_PATH.relative_to(REPO_ROOT)} forbidden module-scope imports: {offenders}."
+    )
+
+
+def test_package_init_re_exports_middleware() -> None:
+    init_text = PKG_INIT_PATH.read_text(encoding="utf-8")
+    assert "ClassifyMiddleware" in init_text, (
+        "telegram_bot/graph/middleware/__init__.py must re-export ClassifyMiddleware."
+    )
+
+
+def test_state_schema_has_query_type_field() -> None:
+    module = importlib.import_module(MODULE_NAME)
+    schema = module._ClassifyAwareState
+    assert "query_type" in getattr(schema, "__annotations__", {})

--- a/tests/contract/test_voice_classify_middleware_contract.py
+++ b/tests/contract/test_voice_classify_middleware_contract.py
@@ -34,7 +34,7 @@ def _parse(path: Path) -> ast.Module:
     return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
 
 
-def test_module_exists_and_exports_required_symbols() -> None:
+def test_classify_middleware_module_exists_and_exports_required_symbols() -> None:
     assert MODULE_PATH.is_file(), (
         f"{MODULE_PATH.relative_to(REPO_ROOT)} must exist (#2051 Slice 2.5)."
     )
@@ -43,7 +43,7 @@ def test_module_exists_and_exports_required_symbols() -> None:
         assert hasattr(module, name), f"{MODULE_NAME} must export {name}."
 
 
-def test_middleware_subclasses_AgentMiddleware() -> None:
+def test_classify_middleware_subclasses_AgentMiddleware() -> None:
     from langchain.agents.middleware import AgentMiddleware
 
     module = importlib.import_module(MODULE_NAME)
@@ -90,7 +90,7 @@ def test_before_agent_is_hook_config_with_jump_to_end() -> None:
     )
 
 
-def test_module_has_no_forbidden_top_imports() -> None:
+def test_classify_module_has_no_forbidden_top_imports() -> None:
     tree = _parse(MODULE_PATH)
     offenders: list[str] = []
     for node in ast.iter_child_nodes(tree):
@@ -113,7 +113,7 @@ def test_module_has_no_forbidden_top_imports() -> None:
     )
 
 
-def test_package_init_re_exports_middleware() -> None:
+def test_package_init_re_exports_classify_middleware() -> None:
     init_text = PKG_INIT_PATH.read_text(encoding="utf-8")
     assert "ClassifyMiddleware" in init_text, (
         "telegram_bot/graph/middleware/__init__.py must re-export ClassifyMiddleware."

--- a/tests/unit/agents/middleware/test_classify_middleware.py
+++ b/tests/unit/agents/middleware/test_classify_middleware.py
@@ -1,0 +1,135 @@
+"""Behaviour parity tests for ``ClassifyMiddleware`` (Slice 2.5 / #2051).
+
+Pin the routing the legacy ``classify_node`` provides today:
+
+* CHITCHAT / OFF_TOPIC → emit canned response + ``jump_to=end``.
+* All other types → annotate ``query_type`` and return without jumping.
+* Empty messages → no-op (``None``).
+* ``skip_canned_response=True`` → set ``query_type`` even on
+  CHITCHAT/OFF_TOPIC but leave message emission to the caller.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from langchain.messages import AIMessage, HumanMessage
+
+from telegram_bot.graph.middleware.classify import (
+    ClassifyMiddleware,
+    _ClassifyAwareState,
+)
+
+
+def _state(text: str = "") -> dict:
+    if not text:
+        return {"messages": []}
+    return {"messages": [HumanMessage(content=text)]}
+
+
+def _runtime() -> MagicMock:
+    rt = MagicMock()
+    rt.context = {}
+    return rt
+
+
+@pytest.fixture(autouse=True)
+def _stub_observability(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = MagicMock()
+    fake.update_current_span = MagicMock()
+    monkeypatch.setattr("telegram_bot.graph.middleware.classify.get_client", lambda: fake)
+
+
+@pytest.fixture
+def middleware() -> ClassifyMiddleware:
+    return ClassifyMiddleware()
+
+
+def test_returns_none_for_empty_messages(middleware: ClassifyMiddleware) -> None:
+    assert middleware.before_agent(_state(""), _runtime()) is None
+
+
+def test_chitchat_short_circuits_with_canned_response(
+    middleware: ClassifyMiddleware,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "telegram_bot.graph.middleware.classify.classify_query", lambda _q: "CHITCHAT"
+    )
+    monkeypatch.setattr(
+        "telegram_bot.graph.middleware.classify._get_chitchat_response",
+        lambda _q: "Привет! Чем могу помочь?",
+    )
+
+    result = middleware.before_agent(_state("привет"), _runtime())
+
+    assert result is not None
+    assert result["jump_to"] == "end"
+    assert result["query_type"] == "CHITCHAT"
+    assert result["response"] == "Привет! Чем могу помочь?"
+    [msg] = result["messages"]
+    assert isinstance(msg, AIMessage)
+    assert msg.content == "Привет! Чем могу помочь?"
+
+
+def test_off_topic_short_circuits_with_canned_response(
+    middleware: ClassifyMiddleware,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "telegram_bot.graph.middleware.classify.classify_query", lambda _q: "OFF_TOPIC"
+    )
+    # Neutralise random.choice so the test is deterministic.
+    monkeypatch.setattr(
+        "telegram_bot.graph.nodes.classify.OFF_TOPIC_RESPONSES",
+        ["Я отвечаю только по недвижимости."],
+    )
+
+    result = middleware.before_agent(_state("сколько весит марс"), _runtime())
+
+    assert result is not None
+    assert result["jump_to"] == "end"
+    assert result["query_type"] == "OFF_TOPIC"
+    [msg] = result["messages"]
+    assert isinstance(msg, AIMessage)
+
+
+@pytest.mark.parametrize("classified_type", ["FAQ", "ENTITY", "STRUCTURED", "GENERAL"])
+def test_cacheable_types_pass_through(
+    middleware: ClassifyMiddleware,
+    monkeypatch: pytest.MonkeyPatch,
+    classified_type: str,
+) -> None:
+    monkeypatch.setattr(
+        "telegram_bot.graph.middleware.classify.classify_query", lambda _q: classified_type
+    )
+
+    result = middleware.before_agent(_state("сколько стоит ВНЖ"), _runtime())
+
+    assert result is not None
+    assert "jump_to" not in result
+    assert result["query_type"] == classified_type
+    # No canned messages on the cacheable paths.
+    assert "messages" not in result
+
+
+def test_skip_canned_response_flag_keeps_query_type_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "telegram_bot.graph.middleware.classify.classify_query", lambda _q: "CHITCHAT"
+    )
+    middleware = ClassifyMiddleware(skip_canned_response=True)
+
+    result = middleware.before_agent(_state("привет"), _runtime())
+
+    assert result is not None
+    assert "jump_to" not in result
+    assert result["query_type"] == "CHITCHAT"
+    assert "messages" not in result
+
+
+def test_state_schema_carries_query_type() -> None:
+    annotations = _ClassifyAwareState.__annotations__
+    assert "query_type" in annotations

--- a/tests/unit/agents/middleware/test_semantic_cache_middleware.py
+++ b/tests/unit/agents/middleware/test_semantic_cache_middleware.py
@@ -109,7 +109,7 @@ async def test_before_agent_returns_none_for_empty_messages(
     middleware: SemanticCacheMiddleware,
 ) -> None:
     """No human message → middleware is a no-op (no embedding, no jump)."""
-    result = await middleware.before_agent({"messages": []}, _runtime_stub())
+    result = await middleware.abefore_agent({"messages": []}, _runtime_stub())
     assert result is None
 
 
@@ -120,7 +120,7 @@ async def test_before_agent_skips_cache_for_non_cacheable_query_type(
 ) -> None:
     """CHITCHAT / OFF_TOPIC bypass cache (matches legacy classify routing)."""
     state = _state(query_type="CHITCHAT")
-    result = await middleware.before_agent(state, _runtime_stub())
+    result = await middleware.abefore_agent(state, _runtime_stub())
     assert result is None
     patched_rag_core["compute"].assert_not_called()
     patched_rag_core["check"].assert_not_called()
@@ -136,7 +136,7 @@ async def test_before_agent_short_circuits_on_cache_hit(
     cached_response = "ВНЖ оформляется в течение 30 рабочих дней."
     patched_rag_core["check"].return_value = (True, cached_response)
 
-    result = await middleware.before_agent(_state(), _runtime_stub())
+    result = await middleware.abefore_agent(_state(), _runtime_stub())
 
     assert result is not None
     assert result["jump_to"] == "end"
@@ -157,7 +157,7 @@ async def test_before_agent_returns_embedding_on_cache_miss(
 ) -> None:
     """Cache MISS must surface the freshly-computed embedding so downstream
     tools (rag_search) reuse it rather than recomputing."""
-    result = await middleware.before_agent(_state(), _runtime_stub())
+    result = await middleware.abefore_agent(_state(), _runtime_stub())
 
     assert result is not None
     assert "jump_to" not in result
@@ -178,7 +178,7 @@ async def test_before_agent_skips_cache_for_contextual_query(
     the no-hit branch; only the ``check_semantic_cache`` call is gated.
     """
     monkeypatch.setattr("telegram_bot.graph.middleware.cache.is_contextual_query", lambda _q: True)
-    result = await middleware.before_agent(_state(), _runtime_stub())
+    result = await middleware.abefore_agent(_state(), _runtime_stub())
 
     assert result is not None
     assert result["cache_hit"] is False
@@ -206,7 +206,7 @@ async def test_before_agent_skips_cache_when_filter_sensitive_without_signature(
         lambda **_: None,
     )
 
-    result = await middleware.before_agent(_state(), _runtime_stub())
+    result = await middleware.abefore_agent(_state(), _runtime_stub())
 
     assert result is not None
     assert result["cache_hit"] is False
@@ -222,7 +222,7 @@ async def test_before_agent_short_circuits_on_embedding_failure(
     the agent loop (matches the early-return shape of cache_check_node)."""
     patched_rag_core["compute"].side_effect = TimeoutError("BGE timeout")
 
-    result = await middleware.before_agent(_state(), _runtime_stub())
+    result = await middleware.abefore_agent(_state(), _runtime_stub())
 
     assert result is not None
     assert result["jump_to"] == "end"
@@ -270,7 +270,7 @@ async def test_after_agent_persists_response_for_cacheable_query(
         cache_hit=False,
     )
 
-    update = await middleware.after_agent(state, _runtime_stub())
+    update = await middleware.aafter_agent(state, _runtime_stub())
 
     patched_store.assert_awaited_once()
     kwargs = patched_store.await_args.kwargs
@@ -295,7 +295,7 @@ async def test_after_agent_noop_on_cache_hit(
         query_embedding=[0.1] * 8,
         cache_hit=True,
     )
-    result = await middleware.after_agent(state, _runtime_stub())
+    result = await middleware.aafter_agent(state, _runtime_stub())
     assert result is None
     patched_store.assert_not_called()
 
@@ -307,7 +307,7 @@ async def test_after_agent_skips_when_response_missing(
 ) -> None:
     """No assistant message → nothing to store."""
     state = _state(messages=[HumanMessage(content="x")], query_embedding=[0.1] * 8)
-    result = await middleware.after_agent(state, _runtime_stub())
+    result = await middleware.aafter_agent(state, _runtime_stub())
     assert result is None
     patched_store.assert_not_called()
 
@@ -321,7 +321,7 @@ async def test_after_agent_skips_when_embedding_missing(
         messages=[HumanMessage(content="x"), AIMessage(content="hi")],
         query_embedding=None,
     )
-    result = await middleware.after_agent(state, _runtime_stub())
+    result = await middleware.aafter_agent(state, _runtime_stub())
     assert result is None
     patched_store.assert_not_called()
 
@@ -337,7 +337,7 @@ async def test_after_agent_skips_for_non_cacheable_query_type(
         messages=[HumanMessage(content="x"), AIMessage(content="off-topic answer")],
         query_embedding=[0.1] * 8,
     )
-    result = await middleware.after_agent(state, _runtime_stub())
+    result = await middleware.aafter_agent(state, _runtime_stub())
     assert result is None
     patched_store.assert_not_called()
 
@@ -356,7 +356,7 @@ async def test_after_agent_swallows_store_failure(
         query_embedding=[0.1] * 8,
     )
 
-    update = await middleware.after_agent(state, _runtime_stub())
+    update = await middleware.aafter_agent(state, _runtime_stub())
 
     # Response is preserved despite the store crash.
     assert update is not None

--- a/tests/unit/agents/middleware/test_semantic_cache_middleware.py
+++ b/tests/unit/agents/middleware/test_semantic_cache_middleware.py
@@ -1,0 +1,380 @@
+"""Behaviour parity tests for ``SemanticCacheMiddleware`` (Slice 2 / #2051).
+
+The middleware replaces the legacy graph nodes
+:func:`telegram_bot.graph.nodes.cache.cache_check_node` and
+:func:`telegram_bot.graph.nodes.cache.cache_store_node`. These tests pin
+the behaviour the legacy nodes ship today so that the middleware shape
+can be wired into ``create_voice_agent`` (Slice 3) without surprising
+the graph-side regression suite.
+
+Every test stubs ``rag_core``/``cache_policy`` collaborators so the
+middleware is exercised in isolation — no Redis, no embedding service,
+no Langfuse client.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain.messages import AIMessage, HumanMessage
+
+from telegram_bot.graph.middleware.cache import (
+    SemanticCacheMiddleware,
+    _CacheAwareState,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def _state(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "messages": [HumanMessage(content="что такое прописка в Болгарии")],
+        "query_type": "FAQ",
+    }
+    base.update(overrides)
+    return base
+
+
+def _runtime_stub() -> Any:
+    runtime = MagicMock()
+    runtime.context = {}
+    return runtime
+
+
+@pytest.fixture
+def cache() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def embeddings() -> AsyncMock:
+    embeddings = AsyncMock()
+    embeddings.aembed_query.return_value = [0.1] * 8
+    return embeddings
+
+
+@pytest.fixture
+def middleware(cache: AsyncMock, embeddings: AsyncMock) -> SemanticCacheMiddleware:
+    return SemanticCacheMiddleware(cache=cache, embeddings=embeddings)
+
+
+@pytest.fixture(autouse=True)
+def _stub_observability(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Silence observability so tests do not depend on Langfuse internals."""
+    fake_client = MagicMock()
+    fake_client.update_current_span = MagicMock()
+    monkeypatch.setattr("telegram_bot.graph.middleware.cache.get_client", lambda: fake_client)
+
+
+@pytest.fixture
+def patched_rag_core(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Replace ``compute_query_embedding`` and ``check_semantic_cache``.
+
+    Default behaviour: embedding succeeds, cache MISS, ColBERT vectors
+    None. Individual tests override return values via the returned dict.
+    """
+    embedding = [0.1] * 8
+    state: dict[str, Any] = {
+        "compute": AsyncMock(return_value=(embedding, None, None, False)),
+        "check": AsyncMock(return_value=(False, None)),
+        "embedding": embedding,
+    }
+    monkeypatch.setattr(
+        "telegram_bot.graph.middleware.cache.compute_query_embedding", state["compute"]
+    )
+    monkeypatch.setattr("telegram_bot.graph.middleware.cache.check_semantic_cache", state["check"])
+    return state
+
+
+@pytest.fixture
+def patched_store(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    fake = AsyncMock(return_value=True)
+    monkeypatch.setattr("telegram_bot.graph.middleware.cache.maybe_store_semantic_response", fake)
+    return fake
+
+
+# --------------------------------------------------------------------------- #
+# before_agent — cache check                                                    #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_before_agent_returns_none_for_empty_messages(
+    middleware: SemanticCacheMiddleware,
+) -> None:
+    """No human message → middleware is a no-op (no embedding, no jump)."""
+    result = await middleware.before_agent({"messages": []}, _runtime_stub())
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_before_agent_skips_cache_for_non_cacheable_query_type(
+    middleware: SemanticCacheMiddleware,
+    patched_rag_core: dict[str, Any],
+) -> None:
+    """CHITCHAT / OFF_TOPIC bypass cache (matches legacy classify routing)."""
+    state = _state(query_type="CHITCHAT")
+    result = await middleware.before_agent(state, _runtime_stub())
+    assert result is None
+    patched_rag_core["compute"].assert_not_called()
+    patched_rag_core["check"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_before_agent_short_circuits_on_cache_hit(
+    middleware: SemanticCacheMiddleware,
+    patched_rag_core: dict[str, Any],
+) -> None:
+    """Cache HIT must return jump_to=end + AIMessage(cached) so the SDK
+    skips both the model call and the after_agent cache_store path."""
+    cached_response = "ВНЖ оформляется в течение 30 рабочих дней."
+    patched_rag_core["check"].return_value = (True, cached_response)
+
+    result = await middleware.before_agent(_state(), _runtime_stub())
+
+    assert result is not None
+    assert result["jump_to"] == "end"
+    assert result["cache_hit"] is True
+    assert result["cached_response"] == cached_response
+    assert result["query_embedding"] == patched_rag_core["embedding"]
+    # Final-message slot carries the cached AI response so handle_voice
+    # / handle_query can read it from state["messages"][-1].
+    [message] = result["messages"]
+    assert isinstance(message, AIMessage)
+    assert message.content == cached_response
+
+
+@pytest.mark.asyncio
+async def test_before_agent_returns_embedding_on_cache_miss(
+    middleware: SemanticCacheMiddleware,
+    patched_rag_core: dict[str, Any],
+) -> None:
+    """Cache MISS must surface the freshly-computed embedding so downstream
+    tools (rag_search) reuse it rather than recomputing."""
+    result = await middleware.before_agent(_state(), _runtime_stub())
+
+    assert result is not None
+    assert "jump_to" not in result
+    assert result["cache_hit"] is False
+    assert result["query_embedding"] == patched_rag_core["embedding"]
+    assert result["cached_response"] is None
+
+
+@pytest.mark.asyncio
+async def test_before_agent_skips_cache_for_contextual_query(
+    middleware: SemanticCacheMiddleware,
+    patched_rag_core: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``is_contextual_query`` short-circuits the lookup (legacy parity).
+
+    The embedding is still computed because downstream tools need it on
+    the no-hit branch; only the ``check_semantic_cache`` call is gated.
+    """
+    monkeypatch.setattr("telegram_bot.graph.middleware.cache.is_contextual_query", lambda _q: True)
+    result = await middleware.before_agent(_state(), _runtime_stub())
+
+    assert result is not None
+    assert result["cache_hit"] is False
+    patched_rag_core["compute"].assert_awaited_once()
+    patched_rag_core["check"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_before_agent_skips_cache_when_filter_sensitive_without_signature(
+    middleware: SemanticCacheMiddleware,
+    patched_rag_core: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Filter-sensitive queries with no resolved filter_signature must NOT
+    hit the shared cache bucket; matches the carve-out in cache_check_node."""
+
+    fake_signal = MagicMock()
+    fake_signal.is_filter_sensitive = True
+    monkeypatch.setattr(
+        "telegram_bot.graph.middleware.cache.detect_filter_sensitive_query",
+        lambda _q: fake_signal,
+    )
+    monkeypatch.setattr(
+        "telegram_bot.graph.middleware.cache.resolve_semantic_cache_signature",
+        lambda **_: None,
+    )
+
+    result = await middleware.before_agent(_state(), _runtime_stub())
+
+    assert result is not None
+    assert result["cache_hit"] is False
+    patched_rag_core["check"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_before_agent_short_circuits_on_embedding_failure(
+    middleware: SemanticCacheMiddleware,
+    patched_rag_core: dict[str, Any],
+) -> None:
+    """Embedding failure surfaces the graceful-fallback response and stops
+    the agent loop (matches the early-return shape of cache_check_node)."""
+    patched_rag_core["compute"].side_effect = TimeoutError("BGE timeout")
+
+    result = await middleware.before_agent(_state(), _runtime_stub())
+
+    assert result is not None
+    assert result["jump_to"] == "end"
+    assert result["embedding_error"] is True
+    assert result["embedding_error_type"] == "TimeoutError"
+    [message] = result["messages"]
+    assert "временно недоступен" in message.content
+
+
+# --------------------------------------------------------------------------- #
+# after_agent — cache store                                                     #
+# --------------------------------------------------------------------------- #
+
+
+@dataclasses.dataclass
+class _FakeDecision:
+    response_state: str = "ok"
+    degraded_reason: str | None = None
+    cache_eligible: bool = True
+    store_reason: str = "ok"
+
+
+@pytest.fixture
+def patched_decision(monkeypatch: pytest.MonkeyPatch) -> _FakeDecision:
+    decision = _FakeDecision()
+    monkeypatch.setattr(
+        "telegram_bot.graph.middleware.cache.build_cacheability_decision",
+        lambda **_: decision,
+    )
+    return decision
+
+
+@pytest.mark.asyncio
+async def test_after_agent_persists_response_for_cacheable_query(
+    middleware: SemanticCacheMiddleware,
+    patched_store: AsyncMock,
+    patched_decision: _FakeDecision,
+) -> None:
+    state = _state(
+        messages=[
+            HumanMessage(content="как получить ВНЖ?"),
+            AIMessage(content="ВНЖ оформляется около 30 дней."),
+        ],
+        query_embedding=[0.1] * 8,
+        cache_hit=False,
+    )
+
+    update = await middleware.after_agent(state, _runtime_stub())
+
+    patched_store.assert_awaited_once()
+    kwargs = patched_store.await_args.kwargs
+    assert kwargs["query_type"] == "FAQ"
+    assert kwargs["response"] == "ВНЖ оформляется около 30 дней."
+    assert kwargs["vector"] == [0.1] * 8
+    assert kwargs["decision"] is patched_decision
+    assert update is not None
+    assert update["response"] == "ВНЖ оформляется около 30 дней."
+    assert update["cache_eligible"] is True
+
+
+@pytest.mark.asyncio
+async def test_after_agent_noop_on_cache_hit(
+    middleware: SemanticCacheMiddleware,
+    patched_store: AsyncMock,
+) -> None:
+    """On HIT, before_agent already stored nothing fresh; after_agent
+    must not re-write the cached response back into Redis."""
+    state = _state(
+        messages=[HumanMessage(content="x"), AIMessage(content="cached")],
+        query_embedding=[0.1] * 8,
+        cache_hit=True,
+    )
+    result = await middleware.after_agent(state, _runtime_stub())
+    assert result is None
+    patched_store.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_after_agent_skips_when_response_missing(
+    middleware: SemanticCacheMiddleware,
+    patched_store: AsyncMock,
+) -> None:
+    """No assistant message → nothing to store."""
+    state = _state(messages=[HumanMessage(content="x")], query_embedding=[0.1] * 8)
+    result = await middleware.after_agent(state, _runtime_stub())
+    assert result is None
+    patched_store.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_after_agent_skips_when_embedding_missing(
+    middleware: SemanticCacheMiddleware,
+    patched_store: AsyncMock,
+) -> None:
+    state = _state(
+        messages=[HumanMessage(content="x"), AIMessage(content="hi")],
+        query_embedding=None,
+    )
+    result = await middleware.after_agent(state, _runtime_stub())
+    assert result is None
+    patched_store.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_after_agent_skips_for_non_cacheable_query_type(
+    middleware: SemanticCacheMiddleware,
+    patched_store: AsyncMock,
+) -> None:
+    """OFF_TOPIC must not be persisted — matches CACHEABLE_QUERY_TYPES gate."""
+    state = _state(
+        query_type="OFF_TOPIC",
+        messages=[HumanMessage(content="x"), AIMessage(content="off-topic answer")],
+        query_embedding=[0.1] * 8,
+    )
+    result = await middleware.after_agent(state, _runtime_stub())
+    assert result is None
+    patched_store.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_after_agent_swallows_store_failure(
+    middleware: SemanticCacheMiddleware,
+    patched_store: AsyncMock,
+    patched_decision: _FakeDecision,
+) -> None:
+    """A cache-store error must never destroy the response (legacy invariant)."""
+    patched_store.side_effect = RuntimeError("redisvl exploded")
+
+    state = _state(
+        messages=[HumanMessage(content="x"), AIMessage(content="answer")],
+        query_embedding=[0.1] * 8,
+    )
+
+    update = await middleware.after_agent(state, _runtime_stub())
+
+    # Response is preserved despite the store crash.
+    assert update is not None
+    assert update["response"] == "answer"
+
+
+# --------------------------------------------------------------------------- #
+# State schema                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_cache_aware_state_extends_agent_state() -> None:
+    """``_CacheAwareState`` must compose with ``AgentState``'s ``messages``
+    field so the SDK's state-merge accepts middleware updates."""
+    annotations = dict(_CacheAwareState.__annotations__)
+    # Inherited annotations should still be reachable via ``__annotations__``
+    # at runtime — fall back to ``getattr`` for safety on older typing
+    # backends. The presence of the cache-specific fields is sufficient
+    # contract evidence.
+    assert "cache_hit" in annotations
+    assert "query_embedding" in annotations

--- a/tests/unit/agents/test_voice_agent_factory.py
+++ b/tests/unit/agents/test_voice_agent_factory.py
@@ -62,15 +62,16 @@ def chat_openai_stub(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     return fake_class
 
 
-@pytest.mark.asyncio
-async def test_factory_returns_compiled_agent_with_three_middleware(
+def test_factory_returns_compiled_agent_with_three_middleware(
     chat_openai_stub: MagicMock,
 ) -> None:
     cache = MagicMock()
     embeddings = MagicMock()
     captured: dict[str, Any] = {}
 
-    real_create_agent = __import__("langchain.agents", fromlist=["create_agent"]).create_agent
+    real_create_agent = __import__(
+        "langchain.agents", fromlist=["create_agent"]
+    ).create_agent
 
     def spy_create_agent(**kwargs: Any) -> Any:
         captured.update(kwargs)

--- a/tests/unit/agents/test_voice_agent_factory.py
+++ b/tests/unit/agents/test_voice_agent_factory.py
@@ -1,0 +1,130 @@
+"""Integration test for ``create_voice_agent`` (Slice 3 / #2051).
+
+Verifies that the factory wires the three voice middleware layers in the
+correct order and that the compiled agent honours the
+``SemanticCacheMiddleware`` cache-HIT short-circuit end-to-end (no real
+LLM is hit on a cache hit, so the test runs offline).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain.messages import HumanMessage
+
+from telegram_bot.agents.voice_agent import VoiceAgentState, create_voice_agent
+
+
+@pytest.fixture
+def cache_hit_stub(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Stub rag_core so the cache-middleware reports a HIT deterministically."""
+    embedding = [0.42] * 8
+    cached_response = "Готовый ответ из кэша."
+    compute = AsyncMock(return_value=(embedding, None, None, False))
+    check = AsyncMock(return_value=(True, cached_response))
+    monkeypatch.setattr("telegram_bot.graph.middleware.cache.compute_query_embedding", compute)
+    monkeypatch.setattr("telegram_bot.graph.middleware.cache.check_semantic_cache", check)
+    monkeypatch.setattr("telegram_bot.graph.middleware.cache.is_contextual_query", lambda _q: False)
+    fake_signal = MagicMock()
+    fake_signal.is_filter_sensitive = False
+    monkeypatch.setattr(
+        "telegram_bot.graph.middleware.cache.detect_filter_sensitive_query",
+        lambda _q: fake_signal,
+    )
+    monkeypatch.setattr(
+        "telegram_bot.graph.middleware.cache.resolve_semantic_cache_signature",
+        lambda **_: None,
+    )
+    fake_lf = MagicMock()
+    fake_lf.update_current_span = MagicMock()
+    monkeypatch.setattr("telegram_bot.graph.middleware.cache.get_client", lambda: fake_lf)
+    monkeypatch.setattr("telegram_bot.graph.middleware.classify.classify_query", lambda _q: "FAQ")
+    monkeypatch.setattr("telegram_bot.graph.middleware.classify.get_client", lambda: fake_lf)
+    monkeypatch.setattr(
+        "telegram_bot.graph.middleware.guard.detect_injection", lambda _q: (False, 0.0, None)
+    )
+    return {"embedding": embedding, "cached": cached_response}
+
+
+@pytest.fixture
+def chat_openai_stub(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Replace ``ChatOpenAI`` with a stub so factory creation is offline."""
+    fake_llm = MagicMock(name="FakeLLM")
+    fake_llm.bind_tools = MagicMock(return_value=fake_llm)
+    fake_llm.with_structured_output = MagicMock(return_value=fake_llm)
+    fake_llm.invoke = MagicMock()
+    fake_llm.ainvoke = AsyncMock()
+
+    fake_class = MagicMock(return_value=fake_llm)
+    monkeypatch.setattr("telegram_bot.agents.voice_agent.ChatOpenAI", fake_class)
+    return fake_class
+
+
+@pytest.mark.asyncio
+async def test_factory_returns_compiled_agent_with_three_middleware(
+    chat_openai_stub: MagicMock,
+) -> None:
+    cache = MagicMock()
+    embeddings = MagicMock()
+    captured: dict[str, Any] = {}
+
+    real_create_agent = __import__("langchain.agents", fromlist=["create_agent"]).create_agent
+
+    def spy_create_agent(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return real_create_agent(**kwargs)
+
+    with patch("telegram_bot.agents.voice_agent.create_agent", side_effect=spy_create_agent):
+        agent = create_voice_agent(
+            cache=cache,
+            embeddings=embeddings,
+            model="openai/gpt-test",
+        )
+
+    assert agent is not None
+    assert "middleware" in captured
+    middleware_names = [type(m).__name__ for m in captured["middleware"]]
+    assert middleware_names == [
+        "GuardMiddleware",
+        "ClassifyMiddleware",
+        "SemanticCacheMiddleware",
+    ]
+    assert captured["state_schema"] is VoiceAgentState
+    assert chat_openai_stub.called
+
+
+@pytest.mark.asyncio
+async def test_factory_short_circuits_on_cache_hit(
+    cache_hit_stub: dict[str, Any],
+    chat_openai_stub: MagicMock,
+) -> None:
+    """End-to-end smoke: build the compiled graph and run a single
+    ``ainvoke``. With the cache stubbed to HIT, the agent must not
+    hit the LLM (the stub would record the call) — the cached AI
+    message is returned via ``jump_to=end``.
+    """
+    cache = MagicMock()
+    embeddings = MagicMock()
+
+    agent = create_voice_agent(
+        cache=cache,
+        embeddings=embeddings,
+        model="openai/gpt-test",
+    )
+
+    result = await agent.ainvoke({"messages": [HumanMessage(content="что нужно для прописки?")]})
+
+    # The cached response is the latest message.
+    assert result["messages"][-1].content == cache_hit_stub["cached"]
+    # The model was never called because before_agent (cache) jumped to end.
+    fake_llm = chat_openai_stub.return_value
+    assert not fake_llm.invoke.called
+    assert not fake_llm.ainvoke.called
+
+
+def test_state_schema_includes_voice_input_fields() -> None:
+    annotations = VoiceAgentState.__annotations__
+    for field in ("voice_audio", "voice_duration_s", "stt_text", "trace_id"):
+        assert field in annotations


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Slice 3 of the voice-path migration to `create_agent` (ADR-0010, parent #1535 / #2051). Assembles the three SDK-native middleware layers — `GuardMiddleware` (#2052, on dev), `ClassifyMiddleware` (#2178), `SemanticCacheMiddleware` (#2177) — on top of the existing `rag_search` tool, returning a compiled agent ready for `handle_voice`'s rewire (Slice 5).

> ⚠ **Stacked PR.** This branch cherry-picks #2177 (Slice 2 cache) and #2178 (Slice 2.5 classify) so local CI runs end-to-end. After both upstream PRs merge to `dev`, rebasing this branch will drop the duplicate commits automatically.

## What landed

- **`telegram_bot/agents/voice_agent.py`**:
  - `VoiceAgentState(AgentState)` — all `NotRequired`:
    - voice-only inputs the handler writes before invoking: `voice_audio`, `voice_duration_s`, `stt_text`, `stt_duration_ms`, `input_type`, `trace_id`
    - cache fields the middleware writes: `query_type`, `cache_hit`, `cached_response`, `query_embedding`, `colbert_query`, `embeddings_cache_hit`, `embedding_error`, `embedding_error_type`
    - shared observability: `response`, `response_state`, `degraded_reason`, `cache_eligible`, `store_reason`, `sources_count`, `show_sources`, `grounding_mode`, `grade_confidence`, `documents`, `latency_stages`, `filters`, `semantic_cache_filter_signature`, `search_results_count`
  - `create_voice_agent(*, cache, embeddings, model, ...)` wires the middleware in deterministic order: `[GuardMiddleware, ClassifyMiddleware, SemanticCacheMiddleware]`
  - Voice-tuned system prompt inline (no Redis-backed prompt-registry dependency at factory construction)
  - Knobs: `extra_middleware`, `tools`, `checkpointer`, `system_prompt`, `base_url`, `api_key`, `cache_scope`, `agent_role`, `guard_mode`, `skip_classify_canned_response`, `max_tokens`

- **`telegram_bot/graph/middleware/cache.py`** (Slice 2 fix):
  - Rename `before_agent` → `abefore_agent`, `after_agent` → `aafter_agent` per the LangChain SDK contract (`AgentMiddleware.types.py:417/636`). Sync method names get called directly and leak coroutines into `langgraph.errors.InvalidUpdateError`. Verified via `langchain.agents.middleware.types`.

- **`tests/contract/test_voice_agent_factory_contract.py`** (5) — pins factory + state-schema export, `AgentState` subclass relationship, voice-specific fields presence, kw-only `cache`/`embeddings`/`model` signature, no aiogram / fastapi / qdrant_client / non-runtime langgraph imports.

- **`tests/unit/agents/test_voice_agent_factory.py`** (3):
  - **Integration smoke**: stubs `ChatOpenAI`, builds the compiled agent, runs `agent.ainvoke({"messages": [HumanMessage(...)]})` end-to-end; with `SemanticCacheMiddleware` cache stubbed to HIT, the LLM is never invoked — proves the short-circuit chain works through compilation.
  - Middleware ordering pinned via spy on `create_agent`.
  - Voice-input fields present in state schema.

- Existing cache tests updated to `abefore_agent` / `aafter_agent` names.

## Verification

```
uv run --python 3.12 pytest \
  tests/unit/graph/ tests/unit/agents/ tests/contract/test_voice_*.py \
  tests/unit/test_bot_handlers.py \
  -q --timeout=30 -n auto --dist=worksteal
```
→ **1129 passed in 31.83s**; ruff clean.

## Out of scope

- **Slice 4** — gold-set parity harness (`graph` vs `agent` backend) — separate PR.
- **Slice 5 / `handle_voice` rewire** (issue #2051's final acceptance) — separate PR after Slice 4 shows regressions ≤ 2%.

## Dependency chain

| PR | Slice | Status |
|----|-------|--------|
| #2177 | 2 — `SemanticCacheMiddleware` | open |
| #2178 | 2.5 — `ClassifyMiddleware` | open |
| **this** | 3 — `VoiceAgentState` + `create_voice_agent` | open (stacked) |
| _next_ | 4 — gold-set parity | TBD |
| _next_ | 5 — `handle_voice` rewire | TBD |

Refs #2051, refs #1535, refs ADR-0010