### PR TITLE
Add core proof guardrails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -757,7 +757,7 @@ LOCAL_INGEST_SERVICES := docling
 LOCAL_ALL_SERVICES := $(LOCAL_SERVICES) $(LOCAL_INGEST_SERVICES)
 
 core-up:  ## Start core proof services only (Qdrant + BGE-M3)
-	$(LOCAL_COMPOSE_CMD) up -d $(CORE_SERVICES)
+	$(LOCAL_COMPOSE_CMD) up -d --wait $(CORE_SERVICES)
 	@echo "$(GREEN)✓ Core proof services started. Run: make e2e-core-live$(NC)"
 
 core-down:  ## Stop and remove core proof services only

--- a/Makefile
+++ b/Makefile
@@ -750,10 +750,19 @@ qa: all-checks test ## Full quality assurance
 # Local Development (compose.yml + compose.dev.yml via COMPOSE_FILE env)
 # =============================================================================
 
-.PHONY: local-up local-up-ingest local-down local-logs local-ps local-build local-redis-recreate run-bot bot
+.PHONY: core-up core-down local-up local-up-ingest local-down local-logs local-ps local-build local-redis-recreate run-bot bot
+CORE_SERVICES := qdrant bge-m3
 LOCAL_SERVICES := postgres redis qdrant bge-m3 litellm
 LOCAL_INGEST_SERVICES := docling
 LOCAL_ALL_SERVICES := $(LOCAL_SERVICES) $(LOCAL_INGEST_SERVICES)
+
+core-up:  ## Start core proof services only (Qdrant + BGE-M3)
+	$(LOCAL_COMPOSE_CMD) up -d $(CORE_SERVICES)
+	@echo "$(GREEN)✓ Core proof services started. Run: make e2e-core-live$(NC)"
+
+core-down:  ## Stop and remove core proof services only
+	$(LOCAL_COMPOSE_CMD) stop $(CORE_SERVICES) || true
+	$(LOCAL_COMPOSE_CMD) rm -f $(CORE_SERVICES) || true
 
 local-up:  ## Start local Docker services (bot runs via make run-bot)
 	$(LOCAL_COMPOSE_CMD) up -d $(LOCAL_SERVICES)

--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ Choose the path that matches your goal:
 | Goal | Start here |
 |---|---|
 | Review safely before running commands | [`docs/review/ACCESS_FOR_REVIEWERS.md`](docs/review/ACCESS_FOR_REVIEWERS.md) |
-| Run core local services | `make local-up` |
-| Prove the simplified core product path | `make local-up` then `make e2e-core-live` |
+| Run core proof services | `make core-up` |
+| Prove the simplified core product path | `make core-up` then `make e2e-core-live` |
 | Try the core path with a real LLM provider | `make e2e-core-live-real-llm` |
 | Run the bot natively for fast iteration | `make test-bot-health` then `make run-bot` |
 | Run the Compose bot stack | `make docker-bot-up` |
@@ -249,7 +249,7 @@ and budget are available.
 ## Honest Scope
 
 - Docker Compose is the primary local runtime path.
-- The main reliability proof is the assistant core path: `make local-up` then `make e2e-core-live`.
+- The main reliability proof is the assistant core path: `make core-up` then `make e2e-core-live`.
 - k3s manifests exist for core services but are not full parity with Compose.
 - Monitoring services are local/dev unless production evidence is added.
 - Langfuse, OTel, trace validation, voice, Mini App, and k8s are not required for the core proof.

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -310,8 +310,9 @@ lf --host "$LANGFUSE_HOST" traces list --name rag-api-query --limit 1
 The simplification core product proof is:
 
 ```bash
-make local-up
+make core-up
 make e2e-core-live
+make core-down
 ```
 
 This runs the live golden set in
@@ -319,6 +320,10 @@ This runs the live golden set in
 against local Qdrant + BGE-M3. It uses deterministic synthetic fixtures and a
 fake LLM by default, so it does not require Telegram, Telethon, Langfuse,
 voice, Mini App, k8s, real CRM credentials, or trace validation.
