### PR TITLE
fix: align trace validation with sdk env contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1232,12 +1232,12 @@ validate-traces-fast: ## No rebuild; trace validation fails if required trace fa
 	QDRANT_URL="$(or $(QDRANT_URL),http://localhost:6333)" \
 	BGE_M3_URL="$(or $(BGE_M3_URL),http://localhost:8000)" \
 	REDIS_URL="$(or $(REDIS_URL),redis://localhost:6379)" \
-	REDIS_PASSWORD="$(or $(REDIS_PASSWORD),dev_redis_pass)" \
 	LLM_BASE_URL="$(or $(LLM_BASE_URL),http://localhost:4000)" \
 	LANGFUSE_HOST="$(or $(LANGFUSE_HOST),http://localhost:3001)" \
 	LANGFUSE_PUBLIC_KEY="$(or $(LANGFUSE_PUBLIC_KEY),pk$(LANGFUSE_DEV_KEY_DASH)lf-dev)" \
 	LANGFUSE_SECRET_KEY="$(or $(LANGFUSE_SECRET_KEY),sk$(LANGFUSE_DEV_KEY_DASH)lf-dev)" \
-	uv run python scripts/validate_traces.py --report
+	uv run dotenv -f "$$TRACE_ENV_FILE" run --no-override -- \
+		uv run python scripts/validate_traces.py --report
 	@echo "$(GREEN)Validation complete — see docs/reports/$(NC)"
 
 langfuse-latency-audit: ## #2179: per-stage observation latencies (retrieve/cache/checkpoint/llm) from recent traces

--- a/docs/engineering/sdk-registry.md
+++ b/docs/engineering/sdk-registry.md
@@ -368,10 +368,12 @@ paths: "telegram_bot/**,src/**,mini_app/**,pyproject.toml,Makefile,.github/workf
 - **паттерны:**
   - Основной bot/query/runtime path: `langfuse.openai.AsyncOpenAI` + `LLM_BASE_URL` → LiteLLM proxy
   - Структурированный output: `response_format=` / Instructor-compatible контракты в основном runtime
+  - OpenAI SDK-native chat kwargs остаются top-level (`reasoning_effort`); provider-specific OpenAI-compatible controls (`disable_reasoning`, `reasoning_format`) идут через `extra_body={...}`.
   - Raw `openai.AsyncOpenAI` / `OpenAI` допустим только в изолированных совместимых/compatibility paths (например, instructor-экстракшн/оценка)
 - **gotchas:**
   - Для основного runtime path НЕ импортировать raw `openai.AsyncOpenAI`; использовать Langfuse wrapper
   - Direct OpenAI SDK не является основным runtime path; использовать только в изолированных contextualization/eval/Instructor-compatibility paths
+  - НЕ прокидывать нестандартные provider kwargs (`disable_reasoning`, `reasoning_format`) напрямую в `chat.completions.create(...)`; OpenAI SDK отвергнет их как unexpected keyword arguments.
   - НЕ хардкодить runtime model name — брать из config/env (`LLM_MODEL`)
   - `LLM_BASE_URL` обязателен для unified routing там, где path идет через LiteLLM
 

--- a/src/runtime/graph/config.py
+++ b/src/runtime/graph/config.py
@@ -100,14 +100,23 @@ class GraphConfig:
     )
 
     def get_reasoning_kwargs(self) -> dict[str, Any]:
-        """Return non-None reasoning params for chat.completions.create()."""
+        """Return SDK-shaped reasoning params for chat.completions.create().
+
+        ``reasoning_effort`` is part of the OpenAI Python SDK chat completions
+        schema. Provider-specific LiteLLM/Cerebras/Z.ai controls must travel in
+        ``extra_body`` so the OpenAI-compatible client does not reject them as
+        unexpected top-level kwargs.
+        """
         kwargs: dict[str, Any] = {}
         if self.reasoning_effort is not None:
             kwargs["reasoning_effort"] = self.reasoning_effort
+        extra_body: dict[str, Any] = {}
         if self.reasoning_format is not None:
-            kwargs["reasoning_format"] = self.reasoning_format
+            extra_body["reasoning_format"] = self.reasoning_format
         if self.disable_reasoning is not None:
-            kwargs["disable_reasoning"] = self.disable_reasoning
+            extra_body["disable_reasoning"] = self.disable_reasoning
+        if extra_body:
+            kwargs["extra_body"] = extra_body
         return kwargs
 
     @classmethod

--- a/tests/unit/graph/test_config.py
+++ b/tests/unit/graph/test_config.py
@@ -265,7 +265,7 @@ class TestGraphConfig:
         from telegram_bot.graph.config import GraphConfig
 
         cfg = GraphConfig(disable_reasoning=True)
-        assert cfg.get_reasoning_kwargs() == {"disable_reasoning": True}
+        assert cfg.get_reasoning_kwargs() == {"extra_body": {"disable_reasoning": True}}
 
     def test_get_reasoning_kwargs_combined(self):
         from telegram_bot.graph.config import GraphConfig
@@ -273,7 +273,23 @@ class TestGraphConfig:
         cfg = GraphConfig(reasoning_effort="high", reasoning_format="hidden")
         assert cfg.get_reasoning_kwargs() == {
             "reasoning_effort": "high",
-            "reasoning_format": "hidden",
+            "extra_body": {"reasoning_format": "hidden"},
+        }
+
+    def test_get_reasoning_kwargs_provider_specific_extra_body(self):
+        from telegram_bot.graph.config import GraphConfig
+
+        cfg = GraphConfig(
+            reasoning_effort="high",
+            reasoning_format="hidden",
+            disable_reasoning=True,
+        )
+        assert cfg.get_reasoning_kwargs() == {
+            "reasoning_effort": "high",
+            "extra_body": {
+                "reasoning_format": "hidden",
+                "disable_reasoning": True,
+            },
         }
 
     def test_from_env_reasoning_effort(self):

