### PR TITLE
feat(observability): Langfuse v4 as_type taxonomy for agent tools + guards (#2216)

### DIFF
--- a/src/runtime/graph/nodes/guard.py
+++ b/src/runtime/graph/nodes/guard.py
@@ -143,7 +143,7 @@ def detect_injection(text: str) -> tuple[bool, float, str | None]:
     return (max_risk > 0, max_risk, max_category)
 
 
-@observe(name="node-guard")
+@observe(name="node-guard", as_type="guardrail")
 async def guard_node(
     state: dict[str, Any],
     runtime: Runtime[GraphContext],

--- a/telegram_bot/agents/apartment_tools.py
+++ b/telegram_bot/agents/apartment_tools.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 @tool
-@observe(name="tool-apartment-search", capture_input=False, capture_output=False)
+@observe(name="tool-apartment-search", capture_input=False, capture_output=False, as_type="tool")
 async def apartment_search(
     query: str,
     config: RunnableConfig,

--- a/telegram_bot/agents/crm_tools.py
+++ b/telegram_bot/agents/crm_tools.py
@@ -47,7 +47,7 @@ def _get_ctx(config: RunnableConfig):
 
 
 @tool
-@observe(name="crm-get-deal")
+@observe(name="crm-get-deal", as_type="tool")
 async def crm_get_deal(deal_id: int, config: RunnableConfig) -> str:
     """Get deal details from CRM by deal ID.
 
@@ -67,7 +67,7 @@ async def crm_get_deal(deal_id: int, config: RunnableConfig) -> str:
 
 
 @tool
-@observe(name="crm-get-contacts")
+@observe(name="crm-get-contacts", as_type="tool")
 async def crm_get_contacts(query: str, config: RunnableConfig) -> str:
     """Search contacts in CRM by name or phone.
 
@@ -93,7 +93,7 @@ async def crm_get_contacts(query: str, config: RunnableConfig) -> str:
 
 
 @tool
-@observe(name="crm-create-lead")
+@observe(name="crm-create-lead", as_type="tool")
 async def crm_create_lead(
     name: str,
     config: RunnableConfig,
@@ -148,7 +148,7 @@ async def crm_create_lead(
 
 
 @tool
-@observe(name="crm-update-lead")
+@observe(name="crm-update-lead", as_type="tool")
 async def crm_update_lead(
     deal_id: int,
     config: RunnableConfig,
@@ -186,7 +186,7 @@ async def crm_update_lead(
 
 
 @tool
-@observe(name="crm-upsert-contact")
+@observe(name="crm-upsert-contact", as_type="tool")
 async def crm_upsert_contact(
     phone: str,
     first_name: str,
@@ -225,7 +225,7 @@ async def crm_upsert_contact(
 
 
 @tool
-@observe(name="crm-add-note")
+@observe(name="crm-add-note", as_type="tool")
 async def crm_add_note(
     entity_type: str,
     entity_id: int,
@@ -252,7 +252,7 @@ async def crm_add_note(
 
 
 @tool
-@observe(name="crm-create-task")
+@observe(name="crm-create-task", as_type="tool")
 async def crm_create_task(
     text: str,
     entity_id: int,
@@ -288,7 +288,7 @@ async def crm_create_task(
 
 
 @tool
-@observe(name="crm-link-contact-to-deal")
+@observe(name="crm-link-contact-to-deal", as_type="tool")
 async def crm_link_contact_to_deal(
     lead_id: int,
     contact_id: int,
@@ -313,7 +313,7 @@ async def crm_link_contact_to_deal(
 
 
 @tool
-@observe(name="crm-search-leads")
+@observe(name="crm-search-leads", as_type="tool")
 async def crm_search_leads(query: str, config: RunnableConfig) -> str:
     """Search deals/leads in CRM by name, keywords, or phone.
 
@@ -339,7 +339,7 @@ async def crm_search_leads(query: str, config: RunnableConfig) -> str:
 
 
 @tool
-@observe(name="crm-get-my-leads")
+@observe(name="crm-get-my-leads", as_type="tool")
 async def crm_get_my_leads(config: RunnableConfig) -> str:
     """Get leads assigned to the current manager."""
     kommo = _get_kommo(config)
@@ -366,7 +366,7 @@ async def crm_get_my_leads(config: RunnableConfig) -> str:
 
 
 @tool
-@observe(name="crm-get-my-tasks")
+@observe(name="crm-get-my-tasks", as_type="tool")
 async def crm_get_my_tasks(
     config: RunnableConfig,
     include_completed: bool = False,
@@ -406,7 +406,7 @@ async def crm_get_my_tasks(
 
 
 @tool
-@observe(name="crm-update-contact")
+@observe(name="crm-update-contact", as_type="tool")
 async def crm_update_contact(
     contact_id: int,
     config: RunnableConfig,

--- a/telegram_bot/agents/history_graph/nodes.py
+++ b/telegram_bot/agents/history_graph/nodes.py
@@ -27,7 +27,7 @@ _HISTORY_BLOCKED_RESPONSE = (
 # --- Guard ---
 
 
-@observe(name="history-guard")
+@observe(name="history-guard", as_type="guardrail")
 async def history_guard_node(
     state: dict[str, Any],
     *,

--- a/telegram_bot/agents/history_tool.py
+++ b/telegram_bot/agents/history_tool.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 @tool
-@observe(name="tool-history-search", capture_input=False, capture_output=False)
+@observe(name="tool-history-search", capture_input=False, capture_output=False, as_type="tool")
 async def history_search(
     query: str,
     config: RunnableConfig,

--- a/telegram_bot/agents/manager_tools.py
+++ b/telegram_bot/agents/manager_tools.py
@@ -46,7 +46,7 @@ def create_manager_nurturing_tools(*, analytics_service: Any, nurturing_service:
     """Create manager-only nurturing + analytics tools."""
 
     @tool
-    @observe(name="manager-get-funnel-analytics")
+    @observe(name="manager-get-funnel-analytics", as_type="tool")
     async def manager_get_funnel_analytics(query: str, config: RunnableConfig) -> str:
         """Get funnel conversion analytics for manager review."""
         role = _resolve_role(config)
@@ -58,7 +58,7 @@ def create_manager_nurturing_tools(*, analytics_service: Any, nurturing_service:
         return str(report)
 
     @tool
-    @observe(name="manager-run-nurturing-batch")
+    @observe(name="manager-run-nurturing-batch", as_type="tool")
     async def manager_run_nurturing_batch(query: str, config: RunnableConfig) -> str:
         """Execute an on-demand nurturing batch for warm/cold leads."""
         role = _resolve_role(config)
@@ -82,7 +82,7 @@ def create_crm_score_sync_tool(
     """Create crm_sync_lead_score production tool."""
 
     @tool
-    @observe(name="tool-crm-sync-lead-score")
+    @observe(name="tool-crm-sync-lead-score", as_type="tool")
     async def crm_sync_lead_score(query: str, config: RunnableConfig) -> str:
         """Sync pending lead scores to Kommo CRM."""
         role = _resolve_role(config)

--- a/telegram_bot/agents/rag_tool.py
+++ b/telegram_bot/agents/rag_tool.py
@@ -56,7 +56,7 @@ def _format_context(result: dict) -> str:
 
 
 @tool
-@observe(name="tool-rag-search", capture_input=False, capture_output=False)
+@observe(name="tool-rag-search", capture_input=False, capture_output=False, as_type="tool")
 async def rag_search(
     query: str,
     config: RunnableConfig,

--- a/telegram_bot/agents/utility_tools.py
+++ b/telegram_bot/agents/utility_tools.py
@@ -40,7 +40,7 @@ def _fmt(value: float) -> str:
 
 
 @tool
-@observe(name="tool-mortgage-calculator")
+@observe(name="tool-mortgage-calculator", as_type="tool")
 async def mortgage_calculator(
     loan_amount: float,
     annual_rate: float,
@@ -129,7 +129,7 @@ async def _summarize_with_llm(data: str, llm: Any, model: str = _DEFAULT_SUMMARY
 
 
 @tool
-@observe(name="tool-daily-summary")
+@observe(name="tool-daily-summary", as_type="tool")
 async def daily_summary(
     config: RunnableConfig,
     date: str = "today",
@@ -184,7 +184,7 @@ async def daily_summary(
 
 
 @tool
-@observe(name="tool-handoff")
+@observe(name="tool-handoff", as_type="tool")
 async def handoff(
     reason: str,
     config: RunnableConfig,

--- a/tests/contract/test_observation_type_taxonomy_contract.py
+++ b/tests/contract/test_observation_type_taxonomy_contract.py
@@ -1,0 +1,156 @@
+"""Observation-type taxonomy contract (#2216 / Epic F).
+
+Langfuse v4 supports a typed observation taxonomy via ``@observe(as_type=...)``:
+span | generation | event | agent | tool | chain | retriever | embedding |
+evaluator | guardrail. The Langfuse UI has dedicated filters / dashboards per
+type (e.g. "show me only guardrail rejections", "tool latency").
+
+Pre-#2216 the repo used ``embedding`` / ``generation`` / ``retriever`` /
+``evaluator`` correctly but every LLM-callable agent tool and every guard
+node landed in the generic ``span`` bucket. This contract enforces the
+semantic taxonomy for the two unambiguous categories:
+
+* **tool** — LLM-callable agent tools (``tool-*``, ``crm-*``, ``manager-*``
+  decorators in ``telegram_bot/agents/``).
+* **guardrail** — pre-flight guard nodes (``node-guard``, ``history-guard``).
+
+A regression that drops ``as_type`` (or sets the wrong one) on a decorated
+agent tool / guard fails this contract.
+
+Scope note: aiogram-dialog handlers (``dialog-*``, ``crm-quick-*``,
+``crm-task-*``) are UI flows, not LLM agent tools, so they intentionally
+stay as the default ``span`` and are not covered here.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# observe-name -> required as_type. Exact-match on the @observe(name=...) value.
+_REQUIRED_AS_TYPE: dict[str, str] = {
+    # --- agent tools -> "tool" ---
+    "tool-rag-search": "tool",
+    "tool-apartment-search": "tool",
+    "tool-history-search": "tool",
+    "tool-mortgage-calculator": "tool",
+    "tool-daily-summary": "tool",
+    "tool-handoff": "tool",
+    "tool-crm-sync-lead-score": "tool",
+    "manager-get-funnel-analytics": "tool",
+    "manager-run-nurturing-batch": "tool",
+    "crm-get-deal": "tool",
+    "crm-get-contacts": "tool",
+    "crm-create-lead": "tool",
+    "crm-update-lead": "tool",
+    "crm-upsert-contact": "tool",
+    "crm-add-note": "tool",
+    "crm-create-task": "tool",
+    "crm-link-contact-to-deal": "tool",
+    "crm-search-leads": "tool",
+    "crm-get-my-leads": "tool",
+    "crm-get-my-tasks": "tool",
+    "crm-update-contact": "tool",
+    # --- guard nodes -> "guardrail" ---
+    "node-guard": "guardrail",
+    "history-guard": "guardrail",
+}
+
+_SCAN_DIRS = (
+    REPO_ROOT / "telegram_bot" / "agents",
+    REPO_ROOT / "src" / "runtime" / "graph" / "nodes",
+)
+
+
+def _decorator_name_and_kwargs(dec: ast.Call) -> tuple[str | None, dict[str, ast.expr]]:
+    """Return (name_value, {kwarg: node}) for an ``@observe(...)`` Call."""
+    name_value: str | None = None
+    kwargs: dict[str, ast.expr] = {}
+    for kw in dec.keywords:
+        if kw.arg is None:
+            continue
+        kwargs[kw.arg] = kw.value
+        if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+            name_value = kw.value.value
+    return name_value, kwargs
+
+
+def _is_observe_call(dec: ast.expr) -> ast.Call | None:
+    if not isinstance(dec, ast.Call):
+        return None
+    func = dec.func
+    if isinstance(func, ast.Name) and func.id == "observe":
+        return dec
+    if isinstance(func, ast.Attribute) and func.attr == "observe":
+        return dec
+    return None
+
+
+def _collect_observe_as_types() -> dict[str, str | None]:
+    """Map every @observe(name=...) in scope to its as_type literal (or None)."""
+    found: dict[str, str | None] = {}
+    for root in _SCAN_DIRS:
+        if not root.exists():
+            continue
+        for py_file in root.rglob("*.py"):
+            if "/tests/" in str(py_file) or "/__pycache__/" in str(py_file):
+                continue
+            try:
+                tree = ast.parse(py_file.read_text(encoding="utf-8"))
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                    continue
+                for dec in node.decorator_list:
+                    call = _is_observe_call(dec)
+                    if call is None:
+                        continue
+                    name_value, kwargs = _decorator_name_and_kwargs(call)
+                    if name_value is None:
+                        continue
+                    as_type_node = kwargs.get("as_type")
+                    as_type_val = (
+                        as_type_node.value if isinstance(as_type_node, ast.Constant) else None
+                    )
+                    found[name_value] = as_type_val
+    return found
+
+
+@pytest.fixture(scope="module")
+def observe_as_types() -> dict[str, str | None]:
+    return _collect_observe_as_types()
+
+
+class TestAgentToolAndGuardTaxonomy:
+    @pytest.mark.parametrize("observe_name,expected_type", _REQUIRED_AS_TYPE.items())
+    def test_observe_has_expected_as_type(
+        self,
+        observe_as_types: dict[str, str | None],
+        observe_name: str,
+        expected_type: str,
+    ) -> None:
+        assert observe_name in observe_as_types, (
+            f"@observe(name={observe_name!r}) not found under "
+            f"telegram_bot/agents or src/runtime/graph/nodes — the taxonomy "
+            f"contract expects it to exist (#2216). Did the span get renamed?"
+        )
+        actual = observe_as_types[observe_name]
+        assert actual == expected_type, (
+            f"@observe(name={observe_name!r}) must set as_type={expected_type!r} "
+            f"so the Langfuse UI groups it under the {expected_type!r} taxonomy "
+            f"(#2216); found as_type={actual!r}."
+        )
+
+    def test_all_required_names_present(self, observe_as_types: dict[str, str | None]) -> None:
+        """Sanity: the scanner is not vacuous — it found the decorators."""
+        missing = set(_REQUIRED_AS_TYPE) - set(observe_as_types)
+        assert not missing, (
+            "Taxonomy contract could not locate these @observe names "
+            f"(scanner regression or renamed spans): {sorted(missing)}"
+        )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Delivers the headline of Epic F: the **Langfuse v4 `as_type` observation taxonomy** for LLM-callable agent tools and guard nodes. The Langfuse UI has dedicated filters/dashboards per type ("show me only guardrail rejections", "tool latency p95"); pre-#2216 every agent tool + guard landed in the generic `span` bucket.

Valid `as_type` literals confirmed via Context7 (`ObservationTypeLiteral` includes `tool` and `guardrail`). Adding `as_type` is a backward-compatible optional `@observe` kwarg.

## What changed (23 decorators)

**`as_type="tool"` — 21 LLM-callable agent tools:**
- `rag_tool` (tool-rag-search), `apartment_tools` (tool-apartment-search), `history_tool` (tool-history-search)
- `crm_tools` — 12: get-deal, get-contacts, create-lead, update-lead, upsert-contact, add-note, create-task, link-contact-to-deal, search-leads, get-my-leads, get-my-tasks, update-contact
- `manager_tools` — manager-get-funnel-analytics, manager-run-nurturing-batch, tool-crm-sync-lead-score
- `utility_tools` — tool-mortgage-calculator, tool-daily-summary, tool-handoff

**`as_type="guardrail"` — 2 guard nodes:** `node-guard` (runtime), `history-guard`.

**Scope note:** aiogram-dialog handlers (`dialog-*`, `crm-quick-*`, `crm-task-*`) are UI flows, not LLM tools — intentionally left as default `span`.

## Deferred to follow-up (the other 4 Epic F sub-items)

Each is a runtime/behavior change (higher risk, separately verifiable), so they land as small dedicated PRs rather than bloating this mechanical taxonomy change:
- `agent.astream(subgraphs=True)` for history sub-graph stream events
- Datasets `item.run()` context manager in `scripts/run_experiment.py`
- `LangfuseMedia` audio attachment on voice transcribe spans
- `CallbackHandler` reuse via `BotContext` (currently per-invoke)

## TDD

`tests/contract/test_observation_type_taxonomy_contract.py` (24 tests): AST-walks `telegram_bot/agents` + `src/runtime/graph/nodes`, asserts each tool/guard `@observe` carries the expected `as_type`. A regression that drops or mis-sets `as_type` fails CI. Includes a non-vacuous scanner sanity test.

## Validation

- Taxonomy contract — 24 passed.
- `test_span_coverage_contract.py` + `test_trace_families_contract.py` — 209 passed (no regression).
- Full suite (excl. flaky mypy timeout) — **8923 passed, 0 failed**.
- ruff check + format clean.

## Refs

- #2215 — umbrella audit, Sprint 3 PR-2.
- #2216 — Epic F P2 (taxonomy slice; 4 sub-items deferred as noted).
- Langfuse v4 `ObservationTypeLiteral`: https://langfuse.com/docs/observability/sdk/python/instrumentation