+
+`make core-up` starts only Qdrant and BGE-M3 for this proof. `make local-up`
+remains the broader native bot development runtime and also starts Postgres,
+Redis, and LiteLLM.
 
 When real provider credentials and budget are available, run the opt-in real
 LLM check:
@@ -383,7 +388,17 @@ run `uv sync --frozen` before restarting.
 
 ## 9. Minimal Stack (Fast Iteration)
 
-Use the `local-*` shortcuts (they now run a minimal subset from `compose.yml:compose.dev.yml`) when full dev stack is unnecessary:
+Use `core-up` for the assistant-core proof when you only need Qdrant and
+BGE-M3:
+
+```bash
+make core-up
+make e2e-core-live
+make core-down
+```
+
+Use the `local-*` shortcuts for native bot iteration when the broader bot-dev
+runtime is needed:
 
 ```bash
 make local-up

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ For the current simplification work, the primary proof is the assistant core
 live E2E path:
 
 ```bash
-make local-up
+make core-up
 make e2e-core-live
 ```
 

--- a/docs/indexes/core-product-path.md
+++ b/docs/indexes/core-product-path.md
@@ -7,13 +7,16 @@ live in [`../designs/product-simplification-stage-0-decisions.md`](../designs/pr
 ## Primary Proof
 
 ```bash
-make local-up
+make core-up
 make e2e-core-live
+make core-down
 ```
 
 `make e2e-core-live` runs the simplification core live golden set against local
 Qdrant + BGE-M3. It uses deterministic synthetic fixtures and a fake LLM by
 default so the product gate is stable and does not depend on provider budget.
+`make core-up` starts only Qdrant and BGE-M3; use `make local-up` for the
+broader native bot development runtime.
 
 ## Optional Real LLM Check
 
@@ -30,7 +33,7 @@ provider credentials and budget are available.
 | Area | Evidence |
 |---|---|
 | Fixture corpus and golden cases | [`../../tests/e2e_core/`](../../tests/e2e_core/) |
-| Live local services | `Qdrant + BGE-M3` via `make local-up` |
+| Live local services | `Qdrant + BGE-M3` via `make core-up` |
 | Assistant classification and retrieval | [`../../tests/e2e/test_core_live_ingest_answer.py`](../../tests/e2e/test_core_live_ingest_answer.py) |
 | CRM/HITL safety | mock CRM in the core live E2E, no real CRM writes |
 | Dependency failure behavior | core live E2E fallback case |

--- a/docs/indexes/runtime-services.md
+++ b/docs/indexes/runtime-services.md
@@ -24,6 +24,8 @@ The canonical source of truth for Compose files, profiles, service names, ports,
 Common commands:
 
 ```bash
+make core-up            # assistant-core proof services only: Qdrant + BGE-M3
+make core-down          # stop/remove assistant-core proof services only
 make docker-up          # default/unprofiled services
 make docker-bot-up      # bot profile
 make docker-ingest-up   # ingestion profile
