### PR TITLE
fix: read-only candidate-check and bot no-sync for stale venv safety

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -382,7 +382,7 @@ PREFLIGHT_BOT_FLAGS ?=
 BOT_RESPONSE_SMOKE_FLAGS ?=
 
 preflight-bot: ## Check bot runtime env before starting (missing .env, invalid token, port issues)
-	@uv run python scripts/probe/check_bot_runtime_env.py $(PREFLIGHT_BOT_FLAGS)
+	@$(UV_RUN_NO_SYNC) python -m scripts.probe.check_bot_runtime_env $(PREFLIGHT_BOT_FLAGS)
 
 bot-response-smoke: ## End-to-end gate: prove `make bot` actually answers a Telegram message (#2192)
 	@echo "$(BLUE)Running bot response smoke gate...$(NC)"
@@ -700,8 +700,25 @@ docs-check: ## Check Markdown relative links for broken targets
 # QUICK COMMANDS
 # =============================================================================
 
+.PHONY: check-frozen candidate-check
+
 check: lint type-check ## Quick check (lint + types)
 	@echo "$(GREEN)✓ Quick check complete$(NC)"
+
+check-frozen: ## Read-only check: fail if .venv is stale, then lint + type-check without uv sync
+	@echo "$(BLUE)Checking frozen uv environment...$(NC)"
+	@uv sync --frozen --check || { \
+		echo "$(RED)Environment is stale. Run 'uv sync --frozen' in an isolated worktree .venv, then retry.$(NC)"; \
+		exit 1; \
+	}
+	@echo "$(BLUE)Running Ruff lint without uv auto-sync...$(NC)"
+	@$(UV_RUN_NO_SYNC) ruff check $(LINT_PATHS)
+	@echo "$(GREEN)✓ Ruff check complete$(NC)"
+	@echo "$(BLUE)Running MyPy type-check without uv auto-sync...$(NC)"
+	@$(UV_RUN_NO_SYNC) mypy $(LINT_PATHS) --ignore-missing-imports --no-error-summary
+	@echo "$(GREEN)✓ Frozen check complete$(NC)"
+
+candidate-check: check-frozen ## Candidate/review check alias (read-only after env preflight)
 
 pre-push: lint format-check ## Pre-push gate (lint + format-check)
 	@echo "$(GREEN)✓ Pre-push gate passed$(NC)"
@@ -730,11 +747,11 @@ local-up-ingest:  ## Start local services + docling for ingestion workflows
 	@echo "$(GREEN)✓ Local services + docling started$(NC)"
 
 run-bot:  ## Run bot locally (requires: make local-up)
-	uv run --env-file "$$RAG_RUNTIME_ENV_FILE" python -m telegram_bot.main
+	$(UV_RUN_NO_SYNC) --env-file "$$RAG_RUNTIME_ENV_FILE" python -m telegram_bot.main
 
 bot: preflight-bot test-bot-health ## Alias: run bot and tee output to logs/bot-run.log
 	@mkdir -p logs
-	@bash -o pipefail -c 'uv run --env-file "$$RAG_RUNTIME_ENV_FILE" python -m telegram_bot.main 2>&1 | tee logs/bot-run.log'; \
+	@bash -o pipefail -c '$(UV_RUN_NO_SYNC) --env-file "$$RAG_RUNTIME_ENV_FILE" python -m telegram_bot.main 2>&1 | tee logs/bot-run.log'; \
 	status=$$?; echo '[COMPLETE]'; exit $$status
 
 # =============================================================================

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -158,6 +158,27 @@ This runs expanded lint (covering `src/` and `telegram_bot/` to match CI),
 and format verification. Run `make check` when you also need the current
 lint + MyPy gate; it may surface known baseline type drift until that is fixed.
 
+For candidate or review validation where the project `.venv` must not be
+changed implicitly, use:
+
+```bash
+make candidate-check
+```
+
+This is a read-only frozen check that runs `uv sync --frozen --check` first to
+detect whether `.venv` matches the lockfile, then runs Ruff lint and MyPy with
+`uv run --no-sync` to prevent implicit environment updates. It does NOT create
+or modify `.venv`. If the environment is absent or stale, it fails with
+guidance instead of uninstalling or installing packages. Keep ordinary
+developer loops on `make check` when auto-sync is acceptable.
+
+Stale `.venv` remediation:
+- If `.venv` exists but is stale (lockfile changed): `uv sync --frozen`
+- If `.venv` is absent or was polluted by another worktree: recreate with
+  `uv sync --frozen` (or `uv sync` for full dev install)
+- When switching between worktrees that share a lockfile, run
+  `make candidate-check` in each before committing changes
+
 ### Hooks and uv environments
 
 Pre-commit hooks use their own isolated virtualenvs managed by the pre-commit
