### PR TITLE
feat(core): add opt-in BGE-M3 local provider spike

### DIFF
--- a/docs/engineering/sdk-registry.md
+++ b/docs/engineering/sdk-registry.md
@@ -324,6 +324,23 @@ paths: "telegram_bot/**,src/**,mini_app/**,pyproject.toml,Makefile,.github/workf
   - Middleware/CORS добавлять только там, где это часть surface contract, не копировать без причины
   - Preserve structured error/health responses; не заменять их ad-hoc debug поведением
 
+## FlagEmbedding / BGE-M3 local provider
+- **triggers:** BGE-M3, FlagEmbedding, embeddings, dense, sparse, ColBERT, in-process embeddings, `ml-local`
+- **context7_id:** FlagEmbedding docs when available; otherwise use repo-local contracts first
+- **как_у_нас:**
+  - `src/models/embedding_model.py` — lazy `get_bge_m3_model()` singleton; imports FlagEmbedding only when used
+  - `src/runtime/integrations/embeddings.py` — `InProcessBgeM3Provider` opt-in adapter and HTTP wrappers
+  - `src/runtime/graph/config.py` — provider flags `RETRIEVAL_DENSE_PROVIDER` / `RETRIEVAL_SPARSE_PROVIDER`
+  - `services/bge-m3-api/app.py` — HTTP ONNX INT8 service contract to preserve
+- **паттерны:**
+  - Keep HTTP BGE-M3 as default unless `RETRIEVAL_DENSE_PROVIDER=local_bge_m3` and/or `RETRIEVAL_SPARSE_PROVIDER=local_bge_m3` explicitly opts in.
+  - Local provider must preserve HTTP client result contracts: dense vectors, `{"indices", "values"}` sparse weights, and ColBERT multivectors.
+  - Use `get_bge_m3_model()`; do not instantiate FlagEmbedding at import time.
+- **gotchas:**
+  - `ml-local` is optional; do not make FlagEmbedding/torch required for default bot runtime without Artem approval.
+  - Do not switch defaults, remove the BGE-M3 container, change Qdrant schema, or require reindexing without an explicit migration decision.
+  - ONNX INT8 service vectors and local PyTorch/FlagEmbedding vectors may differ; measure parity before default migration.
+
 ## httpx
 - **triggers:** httpx, http client, external api, retry, timeout, transport, kommo, docling-serve, vectorizer service
 - **context7_id:** /encode/httpx

--- a/src/runtime/graph/config.py
+++ b/src/runtime/graph/config.py
@@ -35,6 +35,8 @@ class GraphConfig:
 
     bge_m3_url: str = "http://bge-m3:8000"
     bge_m3_timeout: float = 120.0
+    retrieval_dense_provider: str = "http_bge_m3"
+    retrieval_sparse_provider: str = "http_bge_m3"
 
     qdrant_url: str = "http://qdrant:6333"
     qdrant_collection: str = "gdrive_documents_bge"
@@ -137,6 +139,8 @@ class GraphConfig:
             generate_max_tokens=int(os.getenv("GENERATE_MAX_TOKENS", "1024")),
             bge_m3_url=os.getenv("BGE_M3_URL", "http://bge-m3:8000"),
             bge_m3_timeout=float(os.getenv("BGE_M3_TIMEOUT", "120.0")),
+            retrieval_dense_provider=os.getenv("RETRIEVAL_DENSE_PROVIDER", "http_bge_m3"),
+            retrieval_sparse_provider=os.getenv("RETRIEVAL_SPARSE_PROVIDER", "http_bge_m3"),
             qdrant_url=os.getenv("QDRANT_URL", "http://qdrant:6333"),
             qdrant_collection=os.getenv("QDRANT_COLLECTION", "gdrive_documents_bge"),
             search_top_k=int(os.getenv("SEARCH_TOP_K", "40")),
@@ -215,7 +219,10 @@ class GraphConfig:
 
     def create_embeddings(self) -> Any:
         """Create BGEM3Embeddings instance."""
