### PR TITLE
observability(otel): validate log&lt;-&gt;trace correlation for canonical flows (#2255)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -249,6 +249,12 @@ LANGFUSE_DOCKER_HOST=http://langfuse:3000
 # Each service sets a default automatically in Compose; override only when needed.
 # OTEL_SERVICE_NAME=telegram-bot
 
+# Optional newline-delimited JSON log file sampled by scripts/validate_traces.py
+# to validate log<->trace correlation for canonical flows (#2255). When unset,
+# the log-correlation check reports "unavailable" instead of failing. Point this
+# at a captured JSON log dump (the formatter emits trace_id/span_id fields).
+# LOG_CORRELATION_SOURCE=docs/reports/flow-logs.ndjson
+
 # Content filter / guard
 # GUARD_MODE=hard                    # hard (block) | soft (flag+continue) | log (log only)
 # CONTENT_FILTER_ENABLED=true

--- a/scripts/log_correlation.py
+++ b/scripts/log_correlation.py
@@ -57,6 +57,8 @@ FIELD_ALIASES: dict[str, tuple[str, ...]] = {
 _ABSENT_VALUES = {"", "0"}
 
 DEFAULT_REQUIRED_FIELDS: tuple[str, ...] = ("otelTraceID", "otelSpanID")
+FLOW_NAME_KEYS: tuple[str, ...] = ("flow", "flow_name", "trace_flow")
+ROOT_FAMILY_KEYS: tuple[str, ...] = ("root_family", "langfuse_root_family")
 
 
 def get_correlation_value(record: Any, logical_field: str) -> str | None:
@@ -76,6 +78,69 @@ def get_correlation_value(record: Any, logical_field: str) -> str | None:
 
 def record_has_fields(record: Any, fields: tuple[str, ...]) -> bool:
     return all(get_correlation_value(record, f) is not None for f in fields)
+
+
+def _record_value(record: Any, key: str) -> str | None:
+    val = record.get(key) if isinstance(record, dict) else getattr(record, key, None)
+    if val is None:
+        return None
+    text = str(val)
+    return text or None
+
+
+def _record_identifies_flow(record: Any, flow_name: str, flow: dict[str, Any]) -> bool | None:
+    """Return explicit flow match when the log carries flow metadata.
+
+    ``None`` means the record has no flow discriminator, so callers must fall
+    back to trace-id based sampling.
+    """
+    saw_discriminator = False
+    for key in FLOW_NAME_KEYS:
+        value = _record_value(record, key)
+        if value is not None:
+            saw_discriminator = True
+            if value == flow_name:
+                return True
+
+    root_family = str(flow.get("root_family") or "")
+    if root_family:
+        for key in ROOT_FAMILY_KEYS:
+            value = _record_value(record, key)
+            if value is not None:
+                saw_discriminator = True
+                if value == root_family:
+                    return True
+
+    return False if saw_discriminator else None
+
+
+def filter_flow_log_records(
+    flow_name: str,
+    flow: dict[str, Any],
+    log_records: list[Any],
+    expected_trace_id: str | None,
+) -> list[Any]:
+    """Return records attributable to one canonical flow.
+
+    A shared JSON dump can contain several flow traces. When an expected trace id
+    is known, records from other traces must not be treated as mismatches for
+    this flow. Explicit flow/root-family metadata still wins, so a tagged record
+    with a different trace id remains a hard mismatch.
+    """
+    if expected_trace_id is None:
+        return log_records
+
+    selected: list[Any] = []
+    for rec in log_records:
+        flow_match = _record_identifies_flow(rec, flow_name, flow)
+        if flow_match is True:
+            selected.append(rec)
+            continue
+        if flow_match is False:
+            continue
+        if get_correlation_value(rec, "otelTraceID") == expected_trace_id:
+            selected.append(rec)
+    return selected
 
 
 @dataclass
@@ -193,12 +258,14 @@ def check_log_correlation(
         if only is not None and flow_name not in only:
             continue
         required = tuple(flow.get("required_log_fields") or DEFAULT_REQUIRED_FIELDS)
+        expected_trace_id = expected_trace_ids.get(flow_name)
+        flow_records = filter_flow_log_records(flow_name, flow, log_records, expected_trace_id)
         results.append(
             evaluate_log_correlation(
                 flow_name,
                 required,
-                log_records,
-                expected_trace_id=expected_trace_ids.get(flow_name),
+                flow_records,
+                expected_trace_id=expected_trace_id,
             )
         )
     return results

--- a/scripts/log_correlation.py
+++ b/scripts/log_correlation.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Log<->trace correlation checks for canonical end-to-end flows (#2255).
+
+Goal (child of #2246 F6; complements #2252): prove that the logs emitted by the
+canonical bot/RAG/CRM flows carry the OTEL trace/span identifiers and that they
+correlate back to the flow's trace. #2217/#2239 wired the identifiers into JSON
+logs; this is the validation that they actually show up for covered flows.
+
+Dependency-light (stdlib only) so it can be unit-tested without the heavy
+``scripts/validate_traces.py`` import graph; ``validate_traces.py`` imports and
+calls ``check_log_correlation(...)`` so it runs as part of the existing
+validator (and under ``make validate-traces-fast``).
+
+Field-name subtlety (important): the JSON formatter in
+``telegram_bot/logging_config.py`` RENAMES the OTEL LogRecord attributes
+``otelTraceID``/``otelSpanID`` to the emitted JSON keys ``trace_id``/``span_id``
+and treats the string ``"0"`` (OTEL "no active trace" sentinel) as absence. So a
+naive Loki query for ``otelTraceID`` matches nothing — the on-disk/Loki field is
+``trace_id``. This module accepts either spelling and rejects the ``"0"`` /
+empty sentinel.
+
+Status semantics (never silently pass an unproven boundary):
+
+* ``ok``          — sampled flow logs carry the required identifiers and (when an
+  expected trace id is known) match it.
+* ``mismatch``    — a sampled log carries a trace id that does NOT match the
+  flow's expected trace id. Correlation is broken. Hard failure for the gate.
+* ``incomplete``  — logs exist for the run but none carry the identifiers (the
+  traced operation may not have logged, or instrumentation is off). Reported,
+  not failed.
+* ``unavailable`` — no logs available to sample (e.g. local run without a log
+  source). Reported, not failed.
+
+Interpreting failures locally (no production / VPS / secrets / live CRM writes):
+
+* Set ``LOG_CORRELATION_SOURCE`` to a newline-delimited JSON log file to enable
+  the check; without it the check reports ``unavailable`` for every flow.
+* ``mismatch`` is the actionable signal (a log line points at the wrong trace);
+  ``incomplete``/``unavailable`` only tell you the boundary is unproven locally.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+# logical field name -> accepted record keys (emitted JSON first, raw OTEL attr next)
+FIELD_ALIASES: dict[str, tuple[str, ...]] = {
+    "otelTraceID": ("trace_id", "otelTraceID"),
+    "otelSpanID": ("span_id", "otelSpanID"),
+}
+
+# Values that mean "no correlation present".
+_ABSENT_VALUES = {"", "0"}
+
+DEFAULT_REQUIRED_FIELDS: tuple[str, ...] = ("otelTraceID", "otelSpanID")
+
+
+def get_correlation_value(record: Any, logical_field: str) -> str | None:
+    """Return the correlation value for ``logical_field`` from a log record,
+    accepting either the emitted JSON key or the raw OTEL attribute, and
+    treating the ``"0"``/empty sentinel as absent."""
+    keys = FIELD_ALIASES.get(logical_field, (logical_field,))
+    for key in keys:
+        val = record.get(key) if isinstance(record, dict) else getattr(record, key, None)
+        if val is None:
+            continue
+        text = str(val)
+        if text not in _ABSENT_VALUES:
+            return text
+    return None
+
+
+def record_has_fields(record: Any, fields: tuple[str, ...]) -> bool:
+    return all(get_correlation_value(record, f) is not None for f in fields)
+
+
+@dataclass
+class LogCorrelation:
+    """Result of evaluating one canonical flow's log<->trace correlation."""
+
+    flow_name: str
+    required_fields: list[str]
+    sampled: int = 0
+    correlated: int = 0
+    missing_fields: dict[str, int] = field(default_factory=dict)
+    trace_id_mismatches: int = 0
+    expected_trace_id: str | None = None
+    status: str = "unavailable"
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "ok"
+
+
+def evaluate_log_correlation(
+    flow_name: str,
+    required_fields: tuple[str, ...],
+    log_records: list[Any],
+    expected_trace_id: str | None = None,
+) -> LogCorrelation:
+    """Evaluate whether the sampled ``log_records`` correlate to the flow trace."""
+    required = list(required_fields)
+    if not log_records:
+        return LogCorrelation(
+            flow_name=flow_name,
+            required_fields=required,
+            expected_trace_id=expected_trace_id,
+            status="unavailable",
+        )
+
+    correlated = 0
+    missing: dict[str, int] = dict.fromkeys(required, 0)
+    mismatches = 0
+
+    for rec in log_records:
+        has_all = True
+        for f in required:
+            if get_correlation_value(rec, f) is None:
+                missing[f] += 1
+                has_all = False
+        if has_all:
+            correlated += 1
+        if expected_trace_id is not None:
+            tid = get_correlation_value(rec, "otelTraceID")
+            if tid is not None and tid != expected_trace_id:
+                mismatches += 1
+
+    missing = {f: c for f, c in missing.items() if c}
+
+    if mismatches:
+        status = "mismatch"
+    elif correlated == 0 or missing:
+        status = "incomplete"
+    else:
+        status = "ok"
+
+    return LogCorrelation(
+        flow_name=flow_name,
+        required_fields=required,
+        sampled=len(log_records),
+        correlated=correlated,
+        missing_fields=missing,
+        trace_id_mismatches=mismatches,
+        expected_trace_id=expected_trace_id,
+        status=status,
+    )
+
+
+def load_log_records(source: Path | str | None) -> list[dict[str, Any]]:
+    """Load newline-delimited JSON log records from ``source``.
+
+    Returns an empty list when ``source`` is None/missing or unreadable, and
+    silently skips lines that are not valid JSON objects.
+    """
+    if source is None:
+        return []
+    p = Path(source)
+    if not p.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for line in p.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except (ValueError, json.JSONDecodeError):
+            continue
+        if isinstance(obj, dict):
+            records.append(obj)
+    return records
+
+
+def check_log_correlation(
+    flows: dict[str, Any],
+    log_records: list[Any],
+    *,
+    expected_trace_ids: dict[str, str] | None = None,
+    only: set[str] | None = None,
+) -> list[LogCorrelation]:
+    """Evaluate log<->trace correlation for each canonical flow.
+
+    Uses each flow's ``required_log_fields`` (falling back to
+    ``DEFAULT_REQUIRED_FIELDS``) and an optional per-flow expected trace id.
+    """
+    expected_trace_ids = expected_trace_ids or {}
+    results: list[LogCorrelation] = []
+    for flow_name, flow in flows.items():
+        if only is not None and flow_name not in only:
+            continue
+        required = tuple(flow.get("required_log_fields") or DEFAULT_REQUIRED_FIELDS)
+        results.append(
+            evaluate_log_correlation(
+                flow_name,
+                required,
+                log_records,
+                expected_trace_id=expected_trace_ids.get(flow_name),
+            )
+        )
+    return results
+
+
+def summarize_log_correlation(results: list[LogCorrelation]) -> str:
+    """Human-readable summary for the validation report."""
+    if not results:
+        return "log correlation: no canonical flows evaluated."
+
+    symbols = {
+        "ok": "PASS",
+        "mismatch": "FAIL",
+        "incomplete": "INCOMPLETE",
+        "unavailable": "UNAVAILABLE",
+    }
+    lines = ["Log<->trace correlation (#2255):"]
+    for r in results:
+        line = f"  [{symbols.get(r.status, r.status.upper())}] {r.flow_name}"
+        line += f" (sampled={r.sampled}, correlated={r.correlated})"
+        if r.trace_id_mismatches:
+            line += f" | trace_id mismatches: {r.trace_id_mismatches}"
+        if r.missing_fields:
+            miss = ", ".join(f"{f}:{c}" for f, c in sorted(r.missing_fields.items()))
+            line += f" | records missing fields: {miss}"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def has_log_correlation_failure(results: list[LogCorrelation]) -> bool:
+    """True if any flow had a trace-id mismatch (a hard #2255 failure).
+    ``incomplete``/``unavailable`` are unproven, not broken."""
+    return any(r.status == "mismatch" for r in results)

--- a/scripts/validate_traces.py
+++ b/scripts/validate_traces.py
@@ -42,6 +42,12 @@ from tenacity import (
 # Ensure project root importable
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+from scripts.log_correlation import (
+    check_log_correlation,
+    has_log_correlation_failure,
+    load_log_records,
+    summarize_log_correlation,
+)
 from scripts.trace_continuity import (
     check_trace_continuity,
     has_continuity_failure,
@@ -1601,6 +1607,28 @@ def check_trace_continuity_for_report() -> list[Any]:
     return check_trace_continuity(lf, flows)
 
 
+def check_log_correlation_for_report(continuity_results: list[Any]) -> list[Any]:
+    """Evaluate log<->trace correlation for canonical end-to-end flows (#2255).
+
+    Reads newline-delimited JSON logs from ``LOG_CORRELATION_SOURCE`` (when set)
+    and uses the root trace ids discovered by the continuity check as the
+    expected trace ids. Degrades to ``unavailable`` when no log source is
+    configured, so the boundary is reported explicitly rather than passed
+    silently.
+    """
+    flows = load_end_to_end_trace_flows()
+    if not flows:
+        return []
+    source = os.getenv("LOG_CORRELATION_SOURCE")
+    records = load_log_records(source) if source else []
+    expected = {
+        r.flow_name: r.root_trace_id
+        for r in continuity_results
+        if getattr(r, "root_trace_id", None)
+    }
+    return check_log_correlation(flows, records, expected_trace_ids=expected)
+
+
 async def run_validation(args: argparse.Namespace) -> None:
     """Main validation orchestrator."""
     run_id = str(uuid.uuid4())
@@ -1702,11 +1730,15 @@ async def run_validation(args: argparse.Namespace) -> None:
     # Runtime trace_id continuity across service/thread boundaries (#2252).
     # Proves each canonical flow is one trace tree, not several partial traces.
     continuity_results: list[Any] = []
+    log_correlation_results: list[Any] = []
     if not getattr(args, "no_continuity_gate", False):
         logger.info("Checking trace_id continuity for canonical flows...")
         continuity_results = check_trace_continuity_for_report()
         if continuity_results:
             logger.info("%s", summarize_continuity(continuity_results))
+        log_correlation_results = check_log_correlation_for_report(continuity_results)
+        if log_correlation_results:
+            logger.info("%s", summarize_log_correlation(log_correlation_results))
 
     # Evaluate Go/No-Go criteria
     go_no_go = evaluate_go_no_go(
@@ -1750,6 +1782,16 @@ async def run_validation(args: argparse.Namespace) -> None:
             "Trace continuity FAILED: a canonical flow fragmented across a "
             "service/thread boundary (W3C TraceContext/Baggage lost). See #2244.\n%s",
             summarize_continuity(continuity_results),
+        )
+        sys.exit(1)
+
+    # Single-trace gate (#2255): fail only when a sampled log carries a trace_id
+    # that does not match its flow trace. incomplete/unavailable are reported.
+    if has_log_correlation_failure(log_correlation_results):
+        logger.error(
+            "Log<->trace correlation FAILED: a canonical flow logged a trace_id "
+            "that does not match its trace. See #2255.\n%s",
+            summarize_log_correlation(log_correlation_results),
         )
         sys.exit(1)
 
@@ -1814,6 +1856,18 @@ async def run_validation(args: argparse.Namespace) -> None:
                 "cross_trace": r.cross_trace,
             }
             for r in continuity_results
+        ],
+        "log_correlation": [
+            {
+                "flow": r.flow_name,
+                "status": r.status,
+                "sampled": r.sampled,
+                "correlated": r.correlated,
+                "trace_id_mismatches": r.trace_id_mismatches,
+                "missing_fields": r.missing_fields,
+                "expected_trace_id": r.expected_trace_id,
+            }
+            for r in log_correlation_results
         ],
         "traces": [
             {

--- a/tests/unit/observability/test_log_correlation.py
+++ b/tests/unit/observability/test_log_correlation.py
@@ -107,6 +107,7 @@ def test_summarize_mentions_flow_and_status() -> None:
 def test_check_log_correlation_uses_flow_required_log_fields() -> None:
     flows = {
         "telegram_text_rag": {
+            "root_family": "telegram-rag-query",
             "required_log_fields": ["otelTraceID", "otelSpanID"],
         }
     }
@@ -120,6 +121,53 @@ def test_check_log_correlation_unavailable_without_logs() -> None:
     flows = {"telegram_text_rag": {"required_log_fields": list(REQUIRED)}}
     results = check_log_correlation(flows, [])
     assert results[0].status == "unavailable"
+
+
+def test_check_log_correlation_does_not_cross_match_shared_log_dump() -> None:
+    flows = {
+        "telegram_text_rag": {
+            "root_family": "telegram-rag-query",
+            "required_log_fields": list(REQUIRED),
+        },
+        "voice_rag_api": {
+            "root_family": "voice-session",
+            "required_log_fields": list(REQUIRED),
+        },
+    }
+    records = [
+        {"trace_id": "trace-text", "span_id": "span-text"},
+        {"trace_id": "trace-voice", "span_id": "span-voice"},
+    ]
+    results = check_log_correlation(
+        flows,
+        records,
+        expected_trace_ids={
+            "telegram_text_rag": "trace-text",
+            "voice_rag_api": "trace-voice",
+        },
+    )
+    assert {r.flow_name: r.status for r in results} == {
+        "telegram_text_rag": "ok",
+        "voice_rag_api": "ok",
+    }
+    assert all(r.trace_id_mismatches == 0 for r in results)
+
+
+def test_check_log_correlation_keeps_explicit_flow_mismatch() -> None:
+    flows = {
+        "telegram_text_rag": {
+            "root_family": "telegram-rag-query",
+            "required_log_fields": list(REQUIRED),
+        },
+    }
+    records = [{"flow_name": "telegram_text_rag", "trace_id": "wrong", "span_id": "span-1"}]
+    results = check_log_correlation(
+        flows,
+        records,
+        expected_trace_ids={"telegram_text_rag": "trace-text"},
+    )
+    assert results[0].status == "mismatch"
+    assert results[0].trace_id_mismatches == 1
 
 
 def test_load_log_records_parses_ndjson_and_skips_bad_lines(tmp_path) -> None:

--- a/tests/unit/observability/test_log_correlation.py
+++ b/tests/unit/observability/test_log_correlation.py
@@ -1,0 +1,138 @@
+"""Unit tests for log<->trace correlation evaluation (#2255).
+
+Covers the subtlety that the JSON formatter (telegram_bot/logging_config.py)
+renames the OTEL LogRecord attributes ``otelTraceID``/``otelSpanID`` to the
+emitted JSON keys ``trace_id``/``span_id`` and treats the string ``"0"`` (the
+OTEL "no active trace" sentinel) as absence. The evaluator must accept either
+spelling and reject the sentinel.
+"""
+
+from __future__ import annotations
+
+from scripts.log_correlation import (
+    LogCorrelation,
+    check_log_correlation,
+    evaluate_log_correlation,
+    get_correlation_value,
+    has_log_correlation_failure,
+    load_log_records,
+    record_has_fields,
+    summarize_log_correlation,
+)
+
+
+REQUIRED = ("otelTraceID", "otelSpanID")
+
+
+# --- field extraction --------------------------------------------------------
+
+
+def test_get_correlation_value_accepts_emitted_json_keys() -> None:
+    rec = {"trace_id": "abc123", "span_id": "def456"}
+    assert get_correlation_value(rec, "otelTraceID") == "abc123"
+    assert get_correlation_value(rec, "otelSpanID") == "def456"
+
+
+def test_get_correlation_value_accepts_raw_otel_attr_keys() -> None:
+    rec = {"otelTraceID": "abc123", "otelSpanID": "def456"}
+    assert get_correlation_value(rec, "otelTraceID") == "abc123"
+
+
+def test_zero_sentinel_is_treated_as_absent() -> None:
+    rec = {"trace_id": "0", "span_id": ""}
+    assert get_correlation_value(rec, "otelTraceID") is None
+    assert get_correlation_value(rec, "otelSpanID") is None
+
+
+def test_record_has_fields_true_and_false() -> None:
+    assert record_has_fields({"trace_id": "t", "span_id": "s"}, REQUIRED)
+    assert not record_has_fields({"trace_id": "t"}, REQUIRED)
+
+
+# --- evaluation --------------------------------------------------------------
+
+
+def test_ok_when_records_carry_fields_and_match_expected() -> None:
+    recs = [{"trace_id": "t1", "span_id": "s1"}, {"trace_id": "t1", "span_id": "s2"}]
+    result = evaluate_log_correlation("telegram_text_rag", REQUIRED, recs, expected_trace_id="t1")
+    assert isinstance(result, LogCorrelation)
+    assert result.status == "ok"
+    assert result.ok is True
+    assert result.correlated == 2
+
+
+def test_incomplete_when_logs_present_but_uncorrelated() -> None:
+    recs = [{"message": "startup"}, {"trace_id": "0"}]
+    result = evaluate_log_correlation("telegram_text_rag", REQUIRED, recs)
+    assert result.status == "incomplete"
+    assert result.ok is False
+    assert result.correlated == 0
+
+
+def test_mismatch_when_trace_id_differs_from_expected() -> None:
+    recs = [{"trace_id": "WRONG", "span_id": "s1"}]
+    result = evaluate_log_correlation("telegram_text_rag", REQUIRED, recs, expected_trace_id="t1")
+    assert result.status == "mismatch"
+    assert result.ok is False
+    assert result.trace_id_mismatches == 1
+
+
+def test_unavailable_when_no_logs() -> None:
+    result = evaluate_log_correlation("telegram_text_rag", REQUIRED, [], expected_trace_id="t1")
+    assert result.status == "unavailable"
+    assert result.ok is False
+
+
+# --- gate semantics ----------------------------------------------------------
+
+
+def test_has_failure_only_on_mismatch() -> None:
+    mismatch = evaluate_log_correlation("f", REQUIRED, [{"trace_id": "x", "span_id": "y"}], "t1")
+    incomplete = evaluate_log_correlation("f", REQUIRED, [{"message": "m"}])
+    unavailable = evaluate_log_correlation("f", REQUIRED, [])
+    assert has_log_correlation_failure([mismatch]) is True
+    assert has_log_correlation_failure([incomplete, unavailable]) is False
+
+
+def test_summarize_mentions_flow_and_status() -> None:
+    result = evaluate_log_correlation("telegram_text_rag", REQUIRED, [])
+    text = summarize_log_correlation([result])
+    assert "telegram_text_rag" in text
+    assert "unavailable" in text.lower()
+
+
+# --- flow-driven check + log loader ------------------------------------------
+
+
+def test_check_log_correlation_uses_flow_required_log_fields() -> None:
+    flows = {
+        "telegram_text_rag": {
+            "required_log_fields": ["otelTraceID", "otelSpanID"],
+        }
+    }
+    recs = [{"trace_id": "t1", "span_id": "s1"}]
+    results = check_log_correlation(flows, recs, expected_trace_ids={"telegram_text_rag": "t1"})
+    assert len(results) == 1
+    assert results[0].status == "ok"
+
+
+def test_check_log_correlation_unavailable_without_logs() -> None:
+    flows = {"telegram_text_rag": {"required_log_fields": list(REQUIRED)}}
+    results = check_log_correlation(flows, [])
+    assert results[0].status == "unavailable"
+
+
+def test_load_log_records_parses_ndjson_and_skips_bad_lines(tmp_path) -> None:
+    p = tmp_path / "logs.ndjson"
+    p.write_text(
+        '{"trace_id": "t1", "span_id": "s1"}\nnot-json\n{"message": "ok"}\n',
+        encoding="utf-8",
+    )
+    records = load_log_records(p)
+    assert len(records) == 2
+    assert records[0]["trace_id"] == "t1"
+
+
+def test_load_log_records_missing_source_returns_empty(tmp_path) -> None:
+    assert load_log_records(tmp_path / "absent.ndjson") == []
+    assert load_log_records(None) == []


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #2255. Child of #2246 (F6); complements #2252; part of the #2244 single-trace gate.

Validates that the canonical bot/RAG/CRM flows emit logs carrying the OTEL trace/span identifiers and that those identifiers correlate back to the flow trace. #2217/#2239 wired the identifiers into JSON logs; this proves they actually show up for covered flows.

> **Stacked on #2252** (`feat/2252-runtime-trace-continuity` → #2248) — it reuses the continuity check's discovered root trace ids and touches the same `validate_traces.py` region. **Base this PR on #2252**; retarget down the stack as each merges.

## Notable subtlety (audit value)

The JSON formatter (`telegram_bot/logging_config.py`) **renames** `otelTraceID`→`trace_id` and `otelSpanID`→`span_id` in emitted logs, and treats the string `"0"` as the "no active trace" sentinel. So a naive Loki query for `otelTraceID` matches nothing. The evaluator accepts either spelling and rejects the sentinel.

## Status semantics (never silently pass)

- `ok` — sampled flow logs carry the identifiers and match the expected trace id.
- `mismatch` — a sampled log carries a trace id that does **not** match the flow trace → **hard failure**.
- `incomplete` — logs exist but none carry the identifiers → reported, not failed.
- `unavailable` — no logs to sample (no `LOG_CORRELATION_SOURCE`) → reported, not failed.

## Changes

- **`scripts/log_correlation.py`** (new, dependency-light): `get_correlation_value`, `record_has_fields`, `evaluate_log_correlation`, `load_log_records`, `check_log_correlation`, `summarize_log_correlation`, `has_log_correlation_failure`.
- **`scripts/validate_traces.py`**: run the check in `run_validation` (under `make validate-traces-fast`), reusing #2252's root trace ids as expected ids; log a summary, add results to the raw JSON, `sys.exit(1)` only on `mismatch`. Logs are sampled from `LOG_CORRELATION_SOURCE` (newline-delimited JSON); `unavailable` when unset.
- **`.env.example`**: document `LOG_CORRELATION_SOURCE`.
- **`tests/unit/observability/test_log_correlation.py`** (new): 14 tests.

## TDD

- RED: tests written first → collection error (module absent).
- GREEN: implemented helper → **14 passed** (and #2252's 11 still pass: 25 total in the observability suite slice).
- `py_compile` clean; `ruff check` + `ruff format --check` clean on all touched files.

## Interpreting failures locally (no prod/VPS/secrets/live CRM)

- Set `LOG_CORRELATION_SOURCE` to a captured JSON log dump to enable the check; otherwise it is `unavailable`.
- `mismatch` is the actionable signal; `incomplete`/`unavailable` mean the boundary is unproven locally, not broken.

## Acceptance criteria (#2255)

- [x] Extend the validator / local-fast adapter to check logs for canonical flows from `end_to_end_trace_flows`.
- [x] Assert `otelTraceID`/`otelSpanID` present in covered-flow logs (alias-aware).
- [x] Assert sampled `otelTraceID` matches the flow trace id where runtime data is available.
- [x] Clearly skip / mark unavailable when logs are not available (no silent pass).
- [x] Document the command and failure interpretation.