### PR TITLE
docs(security): 2026-05-29 monitoring check for no-patch alerts (#2043)

### DIFF
--- a/docs/security/no-patch-dependency-alerts.md
+++ b/docs/security/no-patch-dependency-alerts.md
@@ -1,6 +1,6 @@
 # No-patch dependency alerts — exposure assessment
 
-**Last reviewed:** 2026-05-22
+**Last reviewed:** 2026-05-29
 **Source artifacts:**
 `logs/NO-PATCH-DEPENDENCY-MITIGATION.audit.md`,
 `logs/SECURITY-ISSUE-POSTMERGE.audit.md`,
@@ -116,6 +116,23 @@ exploitable.
 alerts. The intent is to keep them visible as a monitoring signal — when a
 patched version ships, Dependabot will clear the alert automatically, serving
 as a prompt to upgrade.
+
+---
+
+## Monitoring log
+
+Periodic upstream checks for a patched release (issue #2043 — "Monitor upstream
+for patched releases"). Each entry records the latest version available on PyPI
+at check time and whether it clears the vulnerable range.
+
+| Date | diskcache (vuln `<=5.6.3`) | ragas (vuln `>=0.2.3,<=0.4.3`) | Verdict |
+|------|----------------------------|-------------------------------|---------|
+| 2026-05-22 | 5.6.3 — no patch | 0.4.3 — no patch | Isolation stance holds |
+| 2026-05-29 | 5.6.3 (latest on PyPI) — no patch | 0.4.3 (latest on PyPI) — no patch | No upstream fix; isolation stance holds |
+
+No upstream patch is available for either package as of the latest check, so the
+isolation mitigation above remains the active stance. When Dependabot clears
+either alert (a patched version ships), follow the upgrade criteria above.
 
 ---
 


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Advances the only open task in #2043 — **"Monitor upstream for patched releases."**

#2043's isolation mitigation is already in place on `dev` (an 8-invariant contract `test_dependabot_no_patch_isolation_contract.py` + a thorough `docs/security/no-patch-dependency-alerts.md`). This PR records a fresh, PyPI-verified monitoring check.

## Monitoring check (2026-05-29, verified against PyPI)

| Package | Vulnerable range | Latest on PyPI | Patch? |
|---|---|---|---|
| `diskcache` (CVE-2025-69872) | `<=5.6.3` | **5.6.3** | none |
| `ragas` (CVE-2026-6587) | `>=0.2.3,<=0.4.3` | **0.4.3** | none |

No upstream patch is available for either, so the isolation stance (ragas eval-only, diskcache transitive-only) remains correct.

## Changes

- Add a dated **Monitoring log** table to `docs/security/no-patch-dependency-alerts.md` (2026-05-22 + 2026-05-29 entries).
- Bump **Last reviewed** to 2026-05-29.

## Testing

- `pytest tests/contract/test_dependabot_no_patch_isolation_contract.py` → 6 passed (isolation invariants unchanged).

Docs-only; no dependency change (no patch to adopt). Per the issue, the alerts are intentionally **not** dismissed and **no** Dependabot ignore rule is added — they stay visible as a monitoring signal.
