### PR TITLE
fix(observability): wire user-base Langfuse env + voice auth_check (#2210)

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -59,6 +59,10 @@ services:
   user-base:
     ports:
       - "127.0.0.1:8003:8000"
+    environment:
+      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-pk-lf-dev}
+      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-sk-lf-dev}
+      OTEL_SERVICE_NAME: "${OTEL_SERVICE_NAME:-user-base}"
 
   docling:
     ports:

--- a/compose.yml
+++ b/compose.yml
@@ -150,6 +150,10 @@ services:
       HF_HOME: /models/hf
       TRANSFORMERS_CACHE: /models/hf
       SENTENCE_TRANSFORMERS_HOME: /models/sentence-transformers
+      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}
+      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
+      LANGFUSE_HOST: ${LANGFUSE_DOCKER_HOST:-http://langfuse:3000}
+      OTEL_SERVICE_NAME: "${OTEL_SERVICE_NAME:-user-base}"
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=5)"]
       interval: 30s

--- a/src/voice/agent.py
+++ b/src/voice/agent.py
@@ -275,6 +275,17 @@ def _setup_langfuse() -> None:
         # initialize_langfuse already logged the reason at INFO/WARNING.
         return
 
+    # Verify credentials/host reachability and surface a WARNING log on failure
+    # so operators see "Langfuse degraded" instead of silent no-op tracing.
+    # mini_app/api.py:73-105 is the canonical lifespan reference (#2210).
+    try:
+        client.auth_check()
+    except Exception:
+        logger.warning(
+            "Langfuse auth_check failed; voice traces may not reach the backend",
+            exc_info=True,
+        )
+
     provider = trace.get_tracer_provider()
 
     try:

--- a/tests/unit/test_compose_langfuse.py
+++ b/tests/unit/test_compose_langfuse.py
@@ -29,7 +29,21 @@ def _get_service_env(compose: dict, service: str) -> dict[str, str]:
 
 
 # Сервисы которые ДОЛЖНЫ иметь LANGFUSE vars
