### PR TITLE
test(scanner): bound draft_streamer scan to production roots (#2198)

### DIFF
--- a/docs/runbooks/OBSERVABILITY_DIAGNOSTIC.md
+++ b/docs/runbooks/OBSERVABILITY_DIAGNOSTIC.md
@@ -1,0 +1,137 @@
+# Local Observability Diagnostic Runbook (#2199)
+
+Classifies the four noise patterns currently degrading local Langfuse and
+LiteLLM observability and links each to its remediation. Use the diagnostic
+probe to collect evidence, then act on the matching section.
+
+## Probe
+
+```bash
+uv run python -m scripts.probe.observability_diagnostic
+```
+
+Tails recent logs from `langfuse-worker`, `langfuse-web`, `litellm`, and
+`bot`, classifies each line, and prints a summary like:
+
+```text
+Observability diagnostic summary (#2199):
+  langfuse_queue_timeout      80
+  litellm_auth_noise          0
+  langfuse_prompt_miss        0
+  metrics_port_conflict       0
+  healthy                     0
+  unknown                     320
+```
+
+The probe exits non-zero when `langfuse_queue_timeout` exceeds
+`QUEUE_TIMEOUT_NOISE_THRESHOLD` (currently 3) so it can gate CI dashboards.
+
+For deterministic input use:
+
+```bash
+docker compose logs --no-color --tail 200 langfuse-worker > /tmp/lf.log
+uv run python -m scripts.probe.observability_diagnostic --from-file /tmp/lf.log
+```
+
+## Categories
+
+### langfuse_queue_timeout
+
+Match: `Socket timeout` (ioredis emits `Error: Socket timeout. Expecting data, but didn't receive any in 30000ms.`).
+
+Affects queues: `data-retention`, `evaluation-execution`, `batch-action`,
+`secondary-ingestion`, `trace-delete`, `secondary-otel-ingestion`, `webhook`.
+
+Likely causes (in order of likelihood for the local audit profile):
+
+1. The Langfuse worker is talking to a different Redis than the one
+   `make bot` uses. Local stack publishes Redis on `127.0.0.1:6379`;
+   the worker should target the in-network alias `redis-langfuse:6379`
+   (Langfuse owns its own Redis to keep traces independent from bot
+   cache traffic).
+2. `redis-langfuse` is healthy on RDB writes but has high latency under
+   the local `dev` project load.
+3. A stale legacy `langfuse-worker` container survives the canonical
+   compose graph (see #2195: stray `/tmp/compose.*.yml` overrides).
+
+Remediation:
+
+```bash
+# Confirm worker is attached to the canonical compose project.
+docker inspect dev-langfuse-worker-1 \
+  --format '{{ index .Config.Labels "com.docker.compose.project.config_files"}}'
+
+# Should print only paths under your main checkout. If it includes a
+# worktree path or /tmp, run docs/runbooks/COMPOSE_SOURCE_CLEANUP.md.
+
+# Confirm the worker's Redis URL points at redis-langfuse, not redis.
+docker compose exec langfuse-worker env | grep -E '(REDIS|LANGFUSE_REDIS)'
+
+# Restart the worker after fixing env or recreating the project.
+docker compose --profile ml restart langfuse-worker
+```
+
+### litellm_auth_noise
+
+Match: `No api key passed in.` or `"GET /models" 401`.
+
+Cause: anonymous probes from monitoring/tooling hit `/v1/models` without
+the master key, and LiteLLM logs the rejection at WARNING. The bot uses
+the same proxy with `LITELLM_MASTER_KEY` and is unaffected.
+
+Remediation: either pass the master key from the probe source or filter
+the log line at the LiteLLM proxy. A reproducible diagnostic call is:
+
+```bash
+curl -fsS \
+  -H "Authorization: Bearer ${LITELLM_MASTER_KEY}" \
+  http://localhost:4000/v1/models | jq '.data | length'
+```
+
+If the bot succeeds and the only 401s come from a known prober, this
+category is informational and can stay in the noise summary.
+
+### langfuse_prompt_miss
+
+Match: `Langfuse prompt ... not found ... fallback`.
+
+Cause: prompts referenced by the runtime are not seeded into the local
+Langfuse project. The bot's prompt-management layer falls back to
+inline defaults, so query behavior is unaffected — this is expected
+"dev state" until the operator runs the prompt seed.
+
+Remediation: seed the prompts (see `scripts/setup_langfuse_dashboards.py`
+and the Langfuse SDK docs) or accept the fallback. The probe surfaces
+this category so prompt drift is not silently ignored.
+
+### metrics_port_conflict
+
+Match: `Cannot bind Prometheus metrics server` + `Address already in use`.
+
+Tracked separately in #2190 (resolved by moving the bot metrics default
+from 9091 to 9092). The probe still classifies the line so historical
+log scans surface the conflict in evidence collection.
+
+### unknown
+
+Anything not matched. A high `unknown` count is normal — most lines are
+routine HTTP access logs and progress messages. Investigate `unknown`
+only when total volume changes sharply.
+
+## Acceptance evidence template
+
+When closing the loop on #2199, attach a probe summary captured before
+and after the remediation:
+
+```text
+Before: langfuse_queue_timeout = N (degraded)
+After:  langfuse_queue_timeout = 0 over a 5-minute log window
+Steps:  <numbered list of actions taken>
+```
+
+## Related
+
+- Bot metrics port conflict: #2190
+- Compose source drift: #2195
+- Trace verification gate: #2179
+- Pinned by `tests/unit/scripts/test_observability_diagnostic.py`.

--- a/docs/runbooks/OBSERVABILITY_DIAGNOSTIC.md
+++ b/docs/runbooks/OBSERVABILITY_DIAGNOSTIC.md
@@ -33,6 +33,23 @@ docker compose logs --no-color --tail 200 langfuse-worker > /tmp/lf.log
 uv run python -m scripts.probe.observability_diagnostic --from-file /tmp/lf.log
 ```
 
+For SDK-native config checks, keep live API validation separate from the
+log classifier:
+
+```bash
+uv run python - <<'PY'
+from langfuse import Langfuse
+
+lf = Langfuse()
+print("langfuse_auth_check", lf.auth_check())
+lf.shutdown()
+PY
+
+curl -fsS \
+  -H "Authorization: Bearer ${LITELLM_MASTER_KEY}" \
+  http://localhost:4000/v1/models | jq '.data | length'
+```
+
 ## Categories
 
 ### langfuse_queue_timeout
@@ -80,7 +97,8 @@ the master key, and LiteLLM logs the rejection at WARNING. The bot uses
 the same proxy with `LITELLM_MASTER_KEY` and is unaffected.
 
 Remediation: either pass the master key from the probe source or filter
-the log line at the LiteLLM proxy. A reproducible diagnostic call is:
+the log line at the LiteLLM proxy. A reproducible SDK-compatible diagnostic
+call is:
 
 ```bash
 curl -fsS \

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -9,6 +9,7 @@ Operator entrypoint for container/service investigations and incident response. 
 | Remote Docker workflow (SSH, Colima, env sync, bot container) | See Docker runbook below |
 | Native Git/GitHub hygiene | [`GIT_PR_ISSUE_NATIVE.md`](GIT_PR_ISSUE_NATIVE.md) |
 | Recent Langfuse traces (Russian: "изучи последние трейсы") | `make validate-traces-fast` → [`LANGFUSE_TRACING_GAPS.md`](LANGFUSE_TRACING_GAPS.md) |
+| Langfuse worker queue timeouts / LiteLLM auth noise / prompt misses | `uv run python -m scripts.probe.observability_diagnostic` → [`OBSERVABILITY_DIAGNOSTIC.md`](OBSERVABILITY_DIAGNOSTIC.md) |
 | Qdrant health / query / index issues (Russian: "изучи последние qdrant запросы") | `curl -fsS http://localhost:6333/readyz` → [`QDRANT_TROUBLESHOOTING.md`](QDRANT_TROUBLESHOOTING.md) |
 | Redis / cache degradation (Russian: "сломался redis") | `COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml exec redis sh -lc 'redis-cli -a "$REDIS_PASSWORD" ping'` → [`REDIS_CACHE_DEGRADATION.md`](REDIS_CACHE_DEGRADATION.md) |
 | LiteLLM / provider failure (Russian: "сломался litellm") | `curl -s http://localhost:4000/health` → [`LITEllm_FAILURE.md`](LITEllm_FAILURE.md) |
@@ -27,6 +28,7 @@ Operator entrypoint for container/service investigations and incident response. 
 | Remote Docker workflow (SSH, Colima, env sync, bot container) | See Docker runbook below |
 | Git/GitHub branch, PR, issue, worktree, and stash hygiene | [`GIT_PR_ISSUE_NATIVE.md`](GIT_PR_ISSUE_NATIVE.md) |
 | Langfuse traces missing, gaps, or drift | [`LANGFUSE_TRACING_GAPS.md`](LANGFUSE_TRACING_GAPS.md) |
+| Langfuse worker queue timeouts / LiteLLM auth noise classification | [`OBSERVABILITY_DIAGNOSTIC.md`](OBSERVABILITY_DIAGNOSTIC.md) |
 | LiteLLM / LLM connection failures or proxy errors | [`LITEllm_FAILURE.md`](LITEllm_FAILURE.md) |
 | Redis cache degradation, eviction, or latency | [`REDIS_CACHE_DEGRADATION.md`](REDIS_CACHE_DEGRADATION.md) |
 | Qdrant health, collection, or vector search issues | [`QDRANT_TROUBLESHOOTING.md`](QDRANT_TROUBLESHOOTING.md) |

--- a/scripts/probe/observability_diagnostic.py
+++ b/scripts/probe/observability_diagnostic.py
@@ -213,7 +213,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    if args.tail < 1:
+        parser.error("--tail must be a positive integer")
+
     if args.from_file is not None:
+        if not args.from_file.is_file():
+            parser.error(f"--from-file does not exist: {args.from_file}")
         lines = args.from_file.read_text(encoding="utf-8").splitlines()
     else:
         lines = collect_compose_logs(tail=args.tail)

--- a/scripts/probe/observability_diagnostic.py
+++ b/scripts/probe/observability_diagnostic.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Local Langfuse / LiteLLM observability diagnostic (#2199).
+
+Ingests recent log lines from the running compose stack, classifies each
+into a stable :class:`DiagnosticCategory`, and reports a summary that
+maps directly onto the issue's acceptance criteria:
+
+  - Langfuse worker queue socket timeouts (degraded if above noise
+    threshold over the inspected window).
+  - LiteLLM ``/v1/models`` unauthenticated probes (auth contract noise).
+  - Langfuse prompt-lookup misses (expected dev state vs config drift).
+  - Bot ``/metrics`` port collisions — already tracked in #2190; the
+    classifier still surfaces them so the operator has evidence.
+
+The script is structured so the classification is pure and unit-testable;
+log collection is a thin shell over ``docker compose logs``.
+
+CLI::
+
+    # Collect last 200 lines from the running compose stack and classify.
+    uv run python -m scripts.probe.observability_diagnostic
+
+    # Read pre-collected log lines from a file (CI-friendly, deterministic).
+    uv run python -m scripts.probe.observability_diagnostic --from-file logs.txt
+
+Refs #2199.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess  # nosec B404
+import sys
+from collections import Counter
+from collections.abc import Iterable
+from enum import StrEnum
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Categories + thresholds
+# ---------------------------------------------------------------------------
+
+
+class DiagnosticCategory(StrEnum):
+    LANGFUSE_QUEUE_TIMEOUT = "langfuse_queue_timeout"
+    LITELLM_AUTH_NOISE = "litellm_auth_noise"
+    LANGFUSE_PROMPT_MISS = "langfuse_prompt_miss"
+    METRICS_PORT_CONFLICT = "metrics_port_conflict"
+    HEALTHY = "healthy"
+    UNKNOWN = "unknown"
+
+
+# Threshold for "repeated queue socket timeouts" interpreted from the
+# acceptance criterion "5 minutes of healthy worker logs".  We inspect the
+# last N lines per service; more than this many timeouts in the window is
+# the degraded signal we surface.
+QUEUE_TIMEOUT_NOISE_THRESHOLD = 3
+
+
+# ---------------------------------------------------------------------------
+# Classifier (pure)
+# ---------------------------------------------------------------------------
+
+_PATTERNS: tuple[tuple[re.Pattern[str], DiagnosticCategory], ...] = (
+    # Langfuse worker queue timeouts. Matches the canonical message
+    # "Error: Socket timeout. Expecting data..." emitted by ioredis when a
+    # background queue command exceeds the configured timeout, plus any
+    # truncated form ("Error: Socket timeout.") seen in summaries.
+    (
+        re.compile(
+            r"Socket timeout",
+            re.IGNORECASE,
+        ),
+        DiagnosticCategory.LANGFUSE_QUEUE_TIMEOUT,
+    ),
+    # LiteLLM auth noise: unauthenticated /v1/models probes etc.
+    (
+        re.compile(r"No api key passed in", re.IGNORECASE),
+        DiagnosticCategory.LITELLM_AUTH_NOISE,
+    ),
+    (
+        re.compile(r'"GET /(?:v1/)?models[^"]*"\s+401', re.IGNORECASE),
+        DiagnosticCategory.LITELLM_AUTH_NOISE,
+    ),
+    # Bot metrics bind failure (#2190).
+    (
+        re.compile(
+            r"Cannot bind Prometheus metrics server.*Address already in use",
+            re.IGNORECASE,
+        ),
+        DiagnosticCategory.METRICS_PORT_CONFLICT,
+    ),
+    # Langfuse prompt lookup miss (expected dev state when prompts are not
+    # seeded into the local Langfuse project yet).
+    (
+        re.compile(
+            r"Langfuse prompt .* not found.*fallback",
+            re.IGNORECASE,
+        ),
+        DiagnosticCategory.LANGFUSE_PROMPT_MISS,
+    ),
+    # Healthy markers seen during the audit (used to keep noise out of UNKNOWN).
+    (re.compile(r"BGSAVE done", re.IGNORECASE), DiagnosticCategory.HEALTHY),
+    (
+        re.compile(
+            r"Background saving terminated with success",
+            re.IGNORECASE,
+        ),
+        DiagnosticCategory.HEALTHY,
+    ),
+    (re.compile(r"^INFO:", re.IGNORECASE), DiagnosticCategory.HEALTHY),
+)
+
+
+def classify_log_line(line: str) -> DiagnosticCategory:
+    """Classify one log line using the priority-ordered patterns."""
+    for pattern, category in _PATTERNS:
+        if pattern.search(line):
+            return category
+    return DiagnosticCategory.UNKNOWN
+
+
+def summarize_classifications(lines: Iterable[str]) -> dict[DiagnosticCategory, int]:
+    """Count classified categories across an iterable of log lines."""
+    counts: Counter[DiagnosticCategory] = Counter(classify_log_line(line) for line in lines)
+    # Return a complete dict so callers can index every category.
+    return {cat: counts.get(cat, 0) for cat in DiagnosticCategory}
+
+
+def is_degraded(summary: dict[DiagnosticCategory, int]) -> bool:
+    """Return True when the summary crosses any degraded threshold."""
+    return summary.get(DiagnosticCategory.LANGFUSE_QUEUE_TIMEOUT, 0) > QUEUE_TIMEOUT_NOISE_THRESHOLD
+
+
+# ---------------------------------------------------------------------------
+# Log collection (thin)
+# ---------------------------------------------------------------------------
+
+DEFAULT_SERVICES: tuple[str, ...] = (
+    "langfuse-worker",
+    "langfuse-web",
+    "litellm",
+    "bot",
+)
+DEFAULT_TAIL_LINES = 200
+
+
+def collect_compose_logs(
+    services: Iterable[str] = DEFAULT_SERVICES,
+    *,
+    tail: int = DEFAULT_TAIL_LINES,
+) -> list[str]:
+    """Tail compose service logs and return them as a list of lines.
+
+    Returns an empty list when ``docker`` is not on PATH or any compose
+    invocation fails — the diagnostic should never crash a healthy host
+    just because Docker is unreachable.
+    """
+    if shutil.which("docker") is None:
+        return []
+    out: list[str] = []
+    for service in services:
+        try:
+            cp = subprocess.run(  # nosec B603 B607
+                [
+                    "docker",
+                    "compose",
+                    "logs",
+                    "--no-color",
+                    "--tail",
+                    str(tail),
+                    service,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            continue
+        if cp.returncode != 0:
+            continue
+        out.extend(cp.stdout.splitlines())
+    return out
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _print_summary(summary: dict[DiagnosticCategory, int]) -> None:
+    print("Observability diagnostic summary (#2199):")
+    for cat in DiagnosticCategory:
+        print(f"  {cat.value:<26}  {summary.get(cat, 0)}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--from-file",
+        type=Path,
+        default=None,
+        help="Read log lines from a file instead of running docker compose logs.",
+    )
+    parser.add_argument(
+        "--tail",
+        type=int,
+        default=DEFAULT_TAIL_LINES,
+        help="Lines per service to tail when collecting from compose.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.from_file is not None:
+        lines = args.from_file.read_text(encoding="utf-8").splitlines()
+    else:
+        lines = collect_compose_logs(tail=args.tail)
+
+    summary = summarize_classifications(lines)
+    _print_summary(summary)
+    return 1 if is_degraded(summary) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_observability_diagnostic.py
+++ b/tests/unit/scripts/test_observability_diagnostic.py
@@ -1,0 +1,113 @@
+"""Tests for scripts/probe/observability_diagnostic.py classifier (#2199).
+
+The diagnostic probe ingests recent Langfuse worker logs and LiteLLM proxy
+logs and classifies each line as one of:
+
+  - LANGFUSE_QUEUE_TIMEOUT  — repeated 'Socket timeout' on worker queues
+  - LITELLM_AUTH_NOISE      — 'No api key passed in.' from /v1/models probes
+  - LANGFUSE_PROMPT_MISS    — prompt lookup warnings (expected dev state)
+  - METRICS_PORT_CONFLICT   — bot /metrics bind failure (#2190 — already
+                              tracked, but we still classify it for
+                              evidence collection)
+  - HEALTHY                 — line is benign / informational
+  - UNKNOWN                 — could not be classified
+
+The classifier is pure (no I/O) so it is unit-testable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.probe.observability_diagnostic import (
+    DiagnosticCategory,
+    classify_log_line,
+    summarize_classifications,
+)
+
+
+@pytest.mark.parametrize(
+    "line,expected",
+    [
+        (
+            "Queue job ... errored: Error: Socket timeout. Expecting data, but didn't receive any in 30000ms.",
+            DiagnosticCategory.LANGFUSE_QUEUE_TIMEOUT,
+        ),
+        (
+            "[langfuse] data-retention queue: Error: Socket timeout. Expecting data...",
+            DiagnosticCategory.LANGFUSE_QUEUE_TIMEOUT,
+        ),
+        (
+            "litellm.proxy.proxy_server.user_api_key_auth(): Exception occured - No api key passed in.",
+            DiagnosticCategory.LITELLM_AUTH_NOISE,
+        ),
+        (
+            'INFO: 127.0.0.1:55432 - "GET /models HTTP/1.1" 401 Unauthorized',
+            DiagnosticCategory.LITELLM_AUTH_NOISE,
+        ),
+        (
+            "Cannot bind Prometheus metrics server on 127.0.0.1:9091: [Errno 98] Address already in use; /metrics disabled",
+            DiagnosticCategory.METRICS_PORT_CONFLICT,
+        ),
+        (
+            "Langfuse prompt 'router-classifier' not found in cache or remote; using fallback",
+            DiagnosticCategory.LANGFUSE_PROMPT_MISS,
+        ),
+        (
+            "INFO: app started",
+            DiagnosticCategory.HEALTHY,
+        ),
+        (
+            "BGSAVE done",
+            DiagnosticCategory.HEALTHY,
+        ),
+    ],
+)
+def test_classify_known_lines(line: str, expected: DiagnosticCategory) -> None:
+    assert classify_log_line(line) is expected
+
+
+def test_unknown_pattern_falls_back_to_unknown() -> None:
+    assert classify_log_line("totally novel error pattern from new component") is (
+        DiagnosticCategory.UNKNOWN
+    )
+
+
+def test_summarize_counts_categories() -> None:
+    lines = [
+        "Queue job ... errored: Error: Socket timeout.",
+        "Queue job ... errored: Error: Socket timeout.",
+        "user_api_key_auth(): Exception occured - No api key passed in.",
+        "INFO: routine log",
+    ]
+    summary = summarize_classifications(lines)
+    assert summary[DiagnosticCategory.LANGFUSE_QUEUE_TIMEOUT] == 2
+    assert summary[DiagnosticCategory.LITELLM_AUTH_NOISE] == 1
+    assert summary[DiagnosticCategory.HEALTHY] == 1
+
+
+def test_summarize_handles_empty_input() -> None:
+    summary = summarize_classifications([])
+    # All categories present with zero counts.
+    for cat in DiagnosticCategory:
+        assert summary[cat] == 0
+
+
+def test_summary_threshold_for_queue_timeouts() -> None:
+    """The acceptance criterion 'no repeated queue timeouts in 5 minutes' is
+    interpreted as: more than ``QUEUE_TIMEOUT_NOISE_THRESHOLD`` socket
+    timeouts in the inspected window is a degraded signal.
+    """
+    from scripts.probe.observability_diagnostic import (
+        QUEUE_TIMEOUT_NOISE_THRESHOLD,
+        is_degraded,
+    )
+
+    # Below threshold → not degraded.
+    summary = dict.fromkeys(DiagnosticCategory, 0)
+    summary[DiagnosticCategory.LANGFUSE_QUEUE_TIMEOUT] = max(0, QUEUE_TIMEOUT_NOISE_THRESHOLD - 1)
+    assert is_degraded(summary) is False
+
+    # Above threshold → degraded.
+    summary[DiagnosticCategory.LANGFUSE_QUEUE_TIMEOUT] = QUEUE_TIMEOUT_NOISE_THRESHOLD + 1
+    assert is_degraded(summary) is True

--- a/tests/unit/scripts/test_observability_diagnostic.py
+++ b/tests/unit/scripts/test_observability_diagnostic.py
@@ -17,6 +17,10 @@ The classifier is pure (no I/O) so it is unit-testable.
 
 from __future__ import annotations
 
+import subprocess
+import sys
+from pathlib import Path
+
 import pytest
 
 from scripts.probe.observability_diagnostic import (
@@ -24,6 +28,18 @@ from scripts.probe.observability_diagnostic import (
     classify_log_line,
     summarize_classifications,
 )
+
+
+SCRIPT = Path("scripts/probe/observability_diagnostic.py")
+
+
+def _run_script(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT.resolve()), *args],
+        capture_output=True,
+        text=True,
+        cwd=SCRIPT.parents[2],
+    )
 
 
 @pytest.mark.parametrize(
@@ -111,3 +127,35 @@ def test_summary_threshold_for_queue_timeouts() -> None:
     # Above threshold → degraded.
     summary[DiagnosticCategory.LANGFUSE_QUEUE_TIMEOUT] = QUEUE_TIMEOUT_NOISE_THRESHOLD + 1
     assert is_degraded(summary) is True
+
+
+def test_cli_reports_missing_input_file_without_traceback(tmp_path: Path) -> None:
+    cp = _run_script("--from-file", str(tmp_path / "missing.log"))
+
+    combined = cp.stdout + cp.stderr
+    assert cp.returncode == 2
+    assert "missing.log" in combined
+    assert "Traceback" not in combined
+
+
+def test_cli_rejects_non_positive_tail() -> None:
+    cp = _run_script("--tail", "0")
+
+    combined = cp.stdout + cp.stderr
+    assert cp.returncode == 2
+    assert "--tail" in combined
+    assert "positive" in combined.lower()
+
+
+def test_script_does_not_import_observability_runtime_sdks() -> None:
+    """The probe is an out-of-process log classifier.
+
+    SDK-native live checks belong in the runbook, not in this script, so the
+    diagnostic keeps working when Langfuse/LiteLLM packages are unavailable.
+    """
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert "from langfuse" not in text
+    assert "import langfuse" not in text
+    assert "from litellm" not in text
+    assert "import litellm" not in text

--- a/tests/unit/services/test_draft_streamer_removed.py
+++ b/tests/unit/services/test_draft_streamer_removed.py
@@ -21,7 +21,6 @@ These tests pin the post-deletion state:
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
 import pytest
@@ -39,8 +38,59 @@ _NOISE_PARTS: frozenset[str] = frozenset(
         ".pytest_cache",
         ".ruff_cache",
         ".worktrees",
+        ".git",
     }
 )
+
+# Production source roots scanned for draft_streamer references (#2198).
+# Bounded list — adding ``REPO_ROOT.rglob('*.py')`` walks .venv, worktrees,
+# and caches before filtering, which exceeds the 30s pytest-timeout on
+# local checkouts.
+_PRODUCTION_SOURCE_ROOTS: tuple[str, ...] = ("telegram_bot", "src")
+
+_BANNED_TOKENS: tuple[str, ...] = (
+    "telegram_bot.services.draft_streamer",
+    " draft_streamer ",
+    "from .draft_streamer",
+)
+
+
+def _iter_production_python_files(repo_root: Path):
+    """Yield .py files under known production source roots, pruning noise
+    directories at the directory level (not after rglob)."""
+    for source_root in _PRODUCTION_SOURCE_ROOTS:
+        root = repo_root / source_root
+        if not root.is_dir():
+            continue
+        for dirpath, dirnames, filenames in __import__("os").walk(root):
+            # Prune noise dirs in-place so os.walk stops descending.
+            dirnames[:] = [d for d in dirnames if d not in _NOISE_PARTS]
+            for fname in filenames:
+                if fname.endswith(".py"):
+                    yield Path(dirpath) / fname
+
+
+def _scan_production_for_draft_streamer_references(repo_root: Path) -> list[str]:
+    """Return repo-relative paths of production files referencing the
+    deleted ``telegram_bot.services.draft_streamer`` module.
+
+    Bounded scanner (#2198): only walks ``_PRODUCTION_SOURCE_ROOTS`` and
+    prunes ``_NOISE_PARTS`` at the directory level. Test/script files
+    are not scanned because they may legitimately mention the deleted
+    module name.
+    """
+    bad: list[str] = []
+    for py_file in _iter_production_python_files(repo_root):
+        rel = py_file.relative_to(repo_root)
+        if rel.name in {"test_draft_streamer.py", "test_draft_streamer_removed.py"}:
+            continue
+        try:
+            text = py_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if any(token in text for token in _BANNED_TOKENS):
+            bad.append(str(rel))
+    return bad
 
 
 def test_draft_streamer_module_file_is_gone() -> None:
@@ -84,30 +134,12 @@ def test_new_draft_id_returns_positive_31bit_int() -> None:
 def test_no_production_references_to_draft_streamer_module() -> None:
     """No production module imports `telegram_bot.services.draft_streamer` (#1671).
 
-    Tests are scanned separately; only `tests/` may legitimately mention the
-    deleted module name (e.g. these regression locks). Production code must
-    not depend on it.
+    Bounded to known production source roots (#2198) so a local checkout
+    with .venv / worktrees / caches present cannot exceed the pytest-timeout.
+    Tests and scripts are scanned separately; only production code under
+    ``telegram_bot/`` and ``src/`` is checked here.
     """
-    bad_files: list[str] = []
-    for py_file in REPO_ROOT.rglob("*.py"):
-        rel = py_file.relative_to(REPO_ROOT)
-        rel_str = str(rel)
-        if any(part in _NOISE_PARTS for part in rel.parts):
-            continue
-        if rel_str.startswith(("tests/", ".venv/", "scripts/")):
-            continue
-        if rel.name in {"test_draft_streamer.py", "test_draft_streamer_removed.py"}:
-            continue
-        try:
-            text = py_file.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
-            continue
-        if (
-            "telegram_bot.services.draft_streamer" in text
-            or " draft_streamer " in text
-            or "from .draft_streamer" in text
-        ):
-            bad_files.append(rel_str)
+    bad_files = _scan_production_for_draft_streamer_references(REPO_ROOT)
     assert not bad_files, (
         f"Production code still references the deleted draft_streamer module: {bad_files}"
     )
@@ -123,9 +155,8 @@ def test_production_reference_scanner_excludes_noise_dirs(
         noise_file.parent.mkdir(parents=True, exist_ok=True)
         noise_file.write_text("import telegram_bot.services.draft_streamer\n", encoding="utf-8")
 
-    monkeypatch.setattr(sys.modules[__name__], "REPO_ROOT", tmp_path)
-
-    test_no_production_references_to_draft_streamer_module()
+    refs = _scan_production_for_draft_streamer_references(tmp_path)
+    assert refs == [], f"scanner descended into noise dirs: {refs}"
 
 
 def test_streaming_path_still_uses_send_message_draft_directly() -> None:

--- a/tests/unit/services/test_draft_streamer_scanner_bound.py
+++ b/tests/unit/services/test_draft_streamer_scanner_bound.py
@@ -1,0 +1,105 @@
+"""Bound check for the draft_streamer regression scanner (#2198).
+
+The scanner in ``test_no_production_references_to_draft_streamer_module``
+used ``REPO_ROOT.rglob('*.py')`` which traversed ``.venv``, worktrees,
+caches, and ``node_modules`` before filtering. On a local checkout this
+exceeded the 30s pytest-timeout. The scanner must be bound to known
+production source roots and complete well under the timeout.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from tests.unit.services.test_draft_streamer_removed import (
+    _scan_production_for_draft_streamer_references,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_scanner_completes_well_under_30s_timeout() -> None:
+    """The scanner must finish in a small fraction of the 30s timeout
+    even on a local checkout with .venv, .worktrees, and caches present.
+    """
+    start = time.perf_counter()
+    refs = _scan_production_for_draft_streamer_references(REPO_ROOT)
+    elapsed = time.perf_counter() - start
+
+    # The pytest-timeout is 30s; we want a comfortable margin for slow CI.
+    assert elapsed < 10.0, (
+        f"draft_streamer scanner took {elapsed:.2f}s; must complete under 10s "
+        f"(pytest-timeout is 30s and the fast gate runs >7000 tests)"
+    )
+    # No production refs expected on a clean tree.
+    assert refs == [], f"unexpected production references: {refs}"
+
+
+def test_scanner_skips_dot_venv_even_when_inside_repo_root(tmp_path: Path) -> None:
+    """`.venv/` (or any noise dir) under REPO_ROOT must not be traversed,
+    even when it contains files matching the search string.
+    """
+    # Synthesise a minimal repo-shaped layout.
+    (tmp_path / "telegram_bot").mkdir()
+    (tmp_path / "telegram_bot" / "bot.py").write_text("# clean production code\n", encoding="utf-8")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "stub.py").write_text("# clean\n", encoding="utf-8")
+
+    # Stage many files under .venv that would slow rglob and contain the
+    # banned token. The scanner must NOT see them.
+    venv = tmp_path / ".venv" / "lib" / "python3.12" / "site-packages"
+    venv.mkdir(parents=True)
+    for i in range(100):
+        (venv / f"poison_{i}.py").write_text(
+            "import telegram_bot.services.draft_streamer\n", encoding="utf-8"
+        )
+
+    refs = _scan_production_for_draft_streamer_references(tmp_path)
+    assert refs == [], f"scanner descended into .venv and reported {len(refs)} false positives"
+
+
+def test_scanner_still_catches_real_production_reference(tmp_path: Path) -> None:
+    """Real production references in telegram_bot/ or src/ are still flagged."""
+    (tmp_path / "telegram_bot").mkdir()
+    (tmp_path / "telegram_bot" / "bot.py").write_text(
+        "import telegram_bot.services.draft_streamer\n", encoding="utf-8"
+    )
+
+    refs = _scan_production_for_draft_streamer_references(tmp_path)
+    assert refs and any("bot.py" in r for r in refs), (
+        f"scanner missed a real production reference; refs={refs}"
+    )
+
+
+def test_scanner_ignores_test_and_script_paths(tmp_path: Path) -> None:
+    """tests/ and scripts/ paths legitimately mention the symbol name."""
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_x.py").write_text(
+        "from telegram_bot.services.draft_streamer import X\n", encoding="utf-8"
+    )
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "foo.py").write_text(
+        "# notes about telegram_bot.services.draft_streamer\n", encoding="utf-8"
+    )
+
+    refs = _scan_production_for_draft_streamer_references(tmp_path)
+    assert refs == [], f"scanner falsely flagged tests/scripts paths: {refs}"
+
+
+@pytest.mark.parametrize("source_root", ["telegram_bot", "src"])
+def test_scanner_scopes_to_known_production_roots(source_root: str, tmp_path: Path) -> None:
+    """Each declared production root must be scanned."""
+    (tmp_path / source_root).mkdir()
+    (tmp_path / source_root / "leak.py").write_text(
+        "from telegram_bot.services.draft_streamer import Streamer\n",
+        encoding="utf-8",
+    )
+
+    refs = _scan_production_for_draft_streamer_references(tmp_path)
+    assert any(source_root in r for r in refs), (
+        f"production root {source_root} not scanned; refs={refs}"
+    )


### PR DESCRIPTION
## Summary

`test_no_production_references_to_draft_streamer_module` used `REPO_ROOT.rglob('*.py')` and filtered `.venv/.worktrees/__pycache__/...` AFTER traversal. On a local checkout this hit the 30s pytest-timeout.

## Fix

Extract `_scan_production_for_draft_streamer_references(repo_root)` helper that walks only `telegram_bot/` and `src/` via `os.walk` with in-place `dirnames` pruning so noise dirs are never descended. Banned-token and noise lists are module constants.

## Tested

```
pytest tests/unit/services/test_draft_streamer_removed.py
       tests/unit/services/test_draft_streamer_scanner_bound.py — 14 passed in 6.14s
ruff check — clean
```

The new bound test asserts `elapsed < 10s` on a real local tree.

Closes #2198