### PR TITLE
feat: add core dependency failure live E2E

### DIFF
--- a/tests/e2e/test_core_live_ingest_answer.py
+++ b/tests/e2e/test_core_live_ingest_answer.py
@@ -6,6 +6,7 @@ import pytest
 
 from src.core.assistant import UserContext, run_assistant_request
 from tests.e2e_core.live_harness import (
+    FailingLLMConfig,
     LiveE2EEnv,
     MockCrmClient,
     build_live_core_harness,
@@ -68,6 +69,55 @@ async def _run_core_live_case(
             assert expected in result.response_text
         for forbidden in case.must_not_contain:
             assert forbidden not in result.response_text
+    finally:
+        if harness is not None:
+            await harness.aclose()
+        cleanup_collection(env, context)
+
+
+@pytest.mark.asyncio
+async def test_core_live_llm_dependency_failure_returns_user_safe_fallback() -> None:
+    """LLM provider failure must return explicit user-safe fallback, not crash."""
+
+    env = LiveE2EEnv.from_env()
+    await require_live_services(env)
+
+    case = load_golden_case("beach_studio_sea_under_120k")
+    context = make_qdrant_context(env)
+    harness = None
+
+    try:
+        recreate_collection(env, context.collection_name)
+        indexed_points = await index_fixture_documents(
+            env,
+            context.collection_name,
+            document_ids=["sunny_beach_studio", "mountain_view_villa"],
+        )
+        assert indexed_points >= 1
+
+        harness = build_live_core_harness(
+            env,
+            context.collection_name,
+            config=FailingLLMConfig(error_message="llm provider timeout"),
+        )
+        result = await run_assistant_request(
+            case.query,
+            collection=context.collection_name,
+            user_context=UserContext(
+                user_id="2336",
+                session_id=f"{context.collection_name}:llm-failure",
+                role="client",
+            ),
+            dependencies=harness.dependencies,
+        )
+
+        assert result.error_type is None, result.error_message
+        assert result.route == "rag_search"
+        assert result.llm_model == "fallback"
+        assert result.llm_call_count == 1
+        assert set(case.must_retrieve).issubset(set(result.retrieved_doc_ids))
+        assert result.response_text
+        assert "сервис временно недоступен" in result.response_text.lower()
     finally:
         if harness is not None:
             await harness.aclose()

--- a/tests/e2e_core/live_harness.py
+++ b/tests/e2e_core/live_harness.py
@@ -207,6 +207,27 @@ class FakeLLMConfig:
         return {}
 
 
+@dataclass(frozen=True)
+class FailingLLMConfig:
+    """GraphConfig-compatible config that simulates an LLM provider failure."""
+
+    error_message: str = "llm provider unavailable"
+    domain: str = "недвижимость в Болгарии"
+    llm_model: str = "failing-live-e2e"
+    llm_temperature: float = 0.0
+    generate_max_tokens: int = 600
+    streaming_enabled: bool = False
+    show_sources: bool = False
+    response_style_enabled: bool = False
+    response_style_shadow_mode: bool = False
+
+    def create_llm(self, *, auto_trace: bool = False) -> Any:
+        return _FailingLLM(self.error_message)
+
+    def get_reasoning_kwargs(self) -> dict[str, Any]:
+        return {}
+
+
 @dataclass
 class LiveCoreHarness:
     """Created live dependencies plus async cleanup."""
@@ -391,6 +412,7 @@ def build_live_core_harness(
     collection_name: str,
     *,
     crm: MockCrmClient | None = None,
+    config: Any | None = None,
 ) -> LiveCoreHarness:
     """Build CoreDependencies for ``run_assistant_request`` using live retrieval."""
 
@@ -405,14 +427,14 @@ def build_live_core_harness(
         timeout=30,
         prefer_grpc=False,
     )
-    config = _build_live_llm_config(env)
+    llm_config = config or _build_live_llm_config(env)
     dependencies = CoreDependencies(
         cache=NoopLiveCache(),
         embeddings=embeddings,
         sparse_embeddings=sparse_embeddings,
         qdrant=qdrant,
         reranker=None,
-        config=config,
+        config=llm_config,
     )
     if crm is not None:
         dependencies.crm = crm
@@ -484,6 +506,15 @@ class _FakeLLM:
             usage=SimpleNamespace(prompt_tokens=10, completion_tokens=10, total_tokens=20),
             choices=[SimpleNamespace(message=SimpleNamespace(content=answer))],
         )
+
+
+class _FailingLLM:
+    def __init__(self, error_message: str) -> None:
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
+        self._error_message = error_message
+
+    async def _create(self, **kwargs: Any) -> Any:
+        raise TimeoutError(self._error_message)
 
 
 def _answer_from_context(message: str) -> str:

--- a/tests/unit/e2e_core/test_live_harness.py
+++ b/tests/unit/e2e_core/test_live_harness.py
@@ -147,6 +147,31 @@ def test_build_live_core_harness_attaches_mock_crm() -> None:
     assert harness.dependencies.crm is crm
 
 
+def test_build_live_core_harness_accepts_config_override() -> None:
+    from tests.e2e_core.live_harness import FailingLLMConfig, LiveE2EEnv, build_live_core_harness
+
+    config = FailingLLMConfig(error_message="provider down")
+    env = LiveE2EEnv(qdrant_url="http://qdrant:6333", bge_m3_url="http://bge:8000")
+
+    with (
+        mock.patch("tests.e2e_core.live_harness.LiveBGEEmbeddings"),
+        mock.patch("tests.e2e_core.live_harness.LiveBGESparseEmbeddings"),
+        mock.patch("tests.e2e_core.live_harness.QdrantService"),
+    ):
+        harness = build_live_core_harness(env, "collection", config=config)
+
+    assert harness.dependencies.config is config
+
+
+def test_failing_llm_config_raises_provider_error() -> None:
+    from tests.e2e_core.live_harness import FailingLLMConfig
+
+    llm = FailingLLMConfig(error_message="provider down").create_llm(auto_trace=False)
+
+    with pytest.raises(TimeoutError, match="provider down"):
+        asyncio.run(llm.chat.completions.create(model="fake", messages=[]))
+
+
 def test_mock_crm_client_records_writes() -> None:
     from tests.e2e_core.live_harness import MockCrmClient
 


### PR DESCRIPTION
## Summary
- add live core E2E coverage for LLM provider failure after real retrieval
- add FailingLLMConfig harness override to simulate provider timeout deterministically
- assert user-safe fallback response, fallback llm_model, and preserved retrieved document evidence

## Validation
- uv run pytest tests/e2e/test_core_live_ingest_answer.py::test_core_live_llm_dependency_failure_returns_user_safe_fallback -q
- uv run pytest tests/unit/e2e_core/test_live_harness.py -q
- make e2e-core-live
- uv run pytest tests/unit/e2e_core/test_live_harness.py tests/e2e_core/test_qdrant_helpers.py tests/unit/core/test_assistant_entrypoint.py tests/unit/test_product_events.py -q
- uv run ruff check tests/e2e/test_core_live_ingest_answer.py tests/e2e_core/live_harness.py tests/unit/e2e_core/test_live_harness.py
- make check