--- a/tests/unit/services/test_generate_response.py
+++ b/tests/unit/services/test_generate_response.py
@@ -718,9 +718,9 @@ async def test_reasoning_effort_passed_to_llm_create() -> None:
 
 @pytest.mark.asyncio
 async def test_disable_reasoning_passed_to_llm_create() -> None:
-    """disable_reasoning from config is forwarded to chat.completions.create()."""
+    """disable_reasoning is passed through SDK-supported extra_body."""
     config, client = _make_non_streaming_config(answer="Ответ без reasoning")
-    config.get_reasoning_kwargs.return_value = {"disable_reasoning": True}
+    config.get_reasoning_kwargs.return_value = {"extra_body": {"disable_reasoning": True}}
     lf = MagicMock()
 
     await generate_response(
@@ -731,7 +731,8 @@ async def test_disable_reasoning_passed_to_llm_create() -> None:
     )
 
     call_kwargs = client.chat.completions.create.await_args.kwargs
-    assert call_kwargs["disable_reasoning"] is True
+    assert call_kwargs["extra_body"] == {"disable_reasoning": True}
+    assert "disable_reasoning" not in call_kwargs
 
 
 @pytest.mark.asyncio
@@ -752,6 +753,7 @@ async def test_no_reasoning_kwargs_when_none() -> None:
     assert "reasoning_effort" not in call_kwargs
     assert "disable_reasoning" not in call_kwargs
     assert "reasoning_format" not in call_kwargs
+    assert "extra_body" not in call_kwargs
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_makefile_contract.py
+++ b/tests/unit/test_makefile_contract.py
@@ -214,6 +214,24 @@ def test_trace_validation_targets_use_valid_langfuse_key_fallbacks() -> None:
         )
 
 
+def test_validate_traces_fast_loads_runtime_dotenv_without_redis_default() -> None:
+    """Trace validation must not mask .env REDIS_PASSWORD with a stale default."""
+    text = _makefile_text()
+    block_match = re.search(
+        r"^validate-traces-fast:.*?(?=^[A-Za-z0-9_.-]+:|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert block_match, "validate-traces-fast target not found in Makefile"
+    block = block_match.group(0)
+
+    assert 'uv run dotenv -f "$$TRACE_ENV_FILE" run --no-override --' in block
+    assert 'REDIS_PASSWORD="$(or $(REDIS_PASSWORD),dev_redis_pass)"' not in block, (
+        "validate-traces-fast must let python-dotenv load REDIS_PASSWORD from the "
+        "same env file Compose uses; a hardcoded default causes auth mismatches."
+    )
+
+
 # --- #1307 core trace gate contract tests ---
 
 


### PR DESCRIPTION
## Summary
- route provider-specific reasoning controls through OpenAI SDK `extra_body` instead of unsupported top-level kwargs
- run `validate-traces-fast` through `python-dotenv` CLI so the same env file that Compose uses supplies `REDIS_PASSWORD`
- document the OpenAI-compatible reasoning kwargs rule in the SDK registry

Fixes: #2256
Bug class: Observability trace-coverage drift
Regression guardrail: `tests/unit/graph/test_config.py`, `tests/unit/services/test_generate_response.py`, `tests/unit/test_makefile_contract.py`
Checks run:
- `UV_PROJECT_ENVIRONMENT=/home/user/projects/rag-fresh/.venv uv run --no-sync pytest tests/unit/graph/test_config.py tests/unit/services/test_generate_response.py tests/unit/test_makefile_contract.py -q`
- `make -n validate-traces-fast`
- `QDRANT_URL=http://localhost:6333 REDIS_URL=redis://localhost:6379 UV_PROJECT_ENVIRONMENT=/home/user/projects/rag-fresh/.venv uv run --no-sync dotenv -f tests/fixtures/compose.ci.env run --no-override -- python - <<'PY' ...`
- `UV_PROJECT_ENVIRONMENT=/home/user/projects/rag-fresh/.venv uv run --no-sync ruff check src/runtime/graph/config.py tests/unit/graph/test_config.py tests/unit/services/test_generate_response.py tests/unit/test_makefile_contract.py`
- `UV_PROJECT_ENVIRONMENT=/home/user/projects/rag-fresh/.venv uv run --no-sync ruff format --check src/runtime/graph/config.py tests/unit/graph/test_config.py tests/unit/services/test_generate_response.py tests/unit/test_makefile_contract.py`
- `git diff --check`
- `uv sync --frozen`
- `make test`
- `make check`

SDK evidence:
- Repo SDK registry: `docs/engineering/sdk-registry.md` openai/langfuse sections.
- Context7 `/openai/openai-python`: `chat.completions.create` supports `reasoning_effort` and `extra_body`; `disable_reasoning` is not a top-level SDK kwarg.

Notes:
- First broad `make test` run used the stale root `.venv` and failed on missing package data (`certifi`, `phonenumbers`). After `uv sync --frozen` created a complete worktree-local `.venv`, `make test` passed with `7378 passed, 60 skipped`.
- This PR fixes the Redis auth mismatch and unsupported `disable_reasoning` kwarg blockers observed after PR #2316. Full trace-family runtime validation may still surface separate missing-family issues.
