### PR TITLE
ci: promote trusted fast tests out of shadow

### DIFF
--- a/.github/workflows/trusted-heavy.yml
+++ b/.github/workflows/trusted-heavy.yml
@@ -3,17 +3,6 @@ name: Trusted Heavy Checks
 on:
   pull_request:
     branches: [main, dev]
-    paths:
-      - "src/**"
-      - "telegram_bot/**"
-      - "mini_app/**"
-      - "services/**"
-      - "tests/**"
-      - "compose*.yml"
-      - "Makefile"
-      - "pyproject.toml"
-      - "uv.lock"
-      - ".github/workflows/**"
   workflow_dispatch:
 
 permissions:
@@ -24,12 +13,79 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Trusted Heavy Path Filter
+    runs-on: ubuntu-latest
+    outputs:
+      run_heavy: ${{ steps.filter.outputs.run_heavy }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect heavy-test paths
+        id: filter
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "run_heavy=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          echo "$changed_files"
+
+          run_heavy=false
+          while IFS= read -r path; do
+            case "$path" in
+              src/*|telegram_bot/*|mini_app/*|services/*|tests/*|compose*.yml|Makefile|pyproject.toml|uv.lock|.github/workflows/*)
+                run_heavy=true
+                break
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          echo "run_heavy=$run_heavy" >> "$GITHUB_OUTPUT"
+
+  fast-tests:
+    name: Fast Tests
+    needs: changes
+    if: >
+      needs.changes.outputs.run_heavy == 'true' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Create Python 3.12 virtualenv
+        run: uv venv --python 3.12
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Run fast tests
+        run: make test
+
   heavy-contract-tests-shadow:
     name: Heavy Contract Tests (shadow)
+    needs: changes
     continue-on-error: true
     if: >
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      needs.changes.outputs.run_heavy == 'true' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -51,31 +107,3 @@ jobs:
       - name: Run contract tests in shadow mode
         continue-on-error: true
         run: make test-contract
-
-  fast-tests-shadow:
-    name: Fast Tests (shadow)
-    continue-on-error: true
-    if: >
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64]
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          enable-cache: false
-
-      - name: Set up Python
-        run: uv python install 3.12
-
-      - name: Create Python 3.12 virtualenv
-        run: uv venv --python 3.12
-
-      - name: Install dependencies
-        run: uv sync --frozen
-
-      - name: Run fast tests in shadow mode
-        continue-on-error: true
-        run: make test

--- a/docs/runbooks/SELF_HOSTED_RUNNER.md
+++ b/docs/runbooks/SELF_HOSTED_RUNNER.md
@@ -18,7 +18,7 @@ The repo follows a two-tier runner policy to balance security and capability:
 | Tier | Runner | Scope | Examples |
 |------|--------|-------|----------|
 | **Light (trusted)** | `ubuntu-latest` (GitHub-hosted) | Required PR checks, lint, format | CI.yml |
-| **Heavy (trusted)** | `self-hosted`, `Linux`, `X64` (WSL/Linux host) | Trusted PR shadow checks, nightly, runtime, benchmarks, contract | `trusted-heavy.yml`, `nightly-heavy.yml` |
+| **Heavy (trusted)** | `self-hosted`, `Linux`, `X64` (WSL/Linux host) | Trusted PR fast gate, shadow contract checks, nightly, runtime, benchmarks | `trusted-heavy.yml`, `nightly-heavy.yml` |
 
 ### Policy Rules
 
@@ -66,14 +66,22 @@ The repo follows a two-tier runner policy to balance security and capability:
 
 | Workflow file | Job | `runs-on` | What it runs |
 |---|---|---|---|
-| [`.github/workflows/trusted-heavy.yml`](../../.github/workflows/trusted-heavy.yml) | `heavy-contract-tests-shadow` | `[self-hosted, Linux, X64]` | `make test-contract` in shadow mode for trusted PRs |
-| [`.github/workflows/trusted-heavy.yml`](../../.github/workflows/trusted-heavy.yml) | `fast-tests-shadow` | `[self-hosted, Linux, X64]` | `make test` in shadow mode for trusted PRs |
+| [`.github/workflows/trusted-heavy.yml`](../../.github/workflows/trusted-heavy.yml) | `changes` | `ubuntu-latest` | Always reports a lightweight path-filter result so trusted-heavy checks can be required without disappearing on docs-only PRs |
+| [`.github/workflows/trusted-heavy.yml`](../../.github/workflows/trusted-heavy.yml) | `fast-tests` | `[self-hosted, Linux, X64]` | `make test` for trusted same-repo PRs that touch code/runtime/test paths |
+| [`.github/workflows/trusted-heavy.yml`](../../.github/workflows/trusted-heavy.yml) | `heavy-contract-tests-shadow` | `[self-hosted, Linux, X64]` | `make test-contract` in shadow mode for trusted same-repo PRs that touch code/runtime/test paths |
 | [`.github/workflows/nightly-heavy.yml`](../../.github/workflows/nightly-heavy.yml) | `heavy-tier` | `self-hosted` | `pytest -n auto -m "requires_extras or load or chaos or e2e or benchmark"` |
 
 Trusted PR heavy checks use only GitHub built-in labels: `self-hosted`,
 `Linux`, and `X64`. This avoids custom label drift during the first rollout.
 The nightly workflow currently accepts any repository-level `self-hosted`
 runner.
+
+`Fast Tests` is the first self-hosted PR check promoted out of shadow mode.
+It is safe to make it a branch-protection required check after it stays green
+across trusted PRs because `trusted-heavy.yml` runs on every pull request and
+skips the self-hosted job for docs-only or untrusted fork PRs. `Heavy Contract
+Tests (shadow)` remains telemetry until the contract baseline is stable enough
+to promote separately.
 
 ## Resource Requirements
 

--- a/scripts/ci/validate_pr_guardrails.py
+++ b/scripts/ci/validate_pr_guardrails.py
@@ -37,6 +37,7 @@ WORKFLOW_POLICY_TESTS = {
     "tests/unit/test_ci_deploy_workflow.py",
     "tests/unit/test_codeowners_contract.py",
     "tests/unit/test_semgrep_guardrails.py",
+    "tests/unit/test_trusted_heavy_workflow.py",
 }
 
 BUG_CLASS_REGISTRY = Path(".github/bug-classes.yml")

--- a/tests/unit/scripts/test_validate_pr_guardrails.py
+++ b/tests/unit/scripts/test_validate_pr_guardrails.py
@@ -110,6 +110,19 @@ def test_workflow_change_with_semgrep_policy_test_passes() -> None:
     assert failures == []
 
 
+def test_workflow_change_with_trusted_heavy_policy_test_passes() -> None:
+    failures = validate(
+        _pr("ci: update trusted heavy workflow", "Checks run: pytest trusted-heavy policy tests"),
+        [
+            ".github/workflows/trusted-heavy.yml",
+            "tests/unit/test_trusted_heavy_workflow.py",
+        ],
+        large_threshold=25,
+    )
+
+    assert failures == []
+
+
 def test_duplicate_work_requires_bug_class() -> None:
     failures = validate(
         _pr("fix: duplicate Langfuse context loss", "Fixes #2302", labels=("bug",)),

--- a/tests/unit/test_trusted_heavy_workflow.py
+++ b/tests/unit/test_trusted_heavy_workflow.py
@@ -17,48 +17,114 @@ def _load_workflow() -> dict:
 
 
 def test_trusted_heavy_runs_only_on_builtin_linux_self_hosted_labels() -> None:
-    """Heavy PR checks must use built-in Linux self-hosted runner labels."""
+    """Self-hosted PR checks must use built-in Linux self-hosted runner labels."""
     data = _load_workflow()
     for job_key, job in data["jobs"].items():
+        if "self-hosted" not in str(job.get("runs-on", "")):
+            continue
         labels = job.get("runs-on")
         assert labels == ["self-hosted", "Linux", "X64"], (
             f"{job_key} must run on [self-hosted, Linux, X64], got {labels!r}"
         )
 
 
-def test_trusted_heavy_is_shadow_mode_until_baseline_green() -> None:
-    """Heavy checks stay non-authoritative until contract/test baseline is green."""
+def test_trusted_heavy_workflow_runs_for_all_prs() -> None:
+    """Workflow must create stable check contexts even for docs-only PRs."""
     data = _load_workflow()
-    for job_key, job in data["jobs"].items():
-        assert job.get("continue-on-error") is True, (
-            f"{job_key} must stay shadow mode until baseline is green"
+    pull_request = data["on"]["pull_request"]
+    assert "paths" not in pull_request, (
+        "trusted-heavy.yml must not use workflow-level path filters; required "
+        "checks would otherwise be missing on docs-only PRs."
+    )
+
+
+def test_trusted_heavy_has_github_hosted_path_filter() -> None:
+    """A lightweight GitHub-hosted job decides whether self-hosted tests run."""
+    data = _load_workflow()
+    changes = data["jobs"].get("changes")
+    assert changes is not None, "trusted-heavy.yml must define the changes job"
+    assert changes["name"] == "Trusted Heavy Path Filter"
+    assert changes["runs-on"] == "ubuntu-latest"
+    assert changes["outputs"]["run_heavy"] == "${{ steps.filter.outputs.run_heavy }}"
+
+
+def test_trusted_heavy_path_filter_covers_risk_paths() -> None:
+    """The path filter must match the same code/runtime/test surfaces as before."""
+    data = _load_workflow()
+    changes = data["jobs"]["changes"]
+    filter_step = next(step for step in changes["steps"] if step.get("id") == "filter")
+    script = filter_step["run"]
+
+    assert "git diff --name-only" in script
+    assert "run_heavy=true" in script
+    for token in (
+        "src/*",
+        "telegram_bot/*",
+        "mini_app/*",
+        "services/*",
+        "tests/*",
+        "compose*.yml",
+        "Makefile",
+        "pyproject.toml",
+        "uv.lock",
+        ".github/workflows/*",
+    ):
+        assert token in script
+
+
+def test_fast_tests_is_authoritative_for_trusted_risk_paths() -> None:
+    """Fast Tests is the first self-hosted PR gate promoted out of shadow."""
+    data = _load_workflow()
+    fast = data["jobs"].get("fast-tests")
+    assert fast is not None, "trusted-heavy.yml must define fast-tests"
+    assert fast["name"] == "Fast Tests"
+    assert fast["needs"] == "changes"
+    assert fast.get("continue-on-error") is not True, (
+        "Fast Tests must not stay shadow once promoted to a candidate required gate."
+    )
+
+    run_steps = [step for step in fast["steps"] if step.get("run") == "make test"]
+    assert run_steps, "Fast Tests must run `make test`"
+    assert all(step.get("continue-on-error") is not True for step in run_steps)
+
+
+def test_heavy_contract_tests_remain_shadow_mode_until_baseline_green() -> None:
+    """Heavy contract checks stay non-authoritative until baseline is green."""
+    data = _load_workflow()
+    job = data["jobs"]["heavy-contract-tests-shadow"]
+    assert job.get("continue-on-error") is True
+    test_steps = [
+        step for step in job.get("steps", []) if str(step.get("name", "")).startswith("Run ")
+    ]
+    assert test_steps, "heavy-contract-tests-shadow must include a test execution step"
+    for step in test_steps:
+        assert step.get("continue-on-error") is True, (
+            f"heavy-contract-tests-shadow step {step.get('name')!r} must not "
+            "redline the PR in shadow mode"
         )
-        test_steps = [
-            step for step in job.get("steps", []) if str(step.get("name", "")).startswith("Run ")
-        ]
-        assert test_steps, f"{job_key} must include a test execution step"
-        for step in test_steps:
-            assert step.get("continue-on-error") is True, (
-                f"{job_key} step {step.get('name')!r} must not redline the PR in shadow mode"
-            )
 
 
 def test_trusted_heavy_skips_untrusted_fork_prs() -> None:
     """Self-hosted runner must not execute untrusted fork pull_request code."""
     data = _load_workflow()
     for job_key, job in data["jobs"].items():
+        if "self-hosted" not in str(job.get("runs-on", "")):
+            continue
         condition = str(job.get("if", ""))
         assert "github.event.pull_request.head.repo.full_name == github.repository" in condition, (
             f"{job_key} must restrict pull_request jobs to same-repository branches"
         )
+        assert "needs.changes.outputs.run_heavy == 'true'" in condition, (
+            f"{job_key} must run only when the path filter says heavy tests are needed"
+        )
 
 
-def test_trusted_heavy_contains_contract_and_fast_shadow_jobs() -> None:
+def test_trusted_heavy_contains_contract_shadow_and_fast_gate_jobs() -> None:
     """Trusted heavy workflow must cover both contract and fast tests."""
     data = _load_workflow()
     jobs = data["jobs"]
     assert "heavy-contract-tests-shadow" in jobs
-    assert "fast-tests-shadow" in jobs
+    assert "fast-tests" in jobs
 
     commands = "\n".join(
         step.get("run", "")


### PR DESCRIPTION
## Summary

- make `trusted-heavy.yml` run on every PR so future required check contexts do not disappear on docs-only changes
- add a GitHub-hosted path-filter job and run self-hosted jobs only for trusted same-repo PRs touching code/runtime/test paths
- promote `Fast Tests` out of shadow mode while keeping `Heavy Contract Tests (shadow)` as non-authoritative telemetry
- update self-hosted runner runbook and workflow contracts for the new rollout state

Bug class: Docker/compose drift
Regression guardrail: `.github/workflows/trusted-heavy.yml` now provides an always-reporting path-filtered self-hosted fast-test gate candidate; `tests/unit/test_trusted_heavy_workflow.py` locks runner labels, fork safety, path filtering, and Fast Tests non-shadow behavior.
Checks run: focused workflow pytest; docs-check; actionlint pre-push hook; git diff check; commit hooks; pre-push hooks.

## Checks

- `UV_PROJECT_ENVIRONMENT=/home/user/projects/rag-fresh/.venv uv run --no-sync pytest tests/unit/test_trusted_heavy_workflow.py tests/contract/test_self_hosted_runner_workflow_contract.py tests/unit/test_ci_deploy_workflow.py -q` -> 35 passed
- `make docs-check` -> passed
- `pre-commit run --hook-stage pre-push actionlint --files .github/workflows/trusted-heavy.yml` -> passed
- `git diff --check` -> passed
- commit hooks -> passed
- pre-push hooks -> Bandit/actionlint passed