### PR TITLE
fix(bge-m3): link service spans to Langfuse traces

### DIFF
--- a/docs/runbooks/LANGFUSE_TRACING_GAPS.md
+++ b/docs/runbooks/LANGFUSE_TRACING_GAPS.md
@@ -37,6 +37,63 @@ For cache regression checks:
 2. Immediate repeat of the same query should be a semantic cache hit path only and must not add fresh `bge-m3-encode-*`, Qdrant, or LLM spans.
 3. The semantic-hit replay should not emit new `results_count=0` / `no_results=1` scoring artifacts.
 
+### BGE-M3 hybrid trace check
+
+For BGE-M3 hybrid retrieval regressions, verify the Langfuse trace through the
+Langfuse API/CLI, not only by querying ClickHouse directly. The same trace must
+contain:
+
+- a workflow/root span such as `validation-query`, `rag-pipeline`, or `telegram-rag-query`
+- `bge-m3-encode-*` client span
+- matching `bge-m3-service-encode-*` service span
+- `qdrant-hybrid-search-rrf` or `qdrant-hybrid-search-rrf-colbert`
+
+Generate or select a fresh trace, then run:
+
+```bash
+TRACE_ID=<trace-id>
+LF_ENV_FILE="${LF_ENV_FILE:-.env}" ./scripts/lf trace "$TRACE_ID" > /tmp/lf_trace.json
+```
+
+Required BGE/Qdrant families:
+
+```bash
+jq -e '(.observations | map(.name)) as $n
+  | any($n[]; test("^bge-m3-encode-"))
+  and any($n[]; test("^bge-m3-service-encode-"))
+  and any($n[]; test("^qdrant-hybrid-search-rrf"))
+' /tmp/lf_trace.json
+```
+
+BGE service spans must include curated model/runtime metadata and IO counters,
+while keeping raw user text out of embedding spans:
+
+```bash
+jq -e '.observations
+  | map(select(.name | test("^bge-m3-service-encode-"))) as $svc
+  | ($svc | length) > 0
+  and all($svc[];
+    .metadata.model == "BAAI/bge-m3"
+    and .metadata.runtime == "onnx-int8"
+    and ((.metadata.encode_type // "") | length > 0)
+    and ((.input.texts_count // 0) > 0)
+    and ((.output.processing_time // 0) > 0)
+  )
+' /tmp/lf_trace.json
+```
+
+The service span must be nested under its client span in the same trace:
+
+```bash
+jq -e '.observations as $obs
+  | ($obs | map(select(.id != null) | {key:.id, value:.name}) | from_entries) as $idx
+  | all($obs[] | select(.name | test("^bge-m3-service-"));
+      (.parentObservationId // "") != ""
+      and (($idx[.parentObservationId] // "") | test("^bge-m3-(encode|rerank)"))
+    )
+' /tmp/lf_trace.json
+```
+
 ## Diagnosis
 
 ### 1. Check Langfuse Connectivity

--- a/services/bge-m3-api/app.py
+++ b/services/bge-m3-api/app.py
@@ -8,12 +8,12 @@ import logging
 import os
 import time
 from contextlib import asynccontextmanager
-from typing import Any
+from typing import Annotated, Any
 
 import numpy as np
 import onnxruntime
-from fastapi import FastAPI, HTTPException, Request
-from langfuse import observe
+from fastapi import FastAPI, Header, HTTPException, Request
+from langfuse import get_client, observe
 from opentelemetry import propagate
 from opentelemetry.context import attach, detach
 from prometheus_client import Counter, Gauge, Histogram, make_asgi_app
