### PR TITLE
fix: prefer update_current_span over deprecated set_current_trace_io

### DIFF
--- a/src/observability.py
+++ b/src/observability.py
@@ -247,7 +247,7 @@ def _ensure_otel_resource_attributes(*, service_namespace: str = "rag") -> None:
 
         defaults["host.name"] = socket.gethostname()
     except Exception:
-        pass
+        defaults["host.name"] = "unknown"
 
     # Operator-set keys win; defaults only fill gaps.
     for key, val in defaults.items():

--- a/telegram_bot/services/telegram_formatting.py
+++ b/telegram_bot/services/telegram_formatting.py
@@ -148,9 +148,10 @@ def build_html_messages(
 def record_langfuse_response_output(answer_text: str | None, chunks_count: int) -> None:
     """Best-effort update of the current Langfuse trace/span output after a send.
 
-    Uses ``set_current_trace_io`` when present, falls back to ``update_current_span``,
-    and is a no-op when the client or method is missing so Telegram sending never
-    breaks because of observability.
+    Prefers ``update_current_span`` (SDK-native in Langfuse v4+), falls back to
+    ``set_current_trace_io`` for older clients, and is a no-op when the client or
+    all methods are missing so Telegram sending never breaks because of
+    observability.
     """
     lf = get_client()
     if lf is None:
@@ -158,22 +159,22 @@ def record_langfuse_response_output(answer_text: str | None, chunks_count: int) 
 
     output = build_safe_output_payload(answer_text, chunks_count)
 
-    set_trace_io = getattr(lf, "set_current_trace_io", None)
-    if callable(set_trace_io):
-        try:
-            set_trace_io(output=output)
-            return
-        except Exception:
-            logger.debug(
-                "set_current_trace_io failed, falling back to update_current_span", exc_info=True
-            )
-
     update_span = getattr(lf, "update_current_span", None)
     if callable(update_span):
         try:
             update_span(output=output)
+            return
         except Exception:
-            logger.debug("update_current_span failed", exc_info=True)
+            logger.debug(
+                "update_current_span failed, falling back to set_current_trace_io", exc_info=True
+            )
+
+    set_trace_io = getattr(lf, "set_current_trace_io", None)
+    if callable(set_trace_io):
+        try:
+            set_trace_io(output=output)
+        except Exception:
+            logger.debug("set_current_trace_io failed", exc_info=True)
 
 
 _record_langfuse_response_output = record_langfuse_response_output

--- a/tests/unit/test_telegram_formatting.py
+++ b/tests/unit/test_telegram_formatting.py
@@ -18,7 +18,7 @@ class TestRecordLangfuseResponseOutput:
 
     def test_builds_safe_output_payload(self):
         mock_lf = MagicMock()
-        mock_lf.set_current_trace_io = MagicMock()
+        mock_lf.update_current_span = MagicMock()
 
         with (
             patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf),
@@ -30,19 +30,20 @@ class TestRecordLangfuseResponseOutput:
             record_langfuse_response_output("hello", 2)
 
         mock_build.assert_called_once_with("hello", 2)
-        mock_lf.set_current_trace_io.assert_called_once_with(output={"mock": "payload"})
+        mock_lf.update_current_span.assert_called_once_with(output={"mock": "payload"})
 
-    def test_uses_set_current_trace_io_when_present(self):
+    def test_prefers_update_current_span_when_present(self):
+        """Issue #2280: update_current_span is the SDK-native API; prefer it."""
         mock_lf = MagicMock()
-        mock_lf.set_current_trace_io = MagicMock()
         mock_lf.update_current_span = MagicMock()
+        mock_lf.set_current_trace_io = MagicMock()
 
         with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
             record_langfuse_response_output("hello world", 1)
 
-        mock_lf.set_current_trace_io.assert_called_once()
-        mock_lf.update_current_span.assert_not_called()
-        call_kwargs = mock_lf.set_current_trace_io.call_args.kwargs
+        mock_lf.update_current_span.assert_called_once()
+        mock_lf.set_current_trace_io.assert_not_called()
+        call_kwargs = mock_lf.update_current_span.call_args.kwargs
         assert "output" in call_kwargs
         output = call_kwargs["output"]
         assert "answer_preview" in output
@@ -50,16 +51,17 @@ class TestRecordLangfuseResponseOutput:
         assert output["chunks_count"] == 1
         assert output["delivery_status"] == "sent"
 
-    def test_falls_back_to_update_current_span(self):
+    def test_falls_back_to_set_current_trace_io(self):
+        """Issue #2280: set_current_trace_io is the legacy fallback."""
         mock_lf = MagicMock()
-        del mock_lf.set_current_trace_io
-        mock_lf.update_current_span = MagicMock()
+        del mock_lf.update_current_span
+        mock_lf.set_current_trace_io = MagicMock()
 
         with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
             record_langfuse_response_output("fallback", 3)
 
-        mock_lf.update_current_span.assert_called_once()
-        call_kwargs = mock_lf.update_current_span.call_args.kwargs
+        mock_lf.set_current_trace_io.assert_called_once()
+        call_kwargs = mock_lf.set_current_trace_io.call_args.kwargs
         assert "output" in call_kwargs
         output = call_kwargs["output"]
         assert "answer_preview" in output
@@ -67,27 +69,29 @@ class TestRecordLangfuseResponseOutput:
 
     def test_no_op_when_both_methods_missing(self):
         mock_lf = MagicMock()
-        del mock_lf.set_current_trace_io
         del mock_lf.update_current_span
+        del mock_lf.set_current_trace_io
 
         with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
             record_langfuse_response_output("answer", 1)
 
-    def test_trace_io_failure_falls_back_to_span(self):
+    def test_span_failure_falls_back_to_trace_io(self):
+        """Issue #2280: update_current_span failure falls back to set_current_trace_io."""
         mock_lf = MagicMock()
-        mock_lf.set_current_trace_io = MagicMock(side_effect=RuntimeError("trace io error"))
-        mock_lf.update_current_span = MagicMock()
+        mock_lf.update_current_span = MagicMock(side_effect=RuntimeError("span error"))
+        mock_lf.set_current_trace_io = MagicMock()
 
         with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
             record_langfuse_response_output("answer", 1)
 
-        mock_lf.set_current_trace_io.assert_called_once()
         mock_lf.update_current_span.assert_called_once()
+        mock_lf.set_current_trace_io.assert_called_once()
 
     def test_span_failure_is_silent(self):
+        """Issue #2280: Both methods failing is silent fallthrough."""
         mock_lf = MagicMock()
-        mock_lf.set_current_trace_io = MagicMock(side_effect=RuntimeError("trace io error"))
         mock_lf.update_current_span = MagicMock(side_effect=RuntimeError("span error"))
+        mock_lf.set_current_trace_io = MagicMock(side_effect=RuntimeError("trace io error"))
 
         with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
             # Should not raise
@@ -95,13 +99,13 @@ class TestRecordLangfuseResponseOutput:
 
     def test_preview_truncated_to_safe_limit(self):
         mock_lf = MagicMock()
-        mock_lf.set_current_trace_io = MagicMock()
+        mock_lf.update_current_span = MagicMock()
 
         long_text = "x" * 2000
         with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
             record_langfuse_response_output(long_text, 1)
 
-        call_args = mock_lf.set_current_trace_io.call_args.kwargs
+        call_args = mock_lf.update_current_span.call_args.kwargs
         output = call_args["output"]
         # _preview limit is 240 chars; redactor may append a short suffix
         assert len(output["answer_preview"]) <= 260
@@ -110,12 +114,12 @@ class TestRecordLangfuseResponseOutput:
 
     def test_none_text_handled(self):
         mock_lf = MagicMock()
-        mock_lf.set_current_trace_io = MagicMock()
+        mock_lf.update_current_span = MagicMock()
 
         with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
             record_langfuse_response_output(None, 1)
 
-        call_args = mock_lf.set_current_trace_io.call_args.kwargs
+        call_args = mock_lf.update_current_span.call_args.kwargs
         output = call_args["output"]
         assert output["answer_preview"] == ""
         assert output["answer_len"] == 0


### PR DESCRIPTION
## Summary

Reverses the precedence order in `record_langfuse_response_output()` so SDK-native `update_current_span` is tried first, with `set_current_trace_io` as legacy fallback. Also fixes a Bandit B110 pre-push blocker in `src/observability.py` by replacing a silent hostname failure with `host.name=unknown`.

## Issue

Closes #2280

## Changed Warning Groups

- **~170 eliminated**: Langfuse `DeprecationWarning` from `set_current_trace_io` in `telegram_formatting.py` — now prefers `update_current_span` (SDK-native in v4+)
- **remaining expected warnings**: one resilience test intentionally exercises `set_current_trace_io`; RedisVL `get_async_redis_connection` async change is external dependency noise

## Checks Run

- [x] Focused pytest: `tests/unit/test_telegram_formatting.py tests/unit/observability/test_trace_resilience.py tests/unit/test_langfuse_pydantic_warning.py` — 41 passed
- [x] Focused SummarizationNode retry: `tests/unit/graph/test_summarize_node.py` — 3 passed
- [x] `make check` — Ruff and MyPy clean
- [x] `make test` on rebased branch — 7562 passed, 60 skipped, 11 warnings
- [x] Bandit hook passed on push

## Note

No Docker/Compose changes. Runtime behavior is backward-compatible: `set_current_trace_io` remains as fallback for older Langfuse clients. A repeated full-suite flake was observed around `langmem.short_term.SummarizationNode` namespace import; focused retry passed and this is unrelated to the PR diff.