### PR TITLE
fix: align trace validation coverage with runtime mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -45,6 +46,8 @@ jobs:
 
       - name: Validate PR guardrails
         run: uv run --with pyyaml --no-project python scripts/ci/validate_pr_guardrails.py
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
   semgrep:
     name: Semgrep

--- a/docs/engineering/sdk-registry.md
+++ b/docs/engineering/sdk-registry.md
@@ -200,6 +200,7 @@ paths: "telegram_bot/**,src/**,mini_app/**,pyproject.toml,Makefile,.github/workf
   - @observe(name="node-X", capture_input=False, capture_output=False) на каждый node/step
   - propagate_attributes() — обязательная обёртка entry-point (иначе orphan traces)
   - langfuse.openai.AsyncOpenAI как drop-in замена openai.AsyncOpenAI (auto-tracing)
+  - Trace details: `client.api.trace.get(trace_id, fields="core,io,scores,metrics")`; nested observations сначала читать через SDK-native `client.api.observations.get_many(trace_id=..., fields="core,basic", cursor=...)`, а для self-hosted OSS fallback использовать SDK `client.api.trace.get(trace_id, fields="core,io,scores,observations,metrics")`
   - Prompt management: `telegram_bot.integrations.prompt_manager.get_prompt()` / `get_prompt_with_config()` → `client.get_prompt(...)`
   - CallbackHandler для LangChain/agent calls
   - PII masking через mask= параметр при Langfuse()
@@ -208,6 +209,7 @@ paths: "telegram_bot/**,src/**,mini_app/**,pyproject.toml,Makefile,.github/workf
   - НЕ возвращаться к manual `client.api.prompts.get(...)` probing, пока `client.get_prompt(...)` покрывает нужный path. Semgrep authority: `python.no-langfuse-prompts-api-get`.
   - propagate_attributes() ПЕРЕД любым @observe кодом
   - capture_input/output=False на тяжёлых нодах (payload bloat prevention)
+  - НЕ писать custom HTTP-клиент для observations. Langfuse Cloud: `api.observations.get_many(...)`; self-hosted OSS v4 может отвечать, что v2 observations доступны только Cloud, тогда fallback — SDK `trace.get(..., fields="...,observations,...")`.
   - Для полной локальной диагностики в Langfuse v3 лучше `langfuse api traces get <id> --fields core,io,scores,observations,metrics --json`; `traces list` иногда хватает, а `observations list` может быть 404
 
 ## langmem

--- a/scripts/ci/validate_pr_guardrails.py
+++ b/scripts/ci/validate_pr_guardrails.py
@@ -12,6 +12,8 @@ import json
 import os
 import re
 import subprocess  # nosec B404
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -81,6 +83,53 @@ def _pull_request_from_event(event: dict[str, Any]) -> PullRequest | None:
         labels=labels,
         base_sha=str(base_sha) if base_sha else None,
         head_sha=str(head_sha) if head_sha else None,
