### PR TITLE
fix(bot): disable Telegram reply quotes

### DIFF
--- a/telegram_bot/services/telegram_formatting.py
+++ b/telegram_bot/services/telegram_formatting.py
@@ -14,8 +14,6 @@ from telegram_bot.observability_payloads import build_safe_output_payload
 logger = logging.getLogger(__name__)
 
 _LONG_ANSWER_THRESHOLD = 900
-_QUOTE_THRESHOLD = 120
-_QUOTE_MAX_LEN = 220
 
 
 def _escape_html(text: str) -> str:
@@ -60,33 +58,8 @@ def format_sources_html(documents: list[dict[str, Any]], max_sources: int = 5) -
 
 
 def build_reply_parameters(message: Any, user_text: str) -> Any | None:
-    """Build Telegram reply quote params for long/complex user questions."""
-    if not isinstance(user_text, str):
-        return None
-    original_text = user_text
-    text = user_text.strip()
-    message_id = getattr(message, "message_id", None)
-    if not isinstance(message_id, int):
-        return None
-    if len(text) < _QUOTE_THRESHOLD and "\n" not in text and text.count("?") <= 1:
-        return None
-
-    try:
-        from aiogram.types import ReplyParameters
-    except Exception:
-        return None
-
-    # Telegram requires `quote` to be an exact substring of the original message.
-    # Keep the original whitespace and truncate by prefix only, without adding ellipsis.
-    quote_text = original_text
-    if len(quote_text) > _QUOTE_MAX_LEN:
-        quote_text = quote_text[:_QUOTE_MAX_LEN]
-
-    return ReplyParameters(
-        message_id=message_id,
-        quote=_escape_html(quote_text),
-        quote_parse_mode="HTML",
-    )
+    """Disable Telegram reply quotes for bot answers."""
+    return None
 
 
 def _split_plain_text(text: str, limit: int = _TELEGRAM_MESSAGE_LIMIT) -> list[str]:

--- a/tests/unit/services/test_telegram_formatting.py
+++ b/tests/unit/services/test_telegram_formatting.py
@@ -1,35 +1,23 @@
 from __future__ import annotations
 
-import html
 from types import SimpleNamespace
 
-from telegram_bot.services.telegram_formatting import (
-    _QUOTE_MAX_LEN,
-    build_reply_parameters,
-)
+from telegram_bot.services.telegram_formatting import build_reply_parameters
 
 
-def test_build_reply_parameters_preserves_exact_substring_for_multiline_text() -> None:
+def test_build_reply_parameters_returns_none_for_multiline_text() -> None:
     message = SimpleNamespace(message_id=42)
     user_text = "Первая строка\nВторая <строка>  с  пробелами?\nТретья строка"
 
     reply_parameters = build_reply_parameters(message, user_text)
 
-    assert reply_parameters is not None
-    assert reply_parameters.message_id == 42
-    assert reply_parameters.quote_parse_mode == "HTML"
-    assert reply_parameters.quote == html.escape(user_text, quote=False)
+    assert reply_parameters is None
 
 
-def test_build_reply_parameters_truncates_without_ellipsis() -> None:
+def test_build_reply_parameters_returns_none_for_long_text() -> None:
     message = SimpleNamespace(message_id=42)
     user_text = "Очень длинный вопрос? " + ("данные " * 80)
 
     reply_parameters = build_reply_parameters(message, user_text)
 
-    assert reply_parameters is not None
-    assert not reply_parameters.quote.endswith("...")
-
-    unescaped_quote = html.unescape(reply_parameters.quote)
-    assert len(unescaped_quote) == _QUOTE_MAX_LEN
-    assert user_text.startswith(unescaped_quote)
+    assert reply_parameters is None


### PR DESCRIPTION
## Summary
- disable Telegram reply quote parameters for bot answers
- update formatting tests to assert quotes are not generated for long/multiline user questions

Regression guardrail:
- tests/unit/services/test_telegram_formatting.py asserts build_reply_parameters() returns None for long and multiline user questions, preventing Telegram quote regressions.

Checks run:
- uv run --no-sync pytest tests/unit/services/test_telegram_formatting.py -q
- uv run --no-sync ruff check telegram_bot/services/telegram_formatting.py tests/unit/services/test_telegram_formatting.py
- make check