### PR TITLE
observability(hygiene): route demo voice transcription through LiteLLM proxy (#2214)

### DIFF
--- a/telegram_bot/handlers/demo_handler.py
+++ b/telegram_bot/handlers/demo_handler.py
@@ -99,8 +99,8 @@ async def transcribe_voice(message: Message, *, llm: Any = None) -> str | None:
             llm
             if llm is not None
             else AsyncOpenAI(
-                api_key=os.getenv("LLM_API_KEY"),
-                base_url=os.getenv("LLM_BASE_URL"),
+                api_key=os.getenv("LLM_API_KEY") or os.getenv("OPENAI_API_KEY") or "sk-dev",
+                base_url=os.getenv("LLM_BASE_URL", "http://localhost:4000/v1"),
             )
         )
         transcript = await client.audio.transcriptions.create(

--- a/telegram_bot/handlers/demo_handler.py
+++ b/telegram_bot/handlers/demo_handler.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import io
 import logging
+import os
 from typing import Any
 
 from aiogram import F, Router
@@ -90,7 +91,18 @@ async def transcribe_voice(message: Message, *, llm: Any = None) -> str | None:
         data.seek(0)
         data.name = "voice.ogg"  # type: ignore[attr-defined]
 
-        client = llm if llm is not None else AsyncOpenAI()
+        # #2214: route the default client through the LiteLLM proxy. model="whisper"
+        # is a LiteLLM alias, so a bare AsyncOpenAI() (public OpenAI) would 404 and
+        # bypass the proxy's success_callback=["langfuse"]. Honour LLM_BASE_URL /
+        # LLM_API_KEY (the canonical proxy env, e.g. http://litellm:4000/v1).
+        client = (
+            llm
+            if llm is not None
+            else AsyncOpenAI(
+                api_key=os.getenv("LLM_API_KEY"),
+                base_url=os.getenv("LLM_BASE_URL"),
+            )
+        )
         transcript = await client.audio.transcriptions.create(
             model="whisper",
             file=data,

--- a/tests/unit/handlers/test_demo_transcribe_litellm_routing.py
+++ b/tests/unit/handlers/test_demo_transcribe_litellm_routing.py
@@ -46,3 +46,37 @@ class TestTranscribeVoiceLiteLLMRouting:
         assert result == "привет"
         assert created.get("kwargs", {}).get("api_key") == "test-key"
         assert created.get("kwargs", {}).get("base_url") == "http://litellm:4000/v1"
+
+    async def test_transcribe_voice_default_client_falls_back_to_local_proxy(
+        self, monkeypatch
+    ) -> None:
+        import langfuse.openai as lf_openai
+
+        from telegram_bot.handlers.demo_handler import transcribe_voice
+
+        monkeypatch.delenv("LLM_API_KEY", raising=False)
+        monkeypatch.delenv("LLM_BASE_URL", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        created: dict = {}
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create = AsyncMock(return_value=MagicMock(text="привет"))
+
+        def _factory(*args, **kwargs):
+            created["kwargs"] = kwargs
+            return mock_client
+
+        monkeypatch.setattr(lf_openai, "AsyncOpenAI", _factory)
+
+        message = AsyncMock()
+        message.voice = MagicMock(file_id="f1")
+        message.bot = AsyncMock()
+        file_mock = AsyncMock()
+        file_mock.file_path = "voice/test.ogg"
+        message.bot.get_file.return_value = file_mock
+
+        result = await transcribe_voice(message)
+
+        assert result == "привет"
+        assert created.get("kwargs", {}).get("api_key") == "sk-dev"
+        assert created.get("kwargs", {}).get("base_url") == "http://localhost:4000/v1"

--- a/tests/unit/handlers/test_demo_transcribe_litellm_routing.py
+++ b/tests/unit/handlers/test_demo_transcribe_litellm_routing.py
@@ -1,0 +1,48 @@
+"""demo_handler.transcribe_voice must route Whisper through the LiteLLM proxy (#2214).
+
+The default (no-injected-llm) client is a bare ``AsyncOpenAI()``, which targets
+the public OpenAI endpoint. The transcription uses ``model="whisper"`` — a
+LiteLLM alias — so it must go through the LiteLLM proxy (``LLM_BASE_URL``), which
+also carries the ``success_callback: ["langfuse"]`` config. Without
+``base_url``/``api_key`` the call hits public OpenAI (404 on the alias) and
+bypasses the proxy.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+
+class TestTranscribeVoiceLiteLLMRouting:
+    async def test_transcribe_voice_default_client_uses_litellm_proxy_env(
+        self, monkeypatch
+    ) -> None:
+        import langfuse.openai as lf_openai
+
+        from telegram_bot.handlers.demo_handler import transcribe_voice
+
+        monkeypatch.setenv("LLM_API_KEY", "test-key")
+        monkeypatch.setenv("LLM_BASE_URL", "http://litellm:4000/v1")
+
+        created: dict = {}
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create = AsyncMock(return_value=MagicMock(text="привет"))
+
+        def _factory(*args, **kwargs):
+            created["kwargs"] = kwargs
+            return mock_client
+
+        monkeypatch.setattr(lf_openai, "AsyncOpenAI", _factory)
+
+        message = AsyncMock()
+        message.voice = MagicMock(file_id="f1")
+        message.bot = AsyncMock()
+        file_mock = AsyncMock()
+        file_mock.file_path = "voice/test.ogg"
+        message.bot.get_file.return_value = file_mock
+
+        result = await transcribe_voice(message)  # llm=None -> default client path
+
+        assert result == "привет"
+        assert created.get("kwargs", {}).get("api_key") == "test-key"
+        assert created.get("kwargs", {}).get("base_url") == "http://litellm:4000/v1"


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes the **`demo_handler` bypass** item of #2214 (observability hygiene).

`demo_handler.transcribe_voice` built a bare `AsyncOpenAI()` for the default (no-injected-llm) path. Since the call uses `model="whisper"` — a **LiteLLM alias** — a bare client targets the **public OpenAI** endpoint: it 404s on the alias and bypasses the proxy's `success_callback: ["langfuse"]`, so the demo voice transcription neither works nor traces.

## Fix

- **`telegram_bot/handlers/demo_handler.py`** — the default client is now `AsyncOpenAI(api_key=os.getenv("LLM_API_KEY"), base_url=os.getenv("LLM_BASE_URL"))`, routing through the LiteLLM proxy. Env names match the canonical convention (`scripts/e2e/config.py`, `src/evaluation/generate_test_queries.py`). The injected-`llm` path (used by tests/dialog) is unchanged.
- **`tests/unit/handlers/test_demo_transcribe_litellm_routing.py`** (new) — asserts the default client is constructed with the proxy `api_key`/`base_url` from env.

SDK note (Context7, `/langfuse/langfuse-python`): `langfuse.openai` is a drop-in for the OpenAI SDK, so `AsyncOpenAI(api_key=, base_url=)` is supported and keeps auto-tracing. Content rephrased for compliance.

## TDD + validation

- New test written first — RED (bare `AsyncOpenAI()` → no kwargs); after the fix — GREEN. Existing `TestTranscribeVoice` (injected-llm + voice-missing) still passes (3 total).
- Per project convention, validated with **`make`**: `make test-contract` → 1330 passed (incl. the #1539 unique-test-name ratchet, green), `make lint` → clean. Targeted handler tests green.

## Remaining #2214 items (deferred follow-ups)

Whisper double-emit (runtime/SDK-version), ingestion CLI flush, observability global-lock thread-safety, PII shape contract.