### PR TITLE
fix: stabilize local Langfuse and preflight runtime (#2179, #2182)

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -134,10 +134,11 @@ services:
       LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
       LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
       REDIS_AUTH: ${LANGFUSE_REDIS_PASSWORD:?LANGFUSE_REDIS_PASSWORD is required}
+      NODE_OPTIONS: ${NODE_OPTIONS:---max-old-space-size=1536}
     deploy:
       resources:
         limits:
-          memory: 1G
+          memory: 2G
 
   ingestion:
     profiles: ["ingest", "full"]

--- a/scripts/lf
+++ b/scripts/lf
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Langfuse CLI quick-audit recipes.
+#
+# Wraps `langfuse api ...` with the env-file load and adds curated
+# perf-audit views used during the "виды внж в болгарии" / 2026-05-26
+# investigation. Safe to extend.
+#
+# Requirements:
+#   - `langfuse-cli` installed (npm: langfuse-cli, binary: `langfuse`)
+#   - Repo `.env` with LANGFUSE_PUBLIC_KEY/SECRET_KEY/HOST set
+#
+# Usage:
+#   scripts/lf <command> [args...]
+#
+# Commands:
+#   health                              - Langfuse REST /health
+#   schema                              - List API resources/actions
+#   traces NAME [LIMIT]                 - List traces filtered by name
+#   trace ID                            - Fetch one trace with observations
+#   slowest [N]                         - Top-N slowest rag-pipeline / telegram-message traces
+#   stage-audit ID                      - Per-stage timing breakdown of a single trace
+#   orphans                             - Show recent top-level traces that should be nested
+#   prompts                             - List prompts in Langfuse
+#   skill                               - Print Langfuse skill from GitHub (for AI agents)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${LF_ENV_FILE:-$REPO_ROOT/.env}"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "lf: env file not found at $ENV_FILE (set LF_ENV_FILE to override)" >&2
+  exit 1
+fi
+
+LF=(langfuse --env "$ENV_FILE" api)
+
+cmd="${1:-}"
+shift || true
+
+case "$cmd" in
+  health)
+    "${LF[@]}" healths --help >/dev/null 2>&1 || true
+    # /health endpoint is exposed at /api/public/health, not via CLI subresource
+    # shellcheck disable=SC1090
+    set -a; source "$ENV_FILE" 2>/dev/null || true; set +a
+    : "${LANGFUSE_HOST:?}"
+    curl -fsS -o /dev/null -w "GET /api/public/health -> %{http_code} in %{time_total}s\n" \
+      "${LANGFUSE_HOST}/api/public/health"
+    ;;
+
+  schema)
+    "${LF[@]}" __schema "$@"
+    ;;
+
+  traces)
+    name="${1:-}"; shift || true
+    limit="${1:-20}"; shift || true
+    if [[ -n "$name" ]]; then
+      "${LF[@]}" traces list --name "$name" --limit "$limit" "$@"
+    else
+      "${LF[@]}" traces list --limit "$limit" "$@"
+    fi
+    ;;
+
+  trace)
+    : "${1:?lf trace <trace-id>}"
+    "${LF[@]}" traces get "$@"
+    ;;
+
+  slowest)
+    n="${1:-5}"
+    echo "=== top-$n slowest rag-pipeline traces ==="
+    "${LF[@]}" traces list --name rag-pipeline --limit 50 \
+      | jq --arg n "$n" '.data
+          | sort_by(-.latency)
+          | .[0:($n|tonumber)]
+          | map({id, timestamp, latencyMs: (.latency*1000|floor),
+                 userId, sessionId, observations: (.observations|length),
+                 cost: (.totalCost // 0)})'
+    echo
+    echo "=== top-$n slowest telegram-message traces ==="
+    "${LF[@]}" traces list --name telegram-message --limit 50 \
+      | jq --arg n "$n" '.data
+          | sort_by(-.latency)
+          | .[0:($n|tonumber)]
+          | map({id, timestamp, latencyMs: (.latency*1000|floor),
+                 userId, sessionId, observations: (.observations|length)})'
+    ;;
+
+  stage-audit)
+    : "${1:?lf stage-audit <trace-id>}"
+    tid="$1"
+    tmp="$(mktemp)"
+    trap 'rm -f "$tmp"' EXIT
+    "${LF[@]}" traces get "$tid" > "$tmp"
+    python3 - "$tmp" <<'PY'
+import json, sys
+from datetime import datetime
+from collections import defaultdict
+
+t = json.load(open(sys.argv[1]))
+obs = t.get("observations") or []
+
+def ms(o):
+    try:
+        a = datetime.fromisoformat(o["startTime"].replace("Z","+00:00"))
+        b = datetime.fromisoformat(o["endTime"].replace("Z","+00:00"))
+        return int((b - a).total_seconds() * 1000)
+    except Exception:
+        return 0
+
+print(f"trace={t.get('id')}  name={t.get('name')}  total={int((t.get('latency') or 0)*1000)}ms  obs={len(obs)}")
+inp = t.get("input")
+if isinstance(inp, dict):
+    qp = inp.get("query_preview") or inp.get("original_query_preview") or str(inp)[:120]
+else:
+    qp = str(inp)[:120]
+print(f"query={qp!r}\n")
+
+agg = defaultdict(lambda: {"count":0, "total_ms":0, "max_ms":0})
+for o in obs:
+    a = agg[o.get("name","?")]
+    d = ms(o)
+    a["count"] += 1
+    a["total_ms"] += d
+    a["max_ms"] = max(a["max_ms"], d)
+
+rows = sorted(agg.items(), key=lambda x: -x[1]["total_ms"])
+print(f"{'name':<42} {'cnt':>4} {'total':>8} {'max':>8} {'avg':>8}")
+for n, info in rows[:30]:
+    avg = info["total_ms"]/info["count"]
+    print(f"  {n:<40} {info['count']:>4} {int(info['total_ms']):>6}ms {int(info['max_ms']):>6}ms {int(avg):>6}ms")
+
+llm = sum(v["total_ms"] for n,v in agg.items() if n in ("OpenAI-generation","model","ChatOpenAI"))
+embed = sum(v["total_ms"] for n,v in agg.items() if "bge-m3" in n.lower())
+qdrant = sum(v["total_ms"] for n,v in agg.items() if n.startswith("qdrant"))
+print(f"\nLLM total: {int(llm)}ms   BGE-M3 total: {int(embed)}ms   Qdrant total: {int(qdrant)}ms")
+PY
+    ;;
+
+  orphans)
+    "${LF[@]}" traces list --limit 50 \
+      | jq '.data
+          | map(select(.userId == null and .sessionId == null
+                       and (.name | test("rag-pipeline|bge-m3|cache-|qdrant-|hybrid-retrieve|generate"))))
+          | map({id, name, timestamp, latencyMs: (.latency*1000|floor)})
+          | sort_by(.timestamp) | reverse | .[0:20]'
+    ;;
+
+  prompts)
+    "${LF[@]}" prompts list --limit "${1:-20}"
+    ;;
+
+  skill)
+    langfuse get-skill
+    ;;
+
+  ""|help|-h|--help)
+    grep -E "^#  " "$0" | sed 's/^#  /  /'
+    ;;
+
+  *)
+    echo "lf: unknown command '$cmd' (run 'lf help')" >&2
+    exit 2
+    ;;
+esac

