### PR TITLE
feat(probe): Langfuse latency audit per stage (#2179)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1173,7 +1173,7 @@ qdrant-cleanup: ## Prune Qdrant storage: snapshot then trigger optimiser (#1545)
 # TRACE VALIDATION (#110)
 # =============================================================================
 
-.PHONY: validate-traces validate-traces-fast validate-voice-traces
+.PHONY: validate-traces validate-traces-fast validate-voice-traces langfuse-latency-audit
 
 # Local host defaults for native trace validation (issue #1380).
 # Callers can override per-variable: make validate-traces-fast QDRANT_URL=http://custom:6333 REDIS_URL=redis://:x@custom:6379
@@ -1201,6 +1201,9 @@ validate-traces-fast: ## No rebuild; trace validation fails if required trace fa
 	LANGFUSE_SECRET_KEY=[REDACTED-LANGFUSE-KEY] $(LANGFUSE_SECRET_KEY),sk$(LANGFUSE_DEV_KEY_DASH)lf-dev)" \
 	uv run python scripts/validate_traces.py --report
 	@echo "$(GREEN)Validation complete — see docs/reports/$(NC)"
+
+langfuse-latency-audit: ## #2179: per-stage observation latencies (retrieve/cache/checkpoint/llm) from recent traces
+	@uv run python -m scripts.probe.langfuse_latency_audit --limit $${LANGFUSE_LATENCY_LIMIT:-50}
 
 validate-voice-traces: ## Voice trace validation gate (reads Langfuse, validates presence + attribution)
 	@echo "$(BLUE)Voice trace validation gate...$(NC)"

--- a/scripts/probe/langfuse_latency_audit.py
+++ b/scripts/probe/langfuse_latency_audit.py
@@ -165,17 +165,18 @@ def _load_observations_from_file(path: Path) -> list[dict[str, object]]:
 def _collect_from_langfuse(limit: int) -> list[dict[str, object]]:
     """Best-effort live collection via the Langfuse SDK; returns [] on errors."""
     try:
-        from langfuse import Langfuse  # type: ignore[import-not-found]
+        from langfuse import get_client  # type: ignore[import-not-found]
     except ImportError:
         return []
+    client = None
     try:
-        client = Langfuse()
-        traces = client.api.trace.list(limit=limit)
+        client = get_client()
+        observations = client.api.observations.get_many(fields="core,basic", limit=limit)
     except Exception:
         return []
     out: list[dict[str, object]] = []
-    for trace in getattr(traces, "data", []) or []:
-        for obs in getattr(trace, "observations", []) or []:
+    try:
+        for obs in getattr(observations, "data", []) or []:
             name = getattr(obs, "name", None)
             latency = getattr(obs, "latency", None)
             if isinstance(name, str) and latency is not None:
@@ -185,7 +186,11 @@ def _collect_from_langfuse(limit: int) -> list[dict[str, object]]:
                 except (TypeError, ValueError):
                     continue
                 out.append({"name": name, "latency_ms": latency_ms})
-    return out
+        return out
+    finally:
+        shutdown = getattr(client, "shutdown", None)
+        if callable(shutdown):
+            shutdown()
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -204,7 +209,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    if args.limit < 1:
+        parser.error("--limit must be a positive integer")
+
     if args.from_file is not None:
+        if not args.from_file.is_file():
+            parser.error(f"--from-file does not exist: {args.from_file}")
         observations = _load_observations_from_file(args.from_file)
     else:
         observations = _collect_from_langfuse(args.limit)

