### PR TITLE
build(make): add read-only check-frozen candidate-validation gate (#2285)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -703,6 +703,20 @@ docs-check: ## Check Markdown relative links for broken targets
 check: lint type-check ## Quick check (lint + types)
 	@echo "$(GREEN)✓ Quick check complete$(NC)"
 
+check-frozen: ## Read-only candidate validation (lint + types, no .venv mutation) (#2285)
+	@echo "$(BLUE)Preflight: verifying environment matches uv.lock (read-only)...$(NC)"
+	@uv sync --frozen --check || { \
+		echo "$(YELLOW)✗ Environment is stale or does not match uv.lock.$(NC)"; \
+		echo "$(YELLOW)  This is a read-only candidate gate; it will not mutate .venv.$(NC)"; \
+		echo "$(YELLOW)  Run 'uv sync --frozen' (or use an isolated per-worktree .venv) and retry.$(NC)"; \
+		exit 1; \
+	}
+	@echo "$(BLUE)Running Ruff linter (no-sync)...$(NC)"
+	$(UV_RUN_NO_SYNC) ruff check $(LINT_PATHS)
+	@echo "$(BLUE)Running MyPy type checking (no-sync)...$(NC)"
+	$(UV_RUN_NO_SYNC) mypy $(LINT_PATHS) --ignore-missing-imports --no-error-summary
+	@echo "$(GREEN)✓ Frozen check complete (.venv untouched)$(NC)"
+
 pre-push: lint format-check ## Pre-push gate (lint + format-check)
 	@echo "$(GREEN)✓ Pre-push gate passed$(NC)"
 

--- a/docs/engineering/test-writing-guide.md
+++ b/docs/engineering/test-writing-guide.md
@@ -73,6 +73,11 @@ E2E naming contract:
 - Then run repository baseline:
   - `make check`
   - `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
+- For candidate/review validation on a shared or reused `.venv`, prefer the
+  read-only gate `make check-frozen` (#2285): it preflights with
+  `uv sync --frozen --check` and runs lint/type-check via `uv run --no-sync`,
+  so it fails on a stale env instead of silently mutating `.venv`. Use plain
+  `make check` for everyday local work where auto-sync is fine.
 - If skipping a relevant check, document it explicitly in the report.
 
 ## References

--- a/tests/contract/test_makefile_check_frozen_contract.py
+++ b/tests/contract/test_makefile_check_frozen_contract.py
@@ -1,0 +1,83 @@
+"""Contract test for issue #2285 — read-only candidate-validation gate.
+
+`make check` (and its `lint` / `type-check` deps) invoked plain `uv run`, which
+syncs the project environment before running. In shared/reused `.venv`
+candidate worktrees this silently uninstalls/installs packages during what is
+supposed to be a *validation* step, mutating the environment and potentially
+switching versions between candidates.
+
+This contract pins the fix:
+
+* a dedicated ``check-frozen`` (candidate-validation) target exists;
+* it preflights with a read-only lock check (``uv sync --frozen --check``) so a
+  stale env fails with guidance instead of being auto-synced;
+* its lint/type-check commands run via the no-sync runner (``uv run --no-sync``
+  / ``$(UV_RUN_NO_SYNC)``), never a plain auto-syncing ``uv run``;
+* developer-friendly ``make check`` is left intact (still allowed to auto-sync).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+MAKEFILE = REPO / "Makefile"
+
+
+def _makefile_text() -> str:
+    return MAKEFILE.read_text(encoding="utf-8")
+
+
+def _target_block(text: str, target: str) -> str:
+    pattern = rf"^{re.escape(target)}:.*?(?=^[A-Za-z0-9_.-]+:|\Z)"
+    match = re.search(pattern, text, re.MULTILINE | re.DOTALL)
+    assert match, f"Makefile must define a {target!r} target (#2285)"
+    return match.group(0)
+
+
+def test_check_frozen_target_exists() -> None:
+    text = _makefile_text()
+    assert re.search(r"^check-frozen:", text, re.MULTILINE), (
+        "Makefile must define a read-only candidate-validation target "
+        "'check-frozen' (#2285)."
+    )
+
+
+def test_check_frozen_preflights_with_readonly_lock_check() -> None:
+    block = _target_block(_makefile_text(), "check-frozen")
+    # Read-only env verification: uv sync --frozen --check (no mutation).
+    assert "uv sync --frozen --check" in block, (
+        "check-frozen must preflight the environment read-only with "
+        "'uv sync --frozen --check' so a stale .venv fails with guidance "
+        "instead of being auto-synced (#2285)."
+    )
+
+
+def test_check_frozen_runs_tools_without_autosync() -> None:
+    block = _target_block(_makefile_text(), "check-frozen")
+    # ruff + mypy must run, and must not use a bare auto-syncing `uv run`.
+    assert "ruff check" in block and "mypy" in block, (
+        "check-frozen must run both ruff and mypy (#2285)."
+    )
+    no_sync = "$(UV_RUN_NO_SYNC)" in block or "uv run --no-sync" in block
+    assert no_sync, (
+        "check-frozen must execute lint/type-check via the no-sync runner "
+        "($(UV_RUN_NO_SYNC) / 'uv run --no-sync'), never a plain auto-syncing "
+        "'uv run' (#2285)."
+    )
+    # Guard against an accidental bare `uv run ` (auto-sync) in the recipe.
+    bare_uv_run = re.findall(r"(?<!\S)uv run (?!--no-sync)", block)
+    assert not bare_uv_run, (
+        "check-frozen must not use a bare auto-syncing 'uv run' "
+        f"(found {len(bare_uv_run)}); use $(UV_RUN_NO_SYNC) (#2285)."
+    )
+
+
+def test_check_frozen_is_documented_in_help() -> None:
+    block = _target_block(_makefile_text(), "check-frozen")
+    assert "##" in block, (
+        "check-frozen must carry a '## ' help annotation so it appears in "
+        "`make help` (#2285)."
+    )


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Closes #2285 — adds a read-only candidate-validation gate so review/validation never silently mutates a shared `.venv`.

## Problem

`make check` (via its `lint` / `type-check` deps) ran plain `uv run`, which **syncs the project environment** before running. On shared/reused `.venv` candidate worktrees this silently uninstalls/installs packages during what should be a *validation* step, mutating the env and potentially switching versions between candidates. This diverges from CI, which installs with `uv sync --frozen`.

## Fix

Per the issue's preferred option, add a dedicated target rather than changing developer-friendly `make check`:

```
make check-frozen
```
1. **Read-only preflight:** `uv sync --frozen --check`. If the env is stale it **fails with clear guidance** (run `uv sync --frozen`, or use an isolated per-worktree `.venv`) instead of auto-syncing.
2. Runs `ruff` + `mypy` via `$(UV_RUN_NO_SYNC)` (`uv run --no-sync`) — never a bare auto-syncing `uv run`.
3. Leaves `.venv` untouched.

`make check` is intentionally left as-is for everyday local work where auto-sync is fine.

## Changes

- **`Makefile`** — new `check-frozen` target (help-annotated, shows in `make help`).
- **`tests/contract/test_makefile_check_frozen_contract.py`** — pins: target exists, read-only `uv sync --frozen --check` preflight, lint+type-check run via the no-sync runner, no bare `uv run`, and a help annotation (TDD — verified red first).
- **`docs/engineering/test-writing-guide.md`** — documents when to use `check-frozen` vs `check`.

## Acceptance criteria (from issue)

- ✅ Candidate/review validation has a documented command that is read-only w.r.t. `.venv` after an explicit preflight.
- ✅ If the env is stale, the command fails with clear guidance instead of auto-syncing.
- ✅ Normal local `make check` still uses `uv run` auto-sync.

## Testing

- `pytest tests/contract/ -k makefile` → 58 passed.
- `make -n check-frozen` dry-run confirms the read-only preflight + `uv run --no-sync` tool invocations; `make help` lists the target. Ruff clean.

`verify:repo-only` — no Docker/runtime validation required.