### PR TITLE
feat(observability): propagate Langfuse attrs via W3C Baggage cross-service (#2226)

### DIFF
--- a/mini_app/api.py
+++ b/mini_app/api.py
@@ -237,6 +237,7 @@ async def start_expert(
         user_id=str(user_id),
         tags=["miniapp", "start-expert", request.expert_id],
         metadata={"surface": "miniapp"},
+        as_baggage=True,
     ):
         _update_current_span(
             input={
@@ -412,6 +413,7 @@ async def phone(
         user_id=str(user_id),
         tags=["miniapp", "submit-phone", request.source],
         metadata={"surface": "miniapp"},
+        as_baggage=True,
     ):
         _update_current_span(input={"source": request.source, "has_name": request.name is not None})
         result = await submit_phone(verified_request)

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -368,6 +368,14 @@ async def _execute_query(req: QueryRequest) -> QueryResponse:
         "user_id": str(req.user_id),
         "metadata": {"source": req.channel},
         "tags": ["api", "rag", req.channel],
+        # Inject user_id/session_id/tags into the W3C 'baggage' HTTP header
+        # so downstream calls (bge-m3, user-base, kommo, qdrant) carry the
+        # Langfuse trace attributes automatically. HTTPXClientInstrumentor
+        # (#2225) injects the default OTEL propagator (which includes
+        # baggage by default) on every outbound request — no per-call
+        # plumbing needed (replaces the manual #2229 inject(headers)
+        # pattern; see #2226).
+        "as_baggage": True,
     }
 
     with propagate_attributes(**trace_kwargs):

--- a/telegram_bot/middlewares/langfuse_middleware.py
+++ b/telegram_bot/middlewares/langfuse_middleware.py
@@ -82,6 +82,7 @@ class LangfuseContextMiddleware(BaseMiddleware):
                 session_id=session_id,
                 user_id=str(user_id) if user_id is not None else None,
                 tags=["telegram", action_type],
+                as_baggage=True,
             ),
         ):
             return await handler(event, data)

--- a/tests/unit/api/test_rag_api_runtime.py
+++ b/tests/unit/api/test_rag_api_runtime.py
@@ -106,6 +106,7 @@ async def test_query_updates_current_observation_and_propagates_api_attributes()
         user_id="42",
         metadata={"source": "voice"},
         tags=["api", "rag", "voice"],
+        as_baggage=True,
     )
     lf.update_current_span.assert_called_once()
     call_kwargs = lf.update_current_span.call_args.kwargs

