### PR TITLE
feat: add synthetic E2E core fixture corpus (issue #2332)

### DIFF
--- a/tests/e2e_core/README.md
+++ b/tests/e2e_core/README.md
@@ -1,0 +1,84 @@
+# tests/e2e_core
+
+Synthetic fixture corpus for simplification core E2E tests.
+
+## Purpose
+
+This directory holds a small, stable, synthetic document corpus and
+golden test cases for the product simplification core E2E pipeline.
+
+The corpus is self-contained: no production data, no secrets, no
+customer PII, no real CRM/Telegram contact data.
+
+## Structure
+
+```
+tests/e2e_core/
+  fixtures/
+    docs/              # 8 synthetic Markdown documents
+    golden_cases.yaml  # 7 golden test cases
+  README.md            # this file
+```
+
+## Fixture Documents
+
+| File | Source ID | Type | Key Facts |
+|---|---|---|---|
+| `sunny_beach_studio.md` | `sunny-beach-studio-001` | Listing | Studio, 150m sea, 110 kEUR |
+| `sunny_beach_2bed.md` | `sunny-beach-2bed-002` | Listing | 2-bed, 250m sea, 95 kEUR |
+| `nessebar_penthouse.md` | `nessebar-penthouse-003` | Listing | Penthouse, 100m sea, 130 kEUR |
+| `mountain_view_villa.md` | `mountain-villa-004` | Listing | Villa, Bansko mountains, 90 kEUR |
+| `city_center_sofia.md` | `sofia-center-005` | Listing | 1-bed, Sofia center, 85 kEUR |
+| `sotirovo_garden.md` | `sotirovo-garden-006` | Listing | Garden apt, Burgas area, 78 kEUR |
+| `services_cleaning.md` | `service-cleaning-007` | Service | Cleaning, 25-60 EUR, 48h notice |
+| `rules_hitl.md` | `policy-hitl-008` | Policy | CRM/HITL confirmation workflow |
+
+## Golden Cases
+
+| ID | Scenario | Answer Policy |
+|---|---|---|
+| `beach_studio_sea_under_120k` | Happy path: sea-side studio under budget | `grounded_answer` |
+| `missing_in_corpus_no_claim` | Query targets data not in corpus | `no_data_no_claim` |
+| `price_constraint_cheapest_sunny_beach` | Price/location constraint | `filtered_constraint` |
+| `sea_side_excludes_mountain` | Sea-side must exclude mountain property | `conflict_attribution` |
+| `garden_apartment_near_burgas` | Location + amenity constraint | `filtered_constraint` |
+| `service_cleaning_price_policy` | Service quote retrieval | `service_quote` |
+| `crm_hitl_confirmation_policy` | CRM HITL confirmation metadata | `hitl_confirmation` |
+
+## Validation
+
+Validate fixture integrity:
+
+```bash
+uv run python -c "
+from pathlib import Path
+import yaml
+root = Path('tests/e2e_core/fixtures')
+cases = yaml.safe_load((root / 'golden_cases.yaml').read_text(encoding='utf-8'))
+assert isinstance(cases, list) and cases
+ids = {p.stem for p in (root / 'docs').glob('*.md')}
+for case in cases:
+    assert case['id']
+    assert case['query']
+    for doc_id in case.get('must_retrieve', []):
+        assert doc_id in ids, (case['id'], doc_id)
+print(f'validated {len(cases)} golden cases against {len(ids)} docs')
+"
+```
+
+## Contract
+
+Golden cases are product-check contracts, not prose comparisons. Each case
+asserts:
+- Which documents **must** be retrieved (`must_retrieve`)
+- What facts **must** be present in the answer (`must_contain`)
+- What facts **must not** appear in the answer (`must_not_contain`)
+- What answering policy applies (`answer_policy`)
+
+LLM evaluation uses temperature 0 and fact-based checks to minimize
+non-determinism.
+
+## Related Docs
+
+- Product simplification E2E plan: [`docs/designs/product-simplification-e2e-plan.md`](../../docs/designs/product-simplification-e2e-plan.md)
+- Issue #2332: create synthetic fixture corpus for core E2E

--- a/tests/e2e_core/fixtures/docs/city_center_sofia.md
+++ b/tests/e2e_core/fixtures/docs/city_center_sofia.md
@@ -1,0 +1,38 @@
+# City Center Sofia Apartment
+
+**Source ID:** `sofia-center-005`
+**Category:** Real Estate Listing
+**Last Updated:** 2026-05-28
+
+## Property Details
+
+- **Type:** 1-bedroom apartment
+- **Location:** Sofia City Center, Bulgaria
+- **Distance to sea:** 370 km (inland capital)
+- **Price:** 85,000 EUR
+- **Area:** 55 m²
+- **Floor:** 3
+- **Year built:** 2015
+
+## Description
+
+Modern one-bedroom apartment in central Sofia, close to public transport,
+shopping, and business districts. Not a coastal or resort property —
+ideal for business travelers or city residents.
+
+The apartment has been recently renovated with new flooring, modern
+bathroom fixtures, and energy-efficient windows. The building has an
+elevator and is located on a quiet side street.
+
+## Amenities
+
+- Recently renovated
+- Energy-efficient windows
+- Elevator in building
+- Close to metro station
+- Central heating
+
+## Contact
+
+For inquiries: contact agent via the booking portal.
+Reference listing ID: sofia-center-005

--- a/tests/e2e_core/fixtures/docs/mountain_view_villa.md
+++ b/tests/e2e_core/fixtures/docs/mountain_view_villa.md
@@ -1,0 +1,39 @@
+# Mountain View Villa
+
+**Source ID:** `mountain-villa-004`
+**Category:** Real Estate Listing
+**Last Updated:** 2026-04-20
+
+## Property Details
+
+- **Type:** Villa
+- **Location:** Bansko Mountain Area, Bulgaria
+- **Distance to sea:** 120 km (not a coastal property)
+- **Distance to ski lifts:** 500 meters
+- **Price:** 90,000 EUR
+- **Area:** 120 m²
+- **Land plot:** 450 m²
+- **Year built:** 2018
+
+## Description
+
+Charming villa in the Bansko mountain region, ideal for winter sports
+enthusiasts. The property is NOT a sea-side property — it is located in
+the mountains near the ski resort of Bansko.
+
+The villa features three bedrooms, a fireplace, a private garden with
+mountain views, and a garage. Suitable for year-round living with
+mountain hiking in summer and skiing in winter.
+
+## Amenities
+
+- Three bedrooms with mountain views
+- Fireplace in living room
+- Private garden (450 m²)
+- Garage
+- Ski locker
+
+## Contact
+
+For inquiries: contact agent via the booking portal.
+Reference listing ID: mountain-villa-004

--- a/tests/e2e_core/fixtures/docs/nessebar_penthouse.md
+++ b/tests/e2e_core/fixtures/docs/nessebar_penthouse.md
@@ -1,0 +1,38 @@
+# Nessebar Sea-View Penthouse
+
+**Source ID:** `nessebar-penthouse-003`
+**Category:** Real Estate Listing
+**Last Updated:** 2026-06-01
+
+## Property Details
+
+- **Type:** Penthouse
+- **Location:** Nessebar Old Town, Bulgaria
+- **Distance to sea:** 100 meters
+- **Price:** 130,000 EUR
+- **Area:** 95 m²
+- **Floor:** 5 (top floor)
+- **Year built:** 2023
+
+## Description
+
+Luxury penthouse in the heart of Nessebar Old Town, a UNESCO World
+Heritage site. Panoramic sea views from two terraces. Premium finishes
+throughout, underfloor heating, smart home system, and a private rooftop
+terrace with jacuzzi.
+
+The penthouse is located within walking distance of restaurants, shops,
+and the historic peninsula.
+
+## Amenities
+
+- Two panoramic terraces
+- Private rooftop terrace with jacuzzi
+- Underfloor heating
+- Smart home system
+- Premium finishes
+
+## Contact
+
+For inquiries: contact agent via the booking portal.
+Reference listing ID: nessebar-penthouse-003

--- a/tests/e2e_core/fixtures/docs/rules_hitl.md
+++ b/tests/e2e_core/fixtures/docs/rules_hitl.md
@@ -1,0 +1,47 @@
+# CRM/HITL Policy: Booking and Inquiry Rules
+
+**Source ID:** `policy-hitl-008`
+**Category:** Internal Policy
+**Last Updated:** 2026-05-01
+
+## Human-in-the-Loop (HITL) Policy
+
+All CRM actions require explicit human confirmation before execution.
+No automated writes to the CRM are permitted without a verified
+confirmation step.
+
+## Booking Confirmation Workflow
+
+1. User submits a booking or inquiry request through the assistant.
+2. Assistant prepares the CRM action (lead creation, appointment booking,
+   or document request).
+3. Assistant presents the proposed action to the user with full details.
+4. User must explicitly confirm the action.
+5. Upon confirmation, the action is written to the CRM once.
+6. A confirmation receipt is provided to the user.
+
+## CRM Action Types
+
+| Action | Description | Required Fields |
+|---|---|---|
+| `create_lead` | Create a new lead in CRM | name, phone, interest_property_id |
+| `schedule_viewing` | Schedule a property viewing | lead_id, property_id, datetime |
+| `request_documents` | Request property documents | lead_id, property_id, doc_type |
+
+## Cancellation Policy
+
+- Property viewings can be cancelled up to 2 hours before the scheduled time.
+- Lead entries can be marked as inactive but not deleted.
+- Document requests cannot be cancelled once submitted.
+
+## Pricing and Fees
+
+- All prices are listed in EUR unless otherwise stated.
+- Service fees: 3% of property value for assisted viewings.
+- No hidden fees; all costs are disclosed before confirmation.
+
+## Contact
+
+Internal policy document. For questions, consult the CRM team lead.
+
+Reference listing ID: policy-hitl-008

--- a/tests/e2e_core/fixtures/docs/services_cleaning.md
+++ b/tests/e2e_core/fixtures/docs/services_cleaning.md
@@ -1,0 +1,40 @@
+# Property Cleaning Service
+
+**Source ID:** `service-cleaning-007`
+**Category:** Services
+**Last Updated:** 2026-03-01
+
+## Service Overview
+
+Our company provides professional property cleaning and maintenance
+services across the Bulgarian Black Sea coast.
+
+## Service Tiers
+
+| Tier | Price | Area Covered |
+|---|---|---|
+| Basic | 25 EUR per visit | Up to 60 m² |
+| Standard | 40 EUR per visit | Up to 100 m² |
+| Premium | 60 EUR per visit | Up to 200 m² |
+
+## Coverage Areas
+
+- Sunny Beach
+- Nessebar
+- Sveti Vlas
+- Burgas
+
+## Service Policy
+
+- Cleaning visits are booked in advance, minimum 48 hours notice.
+- Payment is due after each visit via bank transfer.
+- Long-term contracts (6+ months) receive a 15% discount.
+- Cancellations must be made at least 24 hours before the scheduled visit.
+
+## Booking Rules
+
+To book a cleaning service, submit a request through the portal with:
+property address, required tier, preferred schedule. A confirmation
+from our team is required before the first visit.
+
+Reference listing ID: service-cleaning-007

--- a/tests/e2e_core/fixtures/docs/sotirovo_garden.md
+++ b/tests/e2e_core/fixtures/docs/sotirovo_garden.md
@@ -1,0 +1,38 @@
+# Sotirovo Garden Apartment
+
+**Source ID:** `sotirovo-garden-006`
+**Category:** Real Estate Listing
+**Last Updated:** 2026-05-20
+
+## Property Details
+
+- **Type:** Garden apartment
+- **Location:** Sotirovo district, Burgas region, Bulgaria
+- **Distance to sea:** 3 km (Burgas beaches)
+- **Distance to Burgas city center:** 8 km
+- **Price:** 78,000 EUR
+- **Area:** 62 m²
+- **Floor:** ground floor with private garden
+- **Year built:** 2021
+
+## Description
+
+A ground-floor garden apartment in the Sotirovo district, close to Burgas.
+The property includes a private garden of 80 m² with fruit trees, a
+covered terrace, and parking for one car.
+
+Sotirovo is a quiet residential area between Burgas and the sea. Local
+amenities include a supermarket, pharmacy, and bus stop within 500 meters.
+
+## Amenities
+
+- Private garden (80 m²) with fruit trees
+- Covered terrace
+- Parking for one car
+- Supermarket within 500 m
+- Bus stop within 500 m
+
+## Contact
+
+For inquiries: contact agent via the booking portal.
+Reference listing ID: sotirovo-garden-006

--- a/tests/e2e_core/fixtures/docs/sunny_beach_2bed.md
+++ b/tests/e2e_core/fixtures/docs/sunny_beach_2bed.md
@@ -1,0 +1,39 @@
+# Sunny Beach 2-Bedroom Apartment
+
+**Source ID:** `sunny-beach-2bed-002`
+**Category:** Real Estate Listing
+**Last Updated:** 2026-05-10
+
+## Property Details
+
+- **Type:** 2-bedroom apartment
+- **Location:** Sunny Beach, Bulgaria
+- **Distance to sea:** 250 meters
+- **Price:** 95,000 EUR
+- **Area:** 68 m²
+- **Floor:** 2
+- **Year built:** 2020
+
+## Description
+
+Spacious two-bedroom apartment in a quiet part of Sunny Beach. The
+property features an open-plan living area, two bedrooms with built-in
+wardrobes, a fully equipped kitchen, and a large terrace with garden
+access. The complex has a children's playground and bicycle storage.
+
+**Note:** This listing shows a different price point from the Sunny
+Beach studio — studios in this area may sell for more per square meter
+due to sea-view premium.
+
+## Amenities
+
+- Open-plan living area
+- Two bedrooms with wardrobes
+- Large terrace with garden access
+- Children's playground
+- Bicycle storage
+
+## Contact
+
+For inquiries: contact agent via the booking portal.
+Reference listing ID: sunny-beach-2bed-002

--- a/tests/e2e_core/fixtures/docs/sunny_beach_studio.md
+++ b/tests/e2e_core/fixtures/docs/sunny_beach_studio.md
@@ -1,0 +1,34 @@
+# Sunny Beach Studio Apartment
+
+**Source ID:** `sunny-beach-studio-001`
+**Category:** Real Estate Listing
+**Last Updated:** 2026-05-15
+
+## Property Details
+
+- **Type:** Studio apartment
+- **Location:** Sunny Beach, Bulgaria
+- **Distance to sea:** 150 meters
+- **Price:** 110,000 EUR
+- **Area:** 42 m²
+- **Floor:** 4
+- **Year built:** 2022
+
+## Description
+
+Cozy studio apartment in the Sunny Beach resort area. Modern furnishings,
+fully equipped kitchen, air conditioning, and a sea-view balcony. The
+building has a swimming pool, underground parking, and 24/7 security.
+
+## Amenities
+
+- Air conditioning
+- Balcony with sea view
+- Swimming pool
+- Underground parking
+- 24/7 security
+
+## Contact
+
+For inquiries: contact agent via the booking portal.
+Reference listing ID: sunny-beach-studio-001

--- a/tests/e2e_core/fixtures/golden_cases.yaml
+++ b/tests/e2e_core/fixtures/golden_cases.yaml
@@ -1,0 +1,97 @@
+# golden_cases.yaml — synthetic E2E core fixture gold set
+#
+# Design (per docs/designs/product-simplification-e2e-plan.md):
+#   - 6 cases: happy path, missing-in-corpus, price/location constraint,
+#     conflict source, service policy, CRM/HITL metadata
+#   - Product checks, not exact prose comparisons
+#   - answer_policy values:
+#       grounded_answer      — must cite retrieved sources
+#       no_data_no_claim     — must not fabricate facts
+#       filtered_constraint  — retrieved docs match query constraint
+#       conflict_attribution — correct source wins over similar conflicting source
+#       service_quote        — factual service quote from corpus
+#       hitl_confirmation    — CRM action requires explicit user confirm
+
+- id: "beach_studio_sea_under_120k"
+  query: "Найди квартиру-студию у моря до 120000 евро"
+  must_retrieve:
+    - "sunny_beach_studio"
+  must_contain:
+    - "Sunny Beach"
+    - "110000"
+  must_not_contain:
+    - "Mountain View Villa"
+    - "Bansko"
+  answer_policy: "grounded_answer"
+
+- id: "missing_in_corpus_no_claim"
+  query: "Найди замок в Софии с частным аэропортом и вертолётной площадкой"
+  must_retrieve: []
+  must_contain:
+    - "не найдено"
+  must_not_contain:
+    - "стоимость"
+    - "цена"
+    - "EUR"
+    - "кв.м"
+  answer_policy: "no_data_no_claim"
+
+- id: "price_constraint_cheapest_sunny_beach"
+  query: "Какая самая дешёвая квартира в Sunny Beach?"
+  must_retrieve:
+    - "sunny_beach_2bed"
+  must_contain:
+    - "95000"
+  must_not_contain:
+    - "130000"
+    - "Nessebar"
+  answer_policy: "filtered_constraint"
+
+- id: "sea_side_excludes_mountain"
+  query: "Покажи недвижимость у моря с бассейном"
+  must_retrieve:
+    - "sunny_beach_studio"
+  must_contain:
+    - "Sunny Beach"
+    - "swimming pool"
+  must_not_contain:
+    - "Mountain View Villa"
+    - "Bansko"
+    - "ski"
+    - "mountain"
+  answer_policy: "conflict_attribution"
+
+- id: "garden_apartment_near_burgas"
+  query: "Нужна квартира с собственным садом недалеко от Бургаса"
+  must_retrieve:
+    - "sotirovo_garden"
+  must_contain:
+    - "Sotirovo"
+    - "garden"
+  must_not_contain:
+    - "Sofia"
+    - "Bansko"
+  answer_policy: "filtered_constraint"
+
+- id: "service_cleaning_price_policy"
+  query: "Сколько стоит уборка квартиры и какие условия?"
+  must_retrieve:
+    - "services_cleaning"
+  must_contain:
+    - "25 EUR"
+    - "48 hours"
+  must_not_contain: []
+  answer_policy: "service_quote"
+
+# CRM/HITL metadata case — verifies CRM policy doc is retrievable and the
+# assistant understands confirmation workflow. The answer should reference
+# the HITL policy, not execute a CRM write without confirmation.
+- id: "crm_hitl_confirmation_policy"
+  query: "Хочу записаться на просмотр квартиры. Нужно ли подтверждение?"
+  must_retrieve:
+    - "rules_hitl"
+  must_contain:
+    - "confirm"
+    - "confirmation"
+  must_not_contain: []
+  answer_policy: "hitl_confirmation"


### PR DESCRIPTION
## Summary

Closes #2332.

Adds the synthetic E2E core fixture corpus for simplification core E2E testing.

## Changes

- **8 synthetic Markdown documents** under `tests/e2e_core/fixtures/docs/` covering:
  - Real estate listings (studios, apartments, penthouse, villa, garden apartment, city center)
  - Service listing (cleaning)
  - Internal policy (CRM/HITL confirmation workflow)
- **`golden_cases.yaml`** with **7 golden test cases** covering:
  1. Happy path — grounded answer with source attribution
  2. Missing-in-corpus — no-data-no-claim response
  3. Price/location constraint — cheapest matching listing
  4. Disambiguation — sea-side property excluding mountain villa
  5. Amenity/location constraint — garden apartment near Burgas
  6. Service quote — factual price and policy retrieval
  7. CRM/HITL — confirmation workflow metadata
- **`tests/e2e_core/README.md`** documenting the corpus structure and validation

## Design Decisions

- All documents are synthetic and stable with no PII, secrets, or production data
- Each document includes an explicit source ID for traceable attribution
- Golden cases use product checks (facts, doc IDs, answer policies) not exact prose
- Conflict case: Sunny Beach studio vs Mountain View Villa at similar price point with different locations
- Missing-in-corpus case targets data not in any fixture document

## Validation

```
uv run python -c "
from pathlib import Path; import yaml
root = Path('tests/e2e_core/fixtures')
cases = yaml.safe_load((root / 'golden_cases.yaml').read_text(encoding='utf-8'))
assert isinstance(cases, list) and len(cases) == 7
ids = {p.stem for p in (root / 'docs').glob('*.md')}
for case in cases:
    assert case['id'] and case['query']
    assert isinstance(case['must_retrieve'], list)
    assert isinstance(case['must_contain'], list)
    assert isinstance(case['must_not_contain'], list)
    assert case['answer_policy']
    for doc_id in case.get('must_retrieve', []):
        assert doc_id in ids, (case['id'], doc_id)
print(f'validated {len(cases)} golden cases against {len(ids)} docs')
"
```

```
git diff --check  # clean
```

## Related

- Product simplification E2E plan: `docs/designs/product-simplification-e2e-plan.md`