### PR TITLE
fix(observability): migrate ragas_evaluation to Langfuse v4 SDK (#2211)

### DIFF
--- a/src/evaluation/ragas_evaluation.py
+++ b/src/evaluation/ragas_evaluation.py
@@ -131,95 +131,138 @@ def _get_langfuse_client():
         return None
 
 
+# Langfuse v4 SDK imports for ``_log_ragas_scores_to_langfuse``.
+# The ``langfuse`` dependency is pinned ``>=4.0.0,<5.0`` in ``pyproject.toml``,
+# so a v3-style ``langfuse_client.trace(...)`` API call no longer exists.
+# The previous implementation passed unit tests via ``MagicMock`` only — a real
+# RAGAS run raised ``AttributeError`` and the broad ``except`` swallowed it,
+# producing zero scores in Langfuse. See issue #2211 for details.
+try:  # pragma: no cover — import-time fallback for optional dep
+    from langfuse import propagate_attributes  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover
+    propagate_attributes = None  # type: ignore[assignment]
+
+
 def _log_ragas_scores_to_langfuse(
     langfuse_client: Any,
     metrics: dict[str, float],
     session_id: str,
     trace_name: str = "ragas-evaluation",
 ) -> str | None:
-    """
-    Log RAGAS evaluation scores to Langfuse.
+    """Log RAGAS evaluation scores to Langfuse using the v4 SDK.
+
+    SDK-native pattern (see ``src/evaluation/langfuse_integration.py`` for the
+    canonical reference and Langfuse v3-to-v4 upgrade guide):
+
+    1. Open the root span via ``langfuse.start_as_current_observation(
+       as_type="span", name="ragas-evaluation")`` as a context manager so
+       ``observation.update(...)`` and ``langfuse.score_current_trace(...)``
+       resolve against the active observation.
+    2. Set trace attributes (``session_id``, ``tags``) inside the same context
+       via ``propagate_attributes(...)`` rather than passing them as
+       ``trace(...)`` kwargs (those are removed in v4).
+    3. Publish each metric via ``langfuse.score_current_trace(name=, value=,
+       data_type="NUMERIC")`` — the v4 trace-level score API.
+    4. Set the final trace I/O via ``observation.update(output=...)``.
+    5. Flush once at the end so short-lived ``make eval-rag`` runs do not lose
+       scores to ``BatchSpanProcessor`` buffering.
 
     Args:
-        langfuse_client: Langfuse client instance
-        metrics: Dictionary of RAGAS metrics
-        session_id: Session ID for grouping traces
-        trace_name: Name for the trace
+        langfuse_client: Langfuse v4 client instance.
+        metrics: Dictionary of RAGAS metrics (faithfulness, context_precision,
+            context_recall, answer_relevancy, eval_duration_seconds,
+            queries_evaluated).
+        session_id: Session ID for grouping traces in the Langfuse UI.
+        trace_name: Name for the root span (default ``ragas-evaluation``).
 
     Returns:
-        Trace ID if successful, None otherwise
+        Trace ID if successful, ``None`` if the client is missing or the SDK
+        call fails (graceful degradation — does not raise).
     """
     if langfuse_client is None:
         return None
+    if propagate_attributes is None:  # pragma: no cover — defensive
+        return None
 
     try:
-        # Create trace for this evaluation
-        trace = langfuse_client.trace(
-            name=trace_name,
-            session_id=session_id,
-            input={"evaluation_type": "ragas", "metrics_count": len(metrics)},
-            tags=["ragas", "evaluation", "quality"],
-            metadata={
-                "thresholds": {
-                    "faithfulness": FAITHFULNESS_THRESHOLD,
-                    "context_precision": CONTEXT_PRECISION_THRESHOLD,
-                    "context_recall": CONTEXT_RECALL_THRESHOLD,
-                    "answer_relevancy": ANSWER_RELEVANCY_THRESHOLD,
-                }
-            },
-        )
+        thresholds_metadata = {
+            "thresholds": {
+                "faithfulness": FAITHFULNESS_THRESHOLD,
+                "context_precision": CONTEXT_PRECISION_THRESHOLD,
+                "context_recall": CONTEXT_RECALL_THRESHOLD,
+                "answer_relevancy": ANSWER_RELEVANCY_THRESHOLD,
+            }
+        }
 
-        # Log each RAGAS metric as a score
-        score_names = [
-            "faithfulness",
-            "context_precision",
-            "context_recall",
-            "answer_relevancy",
-        ]
+        with (
+            langfuse_client.start_as_current_observation(
+                as_type="span",
+                name=trace_name,
+            ) as observation,
+            propagate_attributes(
+                session_id=session_id,
+                tags=["ragas", "evaluation", "quality"],
+                metadata=thresholds_metadata,
+            ),
+        ):
+            # Step 3: publish each metric via v4 ``score_current_trace``.
+            ragas_metric_names = (
+                "faithfulness",
+                "context_precision",
+                "context_recall",
+                "answer_relevancy",
+            )
+            for metric_name in ragas_metric_names:
+                if metric_name in metrics:
+                    langfuse_client.score_current_trace(
+                        name=metric_name,
+                        value=float(metrics[metric_name]),
+                        data_type="NUMERIC",
+                        comment=f"RAGAS {metric_name} score",
+                    )
 
-        for score_name in score_names:
-            if score_name in metrics:
-                trace.score(
-                    name=score_name,
-                    value=metrics[score_name],
-                    comment=f"RAGAS {score_name} score",
+            if "eval_duration_seconds" in metrics:
+                langfuse_client.score_current_trace(
+                    name="eval_duration_seconds",
+                    value=float(metrics["eval_duration_seconds"]),
+                    data_type="NUMERIC",
+                    comment="Evaluation duration in seconds",
                 )
 
-        # Log additional metrics
-        if "eval_duration_seconds" in metrics:
-            trace.score(
-                name="eval_duration_seconds",
-                value=metrics["eval_duration_seconds"],
-                comment="Evaluation duration in seconds",
+            if "queries_evaluated" in metrics:
+                langfuse_client.score_current_trace(
+                    name="queries_evaluated",
+                    value=float(metrics["queries_evaluated"]),
+                    data_type="NUMERIC",
+                    comment="Number of queries evaluated",
+                )
+
+            passed = metrics.get("faithfulness", 0) >= FAITHFULNESS_THRESHOLD
+            langfuse_client.score_current_trace(
+                name="acceptance_passed",
+                value=1.0 if passed else 0.0,
+                data_type="NUMERIC",
+                comment=(
+                    f"Faithfulness threshold {FAITHFULNESS_THRESHOLD} "
+                    f"{'met' if passed else 'not met'}"
+                ),
             )
 
-        if "queries_evaluated" in metrics:
-            trace.score(
-                name="queries_evaluated",
-                value=float(metrics["queries_evaluated"]),
-                comment="Number of queries evaluated",
+            # Step 4: write final I/O on the root observation.
+            observation.update(
+                input={"evaluation_type": "ragas", "metrics_count": len(metrics)},
+                output={
+                    "metrics": metrics,
+                    "acceptance_passed": passed,
+                },
             )
 
-        # Log pass/fail status
-        passed = metrics.get("faithfulness", 0) >= FAITHFULNESS_THRESHOLD
-        trace.score(
-            name="acceptance_passed",
-            value=1.0 if passed else 0.0,
-            comment=f"Faithfulness threshold {FAITHFULNESS_THRESHOLD} {'met' if passed else 'not met'}",
-        )
+            trace_id = getattr(observation, "trace_id", None)
 
-        # Update trace output
-        trace.update(
-            output={
-                "metrics": metrics,
-                "acceptance_passed": passed,
-            }
-        )
-
-        # Flush to ensure scores are sent
+        # Step 5: flush so short-lived ``make eval-rag`` runs do not drop scores.
         langfuse_client.flush()
 
-        return str(trace.id)
+        return str(trace_id) if trace_id is not None else None
 
     except Exception as e:
         print(f"   Langfuse scoring failed: {e}")

--- a/tests/unit/test_ragas_evaluation.py
+++ b/tests/unit/test_ragas_evaluation.py
@@ -1,8 +1,23 @@
 """Unit tests for src/evaluation/ragas_evaluation.py.
 
-Tests RAGAS v0.4 integration, Langfuse scoring, and threshold enforcement.
+Tests RAGAS v0.4 integration, Langfuse v4 SDK scoring, and threshold enforcement.
+
+Issue #2211: ``_log_ragas_scores_to_langfuse`` was previously written against
+the Langfuse Python v3 API (``langfuse_client.trace(...)``, ``trace.score(...)``,
+``trace.update(...)``). Those methods do not exist on Langfuse v4 SDK
+(``langfuse>=4.0.0,<5.0`` per ``pyproject.toml``), so any real RAGAS run raised
+``AttributeError`` and the function silently returned ``None`` via the broad
+``except`` block. These tests pin the v4 contract:
+
+* uses ``langfuse_client.start_as_current_observation(as_type="span", ...)`` as
+  context manager;
+* sets trace attributes via ``propagate_attributes(session_id=..., tags=...)``;
+* publishes scores via ``langfuse_client.score_current_trace(...)``;
+* updates trace I/O via ``observation.update(input=..., output=...)``;
+* calls ``langfuse_client.flush()`` once at the end.
 """
 
+from contextlib import nullcontext
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -21,86 +36,165 @@ from src.evaluation.ragas_evaluation import (
 )
 
 
-class TestThresholds:
-    """Test threshold constants are correctly set."""
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
+
+def _build_v4_mocks():
+    """Build a mock Langfuse v4 client + observation context manager.
+
+    Returns ``(mock_client, mock_obs)`` where:
+
+    * ``mock_client.start_as_current_observation(...)`` returns a context
+      manager whose ``__enter__`` yields ``mock_obs``;
+    * ``mock_client.score_current_trace(name=, value=, ...)`` is a plain
+      ``MagicMock`` capturing every score call;
+    * ``mock_obs.update(...)`` captures the final I/O update.
+    """
+    mock_obs = MagicMock(name="observation")
+    mock_obs.trace_id = "trace-v4-abc123"
+
+    mock_client = MagicMock(name="langfuse_v4_client")
+    cm = MagicMock()
+    cm.__enter__ = MagicMock(return_value=mock_obs)
+    cm.__exit__ = MagicMock(return_value=False)
+    mock_client.start_as_current_observation.return_value = cm
+    return mock_client, mock_obs
+
+
+def _score_calls(mock_client):
+    """Return list of (name, value) tuples published via ``score_current_trace``."""
+    return [
+        (call.kwargs.get("name"), call.kwargs.get("value"))
+        for call in mock_client.score_current_trace.call_args_list
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Threshold constants
+# ---------------------------------------------------------------------------
+
+
+class TestThresholds:
     def test_faithfulness_threshold(self):
-        """Test faithfulness threshold is 0.80."""
         assert FAITHFULNESS_THRESHOLD == 0.80
 
     def test_context_precision_threshold(self):
-        """Test context precision threshold is 0.80."""
         assert CONTEXT_PRECISION_THRESHOLD == 0.80
 
     def test_context_recall_threshold(self):
-        """Test context recall threshold is 0.90."""
         assert CONTEXT_RECALL_THRESHOLD == 0.90
 
     def test_answer_relevancy_threshold(self):
-        """Test answer relevancy threshold is 0.80."""
         assert ANSWER_RELEVANCY_THRESHOLD == 0.80
 
 
-class TestGetLangfuseClient:
-    """Test _get_langfuse_client function."""
+# ---------------------------------------------------------------------------
+# _get_langfuse_client
+# ---------------------------------------------------------------------------
 
+
+class TestGetLangfuseClient:
     def test_returns_none_when_tracing_disabled(self):
-        """Test returns None when LANGFUSE_TRACING_ENABLED is not set."""
         with patch.dict("os.environ", {}, clear=True):
-            result = _get_langfuse_client()
-            assert result is None
+            assert _get_langfuse_client() is None
 
     def test_returns_none_when_tracing_explicitly_disabled(self):
-        """Test returns None when LANGFUSE_TRACING_ENABLED is false."""
         with patch.dict("os.environ", {"LANGFUSE_TRACING_ENABLED": "false"}):
-            result = _get_langfuse_client()
-            assert result is None
+            assert _get_langfuse_client() is None
 
     def test_creates_client_when_enabled(self):
-        """Test creates Langfuse client when tracing is enabled."""
-        # Patch at the point of import inside the function
-        with patch.dict(
-            "os.environ",
-            {
-                "LANGFUSE_TRACING_ENABLED": "true",
-                "LANGFUSE_HOST": "http://test:3001",
-                "LANGFUSE_PUBLIC_KEY": "pk-test",
-                "LANGFUSE_SECRET_KEY": "sk-test",
-            },
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "LANGFUSE_TRACING_ENABLED": "true",
+                    "LANGFUSE_HOST": "http://test:3001",
+                    "LANGFUSE_PUBLIC_KEY": "pk-test",
+                    "LANGFUSE_SECRET_KEY": "sk-test",
+                },
+            ),
+            patch("langfuse.Langfuse") as mock_langfuse_class,
         ):
-            with patch("langfuse.Langfuse") as mock_langfuse_class:
-                mock_client = MagicMock()
-                mock_langfuse_class.return_value = mock_client
+            mock_client = MagicMock()
+            mock_langfuse_class.return_value = mock_client
 
-                result = _get_langfuse_client()
-
-                # Verify Langfuse was called with correct params
-                mock_langfuse_class.assert_called_once_with(
-                    host="http://test:3001",
-                    public_key="pk-test",
-                    secret_key="sk-test",
-                )
-                assert result == mock_client
+            assert _get_langfuse_client() is mock_client
+            mock_langfuse_class.assert_called_once_with(
+                host="http://test:3001",
+                public_key="pk-test",
+                secret_key="sk-test",
+            )
 
 
-class TestLogRagasScoresToLangfuse:
-    """Test _log_ragas_scores_to_langfuse function."""
+# ---------------------------------------------------------------------------
+# _log_ragas_scores_to_langfuse — v4 SDK contract
+# ---------------------------------------------------------------------------
+
+
+class TestLogRagasScoresToLangfuseV4Contract:
+    """Pin the v4 SDK contract for ragas score publishing (#2211)."""
 
     def test_returns_none_when_client_is_none(self):
-        """Test returns None when langfuse_client is None."""
-        result = _log_ragas_scores_to_langfuse(
-            langfuse_client=None,
-            metrics={"faithfulness": 0.85},
-            session_id="test-session",
+        assert (
+            _log_ragas_scores_to_langfuse(
+                langfuse_client=None,
+                metrics={"faithfulness": 0.85},
+                session_id="test-session",
+            )
+            is None
         )
-        assert result is None
 
-    def test_logs_all_ragas_metrics(self):
-        """Test all 4 RAGAS metrics are logged to Langfuse."""
-        mock_client = MagicMock()
-        mock_trace = MagicMock()
-        mock_trace.id = "trace-123"
-        mock_client.trace.return_value = mock_trace
+    def test_uses_start_as_current_observation_context_manager(self):
+        """v4: must open a span via ``start_as_current_observation`` (not v3 ``trace(...)``)."""
+        mock_client, _mock_obs = _build_v4_mocks()
+
+        with patch(
+            "src.evaluation.ragas_evaluation.propagate_attributes",
+            return_value=nullcontext(),
+        ):
+            _log_ragas_scores_to_langfuse(
+                langfuse_client=mock_client,
+                metrics={"faithfulness": 0.85},
+                session_id="test-session",
+            )
+
+        # v4 contract: start_as_current_observation called exactly once
+        assert mock_client.start_as_current_observation.call_count == 1
+        kwargs = mock_client.start_as_current_observation.call_args.kwargs
+        assert kwargs.get("as_type") == "span"
+        assert kwargs.get("name") == "ragas-evaluation"
+
+        # v3 ``trace(...)`` method is forbidden
+        assert not mock_client.trace.called, (
+            "v3 ``langfuse_client.trace(...)`` API was removed in Langfuse v4 SDK; "
+            "use ``start_as_current_observation`` instead (#2211)."
+        )
+
+    def test_uses_propagate_attributes_for_session_and_tags(self):
+        """v4: session_id/tags travel via ``propagate_attributes(...)`` context manager."""
+        mock_client, _ = _build_v4_mocks()
+
+        with patch(
+            "src.evaluation.ragas_evaluation.propagate_attributes",
+            return_value=nullcontext(),
+        ) as mock_propagate:
+            _log_ragas_scores_to_langfuse(
+                langfuse_client=mock_client,
+                metrics={"faithfulness": 0.85},
+                session_id="ragas-2026-05-28",
+            )
+
+        mock_propagate.assert_called_once()
+        kw = mock_propagate.call_args.kwargs
+        assert kw.get("session_id") == "ragas-2026-05-28"
+        assert "ragas" in kw.get("tags", [])
+        assert "evaluation" in kw.get("tags", [])
+
+    def test_publishes_all_four_ragas_metrics_via_score_current_trace(self):
+        """v4: each RAGAS metric must be published via ``score_current_trace``."""
+        mock_client, _ = _build_v4_mocks()
 
         metrics = {
             "faithfulness": 0.85,
@@ -108,176 +202,157 @@ class TestLogRagasScoresToLangfuse:
             "context_recall": 0.91,
             "answer_relevancy": 0.88,
         }
+        with patch(
+            "src.evaluation.ragas_evaluation.propagate_attributes",
+            return_value=nullcontext(),
+        ):
+            _log_ragas_scores_to_langfuse(
+                langfuse_client=mock_client,
+                metrics=metrics,
+                session_id="s1",
+            )
 
-        result = _log_ragas_scores_to_langfuse(
-            langfuse_client=mock_client,
-            metrics=metrics,
-            session_id="test-session",
-        )
+        published = dict(_score_calls(mock_client))
+        for ragas_metric, value in metrics.items():
+            assert ragas_metric in published, (
+                f"{ragas_metric} must be published via ``score_current_trace``"
+            )
+            assert published[ragas_metric] == value
 
-        assert result == "trace-123"
+    def test_publishes_acceptance_passed_score(self):
+        mock_client, _ = _build_v4_mocks()
 
-        # Verify trace was created
-        mock_client.trace.assert_called_once()
-        call_kwargs = mock_client.trace.call_args.kwargs
-        assert call_kwargs["session_id"] == "test-session"
-        assert "ragas" in call_kwargs["tags"]
+        with patch(
+            "src.evaluation.ragas_evaluation.propagate_attributes",
+            return_value=nullcontext(),
+        ):
+            _log_ragas_scores_to_langfuse(
+                langfuse_client=mock_client,
+                metrics={"faithfulness": 0.85},
+                session_id="s1",
+            )
 
-        # Verify all 4 RAGAS metrics + acceptance_passed were scored
-        # 4 RAGAS metrics + acceptance_passed = 5 score calls minimum
-        assert mock_trace.score.call_count >= 5
+        published = dict(_score_calls(mock_client))
+        assert published.get("acceptance_passed") == 1.0
 
-    def test_logs_eval_duration_when_present(self):
-        """Test eval_duration_seconds is logged when present."""
-        mock_client = MagicMock()
-        mock_trace = MagicMock()
-        mock_trace.id = "trace-456"
-        mock_client.trace.return_value = mock_trace
+    def test_publishes_acceptance_failed_when_faithfulness_below_threshold(self):
+        mock_client, _ = _build_v4_mocks()
 
-        metrics = {
-            "faithfulness": 0.85,
-            "eval_duration_seconds": 42.5,
-        }
+        with patch(
+            "src.evaluation.ragas_evaluation.propagate_attributes",
+            return_value=nullcontext(),
+        ):
+            _log_ragas_scores_to_langfuse(
+                langfuse_client=mock_client,
+                metrics={"faithfulness": 0.75},
+                session_id="s1",
+            )
 
-        _log_ragas_scores_to_langfuse(
-            langfuse_client=mock_client,
-            metrics=metrics,
-            session_id="test-session",
-        )
+        published = dict(_score_calls(mock_client))
+        assert published.get("acceptance_passed") == 0.0
 
-        # Check that eval_duration_seconds was logged
-        score_calls = mock_trace.score.call_args_list
-        duration_calls = [c for c in score_calls if c.kwargs.get("name") == "eval_duration_seconds"]
-        assert len(duration_calls) == 1
-        assert duration_calls[0].kwargs["value"] == 42.5
+    def test_publishes_eval_duration_when_present(self):
+        mock_client, _ = _build_v4_mocks()
 
-    def test_logs_queries_evaluated_when_present(self):
-        """Test queries_evaluated is logged when present."""
-        mock_client = MagicMock()
-        mock_trace = MagicMock()
-        mock_trace.id = "trace-789"
-        mock_client.trace.return_value = mock_trace
+        with patch(
+            "src.evaluation.ragas_evaluation.propagate_attributes",
+            return_value=nullcontext(),
+        ):
+            _log_ragas_scores_to_langfuse(
+                langfuse_client=mock_client,
+                metrics={"faithfulness": 0.85, "eval_duration_seconds": 42.5},
+                session_id="s1",
+            )
 
-        metrics = {
-            "faithfulness": 0.85,
-            "queries_evaluated": 55,
-        }
+        published = dict(_score_calls(mock_client))
+        assert published.get("eval_duration_seconds") == 42.5
 
-        _log_ragas_scores_to_langfuse(
-            langfuse_client=mock_client,
-            metrics=metrics,
-            session_id="test-session",
-        )
+    def test_publishes_queries_evaluated_when_present(self):
+        mock_client, _ = _build_v4_mocks()
 
-        score_calls = mock_trace.score.call_args_list
-        queries_calls = [c for c in score_calls if c.kwargs.get("name") == "queries_evaluated"]
-        assert len(queries_calls) == 1
-        assert queries_calls[0].kwargs["value"] == 55.0
+        with patch(
+            "src.evaluation.ragas_evaluation.propagate_attributes",
+            return_value=nullcontext(),
+        ):
+            _log_ragas_scores_to_langfuse(
+                langfuse_client=mock_client,
+                metrics={"faithfulness": 0.85, "queries_evaluated": 55},
+                session_id="s1",
+            )
 
-    def test_acceptance_passed_when_faithfulness_meets_threshold(self):
-        """Test acceptance_passed=1.0 when faithfulness >= 0.80."""
-        mock_client = MagicMock()
-        mock_trace = MagicMock()
-        mock_trace.id = "trace-pass"
-        mock_client.trace.return_value = mock_trace
+        published = dict(_score_calls(mock_client))
+        assert published.get("queries_evaluated") == 55.0
 
-        metrics = {"faithfulness": 0.85}  # > 0.80
-
-        _log_ragas_scores_to_langfuse(
-            langfuse_client=mock_client,
-            metrics=metrics,
-            session_id="test-session",
-        )
-
-        score_calls = mock_trace.score.call_args_list
-        acceptance_calls = [c for c in score_calls if c.kwargs.get("name") == "acceptance_passed"]
-        assert len(acceptance_calls) == 1
-        assert acceptance_calls[0].kwargs["value"] == 1.0
-
-    def test_acceptance_failed_when_faithfulness_below_threshold(self):
-        """Test acceptance_passed=0.0 when faithfulness < 0.80."""
-        mock_client = MagicMock()
-        mock_trace = MagicMock()
-        mock_trace.id = "trace-fail"
-        mock_client.trace.return_value = mock_trace
-
-        metrics = {"faithfulness": 0.75}  # < 0.80
-
-        _log_ragas_scores_to_langfuse(
-            langfuse_client=mock_client,
-            metrics=metrics,
-            session_id="test-session",
-        )
-
-        score_calls = mock_trace.score.call_args_list
-        acceptance_calls = [c for c in score_calls if c.kwargs.get("name") == "acceptance_passed"]
-        assert len(acceptance_calls) == 1
-        assert acceptance_calls[0].kwargs["value"] == 0.0
-
-    def test_trace_output_includes_metrics_and_acceptance(self):
-        """Test trace output contains metrics and acceptance_passed."""
-        mock_client = MagicMock()
-        mock_trace = MagicMock()
-        mock_trace.id = "trace-output"
-        mock_client.trace.return_value = mock_trace
+    def test_updates_observation_with_input_and_output(self):
+        """v4: trace I/O must be written via ``observation.update(input=, output=)``."""
+        mock_client, mock_obs = _build_v4_mocks()
 
         metrics = {"faithfulness": 0.85, "context_precision": 0.82}
+        with patch(
+            "src.evaluation.ragas_evaluation.propagate_attributes",
+            return_value=nullcontext(),
+        ):
+            _log_ragas_scores_to_langfuse(
+                langfuse_client=mock_client,
+                metrics=metrics,
+                session_id="s1",
+            )
 
-        _log_ragas_scores_to_langfuse(
-            langfuse_client=mock_client,
-            metrics=metrics,
-            session_id="test-session",
-        )
-
-        # Verify trace.update was called with output
-        mock_trace.update.assert_called_once()
-        update_kwargs = mock_trace.update.call_args.kwargs
+        assert mock_obs.update.called, "observation.update(...) must be called"
+        update_kwargs = mock_obs.update.call_args.kwargs
         assert "output" in update_kwargs
         assert update_kwargs["output"]["metrics"] == metrics
         assert update_kwargs["output"]["acceptance_passed"] is True
 
     def test_flushes_client_after_logging(self):
-        """Test langfuse client is flushed after logging."""
-        mock_client = MagicMock()
-        mock_trace = MagicMock()
-        mock_trace.id = "trace-flush"
-        mock_client.trace.return_value = mock_trace
+        mock_client, _ = _build_v4_mocks()
 
-        metrics = {"faithfulness": 0.85}
-
-        _log_ragas_scores_to_langfuse(
-            langfuse_client=mock_client,
-            metrics=metrics,
-            session_id="test-session",
-        )
+        with patch(
+            "src.evaluation.ragas_evaluation.propagate_attributes",
+            return_value=nullcontext(),
+        ):
+            _log_ragas_scores_to_langfuse(
+                langfuse_client=mock_client,
+                metrics={"faithfulness": 0.85},
+                session_id="s1",
+            )
 
         mock_client.flush.assert_called_once()
 
+    def test_returns_trace_id_from_observation(self):
+        mock_client, mock_obs = _build_v4_mocks()
+        mock_obs.trace_id = "trace-v4-xyz789"
+
+        with patch(
+            "src.evaluation.ragas_evaluation.propagate_attributes",
+            return_value=nullcontext(),
+        ):
+            result = _log_ragas_scores_to_langfuse(
+                langfuse_client=mock_client,
+                metrics={"faithfulness": 0.85},
+                session_id="s1",
+            )
+
+        assert result == "trace-v4-xyz789"
+
     def test_handles_langfuse_errors_gracefully(self):
-        """Test returns None when Langfuse raises an exception."""
         mock_client = MagicMock()
-        mock_client.trace.side_effect = Exception("Connection failed")
+        mock_client.start_as_current_observation.side_effect = Exception("Connection failed")
 
         result = _log_ragas_scores_to_langfuse(
             langfuse_client=mock_client,
             metrics={"faithfulness": 0.85},
-            session_id="test-session",
+            session_id="s1",
         )
 
         assert result is None
 
 
 class TestRAGASMetricsFormat:
-    """Test that metrics dict follows expected format."""
+    def test_complete_metrics_dict_publishes_seven_scores(self):
+        """Full metrics dict produces 7 scores: 4 RAGAS + duration + queries + acceptance."""
+        mock_client, _ = _build_v4_mocks()
 
-    def test_all_expected_metrics_can_be_logged(self):
-        """Test complete metrics dict can be logged without errors."""
-        mock_client = MagicMock()
-        mock_trace = MagicMock()
-        mock_trace.id = "trace-complete"
-        mock_client.trace.return_value = mock_trace
-
-        # Complete metrics dict as returned by RAGASEvaluator
         complete_metrics = {
             "faithfulness": 0.85,
             "context_precision": 0.82,
@@ -286,53 +361,45 @@ class TestRAGASMetricsFormat:
             "eval_duration_seconds": 123.4,
             "queries_evaluated": 55,
         }
+        with patch(
+            "src.evaluation.ragas_evaluation.propagate_attributes",
+            return_value=nullcontext(),
+        ):
+            _log_ragas_scores_to_langfuse(
+                langfuse_client=mock_client,
+                metrics=complete_metrics,
+                session_id="s1",
+            )
 
-        result = _log_ragas_scores_to_langfuse(
-            langfuse_client=mock_client,
-            metrics=complete_metrics,
-            session_id="test-session",
-        )
-
-        assert result == "trace-complete"
-
-        # Should have logged 7 scores:
-        # 4 RAGAS metrics + eval_duration + queries_evaluated + acceptance_passed
-        assert mock_trace.score.call_count == 7
+        # 4 RAGAS + eval_duration + queries_evaluated + acceptance_passed = 7
+        assert mock_client.score_current_trace.call_count == 7
 
 
 class TestThresholdEnforcement:
-    """Test threshold enforcement in acceptance criteria."""
-
     @pytest.mark.parametrize(
         "faithfulness,expected_passed",
         [
-            (0.80, True),  # Exactly at threshold
-            (0.81, True),  # Above threshold
-            (0.95, True),  # Well above threshold
-            (0.79, False),  # Just below threshold
-            (0.50, False),  # Well below threshold
-            (0.0, False),  # Zero
+            (0.80, True),
+            (0.81, True),
+            (0.95, True),
+            (0.79, False),
+            (0.50, False),
+            (0.0, False),
         ],
     )
     def test_acceptance_based_on_faithfulness(self, faithfulness, expected_passed):
-        """Test acceptance_passed correctly reflects faithfulness threshold."""
-        mock_client = MagicMock()
-        mock_trace = MagicMock()
-        mock_trace.id = "trace-param"
-        mock_client.trace.return_value = mock_trace
+        mock_client, _ = _build_v4_mocks()
 
-        metrics = {"faithfulness": faithfulness}
+        with patch(
+            "src.evaluation.ragas_evaluation.propagate_attributes",
+            return_value=nullcontext(),
+        ):
+            _log_ragas_scores_to_langfuse(
+                langfuse_client=mock_client,
+                metrics={"faithfulness": faithfulness},
+                session_id="s1",
+            )
 
-        _log_ragas_scores_to_langfuse(
-            langfuse_client=mock_client,
-            metrics=metrics,
-            session_id="test-session",
-        )
-
-        # Find acceptance_passed score call
-        score_calls = mock_trace.score.call_args_list
-        acceptance_calls = [c for c in score_calls if c.kwargs.get("name") == "acceptance_passed"]
-        assert len(acceptance_calls) == 1
-
+        published = dict(_score_calls(mock_client))
         expected_value = 1.0 if expected_passed else 0.0
-        assert acceptance_calls[0].kwargs["value"] == expected_value
+        assert published.get("acceptance_passed") == expected_value


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Migrate `src/evaluation/ragas_evaluation.py::_log_ragas_scores_to_langfuse` from Langfuse v3 SDK to v4. Closes the P0 finding from #2210/#2215 audit (Epic B).

### Why

`pyproject.toml` pins `langfuse>=4.0.0,<5.0` since the v3→v4 upgrade. The function was still using v3 APIs that were removed in v4:

- `langfuse_client.trace(...)` → AttributeError on v4
- `trace.score(...)` → AttributeError on v4
- `trace.update(...)` → AttributeError on v4

A real `make eval-rag` run hit the AttributeError, the broad `except` swallowed it, and the function returned `None` — **zero scores published in production**. Existing unit tests passed only because `MagicMock` returns `MagicMock` for any attribute access.

### What changed

Rewrote `_log_ragas_scores_to_langfuse` using the v4 pattern from the canonical reference `src/evaluation/langfuse_integration.py`:

- `langfuse.start_as_current_observation(as_type="span", name=trace_name)` as context manager
- `propagate_attributes(session_id=, tags=, metadata=)` for trace attributes (replaces v3 `trace(session_id=, tags=, metadata=)` kwargs)
- `langfuse.score_current_trace(name=, value=, data_type="NUMERIC")` per metric (4 RAGAS + duration + queries + acceptance = 7 scores)
- `observation.update(input=, output=)` for trace I/O
- `langfuse.flush()` at the end so short-lived `make eval-rag` runs do not drop scores to `BatchSpanProcessor` buffering
- Graceful degradation preserved (broad `except` returns `None`, prints diagnostic)

### TDD

Tests rewritten **first** to pin the v4 contract (RED), then code rewritten to make them pass (GREEN). New tests:

- `test_uses_start_as_current_observation_context_manager` — explicit guard that forbids v3 `mock_client.trace(...)`
- `test_uses_propagate_attributes_for_session_and_tags`
- `test_publishes_all_four_ragas_metrics_via_score_current_trace`
- `test_publishes_acceptance_passed_score` / `test_publishes_acceptance_failed_when_faithfulness_below_threshold`
- `test_publishes_eval_duration_when_present` / `test_publishes_queries_evaluated_when_present`
- `test_updates_observation_with_input_and_output`
- `test_flushes_client_after_logging`
- `test_returns_trace_id_from_observation`
- `test_handles_langfuse_errors_gracefully`
- `TestRAGASMetricsFormat::test_complete_metrics_dict_publishes_seven_scores`
- Parametrized `TestThresholdEnforcement` (boundary + above/below threshold)

### Validation

- `uv run pytest tests/unit/test_ragas_evaluation.py` — 26/26 passed.
- `uv run pytest tests/unit/evaluation/` — 229/229 passed.
- `uv run pytest tests/contract/` — 1264/1264 passed (no regressions).
- `uv run ruff check` + `ruff format` clean.

### Refs

- #2215 — umbrella audit (Phase 1 / Sprint 0).
- #2211 — this Epic B issue.
- `src/evaluation/langfuse_integration.py:65-180` — v4 reference pattern used as template.
- Langfuse v3→v4 upgrade guide: https://langfuse.com/docs/observability/sdk/upgrade-path/python-v3-to-v4