### PR TITLE
feat: complete core live golden set

### DIFF
--- a/tests/e2e/test_core_live_ingest_answer.py
+++ b/tests/e2e/test_core_live_ingest_answer.py
@@ -20,14 +20,17 @@ from tests.e2e_core.live_harness import (
 pytestmark = [pytest.mark.e2e, pytest.mark.requires_services]
 
 
-@pytest.mark.asyncio
-async def test_core_live_ingest_answer_golden_path() -> None:
-    """First product golden case against live Qdrant/BGE services."""
-
+async def _run_core_live_case(
+    case_id: str,
+    *,
+    document_ids: list[str],
+    session_suffix: str,
+    expected_documents_count: int | None = None,
+) -> None:
     env = LiveE2EEnv.from_env()
     await require_live_services(env)
 
-    case = load_golden_case("beach_studio_sea_under_120k")
+    case = load_golden_case(case_id)
     context = make_qdrant_context(env)
     harness = None
 
@@ -36,7 +39,7 @@ async def test_core_live_ingest_answer_golden_path() -> None:
         indexed_points = await index_fixture_documents(
             env,
             context.collection_name,
-            document_ids=["sunny_beach_studio", "mountain_view_villa"],
+            document_ids=document_ids,
         )
         assert indexed_points >= 1
 
@@ -46,7 +49,7 @@ async def test_core_live_ingest_answer_golden_path() -> None:
             collection=context.collection_name,
             user_context=UserContext(
                 user_id="2336",
-                session_id=f"{context.collection_name}:golden",
+                session_id=f"{context.collection_name}:{session_suffix}",
                 role="client",
             ),
             dependencies=harness.dependencies,
@@ -54,7 +57,10 @@ async def test_core_live_ingest_answer_golden_path() -> None:
 
         assert result.error_type is None, result.error_message
         assert result.route == "rag_search"
-        assert result.documents_count > 0
+        if expected_documents_count is None:
+            assert result.documents_count > 0
+        else:
+            assert result.documents_count == expected_documents_count
         assert set(case.must_retrieve).issubset(set(result.retrieved_doc_ids))
 
         for expected in case.must_contain:
@@ -68,47 +74,55 @@ async def test_core_live_ingest_answer_golden_path() -> None:
 
 
 @pytest.mark.asyncio
+async def test_core_live_ingest_answer_golden_path() -> None:
+    """First product golden case against live Qdrant/BGE services."""
+
+    await _run_core_live_case(
+        "beach_studio_sea_under_120k",
+        document_ids=["sunny_beach_studio", "mountain_view_villa"],
+        session_suffix="golden",
+    )
+
+
+@pytest.mark.asyncio
 async def test_core_live_missing_corpus_returns_no_claim() -> None:
     """Missing-corpus query must not answer from unrelated retrieved docs."""
 
-    env = LiveE2EEnv.from_env()
-    await require_live_services(env)
+    await _run_core_live_case(
+        "missing_in_corpus_no_claim",
+        document_ids=["sunny_beach_studio", "mountain_view_villa", "city_center_sofia"],
+        session_suffix="missing",
+        expected_documents_count=0,
+    )
 
-    case = load_golden_case("missing_in_corpus_no_claim")
-    context = make_qdrant_context(env)
-    harness = None
 
-    try:
-        recreate_collection(env, context.collection_name)
-        indexed_points = await index_fixture_documents(
-            env,
-            context.collection_name,
-            document_ids=["sunny_beach_studio", "mountain_view_villa", "city_center_sofia"],
-        )
-        assert indexed_points >= 1
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("case_id", "document_ids"),
+    [
+        (
+            "price_constraint_cheapest_sunny_beach",
+            ["sunny_beach_2bed", "sunny_beach_studio", "nessebar_penthouse"],
+        ),
+        (
+            "sea_side_excludes_mountain",
+            ["sunny_beach_studio", "mountain_view_villa"],
+        ),
+        (
+            "garden_apartment_near_burgas",
+            ["sotirovo_garden", "city_center_sofia", "mountain_view_villa"],
+        ),
+        (
+            "service_cleaning_price_policy",
+            ["services_cleaning", "sunny_beach_studio", "rules_hitl"],
+        ),
+    ],
+)
+async def test_core_live_remaining_golden_cases(case_id: str, document_ids: list[str]) -> None:
+    """Remaining product golden cases against live Qdrant/BGE services."""
 
