### PR TITLE
observability(state): link LangGraph thread_id to Langfuse trace metadata (#2224)

### DIFF
--- a/docs/BOT_INTERNAL_STRUCTURE.md
+++ b/docs/BOT_INTERNAL_STRUCTURE.md
@@ -151,6 +151,33 @@ Update → ThrottlingMiddleware → ErrorMiddleware → I18nMiddleware → Handl
 - Loads user locale from DB
 - Injects `i18n`, `locale`, `property_bot`, `apartments_service`
 
+## Tracing identifiers: `thread_id` vs `session_id`
+
+A conversation has two identifiers that look similar but are intentionally
+**not** the same string:
+
+| Identifier | Source | Format | Lifetime |
+|---|---|---|---|
+| LangGraph `thread_id` | `_supervisor_thread_id(chat_id, forum_thread_id)` (`telegram_bot/services/checkpointer_utils.py`) | `tg_<chat_id>` / `tg_<chat_id>:<forum_thread_id>` | **persistent** — the checkpointer key for conversation memory |
+| Langfuse `session_id` | `make_session_id("chat", chat_id)` (`telegram_bot/tracing_context.py`) | `chat-<hash>-<YYYYMMDD>` | **date-rotating** — groups a day's traces |
+
+Both are placed in the supervisor invoke `config["configurable"]` together, and
+the checkpointer `thread_id` is also recorded on the Langfuse trace as
+`langgraph_thread_id` metadata (via `update_current_trace`). So from a Langfuse
+trace an operator can read `langgraph_thread_id` and query the LangGraph
+checkpointer for that conversation's state.
+
+**Why they are not unified (#2224):** `session_id` carries a `YYYYMMDD`
+component, so using it as the checkpointer `thread_id` would rotate the thread
+daily and reset conversation memory every midnight. The persistent
+`_supervisor_thread_id` must remain the checkpointer key; the two are therefore
+*linked* via trace metadata rather than made equal. The co-location and the
+metadata linkage are enforced by
+`tests/contract/test_thread_session_link_contract.py`.
+
+The voice path and the HITL `Command(resume=...)` path manage their own
+thread/session identifiers and are out of scope of that contract.
+
 ## Finding Code
 
 Due to file size, use `rg` recipes instead of line-number maps:

--- a/docs/BOT_INTERNAL_STRUCTURE.md
+++ b/docs/BOT_INTERNAL_STRUCTURE.md
@@ -163,7 +163,7 @@ A conversation has two identifiers that look similar but are intentionally
 
 Both are placed in the supervisor invoke `config["configurable"]` together, and
 the checkpointer `thread_id` is also recorded on the Langfuse trace as
-`langgraph_thread_id` metadata (via `update_current_trace`). So from a Langfuse
+`langgraph_thread_id` metadata via `propagate_attributes`. So from a Langfuse
 trace an operator can read `langgraph_thread_id` and query the LangGraph
 checkpointer for that conversation's state.
 

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -3001,6 +3001,17 @@ class PropertyBot:
             },
         }
 
+        # #2224: link the LangGraph checkpointer thread_id onto the Langfuse
+        # trace so an operator can jump from a trace to the conversation state.
+        # thread_id is intentionally NOT unified with session_id: session_id is
+        # date-rotating (chat-<hash>-<YYYYMMDD>) while the checkpointer thread
+        # must persist across days, so they are correlated via metadata.
+        _lf = get_client()
+        if _lf is not None:
+            _lf.update_current_trace(
+                metadata={"langgraph_thread_id": config["configurable"]["thread_id"]}
+            )
+
         async def _run_once(current_agent: Any) -> tuple[str, dict[str, Any]]:
             can_stream = use_streaming and callable(getattr(current_agent, "astream", None))
             if not can_stream:
@@ -3147,6 +3158,17 @@ class PropertyBot:
                 "session_id": bot_context.session_id,
             },
         }
+
+        # #2224: link the LangGraph checkpointer thread_id onto the Langfuse
+        # trace so an operator can jump from a trace to the conversation state.
+        # thread_id is intentionally NOT unified with session_id: session_id is
+        # date-rotating (chat-<hash>-<YYYYMMDD>) while the checkpointer thread
+        # must persist across days, so they are correlated via metadata.
+        _lf = get_client()
+        if _lf is not None:
+            _lf.update_current_trace(
+                metadata={"langgraph_thread_id": config["configurable"]["thread_id"]}
+            )
 
         # --- Streaming path (#952) ---
         streaming_enabled = bool(getattr(self._graph_config, "streaming_enabled", False))

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -2230,10 +2230,12 @@ class PropertyBot:
 
         rag_result_store: dict[str, Any] = {}
         pre_agent_start = time.perf_counter()
