### PR TITLE
docs(observability): decide Mini App browser W3C trace scope — deferred (#2273)

### DIFF
--- a/docs/observability/MINIAPP_BROWSER_TRACING_DECISION.md
+++ b/docs/observability/MINIAPP_BROWSER_TRACING_DECISION.md
@@ -1,0 +1,95 @@
+# Mini App browser W3C TraceContext origin — decision (#2273)
+
+Research-only decision record (same shape as
+[`VOICE_TRACING_BASELINE.md`](VOICE_TRACING_BASELINE.md)). It records the
+browser-tracing scope decision and the SDK-native path **if** it is ever
+adopted. No behavioural change ships with this document. Enforced by
+`tests/contract/test_miniapp_browser_tracing_decision_contract.py`.
+
+## Question
+
+Should a Telegram Mini App click/session in
+`mini_app/frontend/src/api.ts` become the **root** of the same distributed
+trace as `mini_app/api.py` and the downstream CRM/RAG work — i.e. should the
+browser generate or propagate a W3C `traceparent` / `tracestate`?
+
+## Decision
+
+**Deferred — out of scope for now.** Browser-originated traces are **not**
+adopted at this time. The backend one-trace gate (#2244) is server-side and
+does not require browser-originated spans.
+
+Rationale:
+
+- **No product need yet.** The Mini App is a thin WebView surface (config
+  fetch, `start-expert`, remote log). The distributed trace that matters for
+  observability begins at `mini_app/api.py` and flows into CRM/RAG. A browser
+  root span would add a hop above that boundary without a current consumer.
+- **The backend boundary is already correct and SDK-native.**
+  `mini_app/api.py` calls `instrument_fastapi_app(app)` (FastAPI OTEL
+  auto-instrumentation, #2225), which **auto-extracts** `traceparent` /
+  W3C Baggage from incoming requests. So if the frontend ever *does* send a
+  `traceparent`, the backend will honour it with **zero backend changes** —
+  the browser decision can be made later without re-touching the server.
+- **Cost/constraint.** Shipping an OTel JS web bundle into a Telegram WebView
+  (bundle size, an exposed browser-reachable OTLP collector endpoint, CORS,
+  init-data auth interplay) is real work that is not justified by current
+  needs.
+
+This decision is revisited if a concrete product requirement appears (e.g.
+"a Mini App tap must be the visible root of the lead's trace in Langfuse").
+
+## SDK evidence (for the in-scope path, if adopted)
+
+Gathered via Context7. *Content was rephrased for compliance with licensing
+restrictions.*
+
+- **OpenTelemetry JS web is the right tool, not Langfuse browser.** Langfuse
+  ships a JS/TS SDK (`/langfuse/langfuse-js`) but it targets server/Node LLM-app
+  instrumentation, not first-class browser/frontend span emission. For a
+  browser surface the OpenTelemetry JS web packages are the SDK-native choice:
+  - `@opentelemetry/sdk-trace-web` — `WebTracerProvider` registered with a
+    `BatchSpanProcessor` and an OTLP HTTP exporter.
+  - `@opentelemetry/instrumentation-fetch` — `FetchInstrumentation`
+    auto-creates a client span per `fetch(...)` and injects the W3C
+    `traceparent` header. `propagateTraceHeaderCorsUrls` scopes header
+    injection to the Mini App API origin so the token is never leaked to
+    third-party hosts.
+  - `@opentelemetry/core` `W3CTraceContextPropagator` is the default
+    propagator — the same `tracecontext` format the backend already extracts.
+- **Telegram Mini App / WebView compatibility.** The Mini App runs in a
+  standard browser WebView, so the web tracer + `FetchInstrumentation` apply
+  unchanged. The frontend's `fetch` calls target a same-origin `/api` base
+  (nginx-proxied), so `traceparent` injection works without extra CORS config;
+  `propagateTraceHeaderCorsUrls` would only be needed if the API moved
+  cross-origin.
+
+## In-scope path (only if the decision is reversed)
+
+1. Decide whether the browser **generates a root** `traceparent` (Mini App tap
+   is the trace root) or only **propagates a backend-issued** context. Default
+   recommendation: generate a root in the browser for true
+   click-to-CRM traces.
+2. Add the OTel JS web packages above to `mini_app/frontend`.
+3. Register a `WebTracerProvider` + `FetchInstrumentation` (scoped via
+   `propagateTraceHeaderCorsUrls` to the Mini App API origin) so the existing
+   `fetch(...)` calls in `mini_app/frontend/src/api.ts` carry `traceparent`.
+4. Keep `mini_app/api.py` extraction **SDK-native** via `instrument_fastapi_app`
+   (already wired) — no manual header parsing.
+5. Open a dedicated implementation issue and define the header contract
+   (`traceparent` / `tracestate`) on the `api.ts` calls.
+
+## Out of scope
+
+- Any frontend SDK install or `api.ts` header change (this is research-only).
+- A browser-reachable OTLP collector endpoint.
+- Replacing the backend `instrument_fastapi_app` extraction.
+
+## References
+
+- #2244 (one-trace gate, server-side), #2246, #2256 (cross-service W3C).
+- `mini_app/frontend/src/api.ts`, `mini_app/api.py`.
+- OpenTelemetry JS: `@opentelemetry/sdk-trace-web`,
+  `@opentelemetry/instrumentation-fetch`, `@opentelemetry/core`
+  (`W3CTraceContextPropagator`) — via Context7
+  (`/open-telemetry/opentelemetry-js`).

--- a/tests/contract/test_miniapp_browser_tracing_decision_contract.py
+++ b/tests/contract/test_miniapp_browser_tracing_decision_contract.py
@@ -1,0 +1,74 @@
+"""Mini App browser-tracing decision contract (#2273).
+
+Locks in the research-only decision recorded in
+``docs/observability/MINIAPP_BROWSER_TRACING_DECISION.md`` so it cannot silently
+disappear or drift from the code it describes:
+
+* a clear scope decision must be stated (in-scope / deferred / out-of-scope);
+* the doc must keep pointing at the candidate SDK-native browser path
+  (OpenTelemetry JS web), not a non-existent Langfuse browser tracer;
+* the doc's central claim — that ``mini_app/api.py`` extraction stays
+  SDK-native via FastAPI auto-instrumentation — must remain true in code, so
+  the "no backend change needed" decision is not built on a stale fact.
+
+This mirrors ``test_voice_tracing_baseline_contract.py`` (#2257): a documented
+decision, enforced.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DECISION_DOC = REPO_ROOT / "docs" / "observability" / "MINIAPP_BROWSER_TRACING_DECISION.md"
+MINIAPP_API = REPO_ROOT / "mini_app" / "api.py"
+
+
+def _doc_text() -> str:
+    return DECISION_DOC.read_text(encoding="utf-8")
+
+
+def test_decision_doc_exists() -> None:
+    assert DECISION_DOC.exists(), f"missing decision record: {DECISION_DOC}"
+
+
+def test_doc_states_a_clear_scope_decision() -> None:
+    lowered = _doc_text().lower()
+    assert any(marker in lowered for marker in ("out of scope", "deferred", "in scope")), (
+        "docs/observability/MINIAPP_BROWSER_TRACING_DECISION.md must state a clear "
+        "browser-tracing scope decision: in-scope, deferred, or out-of-scope (#2273)."
+    )
+
+
+def test_doc_references_sdk_native_browser_path() -> None:
+    """The candidate path must be OpenTelemetry JS web, not a Langfuse browser SDK."""
+    text = _doc_text()
+    for token in ("@opentelemetry/sdk-trace-web", "@opentelemetry/instrumentation-fetch"):
+        assert token in text, (
+            "The decision record must document the OpenTelemetry JS web path "
+            f"({token}) as the SDK-native browser option (#2273)."
+        )
+    assert "traceparent" in text.lower(), (
+        "The decision record must discuss W3C traceparent propagation (#2273)."
+    )
+
+
+def test_backend_extraction_claim_matches_code() -> None:
+    """The doc claims mini_app/api.py extracts trace context SDK-natively.
+
+    Keep that claim honest: mini_app/api.py must actually wire FastAPI
+    auto-instrumentation (which extracts traceparent/baggage). If this ever
+    changes, the "no backend change needed" rationale must be revisited.
+    """
+    doc = _doc_text()
+    assert "instrument_fastapi_app" in doc, (
+        "The decision rationale relies on FastAPI auto-extraction; the doc must "
+        "name instrument_fastapi_app (#2273)."
+    )
+    api_src = MINIAPP_API.read_text(encoding="utf-8")
+    assert "instrument_fastapi_app(app)" in api_src, (
+        "mini_app/api.py no longer calls instrument_fastapi_app(app); the #2273 "
+        "decision assumed SDK-native backend traceparent extraction — revisit the "
+        "decision record."
+    )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #2273 by recording the requested **browser-tracing scope decision** as a research-only decision record (same shape as `VOICE_TRACING_BASELINE.md`).

## Decision: Deferred / out of scope (for now)

Browser-originated traces are **not** adopted at this time:
- The #2244 one-trace gate is **server-side**; the Mini App is a thin WebView with no current consumer for a browser root span.
- **`mini_app/api.py` already calls `instrument_fastapi_app(app)`** (FastAPI OTEL auto-instrumentation, #2225), which auto-extracts `traceparent`/W3C Baggage. So if the frontend ever *does* send a `traceparent`, the backend honours it with **zero backend changes** — the browser decision can be made later in isolation.
- Shipping an OTel JS web bundle into a Telegram WebView (bundle size, browser-reachable OTLP endpoint, CORS, init-data auth) isn't justified by current needs.

## SDK evidence (for the in-scope path, via Context7)

- The SDK-native browser path is **OpenTelemetry JS web**, not Langfuse: `langfuse-js` (`/langfuse/langfuse-js`) targets server/Node LLM-app tracing, not browser spans.
- `@opentelemetry/sdk-trace-web` (`WebTracerProvider`) + `@opentelemetry/instrumentation-fetch` (`FetchInstrumentation` injects `traceparent`, scoped via `propagateTraceHeaderCorsUrls`) + `@opentelemetry/core` `W3CTraceContextPropagator` (default) — the same `tracecontext` format the backend already extracts. The Mini App WebView is a standard browser, and `api.ts` calls a same-origin `/api` base, so injection works without extra CORS config.

*Content was rephrased for compliance with licensing restrictions.*

## Changes

- **New** `docs/observability/MINIAPP_BROWSER_TRACING_DECISION.md` — the decision + the in-scope path if reversed.
- **New** `tests/contract/test_miniapp_browser_tracing_decision_contract.py` — pins that a clear decision exists, points at the OTel JS web path (not Langfuse browser), and keeps the "backend extraction is SDK-native" claim honest against `mini_app/api.py` (asserts `instrument_fastapi_app(app)` is still wired).

## Testing

- `pytest tests/contract/test_miniapp_browser_tracing_decision_contract.py` → 4 passed. Ruff clean.

Research-only; no frontend/`api.ts` change, no runtime/production validation required (per the issue).
