### PR TITLE
feat(observability): inject otelTraceID/otelSpanID into JSON logs (#2217)

### DIFF
--- a/telegram_bot/logging_config.py
+++ b/telegram_bot/logging_config.py
@@ -35,6 +35,25 @@ class JSONFormatter(logging.Formatter):
             "line": record.lineno,
         }
 
+        # Logs <-> Traces correlation (#2217 / Epic G).
+        # ``opentelemetry.instrumentation.logging.LoggingInstrumentor`` (activated
+        # in src/observability_otel.py per #2225) injects ``otelTraceID`` and
+        # ``otelSpanID`` into every LogRecord from the active OTEL context.
+        # Langfuse v4 SDK runs on top of OTEL, so these IDs match
+        # ``langfuse.get_current_trace_id()`` / ``get_current_observation_id()``
+        # — the same values that:
+        #   * land in Sentry events as ``langfuse_trace_id`` tag (#2218);
+        #   * carry ``traceparent`` across HTTP boundaries (#2225 + #2226).
+        # The OTEL "no active trace" sentinel is the literal string ``"0"``
+        # — treat it as absence so Loki queries can use ``| trace_id != ""``
+        # without matching every line.
+        otel_trace_id = getattr(record, "otelTraceID", None)
+        if otel_trace_id and otel_trace_id != "0":
+            log_data["trace_id"] = otel_trace_id
+        otel_span_id = getattr(record, "otelSpanID", None)
+        if otel_span_id and otel_span_id != "0":
+            log_data["span_id"] = otel_span_id
+
         # Add exception info if present
         if record.exc_info:
             log_data["exception"] = self.formatException(record.exc_info)

