### PR TITLE
fix: restore ClickHouse startup capabilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1235,8 +1235,8 @@ validate-traces-fast: ## No rebuild; trace validation fails if required trace fa
 	REDIS_PASSWORD="$(or $(REDIS_PASSWORD),dev_redis_pass)" \
 	LLM_BASE_URL="$(or $(LLM_BASE_URL),http://localhost:4000)" \
 	LANGFUSE_HOST="$(or $(LANGFUSE_HOST),http://localhost:3001)" \
-	LANGFUSE_PUBLIC_KEY=[REDACTED-LANGFUSE-KEY] $(LANGFUSE_PUBLIC_KEY),pk$(LANGFUSE_DEV_KEY_DASH)lf-dev)" \
-	LANGFUSE_SECRET_KEY=[REDACTED-LANGFUSE-KEY] $(LANGFUSE_SECRET_KEY),sk$(LANGFUSE_DEV_KEY_DASH)lf-dev)" \
+	LANGFUSE_PUBLIC_KEY="$(or $(LANGFUSE_PUBLIC_KEY),pk$(LANGFUSE_DEV_KEY_DASH)lf-dev)" \
+	LANGFUSE_SECRET_KEY="$(or $(LANGFUSE_SECRET_KEY),sk$(LANGFUSE_DEV_KEY_DASH)lf-dev)" \
 	uv run python scripts/validate_traces.py --report
 	@echo "$(GREEN)Validation complete — see docs/reports/$(NC)"
 
@@ -1246,8 +1246,8 @@ langfuse-latency-audit: ## #2179: per-stage observation latencies (retrieve/cach
 validate-voice-traces: ## Voice trace validation gate (reads Langfuse, validates presence + attribution)
 	@echo "$(BLUE)Voice trace validation gate...$(NC)"
 	LANGFUSE_HOST="$(or $(LANGFUSE_HOST),http://localhost:3001)" \
-	LANGFUSE_PUBLIC_KEY=[REDACTED-LANGFUSE-KEY] $(LANGFUSE_PUBLIC_KEY),pk$(LANGFUSE_DEV_KEY_DASH)lf-dev)" \
-	LANGFUSE_SECRET_KEY=[REDACTED-LANGFUSE-KEY] $(LANGFUSE_SECRET_KEY),sk$(LANGFUSE_DEV_KEY_DASH)lf-dev)" \
+	LANGFUSE_PUBLIC_KEY="$(or $(LANGFUSE_PUBLIC_KEY),pk$(LANGFUSE_DEV_KEY_DASH)lf-dev)" \
+	LANGFUSE_SECRET_KEY="$(or $(LANGFUSE_SECRET_KEY),sk$(LANGFUSE_DEV_KEY_DASH)lf-dev)" \
 	uv run python scripts/validate_voice_traces.py
 	@echo "$(GREEN)Voice trace validation complete$(NC)"
 

--- a/compose.yml
+++ b/compose.yml
@@ -515,6 +515,10 @@ services:
   clickhouse:
     <<: *security-defaults
     image: clickhouse/clickhouse-server:26.5.1@sha256:07afc18d8a9706eb9d85c5c5d2752e5270f91bbc2894caeaecb73e4d0f603bf5
+    # Official ClickHouse entrypoint chowns /var/lib/clickhouse and drops to
+    # the clickhouse user. Keep cap_drop:[ALL] but restore only these startup
+    # capabilities so named volumes can boot.
+    cap_add: ["CHOWN", "SETGID", "SETUID"]
     restart: unless-stopped
     stop_grace_period: 30s
     read_only: false

--- a/scripts/ci/validate_pr_guardrails.py
+++ b/scripts/ci/validate_pr_guardrails.py
@@ -36,6 +36,8 @@ WORKFLOW_POLICY_TESTS = {
     "tests/unit/test_ci_workflow_guardrails.py",
     "tests/unit/test_ci_deploy_workflow.py",
     "tests/unit/test_codeowners_contract.py",
+    "tests/unit/test_compose_runtime_contract.py",
+    "tests/unit/test_docker_static_validation.py",
     "tests/unit/test_semgrep_guardrails.py",
     "tests/unit/test_trusted_heavy_workflow.py",
 }

--- a/tests/unit/scripts/test_validate_pr_guardrails.py
+++ b/tests/unit/scripts/test_validate_pr_guardrails.py
@@ -123,6 +123,20 @@ def test_workflow_change_with_trusted_heavy_policy_test_passes() -> None:
     assert failures == []
 
 
+def test_compose_change_with_compose_runtime_policy_test_passes() -> None:
+    failures = validate(
+        _pr(
+            "fix: repair compose runtime contract",
+            "Regression guardrail: tests/unit/test_compose_runtime_contract.py\n"
+            "Checks run: pytest compose policy tests",
+        ),
+        ["compose.yml", "tests/unit/test_compose_runtime_contract.py"],
+        large_threshold=25,
+    )
+
+    assert failures == []
+
+
 def test_duplicate_work_requires_bug_class() -> None:
     failures = validate(
         _pr("fix: duplicate Langfuse context loss", "Fixes #2302", labels=("bug",)),

--- a/tests/unit/test_compose_runtime_contract.py
+++ b/tests/unit/test_compose_runtime_contract.py
@@ -73,6 +73,28 @@ def test_clickhouse_command_has_no_invalid_listen_host_flag() -> None:
     )
 
 
