### PR TITLE
test: mark trace checks optional diagnostics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -905,15 +905,15 @@ e2e-telegram-test: ## Run Telegram userbot E2E runner (Telethon + judge)
 	uv run --env-file "$$RAG_RUNTIME_ENV_FILE" python scripts/e2e/runner.py
 	@echo "$(GREEN)✓ Telegram E2E runner complete$(NC)"
 
-e2e-test-traces: ## Run E2E tests + validate Langfuse traces
-	@echo "$(BLUE)Running E2E tests with Langfuse trace validation...$(NC)"
+e2e-test-traces: ## Optional diagnostic: run Telegram E2E tests + validate Langfuse traces
+	@echo "$(BLUE)Running optional E2E tests with Langfuse trace validation...$(NC)"
 	E2E_VALIDATE_LANGFUSE=1 uv run --env-file "$$RAG_RUNTIME_ENV_FILE" python scripts/e2e/runner.py
-	@echo "$(GREEN)✓ E2E tests with trace validation complete$(NC)"
+	@echo "$(GREEN)✓ Optional E2E trace validation complete$(NC)"
 
-e2e-test-traces-core: ## Run required #1307 Telethon scenarios with Langfuse validation
-	@echo "$(BLUE)Running #1307 core Telethon trace scenarios...$(NC)"
+e2e-test-traces-core: ## Optional diagnostic: run #1307 Telethon scenarios with Langfuse validation
+	@echo "$(BLUE)Running optional #1307 Telethon trace scenarios...$(NC)"
 	E2E_VALIDATE_LANGFUSE=1 uv run --env-file "$$RAG_RUNTIME_ENV_FILE" python scripts/e2e/runner.py --no-judge --scenario 0.1 --scenario 6.3 --scenario 7.1 --scenario 8.1
-	@echo "$(GREEN)✓ #1307 core trace scenarios complete$(NC)"
+	@echo "$(GREEN)✓ Optional #1307 trace scenarios complete$(NC)"
 
 e2e-test-group: ## Run specific test group (usage: make e2e-test-group GROUP=filters)
 	uv run python scripts/e2e/runner.py --group $(GROUP)
@@ -922,7 +922,7 @@ e2e-setup: e2e-install ## Full E2E setup on canonical collection
 	@echo "$(YELLOW)Using canonical collection via E2E_COLLECTION_NAME (default: gdrive_documents_bge)$(NC)"
 	@echo "$(GREEN)✓ E2E setup complete$(NC)"
 
-langfuse-latest-trace-audit: ## Sanitized post-E2E Langfuse latest-trace audit
+langfuse-latest-trace-audit: ## Optional diagnostic: sanitized post-E2E Langfuse latest-trace audit
 	@echo "$(BLUE)Running sanitized latest-trace audit...$(NC)"
 	uv run python scripts/e2e/langfuse_latest_trace_audit.py --limit 20
 	@echo "$(GREEN)✓ Latest-trace audit complete$(NC)"
@@ -1247,15 +1247,15 @@ qdrant-cleanup: ## Prune Qdrant storage: snapshot then trigger optimiser (#1545)
 LANGFUSE_DEV_KEY_DASH ?= -
 TRACE_ENV_FILE ?= $(shell [ -f .env ] && echo .env || echo tests/fixtures/compose.ci.env)
 
-validate-traces: ## Full rebuild + trace validation + report
-	@echo "$(BLUE)Full rebuild + validation...$(NC)"
+validate-traces: ## Optional diagnostic: full rebuild + trace validation + report
+	@echo "$(BLUE)Optional full rebuild + trace validation...$(NC)"
 	$(LOCAL_COMPOSE_CMD) build --no-cache bot litellm bge-m3
 	$(LOCAL_COMPOSE_CMD) --profile bot --profile ml up -d --wait
 	uv run python scripts/validate_traces.py --report
 	@echo "$(GREEN)Validation complete — see docs/reports/$(NC)"
 
-validate-traces-fast: ## No rebuild; trace validation fails if required trace families are missing
-	@echo "$(BLUE)Fast validation (no rebuild)...$(NC)"
+validate-traces-fast: ## Optional diagnostic: no rebuild; validate trace families when requested
+	@echo "$(BLUE)Optional fast trace validation (no rebuild)...$(NC)"
 	uv run python scripts/validate_trace_runtime.py --env-file "$(TRACE_ENV_FILE)"
 	MINIO_API_PORT="$(or $(MINIO_API_PORT),0)" \
 	MINIO_CONSOLE_PORT="$(or $(MINIO_CONSOLE_PORT),0)" \
@@ -1271,11 +1271,11 @@ validate-traces-fast: ## No rebuild; trace validation fails if required trace fa
 		uv run python scripts/validate_traces.py --report
 	@echo "$(GREEN)Validation complete — see docs/reports/$(NC)"
 
-langfuse-latency-audit: ## #2179: per-stage observation latencies (retrieve/cache/checkpoint/llm) from recent traces
+langfuse-latency-audit: ## Optional diagnostic #2179: per-stage observation latencies from recent traces
 	@uv run python -m scripts.probe.langfuse_latency_audit --limit $${LANGFUSE_LATENCY_LIMIT:-50}
 
