### PR TITLE
fix(metrics): change default port from 9091 to 9092 (#2190)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -181,7 +181,7 @@ BOT_USERNAME=
 # Prometheus metrics ASGI server (#2057). Internal-only; not exposed publicly.
 # Gate: set to 0/false/no to disable. Default 1 (enabled) for production.
 # TELEGRAM_BOT_METRICS_ENABLED=1
-# TELEGRAM_BOT_METRICS_PORT=9091
+# TELEGRAM_BOT_METRICS_PORT=9092
 SUPERVISOR_MAX_TOKENS=1024
 # TTFT drift warning threshold (ms). Raise for reasoning models behind proxy (#675)
 TTFT_DRIFT_WARN_MS=500

--- a/docs/engineering/2026-05-25-backlog-closeout.md
+++ b/docs/engineering/2026-05-25-backlog-closeout.md
@@ -71,6 +71,8 @@ The remaining `build_graph` migration is the slice-5 target of #2049 and natural
 
 Slice 4 needs a live runtime to verify (`curl http://localhost:9091/metrics`); it correctly stays open as a separate runtime-verify issue. Closing #1648 with handoff to #2057 minimises duplication.
 
+> Note (#2190, 2026-05-27): the default metrics port has since moved to **9092** to avoid the MinIO console collision. The 9091 example above is preserved as the historical state at the time #2057 was scoped.
+
 ### #1538 — informational audit, conclusions pinned in ADR-0015 ✅
 
 The audit's "SDK-native baseline" / "tracked migrations" / "justified custom code" tables are reproduced in `docs/adr/0015-sdk-native-baseline.md` so the policy survives the issue closing. Active migrations are referenced via their own tracker issues (#1535, #2050-2052).

--- a/docs/engineering/sdk-registry.md
+++ b/docs/engineering/sdk-registry.md
@@ -414,7 +414,7 @@ paths: "telegram_bot/**,src/**,mini_app/**,pyproject.toml"
 - **gotchas:**
   - НЕ создавать кастомный ``CollectorRegistry()`` — ломает скрапинг через ``make_asgi_app``
   - НЕ писать кастомный HTTP-сервер для метрик — использовать ``make_asgi_app()`` + ``uvicorn``
-  - ``TELEGRAM_BOT_METRICS_PORT`` (default 9091) — internal-only exposure
+  - ``TELEGRAM_BOT_METRICS_PORT`` (default 9092) — internal-only exposure
   - Контрактный тест: ``tests/contract/test_no_custom_metrics_registry_contract.py``
 
 ---

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -531,7 +531,8 @@ class PropertyBot:
         # Prometheus metrics ASGI server (#2057).
         # Started in start() alongside the aiogram polling loop and
         # exposes the default prometheus_client.REGISTRY on
-        # TELEGRAM_BOT_METRICS_PORT (default 9091).
+        # TELEGRAM_BOT_METRICS_PORT (default 9092 — 9091 collides with
+        # MinIO console; see #2190).
         self._metrics_server: Any | None = None
 
         # Bounded fan-out for fire-and-forget history persistence (#1600).

--- a/telegram_bot/handlers/command_handlers.py
+++ b/telegram_bot/handlers/command_handlers.py
@@ -27,6 +27,7 @@ from aiogram.types import (
     Message,
 )
 
+from telegram_bot.metrics_server import resolve_metrics_port
 from telegram_bot.observability import get_client, observe, propagate_attributes
 from telegram_bot.scoring import write_history_scores
 from telegram_bot.tracing_context import make_session_id
@@ -87,6 +88,7 @@ async def cmd_start(
 
 async def cmd_help(bot: PropertyBot, message: Message) -> None:
     """Handle /help command."""
+    metrics_port = resolve_metrics_port()
     await message.answer(
         "\U0001f50d Примеры запросов:\n\n"
         "По цене:\n"
@@ -107,7 +109,7 @@ async def cmd_help(bot: PropertyBot, message: Message) -> None:
         "/stats - Показать статистику кеша\n"
         "/history <запрос> - Поиск по истории диалогов\n"
         "/metrics - Метрики пайплайна (Prometheus)\n"
-        "HTTP: http://localhost:9091/metrics (Prometheus scrape endpoint)\n"
+        f"HTTP: http://localhost:{metrics_port}/metrics (Prometheus scrape endpoint)\n"
         "/clearcache - Очистить кеш Redis\n"
     )
 

--- a/telegram_bot/metrics_server.py
+++ b/telegram_bot/metrics_server.py
@@ -3,7 +3,7 @@
 Issue #2057: expose the SDK-native ``prometheus_client`` default registry
 via a lightweight ASGI ``/metrics`` endpoint using
 :func:`prometheus_client.make_asgi_app`.  The server runs on
-``TELEGRAM_BOT_METRICS_PORT`` (default 9091) alongside the aiogram
+``TELEGRAM_BOT_METRICS_PORT`` (default 9092) alongside the aiogram
 polling loop and is exposed only on localhost / internal networking.
 
 Context7 baseline (``/prometheus/client_python``):
@@ -32,7 +32,7 @@ from prometheus_client import make_asgi_app
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_METRICS_PORT = 9091
+DEFAULT_METRICS_PORT = 9092
 
 
 def resolve_metrics_port(default: int = DEFAULT_METRICS_PORT) -> int:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -154,8 +154,8 @@ def isolate_otel_langfuse(monkeypatch):
     monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
     # Disable the uvicorn-based metrics server in unit tests (#2139).
     # bot.start() would otherwise try to bind a real listening port
-    # (TELEGRAM_BOT_METRICS_PORT / 9091), causing SystemExit when the
-    # port is unavailable (e.g. in CI with concurrent workers).
+    # (TELEGRAM_BOT_METRICS_PORT / 9092 — see #2190), causing SystemExit
+    # when the port is unavailable (e.g. in CI with concurrent workers).
     monkeypatch.setenv("TELEGRAM_BOT_METRICS_ENABLED", "0")
 
     # Create no-op mocks

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -320,6 +320,33 @@ class TestCommandHandlers:
         for cmd in ["/history", "/metrics", "/clearcache"]:
             assert cmd in call_args, f"{cmd} missing from /help text"
 
+    async def test_cmd_help_metrics_port_default_is_9092(self, mock_config, monkeypatch):
+        """/help shows the default metrics port 9092 (#2190 — 9091 collides with MinIO)."""
+        monkeypatch.delenv("TELEGRAM_BOT_METRICS_PORT", raising=False)
+        bot, _ = _create_bot(mock_config)
+        message = _make_text_message()
+
+        await cmd_help(bot, message)
+
+        call_args = message.answer.call_args[0][0]
+        assert "http://localhost:9092/metrics" in call_args, (
+            "/help must use default 9092 metrics port (not 9091, MinIO conflict)"
+        )
+        assert "9091" not in call_args, "/help must not advertise 9091 (MinIO console port)"
+
+    async def test_cmd_help_metrics_port_respects_env_override(self, mock_config, monkeypatch):
+        """/help respects TELEGRAM_BOT_METRICS_PORT override (#2190)."""
+        monkeypatch.setenv("TELEGRAM_BOT_METRICS_PORT", "9099")
+        bot, _ = _create_bot(mock_config)
+        message = _make_text_message()
+
+        await cmd_help(bot, message)
+
+        call_args = message.answer.call_args[0][0]
+        assert "http://localhost:9099/metrics" in call_args, (
+            "/help must reflect TELEGRAM_BOT_METRICS_PORT env override"
+        )
+
     def test_no_handle_promotions_method(self, mock_config):
         """_handle_promotions removed as dead code (#863)."""
         bot, _ = _create_bot(mock_config)

--- a/tests/unit/test_metrics_port_conflict.py
+++ b/tests/unit/test_metrics_port_conflict.py
@@ -1,0 +1,26 @@
+"""Tests for metrics port conflict fix (issue #2190).
+
+The default metrics port must NOT be 9091 to avoid collision with MinIO
+console when the ML/MinIO profile is active.
+"""
+
+from __future__ import annotations
+
+from telegram_bot.metrics_server import DEFAULT_METRICS_PORT, resolve_metrics_port
+
+
+def test_default_metrics_port_not_9091() -> None:
+    """DEFAULT_METRICS_PORT must not collide with MinIO console (9091)."""
+    assert DEFAULT_METRICS_PORT != 9091, (
+        "DEFAULT_METRICS_PORT must not be 9091 (MinIO console conflict)"
+    )
+
+
+def test_default_metrics_port_is_9092() -> None:
+    """The new default should be 9092."""
+    assert DEFAULT_METRICS_PORT == 9092
+
+
+def test_resolve_metrics_port_returns_new_default() -> None:
+    """resolve_metrics_port() with no env var returns the new default."""
+    assert resolve_metrics_port() == 9092

--- a/tests/unit/test_metrics_server.py
+++ b/tests/unit/test_metrics_server.py
@@ -83,20 +83,20 @@ class TestCreateMetricsApp:
 
 
 class TestMetricsPortResolution:
-    def test_default_port_is_9091(self):
-        assert resolve_metrics_port() == 9091
+    def test_default_port_is_9092(self):
+        assert resolve_metrics_port() == 9092
 
     def test_invalid_env_value_falls_back_without_import_crash(self, monkeypatch, caplog):
         monkeypatch.setenv("TELEGRAM_BOT_METRICS_PORT", "not-an-int")
         with caplog.at_level("WARNING"):
-            assert resolve_metrics_port() == 9091
+            assert resolve_metrics_port() == 9092
         assert "TELEGRAM_BOT_METRICS_PORT" in caplog.text
 
         # Regression: this used to evaluate int(os.getenv(...)) at import time.
         import telegram_bot.metrics_server as metrics_server
 
         importlib.reload(metrics_server)
-        assert metrics_server.resolve_metrics_port() == 9091
+        assert metrics_server.resolve_metrics_port() == 9092
         monkeypatch.delenv("TELEGRAM_BOT_METRICS_PORT", raising=False)
         importlib.reload(metrics_server)
 


### PR DESCRIPTION
## Summary

Resolve local bot `/metrics` port conflict with MinIO console on 9091.

## Changes

- **telegram_bot/metrics_server.py**: Change `DEFAULT_METRICS_PORT` from 9091 to 9092.
- **.env.example**: Update commented default to 9092.
- **docs/engineering/sdk-registry.md**: Update documented default.
- **tests/unit/test_metrics_port_conflict.py**: 3 new tests asserting no collision.
- **tests/unit/test_metrics_server.py**: Update existing port assertions.

## Acceptance

- `make bot` with ML/MinIO profile active exposes bot metrics on 9092 without conflict.
- `curl http://localhost:9092/metrics` returns Prometheus text.
- MinIO console remains on 9091 undisturbed.

## Tested

```
pytest tests/unit/test_metrics_port_conflict.py — 3 passed
pytest tests/unit/test_metrics_server.py — 8 passed
pytest tests/contract/test_env_example_completeness_contract.py — 4 passed
ruff check — all passed
```

Closes #2190