### PR TITLE
observability(hygiene): complete on_task_complete span instrumentation (#2214 P1)

### DIFF
--- a/telegram_bot/handlers/crm_callbacks.py
+++ b/telegram_bot/handlers/crm_callbacks.py
@@ -163,18 +163,23 @@ async def on_task_complete(
     kommo_client: Any | None = None,
 ) -> None:
     """Handle crm:task:complete:{id} — complete task immediately (no dialog)."""
+    lf = get_client()
     if kommo_client is None:
+        _update_current_span(lf, output={"action": "cancelled"})
         await callback.answer(_NO_CRM, show_alert=True)
         return
     assert callback.data is not None
     task_id = int(callback.data.split(":")[3])
+    _update_current_span(lf, input={"task_id": task_id, "action": "complete"})
     try:
         await kommo_client.complete_task(task_id)
+        _update_current_span(lf, output={"task_id": task_id, "status": "completed"})
         await callback.answer("✅ Задача завершена.")
         if callback.message and not isinstance(callback.message, InaccessibleMessage):
             await callback.message.edit_text("✅ Задача завершена.")
-    except Exception:
+    except Exception as exc:
         logger.exception("Failed to complete task %d", task_id)
+        _update_current_span(lf, level="ERROR", status_message=str(exc)[:200])
         await callback.answer("⚠️ Ошибка при завершении задачи.", show_alert=True)
 
 

--- a/tests/unit/handlers/test_on_task_complete_spans.py
+++ b/tests/unit/handlers/test_on_task_complete_spans.py
@@ -1,0 +1,96 @@
+"""`on_task_complete` span-completeness contract (#2214, P1).
+
+`crm-quick-complete` had `@observe` but neither branch updated the span, so a
+successful completion and a failed one looked identical on the Langfuse
+dashboard. This mirrors the `on_task_postpone` pattern: record input on entry,
+output on success, and `level="ERROR"` + `status_message` on failure. The span
+update must be guarded so a missing Langfuse client never breaks the handler.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _patched_lf(monkeypatch) -> MagicMock:
+    from telegram_bot.handlers import crm_callbacks as cb_mod
+
+    mock_lf = MagicMock()
+    monkeypatch.setattr(cb_mod, "get_client", lambda: mock_lf)
+    return mock_lf
+
+
+def _span_kwargs(mock_lf: MagicMock) -> list[dict]:
+    return [c.kwargs for c in mock_lf.update_current_span.call_args_list]
+
+
+@pytest.mark.asyncio
+async def test_complete_success_sets_output_span(monkeypatch):
+    mock_lf = _patched_lf(monkeypatch)
+    from telegram_bot.handlers.crm_callbacks import on_task_complete
+
+    kommo = AsyncMock()
+    callback = AsyncMock()
+    callback.data = "crm:task:complete:42"
+    callback.message = None  # skip edit_text branch
+
+    await on_task_complete(callback, kommo_client=kommo)
+
+    kommo.complete_task.assert_awaited_once_with(42)
+    kwargs = _span_kwargs(mock_lf)
+    assert any("output" in k for k in kwargs), "success branch must record span output"
+    assert not any(k.get("level") == "ERROR" for k in kwargs), "success must not be ERROR"
+
+
+@pytest.mark.asyncio
+async def test_complete_failure_sets_error_span(monkeypatch):
+    mock_lf = _patched_lf(monkeypatch)
+    from telegram_bot.handlers.crm_callbacks import on_task_complete
+
+    kommo = AsyncMock()
+    kommo.complete_task = AsyncMock(side_effect=RuntimeError("kommo 500"))
+    callback = AsyncMock()
+    callback.data = "crm:task:complete:42"
+    callback.message = None
+
+    await on_task_complete(callback, kommo_client=kommo)
+
+    kwargs = _span_kwargs(mock_lf)
+    assert any(k.get("level") == "ERROR" for k in kwargs), "failure must mark span ERROR"
+    assert any(k.get("status_message") for k in kwargs), "failure must set status_message"
+    # user still gets an alert
+    callback.answer.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_complete_no_kommo_records_cancelled(monkeypatch):
+    mock_lf = _patched_lf(monkeypatch)
+    from telegram_bot.handlers.crm_callbacks import on_task_complete
+
+    callback = AsyncMock()
+    callback.data = "crm:task:complete:42"
+
+    await on_task_complete(callback, kommo_client=None)
+
+    kwargs = _span_kwargs(mock_lf)
+    assert any("output" in k for k in kwargs), "no-CRM branch must record a span output"
+    callback.answer.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_complete_no_crash_when_langfuse_unavailable(monkeypatch):
+    from telegram_bot.handlers import crm_callbacks as cb_mod
+
+    monkeypatch.setattr(cb_mod, "get_client", lambda: None)
+    from telegram_bot.handlers.crm_callbacks import on_task_complete
+
+    kommo = AsyncMock()
+    callback = AsyncMock()
+    callback.data = "crm:task:complete:42"
+    callback.message = None
+
+    # must not raise even though no Langfuse client is available
+    await on_task_complete(callback, kommo_client=kommo)
+    kommo.complete_task.assert_awaited_once_with(42)


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Addresses the **[P1]** item of #2214 (observability hygiene): `crm_callbacks.on_task_complete` partial spans. The other items in the grab-bag are deferred with rationale (below).

`crm-quick-complete` had `@observe` but **neither branch updated the span** — a successful completion and a failed one were indistinguishable on the Langfuse dashboard. This mirrors the existing `on_task_postpone` pattern.

SDK semantics verified via Context7 (`/langfuse/langfuse-python`): `update_current_span(output=..., level="ERROR", status_message=...)`, `SpanLevel = Literal["DEBUG","DEFAULT","WARNING","ERROR"]`. Content rephrased for compliance.

## Changes

- **`telegram_bot/handlers/crm_callbacks.py`** — `on_task_complete` now records: `input` on entry, `output={"status":"completed"}` on success, `level="ERROR"` + truncated `status_message` on failure, and a `{"action":"cancelled"}` output on the no-CRM branch. All via the existing `_update_current_span` guard (no crash when Langfuse is disabled).
- **`tests/unit/handlers/test_on_task_complete_spans.py`** (new): success/failure/no-CRM/Langfuse-unavailable.

## TDD

- 4 new tests written first (RED: 3 failed, the no-crash one passed). After the fix: **GREEN — 21 passed** (4 new + 17 existing `test_crm_callbacks.py`, no regression). The `@observe` decorator kwargs are unchanged, so the span-coverage contract is unaffected.
- `ruff check` + `ruff format --check` clean.

## Deferred items from #2214 (with rationale)

- **Deprecated ColBERT `@observe`:** `colbert-rerank` is in the span catalog (`tests/observability/trace_contract.yaml`) and `tests/contract/test_span_coverage_contract.py`; stripping the decorator requires a coordinated catalog edit. Deferred to avoid breaking those contracts in this focused PR. (Class is already guarded by `_is_deprecated_colbert_reranker`.)
- **Whisper double-emit:** needs SDK-version + runtime confirmation of audio auto-trace.
- **`demo_handler` bypass:** on `dev` it already imports `from langfuse.openai import AsyncOpenAI`; the base_url/api_key wiring is a smaller follow-up.
- **Global-lock thread-safety, PII shape contract, ingestion flush:** independent changes; kept out of this PR to keep it reviewable and low-risk.

## Acceptance (this slice)

- [x] `on_task_complete` success and failure are distinguishable on the dashboard (output vs ERROR span).
- [ ] Remaining #2214 hygiene items — tracked as follow-ups per the rationale above.