### PR TITLE
fix(bot): honor STREAMING_ENABLED=false in Telegram runtime

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -390,6 +390,7 @@ class PropertyBot:
             redis_url=config.redis_url,
             domain=config.domain,
             domain_language=config.domain_language,
+            streaming_enabled=config.streaming_enabled,
         )
 
         # Initialize LangGraph service dependencies
@@ -2643,7 +2644,10 @@ class PropertyBot:
                     bot_context=ctx,
                     rag_result_store=rag_result_store,
                     forum_thread_id=forum_thread_id,
-                    use_streaming=message.chat.type == "private",
+                    use_streaming=(
+                        message.chat.type == "private"
+                        and bool(getattr(self._graph_config, "streaming_enabled", False))
+                    ),
                 )
 
             # Check for HITL interrupt (#443)

--- a/telegram_bot/config.py
+++ b/telegram_bot/config.py
@@ -395,6 +395,10 @@ class BotConfig(BaseSettings):
             "CLIENT_DIRECT_PIPELINE_ENABLED",
         ),
     )
+    streaming_enabled: EmptyStrBool = Field(
+        default=True,
+        validation_alias=AliasChoices("streaming_enabled", "STREAMING_ENABLED"),
+    )
     supervisor_max_tokens: int = Field(
         default=1024,
         validation_alias=AliasChoices(

--- a/tests/unit/test_bot_handlers.py
+++ b/tests/unit/test_bot_handlers.py
@@ -79,6 +79,24 @@ def _create_bot(mock_config):
     return bot, patches
 
 
+def test_bot_config_reads_streaming_enabled_false(monkeypatch):
+    """STREAMING_ENABLED=false should reach BotConfig."""
+    monkeypatch.setenv("STREAMING_ENABLED", "false")
+
+    config = BotConfig(_env_file=None, telegram_token="test-token")
+
+    assert config.streaming_enabled is False
+
+
+def test_property_bot_passes_streaming_enabled_to_graph_config(mock_config):
+    """PropertyBot must not reset streaming_enabled to GraphConfig default True."""
+    mock_config.streaming_enabled = False
+
+    bot, _ = _create_bot(mock_config)
+
+    assert bot._graph_config.streaming_enabled is False
+
+
 def _make_text_message(text="test", user_id=12345, chat_id=12345):
     """Create a mock text message with typing action support."""
     message = MagicMock()
@@ -3313,6 +3331,39 @@ class TestStreamingCoordination:
         assert bot.bot.send_message_draft.await_count >= 1
         bot.bot.send_message.assert_awaited_once()
         assert bot.bot.send_message.await_args.kwargs["text"] == "Добрый день"
+
+    async def test_handle_query_private_sdk_agent_respects_streaming_disabled(self, mock_config):
+        """Private sdk_agent path must not stream when STREAMING_ENABLED=false."""
+        bot, _ = _create_bot(mock_config)
+        bot._graph_config.streaming_enabled = False
+        bot.bot.send_message_draft = AsyncMock(return_value=True)
+
+        async def _agent_stream(*args, **kwargs):
+            raise AssertionError("astream must not be called when streaming is disabled")
+
+        mock_agent = AsyncMock()
+        mock_agent.astream = _agent_stream
+        mock_agent.ainvoke = AsyncMock(
+            return_value=_mock_agent_result(messages=[MagicMock(content="Готовый ответ")])
+        )
+
+        with (
+            patch("telegram_bot.bot.create_bot_agent", return_value=mock_agent),
+            patch("telegram_bot.bot.propagate_attributes"),
+            patch("telegram_bot.bot.create_callback_handler", return_value=None),
+        ):
+            message = _make_text_message("квартиры")
+            message.chat.type = "private"
+            with patch("telegram_bot.bot.ChatActionSender") as mock_cas:
+                mock_cas.typing.return_value = _make_typing_cm()
+                response_text = await bot._handle_query_supervisor(
+                    message=message,
+                    pipeline_start=time.perf_counter(),
+                )
+
+        assert response_text == "Готовый ответ"
+        mock_agent.ainvoke.assert_awaited_once()
+        bot.bot.send_message_draft.assert_not_awaited()
 
     async def test_sdk_agent_draftstreamer_records_langfuse_root_output(self, mock_config):
         """DraftStreamer finalize in private chat must record sanitized root output (#1485)."""


### PR DESCRIPTION
## Problem

VPS had `STREAMING_ENABLED=false` in the bot container, but private Telegram responses still behaved like streaming/draft output.

Root cause:
- `BotConfig` did not expose `STREAMING_ENABLED`, so the env value stopped at the container boundary.
- `PropertyBot.__init__` manually created `GraphConfig(...)` without `streaming_enabled`, so GraphConfig used its dataclass default `True`.
- The private supervisor path called `_astream_supervisor_with_recovery(..., use_streaming=message.chat.type == "private")`, bypassing the graph streaming flag entirely.

## Fix

- Add `BotConfig.streaming_enabled` mapped to `STREAMING_ENABLED`.
- Pass it into `GraphConfig` in `PropertyBot.__init__`.
- Gate the private supervisor draft-streaming path on both private chat and `self._graph_config.streaming_enabled`.

Regression guardrail: `tests/unit/test_bot_handlers.py::test_bot_config_reads_streaming_enabled_false`, `tests/unit/test_bot_handlers.py::test_property_bot_passes_streaming_enabled_to_graph_config`, and `tests/unit/test_bot_handlers.py::TestStreamingCoordination::test_handle_query_private_sdk_agent_respects_streaming_disabled` pin env propagation and ensure private supervisor path uses `ainvoke` without `send_message_draft` when streaming is disabled.

Checks run: `uv run pytest tests/unit/test_bot_handlers.py::test_bot_config_reads_streaming_enabled_false tests/unit/test_bot_handlers.py::test_property_bot_passes_streaming_enabled_to_graph_config tests/unit/test_bot_handlers.py::TestStreamingCoordination::test_handle_query_private_sdk_agent_respects_streaming_disabled -q` passed with 3 passed; `uv run pytest tests/unit/test_bot_handlers.py::TestStreamingCoordination -q` passed with 11 passed; `make check` passed.