+def test_clickhouse_keeps_startup_capabilities_for_named_volumes() -> None:
+    """ClickHouse entrypoint must be able to chown its named data/log volumes.
+
+    The shared security defaults intentionally use cap_drop:[ALL]. The official
+    ClickHouse image still runs an entrypoint that chowns /var/lib/clickhouse on
+    startup and then drops to the clickhouse user; without these capabilities
+    the local Langfuse stack crash-loops before trace validation can start.
+    """
+    compose = _load_compose()
+    clickhouse = compose["services"]["clickhouse"]
+
+    assert "ALL" in clickhouse.get("cap_drop", []), (
+        "compose.yml: clickhouse must keep cap_drop:[ALL] from the shared security defaults."
+    )
+    assert clickhouse.get("cap_add") == ["CHOWN", "SETGID", "SETUID"], (
+        "compose.yml: clickhouse must add only CHOWN/SETGID/SETUID so the "
+        "official entrypoint can chown /var/lib/clickhouse named volumes and "
+        "drop to the clickhouse user. Without this, `make validate-traces-fast` "
+        "fails with ClickHouse `chown` or `setgid` Operation not permitted errors."
+    )
+
+
 # =============================================================================
 # BGE-M3 compose contract — guardrail for #2182 / #2188 / #2185 (Docker/compose drift)
 # =============================================================================

--- a/tests/unit/test_makefile_contract.py
+++ b/tests/unit/test_makefile_contract.py
@@ -188,6 +188,32 @@ def test_validate_traces_fast_runs_postgres_auth_preflight() -> None:
     )
 
 
+def test_trace_validation_targets_use_valid_langfuse_key_fallbacks() -> None:
+    """Trace validation targets must render valid shell env assignments."""
+    text = _makefile_text()
+    for target in ("validate-traces-fast", "validate-voice-traces"):
+        block_match = re.search(
+            rf"^{re.escape(target)}:.*?(?=^[A-Za-z0-9_.-]+:|\Z)",
+            text,
+            re.MULTILINE | re.DOTALL,
+        )
+        assert block_match, f"{target} target not found in Makefile"
+        block = block_match.group(0)
+
+        assert (
+            'LANGFUSE_PUBLIC_KEY="$(or $(LANGFUSE_PUBLIC_KEY),pk$(LANGFUSE_DEV_KEY_DASH)lf-dev)"'
+            in block
+        )
+        assert (
+            'LANGFUSE_SECRET_KEY="$(or $(LANGFUSE_SECRET_KEY),sk$(LANGFUSE_DEV_KEY_DASH)lf-dev)"'
+            in block
+        )
+        assert "[REDACTED-LANGFUSE-KEY]" not in block, (
+            f"{target} must not contain redacted placeholders in shell env "
+            "assignments; they break `make validate-traces-fast` with a shell syntax error."
+        )
+
+
 # --- #1307 core trace gate contract tests ---
 
 


### PR DESCRIPTION
## Summary

Refs #2256, #2301, #2185.

This PR fixes two blockers discovered while trying to run the local runtime trace gate after #2315:

- ClickHouse inherited `cap_drop: [ALL]` but the official image entrypoint needs to `chown` named volumes and drop to the `clickhouse` user. Local `make validate-traces-fast` failed before trace validation with ClickHouse `Operation not permitted` errors.
- `validate-traces-fast` and `validate-voice-traces` had broken `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` shell assignments, causing `/bin/sh: Syntax error: ")" unexpected` once compose got past service startup.

## Anti-regression

Bug class: Docker/compose drift
Regression guardrail:
- `tests/unit/test_compose_runtime_contract.py` now requires ClickHouse to keep `cap_drop: [ALL]` while adding only `CHOWN`, `SETGID`, `SETUID` for startup.
- `tests/unit/test_makefile_contract.py` now checks trace validation targets render valid Langfuse key fallback assignments and do not contain redacted placeholders.
- `scripts/ci/validate_pr_guardrails.py` now recognizes the existing compose runtime/static unit tests as compose policy tests for compose-changing PRs.
Checks run:
- `UV_PROJECT_ENVIRONMENT=/home/user/projects/rag-fresh/.venv uv run --no-sync pytest tests/unit/test_compose_runtime_contract.py tests/unit/test_makefile_contract.py tests/unit/test_docker_static_validation.py tests/unit/test_compose_config.py -q` — 108 passed, 52 skipped
- `docker compose --compatibility --env-file /home/user/projects/rag-fresh/.env --profile bot --profile ml config --quiet` — passed
- `make -n validate-traces-fast` — renders valid shell assignments
- `make validate-traces-fast` — progressed past compose startup; all services reached healthy; then failed later in `scripts/validate_traces.py` on trace-family/LLM/Redis criteria. This PR does not claim full runtime trace proof.
- `git diff --check` — passed

## Runtime Evidence

Before fix:
- `dev-clickhouse-1` failed with `chown: changing ownership of '/var/lib/clickhouse/tmp/': Operation not permitted`.
- After adding only `CHOWN`, it failed with `Cannot do 'setgid' to user (101): Operation not permitted`.

After fix:
- rendered ClickHouse config includes `cap_add: [CHOWN, SETGID, SETUID]` and `cap_drop: [ALL]`;
- recreated ClickHouse became healthy;
- `make validate-traces-fast` reached `scripts/validate_traces.py` and produced the next-layer failures: Redis auth mismatch, `disable_reasoning` OpenAI kwarg error, missing required trace families.

## Issue Disposition

- #2256 remains open: runtime trace proof is still not achieved.
- Next blockers are no longer compose startup; they are trace validation/runtime behavior inside `validate_traces.py`.
