### PR TITLE
feat(observability): one-command trace-data audit snapshot (#2221)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -824,7 +824,7 @@ deploy-vps-local:  ## Fallback/manual deploy: manual instructions only (VPS scri
 # E2E TESTING
 # =============================================================================
 
-.PHONY: e2e-install e2e-generate-data e2e-index-data e2e-test e2e-test-traces e2e-test-traces-core e2e-test-group e2e-telegram-test e2e-setup langfuse-latest-trace-audit
+.PHONY: e2e-install e2e-generate-data e2e-index-data e2e-test e2e-test-traces e2e-test-traces-core e2e-test-group e2e-telegram-test e2e-setup langfuse-latest-trace-audit trace-audit-snapshot
 
 e2e-install: ## Install E2E testing dependencies
 	@echo "$(BLUE)Installing E2E dependencies...$(NC)"
@@ -872,6 +872,11 @@ langfuse-latest-trace-audit: ## Sanitized post-E2E Langfuse latest-trace audit
 	@echo "$(BLUE)Running sanitized latest-trace audit...$(NC)"
 	uv run python scripts/e2e/langfuse_latest_trace_audit.py --limit 20
 	@echo "$(GREEN)✓ Latest-trace audit complete$(NC)"
+
+trace-audit-snapshot: ## One-command runtime trace-data audit -> docs/engineering/<date>-trace-audit-snapshot.md (#2221)
+	@echo "$(BLUE)Running trace-data audit snapshot...$(NC)"
+	uv run python -m scripts.audit.trace_audit_snapshot
+	@echo "$(GREEN)✓ Trace-audit snapshot written$(NC)"
 
 # =============================================================================
 # BASELINE & OBSERVABILITY

--- a/scripts/audit/__init__.py
+++ b/scripts/audit/__init__.py
@@ -1,0 +1,1 @@
+"""Read-only Langfuse audit scripts (#2221, #2222, #2223)."""

--- a/scripts/audit/trace_audit_snapshot.py
+++ b/scripts/audit/trace_audit_snapshot.py
@@ -1,0 +1,151 @@
+"""Runtime trace-data audit snapshot (#2221 / Epic L).
+
+The repo already has the right runtime-audit tooling:
+
+* ``scripts/validate_traces.py``        — required trace-family coverage gate
+* ``scripts/validate_voice_traces.py``  — voice-session trace validation
+* ``scripts/langfuse_triage.py``        — dislike-trace triage (dry-run here)
+* ``scripts/probe/observability_diagnostic.py`` — Langfuse/LiteLLM noise probe
+
+…but no single command that runs them and produces ONE reviewable markdown
+snapshot. This orchestrator wraps them behind ``make trace-audit-snapshot``.
+
+Each underlying script runs as a **best-effort** subprocess: stdout + return
+code are captured into a section. A failing step (Langfuse down, missing dep)
+becomes a section flagged FAIL — it never aborts the whole snapshot. The
+combined report is written to ``docs/engineering/<date>-trace-audit-snapshot.md``.
+
+Usage::
+
+    make trace-audit-snapshot
+    uv run python -m scripts.audit.trace_audit_snapshot
+    uv run python -m scripts.audit.trace_audit_snapshot --stdout   # print, don't write
+    uv run python -m scripts.audit.trace_audit_snapshot --strict   # exit 1 if any step failed
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# (section title, argv). Best-effort dry-run flavours so the snapshot is
+# side-effect-free (e.g. triage --dry-run does not touch the annotation queue).
+AUDIT_STEPS: list[tuple[str, list[str]]] = [
+    (
+        "Required trace-family coverage (validate_traces.py)",
+        ["uv", "run", "python", "scripts/validate_traces.py"],
+    ),
+    (
+        "Voice-session traces (validate_voice_traces.py)",
+        ["uv", "run", "python", "scripts/validate_voice_traces.py"],
+    ),
+    (
+        "Dislike-trace triage dry-run (langfuse_triage.py)",
+        ["uv", "run", "python", "scripts/langfuse_triage.py", "--dry-run"],
+    ),
+    (
+        "Observability diagnostic (probe/observability_diagnostic.py)",
+        ["uv", "run", "python", "scripts/probe/observability_diagnostic.py"],
+    ),
+]
+
+_STEP_TIMEOUT_SEC = 300
+
+
+@dataclass
+class StepResult:
+    title: str
+    returncode: int
+    output: str
+
+
+def run_step(title: str, argv: list[str], *, runner=subprocess.run) -> StepResult:
+    """Run a single audit script best-effort; capture stdout+stderr+rc.
+
+    A runner exception (missing binary, timeout) is captured into the result
+    rather than propagated, so one broken step never aborts the snapshot.
+    """
+    try:
+        completed = runner(
+            argv,
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=_STEP_TIMEOUT_SEC,
+        )
+        rc = int(getattr(completed, "returncode", 1) or 0)
+        stdout = getattr(completed, "stdout", "") or ""
+        stderr = getattr(completed, "stderr", "") or ""
+        output = stdout if rc == 0 else (stdout + "\n" + stderr).strip()
+        return StepResult(title=title, returncode=rc, output=output or "(no output)")
+    except Exception as exc:  # best-effort: never abort the whole snapshot
+        return StepResult(title=title, returncode=1, output=f"{type(exc).__name__}: {exc}")
+
+
+def build_snapshot_markdown(steps: list[StepResult], *, generated_at: datetime) -> str:
+    """Assemble all step results into one reviewable markdown report."""
+    passed = sum(1 for s in steps if s.returncode == 0)
+    failed = len(steps) - passed
+    lines = [
+        "# Langfuse trace-data audit snapshot",
+        "",
+        f"- generated_at: {generated_at.isoformat()}",
+        f"- steps: {len(steps)}  |  passed: {passed}  |  failed: {failed}",
+        "",
+        "## Summary",
+        "",
+        "| step | status |",
+        "| --- | --- |",
+    ]
+    for s in steps:
+        marker = "✅ PASS" if s.returncode == 0 else "❌ FAIL"
+        lines.append(f"| {s.title} | {marker} |")
+    lines.append("")
+    for s in steps:
+        marker = "✅ PASS" if s.returncode == 0 else f"❌ FAIL (rc={s.returncode})"
+        lines.append(f"## {s.title} — {marker}")
+        lines.append("")
+        lines.append("```")
+        lines.append(s.output.strip())
+        lines.append("```")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def default_snapshot_path(generated_at: datetime) -> Path:
+    date = generated_at.strftime("%Y-%m-%d")
+    return REPO_ROOT / "docs" / "engineering" / f"{date}-trace-audit-snapshot.md"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Runtime trace-data audit snapshot")
+    parser.add_argument("--stdout", action="store_true", help="print report, do not write file")
+    parser.add_argument("--strict", action="store_true", help="exit 1 if any audit step failed")
+    args = parser.parse_args(argv)
+
+    generated_at = datetime.now(UTC)
+    steps = [run_step(title, cmd) for title, cmd in AUDIT_STEPS]
+    report = build_snapshot_markdown(steps, generated_at=generated_at)
+
+    if args.stdout:
+        print(report)
+    else:
+        path = default_snapshot_path(generated_at)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(report, encoding="utf-8")
+        print(f"Wrote trace-audit snapshot: {path.relative_to(REPO_ROOT)}")
+
+    if args.strict and any(s.returncode != 0 for s in steps):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_trace_audit_snapshot.py
+++ b/tests/unit/scripts/test_trace_audit_snapshot.py
@@ -1,0 +1,120 @@
+"""Unit tests for scripts/audit/trace_audit_snapshot.py (#2221 / Epic L).
+
+The repo already has the right runtime-audit tooling — validate_traces.py,
+validate_voice_traces.py, langfuse_triage.py, probe/observability_diagnostic.py
+— but no single command that runs them and produces ONE reviewable markdown
+snapshot. Epic L adds ``make trace-audit-snapshot`` wrapping them.
+
+The orchestrator runs each underlying script as a best-effort subprocess,
+captures stdout + return code, and assembles a dated markdown report under
+docs/engineering/. A failing step (Langfuse down, missing dep) becomes a
+section with its error — it never aborts the whole snapshot.
+
+These tests pin the pure/orchestration functions; the subprocess runner is
+injected so no real scripts run.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+
+snap = pytest.importorskip(
+    "scripts.audit.trace_audit_snapshot",
+    reason="trace audit snapshot orchestrator under test",
+)
+
+
+class TestRunStep:
+    def test_captures_output_and_returncode(self) -> None:
+        def fake_runner(argv, **kwargs):
+            from types import SimpleNamespace
+
+            assert argv[:2] == ["uv", "run"]
+            return SimpleNamespace(returncode=0, stdout="OK output", stderr="")
+
+        result = snap.run_step("Validate traces", ["uv", "run", "x"], runner=fake_runner)
+        assert result.title == "Validate traces"
+        assert result.returncode == 0
+        assert "OK output" in result.output
+
+    def test_best_effort_on_runner_exception(self) -> None:
+        def boom_runner(argv, **kwargs):
+            raise FileNotFoundError("uv not found")
+
+        result = snap.run_step("Triage", ["uv", "run", "x"], runner=boom_runner)
+        # Never raises; surfaces the failure in the result.
+        assert result.returncode != 0
+        assert "uv not found" in result.output or "FileNotFoundError" in result.output
+
+    def test_includes_stderr_when_nonzero(self) -> None:
+        def fail_runner(argv, **kwargs):
+            from types import SimpleNamespace
+
+            return SimpleNamespace(returncode=2, stdout="partial", stderr="boom err")
+
+        result = snap.run_step("X", ["uv", "run", "x"], runner=fail_runner)
+        assert result.returncode == 2
+        assert "boom err" in result.output
+
+
+class TestBuildSnapshotMarkdown:
+    def test_assembles_sections_with_status(self) -> None:
+        steps = [
+            snap.StepResult(title="Validate traces", returncode=0, output="all good"),
+            snap.StepResult(title="Voice traces", returncode=1, output="2 missing"),
+        ]
+        md = snap.build_snapshot_markdown(steps, generated_at=datetime(2026, 5, 29, 12, 0))
+        assert "# Langfuse trace-data audit snapshot" in md
+        assert "2026-05-29" in md
+        # Each step renders as a section with a status marker.
+        assert "Validate traces" in md
+        assert "Voice traces" in md
+        assert "all good" in md
+        assert "2 missing" in md
+        # Pass/fail markers present
+        assert "PASS" in md or "✅" in md
+        assert "FAIL" in md or "❌" in md
+
+    def test_summary_counts(self) -> None:
+        steps = [
+            snap.StepResult(title="a", returncode=0, output="x"),
+            snap.StepResult(title="b", returncode=0, output="y"),
+            snap.StepResult(title="c", returncode=1, output="z"),
+        ]
+        md = snap.build_snapshot_markdown(steps, generated_at=datetime(2026, 5, 29))
+        # 2 passed, 1 failed reflected in the summary.
+        assert "2" in md and "1" in md
+
+
+class TestSnapshotPath:
+    def test_dated_path_under_docs_engineering(self) -> None:
+        p = snap.default_snapshot_path(datetime(2026, 5, 29, 8, 30))
+        assert isinstance(p, Path)
+        assert p.name == "2026-05-29-trace-audit-snapshot.md"
+        assert "docs/engineering" in p.as_posix()
+
+
+class TestAuditStepsDefinition:
+    def test_audit_steps_reference_existing_scripts(self) -> None:
+        """Every wrapped script in AUDIT_STEPS must exist on disk so the
+        snapshot does not silently produce 'module not found' sections."""
+        repo_root = Path(snap.__file__).resolve().parents[2]
+        missing = []
+        for _title, argv in snap.AUDIT_STEPS:
+            # argv like ["uv","run","python","scripts/validate_traces.py", ...]
+            script = next(
+                (a for a in argv if a.endswith(".py") or a.startswith("scripts.")),
+                None,
+            )
+            if script is None:
+                continue
+            if script.endswith(".py") and not (repo_root / script).exists():
+                missing.append(script)
+        assert not missing, f"AUDIT_STEPS reference missing scripts: {missing}"
+
+    def test_audit_steps_nonempty(self) -> None:
+        assert len(snap.AUDIT_STEPS) >= 3


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes Epic L from #2215 audit — the **final** Sprint 3 PR. The repo already has the right runtime-audit tooling (`validate_traces.py`, `validate_voice_traces.py`, `langfuse_triage.py`, `probe/observability_diagnostic.py`) but no single command that runs them and produces **one reviewable markdown snapshot**.

Adds `scripts/audit/trace_audit_snapshot.py` + `make trace-audit-snapshot`. Each underlying script runs as a **best-effort** subprocess: stdout + return code captured into a markdown section. A failing step (Langfuse down, missing dep) becomes a section flagged FAIL — it never aborts the whole snapshot. Report written to `docs/engineering/<date>-trace-audit-snapshot.md`.

## CLI

```
make trace-audit-snapshot
uv run python -m scripts.audit.trace_audit_snapshot
uv run python -m scripts.audit.trace_audit_snapshot --stdout   # print, no write
uv run python -m scripts.audit.trace_audit_snapshot --strict   # exit 1 if any step failed
```

`AUDIT_STEPS` uses side-effect-free flavours (`langfuse_triage --dry-run`) so the snapshot never mutates Langfuse state. A contract-style unit test asserts every wrapped script exists on disk → the snapshot can never silently produce "module not found" sections.

## TDD

`tests/unit/scripts/test_trace_audit_snapshot.py` (8 tests): `run_step` (captures output+rc, best-effort on exception, stderr on nonzero), `build_snapshot_markdown` (PASS/FAIL markers + summary counts), `default_snapshot_path`, `AUDIT_STEPS` reference existing scripts + non-empty.

## Validation

- `pytest tests/unit/scripts/test_trace_audit_snapshot.py` — 8 passed.
- **End-to-end smoke** (`--stdout`, offline): ran all 4 real scripts, captured outputs (1 pass / 3 fail-no-keys), assembled markdown — best-effort confirmed.
- `pytest tests/contract/ tests/unit/scripts/` — **1460 passed**.
- ruff check + format clean.

## Follow-up

After #2222 (langfuse_inventory) + #2223 (cost_reconcile) merge, add them as `AUDIT_STEPS` entries; promote `--strict` to a nightly-heavy CI gate.

## Refs

- #2215 — umbrella audit, Sprint 3 PR-5 (final).
- #2221 — Epic L P2.