### PR TITLE
observability(otel): cross-service W3C TraceContext instrumentation contract (#2256)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ For fast orientation by goal rather than by subsystem, see [`indexes/`](indexes/
 - [`BOT_ARCHITECTURE.md`](BOT_ARCHITECTURE.md) — Bot layer architecture.
 - [`BOT_INTERNAL_STRUCTURE.md`](BOT_INTERNAL_STRUCTURE.md) — Bot internal component structure.
 - [`PIPELINE_OVERVIEW.md`](PIPELINE_OVERVIEW.md) — Ingestion, query, and voice runtime flows.
+- [`observability/CROSS_SERVICE_TRACING.md`](observability/CROSS_SERVICE_TRACING.md) — Cross-service W3C TraceContext/Baggage propagation contract.
 - [`PIPELINE_ROUTING.md`](PIPELINE_ROUTING.md) — Query routing and state machine design.
 - [`CONTEXTUALIZED_EMBEDDINGS.md`](CONTEXTUALIZED_EMBEDDINGS.md) — Embedding strategy and contextualization.
 - [`RAG_API.md`](RAG_API.md) — FastAPI RAG API contract.

--- a/docs/observability/CROSS_SERVICE_TRACING.md
+++ b/docs/observability/CROSS_SERVICE_TRACING.md
@@ -1,0 +1,66 @@
+# Cross-service tracing contract
+
+How one user workflow stays a single distributed trace as it crosses HTTP
+service boundaries (bot/RAG -> internal FastAPI services -> third-party APIs).
+This is the propagation layer behind the single-trace gate (#2244) and the
+trace-coverage audit (#2246). It is enforced by
+`tests/contract/test_cross_service_trace_instrumentation_contract.py` (#2256).
+
+## The contract
+
+| Direction | Mechanism | Where |
+|-----------|-----------|-------|
+| Inbound (server) | `FastAPIInstrumentor.instrument_app(app)` extracts `traceparent` + `baggage` from request headers and continues the caller's trace | `services/bge-m3-api/app.py`, `services/user-base/main.py`, `src/api/main.py`, `mini_app/api.py` (via `instrument_fastapi_app(app)`) |
+| Outbound (client) | process-wide `HTTPXClientInstrumentor` injects `traceparent` + `baggage` on every `httpx` request | `src/services/bge_m3_client.py`, `src/services/kommo_client.py`, `src/voice/rag_api_client.py`, `src/ingestion/docling_client.py` |
+| Activation | `activate_otel_instrumentations()` wires httpx/asyncpg/redis/grpc/logging at startup | `src/observability.py` -> `src/observability_otel.py` |
+| Context format | W3C **TraceContext** + W3C **Baggage** | `OTEL_PROPAGATORS=tracecontext,baggage` declared per service (#2254) |
+
+SDK-native APIs verified against the OpenTelemetry Python Contrib docs via
+Context7 (`/open-telemetry/opentelemetry-python-contrib`):
+`FastAPIInstrumentor.instrument_app(app)` for inbound extraction (it carries a
+built-in double-instrumentation guard) and `HTTPXClientInstrumentor().instrument()`
+for outbound injection. *Content was rephrased for compliance with licensing
+restrictions.*
+
+### Why a contract test
+
+Because all four FastAPI entrypoints and all four httpx clients are already
+wired, the risk is **silent regression** — a new service or client that forgets
+to instrument fragments the trace without any error. The contract walks the
+source and fails CI if an inbound entrypoint stops instrumenting or an outbound
+client stops using `httpx`. It is also the precondition for removing the legacy
+manual BGE-M3 propagation (#2253): the manual `inject()` / `x-langfuse-*`
+headers can be dropped only once auto-instrumentation is guaranteed present.
+
+## Third-party APIs (Kommo)
+
+`src/services/kommo_client.py` uses `httpx`, so `HTTPXClientInstrumentor` adds a
+`traceparent` header to outbound Kommo CRM requests. Kommo ignores unknown
+request headers, so this is harmless and **no exclusion is required**. If a
+third-party API is ever found to reject `traceparent`, add a per-client
+exclusion via an httpx request hook rather than disabling instrumentation
+globally.
+
+## Why Prometheus / Loki / Sentry are not replaced by OpenTelemetry traces
+
+OpenTelemetry tracing is one signal among several; the others stay as-is and are
+cross-linked rather than replaced:
+
+- **Prometheus** — application metrics are pull-based via `prometheus_client`
+  and the `/metrics` endpoint. Traces do not replace counters/histograms; the
+  metrics stack is unchanged. (Whether to unify on the OTel Metrics API is an
+  open ADR question, #2228.)
+- **Loki** — structured JSON logs carry `trace_id`/`span_id` (#2217/#2239) so a
+  log line links back to its trace. Logs remain the high-cardinality,
+  full-detail signal; traces are the sampled causal view.
+- **Sentry** — error tracking is cross-linked to Langfuse traces (#2238). Sentry
+  remains the exception aggregator; traces are not an error backend.
+
+No OTLP gRPC exporter is introduced by this layer; the only export path is the
+existing Langfuse OTel ingestion.
+
+## References
+
+- Gate: #2244 · Audit: #2246 · Runtime continuity: #2252 · Propagators: #2254
+- Cleanup unblocked by this contract: #2253
+- Foundation PRs: #2225 (auto-instrumentations), #2226/#2235 (baggage)

--- a/tests/contract/test_cross_service_trace_instrumentation_contract.py
+++ b/tests/contract/test_cross_service_trace_instrumentation_contract.py
@@ -1,0 +1,212 @@
+"""Cross-service W3C TraceContext instrumentation contract (#2256).
+
+Locks in the SDK-native cross-service propagation layer so it cannot silently
+regress, and so the legacy manual BGE-M3 propagation (#2253) can be removed
+safely once a runtime run proves continuity.
+
+Contract:
+
+* **Inbound** FastAPI services must extract W3C TraceContext on every request
+  via ``FastAPIInstrumentor`` — directly (``FastAPIInstrumentor.instrument_app``)
+  or through the shared ``instrument_fastapi_app(app)`` helper.
+* **Outbound** HTTP clients must ride on ``httpx`` so the process-wide
+  ``HTTPXClientInstrumentor`` injects ``traceparent``/``baggage`` automatically.
+* The httpx instrumentation must be activated at startup
+  (``activate_otel_instrumentations`` -> ``HTTPXClientInstrumentor``).
+
+Verified against OpenTelemetry Python Contrib docs via Context7
+(``/open-telemetry/opentelemetry-python-contrib``): ``instrument_app(app)`` for
+inbound extraction (with a built-in double-instrumentation guard) and
+``HTTPXClientInstrumentor().instrument()`` for outbound injection. Content was
+rephrased for compliance with licensing restrictions.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Inbound FastAPI entrypoints that must instrument for W3C TraceContext extraction.
+INBOUND_FASTAPI_ENTRYPOINTS = [
+    "services/bge-m3-api/app.py",
+    "services/user-base/main.py",
+    "src/api/main.py",
+    "mini_app/api.py",
+]
+
+# Outbound HTTP clients that must ride on httpx so HTTPXClientInstrumentor
+# injects traceparent/baggage automatically.
+OUTBOUND_HTTPX_CLIENTS = [
+    "src/services/bge_m3_client.py",
+    "src/services/kommo_client.py",
+    "src/voice/rag_api_client.py",
+    "src/ingestion/docling_client.py",
+]
+
+# Startup site that activates the auto-instrumentations (incl. httpx).
+HTTPX_ACTIVATION_INVOCATION = "src/observability.py"
+HTTPX_ACTIVATION_IMPL = "src/observability_otel.py"
+
+# Either the shared helper (Name call) or the raw instrumentor method (attr call).
+_FASTAPI_INSTRUMENT_NAMES = {"instrument_fastapi_app", "instrument_app"}
+
+
+def _source_of(rel: str) -> str | None:
+    path = REPO_ROOT / rel
+    if not path.exists():
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+def _called_names(tree: ast.AST) -> set[str]:
+    """Collect both ``name(...)`` and ``obj.attr(...)`` call targets."""
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name):
+            found.add(func.id)
+        elif isinstance(func, ast.Attribute):
+            found.add(func.attr)
+    return found
+
+
+def _is_fastapi_instrumented(source: str) -> bool:
+    """True if the module invokes the FastAPI instrumentation (helper or raw)."""
+    tree = ast.parse(source)
+    return bool(_called_names(tree) & _FASTAPI_INSTRUMENT_NAMES)
+
+
+def _imports_httpx(source: str) -> bool:
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import) and any(
+            alias.name == "httpx" or alias.name.startswith("httpx.") for alias in node.names
+        ):
+            return True
+        if (
+            isinstance(node, ast.ImportFrom)
+            and node.module
+            and (node.module == "httpx" or node.module.startswith("httpx."))
+        ):
+            return True
+    return False
+
+
+def _invokes(source: str, name: str) -> bool:
+    return name in _called_names(ast.parse(source))
+
+
+# --- inbound -----------------------------------------------------------------
+
+
+class TestInboundFastAPIInstrumented:
+    """Every internal FastAPI service must extract W3C TraceContext."""
+
+    @pytest.mark.parametrize("rel", INBOUND_FASTAPI_ENTRYPOINTS)
+    def test_entrypoint_exists(self, rel: str) -> None:
+        assert _source_of(rel) is not None, f"FastAPI entrypoint missing: {rel}"
+
+    @pytest.mark.parametrize("rel", INBOUND_FASTAPI_ENTRYPOINTS)
+    def test_entrypoint_instruments_fastapi(self, rel: str) -> None:
+        source = _source_of(rel)
+        assert source is not None, f"missing: {rel}"
+        assert _is_fastapi_instrumented(source), (
+            f"{rel} must call FastAPIInstrumentor.instrument_app(app) or "
+            f"instrument_fastapi_app(app) so inbound requests continue the "
+            f"caller's W3C trace (#2256). Without it the service starts a new "
+            f"root trace and the workflow fragments."
+        )
+
+
+# --- outbound ----------------------------------------------------------------
+
+
+class TestOutboundHttpxCoverage:
+    """Every outbound HTTP client must ride on httpx (-> HTTPXClientInstrumentor)."""
+
+    @pytest.mark.parametrize("rel", OUTBOUND_HTTPX_CLIENTS)
+    def test_client_exists(self, rel: str) -> None:
+        assert _source_of(rel) is not None, f"outbound client missing: {rel}"
+
+    @pytest.mark.parametrize("rel", OUTBOUND_HTTPX_CLIENTS)
+    def test_client_uses_httpx(self, rel: str) -> None:
+        source = _source_of(rel)
+        assert source is not None, f"missing: {rel}"
+        assert _imports_httpx(source), (
+            f"{rel} must use httpx so the process-wide HTTPXClientInstrumentor "
+            f"injects traceparent/baggage automatically (#2256). A different "
+            f"HTTP library would silently drop cross-service trace context."
+        )
+
+
+# --- activation --------------------------------------------------------------
+
+
+class TestHttpxInstrumentationActivated:
+    """The httpx auto-instrumentation must be wired at startup."""
+
+    def test_activation_invoked(self) -> None:
+        source = _source_of(HTTPX_ACTIVATION_INVOCATION)
+        assert source is not None, f"missing: {HTTPX_ACTIVATION_INVOCATION}"
+        assert _invokes(source, "activate_otel_instrumentations"), (
+            f"{HTTPX_ACTIVATION_INVOCATION} must invoke "
+            f"activate_otel_instrumentations() at startup (#2256/#2225)."
+        )
+
+    def test_activation_covers_httpx(self) -> None:
+        source = _source_of(HTTPX_ACTIVATION_IMPL)
+        assert source is not None, f"missing: {HTTPX_ACTIVATION_IMPL}"
+        assert "HTTPXClientInstrumentor" in source, (
+            f"{HTTPX_ACTIVATION_IMPL} must activate HTTPXClientInstrumentor so "
+            f"outbound httpx requests carry W3C TraceContext (#2256/#2225)."
+        )
+
+
+# --- non-vacuity -------------------------------------------------------------
+
+
+class TestScannerIsNotVacuous:
+    def test_lists_are_populated(self) -> None:
+        assert INBOUND_FASTAPI_ENTRYPOINTS
+        assert OUTBOUND_HTTPX_CLIENTS
+
+
+# --- detector self-checks (regression proof) ---------------------------------
+
+
+class TestDetectorsCatchRegressions:
+    _FASTAPI_OK_HELPER = "from x import instrument_fastapi_app\ninstrument_fastapi_app(app)\n"
+    _FASTAPI_OK_RAW = (
+        "from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor\n"
+        "FastAPIInstrumentor.instrument_app(app)\n"
+    )
+    _FASTAPI_MISSING = "app = FastAPI()\n@app.get('/')\ndef root():\n    return {}\n"
+
+    _HTTPX_IMPORT = "import httpx\nclient = httpx.AsyncClient()\n"
+    _HTTPX_FROM = "from httpx import AsyncClient\nclient = AsyncClient()\n"
+    _NO_HTTPX = "import requests\nrequests.get('http://x')\n"
+
+    def test_fastapi_detector_accepts_helper(self) -> None:
+        assert _is_fastapi_instrumented(self._FASTAPI_OK_HELPER)
+
+    def test_fastapi_detector_accepts_raw_instrumentor(self) -> None:
+        assert _is_fastapi_instrumented(self._FASTAPI_OK_RAW)
+
+    def test_fastapi_detector_flags_missing(self) -> None:
+        assert not _is_fastapi_instrumented(self._FASTAPI_MISSING)
+
+    def test_httpx_detector_accepts_import(self) -> None:
+        assert _imports_httpx(self._HTTPX_IMPORT)
+
+    def test_httpx_detector_accepts_from_import(self) -> None:
+        assert _imports_httpx(self._HTTPX_FROM)
+
+    def test_httpx_detector_flags_other_lib(self) -> None:
+        assert not _imports_httpx(self._NO_HTTPX)


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Advances #2256 (cross-service W3C TraceContext instrumentation). Child of #2246; **unblocks #2253**; supports the #2244 single-trace gate.

The cross-service propagation layer is already wired (from #2225): `FastAPIInstrumentor`/`instrument_fastapi_app` on the four internal FastAPI services, and a process-wide `HTTPXClientInstrumentor` (via `activate_otel_instrumentations`) covering all four outbound `httpx` clients. The missing piece — and the precondition #2253 needs — was an **enforceable contract** so this cannot silently regress.

SDK APIs verified against the OpenTelemetry Python Contrib docs via Context7 (`/open-telemetry/opentelemetry-python-contrib`): `FastAPIInstrumentor.instrument_app(app)` for inbound extraction (with a built-in double-instrumentation guard) and `HTTPXClientInstrumentor().instrument()` for outbound injection. Content was rephrased for compliance with licensing restrictions.

## Changes

- **`tests/contract/test_cross_service_trace_instrumentation_contract.py`** (new): asserts
  - each inbound FastAPI entrypoint (`bge-m3-api`, `user-base`, `rag-api`, `mini-app`) invokes `instrument_fastapi_app(` / `FastAPIInstrumentor.instrument_app(`;
  - each outbound client (`bge_m3_client`, `kommo_client`, `voice/rag_api_client`, `ingestion/docling_client`) rides on `httpx`;
  - `activate_otel_instrumentations()` is invoked at startup and activates `HTTPXClientInstrumentor`;
  - AST-detector **self-checks** prove it flags missing FastAPI instrumentation and non-`httpx` clients (regression proof).
- **`docs/observability/CROSS_SERVICE_TRACING.md`** (new): documents the propagation contract, the Kommo/third-party `traceparent` note (httpx-instrumented; Kommo ignores unknown headers; no exclusion needed), and **why Prometheus/Loki/Sentry remain separate** (no OTLP gRPC exporter introduced). Linked from `docs/README.md`.

## TDD

- Lock-in assertions pass (layer already wired); detector **self-checks** provide the RED→GREEN regression proof at the helper level — **25 passed**.
- `ruff check` + `ruff format --check` clean.

## Scope / non-goals (per #2256)

- No new instrumentation code was needed — the invocations already exist; this PR makes them a **contract** + documents the propagation model.
- The runtime acceptance ("bot + ≥1 FastAPI service under one W3C trace") is `verify:local-runtime` and is exercised by `make validate-traces-fast` (now with the #2252 continuity check). No live/secrets validation is required by this PR.
- LiveKit/voice baseline is tracked separately in #2257.

## Acceptance criteria (#2256)

- [x] Confirm FastAPI entrypoints and outbound client libraries for target services.
- [x] FastAPIInstrumentor invoked in selected FastAPI services (contract-locked).
- [x] HTTPXClientInstrumentor activated at startup (contract-locked).
- [x] `rg 'FastAPIInstrumentor|HTTPXClientInstrumentor'` nonzero in intentional locations.
- [x] Document why Prometheus/Loki/Sentry remain separate; no OTLP gRPC exporter introduced.
- [x] Kommo/third-party `traceparent` behavior documented.
- [ ] Runtime same-trace continuity (`verify:local-runtime`) — exercised by maintainer via `make validate-traces-fast`.