### PR TITLE
feat: add core live real LLM mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -859,7 +859,7 @@ deploy-vps-local:  ## Fallback/manual deploy: manual instructions only (VPS scri
 # E2E TESTING
 # =============================================================================
 
-.PHONY: e2e-install e2e-generate-data e2e-index-data e2e-test e2e-core-live e2e-test-traces e2e-test-traces-core e2e-test-group e2e-telegram-test e2e-setup langfuse-latest-trace-audit trace-audit-snapshot
+.PHONY: e2e-install e2e-generate-data e2e-index-data e2e-test e2e-core-live e2e-core-live-real-llm e2e-test-traces e2e-test-traces-core e2e-test-group e2e-telegram-test e2e-setup langfuse-latest-trace-audit trace-audit-snapshot
 
 e2e-install: ## Install E2E testing dependencies
 	@echo "$(BLUE)Installing E2E dependencies...$(NC)"
@@ -885,6 +885,20 @@ e2e-core-live: ## Run simplification core live golden path (Qdrant + BGE-M3)
 	@echo "$(BLUE)Running simplification core live E2E golden path...$(NC)"
 	E2E_CORE_STRICT=1 uv run pytest tests/e2e/test_core_live_ingest_answer.py -v --tb=short -m "e2e and requires_services"
 	@echo "$(GREEN)✓ Simplification core live E2E complete$(NC)"
+
+e2e-core-live-real-llm: ## Run simplification core live golden path with real LLM provider
+	@echo "$(BLUE)Running simplification core live E2E with real LLM...$(NC)"
+	@$(ENV_LOAD) \
+	missing=""; \
+	if [ -z "$$LLM_BASE_URL" ]; then missing="$$missing LLM_BASE_URL"; fi; \
+	if [ -z "$$LLM_MODEL" ]; then missing="$$missing LLM_MODEL"; fi; \
+	if [ -z "$$LLM_API_KEY$$OPENAI_API_KEY" ]; then missing="$$missing (LLM_API_KEY|OPENAI_API_KEY)"; fi; \
+	if [ -n "$$missing" ]; then \
+		echo "$(RED)Missing required real LLM env:$$missing$(NC)"; \
+		exit 1; \
+	fi; \
+	E2E_CORE_STRICT=1 E2E_CORE_REAL_LLM=1 uv run pytest tests/e2e/test_core_live_ingest_answer.py -v --tb=short -m "e2e and requires_services"
+	@echo "$(GREEN)✓ Simplification core live real LLM E2E complete$(NC)"
 
 e2e-telegram-test: ## Run Telegram userbot E2E runner (Telethon + judge)
 	@echo "$(BLUE)Running Telegram E2E runner...$(NC)"

--- a/tests/e2e_core/README.md
+++ b/tests/e2e_core/README.md
@@ -78,6 +78,26 @@ asserts:
 LLM evaluation uses temperature 0 and fact-based checks to minimize
 non-determinism.
 
+## Live LLM Mode
+
+`make e2e-core-live` uses a deterministic fake LLM so the fast product gate
+does not depend on provider availability or spend.
+
+For release/nightly validation with a real OpenAI-compatible provider, run:
+
+```bash
+make e2e-core-live-real-llm
+```
+
+Required environment:
+
+- `LLM_BASE_URL`
+- `LLM_MODEL`
+- `LLM_API_KEY` or `OPENAI_API_KEY`
+
+The real LLM mode sets temperature to `0`, disables streaming and style
+rewrites, and keeps the same fact-based golden assertions.
+
 ## Related Docs
 
 - Product simplification E2E plan: [`docs/designs/product-simplification-e2e-plan.md`](../../docs/designs/product-simplification-e2e-plan.md)

--- a/tests/e2e_core/live_harness.py
+++ b/tests/e2e_core/live_harness.py
@@ -15,6 +15,8 @@ import httpx
 import pytest
 import yaml
 
+from src.runtime.graph.config import GraphConfig
+from src.runtime.services.qdrant import QdrantService
 from tests.e2e_core.qdrant_helpers import (
     QdrantTestContext,
     generate_collection_name,
@@ -47,6 +49,7 @@ class LiveE2EEnv:
     bge_m3_url: str
     qdrant_api_key: str | None = None
     strict: bool = False
+    real_llm: bool = False
 
     @classmethod
     def from_env(cls) -> LiveE2EEnv:
@@ -63,6 +66,7 @@ class LiveE2EEnv:
             ),
             qdrant_api_key=os.getenv("QDRANT_API_KEY") or None,
             strict=_truthy(os.getenv("E2E_CORE_STRICT")),