-validate-voice-traces: ## Voice trace validation gate (reads Langfuse, validates presence + attribution)
-	@echo "$(BLUE)Voice trace validation gate...$(NC)"
+validate-voice-traces: ## Optional diagnostic: voice trace validation (reads Langfuse)
+	@echo "$(BLUE)Optional voice trace validation...$(NC)"
 	LANGFUSE_HOST="$(or $(LANGFUSE_HOST),http://localhost:3001)" \
 	LANGFUSE_PUBLIC_KEY="$(or $(LANGFUSE_PUBLIC_KEY),pk$(LANGFUSE_DEV_KEY_DASH)lf-dev)" \
 	LANGFUSE_SECRET_KEY="$(or $(LANGFUSE_SECRET_KEY),sk$(LANGFUSE_DEV_KEY_DASH)lf-dev)" \

--- a/tests/contract/test_trace_diagnostics_optional_contract.py
+++ b/tests/contract/test_trace_diagnostics_optional_contract.py
@@ -1,0 +1,97 @@
+"""Contract: trace/Langfuse checks are optional diagnostics for simplification.
+
+Product reliability is gated by ``make e2e-core-live``. Langfuse and trace
+validation targets may remain useful diagnostics, but they must not be named or
+wired as required release/PR gates for the simplified assistant core.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MAKEFILE = REPO_ROOT / "Makefile"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+OPTIONAL_TRACE_TARGETS = (
+    "e2e-test-traces",
+    "e2e-test-traces-core",
+    "langfuse-latest-trace-audit",
+    "validate-traces",
+    "validate-traces-fast",
+    "validate-voice-traces",
+    "langfuse-latency-audit",
+)
+REQUIRED_WORDS = ("required", "must", "gate")
+TRACE_GATE_TOKENS = (
+    "validate-traces",
+    "validate-traces-fast",
+    "validate-voice-traces",
+    "e2e-test-traces",
+    "E2E_VALIDATE_LANGFUSE",
+)
+
+
+def _makefile_text() -> str:
+    return MAKEFILE.read_text(encoding="utf-8")
+
+
+def _target_header(text: str, target: str) -> str:
+    match = re.search(rf"^{re.escape(target)}:[^\n]*$", text, re.MULTILINE)
+    assert match is not None, f"Makefile must define {target!r}"
+    return match.group(0)
+
+
+def _target_body(text: str, target: str) -> str:
+    match = re.search(rf"^{re.escape(target)}:[^\n]*$", text, re.MULTILINE)
+    assert match is not None, f"Makefile must define {target!r}"
+    body_lines: list[str] = []
+    for line in text[match.end() :].splitlines():
+        if line and not line.startswith(("\t", " ", "\\")):
+            break
+        body_lines.append(line)
+    return "\n".join(body_lines)
+
+
+def test_trace_targets_are_named_optional_diagnostics() -> None:
+    text = _makefile_text()
+
+    for target in OPTIONAL_TRACE_TARGETS:
+        header = _target_header(text, target)
+        assert "Optional diagnostic" in header, (
+            f"{target} must be labelled as an optional diagnostic in Makefile help"
+        )
+
+
+def test_trace_targets_are_not_described_as_required_gates() -> None:
+    text = _makefile_text()
+
+    for target in OPTIONAL_TRACE_TARGETS:
+        header = _target_header(text, target)
+        body = _target_body(text, target)
+        combined = f"{header}\n{body}".lower()
+        offenders = [word for word in REQUIRED_WORDS if word in combined]
+        assert not offenders, (
+            f"{target} is optional diagnostics and must not be described as a "
+            f"required gate. Offending words: {offenders}"
+        )
+
+
+def test_pr_ci_does_not_run_trace_diagnostics() -> None:
+    text = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    offenders = [token for token in TRACE_GATE_TOKENS if token in text]
+    assert not offenders, (
+        "pull_request CI must not run Langfuse/trace diagnostics as mandatory gates. "
+        f"Offending tokens: {offenders}"
+    )
+
+
+def test_core_live_gate_does_not_enable_langfuse_validation() -> None:
+    text = _makefile_text()
+
+    body = _target_body(text, "e2e-core-live")
+    assert "E2E_VALIDATE_LANGFUSE" not in body
+    assert "langfuse" not in body.lower()


### PR DESCRIPTION
## Summary
- mark Langfuse/trace Makefile targets as optional diagnostics
- add a contract that trace diagnostics are not described as required gates
- assert PR CI and core live E2E do not enable Langfuse trace validation

## Validation
- uv run pytest tests/contract/test_trace_diagnostics_optional_contract.py -q
- uv run pytest tests/contract/test_trace_diagnostics_optional_contract.py tests/contract/test_core_live_gate_contract.py tests/contract/test_core_live_gate_placement_contract.py -q
- uv run ruff check tests/contract/test_trace_diagnostics_optional_contract.py
- make check