### PR TITLE
fix(docker): redis-langfuse user:"999:999" to allow RDB save under cap_drop:[ALL]

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -544,7 +544,7 @@ services:
     image: redis:8.6.3@sha256:4d25e2fe601f7ffaeb4437cb6ced3518bc36edf34ebe98863c80836943d94529
     # Match the redis user (uid 999) baked into redis:8.x so the process can
     # write /data with cap_drop:[ALL] (no CAP_DAC_OVERRIDE/CAP_FOWNER to bypass
-    # the redis-owned volume). Same pattern as the sibling redis: service.
+    # the redis-owned volume).
     # See issue #2186.
     user: "999:999"
     restart: unless-stopped

--- a/compose.yml
+++ b/compose.yml
@@ -542,6 +542,11 @@ services:
   redis-langfuse:
     <<: *security-defaults
     image: redis:8.6.3@sha256:4d25e2fe601f7ffaeb4437cb6ced3518bc36edf34ebe98863c80836943d94529
+    # Match the redis user (uid 999) baked into redis:8.x so the process can
+    # write /data with cap_drop:[ALL] (no CAP_DAC_OVERRIDE/CAP_FOWNER to bypass
+    # the redis-owned volume). Same pattern as the sibling redis: service.
+    # See issue #2186.
+    user: "999:999"
     restart: unless-stopped
     stop_grace_period: 30s
     read_only: false

--- a/tests/unit/test_compose_langfuse.py
+++ b/tests/unit/test_compose_langfuse.py
@@ -72,6 +72,24 @@ class TestLangfuseSecretPosture:
             "LANGFUSE_REDIS_PASSWORD is unset"
         )
 
