### PR TITLE
test(observability): guard raw-thread context loss + OTEL_PROPAGATORS (#2246 F1/F3)

### DIFF
--- a/tests/contract/test_observability_contextvars_contract.py
+++ b/tests/contract/test_observability_contextvars_contract.py
@@ -253,3 +253,233 @@ class TestContractCatchesRegressions:
         )
         # to_thread doesn't match run_in_executor pattern
         assert _find_run_in_executor_calls(tree) == []
+
+
+
+# ---------------------------------------------------------------------------
+# #2246 F1 — raw thread hops also drop contextvars
+# ---------------------------------------------------------------------------
+# ``threading.Thread(target=...)`` and ``ThreadPoolExecutor(...).submit(...)``
+# start a worker with a *fresh* ``contextvars.Context`` exactly like
+# ``run_in_executor`` — so any ``@observe`` span created downstream becomes a
+# new root trace instead of nesting under the active ingestion/bot trace.
+# OpenTelemetry only propagates ``Context`` automatically across ``asyncio``;
+# raw threads require manual capture (verified against the OTel Python docs via
+# Context7). The #2220 contract only guarded ``run_in_executor``; this extends
+# it to the raw-thread primitives.
+#
+# Accepted escape hatch (mirrors the run_in_executor rule): capture the active
+# context and run the worker through it —
+#   ``ctx = contextvars.copy_context()``
+#   ``pool.submit(ctx.run, fn, *args)``                       # executor
+#   ``threading.Thread(target=lambda: ctx.run(fn, *args))``   # raw thread
+
+# (relative_path, thread_target_name) pairs intentionally exempt: infrastructure
+# threads that never run @observe-decorated work, so there is no parent context
+# to preserve. Keep this minimal and justified.
+_INFRA_THREAD_ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
+    {
+        # Voice agent liveness probe: a blocking HTTP health server
+        # (serve_forever); it never creates Langfuse/OTEL spans.
+        ("src/voice/agent.py", "_run"),
+    }
+)
+
+
+def _is_thread_ctor(call: ast.Call) -> bool:
+    """True for ``threading.Thread(...)`` / ``Thread(...)`` constructor calls."""
+    func = call.func
+    return (isinstance(func, ast.Attribute) and func.attr == "Thread") or (
+        isinstance(func, ast.Name) and func.id == "Thread"
+    )
+
+
+def _is_submit_call(call: ast.Call) -> bool:
+    """True for ``<executor>.submit(...)`` calls (ThreadPoolExecutor.submit)."""
+    return isinstance(call.func, ast.Attribute) and call.func.attr == "submit"
+
+
+def _expr_is_copy_context_run(node: ast.AST) -> bool:
+    """True if *node* is (or calls) ``<ctx>.run`` / ``copy_context().run``.
+
+    Accepts both the bare reference (``ctx.run`` passed to ``submit``) and a
+    call form (``ctx.run(fn, ...)`` used inside a ``Thread`` target lambda).
+    """
+    if isinstance(node, ast.Call):
+        node = node.func
+    if isinstance(node, ast.Attribute) and node.attr == "run":
+        value = node.value
+        if isinstance(value, ast.Call):
+            fn = value.func
+            if isinstance(fn, ast.Attribute) and fn.attr == "copy_context":
+                return True
+            if isinstance(fn, ast.Name) and fn.id == "copy_context":
+                return True
+        # A captured context bound to a name like ``ctx`` / ``context``.
+        if isinstance(value, ast.Name) and ("ctx" in value.id or "context" in value.id):
+            return True
+    return False
+
+
+def _thread_target_expr(call: ast.Call) -> ast.AST | None:
+    """Resolve the worker callable for a Thread/submit call."""
+    for kw in call.keywords:
+        if kw.arg == "target":
+            return kw.value
+    if call.args:
+        return call.args[0]
+    return None
+
+
+def _thread_call_is_guarded(call: ast.Call) -> bool:
+    target = _thread_target_expr(call)
+    if target is None:
+        return False
+    if isinstance(target, ast.Lambda):
+        return _expr_is_copy_context_run(target.body)
+    return _expr_is_copy_context_run(target)
+
+
+def _thread_target_name(call: ast.Call) -> str:
+    target = _thread_target_expr(call)
+    if isinstance(target, ast.Name):
+        return target.id
+    if isinstance(target, ast.Attribute):
+        return target.attr
+    if isinstance(target, ast.Lambda):
+        return "<lambda>"
+    return "<unknown>"
+
+
+def _find_thread_primitive_calls(tree: ast.AST) -> list[ast.Call]:
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and (_is_thread_ctor(node) or _is_submit_call(node))
+    ]
+
+
+@pytest.fixture(scope="module")
+def offending_thread_files() -> list[tuple[Path, list[ast.Call]]]:
+    """observe-importing modules with an unguarded, non-allowlisted thread hop."""
+    offenders: list[tuple[Path, list[ast.Call]]] = []
+    for py_file in _iter_python_files():
+        try:
+            tree = ast.parse(py_file.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        if not _imports_observe(tree):
+            continue
+        rel = py_file.relative_to(REPO_ROOT).as_posix()
+        bad: list[ast.Call] = []
+        for call in _find_thread_primitive_calls(tree):
+            if _thread_call_is_guarded(call):
+                continue
+            if (rel, _thread_target_name(call)) in _INFRA_THREAD_ALLOWLIST:
+                continue
+            bad.append(call)
+        if bad:
+            offenders.append((py_file, bad))
+    return offenders
+
+
+class TestNoUnguardedThreadHopNearObserve:
+    """Modules importing ``observe`` must not drop contextvars via raw
+    ``threading.Thread`` / ``ThreadPoolExecutor.submit`` hops (#2246 F1)."""
+
+    def test_no_offending_thread_files(
+        self, offending_thread_files: list[tuple[Path, list[ast.Call]]]
+    ) -> None:
+        if not offending_thread_files:
+            return
+        report_lines: list[str] = []
+        for path, calls in offending_thread_files:
+            relative = path.relative_to(REPO_ROOT).as_posix()
+            for call in calls:
+                report_lines.append(f"  - {relative}:{call.lineno}")
+        pytest.fail(
+            "Found raw thread hops (threading.Thread / ThreadPoolExecutor.submit) "
+            "in modules that import @observe without a contextvars.copy_context() "
+            "guard (#2246 F1). The worker starts with a fresh Context, so any "
+            "@observe span it creates orphans into a new root trace. Capture the "
+            "context first: ctx = contextvars.copy_context(); then run the worker "
+            "via ctx.run(...). If the thread never runs @observe work, add it to "
+            "_INFRA_THREAD_ALLOWLIST with a reason.\n\nOffending sites:\n"
+            + "\n".join(report_lines)
+        )
+
+
+class TestThreadHopContractCatchesRegressions:
+    """Negative-path checks so the F1 detector cannot silently go vacuous."""
+
+    def test_flags_unguarded_thread(self) -> None:
+        tree = ast.parse(
+            "import threading\n"
+            "def worker(): pass\n"
+            "threading.Thread(target=worker).start()\n"
+        )
+        calls = _find_thread_primitive_calls(tree)
+        assert len(calls) == 1
+        assert not _thread_call_is_guarded(calls[0])
+        assert _thread_target_name(calls[0]) == "worker"
+
+    def test_accepts_thread_with_copy_context_lambda(self) -> None:
+        tree = ast.parse(
+            "import threading, contextvars\n"
+            "ctx = contextvars.copy_context()\n"
+            "threading.Thread(target=lambda: ctx.run(worker)).start()\n"
+        )
+        calls = _find_thread_primitive_calls(tree)
+        assert len(calls) == 1
+        assert _thread_call_is_guarded(calls[0])
+
+    def test_flags_unguarded_submit(self) -> None:
+        tree = ast.parse(
+            "from concurrent.futures import ThreadPoolExecutor\n"
+            "with ThreadPoolExecutor() as pool:\n"
+            "    pool.submit(worker, 1, 2)\n"
+        )
+        calls = [c for c in _find_thread_primitive_calls(tree) if _is_submit_call(c)]
+        assert len(calls) == 1
+        assert not _thread_call_is_guarded(calls[0])
+
+    def test_accepts_submit_with_copy_context_run(self) -> None:
+        tree = ast.parse(
+            "import contextvars\n"
+            "from concurrent.futures import ThreadPoolExecutor\n"
+            "ctx = contextvars.copy_context()\n"
+            "with ThreadPoolExecutor() as pool:\n"
+            "    pool.submit(ctx.run, worker, 1, 2)\n"
+        )
+        calls = [c for c in _find_thread_primitive_calls(tree) if _is_submit_call(c)]
+        assert len(calls) == 1
+        assert _thread_call_is_guarded(calls[0])
+
+    def test_accepts_inline_copy_context_run_submit(self) -> None:
+        tree = ast.parse(
+            "import contextvars\n"
+            "from concurrent.futures import ThreadPoolExecutor\n"
+            "with ThreadPoolExecutor() as pool:\n"
+            "    pool.submit(contextvars.copy_context().run, worker)\n"
+        )
+        calls = [c for c in _find_thread_primitive_calls(tree) if _is_submit_call(c)]
+        assert len(calls) == 1
+        assert _thread_call_is_guarded(calls[0])
+
+    def test_scanner_finds_thread_primitive_in_repo(self) -> None:
+        """The repo scan is not vacuous: at least one observe-importing module
+        actually contains a thread primitive (currently the voice health probe,
+        which is allowlisted)."""
+        total = 0
+        for py_file in _iter_python_files():
+            try:
+                tree = ast.parse(py_file.read_text(encoding="utf-8"))
+            except SyntaxError:
+                continue
+            if not _imports_observe(tree):
+                continue
+            total += len(_find_thread_primitive_calls(tree))
+        assert total > 0, (
+            "F1 scanner found no thread primitives in any observe-importing "
+            "module — the contract may be vacuous; verify _find_thread_primitive_calls."
+        )

--- a/tests/contract/test_otel_propagators_contract.py
+++ b/tests/contract/test_otel_propagators_contract.py
@@ -1,0 +1,102 @@
+"""Contract: OTEL_PROPAGATORS is explicitly declared in compose (#2246 F3).
+
+The OpenTelemetry Python SDK defaults its global propagator to
+``tracecontext,baggage``, so cross-service W3C TraceContext + Baggage
+propagation is *currently* correct even without an explicit setting. But that
+default is implicit — a base-image bump or an ``OTEL_PROPAGATORS`` shift in the
+environment could silently change it and break cross-service trace continuity
+with zero signal.
+
+#2246 F3 hardens this for defense-in-depth: every OTEL-instrumented compose
+service (identified by setting ``OTEL_SERVICE_NAME``) must also declare
+``OTEL_PROPAGATORS`` with a default that includes both ``tracecontext`` and
+``baggage``. This contract pins that so the explicit declaration cannot be
+silently dropped.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE = REPO_ROOT / "compose.yml"
+ENV_EXAMPLE = REPO_ROOT / ".env.example"
+
+REQUIRED_PROPAGATORS = ("tracecontext", "baggage")
+
+
+def _load_yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _get_service_env(compose: dict, service: str) -> dict[str, str]:
+    """Normalize a compose service's ``environment`` (mapping or list) to a dict."""
+    svc = compose.get("services", {}).get(service) or {}
+    env = svc.get("environment", {})
+    if isinstance(env, list):
+        return {
+            item.split("=", 1)[0]: (item.split("=", 1)[1] if "=" in item else "") for item in env
+        }
+    return env or {}
+
+
+@pytest.fixture(scope="module")
+def compose_base() -> dict:
+    return _load_yaml(COMPOSE)
+
+
+def _otel_instrumented_services(compose: dict) -> list[str]:
+    """Services that set OTEL_SERVICE_NAME — i.e., emit OTel/Langfuse spans."""
+    services = []
+    for name in compose.get("services", {}):
+        env = _get_service_env(compose, name)
+        if "OTEL_SERVICE_NAME" in env:
+            services.append(name)
+    return services
+
+
+def test_some_services_are_otel_instrumented(compose_base: dict) -> None:
+    """Sanity: the scan is not vacuous."""
+    instrumented = _otel_instrumented_services(compose_base)
+    assert instrumented, (
+        "No compose service sets OTEL_SERVICE_NAME — the OTEL_PROPAGATORS "
+        "contract would be vacuous. Verify compose.yml / the env shape (#2246 F3)."
+    )
+
+
+def test_otel_services_declare_propagators(compose_base: dict) -> None:
+    """Every OTEL-instrumented service declares OTEL_PROPAGATORS w/ the W3C pair."""
+    missing: list[str] = []
+    wrong: list[tuple[str, str]] = []
+    for name in _otel_instrumented_services(compose_base):
+        env = _get_service_env(compose_base, name)
+        value = env.get("OTEL_PROPAGATORS")
+        if value is None:
+            missing.append(name)
+            continue
+        lowered = str(value).lower()
+        if not all(p in lowered for p in REQUIRED_PROPAGATORS):
+            wrong.append((name, str(value)))
+
+    assert not missing, (
+        "OTEL-instrumented compose services missing an explicit OTEL_PROPAGATORS "
+        f"declaration (#2246 F3): {sorted(missing)}. Add "
+        'OTEL_PROPAGATORS: "${OTEL_PROPAGATORS:-tracecontext,baggage}".'
+    )
+    assert not wrong, (
+        "OTEL_PROPAGATORS must include both 'tracecontext' and 'baggage' "
+        f"(#2246 F3). Offending services: {wrong}."
+    )
+
+
+def test_env_example_documents_propagators() -> None:
+    """`.env.example` documents OTEL_PROPAGATORS so operators can see/override it."""
+    text = ENV_EXAMPLE.read_text(encoding="utf-8")
+    assert "OTEL_PROPAGATORS" in text, (
+        ".env.example must document OTEL_PROPAGATORS (tracecontext,baggage) so the "
+        "propagation contract is discoverable and overridable (#2246 F3)."
+    )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Adds the missing **regression guards** for findings **F1** and **F3** of the #2246 trace-coverage audit. Both findings' code fixes already landed on `dev`; this PR ensures they cannot silently drift.

### F1 — raw thread hops drop contextvars

The #2220 contract (`test_observability_contextvars_contract.py`) only flagged `loop.run_in_executor(...)` near `@observe`. But `threading.Thread(...)` and `ThreadPoolExecutor(...).submit(...)` start workers with a **fresh** `contextvars.Context` too — so a downstream `@observe` span orphans into a new root trace. OpenTelemetry only auto-propagates `Context` across `asyncio`; raw threads need manual capture (verified via Context7).

- Extended the contract to also flag `threading.Thread` / `ThreadPoolExecutor.submit` in `@observe`-importing modules, unless guarded by `contextvars.copy_context().run` or allowlisted.
- `_INFRA_THREAD_ALLOWLIST` exempts the voice agent **health-server** thread (`src/voice/agent.py:_run` — runs `serve_forever()`, never creates spans).
- The code fix itself (`src/ingestion/cocoindex_flow.py` `copy_context()` guards at lines 136/265/325) was already present.
- **Verified red:** emptying the allowlist correctly flags `src/voice/agent.py:619`. Plus negative self-checks for flagged/guarded `Thread` and `submit` patterns.

### F3 — explicit `OTEL_PROPAGATORS`

The OTel SDK defaults to `tracecontext,baggage`, so propagation is currently correct — but implicitly. `compose.yml` already declares `OTEL_PROPAGATORS: "${OTEL_PROPAGATORS:-tracecontext,baggage}"` across the 7 OTEL services and `.env.example` documents it. New `test_otel_propagators_contract.py` pins this: every `OTEL_SERVICE_NAME`-bearing compose service must declare `OTEL_PROPAGATORS` with a default including both `tracecontext` and `baggage`, and `.env.example` must document it.

## Testing

- `pytest tests/contract/test_observability_contextvars_contract.py` → 16 passed.
- `pytest tests/contract/test_otel_propagators_contract.py` → 3 passed.
- `pytest tests/contract/` → 1394 passed, 2 skipped (Docker), 3 xfailed (pre-existing). Ruff clean.

## Notes

- **No production code changed** — both F1 and F3 fixes were already on `dev`; this PR is test-only hardening.
- F2/F4/F5/F6 of #2246 require live-runtime trace validation (Docker + Langfuse) and are out of scope here.
