### PR TITLE
fix(redis): keep local app Redis readable under dropped caps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -731,7 +731,7 @@ local-up-ingest:  ## Start local services + docling for ingestion workflows
 run-bot:  ## Run bot locally (requires: make local-up)
 	uv run --env-file "$$RAG_RUNTIME_ENV_FILE" python -m telegram_bot.main
 
-bot: preflight-bot ## Alias: run bot and tee output to logs/bot-run.log
+bot: preflight-bot test-bot-health ## Alias: run bot and tee output to logs/bot-run.log
 	@mkdir -p logs
 	@bash -o pipefail -c 'uv run --env-file "$$RAG_RUNTIME_ENV_FILE" python -m telegram_bot.main 2>&1 | tee logs/bot-run.log'; \
 	status=$$?; echo '[COMPLETE]'; exit $$status

--- a/compose.yml
+++ b/compose.yml
@@ -48,6 +48,10 @@ services:
   redis:
     <<: *security-defaults
     image: redis:8.6.3@sha256:4d25e2fe601f7ffaeb4437cb6ced3518bc36edf34ebe98863c80836943d94529
+    # Match the redis user (uid 999) baked into redis:8.x so the process can
+    # read/write /data with cap_drop:[ALL]. Running as root without
+    # CAP_DAC_OVERRIDE cannot read redis-owned dump.rdb and causes startup loops.
+    user: "999:999"
     restart: unless-stopped
     stop_grace_period: 30s
     read_only: false

--- a/docs/runbooks/REDIS_CACHE_DEGRADATION.md
+++ b/docs/runbooks/REDIS_CACHE_DEGRADATION.md
@@ -97,6 +97,7 @@ Check for:
 |---|---|---|
 | `redis-cli ping` from **inside** the container fails | Service failure | Restart container, check disk/memory on host |
 | `redis-cli ping` works, but bot logs show `Connection refused` | App bug | Verify `REDIS_URL` in bot env; check password encoding |
+| Redis container restarts with `can't open the RDB file dump.rdb for reading: Permission denied` | Container user/capability drift against the `redis_data` volume | Recreate Redis from current Compose (`make local-redis-recreate`) and verify `compose.yml` runs `redis` as uid `999:999` |
 | Bot preflight shows `invalid username-password pair` / `WRONGPASS` / `NOAUTH` after local `.env` edit | Local auth drift | Run `make local-redis-recreate`, then `make test-bot-health` |
 | Redis memory is near limit and `evicted_keys` is rising | Service failure / capacity | Scale `maxmemory` or reduce TTL; see Remediation |
 | Cache hit rate is 0% but Redis is healthy and has keys | App bug | Check semantic cache threshold, query_type mapping, or `CACHE_VERSION` drift in `telegram_bot/integrations/cache.py` |
@@ -142,6 +143,16 @@ Use a canonical query twice, once with a cleared cache and once immediately afte
    ```bash
    COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml ps redis
    ```