--- a/tests/unit/observability/test_w3c_baggage_propagation.py
+++ b/tests/unit/observability/test_w3c_baggage_propagation.py
@@ -1,0 +1,146 @@
+"""Unit tests for W3C Baggage propagation across HTTP boundaries (#2226).
+
+Background: Langfuse v4 SDK is built on top of OpenTelemetry. The default
+``opentelemetry.propagate.get_global_textmap()`` is a CompositePropagator
+that already serializes ``traceparent``, ``tracestate`` and ``baggage``
+on outbound HTTP requests when ``HTTPXClientInstrumentor`` (#2225) is
+active. The Langfuse-canonical way to populate ``baggage`` with
+``user_id`` / ``session_id`` / ``tags`` from a server-side request is
+``propagate_attributes(..., as_baggage=True)``.
+
+Pass-5 finding from #2215 audit confirmed that #2229 used **bare OTEL**
+``propagate.extract`` / ``propagate.inject`` for bge-m3 cross-service
+trace context — that carries ``traceparent`` (parent-child wiring works)
+but does NOT carry the Langfuse trace attributes. Result: bge-m3 spans
+land under the right trace in Langfuse UI but with empty user_id /
+session_id / tags filters.
+
+This file pins the contract:
+
+1. Every entry-point ``propagate_attributes(...)`` in the codebase that
+   surrounds a cross-process boundary (bot ingress, mini-app ingress,
+   rag-api receiver, voice agent) MUST pass ``as_baggage=True``.
+2. After this change, no per-call ``inject(headers)`` plumbing is needed
+   on the client side — ``HTTPXClientInstrumentor`` (#2225) injects the
+   default propagator (which includes baggage) automatically.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+# Entry points that surround cross-process boundaries. Each must call
+# ``propagate_attributes(..., as_baggage=True)`` so the Langfuse SDK puts
+# user_id/session_id/tags into the W3C ``baggage`` HTTP header that
+# HTTPXClientInstrumentor (Epic O #2225) injects automatically.
+_REQUIRED_AS_BAGGAGE_CALL_SITES: tuple[tuple[str, str], ...] = (
+    # (relative_path, function_name_or_class_marker)
+    ("telegram_bot/middlewares/langfuse_middleware.py", "LangfuseContextMiddleware"),
+    ("mini_app/api.py", "start_expert / submit_phone"),
+    ("src/api/main.py", "_execute_query"),
+)
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def _find_propagate_attributes_calls(source: str) -> list[str]:
+    """Return text of every ``propagate_attributes(...)`` call in ``source``."""
+    calls: list[str] = []
+    pattern = re.compile(r"propagate_attributes\s*\(", re.MULTILINE)
+    for match in pattern.finditer(source):
+        depth = 0
+        i = match.end() - 1  # at the opening paren
+        start = i
+        while i < len(source):
+            if source[i] == "(":
+                depth += 1
+            elif source[i] == ")":
+                depth -= 1
+                if depth == 0:
+                    calls.append(source[start : i + 1])
+                    break
+            i += 1
+    return calls
+
+
+class TestPropagateAttributesUsesBaggage:
+    """Each cross-boundary entry point must pass ``as_baggage=True``."""
+
+    @pytest.mark.parametrize("path,marker", _REQUIRED_AS_BAGGAGE_CALL_SITES)
+    def test_propagate_attributes_at_entry_point_uses_as_baggage(
+        self, path: str, marker: str
+    ) -> None:
+        source = _read(path)
+        calls = _find_propagate_attributes_calls(source)
+        assert calls, (
+            f"{path}: expected at least one propagate_attributes(...) call but "
+            f"found none — the {marker} entry point would not propagate "
+            f"user_id/session_id/tags to downstream services (#2226)."
+        )
+
+        # Direct kwarg in the call OR ``"as_baggage": True`` in any kwargs
+        # dict that the file unpacks via ``**kwargs`` into propagate_attributes.
+        baggage_inline = [c for c in calls if "as_baggage=True" in c]
+        baggage_via_kwargs = re.search(
+            r'["\']as_baggage["\']\s*:\s*True', source
+        ) is not None and any("**" in c for c in calls)
+        if baggage_inline or baggage_via_kwargs:
+            return
+
+        pytest.fail(
+            f"{path}: every propagate_attributes(...) at the {marker} entry "
+            f"point must pass as_baggage=True so the Langfuse SDK injects "
+            f"user_id/session_id/tags into the W3C 'baggage' HTTP header "
+            f"(#2226). Found calls without as_baggage=True:\n  "
+            + "\n  ".join(c.replace("\n", " ") for c in calls)
+        )
+
+
+class TestComposedPropagatorIncludesBaggage:
+    """The OTEL default global propagator must include W3C Baggage.
+
+    OTEL Python defaults to ``CompositePropagator(['baggage', 'traceparent',
+    'tracestate'])`` — we don't need to call ``set_global_textmap(...)``,
+    but if anyone changes it later, this test catches a regression that
+    would silently disable as_baggage=True propagation.
+    """
+
+    def test_default_global_propagator_carries_baggage(self) -> None:
+        from opentelemetry import propagate
+
+        propagator = propagate.get_global_textmap()
+        assert "baggage" in propagator.fields, (
+            "Global OTEL propagator must include 'baggage' so "
+            "propagate_attributes(as_baggage=True) actually serializes "
+            "user_id/session_id/tags to outbound HTTP headers (#2226). "
+            f"Current fields: {sorted(propagator.fields)}"
+        )
+        assert "traceparent" in propagator.fields, (
+            "Global OTEL propagator must include 'traceparent' for "
+            "parent-child trace wiring across HTTP boundaries (#2226)."
+        )
+
+
+class TestPropagateAttributesSignatureSupportsBaggage:
+    """Sanity check: the installed Langfuse SDK signature actually accepts
+    ``as_baggage``. If a future SDK upgrade renames the parameter, this
+    test fails fast instead of silently dropping the kwarg."""
+
+    def test_propagate_attributes_accepts_as_baggage_kwarg(self) -> None:
+        from langfuse import propagate_attributes
+
+        sig = inspect.signature(propagate_attributes)
+        assert "as_baggage" in sig.parameters, (
+            "Langfuse SDK propagate_attributes() must accept as_baggage "
+            "kwarg (#2226). Available kwargs: " + ", ".join(sig.parameters)
+        )

--- a/tests/unit/test_langfuse_context_middleware.py
+++ b/tests/unit/test_langfuse_context_middleware.py
@@ -236,4 +236,5 @@ class TestLangfuseContextMiddleware:
             session_id="session-123",
             user_id="42",
             tags=["telegram", "message"],
+            as_baggage=True,
         )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes the **Pass-5 finding** from #2215 audit: #2229 propagates `traceparent` cross-service (so bge-m3 spans nest correctly), but **does not** carry the Langfuse trace attributes (`user_id`, `session_id`, `tags`). Result: filtering bge-m3 spans by user/session in Langfuse UI returns empty.

The SDK-canonical fix is `propagate_attributes(..., as_baggage=True)` (Langfuse v4 SDK; see [propagate_attributes signature](https://github.com/langfuse/langfuse-python/blob/main/langfuse/_client/propagation.py)). Inside that context manager the SDK serializes `user_id`/`session_id`/`tags` into the W3C `baggage` HTTP header. `HTTPXClientInstrumentor` (Epic O #2225) already injects the default OTEL propagator on every outbound httpx request — and that default propagator already includes `baggage`, confirmed by smoke probe:

```python
>>> from opentelemetry import propagate
>>> propagate.get_global_textmap().fields
['baggage', 'traceparent', 'tracestate']
```

So `set_global_textmap(...)` is NOT required — OTEL Python ships the right `CompositePropagator` by default. The PR is therefore minimal: 4 lines in 4 places.

## Changes

| File | Entry point |
|---|---|
| `telegram_bot/middlewares/langfuse_middleware.py:81` | bot ingress |
| `mini_app/api.py:235` | `start_expert` |
| `mini_app/api.py:410` | `submit_phone` |
| `src/api/main.py:357` | `_execute_query` (rag-api receiver) |

Each `propagate_attributes(...)` now sets `as_baggage=True`. Voice agent already uses `trace_context=` (cross-process via `langfuse_trace_id` DTO field, kept as fallback per umbrella plan).

## TDD

`tests/unit/observability/test_w3c_baggage_propagation.py` (5 tests):
- parametrized contract: every entry-point `propagate_attributes(...)` must include `as_baggage=True` (or unpacked from a kwargs dict);
- sanity: default OTEL global propagator includes `'baggage'`;
- sanity: Langfuse SDK signature accepts `as_baggage` kwarg.

Updated existing assertions to expect the new kwarg:
- `tests/unit/api/test_rag_api_runtime.py::test_query_updates_current_observation_and_propagates_api_attributes`
- `tests/unit/test_langfuse_context_middleware.py::test_uses_user_id_when_chat_missing`

## Validation

- `uv run pytest tests/unit/observability/ tests/unit/mini_app/ tests/unit/api/ tests/unit/test_observability.py tests/unit/test_bot_handlers.py tests/unit/agents/` — **959 passed, 0 failed**.
- `uv run pytest tests/contract/ tests/unit/` (excl. flaky mypy timeout) — **8859 passed, 0 failed**.
- `uv run ruff check + format` — clean.

## What's next

This PR closes the Langfuse-attribute side of cross-service propagation. The cleanup of the manual `_trace_context_headers()` + 10 `headers=_trace_context_headers()` inject sites in `src/services/bge_m3_client.py` (#2229) becomes safe **after** Epic O (#2225) lands in production and the next runtime audit (Epic L #2221) confirms baggage flows correctly through `HTTPXClientInstrumentor` end-to-end.

## Refs

- #2215 — umbrella audit, Pass 5 finding, Sprint 1 PR-4 of Phase 2.
- #2226 — this Epic P issue.
- #2225 — Epic O (depends on it; provides `HTTPXClientInstrumentor` that carries the baggage header).
- #2229 — manual plumbing this PR makes obsolete (cleanup follow-up).
- Langfuse SDK [propagate_attributes signature](https://github.com/langfuse/langfuse-python/blob/main/langfuse/_client/propagation.py) — `as_baggage: bool = False` parameter.
- OTEL Python [propagate API](https://opentelemetry-python.readthedocs.io/en/latest/api/propagate.html) — default `CompositePropagator` includes baggage.