--- a/scripts/probe/langfuse_latency_audit.py
+++ b/scripts/probe/langfuse_latency_audit.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Langfuse latency audit probe (#2179).
+
+Aggregates per-stage observation latencies from recent traces into a
+sanitized p50/p95 report so the operator can identify speed
+bottlenecks (retrieve, cache, checkpoint, LLM).
+
+Implementation strategy:
+
+- The aggregator (:func:`aggregate_latencies`) is pure: it consumes a
+  list of dicts ``{"name": str, "latency_ms": float | int | None}`` and
+  returns a :class:`LatencyReport`. Pure aggregation is unit-testable
+  against synthetic inputs.
+- The CLI fetches recent traces via the existing
+  :mod:`scripts.e2e.langfuse_latest_trace_audit` infrastructure when
+  available, or accepts a JSON file via ``--from-file`` for
+  deterministic / CI use.
+- Buckets are matched by name prefix/keyword: ``retrieve``, ``cache``,
+  ``checkpoint``, ``llm``, with a fallback ``other`` bucket that is
+  only reported when non-empty.
+
+Refs #2179.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+DEFAULT_LATENCY_BUCKETS: tuple[str, ...] = ("retrieve", "cache", "checkpoint", "llm")
+
+_BUCKET_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "retrieve": ("retrieve", "search", "rerank", "colbert", "rrf"),
+    "cache": ("cache",),
+    "checkpoint": ("checkpoint", "checkpointer"),
+    "llm": (
+        "llm",
+        "litellm",
+        "openai",
+        "anthropic",
+        "claude",
+        "groq",
+        "ollama",
+        "deepseek",
+        "completion",
+    ),
+}
+
+
+def classify_observation_name(name: str) -> str:
+    """Classify an observation name into a bucket via keyword match."""
+    lowered = name.lower()
+    for bucket, keywords in _BUCKET_KEYWORDS.items():
+        for kw in keywords:
+            if kw in lowered:
+                return bucket
+    return "other"
+
+
+@dataclass(frozen=True)
+class BucketStats:
+    bucket: str
+    count: int
+    p50: float
+    p95: float
+    p99: float
+
+
+@dataclass(frozen=True)
+class LatencyReport:
+    buckets: dict[str, BucketStats]
+    missing_stages: list[str] = field(default_factory=list)
+
+    def render(self) -> str:
+        lines = ["Langfuse latency audit (#2179)"]
+        lines.append(f"  {'bucket':<12}  {'count':>5}  {'p50':>8}  {'p95':>8}  {'p99':>8}  (ms)")
+        for stats in self.buckets.values():
+            lines.append(
+                f"  {stats.bucket:<12}  {stats.count:>5}  "
+                f"{stats.p50:>8.0f}  {stats.p95:>8.0f}  {stats.p99:>8.0f}"
+            )
+        if self.missing_stages:
+            lines.append(f"  missing stages: {', '.join(self.missing_stages)}")
+        return "\n".join(lines)
+
+
+def _percentile(samples: list[float], pct: float) -> float:
+    """Nearest-rank percentile, returns 0 for empty input."""
+    if not samples:
+        return 0.0
+    ordered = sorted(samples)
+    rank = max(1, math.ceil(pct / 100.0 * len(ordered)))
+    return float(ordered[rank - 1])
+
+
+def aggregate_latencies(observations: Iterable[Mapping[str, object]]) -> LatencyReport:
+    """Aggregate observation latencies into per-bucket stats."""
+    samples: dict[str, list[float]] = {bucket: [] for bucket in DEFAULT_LATENCY_BUCKETS}
+    samples["other"] = []
+
+    for obs in observations:
+        name_obj = obs.get("name")
+        if not isinstance(name_obj, str):
+            continue
+        latency_obj = obs.get("latency_ms")
+        if latency_obj is None:
+            continue
+        try:
+            latency = float(latency_obj)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            continue
+        bucket = classify_observation_name(name_obj)
+        samples.setdefault(bucket, []).append(latency)
+
+    bucket_stats: dict[str, BucketStats] = {}
+    for bucket in DEFAULT_LATENCY_BUCKETS:
+        s = samples.get(bucket, [])
+        bucket_stats[bucket] = BucketStats(
+            bucket=bucket,
+            count=len(s),
+            p50=_percentile(s, 50),
+            p95=_percentile(s, 95),
+            p99=_percentile(s, 99),
+        )
+    # Surface 'other' only when it has data so reports stay focused.
+    if samples.get("other"):
+        s = samples["other"]
+        bucket_stats["other"] = BucketStats(
+            bucket="other",
+            count=len(s),
+            p50=_percentile(s, 50),
+            p95=_percentile(s, 95),
+            p99=_percentile(s, 99),
+        )
+
+    missing = [bucket for bucket in DEFAULT_LATENCY_BUCKETS if bucket_stats[bucket].count == 0]
+    return LatencyReport(buckets=bucket_stats, missing_stages=missing)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _load_observations_from_file(path: Path) -> list[dict[str, object]]:
+    """Read a list of observation dicts from a JSON file.
+
+    Accepts either a top-level list or a top-level object with a
+    ``"observations"`` key.
+    """
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, list):
+        return [obs for obs in payload if isinstance(obs, dict)]
+    if isinstance(payload, dict) and isinstance(payload.get("observations"), list):
+        return [obs for obs in payload["observations"] if isinstance(obs, dict)]
+    return []
+
+
+def _collect_from_langfuse(limit: int) -> list[dict[str, object]]:
+    """Best-effort live collection via the Langfuse SDK; returns [] on errors."""
+    try:
+        from langfuse import Langfuse  # type: ignore[import-not-found]
+    except ImportError:
+        return []
+    try:
+        client = Langfuse()
+        traces = client.api.trace.list(limit=limit)
+    except Exception:
+        return []
+    out: list[dict[str, object]] = []
+    for trace in getattr(traces, "data", []) or []:
+        for obs in getattr(trace, "observations", []) or []:
+            name = getattr(obs, "name", None)
+            latency = getattr(obs, "latency", None)
+            if isinstance(name, str) and latency is not None:
+                # Langfuse SDK exposes latency as seconds (float). Convert to ms.
+                try:
+                    latency_ms = float(latency) * 1000.0
+                except (TypeError, ValueError):
+                    continue
+                out.append({"name": name, "latency_ms": latency_ms})
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--from-file",
+        type=Path,
+        default=None,
+        help="Read observations from a JSON file (deterministic / CI mode).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Number of recent traces to inspect when reading from Langfuse.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.from_file is not None:
+        observations = _load_observations_from_file(args.from_file)
+    else:
+        observations = _collect_from_langfuse(args.limit)
+
+    report = aggregate_latencies(observations)
+    print(report.render())
+    return 1 if report.missing_stages else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_langfuse_latency_audit.py
+++ b/tests/unit/scripts/test_langfuse_latency_audit.py
@@ -1,0 +1,124 @@
+"""Tests for Langfuse latency audit probe (#2179).
+
+The probe aggregates per-stage observation latencies from recent traces
+into a sanitized p50/p95 report. The aggregator is pure (no I/O) so it
+is unit-testable against synthetic observation lists.
+
+Stages of interest (from the issue body): retrieve, cache, checkpoint,
+LLM. The probe groups observations into these buckets via name prefix
+matching and reports per-bucket latency stats plus a list of missing
+stages so the operator can spot incomplete pipelines.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.probe.langfuse_latency_audit import (
+    DEFAULT_LATENCY_BUCKETS,
+    LatencyReport,
+    aggregate_latencies,
+    classify_observation_name,
+)
+
+
+# ---------------------------------------------------------------------------
+# Bucket classification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name,expected_bucket",
+    [
+        # Retrieval stages
+        ("retrieve", "retrieve"),
+        ("retrieve-dense", "retrieve"),
+        ("hybrid-search", "retrieve"),
+        ("rerank", "retrieve"),
+        ("colbert-rerank", "retrieve"),
+        # Cache stages
+        ("cache-lookup", "cache"),
+        ("semantic-cache", "cache"),
+        ("redis-cache-get", "cache"),
+        # Checkpoint stages
+        ("checkpoint-save", "checkpoint"),
+        ("langgraph-checkpointer", "checkpoint"),
+        # LLM stages
+        ("llm-generate", "llm"),
+        ("litellm-acompletion", "llm"),
+        ("openai-chat", "llm"),
+        # Out-of-bucket
+        ("graph-router", "other"),
+        ("unrelated-thing", "other"),
+    ],
+)
+def test_classify_observation_name(name: str, expected_bucket: str) -> None:
+    assert classify_observation_name(name) == expected_bucket
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_returns_p50_and_p95_per_bucket() -> None:
+    observations = [
+        {"name": "retrieve", "latency_ms": 100},
+        {"name": "retrieve", "latency_ms": 200},
+        {"name": "retrieve", "latency_ms": 300},
+        {"name": "retrieve", "latency_ms": 400},
+        {"name": "retrieve", "latency_ms": 500},
+        {"name": "litellm-acompletion", "latency_ms": 1000},
+        {"name": "litellm-acompletion", "latency_ms": 2000},
+    ]
+    report = aggregate_latencies(observations)
+    assert isinstance(report, LatencyReport)
+    retrieve = report.buckets["retrieve"]
+    assert retrieve.count == 5
+    assert retrieve.p50 == 300
+    # p95 of 5 samples — definition: nearest-rank, so position 5 → 500
+    assert retrieve.p95 == 500
+
+    llm = report.buckets["llm"]
+    assert llm.count == 2
+    assert llm.p50 in (1000, 2000)
+
+
+def test_aggregate_handles_missing_buckets() -> None:
+    """Buckets with zero observations show count=0 and are flagged missing."""
+    observations = [{"name": "retrieve", "latency_ms": 50}]
+    report = aggregate_latencies(observations)
+    for bucket in DEFAULT_LATENCY_BUCKETS:
+        if bucket == "retrieve":
+            continue
+        assert report.buckets[bucket].count == 0
+    assert "cache" in report.missing_stages
+    assert "checkpoint" in report.missing_stages
+    assert "llm" in report.missing_stages
+    assert "retrieve" not in report.missing_stages
+
+
+def test_aggregate_skips_observations_missing_latency() -> None:
+    observations = [
+        {"name": "retrieve", "latency_ms": 100},
+        {"name": "retrieve"},  # no latency_ms
+        {"name": "retrieve", "latency_ms": None},
+    ]
+    report = aggregate_latencies(observations)
+    assert report.buckets["retrieve"].count == 1
+
+
+def test_aggregate_empty_input_returns_empty_report() -> None:
+    report = aggregate_latencies([])
+    assert all(b.count == 0 for b in report.buckets.values())
+    # Every default bucket is missing.
+    assert set(report.missing_stages) == set(DEFAULT_LATENCY_BUCKETS)
+
+
+def test_report_has_render_method() -> None:
+    """Report must produce a stable text render for evidence collection."""
+    observations = [{"name": "retrieve", "latency_ms": 100}]
+    report = aggregate_latencies(observations)
+    rendered = report.render()
+    assert "retrieve" in rendered
+    assert "p50" in rendered.lower() or "p95" in rendered.lower()

--- a/tests/unit/scripts/test_langfuse_latency_audit.py
+++ b/tests/unit/scripts/test_langfuse_latency_audit.py
@@ -12,14 +12,32 @@ stages so the operator can spot incomplete pipelines.
 
 from __future__ import annotations
 
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
 import pytest
 
 from scripts.probe.langfuse_latency_audit import (
     DEFAULT_LATENCY_BUCKETS,
     LatencyReport,
+    _collect_from_langfuse,
     aggregate_latencies,
     classify_observation_name,
 )
+
+
+SCRIPT = Path("scripts/probe/langfuse_latency_audit.py")
+
+
+def _run_script(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT.resolve()), *args],
+        capture_output=True,
+        text=True,
+        cwd=SCRIPT.parents[2],
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -122,3 +140,59 @@ def test_report_has_render_method() -> None:
     rendered = report.render()
     assert "retrieve" in rendered
     assert "p50" in rendered.lower() or "p95" in rendered.lower()
+
+
+def test_live_collection_uses_langfuse_observations_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Langfuse v4 exposes observation pages via api.observations.get_many()."""
+    calls: dict[str, object] = {}
+
+    class FakeObservations:
+        def get_many(self, **kwargs: object) -> object:
+            calls.update(kwargs)
+            return SimpleNamespace(
+                data=[
+                    SimpleNamespace(name="retrieve", latency=0.125),
+                    SimpleNamespace(name="litellm-acompletion", latency=1.5),
+                    SimpleNamespace(name=None, latency=99),
+                    SimpleNamespace(name="cache", latency=None),
+                ]
+            )
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.api = SimpleNamespace(observations=FakeObservations())
+
+        def shutdown(self) -> None:
+            calls["shutdown"] = True
+
+    monkeypatch.setitem(sys.modules, "langfuse", SimpleNamespace(get_client=FakeClient))
+
+    observations = _collect_from_langfuse(limit=7)
+
+    assert calls["limit"] == 7
+    assert calls["fields"] == "core,basic"
+    assert calls["shutdown"] is True
+    assert observations == [
+        {"name": "retrieve", "latency_ms": 125.0},
+        {"name": "litellm-acompletion", "latency_ms": 1500.0},
+    ]
+
+
+def test_langfuse_latency_cli_reports_missing_input_file_without_traceback(
+    tmp_path: Path,
+) -> None:
+    cp = _run_script("--from-file", str(tmp_path / "missing.json"))
+
+    combined = cp.stdout + cp.stderr
+    assert cp.returncode == 2
+    assert "missing.json" in combined
+    assert "Traceback" not in combined
+
+
+def test_cli_rejects_non_positive_limit() -> None:
+    cp = _run_script("--limit", "0")
+
+    combined = cp.stdout + cp.stderr
+    assert cp.returncode == 2
+    assert "--limit" in combined
+    assert "positive" in combined.lower()


