### PR TITLE
docs: document simplified core product path

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Choose the path that matches your goal:
 |---|---|
 | Review safely before running commands | [`docs/review/ACCESS_FOR_REVIEWERS.md`](docs/review/ACCESS_FOR_REVIEWERS.md) |
 | Run core local services | `make local-up` |
+| Prove the simplified core product path | `make local-up` then `make e2e-core-live` |
+| Try the core path with a real LLM provider | `make e2e-core-live-real-llm` |
 | Run the bot natively for fast iteration | `make test-bot-health` then `make run-bot` |
 | Run the Compose bot stack | `make docker-bot-up` |
 | Run the full Compose stack | `make docker-full-up` |
@@ -230,10 +232,18 @@ High-level entry points:
 ```bash
 make check       # Ruff lint + MyPy strict type checking
 make test-unit   # Unit tests (parallel via pytest-xdist)
+make e2e-core-live  # Simplified core product E2E against local Qdrant + BGE-M3
 make test-full   # Full suite: parallel-safe tiers first, live/stateful tiers after
 ```
 
 Local verification is the release authority for this repo. Run focused checks for the touched area before merging to `dev` or deploying. CI is intentionally lightweight: it runs static/lint guardrails, not pytest suites or the authoritative full-suite signal.
+
+`make e2e-core-live` is the main product simplification proof: it indexes the
+synthetic fixture corpus, answers through the assistant core, covers
+classification, retrieval, generation fallback behavior, CRM/HITL with mock
+CRM, and runs without Telegram, Langfuse, voice, Mini App, k8s, or trace
+validation. Use `make e2e-core-live-real-llm` only when real LLM credentials
+and budget are available.
 
 ## Honest Scope
 

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -286,13 +286,16 @@ before starting a heavy session:
 pgrep -af 'pytest|docker compose'
 ```
 
-Trace coverage gate:
+Optional trace diagnostics:
 
 ```bash
 make validate-traces-fast
 ```
 
-This target runs natively on the host and automatically points to local Docker service endpoints (`localhost:6333`, `localhost:8000`, `localhost:4000`, etc.). You can override individual endpoints if needed: `make validate-traces-fast QDRANT_URL=http://custom:6333`.
+This target is a manual diagnostic, not a product, CI, or release gate. It runs
+natively on the host and automatically points to local Docker service endpoints
+(`localhost:6333`, `localhost:8000`, `localhost:4000`, etc.). You can override
+individual endpoints if needed: `make validate-traces-fast QDRANT_URL=http://custom:6333`.
 
 When `.env` is absent, `validate-traces-fast` runs a preflight guard before `docker compose up`. If fallback uses `tests/fixtures/compose.ci.env` with the local default `POSTGRES_PASSWORD=postgres`, reusing `dev_postgres_data` is allowed. The guard fails fast only when fallback password and existing volume credentials can mismatch, preventing an unhealthy Langfuse/Postgres auth loop.
 
@@ -302,7 +305,39 @@ If Langfuse CLI returns `401` or points to wrong host, run with explicit host:
 lf --host "$LANGFUSE_HOST" traces list --name rag-api-query --limit 1
 ```
 
-## 5. Production Deployment (VPS)
+## 5. Core Product Live E2E
+
+The simplification core product proof is:
+
+```bash
+make local-up
+make e2e-core-live
+```
+
+This runs the live golden set in
+[`tests/e2e/test_core_live_ingest_answer.py`](../tests/e2e/test_core_live_ingest_answer.py)
+against local Qdrant + BGE-M3. It uses deterministic synthetic fixtures and a
+fake LLM by default, so it does not require Telegram, Telethon, Langfuse,
+voice, Mini App, k8s, real CRM credentials, or trace validation.
+
+When real provider credentials and budget are available, run the opt-in real
+LLM check:
+
+```bash
+make e2e-core-live-real-llm
+```
+
+Required env for the real LLM check:
+
+- `LLM_BASE_URL`
+- `LLM_MODEL`
+- `LLM_API_KEY` or `OPENAI_API_KEY`
+
+The real LLM target is a manual confidence check. It is intentionally outside
+fast local gates and CI because it depends on external provider availability
+and spend.
+
+## 6. Production Deployment (VPS)
 
 The recommended production flow is:
 
@@ -318,11 +353,11 @@ and `bot`. Mini app, Docling, ingestion, and self-hosted Langfuse are
 optional/profile-gated. See [`../DOCKER.md`](../DOCKER.md) for details and
 [cleanup commands](../DOCKER.md#vps-cleanup).
 
-## 6. Python Runtime Note
+## 7. Python Runtime Note
 
 Docker images that import `telegram_bot.observability` (and therefore `langfuse`) run on Python 3.13. Local native development via `uv` may use a different Python version (3.11+ supported, 3.12 recommended).
 
-## 7. Running Components Without Docker Wrapper
+## 8. Running Components Without Docker Wrapper
 
 `make bot`, `make run-bot`, and `make preflight-bot` now use
 `uv run --no-sync` to prevent implicit venv updates during runtime loops.
@@ -346,7 +381,7 @@ uv run uvicorn src.api.main:app --host 0.0.0.0 --port 8080
 If your venv is stale and the bot startup fails with a missing import,
 run `uv sync --frozen` before restarting.
 
-## 8. Minimal Stack (Fast Iteration)
+## 9. Minimal Stack (Fast Iteration)
 
 Use the `local-*` shortcuts (they now run a minimal subset from `compose.yml:compose.dev.yml`) when full dev stack is unnecessary:
 
@@ -380,9 +415,9 @@ make local-ps
 make local-down
 ```
 