@@ -292,9 +313,17 @@ Docker images that import `telegram_bot.observability` (and therefore `langfuse`
 
 ## 7. Running Components Without Docker Wrapper
 
+`make bot`, `make run-bot`, and `make preflight-bot` now use
+`uv run --no-sync` to prevent implicit venv updates during runtime loops.
+This keeps the runtime environment stable and avoids lockfile drift when
+the development venv is already in sync.
+
 ```bash
-# Telegram bot
-uv run python -m telegram_bot.main
+# Telegram bot (no-sync)
+make bot                 # tee output to logs/bot-run.log
+
+# Telegram bot without tee
+make run-bot
 
 # Unified ingestion
 uv run python -m src.ingestion.unified.cli
@@ -302,6 +331,9 @@ uv run python -m src.ingestion.unified.cli
 # RAG API
 uv run uvicorn src.api.main:app --host 0.0.0.0 --port 8080
 ```
+
+If your venv is stale and the bot startup fails with a missing import,
+run `uv sync --frozen` before restarting.
 
 ## 8. Minimal Stack (Fast Iteration)
 
@@ -368,3 +400,5 @@ Swarm worktrees start from a fresh `origin/dev` checkout and do not contain the 
 - Ingestion status empty: verify `GDRIVE_SYNC_DIR` and collection bootstrap.
 - Redis auth error (`WRONGPASS` / `NOAUTH`) after changing `.env` `REDIS_PASSWORD`: run `make local-redis-recreate`, then `make test-bot-health`.
 - `make docker-bot-up` or `make bot` exits before starting with no clear error: run `make preflight-bot` to see exactly what is missing. Use `PREFLIGHT_BOT_FLAGS='--no-fail'` to bypass the guardrail if you only need to start infrastructure.
+- `make candidate-check` fails with "Environment is stale": run `uv sync --frozen` to align `.venv` with the current lockfile, then retry. If `.venv` was polluted by another worktree sharing the same lockfile, delete `.venv` and recreate with `uv sync --frozen`.
+- `make bot` fails with a missing import at startup: the venv is stale. Run `uv sync --frozen` before restarting the bot.

--- a/tests/unit/test_makefile_contract.py
+++ b/tests/unit/test_makefile_contract.py
@@ -516,8 +516,8 @@ def test_preflight_bot_is_phony() -> None:
     assert "preflight-bot" in combined, "preflight-bot must be declared in .PHONY"
 
 
-def test_preflight_bot_runs_python_script() -> None:
-    """`preflight-bot` must invoke the check_bot_runtime_env.py script."""
+def test_preflight_bot_runs_no_sync_module() -> None:
+    """`preflight-bot` must invoke the env checker without uv auto-sync."""
     text = _makefile_text()
     block_match = re.search(
         r"^preflight-bot:.*?(?=^[A-Za-z0-9_.-]+:|\Z)",
@@ -526,9 +526,30 @@ def test_preflight_bot_runs_python_script() -> None:
     )
     assert block_match, "preflight-bot target not found in Makefile"
     block = block_match.group(0)
-    assert "scripts/probe/check_bot_runtime_env.py" in block, (
-        "preflight-bot must invoke scripts/probe/check_bot_runtime_env.py"
+    assert "$(UV_RUN_NO_SYNC) python -m scripts.probe.check_bot_runtime_env" in block, (
+        "preflight-bot must invoke scripts.probe.check_bot_runtime_env via "
+        "$(UV_RUN_NO_SYNC) so bot startup checks do not mutate .venv"
     )
+
+
+def test_candidate_check_is_read_only_frozen_gate() -> None:
+    """`make candidate-check` must fail on stale env before no-sync lint/type checks."""
+    text = _makefile_text()
+    assert re.search(r"^candidate-check:\s*check-frozen\b", text, re.MULTILINE), (
+        "candidate-check must depend on check-frozen"
+    )
+    block_match = re.search(
+        r"^check-frozen:.*?(?=^[A-Za-z0-9_.-]+:|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert block_match, "check-frozen target not found in Makefile"
+    block = block_match.group(0)
+    assert "uv sync --frozen --check" in block
+    assert "$(UV_RUN_NO_SYNC) ruff check $(LINT_PATHS)" in block
+    assert "$(UV_RUN_NO_SYNC) mypy $(LINT_PATHS)" in block
+    assert "uv run ruff" not in block
+    assert "uv run mypy" not in block
 
 
 def test_preflight_bot_has_flag_override() -> None:


### PR DESCRIPTION
## Summary

Read-only frozen check for candidate/review validation and `uv run --no-sync` for bot runtime loops to prevent implicit `.venv` mutations.

## Changes

- **`Makefile`**: Add `check-frozen`/`candidate-check` targets that run `uv sync --frozen --check` before lint + MyPy with `uv run --no-sync`. Switch `preflight-bot` to module invocation via `python -m scripts.probe.check_bot_runtime_env`. Switch `run-bot` and `bot` to `$(UV_RUN_NO_SYNC)`, preserving log tee + exit status in `bot`. Keep `bot-response-smoke` on plain `uv run` (it's a verification gate, not a runtime loop, and benefits from the auto-sync guarantee).
- **`docs/LOCAL-DEVELOPMENT.md`**: Document candidate-check usage, no-sync behavior, stale `.venv` remediation, and worktree handling.

## Verification

- `make -n candidate-check` — correct recipe: frozen check → no-sync lint + MyPy
- `make candidate-check` (absent `.venv`) — fails without creating/modifying `.venv` with clear error guidance
- `uv run --no-sync python -m scripts.probe.check_bot_runtime_env --skip-docker` — module invocation works
- `make -n bot`, `make -n run-bot`, `make -n preflight-bot` — all use `uv run --no-sync`
- `make docs-check` — all links OK
- `git diff --check` — clean

Fixes #2285
Fixes #2289