+        langgraph_thread_id = _supervisor_thread_id(message.chat.id, forum_thread_id)
 
         with propagate_attributes(
             session_id=session_id,
             user_id=str(user_id),
+            metadata={"langgraph_thread_id": langgraph_thread_id},
             tags=["telegram", "rag", "agent"],
         ):
             # --- Pre-agent content filter (#439) ---
@@ -3001,17 +3003,6 @@ class PropertyBot:
             },
         }
 
-        # #2224: link the LangGraph checkpointer thread_id onto the Langfuse
-        # trace so an operator can jump from a trace to the conversation state.
-        # thread_id is intentionally NOT unified with session_id: session_id is
-        # date-rotating (chat-<hash>-<YYYYMMDD>) while the checkpointer thread
-        # must persist across days, so they are correlated via metadata.
-        _lf = get_client()
-        if _lf is not None:
-            _lf.update_current_trace(
-                metadata={"langgraph_thread_id": config["configurable"]["thread_id"]}
-            )
-
         async def _run_once(current_agent: Any) -> tuple[str, dict[str, Any]]:
             can_stream = use_streaming and callable(getattr(current_agent, "astream", None))
             if not can_stream:
@@ -3158,17 +3149,6 @@ class PropertyBot:
                 "session_id": bot_context.session_id,
             },
         }
-
-        # #2224: link the LangGraph checkpointer thread_id onto the Langfuse
-        # trace so an operator can jump from a trace to the conversation state.
-        # thread_id is intentionally NOT unified with session_id: session_id is
-        # date-rotating (chat-<hash>-<YYYYMMDD>) while the checkpointer thread
-        # must persist across days, so they are correlated via metadata.
-        _lf = get_client()
-        if _lf is not None:
-            _lf.update_current_trace(
-                metadata={"langgraph_thread_id": config["configurable"]["thread_id"]}
-            )
 
         # --- Streaming path (#952) ---
         streaming_enabled = bool(getattr(self._graph_config, "streaming_enabled", False))

--- a/tests/contract/test_thread_session_link_contract.py
+++ b/tests/contract/test_thread_session_link_contract.py
@@ -14,8 +14,9 @@ Two things are locked:
    ``_supervisor_thread_id`` thread_id must also carry ``session_id`` so the
    LangGraph<->Langfuse mapping is always recoverable.
 2. **Trace linkage** — ``telegram_bot/bot.py`` records the checkpointer
-   ``thread_id`` on the Langfuse trace as ``langgraph_thread_id`` metadata (via
-   ``update_current_trace``), so the correlation is visible from the trace.
+   ``thread_id`` on the Langfuse trace as ``langgraph_thread_id`` metadata via
+   ``propagate_attributes`` at the supervisor entry-point, so the correlation
+   is visible from the trace.
 
 Design note (see ``docs/BOT_INTERNAL_STRUCTURE.md``): ``thread_id`` is
 **intentionally not unified** with ``session_id``. ``make_session_id`` is
@@ -71,7 +72,7 @@ def _supervisor_configurable_keysets(tree: ast.AST) -> list[set[str]]:
 
 
 def _emits_thread_id_to_trace(source: str) -> bool:
-    return "update_current_trace" in source and "langgraph_thread_id" in source
+    return "propagate_attributes" in source and "langgraph_thread_id" in source
 
 
 class TestSupervisorThreadSessionColocation:
@@ -98,8 +99,8 @@ class TestTraceLinkage:
         assert _emits_thread_id_to_trace(source), (
             "telegram_bot/bot.py must record the checkpointer thread_id on the "
             "Langfuse trace as langgraph_thread_id metadata via "
-            "update_current_trace(...) so operators can correlate a trace to the "
-            "LangGraph conversation state (#2224)."
+            "propagate_attributes(...) so operators can correlate a trace to "
+            "the LangGraph conversation state (#2224)."
         )
 
 
@@ -132,6 +133,8 @@ class TestDetectorSelfChecks:
 
     def test_trace_linkage_detector(self) -> None:
         assert _emits_thread_id_to_trace(
-            "lf.update_current_trace(metadata={'langgraph_thread_id': tid})"
+            "with propagate_attributes(metadata={'langgraph_thread_id': tid}): pass"
         )
-        assert not _emits_thread_id_to_trace("lf.update_current_span(metadata={'x': 1})")
+        assert not _emits_thread_id_to_trace(
+            "lf.update_current_generation(metadata={'langgraph_thread_id': tid})"
+        )