+            real_llm=_truthy(os.getenv("E2E_CORE_REAL_LLM")),
         )
 
 
@@ -237,6 +241,8 @@ async def require_live_services(env: LiveE2EEnv) -> None:
     except Exception as exc:
         failures.append(f"BGE-M3 unavailable at {env.bge_m3_url}: {type(exc).__name__}")
 
+    failures.extend(real_llm_config_errors(env))
+
     if not failures:
         return
 
@@ -244,6 +250,24 @@ async def require_live_services(env: LiveE2EEnv) -> None:
     if env.strict:
         pytest.fail(message)
     pytest.skip(message)
+
+
+def real_llm_config_errors(env: LiveE2EEnv) -> list[str]:
+    """Return missing real-LLM configuration for opt-in live LLM runs."""
+
+    if not env.real_llm:
+        return []
+
+    errors: list[str] = []
+    if not os.getenv("E2E_CORE_REAL_LLM"):
+        errors.append("E2E_CORE_REAL_LLM=1 is required for real LLM mode")
+    if not os.getenv("LLM_BASE_URL"):
+        errors.append("LLM_BASE_URL is required for real LLM mode")
+    if not os.getenv("LLM_MODEL"):
+        errors.append("LLM_MODEL is required for real LLM mode")
+    if not (os.getenv("LLM_API_KEY") or os.getenv("OPENAI_API_KEY")):
+        errors.append("LLM_API_KEY or OPENAI_API_KEY is required for real LLM mode")
+    return errors
 
 
 def make_qdrant_context(env: LiveE2EEnv) -> QdrantTestContext:
@@ -347,7 +371,6 @@ def build_live_core_harness(env: LiveE2EEnv, collection_name: str) -> LiveCoreHa
     """Build CoreDependencies for ``run_assistant_request`` using live retrieval."""
 
     from src.core.assistant import CoreDependencies
-    from src.runtime.services.qdrant import QdrantService
 
     embeddings = LiveBGEEmbeddings(env.bge_m3_url)
     sparse_embeddings = LiveBGESparseEmbeddings(env.bge_m3_url)
@@ -358,13 +381,14 @@ def build_live_core_harness(env: LiveE2EEnv, collection_name: str) -> LiveCoreHa
         timeout=30,
         prefer_grpc=False,
     )
+    config = _build_live_llm_config(env)
     dependencies = CoreDependencies(
         cache=NoopLiveCache(),
         embeddings=embeddings,
         sparse_embeddings=sparse_embeddings,
         qdrant=qdrant,
         reranker=None,
-        config=FakeLLMConfig(),
+        config=config,
     )
 
     async def _cleanup() -> None:
@@ -373,6 +397,21 @@ def build_live_core_harness(env: LiveE2EEnv, collection_name: str) -> LiveCoreHa
         await qdrant.close()
 
     return LiveCoreHarness(dependencies=dependencies, cleanup=_cleanup)
+
+
+def _build_live_llm_config(env: LiveE2EEnv) -> Any:
+    if not env.real_llm:
+        return FakeLLMConfig()
+
+    config = GraphConfig.from_env()
+    config.domain = "недвижимость в Болгарии"
+    config.llm_temperature = 0.0
+    config.generate_max_tokens = int(os.getenv("E2E_CORE_REAL_LLM_MAX_TOKENS", "600"))
+    config.streaming_enabled = False
+    config.show_sources = False
+    config.response_style_enabled = False
+    config.response_style_shadow_mode = False
+    return config
 
 
 def cleanup_collection(env: LiveE2EEnv, context: QdrantTestContext) -> None:

--- a/tests/unit/e2e_core/test_live_harness.py
+++ b/tests/unit/e2e_core/test_live_harness.py
@@ -58,6 +58,79 @@ def test_live_env_falls_back_to_runtime_urls() -> None:
     assert parsed.bge_m3_url == "http://runtime-bge:8000"
 
 
