### PR TITLE
ci: add Semgrep project guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,30 @@ jobs:
       - name: Validate PR guardrails
         run: python3 scripts/ci/validate_pr_guardrails.py
 
+  semgrep:
+    name: Semgrep
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Run project Semgrep guardrails
+        run: >
+          uvx --from semgrep==1.163.0 semgrep scan
+          --config .semgrep/project-guardrails.yml
+          --error
+          --metrics=off
+          src
+          telegram_bot
+          scripts
+          .github/workflows
+          compose.yml
+          compose.dev.yml
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.semgrep/project-guardrails.yml
+++ b/.semgrep/project-guardrails.yml
@@ -1,0 +1,63 @@
+rules:
+  - id: python.no-datetime-utcnow
+    message: Use timezone-aware datetime.now(UTC) instead of datetime.utcnow().
+    severity: ERROR
+    languages:
+      - python
+    pattern-either:
+      - pattern: datetime.utcnow(...)
+      - pattern: datetime.datetime.utcnow(...)
+    paths:
+      include:
+        - /src/**
+        - /telegram_bot/**
+        - /scripts/**
+
+  - id: python.no-subprocess-shell-true
+    message: Avoid subprocess shell=True; pass an argv list with shell=False.
+    severity: ERROR
+    languages:
+      - python
+    patterns:
+      - pattern: subprocess.$FUNC(..., shell=True, ...)
+    paths:
+      include:
+        - /src/**
+        - /telegram_bot/**
+        - /scripts/**
+
+  - id: python.no-os-system
+    message: Avoid os.system/os.popen; use subprocess.run with an argv list.
+    severity: ERROR
+    languages:
+      - python
+    pattern-either:
+      - pattern: os.system(...)
+      - pattern: os.popen(...)
+    paths:
+      include:
+        - /src/**
+        - /telegram_bot/**
+        - /scripts/**
+
+  - id: github-actions.no-pull-request-target
+    message: Avoid pull_request_target workflows unless a dedicated security review approves them.
+    severity: ERROR
+    languages:
+      - yaml
+    pattern-regex: '^\s*pull_request_target\s*:'
+    paths:
+      include:
+        - /.github/workflows/*.yml
+        - /.github/workflows/*.yaml
+
+  - id: compose.no-latest-image
+    message: Compose images must not use the mutable :latest tag.
+    severity: ERROR
+    languages:
+      - yaml
+    pattern-regex: '^\s*image\s*:\s*["'']?[^"''\s#]+:latest(?:@sha256:[a-fA-F0-9]+)?["'']?\s*(?:#.*)?$'
+    paths:
+      include:
+        - /compose.yml
+        - /compose.*.yml

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -224,9 +224,10 @@ make test-full
 
 ### CI vs Local Test Gates
 
-GitHub CI runs repository hygiene gates such as secret scanning, Ruff lint, Ruff
-format, and CodeQL. Python test gates are local/manual so failures can be
-debugged against the developer environment that owns the runtime state.
+GitHub CI runs repository hygiene gates such as secret scanning, Semgrep project
+guardrails, Ruff lint, Ruff format, and CodeQL. Python test gates are
+local/manual so failures can be debugged against the developer environment that
+owns the runtime state.
 
 | Local Command | What It Covers |
 |---|---|
@@ -235,6 +236,16 @@ debugged against the developer environment that owns the runtime state.
 | `make test` + `make test-contract` | local test-surface match for unit + contract + graph-path checks |
 | `make local-pr-ready` | `make check` (lint + types) then `make test-unit`; skips contract and graph-path integration tests |
 | `make check` + `make test` + `make test-contract` | recommended merge-readiness ladder on a powerful local machine |
+
+Run the same generic code-pattern guardrails as the `Semgrep` CI job:
+
+```bash
+uvx --from semgrep==1.163.0 semgrep scan \
+  --config .semgrep/project-guardrails.yml \
+  --error \
+  --metrics=off \
+  src telegram_bot scripts .github/workflows compose.yml compose.dev.yml
+```
 
 `make local-pr-ready` is a quick local gate that catches most regressions early
 but is narrower than the full local merge-readiness ladder. Before merging a

--- a/docs/engineering/bug-classes.md
+++ b/docs/engineering/bug-classes.md
@@ -38,6 +38,9 @@ A guardrail is a permanent executable rule that prevents a recurring bug class.
 Guardrails take the form of contract tests, CI gates, or automated checks that
 run on every push and PR. A guardrail is not a comment, not a code-review
 convention, and not a manual checklist -- it is automated and enforced.
+Semgrep is the generic code-pattern guardrail engine for repeated forbidden
+patterns; project-specific root-cause, bug-class, and cross-file contracts stay
+in Python/pytest checks.
 
 ### Quality Gate
 

--- a/scripts/ci/validate_pr_guardrails.py
+++ b/scripts/ci/validate_pr_guardrails.py
@@ -20,6 +20,8 @@ from typing import Any
 BUGFIX_RE = re.compile(r"\b(fix|bug|bugfix|regression|hotfix)\b", re.IGNORECASE)
 FIXES_RE = re.compile(r"\b(fixes|closes|resolves)\s+#\d+\b", re.IGNORECASE)
 DUPLICATE_RE = re.compile(r"\b(duplicate|duplicates|dup)\b", re.IGNORECASE)
+DISPOSITION_TYPE_RE = re.compile(r"(?im)^\s*>?\s*Type\s*:\s*(duplicate|recurrence|umbrella)\b")
+EMPTY_FIELD_VALUES = {"-", "n/a", "N/A", "none", "None", "___________", "____________"}
 
 DEPENDENCY_FILES = {
     "pyproject.toml",
@@ -32,6 +34,7 @@ WORKFLOW_POLICY_TESTS = {
     "tests/unit/test_ci_workflow_guardrails.py",
     "tests/unit/test_ci_deploy_workflow.py",
     "tests/unit/test_codeowners_contract.py",
+    "tests/unit/test_semgrep_guardrails.py",
 }
 
 BUG_CLASS_REGISTRY = Path("docs/engineering/bug-classes.md")
@@ -122,8 +125,12 @@ def _is_bugfix(pr: PullRequest) -> bool:
 
 
 def _is_duplicate_or_bug_class(pr: PullRequest) -> bool:
-    haystack = " ".join((pr.title, pr.body, " ".join(pr.labels)))
-    return bool(DUPLICATE_RE.search(haystack) or "Bug class:" in pr.body)
+    title_and_labels = " ".join((pr.title, " ".join(pr.labels)))
+    return bool(
+        DUPLICATE_RE.search(title_and_labels)
+        or DISPOSITION_TYPE_RE.search(pr.body)
+        or _field_value(pr.body, "Bug class") is not None
+    )
 
 
 def _has_filled_field(body: str, field: str) -> bool:
@@ -132,7 +139,7 @@ def _has_filled_field(body: str, field: str) -> bool:
     if match is None:
         return False
     value = match.group(1).strip()
-    return bool(value and value not in {"-", "n/a", "N/A", "none", "None"})
+    return bool(value and value not in EMPTY_FIELD_VALUES)
 
 
 def _has_filled_any_field(body: str, fields: tuple[str, ...]) -> bool:
@@ -145,7 +152,7 @@ def _field_value(body: str, field: str) -> str | None:
     if match is None:
         return None
     value = match.group(1).strip()
-    if not value or value in {"-", "n/a", "N/A", "none", "None"}:
+    if not value or value in EMPTY_FIELD_VALUES:
         return None
     return value
 

--- a/tests/unit/scripts/test_validate_pr_guardrails.py
+++ b/tests/unit/scripts/test_validate_pr_guardrails.py
@@ -100,10 +100,43 @@ def test_workflow_change_with_policy_test_passes() -> None:
     assert failures == []
 
 
+def test_workflow_change_with_semgrep_policy_test_passes() -> None:
+    failures = validate(
+        _pr("ci: add semgrep workflow", "Checks run: pytest semgrep policy tests"),
+        [".github/workflows/ci.yml", "tests/unit/test_semgrep_guardrails.py"],
+        large_threshold=25,
+    )
+
+    assert failures == []
+
+
 def test_duplicate_work_requires_bug_class() -> None:
     failures = validate(
         _pr("fix: duplicate Langfuse context loss", "Fixes #2302", labels=("bug",)),
         ["src/observability.py", "tests/contract/test_observability_contextvars_contract.py"],
+        large_threshold=25,
+    )
+
+    assert "duplicate/bug-class PR must fill `Bug class:`" in failures
+
+
+def test_duplicate_process_wording_without_disposition_does_not_require_bug_class() -> None:
+    failures = validate(
+        _pr(
+            "ci: add project guardrail",
+            "This keeps project-specific duplicate/root-cause logic in Python.",
+        ),
+        [".github/workflows/ci.yml", "tests/unit/test_semgrep_guardrails.py"],
+        large_threshold=25,
+    )
+
+    assert "duplicate/bug-class PR must fill `Bug class:`" not in failures
+
+
+def test_duplicate_disposition_type_requires_bug_class() -> None:
+    failures = validate(
+        _pr("docs: close issue cluster", "Type: duplicate\nBug class: ___________"),
+        ["docs/engineering/issue-triage.md"],
         large_threshold=25,
     )
 

--- a/tests/unit/test_semgrep_guardrails.py
+++ b/tests/unit/test_semgrep_guardrails.py
@@ -1,0 +1,75 @@
+"""Contract tests for project Semgrep guardrails."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+SEMGREP_CONFIG = REPO_ROOT / ".semgrep" / "project-guardrails.yml"
+SEMGREP_VERSION = "1.163.0"
+
+REQUIRED_RULE_IDS = {
+    "python.no-datetime-utcnow",
+    "python.no-subprocess-shell-true",
+    "python.no-os-system",
+    "github-actions.no-pull-request-target",
+    "compose.no-latest-image",
+}
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    assert path.exists(), f"Missing expected YAML file: {path}"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if path == CI_WORKFLOW and "on" not in data and True in data:
+        data["on"] = data[True]
+    assert isinstance(data, dict), f"{path} must contain a YAML mapping"
+    return data
+
+
+def test_semgrep_config_contains_required_rule_ids() -> None:
+    data = _load_yaml(SEMGREP_CONFIG)
+    rules = data.get("rules")
+    assert isinstance(rules, list), ".semgrep/project-guardrails.yml must define rules"
+
+    actual = {rule.get("id") for rule in rules if isinstance(rule, dict)}
+    assert actual >= REQUIRED_RULE_IDS
+
+
+def test_semgrep_rules_are_errors() -> None:
+    data = _load_yaml(SEMGREP_CONFIG)
+    for rule in data["rules"]:
+        assert rule["severity"] == "ERROR", f"{rule['id']} must block CI"
+
+
+def test_ci_has_semgrep_job() -> None:
+    data = _load_yaml(CI_WORKFLOW)
+    job = data["jobs"].get("semgrep")
+    assert job is not None, "CI workflow must define the semgrep job"
+    assert job["name"] == "Semgrep"
+    assert job["runs-on"] == "ubuntu-latest"
+
+
+def test_ci_semgrep_job_uses_pinned_cli_and_project_rules() -> None:
+    data = _load_yaml(CI_WORKFLOW)
+    job = data["jobs"]["semgrep"]
+    commands = "\n".join(
+        step.get("run", "") for step in job.get("steps", []) if isinstance(step.get("run", ""), str)
+    )
+
+    assert f"semgrep=={SEMGREP_VERSION}" in commands
+    assert "semgrep scan" in commands
+    assert "--config .semgrep/project-guardrails.yml" in commands
+    assert "--error" in commands
+    assert "--metrics=off" in commands
+
+
+def test_ci_semgrep_job_uses_read_only_permissions() -> None:
+    data = _load_yaml(CI_WORKFLOW)
+    assert data["permissions"] == {"contents": "read"}
+    semgrep_job = data["jobs"]["semgrep"]
+    assert semgrep_job.get("permissions") in (None, {"contents": "read"})


### PR DESCRIPTION
## Summary

Adds Semgrep as a generic code-pattern guardrail engine for recurring forbidden patterns. Project-specific root-cause workflow and cross-file contracts remain in Python/pytest.

## Scope

- Infrastructure / CI guardrail
- Adds `.semgrep/project-guardrails.yml` with five blocking rules
- Adds the `Semgrep` CI job using `semgrep==1.163.0`
- Adds contract tests for the Semgrep workflow/config
- Updates PR guardrails to avoid false duplicate-intent detection from process wording

## Validation / Checks Run

Checks run:
- `uvx --from semgrep==1.163.0 semgrep scan --config .semgrep/project-guardrails.yml --error --metrics=off src telegram_bot scripts .github/workflows compose.yml compose.dev.yml` -> 0 findings
- `UV_PROJECT_ENVIRONMENT=/home/user/projects/rag-fresh/.venv uv run --no-sync pytest tests/unit/test_semgrep_guardrails.py tests/unit/test_ci_workflow_guardrails.py tests/unit/test_ci_deploy_workflow.py tests/unit/test_trusted_heavy_workflow.py tests/unit/test_codeowners_contract.py tests/unit/scripts/test_validate_pr_guardrails.py tests/unit/test_bug_class_registry_contract.py -q` -> 81 passed
- `UV_PROJECT_ENVIRONMENT=/home/user/projects/rag-fresh/.venv make test` -> 7645 passed, 60 skipped
- `UV_PROJECT_ENVIRONMENT=/home/user/projects/rag-fresh/.venv make test-contract` -> attempted; blocked by local environment/baseline issues unrelated to this PR: missing `phonenumbers` in shared `.venv`, running dev Compose project has stray `/tmp/compose.postgres-root.yml` and mixed worktree compose sources, and one mypy contract hit pytest-timeout
- pre-commit hooks during commit -> passed

GitHub checks on current HEAD:
- CI -> success
- CodeQL -> success
- Trusted Heavy Checks -> success

## Runtime Impact

No runtime impact. CI/static-analysis only.

## Reviewer Notes

Semgrep is intentionally limited to generic static patterns. RAGAS, observability, LangChain, Langfuse, and complex architecture contracts are out of scope for this PR.