### PR TITLE
feat(observability): link HITL interrupt/resume Langfuse traces (#2224)

### DIFF
--- a/docs/BOT_INTERNAL_STRUCTURE.md
+++ b/docs/BOT_INTERNAL_STRUCTURE.md
@@ -175,8 +175,25 @@ daily and reset conversation memory every midnight. The persistent
 metadata linkage are enforced by
 `tests/contract/test_thread_session_link_contract.py`.
 
-The voice path and the HITL `Command(resume=...)` path manage their own
-thread/session identifiers and are out of scope of that contract.
+### Interrupted/resumed (HITL) trace linkage
+
+A HITL confirmation pauses the graph with `interrupt()` and emits one Langfuse
+trace; the later `Command(resume=...)` click (`handle_hitl_callback`) emits a
+*separate* trace. To keep them correlated:
+
+- At confirmation time, `_send_hitl_confirmation` stores the interrupt trace id
+  keyed by `thread_id` via
+  `telegram_bot.agents.hitl.set_pending_resume_trace_id(...)`.
+- On resume, `handle_hitl_callback` reads it back with
+  `pop_pending_resume_trace_id(...)` and records `resumes_trace_id` metadata on
+  the resume trace via `propagate_attributes(metadata=...)`.
+
+So an operator can filter Langfuse by `resumes_trace_id` to walk from a resume
+trace to its originating interrupt (and from an interrupt forward to its
+resume). The store is a bounded, in-memory, best-effort map: if it is empty
+(tracing was off at interrupt time, or the entry was evicted) no link is
+recorded and the resume trace is simply unlinked. The voice path manages its
+own thread/session identifiers and is out of scope here.
 
 ## Finding Code
 

--- a/telegram_bot/agents/hitl.py
+++ b/telegram_bot/agents/hitl.py
@@ -7,7 +7,53 @@ clicks, the agent is resumed via Command(resume={"action": "approve"|"cancel"}).
 
 from __future__ import annotations
 
+import threading
+from collections import OrderedDict
+
 from langgraph.types import interrupt
+
+
+# ---------------------------------------------------------------------------
+# Pending resume trace-id store (#2224)
+# ---------------------------------------------------------------------------
+# A HITL interrupt emits one Langfuse trace; the later ``Command(resume=...)``
+# click emits a *separate* trace. To link them, the bot records the interrupt
+# trace id here (keyed by the checkpointer ``thread_id``) at confirmation time,
+# then reads it back when the resume trace starts and attaches it as
+# ``resumes_trace_id`` metadata. This is best-effort, in-memory observability
+# glue — a missing entry simply means no back-link is recorded — so the store
+# is bounded to avoid unbounded growth and guarded by a lock for thread safety.
+
+_PENDING_RESUME_TRACE_IDS: OrderedDict[str, str] = OrderedDict()
+_PENDING_RESUME_LOCK = threading.Lock()
+_PENDING_RESUME_MAX = 1024
+
+
+def set_pending_resume_trace_id(thread_id: str, trace_id: str | None) -> None:
+    """Remember the Langfuse trace id that emitted a HITL interrupt for *thread_id*.
+
+    No-op when either argument is empty so callers can pass
+    ``lf.get_current_trace_id()`` directly without guarding (#2224).
+    """
+    if not thread_id or not trace_id:
+        return
+    with _PENDING_RESUME_LOCK:
+        _PENDING_RESUME_TRACE_IDS[thread_id] = trace_id
+        _PENDING_RESUME_TRACE_IDS.move_to_end(thread_id)
+        while len(_PENDING_RESUME_TRACE_IDS) > _PENDING_RESUME_MAX:
+            _PENDING_RESUME_TRACE_IDS.popitem(last=False)
+
+
+def pop_pending_resume_trace_id(thread_id: str) -> str | None:
+    """Retrieve and clear the pending interrupt trace id for *thread_id* (#2224).
+
+    Returns ``None`` when nothing was stored (e.g. tracing disabled at interrupt
+    time or the entry was evicted).
+    """
+    if not thread_id:
+        return None
+    with _PENDING_RESUME_LOCK:
+        return _PENDING_RESUME_TRACE_IDS.pop(thread_id, None)
 
 
 def hitl_guard(

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -3489,7 +3489,9 @@ class PropertyBot:
         action = "approve" if data == "hitl:approve" else "cancel"
         user_id = callback.from_user.id
         chat_id = callback.message.chat.id
-        thread_id = _supervisor_thread_id(chat_id)
+        _raw_thread_id = callback.message.message_thread_id
+        forum_thread_id: int | None = _raw_thread_id if isinstance(_raw_thread_id, int) else None
+        thread_id = _supervisor_thread_id(chat_id, forum_thread_id)
 
         # #2224: link this resume trace back to the interrupt trace stored at
         # confirmation time. Langfuse trace metadata values are strings.
@@ -3584,7 +3586,10 @@ class PropertyBot:
         if response_text:
             bot = callback.message.bot  # type: ignore[union-attr]
             for chunk in _split_telegram_response(response_text):
-                await bot.send_message(chat_id=chat_id, text=chunk)  # type: ignore[union-attr]
+                send_kwargs: dict[str, Any] = {"chat_id": chat_id, "text": chunk}
+                if forum_thread_id is not None:
+                    send_kwargs["message_thread_id"] = forum_thread_id
+                await bot.send_message(**send_kwargs)  # type: ignore[union-attr]
 
         lf = get_client()
         lf.score_current_trace(name="hitl_action", value=action, data_type="CATEGORICAL")

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -3453,6 +3453,13 @@ class PropertyBot:
         """Send inline keyboard for HITL confirmation (#443)."""
         from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
+        from .agents.hitl import set_pending_resume_trace_id
+
+        # #2224: remember the trace that raised this interrupt so the later
+        # Command(resume=...) trace can back-link to it via resumes_trace_id.
+        with contextlib.suppress(Exception):
+            set_pending_resume_trace_id(thread_id, get_client().get_current_trace_id())
+
         preview = payload.get("preview", "Подтвердите операцию")
 
         keyboard = InlineKeyboardMarkup(
@@ -3483,6 +3490,15 @@ class PropertyBot:
         user_id = callback.from_user.id
         chat_id = callback.message.chat.id
         thread_id = _supervisor_thread_id(chat_id)
+
+        # #2224: link this resume trace back to the interrupt trace stored at
+        # confirmation time. Langfuse trace metadata values are strings.
+        from .agents.hitl import pop_pending_resume_trace_id
+
+        _parent_trace_id = pop_pending_resume_trace_id(thread_id)
+        _resume_trace_metadata = (
+            {"resumes_trace_id": _parent_trace_id} if _parent_trace_id else None
+        )
 
         await callback.answer("Принято" if action == "approve" else "Отменено")
 
@@ -3541,6 +3557,7 @@ class PropertyBot:
             session_id=session_id,
             user_id=str(user_id),
             tags=["telegram", "hitl", "resume"],
+            metadata=_resume_trace_metadata,
         ):
             from langgraph.types import Command
 

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -3489,7 +3489,7 @@ class PropertyBot:
         action = "approve" if data == "hitl:approve" else "cancel"
         user_id = callback.from_user.id
         chat_id = callback.message.chat.id
-        _raw_thread_id = callback.message.message_thread_id
+        _raw_thread_id = getattr(callback.message, "message_thread_id", None)
         forum_thread_id: int | None = _raw_thread_id if isinstance(_raw_thread_id, int) else None
         thread_id = _supervisor_thread_id(chat_id, forum_thread_id)
 

--- a/tests/contract/test_thread_session_link_contract.py
+++ b/tests/contract/test_thread_session_link_contract.py
@@ -84,6 +84,14 @@ def _records_resume_trace_link(source: str) -> bool:
     )
 
 
+def _resume_preserves_forum_thread_id(source: str) -> bool:
+    """HITL callbacks in forum topics must resume the same topic-scoped thread."""
+    return (
+        "callback.message.message_thread_id" in source
+        and "thread_id = _supervisor_thread_id(chat_id, forum_thread_id)" in source
+    )
+
+
 class TestSupervisorThreadSessionColocation:
     def test_bot_py_exists(self) -> None:
         assert BOT_PY.exists(), f"missing: {BOT_PY}"
@@ -134,6 +142,15 @@ class TestHitlResumeTraceLinkage:
             "propagate_attributes) so interrupted/resumed runs are linked (#2224)."
         )
 
