### PR TITLE
feat(core): add dependency-backed assistant entrypoint

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -3,6 +3,7 @@
 from .assistant import (
     AssistantError,
     AssistantResult,
+    CoreDependencies,
     CrmAction,
     UserContext,
     run_assistant_request,
@@ -13,6 +14,7 @@ from .pipeline import RAGPipeline
 __all__ = [
     "AssistantError",
     "AssistantResult",
+    "CoreDependencies",
     "CrmAction",
     "RAGPipeline",
     "UserContext",

--- a/src/core/assistant.py
+++ b/src/core/assistant.py
@@ -11,11 +11,16 @@ The module intentionally defines a narrow, synchronous-import-safe contract:
 from __future__ import annotations
 
 import asyncio
+import time
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
 from src.utils.product_events import log_event
+
+
+if TYPE_CHECKING:
+    from telegram_bot.pipelines.state_contract import PreAgentStateContract
 
 
 @dataclass
@@ -27,6 +32,19 @@ class UserContext:
     role: str = "client"
     filters: dict[str, Any] | None = None
     language: str = "ru"
+
+
+@dataclass
+class CoreDependencies:
+    """Runtime collaborators required to execute the existing RAG path."""
+
+    cache: Any
+    embeddings: Any
+    sparse_embeddings: Any
+    qdrant: Any
+    reranker: Any | None = None
+    llm: Any | None = None
+    config: Any | None = None
 
 
 @dataclass
@@ -73,28 +91,153 @@ async def run_assistant_request(
     collection: str,
     user_context: UserContext | None = None,
     request_id: str | None = None,
+    dependencies: CoreDependencies | None = None,
 ) -> AssistantResult:
-    """Execute a single assistant request in skeleton mode.
+    """Execute a single assistant request through the core assistant entrypoint.
 
-    This implementation is intentionally minimal: it validates input shape, emits
-    product events, and returns a recoverable error result without invoking live
-    integrations.
+    Without explicit dependencies this stays in skeleton mode so tests and
+    import-only callers do not touch live integrations.
     """
 
-    _ = (query, collection, user_context)
+    _ = collection
     rid = request_id or str(uuid4())
 
-    log_event("assistant_request_started", request_id=rid)
-    await asyncio.sleep(0)
+    log_event("assistant_request_started", request_id=rid, route="unknown")
 
-    result = AssistantResult(
-        response_text="Assistant execution is not available in the current skeleton.",
-        route="error",
-        request_type="",
-        request_id=rid,
-        error_type="service_unavailable",
-        error_message="Assistant core is in skeleton mode and does not execute live services.",
-    )
+    if dependencies is None:
+        await asyncio.sleep(0)
+
+        result = AssistantResult(
+            response_text="Assistant execution is not available in the current skeleton.",
+            route="error",
+            request_type="",
+            request_id=rid,
+            error_type="service_unavailable",
+            error_message="Assistant core is in skeleton mode and does not execute live services.",
+        )
+
+        log_event(
+            "assistant_request_completed",
+            request_id=result.request_id,
+            route=result.route,
+            request_type=result.request_type,
+            error_type=result.error_type,
+            latency_ms=result.latency_ms,
+        )
+
+        return result
+
+    started = time.perf_counter()
+    ctx = user_context or UserContext()
+
+    try:
+        from src.runtime.graph.nodes.classify import classify_query
+        from telegram_bot.agents.rag_pipeline import rag_pipeline
+        from telegram_bot.services.generate_response import generate_response
+
+        request_type = classify_query(query)
+        state_contract: PreAgentStateContract | None = (
+            cast("PreAgentStateContract", {"filters": ctx.filters}) if ctx.filters else None
+        )
+
+        rag_result = await rag_pipeline(
+            query=query,
+            user_id=_coerce_user_id(ctx.user_id),
+            session_id=ctx.session_id or rid,
+            query_type=request_type,
+            original_query=query,
+            cache=dependencies.cache,
+            embeddings=dependencies.embeddings,
+            sparse_embeddings=dependencies.sparse_embeddings,
+            qdrant=dependencies.qdrant,
+            reranker=dependencies.reranker,
+            llm=dependencies.llm,
+            agent_role=ctx.role,
+            state_contract=state_contract,
+        )
+
+        documents = _as_document_list(rag_result.get("documents"))
+        retrieved_doc_ids = _extract_doc_ids(documents)
+        search_latency_ms = _latency_ms(started)
+        log_event(
+            "search_completed",
+            request_id=rid,
+            route="cache_hit" if rag_result.get("cache_hit") else "rag_search",
+            request_type=request_type,
+            retrieved_doc_ids=retrieved_doc_ids,
+            latency_ms=search_latency_ms,
+            error_type=None,
+        )
+
+        if rag_result.get("cache_hit"):
+            result = AssistantResult(
+                response_text=str(rag_result.get("response", "") or ""),
+                route="cache_hit",
+                request_type=str(rag_result.get("query_type") or request_type),
+                retrieved_doc_ids=retrieved_doc_ids,
+                retrieved_sources=_extract_sources(documents),
+                documents_count=len(documents),
+                latency_ms=_latency_ms(started),
+                request_id=rid,
+                cache_hit=True,
+                rerank_applied=bool(rag_result.get("rerank_applied", False)),
+            )
+        else:
+            generation_kwargs: dict[str, Any] = {
+                "query": query,
+                "documents": documents,
+            }
+            if dependencies.config is not None:
+                generation_kwargs["config"] = dependencies.config
+            generation_result = await generate_response(**generation_kwargs)
+            usage = _as_usage_dict(generation_result.get("usage_details"))
+            llm_model = _extract_llm_model(generation_result)
+
+            log_event(
+                "llm_completed",
+                request_id=rid,
+                route="rag_search",
+                request_type=request_type,
+                latency_ms=_latency_ms(started),
+                error_type=None,
+                llm_model=llm_model,
+                input_tokens=usage.get("input"),
+                output_tokens=usage.get("output"),
+            )
+
+            result = AssistantResult(
+                response_text=str(generation_result.get("response", "") or ""),
+                route="rag_search",
+                request_type=str(rag_result.get("query_type") or request_type),
+                retrieved_doc_ids=retrieved_doc_ids,
+                retrieved_sources=_extract_sources(documents),
+                documents_count=len(documents),
+                latency_ms=_latency_ms(started),
+                error_type=None,
+                request_id=rid,
+                cache_hit=False,
+                llm_model=llm_model,
+                llm_call_count=1,
+                rerank_applied=bool(rag_result.get("rerank_applied", False)),
+            )
+    except Exception as exc:
+        result = AssistantResult(
+            response_text="Сервис временно недоступен. Пожалуйста, повторите через минуту.",
+            route="error",
+            request_type="",
+            latency_ms=_latency_ms(started),
+            error_type="dependency_failed",
+            error_message=str(exc),
+            request_id=rid,
+        )
+        log_event(
+            "dependency_failed",
+            request_id=rid,
+            route=result.route,
+            request_type=result.request_type,
+            latency_ms=result.latency_ms,
+            error_type=result.error_type,
+        )
 
     log_event(
         "assistant_request_completed",
@@ -108,9 +251,82 @@ async def run_assistant_request(
     return result
 
 
+def _coerce_user_id(user_id: str) -> int:
+    """Return an integer user id for the existing Telegram RAG pipeline."""
+    try:
+        return int(user_id)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _latency_ms(started: float) -> float:
+    """Return elapsed wall-clock milliseconds rounded for stable logs/tests."""
+    return round((time.perf_counter() - started) * 1000, 3)
+
+
+def _as_document_list(value: Any) -> list[dict[str, Any]]:
+    """Normalize existing RAG document output to a list of dictionaries."""
+    if not isinstance(value, list):
+        return []
+    return [doc for doc in value if isinstance(doc, dict)]
+
+
+def _metadata_for(document: dict[str, Any]) -> dict[str, Any]:
+    """Return document metadata if present."""
+    metadata = document.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _extract_doc_ids(documents: list[dict[str, Any]]) -> list[str]:
+    """Extract stable source ids used by golden-case checks."""
+    ids: list[str] = []
+    for document in documents:
+        metadata = _metadata_for(document)
+        doc_id = (
+            metadata.get("source_id")
+            or metadata.get("doc_id")
+            or metadata.get("id")
+            or document.get("source_id")
+            or document.get("doc_id")
+            or document.get("id")
+        )
+        if doc_id is not None:
+            ids.append(str(doc_id))
+    return ids
+
+
+def _extract_sources(documents: list[dict[str, Any]]) -> list[dict[str, str]]:
+    """Extract title/url source metadata for adapters."""
+    sources: list[dict[str, str]] = []
+    for document in documents:
+        metadata = _metadata_for(document)
+        source: dict[str, str] = {}
+        title = metadata.get("title") or document.get("title")
+        url = metadata.get("url") or document.get("url")
+        if title is not None:
+            source["title"] = str(title)
+        if url is not None:
+            source["url"] = str(url)
+        if source:
+            sources.append(source)
+    return sources
+
+
+def _as_usage_dict(value: Any) -> dict[str, Any]:
+    """Return usage details from generate_response() when available."""
+    return value if isinstance(value, dict) else {}
+
+
+def _extract_llm_model(generation_result: dict[str, Any]) -> str | None:
+    """Extract the provider model name from generation metadata."""
+    model = generation_result.get("llm_provider_model") or generation_result.get("model")
+    return str(model) if model else None
+
+
 __all__ = [
     "AssistantError",
     "AssistantResult",
+    "CoreDependencies",
     "CrmAction",
     "UserContext",
     "run_assistant_request",

--- a/tests/unit/core/test_assistant_entrypoint.py
+++ b/tests/unit/core/test_assistant_entrypoint.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import importlib
 import logging
+from unittest.mock import AsyncMock, patch
 
 
 # =============================================================================
@@ -79,6 +80,34 @@ class TestUserContext:
         assert is_dataclass(UserContext)
         assert not hasattr(UserContext, "model_validate")
         assert "pydantic" not in UserContext.__module__
+
+
+# =============================================================================
+# CoreDependencies
+# =============================================================================
+
+
+class TestCoreDependencies:
+    """Tests for explicit runtime dependency injection."""
+
+    def test_accepts_required_runtime_dependencies(self) -> None:
+        """CoreDependencies should hold existing RAG runtime collaborators."""
+        from src.core.assistant import CoreDependencies
+
+        deps = CoreDependencies(
+            cache=object(),
+            embeddings=object(),
+            sparse_embeddings=object(),
+            qdrant=object(),
+        )
+
+        assert deps.cache is not None
+        assert deps.embeddings is not None
+        assert deps.sparse_embeddings is not None
+        assert deps.qdrant is not None
+        assert deps.reranker is None
+        assert deps.llm is None
+        assert deps.config is None
 
 
 # =============================================================================
@@ -384,3 +413,211 @@ class TestLogEventIntegration:
         for r in caplog.records:
             if hasattr(r, "event"):
                 assert getattr(r, "request_id", None) == result.request_id
+
+    async def test_started_event_includes_route(self, caplog) -> None:
+        """The started event should include route for contract-compatible logs."""
+        from src.core.assistant import run_assistant_request
+
+        with caplog.at_level(logging.INFO, logger="src.utils.product_events"):
+            await run_assistant_request("q", collection="c", request_id="e2e-route")
+
+        started = next(
+            r
+            for r in caplog.records
+            if hasattr(r, "event") and r.event == "assistant_request_started"
+        )
+        assert getattr(started, "route", None) == "unknown"
+
+
+# =============================================================================
+# run_assistant_request — dependency-backed runtime
+# =============================================================================
+
+
+class TestRunAssistantRequestRuntime:
+    """Tests for the real Stage 2 runtime branch with mocked dependencies."""
+
+    def _deps(self):
+        from src.core.assistant import CoreDependencies
+
+        return CoreDependencies(
+            cache=object(),
+            embeddings=object(),
+            sparse_embeddings=object(),
+            qdrant=object(),
+            reranker=object(),
+            llm=object(),
+            config=object(),
+        )
+
+    async def test_calls_existing_rag_and_generation_pipeline(self) -> None:
+        """Runtime branch must reuse existing rag_pipeline and generate_response."""
+        from src.core.assistant import UserContext, run_assistant_request
+
+        docs = [
+            {
+                "content": "Sunny Beach studio costs 110000 EUR.",
+                "metadata": {
+                    "source_id": "sunny_beach_studio",
+                    "title": "Sunny Beach Studio",
+                    "url": "fixture://sunny_beach_studio",
+                },
+                "score": 0.91,
+            }
+        ]
+        rag = AsyncMock(
+            return_value={
+                "documents": docs,
+                "cache_hit": False,
+                "search_results_count": 1,
+                "rerank_applied": True,
+                "query_type": "GENERAL",
+            }
+        )
+        gen = AsyncMock(
+            return_value={
+                "response": "Sunny Beach Studio is available for 110000 EUR.",
+                "llm_provider_model": "gpt-4o-mini",
+                "usage_details": {"input": 10, "output": 12},
+            }
+        )
+        deps = self._deps()
+
+        with (
+            patch("src.runtime.graph.nodes.classify.classify_query", return_value="GENERAL"),
+            patch("telegram_bot.agents.rag_pipeline.rag_pipeline", rag),
+            patch("telegram_bot.services.generate_response.generate_response", gen),
+        ):
+            result = await run_assistant_request(
+                "Найди студию у моря до 120000",
+                collection="e2e_core_abc",
+                user_context=UserContext(
+                    user_id="42", session_id="s-1", filters={"city": "Sunny Beach"}
+                ),
+                request_id="e2e-beach",
+                dependencies=deps,
+            )
+
+        rag.assert_awaited_once()
+        rag_kwargs = rag.await_args.kwargs
+        assert rag_kwargs["query"] == "Найди студию у моря до 120000"
+        assert rag_kwargs["user_id"] == 42
+        assert rag_kwargs["session_id"] == "s-1"
+        assert rag_kwargs["query_type"] == "GENERAL"
+        assert rag_kwargs["cache"] is deps.cache
+        assert rag_kwargs["embeddings"] is deps.embeddings
+        assert rag_kwargs["sparse_embeddings"] is deps.sparse_embeddings
+        assert rag_kwargs["qdrant"] is deps.qdrant
+        assert rag_kwargs["reranker"] is deps.reranker
+        assert rag_kwargs["llm"] is deps.llm
+        assert rag_kwargs["state_contract"]["filters"] == {"city": "Sunny Beach"}
+
+        gen.assert_awaited_once()
+        assert gen.await_args.kwargs["query"] == "Найди студию у моря до 120000"
+        assert gen.await_args.kwargs["documents"] == docs
+
+        assert result.route == "rag_search"
+        assert result.error_type is None
+        assert result.response_text == "Sunny Beach Studio is available for 110000 EUR."
+        assert result.request_type == "GENERAL"
+        assert result.retrieved_doc_ids == ["sunny_beach_studio"]
+        assert result.retrieved_sources == [
+            {"title": "Sunny Beach Studio", "url": "fixture://sunny_beach_studio"}
+        ]
+        assert result.documents_count == 1
+        assert result.rerank_applied is True
+        assert result.llm_model == "gpt-4o-mini"
+        assert result.llm_call_count == 1
+
+    async def test_cache_hit_skips_generation(self) -> None:
+        """Semantic cache hits should return cached text without calling LLM generation."""
+        from src.core.assistant import run_assistant_request
+
+        rag = AsyncMock(
+            return_value={
+                "response": "Cached answer",
+                "documents": [],
+                "cache_hit": True,
+                "query_type": "FAQ",
+                "latency_stages": {"cache_check": 0.01},
+            }
+        )
+        gen = AsyncMock()
+
+        with (
+            patch("src.runtime.graph.nodes.classify.classify_query", return_value="FAQ"),
+            patch("telegram_bot.agents.rag_pipeline.rag_pipeline", rag),
+            patch("telegram_bot.services.generate_response.generate_response", gen),
+        ):
+            result = await run_assistant_request(
+                "Какие условия рассрочки?",
+                collection="e2e_core_abc",
+                request_id="e2e-cache",
+                dependencies=self._deps(),
+            )
+
+        gen.assert_not_awaited()
+        assert result.route == "cache_hit"
+        assert result.cache_hit is True
+        assert result.response_text == "Cached answer"
+        assert result.llm_call_count == 0
+        assert result.error_type is None
+
+    async def test_runtime_dependency_failure_returns_recoverable_error(self) -> None:
+        """Dependency failures should be returned as AssistantResult errors, not raised."""
+        from src.core.assistant import run_assistant_request
+
+        rag = AsyncMock(side_effect=TimeoutError("qdrant timed out"))
+
+        with (
+            patch("src.runtime.graph.nodes.classify.classify_query", return_value="GENERAL"),
+            patch("telegram_bot.agents.rag_pipeline.rag_pipeline", rag),
+        ):
+            result = await run_assistant_request(
+                "Найди квартиру",
+                collection="e2e_core_abc",
+                request_id="e2e-failure",
+                dependencies=self._deps(),
+            )
+
+        assert result.route == "error"
+        assert result.error_type == "dependency_failed"
+        assert "qdrant timed out" in (result.error_message or "")
+        assert result.request_id == "e2e-failure"
+
+    async def test_runtime_emits_product_events_with_request_id(self, caplog) -> None:
+        """Runtime events should be correlated by caller-provided request_id."""
+        from src.core.assistant import run_assistant_request
+
+        rag = AsyncMock(
+            return_value={
+                "documents": [{"metadata": {"source_id": "doc-1"}, "content": "fact"}],
+                "cache_hit": False,
+                "query_type": "GENERAL",
+            }
+        )
+        gen = AsyncMock(return_value={"response": "answer", "llm_provider_model": "test-model"})
+
+        with (
+            patch("src.runtime.graph.nodes.classify.classify_query", return_value="GENERAL"),
+            patch("telegram_bot.agents.rag_pipeline.rag_pipeline", rag),
+            patch("telegram_bot.services.generate_response.generate_response", gen),
+            caplog.at_level(logging.INFO, logger="src.utils.product_events"),
+        ):
+            await run_assistant_request(
+                "q",
+                collection="c",
+                request_id="e2e-events",
+                dependencies=self._deps(),
+            )
+
+        events = [r for r in caplog.records if hasattr(r, "event")]
+        event_names = [r.event for r in events]
+        assert event_names == [
+            "assistant_request_started",
+            "search_completed",
+            "llm_completed",
+            "assistant_request_completed",
+        ]
+        for record in events:
+            assert getattr(record, "request_id", None) == "e2e-events"


### PR DESCRIPTION
## Summary
- Add `CoreDependencies` so `run_assistant_request()` can execute the existing RAG runtime with explicit injected collaborators.
- Reuse existing `rag_pipeline()` and `generate_response()` instead of creating a parallel RAG path.
- Preserve skeleton behavior when no dependencies are provided and add product-event logging for the runtime path.

## Scope
- Stage 2 runtime entrypoint only.
- No Telegram wiring, no CRM writes, no new services, no Docker/k8s changes, no Langfuse/OTel requirement, no `dev` merge.

## Test Plan
- [x] `uv run pytest tests/e2e_core/test_qdrant_helpers.py tests/unit/core/test_assistant_entrypoint.py tests/unit/test_product_events.py -q`
- [x] `uv run ruff check src/core/assistant.py src/core/__init__.py tests/unit/core/test_assistant_entrypoint.py`
- [x] `git diff --check`

## Agent Review Checklist
- No new service or container.
- No new HTTP service boundary.
- No parallel RAG pipeline; existing `rag_pipeline()` and `generate_response()` are reused.
- No Telegram in E2E.
- No production CRM write path changes.
- Langfuse/OTel are not made required.
- New product logs carry `request_id`; started event carries `route`.