### PR TITLE
fix(qdrant): default runtime transport to REST

### DIFF
--- a/src/runtime/services/qdrant.py
+++ b/src/runtime/services/qdrant.py
@@ -52,6 +52,7 @@ class QdrantService:
         sparse_vector_name: str = "bm42",
         quantization_mode: str = "off",
         timeout: int = 30,
+        prefer_grpc: bool = False,
     ):
         """Initialize Qdrant service.
 
@@ -63,12 +64,18 @@ class QdrantService:
             sparse_vector_name: Name of sparse vector field
             quantization_mode: One of 'off', 'scalar', 'binary' - controls collection suffix
             timeout: Connection timeout in seconds (default 30)
+            prefer_grpc: Enable Qdrant gRPC transport. Defaults to REST because
+                grpc.aio + OpenTelemetry interceptors can break bot runtime
+                search calls on VPS with NotImplementedError.
         """
         # Strip api_key for http:// to avoid "insecure connection" warning (#570)
         scheme = urlparse(url).scheme.lower()
         effective_api_key = api_key if scheme == "https" else None
         self._client = AsyncQdrantClient(
-            url=url, api_key=effective_api_key, prefer_grpc=True, timeout=timeout
+            url=url,
+            api_key=effective_api_key,
+            prefer_grpc=prefer_grpc,
+            timeout=timeout,
         )
         self._base_collection_name = collection_name
         self._quantization_mode = quantization_mode.lower()

--- a/tests/contract/test_grpcio_dependency_audit_contract.py
+++ b/tests/contract/test_grpcio_dependency_audit_contract.py
@@ -99,21 +99,20 @@ def test_qdrant_client_present_where_grpc_used() -> None:
         )
 
 
-def test_qdrant_runtime_still_prefers_grpc() -> None:
-    """The canonical Qdrant service + preflight still use prefer_grpc=True.
+def test_qdrant_preflight_still_exercises_grpc_but_runtime_defaults_rest() -> None:
+    """Preflight may diagnose gRPC, but runtime search defaults to REST.
 
-    If gRPC were ever turned off, grpcio would genuinely become unnecessary
-    and this audit decision would need revisiting — so assert the transport
-    is still gRPC.
+    VPS demo traffic hit grpc.aio + OTel interceptor ``NotImplementedError`` in
+    the bot process. The user-facing QdrantService path must therefore avoid
+    gRPC by default while keeping preflight coverage for explicit diagnostics.
     """
     qdrant_service = REPO / "src" / "runtime" / "services" / "qdrant.py"
     preflight = REPO / "telegram_bot" / "preflight.py"
-    for path in (qdrant_service, preflight):
-        text = path.read_text(encoding="utf-8")
-        assert "prefer_grpc=True" in text, (
-            f"{path.relative_to(REPO)} no longer sets prefer_grpc=True; if gRPC "
-            "is intentionally disabled, revisit the grpcio audit in issue #2241."
-        )
+    qdrant_text = qdrant_service.read_text(encoding="utf-8")
+    preflight_text = preflight.read_text(encoding="utf-8")
+
+    assert "prefer_grpc: bool = False" in qdrant_text
+    assert "prefer_grpc=True" in preflight_text
 
 
 def test_grpcio_transitive_rationale_documented() -> None:

--- a/tests/unit/test_qdrant_service.py
+++ b/tests/unit/test_qdrant_service.py
@@ -465,9 +465,17 @@ class TestQdrantServiceTimeout:
             mock_client.assert_called_once_with(
                 url="http://localhost:6333",
                 api_key=None,
-                prefer_grpc=True,
+                prefer_grpc=False,
                 timeout=expected_timeout,
             )
+
+    def test_runtime_transport_can_enable_grpc_explicitly(self):
+        """Runtime Qdrant transport defaults to REST but can opt into gRPC."""
+        import telegram_bot.services.qdrant as qdrant_mod
+
+        with patch.object(qdrant_mod, "AsyncQdrantClient") as mock_client:
+            qdrant_mod.QdrantService(url="http://localhost:6333", prefer_grpc=True)
+            assert mock_client.call_args.kwargs["prefer_grpc"] is True
 
 
 class TestQdrantServiceBuildFilter:


### PR DESCRIPTION
## Problem

VPS demo query `Виды внж в Болгарии?` returned no retrieved documents through the bot even though Redis, BGE-M3, and Qdrant were alive.

Evidence from VPS:
- Redis from bot container: authenticated `PING` returns true.
- Qdrant collection `gdrive_documents_bge`: green, 352 points.
- Direct Qdrant search for `Виды внж в Болгарии?` returns the expected VNZ/Permanent residence document as top hit.
- Bot runtime logs for the same user path show `Qdrant ColBERT search failed (NotImplementedError)`, `Qdrant search failed (graceful degradation)`, and `retrieve done (..., 0 docs)`.

Root cause: the bot process has OpenTelemetry gRPC aio instrumentation active. Runtime `QdrantService` constructed `AsyncQdrantClient(..., prefer_grpc=True)`, so user-facing retrieval and history upsert could hit the same grpc.aio + OTel `NotImplementedError` and silently degrade to zero docs.

## Fix

- Default runtime `QdrantService` transport to REST (`prefer_grpc=False`).
- Keep explicit `prefer_grpc=True` opt-in for future benchmark/diagnostics.
- Keep preflight gRPC coverage as a diagnostic path.
- Update the grpcio audit contract to distinguish runtime REST default from preflight gRPC diagnostics.

Regression guardrail: `tests/unit/test_qdrant_service.py::TestQdrantServiceTimeout` now asserts runtime Qdrant client defaults to `prefer_grpc=False`, while `test_runtime_transport_can_enable_grpc_explicitly` keeps an explicit gRPC opt-in path. `tests/contract/test_grpcio_dependency_audit_contract.py::test_qdrant_preflight_still_exercises_grpc_but_runtime_defaults_rest` protects the runtime/preflight split.

Checks run: `uv run pytest tests/unit/test_qdrant_service.py::TestQdrantServiceTimeout tests/contract/test_grpcio_dependency_audit_contract.py::test_qdrant_preflight_still_exercises_grpc_but_runtime_defaults_rest -q` passed with 4 passed; `uv run pytest tests/unit/test_qdrant_service.py tests/unit/test_qdrant_error_signal.py tests/unit/runtime/services/test_qdrant_colbert_fallback.py tests/contract/test_grpcio_dependency_audit_contract.py tests/contract/test_qdrant_preflight_contract.py -q` passed with 82 passed; `make check` passed.