-TRACED_SERVICES = ["bge-m3", "bot", "litellm", "rag-api", "voice-agent", "ingestion"]
+#
+# Includes every micro-service whose code carries ``@observe`` decorators.
+# A service that emits ``@observe`` spans without these env vars in its compose
+# block will silently no-op the SDK at startup — see #2210 (bge-m3 was the same
+# class of bug fixed in #2229; user-base + mini-app-api close the rest).
+TRACED_SERVICES = [
+    "bge-m3",
+    "bot",
+    "ingestion",
+    "litellm",
+    "mini-app-api",
+    "rag-api",
+    "user-base",
+    "voice-agent",
+]
 
 # Минимальный набор vars для трейсинга
 REQUIRED_LANGFUSE_VARS = [

--- a/tests/unit/voice/test_voice_agent.py
+++ b/tests/unit/voice/test_voice_agent.py
@@ -87,6 +87,61 @@ def test_voice_bot_stores_trace_session_id():
     assert agent._session_id == "voice-call-xyz"
 
 
+def test_setup_langfuse_calls_auth_check_when_client_is_initialized(monkeypatch):
+    """When a Langfuse client is returned, _setup_langfuse must call
+    ``client.auth_check()`` and warn-log on failure (#2210).
+
+    Without auth_check, an unreachable Langfuse host or rotated keys would
+    silently degrade to no-op tracing and the operator would have no signal
+    in the voice-agent logs. ``mini_app/api.py:73-105`` is the canonical
+    lifespan reference.
+    """
+    import src.voice.agent as mod
+
+    fake_provider = object()
+    fake_client = MagicMock()
+    fake_client.auth_check.return_value = True
+
+    with (
+        patch("src.voice.agent.initialize_langfuse", return_value=fake_client),
+        patch("src.voice.agent.trace.get_tracer_provider", return_value=fake_provider),
+        patch("livekit.agents.telemetry.set_tracer_provider"),
+    ):
+        mod._setup_langfuse()
+
+    fake_client.auth_check.assert_called_once_with()
+
+
+def test_setup_langfuse_logs_warning_when_auth_check_fails(monkeypatch, caplog):
+    """auth_check() failure must produce a WARNING log (not crash). #2210."""
+    import logging
+
+    import src.voice.agent as mod
+
+    fake_provider = object()
+    fake_client = MagicMock()
+    fake_client.auth_check.side_effect = RuntimeError("Langfuse unreachable")
+
+    with (
+        patch("src.voice.agent.initialize_langfuse", return_value=fake_client),
+        patch("src.voice.agent.trace.get_tracer_provider", return_value=fake_provider),
+        patch("livekit.agents.telemetry.set_tracer_provider"),
+        caplog.at_level(logging.WARNING, logger="src.voice.agent"),
+    ):
+        mod._setup_langfuse()  # must not raise
+
+    fake_client.auth_check.assert_called_once_with()
+    # Warning log must surface so operators see "Langfuse degraded"
+    assert any(
+        "auth_check" in record.message.lower() or "langfuse" in record.message.lower()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+    ), (
+        "Voice agent must log a WARNING when Langfuse auth_check fails so the "
+        "operator gets a signal instead of silent no-op tracing (#2210)."
+    )
+
+
 def test_setup_langfuse_delegates_to_canonical_initialize(monkeypatch):
     """Voice OTEL setup reuses src.observability.initialize_langfuse instead of
     building a parallel OTLP/TracerProvider/BatchSpanProcessor pipeline (#2059).


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Continues the #2229 BGE-M3 observability work for the **remaining two findings** of Epic A in the #2215 audit. After this PR Sprint 0 of the umbrella plan is complete.

### What was missing after #2229

#2229 added `LANGFUSE_*` env to `bge-m3`, but **two other gaps remained**:

1. **`services/user-base/main.py`** declares `@observe(name="user-base-service-embed{,-batch}")` at lines 119, 135. The compose service `user-base` (compose.yml:139-164 before this PR) had only `HF_HOME`, `TRANSFORMERS_CACHE`, `SENTENCE_TRANSFORMERS_HOME` in `environment:` — **no `LANGFUSE_*`, no `OTEL_SERVICE_NAME`** — so the SDK silently no-op'd at startup and every embedding span dropped into the void. Same exact pattern as bge-m3 was before #2229's `15a95e7`.
2. **`src/voice/agent.py::_setup_langfuse()`** called `initialize_langfuse()` and forwarded its `TracerProvider` to LiveKit but **never called `client.auth_check()`**. A missing or rotated `LANGFUSE_SECRET_KEY` would silently degrade to no-op tracing with zero log signal — operators had no way to spot Langfuse unreachability from voice-agent logs alone.

### Changes

- **`compose.yml::user-base.environment`** + **`compose.dev.yml`** mirror the bge-m3 `15a95e7` template (`LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST`, `OTEL_SERVICE_NAME=user-base`).
- **`tests/unit/test_compose_langfuse.py::TRACED_SERVICES`** now includes `user-base` and `mini-app-api` (the latter had env wired in compose already but wasn't asserted) — the parametrised contract guards both compose files for every (service × env-var) pair.
- **`src/voice/agent.py::_setup_langfuse()`** calls `client.auth_check()` and emits a `WARNING` log on failure. Does not raise — voice keeps running with degraded tracing, matching the canonical `mini_app/api.py:73-105` reference lifespan.

### TDD

- **RED**: `TRACED_SERVICES` extension makes 3 parametrised tests fail on `user-base` (no env in compose). Two new voice tests (`test_setup_langfuse_calls_auth_check_when_client_is_initialized`, `test_setup_langfuse_logs_warning_when_auth_check_fails`) fail because `auth_check()` is not called.
- **GREEN**: After wiring env in compose and adding `auth_check()` call with try/except, all tests pass.

### Validation

- `uv run pytest tests/unit/test_compose_langfuse.py` — 81 passed.
- `uv run pytest tests/unit/voice/test_voice_agent.py` — 22/22 passed.
- Full contract + unit run: **1434 passed, 62 skipped** (Docker/cocoindex/VPS-only).
- `uv run ruff check` clean.

### Refs

- #2215 — umbrella audit (Sprint 0 PR-2 of Phase 1).
- #2210 — Epic A issue (closes the remaining 2 findings; the bge-m3 finding was closed in #2229).
- #2229 — `15a95e7` BGE-M3 env-wiring template used here.
- `mini_app/api.py:73-105` — canonical lifespan reference for `auth_check()` pattern.