-## 9. E2E Core Trace Gate (#1307)
+## 10. Optional E2E Trace Diagnostics (#1307)
 
-Required core Telethon trace scenarios with Langfuse validation:
+Optional Telethon trace scenarios with Langfuse validation:
 
 ```bash
 make local-up
@@ -391,18 +426,23 @@ make bot
 make e2e-test-traces-core
 ```
 
-Keep `make bot` running in another terminal while the E2E command executes. Use `make run-bot` only when you do not need the tee'd `logs/bot-run.log` evidence.
+Keep `make bot` running in another terminal while the E2E command executes. Use
+`make run-bot` only when you do not need the tee'd `logs/bot-run.log` evidence.
+This is a diagnostic path for transport/tracing investigations; the required
+core product proof is `make e2e-core-live`.
 
-## 10. Runtime env in worktrees
+## 11. Runtime env in worktrees
 
-Swarm worktrees start from a fresh `origin/dev` checkout and do not contain the main checkout's `.env` or Telegram session files. To keep E2E trace gates reproducible without copying secrets into every worktree:
+Swarm worktrees start from a fresh `origin/dev` checkout and do not contain the
+main checkout's `.env` or Telegram session files. To keep optional E2E trace
+diagnostics reproducible without copying secrets into every worktree:
 
 - Compose commands must use `$(LOCAL_COMPOSE_CMD)` (or explicitly `docker compose --env-file tests/fixtures/compose.ci.env ...`) so services start with safe fallback values when `.env` is absent.
 - Telethon/E2E commands must use `uv run --env-file "$RAG_RUNTIME_ENV_FILE" ...` so runner credentials are loaded explicitly.
 - For swarm worktrees, set `RAG_RUNTIME_ENV_FILE=/repo/.env` when local Telegram credentials live only in the main checkout.
 - Do not copy `.env`, Telegram sessions, or provider keys into worker worktrees.
 
-## 11. Common Issues
+## 12. Common Issues
 
 - `docker-bot-up` fails immediately: missing required env variables in `.env`. Run `make preflight-bot` for a diagnostic report.
 - Bot crash-loops with `TokenValidationError`: `.env` is missing and the CI fallback `TELEGRAM_BOT_TOKEN=123456789:ABC...fghi` is not a valid Telegram token. `cp .env.example .env` then set real `TELEGRAM_BOT_TOKEN`, `LITELLM_MASTER_KEY`, and a provider key.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,11 +8,30 @@ Project documentation index for humans and agents. Use this page to understand t
 2. **[LOCAL-DEVELOPMENT.md](LOCAL-DEVELOPMENT.md)** -- day-to-day workflow: commands, profiles, validation ladder.
 3. **[DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md)** -- extending the platform: add graph nodes, tools, query types, ingestion sources.
 
