### PR TITLE
fix: prevent missing corpus answer claims

### DIFF
--- a/telegram_bot/agents/rag_pipeline.py
+++ b/telegram_bot/agents/rag_pipeline.py
@@ -54,6 +54,36 @@ logger = logging.getLogger(__name__)
 _DEFAULT_RERANK_TOP_K = 7
 _CONFIDENT_TRIM_TOP_K = 3
 _QUERY_PREPROCESSOR = QueryPreprocessor()
+_HARD_EVIDENCE_CONSTRAINTS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
+    ("castle", ("замок", "castle", "chateau"), ("замок", "castle", "chateau")),
+    ("airport", ("аэропорт", "airport"), ("аэропорт", "airport")),
+    ("helipad", ("вертол", "helipad", "helicopter"), ("вертол", "helipad", "helicopter")),
+)
+
+
+def _find_missing_evidence_constraints(
+    query: str,
+    documents: list[dict[str, Any]],
+) -> list[str]:
+    """Return hard query constraints that have no evidence in retrieved docs."""
+
+    normalized_query = query.lower()
+    evidence_text = "\n".join(_document_evidence_text(doc) for doc in documents).lower()
+    missing: list[str] = []
+    for name, query_terms, evidence_terms in _HARD_EVIDENCE_CONSTRAINTS:
+        if any(term in normalized_query for term in query_terms) and not any(
+            term in evidence_text for term in evidence_terms
+        ):
+            missing.append(name)
+    return missing
+
+
+def _document_evidence_text(document: dict[str, Any]) -> str:
+    parts = [str(document.get("text", "")), str(document.get("content", ""))]
+    metadata = document.get("metadata")
+    if isinstance(metadata, dict):
+        parts.extend(str(value) for value in metadata.values())
+    return "\n".join(parts)
 
 
 async def _execute_qdrant_retrieval(
@@ -1247,6 +1277,46 @@ async def rag_pipeline(
                 )
                 final_docs = final_docs[:_CONFIDENT_TRIM_TOP_K]
 
+            missing_evidence = _find_missing_evidence_constraints(query, final_docs)
+            if missing_evidence:
+                result = _assemble_context(
+                    query=current_query,
+                    original_query=query,
+                    documents=[],
+                    latency_stages=latency_stages,
+                    cache_hit=False,
+                    embeddings_cache_hit=embeddings_cache_hit,
+                    search_cache_hit=retrieve_result.get("search_cache_hit", False),
+                    search_results_count=retrieve_result["search_results_count"],
+                    rerank_applied=rerank_applied,
+                    rerank_cache_hit=rerank_cache_hit,
+                    grade_confidence=grade_confidence,
+                    rewrite_count=rewrite_count,
+                    query_type=query_type,
+                    query_embedding=query_embedding,
+                    cache_key_embedding=cache_embedding,
+                    retrieved_context=[],
+                    retrieval_backend_error=retrieve_result.get("retrieval_backend_error", False),
+                    retrieval_error_type=retrieve_result.get("retrieval_error_type"),
+                    topic_hint=topic_hint,
+                    score_gap_confident=final_gap_confident,
+                    missing_evidence_constraints=missing_evidence,
+                )
+                result["skip_rewrite"] = skip_rewrite
+                result["semantic_cache_already_checked"] = semantic_cache_already_checked
+                lf.update_current_span(
+                    output={
+                        "cache_hit": False,
+                        "documents_count": 0,
+                        "rerank_applied": rerank_applied,
+                        "rewrite_count": rewrite_count,
+                        "fallback": True,
+                        "fallback_reason": "missing_evidence_constraints",
+                        "missing_evidence_constraints": missing_evidence,
+                    }
+                )
+                return result
+
             # Small-to-big context expansion
             await _expand_small_to_big(final_docs, qdrant=qdrant, config=config)
 
@@ -1310,77 +1380,41 @@ async def rag_pipeline(
         colbert_query = None  # Force re-encode ColBERT on next retrieve
         query_sparse = None  # Force re-compute sparse on next retrieve (query changed)
 
-    # Fallback: ran out of rewrites, return best docs with rerank
-    rerank_from_retrieve = retrieve_result.get("rerank_applied", False)
-    if rerank_from_retrieve:
-        # Server-side ColBERT already applied — skip separate rerank
-        final_docs = sorted(documents, key=lambda d: d.get("score", 0), reverse=True)[
-            :_DEFAULT_RERANK_TOP_K
-        ]
-        rerank_applied = True
-        rerank_cache_hit = False
-    else:
-        rerank_result = await _rerank(
-            current_query,
-            documents,
-            cache=cache,
-            reranker=reranker,
-            latency_stages=latency_stages,
-        )
-        latency_stages = rerank_result["latency_stages"]
-        final_docs = rerank_result["documents"]
-        rerank_applied = rerank_result["rerank_applied"]
-        rerank_cache_hit = rerank_result["rerank_cache_hit"]
-    final_gap = detect_score_gap(
-        [doc.get("score", 0.0) for doc in final_docs if isinstance(doc, dict)]
-    )
-    final_gap_confident = bool(final_gap["confident"])
-    gap_ratio = final_gap.get("ratio", 0.0)
-    if final_gap_confident and len(final_docs) > _CONFIDENT_TRIM_TOP_K:
-        logger.info(
-            "Score gap confident, trimming final docs (fallback)",
-            extra={
-                "gap_ratio": gap_ratio,
-                "before_count": len(final_docs),
-                "after_count": _CONFIDENT_TRIM_TOP_K,
-            },
-        )
-        final_docs = final_docs[:_CONFIDENT_TRIM_TOP_K]
-
-    # Small-to-big context expansion (fallback path)
-    await _expand_small_to_big(final_docs, qdrant=qdrant, config=config)
-
+    # Fallback: ran out of rewrites with only irrelevant documents.
+    # Do not leak "best available" unrelated context into answer generation.
     result = _assemble_context(
         query=current_query,
         original_query=query,
-        documents=final_docs,
+        documents=[],
         latency_stages=latency_stages,
         cache_hit=False,
         embeddings_cache_hit=embeddings_cache_hit,
         search_cache_hit=retrieve_result.get("search_cache_hit", False),
         search_results_count=retrieve_result["search_results_count"],
-        rerank_applied=rerank_applied,
-        rerank_cache_hit=rerank_cache_hit,
+        rerank_applied=False,
+        rerank_cache_hit=False,
         grade_confidence=grade_confidence,
         rewrite_count=rewrite_count,
         query_type=query_type,
         query_embedding=query_embedding,
         cache_key_embedding=cache_embedding,
-        retrieved_context=retrieve_result.get("retrieved_context", []),
+        retrieved_context=[],
         retrieval_backend_error=retrieve_result.get("retrieval_backend_error", False),
         retrieval_error_type=retrieve_result.get("retrieval_error_type"),
         topic_hint=topic_hint,
-        score_gap_confident=final_gap_confident,
+        score_gap_confident=False,
+        missing_evidence_constraints=_find_missing_evidence_constraints(query, documents),
     )
     result["skip_rewrite"] = skip_rewrite
     result["semantic_cache_already_checked"] = semantic_cache_already_checked
     lf.update_current_span(
         output={
             "cache_hit": False,
-            "documents_count": len(final_docs),
-            "rerank_applied": rerank_applied,
+            "documents_count": 0,
+            "rerank_applied": False,
             "rewrite_count": rewrite_count,
             "fallback": True,
+            "fallback_reason": "no_relevant_documents",
         }
     )
     return result
@@ -1450,6 +1484,7 @@ def _assemble_context(
     retrieval_error_type: str | None = None,
     topic_hint: str | None = None,
     score_gap_confident: bool | None = None,
+    missing_evidence_constraints: list[str] | None = None,
 ) -> dict[str, Any]:
     """Assemble context dict from pipeline results."""
     return {
@@ -1473,6 +1508,7 @@ def _assemble_context(
         "retrieval_error_type": retrieval_error_type,
         "topic_hint": topic_hint,
         "score_gap_confident": score_gap_confident,
+        "missing_evidence_constraints": missing_evidence_constraints or [],
         "embedding_error": False,
         "embedding_error_type": None,
     }

--- a/tests/e2e/test_core_live_ingest_answer.py
+++ b/tests/e2e/test_core_live_ingest_answer.py
@@ -65,3 +65,50 @@ async def test_core_live_ingest_answer_golden_path() -> None:
         if harness is not None:
             await harness.aclose()
         cleanup_collection(env, context)
+
+
+@pytest.mark.asyncio
+async def test_core_live_missing_corpus_returns_no_claim() -> None:
+    """Missing-corpus query must not answer from unrelated retrieved docs."""
+
+    env = LiveE2EEnv.from_env()
+    await require_live_services(env)
+
+    case = load_golden_case("missing_in_corpus_no_claim")
+    context = make_qdrant_context(env)
+    harness = None
+
+    try:
+        recreate_collection(env, context.collection_name)
+        indexed_points = await index_fixture_documents(
+            env,
+            context.collection_name,
+            document_ids=["sunny_beach_studio", "mountain_view_villa", "city_center_sofia"],
+        )
+        assert indexed_points >= 1
+
+        harness = build_live_core_harness(env, context.collection_name)
+        result = await run_assistant_request(
+            case.query,
+            collection=context.collection_name,
+            user_context=UserContext(
+                user_id="2336",
+                session_id=f"{context.collection_name}:missing",
+                role="client",
+            ),
+            dependencies=harness.dependencies,
+        )
+
+        assert result.error_type is None, result.error_message
+        assert result.route == "rag_search"
+        assert result.documents_count == 0
+        assert result.retrieved_doc_ids == case.must_retrieve
+
+        for expected in case.must_contain:
+            assert expected in result.response_text
+        for forbidden in case.must_not_contain:
+            assert forbidden not in result.response_text
+    finally:
+        if harness is not None:
+            await harness.aclose()
+        cleanup_collection(env, context)

--- a/tests/unit/agents/test_rag_pipeline.py
+++ b/tests/unit/agents/test_rag_pipeline.py
@@ -1074,6 +1074,71 @@ async def test_pipeline_rewrite_loop(
     assert len(result["documents"]) > 0
 
 
+async def test_pipeline_returns_empty_docs_when_retrieval_is_irrelevant(
+    mock_cache, mock_embeddings, mock_sparse, mock_qdrant, mock_reranker
+):
+    """Irrelevant retrieved docs must not leak into answer context."""
+    from telegram_bot.agents.rag_pipeline import rag_pipeline
+
+    mock_qdrant.hybrid_search_rrf = AsyncMock(
+        return_value=(
+            [{"text": "unrelated listing with price 110000 EUR", "score": 0.001, "metadata": {}}],
+            {"backend_error": False, "error_type": None, "error_message": None},
+        )
+    )
+
+    with patch.dict("os.environ", {"MAX_REWRITE_ATTEMPTS": "0"}):
+        result = await rag_pipeline(
+            "замок с частным аэропортом",
+            user_id=42,
+            session_id="test",
+            cache=mock_cache,
+            embeddings=mock_embeddings,
+            sparse_embeddings=mock_sparse,
+            qdrant=mock_qdrant,
+            reranker=mock_reranker,
+        )
+
+    assert result["documents"] == []
+    assert result["search_results_count"] == 1
+    assert result["grade_confidence"] < 0.005
+
+
+async def test_pipeline_clears_high_score_docs_missing_hard_constraints(
+    mock_cache, mock_embeddings, mock_sparse, mock_qdrant, mock_reranker
+):
+    """High RRF score is not enough when hard query constraints are absent."""
+    from telegram_bot.agents.rag_pipeline import rag_pipeline
+
+    mock_qdrant.hybrid_search_rrf = AsyncMock(
+        return_value=(
+            [
+                {
+                    "text": "Sofia city center apartment. Price 150000 EUR.",
+                    "score": 0.02,
+                    "metadata": {"doc_id": "city_center_sofia"},
+                }
+            ],
+            {"backend_error": False, "error_type": None, "error_message": None},
+        )
+    )
+
+    result = await rag_pipeline(
+        "Найди замок в Софии с частным аэропортом",
+        user_id=42,
+        session_id="test",
+        cache=mock_cache,
+        embeddings=mock_embeddings,
+        sparse_embeddings=mock_sparse,
+        qdrant=mock_qdrant,
+        reranker=mock_reranker,
+    )
+
+    assert result["documents"] == []
+    assert result["search_results_count"] == 1
+    assert result["missing_evidence_constraints"] == ["castle", "airport"]
+
+
 # ---------------------------------------------------------------------------
 # original_query cache key tests (#430)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add missing-corpus live golden case for no-data/no-claim behavior
- prevent irrelevant fallback docs from leaking into answer context after failed relevance/rewrite
- add hard evidence guard for explicit unavailable constraints such as castle/private airport/helipad

## Validation
- uv run pytest tests/unit/agents/test_rag_pipeline.py tests/e2e/test_core_live_ingest_answer.py -q
- make e2e-core-live
- make check