-        from src.runtime.integrations.embeddings import BGEM3Embeddings
+        from src.runtime.integrations.embeddings import BGEM3Embeddings, InProcessBgeM3Provider
+
+        if self.retrieval_dense_provider == "local_bge_m3":
+            return BGEM3Embeddings(client=InProcessBgeM3Provider())
 
         return BGEM3Embeddings(
             base_url=self.bge_m3_url,
@@ -224,7 +231,13 @@ class GraphConfig:
 
     def create_sparse_embeddings(self) -> Any:
         """Create BGEM3SparseEmbeddings instance."""
-        from src.runtime.integrations.embeddings import BGEM3SparseEmbeddings
+        from src.runtime.integrations.embeddings import (
+            BGEM3SparseEmbeddings,
+            InProcessBgeM3Provider,
+        )
+
+        if self.retrieval_sparse_provider == "local_bge_m3":
+            return BGEM3SparseEmbeddings(client=InProcessBgeM3Provider())
 
         return BGEM3SparseEmbeddings(
             base_url=self.bge_m3_url,
@@ -233,7 +246,16 @@ class GraphConfig:
 
     def create_hybrid_embeddings(self) -> Any:
         """Create BGEM3HybridEmbeddings instance."""
-        from src.runtime.integrations.embeddings import BGEM3HybridEmbeddings
+        from src.runtime.integrations.embeddings import (
+            BGEM3HybridEmbeddings,
+            InProcessBgeM3Provider,
+        )
+
+        if (
+            self.retrieval_dense_provider == "local_bge_m3"
+            and self.retrieval_sparse_provider == "local_bge_m3"
+        ):
+            return BGEM3HybridEmbeddings(client=InProcessBgeM3Provider())
 
         return BGEM3HybridEmbeddings(
             base_url=self.bge_m3_url,

--- a/src/runtime/integrations/embeddings.py
+++ b/src/runtime/integrations/embeddings.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, Protocol
 
 import httpx
 from langchain_core.embeddings import Embeddings
@@ -33,6 +33,18 @@ from src.services.bge_m3_client import (
 
 
 logger = logging.getLogger(__name__)
+
+
+class BgeM3Provider(Protocol):
+    async def encode_dense(self, texts: list[str]) -> DenseResult: ...
+
+    async def encode_sparse(self, texts: list[str]) -> SparseResult: ...
+
+    async def encode_hybrid(self, texts: list[str]) -> HybridResult: ...
+
+    async def encode_colbert(self, texts: list[str]) -> ColbertResult: ...
+
+    async def aclose(self) -> None: ...
 
 
 def _as_list(value: Any) -> Any:
@@ -192,7 +204,7 @@ class BGEM3Embeddings(Embeddings):
         batch_size: int = 32,
         max_length: int = 512,
         *,
-        client: BGEM3Client | None = None,
+        client: BgeM3Provider | None = None,
     ) -> None:
         self.base_url = base_url
         self.timeout = timeout
@@ -230,7 +242,7 @@ class BGEM3SparseEmbeddings:
         timeout: float = 120.0,
         max_length: int = 512,
         *,
-        client: BGEM3Client | None = None,
+        client: BgeM3Provider | None = None,
     ) -> None:
         self.base_url = base_url
         self.timeout = timeout
@@ -267,7 +279,7 @@ class BGEM3HybridEmbeddings(Embeddings):
         timeout: float | httpx.Timeout | None = None,
         max_length: int = 512,
         *,
-        client: BGEM3Client | None = None,
+        client: BgeM3Provider | None = None,
     ) -> None:
         self._client = client or BGEM3Client(
             base_url=base_url,
@@ -348,5 +360,6 @@ __all__ = [
     "BGEM3Embeddings",
     "BGEM3HybridEmbeddings",
     "BGEM3SparseEmbeddings",
+    "BgeM3Provider",
     "InProcessBgeM3Provider",
 ]

--- a/src/runtime/integrations/embeddings.py
+++ b/src/runtime/integrations/embeddings.py
@@ -23,10 +23,163 @@ import httpx
 from langchain_core.embeddings import Embeddings
 
 from src.observability import observe
-from src.services.bge_m3_client import BGEM3Client
+from src.services.bge_m3_client import (
+    BGEM3Client,
+    ColbertResult,
+    DenseResult,
+    HybridResult,
+    SparseResult,
+)
 
 
 logger = logging.getLogger(__name__)
+
+
+def _as_list(value: Any) -> Any:
+    """Convert numpy/torch-like outputs into plain JSON-compatible lists."""
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    if isinstance(value, list):
+        return [_as_list(item) for item in value]
+    if isinstance(value, tuple):
+        return [_as_list(item) for item in value]
+    return value
+
+
+def _normalize_sparse_row(row: dict[Any, Any]) -> dict[str, list[Any]]:
+    if "indices" in row and "values" in row:
+        return {
+            "indices": [int(idx) for idx in row["indices"]],
+            "values": [float(value) for value in row["values"]],
+        }
+    indices: list[int] = []
+    values: list[float] = []
+    for index, value in row.items():
+        indices.append(int(index))
+        values.append(float(value))
+    return {"indices": indices, "values": values}
+
+
+class InProcessBgeM3Provider:
+    """Async-compatible BGE-M3 provider backed by local FlagEmbedding.
+
+    This is an opt-in Stage 4 spike adapter. It preserves the HTTP
+    ``BGEM3Client`` result contracts while leaving the default HTTP runtime
+    unchanged.
+    """
+
+    def __init__(
+        self,
+        *,
+        model_factory: Any | None = None,
+        batch_size: int = 32,
+        max_length: int = 512,
+    ) -> None:
+        self.batch_size = batch_size
+        self.max_length = max_length
+        self._model_factory = model_factory
+
+    def _get_model(self) -> Any:
+        if self._model_factory is not None:
+            return self._model_factory()
+        from src.models.embedding_model import get_bge_m3_model
+
+        return get_bge_m3_model()
+
+    async def _encode(
+        self,
+        texts: list[str],
+        *,
+        return_dense: bool,
+        return_sparse: bool,
+        return_colbert_vecs: bool,
+    ) -> dict[str, Any]:
+        model = self._get_model()
+        return await asyncio.to_thread(
+            model.encode,
+            texts,
+            batch_size=self.batch_size,
+            max_length=self.max_length,
+            return_dense=return_dense,
+            return_sparse=return_sparse,
+            return_colbert_vecs=return_colbert_vecs,
+        )
+
+    @observe(
+        name="bge-m3-local-encode-dense",
+        as_type="embedding",
+        capture_input=False,
+        capture_output=False,
+    )
+    async def encode_dense(self, texts: list[str]) -> DenseResult:
+        if not texts:
+            return DenseResult(vectors=[])
+        data = await self._encode(
+            texts,
+            return_dense=True,
+            return_sparse=False,
+            return_colbert_vecs=False,
+        )
+        return DenseResult(vectors=_as_list(data["dense_vecs"]))
+
+    @observe(
+        name="bge-m3-local-encode-sparse",
+        as_type="embedding",
+        capture_input=False,
+        capture_output=False,
+    )
+    async def encode_sparse(self, texts: list[str]) -> SparseResult:
+        if not texts:
+            return SparseResult(weights=[])
+        data = await self._encode(
+            texts,
+            return_dense=False,
+            return_sparse=True,
+            return_colbert_vecs=False,
+        )
+        weights = [_normalize_sparse_row(row) for row in data["lexical_weights"]]
+        return SparseResult(weights=weights)
+
+    @observe(
+        name="bge-m3-local-encode-hybrid",
+        as_type="embedding",
+        capture_input=False,
+        capture_output=False,
+    )
+    async def encode_hybrid(self, texts: list[str]) -> HybridResult:
+        if not texts:
+            return HybridResult(dense_vecs=[], lexical_weights=[], colbert_vecs=[])
+        data = await self._encode(
+            texts,
+            return_dense=True,
+            return_sparse=True,
+            return_colbert_vecs=True,
+        )
+        return HybridResult(
+            dense_vecs=_as_list(data["dense_vecs"]),
+            lexical_weights=[_normalize_sparse_row(row) for row in data["lexical_weights"]],
+            colbert_vecs=_as_list(data.get("colbert_vecs") or []),
+        )
+
+    @observe(
+        name="bge-m3-local-encode-colbert",
+        as_type="embedding",
+        capture_input=False,
+        capture_output=False,
+    )
+    async def encode_colbert(self, texts: list[str]) -> ColbertResult:
+        if not texts:
+            return ColbertResult(colbert_vecs=[])
+        data = await self._encode(
+            texts,
+            return_dense=False,
+            return_sparse=False,
+            return_colbert_vecs=True,
+        )
+        return ColbertResult(colbert_vecs=_as_list(data["colbert_vecs"]))
+
+    async def aclose(self) -> None:
+        return None
 
 
 class BGEM3Embeddings(Embeddings):
@@ -195,4 +348,5 @@ __all__ = [
     "BGEM3Embeddings",
     "BGEM3HybridEmbeddings",
     "BGEM3SparseEmbeddings",
+    "InProcessBgeM3Provider",
 ]

--- a/tests/unit/integrations/test_embeddings.py
+++ b/tests/unit/integrations/test_embeddings.py
@@ -11,6 +11,7 @@ import httpx
 import pytest
 from langchain_core.embeddings import Embeddings
 
+from src.runtime.integrations.embeddings import InProcessBgeM3Provider
 from telegram_bot.integrations.embeddings import (
     BGEM3Embeddings,
     BGEM3HybridEmbeddings,
@@ -366,3 +367,103 @@ class TestBGEM3HybridTimeout:
         client = await emb._client._get_client()
         assert client.timeout.read == expected_read
         assert client.timeout.connect == expected_connect
+
+
+class TestInProcessBgeM3Provider:
+    class _FakeBgeM3Model:
+        def encode(
+            self,
+            texts,
+            *,
+            batch_size,
+            max_length,
+            return_dense,
+            return_sparse,
+            return_colbert_vecs,
+        ):
+            assert texts == ["query"]
+            assert batch_size == 4
+            assert max_length == 128
+            result = {}
+            if return_dense:
+                result["dense_vecs"] = [[0.1, 0.2, 0.3]]
+            if return_sparse:
+                result["lexical_weights"] = [{"10": 0.5, 20: 0.25}]
+            if return_colbert_vecs:
+                result["colbert_vecs"] = [[[0.01, 0.02], [0.03, 0.04]]]
+            return result
+
+    async def test_local_provider_matches_http_client_contract(self):
+        provider = InProcessBgeM3Provider(
+            model_factory=lambda: self._FakeBgeM3Model(),
+            batch_size=4,
+            max_length=128,
+        )
+
+        dense = await provider.encode_dense(["query"])
+        sparse = await provider.encode_sparse(["query"])
+        hybrid = await provider.encode_hybrid(["query"])
+        colbert = await provider.encode_colbert(["query"])
+
+        assert dense.vectors == [[0.1, 0.2, 0.3]]
+        assert sparse.weights == [{"indices": [10, 20], "values": [0.5, 0.25]}]
+        assert hybrid.dense_vecs == [[0.1, 0.2, 0.3]]
+        assert hybrid.lexical_weights == [{"indices": [10, 20], "values": [0.5, 0.25]}]
+        assert hybrid.colbert_vecs == [[[0.01, 0.02], [0.03, 0.04]]]
+        assert colbert.colbert_vecs == [[[0.01, 0.02], [0.03, 0.04]]]
+
+    async def test_local_provider_handles_empty_batches_without_loading_model(self):
+        called = False
+
+        def _factory():
+            nonlocal called
+            called = True
+            return self._FakeBgeM3Model()
+
+        provider = InProcessBgeM3Provider(model_factory=_factory)
+
+        assert (await provider.encode_dense([])).vectors == []
+        assert (await provider.encode_sparse([])).weights == []
+        assert (await provider.encode_hybrid([])).dense_vecs == []
+        assert (await provider.encode_colbert([])).colbert_vecs == []
+        assert called is False
+
+
+class TestGraphConfigBgeM3ProviderSelection:
+    def test_default_embedding_provider_remains_http(self):
+        from src.runtime.graph.config import GraphConfig
+        from src.services.bge_m3_client import BGEM3Client
+
+        cfg = GraphConfig()
+
+        assert cfg.retrieval_dense_provider == "http_bge_m3"
+        assert cfg.retrieval_sparse_provider == "http_bge_m3"
+        assert isinstance(cfg.create_embeddings()._client, BGEM3Client)
+        assert isinstance(cfg.create_sparse_embeddings()._client, BGEM3Client)
+        assert isinstance(cfg.create_hybrid_embeddings()._client, BGEM3Client)
+
+    def test_env_can_select_local_bge_m3_provider(self, monkeypatch):
+        from src.runtime.graph.config import GraphConfig
+        from src.runtime.integrations.embeddings import InProcessBgeM3Provider
+
+        monkeypatch.setenv("RETRIEVAL_DENSE_PROVIDER", "local_bge_m3")
+        monkeypatch.setenv("RETRIEVAL_SPARSE_PROVIDER", "local_bge_m3")
+
+        cfg = GraphConfig.from_env()
+
+        assert cfg.retrieval_dense_provider == "local_bge_m3"
+        assert cfg.retrieval_sparse_provider == "local_bge_m3"
+        assert isinstance(cfg.create_embeddings()._client, InProcessBgeM3Provider)
+        assert isinstance(cfg.create_sparse_embeddings()._client, InProcessBgeM3Provider)
+        assert isinstance(cfg.create_hybrid_embeddings()._client, InProcessBgeM3Provider)
+
+    def test_hybrid_provider_stays_http_when_only_one_channel_is_local(self, monkeypatch):
+        from src.runtime.graph.config import GraphConfig
+        from src.services.bge_m3_client import BGEM3Client
+
+        monkeypatch.setenv("RETRIEVAL_DENSE_PROVIDER", "local_bge_m3")
+        monkeypatch.setenv("RETRIEVAL_SPARSE_PROVIDER", "http_bge_m3")
+
+        cfg = GraphConfig.from_env()
+
+        assert isinstance(cfg.create_hybrid_embeddings()._client, BGEM3Client)


### PR DESCRIPTION
## Summary
- Add opt-in `InProcessBgeM3Provider` backed by the existing lazy `get_bge_m3_model()` singleton.
- Add `RETRIEVAL_DENSE_PROVIDER=local_bge_m3` / `RETRIEVAL_SPARSE_PROVIDER=local_bge_m3` switches while keeping HTTP BGE-M3 as the default path.
- Add contract tests for dense, sparse, hybrid, ColBERT, empty batches, default-vs-local provider selection, and mixed-provider safety.
- Document the FlagEmbedding/BGE-M3 local-provider SDK pattern and Artem decision gates in the SDK registry.

## Validation
- `UV_PROJECT_ENVIRONMENT=/home/user/projects/rag-fresh/.venv uv run --no-sync pytest tests/unit/integrations/test_embeddings.py -q` — 28 passed
- `UV_PROJECT_ENVIRONMENT=/home/user/projects/rag-fresh/.venv uv run --no-sync pytest tests/unit/pipelines/test_client_pipeline.py -q` — 78 passed
- `UV_PROJECT_ENVIRONMENT=/home/user/projects/rag-fresh/.venv uv run --no-sync pytest tests/unit/utils/test_embedding_model.py -q` — 27 passed
- `UV_PROJECT_ENVIRONMENT=/home/user/projects/rag-fresh/.venv uv run --no-sync ruff check src/runtime/integrations/embeddings.py src/runtime/graph/config.py tests/unit/integrations/test_embeddings.py` — passed
- `make local-up && make e2e-core-live` — 8 passed, 1 warning
- `make e2e-core-live` after review fix — 8 passed, 1 warning

## Notes
- Closes #2374.
- This is a spike, not a default migration.
- Does not remove or demote the HTTP BGE-M3 container.
- Does not change Compose, Qdrant schema, vector dimensions, or default runtime dependencies.
- Local-provider live validation was skipped because `FlagEmbedding` is not installed in the current env (`ModuleNotFoundError`). Unit tests use a fake model to verify provider contracts without requiring `ml-local`.
- Merge requires Artem approval because this introduces runtime provider flags / an opt-in runtime surface.