+    def test_hitl_callback_uses_topic_scoped_thread_id(self) -> None:
+        source = BOT_PY.read_text(encoding="utf-8")
+        assert _resume_preserves_forum_thread_id(source), (
+            "handle_hitl_callback must recover callback.message.message_thread_id "
+            "and call _supervisor_thread_id(chat_id, forum_thread_id). Otherwise "
+            "forum-topic HITL resumes pop a different pending-resume key than "
+            "the interrupt stored, so resumes_trace_id is lost (#2224)."
+        )
+
 
 class TestDetectorSelfChecks:
     _COLOCATED = (
@@ -181,3 +198,11 @@ class TestDetectorSelfChecks:
         assert not _records_resume_trace_link(
             "set_pending_resume_trace_id(tid, parent)\npop_pending_resume_trace_id(tid)\n"
         )
+
+    def test_forum_thread_resume_detector(self) -> None:
+        good = (
+            "forum_thread_id = callback.message.message_thread_id\n"
+            "thread_id = _supervisor_thread_id(chat_id, forum_thread_id)\n"
+        )
+        assert _resume_preserves_forum_thread_id(good)
+        assert not _resume_preserves_forum_thread_id("thread_id = _supervisor_thread_id(chat_id)\n")

--- a/tests/contract/test_thread_session_link_contract.py
+++ b/tests/contract/test_thread_session_link_contract.py
@@ -75,6 +75,15 @@ def _emits_thread_id_to_trace(source: str) -> bool:
     return "propagate_attributes" in source and "langgraph_thread_id" in source
 
 
+def _records_resume_trace_link(source: str) -> bool:
+    """bot.py stores the interrupt trace id and back-links it on resume (#2224)."""
+    return (
+        "set_pending_resume_trace_id" in source
+        and "pop_pending_resume_trace_id" in source
+        and "resumes_trace_id" in source
+    )
+
+
 class TestSupervisorThreadSessionColocation:
     def test_bot_py_exists(self) -> None:
         assert BOT_PY.exists(), f"missing: {BOT_PY}"
@@ -101,6 +110,28 @@ class TestTraceLinkage:
             "Langfuse trace as langgraph_thread_id metadata via "
             "propagate_attributes(...) so operators can correlate a trace to "
             "the LangGraph conversation state (#2224)."
+        )
+
+
+class TestHitlResumeTraceLinkage:
+    """Interrupt -> resume traces must be linked via metadata (#2224).
+
+    A HITL interrupt emits one Langfuse trace; the later
+    ``Command(resume=...)`` click emits a *separate* trace. Without a link an
+    operator cannot tell the resume continued an earlier interrupted run. The
+    bot stores the interrupt trace id at confirmation time
+    (``set_pending_resume_trace_id``) and back-links it on the resume trace as
+    ``resumes_trace_id`` metadata (``pop_pending_resume_trace_id`` +
+    ``propagate_attributes``).
+    """
+
+    def test_bot_py_links_resume_trace_to_parent(self) -> None:
+        source = BOT_PY.read_text(encoding="utf-8")
+        assert _records_resume_trace_link(source), (
+            "telegram_bot/bot.py must store the interrupt trace id "
+            "(set_pending_resume_trace_id) and record resumes_trace_id metadata "
+            "on the resume trace (pop_pending_resume_trace_id + "
+            "propagate_attributes) so interrupted/resumed runs are linked (#2224)."
         )
 
 
