### PR TITLE
observability: migrate off deprecated Langfuse set_current_trace_io (#2276)

### DIFF
--- a/telegram_bot/services/telegram_formatting.py
+++ b/telegram_bot/services/telegram_formatting.py
@@ -146,12 +146,12 @@ def build_html_messages(
 
 
 def record_langfuse_response_output(answer_text: str | None, chunks_count: int) -> None:
-    """Best-effort update of the current Langfuse trace/span output after a send.
+    """Best-effort update of the current Langfuse observation output after a send.
 
-    Prefers ``update_current_span`` (SDK-native in Langfuse v4+), falls back to
-    ``set_current_trace_io`` for older clients, and is a no-op when the client or
-    all methods are missing so Telegram sending never breaks because of
-    observability.
+    Records response metadata via span-level IO (``update_current_span``).
+    Trace-level IO (``set_current_trace_io``) is deprecated in Langfuse v4 and
+    intentionally not used. No-op when the client or method is missing so
+    Telegram sending never breaks because of observability.
     """
     lf = get_client()
     if lf is None:
@@ -163,18 +163,8 @@ def record_langfuse_response_output(answer_text: str | None, chunks_count: int) 
     if callable(update_span):
         try:
             update_span(output=output)
-            return
         except Exception:
-            logger.debug(
-                "update_current_span failed, falling back to set_current_trace_io", exc_info=True
-            )
-
-    set_trace_io = getattr(lf, "set_current_trace_io", None)
-    if callable(set_trace_io):
-        try:
-            set_trace_io(output=output)
-        except Exception:
-            logger.debug("set_current_trace_io failed", exc_info=True)
+            logger.debug("update_current_span failed", exc_info=True)
 
 
 _record_langfuse_response_output = record_langfuse_response_output

--- a/tests/unit/observability/test_trace_resilience.py
+++ b/tests/unit/observability/test_trace_resilience.py
@@ -57,9 +57,6 @@ class TestSdkDisabledClientResilience:
 
         return get_client()
 
-    def test_set_current_trace_io_no_raise(self):
-        self._client().set_current_trace_io(input={"query": "test"}, output={"response": "ok"})
-
     def test_update_current_span_no_raise(self):
         self._client().update_current_span(
             input={"x": 1}, output={"y": 2}, level="WARNING", status_message="msg"

--- a/tests/unit/test_telegram_formatting.py
+++ b/tests/unit/test_telegram_formatting.py
@@ -32,8 +32,8 @@ class TestRecordLangfuseResponseOutput:
         mock_build.assert_called_once_with("hello", 2)
         mock_lf.update_current_span.assert_called_once_with(output={"mock": "payload"})
 
-    def test_prefers_update_current_span_when_present(self):
-        """Issue #2280: update_current_span is the SDK-native API; prefer it."""
+    def test_uses_span_level_io_not_deprecated_trace_io(self):
+        """Issue #2276: use span-level IO, never deprecated trace-level IO."""
         mock_lf = MagicMock()
         mock_lf.update_current_span = MagicMock()
         mock_lf.set_current_trace_io = MagicMock()
@@ -51,51 +51,27 @@ class TestRecordLangfuseResponseOutput:
         assert output["chunks_count"] == 1
         assert output["delivery_status"] == "sent"
 
-    def test_falls_back_to_set_current_trace_io(self):
-        """Issue #2280: set_current_trace_io is the legacy fallback."""
+    def test_no_op_when_update_span_missing(self):
         mock_lf = MagicMock()
         del mock_lf.update_current_span
         mock_lf.set_current_trace_io = MagicMock()
 
         with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
-            record_langfuse_response_output("fallback", 3)
-
-        mock_lf.set_current_trace_io.assert_called_once()
-        call_kwargs = mock_lf.set_current_trace_io.call_args.kwargs
-        assert "output" in call_kwargs
-        output = call_kwargs["output"]
-        assert "answer_preview" in output
-        assert output["chunks_count"] == 3
-
-    def test_no_op_when_both_methods_missing(self):
-        mock_lf = MagicMock()
-        del mock_lf.update_current_span
-        del mock_lf.set_current_trace_io
-
-        with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
             record_langfuse_response_output("answer", 1)
 
-    def test_span_failure_falls_back_to_trace_io(self):
-        """Issue #2280: update_current_span failure falls back to set_current_trace_io."""
-        mock_lf = MagicMock()
-        mock_lf.update_current_span = MagicMock(side_effect=RuntimeError("span error"))
-        mock_lf.set_current_trace_io = MagicMock()
-
-        with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
-            record_langfuse_response_output("answer", 1)
-
-        mock_lf.update_current_span.assert_called_once()
-        mock_lf.set_current_trace_io.assert_called_once()
+        mock_lf.set_current_trace_io.assert_not_called()
 
     def test_span_failure_is_silent(self):
-        """Issue #2280: Both methods failing is silent fallthrough."""
+        """Issue #2276: update_current_span failure is silent without deprecated fallback."""
         mock_lf = MagicMock()
         mock_lf.update_current_span = MagicMock(side_effect=RuntimeError("span error"))
-        mock_lf.set_current_trace_io = MagicMock(side_effect=RuntimeError("trace io error"))
+        mock_lf.set_current_trace_io = MagicMock()
 
         with patch("telegram_bot.services.telegram_formatting.get_client", return_value=mock_lf):
             # Should not raise
             record_langfuse_response_output("answer", 1)
+
+        mock_lf.set_current_trace_io.assert_not_called()
 
     def test_preview_truncated_to_safe_limit(self):
         mock_lf = MagicMock()


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #2276 — removes the Langfuse `set_current_trace_io` DeprecationWarning emitted on every traced bot response.

`telegram_bot/services/telegram_formatting.py::record_langfuse_response_output` called the deprecated trace-level `lf.set_current_trace_io(output=...)`. Langfuse v4.3.1 marks trace-level input/output `@deprecated` ("will be removed in a future major version").

## Migration: trace-level IO → span-level IO

- Drop the `set_current_trace_io` branch; record the response via **`update_current_span(output=...)`** only (it was already the existing fallback).
- This runs inside the root `@observe` span of the message handler, so the root observation's output is what the Langfuse UI surfaces as the trace output — **behavior in the UI is preserved** while the deprecated API is dropped.
- Note: there is no `update_current_trace` in v4, and the SDK's deprecation message steers `propagate_attributes()` only for trace *attributes* (user_id/session_id/tags/metadata), not output — so span-level IO is the correct replacement (as the issue states).

## Changes

- `telegram_formatting.py` — span-level IO only (best-effort, no-op when the client/method is missing).
- `tests/unit/test_telegram_formatting.py` — assert span-level IO is used and `set_current_trace_io` is **never** called (verified red first); removed the now-obsolete fallback/trace-io-failure tests.
- `tests/unit/observability/test_trace_resilience.py` — removed the direct `set_current_trace_io` no-raise probe (production no longer uses it; this removes the DeprecationWarning source in the fast gate).

## Testing

- `pytest -W error::DeprecationWarning` scoped to `telegram_bot.services.telegram_formatting` → passes (warning gone).
- `pytest tests/unit/test_telegram_formatting.py tests/unit/observability/test_trace_resilience.py tests/unit/services/test_generate_response.py` → 80 passed.
- `pytest tests/unit/test_bot_handlers.py` → 201 passed (remaining warnings are redisvl = #2277, separate). Ruff clean.

`verify:repo-only` — no runtime/Docker validation required.
