### PR TITLE
feat(observability): mark agent-loop entry points as_type=agent (#2216)

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -2205,7 +2205,6 @@ class PropertyBot:
         name="telegram-rag-supervisor",
         capture_input=False,
         capture_output=False,
-        as_type="agent",
     )
     async def _handle_query_supervisor(
         self,
@@ -2980,6 +2979,12 @@ class PropertyBot:
 
         return response_text
 
+    @observe(
+        name="telegram-rag-agent-stream",
+        capture_input=False,
+        capture_output=False,
+        as_type="agent",
+    )
     async def _astream_supervisor_with_recovery(
         self,
         *,
@@ -3122,6 +3127,12 @@ class PropertyBot:
         )
         return await _run_once(fallback_agent)
 
+    @observe(
+        name="telegram-rag-agent-invoke",
+        capture_input=False,
+        capture_output=False,
+        as_type="agent",
+    )
     async def _ainvoke_supervisor_with_recovery(
         self,
         *,

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -2201,7 +2201,12 @@ class PropertyBot:
             return None  # caller falls through to sdk_agent path
         return result.answer
 
-    @observe(name="telegram-rag-supervisor", capture_input=False, capture_output=False)
+    @observe(
+        name="telegram-rag-supervisor",
+        capture_input=False,
+        capture_output=False,
+        as_type="agent",
+    )
     async def _handle_query_supervisor(
         self,
         message: Message,
@@ -3469,7 +3474,7 @@ class PropertyBot:
             reply_markup=keyboard,
         )
 
-    @observe(name="telegram-hitl-callback")
+    @observe(name="telegram-hitl-callback", as_type="agent")
     async def handle_hitl_callback(self, callback: CallbackQuery) -> None:
         """Handle HITL approve/cancel button click (#443)."""
         from .agents.context import BotContext

--- a/tests/contract/test_observation_type_taxonomy_contract.py
+++ b/tests/contract/test_observation_type_taxonomy_contract.py
@@ -157,13 +157,21 @@ class TestAgentToolAndGuardTaxonomy:
         )
 
 
-# observe-name -> required as_type for the agent-loop entry points in bot.py.
-# These wrap ``create_agent`` invocations (ainvoke / astream / Command(resume)),
-# so Langfuse v4 should group them under the ``agent`` taxonomy (#2216).
+# observe-name -> required as_type for actual agent-loop invocations in bot.py.
+# These spans directly wrap ``create_agent`` SDK execution (ainvoke / astream /
+# Command(resume)), so Langfuse v4 should group them under the ``agent``
+# taxonomy (#2216).
 _REQUIRED_AGENT_AS_TYPE: dict[str, str] = {
-    "telegram-rag-supervisor": "agent",
+    "telegram-rag-agent-stream": "agent",
+    "telegram-rag-agent-invoke": "agent",
     "telegram-hitl-callback": "agent",
 }
+
+# Parent/orchestration spans that may return before any agent SDK invocation
+# (pre-agent guard, semantic cache hit, client direct pipeline) must stay as the
+# default span type. Marking these as ``agent`` would make non-agent requests
+# look like agent-loop traces in Langfuse (#2216).
+_REQUIRED_DEFAULT_SPAN_TYPE: tuple[str, ...] = ("telegram-rag-supervisor",)
 
 
 def _collect_bot_py_observe_as_types() -> dict[str, str | None]:
@@ -193,7 +201,7 @@ def bot_py_observe_as_types() -> dict[str, str | None]:
 
 
 class TestAgentEntrypointTaxonomy:
-    """The supervisor / HITL-resume agent-loop entry points must be ``agent`` (#2216)."""
+    """Only actual SDK agent-loop entry points are ``agent`` (#2216)."""
 
     @pytest.mark.parametrize("observe_name,expected_type", _REQUIRED_AGENT_AS_TYPE.items())
     def test_agent_entrypoint_has_agent_as_type(
@@ -212,4 +220,20 @@ class TestAgentEntrypointTaxonomy:
             f"@observe(name={observe_name!r}) must set as_type={expected_type!r} so "
             f"the Langfuse UI groups the agent invocation under the {expected_type!r} "
             f"taxonomy (#2216); found as_type={actual!r}."
+        )
+
+    @pytest.mark.parametrize("observe_name", _REQUIRED_DEFAULT_SPAN_TYPE)
+    def test_orchestration_parent_stays_default_span(
+        self,
+        bot_py_observe_as_types: dict[str, str | None],
+        observe_name: str,
+    ) -> None:
+        assert observe_name in bot_py_observe_as_types, (
+            f"@observe(name={observe_name!r}) not found in telegram_bot/bot.py."
+        )
+        actual = bot_py_observe_as_types[observe_name]
+        assert actual is None, (
+            f"@observe(name={observe_name!r}) must stay at the default span type "
+            "because it includes pre-agent cache/direct-pipeline return paths; "
+            f"found as_type={actual!r}."
         )

--- a/tests/contract/test_observation_type_taxonomy_contract.py
+++ b/tests/contract/test_observation_type_taxonomy_contract.py
@@ -31,6 +31,7 @@ import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+BOT_PY = REPO_ROOT / "telegram_bot" / "bot.py"
 
 # observe-name -> required as_type. Exact-match on the @observe(name=...) value.
 _REQUIRED_AS_TYPE: dict[str, str] = {
@@ -153,4 +154,62 @@ class TestAgentToolAndGuardTaxonomy:
         assert not missing, (
             "Taxonomy contract could not locate these @observe names "
             f"(scanner regression or renamed spans): {sorted(missing)}"
+        )
+
+
+# observe-name -> required as_type for the agent-loop entry points in bot.py.
+# These wrap ``create_agent`` invocations (ainvoke / astream / Command(resume)),
+# so Langfuse v4 should group them under the ``agent`` taxonomy (#2216).
+_REQUIRED_AGENT_AS_TYPE: dict[str, str] = {
+    "telegram-rag-supervisor": "agent",
+    "telegram-hitl-callback": "agent",
+}
+
+
+def _collect_bot_py_observe_as_types() -> dict[str, str | None]:
+    """Map every @observe(name=...) in bot.py (functions/methods) to its as_type."""
+    found: dict[str, str | None] = {}
+    tree = ast.parse(BOT_PY.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        for dec in node.decorator_list:
+            call = _is_observe_call(dec)
+            if call is None:
+                continue
+            name_value, kwargs = _decorator_name_and_kwargs(call)
+            if name_value is None:
+                continue
+            as_type_node = kwargs.get("as_type")
+            found[name_value] = (
+                as_type_node.value if isinstance(as_type_node, ast.Constant) else None
+            )
+    return found
+
+
+@pytest.fixture(scope="module")
+def bot_py_observe_as_types() -> dict[str, str | None]:
+    return _collect_bot_py_observe_as_types()
+
+
+class TestAgentEntrypointTaxonomy:
+    """The supervisor / HITL-resume agent-loop entry points must be ``agent`` (#2216)."""
+
+    @pytest.mark.parametrize("observe_name,expected_type", _REQUIRED_AGENT_AS_TYPE.items())
+    def test_agent_entrypoint_has_agent_as_type(
+        self,
+        bot_py_observe_as_types: dict[str, str | None],
+        observe_name: str,
+        expected_type: str,
+    ) -> None:
+        assert observe_name in bot_py_observe_as_types, (
+            f"@observe(name={observe_name!r}) not found in telegram_bot/bot.py — "
+            f"the taxonomy contract expects this agent-loop entry point (#2216). "
+            "Did the span get renamed?"
+        )
+        actual = bot_py_observe_as_types[observe_name]
+        assert actual == expected_type, (
+            f"@observe(name={observe_name!r}) must set as_type={expected_type!r} so "
+            f"the Langfuse UI groups the agent invocation under the {expected_type!r} "
+            f"taxonomy (#2216); found as_type={actual!r}."
         )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes one concrete task from #2216 (Epic F SDK modernization): mark the agent-loop entry points with `as_type="agent"`.

The `as_type="tool"` (≈22 spans) and `as_type="guardrail"` (`node-guard`, `history-guard`) mechanical pass was **already complete** on `dev` and is guarded by `tests/contract/test_observation_type_taxonomy_contract.py` (24 passing tests). The remaining gap: the supervisor/agent-loop spans still landed in the generic `span` bucket.

## Changes

- **`telegram_bot/bot.py`** — add `as_type="agent"` to the two `create_agent` invocation wrappers:
  - `telegram-rag-supervisor` (`_handle_query_supervisor` — `agent.ainvoke`/`agent.astream`).
  - `telegram-hitl-callback` (HITL resume via `agent.ainvoke(Command(resume=...))`).
- **`tests/contract/test_observation_type_taxonomy_contract.py`** — new `TestAgentEntrypointTaxonomy` (scans `bot.py`) asserting both spans carry `as_type="agent"`.

`as_type="agent"` is a valid Langfuse v4 observation type (confirmed via Context7 + the existing contract's enumeration). The Langfuse UI gains a dedicated "agents" filter for these spans.

## Testing (TDD — verified red first)

- New contract tests failed with `as_type=None` before the change; pass after.
- `pytest tests/contract/` → 1385 passed, 2 skipped (Docker), 3 xfailed (pre-existing).
- `pytest tests/unit/test_bot_handlers.py -k "supervisor or hitl or agent or stream"` → 73 passed.
- Ruff clean.

## Deferred #2216 items (out of scope for this repo-only wave)

- **`subgraphs=True` on `astream`** — changes the stream tuple to `(ns, mode, data)`; both streaming consumers (`_bot_streaming._stream_agent_to_draft` and the inline `bot.py` streamer) are contract-pinned and this needs live-bot runtime validation (`verify:local-runtime`), not repo-only.
- **CallbackHandler reuse via `BotContext`** (P3) — invasive DI change across many `BotContext` construction sites for marginal (micro-allocation) benefit.
- **Datasets `item.run()` rewrite / voice `LangfuseMedia`** (P3) — separate slices.
- **`hitl_guard` guardrail `@observe`** — intentionally **not** added: wrapping `interrupt()` would record the normal `GraphInterrupt` pause as an ERROR span.

No production/VPS/secrets/cloud/live CRM validation was performed (not required).
