### PR TITLE
fix: add end-to-end OTel trace gate

### DIFF
--- a/src/voice/agent.py
+++ b/src/voice/agent.py
@@ -469,6 +469,7 @@ async def entrypoint(ctx: agents.JobContext):
             user_id="voice-agent",
             tags=["voice", "call-lifecycle"],
             metadata={"call_id": call_id},
+            as_baggage=True,
         )
     else:
         session_cm = contextlib.nullcontext()

--- a/tests/contract/test_end_to_end_trace_flow_contract.py
+++ b/tests/contract/test_end_to_end_trace_flow_contract.py
@@ -1,0 +1,165 @@
+"""End-to-end single-trace flow contract (#2244).
+
+This is a static CI gate for the runtime goal: one user workflow should appear
+as one distributed Langfuse/OTEL trace. Live validation still happens through
+``make validate-traces-fast`` and Langfuse-backed checks, but this contract
+keeps the canonical flow matrix wired to the span catalog, service env contract,
+W3C Baggage propagation, logs, and scores.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_REQUIRED_PROPAGATION_KEYS = {
+    "carrier",
+    "requires_trace_context",
+    "requires_baggage",
+    "forbid_manual_langfuse_trace_id",
+    "propagation_entrypoints",
+}
+
+_REQUIRED_LOG_FIELDS = {"otelTraceID", "otelSpanID"}
+
+
+def _catalog_span_names(trace_contract: dict[str, Any]) -> set[str]:
+    spans: set[str] = set(trace_contract.get("required_families", []))
+    for group in trace_contract.get("spans", {}).values():
+        spans.update(group)
+    return spans
+
+
+def _iter_flow_spans(flow: dict[str, Any]) -> set[str]:
+    names: set[str] = set()
+    for group in flow["required_spans"].values():
+        names.update(group)
+    return names
+
+
+def test_end_to_end_flow_matrix_is_declared(trace_contract: dict[str, Any]) -> None:
+    flows = trace_contract.get("end_to_end_trace_flows")
+
+    assert isinstance(flows, dict) and len(flows) >= 3, (
+        "trace_contract.yaml must declare at least three canonical "
+        "end_to_end_trace_flows for #2244: bot/RAG, voice/RAG API, and CRM."
+    )
+    for flow_name in ("telegram_text_rag", "voice_rag_api", "crm_handoff_write"):
+        assert flow_name in flows, f"Missing canonical #2244 flow: {flow_name}"
+
+
+def test_each_flow_references_known_services(trace_contract: dict[str, Any]) -> None:
+    services = trace_contract["services_with_observe"]
+    service_names = set(services)
+
+    for flow_name, flow in trace_contract["end_to_end_trace_flows"].items():
+        referenced = {flow["entry_service"], *flow["required_services"]}
+        unknown = referenced - service_names
+        assert not unknown, (
+            f"{flow_name}: references services that are not in "
+            "services_with_observe: " + ", ".join(sorted(unknown))
+        )
+
+
+def test_each_flow_root_family_is_required(trace_contract: dict[str, Any]) -> None:
+    required_families = set(trace_contract["required_families"])
+
+    for flow_name, flow in trace_contract["end_to_end_trace_flows"].items():
+        root_family = flow["root_family"]
+        assert root_family in required_families, (
+            f"{flow_name}: root_family {root_family!r} must be in "
+            "required_families so live trace validation can find the root."
+        )
+
+
+def test_each_flow_required_spans_exist_in_catalog(trace_contract: dict[str, Any]) -> None:
+    catalog_spans = _catalog_span_names(trace_contract)
+
+    for flow_name, flow in trace_contract["end_to_end_trace_flows"].items():
+        flow_spans = _iter_flow_spans(flow)
+        missing = flow_spans - catalog_spans
+        assert not missing, (
+            f"{flow_name}: required_spans contain names not declared in the "
+            "canonical trace catalog: " + ", ".join(sorted(missing))
+        )
+
+
+def test_each_flow_has_runtime_validation_shape(trace_contract: dict[str, Any]) -> None:
+    score_groups = set(trace_contract["scores"])
+
+    for flow_name, flow in trace_contract["end_to_end_trace_flows"].items():
+        assert flow.get("description"), f"{flow_name}: description is required"
+        assert flow.get("required_spans", {}).get("root") == [flow["root_family"]], (
+            f"{flow_name}: required_spans.root must contain only root_family"
+        )
+
+        required_spans = flow["required_spans"]
+        assert len(required_spans) >= 3, (
+            f"{flow_name}: must cover root plus at least two downstream span groups"
+        )
+
+        score_group_refs = set(flow.get("required_score_groups", []))
+        assert score_group_refs, f"{flow_name}: required_score_groups must not be empty"
+        assert score_group_refs <= score_groups, f"{flow_name}: unknown score groups: " + ", ".join(
+            sorted(score_group_refs - score_groups)
+        )
+
+        log_fields = set(flow.get("required_log_fields", []))
+        assert log_fields >= _REQUIRED_LOG_FIELDS, (
+            f"{flow_name}: required_log_fields must include otelTraceID and otelSpanID"
+        )
+
+        commands = flow.get("validation_commands", [])
+        assert "make validate-traces-fast" in commands, (
+            f"{flow_name}: must document make validate-traces-fast as the local "
+            "runtime validation command"
+        )
+
+
+def test_each_flow_requires_w3c_tracecontext_and_baggage(
+    trace_contract: dict[str, Any],
+) -> None:
+    for flow_name, flow in trace_contract["end_to_end_trace_flows"].items():
+        propagation = flow.get("propagation", {})
+        missing_keys = _REQUIRED_PROPAGATION_KEYS - set(propagation)
+        assert not missing_keys, f"{flow_name}: propagation missing keys: " + ", ".join(
+            sorted(missing_keys)
+        )
+
+        assert propagation["carrier"] == "w3c_tracecontext_baggage"
+        assert propagation["requires_trace_context"] is True
+        assert propagation["requires_baggage"] is True
+        assert propagation["forbid_manual_langfuse_trace_id"] is True
+
+
+def test_flow_propagation_entrypoints_use_baggage(
+    trace_contract: dict[str, Any],
+) -> None:
+    for flow_name, flow in trace_contract["end_to_end_trace_flows"].items():
+        entrypoints = flow["propagation"]["propagation_entrypoints"]
+        assert entrypoints, f"{flow_name}: propagation_entrypoints must not be empty"
+
+        for relative_path in entrypoints:
+            source_path = REPO_ROOT / relative_path
+            assert source_path.exists(), f"{flow_name}: missing entrypoint {relative_path}"
+
+            source = source_path.read_text(encoding="utf-8")
+            has_baggage = "as_baggage=True" in source or '"as_baggage": True' in source
+            assert has_baggage, (
+                f"{flow_name}: {relative_path} must call "
+                "propagate_attributes(..., as_baggage=True) so Langfuse "
+                "user/session/tags cross HTTP/service boundaries via W3C Baggage."
+            )
+
+
+def test_crm_flow_requires_confirmed_write_success(trace_contract: dict[str, Any]) -> None:
+    crm_flow = trace_contract["end_to_end_trace_flows"]["crm_handoff_write"]
+
+    assert crm_flow["propagation"].get("requires_confirmed_write_success") is True, (
+        "crm_handoff_write must keep #2212's guard explicit: success spans/scores "
+        "are valid only after confirmed Kommo writes."
+    )
+    assert "crm" in crm_flow["required_score_groups"]

--- a/tests/observability/trace_contract.yaml
+++ b/tests/observability/trace_contract.yaml
@@ -68,6 +68,134 @@ coverage_tiers:
   opportunistic_for_1307:
     - voice-session
 
+# Canonical end-to-end trace flows for #2244.
+#
+# These are not live fixtures. They are the runtime coverage contract that
+# validates what a live Langfuse trace must eventually prove: one user workflow
+# should appear as one distributed trace, with W3C TraceContext carrying parent
+# span identity and W3C Baggage carrying Langfuse user/session/tags across
+# service and background boundaries.
+end_to_end_trace_flows:
+  telegram_text_rag:
+    description: "Telegram text request through RAG, retrieval, embeddings, rerank, generation, logs, and scores."
+    root_family: telegram-rag-query
+    entry_service: bot
+    required_services:
+      - bot
+      - rag-api
+      - bge-m3-api
+    propagation:
+      carrier: w3c_tracecontext_baggage
+      requires_trace_context: true
+      requires_baggage: true
+      forbid_manual_langfuse_trace_id: true
+      propagation_entrypoints:
+        - telegram_bot/middlewares/langfuse_middleware.py
+        - src/api/main.py
+    required_spans:
+      root:
+        - telegram-rag-query
+      graph:
+        - node-classify
+        - node-retrieve
+        - node-grade
+        - node-rerank
+        - node-generate
+        - node-respond
+      retrieval:
+        - tool-rag-search
+        - rag-pipeline
+        - hybrid-retrieve
+        - retrieval.initial
+      backend:
+        - cache-semantic-check
+        - bge-m3-encode-hybrid
+        - bge-m3-rerank
+        - qdrant-hybrid-search-rrf
+      generation:
+        - service-generate-response
+    required_score_groups:
+      - core_rag
+    required_log_fields:
+      - otelTraceID
+      - otelSpanID
+    validation_commands:
+      - make validate-traces-fast
+
+  voice_rag_api:
+    description: "Voice session that continues user/session context into the RAG API and downstream retrieval services."
+    root_family: voice-session
+    entry_service: voice-agent
+    required_services:
+      - voice-agent
+      - rag-api
+      - bge-m3-api
+    propagation:
+      carrier: w3c_tracecontext_baggage
+      requires_trace_context: true
+      requires_baggage: true
+      forbid_manual_langfuse_trace_id: true
+      propagation_entrypoints:
+        - src/voice/agent.py
+        - src/api/main.py
+    required_spans:
+      root:
+        - voice-session
+      api:
+        - rag-api-query
+      voice:
+        - voice-tool-search-knowledge-base
+      retrieval:
+        - rag-pipeline
+        - hybrid-retrieve
+        - retrieval.initial
+      backend:
+        - bge-m3-encode-hybrid
+        - bge-m3-rerank
+        - qdrant-hybrid-search-rrf
+      generation:
+        - service-generate-response
+    required_score_groups:
+      - core_rag
+    required_log_fields:
+      - otelTraceID
+      - otelSpanID
+    validation_commands:
+      - make validate-traces-fast
+
+  crm_handoff_write:
+    description: "CRM handoff/write path where success spans and scores are emitted only after confirmed Kommo writes."
+    root_family: telegram-hitl-callback
+    entry_service: bot
+    required_services:
+      - bot
+    propagation:
+      carrier: w3c_tracecontext_baggage
+      requires_trace_context: true
+      requires_baggage: true
+      forbid_manual_langfuse_trace_id: true
+      requires_confirmed_write_success: true
+      propagation_entrypoints:
+        - telegram_bot/middlewares/langfuse_middleware.py
+    required_spans:
+      root:
+        - telegram-hitl-callback
+      handoff:
+        - tool-handoff
+        - handoff-generate-summary
+      crm:
+        - kommo-create-lead
+        - kommo-upsert-contact
+        - kommo-add-note
+        - kommo-create-task
+    required_score_groups:
+      - crm
+    required_log_fields:
+      - otelTraceID
+      - otelSpanID
+    validation_commands:
+      - make validate-traces-fast
+
 spans:
   graph_nodes:
     - node-guard

--- a/tests/unit/voice/test_voice_observability.py
+++ b/tests/unit/voice/test_voice_observability.py
@@ -140,7 +140,9 @@ async def test_entrypoint_reuses_one_trace_id_for_parent_span_and_rag_api() -> N
     with (
         patch.object(agent_mod, "_LIVEKIT_IMPORT_ERROR", None),
         patch.object(agent_mod, "get_client", return_value=fake_lf),
-        patch.object(agent_mod, "propagate_attributes", return_value=contextlib.nullcontext()),
+        patch.object(
+            agent_mod, "propagate_attributes", return_value=contextlib.nullcontext()
+        ) as propagate,
         patch.object(agent_mod, "_entrypoint_body", new_callable=AsyncMock) as body,
     ):
         await agent_mod.entrypoint(fake_ctx)
@@ -150,5 +152,7 @@ async def test_entrypoint_reuses_one_trace_id_for_parent_span_and_rag_api() -> N
     observation_kwargs = fake_lf.start_as_current_observation.call_args.kwargs
     assert observation_kwargs["name"] == "voice-session"
     assert observation_kwargs["trace_context"] == {"trace_id": "trace-voice-call-1"}
+    propagate.assert_called_once()
+    assert propagate.call_args.kwargs["as_baggage"] is True
     body.assert_awaited_once()
     assert body.call_args.kwargs["langfuse_trace_id"] == "trace-voice-call-1"


### PR DESCRIPTION
## Summary

Refs #2244. Refs #2246.

Adds the static/local-fast contract layer for the single-trace goal: a canonical end-to-end flow matrix for the representative workflows we want to keep visible as one distributed Langfuse/OTel trace:

- Telegram text -> RAG -> retrieval/embed/rerank -> LLM
- Voice session -> RAG API -> downstream retrieval services
- CRM handoff/write path with confirmed Kommo-write success semantics

The new gate also exposed one additional gap not called out in #2246: the voice agent opened a `voice-session` trace but did not pass `as_baggage=True` to `propagate_attributes(...)`. This PR fixes that so voice user/session/tags can cross HTTP/service boundaries through W3C Baggage.

## Scope

This PR does **not** close #2244. It establishes the static contract surface and fixes the voice baggage gap. The runtime blockers from #2246 remain follow-up work:

- F1: raw-thread ingestion context propagation
- F2: remove legacy manual BGE-M3 propagation after runtime proof
- F3: declare `OTEL_PROPAGATORS=tracecontext,baggage`
- F4: add runtime cross-process/thread `trace_id` continuity assertion
- F5: CRM false-success blocker from #2212
- F6: log-to-trace assertion per canonical flow

## Validation

- `/home/user/projects/rag-fresh/.venv/bin/python -m pytest tests/contract/test_end_to_end_trace_flow_contract.py tests/contract/test_trace_families_contract.py tests/contract/test_compose_observe_coverage_contract.py tests/unit/observability/test_w3c_baggage_propagation.py tests/unit/voice/test_voice_observability.py -q`
- `/home/user/projects/rag-fresh/.venv/bin/python -m ruff check src/voice/agent.py tests/contract/test_end_to_end_trace_flow_contract.py tests/unit/voice/test_voice_observability.py`
- `git diff --check`
- commit hooks: py_compile, ruff check, ruff format, YAML/TOML/JSON checks, secret/private-key checks, bandit, shell/action/docker linters where applicable

## Notes

This is a static/local-fast contract gate. Live proof still comes from `make validate-traces-fast` and Langfuse-backed runtime validation once the stack is running with credentials.
