### PR TITLE
docs(observability): three OTEL roadmap ADRs (#2228)

### DIFF
--- a/docs/adr/0016-otel-metrics-vs-prometheus.md
+++ b/docs/adr/0016-otel-metrics-vs-prometheus.md
@@ -1,0 +1,37 @@
+# ADR-0016: OpenTelemetry Metrics vs Prometheus
+
+**Status:** Accepted
+
+**Date:** 2026-05-29
+
+**Closes:** [#2228](https://github.com/yastman/rag/issues/2228) (roadmap ADRs)
+
+**Related:** [#2215](https://github.com/yastman/rag/issues/2215) (observability audit umbrella), [ADR-0015](0015-sdk-native-baseline.md) (observability baseline)
+
+## Context
+
+The runtime carries two metric systems:
+
+- **Prometheus (pull):** application metrics via `prometheus_client` — `pipeline_latency_seconds` Histogram, `rag_pipeline_events_total` Counter — registered against the default `prometheus_client.REGISTRY` and scraped over an ASGI `/metrics` mount. This feeds Grafana dashboards and alert rules.
+- **OpenTelemetry Metrics (SDK-internal):** the Langfuse v4 SDK uses an OTel `MeterProvider` internally for its own SDK metrics. No operator-visible exporter is wired to it (it is mocked to no-op in unit tests).
+
+The audit (#2215) flagged that this duality is undocumented: there is no recorded decision about whether to unify on the OTel Metrics API (`meter.create_counter(...)`), which could route to Prometheus or OTLP by configuration.
+
+## Decision
+
+**Keep the dual stack, deliberately.** Prometheus pull remains the production metrics backbone. The OTel Metrics API stays SDK-internal and is **not** wired to an operator-visible backend. No OTLP metric exporter is introduced.
+
+Rationale:
+
+- The production observability surface (Grafana dashboards, alert rules, scrape config) is built on Prometheus. Migrating application metrics to the OTel Metrics API + `PrometheusMetricReader` is a pure refactor with no functional gain today.
+- Traces (Langfuse/OTel) and metrics (Prometheus) are complementary signals; logs↔traces and Sentry↔traces are already cross-linked (#2217/#2239, #2218). Metrics do not need to move under the trace exporter.
+
+## Consequences
+
+- Two metrics systems coexist by design; new application metrics go through `prometheus_client`, not the OTel Metrics API.
+- If a future need arises to export metrics over OTLP centrally (e.g., a collector), revisit with a migration to the OTel Metrics API + `PrometheusMetricReader`, keeping the `/metrics` scrape contract unchanged. That is explicitly out of scope here.
+
+## Implementation notes
+
+- Application metrics: `src/runtime/services/metrics.py` (`PipelineMetrics` facade over Histogram + Counter), `/metrics` ASGI mount.
+- Langfuse SDK OTel `MeterProvider`: internal only; no exporter wired.

--- a/docs/adr/0017-otel-trace-sampling-roadmap.md
+++ b/docs/adr/0017-otel-trace-sampling-roadmap.md
@@ -1,0 +1,39 @@
+# ADR-0017: OpenTelemetry Trace Sampling Roadmap
+
+**Status:** Accepted
+
+**Date:** 2026-05-29
+
+**Closes:** [#2228](https://github.com/yastman/rag/issues/2228) (roadmap ADRs)
+
+**Related:** [#2215](https://github.com/yastman/rag/issues/2215) (observability audit), [#2218](https://github.com/yastman/rag/issues/2218) (Sentry↔Langfuse cross-link), [#2244](https://github.com/yastman/rag/issues/2244) (single-trace gate)
+
+## Context
+
+Every `@observe` and every auto-instrumented HTTP call currently produces a span; no sampler is configured, so the implicit behaviour is **AlwaysOn** (100% of root traces are kept). At current volume this is desirable — full traces aid debugging and the single-trace gate (#2244). As volume grows, AlwaysOn scales Langfuse ingestion/storage cost linearly and risks silent span drops under `BatchSpanProcessor` backpressure.
+
+## Decision
+
+**Record AlwaysOn as today's intentional default** and declare the trigger and mechanism for switching, without changing code now.
+
+- **Today:** no sampler env set ⇒ AlwaysOn. Keep it.
+- **Trigger to switch:** when monthly Langfuse trace volume or ingestion/storage cost crosses the team's review threshold (tracked alongside the cost reconciliation work, #2223), switch root-trace sampling on.
+- **Mechanism (declarative, no code):**
+
+  ```yaml
+  OTEL_TRACES_SAMPLER: parentbased_traceidratio
+  OTEL_TRACES_SAMPLER_ARG: "0.1"   # keep 10% of root traces; children follow the parent decision
+  ```
+
+  `parentbased_*` ensures a sampled root keeps its whole tree intact — essential for the single-trace goal (#2244).
+- **Error-aware sampling is not required now:** Sentry already captures errors and cross-links to the Langfuse trace (#2218), so "always trace failures" can be deferred. If needed later, add a custom `Sampler` that forces-keep `Status.ERROR` spans.
+
+## Consequences
+
+- Cost grows linearly with volume until the trigger fires; the trigger is now explicit rather than discovered via a surprise bill or dropped spans.
+- Switching is an env change on traced services, not a code change.
+- Sampling interacts with the single-trace gate: only `parentbased` ratio sampling is acceptable, so a kept trace remains complete end-to-end.
+
+## Implementation notes
+
+- No code today. When triggered, set `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG` on the OTEL-SDK services (the same set that declares `OTEL_PROPAGATORS`, #2254).

--- a/docs/adr/0018-w3c-baggage-vs-propagate-attributes.md
+++ b/docs/adr/0018-w3c-baggage-vs-propagate-attributes.md
@@ -1,0 +1,36 @@
+# ADR-0018: W3C Baggage vs `propagate_attributes`
+
+**Status:** Accepted
+
+**Date:** 2026-05-29
+
+**Closes:** [#2228](https://github.com/yastman/rag/issues/2228) (roadmap ADRs)
+
+**Related:** [#2226](https://github.com/yastman/rag/issues/2226) / [#2235](https://github.com/yastman/rag/issues/2235) (baggage propagation), [#2254](https://github.com/yastman/rag/issues/2254) (declare `OTEL_PROPAGATORS`), [#2256](https://github.com/yastman/rag/issues/2256) (cross-service instrumentation), [#2253](https://github.com/yastman/rag/issues/2253) / [#2266](https://github.com/yastman/rag/issues/2266) (manual trace-id cleanup), [#2244](https://github.com/yastman/rag/issues/2244) (single-trace gate)
+
+## Context
+
+Two mechanisms carry user/session/tag context:
+
+- **`propagate_attributes(session_id=..., user_id=..., tags=[...])`** — a Langfuse contextvars wrapper. It works **in-process** and is the established way the bot/voice transports attach Langfuse trace attributes.
+- **W3C Baggage** — the OTel-standard cross-cutting context that auto-propagates over any instrumented transport (HTTP/gRPC) as a `baggage` header. With the propagators declared (`tracecontext,baggage`, #2254) and FastAPI/httpx auto-instrumentation active (#2256), Baggage now flows across service boundaries. `propagate_attributes(as_baggage=True)` bridges Langfuse attrs into Baggage at the transport edge.
+
+Historically, cross-service trace context was carried by hand-written `langfuse_trace_id` / `x-langfuse-*` headers (BGE-M3 path, voice→RAG payload) — a workaround that predates the SDK-native layer.
+
+## Decision
+
+1. **In-process:** `propagate_attributes(...)` remains canonical for setting `user_id` / `session_id` / `tags`.
+2. **Cross-service:** rely on **W3C TraceContext + Baggage** (auto-injected by `HTTPXClientInstrumentor`, auto-extracted by `FastAPIInstrumentor`); bridge Langfuse attrs with `propagate_attributes(as_baggage=True)` at the transport boundary.
+3. **No hand-rolled trace-context headers.** The legacy `langfuse_trace_id` / `x-langfuse-*` workarounds are deprecated and tracked for removal once runtime continuity is proven (BGE-M3 #2253, voice→RAG #2266).
+4. **Full migration deferred:** moving *every* cross-service attribute from `propagate_attributes` to raw `set_baggage(...)` is deferred until a concrete cross-service field beyond `user_id`/`session_id`/`tags` needs auto-propagation. Today's split (in-process wrapper + Baggage at the edge) is correct.
+
+## Consequences
+
+- One clear boundary: in-process wrapper, cross-service Baggage. New cross-service work uses Baggage, not custom headers.
+- The contract test in #2256 plus the propagator declaration in #2254 keep this enforceable; the cleanup issues (#2253/#2266) remove the legacy duplication.
+
+## Implementation notes
+
+- Propagators: `OTEL_PROPAGATORS=tracecontext,baggage` per OTEL-SDK service (#2254).
+- Bridge: bot middleware and voice entrypoint call `propagate_attributes(..., as_baggage=True)`.
+- Cross-service inbound/outbound instrumentation locked by the #2256 contract.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,6 +19,9 @@ This directory is the canonical entrypoint for architecture decision records. [`
 - [0013 - CocoIndex + Docling ingestion pipeline](0013-cocoindex-docling-ingestion.md)
 - [0014 - Properties CSV as source of truth (no admin panel)](0014-properties-csv-as-source-of-truth.md)
 - [0015 - SDK-native baseline (aiogram, LangGraph, Langfuse, Qdrant)](0015-sdk-native-baseline.md)
+- [0016 - OpenTelemetry Metrics vs Prometheus](0016-otel-metrics-vs-prometheus.md)
+- [0017 - OpenTelemetry trace sampling roadmap](0017-otel-trace-sampling-roadmap.md)
+- [0018 - W3C Baggage vs `propagate_attributes`](0018-w3c-baggage-vs-propagate-attributes.md)
 
 ## When To Use
 


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #2228. Records the three forward-looking observability decisions deferred during the audit (#2215), so they survive the issue closing. Pure documentation — no code.

These ADRs formalize the policy behind the trace work landed in #2254/#2255/#2256/#2257.

## ADRs

- **[ADR-0016 — OTel Metrics vs Prometheus](https://github.com/yastman/rag/blob/feat/2228-otel-adrs/docs/adr/0016-otel-metrics-vs-prometheus.md):** keep the dual stack deliberately. Prometheus pull (`prometheus_client` + `/metrics`) is the production backbone; the OTel Metrics API stays SDK-internal; no OTLP metric exporter. Unification is an explicit non-goal until a central collector need arises.
- **[ADR-0017 — Trace sampling roadmap](https://github.com/yastman/rag/blob/feat/2228-otel-adrs/docs/adr/0017-otel-trace-sampling-roadmap.md):** AlwaysOn is today's intentional default; declares the **trigger** (volume/cost threshold, tracked with #2223) and the declarative `OTEL_TRACES_SAMPLER=parentbased_traceidratio` + `OTEL_TRACES_SAMPLER_ARG` mechanism. `parentbased` keeps a sampled trace whole (single-trace gate #2244). Error-aware sampling deferred (Sentry cross-link #2218 already captures errors).
- **[ADR-0018 — W3C Baggage vs `propagate_attributes`](https://github.com/yastman/rag/blob/feat/2228-otel-adrs/docs/adr/0018-w3c-baggage-vs-propagate-attributes.md):** in-process `propagate_attributes` stays canonical; cross-service uses W3C TraceContext + Baggage (#2254/#2256); no hand-rolled `langfuse_trace_id`/`x-langfuse-*` headers (cleanups #2253/#2266); full `set_baggage` migration deferred.

## Changes

- `docs/adr/0016-otel-metrics-vs-prometheus.md`, `0017-otel-trace-sampling-roadmap.md`, `0018-w3c-baggage-vs-propagate-attributes.md` (new).
- `docs/adr/README.md` index updated.

## Validation

- Markdown-link checker (`tests/unit/scripts/test_check_markdown_links.py`) green — links use issue URLs and existing-file relative paths only (no links to docs introduced by other open PRs).
- ADR-referencing contract tests still pass (61).
- No trailing whitespace; matches the ADR template (Status/Date/Closes/Related/Context/Decision/Consequences/Implementation notes).

## Acceptance criteria (#2228)

- [x] `docs/adr/0016-otel-metrics-vs-prometheus.md` — decision (a) keep dual stack.
- [x] `docs/adr/0017-otel-trace-sampling-roadmap.md` — AlwaysOn intent + sampling trigger.
- [x] `docs/adr/0018-w3c-baggage-vs-propagate-attributes.md` — in-process canonical; baggage migration deferred.