@@ -137,4 +168,16 @@ class TestDetectorSelfChecks:
         )
         assert not _emits_thread_id_to_trace(
             "lf.update_current_generation(metadata={'langgraph_thread_id': tid})"
+        )
+
+    def test_resume_link_detector(self) -> None:
+        good = (
+            "set_pending_resume_trace_id(tid, parent)\n"
+            "p = pop_pending_resume_trace_id(tid)\n"
+            "propagate_attributes(metadata={'resumes_trace_id': p})\n"
+        )
+        assert _records_resume_trace_link(good)
+        # Missing the back-link metadata key -> not satisfied.
+        assert not _records_resume_trace_link(
+            "set_pending_resume_trace_id(tid, parent)\npop_pending_resume_trace_id(tid)\n"
         )

--- a/tests/contract/test_thread_session_link_contract.py
+++ b/tests/contract/test_thread_session_link_contract.py
@@ -87,7 +87,7 @@ def _records_resume_trace_link(source: str) -> bool:
 def _resume_preserves_forum_thread_id(source: str) -> bool:
     """HITL callbacks in forum topics must resume the same topic-scoped thread."""
     return (
-        "callback.message.message_thread_id" in source
+        'getattr(callback.message, "message_thread_id", None)' in source
         and "thread_id = _supervisor_thread_id(chat_id, forum_thread_id)" in source
     )
 