--- a/tests/unit/test_logging_trace_correlation.py
+++ b/tests/unit/test_logging_trace_correlation.py
@@ -1,0 +1,127 @@
+"""Logs <-> Traces correlation contract (#2217 / Epic G).
+
+Background. Pre-#2225 the project's JSONFormatter emitted log lines without
+any trace identifier. On a Loki ERROR line, on-call could not pivot to the
+matching Langfuse trace in one click — there was no shared identifier.
+
+Epic O (#2225) activated ``LoggingInstrumentor`` in
+``src/observability_otel.py``. The OTEL ``LoggingInstrumentor`` injects two
+attributes into every ``LogRecord`` automatically:
+
+* ``otelTraceID`` — the active OTEL trace ID (matches Langfuse's
+  ``get_current_trace_id()`` because Langfuse v4 SDK runs on top of OTEL).
+* ``otelSpanID`` — the active OTEL span ID (matches the active observation).
+
+This contract pins:
+
+1. ``JSONFormatter`` reads ``record.otelTraceID`` / ``record.otelSpanID``
+   when present and emits them as ``trace_id`` / ``span_id`` keys in the
+   JSON payload.
+2. The keys are absent (not ``null``, not ``"0"``) when there is no active
+   trace, so Loki queries can use ``| trace_id != ""`` to filter.
+3. The default OTEL "no trace" sentinel ``"0"`` is treated as absence.
+
+After this PR + Epic G follow-ups (Loki promtail label, deep-link metadata
+on traces) the Sentry -> Langfuse -> Loki triage chain works end-to-end:
+
+    Sentry event ─[langfuse_trace_id tag, #2218]─> Langfuse trace
+    Langfuse trace.metadata.loki_url ─> Loki query (auto-filtered by trace_id)
+    Loki line ─[trace_id key, this PR]─> back to the same Langfuse trace
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from telegram_bot.logging_config import JSONFormatter
+
+
+def _make_record(**otel_attrs: Any) -> logging.LogRecord:
+    """Build a LogRecord, optionally pre-populated with OTEL attrs."""
+    record = logging.LogRecord(
+        name="test.logger",
+        level=logging.INFO,
+        pathname="/test.py",
+        lineno=42,
+        msg="hello world",
+        args=(),
+        exc_info=None,
+    )
+    for key, value in otel_attrs.items():
+        setattr(record, key, value)
+    return record
+
+
+class TestJsonFormatterEmitsTraceContext:
+    def test_emits_trace_id_and_span_id_when_present(self) -> None:
+        record = _make_record(
+            otelTraceID="abcdef1234567890abcdef1234567890",
+            otelSpanID="fedcba0987654321",
+        )
+        formatted = JSONFormatter().format(record)
+        payload = json.loads(formatted)
+
+        assert payload["trace_id"] == "abcdef1234567890abcdef1234567890"
+        assert payload["span_id"] == "fedcba0987654321"
+
+    def test_omits_trace_id_when_no_active_trace(self) -> None:
+        """No ``record.otelTraceID`` -> no ``trace_id`` key (not null)."""
+        record = _make_record()
+        formatted = JSONFormatter().format(record)
+        payload = json.loads(formatted)
+
+        assert "trace_id" not in payload
+        assert "span_id" not in payload
+
+    def test_omits_trace_id_when_otel_sentinel_zero(self) -> None:
+        """LoggingInstrumentor injects ``"0"`` when there is no active OTEL
+        context — must be treated as absence, not a real trace ID."""
+        record = _make_record(otelTraceID="0", otelSpanID="0")
+        formatted = JSONFormatter().format(record)
+        payload = json.loads(formatted)
+
+        assert "trace_id" not in payload
+        assert "span_id" not in payload
+
+    def test_emits_only_trace_id_when_span_missing(self) -> None:
+        """Robust to partial population (defensive)."""
+        record = _make_record(otelTraceID="trace-xyz")
+        formatted = JSONFormatter().format(record)
+        payload = json.loads(formatted)
+
+        assert payload["trace_id"] == "trace-xyz"
+        assert "span_id" not in payload
+
+    def test_existing_extra_fields_still_emit(self) -> None:
+        """Adding trace_id MUST NOT regress the existing extra-fields path."""
+        record = _make_record(
+            otelTraceID="trace-1",
+            otelSpanID="span-1",
+            user_id=12345,
+            latency_ms=42,
+            cache_hit=True,
+        )
+        formatted = JSONFormatter().format(record)
+        payload = json.loads(formatted)
+
+        assert payload["trace_id"] == "trace-1"
+        assert payload["user_id"] == 12345
+        assert payload["latency_ms"] == 42
+        assert payload["cache_hit"] is True
+
+
+class TestLoggingInstrumentorIsActivatedAtBoot:
+    """``activate_otel_instrumentations()`` (#2225) must include the
+    ``logging`` instrumentor so ``record.otelTraceID`` is populated."""
+
+    def test_logging_instrumentor_in_resolved_set(self) -> None:
+        from src.observability_otel import _resolve_instrumentors
+
+        resolved = _resolve_instrumentors()
+        assert "logging" in resolved, (
+            "LoggingInstrumentor must be in _resolve_instrumentors() so it "
+            "activates at boot and populates record.otelTraceID for the "
+            "JSONFormatter (#2217). Found: " + ", ".join(sorted(resolved))
+        )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes the operational triage gap from #2215 audit (Epic G P1). Pre-#2225 the project's `JSONFormatter` emitted log lines without any trace identifier — on a Loki `ERROR` line, on-call could not pivot to the matching Langfuse trace in one click.

## What changed

Epic O (#2225, merged) already activated `LoggingInstrumentor` in `src/observability_otel.py`. `LoggingInstrumentor` injects two attributes into every `LogRecord` automatically:

- `otelTraceID` — the active OTEL trace ID
- `otelSpanID` — the active OTEL span ID

This PR teaches `telegram_bot/logging_config.py::JSONFormatter` to read those attributes and emit them as `trace_id` / `span_id` keys in the JSON payload. The OTEL "no active trace" sentinel (literal string `"0"`) is treated as absence so Loki queries can use `| trace_id != ""` to filter.

## SDK-native chain

Langfuse v4 SDK runs on top of OTEL, so the IDs match across three observability surfaces:

- `langfuse.get_client().get_current_trace_id()` — used by #2218 to attach `langfuse_trace_id` tag to every Sentry event.
- W3C `traceparent` header — carried across HTTP boundaries by #2225 (HTTPXClientInstrumentor) + #2226 (W3C Baggage).
- `record.otelTraceID` — used by **this PR** in JSON logs.

After this PR the **Sentry → Langfuse → Loki** triage chain works end-to-end:

```
Sentry event ─[langfuse_trace_id tag, #2218]─> Langfuse trace
Langfuse trace ─[OTEL trace_id from get_current_trace_id]─> shared ID
shared trace_id ─[record.otelTraceID, this PR]─> Loki line
```

## TDD

`tests/unit/test_logging_trace_correlation.py` (6 tests):

- emits `trace_id` / `span_id` when present;
- omits keys when no active trace (not `null`);
- omits keys when OTEL `"0"` sentinel (not a real ID);
- emits only `trace_id` when span missing (defensive);
- existing extra-fields path still works (regression guard for `user_id`, `latency_ms`, `cache_hit`, etc.);
- `LoggingInstrumentor` in `_resolve_instrumentors()` (boot-time activation guard).

## Validation

- `uv run pytest tests/unit/test_logging_trace_correlation.py tests/unit/test_logging_config.py` — 24 passed.
- `uv run pytest tests/unit/ tests/contract/` (excl. flaky mypy timeout) — **8889 passed, 0 failed**.
- `uv run ruff check + format` — clean.

## Refs

- #2215 — umbrella audit, Sprint 2 PR-2 of Phase 2.
- #2217 — Epic G P1.
- #2225 — Epic O (LoggingInstrumentor activation, merged).
- #2218 — Epic H (same trace_id reaches Sentry events).
- Sets up: `docker/monitoring/promtail.yaml` — make `trace_id` a Loki label (follow-up task).