### PR TITLE
fix: unblock trace validation runtime gates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,8 @@ REDIS_MAXMEMORY=512mb  # dev: 512mb, VPS: 256mb (default in compose.yml)
 # ==============================================================================
 # REQUIRED FOR ML PROFILE (make docker-ml-up, langfuse)
 # ==============================================================================
+MINIO_API_PORT=9090  # Override if Docker Desktop host port forwarding keeps 9090 busy.
+MINIO_CONSOLE_PORT=9091  # Override if Docker Desktop host port forwarding keeps 9091 busy.
 NEXTAUTH_SECRET=   # generate: openssl rand -base64 32
 SALT=              # generate: openssl rand -base64 32
 ENCRYPTION_KEY=    # generate: openssl rand -hex 32

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -115,6 +115,8 @@ still need to be throwaway/dev-only:
 | Mini App Frontend | `http://localhost:8091` |
 | LiteLLM | `http://localhost:4000` |
 | Langfuse | `http://localhost:3001` |
+| MinIO API | `http://localhost:${MINIO_API_PORT:-9090}` |
+| MinIO Console | `http://localhost:${MINIO_CONSOLE_PORT:-9091}` |
 | Loki | `http://localhost:3100` |
 | Alertmanager | `http://localhost:9093` |
 | RAG API (voice path) | `http://localhost:8080` |

--- a/Makefile
+++ b/Makefile
@@ -1216,6 +1216,7 @@ qdrant-cleanup: ## Prune Qdrant storage: snapshot then trigger optimiser (#1545)
 # Local host defaults for native trace validation (issue #1380).
 # Callers can override per-variable: make validate-traces-fast QDRANT_URL=http://custom:6333 REDIS_URL=redis://:x@custom:6379
 LANGFUSE_DEV_KEY_DASH ?= -
+TRACE_ENV_FILE ?= $(shell [ -f .env ] && echo .env || echo tests/fixtures/compose.ci.env)
 
 validate-traces: ## Full rebuild + trace validation + report
 	@echo "$(BLUE)Full rebuild + validation...$(NC)"
@@ -1226,8 +1227,9 @@ validate-traces: ## Full rebuild + trace validation + report
 
 validate-traces-fast: ## No rebuild; trace validation fails if required trace families are missing
 	@echo "$(BLUE)Fast validation (no rebuild)...$(NC)"
-	TRACE_ENV_FILE="$$( [ -f .env ] && echo .env || echo tests/fixtures/compose.ci.env )"; \
-	uv run python scripts/validate_trace_runtime.py --env-file "$$TRACE_ENV_FILE"
+	uv run python scripts/validate_trace_runtime.py --env-file "$(TRACE_ENV_FILE)"
+	MINIO_API_PORT="$(or $(MINIO_API_PORT),0)" \
+	MINIO_CONSOLE_PORT="$(or $(MINIO_CONSOLE_PORT),0)" \
 	$(LOCAL_COMPOSE_CMD) --profile bot --profile ml up -d --wait
 	QDRANT_URL="$(or $(QDRANT_URL),http://localhost:6333)" \
 	BGE_M3_URL="$(or $(BGE_M3_URL),http://localhost:8000)" \
@@ -1236,7 +1238,7 @@ validate-traces-fast: ## No rebuild; trace validation fails if required trace fa
 	LANGFUSE_HOST="$(or $(LANGFUSE_HOST),http://localhost:3001)" \
 	LANGFUSE_PUBLIC_KEY="$(or $(LANGFUSE_PUBLIC_KEY),pk$(LANGFUSE_DEV_KEY_DASH)lf-dev)" \
 	LANGFUSE_SECRET_KEY="$(or $(LANGFUSE_SECRET_KEY),sk$(LANGFUSE_DEV_KEY_DASH)lf-dev)" \