+## Core Product Path
+
+For the current simplification work, the primary proof is the assistant core
+live E2E path:
+
+```bash
+make local-up
+make e2e-core-live
+```
+
+This path exercises local Qdrant + BGE-M3, the synthetic fixture corpus, the
+assistant workflow, mocked CRM/HITL, and dependency-failure fallback behavior.
+It intentionally does not require Telegram, Langfuse, voice, Mini App, k8s, or
+trace validation. See [`LOCAL-DEVELOPMENT.md`](LOCAL-DEVELOPMENT.md#5-core-product-live-e2e)
+for the local workflow and
+[`designs/product-simplification-e2e-plan.md`](designs/product-simplification-e2e-plan.md)
+for the staged plan.
+
 ## Task-Oriented Indexes
 
 For fast orientation by goal rather than by subsystem, see [`indexes/`](indexes/):
 
 - [`indexes/fast-search.md`](indexes/fast-search.md) — "I need to find docs about X"
+- [`indexes/core-product-path.md`](indexes/core-product-path.md) — simplified assistant core E2E, real LLM opt-in, optional surfaces
 - [`indexes/runtime-services.md`](indexes/runtime-services.md) — Docker, ingestion, mini app, bot, voice
 - [`indexes/observability-and-storage.md`](indexes/observability-and-storage.md) — Langfuse, Qdrant, Redis, LiteLLM, Postgres
 - [`indexes/local-runtime.md`](indexes/local-runtime.md) — local bot startup, Telegram E2E, Telethon sessions, polling locks

--- a/docs/designs/product-simplification-stage-0-decisions.md
+++ b/docs/designs/product-simplification-stage-0-decisions.md
@@ -1,8 +1,12 @@
 # Решения Этапа 0: Фиксация Направления Упрощения
 
-Статус: предлагается
+Статус: принято; выполнение идет через ветку `simplification/core`
 Дата: 2026-06-03
 Источник плана: [`product-simplification-e2e-plan.md`](product-simplification-e2e-plan.md)
+
+Текущий основной proof: `make e2e-core-live` против локальных Qdrant + BGE-M3,
+с синтетическим корпусом, мок CRM/HITL и без обязательных Telegram, Langfuse,
+voice, Mini App, k8s или trace validation.
 
 ## Цель Этапа 0
 

--- a/docs/indexes/README.md
+++ b/docs/indexes/README.md
@@ -9,6 +9,7 @@ For the full documentation map, see [`../README.md`](../README.md). For operatio
 | Page | Use When |
 |---|---|
 | [`fast-search.md`](fast-search.md) | You need to grep the doc tree by topic or find the right canonical doc quickly. |
+| [`core-product-path.md`](core-product-path.md) | You need the simplified assistant core E2E path, real LLM opt-in check, or optional-surface boundaries. |
 | [`runtime-services.md`](runtime-services.md) | You need to understand Docker services, the ingestion pipeline, the mini app, or the Telegram bot flow. |
 | [`observability-and-storage.md`](observability-and-storage.md) | You need to study Langfuse traces, inspect Qdrant, or debug Redis/cache behavior. |
 | [`local-runtime.md`](local-runtime.md) | You need local bot startup, Telegram E2E, Telethon session, or polling lock guidance. |

--- a/docs/indexes/core-product-path.md
+++ b/docs/indexes/core-product-path.md
@@ -1,0 +1,51 @@
+# Core Product Path Index
+
+Fast lookup for the product simplification core path. Canonical command details
+live in [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md); design decisions
+live in [`../designs/product-simplification-stage-0-decisions.md`](../designs/product-simplification-stage-0-decisions.md).
+
+## Primary Proof
+
+```bash
+make local-up
+make e2e-core-live
+```
+
+`make e2e-core-live` runs the simplification core live golden set against local
+Qdrant + BGE-M3. It uses deterministic synthetic fixtures and a fake LLM by
+default so the product gate is stable and does not depend on provider budget.
+
+## Optional Real LLM Check
+
+```bash
+make e2e-core-live-real-llm
+```
+
+This target is opt-in and requires `LLM_BASE_URL`, `LLM_MODEL`, and either
+`LLM_API_KEY` or `OPENAI_API_KEY`. Use it for manual confidence when real
+provider credentials and budget are available.
+
+## What The Core Gate Covers
+
+| Area | Evidence |
+|---|---|
+| Fixture corpus and golden cases | [`../../tests/e2e_core/`](../../tests/e2e_core/) |
+| Live local services | `Qdrant + BGE-M3` via `make local-up` |
+| Assistant classification and retrieval | [`../../tests/e2e/test_core_live_ingest_answer.py`](../../tests/e2e/test_core_live_ingest_answer.py) |
+| CRM/HITL safety | mock CRM in the core live E2E, no real CRM writes |
+| Dependency failure behavior | core live E2E fallback case |
+
+## Optional Surfaces
+
+The simplified product gate intentionally does not require:
+
+- Telegram or Telethon transport;
+- Langfuse, OTel, or trace validation;
+- voice/LiveKit;
+- Mini App;
+- k8s manifests;
+- real CRM writes.
+
+Use [`local-runtime.md`](local-runtime.md) for Telegram/native bot tasks and
+[`observability-and-storage.md`](observability-and-storage.md) for Langfuse,
+trace, Qdrant, Redis, and storage investigations.

--- a/docs/indexes/local-runtime.md
+++ b/docs/indexes/local-runtime.md
@@ -6,15 +6,15 @@ in [`../../DOCKER.md`](../../DOCKER.md).
 
 | Goal / Symptom | Canonical Doc | Focused Check |
 |---|---|---|
-| Bootstrap local services for native bot iteration | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#8-minimal-stack-fast-iteration) | `make local-up && make test-bot-health` |
-| Run the bot natively from `.env` | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#8-minimal-stack-fast-iteration) | `make bot` |
+| Bootstrap local services for native bot iteration | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#9-minimal-stack-fast-iteration) | `make local-up && make test-bot-health` |
+| Run the bot natively from `.env` | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#9-minimal-stack-fast-iteration) | `make bot` |
 | Check the bot username behind the current token | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#1-bootstrap-workspace) | Telegram `getMe` snippet in the local guide |
 | Configure Telegram E2E userbot credentials | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#1-bootstrap-workspace) | `TELEGRAM_API_ID`, `TELEGRAM_API_HASH`, `E2E_BOT_USERNAME` |
 | Create or refresh the Telethon session | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#1-bootstrap-workspace) and [`../../tests/README.md`](../../tests/README.md#e2e) | `uv run python -m scripts.e2e.auth --phone ... --code ...` |
 | Smoke test Telegram bot response through Telethon | [`../../tests/README.md`](../../tests/README.md#e2e) | `uv run python -m scripts.e2e.quick_test` |
-| Prove `make bot` actually answers a Telegram message | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#11-common-issues) | `make bot-response-smoke` (preflight + Telethon send) |
-| `make bot` fails with polling lock busy | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#11-common-issues) | Stop the Docker bot container or wait for Redis lock TTL |
-| Telethon session file exists but is not authorized | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#11-common-issues) | Refresh with `scripts.e2e.auth` |
+| Prove `make bot` actually answers a Telegram message | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#12-common-issues) | `make bot-response-smoke` (preflight + Telethon send) |
+| `make bot` fails with polling lock busy | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#12-common-issues) | Stop the Docker bot container or wait for Redis lock TTL |
+| Telethon session file exists but is not authorized | [`../LOCAL-DEVELOPMENT.md`](../LOCAL-DEVELOPMENT.md#12-common-issues) | Refresh with `scripts.e2e.auth` |
 
 Runtime reminders:
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -110,7 +110,7 @@ make test-nightly            # chaos + smoke + slow unit
 ```bash
 make e2e-test                # pytest E2E suite (live services)
 make e2e-telegram-test       # Telegram userbot runner
-make e2e-test-traces-core    # required #1307 core Telethon trace gate
+make e2e-test-traces-core    # optional #1307 Telethon trace diagnostic
 make bot-response-smoke      # #2192: prove make bot actually answers
 ```
 
@@ -119,7 +119,9 @@ session file, `getMe` username match, `getWebhookInfo` empty, polling
 lock state) before delegating to `scripts.e2e.quick_test` for one safe
 query. Use it to gate "make bot is healthy" against "make bot answers".
 
-The `e2e-test-traces-core` target runs the required #1307 Telethon scenarios with Langfuse validation (`E2E_VALIDATE_LANGFUSE=1`). Ensure the bot is running locally (`make bot`) before executing this gate.
+The `e2e-test-traces-core` target runs optional #1307 Telethon scenarios with
+Langfuse validation (`E2E_VALIDATE_LANGFUSE=1`). Ensure the bot is running
+locally (`make bot`) before executing this diagnostic.
 
 ### RAG evaluation
 ```bash


### PR DESCRIPTION
## Summary
- add a core product path docs index for the simplification E2E gate
- make README and docs navigation point to `make e2e-core-live` as the primary proof
- mark trace/Langfuse E2E docs as optional diagnostics and fix local-runtime anchors

## Validation
- `make docs-check`
- `git diff --check`
- `uv run pytest tests/contract/test_core_live_gate_contract.py tests/contract/test_core_live_gate_placement_contract.py tests/contract/test_trace_diagnostics_optional_contract.py -q`
- `make check`

## Not run
- `make e2e-core-live` was not part of this docs-only PR validation. It was accidentally invoked while creating the PR body and failed because local Qdrant/BGE-M3 services were not running (`make local-up` was not started in this worktree). Previous core-live implementation PRs already validated the target against services.