### PR TITLE
fix(core): make langfuse observe imports optional

### DIFF
--- a/src/contextualization/claude.py
+++ b/src/contextualization/claude.py
@@ -3,10 +3,10 @@
 from typing import Any, cast
 
 from anthropic import Anthropic, APIStatusError, AsyncAnthropic, RateLimitError
-from langfuse import observe
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_random_exponential
 
 from src.config import Settings
+from src.observability import observe
 
 from .base import ContextualizedChunk, ContextualizeProvider
 

--- a/src/contextualization/groq.py
+++ b/src/contextualization/groq.py
@@ -1,10 +1,10 @@
 """Groq-based contextualization provider (high-speed alternative)."""
 
 from groq import APIStatusError, AsyncGroq, Groq, RateLimitError
-from langfuse import observe
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_random_exponential
 
 from src.config import Settings
+from src.observability import observe
 
 from .base import ContextualizedChunk, ContextualizeProvider
 

--- a/src/contextualization/openai.py
+++ b/src/contextualization/openai.py
@@ -1,7 +1,12 @@
 """OpenAI-based contextualization provider."""
 
-from langfuse import observe
-from langfuse.openai import AsyncOpenAI, OpenAI
+from src.observability import observe
+
+
+try:
+    from langfuse.openai import AsyncOpenAI, OpenAI
+except Exception:
+    from openai import AsyncOpenAI, OpenAI  # type: ignore[assignment]
 
 from src.config import Settings
 

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -4,8 +4,6 @@ import asyncio
 from dataclasses import dataclass
 from typing import Any
 
-from langfuse import observe
-
 from src.config import APIProvider, Settings
 from src.contextualization import (
     ClaudeContextualizer,
@@ -14,6 +12,7 @@ from src.contextualization import (
 )
 from src.ingestion import DocumentChunker, DocumentIndexer, UniversalDocumentParser
 from src.models import get_sentence_transformer
+from src.observability import observe
 from src.retrieval import create_search_engine
 
 

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -1018,6 +1018,63 @@ class TestOtelServiceName:
         assert os.environ.get("OTEL_SERVICE_NAME") == "custom-service"
 
 
+class TestLangfuseOptionalImport:
+    """Tests that reserved files use the optional facade, not direct from langfuse.
+
+    Issue #2372: Replace direct ``from langfuse import observe`` with the
+    optional facade ``from src.observability import observe`` so core modules
+    import cleanly when langfuse is not installed.
+
+    Verifies source-code level compliance: each reserved module must import
+    ``observe`` from ``src.observability``, never directly from ``langfuse``.
+    """
+
+    _RESERVED_MODULES = [
+        "src/core/pipeline.py",
+        "src/contextualization/claude.py",
+        "src/contextualization/groq.py",
+        "src/contextualization/openai.py",
+    ]
+
+    def test_no_direct_langfuse_observe_import_in_reserved_files(self):
+        """No reserved file should have ``from langfuse import observe``."""
+        import os
+
+        project_root = os.getcwd()
+        violations: list[str] = []
+        for rel_path in self._RESERVED_MODULES:
+            full_path = os.path.join(project_root, rel_path)
+            with open(full_path) as f:
+                for lineno, line in enumerate(f, 1):
+                    stripped = line.strip()
+                    # Only flag the exact direct import pattern
+                    if stripped == "from langfuse import observe":
+                        violations.append(f"{rel_path}:{lineno}: {stripped}")
+
+        assert not violations, (
+            "Reserved files still use direct 'from langfuse import observe'.\n"
+            "Violations:\n" + "\n".join(violations) + "\n"
+            "Expected: 'from src.observability import observe'"
+        )
+
+    def test_reserved_files_have_facade_observe_import(self):
+        """Each reserved file must import observe from src.observability."""
+        import os
+
+        project_root = os.getcwd()
+        missing: list[str] = []
+        for rel_path in self._RESERVED_MODULES:
+            full_path = os.path.join(project_root, rel_path)
+            with open(full_path) as f:
+                content = f.read()
+            if "from src.observability import observe" not in content:
+                missing.append(rel_path)
+
+        assert not missing, (
+            "Reserved files missing 'from src.observability import observe':\n" + "\n".join(missing)
+        )
+
+
 class TestOtelExportDefaults:
     """Tests for conservative OTEL export defaults (#1408)."""
 


### PR DESCRIPTION
## Summary

Replace direct `from langfuse import observe` with the optional facade `from src.observability import observe` in core pipeline and contextualization modules.

Closes #2372. Part of umbrella #2329 (Stage 4: Langfuse optional).

## Changes

- **`src/core/pipeline.py`**: `from langfuse import observe` → `from src.observability import observe`
- **`src/contextualization/claude.py`**: `from langfuse import observe` → `from src.observability import observe`
- **`src/contextualization/groq.py`**: `from langfuse import observe` → `from src.observability import observe`
- **`src/contextualization/openai.py`**: `from langfuse import observe` → `from src.observability import observe` + graceful fallback from `langfuse.openai` to raw `openai` SDK
- **`tests/unit/test_observability.py`**: Added `TestLangfuseOptionalImport` (2 source-level compliance tests)

## Verification

| Step | Result |
|------|--------|
| `pytest tests/unit/test_observability.py -x -q` | 62 passed |
| `pytest tests/unit/pipelines/test_client_pipeline.py -x -q` | 78 passed |
| `make local-up && make e2e-core-live` | 7/8 passed (1 infra: Qdrant ReadError) |
| Golden path E2E | ✅ Passed |

## Notes

The `src/observability` facade already provides graceful degradation when Langfuse is unavailable (no-op `observe`, `get_client` returns None, `propagate_attributes` is a nullcontext). This PR removes the last hard imports that would prevent core modules from loading without langfuse installed.

The `src/contextualization/openai.py` module also used `from langfuse.openai import AsyncOpenAI, OpenAI` for the tracing wrapper clients. A try/except fallback to the raw `openai` SDK has been added so the module can import without langfuse (tracing is lost but the LLM path still works).