--- a/tests/unit/test_compose_langfuse.py
+++ b/tests/unit/test_compose_langfuse.py
@@ -173,3 +173,59 @@ class TestLitellmCallbacks:
         assert "langfuse" in callbacks, (
             "docker/litellm/config.yaml: litellm_settings.failure_callback must include 'langfuse'"
         )
+
+
+class TestLangfuseMemoryLimits:
+    """Langfuse dev container must have enough memory to avoid Node heap OOM (#2179).
+
+    Advisory found v3.175.0 crashes with ``JavaScript heap out of memory`` at the
+    1GiB container limit.  Fix: at least 2GiB in compose.dev.yml, plus an explicit
+    ``NODE_OPTIONS=--max-old-space-size=1536`` for safety.
+    """
+
+    def test_dev_langfuse_memory_at_least_2gib(self, compose_dev: dict):
+        svc = compose_dev["services"]["langfuse"]
+        deploy = svc.get("deploy", {})
+        resources = deploy.get("resources", {})
+        limits = resources.get("limits", {})
+        memory_raw = limits.get("memory", "0")
+        mem_str = str(memory_raw).upper()
+
+        # Parse memory value (support "2G", "2g", "2048M", "2147483648")
+        if mem_str.endswith("G"):
+            mem_gib = float(mem_str[:-1])
+        elif mem_str.endswith("M"):
+            mem_gib = float(mem_str[:-1]) / 1024
+        else:
+            # Try raw bytes
+            try:
+                mem_gib = int(mem_str) / (1024**3)
+            except (ValueError, TypeError):
+                mem_gib = 0
+
+        assert mem_gib >= 2.0, (
+            f"compose.dev.yml langfuse service memory limit is {memory_raw!r} "
+            f"({mem_gib:.1f} GiB). The advisory found v3.175.0 crashes with "
+            f"Node heap OOM at 1 GiB.  Raise to at least 2G."
+        )
+
+    def test_dev_langfuse_node_options_heap_size(self, compose_dev: dict):
+        """Verify NODE_OPTIONS with --max-old-space-size is set for langfuse."""
+        env = _get_service_env(compose_dev, "langfuse")
+
+        node_opts = str(env.get("NODE_OPTIONS", ""))
+        assert "--max-old-space-size=" in node_opts, (
+            f"compose.dev.yml langfuse service must set "
+            f"NODE_OPTIONS=--max-old-space-size=<value> to prevent Node heap OOM. "
+            f"Got: {node_opts!r}"
+        )
+
+        # Extract the value and verify it's at least 1536
+        import re
+        match = re.search(r"--max-old-space-size=(\d+)", node_opts)
+        assert match, f"Could not parse --max-old-space-size from {node_opts!r}"
+        size_mb = int(match.group(1))
+        assert size_mb >= 1536, (
+            f"compose.dev.yml langfuse NODE_OPTIONS max-old-space-size is {size_mb} MB. "
+            f"Must be at least 1536 to prevent Node heap OOM at 2 GiB container limit."
+        )

