### PR TITLE
docs(runbook): canonical compose source cleanup (#2195)

### DIFF
--- a/docs/runbooks/COMPOSE_SOURCE_CLEANUP.md
+++ b/docs/runbooks/COMPOSE_SOURCE_CLEANUP.md
@@ -1,0 +1,114 @@
+# Compose Source Cleanup Runbook (#2195)
+
+Local Docker validation is only meaningful when the `dev` Compose project
+references a single, canonical checkout. When `docker compose ls` shows
+mixed `ConfigFiles` from multiple worktrees plus stray `/tmp/compose.*.yml`
+overrides, container state diverges from what the main `compose.yml` and
+`compose.dev.yml` actually describe — port bindings, env files, and image
+digests stop matching the source of truth.
+
+This runbook recreates the `dev` project from canonical sources without
+deleting persistent volumes (Postgres, Redis, Qdrant, Langfuse data).
+
+## Symptoms
+
+- `docker compose ls --format json` lists more than two entries under
+  `ConfigFiles` for the `dev` project, or any entry under `/tmp`.
+- Container labels (`com.docker.compose.project.config_files`) reference
+  worktree paths like `/home/user/projects/rag-fresh-*/compose.yml`.
+- `make bot` works through workarounds while `docker compose ps` shows
+  containers that the canonical compose graph does not declare.
+- `bge-m3-tmp` or other manually-created containers exist outside the
+  Compose lifecycle.
+- The contract test
+  `tests/contract/test_compose_source_cleanup_contract.py` reports
+  stray `/tmp` sources or multiple checkout roots.
+
+## Diagnosis
+
+```bash
+# 1. List all Compose projects on the host.
+docker compose ls --all --format json | jq
+
+# 2. Inspect the dev project's effective config files.
+docker compose ls --all --format json \
+  | jq -r '.[] | select(.Name=="dev") | .ConfigFiles'
+
+# 3. Audit container labels for stale worktree references.
+docker ps --format '{{.Names}}\t{{.Label "com.docker.compose.project.config_files"}}\t{{.Label "com.docker.compose.project.environment_file"}}' \
+  | grep -E 'rag-fresh|/tmp/compose' || echo "clean"
+```
+
+## Cleanup (no volume loss)
+
+The cleanup brings down the project containers but keeps named volumes,
+so persistent data survives.
+
+```bash
+# 0. Move to the canonical checkout — stop everything else first.
+cd /home/user/projects/rag-fresh
+
+# 1. Stop the dev project from EVERY checkout that may have started it.
+#    This is the part that allows mixed config_files to accumulate; we
+#    have to ask each known checkout to stop its containers, otherwise
+#    Compose will keep re-attaching them.
+for d in /home/user/projects/rag-fresh*; do
+  if [ -f "$d/compose.yml" ]; then
+    echo "[stopping from $d]"
+    (cd "$d" && docker compose -p dev down --remove-orphans) || true
+  fi
+done
+
+# 2. Remove the stray temp override and any other /tmp/compose.*.yml.
+rm -f /tmp/compose.postgres-root.yml /tmp/compose.*.yml
+
+# 3. Sweep manually-created containers that are not part of the canonical
+#    compose graph. Review the list before running the rm command.
+docker ps -a --filter 'name=bge-m3-tmp' --filter 'name=^/dev-.*-legacy$' \
+  --format '{{.Names}}'
+# After review:
+docker ps -a --filter 'name=bge-m3-tmp' --format '{{.Names}}' \
+  | xargs -r docker rm -f
+
+# 4. Recreate the project from canonical sources only.
+docker compose --env-file .env \
+  -f compose.yml -f compose.dev.yml \
+  --profile full \
+  up -d
+```
+
+## Verification
+
+```bash
+# Single checkout, no /tmp overrides:
+docker compose ls --all --format json \
+  | jq -r '.[] | select(.Name=="dev") | .ConfigFiles' \
+  | tr ',' '\n' \
+  | grep -v '^/home/user/projects/rag-fresh/' && echo "DRIFT" || echo "OK"
+
+# Image digests and port bindings match docker compose config:
+docker compose --env-file .env \
+  -f compose.yml -f compose.dev.yml --profile full ps -a
+
+# Contract test:
+uv run --python 3.12 pytest tests/contract/test_compose_source_cleanup_contract.py -q
+```
+
+The contract test skips when Docker is unavailable or the `dev` project
+is not running, so it is safe in CI; locally it surfaces drift.
+
+## Volume safety
+
+`docker compose down` (without `-v`) leaves named volumes intact. Persistent
+data lives in the volumes declared at the bottom of `compose.yml` —
+`postgres_data`, `qdrant_data`, `redis_data`, `langfuse_clickhouse_data`,
+`langfuse_minio_data`, etc. Do **not** add `-v` to the `down` invocations
+above unless you have an external backup.
+
+## Related
+
+- Broad Docker audit: #2185
+- BGE temp endpoint vs canonical service: #2188
+- Bot response smoke gate: #2192
+- Smoke-zoo redis-cli host-independence: #2196
+- Pinned by `tests/contract/test_compose_source_cleanup_contract.py`.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -13,6 +13,7 @@ Operator entrypoint for container/service investigations and incident response. 
 | Redis / cache degradation (Russian: "сломался redis") | `COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec redis sh -lc 'redis-cli -a "$REDIS_PASSWORD" ping'` → [`REDIS_CACHE_DEGRADATION.md`](REDIS_CACHE_DEGRADATION.md) |
 | LiteLLM / provider failure (Russian: "сломался litellm") | `curl -s http://localhost:4000/health` → [`LITEllm_FAILURE.md`](LITEllm_FAILURE.md) |
 | Compose service health | `make docker-ps` → [`DOCKER.md`](../../DOCKER.md) |
+| `docker compose ls` shows mixed sources / `/tmp/compose.*.yml` overrides | `docker compose ls --format json` → [`COMPOSE_SOURCE_CLEANUP.md`](COMPOSE_SOURCE_CLEANUP.md) |
 | Self-hosted runner offline / nightly-heavy queued | `scripts/check_self_hosted_runner.sh` → [`SELF_HOSTED_RUNNER.md`](SELF_HOSTED_RUNNER.md) |
 | Telegram bot is down / restarting / high error rate | `docker compose ps bot` → [`TELEGRAM_BOT_FAILURE.md`](TELEGRAM_BOT_FAILURE.md) |
 | Embedding service (BGE-M3 / BM42 / Voyage) errors | `docker compose ps bge-m3` → [`EMBEDDING_SERVICE_FAILURE.md`](EMBEDDING_SERVICE_FAILURE.md) |
@@ -31,6 +32,7 @@ Operator entrypoint for container/service investigations and incident response. 
 | Redis cache degradation, eviction, or latency | [`REDIS_CACHE_DEGRADATION.md`](REDIS_CACHE_DEGRADATION.md) |
 | Qdrant health, collection, or vector search issues | [`QDRANT_TROUBLESHOOTING.md`](QDRANT_TROUBLESHOOTING.md) |
 | Postgres WAL recovery or replication issues | [`POSTGRESQL_WAL_RECOVERY.md`](POSTGRESQL_WAL_RECOVERY.md) |
+| Compose project drifted across worktrees / `/tmp` overrides | [`COMPOSE_SOURCE_CLEANUP.md`](COMPOSE_SOURCE_CLEANUP.md) |
 | VPS / Google Drive ingestion recovery | [`vps-gdrive-ingestion-recovery.md`](vps-gdrive-ingestion-recovery.md) |
 | Self-hosted GitHub Actions runner for `nightly-heavy.yml` is offline | [`SELF_HOSTED_RUNNER.md`](SELF_HOSTED_RUNNER.md) |
 | Telegram bot container, Telegram API, or query-processing alerts | [`TELEGRAM_BOT_FAILURE.md`](TELEGRAM_BOT_FAILURE.md) |

--- a/tests/contract/test_compose_source_cleanup_contract.py
+++ b/tests/contract/test_compose_source_cleanup_contract.py
@@ -1,0 +1,115 @@
+"""Contract test for compose source hygiene (#2195).
+
+The dev Compose project must only reference canonical files inside the
+main checkout. Stray temp compose files (``/tmp/compose.*.yml``) and
+worktree-checkout compose files mixed into the same project are a
+known source of container drift, port-binding overrides, and stale
+env files (#2185, #2195).
+
+Behaviour:
+
+- When Docker is unavailable or the ``dev`` project is not running,
+  the test is skipped (developer-machine context).
+- When the ``dev`` project IS running, its declared ConfigFiles must
+  not include any path under ``/tmp`` and must not span more than one
+  checkout root.
+
+Operator runbook: ``docs/runbooks/COMPOSE_SOURCE_CLEANUP.md``.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNBOOK = REPO_ROOT / "docs" / "runbooks" / "COMPOSE_SOURCE_CLEANUP.md"
+
+
+def _docker_available() -> bool:
+    return shutil.which("docker") is not None
+
+
+def _list_dev_compose_sources() -> list[str] | None:
+    """Return ConfigFiles for the local 'dev' Compose project, or None when
+    Docker / the project is not present.
+    """
+    if not _docker_available():
+        return None
+    try:
+        cp = subprocess.run(  # nosec B603 B607
+            ["docker", "compose", "ls", "--all", "--format", "json"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if cp.returncode != 0:
+        return None
+    try:
+        projects = json.loads(cp.stdout or "[]")
+    except json.JSONDecodeError:
+        return None
+    for project in projects:
+        if project.get("Name") == "dev":
+            raw = project.get("ConfigFiles") or ""
+            return [p for p in raw.split(",") if p]
+    return None
+
+
+def test_compose_source_cleanup_runbook_exists() -> None:
+    """The runbook documenting the canonical cleanup must exist."""
+    assert RUNBOOK.is_file(), f"missing runbook: {RUNBOOK}"
+    text = RUNBOOK.read_text(encoding="utf-8")
+    # Must contain key terms operators search for.
+    for term in ("compose.yml", "compose.dev.yml", "/tmp/compose", "docker compose ls"):
+        assert term in text, f"runbook must mention {term!r}"
+
+
+def test_runbook_referenced_from_runbooks_index() -> None:
+    """The new runbook must be linked from docs/runbooks/README.md."""
+    index = REPO_ROOT / "docs" / "runbooks" / "README.md"
+    text = index.read_text(encoding="utf-8")
+    assert "COMPOSE_SOURCE_CLEANUP.md" in text, (
+        "runbook must be linked from docs/runbooks/README.md"
+    )
+
+
+def test_dev_compose_project_has_no_stray_tmp_sources() -> None:
+    """When the dev Compose project is running, ConfigFiles must not include
+    ``/tmp/compose.*.yml`` overrides (#2195)."""
+    sources = _list_dev_compose_sources()
+    if sources is None:
+        pytest.skip("Docker not available or 'dev' Compose project not running")
+    stray = [s for s in sources if s.startswith("/tmp/")]
+    assert not stray, (
+        f"stray /tmp compose sources active in dev project: {stray}; "
+        f"see docs/runbooks/COMPOSE_SOURCE_CLEANUP.md to recreate the project"
+    )
+
+
+def test_dev_compose_project_uses_single_checkout_root() -> None:
+    """When the dev Compose project is running, its compose files must come
+    from a single checkout root — not be a mix of multiple worktrees (#2195)."""
+    sources = _list_dev_compose_sources()
+    if sources is None:
+        pytest.skip("Docker not available or 'dev' Compose project not running")
+    roots: set[str] = set()
+    for raw in sources:
+        path = Path(raw)
+        # Pick a stable parent — the directory containing compose*.yml
+        # is the checkout root for our purposes.
+        roots.add(str(path.parent))
+    # Allow a single canonical root + at most one /tmp override caught by the
+    # other test; the meaningful failure is mixing 2+ real checkouts.
+    real_roots = {r for r in roots if not r.startswith("/tmp")}
+    assert len(real_roots) <= 1, (
+        f"dev project mixes compose files from multiple checkouts: {sorted(real_roots)}; "
+        f"see docs/runbooks/COMPOSE_SOURCE_CLEANUP.md"
+    )


### PR DESCRIPTION
## Summary

Local `dev` Compose project drifts across worktrees and accumulates `/tmp/compose.*.yml` overrides. Adds the canonical recovery runbook plus contract canaries that surface drift locally without breaking CI.

## What's delivered

| File | Purpose |
|---|---|
| `docs/runbooks/COMPOSE_SOURCE_CLEANUP.md` | Volume-safe recovery: bring project down from every checkout, remove `/tmp` overrides, sweep manual containers, recreate from `compose.yml` + `compose.dev.yml` only |
| `docs/runbooks/README.md` | Linked from both Quick Access and Start Here tables |
| `tests/contract/test_compose_source_cleanup_contract.py` | 4 tests: runbook exists, indexed, no stray `/tmp` sources, single checkout root |

## Why the runtime canaries are skip-on-CI

The two runtime tests (`no_stray_tmp_sources`, `single_checkout_root`) call `docker compose ls` and skip when the `dev` project is not running. CI runners do not run the `dev` project, so they skip cleanly. Locally, they fail until the operator runs the runbook — that is the intended canary behaviour.

## Why not auto-clean from this PR

Cleaning the live `dev` stack is destructive (`docker compose down` per checkout, container removal). That has to be operator-driven on the running host. This PR delivers the documented procedure plus the canary; the operator runs the cleanup.

## Tested

```
pytest tests/contract/test_compose_source_cleanup_contract.py::test_compose_source_cleanup_runbook_exists \
       tests/contract/test_compose_source_cleanup_contract.py::test_runbook_referenced_from_runbooks_index — 2 passed
ruff check — clean
```

The 2 runtime canaries currently fail locally — that is the drift this issue describes (`/tmp/compose.postgres-root.yml` + `rag-fresh-runtime-observability-2179` mixed into project `dev`). Running the runbook clears them.

Closes #2195