### PR TITLE
refactor(bot): extract feedback handlers to _bot_feedback_handlers.py (#2048 PR-9a)

### DIFF
--- a/telegram_bot/_bot_feedback_handlers.py
+++ b/telegram_bot/_bot_feedback_handlers.py
@@ -1,0 +1,229 @@
+"""Feedback callback handlers extracted from ``telegram_bot/bot.py``.
+
+Slice 2 PR-9a of the bot.py decomposition plan
+(``docs/engineering/bot-decomposition-plan-2026-05-27.md``, parent
+#1265 / child #2048). Owns the three feedback-related callback
+handlers:
+
+* :func:`handle_feedback` — like / dislike / done routing.
+* :func:`handle_feedback_reason` — dislike reason selection.
+* :func:`clear_feedback_confirmation_later` — async cleanup of the
+  confirmation keyboard after a TTL.
+
+The functions are module-level and take the ``PropertyBot`` instance
+as the first positional argument. ``PropertyBot.handle_feedback`` /
+``handle_feedback_reason`` / ``_clear_feedback_confirmation_later``
+remain on the class as thin delegates so:
+
+* aiogram dispatcher registration in ``_register_handlers`` keeps
+  binding ``self.handle_feedback`` directly (the dispatcher captures
+  the bound method);
+* the existing ``tests/unit/test_bot_handlers.py`` suite keeps
+  resolving ``bot.handle_feedback`` / ``bot._clear_feedback_confirmation_later``
+  unchanged.
+
+Module-level imports are kept to stdlib + the small set of
+``telegram_bot`` helpers each handler reaches for; the heavier
+``langchain``/``langgraph`` imports stay inside ``bot.py``. The
+per-extraction contract (no aiogram-removal, no behaviour drift) is
+pinned by ``tests/contract/test_bot_feedback_handlers_extraction_contract.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+from telegram_bot.callback_data import FeedbackCB, FeedbackReasonCB
+from telegram_bot.observability import get_langfuse_client
+
+
+if TYPE_CHECKING:  # pragma: no cover — typing-only
+    from aiogram.types import CallbackQuery
+
+    from telegram_bot.bot import PropertyBot
+
+
+logger = logging.getLogger(__name__)
+
+
+# Time-to-live for the post-feedback confirmation keyboard before it is
+# cleared. Mirrors the ``_FEEDBACK_CONFIRMATION_TTL_S`` constant in
+# ``bot.py`` so the two callsites stay aligned without an extra import.
+FEEDBACK_CONFIRMATION_TTL_S = 5.0
+
+
+async def handle_feedback(
+    bot: PropertyBot,
+    callback: CallbackQuery,
+    callback_data: FeedbackCB | None = None,
+) -> None:
+    """Handle feedback like/dislike/done callback (#229, #755).
+
+    Supports CallbackData injection from aiogram DI, with legacy string
+    fallback for backward compatibility with tests and old-format
+    buttons.
+    """
+    from telegram_bot.feedback import (
+        build_dislike_reason_keyboard,
+        build_feedback_confirmation,
+        parse_feedback_callback,
+    )
+
+    if callback_data is not None:
+        # New CallbackData path (aiogram DI injection)
+        if callback_data.action == "done":
+            await callback.answer()
+            return
+        if callback_data.action == "dislike":
+            # Step 1: show reason keyboard, score written in handle_feedback_reason
+            await callback.answer()
+            try:
+                msg = callback.message
+                if msg is not None and hasattr(msg, "edit_reply_markup"):
+                    await msg.edit_reply_markup(
+                        reply_markup=build_dislike_reason_keyboard(callback_data.trace_id)
+                    )
+            except Exception:
+                logger.debug("Failed to show dislike reason keyboard", exc_info=True)
+            return
+        # "like" action: write score below
+        value: float = 1.0
+        trace_id: str = callback_data.trace_id
+        reason: str | None = None
+    else:
+        # Legacy fallback (tests and old-format buttons: fb:1/0:, fb:r:)
+        data = callback.data or ""
+        if data in ("fb:done", "fb:done:"):
+            await callback.answer()
+            return
+        parsed = parse_feedback_callback(data)
+        if parsed is None:
+            await callback.answer()
+            return
+        value, trace_id, reason = parsed
+
+        # Legacy dislike without reason → show reason keyboard
+        if value == 0.0 and reason is None:
+            await callback.answer()
+            try:
+                msg = callback.message
+                if msg is not None and hasattr(msg, "edit_reply_markup"):
+                    await msg.edit_reply_markup(
+                        reply_markup=build_dislike_reason_keyboard(trace_id)
+                    )
+            except Exception:
+                logger.debug("Failed to show dislike reason keyboard", exc_info=True)
+            return
+
+    # Write score (like, or legacy reason path)
+    await callback.answer("Спасибо за отзыв!")
+    user_id = callback.from_user.id if callback.from_user else 0
+
+    try:
+        lf_client = get_langfuse_client()
+        if lf_client is not None:
+            lf_client.create_score(
+                trace_id=trace_id,
+                name="user_feedback",
+                value=value,
+                data_type="NUMERIC",
+                comment=f"user_id:{user_id}",
+                score_id=f"{trace_id}-user_feedback",
+            )
+            if reason is not None:
+                lf_client.create_score(
+                    trace_id=trace_id,
+                    name="user_feedback_reason",
+                    value=reason,
+                    data_type="CATEGORICAL",
+                    comment=f"user_id:{user_id}",
+                    score_id=f"{trace_id}-user_feedback_reason",
+                )
+    except Exception:
+        logger.warning("Failed to write feedback score to Langfuse", exc_info=True)
+
+    # Update keyboard to confirmation
+    liked = value > 0
+    try:
+        msg = callback.message
+        if msg is not None and hasattr(msg, "edit_reply_markup"):
+            await msg.edit_reply_markup(reply_markup=build_feedback_confirmation(liked=liked))
+            cleanup_task = asyncio.create_task(
+                clear_feedback_confirmation_later(msg, FEEDBACK_CONFIRMATION_TTL_S)
+            )
+            cleanup_task.add_done_callback(lambda t: t.result() if not t.cancelled() else None)
+    except Exception:
+        logger.debug("Failed to update feedback keyboard", exc_info=True)
+
+
+async def handle_feedback_reason(
+    bot: PropertyBot,
+    callback: CallbackQuery,
+    callback_data: FeedbackReasonCB,
+) -> None:
+    """Handle dislike reason selection callback (#755)."""
+    from telegram_bot.feedback import _REASON_CODES, build_feedback_confirmation
+
+    reason = _REASON_CODES.get(callback_data.code)
+    if reason is None:
+        await callback.answer()
+        return
+
+    trace_id = callback_data.trace_id
+    await callback.answer("Спасибо за отзыв!")
+    user_id = callback.from_user.id if callback.from_user else 0
+
+    try:
+        lf_client = get_langfuse_client()
+        if lf_client is not None:
+            lf_client.create_score(
+                trace_id=trace_id,
+                name="user_feedback",
+                value=0.0,
+                data_type="NUMERIC",
+                comment=f"user_id:{user_id}",
+                score_id=f"{trace_id}-user_feedback",
+            )
+            lf_client.create_score(
+                trace_id=trace_id,
+                name="user_feedback_reason",
+                value=reason,
+                data_type="CATEGORICAL",
+                comment=f"user_id:{user_id}",
+                score_id=f"{trace_id}-user_feedback_reason",
+            )
+    except Exception:
+        logger.warning("Failed to write feedback reason score to Langfuse", exc_info=True)
+
+    try:
+        msg = callback.message
+        if msg is not None and hasattr(msg, "edit_reply_markup"):
+            await msg.edit_reply_markup(reply_markup=build_feedback_confirmation(liked=False))
+            cleanup_task = asyncio.create_task(
+                clear_feedback_confirmation_later(msg, FEEDBACK_CONFIRMATION_TTL_S)
+            )
+            cleanup_task.add_done_callback(lambda t: t.result() if not t.cancelled() else None)
+    except Exception:
+        logger.debug("Failed to update feedback keyboard after reason", exc_info=True)
+
+
+async def clear_feedback_confirmation_later(
+    message: Any,
+    delay_s: float = FEEDBACK_CONFIRMATION_TTL_S,
+) -> None:
+    """Clear feedback confirmation keyboard after a short delay."""
+    await asyncio.sleep(delay_s)
+    try:
+        await message.edit_reply_markup(reply_markup=None)
+    except Exception:
+        logger.debug("Failed to clear feedback confirmation keyboard", exc_info=True)
+
+
+__all__ = (
+    "FEEDBACK_CONFIRMATION_TTL_S",
+    "clear_feedback_confirmation_later",
+    "handle_feedback",
+    "handle_feedback_reason",
+)

--- a/telegram_bot/_bot_feedback_handlers.py
+++ b/telegram_bot/_bot_feedback_handlers.py
@@ -36,7 +36,6 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from telegram_bot.callback_data import FeedbackCB, FeedbackReasonCB
-from telegram_bot.observability import get_langfuse_client
 
 
 if TYPE_CHECKING:  # pragma: no cover — typing-only
@@ -46,6 +45,20 @@ if TYPE_CHECKING:  # pragma: no cover — typing-only
 
 
 logger = logging.getLogger(__name__)
+
+
+def _get_langfuse_client() -> Any:
+    """Resolve ``get_langfuse_client`` via ``telegram_bot.bot`` module.
+
+    Existing tests patch ``telegram_bot.bot.get_langfuse_client`` directly
+    (``patch.object(bot_module, "get_langfuse_client", ...)``). Looking the
+    function up through the bot module preserves that patch contract after
+    the PR-9a extraction. The lazy import is also necessary to avoid a
+    circular import: ``bot.py`` imports this helper module at startup.
+    """
+    from telegram_bot import bot as _bot_module
+
+    return _bot_module.get_langfuse_client()
 
 
 # Time-to-live for the post-feedback confirmation keyboard before it is
@@ -122,7 +135,7 @@ async def handle_feedback(
     user_id = callback.from_user.id if callback.from_user else 0
 
     try:
-        lf_client = get_langfuse_client()
+        lf_client = _get_langfuse_client()
         if lf_client is not None:
             lf_client.create_score(
                 trace_id=trace_id,
@@ -176,7 +189,7 @@ async def handle_feedback_reason(
     user_id = callback.from_user.id if callback.from_user else 0
 
     try:
-        lf_client = get_langfuse_client()
+        lf_client = _get_langfuse_client()
         if lf_client is not None:
             lf_client.create_score(
                 trace_id=trace_id,

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -106,6 +106,7 @@ from .middlewares.langfuse_middleware import LangfuseContextMiddleware
 from .observability import (
     create_callback_handler,
     get_client,
+    get_langfuse_client,  # noqa: F401 — re-export kept so legacy tests can patch telegram_bot.bot.get_langfuse_client (#2048 PR-9a)
     observe,
     propagate_attributes,
 )

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -71,6 +71,7 @@ from src.retrieval.topic_classifier import get_query_topic_hint
 
 from . import (
     _bot_error_classification,  # #1265 Slice 1 PR-3: extracted error-classification helpers
+    _bot_feedback_handlers,  # #2048 PR-9a: extracted feedback callback handlers
     _bot_kommo,  # #1265 Slice 1 PR-6: extracted Kommo startup helpers
     _bot_lifecycle,  # #1265 Slice 2 PR-8 / #2048: extracted lifecycle helpers
     _bot_observability,  # #1265 Slice 1 PR-2: extracted observability helpers
@@ -105,7 +106,6 @@ from .middlewares.langfuse_middleware import LangfuseContextMiddleware
 from .observability import (
     create_callback_handler,
     get_client,
-    get_langfuse_client,
     observe,
     propagate_attributes,
 )
@@ -3572,161 +3572,21 @@ class PropertyBot:
     async def handle_feedback(
         self, callback: CallbackQuery, callback_data: FeedbackCB | None = None
     ) -> None:
-        """Handle feedback like/dislike/done callback (#229, #755).
-
-        Supports CallbackData injection from aiogram DI, with legacy string fallback
-        for backward compatibility with tests and old-format buttons.
-        """
-        from .feedback import (
-            build_dislike_reason_keyboard,
-            build_feedback_confirmation,
-            parse_feedback_callback,
-        )
-
-        if callback_data is not None:
-            # New CallbackData path (aiogram DI injection)
-            if callback_data.action == "done":
-                await callback.answer()
-                return
-            if callback_data.action == "dislike":
-                # Step 1: show reason keyboard, score written in handle_feedback_reason
-                await callback.answer()
-                try:
-                    msg = callback.message
-                    if msg is not None and hasattr(msg, "edit_reply_markup"):
-                        await msg.edit_reply_markup(
-                            reply_markup=build_dislike_reason_keyboard(callback_data.trace_id)
-                        )
-                except Exception:
-                    logger.debug("Failed to show dislike reason keyboard", exc_info=True)
-                return
-            # "like" action: write score below
-            value: float = 1.0
-            trace_id: str = callback_data.trace_id
-            reason: str | None = None
-        else:
-            # Legacy fallback (tests and old-format buttons: fb:1/0:, fb:r:)
-            data = callback.data or ""
-            if data in ("fb:done", "fb:done:"):
-                await callback.answer()
-                return
-            parsed = parse_feedback_callback(data)
-            if parsed is None:
-                await callback.answer()
-                return
-            value, trace_id, reason = parsed
-
-            # Legacy dislike without reason → show reason keyboard
-            if value == 0.0 and reason is None:
-                await callback.answer()
-                try:
-                    msg = callback.message
-                    if msg is not None and hasattr(msg, "edit_reply_markup"):
-                        await msg.edit_reply_markup(
-                            reply_markup=build_dislike_reason_keyboard(trace_id)
-                        )
-                except Exception:
-                    logger.debug("Failed to show dislike reason keyboard", exc_info=True)
-                return
-
-        # Write score (like, or legacy reason path)
-        await callback.answer("Спасибо за отзыв!")
-        user_id = callback.from_user.id if callback.from_user else 0
-
-        try:
-            lf_client = get_langfuse_client()
-            if lf_client is not None:
-                lf_client.create_score(
-                    trace_id=trace_id,
-                    name="user_feedback",
-                    value=value,
-                    data_type="NUMERIC",
-                    comment=f"user_id:{user_id}",
-                    score_id=f"{trace_id}-user_feedback",
-                )
-                if reason is not None:
-                    lf_client.create_score(
-                        trace_id=trace_id,
-                        name="user_feedback_reason",
-                        value=reason,
-                        data_type="CATEGORICAL",
-                        comment=f"user_id:{user_id}",
-                        score_id=f"{trace_id}-user_feedback_reason",
-                    )
-        except Exception:
-            logger.warning("Failed to write feedback score to Langfuse", exc_info=True)
-
-        # Update keyboard to confirmation
-        liked = value > 0
-        try:
-            msg = callback.message
-            if msg is not None and hasattr(msg, "edit_reply_markup"):
-                await msg.edit_reply_markup(reply_markup=build_feedback_confirmation(liked=liked))
-                cleanup_task = asyncio.create_task(
-                    self._clear_feedback_confirmation_later(msg, _FEEDBACK_CONFIRMATION_TTL_S)
-                )
-                cleanup_task.add_done_callback(lambda t: t.result() if not t.cancelled() else None)
-        except Exception:
-            logger.debug("Failed to update feedback keyboard", exc_info=True)
+        """Thin wrapper — see ``_bot_feedback_handlers`` (#2048 PR-9a)."""
+        await _bot_feedback_handlers.handle_feedback(self, callback, callback_data)
 
     @observe(name="cb-feedback-reason", capture_input=False, capture_output=False)
     async def handle_feedback_reason(
         self, callback: CallbackQuery, callback_data: FeedbackReasonCB
     ) -> None:
-        """Handle dislike reason selection callback (#755)."""
-        from .feedback import _REASON_CODES, build_feedback_confirmation
-
-        reason = _REASON_CODES.get(callback_data.code)
-        if reason is None:
-            await callback.answer()
-            return
-
-        trace_id = callback_data.trace_id
-        await callback.answer("Спасибо за отзыв!")
-        user_id = callback.from_user.id if callback.from_user else 0
-
-        try:
-            lf_client = get_langfuse_client()
-            if lf_client is not None:
-                lf_client.create_score(
-                    trace_id=trace_id,
-                    name="user_feedback",
-                    value=0.0,
-                    data_type="NUMERIC",
-                    comment=f"user_id:{user_id}",
-                    score_id=f"{trace_id}-user_feedback",
-                )
-                lf_client.create_score(
-                    trace_id=trace_id,
-                    name="user_feedback_reason",
-                    value=reason,
-                    data_type="CATEGORICAL",
-                    comment=f"user_id:{user_id}",
-                    score_id=f"{trace_id}-user_feedback_reason",
-                )
-        except Exception:
-            logger.warning("Failed to write feedback reason score to Langfuse", exc_info=True)
-
-        try:
-            msg = callback.message
-            if msg is not None and hasattr(msg, "edit_reply_markup"):
-                await msg.edit_reply_markup(reply_markup=build_feedback_confirmation(liked=False))
-                cleanup_task = asyncio.create_task(
-                    self._clear_feedback_confirmation_later(msg, _FEEDBACK_CONFIRMATION_TTL_S)
-                )
-                cleanup_task.add_done_callback(lambda t: t.result() if not t.cancelled() else None)
-        except Exception:
-            logger.debug("Failed to update feedback keyboard after reason", exc_info=True)
+        """Thin wrapper — see ``_bot_feedback_handlers`` (#2048 PR-9a)."""
+        await _bot_feedback_handlers.handle_feedback_reason(self, callback, callback_data)
 
     async def _clear_feedback_confirmation_later(
         self, message: Any, delay_s: float = _FEEDBACK_CONFIRMATION_TTL_S
     ) -> None:
-        """Clear feedback confirmation button after a short delay."""
-        await asyncio.sleep(delay_s)
-        try:
-            await message.edit_reply_markup(reply_markup=None)
-        except Exception:
-            logger.debug("Failed to clear feedback confirmation keyboard", exc_info=True)
+        """Thin wrapper — see ``_bot_feedback_handlers`` (#2048 PR-9a)."""
+        await _bot_feedback_handlers.clear_feedback_confirmation_later(message, delay_s)
 
     @observe(name="cb-clearcache", capture_input=False, capture_output=False)
     async def handle_clearcache_callback(self, callback_query: CallbackQuery) -> None:

--- a/tests/contract/test_bot_feedback_handlers_extraction_contract.py
+++ b/tests/contract/test_bot_feedback_handlers_extraction_contract.py
@@ -1,0 +1,140 @@
+"""Contract: feedback handlers live in ``telegram_bot/_bot_feedback_handlers.py``.
+
+PR-9a of the Slice 2 decomposition plan
+(``docs/engineering/bot-decomposition-plan-2026-05-27.md``, parent
+#1265 / child #2048). Feedback callbacks are the first vertical of
+PropertyBot's callback layer to move off the god-object — keeping the
+class methods as thin wrappers preserves the aiogram dispatcher
+registration sites and the existing ``tests/unit/test_bot_handlers.py``
+suite.
+
+The contract pins:
+
+1. ``telegram_bot._bot_feedback_handlers`` exposes the three module-level
+   helpers ``handle_feedback`` / ``handle_feedback_reason`` /
+   ``clear_feedback_confirmation_later`` (all async).
+2. The module's top-level imports stay narrow — no aiogram /
+   langgraph / qdrant_client / fastapi at module scope.
+3. ``PropertyBot.handle_feedback`` / ``handle_feedback_reason`` /
+   ``_clear_feedback_confirmation_later`` delegate to the module-level
+   helpers (verified statically via AST).
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_NAME = "telegram_bot._bot_feedback_handlers"
+MODULE_PATH = REPO_ROOT / "telegram_bot" / "_bot_feedback_handlers.py"
+BOT_PATH = REPO_ROOT / "telegram_bot" / "bot.py"
+
+FORBIDDEN_TOP_IMPORTS = {
+    "aiogram",
+    "langgraph",
+    "langchain",
+    "qdrant_client",
+    "fastapi",
+}
+
+REQUIRED_HELPERS = (
+    "handle_feedback",
+    "handle_feedback_reason",
+    "clear_feedback_confirmation_later",
+)
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def test_module_exists_and_exports_required_helpers() -> None:
+    assert MODULE_PATH.is_file(), f"{MODULE_PATH.relative_to(REPO_ROOT)} must exist (#2048 PR-9a)."
+    module = importlib.import_module(MODULE_NAME)
+    for name in REQUIRED_HELPERS:
+        assert hasattr(module, name), f"{MODULE_NAME} must export {name}."
+        assert inspect.iscoroutinefunction(getattr(module, name)), (
+            f"{MODULE_NAME}.{name} must be async (`async def`)."
+        )
+
+
+def test_module_has_no_heavy_top_imports() -> None:
+    """Feedback helpers must stay cheap to import — no aiogram /
+    langchain / langgraph / qdrant_client / fastapi at module scope.
+    Lazy-import inside function bodies if needed."""
+    tree = _parse(MODULE_PATH)
+    offenders: list[str] = []
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                top = alias.name.split(".", 1)[0]
+                if top in FORBIDDEN_TOP_IMPORTS:
+                    offenders.append(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            module = (node.module or "").split(".", 1)[0]
+            if module in FORBIDDEN_TOP_IMPORTS:
+                offenders.append(node.module or "")
+    assert not offenders, (
+        f"{MODULE_PATH.relative_to(REPO_ROOT)} forbidden module-scope imports: {offenders}."
+    )
+
+
+def _find_class_method(tree: ast.Module, class_name: str, method_name: str) -> ast.AsyncFunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for item in node.body:
+                if isinstance(item, ast.AsyncFunctionDef) and item.name == method_name:
+                    return item
+    raise AssertionError(f"PropertyBot.{method_name} not found in bot.py")
+
+
+def _method_awaits_helper(method: ast.AsyncFunctionDef, helper_name: str) -> bool:
+    """True iff the method body awaits a call to ``helper_name``.
+
+    Accepted shapes:
+      * ``await _bot_feedback_handlers.HELPER(...)``
+      * ``await HELPER(...)`` (when imported by name)
+    """
+    for node in ast.walk(method):
+        if not isinstance(node, ast.Await):
+            continue
+        call = node.value
+        if not isinstance(call, ast.Call):
+            continue
+        func = call.func
+        if isinstance(func, ast.Name) and func.id == helper_name:
+            return True
+        if isinstance(func, ast.Attribute) and func.attr == helper_name:
+            return True
+    return False
+
+
+def test_handle_feedback_method_delegates() -> None:
+    tree = _parse(BOT_PATH)
+    method = _find_class_method(tree, "PropertyBot", "handle_feedback")
+    assert _method_awaits_helper(method, "handle_feedback"), (
+        "PropertyBot.handle_feedback must delegate to "
+        "telegram_bot._bot_feedback_handlers.handle_feedback."
+    )
+
+
+def test_handle_feedback_reason_method_delegates() -> None:
+    tree = _parse(BOT_PATH)
+    method = _find_class_method(tree, "PropertyBot", "handle_feedback_reason")
+    assert _method_awaits_helper(method, "handle_feedback_reason"), (
+        "PropertyBot.handle_feedback_reason must delegate to "
+        "telegram_bot._bot_feedback_handlers.handle_feedback_reason."
+    )
+
+
+def test_clear_feedback_confirmation_method_delegates() -> None:
+    tree = _parse(BOT_PATH)
+    method = _find_class_method(tree, "PropertyBot", "_clear_feedback_confirmation_later")
+    assert _method_awaits_helper(method, "clear_feedback_confirmation_later"), (
+        "PropertyBot._clear_feedback_confirmation_later must delegate to "
+        "telegram_bot._bot_feedback_handlers.clear_feedback_confirmation_later."
+    )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

PR-9a of the Slice 2 decomposition plan ([`docs/engineering/bot-decomposition-plan-2026-05-27.md`](https://github.com/yastman/rag/blob/dev/docs/engineering/bot-decomposition-plan-2026-05-27.md), parent #1265 / child #2048). First vertical of the callback-layer extraction — feedback handlers move off the `PropertyBot` god-object.

## Why feedback first

Feedback callbacks are a self-contained, well-tested vertical with clear boundaries (no shared state with menus, favourites or HITL). Extracting them first sets the pattern for PR-9b (favourites) and PR-9c (HITL/handoff) without forcing those riskier surfaces to share a single PR review.

## What landed

- **`telegram_bot/_bot_feedback_handlers.py`** — three module-level helpers, each taking `bot: PropertyBot` as the first arg:
  - `handle_feedback` — like / dislike / done routing + Langfuse score writes (legacy + CallbackData paths preserved)
  - `handle_feedback_reason` — dislike-reason follow-up
  - `clear_feedback_confirmation_later` — async TTL-driven keyboard cleanup
  - Module-level imports stay narrow: stdlib + `telegram_bot.callback_data` + `telegram_bot.observability` only

- **`telegram_bot/bot.py`** — `PropertyBot.handle_feedback` / `handle_feedback_reason` / `_clear_feedback_confirmation_later` are now thin delegates. Aiogram dispatcher registration in `_register_handlers` continues to bind `self.handle_feedback` / `self.handle_feedback_reason` directly (the dispatcher captures the bound method), and existing call-sites resolve unchanged via `bot._clear_feedback_confirmation_later`.

- **`tests/contract/test_bot_feedback_handlers_extraction_contract.py`** — pins:
  - module + helper presence (all three are `async def`)
  - no aiogram / langgraph / langchain / qdrant_client / fastapi at module scope
  - AST-verified delegation: `PropertyBot.handle_feedback` body awaits `_bot_feedback_handlers.handle_feedback`, etc.

## Verification

```
uv run --python 3.12 pytest \
  tests/contract/test_bot_feedback_handlers_extraction_contract.py \
  tests/unit/test_bot_handlers.py tests/unit/test_bot_scores.py \
  tests/unit/test_bot_observability.py \
  -q --timeout=30 -n auto --dist=worksteal
```
→ **251 passed in 27.94s**; ruff clean.

## bot.py shrinkage

| | LOC |
|---|---|
| before | 4574 |
| after | **4434** |

Δ −140 LOC; new helper module = 229 LOC.

## Out of scope (PR-9b / PR-9c)

- favourites callbacks (`handle_fav_*`, `handle_favorite_callback`) — separate vertical, depends on `_state_apartment_results` + `_favorites_service`
- card / results / bookmarks callbacks — separate vertical
- HITL / handoff callbacks (`handle_hitl_callback`, `_complete_handoff`, `_close_handoff`) — most stateful, last
- query handlers (`handle_query`, `_handle_query_supervisor`) — covered by PR-9b/9c per the bot-decomposition plan

Refs #2048, refs #1265