### PR TITLE
observability(hygiene): strip @observe from deprecated ColBERT reranker (#2214)

### DIFF
--- a/telegram_bot/services/colbert_reranker.py
+++ b/telegram_bot/services/colbert_reranker.py
@@ -12,7 +12,6 @@ import logging
 import os
 import warnings
 
-from telegram_bot.observability import observe
 from telegram_bot.services.bge_m3_client import BGEM3Client
 
 
@@ -49,7 +48,6 @@ class ColbertRerankerService:
         self._client = client or BGEM3Client(base_url=base_url, timeout=timeout)
         logger.info("ColbertRerankerService initialized: %s (timeout=%ss)", base_url, timeout)
 
-    @observe(name="colbert-rerank")
     async def rerank(
         self,
         query: str,

--- a/tests/contract/test_colbert_observe_removed_contract.py
+++ b/tests/contract/test_colbert_observe_removed_contract.py
@@ -1,0 +1,102 @@
+"""Deprecated ColBERT reranker must not carry @observe (#2214).
+
+`ColbertRerankerService` is deprecated — server-side ColBERT via
+`hybrid_search_rrf_colbert()` (#569) is the production path, emitting the
+`qdrant-hybrid-search-rrf-colbert` span. If the client-side service keeps an
+`@observe(name="colbert-rerank")` and is ever re-enabled, it double-emits a
+second reranking span. This contract locks the decorator out and keeps the
+deprecated module from re-introducing the span catalog entry.
+
+It also documents the rule that `colbert-rerank` is intentionally absent from
+the `trace_contract.yaml` span catalog (removed alongside the decorator).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COLBERT_MODULE = REPO_ROOT / "telegram_bot" / "services" / "colbert_reranker.py"
+TRACE_CONTRACT = REPO_ROOT / "tests" / "observability" / "trace_contract.yaml"
+
+
+def _observe_calls(source: str) -> list[str]:
+    """Return @observe(name=...) names found in the module (decorator or call)."""
+    tree = ast.parse(source)
+    names: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        is_observe = (isinstance(func, ast.Attribute) and func.attr == "observe") or (
+            isinstance(func, ast.Name) and func.id == "observe"
+        )
+        if not is_observe:
+            continue
+        name_found: str | None = None
+        for kw in node.keywords:
+            if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+                name_found = kw.value.value
+        names.append(name_found if name_found is not None else "<observe>")
+    return names
+
+
+def _imports_observe(source: str) -> bool:
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and any(a.name == "observe" for a in node.names):
+            return True
+    return False
+
+
+def _all_catalog_spans(contract: dict) -> set[str]:
+    spans: set[str] = set(contract.get("required_families", []))
+    for group in (contract.get("spans") or {}).values():
+        if isinstance(group, list):
+            spans.update(group)
+    return spans
+
+
+class TestColbertObserveRemoved:
+    def test_module_exists(self) -> None:
+        assert COLBERT_MODULE.exists(), f"missing: {COLBERT_MODULE}"
+
+    def test_no_observe_decorator_in_deprecated_module(self) -> None:
+        source = COLBERT_MODULE.read_text(encoding="utf-8")
+        found = _observe_calls(source)
+        assert not found, (
+            "Deprecated ColbertRerankerService must not carry @observe (#2214): "
+            f"found {found}. Server-side ColBERT (qdrant-hybrid-search-rrf-colbert) "
+            "is the production span; a client-side colbert-rerank span double-emits."
+        )
+
+    def test_module_does_not_import_observe(self) -> None:
+        source = COLBERT_MODULE.read_text(encoding="utf-8")
+        assert not _imports_observe(source), (
+            "colbert_reranker.py should not import `observe` once the decorator is removed."
+        )
+
+    def test_colbert_rerank_absent_from_span_catalog(self) -> None:
+        contract = yaml.safe_load(TRACE_CONTRACT.read_text(encoding="utf-8"))
+        spans = _all_catalog_spans(contract)
+        assert "colbert-rerank" not in spans, (
+            "'colbert-rerank' must be removed from trace_contract.yaml when the "
+            "deprecated @observe is stripped, or the trace-families contract "
+            "(all_contract_spans_exist_in_codebase) will fail."
+        )
+
+
+class TestDetectorSelfChecks:
+    def test_detects_observe_decorator(self) -> None:
+        src = "from telegram_bot.observability import observe\n@observe(name='x')\ndef f():\n    pass\n"
+        assert _observe_calls(src) == ["x"]
+        assert _imports_observe(src)
+
+    def test_clean_module_has_none(self) -> None:
+        src = "def f():\n    return 1\n"
+        assert _observe_calls(src) == []
+        assert not _imports_observe(src)

--- a/tests/contract/test_colbert_observe_removed_contract.py
+++ b/tests/contract/test_colbert_observe_removed_contract.py
@@ -62,7 +62,7 @@ def _all_catalog_spans(contract: dict) -> set[str]:
 
 
 class TestColbertObserveRemoved:
-    def test_module_exists(self) -> None:
+    def test_colbert_module_exists(self) -> None:
         assert COLBERT_MODULE.exists(), f"missing: {COLBERT_MODULE}"
 
     def test_no_observe_decorator_in_deprecated_module(self) -> None:
@@ -91,12 +91,12 @@ class TestColbertObserveRemoved:
 
 
 class TestDetectorSelfChecks:
-    def test_detects_observe_decorator(self) -> None:
+    def test_colbert_detector_detects_observe(self) -> None:
         src = "from telegram_bot.observability import observe\n@observe(name='x')\ndef f():\n    pass\n"
         assert _observe_calls(src) == ["x"]
         assert _imports_observe(src)
 
-    def test_clean_module_has_none(self) -> None:
+    def test_colbert_detector_clean_module_has_none(self) -> None:
         src = "def f():\n    return 1\n"
         assert _observe_calls(src) == []
         assert not _imports_observe(src)

--- a/tests/contract/test_span_coverage_contract.py
+++ b/tests/contract/test_span_coverage_contract.py
@@ -72,7 +72,6 @@ LIGHT_SPANS = [
     "grade-documents",
     "rerank",
     "query-rewrite",
-    "colbert-rerank",
 ]
 
 

--- a/tests/observability/trace_contract.yaml
+++ b/tests/observability/trace_contract.yaml
@@ -346,7 +346,6 @@ spans:
     - get-prompt
     - kommo-token-refresh
     - cross-encoder-rerank
-    - colbert-rerank
     - session-summary-check
     - lead-score-upsert
     - funnel-rollup


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes the **deprecated-ColBERT `@observe`** item of #2214 (the one I deferred in PR #2268 due to span-catalog coupling — now done cleanly).

`ColbertRerankerService` is deprecated: server-side ColBERT via `hybrid_search_rrf_colbert()` (#569) is the production path and already emits `qdrant-hybrid-search-rrf-colbert`. The client-side service kept `@observe(name="colbert-rerank")`, which would **double-emit** a second reranking span if it were ever re-enabled.

## The catalog coupling (why this is 4 coordinated edits)

`tests/contract/test_trace_families_contract.py` asserts **both** directions:
- `test_all_contract_spans_exist_in_codebase` — every YAML catalog span must have an `@observe` in code.
- `test_no_undocumented_observe_spans` — every `@observe` in code must be in the YAML catalog.

So the decorator and the catalog entry must be removed **together**.

## Changes

- **`telegram_bot/services/colbert_reranker.py`** — remove the `@observe` decorator + the now-unused `observe` import.
- **`tests/observability/trace_contract.yaml`** — drop `colbert-rerank` from `spans: services:` (sole occurrence).
- **`tests/contract/test_span_coverage_contract.py`** — drop the stale `colbert-rerank` `LIGHT_SPANS` entry.
- **`tests/contract/test_colbert_observe_removed_contract.py`** (new) — lock-in contract: the deprecated module carries no `@observe`/`observe` import, and `colbert-rerank` is absent from the span catalog; with AST detector self-checks.

## TDD

- New lock-in contract written first — RED (3 failed: decorator present, import present, catalog entry present).
- After the strip — GREEN. Full contract sweep (lock-in + `test_trace_families_contract` + `test_span_coverage_contract`) **214 passed**.
- Existing `tests/unit/test_colbert_reranker.py` (behavior) still **4 passed** — removing `@observe` doesn't change the deprecated service's behavior; the `DeprecationWarning` in `__init__` is untouched.
- `ruff check` + `ruff format --check` clean.

## Remaining #2214 items (still deferred)

Whisper double-emit (runtime/SDK-version), `demo_handler` (already `langfuse.openai`), global-lock thread-safety, PII shape contract, ingestion flush — independent follow-ups.