### PR TITLE
test(observability): document telegram-rag-agent-invoke/-stream spans (fix red contract gate)

### DIFF
--- a/tests/observability/trace_contract.yaml
+++ b/tests/observability/trace_contract.yaml
@@ -241,6 +241,12 @@ spans:
   voice_tools:
     - voice-tool-search-knowledge-base
 
+  supervisor_recovery:
+    # bot.py supervisor agent-loop wrappers with checkpointer-error recovery.
+    # capture disabled (also under sensitive_spans); as_type=agent.
+    - telegram-rag-agent-invoke
+    - telegram-rag-agent-stream
+
   history_graph:
     - history-guard
     - history-retrieve
@@ -599,6 +605,9 @@ sensitive_spans:
   - cb-clearcache
   - telegram-rag-query
   - telegram-rag-supervisor
+  # supervisor agent-loop recovery wrappers (capture disabled, as_type=agent)
+  - telegram-rag-agent-invoke
+  - telegram-rag-agent-stream
   # dialog/handler spans with capture disabled
   - dialog-crm-create-note
   - dialog-crm-create-contact


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Fixes **2 contract-suite failures present on clean `dev`** — `make test` / the contract gate is currently red for everyone.

## Root cause

Supervisor agent-loop recovery wrappers were added to `telegram_bot/bot.py`:
- `telegram-rag-agent-stream` (`_astream_supervisor_with_recovery`)
- `telegram-rag-agent-invoke` (`_ainvoke_supervisor_with_recovery`)

Both are `@observe(capture_input=False, capture_output=False, as_type="agent")` but were never registered in `tests/observability/trace_contract.yaml`, so two contracts failed:
- `test_span_coverage_contract::test_all_observed_spans_accounted_for` — every `capture_input=False` span must be in `sensitive_spans`.
- `test_trace_families_contract::test_no_undocumented_observe_spans` — every `@observe` name must appear in the `spans:` inventory.

(Confirmed pre-existing: reproduced on clean `dev` with my unrelated work stashed.)

## Fix

Register both spans in `trace_contract.yaml` (docs/inventory only, **no production code changed**):
- `sensitive_spans:` — added next to `telegram-rag-supervisor` (capture disabled).
- `spans.supervisor_recovery:` — new group so the reverse undocumented-span check passes.

## Testing

- `pytest tests/contract/test_span_coverage_contract.py tests/contract/test_trace_families_contract.py` → 210 passed (was 2 failed).
- `pytest tests/contract/` → **1422 passed**, 2 skipped, 3 xfailed (full gate green again).
- YAML validated; existing groups (`history_graph`, `voice_tools`) intact.

`verify:repo-only` — no Docker/runtime validation required.