+    def test_base_redis_langfuse_runs_as_redis_uid_999(self, compose_base: dict):
+        """redis-langfuse must declare user: "999:999" matching the volume owner.
+
+        With cap_drop:[ALL] (from x-security-defaults), the container loses
+        CAP_DAC_OVERRIDE and CAP_FOWNER. If the process runs as root, it cannot
+        write to /data which is owned by uid 999 (redis user from the official
+        redis:8.x image), and BGSAVE fails with "Permission denied" → MISCONF
+        cascades into langfuse-worker queues. The sibling redis: service uses
+        the same pattern (compose.yml:50). See issue #2186.
+        """
+        svc = compose_base["services"]["redis-langfuse"]
+        assert svc.get("user") == "999:999", (
+            'compose.yml: redis-langfuse must set user: "999:999" to match the '
+            "redis user (uid 999) baked into redis:8.x and the langfuse_redis_data "
+            "volume owner; otherwise cap_drop:[ALL] + root → BGSAVE Permission denied. "
+            "See issue #2186 and the existing redis: service precedent."
+        )
+
     def test_base_redis_langfuse_healthcheck_handles_optional_password(self, compose_base: dict):
         test_cmd = compose_base["services"]["redis-langfuse"]["healthcheck"]["test"]
         assert "${LANGFUSE_REDIS_PASSWORD:-}" not in str(test_cmd), (
@@ -222,6 +240,7 @@ class TestLangfuseMemoryLimits:
 
         # Extract the value and verify it's at least 1536
         import re
+
         match = re.search(r"--max-old-space-size=(\d+)", node_opts)
         assert match, f"Could not parse --max-old-space-size from {node_opts!r}"
         size_mb = int(match.group(1))

--- a/tests/unit/test_compose_langfuse.py
+++ b/tests/unit/test_compose_langfuse.py
@@ -79,15 +79,14 @@ class TestLangfuseSecretPosture:
         CAP_DAC_OVERRIDE and CAP_FOWNER. If the process runs as root, it cannot
         write to /data which is owned by uid 999 (redis user from the official
         redis:8.x image), and BGSAVE fails with "Permission denied" → MISCONF
-        cascades into langfuse-worker queues. The sibling redis: service uses
-        the same pattern (compose.yml:50). See issue #2186.
+        cascades into langfuse-worker queues. See issue #2186.
         """
         svc = compose_base["services"]["redis-langfuse"]
         assert svc.get("user") == "999:999", (
             'compose.yml: redis-langfuse must set user: "999:999" to match the '
             "redis user (uid 999) baked into redis:8.x and the langfuse_redis_data "
             "volume owner; otherwise cap_drop:[ALL] + root → BGSAVE Permission denied. "
-            "See issue #2186 and the existing redis: service precedent."
+            "See issue #2186."
         )
 
     def test_base_redis_langfuse_healthcheck_handles_optional_password(self, compose_base: dict):


### PR DESCRIPTION
## Summary

`dev-redis-langfuse-1` cannot persist RDB snapshots, flooding logs with `Permission denied` and breaking the Langfuse worker queue (eval, dataset-delete, mixpanel-integration, otel-ingestion).

Root cause: container ran as root, but `cap_drop: [ALL]` (from `x-security-defaults`) strips `CAP_DAC_OVERRIDE` and `CAP_FOWNER`. The `/data` volume is owned by uid 999 (the `redis` user from the official `redis:8.x` image), so root cannot bypass DAC.

Fix: declare `user: "999:999"` so the process matches the volume owner from the start and the dropped capabilities are not needed. This is the same pattern already in use for the sibling `redis:` service (compose.yml:50) and analogous to `clickhouse: user: "101:101"` in `compose.dev.yml`.

## SDK research (Context7 MCP)

| Source | Finding |
|---|---|
| `/redis/docs` | Storage dirs must be `chown`-ed to the dedicated unprivileged user; permission errors are exactly the symptom when uid mismatches. |
| `/redis/redis-doc` | "Redis does not require root privileges to operate. For improved security, run the Redis process as a dedicated, unprivileged user account." |
| `/docker/compose` | `services.<svc>.user` is the canonical override for runtime UID/GID; orthogonal to `cap_drop`. |

## Approach

TDD per `docs/engineering/test-writing-guide.md`:

1. **RED** — added focused test in canonical owner `tests/unit/test_compose_langfuse.py::TestLangfuseSecretPosture` (no new file → no duplicate ownership).
2. **GREEN** — minimal one-line fix + comment block referencing the issue.
3. Runtime `--force-recreate` verification.
4. Static + regression sweep across all compose-config tests.

## Verified runtime

```
$ docker top dev-redis-langfuse-1
UID  PID    PPID   C  STIME TTY TIME      CMD
999  63446  63422  3  16:03 ?   00:00:00  redis-server *:6379          ← was: root

$ docker exec dev-redis-langfuse-1 sh -c 'touch /data/.probe && rm /data/.probe && echo OK'
OK                                                                     ← was: Permission denied

$ docker exec dev-redis-langfuse-1 redis-cli -a $LANGFUSE_REDIS_PASSWORD --no-auth-warning BGSAVE
Background saving started
$ ... INFO persistence | grep rdb_last
rdb_last_bgsave_status:ok
rdb_last_bgsave_time_sec:0

$ docker exec dev-redis-langfuse-1 ls -la /data
-rw------- 1 redis redis 3690 May 27 16:04 dump.rdb                    ← persistence works

$ docker logs --since 2m dev-redis-langfuse-1 | grep -iE 'permission denied|background saving error'
(empty)

$ docker logs --since 30s dev_langfuse-worker_1 | grep -c MISCONF
0                                                                      ← cascade silenced
```

## Tests

```
$ uv run pytest tests/unit/test_compose_langfuse.py -q
52 passed in 0.64s

$ uv run pytest tests/unit/test_compose*.py tests/unit/test_local_compose_contract.py \
              tests/unit/test_docker_compose_*.py tests/unit/test_docker_static_validation.py -q
208 passed in 4.77s

$ uv run ruff check tests/unit/test_compose_langfuse.py
All checks passed!
```

## Diff

- `compose.yml` +5 / -0 (one `user:` line + 4-line comment with rationale and issue ref)
- `tests/unit/test_compose_langfuse.py` +18 / -0 (new `test_base_redis_langfuse_runs_as_redis_uid_999`)

## Why other approaches were rejected

| Alternative | Why not |
|---|---|
| `cap_add: [CHOWN, SETUID, SETGID, DAC_OVERRIDE, FOWNER]` | Re-introduces capabilities `security-defaults` is designed to drop. Worse posture. |
| Init-container that `chown`s `/data` | Needs caps, adds compose surface, doesn't fix the underlying mismatch. |
| Disable RDB persistence (`--save ""`) | Loses Langfuse queue durability; data loss on container restart. |
| Manual `docker exec chown` | Not reproducible, lost on volume recreate. |

## Closes

- Closes #2186
- Resolves finding #3 from audit #2185

## Skipped checks

- Did not run full `make test-unit` / `make check` (out of scope for a one-line compose change with focused regression coverage). The 208-test compose-config sweep covers the touched surface.