@@ -201,7 +201,7 @@ class TestDetectorSelfChecks:
 
     def test_forum_thread_resume_detector(self) -> None:
         good = (
-            "forum_thread_id = callback.message.message_thread_id\n"
+            '_raw_thread_id = getattr(callback.message, "message_thread_id", None)\n'
             "thread_id = _supervisor_thread_id(chat_id, forum_thread_id)\n"
         )
         assert _resume_preserves_forum_thread_id(good)

--- a/tests/unit/agents/test_hitl.py
+++ b/tests/unit/agents/test_hitl.py
@@ -239,3 +239,78 @@ async def test_crm_update_contact_cancel():
         )
     assert "Операция отменена" in result
     mock_kommo.update_contact.assert_not_called()
+
+
+
+# --- pending resume trace-id store (#2224) ---
+
+
+def _clear_pending_store() -> None:
+    from telegram_bot.agents import hitl
+
+    hitl._PENDING_RESUME_TRACE_IDS.clear()
+
+
+def test_pending_resume_trace_id_roundtrip():
+    """set then pop returns the stored parent trace id for a thread."""
+    from telegram_bot.agents.hitl import (
+        pop_pending_resume_trace_id,
+        set_pending_resume_trace_id,
+    )
+
+    _clear_pending_store()
+    set_pending_resume_trace_id("tg_42", "trace-abc")
+    assert pop_pending_resume_trace_id("tg_42") == "trace-abc"
+
+
+def test_pending_resume_trace_id_pop_is_one_shot():
+    """A second pop returns None — the entry is cleared on first read."""
+    from telegram_bot.agents.hitl import (
+        pop_pending_resume_trace_id,
+        set_pending_resume_trace_id,
+    )
+
+    _clear_pending_store()
+    set_pending_resume_trace_id("tg_42", "trace-abc")
+    assert pop_pending_resume_trace_id("tg_42") == "trace-abc"
+    assert pop_pending_resume_trace_id("tg_42") is None
+
+
+def test_pending_resume_trace_id_missing_returns_none():
+    from telegram_bot.agents.hitl import pop_pending_resume_trace_id
+
+    _clear_pending_store()
+    assert pop_pending_resume_trace_id("tg_does_not_exist") is None
+
+
+def test_pending_resume_trace_id_ignores_empty_inputs():
+    """Empty thread_id or trace_id must not create an entry."""
+    from telegram_bot.agents.hitl import (
+        pop_pending_resume_trace_id,
+        set_pending_resume_trace_id,
+    )
+
+    _clear_pending_store()
+    set_pending_resume_trace_id("", "trace-abc")
+    set_pending_resume_trace_id("tg_42", None)
+    set_pending_resume_trace_id("tg_42", "")
+    assert pop_pending_resume_trace_id("tg_42") is None
+
+
+def test_pending_resume_trace_id_store_is_bounded():
+    """The store evicts oldest entries past its cap (no unbounded growth)."""
+    from telegram_bot.agents import hitl
+    from telegram_bot.agents.hitl import (
+        pop_pending_resume_trace_id,
+        set_pending_resume_trace_id,
+    )
+
+    _clear_pending_store()
+    with patch.object(hitl, "_PENDING_RESUME_MAX", 3):
+        for i in range(5):
+            set_pending_resume_trace_id(f"tg_{i}", f"trace-{i}")
+        # Oldest two (tg_0, tg_1) evicted; newest three retained.
+        assert pop_pending_resume_trace_id("tg_0") is None
+        assert pop_pending_resume_trace_id("tg_1") is None
+        assert pop_pending_resume_trace_id("tg_4") == "trace-4"
+    _clear_pending_store()


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Addresses the remaining open task in #2224 — linking interrupted and resumed HITL Langfuse traces.

