### PR TITLE
observability(otel): runtime trace_id continuity for canonical flows (#2252)

### DIFF
--- a/scripts/trace_continuity.py
+++ b/scripts/trace_continuity.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Runtime trace_id continuity checks for canonical end-to-end flows (#2252).
+
+Goal (child of #2246 F4, core of the #2244 single-trace gate): prove that each
+canonical workflow keeps **one** stable trace tree across process and thread
+boundaries, instead of fragmenting into several partial Langfuse traces.
+
+This module is intentionally dependency-light (stdlib + PyYAML) so it can be
+unit-tested without the heavy ``scripts/validate_traces.py`` import graph
+(langfuse, numpy, tenacity, ...). ``validate_traces.py`` imports and calls
+``check_trace_continuity(...)`` so the check runs as part of the existing
+validator (and therefore under ``make validate-traces-fast``) rather than as a
+separate ad-hoc checker.
+
+Status semantics (never silently pass an unproven boundary):
+
+* ``ok``          — every required span for the flow is present under the root
+  trace_id; the workflow is a single trace tree.
+* ``fragmented``  — a required span exists but under a *different* trace_id than
+  the root. Propagation broke across a service/thread boundary. This is a hard
+  failure for the #2244 gate.
+* ``incomplete``  — a required span was not observed at all. The boundary was
+  not exercised in this run (e.g. a downstream service was not running
+  locally). Reported explicitly, not treated as success.
+* ``unavailable`` — no root trace was found for the flow (no runtime data).
+  Reported explicitly, not treated as success.
+
+Interpreting failures locally (no production / VPS / secrets / live CRM writes):
+
+* ``incomplete`` / ``unavailable`` are expected when you only run a subset of
+  services locally; they tell you which boundary is unproven, not that the code
+  is broken.
+* ``fragmented`` is the actionable signal: it means trace context (W3C
+  TraceContext + Baggage) was lost on a real boundary and must be fixed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore[import-untyped]
+
+
+TRACE_CONTRACT_PATH = (
+    Path(__file__).resolve().parent.parent / "tests" / "observability" / "trace_contract.yaml"
+)
+
+
+def load_end_to_end_trace_flows(path: Path | str = TRACE_CONTRACT_PATH) -> dict[str, Any]:
+    """Load the ``end_to_end_trace_flows`` mapping from the trace contract.
+
+    Returns an empty dict when the file or key is absent so callers can degrade
+    gracefully instead of raising.
+    """
+    p = Path(path)
+    if not p.exists():
+        return {}
+    data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+    flows = data.get("end_to_end_trace_flows", {})
+    return flows if isinstance(flows, dict) else {}
+
+
+def flatten_required_spans(flow: dict[str, Any]) -> list[str]:
+    """Flatten the grouped ``required_spans`` of a flow into a flat name list."""
+    names: list[str] = []
+    for group in (flow.get("required_spans") or {}).values():
+        names.extend(group)
+    return names
+
+
+@dataclass
+class FlowContinuity:
+    """Result of evaluating one canonical flow's trace continuity."""
+
+    flow_name: str
+    root_family: str
+    root_trace_id: str | None
+    present: list[str] = field(default_factory=list)
+    missing: list[str] = field(default_factory=list)
+    cross_trace: dict[str, str] = field(default_factory=dict)
+    status: str = "unavailable"
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "ok"
+
+
+def _obs_attr(obs: Any, name: str) -> Any:
+    if isinstance(obs, dict):
+        return obs.get(name)
+    return getattr(obs, name, None)
+
+
+def evaluate_flow_continuity(
+    flow_name: str,
+    flow: dict[str, Any],
+    observations: list[Any],
+    root_trace_id: str | None,
+) -> FlowContinuity:
+    """Evaluate whether ``flow``'s required spans form one trace tree.
+
+    Args:
+        flow_name: canonical flow key (e.g. ``telegram_text_rag``).
+        flow: the flow spec from ``end_to_end_trace_flows``.
+        observations: objects/dicts exposing ``name`` and ``trace_id``. May
+            include observations from sibling traces to enable fragmentation
+            detection.
+        root_trace_id: trace id of the flow's root trace, or ``None`` if no
+            root trace was found.
+    """
+    required = flatten_required_spans(flow)
+
+    seen: dict[str, set[str]] = {}
+    for obs in observations:
+        name = _obs_attr(obs, "name")
+        if not name:
+            continue
+        tid = _obs_attr(obs, "trace_id")
+        seen.setdefault(name, set()).add(tid)
+
+    present: list[str] = []
+    missing: list[str] = []
+    cross_trace: dict[str, str] = {}
+
+    for span in required:
+        tids = seen.get(span)
+        if not tids:
+            missing.append(span)
+            continue
+        if root_trace_id is None:
+            # No root anchor; record presence but cannot assert continuity.
+            present.append(span)
+            continue
+        if root_trace_id in tids:
+            present.append(span)
+            others = sorted(t for t in tids if t and t != root_trace_id)
+            if others:
+                cross_trace[span] = others[0]
+        else:
+            # Span exists only under a different trace -> fragmented boundary.
+            other = sorted(t for t in tids if t)
+            cross_trace[span] = other[0] if other else "<unknown>"
+
+    if root_trace_id is None:
+        status = "unavailable"
+    elif cross_trace:
+        status = "fragmented"
+    elif missing:
+        status = "incomplete"
+    else:
+        status = "ok"
+
+    return FlowContinuity(
+        flow_name=flow_name,
+        root_family=str(flow.get("root_family", "")),
+        root_trace_id=root_trace_id,
+        present=present,
+        missing=missing,
+        cross_trace=cross_trace,
+        status=status,
+    )
+
+
+def fetch_flow_observations(
+    lf: Any, root_family: str, limit: int = 5
+) -> tuple[str | None, list[Any]]:
+    """Fetch the most recent root trace for ``root_family`` and its observations.
+
+    Returns ``(root_trace_id, observations)``. Degrades to ``(None, [])`` on any
+    API error or when no trace exists, so a missing boundary is reported as
+    ``unavailable`` rather than crashing the validator.
+    """
+    try:
+        page = lf.api.trace.list(name=root_family, limit=limit)
+    except Exception:
+        return None, []
+    traces = list(getattr(page, "data", None) or [])
+    if not traces:
+        return None, []
+    root = traces[0]
+    root_id = getattr(root, "id", None) or getattr(root, "trace_id", None)
+    if not root_id:
+        return None, []
+    try:
+        full = lf.api.trace.get(root_id)
+    except Exception:
+        return root_id, []
+    observations = list(getattr(full, "observations", None) or [])
+    normalized = [
+        {
+            "name": _obs_attr(o, "name"),
+            "trace_id": _obs_attr(o, "trace_id") or root_id,
+        }
+        for o in observations
+    ]
+    return root_id, normalized
+
+
+def check_trace_continuity(
+    lf: Any,
+    flows: dict[str, Any],
+    *,
+    only: set[str] | None = None,
+) -> list[FlowContinuity]:
+    """Evaluate trace_id continuity for each canonical flow via ``lf``.
+
+    Args:
+        lf: a Langfuse client (duck-typed: ``lf.api.trace.list/get``).
+        flows: ``end_to_end_trace_flows`` mapping.
+        only: optional subset of flow names to evaluate.
+    """
+    results: list[FlowContinuity] = []
+    for flow_name, flow in flows.items():
+        if only is not None and flow_name not in only:
+            continue
+        root_family = str(flow.get("root_family", ""))
+        root_id, observations = fetch_flow_observations(lf, root_family)
+        results.append(evaluate_flow_continuity(flow_name, flow, observations, root_id))
+    return results
+
+
+def summarize_continuity(results: list[FlowContinuity]) -> str:
+    """Human-readable summary for the validation report."""
+    if not results:
+        return "trace continuity: no canonical flows evaluated."
+
+    symbols = {
+        "ok": "PASS",
+        "fragmented": "FAIL",
+        "incomplete": "INCOMPLETE",
+        "unavailable": "UNAVAILABLE",
+    }
+    lines = ["Trace continuity (single-trace gate #2244):"]
+    for r in results:
+        line = f"  [{symbols.get(r.status, r.status.upper())}] {r.flow_name} (root={r.root_family})"
+        if r.cross_trace:
+            broken = ", ".join(f"{span}->{tid}" for span, tid in sorted(r.cross_trace.items()))
+            line += f" | fragmented spans: {broken}"
+        if r.missing:
+            line += f" | unproven spans: {', '.join(r.missing)}"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def has_continuity_failure(results: list[FlowContinuity]) -> bool:
+    """True if any flow fragmented (a hard #2244 failure). ``incomplete`` /
+    ``unavailable`` do not count — they are unproven, not broken."""
+    return any(r.status == "fragmented" for r in results)

--- a/scripts/trace_continuity.py
+++ b/scripts/trace_continuity.py
@@ -37,6 +37,7 @@ Interpreting failures locally (no production / VPS / secrets / live CRM writes):
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import timedelta
 from pathlib import Path
 from typing import Any
 
@@ -46,6 +47,8 @@ import yaml  # type: ignore[import-untyped]
 TRACE_CONTRACT_PATH = (
     Path(__file__).resolve().parent.parent / "tests" / "observability" / "trace_contract.yaml"
 )
+_FRAGMENT_LOOKBACK = timedelta(minutes=5)
+_FRAGMENT_LOOKAHEAD = timedelta(minutes=15)
 
 
 def load_end_to_end_trace_flows(path: Path | str = TRACE_CONTRACT_PATH) -> dict[str, Any]:
@@ -183,6 +186,7 @@ def fetch_flow_observations(
     root_id = getattr(root, "id", None) or getattr(root, "trace_id", None)
     if not root_id:
         return None, []
+    root_timestamp = getattr(root, "timestamp", None)
     try:
         full = lf.api.trace.get(root_id)
     except Exception:
@@ -195,6 +199,37 @@ def fetch_flow_observations(
         }
         for o in observations
     ]
+
+    # Trace.get(root_id) only returns observations already attached to the root
+    # trace. To distinguish "missing" from "fragmented", also look for required
+    # span names that appeared in nearby sibling traces. Keep this bounded to
+    # the root trace time window to avoid old observations causing false alarms.
+    seen_names = {obs["name"] for obs in normalized if obs.get("name")}
+    try:
+        flows = load_end_to_end_trace_flows()
+        required_names = {
+            span
+            for flow in flows.values()
+            if str(flow.get("root_family", "")) == root_family
+            for span in flatten_required_spans(flow)
+        }
+        missing_names = sorted(required_names - seen_names)
+        if root_timestamp is not None and missing_names:
+            for span_name in missing_names:
+                page = lf.api.observations.get_many(
+                    name=span_name,
+                    from_start_time=root_timestamp - _FRAGMENT_LOOKBACK,
+                    to_start_time=root_timestamp + _FRAGMENT_LOOKAHEAD,
+                    limit=20,
+                )
+                for obs in getattr(page, "data", []) or []:
+                    trace_id = _obs_attr(obs, "trace_id")
+                    if trace_id and trace_id != root_id:
+                        normalized.append({"name": _obs_attr(obs, "name"), "trace_id": trace_id})
+    except Exception:
+        # Fragment search is best-effort; the root trace still provides an
+        # explicit incomplete/unavailable result instead of a silent pass.
+        return root_id, normalized
     return root_id, normalized
 
 

--- a/scripts/validate_traces.py
+++ b/scripts/validate_traces.py
@@ -42,6 +42,12 @@ from tenacity import (
 # Ensure project root importable
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+from scripts.trace_continuity import (
+    check_trace_continuity,
+    has_continuity_failure,
+    load_end_to_end_trace_flows,
+    summarize_continuity,
+)
 from scripts.validate_queries import (
     ValidationQuery,
     get_cache_hit_queries,
@@ -1569,6 +1575,32 @@ def generate_report(
 # ---------------------------------------------------------------------------
 
 
+def check_trace_continuity_for_report() -> list[Any]:
+    """Evaluate single-trace continuity for canonical end-to-end flows (#2252).
+
+    Loads ``end_to_end_trace_flows`` from the trace contract and, for each flow,
+    asserts the required downstream spans belong to the same trace tree as the
+    root. Degrades gracefully: when flows or runtime data are unavailable the
+    boundary is reported as ``incomplete``/``unavailable`` (never a silent pass)
+    and an empty list is returned so the validator continues.
+    """
+    flows = load_end_to_end_trace_flows()
+    if not flows:
+        logger.info("No end_to_end_trace_flows declared in trace contract; skipping continuity.")
+        return []
+    try:
+        from telegram_bot.observability import get_langfuse_client
+
+        lf = get_langfuse_client()
+    except Exception as exc:  # pragma: no cover - import/runtime guard
+        logger.debug("Langfuse client unavailable for continuity check: %s", exc)
+        return []
+    if lf is None:
+        logger.info("Langfuse disabled; skipping trace continuity check.")
+        return []
+    return check_trace_continuity(lf, flows)
+
+
 async def run_validation(args: argparse.Namespace) -> None:
     """Main validation orchestrator."""
     run_id = str(uuid.uuid4())
@@ -1667,6 +1699,15 @@ async def run_validation(args: argparse.Namespace) -> None:
     logger.info("Checking required trace family coverage...")
     required_trace_coverage = check_required_trace_coverage()
 
+    # Runtime trace_id continuity across service/thread boundaries (#2252).
+    # Proves each canonical flow is one trace tree, not several partial traces.
+    continuity_results: list[Any] = []
+    if not getattr(args, "no_continuity_gate", False):
+        logger.info("Checking trace_id continuity for canonical flows...")
+        continuity_results = check_trace_continuity_for_report()
+        if continuity_results:
+            logger.info("%s", summarize_continuity(continuity_results))
+
     # Evaluate Go/No-Go criteria
     go_no_go = evaluate_go_no_go(
         aggregates,
@@ -1698,6 +1739,17 @@ async def run_validation(args: argparse.Namespace) -> None:
         logger.error(
             "Missing required trace families: %s",
             required_coverage_gate.get("actual", "unknown"),
+        )
+        sys.exit(1)
+
+    # Single-trace gate (#2244/#2252): fail only on a genuine fragmentation —
+    # a required span observed under a DIFFERENT trace than its flow root.
+    # incomplete/unavailable boundaries are reported but do not fail locally.
+    if has_continuity_failure(continuity_results):
+        logger.error(
+            "Trace continuity FAILED: a canonical flow fragmented across a "
+            "service/thread boundary (W3C TraceContext/Baggage lost). See #2244.\n%s",
+            summarize_continuity(continuity_results),
         )
         sys.exit(1)
 
@@ -1751,6 +1803,18 @@ async def run_validation(args: argparse.Namespace) -> None:
         "payload_summary": payload_summary,
         "orphan_rate": orphan_rate,
         "required_trace_coverage": required_trace_coverage,
+        "trace_continuity": [
+            {
+                "flow": r.flow_name,
+                "root_family": r.root_family,
+                "root_trace_id": r.root_trace_id,
+                "status": r.status,
+                "present": r.present,
+                "missing": r.missing,
+                "cross_trace": r.cross_trace,
+            }
+            for r in continuity_results
+        ],
         "traces": [
             {
                 "trace_id": r.trace_id,
@@ -1793,6 +1857,16 @@ def main() -> None:
         action="store_true",
         default=False,
         help="Fail if git worktree is dirty (default: warn only)",
+    )
+    parser.add_argument(
+        "--no-continuity-gate",
+        action="store_true",
+        default=False,
+        help=(
+            "Disable the #2244 single-trace continuity check "
+            "(by default the run fails if a canonical flow fragments across a "
+            "service/thread boundary)."
+        ),
     )
     args = parser.parse_args()
     asyncio.run(run_validation(args))

--- a/tests/unit/observability/test_trace_continuity.py
+++ b/tests/unit/observability/test_trace_continuity.py
@@ -1,0 +1,187 @@
+"""Unit tests for runtime trace_id continuity evaluation (#2252).
+
+These tests exercise the pure logic in ``scripts.trace_continuity`` without a
+live Langfuse stack, using a small fake client. They cover:
+
+* loading canonical flows from ``trace_contract.yaml::end_to_end_trace_flows``,
+* a continuous flow (all required spans under one trace_id) -> ``ok``,
+* a fragmented flow (a required span under a different trace_id) -> ``fragmented``,
+* an incomplete flow (a required span never seen) -> ``incomplete`` (explicitly
+  marked, never a silent pass),
+* an unavailable flow (no root trace at all) -> ``unavailable``,
+* the fetch glue against a fake Langfuse client.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from scripts.trace_continuity import (
+    FlowContinuity,
+    check_trace_continuity,
+    evaluate_flow_continuity,
+    flatten_required_spans,
+    load_end_to_end_trace_flows,
+    summarize_continuity,
+)
+
+
+# --- fakes -------------------------------------------------------------------
+
+
+@dataclass
+class FakeObs:
+    name: str
+    trace_id: str
+
+
+@dataclass
+class FakeTrace:
+    id: str
+    observations: list[FakeObs]
+
+
+class FakeTracePage:
+    def __init__(self, data: list[FakeTrace]) -> None:
+        self.data = data
+
+
+class FakeTraceApi:
+    def __init__(self, traces_by_name: dict[str, list[FakeTrace]]) -> None:
+        self._by_name = traces_by_name
+        self._by_id = {t.id: t for ts in traces_by_name.values() for t in ts}
+
+    def list(self, name: str | None = None, limit: int = 5, **_: object) -> FakeTracePage:
+        return FakeTracePage(self._by_name.get(name or "", []))
+
+    def get(self, trace_id: str) -> FakeTrace:
+        return self._by_id[trace_id]
+
+
+class FakeApi:
+    def __init__(self, trace_api: FakeTraceApi) -> None:
+        self.trace = trace_api
+
+
+class FakeLangfuse:
+    def __init__(self, traces_by_name: dict[str, list[FakeTrace]]) -> None:
+        self.api = FakeApi(FakeTraceApi(traces_by_name))
+
+
+# --- a minimal canonical flow spec (shape mirrors trace_contract.yaml) -------
+
+FLOW = {
+    "root_family": "telegram-rag-query",
+    "entry_service": "bot",
+    "required_services": ["bot", "rag-api", "bge-m3-api"],
+    "required_spans": {
+        "root": ["telegram-rag-query"],
+        "retrieval": ["rag-pipeline", "hybrid-retrieve"],
+        "backend": ["bge-m3-encode-hybrid"],
+    },
+}
+
+ALL_REQUIRED = [
+    "telegram-rag-query",
+    "rag-pipeline",
+    "hybrid-retrieve",
+    "bge-m3-encode-hybrid",
+]
+
+
+# --- pure-logic tests --------------------------------------------------------
+
+
+def test_flatten_required_spans_collects_all_groups() -> None:
+    assert sorted(flatten_required_spans(FLOW)) == sorted(ALL_REQUIRED)
+
+
+def test_continuous_flow_is_ok() -> None:
+    root = "trace-aaa"
+    obs = [FakeObs(name=n, trace_id=root) for n in ALL_REQUIRED]
+    result = evaluate_flow_continuity("telegram_text_rag", FLOW, obs, root)
+    assert isinstance(result, FlowContinuity)
+    assert result.status == "ok"
+    assert result.ok is True
+    assert not result.missing
+    assert not result.cross_trace
+
+
+def test_fragmented_flow_is_flagged() -> None:
+    root = "trace-aaa"
+    obs = [FakeObs(name=n, trace_id=root) for n in ALL_REQUIRED[:-1]]
+    # bge-m3 span landed under a DIFFERENT trace -> propagation broke
+    obs.append(FakeObs(name="bge-m3-encode-hybrid", trace_id="trace-bbb"))
+    result = evaluate_flow_continuity("telegram_text_rag", FLOW, obs, root)
+    assert result.status == "fragmented"
+    assert result.ok is False
+    assert "bge-m3-encode-hybrid" in result.cross_trace
+    assert result.cross_trace["bge-m3-encode-hybrid"] == "trace-bbb"
+
+
+def test_incomplete_flow_is_marked_not_silently_passed() -> None:
+    root = "trace-aaa"
+    # bge-m3 span never seen anywhere
+    obs = [FakeObs(name=n, trace_id=root) for n in ALL_REQUIRED[:-1]]
+    result = evaluate_flow_continuity("telegram_text_rag", FLOW, obs, root)
+    assert result.status == "incomplete"
+    assert result.ok is False
+    assert result.missing == ["bge-m3-encode-hybrid"]
+
+
+def test_unavailable_when_no_root_trace() -> None:
+    result = evaluate_flow_continuity("telegram_text_rag", FLOW, [], None)
+    assert result.status == "unavailable"
+    assert result.ok is False
+
+
+# --- fetch-glue tests --------------------------------------------------------
+
+
+def test_check_trace_continuity_against_fake_client_ok() -> None:
+    root = FakeTrace(
+        id="trace-aaa",
+        observations=[FakeObs(name=n, trace_id="trace-aaa") for n in ALL_REQUIRED],
+    )
+    lf = FakeLangfuse({"telegram-rag-query": [root]})
+    flows = {"telegram_text_rag": FLOW}
+    results = check_trace_continuity(lf, flows)
+    assert len(results) == 1
+    assert results[0].status == "ok"
+
+
+def test_check_trace_continuity_unavailable_when_family_absent() -> None:
+    lf = FakeLangfuse({})  # no traces for the family
+    results = check_trace_continuity(lf, {"telegram_text_rag": FLOW})
+    assert results[0].status == "unavailable"
+
+
+def test_check_trace_continuity_only_filter() -> None:
+    lf = FakeLangfuse({})
+    flows = {"telegram_text_rag": FLOW, "voice_rag_api": FLOW}
+    results = check_trace_continuity(lf, flows, only={"telegram_text_rag"})
+    assert {r.flow_name for r in results} == {"telegram_text_rag"}
+
+
+def test_summarize_continuity_mentions_status_and_flow() -> None:
+    result = evaluate_flow_continuity("telegram_text_rag", FLOW, [], None)
+    text = summarize_continuity([result])
+    assert "telegram_text_rag" in text
+    assert "unavailable" in text.lower()
+
+
+# --- contract loader against the real YAML -----------------------------------
+
+
+def test_load_end_to_end_trace_flows_from_contract() -> None:
+    flows = load_end_to_end_trace_flows()
+    # Provided by the #2248 contract surface this work stacks on.
+    assert isinstance(flows, dict)
+    assert "telegram_text_rag" in flows
+    for required_key in ("root_family", "required_services", "required_spans"):
+        assert required_key in flows["telegram_text_rag"]
+
+
+def test_load_end_to_end_trace_flows_missing_file_returns_empty(tmp_path) -> None:
+    missing = tmp_path / "nope.yaml"
+    assert load_end_to_end_trace_flows(missing) == {}

--- a/tests/unit/observability/test_trace_continuity.py
+++ b/tests/unit/observability/test_trace_continuity.py
@@ -15,6 +15,7 @@ live Langfuse stack, using a small fake client. They cover:
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import UTC, datetime
 
 from scripts.trace_continuity import (
     FlowContinuity,
@@ -39,6 +40,7 @@ class FakeObs:
 class FakeTrace:
     id: str
     observations: list[FakeObs]
+    timestamp: datetime = datetime(2026, 5, 29, tzinfo=UTC)
 
 
 class FakeTracePage:
@@ -58,14 +60,39 @@ class FakeTraceApi:
         return self._by_id[trace_id]
 
 
+class FakeObservationsPage:
+    def __init__(self, data: list[FakeObs]) -> None:
+        self.data = data
+
+
+class FakeObservationsApi:
+    def __init__(self, observations_by_name: dict[str, list[FakeObs]] | None = None) -> None:
+        self._by_name = observations_by_name or {}
+
+    def get_many(self, name: str | None = None, **_: object) -> FakeObservationsPage:
+        return FakeObservationsPage(self._by_name.get(name or "", []))
+
+
 class FakeApi:
-    def __init__(self, trace_api: FakeTraceApi) -> None:
+    def __init__(
+        self,
+        trace_api: FakeTraceApi,
+        observations_api: FakeObservationsApi | None = None,
+    ) -> None:
         self.trace = trace_api
+        self.observations = observations_api or FakeObservationsApi()
 
 
 class FakeLangfuse:
-    def __init__(self, traces_by_name: dict[str, list[FakeTrace]]) -> None:
-        self.api = FakeApi(FakeTraceApi(traces_by_name))
+    def __init__(
+        self,
+        traces_by_name: dict[str, list[FakeTrace]],
+        observations_by_name: dict[str, list[FakeObs]] | None = None,
+    ) -> None:
+        self.api = FakeApi(
+            FakeTraceApi(traces_by_name),
+            FakeObservationsApi(observations_by_name),
+        )
 
 
 # --- a minimal canonical flow spec (shape mirrors trace_contract.yaml) -------
@@ -154,6 +181,20 @@ def test_check_trace_continuity_unavailable_when_family_absent() -> None:
     lf = FakeLangfuse({})  # no traces for the family
     results = check_trace_continuity(lf, {"telegram_text_rag": FLOW})
     assert results[0].status == "unavailable"
+
+
+def test_check_trace_continuity_detects_fragmented_sibling_trace() -> None:
+    root = FakeTrace(
+        id="trace-aaa",
+        observations=[FakeObs(name=n, trace_id="trace-aaa") for n in ALL_REQUIRED[:-1]],
+    )
+    lf = FakeLangfuse(
+        {"telegram-rag-query": [root]},
+        {"bge-m3-encode-hybrid": [FakeObs(name="bge-m3-encode-hybrid", trace_id="trace-bbb")]},
+    )
+    results = check_trace_continuity(lf, {"telegram_text_rag": FLOW})
+    assert results[0].status == "fragmented"
+    assert results[0].cross_trace == {"bge-m3-encode-hybrid": "trace-bbb"}
 
 
 def test_check_trace_continuity_only_filter() -> None:


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #2252. Core implementation for the #2244 single-trace gate; child of #2246 (F4).

Proves each canonical end-to-end flow keeps **one** trace tree across process/thread boundaries instead of fragmenting into partial Langfuse traces. Extends the existing validator (`scripts/validate_traces.py`) rather than adding a parallel ad-hoc checker.

> **Stacked on #2248** (`fix/2244-otel-single-trace-gate`) because it consumes `trace_contract.yaml::end_to_end_trace_flows`, which #2248 introduces. **Base this PR on #2248**; retarget to `dev` once #2248 merges.

## Design

`scripts/validate_traces.py` pulls heavy deps (langfuse, numpy, tenacity), so the logic lives in a dependency-light helper (`scripts/trace_continuity.py`, stdlib + PyYAML) that the validator imports and calls. This keeps it fully unit-testable with a fake Langfuse client while still running as part of the validator.

Status semantics (never silently pass an unproven boundary):
- `ok` — all required spans present under the flow root trace_id → single trace tree.
- `fragmented` — a required span exists under a **different** trace_id → propagation broke. **Hard failure** for the gate.
- `incomplete` — a required span not observed (boundary not exercised locally). Reported, not failed.
- `unavailable` — no root trace found (no runtime data). Reported, not failed.

## Changes

- **`scripts/trace_continuity.py`** (new): `load_end_to_end_trace_flows`, `evaluate_flow_continuity`, `fetch_flow_observations`, `check_trace_continuity`, `summarize_continuity`, `has_continuity_failure`.
- **`scripts/validate_traces.py`**: run the check in `run_validation` (so it runs under `make validate-traces-fast`, which calls `validate_traces.py --report`); log a per-flow summary; include results in the raw JSON dump; `sys.exit(1)` only on genuine fragmentation; add `--no-continuity-gate` opt-out.
- **`tests/unit/observability/test_trace_continuity.py`** (new): 11 tests.

## TDD

- RED: tests written first → collection error (module absent).
- GREEN: implemented helper → **11 passed**.
- `validate_traces.py` `py_compile` clean; `ruff check` + `ruff format --check` clean on all touched files.

## Interpreting failures locally (no prod/VPS/secrets/live CRM)

- `incomplete`/`unavailable` are expected when only a subset of services runs locally — they identify which boundary is unproven, not that code is broken.
- `fragmented` is the actionable signal: W3C TraceContext/Baggage was lost on a real boundary.

## Acceptance criteria (#2252)

- [x] Extend the existing trace validator (not an ad-hoc checker).
- [x] Load canonical flows from `trace_contract.yaml::end_to_end_trace_flows`.
- [x] For each flow, assert required downstream observations belong to the same trace tree.
- [x] Validate the bot/RAG path; mark unavailable boundaries explicitly (no silent pass).
- [x] Wire into `make validate-traces-fast` (via `validate_traces.py` run path).
- [x] Document how to interpret failures without production/VPS/secrets/live CRM writes.