-	uv run dotenv -f "$$TRACE_ENV_FILE" run --no-override -- \
+	uv run dotenv -f "$(TRACE_ENV_FILE)" run --no-override -- \
 		uv run python scripts/validate_traces.py --report
 	@echo "$(GREEN)Validation complete — see docs/reports/$(NC)"
 

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -102,8 +102,8 @@ services:
   minio:
     profiles: ["ml", "full"]
     ports:
-      - "127.0.0.1:9090:9000"
-      - "127.0.0.1:9091:9001"
+      - "127.0.0.1:${MINIO_API_PORT:-9090}:9000"
+      - "127.0.0.1:${MINIO_CONSOLE_PORT:-9091}:9001"
     command: -c 'mkdir -p /data/langfuse && minio server --address ":9000" --console-address ":9001" /data'
     environment:
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}

--- a/docs/engineering/sdk-registry.md
+++ b/docs/engineering/sdk-registry.md
@@ -368,12 +368,13 @@ paths: "telegram_bot/**,src/**,mini_app/**,pyproject.toml,Makefile,.github/workf
 - **паттерны:**
   - Основной bot/query/runtime path: `langfuse.openai.AsyncOpenAI` + `LLM_BASE_URL` → LiteLLM proxy
   - Структурированный output: `response_format=` / Instructor-compatible контракты в основном runtime
-  - OpenAI SDK-native chat kwargs остаются top-level (`reasoning_effort`); provider-specific OpenAI-compatible controls (`disable_reasoning`, `reasoning_format`) идут через `extra_body={...}`.
+  - OpenAI SDK-native chat kwargs остаются top-level (`reasoning_effort`); provider-specific OpenAI-compatible controls (`disable_reasoning`, `reasoning_format`) идут через `extra_body={...}`. `disable_reasoning` взаимоисключает `reasoning_effort` / `reasoning_format`.
   - Raw `openai.AsyncOpenAI` / `OpenAI` допустим только в изолированных совместимых/compatibility paths (например, instructor-экстракшн/оценка)
 - **gotchas:**
   - Для основного runtime path НЕ импортировать raw `openai.AsyncOpenAI`; использовать Langfuse wrapper
   - Direct OpenAI SDK не является основным runtime path; использовать только в изолированных contextualization/eval/Instructor-compatibility paths
   - НЕ прокидывать нестандартные provider kwargs (`disable_reasoning`, `reasoning_format`) напрямую в `chat.completions.create(...)`; OpenAI SDK отвергнет их как unexpected keyword arguments.
+  - НЕ отправлять `disable_reasoning` вместе с `reasoning_effort`/`reasoning_format`; LiteLLM/Cerebras отвергает такой запрос.
   - НЕ хардкодить runtime model name — брать из config/env (`LLM_MODEL`)
   - `LLM_BASE_URL` обязателен для unified routing там, где path идет через LiteLLM
 