The core `thread_id` ↔ `session_id` mapping (co-location in `config["configurable"]` + `langgraph_thread_id` trace metadata) was **already implemented** on `dev` and guarded by `tests/contract/test_thread_session_link_contract.py` (8 passing tests). The one piece still missing — and explicitly marked "out of scope" by the old contract docstring — was the interrupt→resume trace linkage. This PR adds it.

## Problem

A HITL confirmation pauses the graph with `interrupt()` and emits **one** Langfuse trace. The later `Command(resume=...)` click (`handle_hitl_callback`) emits a **separate** trace. They were previously unlinked, so an operator couldn't tell a resume continued an earlier interrupted run.

## Changes

- **`telegram_bot/agents/hitl.py`** — new bounded, thread-safe, in-memory pending-resume store: `set_pending_resume_trace_id(thread_id, trace_id)` / `pop_pending_resume_trace_id(thread_id)`. Best-effort (no-op on empty inputs), capped at 1024 entries (LRU eviction).
- **`telegram_bot/bot.py`**:
  - `_send_hitl_confirmation` stores the interrupt trace id (`get_current_trace_id()`) keyed by checkpointer `thread_id`.
  - `handle_hitl_callback` pops it and records `resumes_trace_id` metadata on the resume trace via `propagate_attributes(metadata=...)` — the SDK-native, string-valued metadata pattern (same as `langgraph_thread_id`; confirmed via Context7).
- **`docs/BOT_INTERNAL_STRUCTURE.md`** — documents the interrupt/resume linkage and the best-effort/bounded semantics.

## Testing (TDD — verified red first)

- `tests/unit/agents/test_hitl.py`: store roundtrip, one-shot pop, missing key, empty-input no-op, bounded eviction (5 new tests).
- `tests/contract/test_thread_session_link_contract.py`: new `TestHitlResumeTraceLinkage` + detector self-check.
- `pytest tests/unit/test_bot_handlers.py tests/unit/agents/test_hitl.py tests/contract/test_thread_session_link_contract.py` → 231 passed. Ruff clean.

## Design notes / limitations

- `thread_id` and `session_id` are **intentionally not unified** (session_id is date-rotating; the checkpointer thread must persist) — they are linked via metadata, per the existing ADR/doc.
- The store is in-memory per bot process; a missing entry simply means no back-link is recorded.
- The **backward** parent-trace update (`resumed_into_trace_id`) is intentionally not attempted: Langfuse metadata filtering on `resumes_trace_id` already makes the relationship queryable in both directions, and updating an already-flushed parent trace is not cleanly supported by the v4 SDK from a different context.
- No production/VPS/secrets/cloud/live CRM validation was performed (not required).
