### PR TITLE
feat(observability): cross-link Sentry events to Langfuse traces (#2218)

### DIFF
--- a/src/observability_sentry.py
+++ b/src/observability_sentry.py
@@ -194,8 +194,80 @@ def _redact_breadcrumbs(event: dict[str, Any]) -> None:
                 crumb[key] = _redact(crumb[key])
 
 
+def _get_langfuse_client() -> Any | None:
+    """Return the active Langfuse v4 client or ``None``.
+
+    Tolerates missing Langfuse SDK (e.g. minimal CI envs without the optional
+    extra) and uninitialised clients. Used by ``_make_before_send`` to attach
+    the active trace ID to every Sentry event so on-call can pivot from a
+    Sentry incident → Langfuse trace → Loki logs in one click (#2218).
+    """
+    try:
+        from langfuse import get_client
+    except ImportError:
+        return None
+    try:
+        return get_client()
+    except Exception:
+        # Langfuse may raise when no client has been initialised yet — that
+        # is the documented v4 SDK behaviour. Treat it as "no active trace".
+        return None
+
+
+def _attach_langfuse_trace_to_event(event: dict[str, Any]) -> None:
+    """Attach the active Langfuse trace_id / observation_id to a Sentry event.
+
+    SDK-native: reads ``langfuse.get_client().get_current_trace_id()`` (v4)
+    which returns the OTEL trace ID for the active ``@observe`` context.
+    The Langfuse SDK runs on top of OpenTelemetry, so this trace_id matches
+    the one ``otelTraceID`` is injected into structured logs (Epic G #2217)
+    and the one ``traceparent`` carries across HTTP boundaries (Epic O+P).
+
+    Result: Sentry UI shows a clickable ``langfuse_trace_id`` tag on every
+    captured event + a ``langfuse`` context block with a deep-link URL.
+
+    Failures are swallowed: a broken Langfuse SDK must NEVER block a Sentry
+    event from being captured.
+    """
+    try:
+        client = _get_langfuse_client()
+        if client is None:
+            return
+        trace_id = client.get_current_trace_id()
+        if not trace_id:
+            return
+
+        observation_id = client.get_current_observation_id()
+
+        tags = event.setdefault("tags", {})
+        if isinstance(tags, dict):
+            tags["langfuse_trace_id"] = trace_id
+
+        contexts = event.setdefault("contexts", {})
+        if isinstance(contexts, dict):
+            langfuse_ctx: dict[str, str] = {"trace_id": trace_id}
+            if observation_id:
+                langfuse_ctx["observation_id"] = observation_id
+            host = (os.getenv("LANGFUSE_HOST", "") or "").strip().rstrip("/")
+            if host:
+                langfuse_ctx["url"] = f"{host}/trace/{trace_id}"
+            contexts["langfuse"] = langfuse_ctx
+    except Exception:
+        # Cross-link is a best-effort enrichment; never let it kill the event.
+        logger.debug("Sentry <-> Langfuse cross-link failed", exc_info=True)
+
+
 def _make_before_send():
-    """Return a ``before_send`` callable that masks PII before egress."""
+    """Return a ``before_send`` callable that masks PII before egress.
+
+    Two-stage hook:
+
+    1. PII redaction (existing — unchanged).
+    2. Langfuse trace cross-link enrichment (#2218): attaches
+       ``langfuse_trace_id`` tag + ``langfuse`` context block when an
+       ``@observe`` span is active. Runs after PII scrub so the trace IDs
+       (which are 16-char hex, never PII) are not accidentally masked.
+    """
 
     def before_send(event: dict[str, Any], hint: Any | None = None) -> dict[str, Any] | None:
         try:
@@ -208,6 +280,7 @@ def _make_before_send():
             _redact_breadcrumbs(event)
         except Exception:
             logger.warning("Sentry before_send PII scrub failed", exc_info=True)
+        _attach_langfuse_trace_to_event(event)
         return event
 
     return before_send

--- a/tests/unit/observability/test_sentry_langfuse_crosslink.py
+++ b/tests/unit/observability/test_sentry_langfuse_crosslink.py
@@ -1,0 +1,167 @@
+"""Sentry <-> Langfuse cross-link contract (#2218).
+
+When a Sentry event is captured inside an active Langfuse observation, the
+event MUST automatically carry the Langfuse trace_id so on-call can pivot
+in one click from Sentry incident → Langfuse trace → Loki logs.
+
+The implementation extends the existing ``_make_before_send`` hook in
+``src/observability_sentry.py`` (already running for PII redaction). After
+PII scrub, it reads ``langfuse.get_client().get_current_trace_id()`` and
+attaches:
+
+* ``event["tags"]["langfuse_trace_id"]`` — searchable tag
+* ``event["contexts"]["langfuse"]`` — structured context block with
+  ``trace_id``, ``observation_id``, and a deep-link URL when
+  ``LANGFUSE_HOST`` is configured.
+
+Implementation notes (from Langfuse v4 SDK ``code_review.md`` via
+Context7):
+
+* ``get_current_trace_id()`` returns ``None`` when no Langfuse client is
+  initialized — the hook tolerates that and just returns the event.
+* The hook is wrapped in try/except: a failure to read the Langfuse client
+  must never block a Sentry event from being captured.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def reset_observability_sentry() -> None:
+    import src.observability_sentry as mod
+
+    mod._reset_for_tests()
+    yield
+    mod._reset_for_tests()
+
+
+class TestBeforeSendAttachesLangfuseTraceId:
+    """``_make_before_send`` must attach Langfuse trace IDs to every event."""
+
+    def test_event_carries_langfuse_trace_id_tag(self, reset_observability_sentry) -> None:
+        import src.observability_sentry as mod
+
+        fake_lf = MagicMock(name="LangfuseClient")
+        fake_lf.get_current_trace_id.return_value = "abcdef1234567890abcdef1234567890"
+        fake_lf.get_current_observation_id.return_value = "fedcba0987654321"
+
+        with patch.object(mod, "_get_langfuse_client", return_value=fake_lf):
+            before_send = mod._make_before_send()
+            event: dict = {"event_id": "e1", "message": "boom"}
+            result = before_send(event, hint=None)
+
+        assert result is not None
+        assert result["tags"]["langfuse_trace_id"] == ("abcdef1234567890abcdef1234567890")
+
+    def test_event_carries_langfuse_context_block(self, reset_observability_sentry) -> None:
+        import src.observability_sentry as mod
+
+        fake_lf = MagicMock(name="LangfuseClient")
+        fake_lf.get_current_trace_id.return_value = "trace-xyz"
+        fake_lf.get_current_observation_id.return_value = "obs-456"
+
+        with (
+            patch.object(mod, "_get_langfuse_client", return_value=fake_lf),
+            patch.dict("os.environ", {"LANGFUSE_HOST": "http://langfuse:3000"}),
+        ):
+            before_send = mod._make_before_send()
+            event: dict = {"event_id": "e1"}
+            result = before_send(event, hint=None)
+
+        assert "contexts" in result
+        ctx = result["contexts"]["langfuse"]
+        assert ctx["trace_id"] == "trace-xyz"
+        assert ctx["observation_id"] == "obs-456"
+        assert ctx["url"] == "http://langfuse:3000/trace/trace-xyz"
+
+    def test_event_unchanged_when_no_langfuse_client(self, reset_observability_sentry) -> None:
+        """Without an initialized Langfuse client, no langfuse_* fields appear."""
+        import src.observability_sentry as mod
+
+        with patch.object(mod, "_get_langfuse_client", return_value=None):
+            before_send = mod._make_before_send()
+            event: dict = {"event_id": "e1", "message": "boom"}
+            result = before_send(event, hint=None)
+
+        assert result is not None
+        assert "langfuse_trace_id" not in result.get("tags", {})
+        assert "langfuse" not in result.get("contexts", {})
+
+    def test_event_unchanged_when_no_active_trace(self, reset_observability_sentry) -> None:
+        """When Langfuse client exists but no @observe is active, skip."""
+        import src.observability_sentry as mod
+
+        fake_lf = MagicMock(name="LangfuseClient")
+        fake_lf.get_current_trace_id.return_value = None
+        fake_lf.get_current_observation_id.return_value = None
+
+        with patch.object(mod, "_get_langfuse_client", return_value=fake_lf):
+            before_send = mod._make_before_send()
+            event: dict = {"event_id": "e1"}
+            result = before_send(event, hint=None)
+
+        assert "langfuse_trace_id" not in result.get("tags", {})
+        assert "langfuse" not in result.get("contexts", {})
+
+    def test_hook_never_blocks_event_on_langfuse_error(self, reset_observability_sentry) -> None:
+        """A failure to read Langfuse must not drop the Sentry event."""
+        import src.observability_sentry as mod
+
+        fake_lf = MagicMock(name="LangfuseClient")
+        fake_lf.get_current_trace_id.side_effect = RuntimeError("Langfuse exploded")
+
+        with patch.object(mod, "_get_langfuse_client", return_value=fake_lf):
+            before_send = mod._make_before_send()
+            event: dict = {"event_id": "e1", "message": "boom"}
+            result = before_send(event, hint=None)
+
+        # The event must still be returned (PII scrub may have run, that's fine).
+        assert result is not None
+        assert result["event_id"] == "e1"
+
+    def test_pii_redaction_still_happens_when_langfuse_attaches(
+        self, reset_observability_sentry
+    ) -> None:
+        """The Langfuse cross-link must run AFTER PII scrub, not replace it."""
+        import src.observability_sentry as mod
+
+        fake_lf = MagicMock(name="LangfuseClient")
+        fake_lf.get_current_trace_id.return_value = "trace-42"
+        fake_lf.get_current_observation_id.return_value = None
+
+        with patch.object(mod, "_get_langfuse_client", return_value=fake_lf):
+            before_send = mod._make_before_send()
+            event: dict = {
+                "event_id": "e1",
+                "message": "User phone: +380501112233 was seen",
+            }
+            result = before_send(event, hint=None)
+
+        assert result["tags"]["langfuse_trace_id"] == "trace-42"
+        # PIIRedactor masks long digit sequences; phone must not appear verbatim.
+        assert "+380501112233" not in result["message"]
+
+
+class TestGetLangfuseClient:
+    """``_get_langfuse_client`` must tolerate missing Langfuse SDK / no init."""
+
+    def test_returns_none_when_langfuse_not_imported(self) -> None:
+        import src.observability_sentry as mod
+
+        # Simulate ImportError on langfuse import
+        with patch.dict("sys.modules", {"langfuse": None}):
+            client = mod._get_langfuse_client()
+            assert client is None
+
+    def test_returns_client_when_get_client_works(self) -> None:
+        import src.observability_sentry as mod
+
+        fake_client = MagicMock(name="LangfuseClient")
+
+        with patch("langfuse.get_client", return_value=fake_client, create=True):
+            client = mod._get_langfuse_client()
+            assert client is fake_client


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes the operational triage gap from #2215 audit (Epic H). On a Sentry incident, on-call could not pivot from the alert to the matching Langfuse trace in one click — there was no shared identifier in the event payload.

## What changed

Extends the existing `_make_before_send` hook in `src/observability_sentry.py` (already running for PII redaction). After PII scrub it reads the active Langfuse trace via `langfuse.get_client().get_current_trace_id()` and attaches:

- `event["tags"]["langfuse_trace_id"]` — searchable Sentry tag.
- `event["contexts"]["langfuse"]` — structured context block with `trace_id`, `observation_id`, and a deep-link URL when `LANGFUSE_HOST` is configured (e.g. `http://langfuse:3000/trace/<id>`).

## SDK-native

Langfuse v4 SDK is built on top of OpenTelemetry, so the `trace_id` we attach matches:

- the `otelTraceID` injected into structured logs (Epic G #2217);
- the W3C `traceparent` header carried across HTTP boundaries (Epic O #2225, Epic P #2226).

This is the third leg of the **Sentry ↔ Langfuse ↔ Loki** triage chain.

## Failure modes (graceful degradation)

| Condition | Behavior |
|---|---|
| Langfuse SDK not installed | `_get_langfuse_client` returns `None` → event passes through unchanged |
| Langfuse client not initialised | `get_client()` raises → caught, treated as "no active trace" |
| No `@observe` context active | `get_current_trace_id()` returns `None` → no tag/context attached |
| Any other exception in cross-link | Caught + logged at DEBUG; Sentry event still reaches the backend |

## TDD

`tests/unit/observability/test_sentry_langfuse_crosslink.py` (8 tests):

- `test_event_carries_langfuse_trace_id_tag`
- `test_event_carries_langfuse_context_block` (with deep-link URL)
- `test_event_unchanged_when_no_langfuse_client`
- `test_event_unchanged_when_no_active_trace`
- `test_hook_never_blocks_event_on_langfuse_error`
- `test_pii_redaction_still_happens_when_langfuse_attaches` (ordering)
- `_get_langfuse_client` tolerates missing SDK + uninitialised client (2 tests)

## Validation

- `uv run pytest tests/unit/observability/test_sentry_langfuse_crosslink.py` — 8/8 passed.
- `uv run pytest tests/unit/observability/ tests/contract/` — **1524 passed**.
- `uv run ruff check + format` — clean.

## Refs

- #2215 — umbrella audit, Sprint 2 PR-1 of Phase 2.
- #2218 — Epic H issue.
- Sets up: `docs/ALERTING.md` update with Sentry → Langfuse → Loki triage chain (follow-up task).