### PR TITLE
docs(runbooks): canonical bge-m3 endpoint recovery for #2188

### DIFF
--- a/docs/runbooks/EMBEDDING_SERVICE_FAILURE.md
+++ b/docs/runbooks/EMBEDDING_SERVICE_FAILURE.md
@@ -154,6 +154,118 @@ Critical. Bot embedding calls have exhausted retries and are surfacing failures 
 2. If Voyage is optional, switch to local BGE-M3 fallback for ingestion.
 3. Coordinate with the API key owner before bumping the Voyage tier.
 
+### Canonical bge-m3 endpoint forwarding stuck on port 8000 (#2188 / #2182)
+
+> **Symptom:** `make bot` preflight fails with
+> `Preflight FAIL: bge_m3 [CRITICAL] ... Unreachable after 3 attempts: bge_m3`,
+> `curl http://localhost:8000/health` returns `Connection refused`, and
+> `docker compose ... ps bge-m3` shows no `dev-bge-m3-1` container — even
+> though the image is healthy and the model cache is warm. Tracked under
+> #2188; the upstream Docker Desktop port-forwarding-API stall is #2182.
+
+In this state operators commonly side-load a temporary container as a
+workaround:
+
+```bash
+# Workaround only — bge-m3-tmp binds 127.0.0.1:8888 -> container :8000
+docker run -d --rm --name bge-m3-tmp \
+  -p 127.0.0.1:8888:8000 \
+  -v dev_hf_cache:/models \
+  dev_bge-m3
+# .env (workaround line — must be removed after canonical restore):
+#   BGE_M3_URL=http://localhost:8888
+```
+
+The workaround unblocks `make bot` but leaves the canonical endpoint
+broken. Use the steps below to restore canonical `127.0.0.1:8000`
+forwarding so the side-load and the `.env` override can be retired.
+
+#### 1. Confirm the failure mode
+
+```bash
+# Canonical port should be free; canonical service should be missing.
+ss -lntp | awk '$4 ~ /:8000$|:8888$/ {print}'
+docker compose --env-file .env -f compose.yml -f compose.dev.yml ps bge-m3
+docker ps --filter name=bge-m3 --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
+curl -fsS --max-time 3 http://localhost:8000/health || echo "canonical endpoint down"
+```
+
+If the workaround container `bge-m3-tmp` shows up on `127.0.0.1:8888`
+and `dev-bge-m3-1` is missing from `compose ps`, you are in the #2188
+state and the recovery below applies.
+
+#### 2. Restart Docker forwarding
+
+```bash
+# macOS (Docker Desktop)
+osascript -e 'quit app "Docker"' && open -a Docker
+# Linux (Docker Engine)
+sudo systemctl restart docker
+# Windows (Docker Desktop)
+# Restart Docker Desktop from the tray icon, or:
+#   wsl --shutdown && start "" "C:\Program Files\Docker\Docker\Docker Desktop.exe"
+```
+
+Wait for the daemon to come back (`docker info` succeeds) before moving on.
+
+#### 3. Stop the workaround container
+
+```bash
+docker stop bge-m3-tmp 2>/dev/null || true
+docker rm   bge-m3-tmp 2>/dev/null || true
+ss -lntp | awk '$4 ~ /:8000$|:8888$/ {print}'   # both ports should now be free
+```
+
+#### 4. Recreate the canonical compose service
+
+```bash
+docker compose --env-file .env -f compose.yml -f compose.dev.yml up -d --force-recreate --no-deps bge-m3
+docker compose --env-file .env -f compose.yml -f compose.dev.yml ps bge-m3
+```
+
+The first cold start can take several minutes while the model download
+completes; the compose healthcheck has a `start_period: 420s` budget.
+
+#### 5. Verify the canonical endpoint
+
+```bash
+curl -fsS http://localhost:8000/health
+curl -fsS -X POST http://localhost:8000/encode/dense \
+  -H 'content-type: application/json' \
+  -d '{"texts": ["recovery probe"], "max_length": 64, "batch_size": 1}' | head -c 200
+```
+
+Both calls must succeed before continuing.
+
+#### 6. Remove the `.env` workaround override
+
+Edit `.env` and delete the temporary line plus its workaround comment so
+the bot picks up the canonical compose-internal default
+(`http://bge-m3:8000` for compose runs; `http://localhost:8000` for
+native bot runs):
+
+```diff
+- # Workaround: Docker Desktop forwards-API stuck on port 8000 (issue #2182).
+- # Temp bge-m3 container is bound to 8888. Remove this line after Docker daemon
+- # restart + `docker compose up -d --force-recreate --no-deps bge-m3`.
+- BGE_M3_URL=http://localhost:8888
+```
+
+`.env.example` documents the canonical default
+(`# BGE_M3_URL=http://localhost:8000`) — leave it commented out for
+local dev.
+
+#### 7. Re-validate the bot path
+
+```bash
+make test-bot-health
+make bot   # expect "Startup verdict: OK" without referencing port 8888
+```
+
+If `make test-bot-health` still flags `bge_m3`, repeat steps 1-5 with
+fresh diagnostics — do not re-introduce the `8888` override or the
+`bge-m3-tmp` container, or #2188 will silently recur.
+
 ## Prevention
 
 - Pre-warm the BGE-M3 model on container start so the first request after deploy is not slow.

