### PR TITLE
test(settings): isolate default model tests from dotenv

### DIFF
--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,6 +1,7 @@
 """Unit tests for src/config/settings.py."""
 
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -115,26 +116,32 @@ class TestAPIKeyValidation:
 class TestDefaultModelSelection:
     """Test default model selection for providers."""
 
-    def test_claude_default_model(self, monkeypatch):
+    def test_claude_default_model(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         """Test default model for Claude provider."""
         # #2197: delenv MODEL_NAME so a local .env value does not leak in.
+        empty_env = tmp_path / ".env"
+        empty_env.write_text("", encoding="utf-8")
         monkeypatch.delenv("MODEL_NAME", raising=False)
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
-        settings = Settings(api_provider="claude")
+        settings = Settings(env_file=str(empty_env), api_provider="claude")
         assert settings.model_name == ModelName.CLAUDE_SONNET.value
 
-    def test_openai_default_model(self, monkeypatch):
+    def test_openai_default_model(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         """Test default model for OpenAI provider."""
+        empty_env = tmp_path / ".env"
+        empty_env.write_text("", encoding="utf-8")
         monkeypatch.delenv("MODEL_NAME", raising=False)
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-        settings = Settings(api_provider="openai")
+        settings = Settings(env_file=str(empty_env), api_provider="openai")
         assert settings.model_name == ModelName.GPT_4_TURBO.value
 
-    def test_groq_default_model(self, monkeypatch):
+    def test_groq_default_model(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         """Test default model for Groq provider."""
+        empty_env = tmp_path / ".env"
+        empty_env.write_text("", encoding="utf-8")
         monkeypatch.delenv("MODEL_NAME", raising=False)
         monkeypatch.setenv("GROQ_API_KEY", "test-key")
-        settings = Settings(api_provider="groq")
+        settings = Settings(env_file=str(empty_env), api_provider="groq")
         assert settings.model_name == ModelName.GROQ_LLAMA3_70B.value
 
     def test_custom_model_override(self):

--- a/tests/unit/test_settings_default_model_env_isolation.py
+++ b/tests/unit/test_settings_default_model_env_isolation.py
@@ -16,6 +16,8 @@ environment, the provider default applies regardless of what the host
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from src.config.constants import ModelName
@@ -35,6 +37,7 @@ def test_provider_default_applies_when_model_name_env_isolated(
     key_name: str,
     expected_model: str,
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     """When MODEL_NAME is removed from env, the provider default applies.
 
@@ -42,11 +45,13 @@ def test_provider_default_applies_when_model_name_env_isolated(
     (MODEL_NAME=zai-glm-4.7), then explicitly delenv it, then construct
     Settings. The provider default must win.
     """
+    empty_env = tmp_path / ".env"
+    empty_env.write_text("", encoding="utf-8")
     monkeypatch.setenv("MODEL_NAME", "zai-glm-4.7")  # simulate .env pollution
     monkeypatch.delenv("MODEL_NAME", raising=False)  # the isolation contract
     monkeypatch.setenv(key_name, "test-key")
 
-    settings = Settings(api_provider=provider)
+    settings = Settings(env_file=str(empty_env), api_provider=provider)
 
     assert settings.model_name == expected_model, (
         f"provider default for {provider} regressed under env isolation "


### PR DESCRIPTION
## Summary

Follow-up from final fresh origin/dev validation after #2204 and #2206: local make test still failed when root .env contained MODEL_NAME=zai-glm-4.7.

monkeypatch.delenv(MODEL_NAME) was not enough because Settings() calls load_dotenv() during construction and reloaded root .env. These default-model tests now pass an explicit empty env_file while still setting the provider API key through monkeypatch.

## Verification

- uv run --python 3.12 pytest tests/unit/test_settings.py tests/unit/test_settings_default_model_env_isolation.py -q -> 24 passed
- MODEL_NAME=zai-glm-4.7 uv run --python 3.12 pytest tests/unit/test_settings.py tests/unit/test_settings_default_model_env_isolation.py -q -> 24 passed
- targeted ruff check/format -> passed
- make check -> passed

Follow-up to #2197 / #2204.