@@ -44,6 +44,35 @@ model_loaded = Gauge("bge_model_loaded", "Model loaded status (1=loaded, 0=not l
 _onnx_session = None
 _tokenizer = None
 _warmed_up = False
+
+LangfuseTraceIdHeader = Annotated[str | None, Header(alias="x-langfuse-trace-id")]
+LangfuseParentObservationIdHeader = Annotated[
+    str | None, Header(alias="x-langfuse-parent-observation-id")
+]
+
+
+def _update_current_bge_span(
+    *,
+    input: dict[str, Any] | None = None,
+    output: dict[str, Any] | None = None,
+    encode_type: str,
+) -> None:
+    """Attach curated BGE service metadata to the active Langfuse observation."""
+    payload: dict[str, Any] = {
+        "metadata": {
+            "model": settings.MODEL_NAME,
+            "runtime": "onnx-int8",
+            "encode_type": encode_type,
+        }
+    }
+    if input is not None:
+        payload["input"] = input
+    if output is not None:
+        payload["output"] = output
+    try:
+        get_client().update_current_span(**payload)
+    except Exception:
+        logger.debug("Langfuse BGE span update skipped", exc_info=True)
 
 
 class ONNXEmbeddingModel:
@@ -377,7 +406,11 @@ async def health():
     capture_input=False,
     capture_output=False,
 )
-async def encode_dense(request: EncodeRequest):
+async def encode_dense(
+    request: EncodeRequest,
+    langfuse_trace_id: LangfuseTraceIdHeader = None,
+    langfuse_parent_observation_id: LangfuseParentObservationIdHeader = None,
+):
     """
     Encode texts to dense vectors (1024-dim)
 
@@ -385,6 +418,14 @@ async def encode_dense(request: EncodeRequest):
     """
     encode_requests_total.labels(encode_type="dense").inc()
     encode_batch_size.observe(len(request.texts))
+    _update_current_bge_span(
+        input={
+            "texts_count": len(request.texts),
+            "batch_size": request.batch_size,
+            "max_length": request.max_length,
+        },
+        encode_type="dense",
+    )
 
     try:
         valid_indices, invalid_indices, error_messages = _validate_texts(request.texts)
@@ -424,6 +465,15 @@ async def encode_dense(request: EncodeRequest):
         for i in invalid_indices:
             dense_vecs[i] = dense_sentinel.copy()
 
+        _update_current_bge_span(
+            output={
+                "vectors_count": len(dense_vecs),
+                "vector_dim": len(dense_vecs[0]) if dense_vecs else 0,
+                "processing_time": processing_time,
+                "partial_failures": len(partial_failures),
+            },
+            encode_type="dense",
+        )
         return DenseResponse(
             dense_vecs=dense_vecs,
             processing_time=processing_time,
@@ -442,7 +492,11 @@ async def encode_dense(request: EncodeRequest):
     capture_input=False,
     capture_output=False,
 )
-async def encode_sparse(request: EncodeRequest):
+async def encode_sparse(
+    request: EncodeRequest,
+    langfuse_trace_id: LangfuseTraceIdHeader = None,
+    langfuse_parent_observation_id: LangfuseParentObservationIdHeader = None,
+):
     """
     Encode texts to sparse vectors (BM25-style)
 
@@ -450,6 +504,14 @@ async def encode_sparse(request: EncodeRequest):
     """
     encode_requests_total.labels(encode_type="sparse").inc()
     encode_batch_size.observe(len(request.texts))
+    _update_current_bge_span(
+        input={
+            "texts_count": len(request.texts),
+            "batch_size": request.batch_size,
+            "max_length": request.max_length,
+        },
+        encode_type="sparse",
+    )
 
     try:
         valid_indices, invalid_indices, error_messages = _validate_texts(request.texts)
@@ -490,6 +552,14 @@ async def encode_sparse(request: EncodeRequest):
         for i in invalid_indices:
             lexical_weights[i] = sparse_sentinel.copy()
 