--- a/tests/contract/test_runbook_bge_m3_canonical_endpoint_2188_contract.py
+++ b/tests/contract/test_runbook_bge_m3_canonical_endpoint_2188_contract.py
@@ -1,0 +1,156 @@
+"""Contract: ``EMBEDDING_SERVICE_FAILURE.md`` documents the canonical
+BGE-M3 endpoint recovery procedure for issue #2188.
+
+Issue #2188 ("Restore canonical BGE-M3 compose endpoint on
+``localhost:8000``") describes a recurring local-development failure
+mode: the canonical compose service ``dev-bge-m3-1`` cannot bind
+``127.0.0.1:8000`` because Docker Desktop's port-forwarding API is
+stuck (tracked under #2182), so an operator side-loads a temporary
+``bge-m3-tmp`` container on ``127.0.0.1:8888`` and overrides
+``BGE_M3_URL=http://localhost:8888`` in ``.env``.
+
+The acceptance criteria call for an operational restore:
+
+* recreate the canonical compose service so port ``8000`` is bound;
+* verify ``curl -fsS http://localhost:8000/health`` returns healthy;
+* stop / remove the temporary ``bge-m3-tmp`` container;
+* remove the ``BGE_M3_URL=http://localhost:8888`` override;
+* re-run ``make test-bot-health`` and confirm preflight passes.
+
+For the recovery to be reproducible across operators and shifts, the
+existing embedding-service runbook must spell out these steps verbatim.
+This contract pins the runbook so future edits cannot silently drop the
+recovery procedure or its diagnostic markers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNBOOK = REPO_ROOT / "docs" / "runbooks" / "EMBEDDING_SERVICE_FAILURE.md"
+
+
+REQUIRED_MARKERS: tuple[tuple[str, str], ...] = (
+    # Issue references: anchor the section to the tracked work.
+    ("#2188", "links the recovery section to issue #2188"),
+    ("#2182", "links the recovery section to the upstream Docker forwarding bug"),
+    # Section heading: operators should be able to grep for the failure name.
+    (
+        "Canonical bge-m3 endpoint",
+        "section heading naming the canonical-endpoint recovery procedure",
+    ),
+    # Diagnostic markers: surface the symptoms before the fix.
+    (
+        "127.0.0.1:8000",
+        "names the canonical host:port operators must restore",
+    ),
+    (
+        "bge-m3-tmp",
+        "names the temporary side-loaded container that must be removed",
+    ),
+    (
+        "BGE_M3_URL=http://localhost:8888",
+        "calls out the temporary .env override that must be removed",
+    ),
+    # Recovery commands: pinned verbatim so on-call can copy/paste.
+    (
+        "docker compose --env-file .env -f compose.yml -f compose.dev.yml up -d --force-recreate --no-deps bge-m3",
+        "documents the canonical recreate command from the issue",
+    ),
+    (
+        "curl -fsS http://localhost:8000/health",
+        "documents the canonical health probe command from the issue",
+    ),
+    (
+        "make test-bot-health",
+        "documents the post-restore validation step",
+    ),
+)
+
+
+@pytest.fixture(scope="module")
+def runbook_text() -> str:
+    assert RUNBOOK.exists(), f"runbook missing at {RUNBOOK}"
+    return RUNBOOK.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("marker", "purpose"),
+    REQUIRED_MARKERS,
+    ids=[purpose for _, purpose in REQUIRED_MARKERS],
+)
+def test_runbook_documents_canonical_endpoint_recovery(
+    runbook_text: str, marker: str, purpose: str
+) -> None:
+    assert marker in runbook_text, (
+        f"{RUNBOOK.relative_to(REPO_ROOT)} is missing required marker for "
+        f"#2188 canonical-endpoint recovery: {purpose!r}. "
+        f"Expected substring not found: {marker!r}."
+    )
+
+
+def _extract_recovery_section(runbook_text: str) -> str:
+    """Return the substring covering the #2188 recovery section.
+
+    The section is delimited by its named ``###`` heading and the next
+    sibling ``##`` heading (typically ``## Prevention``). Scoping the
+    ordering assertion to this slice prevents earlier mentions of
+    ``make test-bot-health`` (e.g. the Fast-Path Diagnosis block) from
+    bleeding into the check.
+    """
+    heading = "### Canonical bge-m3 endpoint"
+    start = runbook_text.find(heading)
+    assert start >= 0, (
+        "recovery section heading not found in "
+        f"{RUNBOOK.relative_to(REPO_ROOT)}; expected to start with {heading!r}."
+    )
+    rest = runbook_text[start:]
+    # Stop at the next sibling ``## ``-level heading.
+    next_section = rest.find("\n## ", 1)
+    return rest if next_section < 0 else rest[:next_section]
+
+
+def test_runbook_recovery_section_lists_acceptance_steps(runbook_text: str) -> None:
+    """The recovery section must enumerate the issue's acceptance steps in order.
+
+    The section may use any prose, but the canonical recreate command must
+    appear *before* the canonical health probe, which must appear before the
+    .env override removal, which must appear before ``make test-bot-health``.
+    This mirrors the operational order from the issue body.
+    """
+    section = _extract_recovery_section(runbook_text)
+    recreate = (
+        "docker compose --env-file .env -f compose.yml -f compose.dev.yml "
+        "up -d --force-recreate --no-deps bge-m3"
+    )
+    health = "curl -fsS http://localhost:8000/health"
+    override = "BGE_M3_URL=http://localhost:8888"
+    revalidate = "make test-bot-health"
+
+    positions = {
+        name: section.find(token)
+        for name, token in (
+            ("recreate", recreate),
+            ("health", health),
+            ("override", override),
+            ("revalidate", revalidate),
+        )
+    }
+    missing = [name for name, pos in positions.items() if pos < 0]
+    assert not missing, (
+        f"recovery section is missing acceptance-step tokens: {missing}. "
+        "All four steps from #2188 must appear in the recovery section."
+    )
+    assert positions["recreate"] < positions["health"] < positions["revalidate"], (
+        "Recovery steps appear out of order in "
+        f"{RUNBOOK.relative_to(REPO_ROOT)} #2188 section; expected: "
+        f"recreate -> health -> revalidate. Got positions: {positions}."
+    )
+    assert positions["override"] < positions["revalidate"], (
+        "The .env override removal must be documented before the post-restore "
+        f"`make test-bot-health` step in {RUNBOOK.relative_to(REPO_ROOT)}."
+    )


### PR DESCRIPTION
Closes part of #2188 — adds the missing recovery runbook + regression contract; the operational restore on `127.0.0.1:8000` itself remains for the host operator (see "Verification" below).

## What this PR adds

- A new **"Canonical bge-m3 endpoint forwarding stuck on port 8000 (#2188 / #2182)"** section in `docs/runbooks/EMBEDDING_SERVICE_FAILURE.md`, inserted before `Prevention`.
  - Symptoms (preflight CRITICAL, `connection refused` on `:8000`, missing `dev-bge-m3-1`, `bge-m3-tmp` on `:8888`, `BGE_M3_URL=http://localhost:8888` override).
  - Per-OS Docker forwarding restart command (Docker Desktop on macOS / Linux engine / Windows).
  - Stop / remove the `bge-m3-tmp` side-load.
  - Canonical recreate: `docker compose --env-file .env -f compose.yml -f compose.dev.yml up -d --force-recreate --no-deps bge-m3`.
  - Verify `curl -fsS http://localhost:8000/health` and a warm `/encode/dense` probe.
  - Diff-style guidance for removing the temp `.env` override.
  - Re-validate with `make test-bot-health` and `make bot` (Startup verdict: OK without `:8888`).

- A new contract test `tests/contract/test_runbook_bge_m3_canonical_endpoint_2188_contract.py` that pins the runbook so future edits cannot silently lose the recovery procedure:
  - 9 parametrised marker checks (issue refs `#2188` / `#2182`, section heading, `127.0.0.1:8000`, `bge-m3-tmp`, `BGE_M3_URL=http://localhost:8888`, the canonical recreate command, `curl -fsS http://localhost:8000/health`, `make test-bot-health`).
  - 1 ordering check scoped to the recovery section: recreate → health → revalidate, with the `.env` override removal documented before `make test-bot-health`.
  - Section is extracted between its `### Canonical bge-m3 endpoint ...` heading and the next sibling `## ` heading so unrelated earlier mentions of `make test-bot-health` (in Fast-Path Diagnosis) don't pollute the ordering check.

## TDD evidence

```text
# Red — runbook section did not yet exist
$ uv run --python 3.12 pytest tests/contract/test_runbook_bge_m3_canonical_endpoint_2188_contract.py -q
9 failed, 1 passed in 0.13s

# Green — after adding the recovery section
$ uv run --python 3.12 pytest tests/contract/test_runbook_bge_m3_canonical_endpoint_2188_contract.py -q
10 passed in 0.04s

# Existing runbook structural contract still passes
$ uv run --python 3.12 pytest tests/contract/test_runbooks_1960_1964_contract.py -q
15 passed in 0.05s

# Lint / types clean on touched files
$ uv run --python 3.12 ruff check tests/contract/test_runbook_bge_m3_canonical_endpoint_2188_contract.py
All checks passed!
$ uv run --python 3.12 ruff format --check tests/contract/test_runbook_bge_m3_canonical_endpoint_2188_contract.py
1 file already formatted
$ uv run --python 3.12 mypy tests/contract/test_runbook_bge_m3_canonical_endpoint_2188_contract.py
Success: no issues found in 1 source file
```

## Operational restore — status

Attempted on this host while authoring the PR. The recreate command reproduced the exact #2182 stall the runbook documents:

```text
$ docker compose --env-file .env -f compose.yml -f compose.dev.yml up -d --force-recreate --no-deps bge-m3
 Container dev-bge-m3-1 Created
 Container dev-bge-m3-1 Starting
Error response from daemon: ports are not available: exposing port TCP 127.0.0.1:8000 -> 127.0.0.1:0: /forwards/expose returned unexpected status: 500
```

Resolving this requires restarting Docker Desktop / the Docker daemon on the host, which is destructive (kills every running container, including the user's healthy `postgres`, `qdrant`, `langfuse`, `litellm`, `redis-langfuse`, `clickhouse`, `minio` stack). I did not perform that unilaterally. The `bge-m3-tmp` workaround was restored on `127.0.0.1:8888` (healthy), and the `.env` `BGE_M3_URL=http://localhost:8888` override was left in place so `make bot` continues to work.

The remaining acceptance-criteria items from #2188 (canonical `:8000` health check, `.env` override removal, `make test-bot-health` / `make bot` without `:8888`) are operator-side actions that the runbook now describes step-by-step. They should be performed in a follow-up after the host operator restarts Docker Desktop, and #2188 can then be closed.

## Files changed

- `docs/runbooks/EMBEDDING_SERVICE_FAILURE.md` (+112 lines)
- `tests/contract/test_runbook_bge_m3_canonical_endpoint_2188_contract.py` (+156 lines, new)

## Risk

Documentation + contract test only. No runtime/code paths touched. Affects local dev and CI contract suite; no production behavior change.
