### PR TITLE
fix: fail-fast when Qdrant is unreachable in make bot (#2294)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -749,8 +749,13 @@ local-up-ingest:  ## Start local services + docling for ingestion workflows
 run-bot:  ## Run bot locally (requires: make local-up)
 	$(UV_RUN_NO_SYNC) --env-file "$$RAG_RUNTIME_ENV_FILE" python -m telegram_bot.main
 
-bot: preflight-bot test-bot-health ## Alias: run bot and tee output to logs/bot-run.log
+bot: preflight-bot test-bot-health ## Alias: run bot (fail-fast when Qdrant is down; tee output to logs/bot-run.log)
 	@mkdir -p logs
+	@if ! timeout 1 bash -c 'echo >/dev/tcp/localhost/6333' 2>/dev/null; then \
+		echo "$(RED)✗ Qdrant is not reachable on localhost:6333$(NC)" >&2; \
+		echo "$(YELLOW)Run 'make local-up' to start required local services (redis, qdrant, bge-m3, litellm)$(NC)" >&2; \
+		exit 1; \
+	fi
 	@bash -o pipefail -c '$(UV_RUN_NO_SYNC) --env-file "$$RAG_RUNTIME_ENV_FILE" python -m telegram_bot.main 2>&1 | tee logs/bot-run.log'; \
 	status=$$?; echo '[COMPLETE]'; exit $$status
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@
 	docker-clean docker-clean-aggressive
 	test-contract \
 	preflight-bot \
+	preflight-qdrant \
 	docs-check \
 	remote-docker-status remote-compose-config remote-docker-ps remote-env-sync remote-env-check \
 	remote-active-up remote-core-up remote-core-ps remote-core-logs remote-core-health remote-core-env-check \
@@ -381,6 +382,14 @@ test-redis: ## Verify Redis Query Engine is available
 PREFLIGHT_BOT_FLAGS ?=
 BOT_RESPONSE_SMOKE_FLAGS ?=
 
+preflight-qdrant: ## Fail fast when localhost:6333 is unreachable (run before preflight-bot and bot)
+	@if ! timeout 1 bash -c 'echo >/dev/tcp/localhost/6333' 2>/dev/null; then \
+		echo "$(RED)✗ Qdrant is not reachable on localhost:6333$(NC)" >&2; \
+		echo "$(YELLOW)Run 'make local-up' to start required local services (redis, qdrant, bge-m3, litellm)$(NC)" >&2; \
+		exit 1; \
+	fi
+	@echo "$(GREEN)✓ Qdrant reachable$(NC)"
+
 preflight-bot: ## Check bot runtime env before starting (missing .env, invalid token, port issues)
 	@$(UV_RUN_NO_SYNC) python -m scripts.probe.check_bot_runtime_env $(PREFLIGHT_BOT_FLAGS)
 
@@ -749,13 +758,8 @@ local-up-ingest:  ## Start local services + docling for ingestion workflows
 run-bot:  ## Run bot locally (requires: make local-up)
 	$(UV_RUN_NO_SYNC) --env-file "$$RAG_RUNTIME_ENV_FILE" python -m telegram_bot.main
 
-bot: preflight-bot test-bot-health ## Alias: run bot (fail-fast when Qdrant is down; tee output to logs/bot-run.log)
+bot: preflight-qdrant preflight-bot test-bot-health ## Alias: run bot (fail-fast when Qdrant is down; tee output to logs/bot-run.log)
 	@mkdir -p logs
-	@if ! timeout 1 bash -c 'echo >/dev/tcp/localhost/6333' 2>/dev/null; then \
-		echo "$(RED)✗ Qdrant is not reachable on localhost:6333$(NC)" >&2; \
-		echo "$(YELLOW)Run 'make local-up' to start required local services (redis, qdrant, bge-m3, litellm)$(NC)" >&2; \
-		exit 1; \
-	fi
 	@bash -o pipefail -c '$(UV_RUN_NO_SYNC) --env-file "$$RAG_RUNTIME_ENV_FILE" python -m telegram_bot.main 2>&1 | tee logs/bot-run.log'; \
 	status=$$?; echo '[COMPLETE]'; exit $$status
 

--- a/telegram_bot/preflight.py
+++ b/telegram_bot/preflight.py
@@ -101,7 +101,7 @@ DEP_CLASSIFICATION: dict[str, DepLevel] = {
 _DEP_REMEDIATION: dict[str, str] = {
     "redis": "start Redis and verify REDIS_PASSWORD / redis_url",
     "redis_cache": "restore Redis cache write/read path",
-    "qdrant": "start Qdrant and verify collection configuration",
+    "qdrant": "Run `make local-up` to start Qdrant, then verify collection configuration",
     "bge_m3": "start the repo-local BGE-M3 service and verify /health and /encode/dense",
     "postgres": "start PostgreSQL or accept degraded user-feature mode",
     "litellm": "restore LiteLLM proxy readiness or accept degraded generation path",

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -887,6 +887,17 @@ class TestPostgresOptionalBehavior:
 # ===========================================================================
 
 
+class TestQdrantRemediationHint:
+    """Qdrant remediation tells users about make local-up."""
+
+    def test_qdrant_remediation_mentions_make_local_up(self):
+        from telegram_bot.preflight import _DEP_REMEDIATION
+
+        assert "make local-up" in _DEP_REMEDIATION["qdrant"].lower(), (
+            f"Qdrant remediation should mention 'make local-up', got: {_DEP_REMEDIATION['qdrant']}"
+        )
+
+
 class TestQdrantPreflightEnsureCollection:
     """Preflight auto-creates Qdrant collection when it is missing."""
 


### PR DESCRIPTION
## Problem

`make bot` takes 30+ seconds and produces a confusing traceback when local Qdrant (required for native bot runs) is unreachable.

## Fix

1. **Makefile `bot:` target**: Added a fast TCP pre-check (via `/dev/tcp`) to verify Qdrant is listening on localhost:6333 before launching Python. Fails fast (~1s) with a clear remediation hint to run `make local-up`.
2. **Preflight remediation**: Updated `_DEP_REMEDIATION["qdrant"]` to reference `make local-up` as the first remediation step.

## Changes

- `Makefile` — `bot:` target with TCP pre-check
- `telegram_bot/preflight.py` — remediation string update
- `tests/unit/test_preflight.py` — new test for remediation message content

## Validation

- 55/55 unit tests pass
- Ruff lint + format clean
- Qdrant remains CRITICAL in preflight (no change to classification)
- TCP pre-check fails fast (~1s) when Qdrant is down

Fixes #2294