### PR TITLE
observability(crm): emit honest CRM scores only on real action (#2212)

### DIFF
--- a/telegram_bot/agents/utility_tools.py
+++ b/telegram_bot/agents/utility_tools.py
@@ -221,9 +221,11 @@ async def handoff(
     if context_summary:
         text += f"Контекст: {context_summary}\n"
 
+    delivered = 0
     for mid in manager_ids:
         try:
             await bot.send_message(chat_id=mid, text=text)
+            delivered += 1
         except Exception:
             logger.warning("Failed to notify manager %s", mid, exc_info=True)
 
@@ -232,11 +234,26 @@ async def handoff(
     # implemented). Manager notification above remains the single handoff
     # surface until lead_id resolution lands as a separate behavioural change.
 
+    # Honest scoring (#2212): handoff_triggered must reflect a REAL action — at
+    # least one manager actually notified — not merely that the tool ran. If no
+    # notification succeeded, emit handoff_delivery_failed instead of a false
+    # success so the CRM/ops dashboard is not misled. Guard get_client() which
+    # may be None when Langfuse is disabled.
     lf = get_client()
-    lf.score_current_trace(name="handoff_triggered", value=1, data_type="BOOLEAN")
-    lf.score_current_trace(name="handoff_urgency", value=urgency, data_type="CATEGORICAL")
+    if delivered > 0:
+        if lf is not None:
+            lf.score_current_trace(name="handoff_triggered", value=1, data_type="BOOLEAN")
+            lf.score_current_trace(name="handoff_urgency", value=urgency, data_type="CATEGORICAL")
+        return "Ваш запрос передан менеджеру. Ожидайте ответа."
 
-    return "Ваш запрос передан менеджеру. Ожидайте ответа."
+    if lf is not None:
+        lf.score_current_trace(name="handoff_delivery_failed", value=1, data_type="BOOLEAN")
+    logger.error(
+        "handoff: all %d manager notification(s) failed for user %s",
+        len(manager_ids),
+        ctx.telegram_user_id,
+    )
+    return "К сожалению, не удалось связаться с менеджером. Попробуйте позже."
 
 
 # ---------------------------------------------------------------------------

--- a/telegram_bot/services/session_summary_worker.py
+++ b/telegram_bot/services/session_summary_worker.py
@@ -125,6 +125,9 @@ class SessionSummaryWorker:
         now = time.time()
         threshold = self._idle_timeout_min * 60
         count = 0
+        kommo_written = 0
+        kommo_skipped = 0
+        kommo_failed = 0
         scanned = 0
         deferred = 0
         cap = self._max_sessions_per_cycle
@@ -164,8 +167,14 @@ class SessionSummaryWorker:
 
                 summary = await self._generate_summary(history)
                 if summary:
-                    await self._write_summary(user_id, summary)
+                    outcome = await self._write_summary(user_id, summary)
                     count += 1
+                    if outcome == "written":
+                        kommo_written += 1
+                    elif outcome == "skipped_no_lead":
+                        kommo_skipped += 1
+                    elif outcome == "failed":
+                        kommo_failed += 1
 
                 await self._redis.delete(key)
 
@@ -188,6 +197,19 @@ class SessionSummaryWorker:
                     name="session_summary_generated", value=1, data_type="BOOLEAN"
                 )
                 lf.score_current_trace(name="session_summary_count", value=float(count))
+            # Honest CRM outcome scores (#2212): "generated" != "written to Kommo".
+            if kommo_written > 0:
+                lf.score_current_trace(
+                    name="session_summary_kommo_written", value=float(kommo_written)
+                )
+            if kommo_skipped > 0:
+                lf.score_current_trace(
+                    name="session_summary_kommo_skipped", value=float(kommo_skipped)
+                )
+            if kommo_failed > 0:
+                lf.score_current_trace(
+                    name="session_summary_kommo_failed", value=float(kommo_failed)
+                )
             if cap_hit:
                 lf.score_current_trace(name="session_summary_cap_hit", value=1, data_type="BOOLEAN")
 
@@ -266,20 +288,47 @@ class SessionSummaryWorker:
                 )
             raise
 
-    async def _write_summary(self, user_id: str, summary: str) -> None:
-        """Log the summary and write to Kommo if available."""
+    async def _resolve_lead_id(self, user_id: str) -> int | None:
+        """Resolve the Kommo ``lead_id`` for ``user_id``.
+
+        Placeholder pending lead-scoring-store integration (#445/#2212). Returns
+        ``None`` until resolution lands. Kept as an overridable seam so the
+        honest-scoring path can distinguish a real CRM write from a drop, and so
+        tests can simulate a resolved lead.
+        """
+        return None
+
+    async def _write_summary(self, user_id: str, summary: str) -> str:
+        """Log the summary and write it to Kommo when possible.
+
+        Returns the truthful CRM outcome so the caller can score it honestly
+        (#2212) — we must never imply a CRM write happened when it did not:
+
+        * ``"no_kommo"``        — no Kommo client configured (no CRM claim).
+        * ``"skipped_no_lead"`` — generated but dropped: lead_id unresolved (#445).
+        * ``"written"``         — note successfully added to Kommo.
+        * ``"failed"``          — Kommo write attempted but raised.
+        """
         logger.info("Session summary for user %s: %s", user_id, summary[:100])
-        if self._kommo:
-            # TODO: resolve lead_id from user_id via lead scoring store (#445)
-            lead_id: int | None = None
-            if lead_id:
-                try:
-                    await self._kommo.add_note(
-                        entity_type="leads",
-                        entity_id=lead_id,
-                        text=f"[Auto-summary]\n{summary}",
-                    )
-                except Exception:
-                    logger.warning("Failed to write summary to Kommo", exc_info=True)
-            else:
-                logger.debug("Skipping Kommo note for user %s: lead_id not yet resolved", user_id)
+        if not self._kommo:
+            return "no_kommo"
+
+        lead_id = await self._resolve_lead_id(user_id)
+        if not lead_id:
+            logger.info(
+                "Session summary for user %s generated but NOT written to Kommo: "
+                "lead_id unresolved (#445); scored as session_summary_kommo_skipped.",
+                user_id,
+            )
+            return "skipped_no_lead"
+
+        try:
+            await self._kommo.add_note(
+                entity_type="leads",
+                entity_id=lead_id,
+                text=f"[Auto-summary]\n{summary}",
+            )
+            return "written"
+        except Exception:
+            logger.warning("Failed to write summary to Kommo", exc_info=True)
+            return "failed"

--- a/tests/unit/agents/test_handoff_honest_scoring.py
+++ b/tests/unit/agents/test_handoff_honest_scoring.py
@@ -1,0 +1,111 @@
+"""Handoff honest-scoring contract (#2212, finding #4).
+
+The real handoff action today is the manager Telegram notification (the Kommo
+task was removed in #1541). So ``handoff_triggered`` must reflect that at least
+one manager was actually notified — not merely that the tool ran. When every
+notification fails, the tool must emit ``handoff_delivery_failed`` instead of a
+false success, and it must not crash when Langfuse is disabled
+(``get_client()`` -> ``None``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.runnables import RunnableConfig
+
+from telegram_bot.agents.context import BotContext
+
+
+def _ctx(**kwargs) -> BotContext:
+    defaults: dict = {
+        "telegram_user_id": 42,
+        "session_id": "s-test",
+        "language": "ru",
+        "kommo_client": None,
+        "history_service": AsyncMock(),
+        "embeddings": AsyncMock(),
+        "sparse_embeddings": AsyncMock(),
+        "qdrant": AsyncMock(),
+        "cache": AsyncMock(),
+        "reranker": None,
+        "llm": MagicMock(),
+        "content_filter_enabled": True,
+        "guard_mode": "hard",
+    }
+    defaults.update(kwargs)
+    return BotContext(**defaults)
+
+
+def _cfg(ctx: BotContext) -> RunnableConfig:
+    return RunnableConfig(configurable={"bot_context": ctx})
+
+
+def _score_names(lf: MagicMock) -> list[str]:
+    return [c.kwargs.get("name") for c in lf.score_current_trace.call_args_list]
+
+
+@pytest.mark.asyncio
+async def test_handoff_scores_triggered_when_delivered():
+    bot = AsyncMock()
+    bot.send_message = AsyncMock()
+    ctx = _ctx(bot=bot, manager_ids=[100, 200])
+    lf = MagicMock()
+    from telegram_bot.agents import utility_tools
+
+    with patch.object(utility_tools, "get_client", return_value=lf):
+        result = await utility_tools.handoff.ainvoke({"reason": "x"}, config=_cfg(ctx))
+
+    names = _score_names(lf)
+    assert "handoff_triggered" in names
+    assert "handoff_delivery_failed" not in names
+    assert "передан" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_handoff_all_notifications_fail_no_false_success():
+    bot = AsyncMock()
+    bot.send_message = AsyncMock(side_effect=RuntimeError("network down"))
+    ctx = _ctx(bot=bot, manager_ids=[100, 200])
+    lf = MagicMock()
+    from telegram_bot.agents import utility_tools
+
+    with patch.object(utility_tools, "get_client", return_value=lf):
+        result = await utility_tools.handoff.ainvoke({"reason": "x"}, config=_cfg(ctx))
+
+    names = _score_names(lf)
+    assert "handoff_triggered" not in names, "must not claim success when no manager was notified"
+    assert "handoff_delivery_failed" in names
+    assert "не удалось" in result.lower() or "позже" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_handoff_partial_delivery_counts_as_triggered():
+    bot = AsyncMock()
+    # first manager fails, second succeeds -> delivered == 1
+    bot.send_message = AsyncMock(side_effect=[RuntimeError("boom"), None])
+    ctx = _ctx(bot=bot, manager_ids=[100, 200])
+    lf = MagicMock()
+    from telegram_bot.agents import utility_tools
+
+    with patch.object(utility_tools, "get_client", return_value=lf):
+        result = await utility_tools.handoff.ainvoke({"reason": "x"}, config=_cfg(ctx))
+
+    names = _score_names(lf)
+    assert "handoff_triggered" in names
+    assert "handoff_delivery_failed" not in names
+    assert "передан" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_handoff_does_not_crash_when_langfuse_disabled():
+    bot = AsyncMock()
+    bot.send_message = AsyncMock()
+    ctx = _ctx(bot=bot, manager_ids=[100])
+    from telegram_bot.agents import utility_tools
+
+    with patch.object(utility_tools, "get_client", return_value=None):
+        result = await utility_tools.handoff.ainvoke({"reason": "x"}, config=_cfg(ctx))
+
+    assert "передан" in result.lower()

--- a/tests/unit/services/test_session_summary_honest_scoring.py
+++ b/tests/unit/services/test_session_summary_honest_scoring.py
@@ -1,0 +1,120 @@
+"""Session-summary honest CRM scoring (#2212, finding #2).
+
+``_write_summary`` must report a truthful CRM outcome so Langfuse scores can
+distinguish "summary generated" from "summary actually written to Kommo".
+Today the summary is generated and silently dropped (lead_id unresolved, #445)
+while the dashboard still shows summary counts — a false-success signal.
+
+Outcomes: ``no_kommo`` | ``skipped_no_lead`` | ``written`` | ``failed``.
+A worker cycle emits ``session_summary_kommo_written`` /
+``session_summary_kommo_skipped`` accordingly.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from telegram_bot.services import session_summary_worker as ssw_mod
+from telegram_bot.services.session_summary_worker import SessionSummaryWorker
+
+
+def _worker(**kwargs) -> SessionSummaryWorker:
+    defaults: dict = {
+        "redis": AsyncMock(),
+        "llm": MagicMock(),
+        "kommo_client": None,
+        "idle_timeout_min": 30,
+        "poll_interval_sec": 10,
+    }
+    defaults.update(kwargs)
+    return SessionSummaryWorker(**defaults)
+
+
+def _one_idle_session(worker: SessionSummaryWorker) -> None:
+    worker._redis.scan = AsyncMock(return_value=(0, [b"session:last_active:111"]))
+    worker._redis.get = AsyncMock(return_value=str(time.time() - 2000).encode())
+    worker._redis.delete = AsyncMock()
+    worker._get_conversation_history = AsyncMock(
+        return_value=[
+            {"role": "user", "content": "Budget is 80k EUR"},
+            {"role": "assistant", "content": "I have options in range"},
+        ]
+    )
+    worker._generate_summary = AsyncMock(return_value="summary text")
+
+
+def _score_names(lf: MagicMock) -> list[str]:
+    return [c.kwargs.get("name") for c in lf.score_current_trace.call_args_list]
+
+
+# --- _write_summary outcomes -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_write_summary_no_kommo_returns_no_kommo():
+    worker = _worker(kommo_client=None)
+    assert await worker._write_summary("u1", "s") == "no_kommo"
+
+
+@pytest.mark.asyncio
+async def test_write_summary_skipped_when_lead_unresolved():
+    kommo = AsyncMock()
+    worker = _worker(kommo_client=kommo)
+    # default _resolve_lead_id returns None (lead resolution pending, #445)
+    assert await worker._write_summary("u1", "s") == "skipped_no_lead"
+    kommo.add_note.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_write_summary_written_when_lead_resolved():
+    kommo = AsyncMock()
+    worker = _worker(kommo_client=kommo)
+    worker._resolve_lead_id = AsyncMock(return_value=555)
+    assert await worker._write_summary("u1", "s") == "written"
+    kommo.add_note.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_write_summary_failed_when_add_note_raises():
+    kommo = AsyncMock()
+    kommo.add_note = AsyncMock(side_effect=RuntimeError("kommo 500"))
+    worker = _worker(kommo_client=kommo)
+    worker._resolve_lead_id = AsyncMock(return_value=555)
+    assert await worker._write_summary("u1", "s") == "failed"
+
+
+# --- cycle-level honest scoring ---------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cycle_scores_kommo_skipped_not_written(monkeypatch):
+    lf = MagicMock()
+    monkeypatch.setattr(ssw_mod, "get_client", lambda: lf)
+    worker = _worker(kommo_client=AsyncMock())  # lead unresolved -> skipped
+    _one_idle_session(worker)
+
+    await worker._check_idle_sessions()
+
+    names = _score_names(lf)
+    assert "session_summary_kommo_skipped" in names
+    assert "session_summary_kommo_written" not in names
+
+
+@pytest.mark.asyncio
+async def test_cycle_scores_kommo_written_when_resolved(monkeypatch):
+    lf = MagicMock()
+    monkeypatch.setattr(ssw_mod, "get_client", lambda: lf)
+    kommo = AsyncMock()
+    worker = _worker(kommo_client=kommo)
+    worker._resolve_lead_id = AsyncMock(return_value=555)
+    _one_idle_session(worker)
+
+    await worker._check_idle_sessions()
+
+    names = _score_names(lf)
+    assert "session_summary_kommo_written" in names
+    assert "session_summary_kommo_skipped" not in names
+    kommo.add_note.assert_awaited_once()


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #2212 (the honest-scoring path). P1 bug: three paths emitted Langfuse success spans/scores while no CRM/handoff work actually happened, misleading dashboards. Directly supports the #2244 single-trace gate acceptance ("Failures do not emit false success spans/scores").

Scope note: finding **#1** (mini_app phone `KommoClient()`) was already fixed by merged **#2240**; finding **#3** (`history_source` no-op) is covered by **#1599** (warn + `session_summary_history_source_missing` score). This PR closes the two remaining false-success scores — findings **#2** and **#4** — via the issue's repo-only "make scores honest" path (no live Kommo / lead-resolution required).

## Changes

### Session summary (finding #2) — `telegram_bot/services/session_summary_worker.py`
- `_write_summary` now returns a truthful CRM outcome: `no_kommo` | `skipped_no_lead` | `written` | `failed`, via an overridable `_resolve_lead_id(user_id)` seam (real lead resolution still pending #445).
- The worker cycle counts outcomes and emits honest scores: `session_summary_kommo_written`, `session_summary_kommo_skipped`, `session_summary_kommo_failed` — so the dashboard distinguishes "summary generated" (`session_summary_count`, unchanged) from "actually written to Kommo". Previously a generated summary was silently dropped while the count still ticked.

### Handoff (finding #4) — `telegram_bot/agents/utility_tools.py`
- The real handoff action today is the manager Telegram notification (the Kommo task was removed in #1541). `handoff_triggered` is now emitted only when **≥1 manager was actually notified**; if every notification fails, `handoff_delivery_failed` is emitted and the user gets an honest failure message.
- Guard `get_client()` (it can return `None` when Langfuse is disabled) — fixes a **latent crash** on the handoff path.

## TDD

- 10 new tests written first (RED), then implemented (GREEN):
  - `tests/unit/agents/test_handoff_honest_scoring.py` — delivered / all-fail / partial / Langfuse-disabled.
  - `tests/unit/services/test_session_summary_honest_scoring.py` — `_write_summary` outcomes + cycle-level `kommo_written`/`kommo_skipped` scoring.
- No regression: existing `test_utility_tools.py` + `test_session_summary_worker.py` still green (**56 passed** locally in a targeted venv). Other handoff suites couldn't run locally only due to missing deps (`aiogram_dialog`, etc.) and are unrelated to these modules — CI runs them with full deps.
- `ruff check` + `ruff format --check` clean.

## Acceptance criteria (#2212)

- [x] `session_summary_count` / `handoff_triggered` only emit when the real action succeeds (or are renamed to reflect reality) — handoff gated on delivery; session summary CRM scores split into written vs skipped vs failed.
- [x] Mini App `kommo_submission_failed: TypeError` — already resolved by #2240.
- [ ] `SessionSummaryWorker` cannot start in a no-op configuration — `history_source` warn+score contract is owned by #1599 (left as-is to avoid conflicting with that decision).
- [ ] Langfuse-UI verification of real `kommo-add-note` / Kommo task — requires live Kommo + lead resolution (#445); out of scope for this repo-only honest-scoring slice.

## Notes / follow-ups

- Full CRM write (real `kommo-add-note` for summaries, real handoff task) still needs `_resolve_lead_id` to return actual ids — the seam is in place; tracked by #445.