+
+   If the status is `Restarting`, inspect startup logs before debugging the bot:
+   ```bash
+   COMPOSE_PROJECT_NAME=dev docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml logs --tail=120 redis
+   ```
+
+   `Fatal error: can't open the RDB file dump.rdb for reading: Permission denied`
+   means the Redis process cannot read the persisted `redis_data` volume. The
+   Compose contract is that app Redis runs as uid `999:999`, matching the
+   official Redis image volume owner.
 
 2. Restart Redis:
    ```bash

--- a/tests/unit/test_compose_langfuse.py
+++ b/tests/unit/test_compose_langfuse.py
@@ -72,6 +72,20 @@ class TestLangfuseSecretPosture:
             "LANGFUSE_REDIS_PASSWORD is unset"
         )
 
+    def test_base_app_redis_runs_as_redis_uid_999(self, compose_base: dict):
+        """App Redis must run as uid 999 to read/write the official image /data volume.
+
+        With cap_drop:[ALL], root lacks CAP_DAC_OVERRIDE and cannot read a
+        redis-owned 0600 dump.rdb. That leaves local Redis in a restart loop and
+        native bot preflight fails later with localhost:6379 connection refused.
+        """
+        svc = compose_base["services"]["redis"]
+        assert svc.get("user") == "999:999", (
+            'compose.yml: redis must set user: "999:999" to match the redis user '
+            "baked into redis:8.x and the redis_data volume owner; otherwise "
+            "cap_drop:[ALL] + root can fail to read redis-owned dump.rdb."
+        )
+
     def test_base_redis_langfuse_runs_as_redis_uid_999(self, compose_base: dict):
         """redis-langfuse must declare user: "999:999" matching the volume owner.
 

--- a/tests/unit/test_makefile_contract.py
+++ b/tests/unit/test_makefile_contract.py
@@ -394,6 +394,19 @@ def test_bot_uses_runtime_env_file_fallback() -> None:
     assert "--env-file .env" not in block
 
 
+def test_bot_depends_on_local_health_preflight() -> None:
+    """`make bot` must gate startup on local health checks to fail fast on Redis drift/outage."""
+    text = _makefile_text()
+    match = re.search(r"^bot:\s*(.+?)\s*##", text, re.MULTILINE)
+    assert match, "bot target not found in Makefile"
+    prerequisites = match.group(1).split()
+    assert "preflight-bot" in prerequisites, "bot target must keep env preflight gate"
+    assert "test-bot-health" in prerequisites, (
+        "bot target must depend on test-bot-health so Redis/Qdrant/LLM readiness "
+        "fails before runtime deep-checks"
+    )
+
+
 def test_bot_preserves_pipeline_failure_exit_code() -> None:
     """`make bot` must not hide Python startup failures behind tee/echo."""
     text = _makefile_text()


### PR DESCRIPTION
## Summary
- run the app Redis container as the official Redis uid/gid 999:999, matching redis_data ownership under cap_drop: [ALL]
- gate make bot on test-bot-health so Redis/Qdrant/LLM readiness fails before Telegram runtime startup
- document the dump.rdb permission-denied restart-loop symptom in the Redis runbook

## Validation
- `../rag-fresh/.venv/bin/python -m pytest -q tests/unit/test_compose_langfuse.py -k 'redis_runs_as_redis_uid_999' --override-ini=addopts=`
- `../rag-fresh/.venv/bin/python -m pytest -q tests/unit/test_compose_langfuse.py tests/unit/test_compose.py -k 'redis' --override-ini=addopts=`
- `../rag-fresh/.venv/bin/python -m pytest -q tests/unit/test_docker_static_validation.py -k 'compose_dev_config_renders' --override-ini=addopts=`
- `../rag-fresh/.venv/bin/python -m pytest -q tests/unit/scripts/test_bot_health_script.py tests/unit/test_preflight.py -k 'redis' --override-ini=addopts=`
- `../rag-fresh/.venv/bin/python -m pytest -q tests/unit/test_makefile_contract.py -k 'bot_depends_on_local_health_preflight or bot_uses_runtime_env_file_fallback or bot_preserves_pipeline_failure_exit_code or test_bot_health_target' --override-ini=addopts=`
- `../rag-fresh/.venv/bin/python -m pytest -q tests/unit/test_compose_langfuse.py tests/unit/test_compose.py tests/unit/test_makefile_contract.py tests/unit/scripts/test_bot_health_script.py tests/unit/test_preflight.py -k 'redis or bot_depends_on_local_health_preflight or bot_uses_runtime_env_file_fallback or bot_preserves_pipeline_failure_exit_code or test_bot_health_target' --override-ini=addopts=`
- `docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml config redis`
- `docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml up -d --no-deps --force-recreate redis`
- `docker compose --env-file tests/fixtures/compose.ci.env -f compose.yml -f compose.dev.yml ps redis`
- `docker exec dev-redis-1 redis-cli -a test-redis-password ping`
- `UV_PROJECT_ENVIRONMENT=/home/user/projects/rag-fresh/.venv timeout 75 make test-bot-health`
- `make -n bot`
- `git diff --check`

## Notes
The original local failure was reproduced as a Redis container restart loop: `Fatal error: can't open the RDB file dump.rdb for reading: Permission denied`. After the fix, `dev-redis-1` is healthy and logs `Ready to accept connections tcp`.