--- a/tests/unit/test_scripts_lf.py
+++ b/tests/unit/test_scripts_lf.py
@@ -1,0 +1,92 @@
+"""Tests for scripts/lf — Langfuse CLI quick-audit recipes.
+
+Issue #2179: ``scripts/lf health`` must source ``.env`` before requiring
+``LANGFUSE_HOST``, otherwise it fails when the variable is only in ``.env``
+and not already in the shell environment.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LF_SCRIPT = REPO_ROOT / "scripts" / "lf"
+
+
+def _run_lf_health(
+    *,
+    env_file: Path,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``scripts/lf health`` with a controlled env file."""
+    env = os.environ.copy()
+    # Purge LANGFUSE_HOST so the test must rely on the env file
+    env.pop("LANGFUSE_HOST", None)
+    # And the other Langfuse vars to remove any ambient env
+    env.pop("LANGFUSE_PUBLIC_KEY", None)
+    env.pop("LANGFUSE_SECRET_KEY", None)
+    env["LF_ENV_FILE"] = str(env_file)
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["bash", str(LF_SCRIPT), "health"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+
+
+class TestLfHealthEnvLoading:
+    """scripts/lf health must source .env before checking LANGFUSE_HOST."""
+
+    def test_health_works_when_langfuse_host_only_in_env_file(self):
+        """If LANGFUSE_HOST is only in .env (not exported), health must not fail."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env_path = Path(tmpdir) / ".env"
+            env_path.write_text(
+                "LANGFUSE_HOST=http://localhost:9999\n"
+                "LANGFUSE_PUBLIC_KEY=pk-test\n"
+                "LANGFUSE_SECRET_KEY=sk-test\n"
+            )
+
+            result = _run_lf_health(env_file=env_path)
+
+            # The curl will likely fail (localhost:9999 not running), but
+            # it should NOT fail with a shell-level "LANGFUSE_HOST: parameter
+            # null or not set" error — that's the bug we're fixing.
+            # A shell parameter-expansion failure returns exit code 1 with stderr.
+            assert ": parameter null or not set" not in result.stderr, (
+                "scripts/lf health failed to source .env before checking LANGFUSE_HOST;\n"
+                f"stderr={result.stderr!r}"
+            )
+            # curl failure is expected (no real service), but not shell syntax error
+            assert "LANGFUSE_HOST" not in result.stderr.split(": parameter")[0] if ": parameter" in result.stderr else True
+
+    def test_health_sources_env_file_before_host_check(self):
+        """The env file must be sourced before the host variable is expanded."""
+        # Read the script to verify source order — structural check
+        content = LF_SCRIPT.read_text()
+        # Find the line order in the health case block
+        lines = content.split("\n")
+        host_check_line = -1
+        source_line = -1
+        for i, line in enumerate(lines):
+            if "LANGFUSE_HOST" in line and ":?" in line:
+                host_check_line = i
+            if "source" in line and "ENV_FILE" in line:
+                source_line = i
+
+        assert source_line >= 0, "scripts/lf must have a 'source $ENV_FILE' line"
+        assert host_check_line >= 0, "scripts/lf must check LANGFUSE_HOST"
+        assert source_line < host_check_line, (
+            f"scripts/lf must source .env (line {source_line}) "
+            f"before checking LANGFUSE_HOST (line {host_check_line}); "
+            f"current order is wrong — source is AFTER the variable check"
+        )


### PR DESCRIPTION
## Summary

Fixes two runtime blockers identified in the [Langfuse trace advisory](https://github.com/yastman/rag/issues/2179) and [BGE-M3 preflight issue](https://github.com/yastman/rag/issues/2182):

### Changes

1. **`scripts/lf health` env-load fix**: Moved `.env` sourcing **before** `LANGFUSE_HOST` check so the health command works when the variable is only in `.env` (not exported).

2. **Langfuse memory stabilization**: Raised `compose.dev.yml` Langfuse service memory from `1G` to `2G`, added `NODE_OPTIONS=--max-old-space-size=1536`. The advisory found v3.175.0 crashes with `JavaScript heap out of memory` at the 1GiB container limit.

3. **TDD coverage**: Added focused tests for both fixes.

### Verification

- `uv run pytest tests/unit/test_compose_langfuse.py -x -v` → **53 passed**
- `uv run pytest tests/contract/test_env_example_completeness_contract.py -x -v` → **4 passed**
- `uv run pytest tests/unit/config/test_bot_config_settings.py -x -v` → **19 passed**
- `uv run pytest tests/unit/test_scripts_lf.py -x -v` → **2 passed**
- `scripts/lf health` → correctly sources `.env` before checking `LANGFUSE_HOST`

### BGE-M3 Audit

Preflight (`telegram_bot/preflight.py`) and smoke tests (`tests/smoke/test_smoke_bge_litellm_cache.py`) already cover the expected BGE-M3 health and warmup contracts. Docs (`DOCKER.md`, `docs/LOCAL-DEVELOPMENT.md`) clearly document the local BGE-M3 service path. No changes needed.

### Blocked Items

- Full latest-trace audit remains blocked until Langfuse API is stable and traces are persisted.
- `make bot` cannot run in this isolated worktree (no `.env` with real credentials — expected).
- Docker compose not available in this environment for live validation of the 2G memory fix.