+        _update_current_bge_span(
+            output={
+                "weights_count": len(lexical_weights),
+                "processing_time": processing_time,
+                "partial_failures": len(partial_failures),
+            },
+            encode_type="sparse",
+        )
         return SparseResponse(
             lexical_weights=lexical_weights,
             processing_time=processing_time,
@@ -508,7 +578,11 @@ async def encode_sparse(request: EncodeRequest):
     capture_input=False,
     capture_output=False,
 )
-async def encode_colbert(request: EncodeRequest):
+async def encode_colbert(
+    request: EncodeRequest,
+    langfuse_trace_id: LangfuseTraceIdHeader = None,
+    langfuse_parent_observation_id: LangfuseParentObservationIdHeader = None,
+):
     """
     Encode texts to ColBERT multivectors
 
@@ -516,6 +590,14 @@ async def encode_colbert(request: EncodeRequest):
     """
     encode_requests_total.labels(encode_type="colbert").inc()
     encode_batch_size.observe(len(request.texts))
+    _update_current_bge_span(
+        input={
+            "texts_count": len(request.texts),
+            "batch_size": request.batch_size,
+            "max_length": request.max_length,
+        },
+        encode_type="colbert",
+    )
 
     try:
         valid_indices, invalid_indices, error_messages = _validate_texts(request.texts)
@@ -555,6 +637,15 @@ async def encode_colbert(request: EncodeRequest):
         for i in invalid_indices:
             colbert_vecs[i] = [row[:] for row in colbert_sentinel]
 
+        _update_current_bge_span(
+            output={
+                "colbert_count": len(colbert_vecs),
+                "colbert_vector_count": len(colbert_vecs[0]) if colbert_vecs else 0,
+                "processing_time": processing_time,
+                "partial_failures": len(partial_failures),
+            },
+            encode_type="colbert",
+        )
         return ColbertResponse(
             colbert_vecs=colbert_vecs,
             processing_time=processing_time,
@@ -573,7 +664,11 @@ async def encode_colbert(request: EncodeRequest):
     capture_input=False,
     capture_output=False,
 )
-async def encode_hybrid(request: EncodeRequest):
+async def encode_hybrid(
+    request: EncodeRequest,
+    langfuse_trace_id: LangfuseTraceIdHeader = None,
+    langfuse_parent_observation_id: LangfuseParentObservationIdHeader = None,
+):
     """
     Encode texts to all three representations at once
 
@@ -582,6 +677,14 @@ async def encode_hybrid(request: EncodeRequest):
     """
     encode_requests_total.labels(encode_type="hybrid").inc()
     encode_batch_size.observe(len(request.texts))
+    _update_current_bge_span(
+        input={
+            "texts_count": len(request.texts),
+            "batch_size": request.batch_size,
+            "max_length": request.max_length,
+        },
+        encode_type="hybrid",
+    )
 
     try:
         valid_indices, invalid_indices, error_messages = _validate_texts(request.texts)
@@ -637,6 +740,16 @@ async def encode_hybrid(request: EncodeRequest):
             lexical_weights[i] = sparse_sentinel.copy()
             colbert_vecs[i] = [row[:] for row in colbert_sentinel]
 
+        _update_current_bge_span(
+            output={
+                "dense_count": len(dense_vecs),
+                "sparse_count": len(lexical_weights),
+                "colbert_count": len(colbert_vecs),
+                "processing_time": processing_time,
+                "partial_failures": len(partial_failures),
+            },
+            encode_type="hybrid",
+        )
         return HybridResponse(
             dense_vecs=dense_vecs,
             lexical_weights=lexical_weights,
@@ -657,13 +770,26 @@ async def encode_hybrid(request: EncodeRequest):
     capture_input=False,
     capture_output=False,
 )
-async def rerank(request: RerankRequest):
+async def rerank(
+    request: RerankRequest,
+    langfuse_trace_id: LangfuseTraceIdHeader = None,
+    langfuse_parent_observation_id: LangfuseParentObservationIdHeader = None,
+):
     """
     Rerank documents using ColBERT MaxSim.
 
     Returns documents sorted by relevance score (highest first).
     """
     encode_requests_total.labels(encode_type="rerank").inc()
