### PR TITLE
observability(otel): voice/LiveKit W3C TraceContext SDK baseline (#2257)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ For fast orientation by goal rather than by subsystem, see [`indexes/`](indexes/
 - [`BOT_ARCHITECTURE.md`](BOT_ARCHITECTURE.md) — Bot layer architecture.
 - [`BOT_INTERNAL_STRUCTURE.md`](BOT_INTERNAL_STRUCTURE.md) — Bot internal component structure.
 - [`PIPELINE_OVERVIEW.md`](PIPELINE_OVERVIEW.md) — Ingestion, query, and voice runtime flows.
+- [`observability/VOICE_TRACING_BASELINE.md`](observability/VOICE_TRACING_BASELINE.md) — Voice/LiveKit W3C TraceContext SDK baseline.
 - [`PIPELINE_ROUTING.md`](PIPELINE_ROUTING.md) — Query routing and state machine design.
 - [`CONTEXTUALIZED_EMBEDDINGS.md`](CONTEXTUALIZED_EMBEDDINGS.md) — Embedding strategy and contextualization.
 - [`RAG_API.md`](RAG_API.md) — FastAPI RAG API contract.

--- a/docs/observability/VOICE_TRACING_BASELINE.md
+++ b/docs/observability/VOICE_TRACING_BASELINE.md
@@ -1,0 +1,75 @@
+# Voice / LiveKit W3C TraceContext baseline (#2257)
+
+SDK baseline for how the voice path participates in the single distributed trace
+(#2244). Research-only decision record: it documents the supported approach and
+the current state, and defers the behavioural change (deprecating the manual
+`langfuse_trace_id`) to a follow-up implementation issue. Enforced by
+`tests/contract/test_voice_tracing_baseline_contract.py`.
+
+## Question
+
+Can voice lifecycle spans and the voice -> RAG hop join the same W3C trace as
+the bot/RAG path, using SDK-native mechanisms rather than a handwritten
+`langfuse_trace_id`?
+
+## SDK evidence
+
+- **LiveKit Agents exposes an OTel hook.** `livekit.agents.telemetry` provides
+  `set_tracer_provider(provider)`: register a `TracerProvider` and LiveKit
+  emits its spans (LLM calls auto-trace as nested spans, alongside your own
+  manual root spans) on that provider's exporter. Evidence: the LiveKit JS API
+  reference documents the equivalent `setTracerProvider` in
+  `@livekit/agents/telemetry`
+  ([reference](https://docs.livekit.io/reference/agents-js/functions/agents.telemetry.setTracerProvider.html)),
+  and the OpenObserve LiveKit integration documents registering a
+  `TracerProvider` via `telemetry.set_tracer_provider()`
+  ([docs](https://openobserve.ai/docs/integration/ai/frameworks/livekit/)).
+  *Content was rephrased for compliance with licensing restrictions.*
+- **OpenTelemetry context propagates over HTTP via `httpx`.** The voice -> RAG
+  hop uses `httpx.AsyncClient`, so the process-wide `HTTPXClientInstrumentor`
+  (#2225/#2256) injects W3C `traceparent` + `baggage` automatically.
+
+## Current state in the repo
+
+- `src/voice/agent.py::_setup_langfuse()` forwards the Langfuse-registered
+  global OTel `TracerProvider` to LiveKit via
+  `livekit.agents.telemetry.set_tracer_provider(provider)` (guarded by
+  try/except for older LiveKit installs). So LiveKit spans already land on the
+  same exporter as the rest of the runtime.
+- The `entrypoint` opens a `voice-session` root observation (#2160) so child
+  `@observe` spans (`voice-tool-search-knowledge-base`, downstream
+  `rag-api-query`) nest into one Langfuse trace per call.
+- `src/voice/rag_api_client.py` uses `httpx` (covered by `HTTPXClientInstrumentor`)
+  **but also** passes a manual `langfuse_trace_id` in the `/query` payload, and
+  the trace id is threaded through LiveKit job metadata. This is a legacy
+  belt-and-suspenders workaround — the voice analogue of the BGE-M3 manual
+  headers tracked in #2253.
+
+## Decision (baseline)
+
+1. **Voice lifecycle spans:** SDK-native via
+   `livekit.agents.telemetry.set_tracer_provider` (already wired). This is the
+   supported approach; keep it.
+2. **Voice -> RAG hop:** SDK-native W3C TraceContext via `HTTPXClientInstrumentor`
+   (already active). The RAG API spans nest under the `voice-session` trace as
+   long as that span's context is active during the `httpx` call.
+3. **Manual `langfuse_trace_id`:** keep as a documented fallback **for now**.
+   It is redundant with W3C TraceContext once runtime continuity is proven, and
+   should then be deprecated — mirroring #2253 for the BGE-M3 boundary. This is
+   the implementation follow-up; it is intentionally out of scope here.
+
+No new dependency is required; no OTLP gRPC exporter is introduced (the export
+path is the existing Langfuse OTel ingestion).
+
+## Follow-up implementation issue
+
+Because SDK-native support exists, the behavioural change is tracked separately:
+prove voice -> RAG same-trace continuity at runtime (via `make
+validate-traces-fast` + the #2252 continuity check), then deprecate the manual
+`langfuse_trace_id` payload/metadata path. See the issue linked from #2257.
+
+## References
+
+- Single-trace gate: #2244 · Audit: #2246 · Cross-service contract: #2256
+- Manual-propagation cleanup pattern: #2253 · Voice-session root span: #2160
+- Cross-service tracing contract doc: [`CROSS_SERVICE_TRACING.md`](CROSS_SERVICE_TRACING.md)

--- a/docs/observability/VOICE_TRACING_BASELINE.md
+++ b/docs/observability/VOICE_TRACING_BASELINE.md
@@ -72,4 +72,4 @@ validate-traces-fast` + the #2252 continuity check), then deprecate the manual
 
 - Single-trace gate: #2244 · Audit: #2246 · Cross-service contract: #2256
 - Manual-propagation cleanup pattern: #2253 · Voice-session root span: #2160
-- Cross-service tracing contract doc: [`CROSS_SERVICE_TRACING.md`](CROSS_SERVICE_TRACING.md)
+- Cross-service tracing contract (inbound FastAPIInstrumentor / outbound HTTPXClientInstrumentor): #2256

--- a/tests/contract/test_voice_tracing_baseline_contract.py
+++ b/tests/contract/test_voice_tracing_baseline_contract.py
@@ -1,0 +1,111 @@
+"""Voice tracing baseline contract (#2257).
+
+Locks in the voice-specific OpenTelemetry wiring that the SDK baseline
+(``docs/observability/VOICE_TRACING_BASELINE.md``) documents, so it cannot
+silently regress:
+
+* ``src/voice/agent.py`` must forward the active OTel ``TracerProvider`` to
+  LiveKit via ``livekit.agents.telemetry.set_tracer_provider(provider)`` — this
+  is the LiveKit-native hook that makes LiveKit-emitted spans land on the same
+  exporter as the rest of the runtime (so voice lifecycle spans share the
+  Langfuse trace tree).
+
+The voice -> RAG hop (``src/voice/rag_api_client.py`` using ``httpx`` ->
+``HTTPXClientInstrumentor``) is already locked by the cross-service contract in
+``test_cross_service_trace_instrumentation_contract.py`` (#2256) and is not
+re-asserted here.
+
+SDK evidence (see the baseline doc): the LiveKit Agents telemetry API exposes
+``set_tracer_provider`` (LiveKit JS API reference documents the equivalent
+``setTracerProvider`` in ``@livekit/agents/telemetry``; the OpenObserve LiveKit
+integration documents registering a ``TracerProvider`` via
+``telemetry.set_tracer_provider()``). Content was rephrased for compliance with
+licensing restrictions.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VOICE_AGENT = "src/voice/agent.py"
+
+
+def _source_of(rel: str) -> str | None:
+    path = REPO_ROOT / rel
+    if not path.exists():
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+def _calls_name(tree: ast.AST, name: str) -> bool:
+    """True if the module invokes ``name(...)`` (bare or attribute call)."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == name:
+            return True
+        if isinstance(func, ast.Attribute) and func.attr == name:
+            return True
+    return False
+
+
+def _imports_name(tree: ast.AST, module_substr: str, name: str) -> bool:
+    """True if the module does ``from <...module_substr...> import <name>``."""
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ImportFrom)
+            and node.module
+            and module_substr in node.module
+            and any(alias.name == name for alias in node.names)
+        ):
+            return True
+    return False
+
+
+def _forwards_tracer_provider(source: str) -> bool:
+    tree = ast.parse(source)
+    return _imports_name(tree, "livekit.agents.telemetry", "set_tracer_provider") and _calls_name(
+        tree, "set_tracer_provider"
+    )
+
+
+class TestVoiceAgentForwardsTracerProvider:
+    """The voice agent must wire LiveKit telemetry to the runtime provider."""
+
+    def test_voice_agent_exists(self) -> None:
+        assert _source_of(VOICE_AGENT) is not None, f"missing: {VOICE_AGENT}"
+
+    def test_voice_agent_forwards_tracer_provider_to_livekit(self) -> None:
+        source = _source_of(VOICE_AGENT)
+        assert source is not None
+        assert _forwards_tracer_provider(source), (
+            f"{VOICE_AGENT} must import and call "
+            f"livekit.agents.telemetry.set_tracer_provider(provider) so LiveKit "
+            f"spans share the Langfuse OTel trace tree (#2257). Without it the "
+            f"voice lifecycle spans would not participate in the single trace."
+        )
+
+
+class TestDetectorSelfChecks:
+    _OK = (
+        "from livekit.agents.telemetry import set_tracer_provider\nset_tracer_provider(provider)\n"
+    )
+    _MISSING_CALL = "from livekit.agents.telemetry import set_tracer_provider\n"
+    _MISSING_IMPORT = "set_tracer_provider(provider)\n"
+    _UNRELATED = "import os\nos.getenv('X')\n"
+
+    def test_detector_accepts_import_and_call(self) -> None:
+        assert _forwards_tracer_provider(self._OK)
+
+    def test_detector_requires_the_call(self) -> None:
+        assert not _forwards_tracer_provider(self._MISSING_CALL)
+
+    def test_detector_requires_the_import(self) -> None:
+        assert not _forwards_tracer_provider(self._MISSING_IMPORT)
+
+    def test_detector_rejects_unrelated_module(self) -> None:
+        assert not _forwards_tracer_provider(self._UNRELATED)


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #2257 (research / SDK baseline). Continues the cross-service tracing thread (#2256) into the voice path; the single-trace gate is #2244.

Answers, with evidence, whether the voice path can join the same W3C trace as bot/RAG using SDK-native mechanisms instead of a handwritten `langfuse_trace_id`.

## Findings (SDK evidence)

- **LiveKit Agents Python exposes an OTel hook** — `livekit.agents.telemetry.set_tracer_provider(provider)`. Evidence: the [LiveKit JS API reference](https://docs.livekit.io/reference/agents-js/functions/agents.telemetry.setTracerProvider.html) (`@livekit/agents/telemetry` `setTracerProvider`) and the [OpenObserve LiveKit integration](https://openobserve.ai/docs/integration/ai/frameworks/livekit/) (register a `TracerProvider` via `telemetry.set_tracer_provider()`; LLM calls auto-trace as nested spans). *Content rephrased for compliance.* The repo **already** forwards the Langfuse-registered provider in `src/voice/agent.py::_setup_langfuse()`.
- **voice → RAG hop** uses `httpx` → covered by the process-wide `HTTPXClientInstrumentor` (#2225/#2256) for W3C `traceparent`+`baggage`.
- The manual `langfuse_trace_id` (RAG payload + LiveKit job metadata) is a legacy belt-and-suspenders workaround — the voice analogue of the BGE-M3 manual headers (#2253).

## Decision (baseline)

1. Voice lifecycle spans → SDK-native via `set_tracer_provider` (already wired). Keep.
2. voice → RAG hop → SDK-native W3C TraceContext via `HTTPXClientInstrumentor` (already active).
3. Manual `langfuse_trace_id` → keep as documented fallback **for now**; deprecate after runtime continuity is proven (mirrors #2253). Tracked as a follow-up implementation issue.

No new dependency; no OTLP gRPC exporter introduced.

## Changes

- **`docs/observability/VOICE_TRACING_BASELINE.md`** (new): the decision record (evidence, current state, decision, follow-up). Linked from `docs/README.md`.
- **`tests/contract/test_voice_tracing_baseline_contract.py`** (new): locks in that `src/voice/agent.py` forwards the OTel `TracerProvider` to LiveKit via `set_tracer_provider`; AST detector self-checks. (The voice→RAG `httpx` coverage is already locked by #2256's contract — not duplicated.)

## TDD

- Lock-in assertion passes (wiring exists); detector self-checks provide RED→GREEN regression proof — **6 passed**.
- `ruff check` + `ruff format --check` clean.

## Scope (per #2257)

- [x] Resolve LiveKit Agents OTel surface with recorded evidence.
- [x] Confirm `set_tracer_provider` hook + voice→RAG `httpx` path.
- [x] Decide approach (SDK-native W3C TraceContext; manual id as fallback).
- [x] Document the baseline (`docs/observability/VOICE_TRACING_BASELINE.md`).
- [x] Open a follow-up implementation issue (linked in the issue thread).
- Out of scope: implementing the `langfuse_trace_id` deprecation (the follow-up).