### PR TITLE
feat(observability): Langfuse prompt + score-config inventory script (#2222)

### DIFF
--- a/scripts/audit/__init__.py
+++ b/scripts/audit/__init__.py
@@ -1,1 +1,1 @@
-"""Read-only Langfuse audit scripts (#2222, #2223)."""
+"""Read-only Langfuse audit scripts (#2221, #2222, #2223)."""

--- a/scripts/audit/__init__.py
+++ b/scripts/audit/__init__.py
@@ -1,0 +1,1 @@
+"""Read-only Langfuse audit scripts (#2222, #2223)."""

--- a/scripts/audit/langfuse_inventory.py
+++ b/scripts/audit/langfuse_inventory.py
@@ -1,0 +1,276 @@
+"""Langfuse prompt + score-config inventory (#2222 / Epic M).
+
+Read-only audit that surfaces drift between what the code references and what
+actually lives in Langfuse:
+
+* **Prompts** — code calls ``get_prompt("<name>")`` /
+  ``get_prompt_with_config("<name>")``. Compared against
+  ``langfuse.api.prompts.list()``:
+    - ``local_only``  : code references a prompt that does NOT exist in
+      Langfuse -> the SDK silently falls back to the hardcoded ``fallback=``
+      string. A real drift the operator should fix (create the prompt or drop
+      the reference).
+    - ``remote_only`` : a prompt exists in Langfuse but nothing fetches it
+      (orphan / cleanup candidate).
+* **Score configs** — code emits scores via ``score_current_trace(name=...)``
+  in ``src/scoring.py``. Compared against ``langfuse.api.score_configs.get()``:
+    - ``local_only``  : score emitted with no Score Config in Langfuse (no UI
+      data-type / categories).
+    - ``remote_only`` : a Score Config with no emitter.
+
+Usage::
+
+    uv run python -m scripts.audit.langfuse_inventory            # human report
+    uv run python -m scripts.audit.langfuse_inventory --json     # machine-readable
+    uv run python -m scripts.audit.langfuse_inventory --strict   # exit 1 on prompt local_only
+
+The script is best-effort: a Langfuse fetch failure degrades to an empty
+remote set (so the report still shows code-side names) and never raises.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Prompt-name source: first positional string arg to these callables.
+_PROMPT_FETCH_FUNCS = {"get_prompt", "get_prompt_with_config"}
+
+# Default code roots to scan for prompt references.
+_DEFAULT_CODE_ROOTS = (
+    REPO_ROOT / "src",
+    REPO_ROOT / "telegram_bot",
+    REPO_ROOT / "mini_app",
+)
+
+_SKIP_PATH_FRAGMENTS = ("/tests/", "/.venv/", "/__pycache__/", "/archive/")
+
+
+@dataclass
+class InventoryDiff:
+    """Partition of code-referenced vs remote-present names."""
+
+    local_only: set[str] = field(default_factory=set)
+    remote_only: set[str] = field(default_factory=set)
+    both: set[str] = field(default_factory=set)
+
+
+# ---------------------------------------------------------------------------
+# Code scanning (pure)
+# ---------------------------------------------------------------------------
+
+
+def _first_literal_arg(call: ast.Call) -> str | None:
+    if call.args and isinstance(call.args[0], ast.Constant):
+        value = call.args[0].value
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def _call_func_name(call: ast.Call) -> str | None:
+    func = call.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def scan_code_prompt_names(roots: list[Path]) -> set[str]:
+    """Return prompt names passed as the first string literal to
+    ``get_prompt`` / ``get_prompt_with_config`` across ``roots``."""
+    names: set[str] = set()
+    for root in roots:
+        if not root.exists():
+            continue
+        for py_file in root.rglob("*.py"):
+            if any(frag in str(py_file) for frag in _SKIP_PATH_FRAGMENTS):
+                continue
+            try:
+                tree = ast.parse(py_file.read_text(encoding="utf-8"))
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                if _call_func_name(node) in _PROMPT_FETCH_FUNCS:
+                    literal = _first_literal_arg(node)
+                    if literal:
+                        names.add(literal)
+    return names
+
+
+def scan_code_score_names(scoring_py: Path) -> set[str]:
+    """Return score names emitted via ``score_*(name="...")`` in scoring.py."""
+    names: set[str] = set()
+    if not scoring_py.exists():
+        return names
+    try:
+        tree = ast.parse(scoring_py.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return names
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fname = _call_func_name(node) or ""
+        if "score" not in fname.lower():
+            continue
+        for kw in node.keywords:
+            if (
+                kw.arg == "name"
+                and isinstance(kw.value, ast.Constant)
+                and isinstance(kw.value.value, str)
+            ):
+                names.add(kw.value.value)
+    return names
+
+
+def diff_inventory(*, code: set[str], remote: set[str]) -> InventoryDiff:
+    """Partition names into local_only / remote_only / both."""
+    return InventoryDiff(
+        local_only=code - remote,
+        remote_only=remote - code,
+        both=code & remote,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Remote fetch (best-effort, mocked in tests)
+# ---------------------------------------------------------------------------
+
+
+def _paginate(fetch, **kwargs) -> list[Any]:
+    """Collect ``.data`` across pages using ``.meta.total_pages``."""
+    out: list[Any] = []
+    page = 1
+    while True:
+        resp = fetch(page=page, limit=100, **kwargs)
+        out.extend(getattr(resp, "data", []) or [])
+        meta = getattr(resp, "meta", None)
+        total_pages = getattr(meta, "total_pages", 1) or 1
+        if page >= total_pages:
+            break
+        page += 1
+    return out
+
+
+def fetch_remote_prompt_names(client: Any) -> set[str]:
+    """Return the set of prompt names from ``langfuse.api.prompts.list()``."""
+    try:
+        items = _paginate(client.api.prompts.list)
+        return {getattr(p, "name", None) for p in items if getattr(p, "name", None)}
+    except Exception:
+        return set()
+
+
+def fetch_remote_score_config_names(client: Any) -> set[str]:
+    """Return the set of Score Config names from
+    ``langfuse.api.score_configs.get()``."""
+    try:
+        items = _paginate(client.api.score_configs.get)
+        return {getattr(c, "name", None) for c in items if getattr(c, "name", None)}
+    except Exception:
+        return set()
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def _section(title: str, diff: InventoryDiff) -> list[str]:
+    lines = [
+        f"## {title}",
+        f"  in both code & Langfuse : {len(diff.both)}",
+        f"  code only (DRIFT)       : {len(diff.local_only)}",
+    ]
+    for n in sorted(diff.local_only):
+        lines.append(f"      - {n}")
+    lines.append(f"  Langfuse only (orphan)  : {len(diff.remote_only)}")
+    for n in sorted(diff.remote_only):
+        lines.append(f"      - {n}")
+    return lines
+
+
+def format_report(*, prompt_diff: InventoryDiff, score_diff: InventoryDiff) -> str:
+    lines = ["# Langfuse inventory (#2222)", ""]
+    lines += _section("PROMPTS", prompt_diff)
+    lines.append("")
+    lines += _section("SCORE CONFIGS", score_diff)
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_client() -> Any | None:
+    try:
+        from langfuse import get_client
+
+        return get_client()
+    except Exception:
+        return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Langfuse prompt + score-config inventory")
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit 1 when code references a prompt missing from Langfuse",
+    )
+    args = parser.parse_args(argv)
+
+    code_prompts = scan_code_prompt_names(list(_DEFAULT_CODE_ROOTS))
+    code_scores = scan_code_score_names(REPO_ROOT / "src" / "scoring.py")
+
+    client = _build_client()
+    remote_prompts = fetch_remote_prompt_names(client) if client else set()
+    remote_scores = fetch_remote_score_config_names(client) if client else set()
+
+    prompt_diff = diff_inventory(code=code_prompts, remote=remote_prompts)
+    score_diff = diff_inventory(code=code_scores, remote=remote_scores)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "prompts": {
+                        "local_only": sorted(prompt_diff.local_only),
+                        "remote_only": sorted(prompt_diff.remote_only),
+                        "both": sorted(prompt_diff.both),
+                    },
+                    "score_configs": {
+                        "local_only": sorted(score_diff.local_only),
+                        "remote_only": sorted(score_diff.remote_only),
+                        "both": sorted(score_diff.both),
+                    },
+                    "langfuse_reachable": client is not None,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(format_report(prompt_diff=prompt_diff, score_diff=score_diff))
+        if client is None:
+            print("\n(note: Langfuse client unavailable — remote sets empty)")
+
+    if args.strict and prompt_diff.local_only:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit/langfuse_inventory.py
+++ b/scripts/audit/langfuse_inventory.py
@@ -167,7 +167,12 @@ def fetch_remote_prompt_names(client: Any) -> set[str]:
     """Return the set of prompt names from ``langfuse.api.prompts.list()``."""
     try:
         items = _paginate(client.api.prompts.list)
-        return {getattr(p, "name", None) for p in items if getattr(p, "name", None)}
+        names: set[str] = set()
+        for prompt in items:
+            name = getattr(prompt, "name", None)
+            if isinstance(name, str) and name:
+                names.add(name)
+        return names
     except Exception:
         return set()
 
@@ -177,7 +182,12 @@ def fetch_remote_score_config_names(client: Any) -> set[str]:
     ``langfuse.api.score_configs.get()``."""
     try:
         items = _paginate(client.api.score_configs.get)
-        return {getattr(c, "name", None) for c in items if getattr(c, "name", None)}
+        names: set[str] = set()
+        for config in items:
+            name = getattr(config, "name", None)
+            if isinstance(name, str) and name:
+                names.add(name)
+        return names
     except Exception:
         return set()
 

--- a/scripts/audit/langfuse_inventory.py
+++ b/scripts/audit/langfuse_inventory.py
@@ -218,7 +218,8 @@ def _build_client() -> Any | None:
     try:
         from langfuse import get_client
 
-        return get_client()
+        client = get_client()
+        return client if hasattr(client, "api") else None
     except Exception:
         return None
 

--- a/tests/unit/scripts/test_langfuse_inventory.py
+++ b/tests/unit/scripts/test_langfuse_inventory.py
@@ -24,7 +24,8 @@ Langfuse fetch is mocked.
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -133,6 +134,16 @@ class TestFetchRemoteScoreConfigNames:
         client = MagicMock()
         client.api.score_configs.get.side_effect = RuntimeError("boom")
         assert inventory.fetch_remote_score_config_names(client) == set()
+
+
+class TestBuildClient:
+    def test_disabled_langfuse_client_is_treated_as_unavailable(self) -> None:
+        with patch.dict("sys.modules", {"langfuse": MagicMock()}):
+            import langfuse
+
+            langfuse.get_client.return_value = SimpleNamespace()
+
+            assert inventory._build_client() is None
 
 
 class TestFormatReport:

--- a/tests/unit/scripts/test_langfuse_inventory.py
+++ b/tests/unit/scripts/test_langfuse_inventory.py
@@ -1,0 +1,152 @@
+"""Unit tests for scripts/audit/langfuse_inventory.py (#2222 / Epic M).
+
+The inventory script surfaces drift between what the code references and what
+actually exists in Langfuse:
+
+* **Prompts**: code calls ``get_prompt("<name>")`` / ``get_prompt_with_config(
+  "<name>")``. The script compares those names against
+  ``langfuse.api.prompts.list()``:
+    - ``local_only``  -> code references a prompt that does NOT exist in
+      Langfuse (the SDK silently uses the hardcoded ``fallback=`` instead —
+      a real drift the operator should know about).
+    - ``remote_only`` -> a prompt exists in Langfuse but no code path fetches
+      it (orphan / candidate for cleanup).
+* **Score configs**: code emits scores via ``score_current_trace(name=...)``
+  in ``src/scoring.py``. The script compares those against
+  ``langfuse.api.score_configs.get()`` so operators can spot scores emitted
+  without a configured Score Config (no UI metadata / data-type) and configs
+  with no emitter.
+
+These tests pin the pure functions (code scan + diff + report). The live
+Langfuse fetch is mocked.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+inventory = pytest.importorskip(
+    "scripts.audit.langfuse_inventory",
+    reason="inventory script under test",
+)
+
+
+class TestScanCodePromptNames:
+    def test_finds_get_prompt_literal(self, tmp_path: Path) -> None:
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "from x import get_prompt\n"
+            "def g():\n"
+            "    return get_prompt('generate', fallback='...')\n"
+        )
+        names = inventory.scan_code_prompt_names([tmp_path])
+        assert "generate" in names
+
+    def test_finds_get_prompt_with_config_literal(self, tmp_path: Path) -> None:
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "def g(pm):\n    return pm.get_prompt_with_config('client_agent', cache_ttl=60)\n"
+        )
+        names = inventory.scan_code_prompt_names([tmp_path])
+        assert "client_agent" in names
+
+    def test_ignores_non_literal_first_arg(self, tmp_path: Path) -> None:
+        f = tmp_path / "mod.py"
+        f.write_text("def g(name):\n    return get_prompt(name)\n")
+        names = inventory.scan_code_prompt_names([tmp_path])
+        assert names == set()
+
+    def test_skips_tests_and_pycache(self, tmp_path: Path) -> None:
+        (tmp_path / "tests").mkdir()
+        (tmp_path / "tests" / "t.py").write_text("get_prompt('should_skip')\n")
+        (tmp_path / "real.py").write_text("get_prompt('keep')\n")
+        names = inventory.scan_code_prompt_names([tmp_path])
+        assert "keep" in names
+        assert "should_skip" not in names
+
+
+class TestDiffInventory:
+    def test_partitions_local_remote_both(self) -> None:
+        diff = inventory.diff_inventory(
+            code={"a", "b", "c"},
+            remote={"b", "c", "d"},
+        )
+        assert diff.local_only == {"a"}
+        assert diff.remote_only == {"d"}
+        assert diff.both == {"b", "c"}
+
+    def test_empty_sets(self) -> None:
+        diff = inventory.diff_inventory(code=set(), remote=set())
+        assert diff.local_only == set()
+        assert diff.remote_only == set()
+        assert diff.both == set()
+
+
+class TestFetchRemotePromptNames:
+    def test_paginates_and_collects_names(self) -> None:
+        client = MagicMock()
+
+        page1 = MagicMock()
+        page1.data = [MagicMock(name="p"), MagicMock(name="p")]
+        page1.data[0].name = "generate"
+        page1.data[1].name = "client_agent"
+        page1.meta = MagicMock(total_pages=2)
+
+        page2 = MagicMock()
+        page2.data = [MagicMock()]
+        page2.data[0].name = "manager_agent"
+        page2.meta = MagicMock(total_pages=2)
+
+        client.api.prompts.list.side_effect = [page1, page2]
+
+        names = inventory.fetch_remote_prompt_names(client)
+        assert names == {"generate", "client_agent", "manager_agent"}
+        assert client.api.prompts.list.call_count == 2
+
+    def test_returns_empty_on_error(self) -> None:
+        client = MagicMock()
+        client.api.prompts.list.side_effect = RuntimeError("network down")
+        # Best-effort: a failed fetch yields an empty set, never raises.
+        assert inventory.fetch_remote_prompt_names(client) == set()
+
+
+class TestFetchRemoteScoreConfigNames:
+    def test_collects_config_names(self) -> None:
+        client = MagicMock()
+        page = MagicMock()
+        c1 = MagicMock()
+        c1.name = "confidence_score"
+        c2 = MagicMock()
+        c2.name = "grounded"
+        page.data = [c1, c2]
+        page.meta = MagicMock(total_pages=1)
+        client.api.score_configs.get.return_value = page
+
+        names = inventory.fetch_remote_score_config_names(client)
+        assert names == {"confidence_score", "grounded"}
+
+    def test_returns_empty_on_error(self) -> None:
+        client = MagicMock()
+        client.api.score_configs.get.side_effect = RuntimeError("boom")
+        assert inventory.fetch_remote_score_config_names(client) == set()
+
+
+class TestFormatReport:
+    def test_report_lists_drift_sections(self) -> None:
+        prompt_diff = inventory.diff_inventory(
+            code={"generate", "missing_prompt"}, remote={"generate", "orphan"}
+        )
+        score_diff = inventory.diff_inventory(
+            code={"confidence_score"}, remote={"confidence_score", "unused_cfg"}
+        )
+        report = inventory.format_report(prompt_diff=prompt_diff, score_diff=score_diff)
+        assert "missing_prompt" in report  # local_only prompt (drift!)
+        assert "orphan" in report  # remote_only prompt
+        assert "unused_cfg" in report  # remote_only score config
+        # Headline counts present
+        assert "PROMPTS" in report.upper()
+        assert "SCORE" in report.upper()


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes Epic M from #2215 audit. Adds `scripts/audit/langfuse_inventory.py` — a **read-only** audit that surfaces drift between what the code references and what actually lives in Langfuse.

### PROMPTS
Scans `get_prompt("<name>")` / `get_prompt_with_config("<name>")` literals across `src/` + `telegram_bot/` + `mini_app/` (AST, first string arg) and compares against `langfuse.api.prompts.list()`:
- **`local_only`** — code references a prompt absent from Langfuse → the SDK silently uses the hardcoded `fallback=` (real drift to fix).
- **`remote_only`** — prompt exists in Langfuse but nothing fetches it (orphan / cleanup candidate).

### SCORE CONFIGS
Scans `score_*(name=...)` in `src/scoring.py` and compares against `langfuse.api.score_configs.get()`:
- **`local_only`** — score emitted with no Score Config (no UI data-type/categories).
- **`remote_only`** — Score Config with no emitter.

## SDK-native

Uses `langfuse.api.prompts.list()` + `langfuse.api.score_configs.get()` (both paginated via `.meta.total_pages`), confirmed via Context7. Best-effort: a Langfuse fetch failure degrades to an empty remote set and never raises, so the report still shows code-side names offline.

## CLI

```
uv run python -m scripts.audit.langfuse_inventory          # human report
uv run python -m scripts.audit.langfuse_inventory --json   # machine-readable
uv run python -m scripts.audit.langfuse_inventory --strict # exit 1 on prompt drift
```

Offline smoke already surfaces real code-side prompt names (`generate`, `generate_exhaustive_list`, `apartment-extraction-system-prompt`, ...) and ~40 score names.

## TDD

`tests/unit/scripts/test_langfuse_inventory.py` (11 tests): `scan_code_prompt_names` (literals / ignores non-literal / skips tests), `diff_inventory` partition, `fetch_remote_prompt_names` pagination + empty-on-error, `fetch_remote_score_config_names`, `format_report` drift sections.

## Validation

- `pytest tests/unit/scripts/test_langfuse_inventory.py` — 11 passed.
- `pytest tests/contract/ tests/unit/scripts/` — **1463 passed**.
- ruff check + format clean.

## Follow-up

Wire a weekly CI job that commits the snapshot to `docs/engineering/<date>-langfuse-inventory.md`.

## Refs

- #2215 — umbrella audit, Sprint 3 PR-3.
- #2222 — Epic M P2.