### PR TITLE
feat: add core CRM HITL live E2E

### DIFF
--- a/tests/e2e/test_core_live_ingest_answer.py
+++ b/tests/e2e/test_core_live_ingest_answer.py
@@ -7,6 +7,7 @@ import pytest
 from src.core.assistant import UserContext, run_assistant_request
 from tests.e2e_core.live_harness import (
     LiveE2EEnv,
+    MockCrmClient,
     build_live_core_harness,
     cleanup_collection,
     index_fixture_documents,
@@ -126,3 +127,50 @@ async def test_core_live_remaining_golden_cases(case_id: str, document_ids: list
         document_ids=document_ids,
         session_suffix=case_id,
     )
+
+
+@pytest.mark.asyncio
+async def test_core_live_crm_hitl_requires_confirmation_before_mock_crm_write() -> None:
+    """CRM/HITL golden case must propose confirmation policy without CRM writes."""
+
+    crm = MockCrmClient()
+    env = LiveE2EEnv.from_env()
+    await require_live_services(env)
+
+    case = load_golden_case("crm_hitl_confirmation_policy")
+    context = make_qdrant_context(env)
+    harness = None
+
+    try:
+        recreate_collection(env, context.collection_name)
+        indexed_points = await index_fixture_documents(
+            env,
+            context.collection_name,
+            document_ids=["rules_hitl", "sunny_beach_studio"],
+        )
+        assert indexed_points >= 1
+
+        harness = build_live_core_harness(env, context.collection_name, crm=crm)
+        result = await run_assistant_request(
+            case.query,
+            collection=context.collection_name,
+            user_context=UserContext(
+                user_id="2336",
+                session_id=f"{context.collection_name}:crm-hitl",
+                role="client",
+            ),
+            dependencies=harness.dependencies,
+        )
+
+        assert result.error_type is None, result.error_message
+        assert result.route == "rag_search"
+        assert set(case.must_retrieve).issubset(set(result.retrieved_doc_ids))
+        assert result.proposed_crm_action is None
+        assert crm.writes == []
+
+        for expected in case.must_contain:
+            assert expected in result.response_text
+    finally:
+        if harness is not None:
+            await harness.aclose()
+        cleanup_collection(env, context)

--- a/tests/e2e_core/live_harness.py
+++ b/tests/e2e_core/live_harness.py
@@ -6,7 +6,7 @@ import contextlib
 import os
 import re
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -79,6 +79,25 @@ class MarkdownChunk:
     chunk_id: int
     document_name: str
     extra_metadata: dict[str, Any]
+
+
+@dataclass
+class MockCrmClient:
+    """Recording CRM mock for HITL E2E assertions."""
+
+    writes: list[dict[str, Any]] = field(default_factory=list)
+
+    async def create_lead(self, payload: dict[str, Any]) -> dict[str, Any]:
+        self.writes.append({"action": "create_lead", "payload": payload})
+        return {"id": len(self.writes), **payload}
+
+    async def schedule_viewing(self, payload: dict[str, Any]) -> dict[str, Any]:
+        self.writes.append({"action": "schedule_viewing", "payload": payload})
+        return {"id": len(self.writes), **payload}
+
+    async def request_documents(self, payload: dict[str, Any]) -> dict[str, Any]:
+        self.writes.append({"action": "request_documents", "payload": payload})
+        return {"id": len(self.writes), **payload}
 
 
 class NoopLiveCache:
@@ -367,7 +386,12 @@ async def index_fixture_documents(
     return total
 
 
-def build_live_core_harness(env: LiveE2EEnv, collection_name: str) -> LiveCoreHarness:
+def build_live_core_harness(
+    env: LiveE2EEnv,
+    collection_name: str,
+    *,
+    crm: MockCrmClient | None = None,
+) -> LiveCoreHarness:
     """Build CoreDependencies for ``run_assistant_request`` using live retrieval."""
 
     from src.core.assistant import CoreDependencies
@@ -390,6 +414,8 @@ def build_live_core_harness(env: LiveE2EEnv, collection_name: str) -> LiveCoreHa
         reranker=None,
         config=config,
     )
+    if crm is not None:
+        dependencies.crm = crm
 
     async def _cleanup() -> None:
         await embeddings.aclose()
@@ -469,6 +495,11 @@ def _answer_from_context(message: str) -> str:
 
     lines = [line.strip() for line in context.splitlines() if line.strip()]
     sections = _split_context_sections(lines)
+
+    if "просмотр" in question or "подтвержд" in question or "confirmation" in question:
+        selected = _select_section_lines(sections, ("hitl", "confirmation", "confirm"))
+        if selected:
+            return "\n".join(selected)
 
     if "уборк" in question or "cleaning" in question:
         selected = _select_section_lines(sections, ("cleaning", "25 eur", "48 hours"))

--- a/tests/unit/e2e_core/test_live_harness.py
+++ b/tests/unit/e2e_core/test_live_harness.py
@@ -131,6 +131,33 @@ def test_build_live_core_harness_uses_graph_config_for_real_llm() -> None:
     assert fake_config.response_style_shadow_mode is False
 
 
+def test_build_live_core_harness_attaches_mock_crm() -> None:
+    from tests.e2e_core.live_harness import LiveE2EEnv, MockCrmClient, build_live_core_harness
+
+    crm = MockCrmClient()
+    env = LiveE2EEnv(qdrant_url="http://qdrant:6333", bge_m3_url="http://bge:8000")
+
+    with (
+        mock.patch("tests.e2e_core.live_harness.LiveBGEEmbeddings"),
+        mock.patch("tests.e2e_core.live_harness.LiveBGESparseEmbeddings"),
+        mock.patch("tests.e2e_core.live_harness.QdrantService"),
+    ):
+        harness = build_live_core_harness(env, "collection", crm=crm)
+
+    assert harness.dependencies.crm is crm
+
+
+def test_mock_crm_client_records_writes() -> None:
+    from tests.e2e_core.live_harness import MockCrmClient
+
+    crm = MockCrmClient()
+
+    result = asyncio.run(crm.create_lead({"name": "Test Lead"}))
+
+    assert result == {"id": 1, "name": "Test Lead"}
+    assert crm.writes == [{"action": "create_lead", "payload": {"name": "Test Lead"}}]
+
+
 def test_fake_llm_config_builds_grounded_answer_from_context() -> None:
     from tests.e2e_core.live_harness import FakeLLMConfig
 


### PR DESCRIPTION
## Summary
- add CRM/HITL live core golden case for the rules_hitl policy fixture
- add test-only MockCrmClient recorder and attach it to live harness dependencies
- verify the assistant answers with confirmation policy evidence and performs no CRM writes before explicit confirmation

## Validation
- uv run pytest tests/e2e/test_core_live_ingest_answer.py::test_core_live_crm_hitl_requires_confirmation_before_mock_crm_write -q
- uv run pytest tests/unit/e2e_core/test_live_harness.py -q
- make e2e-core-live
- uv run pytest tests/unit/e2e_core/test_live_harness.py tests/e2e_core/test_qdrant_helpers.py tests/unit/core/test_assistant_entrypoint.py tests/unit/test_product_events.py -q
- uv run ruff check tests/e2e/test_core_live_ingest_answer.py tests/e2e_core/live_harness.py tests/unit/e2e_core/test_live_harness.py
- make check