@@ -32,6 +34,11 @@ make docker-obs-up      # observability profile (Loki, Promtail, Alertmanager)
 make monitoring-up      # observability alias with endpoint hints
 make docker-ps          # list running containers
 ```
+
+For native bot development, use `make local-up` / `make local-down`; that
+broader local runtime starts Postgres, Redis, Qdrant, BGE-M3, and LiteLLM.
+For the simplification core proof, prefer `make core-up` before
+`make e2e-core-live`.
 
 ### Local Service Containers
 

--- a/src/core/assistant.py
+++ b/src/core/assistant.py
@@ -45,6 +45,7 @@ class CoreDependencies:
     reranker: Any | None = None
     llm: Any | None = None
     config: Any | None = None
+    generation_kwargs: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -189,6 +190,7 @@ async def run_assistant_request(
             }
             if dependencies.config is not None:
                 generation_kwargs["config"] = dependencies.config
+            generation_kwargs.update(dependencies.generation_kwargs)
             generation_result = await generate_response(**generation_kwargs)
             usage = _as_usage_dict(generation_result.get("usage_details"))
             llm_model = _extract_llm_model(generation_result)

--- a/src/core/assistant.py
+++ b/src/core/assistant.py
@@ -192,6 +192,7 @@ async def run_assistant_request(
             generation_result = await generate_response(**generation_kwargs)
             usage = _as_usage_dict(generation_result.get("usage_details"))
             llm_model = _extract_llm_model(generation_result)
+            proposed_crm_action = _extract_crm_action(generation_result)
 
             log_event(
                 "llm_completed",
@@ -215,6 +216,7 @@ async def run_assistant_request(
                 latency_ms=_latency_ms(started),
                 error_type=None,
                 request_id=rid,
+                proposed_crm_action=proposed_crm_action,
                 cache_hit=False,
                 llm_model=llm_model,
                 llm_call_count=1,
@@ -321,6 +323,27 @@ def _extract_llm_model(generation_result: dict[str, Any]) -> str | None:
     """Extract the provider model name from generation metadata."""
     model = generation_result.get("llm_provider_model") or generation_result.get("model")
     return str(model) if model else None
+
+
+def _extract_crm_action(generation_result: dict[str, Any]) -> CrmAction | None:
+    """Return a proposed CRM action without executing the write path."""
+    value = generation_result.get("proposed_crm_action")
+    if isinstance(value, CrmAction):
+        return value
+    if not isinstance(value, dict):
+        return None
+
+    action_type = value.get("action_type")
+    payload = value.get("payload")
+    summary = value.get("summary")
+    if not isinstance(action_type, str) or not isinstance(payload, dict):
+        return None
+
+    return CrmAction(
+        action_type=action_type,
+        payload=payload,
+        summary=str(summary or ""),
+    )
 
 
 __all__ = [

--- a/src/runtime/services/qdrant.py
+++ b/src/runtime/services/qdrant.py
@@ -64,7 +64,9 @@ class QdrantService:
             sparse_vector_name: Name of sparse vector field
             quantization_mode: One of 'off', 'scalar', 'binary' - controls collection suffix
             timeout: Connection timeout in seconds (default 30)
-            prefer_grpc: Whether the SDK should prefer gRPC transport
+            prefer_grpc: Whether the SDK should prefer gRPC transport.
+                Defaults to prefer_grpc=True so grpcio remains a transitive
+                qdrant-client runtime dependency.
         """
         # Strip api_key for http:// to avoid "insecure connection" warning (#570)
         scheme = urlparse(url).scheme.lower()

--- a/telegram_bot/services/generate_response.py
+++ b/telegram_bot/services/generate_response.py
@@ -593,6 +593,12 @@ async def generate_response(
     format_context: Callable[..., str] = _format_context,
     select_recent_history: Callable[[list[Any], int], list[Any]] = _select_recent_history,
     build_system_prompt: Callable[[str], str] = _build_system_prompt,
+    build_system_prompt_with_config: Callable[
+        [str], tuple[str, dict[str, Any]]
+    ] = _build_system_prompt_with_config,
+    get_linkable_prompt_object: Callable[
+        [str, str, dict[str, str]], Any | None
+    ] = _get_linkable_prompt_object,
     ensure_history_instruction: Callable[[str], str] = _ensure_history_instruction,
     build_fallback_response: Callable[[list[dict[str, Any]]], str] = _build_fallback_response,
     generate_streaming: Callable[..., Any] = _generate_streaming,
@@ -741,10 +747,10 @@ async def generate_response(
             fallback=_EXHAUSTIVE_GENERATE_FALLBACK,
             variables={"domain": config.domain},
         )
-        prompt_obj = _get_linkable_prompt_object(
+        prompt_obj = get_linkable_prompt_object(
             "generate_exhaustive_list",
-            fallback=_EXHAUSTIVE_GENERATE_FALLBACK,
-            variables={"domain": config.domain},
+            _EXHAUSTIVE_GENERATE_FALLBACK,
+            {"domain": config.domain},
         )
         if "max_tokens" in prompt_config:
             max_tokens = min(int(prompt_config["max_tokens"]), legacy_max_tokens)
@@ -773,9 +779,11 @@ async def generate_response(
         # Prompt Management — there is no linkable Prompt object.
         prompt_obj = None
     else:
-        system_prompt, prompt_config = _build_system_prompt_with_config(config.domain)
-        prompt_obj = _get_linkable_prompt_object(
-            "generate", fallback=_GENERATE_FALLBACK, variables={"domain": config.domain}
+        system_prompt, prompt_config = build_system_prompt_with_config(config.domain)
+        prompt_obj = get_linkable_prompt_object(
+            "generate",
+            _GENERATE_FALLBACK,
+            {"domain": config.domain},
         )
         # Langfuse prompt config overrides: temperature, max_tokens editable in UI
         if "max_tokens" in prompt_config:

--- a/tests/contract/test_core_monolith_boundaries_contract.py
+++ b/tests/contract/test_core_monolith_boundaries_contract.py
@@ -1,0 +1,109 @@
+"""Contract: assistant core boundaries must not grow Telegram/runtime coupling.
+
+The simplification roadmap is moving core orchestration behind explicit
+runtime contracts. Until that migration is complete, ``src/core`` has a small
+known set of compatibility imports. This ratchet prevents new static or dynamic
+imports from creeping into the assistant core while later PRs shrink the
+allowlist.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CORE_ROOT = REPO_ROOT / "src" / "core"
+
+ALLOWED_TELEGRAM_IMPORTS = {
+    "src/core/assistant.py": {
+        "telegram_bot.agents.rag_pipeline",
+        "telegram_bot.pipelines.state_contract",
+        "telegram_bot.services.generate_response",
+    },
+}
+
+FORBIDDEN_RUNTIME_PREFIXES = (
+    "aiogram",
+    "fastapi",
+    "k8s",
+    "mini_app",
+    "src.api",
+    "src.voice",
+    "telegram_bot",
+)
+
+
+def _module_roots(module: str) -> tuple[str, ...]:
+    parts = module.split(".")
+    if not parts:
+        return ()
+    if parts[0] == "src" and len(parts) >= 2:
+        return (parts[0], f"{parts[0]}.{parts[1]}")
+    return (parts[0],)
+
+
+def _is_forbidden(module: str) -> bool:
+    roots = _module_roots(module)
+    return any(
+        module == prefix or module.startswith(f"{prefix}.") or prefix in roots
+        for prefix in FORBIDDEN_RUNTIME_PREFIXES
+    )
+
+
+def _literal_import_module_name(node: ast.Call) -> str | None:
+    if not (
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr == "import_module"
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+        and isinstance(node.args[0].value, str)
+    ):
+        return None
+    return node.args[0].value
+
+
+def _collect_forbidden_imports() -> dict[str, list[str]]:
+    violations: dict[str, set[str]] = {}
+    for path in sorted(CORE_ROOT.rglob("*.py")):
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        allowed = ALLOWED_TELEGRAM_IMPORTS.get(rel, set())
+
+        for node in ast.walk(tree):
+            modules: list[str] = []
+            if isinstance(node, ast.Import):
+                modules.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    modules.append(node.module)
+            elif isinstance(node, ast.Call):
+                dynamic_module = _literal_import_module_name(node)
+                if dynamic_module:
+                    modules.append(dynamic_module)
+
+            for module in modules:
+                if _is_forbidden(module) and module not in allowed:
+                    violations.setdefault(rel, set()).add(module)
+
+    return {path: sorted(modules) for path, modules in violations.items()}
+
+
+def test_src_core_has_no_new_runtime_surface_imports() -> None:
+    violations = _collect_forbidden_imports()
+    assert not violations, (
+        "src/core must not add Telegram, transport, API, voice, Mini App, or k8s "
+        "coupling. Move shared runtime behavior under src.runtime or add a "
+        f"documented shrink-only exception. Violations: {violations}"
+    )
+
+
+def test_core_telegram_allowlist_stays_small_and_explicit() -> None:
+    assert {
+        "src/core/assistant.py": {
+            "telegram_bot.agents.rag_pipeline",
+            "telegram_bot.pipelines.state_contract",
+            "telegram_bot.services.generate_response",
+        },
+    } == ALLOWED_TELEGRAM_IMPORTS

--- a/tests/contract/test_core_proof_compose_contract.py
+++ b/tests/contract/test_core_proof_compose_contract.py
@@ -1,0 +1,93 @@
+"""Contract: core proof runtime starts only Qdrant and BGE-M3."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MAKEFILE = REPO_ROOT / "Makefile"
+
+CORE_PROOF_SERVICES = {"qdrant", "bge-m3"}
+BOT_DEV_SERVICES = {"postgres", "redis", "qdrant", "bge-m3", "litellm"}
+OPTIONAL_SURFACE_SERVICES = {
+    "bot",
+    "docling",
+    "ingestion",
+    "langfuse",
+    "langfuse-worker",
+    "livekit",
+    "mini-app-api",
+    "mini-app-frontend",
+    "postgres",
+    "promtail",
+    "redis",
+    "sip",
+    "voice-agent",
+}
+
+
+def _makefile_text() -> str:
+    return MAKEFILE.read_text(encoding="utf-8")
+
+
+def _target_body(text: str, target: str) -> str:
+    pattern = re.compile(rf"^{re.escape(target)}:.*$", re.MULTILINE)
+    match = pattern.search(text)
+    assert match is not None, f"Makefile must define {target!r}"
+
+    body_lines: list[str] = []
+    for line in text[match.end() :].splitlines():
+        if line and not line.startswith(("\t", " ", "\\")):
+            break
+        body_lines.append(line)
+    return "\n".join(body_lines)
+
+
+def _make_var(text: str, name: str) -> set[str]:
+    pattern = re.compile(rf"^{re.escape(name)}\s*:?=\s*(.*?)$", re.MULTILINE)
+    match = pattern.search(text)
+    assert match is not None, f"Makefile must define {name}"
+    return set(match.group(1).split())
+
+
+def test_core_services_are_qdrant_and_bge_only() -> None:
+    text = _makefile_text()
+    assert _make_var(text, "CORE_SERVICES") == CORE_PROOF_SERVICES
+
+
+def test_core_up_and_down_use_only_core_services() -> None:
+    text = _makefile_text()
+    for target in ("core-up", "core-down"):
+        body = _target_body(text, target)
+        assert "$(CORE_SERVICES)" in body
+        offenders = sorted(service for service in OPTIONAL_SURFACE_SERVICES if service in body)
+        assert not offenders, f"{target} must not mention non-core services: {offenders}"
+
+
+def test_e2e_core_live_does_not_start_optional_surfaces() -> None:
+    body = _target_body(_makefile_text(), "e2e-core-live")
+    forbidden = sorted(
+        token
+        for token in (
+            "local-up",
+            "docker-bot-up",
+            "docker-ml-up",
+            "docker-ingest-up",
+            "langfuse",
+            "telegram",
+            "voice",
+            "mini-app",
+            "redis",
+            "postgres",
+            "litellm",
+        )
+        if token in body.lower()
+    )
+    assert not forbidden, f"e2e-core-live must stay Qdrant+BGE-only: {forbidden}"
+
+
+def test_local_up_remains_broader_bot_dev_runtime_for_now() -> None:
+    text = _makefile_text()
+    assert _make_var(text, "LOCAL_SERVICES") == BOT_DEV_SERVICES

--- a/tests/contract/test_core_proof_compose_contract.py
+++ b/tests/contract/test_core_proof_compose_contract.py
@@ -66,6 +66,11 @@ def test_core_up_and_down_use_only_core_services() -> None:
         assert not offenders, f"{target} must not mention non-core services: {offenders}"
 
 
+def test_core_up_waits_for_core_service_healthchecks() -> None:
+    body = _target_body(_makefile_text(), "core-up")
+    assert "--wait" in body
+
+
 def test_e2e_core_live_does_not_start_optional_surfaces() -> None:
     body = _target_body(_makefile_text(), "e2e-core-live")
     forbidden = sorted(

--- a/tests/data/known_layering_violations.json
+++ b/tests/data/known_layering_violations.json
@@ -1,1 +1,7 @@
-{}
+{
+  "src/core/assistant.py": [
+    "telegram_bot.agents.rag_pipeline",
+    "telegram_bot.pipelines.state_contract",
+    "telegram_bot.services.generate_response"
+  ]
+}

--- a/tests/e2e_core/live_harness.py
+++ b/tests/e2e_core/live_harness.py
@@ -435,6 +435,10 @@ def build_live_core_harness(
         qdrant=qdrant,
         reranker=None,
         config=llm_config,
+        generation_kwargs={
+            "build_system_prompt_with_config": _build_local_system_prompt_with_config,
+            "get_linkable_prompt_object": _no_linkable_prompt_object,
+        },
     )
     if crm is not None:
         dependencies.crm = crm
@@ -491,6 +495,22 @@ def _extract_title(path: Path) -> str:
         if line.startswith("#"):
             return line.lstrip("#").strip()
     return path.stem
+
+
+def _build_local_system_prompt_with_config(domain: str) -> tuple[str, dict[str, Any]]:
+    """Return a local prompt for core-live proof without Langfuse prompt fetches."""
+
+    return (
+        f"Ты — консультант по {domain}. Отвечай только на основе переданного "
+        "контекста. Если релевантной информации нет, скажи: не найдено."
+    ), {}
+
+
+def _no_linkable_prompt_object(name: str, fallback: str, variables: dict[str, str]) -> None:
+    """Disable Langfuse Prompt object linking for optional-surface-free core proof."""
+
+    _ = name, fallback, variables
+    return
 
 
 class _FakeLLM:

--- a/tests/unit/core/test_assistant_entrypoint.py
+++ b/tests/unit/core/test_assistant_entrypoint.py
@@ -118,7 +118,7 @@ class TestCoreDependencies:
 class TestAssistantResult:
     """Tests for the AssistantResult dataclass."""
 
-    def test_defaults(self) -> None:
+    def test_assistant_result_defaults(self) -> None:
         """AssistantResult should have sensible defaults for optional fields."""
         from src.core.assistant import AssistantResult
 

--- a/tests/unit/core/test_assistant_entrypoint.py
+++ b/tests/unit/core/test_assistant_entrypoint.py
@@ -529,6 +529,40 @@ class TestRunAssistantRequestRuntime:
         assert result.llm_model == "gpt-4o-mini"
         assert result.llm_call_count == 1
 
+    async def test_passes_generation_kwargs_to_response_service(self) -> None:
+        """Runtime callers can override generation hooks without touching global state."""
+        from src.core.assistant import UserContext, run_assistant_request
+
+        def local_prompt_builder(domain: str) -> tuple[str, dict[str, object]]:
+            return f"local prompt for {domain}", {}
+
+        rag = AsyncMock(
+            return_value={
+                "documents": [],
+                "cache_hit": False,
+                "query_type": "GENERAL",
+            }
+        )
+        gen = AsyncMock(return_value={"response": "answer", "model": "fake"})
+        deps = self._deps()
+        deps.generation_kwargs = {"build_system_prompt_with_config": local_prompt_builder}
+
+        with (
+            patch("src.runtime.graph.nodes.classify.classify_query", return_value="GENERAL"),
+            patch("telegram_bot.agents.rag_pipeline.rag_pipeline", rag),
+            patch("telegram_bot.services.generate_response.generate_response", gen),
+        ):
+            result = await run_assistant_request(
+                "q",
+                collection="core",
+                user_context=UserContext(user_id="42", session_id="s-1"),
+                request_id="generation-hooks",
+                dependencies=deps,
+            )
+
+        assert result.response_text == "answer"
+        assert gen.await_args.kwargs["build_system_prompt_with_config"] is local_prompt_builder
+
     async def test_cache_hit_skips_generation(self) -> None:
         """Semantic cache hits should return cached text without calling LLM generation."""
         from src.core.assistant import run_assistant_request

--- a/tests/unit/core/test_assistant_provider_contract.py
+++ b/tests/unit/core/test_assistant_provider_contract.py
@@ -1,0 +1,114 @@
+"""Provider and HITL safety contract for the assistant core entrypoint."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+
+def _deps():
+    from src.core.assistant import CoreDependencies
+
+    return CoreDependencies(
+        cache=object(),
+        embeddings=object(),
+        sparse_embeddings=object(),
+        qdrant=object(),
+        reranker=None,
+        llm=object(),
+        config=None,
+    )
+
+
+async def test_fake_provider_path_returns_stable_assistant_result() -> None:
+    from src.core.assistant import AssistantResult, run_assistant_request
+
+    result = await run_assistant_request("hello", collection="core")
+
+    assert isinstance(result, AssistantResult)
+    assert result.route == "error"
+    assert result.error_type == "service_unavailable"
+    assert result.proposed_crm_action is None
+    assert result.llm_call_count == 0
+
+
+async def test_direct_provider_model_metadata_is_preserved() -> None:
+    from src.core.assistant import run_assistant_request
+
+    rag = AsyncMock(return_value={"documents": [], "cache_hit": False, "query_type": "GENERAL"})
+    gen = AsyncMock(return_value={"response": "answer", "model": "direct/test-model"})
+
+    with (
+        patch("src.runtime.graph.nodes.classify.classify_query", return_value="GENERAL"),
+        patch("telegram_bot.agents.rag_pipeline.rag_pipeline", rag),
+        patch("telegram_bot.services.generate_response.generate_response", gen),
+    ):
+        result = await run_assistant_request(
+            "q",
+            collection="core",
+            request_id="direct-provider",
+            dependencies=_deps(),
+        )
+
+    assert result.response_text == "answer"
+    assert result.llm_model == "direct/test-model"
+    assert result.llm_call_count == 1
+
+
+async def test_litellm_compatible_provider_model_metadata_is_preserved() -> None:
+    from src.core.assistant import run_assistant_request
+
+    rag = AsyncMock(return_value={"documents": [], "cache_hit": False, "query_type": "GENERAL"})
+    gen = AsyncMock(return_value={"response": "answer", "llm_provider_model": "openai/gpt-4o-mini"})
+
+    with (
+        patch("src.runtime.graph.nodes.classify.classify_query", return_value="GENERAL"),
+        patch("telegram_bot.agents.rag_pipeline.rag_pipeline", rag),
+        patch("telegram_bot.services.generate_response.generate_response", gen),
+    ):
+        result = await run_assistant_request(
+            "q",
+            collection="core",
+            request_id="litellm-provider",
+            dependencies=_deps(),
+        )
+
+    assert result.response_text == "answer"
+    assert result.llm_model == "openai/gpt-4o-mini"
+    assert result.llm_call_count == 1
+
+
+async def test_crm_intent_is_returned_as_proposal_without_write_before_hitl() -> None:
+    from src.core.assistant import CrmAction, run_assistant_request
+
+    rag = AsyncMock(return_value={"documents": [], "cache_hit": False, "query_type": "GENERAL"})
+    gen = AsyncMock(
+        return_value={
+            "response": "I can prepare a lead.",
+            "model": "fake",
+            "proposed_crm_action": {
+                "action_type": "create_lead",
+                "payload": {"name": "Alice", "phone": "+10000000000"},
+                "summary": "Create lead for Alice",
+            },
+        }
+    )
+    forbidden_write = AsyncMock()
+
+    with (
+        patch("src.runtime.graph.nodes.classify.classify_query", return_value="GENERAL"),
+        patch("telegram_bot.agents.rag_pipeline.rag_pipeline", rag),
+        patch("telegram_bot.services.generate_response.generate_response", gen),
+        patch("src.core.assistant._execute_crm_write", forbidden_write, create=True),
+    ):
+        result = await run_assistant_request(
+            "Create a lead for Alice",
+            collection="core",
+            request_id="hitl-proposal",
+            dependencies=_deps(),
+        )
+
+    assert isinstance(result.proposed_crm_action, CrmAction)
+    assert result.proposed_crm_action.action_type == "create_lead"
+    assert result.proposed_crm_action.payload == {"name": "Alice", "phone": "+10000000000"}
+    assert result.proposed_crm_action.summary == "Create lead for Alice"
+    forbidden_write.assert_not_awaited()

--- a/tests/unit/e2e_core/test_live_harness.py
+++ b/tests/unit/e2e_core/test_live_harness.py
@@ -163,6 +163,27 @@ def test_build_live_core_harness_accepts_config_override() -> None:
     assert harness.dependencies.config is config
 
 
+def test_build_live_core_harness_uses_local_prompt_hooks_for_fake_core_proof() -> None:
+    """Fake core proof must not fetch Langfuse Prompt Management prompts."""
+    from tests.e2e_core.live_harness import LiveE2EEnv, build_live_core_harness
+
+    env = LiveE2EEnv(qdrant_url="http://qdrant:6333", bge_m3_url="http://bge:8000")
+
+    with (
+        mock.patch("tests.e2e_core.live_harness.LiveBGEEmbeddings"),
+        mock.patch("tests.e2e_core.live_harness.LiveBGESparseEmbeddings"),
+        mock.patch("tests.e2e_core.live_harness.QdrantService"),
+    ):
+        harness = build_live_core_harness(env, "collection")
+
+    hooks = harness.dependencies.generation_kwargs
+    system_prompt, prompt_config = hooks["build_system_prompt_with_config"]("domain")
+
+    assert "domain" in system_prompt
+    assert prompt_config == {}
+    assert hooks["get_linkable_prompt_object"]("generate", "fallback", {"domain": "domain"}) is None
+
+
 def test_failing_llm_config_raises_provider_error() -> None:
     from tests.e2e_core.live_harness import FailingLLMConfig
 


### PR DESCRIPTION
## Summary
- Add shrink-only contract tests for `src/core` boundary imports, core proof Compose services, and assistant provider/HITL behavior.
- Add `make core-up` / `make core-down` for the Qdrant+BGE-only proof path while keeping `local-up` as the broader native bot runtime.
- Preserve CRM write safety by mapping generated CRM intent into `AssistantResult.proposed_crm_action` without executing writes.
- Update local development/runtime docs to distinguish `core-up` from `local-up`.

Plan:
- Keep the core proof runtime limited to Qdrant + BGE-M3.
- Add shrink-only contracts for core boundaries and proof services.
- Preserve CRM/HITL safety by returning proposed actions without writes.
- Keep optional Langfuse/prompt surfaces out of the required fake core proof.

## Test Plan
- [x] `uv run pytest tests/contract/test_core_monolith_boundaries_contract.py -v`
- [x] `uv run pytest tests/contract/test_core_proof_compose_contract.py -v`
- [x] `uv run pytest tests/unit/core/test_assistant_provider_contract.py -v`
- [x] `uv run pytest tests/contract/test_core_monolith_boundaries_contract.py tests/contract/test_core_proof_compose_contract.py tests/unit/core/test_assistant_provider_contract.py -v`
- [x] `uv run pytest tests/contract/test_layering_no_telegram_bot_imports_contract.py tests/contract/test_no_new_duplicate_test_names.py tests/contract/test_grpcio_dependency_audit_contract.py -v`
- [x] `make test-contract`
- [x] `uv run pytest tests/unit/core/test_assistant_entrypoint.py tests/unit/core/test_assistant_provider_contract.py -v`
- [x] `python3 scripts/check_markdown_links.py docs/LOCAL-DEVELOPMENT.md docs/indexes/core-product-path.md docs/indexes/runtime-services.md docs/designs/README.md`
- [x] `git diff --check`
- [x] `make -n core-up core-down local-up local-down`
- [x] `make core-up`
- [x] `make e2e-core-live`
- [x] `make core-down`
- [x] `make local-up`
- [x] `make local-down`