+    _update_current_bge_span(
+        input={
+            "query_length": len(request.query),
+            "documents_count": len(request.documents),
+            "top_k": request.top_k,
+            "max_length": request.max_length,
+        },
+        encode_type="rerank",
+    )
 
     # Validate limits
     if len(request.documents) > settings.RERANK_MAX_DOCS:
@@ -678,6 +804,10 @@ async def rerank(request: RerankRequest):
 
     documents = [d for d in (doc.strip() for doc in request.documents) if d]
     if not documents:
+        _update_current_bge_span(
+            output={"results_count": 0, "processing_time": 0.0},
+            encode_type="rerank",
+        )
         return RerankResponse(results=[], processing_time=0.0)
 
     try:
@@ -713,6 +843,14 @@ async def rerank(request: RerankRequest):
 
         results = [RerankResult(index=idx, score=score) for idx, score in top_results]
 
+        _update_current_bge_span(
+            output={
+                "results_count": len(results),
+                "top_score": results[0].score if results else None,
+                "processing_time": processing_time,
+            },
+            encode_type="rerank",
+        )
         return RerankResponse(results=results, processing_time=processing_time)
 
     except Exception as e:

--- a/src/services/bge_m3_client.py
+++ b/src/services/bge_m3_client.py
@@ -27,12 +27,34 @@ DEFAULT_TIMEOUT = httpx.Timeout(connect=5.0, read=30.0, write=5.0, pool=5.0)
 DEFAULT_BATCH_SIZE = 32
 DEFAULT_MAX_LENGTH = 512
 BGE_M3_MODEL_NAME = "BAAI/bge-m3"
+LANGFUSE_TRACE_ID_HEADER = "x-langfuse-trace-id"
+LANGFUSE_PARENT_OBSERVATION_ID_HEADER = "x-langfuse-parent-observation-id"
 
 
 def _trace_context_headers() -> dict[str, str]:
-    """Return W3C trace context headers for downstream BGE service calls."""
+    """Return trace context headers for downstream BGE service calls."""
     headers: dict[str, str] = {}
     inject(headers)
+    headers.update(_langfuse_trace_context_headers())
+    return headers
+
+
+def _langfuse_trace_context_headers() -> dict[str, str]:
+    """Return Langfuse context headers consumed by BGE service @observe spans."""
+    try:
+        lf = get_client()
+        trace_id = lf.get_current_trace_id() if hasattr(lf, "get_current_trace_id") else None
+        parent_id = (
+            lf.get_current_observation_id() if hasattr(lf, "get_current_observation_id") else None
+        )
+    except Exception:
+        return {}
+
+    headers: dict[str, str] = {}
+    if trace_id:
+        headers[LANGFUSE_TRACE_ID_HEADER] = str(trace_id)
+    if parent_id:
+        headers[LANGFUSE_PARENT_OBSERVATION_ID_HEADER] = str(parent_id)
     return headers
 
 

--- a/tests/unit/services/test_bge_m3_client.py
+++ b/tests/unit/services/test_bge_m3_client.py
@@ -121,6 +121,16 @@ class TestBGEM3Client:
             headers["traceparent"] = "00-11111111111111111111111111111111-2222222222222222-01"
 
         monkeypatch.setattr(mod, "inject", fake_inject)