+def test_live_env_reads_real_llm_opt_in() -> None:
+    from tests.e2e_core.live_harness import LiveE2EEnv
+
+    with mock.patch.dict(os.environ, {"E2E_CORE_REAL_LLM": "1"}, clear=True):
+        parsed = LiveE2EEnv.from_env()
+
+    assert parsed.real_llm is True
+
+
+def test_real_llm_preflight_requires_opt_in_and_provider_env() -> None:
+    from tests.e2e_core.live_harness import LiveE2EEnv, real_llm_config_errors
+
+    with mock.patch.dict(os.environ, {}, clear=True):
+        fake_mode_errors = real_llm_config_errors(LiveE2EEnv.from_env())
+
+    assert fake_mode_errors == []
+
+    env = LiveE2EEnv(qdrant_url="http://qdrant:6333", bge_m3_url="http://bge:8000", real_llm=True)
+    with mock.patch.dict(os.environ, {}, clear=True):
+        errors = real_llm_config_errors(env)
+
+    assert errors == [
+        "E2E_CORE_REAL_LLM=1 is required for real LLM mode",
+        "LLM_BASE_URL is required for real LLM mode",
+        "LLM_MODEL is required for real LLM mode",
+        "LLM_API_KEY or OPENAI_API_KEY is required for real LLM mode",
+    ]
+
+    provider_env = {
+        "E2E_CORE_REAL_LLM": "1",
+        "LLM_BASE_URL": "http://localhost:4000/v1",
+        "LLM_MODEL": "gpt-test",
+    }
+    with mock.patch.dict(os.environ, provider_env, clear=True):
+        errors = real_llm_config_errors(env)
+
+    assert errors == ["LLM_API_KEY or OPENAI_API_KEY is required for real LLM mode"]
+
+
+def test_build_live_core_harness_uses_graph_config_for_real_llm() -> None:
+    from tests.e2e_core.live_harness import LiveE2EEnv, build_live_core_harness
+
+    fake_config = mock.MagicMock()
+    fake_config.llm_temperature = 0.7
+    fake_config.generate_max_tokens = 1024
+    fake_config.streaming_enabled = True
+    fake_config.show_sources = True
+    fake_config.response_style_enabled = True
+    fake_config.response_style_shadow_mode = True
+
+    env = LiveE2EEnv(
+        qdrant_url="http://qdrant:6333",
+        bge_m3_url="http://bge:8000",
+        real_llm=True,
+    )
+
+    with (
+        mock.patch("tests.e2e_core.live_harness.LiveBGEEmbeddings"),
+        mock.patch("tests.e2e_core.live_harness.LiveBGESparseEmbeddings"),
+        mock.patch("tests.e2e_core.live_harness.QdrantService"),
+        mock.patch("tests.e2e_core.live_harness.GraphConfig.from_env", return_value=fake_config),
+    ):
+        harness = build_live_core_harness(env, "collection")
+
+    assert harness.dependencies.config is fake_config
+    assert fake_config.llm_temperature == 0.0
+    assert fake_config.generate_max_tokens == 600
+    assert fake_config.streaming_enabled is False
+    assert fake_config.show_sources is False
+    assert fake_config.response_style_enabled is False
+    assert fake_config.response_style_shadow_mode is False
+
+
 def test_fake_llm_config_builds_grounded_answer_from_context() -> None:
     from tests.e2e_core.live_harness import FakeLLMConfig
 


### PR DESCRIPTION
## Summary
- add opt-in real LLM mode for the simplification core live E2E harness
- add make e2e-core-live-real-llm with explicit LLM env preflight
- document stable fake LLM gate versus release/nightly real LLM validation

## Validation
- uv run pytest tests/unit/e2e_core/test_live_harness.py -q
- make e2e-core-live
- env -u LLM_BASE_URL -u LLM_MODEL -u LLM_API_KEY -u OPENAI_API_KEY make e2e-core-live-real-llm (expected explicit env preflight failure)
- uv run pytest tests/unit/e2e_core/test_live_harness.py tests/e2e_core/test_qdrant_helpers.py tests/unit/core/test_assistant_entrypoint.py tests/unit/test_product_events.py -q
- uv run ruff check tests/e2e_core/live_harness.py tests/unit/e2e_core/test_live_harness.py
- make check

## Notes
Real provider execution was not run here because this workspace does not expose the required LLM env. The new target fails explicitly when those env vars are missing.