### PR TITLE
fix: update redis smoke fixture imports

### DIFF
--- a/tests/smoke/test_smoke_fixtures.py
+++ b/tests/smoke/test_smoke_fixtures.py
@@ -24,12 +24,12 @@ def test_redis_url_fixture_is_provided(redis_url: str) -> None:
 
 @pytest.mark.smoke
 def test_redis_url_fixture_injects_password(monkeypatch: pytest.MonkeyPatch) -> None:
-    """`redis_url` mirrors `_build_redis_url`: injects REDIS_PASSWORD if not embedded."""
+    """`redis_url` fixture injects REDIS_PASSWORD if not embedded in REDIS_URL."""
     monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
     monkeypatch.setenv("REDIS_PASSWORD", "topsecret")
 
     # Reimport / recompute by calling the fixture function directly.
-    from tests.smoke.conftest import redis_url as redis_url_fixture
+    from tests.fixtures.config import redis_url as redis_url_fixture
 
     # Module-scoped pytest fixtures are wrapped; reach the underlying function.
     func = getattr(redis_url_fixture, "__wrapped__", redis_url_fixture)
@@ -43,7 +43,7 @@ def test_redis_url_fixture_preserves_explicit_credentials(monkeypatch: pytest.Mo
     monkeypatch.setenv("REDIS_URL", "redis://:already@host:6379")
     monkeypatch.setenv("REDIS_PASSWORD", "ignored")
 
-    from tests.smoke.conftest import redis_url as redis_url_fixture
+    from tests.fixtures.config import redis_url as redis_url_fixture
 
     func = getattr(redis_url_fixture, "__wrapped__", redis_url_fixture)
     url = func() if callable(func) else None


### PR DESCRIPTION
## Summary

- Update stale redis fixture imports in `tests/smoke/test_smoke_fixtures.py` from `tests.smoke.conftest` to `tests.fixtures.config`.
- Keep #2324 scoped to Phase 0.1 only; no Phase 1 marker/nightly/coverage changes.

Bug class: Testing hygiene/tautological assertions
Regression guardrail: `tests/smoke/test_smoke_fixtures.py::test_redis_url_fixture_injects_password` and `tests/smoke/test_smoke_fixtures.py::test_redis_url_fixture_preserves_explicit_credentials` now run against the real `redis_url` fixture location and pass without Docker/services.
Checks run: `UV_PROJECT_ENVIRONMENT=/home/user/projects/rag-fresh/.venv uv run --no-sync pytest -q tests/smoke/test_smoke_fixtures.py`; `make compile-python`; `git diff --check`; commit hooks (py_compile, Ruff, Gitleaks, Bandit, pre-push hooks).

## Review notes

- Related roadmap: #2324 Phase 0.1. Do not close #2324 from this PR.
- Related audit evidence: #2319.
- Related bug context: #2320, #2323.
- Native/tooling alternative considered: not applicable for this patch; this fixes stale test imports while preserving existing pytest smoke guardrails.
