### PR TITLE
fix(preflight): fail fast on Redis polling lock (#2189)

### DIFF
--- a/scripts/probe/check_bot_runtime_env.py
+++ b/scripts/probe/check_bot_runtime_env.py
@@ -144,14 +144,16 @@ def _check_polling_lock_probe(env_file: Path) -> list[str]:
     try:
         import redis
 
+        from telegram_bot.integrations.polling_lock import POLLING_LOCK_KEY
+
         r = redis.from_url(redis_url, decode_responses=True, socket_connect_timeout=3)
-        owner = r.get("telegram-bot:polling")
+        owner = r.get(POLLING_LOCK_KEY)
         if owner is None:
             issues.append("  Polling lock: free  ✓")
         else:
-            pttl = r.pttl("telegram-bot:polling")
+            pttl = r.pttl(POLLING_LOCK_KEY)
             issues.append("  Polling lock: BUSY  ✗")
-            issues.append("    key: telegram-bot:polling")
+            issues.append(f"    key: {POLLING_LOCK_KEY}")
             issues.append(f"    owner: {owner}")
             issues.append(f"    pttl_ms: {pttl}")
             issues.append(

--- a/scripts/probe/check_bot_runtime_env.py
+++ b/scripts/probe/check_bot_runtime_env.py
@@ -128,6 +128,46 @@ def _check_telegram_token(env_file: Path) -> list[str]:
     return issues
 
 
+def _check_polling_lock_probe(env_file: Path) -> list[str]:
+    """Check if a Redis polling lock is held by another bot instance (issue #2189)."""
+    issues: list[str] = []
+    redis_url = _read_env_var(env_file, "REDIS_URL")
+    if not redis_url:
+        redis_password = _read_env_var(env_file, "REDIS_PASSWORD") or ""
+        redis_host = _read_env_var(env_file, "REDIS_HOST") or "localhost"
+        redis_port = _read_env_var(env_file, "REDIS_PORT") or "6379"
+        if redis_password:
+            redis_url = f"redis://:{redis_password}@{redis_host}:{redis_port}/0"
+        else:
+            redis_url = f"redis://{redis_host}:{redis_port}/0"
+
+    try:
+        import redis
+
+        r = redis.from_url(redis_url, decode_responses=True, socket_connect_timeout=3)
+        owner = r.get("telegram-bot:polling")
+        if owner is None:
+            issues.append("  Polling lock: free  ✓")
+        else:
+            pttl = r.pttl("telegram-bot:polling")
+            issues.append("  Polling lock: BUSY  ✗")
+            issues.append("    key: telegram-bot:polling")
+            issues.append(f"    owner: {owner}")
+            issues.append(f"    pttl_ms: {pttl}")
+            issues.append(
+                "    Remediation: stop the other bot process if alive, "
+                "or wait for TTL expiry. Do NOT delete the key manually "
+                "unless you are certain the owner process is dead."
+            )
+        r.close()
+    except ImportError:
+        issues.append("  Polling lock: skipped (redis package not available)")
+    except Exception as exc:
+        issues.append(f"  Polling lock: skipped (Redis unreachable: {exc})")
+
+    return issues
+
+
 def _check_litellm_port() -> list[str]:
     """Check whether LiteLLM port 4000 is published on the Docker host.
 
@@ -267,6 +307,14 @@ def main(argv: list[str] | None = None) -> NoReturn:
 
     # TELEGRAM_BOT_TOKEN
     all_issues.extend(_check_telegram_token(env_file))
+
+    all_issues.append("")
+
+    # Polling lock (issue #2189)
+    if args.skip_docker:
+        all_issues.append("  Polling lock: skipped (--skip-docker)")
+    else:
+        all_issues.extend(_check_polling_lock_probe(env_file))
 
     all_issues.append("")
 

--- a/scripts/probe/check_bot_runtime_env.py
+++ b/scripts/probe/check_bot_runtime_env.py
@@ -144,7 +144,7 @@ def _check_polling_lock_probe(env_file: Path) -> list[str]:
     try:
         import redis
 
-        from telegram_bot.integrations.polling_lock import POLLING_LOCK_KEY
+        from src.runtime.integrations.polling_lock import POLLING_LOCK_KEY
 
         r = redis.from_url(redis_url, decode_responses=True, socket_connect_timeout=3)
         owner = r.get(POLLING_LOCK_KEY)

--- a/src/runtime/integrations/polling_lock.py
+++ b/src/runtime/integrations/polling_lock.py
@@ -1,0 +1,8 @@
+"""Shared polling-lock constants for bot and preflight tooling."""
+
+from __future__ import annotations
+
+
+# Canonical Redis key for the bot polling lock. Keep this in ``src.runtime`` so
+# out-of-process scripts do not import ``telegram_bot`` runtime modules.
+POLLING_LOCK_KEY = "telegram-bot:polling"

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -96,7 +96,7 @@ from .integrations.memory import (
     end_checkpoint_overhead_capture,
     sum_checkpoint_overhead_ms,
 )
-from .integrations.polling_lock import RedisPollingLock
+from .integrations.polling_lock import POLLING_LOCK_KEY, RedisPollingLock
 from .keyboards.client_keyboard import (
     parse_menu_button,
 )
@@ -4262,7 +4262,7 @@ class PropertyBot:
         if self._cache.redis is not None:
             self._polling_lock = RedisPollingLock(
                 redis=self._cache.redis,
-                key="telegram-bot:polling",
+                key=POLLING_LOCK_KEY,
             )
             self._polling_lock_owner = f"{socket.gethostname()}:{os.getpid()}"
             await self._polling_lock.acquire(self._polling_lock_owner)

--- a/telegram_bot/integrations/polling_lock.py
+++ b/telegram_bot/integrations/polling_lock.py
@@ -4,11 +4,10 @@ import inspect
 from dataclasses import dataclass, field
 from typing import Any
 
+from src.runtime.integrations.polling_lock import POLLING_LOCK_KEY
 
-# Canonical Redis key for the bot polling lock. Single source of truth shared
-# between the lock implementation, preflight probe (telegram_bot.preflight.
-# check_polling_lock), and PropertyBot.start (#2189).
-POLLING_LOCK_KEY = "telegram-bot:polling"
+
+__all__ = ["POLLING_LOCK_KEY", "PollingLockBusy", "RedisPollingLock"]
 
 
 class PollingLockBusy(RuntimeError):

--- a/telegram_bot/integrations/polling_lock.py
+++ b/telegram_bot/integrations/polling_lock.py
@@ -5,6 +5,12 @@ from dataclasses import dataclass, field
 from typing import Any
 
 
+# Canonical Redis key for the bot polling lock. Single source of truth shared
+# between the lock implementation, preflight probe (telegram_bot.preflight.
+# check_polling_lock), and PropertyBot.start (#2189).
+POLLING_LOCK_KEY = "telegram-bot:polling"
+
+
 class PollingLockBusy(RuntimeError):
     """Raised when another polling owner is already active."""
 

--- a/telegram_bot/preflight.py
+++ b/telegram_bot/preflight.py
@@ -16,6 +16,7 @@ from qdrant_client import AsyncQdrantClient, models
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from .config import BotConfig
+from .integrations.polling_lock import POLLING_LOCK_KEY
 from .startup_status import DependencyCheckResult, StartupReport, StartupSeverity, StartupSignal
 
 
@@ -618,8 +619,6 @@ async def check_dependencies(
 # ---------------------------------------------------------------------------
 # Polling lock pre-start guard (issue #2189)
 # ---------------------------------------------------------------------------
-
-POLLING_LOCK_KEY = "telegram-bot:polling"
 
 
 async def check_polling_lock(

--- a/telegram_bot/preflight.py
+++ b/telegram_bot/preflight.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 from enum import StrEnum
+from typing import Any
 from urllib.parse import urlparse
 
 import asyncpg
@@ -612,3 +613,28 @@ async def check_dependencies(
         raise PreflightError(critical_failures, report=report)
 
     return DependencyCheckResult(results, report=report)
+
+
+# ---------------------------------------------------------------------------
+# Polling lock pre-start guard (issue #2189)
+# ---------------------------------------------------------------------------
+
+POLLING_LOCK_KEY = "telegram-bot:polling"
+
+
+async def check_polling_lock(
+    redis: Any,
+    key: str = POLLING_LOCK_KEY,
+) -> dict[str, Any] | None:
+    """Check if a Redis polling lock is held without acquiring or deleting it.
+
+    Returns None when no lock exists, or a diagnostics dict with key, owner,
+    and pttl_ms when the lock is active.
+    """
+    owner = await redis.get(key)
+    if owner is None:
+        return None
+    if isinstance(owner, bytes):
+        owner = owner.decode("utf-8", errors="replace")
+    pttl = await redis.pttl(key)
+    return {"key": key, "owner": owner, "pttl_ms": pttl}

--- a/tests/unit/scripts/test_check_bot_runtime_env.py
+++ b/tests/unit/scripts/test_check_bot_runtime_env.py
@@ -216,6 +216,14 @@ def test_script_has_shebang_and_main_guard() -> None:
     )
 
 
+def test_script_does_not_import_telegram_bot_runtime_modules() -> None:
+    """Scripts are out-of-process tools and must not import telegram_bot runtime modules."""
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert "from telegram_bot" not in text
+    assert "import telegram_bot" not in text
+
+
 def test_script_provides_help() -> None:
     """The script must support --help for operator documentation."""
     cp = subprocess.run(

--- a/tests/unit/test_preflight_polling_lock.py
+++ b/tests/unit/test_preflight_polling_lock.py
@@ -1,0 +1,71 @@
+"""Tests for the polling-lock preflight guard (issue #2189).
+
+The guard must detect an existing Redis polling lock BEFORE full bot
+startup and report key, owner, PTTL, and remediation without deleting
+the lock.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from telegram_bot.preflight import check_polling_lock
+
+
+@pytest.mark.asyncio
+async def test_no_lock_returns_none() -> None:
+    """When no polling lock exists, the guard returns None (no issue)."""
+    redis = MagicMock()
+    redis.get = AsyncMock(return_value=None)
+    result = await check_polling_lock(redis)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_lock_exists_returns_diagnostics() -> None:
+    """When a polling lock exists, the guard returns diagnostics dict."""
+    redis = MagicMock()
+    redis.get = AsyncMock(return_value=b"WIN-HOST:12345")
+    redis.pttl = AsyncMock(return_value=70000)
+    result = await check_polling_lock(redis)
+    assert result is not None
+    assert result["key"] == "telegram-bot:polling"
+    assert result["owner"] == "WIN-HOST:12345"
+    assert result["pttl_ms"] == 70000
+
+
+@pytest.mark.asyncio
+async def test_lock_exists_with_no_expiry() -> None:
+    """When the lock has no TTL (-1), diagnostics still returned."""
+    redis = MagicMock()
+    redis.get = AsyncMock(return_value=b"host:999")
+    redis.pttl = AsyncMock(return_value=-1)
+    result = await check_polling_lock(redis)
+    assert result is not None
+    assert result["pttl_ms"] == -1
+    assert result["owner"] == "host:999"
+
+
+@pytest.mark.asyncio
+async def test_does_not_delete_lock() -> None:
+    """The guard must NOT delete the lock automatically."""
+    redis = MagicMock()
+    redis.get = AsyncMock(return_value=b"host:123")
+    redis.pttl = AsyncMock(return_value=50000)
+    redis.delete = AsyncMock()
+    await check_polling_lock(redis)
+    redis.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_custom_key() -> None:
+    """The guard accepts a custom key name."""
+    redis = MagicMock()
+    redis.get = AsyncMock(return_value=b"owner:1")
+    redis.pttl = AsyncMock(return_value=1000)
+    result = await check_polling_lock(redis, key="custom:lock")
+    assert result is not None
+    assert result["key"] == "custom:lock"
+    redis.get.assert_awaited_once_with("custom:lock")


### PR DESCRIPTION
## Summary

Add a pre-start guard that detects an existing `telegram-bot:polling` Redis lock before full bot initialization.

## Changes

- **telegram_bot/preflight.py**: Add `check_polling_lock()` — probes key via GET + PTTL without acquiring or deleting.
- **scripts/probe/check_bot_runtime_env.py**: Integrate polling lock check into `make preflight-bot` flow.
- **tests/unit/test_preflight_polling_lock.py**: 5 focused unit tests covering: no lock, lock exists, no-expiry lock, no-delete guarantee, custom key.

## Acceptance

- `make preflight-bot` detects existing lock with key, owner, PTTL, and remediation.
- Guard does NOT auto-delete the lock.
- `make bot` still starts normally when no lock exists.

## Tested

```
pytest tests/unit/test_preflight_polling_lock.py — 5 passed
pytest tests/unit/integrations/test_polling_lock.py — 4 passed
pytest tests/unit/scripts/test_check_bot_runtime_env.py — 13 passed
ruff check — all passed
```

Closes #2189