### PR TITLE
docs: add BGE-M3 runtime closure checklist

### DIFF
--- a/docs/runbooks/COMPOSE_SOURCE_CLEANUP.md
+++ b/docs/runbooks/COMPOSE_SOURCE_CLEANUP.md
@@ -97,6 +97,42 @@ uv run --python 3.12 pytest tests/contract/test_compose_source_cleanup_contract.
 The contract test skips when Docker is unavailable or the `dev` project
 is not running, so it is safe in CI; locally it surfaces drift.
 
+## BGE-M3 Closure Check
+
+For BGE-M3 endpoint regressions such as #2182 and #2188, do not close the
+issue only because the Compose file declares the right port. Close it after the
+running local stack proves the canonical endpoint and startup path.
+
+```bash
+# Canonical project source only:
+docker compose ls --format json
+
+# Canonical BGE-M3 endpoint is healthy:
+curl -fsS http://localhost:8000/health
+
+# No port-8888 workaround:
+grep '^BGE_M3_URL=' .env
+
+# The canonical Compose container publishes host port 8000:
+docker inspect dev-bge-m3-1 --format '{{json .NetworkSettings.Ports}}'
+
+# Runtime drift and bot startup guards:
+make verify-compose-runtime
+make test-bot-health
+PREFLIGHT_BOT_FLAGS="--env-file /home/user/projects/rag-fresh/.env" make preflight-bot
+make bot
+```
+
+Expected evidence:
+
+- `curl` returns `status=ok`, `model_loaded=true`, and `warmed_up=true`.
+- `BGE_M3_URL` points to `http://localhost:8000`, not a temporary port such as
+  `8888`.
+- `dev-bge-m3-1` publishes `127.0.0.1:8000->8000/tcp`.
+- `make verify-compose-runtime` reports zero image drift and zero port drift.
+- `make bot` reaches polling with `bge_m3 [CRITICAL]` passing. A degraded
+  optional Langfuse check is not the BGE-M3 root cause; track it separately.
+
 ## Volume safety
 
 `docker compose down` (without `-v`) leaves named volumes intact. Persistent


### PR DESCRIPTION
## Summary

- document the BGE-M3 live runtime evidence required before closing endpoint/preflight regressions like #2182 and #2188
- add the exact local commands for canonical compose source, health, port mapping, drift checks, bot health, preflight, and live `make bot`
- clarify that optional Langfuse degradation is separate from the BGE-M3 root cause

Bug class: Docker/compose drift
Regression guardrail: `docs/runbooks/COMPOSE_SOURCE_CLEANUP.md` now records the BGE-M3 closure checklist tied to `make verify-compose-runtime`, bot health, and live startup verification.
No regression test: docs-only runbook update; the existing compose source cleanup contract was run to verify the documented surface.
Checks run: `make docs-check`; `UV_PROJECT_ENVIRONMENT=/home/user/projects/rag-fresh/.venv uv run --no-sync pytest tests/contract/test_compose_source_cleanup_contract.py -q`; `git diff --check`.

## Checks

- `make docs-check` -> passed
- `UV_PROJECT_ENVIRONMENT=/home/user/projects/rag-fresh/.venv uv run --no-sync pytest tests/contract/test_compose_source_cleanup_contract.py -q` -> 4 passed
- `git diff --check` -> passed