### PR TITLE
fix(history): route ensure_collection through REST-only client (#2346)

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -3875,11 +3875,16 @@ class PropertyBot:
             # REST-only client for collection admin ops: the shared retrieval
             # client is prefer_grpc=True, and gRPC collection calls hit a
             # grpc.aio + OTel interceptor NotImplementedError (#2346).
+            from urllib.parse import urlparse
+
             from qdrant_client import AsyncQdrantClient
 
+            # Strip api_key for http:// to avoid insecure-connection warning (#570).
+            _hist_scheme = urlparse(self.config.qdrant_url).scheme.lower()
+            _hist_api_key = self.config.qdrant_api_key if _hist_scheme == "https" else None
             self._history_rest_client: AsyncQdrantClient | None = AsyncQdrantClient(
                 url=self.config.qdrant_url,
-                api_key=self.config.qdrant_api_key,
+                api_key=_hist_api_key,
                 timeout=self.config.qdrant_timeout,
                 prefer_grpc=False,
             )

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -469,6 +469,7 @@ class PropertyBot:
 
         # History service (initialized in start())
         self._history_service: HistoryService | None = None
+        self._history_rest_client: Any = None
 
         # i18n hub (fluentogram) — initialize early for localized menu filters.
         self._i18n_hub: Any = None
@@ -3871,10 +3872,22 @@ class PropertyBot:
             if history_service_cls is None:
                 from .services.history_service import HistoryService as history_service_cls
 
+            # REST-only client for collection admin ops: the shared retrieval
+            # client is prefer_grpc=True, and gRPC collection calls hit a
+            # grpc.aio + OTel interceptor NotImplementedError (#2346).
+            from qdrant_client import AsyncQdrantClient
+
+            self._history_rest_client: AsyncQdrantClient | None = AsyncQdrantClient(
+                url=self.config.qdrant_url,
+                api_key=self.config.qdrant_api_key,
+                timeout=self.config.qdrant_timeout,
+                prefer_grpc=False,
+            )
             self._history_service = history_service_cls(
                 client=self._qdrant.client,
                 embeddings=self._embeddings,
                 collection_name=self.config.qdrant_history_collection,
+                rest_client=self._history_rest_client,
             )
             await self._history_service.ensure_collection()
             logger.info("History service ready (%s)", self.config.qdrant_history_collection)
@@ -4430,6 +4443,10 @@ class PropertyBot:
         await self._redis_monitor.stop()
         await self._cache.close()
         await self._qdrant.close()
+        if self._history_rest_client is not None:
+            with contextlib.suppress(Exception):
+                await self._history_rest_client.close()
+            self._history_rest_client = None
         if hasattr(self._embeddings, "aclose"):
             await self._embeddings.aclose()
         if hasattr(self._sparse, "aclose"):

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -142,6 +142,7 @@ else:
 
 # Keep a patchable module-level symbol for tests without importing qdrant-heavy code.
 HistoryService: Any = None  # type: ignore[no-redef]
+AsyncQdrantClient: Any = None
 BotContext: Any = Any
 
 
@@ -3877,12 +3878,14 @@ class PropertyBot:
             # grpc.aio + OTel interceptor NotImplementedError (#2346).
             from urllib.parse import urlparse
 
-            from qdrant_client import AsyncQdrantClient
-
             # Strip api_key for http:// to avoid insecure-connection warning (#570).
+            async_qdrant_client_cls = AsyncQdrantClient
+            if async_qdrant_client_cls is None:
+                from qdrant_client import AsyncQdrantClient as async_qdrant_client_cls
+
             _hist_scheme = urlparse(self.config.qdrant_url).scheme.lower()
             _hist_api_key = self.config.qdrant_api_key if _hist_scheme == "https" else None
-            self._history_rest_client: AsyncQdrantClient | None = AsyncQdrantClient(
+            self._history_rest_client = async_qdrant_client_cls(
                 url=self.config.qdrant_url,
                 api_key=_hist_api_key,
                 timeout=self.config.qdrant_timeout,

--- a/telegram_bot/services/history_service.py
+++ b/telegram_bot/services/history_service.py
@@ -31,24 +31,32 @@ class HistoryService:
         client: AsyncQdrantClient,
         embeddings: Any,
         collection_name: str = "conversation_history",
+        rest_client: AsyncQdrantClient | None = None,
     ):
         self._client = client
         self._embeddings = embeddings
         self._collection_name = collection_name
+        # Admin ops (get/create collection, payload index) must avoid the
+        # grpc.aio + OTel interceptor NotImplementedError (#2346). When a
+        # REST-only client is injected, route ensure_collection() through it;
+        # otherwise fall back to the primary client.
+        self._admin_client = rest_client or client
         self._ensured = False
 
     async def ensure_collection(self) -> None:
         """Create history collection and payload indexes if not present.
 
-        Uses get_collections() (REST path) instead of collection_exists() to avoid
-        the grpc.aio + OTel interceptor NotImplementedError (#2346).
+        Routes admin ops through a REST-only client (when injected) to avoid
+        the grpc.aio + OTel interceptor NotImplementedError (#2346). The shared
+        retrieval client stays prefer_grpc=True.
         """
         if self._ensured:
             return
-        resp = await self._client.get_collections()
+        client = self._admin_client
+        resp = await client.get_collections()
         names = {c.name for c in resp.collections}
         if self._collection_name not in names:
-            await self._client.create_collection(
+            await client.create_collection(
                 collection_name=self._collection_name,
                 vectors_config={
                     _DENSE_VECTOR_NAME: models.VectorParams(
@@ -66,7 +74,7 @@ class HistoryService:
             ("metadata.deal_id", models.PayloadSchemaType.INTEGER),
         ):
             try:
-                await self._client.create_payload_index(
+                await client.create_payload_index(
                     collection_name=self._collection_name,
                     field_name=field_name,
                     field_schema=field_schema,

--- a/tests/unit/services/test_history_service.py
+++ b/tests/unit/services/test_history_service.py
@@ -90,6 +90,45 @@ class TestEnsureCollectionUsesRestPath:
         mock_client.create_collection.assert_awaited_once()
 
 
+class TestEnsureCollectionUsesRestClient:
+    """#2346 follow-up: ensure_collection must route admin ops through a
+    dedicated REST client when one is provided, so the shared gRPC client
+    (prefer_grpc=True) never hits the grpc.aio + OTel NotImplementedError."""
+
+    @pytest.fixture
+    def rest_client(self):
+        rc = AsyncMock()
+        empty = MagicMock()
+        empty.collections = []
+        rc.get_collections = AsyncMock(return_value=empty)
+        rc.create_collection = AsyncMock()
+        rc.create_payload_index = AsyncMock()
+        return rc
+
+    async def test_ensure_collection_uses_rest_client_when_grpc_fails(
+        self, mock_client, mock_embeddings, rest_client
+    ):
+        """Primary gRPC client raises on get_collections; ensure_collection still
+        succeeds via the REST client and runs every admin op against it."""
+        mock_client.get_collections = AsyncMock(
+            side_effect=NotImplementedError("grpc.aio interceptor")
+        )
+        svc = HistoryService(
+            client=mock_client,
+            embeddings=mock_embeddings,
+            collection_name="test_history",
+            rest_client=rest_client,
+        )
+
+        await svc.ensure_collection()
+
+        rest_client.get_collections.assert_awaited_once()
+        rest_client.create_collection.assert_awaited_once()
+        assert rest_client.create_payload_index.await_count == 3
+        mock_client.get_collections.assert_not_called()
+        mock_client.create_collection.assert_not_called()
+
+
 class TestEnsureCollection:
     """Test ensure_collection creates collection and indexes if absent."""
 

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -2060,6 +2060,7 @@ class TestHistoryServiceLifecycle:
         bot.bot.set_chat_menu_button = AsyncMock()
 
         mock_checkpointer = AsyncMock()
+        mock_rest_client = MagicMock()
         with (
             patch("telegram_bot.preflight.check_dependencies", new_callable=AsyncMock),
             patch(
@@ -2067,12 +2068,21 @@ class TestHistoryServiceLifecycle:
                 return_value=mock_checkpointer,
             ),
             patch("telegram_bot.bot.HistoryService") as mock_history_cls,
+            patch("telegram_bot.bot.AsyncQdrantClient") as mock_rest_client_cls,
         ):
             mock_svc = AsyncMock()
             mock_history_cls.return_value = mock_svc
+            mock_rest_client_cls.return_value = mock_rest_client
             await bot.start()
 
         assert bot._history_service is not None
+        mock_rest_client_cls.assert_called_once_with(
+            url=mock_config.qdrant_url,
+            api_key=None,
+            timeout=mock_config.qdrant_timeout,
+            prefer_grpc=False,
+        )
+        assert mock_history_cls.call_args.kwargs["rest_client"] is mock_rest_client
         mock_svc.ensure_collection.assert_awaited_once()
 
     async def test_start_history_failure_does_not_crash(self, mock_config):


### PR DESCRIPTION
## Problem

Follow-up to #2348. The first fix (#2346) swapped collection_exists() to get_collections() in HistoryService.ensure_collection(), assuming get_collections() is a REST path. It is not: transport is decided by prefer_grpc on the client, not by the method. HistoryService received the shared QdrantService client, constructed with prefer_grpc=True, so on VPS the call still used gRPC and hit the grpc.aio plus OTel interceptor NotImplementedError.

## Fix

- Inject an optional REST-only AsyncQdrantClient(prefer_grpc=False) into HistoryService and route admin ops through it: get_collections, create_collection, create_payload_index.
- Fall back to the primary client when no admin client is injected, preserving existing fixtures.
- Wire the REST client in telegram_bot/bot.py from qdrant_url/api_key/timeout and close it on shutdown.
- Strip api_key for non-https URLs, mirroring QdrantService issue #570 behavior, to avoid insecure-connection startup warnings.
- Keep retrieval, QdrantService, and preflight on prefer_grpc=True.
- Autofix: make telegram_bot.bot.AsyncQdrantClient patchable at module scope so startup unit tests do not import/construct the real qdrant client.

## Commits

1. route ensure_collection admin ops through REST-only client (#2346)
2. strip api_key for http REST client (#570 pattern)
3. keep REST client startup testable

## Guardrails

Regression guardrail: tests/unit/test_bot_handlers.py::TestHistoryServiceLifecycle::test_start_initializes_history_service patches telegram_bot.bot.AsyncQdrantClient and asserts the REST-only admin client is passed into HistoryService; tests/unit/services/test_history_service.py::TestEnsureCollectionUsesRestClient covers primary gRPC admin-call failure.

Checks run: pytest tests/unit/test_bot_handlers.py::TestHistoryServiceLifecycle::test_start_initializes_history_service -q passed; pytest tests/unit/test_bot_handlers.py -q passed with 201 passed; pytest tests/unit/services/test_history_service.py tests/contract/test_grpcio_dependency_audit_contract.py tests/contract/test_qdrant_preflight_contract.py -q passed with 36 passed; make test passed with 7397 passed, 60 skipped; make check passed; ruff check telegram_bot/bot.py telegram_bot/services/history_service.py tests/unit/test_bot_handlers.py tests/unit/services/test_history_service.py passed; mypy telegram_bot/bot.py telegram_bot/services/history_service.py --ignore-missing-imports --no-error-summary passed.

## Deploy

Merge to dev, then main. On VPS, git pull and rebuild bot only. Verify startup log shows History service ready; before this fix the service fell into the history disabled branch.
