### PR TITLE
fix(observability): thread-safe Langfuse init + explicit ingestion CLI flush (#2214)

### DIFF
--- a/src/ingestion/unified/cli.py
+++ b/src/ingestion/unified/cli.py
@@ -17,7 +17,11 @@ from src.ingestion.unified.colbert_backfill import (
     compute_colbert_coverage,
     inspect_collection_schema,
 )
-from src.ingestion.unified.observability import observe, try_update_ingestion_trace
+from src.ingestion.unified.observability import (
+    flush_ingestion_traces,
+    observe,
+    try_update_ingestion_trace,
+)
 
 
 def setup_logging(verbose: bool = False) -> None:
@@ -721,24 +725,30 @@ def main() -> int:
     args = parser.parse_args()
     setup_logging(args.verbose)
 
-    if args.command == "run":
-        return cmd_run(args)
-    if args.command == "status":
-        return asyncio.run(cmd_status(args))
-    if args.command == "preflight":
-        return asyncio.run(cmd_preflight(args))
-    if args.command == "bootstrap":
-        return asyncio.run(cmd_bootstrap(args))
-    if args.command == "schema-check":
-        return asyncio.run(cmd_schema_check(args))
-    if args.command == "coverage-check":
-        return asyncio.run(cmd_coverage_check(args))
-    if args.command == "backfill-colbert":
-        return cmd_backfill_colbert(args)
-    if args.command == "reprocess":
-        return asyncio.run(cmd_reprocess(args))
+    # #2214: ensure buffered ingestion traces are flushed even if a command
+    # raises or exits abruptly (the BatchSpanProcessor only auto-flushes on a
+    # clean atexit). flush_ingestion_traces() is a no-op when tracing is off.
+    try:
+        if args.command == "run":
+            return cmd_run(args)
+        if args.command == "status":
+            return asyncio.run(cmd_status(args))
+        if args.command == "preflight":
+            return asyncio.run(cmd_preflight(args))
+        if args.command == "bootstrap":
+            return asyncio.run(cmd_bootstrap(args))
+        if args.command == "schema-check":
+            return asyncio.run(cmd_schema_check(args))
+        if args.command == "coverage-check":
+            return asyncio.run(cmd_coverage_check(args))
+        if args.command == "backfill-colbert":
+            return cmd_backfill_colbert(args)
+        if args.command == "reprocess":
+            return asyncio.run(cmd_reprocess(args))
 
-    return 1
+        return 1
+    finally:
+        flush_ingestion_traces()
 
 
 if __name__ == "__main__":

--- a/src/ingestion/unified/observability.py
+++ b/src/ingestion/unified/observability.py
@@ -5,16 +5,32 @@ from __future__ import annotations
 from contextlib import suppress
 from typing import Any
 
-from src.observability import make_lifecycle_session_id, observe, update_lifecycle_trace
+from src.observability import (
+    flush_langfuse,
+    make_lifecycle_session_id,
+    observe,
+    update_lifecycle_trace,
+)
 
 
 INGESTION_TAGS = ["ingestion", "unified"]
 __all__ = [
+    "flush_ingestion_traces",
     "ingestion_session_id",
     "observe",
     "try_update_ingestion_trace",
     "update_ingestion_trace",
 ]
+
+
+def flush_ingestion_traces() -> None:
+    """Flush buffered ingestion traces on shutdown (best-effort, #2214).
+
+    Wraps :func:`src.observability.flush_langfuse` so CLI entry points can call
+    a single ingestion-scoped helper in a ``finally`` block without reaching
+    across module boundaries. No-op when tracing was never initialized.
+    """
+    flush_langfuse()
 
 
 def ingestion_session_id(command: str) -> str:

--- a/src/observability.py
+++ b/src/observability.py
@@ -13,6 +13,7 @@ import contextlib
 import json
 import logging
 import os
+import threading
 import warnings
 from datetime import UTC, datetime
 from typing import Any
@@ -120,6 +121,13 @@ except Exception as _e:
 
 _langfuse_client: Langfuse | None = None
 _langfuse_init_attempted = False
+# #2214: guard the lazy singleton init. Without a lock, two startup threads can
+# both pass the ``_langfuse_client is None`` check and each construct a Langfuse
+# client + register an atexit shutdown; the second client overwrites the global
+# and the first leaks (its buffered spans are never flushed). Use a re-entrant
+# lock so a thread already inside ``initialize_langfuse`` can call it again
+# (e.g. via ``get_langfuse_client``) without deadlocking.
+_langfuse_init_lock = threading.RLock()
 
 
 # ---------------------------------------------------------------------------
@@ -489,7 +497,32 @@ def initialize_langfuse(
 
     Returns None when credentials are missing, endpoint unreachable, or client creation fails.
     When the endpoint is unreachable, logs a WARNING once and skips OTEL exporter registration.
+
+    Thread-safe (#2214): initialization is serialized by ``_langfuse_init_lock``
+    so concurrent startup threads cannot each build a client and
+    double-register the atexit shutdown hook (the second client would
+    overwrite the global and the first would never flush).
     """
+    # Fast path: already initialized — avoid lock contention on the hot path.
+    if _langfuse_client is not None and not force:
+        return _langfuse_client
+    with _langfuse_init_lock:
+        return _initialize_langfuse_locked(
+            public_key=public_key,
+            secret_key=secret_key,
+            host=host,
+            force=force,
+        )
+
+
+def _initialize_langfuse_locked(
+    *,
+    public_key: str | None,
+    secret_key: str | None,
+    host: str | None,
+    force: bool,
+) -> Langfuse | None:
+    """Body of :func:`initialize_langfuse`; must run while holding the lock."""
     global _langfuse_client
     global _langfuse_init_attempted
     global _langfuse_endpoint_warned
@@ -596,6 +629,24 @@ def get_langfuse_client() -> Langfuse | None:
     if _langfuse_client is not None:
         return _langfuse_client
     return initialize_langfuse()
+
+
+def flush_langfuse() -> None:
+    """Flush buffered spans/scores on the initialized client, if one exists.
+
+    #2214: the ``BatchSpanProcessor`` flushes on a clean ``atexit``, but a hard
+    ``os._exit()`` or a signal kill drops whatever is still buffered. Long-lived
+    CLI entry points (e.g. ingestion) should call this in a ``finally`` block so
+    their lifecycle traces are not silently lost on abrupt shutdown.
+
+    This is a no-op when no client has been initialized (so it never triggers a
+    lazy init just to flush) and swallows flush errors — losing observability on
+    shutdown must never crash the caller.
+    """
+    if _langfuse_client is None:
+        return
+    with contextlib.suppress(Exception):
+        _langfuse_client.flush()
 
 
 def traced_pipeline(

--- a/tests/unit/ingestion/test_unified_cli.py
+++ b/tests/unit/ingestion/test_unified_cli.py
@@ -975,3 +975,44 @@ class TestMainDispatch:
             main()
 
         mock_logging.assert_called_once_with(True)
+
+
+
+# ---------------------------------------------------------------------------
+# main() lifecycle flush (#2214)
+# ---------------------------------------------------------------------------
+
+
+class TestMainFlushesIngestionTraces:
+    """main() must flush buffered ingestion traces in a finally block (#2214).
+
+    The BatchSpanProcessor only auto-flushes on a clean atexit; a command that
+    raises (or an abrupt exit) would otherwise drop buffered ingestion spans.
+    """
+
+    def test_main_flushes_on_success(self):
+        from src.ingestion.unified import cli
+
+        with (
+            patch.object(cli, "cmd_run", return_value=0) as mock_cmd,
+            patch.object(cli, "flush_ingestion_traces") as mock_flush,
+            patch("sys.argv", ["unified", "run"]),
+        ):
+            result = cli.main()
+
+        assert result == 0
+        mock_cmd.assert_called_once()
+        mock_flush.assert_called_once_with()
+
+    def test_main_flushes_even_when_command_raises(self):
+        from src.ingestion.unified import cli
+
+        with (
+            patch.object(cli, "cmd_run", side_effect=RuntimeError("boom")),
+            patch.object(cli, "flush_ingestion_traces") as mock_flush,
+            patch("sys.argv", ["unified", "run"]),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            cli.main()
+
+        mock_flush.assert_called_once_with()

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -1,6 +1,8 @@
 # tests/unit/test_observability.py
 """Unit tests for PII masking and Langfuse client initialization."""
 
+import threading
+import time
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -318,6 +320,112 @@ class TestLangfuseFlushConfig:
 
         assert result is None
         mock_atexit.register.assert_not_called()
+
+
+class TestFlushLangfuse:
+    """Tests for flush_langfuse() shutdown helper (#2214)."""
+
+    def test_flush_calls_client_flush_when_initialized(self):
+        import src.observability as observability
+
+        fake_client = MagicMock()
+        observability._langfuse_client = fake_client
+        try:
+            observability.flush_langfuse()
+            fake_client.flush.assert_called_once_with()
+        finally:
+            observability._reset_langfuse_client_for_tests()
+
+    def test_flush_is_noop_and_does_not_lazy_init_when_no_client(self):
+        """flush_langfuse() must not trigger a lazy init just to flush."""
+        import src.observability as observability
+
+        observability._reset_langfuse_client_for_tests()
+        with patch("src.observability.initialize_langfuse") as mock_init:
+            observability.flush_langfuse()  # should not raise
+            mock_init.assert_not_called()
+
+    def test_flush_swallows_client_errors(self):
+        """A failing flush on shutdown must never propagate to the caller."""
+        import src.observability as observability
+
+        fake_client = MagicMock()
+        fake_client.flush.side_effect = RuntimeError("boom")
+        observability._langfuse_client = fake_client
+        try:
+            observability.flush_langfuse()  # must not raise
+            fake_client.flush.assert_called_once_with()
+        finally:
+            observability._reset_langfuse_client_for_tests()
+
+
+class TestLangfuseInitThreadSafety:
+    """initialize_langfuse() must be safe under concurrent startup (#2214)."""
+
+    def test_concurrent_init_creates_single_client(self, monkeypatch):
+        """Many threads racing into init must build exactly one Langfuse client.
+
+        Without a lock, multiple threads pass the ``_langfuse_client is None``
+        check together and each construct a client + register an atexit hook.
+        A slow constructor widens that race window so the test is deterministic.
+        """
+        import src.observability as observability
+
+        observability._reset_langfuse_client_for_tests()
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+        monkeypatch.delenv("LANGFUSE_HOST", raising=False)
+
+        construct_count = 0
+        count_lock = threading.Lock()
+
+        def _slow_factory(*_args, **_kwargs):
+            nonlocal construct_count
+            with count_lock:
+                construct_count += 1
+            time.sleep(0.05)  # widen the race window
+            return MagicMock()
+
+        n_threads = 8
+        barrier = threading.Barrier(n_threads)
+        results: list[object] = []
+        results_lock = threading.Lock()
+
+        def _worker():
+            barrier.wait()  # release all threads simultaneously
+            client = observability.initialize_langfuse()
+            with results_lock:
+                results.append(client)
+
+        with (
+            patch("src.observability.Langfuse", side_effect=_slow_factory),
+            patch("src.observability.sync_langfuse_model_definitions", return_value=0),
+            patch("src.observability.atexit") as mock_atexit,
+            patch(
+                "src.observability_otel.activate_otel_instrumentations",
+                lambda: None,
+            ),
+        ):
+            threads = [threading.Thread(target=_worker) for _ in range(n_threads)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            try:
+                assert construct_count == 1, (
+                    f"Langfuse client constructed {construct_count} times under "
+                    "concurrency; initialize_langfuse must be serialized (#2214)."
+                )
+                assert mock_atexit.register.call_count == 1, (
+                    "atexit shutdown hook registered "
+                    f"{mock_atexit.register.call_count} times; only the single "
+                    "surviving client should register one (#2214)."
+                )
+                # Every caller observes the same single client instance.
+                assert len({id(r) for r in results}) == 1
+            finally:
+                observability._reset_langfuse_client_for_tests()
 
 
 class TestEndpointReachability:


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Addresses two repo-only hygiene findings from the #2214 audit grab-bag with TDD.

### 1. [P2] Thread-safe Langfuse init (`src/observability.py`)

The `_langfuse_client` module global was not thread-safe. Two startup threads could both pass the `_langfuse_client is None` check and each construct a `Langfuse` client + register an `atexit` shutdown hook; the second client overwrote the global and the first leaked (its buffered spans never flushed).

- Added a module-level `threading.RLock` (`_langfuse_init_lock`).
- Refactored `initialize_langfuse()` into a thin lock wrapper + `_initialize_langfuse_locked()` body. The already-initialized fast path stays lock-free (double-checked locking).

### 2. [P2] Explicit ingestion CLI flush (`src/ingestion/unified/cli.py`)

`main()` never flushed Langfuse. The `BatchSpanProcessor` only auto-flushes on a clean `atexit`; a hard `os._exit()` / signal kill drops buffered ingestion spans.

- Wrapped the command dispatch in `try/finally` and call a new `flush_ingestion_traces()` (in `src/ingestion/unified/observability.py`), which wraps a new `src.observability.flush_langfuse()`.
- `flush_langfuse()` is a no-op when tracing is off and **never lazy-inits** just to flush; flush errors are swallowed (losing observability on shutdown must never crash the caller).

## Testing (TDD)

- `tests/unit/test_observability.py`:
  - `TestFlushLangfuse` — flush/no-op/error-swallow behavior.
  - `TestLangfuseInitThreadSafety` — concurrent init creates exactly one client + one atexit registration. **Verified red without the lock** (8 clients constructed under 8 racing threads); green with the lock.
- `tests/unit/ingestion/test_unified_cli.py`:
  - `TestMainFlushesIngestionTraces` — `main()` flushes on success and even when the command raises.
- `pytest tests/unit/test_observability.py tests/unit/observability/ tests/unit/ingestion/test_unified_cli.py` — all pass (409 + 50, livekit-only skips). Ruff clean.

## Findings already complete on `dev` (confirmed, no change)

- `crm_callbacks.on_task_complete` already updates spans in both branches.
- Deprecated `ColbertRerankerService` already has `@observe` removed (guarded by `test_colbert_observe_removed_contract.py`).
- `demo_handler.transcribe_voice` already routes `AsyncOpenAI` through `LLM_BASE_URL`/`LLM_API_KEY`.

## Deferred (out of scope here)

- Whisper double-emit (finding 3) — needs runtime `langfuse[openai]` audio auto-trace verification (no Docker/live stack in this environment).
- PII-shape contract test (finding 6) — separate, higher-false-positive-risk addition.

No production/VPS/secrets/cloud/live CRM validation was performed (not required).
