### PR TITLE
docs: fix HITL_CRM_FLOW drift + document score write timing (#2213)

### DIFF
--- a/docs/CACHE_DEGRADATION.md
+++ b/docs/CACHE_DEGRADATION.md
@@ -78,6 +78,12 @@ use `cache_scope="rag"`; history lookups use `cache_scope="history"`.
 | `cache_error_total` | Cache errors by tier |
 | `cache_latency_ms` | Cache operation latency |
 
+> Cache hit/miss is also surfaced per-query on the Langfuse trace. The cache
+> node reports live hit/miss via `update_current_span(...)`, while the
+> `semantic_cache_hit` / `embeddings_cache_hit` / `search_cache_hit` **scores**
+> are written once per query at the end of the pipeline. See
+> [`docs/RAG_QUALITY_SCORES.md` → "When are scores written"](RAG_QUALITY_SCORES.md#when-are-scores-written).
+
 ## Configuration
 
 Environment variables:

--- a/docs/HITL_CRM_FLOW.md
+++ b/docs/HITL_CRM_FLOW.md
@@ -79,11 +79,16 @@ flow — pause/resume rides entirely on the LangGraph checkpointer keyed by
 
 ## Tracing
 
-A HITL turn produces a **linear** trace: the supervisor span
-(`telegram-rag-supervisor`, `as_type="agent"`) contains the CRM tool span
-(e.g. `crm-create-lead`, `as_type="tool"`); the confirmation keyboard is sent
-and the run pauses. The resume click is a **separate** trace
-(`telegram-hitl-callback`, `as_type="agent"`) that scores `hitl_action`.
+A HITL turn produces a **linear** trace. `telegram-rag-supervisor` stays a
+generic parent span because it also covers pre-agent guard, semantic-cache, and
+client-direct paths that can return before any SDK agent invocation. The actual
+agent execution is typed separately as `as_type="agent"`:
+`telegram-rag-agent-stream` for the streaming supervisor path and
+`telegram-rag-agent-invoke` for the non-streaming/menu invoke path. The CRM tool
+span (e.g. `crm-create-lead`, `as_type="tool"`) is nested under the agent run;
+the confirmation keyboard is sent and the run pauses. The resume click is a
+**separate** trace (`telegram-hitl-callback`, `as_type="agent"`) that scores
+`hitl_action`.
 
 The two traces are linked: at interrupt time the bot stores the parent trace id
 and the resume trace records it as `resumes_trace_id` metadata. See

--- a/docs/HITL_CRM_FLOW.md
+++ b/docs/HITL_CRM_FLOW.md
@@ -1,98 +1,109 @@
 # HITL CRM Flow
 
-Human-in-the-loop (HITL) pattern for CRM operations requiring human approval.
+Human-in-the-loop (HITL) confirmation for CRM **write** operations. Every CRM
+write tool pauses the agent and asks the user to confirm before the write hits
+Kommo.
+
+> Scope: this document describes the **CRM write-confirmation** flow only. The
+> separate *manager handoff* mechanism (`telegram_bot/services/handoff_state.py`
+> `HandoffData` / `handoff:{client_id}` Redis hash, `telegram_bot/handlers/handoff.py`)
+> is a different feature and is **not** part of this flow.
 
 ## Architecture
 
+The flow is SDK-native: LangGraph `interrupt()` pauses the graph, the bot
+surfaces an inline keyboard, and `Command(resume=...)` continues the same
+checkpointed run.
+
 ```
-User → Telegram Bot → LangGraph Agent
-                         ↓
-                   CRM Tool Call
-                         ↓
-                   interrupt() ← HITL trigger
-                         ↓
-                   Bot waits...
-                         ↓
-Human approves/rejects in Telegram
-                         ↓
-                  Command(resume=)
-                         ↓
-                  Graph resumes
-```
-
-## HITL Trigger Points
-
-CRM tools that trigger HITL via `interrupt()`:
-
-| Tool | Trigger Condition |
-|------|-------------------|
-| `create_lead` | All lead creation |
-| `schedule_viewing` | All viewing scheduling |
-| `transfer_lead` | Lead ownership transfer |
-| `update_lead_status` | Status changes to qualified |
-
-## Flow States
-
-Defined in `telegram_bot/services/handoff_state.py`:
-
-```python
-class HandoffState(TypedDict):
-    """HITL state persisted in Redis."""
-    state: str                    # "waiting", "approved", "rejected"
-    lead_id: int | None
-    action: str                   # "create_lead", "schedule_viewing", etc.
-    payload: dict                 # Action parameters
-    supervisor_chat_id: int       # Where to send approval request
-    created_at: float
-    expires_at: float
+User → Telegram → _handle_query_supervisor → agent.ainvoke(...)
+                                                   │
+                              CRM write tool (crm_create_lead, ...)
+                                                   │
+                              hitl_guard(tool, preview, args)
+                                                   │
+                                   interrupt({tool, preview, args})   ← graph pauses
+                                                   │
+        result["__interrupt__"] detected → _send_hitl_confirmation(...)
+                                                   │
+                      inline keyboard: ✅ hitl:approve  /  ❌ hitl:cancel
+                                                   │
+        handle_hitl_callback → agent.ainvoke(Command(resume={"action": ...}))
+                                                   │
+                 hitl_guard returns {"action": ...} → tool proceeds or aborts
 ```
 
-## HandoffData Schema
+## HITL trigger points
 
-```python
-class HandoffData(TypedDict):
-    """Passed through graph state for HITL decisions."""
-    is_handoff: bool
-    handoff_reason: str | None
-    lead_id: int | None
-    action: str | None
-    qualification_score: float | None
-```
+The CRM write tools in `telegram_bot/agents/crm_tools.py` each call
+`hitl_guard(...)` before performing the write:
 
-## Supervisor Notification
+| Tool | hitl_guard label | Effect on approve |
+|------|------------------|-------------------|
+| `crm_create_lead` | `crm_create_lead` | `kommo.create_lead(...)` |
+| `crm_update_lead` | `crm_update_lead` | `kommo.update_lead(...)` |
+| `crm_upsert_contact` | `crm_upsert_contact` | `kommo.upsert_contact(...)` |
+| `crm_update_contact` | `crm_update_contact` | `kommo.update_contact(...)` |
 
-When `interrupt()` fires:
-1. Graph execution pauses
-2. Supervisor thread receives notification with action details
-3. Supervisor approves/rejects via inline keyboard
-4. `Command(resume=...)` fires with decision
+Read-only CRM tools (`crm_get_deal`, `crm_search_leads`, `crm_get_my_tasks`,
+notes/tasks creation, etc.) do **not** trigger HITL.
 
-## Redis Keys
+On `{"action": "cancel"}` (or anything other than `approve`) the tool returns
+`"Операция отменена пользователем."` and never calls Kommo.
 
-| Key Pattern | TTL | Content |
-|-------------|-----|---------|
-| `handoff:{thread_id}` | 300s | Serialized HandoffState |
-| `kommo:oauth:tokens` | long-lived | OAuth tokens (shared) |
+## How the pause/resume works
 
-## Code Locations
+1. `hitl_guard(tool_name, preview, args)` (`telegram_bot/agents/hitl.py`) calls
+   LangGraph `interrupt({"tool": ..., "preview": ..., "args": ...})`. LangGraph
+   persists the graph state via the checkpointer and unwinds with that payload.
+2. The supervisor invoke returns a result whose `result["__interrupt__"][0].value`
+   carries that payload. `PropertyBot._send_hitl_confirmation` posts an inline
+   keyboard with `hitl:approve` / `hitl:cancel` buttons.
+3. `PropertyBot.handle_hitl_callback` rebuilds the agent with the **same
+   checkpointer** and resumes with `agent.ainvoke(Command(resume={"action":
+   "approve"|"cancel"}), config={"configurable": {"thread_id": ...}})`.
+4. Inside the resumed run, `interrupt()` returns the resume value, so
+   `hitl_guard` returns `{"action": ...}` and the tool continues.
+
+The resume value is the user's decision; there is no custom Redis state for this
+flow — pause/resume rides entirely on the LangGraph checkpointer keyed by
+`thread_id` (`_supervisor_thread_id(chat_id, forum_thread_id)`).
+
+## State persistence
+
+| Concern | Mechanism |
+|---------|-----------|
+| Paused graph state | LangGraph checkpointer (`AsyncRedisSaver` in prod, `MemorySaver` in dev), keyed by `thread_id` |
+| Interrupt payload | `{"tool", "preview", "args"}` returned in `result["__interrupt__"][0].value` |
+| Resume decision | `Command(resume={"action": "approve"|"cancel"})` |
+
+## Tracing
+
+A HITL turn produces a **linear** trace: the supervisor span
+(`telegram-rag-supervisor`, `as_type="agent"`) contains the CRM tool span
+(e.g. `crm-create-lead`, `as_type="tool"`); the confirmation keyboard is sent
+and the run pauses. The resume click is a **separate** trace
+(`telegram-hitl-callback`, `as_type="agent"`) that scores `hitl_action`.
+
+The two traces are linked: at interrupt time the bot stores the parent trace id
+and the resume trace records it as `resumes_trace_id` metadata. See
+[`docs/BOT_INTERNAL_STRUCTURE.md`](BOT_INTERNAL_STRUCTURE.md) ("Interrupted/resumed
+(HITL) trace linkage") and issue #2224.
+
+## Code locations
 
 | File | Purpose |
 |------|---------|
-| `telegram_bot/agents/hitl.py` | `interrupt()` wrapper and handlers |
-| `telegram_bot/services/handoff_state.py` | State definitions |
-| `telegram_bot/handlers/handoff.py` | Handoff FSM states and handlers |
-| `telegram_bot/graph/nodes/` | Nodes that may trigger HITL |
-
-## Error Handling
-
-If supervisor times out (300s TTL):
-- Action is automatically rejected
-- User receives timeout message
-- Graph resumes with `rejected` state
+| `telegram_bot/agents/hitl.py` | `hitl_guard()` (`interrupt()` wrapper), `format_hitl_preview()`, pending-resume trace store |
+| `telegram_bot/agents/crm_tools.py` | CRM write tools that call `hitl_guard()` |
+| `telegram_bot/bot.py` | `_send_hitl_confirmation()` (keyboard) and `handle_hitl_callback()` (`Command(resume=...)`) |
 
 ## Testing
 
 ```bash
-# Test HITL flow
-uv run pytest tests/unit/telegram_bot/test_handoff.py -v
+# HITL guard, preview formatting, approve/cancel tool behavior, resume-trace store
+uv run pytest tests/unit/agents/test_hitl.py -v
+
+# thread_id <-> session_id co-location and interrupt/resume trace linkage
+uv run pytest tests/contract/test_thread_session_link_contract.py -v
 ```

--- a/docs/RAG_QUALITY_SCORES.md
+++ b/docs/RAG_QUALITY_SCORES.md
@@ -4,7 +4,8 @@ Observability metrics written to Langfuse for every query.
 
 ## Score Writing
 
-Scores are computed and written via `telegram_bot/scoring.py`:
+Scores are computed and written via `src/scoring.py` (re-exported through the
+`telegram_bot/scoring.py` shim for historical bot imports):
 - `write_langfuse_scores()` — main query scores
 - `write_history_scores()` — history search scores
 - `write_crm_scores()` — CRM tool usage scores
@@ -13,6 +14,32 @@ Scores are computed and written via `telegram_bot/scoring.py`:
 > [`tests/contract/test_rag_quality_scores_doc_drift.py`](../tests/contract/test_rag_quality_scores_doc_drift.py).
 > Whenever a new `name=...` is added to `scoring.py`, add a row below or
 > entry in `DOC_EXEMPT_SCORE_NAMES`.
+
+## When are scores written
+
+Quality scores and per-node observability use **two different** Langfuse
+mechanisms with different timing:
+
+- **Quality scores are written once per query, at the end of the pipeline**, by
+  `write_langfuse_scores()` (`src/scoring.py`). It reads the final graph
+  `result` state and emits every score in one pass via the `score(...)` helper,
+  which calls `lf.create_score(trace_id=..., score_id="<trace_id>-<name>")` —
+  explicit trace scoping plus an idempotency key (#435). The bot calls it after
+  the supervisor run completes (`telegram_bot/bot.py`); the RAG API calls it at
+  the end of `/query` (`src/api/main.py`). `write_history_scores()` and
+  `write_crm_scores()` follow the same once-per-flow pattern.
+- **Per-node hit/miss and grade signals are NOT scores.** Nodes such as the
+  cache node (`telegram_bot/graph/nodes/cache.py`) report real-time state with
+  `lf.update_current_span(input=..., output=..., metadata=...)`, not
+  `score_current_trace` / `create_score`. That is why you will not find a
+  `score_current_trace` call inside `cache_check_node`: the cache hit/miss is
+  surfaced on the span in real time and the corresponding `semantic_cache_hit` /
+  `embeddings_cache_hit` / `search_cache_hit` *scores* are written later, in the
+  single end-of-query `write_langfuse_scores()` pass.
+
+In short: span `input`/`output`/`metadata` is the live, per-node channel;
+Langfuse **scores** are the end-of-query summary. Entry point and ordering:
+`write_langfuse_scores(lf, result, trace_id=...)` in `src/scoring.py`.
 
 ## Main Query Scores
 
@@ -117,6 +144,7 @@ Required trace families validated by `make validate-traces-fast`:
 
 | File | Purpose |
 |------|---------|
-| `telegram_bot/scoring.py` | Score computation and writing |
+| `src/scoring.py` | Canonical score computation and writing (`write_langfuse_scores`, `write_history_scores`, `write_crm_scores`, `score`) |
+| `telegram_bot/scoring.py` | Re-export shim for historical bot imports |
 | `telegram_bot/observability.py` | Langfuse client setup |
 | `docker/monitoring/rules/` | Alert rules |

--- a/tests/contract/test_hitl_crm_flow_doc_contract.py
+++ b/tests/contract/test_hitl_crm_flow_doc_contract.py
@@ -1,0 +1,93 @@
+"""Contract: ``docs/HITL_CRM_FLOW.md`` matches the real HITL CRM code (#2213).
+
+The HITL CRM write-confirmation flow is real and SDK-native:
+
+* ``telegram_bot/agents/crm_tools.py`` write tools call
+  ``hitl_guard(tool, preview, args)``;
+* ``hitl_guard`` (``telegram_bot/agents/hitl.py``) calls LangGraph
+  ``interrupt({...})``, pausing the graph;
+* the bot detects ``result["__interrupt__"]`` and ``_send_hitl_confirmation``
+  posts an inline keyboard (``hitl:approve`` / ``hitl:cancel``);
+* ``handle_hitl_callback`` resumes via ``Command(resume={"action": ...})``.
+
+The previous doc drifted: it listed tools that do not exist
+(``schedule_viewing`` / ``transfer_lead`` / ``update_lead_status``), described
+the *separate* manager-handoff state machine (``HandoffState`` /
+``handoff:{client_id}`` Redis hash / 300s auto-reject) as if it were the HITL
+CRM mechanism, and pointed at a non-existent test path. This contract pins the
+doc to the real code so it cannot drift back.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOC_PATH = REPO_ROOT / "docs" / "HITL_CRM_FLOW.md"
+
+
+def _doc_text() -> str:
+    return DOC_PATH.read_text(encoding="utf-8")
+
+
+def test_doc_exists() -> None:
+    assert DOC_PATH.exists(), f"missing: {DOC_PATH}"
+
+
+def test_doc_describes_real_interrupt_resume_mechanism() -> None:
+    text = _doc_text()
+    for token in ("hitl_guard", "interrupt(", "Command(resume", "__interrupt__"):
+        assert token in text, (
+            f"docs/HITL_CRM_FLOW.md must describe the real HITL mechanism and "
+            f"mention {token!r} (#2213)."
+        )
+
+
+def test_doc_lists_real_hitl_wrapped_tools() -> None:
+    """The doc's trigger list must be the tools that actually call hitl_guard."""
+    text = _doc_text()
+    real_tools = (
+        "crm_create_lead",
+        "crm_update_lead",
+        "crm_upsert_contact",
+        "crm_update_contact",
+    )
+    for tool in real_tools:
+        assert tool in text, (
+            f"docs/HITL_CRM_FLOW.md must list the real HITL-wrapped tool {tool!r} "
+            "(it calls hitl_guard in telegram_bot/agents/crm_tools.py) (#2213)."
+        )
+
+
+def test_doc_does_not_reference_nonexistent_tools() -> None:
+    """Stale tool names from the old doc must be gone."""
+    text = _doc_text()
+    for stale in ("schedule_viewing", "transfer_lead", "update_lead_status"):
+        assert stale not in text, (
+            f"docs/HITL_CRM_FLOW.md references {stale!r}, which is not a real HITL "
+            "CRM tool. Remove the stale entry (#2213)."
+        )
+
+
+def test_doc_references_only_existing_code_locations() -> None:
+    """Real code locations the doc points to must exist; stale ones must be absent."""
+    text = _doc_text()
+    must_exist = (
+        "telegram_bot/agents/hitl.py",
+        "telegram_bot/agents/crm_tools.py",
+        "tests/unit/agents/test_hitl.py",
+    )
+    for rel in must_exist:
+        assert rel in text, (
+            f"docs/HITL_CRM_FLOW.md should reference the real location {rel!r} (#2213)."
+        )
+        assert (REPO_ROOT / rel).exists(), (
+            f"doc references {rel!r} but it does not exist in the repo (#2213)."
+        )
+    # The old doc pointed at a test path that never existed.
+    assert "tests/unit/telegram_bot/test_handoff.py" not in text, (
+        "docs/HITL_CRM_FLOW.md references a non-existent test path "
+        "tests/unit/telegram_bot/test_handoff.py; the real HITL tests live in "
+        "tests/unit/agents/test_hitl.py (#2213)."
+    )

--- a/tests/contract/test_hitl_crm_flow_doc_contract.py
+++ b/tests/contract/test_hitl_crm_flow_doc_contract.py
@@ -44,6 +44,24 @@ def test_doc_describes_real_interrupt_resume_mechanism() -> None:
         )
 
 
+def test_doc_describes_agent_taxonomy_without_mistyping_parent_span() -> None:
+    text = _doc_text()
+    assert 'telegram-rag-supervisor`, `as_type="agent"' not in text, (
+        "docs/HITL_CRM_FLOW.md must not claim telegram-rag-supervisor is an "
+        "agent span: that parent can return from pre-agent cache/direct-pipeline "
+        "paths before any create_agent invocation (#2213/#2216)."
+    )
+    for token in ("telegram-rag-agent-stream", "telegram-rag-agent-invoke"):
+        assert token in text, (
+            "docs/HITL_CRM_FLOW.md must name the actual SDK agent invocation "
+            f"span {token!r} as the as_type='agent' observation (#2213/#2216)."
+        )
+    assert "generic parent span" in text, (
+        "docs/HITL_CRM_FLOW.md must explain that telegram-rag-supervisor stays "
+        "a generic parent span around orchestration/pre-agent paths (#2213/#2216)."
+    )
+
+
 def test_doc_lists_real_hitl_wrapped_tools() -> None:
     """The doc's trigger list must be the tools that actually call hitl_guard."""
     text = _doc_text()

--- a/tests/contract/test_rag_quality_scores_doc_drift.py
+++ b/tests/contract/test_rag_quality_scores_doc_drift.py
@@ -135,3 +135,38 @@ def test_main_query_score_count_is_above_legacy_14() -> None:
         f"Expected scoring.py to emit more than 30 distinct score names, found {len(code_names)}: "
         f"{sorted(code_names)}"
     )
+
+
+
+# --- #2213: document WHEN scores are written ---
+
+_WHEN_SECTION_RE = re.compile(r"^#{2,3}\s+When are scores written", re.MULTILINE | re.IGNORECASE)
+
+
+def test_doc_documents_when_scores_are_written() -> None:
+    """#2213: the doc must explain the score write *timing*.
+
+    New contributors look for ``score_current_trace`` calls in the cache node
+    and find none (the cache node uses ``update_current_span`` for real-time
+    hit/miss). The doc must state that quality scores are written once per
+    query at the end of the pipeline via ``write_langfuse_scores`` while
+    per-node observability uses ``update_current_span``.
+    """
+    text = DOC_PATH.read_text(encoding="utf-8")
+    assert _WHEN_SECTION_RE.search(text), (
+        "docs/RAG_QUALITY_SCORES.md must contain a 'When are scores written' "
+        "section (#2213) explaining once-per-query end-of-pipeline writes vs "
+        "per-node update_current_span."
+    )
+    assert "write_langfuse_scores" in text, (
+        "The 'when written' section must name write_langfuse_scores as the "
+        "once-per-query writer (#2213)."
+    )
+    assert "update_current_span" in text, (
+        "The 'when written' section must mention update_current_span as the "
+        "per-node real-time hit/miss mechanism (#2213)."
+    )
+    assert "src/scoring.py" in text, (
+        "The doc must point to the canonical scoring module src/scoring.py "
+        "(not only the telegram_bot/scoring.py re-export shim) (#2213)."
+    )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #2213 — fixes documentation drift in `HITL_CRM_FLOW.md` and `RAG_QUALITY_SCORES.md`, with contract tests pinning both docs to the real code.

## `HITL_CRM_FLOW.md`

⚠️ **Important correction:** the issue claimed "the doc describes a non-existent `interrupt()` flow; reality is synchronous `hitl_guard` with no interrupt/resume." That claim is **stale** — the current code *does* use `interrupt()` + `Command(resume=...)`. I made the doc match the **actual code**, not the issue's outdated description.

The doc's high-level `interrupt()`/`Command(resume)` diagram was already correct; the *details* had drifted:
- Listed tools that **don't exist** (`schedule_viewing`, `transfer_lead`, `update_lead_status`).
- Described the **separate** manager-handoff state machine (`HandoffState` / `handoff:{client_id}` Redis hash / 300s auto-reject) as if it were the HITL CRM mechanism.
- Pointed at a non-existent test path (`tests/unit/telegram_bot/test_handoff.py`).

Rewritten to match reality: `crm_create_lead`/`crm_update_lead`/`crm_upsert_contact`/`crm_update_contact` call `hitl_guard()` → `interrupt()` → bot detects `result["__interrupt__"]` → `_send_hitl_confirmation` keyboard → `handle_hitl_callback` resumes via `Command(resume=...)`. State rides the LangGraph checkpointer keyed by `thread_id`. Cross-references the #2224 `resumes_trace_id` trace linkage.

## `RAG_QUALITY_SCORES.md`

Added a **"When are scores written"** section: quality scores are written **once per query at pipeline end** by `write_langfuse_scores()` (via `create_score(trace_id=..., score_id=...)` — explicit scoping + idempotency key), while per-node hit/miss uses `update_current_span(...)` (not `score_current_trace`). This answers "why is there no `score_current_trace` in `cache_check_node`?". Code Locations now point at the canonical `src/scoring.py` (the `telegram_bot/scoring.py` is a re-export shim). Cross-linked from `CACHE_DEGRADATION.md`.

## Testing (TDD — verified red first)

- **New** `tests/contract/test_hitl_crm_flow_doc_contract.py`: asserts the doc names the real mechanism (`hitl_guard`, `interrupt(`, `Command(resume`, `__interrupt__`) + the 4 real tools, references only existing code/test paths, and contains no stale tool names.
- **Extended** `test_rag_quality_scores_doc_drift.py` with `test_doc_documents_when_scores_are_written` (section anchor + `write_langfuse_scores`/`update_current_span`/`src/scoring.py`).
- `pytest tests/contract/` → 1390 passed, 2 skipped (Docker), 3 xfailed (pre-existing).

`verify:docs-review` — no runtime/production validation required.