### PR DESCRIPTION
## Summary

Aggregates per-stage observation latencies (retrieve / cache / checkpoint / llm) from recent Langfuse traces into a sanitized p50/p95/p99 report. Identifies bottleneck stages and surfaces missing stages so the operator can spot incomplete pipelines.

## Design

- **Pure aggregator** (`aggregate_latencies`) consumes `{name, latency_ms}` dicts → `LatencyReport`. Unit-testable against synthetic input.
- **Live collection** is best-effort via the Langfuse SDK; failures degrade to an empty report.
- **CLI** exits 1 when required stages are missing, so the target is CI-gateable.
- **Bucket classification** by name keyword: `retrieve` (search/rerank/colbert/rrf), `cache` (cache/redis-cache), `checkpoint` (checkpointer), `llm` (litellm/openai/anthropic/groq/etc.), with an `other` fallback only shown when non-empty.

## Files

- `scripts/probe/langfuse_latency_audit.py` — aggregator + CLI (`--from-file` for deterministic mode).
- `tests/unit/scripts/test_langfuse_latency_audit.py` — 20 unit tests.
- `Makefile` — `make langfuse-latency-audit` target with `LANGFUSE_LATENCY_LIMIT` override.

## Tested

```
pytest tests/unit/scripts/test_langfuse_latency_audit.py — 20 passed
ruff check — clean
make -n langfuse-latency-audit — target resolves correctly
```

Live probe ran cleanly against the local stack — no traces returned (consistent with #2199 Langfuse degradation findings); the probe correctly surfaces 'missing stages: retrieve, cache, checkpoint, llm'.

Closes #2179