-        harness = build_live_core_harness(env, context.collection_name)
-        result = await run_assistant_request(
-            case.query,
-            collection=context.collection_name,
-            user_context=UserContext(
-                user_id="2336",
-                session_id=f"{context.collection_name}:missing",
-                role="client",
-            ),
-            dependencies=harness.dependencies,
-        )
-
-        assert result.error_type is None, result.error_message
-        assert result.route == "rag_search"
-        assert result.documents_count == 0
-        assert result.retrieved_doc_ids == case.must_retrieve
-
-        for expected in case.must_contain:
-            assert expected in result.response_text
-        for forbidden in case.must_not_contain:
-            assert forbidden not in result.response_text
-    finally:
-        if harness is not None:
-            await harness.aclose()
-        cleanup_collection(env, context)
+    await _run_core_live_case(
+        case_id,
+        document_ids=document_ids,
+        session_suffix=case_id,
+    )

--- a/tests/e2e_core/live_harness.py
+++ b/tests/e2e_core/live_harness.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -421,16 +422,78 @@ class _FakeLLM:
 
 
 def _answer_from_context(message: str) -> str:
-    context = message.split("Вопрос:", 1)[0].replace("Контекст:", "").strip()
+    context_part, _, question_part = message.partition("Вопрос:")
+    context = context_part.replace("Контекст:", "").strip()
+    question = question_part.lower()
     if not context or "Релевантной информации не найдено" in context:
         return "не найдено"
 
     lines = [line.strip() for line in context.splitlines() if line.strip()]
-    selected = [
-        line.replace(",", "")
-        for line in lines
-        if "Sunny Beach" in line or "110000" in line.replace(",", "")
-    ]
+    sections = _split_context_sections(lines)
+
+    if "уборк" in question or "cleaning" in question:
+        selected = _select_section_lines(sections, ("cleaning", "25 eur", "48 hours"))
+        if selected:
+            return "\n".join(selected)
+
+    if "сад" in question or "garden" in question or "бургас" in question or "burgas" in question:
+        selected = _select_section_lines(sections, ("sotirovo", "garden", "burgas"))
+        if selected:
+            return "\n".join(selected)
+
+    if "мор" in question or "sea" in question or "бассейн" in question or "pool" in question:
+        selected = _select_section_lines(sections, ("sunny beach", "swimming pool", "110000"))
+        if selected:
+            return "\n".join(selected)
+
+    if "деш" in question or "cheapest" in question:
+        selected = _select_cheapest_sunny_beach_section(sections)
+        if selected:
+            return "\n".join(selected)
+
+    selected = _select_section_lines(sections, ("sunny beach", "110000"))
     if selected:
         return "\n".join(selected)
     return "\n".join(lines[:6])
+
+
+def _split_context_sections(lines: list[str]) -> list[list[str]]:
+    sections: list[list[str]] = []
+    current: list[str] = []
+    for line in lines:
+        if line.startswith("# ") and current:
+            sections.append(current)
+            current = []
+        current.append(line.replace(",", ""))
+    if current:
+        sections.append(current)
+    return sections
+
+
+def _select_section_lines(sections: list[list[str]], keywords: tuple[str, ...]) -> list[str]:
+    for section in sections:
+        normalized = "\n".join(section).lower()
+        if any(keyword in normalized for keyword in keywords):
+            return section
+    return []
+
+
+def _select_cheapest_sunny_beach_section(sections: list[list[str]]) -> list[str]:
+    candidates: list[tuple[int, list[str]]] = []
+    for section in sections:
+        normalized = "\n".join(section).lower()
+        if "sunny beach" not in normalized:
+            continue
+        price = _extract_price_eur(normalized)
+        if price is not None:
+            candidates.append((price, section))
+    if not candidates:
+        return []
+    return min(candidates, key=lambda candidate: candidate[0])[1]
+
+
+def _extract_price_eur(text: str) -> int | None:
+    match = re.search(r"price:\*\*\s*([0-9 ]+)\s*eur", text)
+    if not match:
+        return None
+    return int(match.group(1).replace(" ", ""))


### PR DESCRIPTION
## Summary
- expand the live core E2E gate to cover the remaining product golden cases
- add reusable live-case runner with focused fixture document sets
- make the deterministic live fake LLM select answer evidence for price, seaside, garden, and cleaning-policy cases

## Validation
- uv run pytest tests/e2e/test_core_live_ingest_answer.py -q
- make e2e-core-live
- uv run pytest tests/unit/e2e_core/test_live_harness.py tests/e2e_core/test_qdrant_helpers.py tests/unit/core/test_assistant_entrypoint.py tests/unit/test_product_events.py -q
- uv run ruff check tests/e2e/test_core_live_ingest_answer.py tests/e2e_core/live_harness.py
- make check