+    )
+
+
+def _refresh_pull_request_from_github(
+    event: dict[str, Any],
+    pr: PullRequest | None,
+) -> PullRequest | None:
+    """Return current PR metadata from GitHub when running in Actions.
+
+    Re-running a failed GitHub Actions job reuses the original event payload.
+    PR body edits made after the first run would otherwise remain invisible to
+    this guardrail. Keep the event SHA values because they define the checked
+    merge diff; refresh only human-editable PR metadata.
+    """
+    if pr is None:
+        return None
+    token = os.environ.get("GITHUB_TOKEN")
+    raw_pr = event.get("pull_request")
+    api_url = raw_pr.get("url") if isinstance(raw_pr, dict) else None
+    if not token or not isinstance(api_url, str) or not api_url:
+        return pr
+
+    request = urllib.request.Request(
+        api_url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:  # nosec B310
+            data = json.loads(response.read().decode("utf-8"))
+    except (OSError, urllib.error.URLError, json.JSONDecodeError):
+        return pr
+    if not isinstance(data, dict):
+        return pr
+
+    labels = tuple(
+        str(label.get("name", "")) for label in data.get("labels", []) if isinstance(label, dict)
+    )
+    return PullRequest(
+        title=str(data.get("title") or pr.title),
+        body=str(data.get("body") or ""),
+        labels=labels or pr.labels,
+        base_sha=pr.base_sha,
+        head_sha=pr.head_sha,
     )
 
 
@@ -276,6 +325,7 @@ def main(argv: list[str] | None = None) -> int:
 
     event = _load_event(args.event_path)
     pr = _pull_request_from_event(event)
+    pr = _refresh_pull_request_from_github(event, pr)
     files = _changed_files(args, pr)
     failures = validate(pr, files, large_threshold=args.large_threshold)
 

--- a/scripts/validate_traces.py
+++ b/scripts/validate_traces.py
@@ -96,6 +96,9 @@ TRACKED_NODE_NAMES = [
     "summarize",
 ]
 _TRACKED_NODE_SET = frozenset(TRACKED_NODE_NAMES)
+LANGFUSE_TRACE_FIELDS_WITHOUT_OBSERVATIONS = "core,io,scores,metrics"
+LANGFUSE_TRACE_FIELDS_WITH_OBSERVATIONS = "core,io,scores,observations,metrics"
+LANGFUSE_OBSERVATIONS_FIELDS = "core,basic"
 REQUIRED_TRACE_NAMES = ["rag-api-query", "voice-session", "ingestion-cli-run"]
 REQUIRED_TELEGRAM_OBSERVATION_FAMILIES = ["telegram-rag-query", "telegram-rag-supervisor"]
 TELEGRAM_ROOT_TRACE_NAME = "telegram-message"
@@ -115,6 +118,7 @@ TELEGRAM_ROOT_CONTEXT_FORBIDDEN_FIELDS = (
     "event_chat",
     "raw_update",
 )
+_OBSERVATIONS_V2_UNAVAILABLE = False
 
 GO_NO_GO_THRESHOLDS_PATH = (
     Path(__file__).resolve().parent.parent / "tests" / "baseline" / "thresholds.yaml"
@@ -155,6 +159,17 @@ def load_trace_coverage_tiers() -> dict[str, list[str]]:
         "required_when_exercised": tiers.get("required_when_exercised", []),
         "opportunistic_for_1307": tiers.get("opportunistic_for_1307", []),
     }
+
+
+def _default_required_direct_trace_names(tiers: dict[str, list[str]]) -> list[str]:
+    """Return direct trace families required by the default fast validation gate.
+
+    ``trace_contract.yaml`` is the source of truth for blocking tiers. Families
+    in ``required_when_exercised`` are checked by the runtime flows that
+    exercise them, not by a graph-only fast run.
+    """
+    required_for_default = set(tiers.get("required_for_1307", []))
+    return [name for name in REQUIRED_TRACE_NAMES if name in required_for_default]
 
 
 class FakeSentMessage:
@@ -279,6 +294,78 @@ def _langfuse_auth_probe() -> None:
     lf = Langfuse()
     if not lf.auth_check():
         raise RuntimeError("Langfuse auth_check returned False")
+
+
+def _next_cursor(response: Any) -> str | None:
+    """Return Langfuse cursor metadata across SDK response variants."""
+    meta = getattr(response, "meta", None)
+    if meta is None:
+        return None
+    cursor = getattr(meta, "next_cursor", None) or getattr(meta, "cursor", None)
+    return str(cursor) if cursor else None
+
+
+def _list_trace_observations(
+    lf: Any,
+    trace_id: str,
+    *,
+    limit: int = 100,
+) -> list[Any]:
+    """Fetch trace observations through the Langfuse SDK-native API.
+
+    Langfuse Cloud v4 exposes observations as a dedicated SDK-native v2
+    endpoint. Langfuse OSS v4 can report that v2 observations are Cloud-only;
+    for that local/self-hosted case, fall back to SDK ``trace.get`` with
+    observations fields instead of adding a custom HTTP client.
+    """
+    global _OBSERVATIONS_V2_UNAVAILABLE
+
+    if _OBSERVATIONS_V2_UNAVAILABLE:
+        return _list_trace_observations_from_trace_get(lf, trace_id)
+
+    observations: list[Any] = []
+    cursor: str | None = None
+    try:
+        while True:
+            page = lf.api.observations.get_many(
+                trace_id=trace_id,
+                fields=LANGFUSE_OBSERVATIONS_FIELDS,
+                limit=limit,
+                cursor=cursor,
+            )
+            observations.extend(list(getattr(page, "data", None) or []))
+            cursor = _next_cursor(page)
+            if not cursor:
+                break
+        return observations
+    except Exception as exc:
+        if _looks_like_observations_v2_unavailable(exc):
+            _OBSERVATIONS_V2_UNAVAILABLE = True
+            logger.info(
+                "Langfuse Observations API v2 unavailable on this host; "
+                "falling back to SDK trace.get observations."
+            )
+            return _list_trace_observations_from_trace_get(lf, trace_id)
+        raise
+
+
+def _looks_like_observations_v2_unavailable(exc: Exception) -> bool:
+    """Detect Langfuse OSS response for Cloud-only observations v2 API."""
+    text = str(exc).lower()
+    return (
+        "v2 apis are currently in beta" in text
+        or "only available on langfuse cloud" in text
+        or "langfusenotfounderror" in text
+    )
+
+
+def _list_trace_observations_from_trace_get(lf: Any, trace_id: str) -> list[Any]:
+    """Fetch observations via SDK trace details for self-hosted Langfuse."""
+    trace = lf.api.trace.get(
+        trace_id,
+        fields=LANGFUSE_TRACE_FIELDS_WITH_OBSERVATIONS,
+    )
+    return list(getattr(trace, "observations", None) or [])
 
 
 def check_worktree_clean(strict: bool = False) -> None:
@@ -750,7 +837,10 @@ async def enrich_results_from_langfuse(
         if r.phase == "warmup" or r.state.get("cold_skipped"):
             continue
         try:
-            trace = lf.api.trace.get(r.trace_id)
+            trace = lf.api.trace.get(
+                r.trace_id,
+                fields=LANGFUSE_TRACE_FIELDS_WITHOUT_OBSERVATIONS,
+            )
             # Populate scores from Langfuse
             if hasattr(trace, "scores") and trace.scores:
                 for score in trace.scores:
@@ -760,8 +850,9 @@ async def enrich_results_from_langfuse(
                         r.scores[name] = float(value)
             # Populate node span durations and error count from observations
             observation_error_count = 0
-            if hasattr(trace, "observations") and trace.observations:
-                for obs in trace.observations:
+            observations = _list_trace_observations(lf, r.trace_id)
+            if observations:
+                for obs in observations:
                     level = getattr(obs, "level", None)
                     if level and str(level).upper().endswith("ERROR"):
                         observation_error_count += 1
@@ -796,6 +887,8 @@ async def enrich_results_from_langfuse(
                     if start_time and end_time:
                         delta_ms = (end_time - start_time).total_seconds() * 1000
                         r.node_spans_ms[node_name] = delta_ms
+                    elif (latency := getattr(obs, "latency", None)) is not None:
+                        r.node_spans_ms[node_name] = float(latency) * 1000
             r.state["observation_error_count"] = observation_error_count
             enriched += 1
         except Exception as e:
@@ -836,6 +929,7 @@ def check_required_trace_coverage(
     *,
     required_trace_names: list[str] | None = None,
     required_observation_names: list[str] | None = None,
+    coverage_mode: str = "full",
     lookback_hours: int = 24,
 ) -> dict[str, Any]:
     """Check required trace coverage in Langfuse within lookback window.
@@ -845,12 +939,23 @@ def check_required_trace_coverage(
     2) Required observation families nested under telegram-message root traces.
     3) Sanitized root input contract for telegram-message traces.
     """
-    required_direct = REQUIRED_TRACE_NAMES if required_trace_names is None else required_trace_names
-    required_nested = (
-        REQUIRED_TELEGRAM_OBSERVATION_FAMILIES
-        if required_observation_names is None
-        else required_observation_names
-    )
+    tiers = load_trace_coverage_tiers()
+    if coverage_mode not in {"fast", "full"}:
+        raise ValueError(f"Unsupported trace coverage mode: {coverage_mode}")
+
+    if required_trace_names is not None:
+        required_direct = required_trace_names
+    elif coverage_mode == "fast":
+        required_direct = _default_required_direct_trace_names(tiers)
+    else:
+        required_direct = REQUIRED_TRACE_NAMES
+
+    if required_observation_names is not None:
+        required_nested = required_observation_names
+    elif coverage_mode == "fast":
+        required_nested = []
+    else:
+        required_nested = REQUIRED_TELEGRAM_OBSERVATION_FAMILIES
     required = [*required_direct, *required_nested]
     include_root_context_contract = bool(required_nested)
     if include_root_context_contract:
@@ -886,7 +991,6 @@ def check_required_trace_coverage(
             missing.append(trace_name)
 
     # Opportunistic families — tracked but non-blocking
-    tiers = load_trace_coverage_tiers()
     opportunistic = [t for t in tiers.get("opportunistic_for_1307", []) if t not in required_direct]
     opportunistic_present: list[str] = []
     opportunistic_missing: list[str] = []
@@ -928,13 +1032,20 @@ def check_required_trace_coverage(
         if not trace_id:
             continue
         try:
-            trace = lf.api.trace.get(trace_id)
+            trace = lf.api.trace.get(
+                trace_id,
+                fields=LANGFUSE_TRACE_FIELDS_WITHOUT_OBSERVATIONS,
+            )
         except Exception as exc:
             logger.warning("Failed to fetch root trace '%s': %s", trace_id, exc)
             continue
 
         root_traces_checked += 1
-        observations = list(getattr(trace, "observations", None) or [])
+        try:
+            observations = _list_trace_observations(lf, trace_id)
+        except Exception as exc:
+            logger.warning("Failed to fetch root trace observations '%s': %s", trace_id, exc)
+            observations = []
         observation_names: list[str] = []
 
         for obs in observations:
@@ -1010,6 +1121,7 @@ def check_required_trace_coverage(
     lf.flush()
     logger.info("Required trace coverage: present=%s missing=%s", present, missing)
     return {
+        "mode": coverage_mode,
         "required": required,
         "present": present,
         "missing": missing,
@@ -1725,7 +1837,9 @@ async def run_validation(args: argparse.Namespace) -> None:
     orphan_rate = check_orphan_traces(all_results)
 
     logger.info("Checking required trace family coverage...")
-    required_trace_coverage = check_required_trace_coverage()
+    required_trace_coverage = check_required_trace_coverage(
+        coverage_mode=args.trace_coverage_mode,
+    )
 
     # Runtime trace_id continuity across service/thread boundaries (#2252).
     # Proves each canonical flow is one trace tree, not several partial traces.
@@ -1920,6 +2034,16 @@ def main() -> None:
             "Disable the #2244 single-trace continuity check "
             "(by default the run fails if a canonical flow fragments across a "
             "service/thread boundary)."
+        ),
+    )
+    parser.add_argument(
+        "--trace-coverage-mode",
+        choices=("fast", "full"),
+        default="fast",
+        help=(
+            "Trace-family coverage strictness. fast checks only families exercised "
+            "by the local graph validation workload; full also requires all "
+            "canonical runtime families."
         ),
     )
     args = parser.parse_args()

--- a/telegram_bot/middlewares/langfuse_middleware.py
+++ b/telegram_bot/middlewares/langfuse_middleware.py
@@ -29,18 +29,21 @@ def _extract_event_input(event: TelegramObject, action_type: str) -> dict[str, A
             content_type=str(getattr(event, "content_type", "unknown")),
             text=text,
             action=action_type,
+            route=action_type,
         )
     if isinstance(event, CallbackQuery):
         return build_safe_input_payload(
             content_type="callback",
             text=event.data or "",
             action=action_type,
+            route=action_type,
             extra={"callback_data": event.data or ""},
         )
     return build_safe_input_payload(
         content_type="unknown",
         text="",
         action=action_type,
+        route=action_type,
     )
 
 

--- a/tests/contract/test_env_example_completeness_contract.py
+++ b/tests/contract/test_env_example_completeness_contract.py
@@ -91,6 +91,7 @@ ALLOWLIST_NOT_IN_ENV_EXAMPLE: dict[str, str] = {
     "GITHUB_OUTPUT": "GitHub Actions output channel",
     "GITHUB_ENV": "GitHub Actions env channel",
     "GITHUB_EVENT_PATH": "GitHub Actions event payload path; CI-only",
+    "GITHUB_TOKEN": "GitHub Actions ephemeral API token; CI-only",
     "GITHUB_STEP_SUMMARY": "GitHub Actions step summary channel",
     "RUNNER_OS": "GitHub Actions self-hosted runner detection",
     "RUNNER_TEMP": "GitHub Actions temp dir",

--- a/tests/unit/middlewares/test_langfuse_middleware.py
+++ b/tests/unit/middlewares/test_langfuse_middleware.py
@@ -76,6 +76,7 @@ async def test_creates_span_when_langfuse_enabled(middleware, handler, message_e
     assert call_kwargs["name"] == "telegram-cmd-start"
     input_payload = call_kwargs["input"]
     assert input_payload["action"] == "cmd-start"
+    assert input_payload["route"] == "cmd-start"
     assert input_payload["content_type"] == "text"
     assert "query_preview" in input_payload
     assert "query_hash" in input_payload
@@ -128,6 +129,7 @@ async def test_callback_action_type(middleware, handler, event_data):
     assert call_kwargs["name"] == "telegram-callback-fav"
     input_payload = call_kwargs["input"]
     assert input_payload["action"] == "callback-fav"
+    assert input_payload["route"] == "callback-fav"
     assert input_payload["content_type"] == "callback"
     assert "query_preview" in input_payload
     assert "query_hash" in input_payload

--- a/tests/unit/scripts/test_validate_pr_guardrails.py
+++ b/tests/unit/scripts/test_validate_pr_guardrails.py
@@ -1,10 +1,67 @@
 from __future__ import annotations
 
-from scripts.ci.validate_pr_guardrails import PullRequest, validate
+import json
+from unittest.mock import patch
+
+from scripts.ci.validate_pr_guardrails import (
+    PullRequest,
+    _pull_request_from_event,
+    _refresh_pull_request_from_github,
+    validate,
+)
 
 
 def _pr(title: str, body: str, labels: tuple[str, ...] = ()) -> PullRequest:
     return PullRequest(title=title, body=body, labels=labels)
+
+
+def test_refresh_pull_request_from_github_uses_current_body_and_keeps_event_shas(
+    monkeypatch,
+) -> None:
+    event = {
+        "pull_request": {
+            "url": "https://api.github.com/repos/acme/rag/pulls/123",
+            "title": "fix: stale event",
+            "body": "Fixes #123",
+            "labels": [{"name": "bug"}],
+            "base": {"sha": "base-sha"},
+            "head": {"sha": "head-sha"},
+        }
+    }
+    event_pr = _pull_request_from_event(event)
+    assert event_pr is not None
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+
+    class Response:
+        def __enter__(self) -> Response:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "title": "fix: stale event",
+                    "body": (
+                        "Fixes #123\n"
+                        "Bug class: Observability trace-family coverage drift\n"
+                        "Regression guardrail: tests/unit/test_validate_pr_guardrails.py\n"
+                        "Checks run: pytest tests/unit/scripts/test_validate_pr_guardrails.py\n"
+                    ),
+                    "labels": [{"name": "bug"}, {"name": "observability"}],
+                }
+            ).encode()
+
+    with patch("scripts.ci.validate_pr_guardrails.urllib.request.urlopen", return_value=Response()):
+        refreshed = _refresh_pull_request_from_github(event, event_pr)
+
+    assert refreshed is not None
+    assert refreshed.body != event_pr.body
+    assert "Regression guardrail:" in refreshed.body
+    assert refreshed.labels == ("bug", "observability")
+    assert refreshed.base_sha == "base-sha"
+    assert refreshed.head_sha == "head-sha"
 
 
 def test_bugfix_requires_regression_guardrail_checks_and_test_change() -> None:

--- a/tests/unit/test_ci_workflow_guardrails.py
+++ b/tests/unit/test_ci_workflow_guardrails.py
@@ -70,6 +70,16 @@ def test_top_level_permissions_contents_read() -> None:
     assert permissions.get("contents") == "read", f"expected `contents: read`, got {permissions}"
 
 
+def test_top_level_permissions_pull_requests_read() -> None:
+    """pr-guardrails reads current PR metadata via GitHub API."""
+    data = _load_workflow()
+    permissions = data.get("permissions")
+    assert permissions is not None, "missing top-level `permissions` key"
+    assert permissions.get("pull-requests") == "read", (
+        f"expected `pull-requests: read`, got {permissions}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Job secrets safety
 # ---------------------------------------------------------------------------
@@ -231,6 +241,20 @@ def test_pr_guardrails_installs_yaml_dependency_without_project_sync() -> None:
     assert "--no-project" in combined, (
         "pr-guardrails must not sync the whole project just to validate PR metadata."
     )
+
+
+def test_pr_guardrails_passes_ephemeral_github_token_for_live_pr_metadata() -> None:
+    """Rerun jobs must see current PR body, not only the stale event payload."""
+    data = _load_workflow()
+    job = data["jobs"]["pr-guardrails"]
+    validate_steps = [
+        step
+        for step in job.get("steps", [])
+        if "validate_pr_guardrails.py" in str(step.get("run", ""))
+    ]
+    assert len(validate_steps) == 1
+    env = validate_steps[0].get("env", {})
+    assert env.get("GITHUB_TOKEN") == "${{ github.token }}"
 
 
 def test_pr_guardrails_uses_github_hosted_runner() -> None:

--- a/tests/unit/test_langfuse_context_middleware.py
+++ b/tests/unit/test_langfuse_context_middleware.py
@@ -25,6 +25,7 @@ class TestExtractEventInput:
         msg.content_type = "text"
         result = _extract_event_input(msg, "message")
         assert result["action"] == "message"
+        assert result["route"] == "message"
         assert result["content_type"] == "text"
         assert "query_preview" in result
         assert "query_hash" in result
@@ -77,6 +78,7 @@ class TestExtractEventInput:
         cb.data = "menu:search"
         result = _extract_event_input(cb, "callback-menu")
         assert result["action"] == "callback-menu"
+        assert result["route"] == "callback-menu"
         assert result["content_type"] == "callback"
         assert "query_preview" in result
         assert result["query_len"] == 11
@@ -91,6 +93,7 @@ class TestExtractEventInput:
         event = MagicMock()
         result = _extract_event_input(event, "update")
         assert result["action"] == "update"
+        assert result["route"] == "update"
         assert result["content_type"] == "unknown"
 
 
@@ -138,6 +141,7 @@ class TestLangfuseContextMiddleware:
         assert call_kwargs["name"] == "telegram-message"
         input_payload = call_kwargs["input"]
         assert input_payload["action"] == "message"
+        assert input_payload["route"] == "message"
         assert input_payload["content_type"] == "text"
         assert "query_preview" in input_payload
         assert "text_preview" not in input_payload
@@ -170,6 +174,7 @@ class TestLangfuseContextMiddleware:
         assert call_kwargs["name"] == "telegram-rag-voice"
         input_payload = call_kwargs["input"]
         assert input_payload["action"] == "rag-voice"
+        assert input_payload["route"] == "rag-voice"
         assert input_payload["content_type"] == "voice"
         mock_prop.assert_called_once()
         handler.assert_called_once_with(msg, data)
@@ -200,6 +205,7 @@ class TestLangfuseContextMiddleware:
         assert call_kwargs["name"] == "telegram-callback-filter"
         input_payload = call_kwargs["input"]
         assert input_payload["action"] == "callback-filter"
+        assert input_payload["route"] == "callback-filter"
         assert input_payload["content_type"] == "callback"
         assert "query_preview" in input_payload
         assert "text_preview" not in input_payload

--- a/tests/unit/test_semgrep_guardrails.py
+++ b/tests/unit/test_semgrep_guardrails.py
@@ -109,6 +109,10 @@ def test_ci_semgrep_job_uses_pinned_cli_and_project_rules() -> None:
 
 def test_ci_semgrep_job_uses_read_only_permissions() -> None:
     data = _load_yaml(CI_WORKFLOW)
-    assert data["permissions"] == {"contents": "read"}
+    permissions = data["permissions"]
+    assert permissions["contents"] == "read"
+    assert all(value == "read" for value in permissions.values())
+    assert "actions" not in permissions
+    assert "id-token" not in permissions
     semgrep_job = data["jobs"]["semgrep"]
     assert semgrep_job.get("permissions") in (None, {"contents": "read"})

--- a/tests/unit/test_validate_traces_coverage_gate.py
+++ b/tests/unit/test_validate_traces_coverage_gate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from scripts import validate_traces
 from scripts.validate_traces import (
     REQUIRED_TELEGRAM_OBSERVATION_FAMILIES,
     REQUIRED_TRACE_NAMES,
@@ -35,10 +36,32 @@ def test_check_required_trace_coverage_marks_missing_trace_families() -> None:
     ]
 
     with patch("scripts.validate_traces.Langfuse", return_value=mock_lf):
-        coverage = check_required_trace_coverage(required_observation_names=[])
+        coverage = check_required_trace_coverage(
+            required_trace_names=REQUIRED_TRACE_NAMES,
+            required_observation_names=[],
+        )
 
     assert coverage["present"] == ["rag-api-query"]
     assert set(coverage["missing"]) == {"voice-session", "ingestion-cli-run"}
+
+
+def test_check_required_trace_coverage_default_does_not_block_unexercised_families() -> None:
+    """Default fast gate follows trace_contract.yaml coverage tiers."""
+    mock_lf = MagicMock()
+    mock_lf.api.trace.list.side_effect = [
+        SimpleNamespace(data=[]),  # opportunistic voice-session check
+    ]
+
+    with patch("scripts.validate_traces.Langfuse", return_value=mock_lf):
+        coverage = check_required_trace_coverage(
+            required_observation_names=[],
+            coverage_mode="fast",
+        )
+
+    assert coverage["required"] == []
+    assert coverage["missing"] == []
+    assert coverage["opportunistic_missing"] == ["voice-session"]
+    assert coverage["mode"] == "fast"
 
 
 def test_check_required_trace_coverage_accepts_telegram_observations_under_root() -> None:
@@ -88,9 +111,13 @@ def test_check_required_trace_coverage_accepts_telegram_observations_under_root(
     ]
 
     mock_lf.api.trace.get.side_effect = [root_1, root_2]
+    mock_lf.api.observations.get_many.side_effect = [
+        SimpleNamespace(data=root_1.observations),
+        SimpleNamespace(data=root_2.observations),
+    ]
 
     with patch("scripts.validate_traces.Langfuse", return_value=mock_lf):
-        coverage = check_required_trace_coverage()
+        coverage = check_required_trace_coverage(coverage_mode="full")
 
     expected_present = set(REQUIRED_TRACE_NAMES) | set(REQUIRED_TELEGRAM_OBSERVATION_FAMILIES)
     assert expected_present.issubset(set(coverage["present"]))
@@ -101,6 +128,59 @@ def test_check_required_trace_coverage_accepts_telegram_observations_under_root(
     assert coverage["root_context_missing"] == {}
     assert coverage["root_context_pii_violations"] == {}
     assert coverage["cache_hit_without_retrieve_generation"] == 1
+    mock_lf.api.observations.get_many.assert_any_call(
+        trace_id="root-1",
+        fields="core,basic",
+        limit=100,
+        cursor=None,
+    )
+    mock_lf.api.observations.get_many.assert_any_call(
+        trace_id="root-2",
+        fields="core,basic",
+        limit=100,
+        cursor=None,
+    )
+
+
+def test_check_required_trace_coverage_falls_back_when_observations_v2_unavailable(
+    monkeypatch,
+) -> None:
+    """Langfuse OSS v4 can expose observations only through trace.get details."""
+    monkeypatch.setattr(validate_traces, "_OBSERVATIONS_V2_UNAVAILABLE", False)
+    mock_lf = MagicMock()
+    mock_lf.api.trace.list.side_effect = [
+        SimpleNamespace(data=[]),
+        SimpleNamespace(data=[SimpleNamespace(id="root-1")]),
+    ]
+    root_without_observations = _trace(
+        "root-1",
+        input_data={
+            "content_type": "text",
+            "query_preview": "q",
+            "query_hash": "hash",
+            "query_len": 1,
+            "route": "message",
+        },
+    )
+    root_with_observations = _trace("root-1")
+    root_with_observations.observations = [_obs("telegram-rag-query")]
+    mock_lf.api.trace.get.side_effect = [root_without_observations, root_with_observations]
+    mock_lf.api.observations.get_many.side_effect = RuntimeError(
+        "v2 APIs are currently in beta and only available on Langfuse Cloud"
+    )
+
+    with patch("scripts.validate_traces.Langfuse", return_value=mock_lf):
+        coverage = check_required_trace_coverage(
+            required_trace_names=[],
+            required_observation_names=["telegram-rag-query"],
+        )
+
+    assert "telegram-rag-query" in coverage["present"]
+    assert validate_traces._OBSERVATIONS_V2_UNAVAILABLE is True
+    mock_lf.api.trace.get.assert_any_call(
+        "root-1",
+        fields="core,io,scores,observations,metrics",
+    )
 
 
 def test_check_required_trace_coverage_fails_when_root_context_is_unsanitized() -> None:
@@ -122,6 +202,7 @@ def test_check_required_trace_coverage_fails_when_root_context_is_unsanitized() 
     )
     bad_root.observations = [_obs("telegram-rag-query")]
     mock_lf.api.trace.get.return_value = bad_root
+    mock_lf.api.observations.get_many.return_value = SimpleNamespace(data=bad_root.observations)
     mock_lf.api.trace.list.side_effect = [
         SimpleNamespace(data=[]),  # opportunistic voice-session check
         SimpleNamespace(data=[SimpleNamespace(id="bad-root")]),  # telegram root check
@@ -149,7 +230,7 @@ def test_check_required_trace_coverage_litellm_proxy_traces_do_not_count_as_app_
     ]
 
     with patch("scripts.validate_traces.Langfuse", return_value=mock_lf):
-        coverage = check_required_trace_coverage()
+        coverage = check_required_trace_coverage(coverage_mode="full")
 
     assert "telegram-rag-query" in coverage["missing"]
     assert "telegram-rag-supervisor" in coverage["missing"]


### PR DESCRIPTION
## Summary
- split trace-family coverage into fast/full modes so graph-only validation does not block on unexercised runtime families
- fetch Langfuse observations through SDK-native `api.observations.get_many(...)` first, with self-hosted OSS fallback through SDK `trace.get(...observations...)`
- include `route` in Telegram root trace input so the existing root-context contract can pass for live message traces
- refresh PR guardrail metadata from GitHub API so reruns after PR body edits do not use stale event payloads

Refs: #2256
Refs: #2301

Bug class: Observability trace-coverage drift

Regression guardrail: `tests/unit/test_validate_traces_coverage_gate.py`, `tests/unit/test_langfuse_context_middleware.py`, `tests/unit/middlewares/test_langfuse_middleware.py`, `tests/unit/scripts/test_validate_pr_guardrails.py`, `docs/engineering/sdk-registry.md`

Checks run: focused pytest 43 passed; ruff touched files passed; git diff --check passed; make check passed; make validate-traces-fast GO 14/14 with Langfuse SDK fallback enriching 36/48 results; root compose-source contract 4 passed.

## Validation Detail
- `UV_PROJECT_ENVIRONMENT=/home/user/projects/rag-fresh/.venv uv run --no-sync pytest tests/unit/scripts/test_validate_pr_guardrails.py tests/unit/test_validate_traces_coverage_gate.py tests/unit/test_langfuse_context_middleware.py tests/unit/middlewares/test_langfuse_middleware.py -q`
- `UV_PROJECT_ENVIRONMENT=/home/user/projects/rag-fresh/.venv uv run --no-sync ruff check scripts/ci/validate_pr_guardrails.py scripts/validate_traces.py telegram_bot/middlewares/langfuse_middleware.py tests/unit/scripts/test_validate_pr_guardrails.py tests/unit/test_validate_traces_coverage_gate.py tests/unit/test_langfuse_context_middleware.py tests/unit/middlewares/test_langfuse_middleware.py`
- `git diff --check`
- `UV_PROJECT_ENVIRONMENT=/home/user/projects/rag-fresh/.venv make check`
- `make validate-traces-fast` -> GO 14/14, enriched 36/48 results from Langfuse via SDK fallback
- root `uv run --no-sync pytest tests/contract/test_compose_source_cleanup_contract.py -q` -> 4 passed

## Notes
- This PR intentionally does not close #2256. It fixes the fast validation false-blocker and SDK observation-read fallback; full runtime proof should remain tracked separately.
- Full `make test` was attempted earlier and hit an unrelated xdist/order-sensitive voice graph test; the same test passed when isolated.