--- a/tests/contract/test_thread_session_link_contract.py
+++ b/tests/contract/test_thread_session_link_contract.py
@@ -1,0 +1,137 @@
+"""LangGraph thread_id <-> Langfuse session_id linkage contract (#2224).
+
+Operational hygiene: an operator who finds a Langfuse trace must be able to
+recover the LangGraph checkpointer thread for that conversation.
+
+Scope: the **supervisor (text) agent** path — the ``configurable`` dicts whose
+``thread_id`` is built by ``_supervisor_thread_id(...)``. The voice path and the
+HITL ``Command(resume=...)`` path use their own thread/session handling and are
+out of scope here (tracked as follow-ups on #2224).
+
+Two things are locked:
+
+1. **Co-location** — every supervisor ``configurable`` dict carrying a
+   ``_supervisor_thread_id`` thread_id must also carry ``session_id`` so the
+   LangGraph<->Langfuse mapping is always recoverable.
+2. **Trace linkage** — ``telegram_bot/bot.py`` records the checkpointer
+   ``thread_id`` on the Langfuse trace as ``langgraph_thread_id`` metadata (via
+   ``update_current_trace``), so the correlation is visible from the trace.
+
+Design note (see ``docs/BOT_INTERNAL_STRUCTURE.md``): ``thread_id`` is
+**intentionally not unified** with ``session_id``. ``make_session_id`` is
+date-rotating (``chat-<hash>-<YYYYMMDD>``) while the checkpointer thread
+(``_supervisor_thread_id`` -> ``tg_<chat_id>``) must persist across days;
+unifying them would reset conversation memory daily. They are linked via
+metadata, not made equal.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BOT_PY = REPO_ROOT / "telegram_bot" / "bot.py"
+
+
+def _dict_string_keys(node: ast.Dict) -> set[str]:
+    return {k.value for k in node.keys if isinstance(k, ast.Constant) and isinstance(k.value, str)}
+
+
+def _is_supervisor_thread_id_call(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_supervisor_thread_id"
+    )
+
+
+def _supervisor_configurable_keysets(tree: ast.AST) -> list[set[str]]:
+    """Key-sets of every ``"configurable": {...}`` whose thread_id is built by
+    ``_supervisor_thread_id(...)`` (i.e. the supervisor/text-agent path)."""
+    out: list[set[str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        for key, value in zip(node.keys, node.values, strict=False):
+            if not (
+                isinstance(key, ast.Constant)
+                and key.value == "configurable"
+                and isinstance(value, ast.Dict)
+            ):
+                continue
+            tid_value = None
+            for k2, v2 in zip(value.keys, value.values, strict=False):
+                if isinstance(k2, ast.Constant) and k2.value == "thread_id":
+                    tid_value = v2
+            if tid_value is not None and _is_supervisor_thread_id_call(tid_value):
+                out.append(_dict_string_keys(value))
+    return out
+
+
+def _emits_thread_id_to_trace(source: str) -> bool:
+    return "update_current_trace" in source and "langgraph_thread_id" in source
+
+
+class TestSupervisorThreadSessionColocation:
+    def test_bot_py_exists(self) -> None:
+        assert BOT_PY.exists(), f"missing: {BOT_PY}"
+
+    def test_supervisor_configurable_has_thread_and_session(self) -> None:
+        tree = ast.parse(BOT_PY.read_text(encoding="utf-8"))
+        keysets = _supervisor_configurable_keysets(tree)
+        assert keysets, (
+            "expected at least one supervisor 'configurable' using _supervisor_thread_id"
+        )
+        offenders = [keys for keys in keysets if "session_id" not in keys]
+        assert not offenders, (
+            "Every supervisor 'configurable' (thread_id via _supervisor_thread_id) "
+            "must also carry session_id so the LangGraph<->Langfuse mapping stays "
+            f"recoverable (#2224). Offending key-sets: {offenders}"
+        )
+
+
+class TestTraceLinkage:
+    def test_bot_py_records_langgraph_thread_id_on_trace(self) -> None:
+        source = BOT_PY.read_text(encoding="utf-8")
+        assert _emits_thread_id_to_trace(source), (
+            "telegram_bot/bot.py must record the checkpointer thread_id on the "
+            "Langfuse trace as langgraph_thread_id metadata via "
+            "update_current_trace(...) so operators can correlate a trace to the "
+            "LangGraph conversation state (#2224)."
+        )
+
+
+class TestDetectorSelfChecks:
+    _COLOCATED = (
+        "config = {'configurable': {'thread_id': _supervisor_thread_id(c), "
+        "'session_id': sid, 'role': r}}\n"
+    )
+    _MISSING_SESSION = (
+        "config = {'configurable': {'thread_id': _supervisor_thread_id(c), 'role': r}}\n"
+    )
+    _VOICE_PATH = "cfg = {'configurable': {'thread_id': str(uid), 'checkpoint_ns': ns}}\n"
+    _BARE_THREAD = "draft_state = {'thread_id': forum_thread_id}\n"
+
+    def test_supervisor_colocated_passes(self) -> None:
+        keysets = _supervisor_configurable_keysets(ast.parse(self._COLOCATED))
+        assert keysets == [{"thread_id", "session_id", "role"}]
+
+    def test_missing_session_is_detectable(self) -> None:
+        keysets = _supervisor_configurable_keysets(ast.parse(self._MISSING_SESSION))
+        assert keysets == [{"thread_id", "role"}]
+        assert "session_id" not in keysets[0]
+
+    def test_voice_path_excluded(self) -> None:
+        # thread_id is not built by _supervisor_thread_id -> out of scope
+        assert _supervisor_configurable_keysets(ast.parse(self._VOICE_PATH)) == []
+
+    def test_bare_thread_dict_excluded(self) -> None:
+        assert _supervisor_configurable_keysets(ast.parse(self._BARE_THREAD)) == []
+
+    def test_trace_linkage_detector(self) -> None:
+        assert _emits_thread_id_to_trace(
+            "lf.update_current_trace(metadata={'langgraph_thread_id': tid})"
+        )
+        assert not _emits_thread_id_to_trace("lf.update_current_span(metadata={'x': 1})")


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Addresses #2224 (unify LangGraph `thread_id` with Langfuse `session_id`; link traces). `verify:repo-only`, observability/langgraph — continues the single-trace correlation thread.

## Key finding — the issue's literal proposal is unsafe

#2224 suggests `config["configurable"]["thread_id"] = session_id`. But `make_session_id` is **date-rotating** (`chat-<hash>-<YYYYMMDD>`) while the LangGraph checkpointer thread (`_supervisor_thread_id` → `tg_<chat_id>`) is **persistent**. Setting `thread_id = session_id` would rotate the checkpointer key daily and **reset conversation memory every midnight**.

So this PR achieves the operational goal (correlate a Langfuse trace → LangGraph state) **without** that regression: it *links* the identifiers via trace metadata instead of unifying them.

## Changes

- **`telegram_bot/bot.py`** — at both supervisor invoke config sites, record the checkpointer `thread_id` on the Langfuse trace as `langgraph_thread_id` metadata via `update_current_trace(...)`, guarded for a missing client (`get_client()` can be `None`). `thread_id` is unchanged.
- **`docs/BOT_INTERNAL_STRUCTURE.md`** — new section documenting the two identifiers (source/format/lifetime) and the deliberate non-unification rationale.
- **`tests/contract/test_thread_session_link_contract.py`** (new) — AST contract: (a) every supervisor `configurable` (thread_id via `_supervisor_thread_id`) co-locates `session_id`; (b) `bot.py` emits `langgraph_thread_id` to the trace. Detector self-checks prove it flags a missing `session_id` and excludes the voice / bare-thread dicts (8 tests).

## TDD

- The broad first cut of the contract **caught real divergence** (voice path `str(from_user.id)` and HITL `Command(resume=...)` configs lack `session_id`); I narrowed scope to the supervisor path (`_supervisor_thread_id`) — those out-of-scope flows are documented follow-ups.
- Final: contract **8 passed**; `bot.py` `py_compile` clean; markdown-link checker green; `ruff check`/`format` clean.

SDK semantics verified via Context7 (`/langfuse/langfuse-python`): `update_current_span`/`update_current_trace` `metadata` param. Content rephrased for compliance.

## Acceptance criteria (#2224)

- [x] Operator can correlate a Langfuse trace → LangGraph checkpointer thread (`langgraph_thread_id` on the trace; `thread_id` already in `configurable`).
- [x] Contract test catches future drift (co-location + linkage).
- [x] Mapping documented in `docs/BOT_INTERNAL_STRUCTURE.md`.
- [ ] `thread_id == session_id` unification — **intentionally not done** (would reset checkpointer daily); rationale documented; revisit only if daily-scoped conversations become desired.
- [ ] Interrupt/resume bidirectional `resumes_trace_id` linkage — deferred (HITL `Command(resume=...)` path, follow-up on #2224).