+        monkeypatch.setattr(
+            mod,
+            "get_client",
+            lambda: MagicMock(
+                get_current_trace_id=MagicMock(
+                    return_value="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                ),
+                get_current_observation_id=MagicMock(return_value="bbbbbbbbbbbbbbbb"),
+            ),
+        )
 
         mock_resp = MagicMock()
         mock_resp.status_code = 200
@@ -140,6 +150,8 @@ class TestBGEM3Client:
 
         headers = mock_http.post.call_args.kwargs["headers"]
         assert headers["traceparent"] == ("00-11111111111111111111111111111111-2222222222222222-01")
+        assert headers["x-langfuse-trace-id"] == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        assert headers["x-langfuse-parent-observation-id"] == "bbbbbbbbbbbbbbbb"
 
     async def test_encode_hybrid_empty_input(self, client):
         result = await client.encode_hybrid([])
@@ -399,6 +411,16 @@ class TestBGEM3SyncClient:
             headers["traceparent"] = "00-33333333333333333333333333333333-4444444444444444-01"
 
         monkeypatch.setattr(mod, "inject", fake_inject)
+        monkeypatch.setattr(
+            mod,
+            "get_client",
+            lambda: mock.MagicMock(
+                get_current_trace_id=mock.MagicMock(
+                    return_value="cccccccccccccccccccccccccccccccc",
+                ),
+                get_current_observation_id=mock.MagicMock(return_value="dddddddddddddddd"),
+            ),
+        )
 
         mock_resp = mock.MagicMock()
         mock_resp.json.return_value = {
@@ -414,6 +436,8 @@ class TestBGEM3SyncClient:
 
         headers = mock_post.call_args.kwargs["headers"]
         assert headers["traceparent"] == ("00-33333333333333333333333333333333-4444444444444444-01")
+        assert headers["x-langfuse-trace-id"] == "cccccccccccccccccccccccccccccccc"
+        assert headers["x-langfuse-parent-observation-id"] == "dddddddddddddddd"
 
     def test_encode_hybrid_empty_input(self, sync_client):
         """Empty input returns empty HybridResult without HTTP call."""

--- a/tests/unit/test_bge_m3_endpoints.py
+++ b/tests/unit/test_bge_m3_endpoints.py
@@ -6,8 +6,10 @@ Covers /encode/sparse, /encode/colbert, /encode/hybrid, /encode/dense,
 All sys.modules mocking is fixture-scoped (no module-level pollution).
 """
 
+import inspect
 import sys
 from pathlib import Path
+from typing import get_args
 from unittest.mock import MagicMock
 
 import httpx
@@ -78,6 +80,7 @@ def bge_app():
         mock_prom.make_asgi_app = MagicMock(return_value=MagicMock())
         mock_lf = MagicMock()
         mock_lf.observe = lambda *_a, **_k: lambda f: f
+        mock_lf.get_client = MagicMock(return_value=MagicMock())
 
         mp.setitem(sys.modules, "onnxruntime", mock_ort)
         mp.setitem(sys.modules, "transformers", mock_transformers)
@@ -162,6 +165,43 @@ class TestEncodeHybrid:
         assert "dense_vecs" in data
         assert "lexical_weights" in data
         assert "colbert_vecs" in data
+
+    async def test_hybrid_updates_langfuse_service_span_model_metadata(
+        self, client, bge_app, monkeypatch
+    ):
+        app_module = bge_app["app_module"]
+        fake_lf = MagicMock()
+        monkeypatch.setattr(app_module, "get_client", MagicMock(return_value=fake_lf))
+
+        resp = await client.post("/encode/hybrid", json={"texts": ["hello"]})
+
+        assert resp.status_code == 200
+        metadata_calls = [
+            call.kwargs["metadata"]
+            for call in fake_lf.update_current_span.call_args_list
+            if "metadata" in call.kwargs
+        ]
+        assert metadata_calls
+        assert all(metadata["model"] == "BAAI/bge-m3" for metadata in metadata_calls)
+        assert any(metadata["runtime"] == "onnx-int8" for metadata in metadata_calls)
+        assert any(metadata["encode_type"] == "hybrid" for metadata in metadata_calls)
+
+    @pytest.mark.parametrize(
+        "handler_name",
+        ["encode_dense", "encode_sparse", "encode_colbert", "encode_hybrid", "rerank"],
+    )
+    def test_langfuse_trace_headers_are_declared_for_observe(self, bge_app, handler_name):
+        app_module = bge_app["app_module"]
+        signature = inspect.signature(getattr(app_module, handler_name))
+
+        trace_param = signature.parameters["langfuse_trace_id"]
+        parent_param = signature.parameters["langfuse_parent_observation_id"]
+
+        trace_header = get_args(trace_param.annotation)[1]
+        parent_header = get_args(parent_param.annotation)[1]
+
+        assert trace_header.alias == "x-langfuse-trace-id"
+        assert parent_header.alias == "x-langfuse-parent-observation-id"
 
     async def test_traceparent_header_is_extracted(self, client, bge_app, monkeypatch):
         app_module = bge_app["app_module"]


### PR DESCRIPTION
## Summary

- Propagate the active Langfuse trace/observation ids from `BGEM3Client` to the BGE-M3 FastAPI service alongside W3C `traceparent`.
- Let BGE service `@observe` endpoints consume those headers so service spans nest under the client `bge-m3-*` spans instead of appearing as separate/orphan traces.
- Attach curated BGE service metadata/input/output counters to Langfuse spans: `model=BAAI/bge-m3`, `runtime=onnx-int8`, `encode_type`, counts, and processing time.
- Document a Langfuse CLI acceptance plan for BGE hybrid trace checks in `docs/runbooks/LANGFUSE_TRACING_GAPS.md`.

## Docs/SDK Notes

Checked current docs via Context7:

- Langfuse Python SDK: `@observe`, current trace/observation ids, and span update APIs.
- OpenTelemetry Python: keep W3C propagation with `propagate.inject/extract`.
- FastAPI: use `Header(alias=...)` to map incoming trace headers without changing JSON request bodies.

## Live Langfuse Validation

Generated a fresh local trace through BGE-M3 + Qdrant hybrid retrieval for query `виды ВНЖ в Болгарии`.

Trace id: `f5e76e417b39cd092caea837750d50a0`

`langfuse api traces get` via `./scripts/lf trace` returned one trace containing:

- `bge-qdrant-live-link-smoke`
- `bge-m3-encode-hybrid`
- `bge-m3-service-encode-hybrid`
- `qdrant-hybrid-search-rrf`
- `qdrant-hybrid-search-rrf-colbert`

Accepted jq gates:

- required BGE/Qdrant observation families present in one Langfuse trace
- BGE service metadata has `model=BAAI/bge-m3`, `runtime=onnx-int8`, `encode_type=hybrid`
- BGE service span input/output counters are present
- BGE service span `parentObservationId` points to `bge-m3-encode-hybrid`

BGE health during validation:

```json
{"status":"ok","model_loaded":true,"warmed_up":true}
```

BGE logs for the validation window had no errors/tracebacks/401/403 failures.

## Validation

- `python -m pytest -q tests/unit/services/test_bge_m3_client.py tests/unit/test_bge_m3_endpoints.py --override-ini=addopts=`: 60 passed
- `python -m pytest -q tests/unit/services/test_bge_m3_client.py tests/unit/test_bge_m3_endpoints.py tests/unit/test_makefile_contract.py --override-ini=addopts=`: 102 passed
- `python -m ruff check src/services/bge_m3_client.py services/bge-m3-api/app.py tests/unit/services/test_bge_m3_client.py tests/unit/test_bge_m3_endpoints.py`: passed
- `git diff --check origin/dev..HEAD`: passed
- BGE image rebuild + recreate: passed
- Langfuse CLI/API trace read + jq acceptance: passed
- Bot preflight equivalent via existing venv: passed for env/token/LiteLLM; polling lock check skipped because that venv lacks the `redis` package

Note: running `make preflight-bot` directly in this isolated worktree triggered a fresh `uv` bootstrap and started compiling `grpcio` for Python 3.14, so I stopped that bootstrap and removed the generated worktree `.venv`.