--- a/src/runtime/graph/config.py
+++ b/src/runtime/graph/config.py
@@ -107,14 +107,16 @@ class GraphConfig:
         ``extra_body`` so the OpenAI-compatible client does not reject them as
         unexpected top-level kwargs.
         """
+        extra_body: dict[str, Any] = {}
+        if self.disable_reasoning is not None:
+            extra_body["disable_reasoning"] = self.disable_reasoning
+            return {"extra_body": extra_body}
+
         kwargs: dict[str, Any] = {}
         if self.reasoning_effort is not None:
             kwargs["reasoning_effort"] = self.reasoning_effort
-        extra_body: dict[str, Any] = {}
         if self.reasoning_format is not None:
             extra_body["reasoning_format"] = self.reasoning_format
-        if self.disable_reasoning is not None:
-            extra_body["disable_reasoning"] = self.disable_reasoning
         if extra_body:
             kwargs["extra_body"] = extra_body
         return kwargs

--- a/tests/contract/test_env_example_completeness_contract.py
+++ b/tests/contract/test_env_example_completeness_contract.py
@@ -210,6 +210,8 @@ ALLOWLIST_NOT_IN_CODE: dict[str, str] = {
     # --- Docker Compose top-level controls ----------------------------------
     "COMPOSE_FILE": "Read by docker compose CLI, not Python",
     "BGE_M3_ONNX_MODEL_HOST_DIR": "Consumed by Compose named-context interpolation (compose.yml) at build time; not read by Python",
+    "MINIO_API_PORT": "Consumed by compose.dev.yml host-port interpolation for the MinIO API; not read by Python",
+    "MINIO_CONSOLE_PORT": "Consumed by compose.dev.yml host-port interpolation for the MinIO console; not read by Python",
     # --- Service credentials consumed by service entrypoints ---------------
     "REDIS_MAXMEMORY": "Read by redis container CMD args, not Python",
     "CLICKHOUSE_PASSWORD": "Read by clickhouse image entrypoint",

--- a/tests/unit/graph/test_config.py
+++ b/tests/unit/graph/test_config.py
@@ -282,12 +282,24 @@ class TestGraphConfig:
         cfg = GraphConfig(
             reasoning_effort="high",
             reasoning_format="hidden",
-            disable_reasoning=True,
         )
         assert cfg.get_reasoning_kwargs() == {
             "reasoning_effort": "high",
             "extra_body": {
                 "reasoning_format": "hidden",
+            },
+        }
+
+    def test_disable_reasoning_is_mutually_exclusive_with_reasoning_controls(self):
+        from telegram_bot.graph.config import GraphConfig
+
+        cfg = GraphConfig(
+            reasoning_effort="high",
+            reasoning_format="hidden",
+            disable_reasoning=True,
+        )
+        assert cfg.get_reasoning_kwargs() == {
+            "extra_body": {
                 "disable_reasoning": True,
             },
         }

--- a/tests/unit/test_compose_runtime_contract.py
+++ b/tests/unit/test_compose_runtime_contract.py
@@ -25,6 +25,23 @@ def test_minio_base_command_exposes_console_address() -> None:
     assert '--console-address ":9001"' in command
 
 
+def test_minio_dev_host_ports_are_overrideable() -> None:
+    """MinIO host ports must not hard-block local trace validation.
+
+    Docker Desktop can leave host port forwards such as 9090/9091 in a bad
+    state. The host ports are useful for operators, but Langfuse talks to
+    MinIO over the container network; validation must be able to pick different
+    host ports without editing compose.dev.yml.
+    """
+    merged = _merge_compose_dev()
+    ports = merged["services"]["minio"].get("ports", [])
+
+    assert "127.0.0.1:${MINIO_API_PORT:-9090}:9000" in ports
+    assert "127.0.0.1:${MINIO_CONSOLE_PORT:-9091}:9001" in ports
+    assert "127.0.0.1:9090:9000" not in ports
+    assert "127.0.0.1:9091:9001" not in ports
+
+
 def test_voice_agent_uses_env_driven_livekit_url() -> None:
     compose = _load_compose()
     environment = compose["services"]["voice-agent"]["environment"]

--- a/tests/unit/test_makefile_contract.py
+++ b/tests/unit/test_makefile_contract.py
@@ -225,11 +225,30 @@ def test_validate_traces_fast_loads_runtime_dotenv_without_redis_default() -> No
     assert block_match, "validate-traces-fast target not found in Makefile"
     block = block_match.group(0)
 
-    assert 'uv run dotenv -f "$$TRACE_ENV_FILE" run --no-override --' in block
+    assert (
+        "TRACE_ENV_FILE ?= $(shell [ -f .env ] && echo .env || echo tests/fixtures/compose.ci.env)"
+        in text
+    )
+    assert 'uv run dotenv -f "$(TRACE_ENV_FILE)" run --no-override --' in block
     assert 'REDIS_PASSWORD="$(or $(REDIS_PASSWORD),dev_redis_pass)"' not in block, (
         "validate-traces-fast must let python-dotenv load REDIS_PASSWORD from the "
         "same env file Compose uses; a hardcoded default causes auth mismatches."
     )
+
+
+def test_validate_traces_fast_randomizes_minio_host_ports_by_default() -> None:
+    """Trace validation must not depend on fixed optional MinIO host ports."""
+    text = _makefile_text()
+    block_match = re.search(
+        r"^validate-traces-fast:.*?(?=^[A-Za-z0-9_.-]+:|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert block_match, "validate-traces-fast target not found in Makefile"
+    block = block_match.group(0)
+
+    assert 'MINIO_API_PORT="$(or $(MINIO_API_PORT),0)"' in block
+    assert 'MINIO_CONSOLE_PORT="$(or $(MINIO_CONSOLE_PORT),0)"' in block
 
 
 # --- #1307 core trace gate contract tests ---


### PR DESCRIPTION
## Summary
- make MinIO dev host ports configurable and randomize them for `validate-traces-fast` so optional host port forwards do not block local trace validation
- promote `TRACE_ENV_FILE` to a Make variable so `python-dotenv` receives a real env-file path across recipe lines
- keep provider-specific reasoning kwargs SDK-shaped and make `disable_reasoning` mutually exclusive with `reasoning_effort` / `reasoning_format`
- document MinIO host endpoints and the OpenAI-compatible reasoning conflict rule

Fixes: #2256
Bug class: Observability trace-coverage drift
Regression guardrail: `tests/unit/test_makefile_contract.py`, `tests/unit/test_compose_runtime_contract.py`, `tests/unit/graph/test_config.py`, `tests/contract/test_env_example_completeness_contract.py`
Checks run:
- `uv sync --frozen`
- `make -n validate-traces-fast`
- `uv run --no-sync pytest tests/unit/test_compose_runtime_contract.py tests/unit/test_env_example.py tests/contract/test_env_example_completeness_contract.py -q`
- `MINIO_API_PORT=9094 MINIO_CONSOLE_PORT=9092 docker compose --compatibility --env-file /home/user/projects/rag-fresh/.env -f compose.yml -f compose.dev.yml --profile ml config --quiet`
- `MINIO_API_PORT=9094 MINIO_CONSOLE_PORT=9092 docker compose --compatibility --env-file /home/user/projects/rag-fresh/.env -f compose.yml -f compose.dev.yml --profile ml config | uv run --no-sync python -c ...`
- `uv run --no-sync pytest tests/unit/graph/test_config.py tests/unit/services/test_generate_response.py tests/unit/test_makefile_contract.py tests/unit/test_compose_runtime_contract.py tests/unit/test_env_example.py tests/contract/test_env_example_completeness_contract.py -q`
- `uv run --no-sync ruff check src/runtime/graph/config.py tests/unit/graph/test_config.py tests/unit/test_makefile_contract.py tests/unit/test_compose_runtime_contract.py tests/contract/test_env_example_completeness_contract.py`
- `git diff --check`
- `make validate-traces-fast` (live): Compose startup passed, Redis auth passed, LLM calls passed without `disable_reasoning` conflict; final NO-GO remains only on missing required trace families
- `make check`
- `make test`
- `MINIO_API_PORT=0 MINIO_CONSOLE_PORT=0 docker compose --compatibility --env-file /home/user/projects/rag-fresh/.env -f compose.yml -f compose.dev.yml --profile bot --profile ml up -d --wait --force-recreate`
- `uv run --no-sync pytest tests/contract/test_compose_source_cleanup_contract.py -q`

Live validation result:
- Previous blockers removed: MinIO host port forwarding, empty `TRACE_ENV_FILE`, Redis auth mismatch, OpenAI SDK unexpected kwarg, LiteLLM/Cerebras `disable_reasoning + reasoning_effort` conflict.
- Remaining #2256 blocker after this PR: `required_trace_families_present` fails with missing `ingestion-cli-run`, `rag-api-query`, `telegram-message-root-context`, `telegram-rag-query`, `telegram-rag-supervisor`, `voice-session`.
