### PR TITLE
core: land monolith-core seams (rebased #2381) — CORE-001..008

### DIFF
--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -24,12 +24,18 @@
   функции `run_assistant_request()`, тип результата `AssistantResult`, политику
   CRM/HITL, корреляцию логов и повторное использование существующих модулей.
 
+- [`monolith-core-audit-implementation-plan.md`](monolith-core-audit-implementation-plan.md) —
+  аудит текущей архитектуры и подробный инкрементальный план реализации
+  монолитного ядра: runtime coupling, перенос grounding/generation/RAG,
+  подключение Telegram как тонкого адаптера и E2E/contract gates.
+
 ## Навигация
 
 - Основной план: [`product-simplification-e2e-plan.md`](product-simplification-e2e-plan.md)
 - Рабочий процесс: [`yaroslav-simplification-workflow.md`](yaroslav-simplification-workflow.md)
 - Решения Этапа 0: [`product-simplification-stage-0-decisions.md`](product-simplification-stage-0-decisions.md)
 - Контракт точки входа: [`unified-assistant-entrypoint-contract.md`](unified-assistant-entrypoint-contract.md)
+- Аудит и план монолитного ядра: [`monolith-core-audit-implementation-plan.md`](monolith-core-audit-implementation-plan.md)
 
 ## Статус
 

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -34,6 +34,14 @@
   выполнения без лишних зависимостей, week-1 focus и шаблоны `CORE-001` …
   `CORE-010`.
 
+- [`monolith-core-optional-surfaces-status.md`](monolith-core-optional-surfaces-status.md) —
+  статус optional surfaces после стабилизации ядра: Telegram как adapter,
+  API/voice/Mini App/Langfuse/OTel/k8s/monitoring как необязательные поверхности.
+
+- [`monolith-core-shim-cleanup-checklist.md`](monolith-core-shim-cleanup-checklist.md) —
+  checklist для `CORE-010`: какие transitional shims/couplings остаются и когда
+  их можно удалять.
+
 ## Навигация
 
 - Основной план: [`product-simplification-e2e-plan.md`](product-simplification-e2e-plan.md)
@@ -42,6 +50,8 @@
 - Контракт точки входа: [`unified-assistant-entrypoint-contract.md`](unified-assistant-entrypoint-contract.md)
 - Аудит и план монолитного ядра: [`monolith-core-audit-implementation-plan.md`](monolith-core-audit-implementation-plan.md)
 - Backlog issues для стабилизации ядра: [`monolith-core-issue-backlog.md`](monolith-core-issue-backlog.md)
+- Optional surfaces status: [`monolith-core-optional-surfaces-status.md`](monolith-core-optional-surfaces-status.md)
+- Shim cleanup checklist: [`monolith-core-shim-cleanup-checklist.md`](monolith-core-shim-cleanup-checklist.md)
 
 ## Статус
 

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -29,6 +29,11 @@
   монолитного ядра: runtime coupling, перенос grounding/generation/RAG,
   подключение Telegram как тонкого адаптера и E2E/contract gates.
 
+- [`monolith-core-issue-backlog.md`](monolith-core-issue-backlog.md) —
+  исполняемый backlog issues для стабилизации ядра: milestone, правила
+  выполнения без лишних зависимостей, week-1 focus и шаблоны `CORE-001` …
+  `CORE-010`.
+
 ## Навигация
 
 - Основной план: [`product-simplification-e2e-plan.md`](product-simplification-e2e-plan.md)
@@ -36,6 +41,7 @@
 - Решения Этапа 0: [`product-simplification-stage-0-decisions.md`](product-simplification-stage-0-decisions.md)
 - Контракт точки входа: [`unified-assistant-entrypoint-contract.md`](unified-assistant-entrypoint-contract.md)
 - Аудит и план монолитного ядра: [`monolith-core-audit-implementation-plan.md`](monolith-core-audit-implementation-plan.md)
+- Backlog issues для стабилизации ядра: [`monolith-core-issue-backlog.md`](monolith-core-issue-backlog.md)
 
 ## Статус
 

--- a/docs/designs/monolith-core-audit-implementation-plan.md
+++ b/docs/designs/monolith-core-audit-implementation-plan.md
@@ -1,0 +1,844 @@
+# Аудит Архитектуры И План Реализации Монолитного Ядра
+
+Статус: предлагается к исполнению
+Дата: 2026-06-08
+Связанные документы:
+
+- [`product-simplification-e2e-plan.md`](product-simplification-e2e-plan.md)
+- [`product-simplification-stage-0-decisions.md`](product-simplification-stage-0-decisions.md)
+- [`unified-assistant-entrypoint-contract.md`](unified-assistant-entrypoint-contract.md)
+- [`yaroslav-simplification-workflow.md`](yaroslav-simplification-workflow.md)
+
+## 1. Цель Документа
+
+Этот документ фиксирует аудит текущего состояния проекта и даёт подробный план
+реализации будущего монолитного ядра ассистента.
+
+Цель реализации — не переписать продукт заново, а развернуть ownership:
+
+```text
+сейчас:   telegram_bot владеет значимой частью RAG/runtime-логики
+цель:     src.core + src.runtime владеют продуктовым ядром,
+          telegram_bot остаётся production-адаптером
+```
+
+Главный результат:
+
+```text
+Telegram / E2E / будущий API
+  -> src.core.run_assistant_request()
+  -> src.runtime: classify -> retrieve -> generate -> grounding -> CRM proposal
+  -> AssistantResult
+```
+
+## 2. Executive Summary
+
+Проект уже движется в правильную сторону:
+
+- Stage 0 принял направление на монолитное ядро в одном Python-процессе.
+- `src/core/assistant.py` уже содержит публичную функцию
+  `run_assistant_request()` и контракт `AssistantResult`.
+- `src/runtime/` уже существует как место для shared runtime kernel.
+- `tests/e2e_core/` уже содержит основу будущего live E2E: fixtures,
+  golden cases, Qdrant helpers и harness.
+- Статический layering ratchet уже доведён до пустого allowlist:
+  `tests/data/known_layering_violations.json` содержит `{}`.
+
+Главная оставшаяся проблема не в статических imports, а в runtime ownership:
+
+- `src.core.assistant` при live dependencies динамически импортирует
+  `telegram_bot.agents.rag_pipeline` и
+  `telegram_bot.services.generate_response`.
+- `src.runtime.graph.builder` по умолчанию всё ещё указывает на
+  `telegram_bot.graph.graph:build_graph`.
+- Grounding, generation, cache policy, response policy и часть pre-agent
+  подготовки всё ещё принадлежат `telegram_bot`.
+- `generate_response()` всё ещё смешивает core generation, Langfuse hooks,
+  metrics и Telegram streaming/formatting concerns.
+- `telegram_bot/bot.py` остаётся крупным orchestration модулем, где рядом живут
+  Telegram transport, pre-agent logic, cache lookup, grounding mode и результат
+  RAG.
+
+План реализации должен быть инкрементальным: сначала защита поведения через
+unit/contract/E2E, затем перенос runtime seams, затем подключение Telegram как
+тонкого adapter, затем расширение golden E2E.
+
+## 3. Фактическая Карта Кода
+
+### 3.1. Размеры Основных Зон
+
+Аудит строк Python-кода без учёта vendored virtualenv показал:
+
+| Зона | Путь | Файлов | Строк | Будущая роль |
+|---|---:|---:|---:|---|
+| Bot services | `telegram_bot/services` | 66 | ~9.2k | Частично перенести в `src.runtime/*`, частично оставить adapter helpers |
+| Bot agents | `telegram_bot/agents` | 17 | ~4.4k | RAG/tool logic переносить в runtime/domain |
+| Bot graph | `telegram_bot/graph` | 25 | ~3.0k | Canonical graph должен быть в `src.runtime.graph` |
+| Bot pipelines | `telegram_bot/pipelines` | 3 | ~0.7k | Client pipeline split: core runtime + Telegram adapter |
+| Telegram dialogs | `telegram_bot/dialogs` | 23 | ~7.1k | Оставить в Telegram UI layer |
+| Telegram handlers | `telegram_bot/handlers` | 6 | ~1.4k | Оставить в Telegram UI layer |
+| Telegram keyboards | `telegram_bot/keyboards` | 7 | ~0.6k | Оставить в Telegram UI layer |
+| Telegram middlewares | `telegram_bot/middlewares` | 6 | ~0.6k | Оставить transport/security layer |
+| Core | `src/core` | 3 | ~0.7k | Публичный contract и entrypoint |
+| Runtime | `src/runtime` | 18 | ~4.1k | Целевой дом для shared runtime kernel |
+| Retrieval | `src/retrieval` | 5 | ~1.3k | Оставить core-facing retrieval helpers |
+| Ingestion | `src/ingestion` | 27 | ~6.7k | Batch/offline ingestion path |
+| API | `src/api` | 3 | ~0.5k | Optional adapter |
+| Voice | `src/voice` | 8 | ~1.0k | Optional adapter |
+
+Вывод: будущий монолит — это не перенос всего `telegram_bot`. Основной объём
+UI (`dialogs`, `handlers`, `keyboards`, `middlewares`) должен остаться в
+Telegram layer. Переносу подлежит только продуктовая и runtime-логика, которая
+сейчас исторически живёт рядом с Telegram.
+
+### 3.2. Текущие Product Entrypoints
+
+| Entrypoint | Текущий модуль | Роль сейчас | Целевая роль |
+|---|---|---|---|
+| `run_assistant_request()` | `src/core/assistant.py` | Public skeleton/live seam, но live path динамически идёт в `telegram_bot` | Единственная core entrypoint для E2E/adapters |
+| `PropertyBot._handle_query_supervisor()` | `telegram_bot/bot.py` | Главный Telegram text handler + orchestration | Adapter: собрать request context, вызвать core, отрендерить result |
+| `run_client_pipeline()` | `telegram_bot/pipelines/client.py` | Deterministic path: classify/intent/RAG/generate/send/post-process | Split: runtime pipeline + Telegram send wrapper |
+| `rag_pipeline()` | `telegram_bot/agents/rag_pipeline.py` | Retrieval/cache/grade/rerank/rewrite loop | `src.runtime.pipeline.rag_pipeline` или `src.runtime.retrieval` |
+| `generate_response()` | `telegram_bot/services/generate_response.py` | LLM generation + grounding fallback + telemetry + Telegram streaming hooks | Core generation service + adapter streaming wrapper |
+| `build_graph()` | `telegram_bot/graph/graph.py` | LangGraph factory | Canonical graph factory under `src.runtime.graph` |
+| `POST /query` | `src/api/main.py` | Optional HTTP RAG API | Optional adapter over core if retained |
+| Voice RAG client | `src/voice/*` | Optional voice surface | Optional adapter over core/API if retained |
+
+## 4. Главные Архитектурные Находки
+
+### 4.1. Static Layering Почти Исправлен, Но Runtime Coupling Остался
+
+Статический contract проверяет `ast.Import` и `ast.ImportFrom` под `src/` и
+`mini_app/`. Текущий allowlist пустой. Это хорошо, но не означает, что core уже
+самостоятельный.
+
+Оставшиеся coupling points:
+
+| Coupling | Где | Почему важно | Целевое состояние |
+|---|---|---|---|
+| Dynamic import RAG | `src/core/assistant.py` -> `telegram_bot.agents.rag_pipeline` | Core live path зависит от bot package | `src.runtime.pipeline` |
+| Dynamic import generation | `src/core/assistant.py` -> `telegram_bot.services.generate_response` | Ответ генерирует bot-owned module | `src.runtime.generation` |
+| Graph default factory | `src/runtime/graph/builder.py` -> `telegram_bot.graph.graph:build_graph` | Runtime default указывает наружу в adapter | Default на `src.runtime.graph.graph:build_graph` |
+| Generation transport leakage | `generate_response(message=...)` | Telegram streaming concern в generation service | Split core generation / Telegram streaming renderer |
+| Grounding ownership | `telegram_bot.services.grounding_policy` + callers | Safety policy принадлежит bot layer | `src.runtime.grounding` |
+| Cache policy ownership | `telegram_bot.services.cache_policy` | Response cache policy влияет на core result | `src.runtime.cache_policy` или runtime service |
+| Langfuse hooks inside path | decorators/client calls in bot pipeline/generation | Optional diagnostics смешаны с product path | `log_event` first, optional instrumentation wrapper |
+
+### 4.2. `src.core.assistant` Уже Правильный Public Contract, Но Нужен Split
+
+Текущие dataclass-контракты полезны:
+
+- `UserContext`
+- `CoreDependencies`
+- `CrmAction`
+- `AssistantResult`
+- `AssistantError`
+
+Но они живут в одном файле с orchestration. Для роста лучше разделить:
+
+```text
+src/core/contracts.py     dataclass/protocol contracts
+src/core/assistant.py     public entrypoint and orchestration shell
+```
+
+При этом первый implementation PR не обязан менять внешний импорт:
+`src.core.__init__` может реэкспортировать старые имена.
+
+### 4.3. Grounding — Обязательная Политика Ядра, Не Bot Helper
+
+Grounding сейчас состоит из нескольких частей:
+
+- detection of strict topics / strict query types;
+- `grounding_mode` в state contract;
+- safe fallback decision;
+- semantic cache reuse policy;
+- generation output flags (`grounded`, `legal_answer_safe`,
+  `safe_fallback_used`, `semantic_cache_safe_reuse`);
+- observability/cache metadata.
+
+Целевой модуль:
+
+```text
+src/runtime/grounding/policy.py
+src/runtime/grounding/contracts.py  (если понадобится)
+```
+
+Telegram может иметь shim:
+
+```text
+telegram_bot/services/grounding_policy.py
+  # Deprecated: re-export shim, drop after migration cleanup.
+  from src.runtime.grounding.policy import *
+```
+
+### 4.4. Generation Нужно Разделить На Core И Adapter Rendering
+
+`generate_response()` сейчас делает слишком много:
+
+- строит prompt/context;
+- вызывает LLM streaming path;
+- принимает `message` для Telegram streaming;
+- форматирует/санитизирует ответ;
+- пишет metrics и Langfuse metadata;
+- применяет strict grounding fallback.
+
+Целевой split:
+
+```text
+src/runtime/generation/service.py
+  generate_answer(request, deps) -> GenerationResult
+
+src/runtime/generation/context.py
+  format retrieved docs for LLM context
+
+src/runtime/generation/policy.py
+  response style, coverage mode, fallback/default result helpers
+
+telegram_bot/services/generate_response.py
+  temporary shim or Telegram streaming wrapper
+```
+
+Правило: core generation не должен принимать Telegram `message` и не должен
+сам отправлять сообщения. Он возвращает данные, которые adapter затем рендерит.
+
+### 4.5. Ingestion Уже Достаточно Отделён
+
+`src/ingestion` уже находится вне Telegram и должен оставаться offline/batch
+частью. В online assistant path ingestion не должен становиться обязательной
+runtime стадией. Для E2E он нужен как подготовка коллекции:
+
+```text
+test docs -> ingest/index -> Qdrant collection -> assistant request
+```
+
+### 4.6. Observability Должна Быть Product Logs First
+
+Принятая модель Stage 0: structured JSON logs через `log_event(...)` — основной
+механизм отладки. Langfuse/OTel могут оставаться, но не должны быть обязательным
+runtime, CI или release gate.
+
+Обязательные product events для core path:
+
+- `assistant_request_started`
+- `search_completed`
+- `llm_completed`
+- `grounding_completed`
+- `crm_action_proposed`
+- `assistant_request_completed`
+- `dependency_failed`
+
+## 5. Целевая Архитектура
+
+### 5.1. Целевое Дерево
+
+```text
+src/
+  core/
+    __init__.py
+    assistant.py              # run_assistant_request()
+    contracts.py              # AssistantRequest/Result, UserContext, CrmAction
+    dependencies.py           # optional Protocols / dependency bundle
+
+  runtime/
+    pipeline/
+      assistant_pipeline.py   # classify -> retrieve -> generate -> grounding -> crm proposal
+      contracts.py
+    retrieval/
+      service.py              # wrapper over existing retrieval/qdrant/rerank/cache path
+      contracts.py
+    generation/
+      service.py              # pure core generation, no Telegram message send
+      context.py
+      contracts.py
+    grounding/
+      policy.py
+    crm/
+      actions.py              # propose only; no live writes without HITL
+    graph/
+      ...                     # canonical LangGraph modules if retained
+    cache/
+      policy.py               # semantic response cache policy if moved
+
+  retrieval/                  # existing lower-level retrieval helpers
+  ingestion/                  # existing batch/offline ingestion
+  services/                   # external/client helpers already outside bot
+  utils/product_events.py     # structured product logs
+
+telegram_bot/
+  bot.py / handlers / dialogs / keyboards / middlewares
+  services/*                  # adapter-only helpers + temporary shims
+  pipelines/*                 # temporary wrappers during migration
+```
+
+### 5.2. Dependency Direction
+
+Allowed:
+
+```text
+telegram_bot -> src.core -> src.runtime -> src.retrieval/src.services/external clients
+src/api      -> src.core
+src/voice    -> src.core or optional API adapter
+```
+
+Forbidden for final state:
+
+```text
+src.core     -> telegram_bot
+src.runtime  -> telegram_bot
+src.retrieval -> telegram_bot
+```
+
+Temporary exception: compatibility shims under `telegram_bot/*` may re-export
+from `src.runtime/*` until adapter imports are fully migrated.
+
+### 5.3. Product Request Flow
+
+```text
+1. Adapter receives user input
+   - Telegram Update
+   - E2E direct call
+   - optional API request
+
+2. Adapter constructs AssistantRequest/UserContext
+   - query
+   - collection
+   - request_id
+   - user/session context
+   - filters/role/language
+
+3. src.core.run_assistant_request()
+   - emits assistant_request_started
+   - delegates to runtime assistant pipeline
+
+4. Runtime pipeline
+   - classify query
+   - detect topic/filter/grounding hints
+   - retrieve from Qdrant via existing hybrid path
+   - rerank/grade/cache according to policy
+   - generate answer via LLM provider
+   - apply grounding/no-data/safe-fallback policy
+   - propose CRM action only as data
+
+5. Core returns AssistantResult
+   - response_text
+   - route/request_type
+   - retrieved_doc_ids/sources/count
+   - grounding fields
+   - cache/generation metadata
+   - proposed_crm_action, if any
+   - request_id/latency/error fields
+
+6. Adapter renders result
+   - Telegram sends text/buttons/sources
+   - HITL buttons confirm or reject CRM writes
+   - E2E asserts product facts and logs
+```
+
+## 6. Реализационный План
+
+План рассчитан на маленькие PR с сохранением поведения. Каждый этап должен
+оставлять runnable state и focused tests.
+
+### Phase A — Зафиксировать Аудит И Текущую Карту
+
+**Цель:** чтобы команда договорилась о реальном состоянии и порядке миграции.
+
+**Deliverables:**
+
+- этот документ;
+- обновлённый index в `docs/designs/README.md`;
+- no runtime behavior changes.
+
+**Checks:**
+
+```bash
+uv run pytest tests/contract/test_layering_no_telegram_bot_imports_contract.py -q
+```
+
+**Exit criteria:**
+
+- план виден из design docs index;
+- в документе явно различены static import violations и runtime coupling.
+
+### Phase B — Укрепить Public Core Contract
+
+**Цель:** сделать `src.core` стабильной поверхностью до переноса логики.
+
+**Tasks:**
+
+1. Создать `src/core/contracts.py`.
+2. Перенести туда `UserContext`, `CoreDependencies`, `CrmAction`,
+   `AssistantResult`, `AssistantError` или оставить `AssistantError` в
+   `assistant.py`, если так проще.
+3. Добавить `AssistantRequest` как явный request object:
+
+   ```python
+   @dataclass
+   class AssistantRequest:
+       query: str
+       collection: str
+       user_context: UserContext = field(default_factory=UserContext)
+       request_id: str = ""
+   ```
+
+4. Сохранить backward compatibility текущей функции:
+
+   ```python
+   async def run_assistant_request(query: str, *, collection: str, ...)
+   ```
+
+5. Обновить `src/core/__init__.py` re-exports.
+6. Расширить `tests/unit/core/test_assistant_entrypoint.py`:
+   - import-only без Telegram;
+   - skeleton mode без dependencies;
+   - request_id propagation;
+   - error result shape.
+
+**Risks:** низкие. Это contract-only split.
+
+**Exit criteria:**
+
+- public imports не ломаются;
+- no new `telegram_bot` imports under `src`;
+- unit core tests pass.
+
+### Phase C — Перенести Grounding Policy В Runtime
+
+**Цель:** safety policy принадлежит ядру, а не Telegram.
+
+**Tasks:**
+
+1. Создать `src/runtime/grounding/policy.py`.
+2. Перенести функции:
+   - `is_high_risk_grounding_request`
+   - `get_grounding_mode`
+   - `is_strict_grounding_safe`
+   - `semantic_cache_safe_reuse_allowed`
+   - `should_safe_fallback`
+   - `build_safe_fallback_response`
+3. Оставить shim в `telegram_bot/services/grounding_policy.py`.
+4. Переключить internal callers, где безопасно:
+   - `telegram_bot/pipelines/client.py`
+   - `telegram_bot/bot.py`
+   - `telegram_bot/services/generate_response.py`
+5. Добавить/обновить unit tests на новый canonical module.
+
+**Write scope:**
+
+```text
+src/runtime/grounding/*
+telegram_bot/services/grounding_policy.py
+telegram_bot/pipelines/client.py
+telegram_bot/bot.py
+telegram_bot/services/generate_response.py
+tests/unit/... grounding tests
+```
+
+**Risks:** средние. Grounding влияет на cache reuse и safe fallback.
+
+**Mitigation:** сначала перенос без изменения логики, byte-for-byte где возможно,
+затем tests.
+
+**Exit criteria:**
+
+- старые imports продолжают работать через shim;
+- strict/no-data fallback behaviour не меняется;
+- focused grounding/generation/client-pipeline tests pass.
+
+### Phase D — Выделить Runtime Generation Core
+
+**Цель:** отделить генерацию ответа от Telegram отправки сообщений.
+
+**Tasks:**
+
+1. Создать `src/runtime/generation/contracts.py`:
+
+   ```text
+   GenerationRequest
+   GenerationResult
+   GenerationDependencies
+   ```
+
+2. Создать `src/runtime/generation/service.py` с core-facing функцией:
+
+   ```python
+   async def generate_answer(request: GenerationRequest, deps: GenerationDependencies) -> GenerationResult:
+       ...
+   ```
+
+3. Перенести pure helpers:
+   - context formatting;
+   - source/citation sanitization if not Telegram-specific;
+   - fallback result shaping;
+   - grounding fallback integration.
+4. Оставить Telegram streaming и send-specific code в `telegram_bot`.
+5. Сделать `telegram_bot/services/generate_response.py` thin wrapper:
+   - вызывает `src.runtime.generation.generate_answer`;
+   - если `message` передан, выполняет adapter streaming/rendering;
+   - сохраняет старую signature на время миграции.
+6. Обновить tests:
+   - core generation без Telegram message;
+   - wrapper compatibility;
+   - safe fallback;
+   - no documents / missing corpus.
+
+**Risks:** высокие. Здесь смешаны LLM, streaming, formatting, Langfuse, metrics.
+
+**Mitigation:** split по return-shape first, не менять prompt/LLM behavior в этом
+PR. Langfuse hooks оставить wrapper-level до отдельного optionalization pass.
+
+**Exit criteria:**
+
+- core generation можно вызвать без Telegram imports и без `message`;
+- old `generate_response()` callers работают;
+- no user-visible answer behavior change outside intentional tests.
+
+### Phase E — Перенести RAG Pipeline Ownership
+
+**Цель:** core больше не должен динамически импортировать
+`telegram_bot.agents.rag_pipeline`.
+
+**Tasks:**
+
+1. Создать `src/runtime/pipeline/rag.py` или
+   `src/runtime/retrieval/service.py`.
+2. Перенести `rag_pipeline()` как canonical implementation.
+3. Оставить shim:
+
+   ```text
+   telegram_bot/agents/rag_pipeline.py -> src.runtime.pipeline.rag
+   ```
+
+4. Переключить callers:
+   - `src/core/assistant.py`
+   - `telegram_bot/pipelines/client.py`
+   - tests where practical.
+5. Сохранить old signature до завершения adapter migration.
+6. Обновить docs/runtime README, если текущий migration table устарел.
+
+**Risks:** высокие. RAG pipeline большой и связан с cache/qdrant/reranker/LLM
+state.
+
+**Mitigation:** PR должен быть mostly `git mv` + import rewrite + shim. Не менять
+алгоритмы retrieve/grade/rerank/rewrite.
+
+**Exit criteria:**
+
+- `src.core.assistant` больше не импортирует `telegram_bot.agents.rag_pipeline`;
+- legacy import path works through shim;
+- focused RAG pipeline tests pass;
+- E2E harness can call core path with dependencies.
+
+### Phase F — Собрать `src.runtime.pipeline.assistant_pipeline`
+
+**Цель:** единая runtime orchestration функция становится реальным ядром.
+
+**Target API:**
+
+```python
+async def run_assistant_pipeline(
+    request: AssistantRequest,
+    dependencies: CoreDependencies,
+) -> AssistantResult:
+    ...
+```
+
+**Responsibilities:**
+
+- classify;
+- topic/filter/grounding hints;
+- cache pre-check or delegate to RAG pipeline;
+- retrieval/rerank/grade;
+- generation;
+- grounding completion;
+- CRM action proposal;
+- product logs;
+- convert exceptions to recoverable `AssistantResult`.
+
+**Tasks:**
+
+1. Move live orchestration from `src/core/assistant.py` into runtime pipeline.
+2. Keep `src.core.run_assistant_request()` as thin public wrapper.
+3. Add `grounding_completed` log event.
+4. Add optional `proposed_crm_action` plumbing as data only.
+5. Add focused tests with fake dependencies.
+
+**Exit criteria:**
+
+- `src/core/assistant.py` has no dynamic imports from `telegram_bot`;
+- `src.core` remains import-safe;
+- all product logs include `request_id`;
+- core tests cover success, cache hit, generation, fallback, dependency failure.
+
+### Phase G — Подключить Telegram Как Тонкий Adapter
+
+**Цель:** Telegram text path вызывает core entrypoint и рендерит
+`AssistantResult`.
+
+**Tasks:**
+
+1. В `PropertyBot` собрать adapter dependency bundle once at startup:
+   - cache;
+   - embeddings;
+   - sparse embeddings;
+   - qdrant;
+   - reranker;
+   - llm;
+   - config.
+2. В text handler заменить direct orchestration на:
+
+   ```python
+   result = await run_assistant_request(
+       user_text,
+       collection=config.qdrant_collection,
+       user_context=UserContext(...),
+       dependencies=core_dependencies,
+   )
+   ```
+
+3. Оставить legacy branch behind feature flag на 1-2 PR, если риск высок:
+
+   ```text
+   ASSISTANT_CORE_ENTRYPOINT_ENABLED=true
+   ```
+
+4. Adapter renders:
+   - `response_text`;
+   - sources;
+   - HITL buttons for `proposed_crm_action`;
+   - fallback/error messages.
+5. Перенести Telegram-specific formatting out of runtime.
+6. Добавить smoke tests:
+   - adapter calls core with expected context;
+   - result rendering;
+   - error result rendering;
+   - CRM HITL proposal rendering.
+
+**Risks:** высокие. `telegram_bot/bot.py` содержит много edge cases:
+streaming, cache, pre-agent filters, role/agent intent, feedback, handoff.
+
+**Mitigation:** feature flag + shadow logging: сначала core result может
+считаться в тестовом mode без замены отправки, затем включение для golden path.
+
+**Exit criteria:**
+
+- основной text flow может идти через `run_assistant_request()`;
+- старый behavior сохранён или доступен behind rollback flag;
+- Telegram smoke не является главным product proof.
+
+### Phase H — Live E2E Golden Path
+
+**Цель:** доказать продукт через core, не через Telegram.
+
+**Tasks:**
+
+1. Довести `tests/e2e_core/live_harness.py` до полного пути:
+
+   ```text
+   synthetic docs -> indexing/upsert -> Qdrant -> run_assistant_request -> assertions
+   ```
+
+2. Добавить live tests:
+   - ingest + answer;
+   - missing-in-corpus no-claim;
+   - grounding strict fallback;
+   - CRM/HITL proposal with mock CRM;
+   - dependency failure shape.
+3. Добавить/стабилизировать `make e2e-core-live`.
+4. Добавить artifact writing:
+   - query;
+   - retrieved docs;
+   - answer;
+   - assertion result;
+   - relevant product logs.
+
+**Exit criteria:**
+
+- `make e2e-core-live` доказывает real Qdrant + embeddings + LLM path или
+  documented opt-in real LLM variant;
+- Telegram не участвует в main E2E gate;
+- artifacts достаточны для debugging.
+
+### Phase I — Optional Surface Simplification
+
+**Цель:** после защищённого golden path перестать держать optional surfaces как
+обязательные release proof.
+
+**Tasks:**
+
+1. API: если нужен, сделать adapter over core. Если нет — пометить optional.
+2. Voice: оставить optional route, не release gate.
+3. Mini App: оставить optional; не должен тянуть Telegram internals.
+4. Langfuse/OTel: optional diagnostics only.
+5. k8s/monitoring: не основной local validation path.
+
+**Exit criteria:**
+
+- required checks не зависят от Langfuse/voice/mini app/k8s;
+- docs ясно показывают core proof first;
+- optional surfaces имеют маленькие smoke checks или явный статус.
+
+### Phase J — Cleanup И Contract Ratchets
+
+**Цель:** закрепить новую архитектуру статическими и runtime guardrails.
+
+**Tasks:**
+
+1. Добавить contract: `src/core` и `src/runtime` не содержат строковых dynamic
+   imports `telegram_bot.*`, кроме allowlisted comments/docs if needed.
+2. Добавить contract: `src.runtime.graph.builder.DEFAULT_FACTORY_SPEC` не
+   указывает на `telegram_bot`.
+3. Добавить contract: `generate_answer` не принимает Telegram `message`.
+4. Удалить temporary feature flag после стабилизации.
+5. Удалить shims по заранее принятому cleanup issue.
+6. Обновить README architecture snapshot.
+
+**Exit criteria:**
+
+- dependency arrows enforced;
+- old bot-owned RAG path удалён или shim-only;
+- docs больше не утверждают устаревшее состояние.
+
+## 7. Рекомендуемый Порядок PR
+
+| PR | Название | Основной write scope | Риск | Проверки |
+|---|---|---|---|---|
+| 0 | Audit + implementation plan | `docs/designs/*` | Низкий | doc grep + layering contract |
+| 1 | Core contracts split | `src/core/*`, `tests/unit/core/*` | Низкий | unit core + layering contract |
+| 2 | Grounding runtime move | `src/runtime/grounding/*`, shims, focused callers/tests | Средний | grounding/generation/client tests |
+| 3 | Generation core split | `src/runtime/generation/*`, `telegram_bot/services/generate_response.py` | Высокий | generation tests + client pipeline tests |
+| 4 | RAG pipeline runtime move | `src/runtime/pipeline/*`, rag shim, core assistant | Высокий | RAG tests + core assistant tests |
+| 5 | Runtime assistant pipeline | `src/runtime/pipeline/assistant_pipeline.py`, `src/core/assistant.py` | Средний | core success/error/cache tests |
+| 6 | Telegram adapter integration | `telegram_bot/bot.py`, adapter tests | Высокий | bot smoke + focused integration |
+| 7 | E2E golden path | `tests/e2e_core/*`, Makefile/docs | Средний | `make e2e-core-live` |
+| 8 | Optional surfaces/docs cleanup | API/voice/docs/contracts | Средний | check + contract + smoke |
+| 9 | Ratchets/shim cleanup | contracts, old shims | Средний | full focused contract suite |
+
+## 8. Test Strategy
+
+### 8.1. Per-PR Fast Checks
+
+Baseline for docs/contract PRs:
+
+```bash
+uv run pytest tests/contract/test_layering_no_telegram_bot_imports_contract.py -q
+```
+
+Core contract changes:
+
+```bash
+uv run pytest tests/unit/core/ -q
+uv run pytest tests/contract/test_layering_no_telegram_bot_imports_contract.py -q
+```
+
+Runtime move changes:
+
+```bash
+uv run pytest tests/unit/core/ -q
+uv run pytest tests/unit/pipelines/test_client_pipeline.py -q
+uv run pytest tests/contract/test_layering_no_telegram_bot_imports_contract.py -q
+```
+
+Generation/grounding changes:
+
+```bash
+uv run pytest tests/unit/pipelines/test_client_pipeline.py -q
+uv run pytest tests/unit/core/ -q
+```
+
+E2E changes:
+
+```bash
+make e2e-core-live
+```
+
+### 8.2. Product Acceptance Checks
+
+Golden cases should assert product behavior, not exact full answer text:
+
+- required facts are present;
+- forbidden facts are absent;
+- expected docs are retrieved;
+- missing corpus questions do not hallucinate;
+- strict grounding either cites enough evidence or returns safe fallback;
+- CRM writes are only proposed, never executed without HITL.
+
+### 8.3. Observability Checks
+
+Every request through core should be reconstructable by `request_id` from
+structured logs:
+
+```text
+assistant_request_started
+search_completed
+llm_completed
+grounding_completed
+assistant_request_completed
+```
+
+Errors should use stable `error_type` values:
+
+- `service_unavailable`
+- `dependency_failed`
+- `validation_error`
+- `timeout`
+- `rate_limited`
+
+## 9. Main Risks And Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Generation split changes user-visible answers | High | First PR keeps prompts/context behavior unchanged; wrapper compatibility tests |
+| Telegram streaming gets broken | High | Keep streaming in adapter wrapper; feature flag rollout |
+| Cache policy diverges in strict grounding | High | Move grounding first with no logic changes; focused cache tests |
+| RAG pipeline move causes import cycles | Medium | `git mv` + shims; no algorithm change in move PR |
+| Langfuse decorators keep core non-optional | Medium | Do not remove immediately; wrap after core E2E is stable |
+| E2E flakiness from real LLM | Medium | Separate mock/fake LLM fast path from opt-in real LLM where necessary |
+| Too much provider abstraction | Medium | Add protocols only when demanded by tests/callers; avoid platform rebuild |
+| Large `telegram_bot/bot.py` makes adapter PR risky | High | Shadow mode + small render tests + keep rollback flag briefly |
+
+## 10. Decisions Needed From Артём
+
+Before implementation beyond low-risk contract moves:
+
+1. Should Telegram text path switch to core behind a feature flag first, or should
+   the branch cut directly once E2E is green?
+2. Should `src/api` remain a maintained adapter, or be explicitly optional until
+   a real consumer appears?
+3. What is the minimal acceptable live E2E dependency set:
+   - Qdrant + local embeddings + fake LLM;
+   - Qdrant + local embeddings + real LLM opt-in;
+   - Qdrant + service embeddings + real LLM?
+4. Which CRM actions must appear in first `CrmAction` contract?
+5. How long should legacy `telegram_bot.*` shims remain after migration?
+
+## 11. Definition Of Done For The Monolith
+
+The monolith implementation is complete when all statements below are true:
+
+- `src.core.run_assistant_request()` executes the real product path without
+  importing `telegram_bot` statically or dynamically.
+- `src.runtime` owns classification/retrieval/generation/grounding/CRM proposal
+  orchestration.
+- `telegram_bot` is a production adapter: receive, call core, render,
+  confirm/reject HITL.
+- `make e2e-core-live` or its accepted equivalent proves the core product path
+  against prepared documents and Qdrant.
+- Langfuse/OTel/voice/mini app/k8s are optional diagnostics/surfaces, not
+  required proof of product correctness.
+- CRM writes remain behind explicit HITL confirmation.
+- Documentation and contract tests enforce the dependency direction.
+
+## 12. Immediate Next Step
+
+After this audit lands, start with **PR 1: Core contracts split**. It is the
+lowest-risk code PR and gives later PRs a stable target without moving RAG logic
+yet.
+
+Suggested first task description:
+
+```text
+Extract src.core contracts into src/core/contracts.py, add AssistantRequest,
+preserve run_assistant_request() compatibility, and extend unit tests for
+skeleton/error result shape. Do not move RAG/generation yet.
+```

--- a/docs/designs/monolith-core-issue-backlog.md
+++ b/docs/designs/monolith-core-issue-backlog.md
@@ -1,0 +1,604 @@
+# План Issues Для Стабилизации Ядра
+
+Статус: предлагается к старту выполнения
+Дата: 2026-06-08
+Источник:
+
+- [`product-simplification-stage-0-decisions.md`](product-simplification-stage-0-decisions.md)
+- [`monolith-core-audit-implementation-plan.md`](monolith-core-audit-implementation-plan.md)
+- [`yaroslav-simplification-workflow.md`](yaroslav-simplification-workflow.md)
+
+## Цель
+
+Стабилизировать ядро ассистента и убрать лишнее из обязательного продуктового
+пути без переписывания проекта и без раннего удаления опциональных поверхностей.
+
+Главная проблема проекта сейчас:
+
+```text
+telegram_bot всё ещё владеет значимой частью RAG/runtime-логики,
+а optional surfaces выглядят как обязательные для понимания и проверки продукта.
+```
+
+Целевое состояние:
+
+```text
+telegram_bot / E2E / optional API
+  -> src.core.run_assistant_request()
+  -> src.runtime owns classify/retrieve/generate/grounding/CRM proposal
+  -> AssistantResult
+```
+
+Не цель текущего пакета:
+
+- не удалять voice, Mini App, API, Langfuse, OTel, k8s или monitoring;
+- не трогать production CRM write paths;
+- не добавлять новые зависимости;
+- не запускать установку зависимостей как часть обычной проверки;
+- не делать большой PR «сделать монолит».
+
+## Milestone
+
+```text
+Milestone: stabilize-core-monolith
+```
+
+Описание milestone:
+
+```text
+Make the assistant core the only product owner for text RAG requests:
+contracts first, then grounding/generation/RAG ownership, then Telegram as a thin
+adapter, then one core E2E proof. Optional platform surfaces stay optional until
+core reliability is proven.
+```
+
+## Правила Выполнения
+
+1. Один issue = один архитектурный шов.
+2. Каждый issue имеет явный allowed write scope.
+3. Не запускать `uv sync`, `pip install`, `npm install`, `docker build`,
+   `docker compose up` без отдельного решения.
+4. Для docs/plan PR использовать только лёгкие проверки:
+   - `git diff --check`;
+   - local Markdown link check через `python`, если нужно.
+5. Для code PR запускать только focused checks, если окружение уже готово.
+6. Не делать optional surfaces обязательными для core proof.
+7. Любые CRM writes остаются только после HITL.
+
+## Week 1 Focus
+
+Цель первой недели — начать выполнение безопасно: стабилизировать public contract
+ядра и вынести первую safety policy из Telegram ownership.
+
+На этой неделе делаем:
+
+1. `CORE-001`: Core contracts split.
+2. `CORE-002`: Grounding policy canonical runtime home.
+3. `CORE-003`: Runtime coupling ratchet design, если останется время.
+
+На этой неделе не делаем:
+
+- перенос всего `rag_pipeline()`;
+- split `generate_response()`;
+- переключение Telegram text path на core;
+- изменения Docker/Compose/k8s;
+- Langfuse/OTel optionalization beyond docs/contracts;
+- live CRM writes.
+
+## Backlog Overview
+
+| Issue | Название | Lane | Риск | Блокирует | Основной результат |
+|---|---|---|---|---|---|
+| `CORE-001` | Core contracts split | Quick execution | Низкий | `CORE-004`, `CORE-005` | `src.core` имеет явный stable contract |
+| `CORE-002` | Move grounding policy to runtime | Plan needed | Средний | `CORE-004`, `CORE-005` | Safety policy принадлежит `src.runtime` |
+| `CORE-003` | Runtime coupling ratchets | Plan needed | Низкий | cleanup | Зафиксировать запрет dynamic `telegram_bot` coupling |
+| `CORE-004` | Split generation core from Telegram rendering | Plan needed | Высокий | `CORE-005` | Core generation без Telegram `message` |
+| `CORE-005` | Move RAG pipeline ownership to runtime | Plan needed | Высокий | `CORE-006` | Core больше не импортирует bot RAG path |
+| `CORE-006` | Build runtime assistant pipeline | Plan needed | Средний | `CORE-007`, `CORE-008` | Real `run_assistant_pipeline()` returns `AssistantResult` |
+| `CORE-007` | Core E2E golden path | Plan needed | Средний | optional cleanup | `make e2e-core-live` или accepted equivalent доказывает ядро |
+| `CORE-008` | Telegram thin adapter rollout | Plan needed | Высокий | cleanup | Telegram вызывает core и рендерит `AssistantResult` |
+| `CORE-009` | Optional surfaces status cleanup | Design first | Средний | docs cleanup | API/voice/miniapp/Langfuse/k8s явно optional |
+| `CORE-010` | Shim cleanup and final docs | Plan needed | Средний | final | Удалены временные shims/flags после стабилизации |
+
+## Issue Templates
+
+### CORE-001: Core Contracts Split
+
+```md
+## Goal
+
+Extract the public assistant core contracts into `src/core/contracts.py` without
+changing runtime behavior.
+
+## Lane
+
+Quick execution.
+
+## Why
+
+Later migration issues need a stable request/result/dependency contract before
+moving grounding, generation, RAG, or Telegram adapter code.
+
+## Allowed Write Scope
+
+- `src/core/contracts.py`
+- `src/core/assistant.py`
+- `src/core/__init__.py`
+- `tests/unit/core/test_assistant_entrypoint.py`
+- docs only if import paths need clarification
+
+## Forbidden Scope
+
+- Do not move `rag_pipeline()`.
+- Do not move `generate_response()`.
+- Do not change Telegram behavior.
+- Do not touch Docker/Compose/k8s.
+- Do not add dependencies.
+
+## Tasks
+
+- Move or re-export `UserContext`, `CoreDependencies`, `CrmAction`,
+  `AssistantResult` from `src/core/contracts.py`.
+- Add `AssistantRequest` as a first-class request object.
+- Preserve current `run_assistant_request(query, *, collection, ...)` API.
+- Keep skeleton mode behavior unchanged when dependencies are absent.
+- Update unit tests for import compatibility and request id propagation.
+
+## Acceptance Criteria
+
+- Existing imports from `src.core` still work.
+- `AssistantRequest` is available for future adapter/E2E code.
+- No new `telegram_bot` imports are introduced under `src`.
+- Runtime behavior is unchanged.
+
+## Validation
+
+Preferred if environment is already ready:
+
+- `python -m pytest tests/unit/core/test_assistant_entrypoint.py -q`
+
+If dependencies are not ready, do not install them automatically. Use:
+
+- `git diff --check`
+- static import inspection with `rg` / `python ast` only.
+```
+
+### CORE-002: Move Grounding Policy To `src.runtime.grounding`
+
+```md
+## Goal
+
+Make grounding policy a runtime/core-owned module while preserving old Telegram
+imports through a compatibility shim.
+
+## Lane
+
+Plan needed.
+
+## Why
+
+Grounding is safety/product policy, not Telegram UI. It controls strict mode,
+safe fallback, legal-answer safety, and semantic cache reuse.
+
+## Allowed Write Scope
+
+- `src/runtime/grounding/__init__.py`
+- `src/runtime/grounding/policy.py`
+- `telegram_bot/services/grounding_policy.py`
+- focused callers only if needed:
+  - `telegram_bot/pipelines/client.py`
+  - `telegram_bot/bot.py`
+  - `telegram_bot/services/generate_response.py`
+- focused grounding tests
+
+## Forbidden Scope
+
+- Do not change grounding thresholds or response text.
+- Do not change generation prompt behavior.
+- Do not change Telegram rendering.
+- Do not move cache policy in this issue unless required for imports.
+
+## Tasks
+
+- Move the existing grounding functions to `src.runtime.grounding.policy`.
+- Leave `telegram_bot/services/grounding_policy.py` as a deprecated re-export shim.
+- Update safe internal callers to use the canonical `src.runtime` module.
+- Add a focused test or static check proving old and new import paths expose the
+  same functions.
+
+## Acceptance Criteria
+
+- Old import path remains compatible.
+- New canonical import path works.
+- Strict/no-data fallback behavior is unchanged.
+- No new dependency install is required.
+
+## Validation
+
+Preferred if environment is already ready:
+
+- focused grounding tests
+- focused client pipeline grounding tests
+
+No automatic dependency installation. At minimum:
+
+- `git diff --check`
+- `python` import/static check only if current environment can import project code
+  without installing dependencies.
+```
+
+### CORE-003: Runtime Coupling Ratchets
+
+```md
+## Goal
+
+Add or design lightweight guardrails that prevent `src.core` and `src.runtime`
+from reintroducing runtime coupling to `telegram_bot`.
+
+## Lane
+
+Plan needed.
+
+## Why
+
+The static layering allowlist is empty, but dynamic string imports and default
+factory specs can still point back to `telegram_bot`.
+
+## Allowed Write Scope
+
+- `tests/contract/*runtime*` or a new focused contract test
+- `tests/data/*` only if an explicit allowlist is needed
+- docs explaining temporary exceptions
+
+## Forbidden Scope
+
+- Do not break existing dynamic factory behavior before runtime replacements
+  exist.
+- Do not remove compatibility shims prematurely.
+
+## Tasks
+
+- Detect string literals under `src/core` and `src/runtime` that reference
+  `telegram_bot.` in executable code.
+- Decide temporary allowlist entries for documented transitional seams.
+- Add a ratchet so the list can only shrink.
+
+## Acceptance Criteria
+
+- Current known transitional seams are explicit.
+- New hidden dynamic coupling fails the contract.
+- Docs distinguish static import compliance from runtime ownership.
+
+## Validation
+
+- `python` static check script or focused pytest if environment is ready.
+- `git diff --check`.
+```
+
+### CORE-004: Split Generation Core From Telegram Rendering
+
+```md
+## Goal
+
+Create a core generation service that does not accept Telegram `message` and does
+not send/stream Telegram messages directly.
+
+## Lane
+
+Plan needed.
+
+## Why
+
+`generate_response()` currently mixes LLM answer generation, grounding fallback,
+Langfuse/metrics hooks, formatting, and Telegram streaming concerns.
+
+## Allowed Write Scope
+
+- `src/runtime/generation/*`
+- `telegram_bot/services/generate_response.py`
+- focused generation/client pipeline tests
+
+## Forbidden Scope
+
+- Do not change prompts intentionally.
+- Do not change user-visible answer formatting except where tests require a
+  clearly documented adapter split.
+- Do not remove Langfuse/metrics in this issue; only make them non-core if safe.
+
+## Tasks
+
+- Introduce `GenerationRequest` and `GenerationResult`.
+- Move pure context formatting and fallback result shaping into runtime.
+- Keep Telegram streaming in the Telegram wrapper.
+- Preserve old `generate_response()` signature as a compatibility wrapper.
+
+## Acceptance Criteria
+
+- Core generation can be called without Telegram `message`.
+- Old Telegram caller path remains compatible.
+- Grounding fallback still works.
+```
+
+### CORE-005: Move RAG Pipeline Ownership To Runtime
+
+```md
+## Goal
+
+Make the existing RAG pipeline canonical under `src.runtime` so `src.core` no
+longer imports `telegram_bot.agents.rag_pipeline` dynamically.
+
+## Lane
+
+Plan needed.
+
+## Why
+
+RAG retrieval/cache/grade/rerank/rewrite is product runtime logic and should not
+be owned by the Telegram adapter package.
+
+## Allowed Write Scope
+
+- `src/runtime/pipeline/*` or `src/runtime/retrieval/*`
+- `telegram_bot/agents/rag_pipeline.py` compatibility shim
+- `src/core/assistant.py`
+- focused RAG/core tests
+
+## Forbidden Scope
+
+- Do not change retrieval algorithms.
+- Do not change Qdrant schema.
+- Do not change embedding provider behavior.
+- Do not change Telegram UI.
+
+## Tasks
+
+- Move canonical implementation with minimal code changes.
+- Leave old import path as shim.
+- Switch `src.core.assistant` to canonical runtime module.
+- Keep old function signature until adapter migration is complete.
+
+## Acceptance Criteria
+
+- `src.core.assistant` no longer references `telegram_bot.agents.rag_pipeline`.
+- Legacy import path still works.
+- RAG result shape is unchanged.
+```
+
+### CORE-006: Build Runtime Assistant Pipeline
+
+```md
+## Goal
+
+Move live orchestration from `src.core.assistant` into
+`src.runtime.pipeline.assistant_pipeline` while keeping `run_assistant_request()`
+as the public wrapper.
+
+## Lane
+
+Plan needed.
+
+## Why
+
+`src.core` should expose the product API, while `src.runtime` owns the internal
+classify/retrieve/generate/grounding/CRM proposal flow.
+
+## Allowed Write Scope
+
+- `src/runtime/pipeline/assistant_pipeline.py`
+- `src/runtime/pipeline/contracts.py`
+- `src/core/assistant.py`
+- `src/core/contracts.py`
+- `tests/unit/core/*`
+
+## Forbidden Scope
+
+- Do not switch Telegram adapter yet.
+- Do not add new providers unless tests require them.
+- Do not write to CRM.
+
+## Tasks
+
+- Introduce `run_assistant_pipeline(request, dependencies)`.
+- Emit product logs with `request_id`.
+- Return `AssistantResult` for success, cache hit, safe fallback, and dependency
+  failure.
+- Keep public `run_assistant_request()` compatible.
+
+## Acceptance Criteria
+
+- `src.core.assistant` has no dynamic `telegram_bot` imports.
+- Runtime pipeline owns live orchestration.
+- Errors are recoverable result objects with stable `error_type`.
+```
+
+### CORE-007: Core E2E Golden Path
+
+```md
+## Goal
+
+Prove core product behavior through direct `run_assistant_request()` calls, not
+through Telegram.
+
+## Lane
+
+Plan needed.
+
+## Why
+
+Reliability should be proven by user outcomes: prepared docs -> Qdrant -> core
+request -> grounded answer checks.
+
+## Allowed Write Scope
+
+- `tests/e2e_core/*`
+- `Makefile` only if target wiring is missing
+- docs for local E2E usage
+
+## Forbidden Scope
+
+- Do not require Telegram.
+- Do not require Langfuse/OTel.
+- Do not require live CRM writes.
+
+## Tasks
+
+- Index synthetic docs into a test Qdrant collection.
+- Call core directly.
+- Assert retrieved docs, required facts, forbidden facts, missing-corpus behavior,
+  and grounding fallback.
+- Store lightweight artifacts for debugging.
+
+## Acceptance Criteria
+
+- One command or documented focused command proves the golden path.
+- Telegram remains outside the main E2E gate.
+```
+
+### CORE-008: Telegram Thin Adapter Rollout
+
+```md
+## Goal
+
+Route the main Telegram text path through `src.core.run_assistant_request()` and
+render `AssistantResult` in Telegram.
+
+## Lane
+
+Plan needed.
+
+## Why
+
+Telegram is the production adapter, but it should not own core RAG/runtime logic.
+
+## Allowed Write Scope
+
+- `telegram_bot/bot.py`
+- small adapter helper modules if needed
+- focused Telegram adapter tests
+
+## Forbidden Scope
+
+- Do not change core contracts in this issue unless a blocker is found.
+- Do not remove legacy branch until rollout is proven.
+- Do not touch production CRM writes.
+
+## Tasks
+
+- Build `CoreDependencies` from existing bot runtime dependencies.
+- Construct `UserContext` / `AssistantRequest` from Telegram state.
+- Call `run_assistant_request()`.
+- Render response text, sources, fallback/error states, and HITL action buttons.
+- Use feature flag or shadow mode if risk is high.
+
+## Acceptance Criteria
+
+- Telegram text path can use core entrypoint.
+- Adapter only renders and handles HITL confirmation.
+- Rollback path exists until E2E and smoke checks are stable.
+```
+
+### CORE-009: Optional Surfaces Status Cleanup
+
+```md
+## Goal
+
+Make optional surfaces explicit after the core golden path exists.
+
+## Lane
+
+Design first.
+
+## Why
+
+The project should not require voice, Mini App, API, Langfuse, OTel, k8s, or
+monitoring to prove the core assistant path.
+
+## Allowed Write Scope
+
+- docs for API/voice/miniapp/Langfuse/k8s status
+- small smoke checks only if needed
+
+## Forbidden Scope
+
+- Do not delete surfaces without explicit approval.
+- Do not break active users.
+
+## Tasks
+
+- Mark each surface as required, optional, or archived candidate.
+- Define a small smoke check for retained optional surfaces.
+- Remove outdated docs that imply optional surfaces are required gates.
+
+## Acceptance Criteria
+
+- Core proof is documented as primary.
+- Optional surfaces have clear status and do not block core release.
+```
+
+### CORE-010: Shim Cleanup And Final Docs
+
+```md
+## Goal
+
+Remove temporary compatibility shims and feature flags after the runtime core path
+is stable.
+
+## Lane
+
+Plan needed.
+
+## Why
+
+Shims are useful during migration but should not become permanent architecture.
+
+## Allowed Write Scope
+
+- old `telegram_bot/*` shim modules
+- runtime contracts
+- README/design docs
+- focused import/path tests
+
+## Forbidden Scope
+
+- Do not remove a shim while any known caller still uses it.
+- Do not remove rollback flags until Telegram adapter rollout is accepted.
+
+## Tasks
+
+- Find remaining shim imports.
+- Switch callers to canonical `src.runtime` paths.
+- Remove shims only when safe.
+- Update architecture docs and final Definition of Done.
+
+## Acceptance Criteria
+
+- Dependency direction is enforced.
+- Docs match code.
+- Old bot-owned core path is gone or explicitly archived.
+```
+
+## First Execution Recommendation
+
+Start with `CORE-001`. It is small, low-risk, and creates the stable contract
+needed by every later issue.
+
+Recommended branch:
+
+```text
+simplification/core-001-core-contracts
+```
+
+Recommended PR title:
+
+```text
+core: split assistant contracts
+```
+
+Recommended first implementation prompt:
+
+```text
+Implement CORE-001 only. Extract assistant contracts into src/core/contracts.py,
+add AssistantRequest, preserve src.core public imports and run_assistant_request()
+behavior, update focused core tests if possible, and do not touch Telegram,
+RAG pipeline, generation, Docker, or dependencies.
+```

--- a/docs/designs/monolith-core-optional-surfaces-status.md
+++ b/docs/designs/monolith-core-optional-surfaces-status.md
@@ -1,0 +1,30 @@
+# Optional Surfaces Status After Core Stabilization
+
+Статус: предлагается
+Дата: 2026-06-08
+
+Этот документ относится к `CORE-009`: после стабилизации ядра эти поверхности не
+должны быть обязательным доказательством корректности основного продукта.
+
+| Surface | Status | Core requirement |
+|---|---|---|
+| Telegram text bot | production adapter | calls/renders `AssistantResult`; transport smoke only |
+| FastAPI RAG API | optional adapter | may call core if retained |
+| Voice / LiveKit | optional adapter | not part of core E2E gate |
+| Mini App | optional surface | not part of core E2E gate |
+| Langfuse | optional diagnostics | absence must not change product behavior |
+| OpenTelemetry / trace validation | optional diagnostics | not release proof for core |
+| k8s manifests | optional deploy surface | not required for local core proof |
+| Loki / Promtail / Alertmanager | optional monitoring | not required for local core proof |
+| BGE-M3 API container | optional service boundary | core proof may use local/service embeddings by accepted gate |
+| Docling service | optional service boundary | ingestion can run batch/in-process |
+| LiteLLM proxy | optional service boundary | core may use direct SDK/client path |
+
+Primary proof remains:
+
+```text
+prepared docs -> Qdrant -> run_assistant_request() -> AssistantResult checks
+```
+
+No surface above should become mandatory for `make e2e-core-live` unless Артём
+explicitly changes the product simplification decision.

--- a/docs/designs/monolith-core-shim-cleanup-checklist.md
+++ b/docs/designs/monolith-core-shim-cleanup-checklist.md
@@ -1,0 +1,28 @@
+# Shim Cleanup Checklist
+
+Статус: blocked until runtime core path is stable
+Дата: 2026-06-08
+
+`CORE-010` нельзя завершать до тех пор, пока generation/RAG/runtime pipeline и
+Telegram adapter rollout не пройдут ревью. До этого shims являются rollback
+механизмом.
+
+## Transitional Shims / Couplings
+
+- `telegram_bot/services/grounding_policy.py` -> `src.runtime.grounding.policy`
+- `src/runtime/pipeline/rag.py` -> legacy `telegram_bot.agents.rag_pipeline`
+- `src/runtime/pipeline/assistant_pipeline.py` -> legacy `telegram_bot.services.generate_response`
+- `src/runtime/graph/builder.py` default factory -> `telegram_bot.graph.graph:build_graph`
+
+## Cleanup Conditions
+
+1. `src.runtime.generation` owns the full core generation implementation.
+2. `src.runtime.pipeline.rag` owns the full RAG implementation.
+3. `src.runtime.pipeline.assistant_pipeline` has no `telegram_bot.*` executable strings.
+4. Telegram text path can render `AssistantResult` with rollback removed.
+5. `tests/data/known_runtime_telegram_bot_couplings.json` is empty or removed.
+6. README/design docs no longer describe transitional shims as active runtime paths.
+
+## Cleanup Rule
+
+Remove one shim per PR and run the focused contract/static checks for that seam.

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,12 +1,13 @@
 """Core application module exports."""
 
-from .assistant import (
+from .assistant import run_assistant_request
+from .contracts import (
     AssistantError,
+    AssistantRequest,
     AssistantResult,
     CoreDependencies,
     CrmAction,
     UserContext,
-    run_assistant_request,
 )
 
 
@@ -22,6 +23,7 @@ def __getattr__(name: str) -> object:
 
 __all__ = [
     "AssistantError",
+    "AssistantRequest",
     "AssistantResult",
     "CoreDependencies",
     "CrmAction",

--- a/src/core/assistant.py
+++ b/src/core/assistant.py
@@ -2,7 +2,7 @@
 
 The module intentionally defines a narrow, synchronous-import-safe contract:
 
-- lightweight data containers (`UserContext`, `AssistantResult`, `CrmAction`)
+- public data containers imported from `src.core.contracts`
 - recoverable core result model
 - thin async entrypoint `run_assistant_request()` that preserves caller API without
   touching live integrations
@@ -13,73 +13,18 @@ from __future__ import annotations
 import asyncio
 import importlib
 import time
-from dataclasses import dataclass, field
 from typing import Any
 from uuid import uuid4
 
+from src.core.contracts import (
+    AssistantError,
+    AssistantRequest,
+    AssistantResult,
+    CoreDependencies,
+    CrmAction,
+    UserContext,
+)
 from src.utils.product_events import log_event
-
-
-@dataclass
-class UserContext:
-    """Minimal user/session context for core assistant request handling."""
-
-    user_id: str = ""
-    session_id: str = ""
-    role: str = "client"
-    filters: dict[str, Any] | None = None
-    language: str = "ru"
-
-
-@dataclass
-class CoreDependencies:
-    """Runtime collaborators required to execute the existing RAG path."""
-
-    cache: Any
-    embeddings: Any
-    sparse_embeddings: Any
-    qdrant: Any
-    reranker: Any | None = None
-    llm: Any | None = None
-    config: Any | None = None
-
-
-@dataclass
-class CrmAction:
-    """Intent for a proposed CRM action, awaiting explicit confirmation."""
-
-    action_type: str
-    payload: dict[str, Any]
-    summary: str
-
-
-@dataclass
-class AssistantResult:
-    """Structured response object returned by the assistant core entrypoint."""
-
-    response_text: str
-    route: str = ""
-    request_type: str = ""
-    retrieved_doc_ids: list[str] = field(default_factory=list)
-    retrieved_sources: list[dict[str, str]] = field(default_factory=list)
-    documents_count: int = 0
-    latency_ms: float = 0.0
-    error_type: str | None = None
-    error_message: str | None = None
-    proposed_crm_action: CrmAction | None = None
-    request_id: str = ""
-    cache_hit: bool = False
-    llm_model: str | None = None
-    llm_call_count: int = 0
-    rerank_applied: bool = False
-
-
-class AssistantError(RuntimeError):
-    """Unrecoverable error from the core assistant."""
-
-    def __init__(self, message: str, *, error_type: str = "internal") -> None:
-        super().__init__(message)
-        self.error_type = error_type
 
 
 async def run_assistant_request(
@@ -322,6 +267,7 @@ def _extract_llm_model(generation_result: dict[str, Any]) -> str | None:
 
 __all__ = [
     "AssistantError",
+    "AssistantRequest",
     "AssistantResult",
     "CoreDependencies",
     "CrmAction",

--- a/src/core/assistant.py
+++ b/src/core/assistant.py
@@ -1,19 +1,8 @@
-"""Core assistant entrypoint contract (PR A skeleton).
-
-The module intentionally defines a narrow, synchronous-import-safe contract:
-
-- public data containers imported from `src.core.contracts`
-- recoverable core result model
-- thin async entrypoint `run_assistant_request()` that preserves caller API without
-  touching live integrations
-"""
+"""Core assistant public entrypoint."""
 
 from __future__ import annotations
 
 import asyncio
-import importlib
-import time
-from typing import Any
 from uuid import uuid4
 
 from src.core.contracts import (
@@ -24,6 +13,7 @@ from src.core.contracts import (
     CrmAction,
     UserContext,
 )
+from src.runtime.pipeline.assistant_pipeline import run_assistant_pipeline
 from src.utils.product_events import log_event
 
 
@@ -41,7 +31,6 @@ async def run_assistant_request(
     import-only callers do not touch live integrations.
     """
 
-    _ = collection
     rid = request_id or str(uuid4())
 
     log_event("assistant_request_started", request_id=rid, route="unknown")
@@ -69,117 +58,13 @@ async def run_assistant_request(
 
         return result
 
-    started = time.perf_counter()
-    ctx = user_context or UserContext()
-
-    try:
-        classify_query = importlib.import_module("src.runtime.graph.nodes.classify").classify_query
-        rag_pipeline = importlib.import_module("telegram_bot.agents.rag_pipeline").rag_pipeline
-        generate_response = importlib.import_module(
-            "telegram_bot.services.generate_response"
-        ).generate_response
-
-        request_type = classify_query(query)
-        state_contract: dict[str, Any] | None = {"filters": ctx.filters} if ctx.filters else None
-
-        rag_result = await rag_pipeline(
-            query=query,
-            user_id=_coerce_user_id(ctx.user_id),
-            session_id=ctx.session_id or rid,
-            query_type=request_type,
-            original_query=query,
-            cache=dependencies.cache,
-            embeddings=dependencies.embeddings,
-            sparse_embeddings=dependencies.sparse_embeddings,
-            qdrant=dependencies.qdrant,
-            reranker=dependencies.reranker,
-            llm=dependencies.llm,
-            agent_role=ctx.role,
-            state_contract=state_contract,
-        )
-
-        documents = _as_document_list(rag_result.get("documents"))
-        retrieved_doc_ids = _extract_doc_ids(documents)
-        search_latency_ms = _latency_ms(started)
-        log_event(
-            "search_completed",
-            request_id=rid,
-            route="cache_hit" if rag_result.get("cache_hit") else "rag_search",
-            request_type=request_type,
-            retrieved_doc_ids=retrieved_doc_ids,
-            latency_ms=search_latency_ms,
-            error_type=None,
-        )
-
-        if rag_result.get("cache_hit"):
-            result = AssistantResult(
-                response_text=str(rag_result.get("response", "") or ""),
-                route="cache_hit",
-                request_type=str(rag_result.get("query_type") or request_type),
-                retrieved_doc_ids=retrieved_doc_ids,
-                retrieved_sources=_extract_sources(documents),
-                documents_count=len(documents),
-                latency_ms=_latency_ms(started),
-                request_id=rid,
-                cache_hit=True,
-                rerank_applied=bool(rag_result.get("rerank_applied", False)),
-            )
-        else:
-            generation_kwargs: dict[str, Any] = {
-                "query": query,
-                "documents": documents,
-            }
-            if dependencies.config is not None:
-                generation_kwargs["config"] = dependencies.config
-            generation_result = await generate_response(**generation_kwargs)
-            usage = _as_usage_dict(generation_result.get("usage_details"))
-            llm_model = _extract_llm_model(generation_result)
-
-            log_event(
-                "llm_completed",
-                request_id=rid,
-                route="rag_search",
-                request_type=request_type,
-                latency_ms=_latency_ms(started),
-                error_type=None,
-                llm_model=llm_model,
-                input_tokens=usage.get("input"),
-                output_tokens=usage.get("output"),
-            )
-
-            result = AssistantResult(
-                response_text=str(generation_result.get("response", "") or ""),
-                route="rag_search",
-                request_type=str(rag_result.get("query_type") or request_type),
-                retrieved_doc_ids=retrieved_doc_ids,
-                retrieved_sources=_extract_sources(documents),
-                documents_count=len(documents),
-                latency_ms=_latency_ms(started),
-                error_type=None,
-                request_id=rid,
-                cache_hit=False,
-                llm_model=llm_model,
-                llm_call_count=1,
-                rerank_applied=bool(rag_result.get("rerank_applied", False)),
-            )
-    except Exception as exc:
-        result = AssistantResult(
-            response_text="Сервис временно недоступен. Пожалуйста, повторите через минуту.",
-            route="error",
-            request_type="",
-            latency_ms=_latency_ms(started),
-            error_type="dependency_failed",
-            error_message=str(exc),
-            request_id=rid,
-        )
-        log_event(
-            "dependency_failed",
-            request_id=rid,
-            route=result.route,
-            request_type=result.request_type,
-            latency_ms=result.latency_ms,
-            error_type=result.error_type,
-        )
+    request = AssistantRequest(
+        query=query,
+        collection=collection,
+        user_context=user_context or UserContext(),
+        request_id=rid,
+    )
+    result = await run_assistant_pipeline(request, dependencies=dependencies)
 
     log_event(
         "assistant_request_completed",
@@ -189,80 +74,7 @@ async def run_assistant_request(
         error_type=result.error_type,
         latency_ms=result.latency_ms,
     )
-
     return result
-
-
-def _coerce_user_id(user_id: str) -> int:
-    """Return an integer user id for the existing Telegram RAG pipeline."""
-    try:
-        return int(user_id)
-    except (TypeError, ValueError):
-        return 0
-
-
-def _latency_ms(started: float) -> float:
-    """Return elapsed wall-clock milliseconds rounded for stable logs/tests."""
-    return round((time.perf_counter() - started) * 1000, 3)
-
-
-def _as_document_list(value: Any) -> list[dict[str, Any]]:
-    """Normalize existing RAG document output to a list of dictionaries."""
-    if not isinstance(value, list):
-        return []
-    return [doc for doc in value if isinstance(doc, dict)]
-
-
-def _metadata_for(document: dict[str, Any]) -> dict[str, Any]:
-    """Return document metadata if present."""
-    metadata = document.get("metadata")
-    return metadata if isinstance(metadata, dict) else {}
-
-
-def _extract_doc_ids(documents: list[dict[str, Any]]) -> list[str]:
-    """Extract stable source ids used by golden-case checks."""
-    ids: list[str] = []
-    for document in documents:
-        metadata = _metadata_for(document)
-        doc_id = (
-            metadata.get("source_id")
-            or metadata.get("doc_id")
-            or metadata.get("id")
-            or document.get("source_id")
-            or document.get("doc_id")
-            or document.get("id")
-        )
-        if doc_id is not None:
-            ids.append(str(doc_id))
-    return ids
-
-
-def _extract_sources(documents: list[dict[str, Any]]) -> list[dict[str, str]]:
-    """Extract title/url source metadata for adapters."""
-    sources: list[dict[str, str]] = []
-    for document in documents:
-        metadata = _metadata_for(document)
-        source: dict[str, str] = {}
-        title = metadata.get("title") or document.get("title")
-        url = metadata.get("url") or document.get("url")
-        if title is not None:
-            source["title"] = str(title)
-        if url is not None:
-            source["url"] = str(url)
-        if source:
-            sources.append(source)
-    return sources
-
-
-def _as_usage_dict(value: Any) -> dict[str, Any]:
-    """Return usage details from generate_response() when available."""
-    return value if isinstance(value, dict) else {}
-
-
-def _extract_llm_model(generation_result: dict[str, Any]) -> str | None:
-    """Extract the provider model name from generation metadata."""
-    model = generation_result.get("llm_provider_model") or generation_result.get("model")
-    return str(model) if model else None
 
 
 __all__ = [

--- a/src/core/contracts.py
+++ b/src/core/contracts.py
@@ -1,0 +1,94 @@
+"""Public assistant core contracts.
+
+These dataclasses define the stable boundary between transports (Telegram,
+E2E, optional API) and the assistant core. They intentionally avoid importing
+Telegram, FastAPI, Langfuse, OTel, or live integrations so callers can import
+them in lightweight tests and tooling.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class UserContext:
+    """Minimal user/session context for core assistant request handling."""
+
+    user_id: str = ""
+    session_id: str = ""
+    role: str = "client"
+    filters: dict[str, Any] | None = None
+    language: str = "ru"
+
+
+@dataclass
+class AssistantRequest:
+    """Structured request object for future adapter and E2E callers."""
+
+    query: str
+    collection: str
+    user_context: UserContext = field(default_factory=UserContext)
+    request_id: str = ""
+
+
+@dataclass
+class CoreDependencies:
+    """Runtime collaborators required to execute the existing RAG path."""
+
+    cache: Any
+    embeddings: Any
+    sparse_embeddings: Any
+    qdrant: Any
+    reranker: Any | None = None
+    llm: Any | None = None
+    config: Any | None = None
+
+
+@dataclass
+class CrmAction:
+    """Intent for a proposed CRM action, awaiting explicit confirmation."""
+
+    action_type: str
+    payload: dict[str, Any]
+    summary: str
+
+
+@dataclass
+class AssistantResult:
+    """Structured response object returned by the assistant core entrypoint."""
+
+    response_text: str
+    route: str = ""
+    request_type: str = ""
+    retrieved_doc_ids: list[str] = field(default_factory=list)
+    retrieved_sources: list[dict[str, str]] = field(default_factory=list)
+    documents_count: int = 0
+    latency_ms: float = 0.0
+    error_type: str | None = None
+    error_message: str | None = None
+    proposed_crm_action: CrmAction | None = None
+    request_id: str = ""
+    cache_hit: bool = False
+    llm_model: str | None = None
+    llm_call_count: int = 0
+    rerank_applied: bool = False
+
+
+class AssistantError(RuntimeError):
+    """Unrecoverable error from the core assistant."""
+
+    def __init__(self, message: str, *, error_type: str = "internal") -> None:
+        super().__init__(message)
+        self.error_type = error_type
+
+
+__all__ = [
+    "AssistantError",
+    "AssistantRequest",
+    "AssistantResult",
+    "CoreDependencies",
+    "CrmAction",
+    "UserContext",
+]

--- a/src/runtime/generation/__init__.py
+++ b/src/runtime/generation/__init__.py
@@ -1,0 +1,6 @@
+"""Runtime generation exports."""
+
+from .contracts import GenerationCallable, GenerationRequest, GenerationResult
+from .service import generate_answer
+
+__all__ = ["GenerationCallable", "GenerationRequest", "GenerationResult", "generate_answer"]

--- a/src/runtime/generation/contracts.py
+++ b/src/runtime/generation/contracts.py
@@ -1,0 +1,40 @@
+"""Runtime generation request/result contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class GenerationRequest:
+    """Core generation request, independent from Telegram message rendering."""
+
+    query: str
+    documents: list[dict[str, Any]]
+    retrieved_context: list[dict[str, Any]] | None = None
+    raw_messages: list[Any] | None = None
+    latency_stages: dict[str, float] | None = None
+    llm_call_count: int = 0
+    grounding_mode: str = "normal"
+    grade_confidence: float | None = None
+    config: Any | None = None
+    extra_kwargs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class GenerationResult:
+    """Normalized generation result returned by the runtime generation seam."""
+
+    payload: dict[str, Any]
+
+    @property
+    def response_text(self) -> str:
+        return str(self.payload.get("response", "") or "")
+
+
+GenerationCallable = Callable[..., Awaitable[dict[str, Any]]]
+
+
+__all__ = ["GenerationCallable", "GenerationRequest", "GenerationResult"]

--- a/src/runtime/generation/service.py
+++ b/src/runtime/generation/service.py
@@ -1,0 +1,44 @@
+"""Runtime generation seam.
+
+The core generation entrypoint does not accept a Telegram ``message`` object and
+does not send or stream Telegram messages. During the migration it delegates to
+an injected generation callable, which lets existing adapters keep using the
+legacy implementation while the runtime owns the transport-free request shape.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .contracts import GenerationCallable, GenerationRequest, GenerationResult
+
+
+async def generate_answer(
+    request: GenerationRequest,
+    *,
+    generate: GenerationCallable,
+) -> GenerationResult:
+    """Generate an answer using a transport-free request contract."""
+
+    kwargs: dict[str, Any] = {
+        "query": request.query,
+        "documents": request.documents,
+        "grounding_mode": request.grounding_mode,
+        "llm_call_count": request.llm_call_count,
+    }
+    if request.retrieved_context is not None:
+        kwargs["retrieved_context"] = request.retrieved_context
+    if request.raw_messages is not None:
+        kwargs["raw_messages"] = request.raw_messages
+    if request.latency_stages is not None:
+        kwargs["latency_stages"] = request.latency_stages
+    if request.grade_confidence is not None:
+        kwargs["grade_confidence"] = request.grade_confidence
+    if request.config is not None:
+        kwargs["config"] = request.config
+    kwargs.update(request.extra_kwargs)
+
+    return GenerationResult(payload=await generate(**kwargs))
+
+
+__all__ = ["generate_answer"]

--- a/src/runtime/grounding/__init__.py
+++ b/src/runtime/grounding/__init__.py
@@ -1,12 +1,6 @@
-"""Compatibility shim for runtime grounding policy.
+"""Runtime grounding policy exports."""
 
-Deprecated: re-export shim for CORE-002. Import from
-``src.runtime.grounding.policy`` in new code.
-"""
-
-from __future__ import annotations
-
-from src.runtime.grounding.policy import (
+from .policy import (
     STRICT_GROUNDING_CONFIDENCE_THRESHOLD,
     STRICT_QUERY_TYPES,
     STRICT_TOPICS,

--- a/src/runtime/grounding/policy.py
+++ b/src/runtime/grounding/policy.py
@@ -1,0 +1,99 @@
+"""Grounding policy for assistant runtime answers.
+
+This module is the canonical home for strict grounding decisions used by the
+core runtime. Telegram keeps a compatibility shim so existing imports continue
+to work during the monolith-core migration.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+STRICT_TOPICS = {"legal", "relocation", "immigration"}
+STRICT_QUERY_TYPES = {"LEGAL", "RELOCATION", "IMMIGRATION"}
+STRICT_GROUNDING_CONFIDENCE_THRESHOLD = 0.5
+
+
+def is_high_risk_grounding_request(*, query_type: str, topic_hint: str | None) -> bool:
+    normalized_query_type = query_type.strip().upper()
+    normalized_topic_hint = topic_hint.strip().lower() if isinstance(topic_hint, str) else None
+    return normalized_query_type in STRICT_QUERY_TYPES or normalized_topic_hint in STRICT_TOPICS
+
+
+def get_grounding_mode(*, query_type: str, topic_hint: str | None) -> str:
+    return (
+        "strict"
+        if is_high_risk_grounding_request(query_type=query_type, topic_hint=topic_hint)
+        else "normal"
+    )
+
+
+def is_strict_grounding_safe(
+    *,
+    documents: list[dict[str, Any]],
+    sources_enabled: bool,
+    grade_confidence: float | None = None,
+) -> bool:
+    if not documents or not sources_enabled:
+        return False
+    if grade_confidence is None:
+        return True
+    return grade_confidence >= STRICT_GROUNDING_CONFIDENCE_THRESHOLD
+
+
+def semantic_cache_safe_reuse_allowed(
+    *,
+    grounding_mode: str,
+    grounded: bool,
+    legal_answer_safe: bool,
+    semantic_cache_safe_reuse: bool,
+    safe_fallback_used: bool,
+) -> bool:
+    if grounding_mode != "strict":
+        return True
+    return grounded and legal_answer_safe and semantic_cache_safe_reuse and not safe_fallback_used
+
+
+def should_safe_fallback(
+    *,
+    grounding_mode: str,
+    documents: list[dict[str, Any]],
+    sources_enabled: bool,
+    grade_confidence: float | None = None,
+    legal_answer_safe: bool | None = None,
+) -> bool:
+    if grounding_mode != "strict":
+        return False
+    if legal_answer_safe is not None:
+        return not legal_answer_safe
+    return not is_strict_grounding_safe(
+        documents=documents,
+        sources_enabled=sources_enabled,
+        grade_confidence=grade_confidence,
+    )
+
+
+def build_safe_fallback_response(documents: list[dict[str, Any]]) -> str:
+    if documents:
+        return (
+            "Не могу дать надежный ответ только на основе найденных материалов.\n\n"
+            "Уточните вопрос или попросите менеджера проверить документы вручную."
+        )
+    return (
+        "Не могу дать надежный ответ без подтвержденных материалов по этому вопросу.\n\n"
+        "Уточните запрос или обратитесь к менеджеру за проверенной консультацией."
+    )
+
+
+__all__ = [
+    "STRICT_GROUNDING_CONFIDENCE_THRESHOLD",
+    "STRICT_QUERY_TYPES",
+    "STRICT_TOPICS",
+    "build_safe_fallback_response",
+    "get_grounding_mode",
+    "is_high_risk_grounding_request",
+    "is_strict_grounding_safe",
+    "semantic_cache_safe_reuse_allowed",
+    "should_safe_fallback",
+]

--- a/src/runtime/pipeline/__init__.py
+++ b/src/runtime/pipeline/__init__.py
@@ -1,0 +1,6 @@
+"""Runtime assistant pipeline exports."""
+
+from .assistant_pipeline import run_assistant_pipeline
+from .rag import rag_pipeline
+
+__all__ = ["rag_pipeline", "run_assistant_pipeline"]

--- a/src/runtime/pipeline/assistant_pipeline.py
+++ b/src/runtime/pipeline/assistant_pipeline.py
@@ -1,0 +1,201 @@
+"""Runtime assistant orchestration pipeline."""
+
+from __future__ import annotations
+
+import importlib
+import time
+from typing import Any
+
+from src.core.contracts import (
+    AssistantRequest,
+    AssistantResult,
+    CoreDependencies,
+    UserContext,
+)
+from src.runtime.generation import GenerationRequest, generate_answer
+from src.runtime.pipeline.rag import rag_pipeline
+from src.utils.product_events import log_event
+
+
+async def run_assistant_pipeline(
+    request: AssistantRequest,
+    *,
+    dependencies: CoreDependencies,
+) -> AssistantResult:
+    """Execute the live assistant path and return the public core result."""
+
+    started = time.perf_counter()
+    rid = request.request_id
+    ctx = request.user_context or UserContext()
+
+    try:
+        classify_query = importlib.import_module("src.runtime.graph.nodes.classify").classify_query
+        legacy_generate = importlib.import_module(
+            "telegram_bot.services.generate_response"
+        ).generate_response
+
+        request_type = classify_query(request.query)
+        state_contract: dict[str, Any] | None = {"filters": ctx.filters} if ctx.filters else None
+
+        rag_result = await rag_pipeline(
+            query=request.query,
+            user_id=_coerce_user_id(ctx.user_id),
+            session_id=ctx.session_id or rid,
+            query_type=request_type,
+            original_query=request.query,
+            cache=dependencies.cache,
+            embeddings=dependencies.embeddings,
+            sparse_embeddings=dependencies.sparse_embeddings,
+            qdrant=dependencies.qdrant,
+            reranker=dependencies.reranker,
+            llm=dependencies.llm,
+            agent_role=ctx.role,
+            state_contract=state_contract,
+        )
+
+        documents = _as_document_list(rag_result.get("documents"))
+        retrieved_doc_ids = _extract_doc_ids(documents)
+        log_event(
+            "search_completed",
+            request_id=rid,
+            route="cache_hit" if rag_result.get("cache_hit") else "rag_search",
+            request_type=request_type,
+            retrieved_doc_ids=retrieved_doc_ids,
+            latency_ms=_latency_ms(started),
+            error_type=None,
+        )
+
+        if rag_result.get("cache_hit"):
+            return AssistantResult(
+                response_text=str(rag_result.get("response", "") or ""),
+                route="cache_hit",
+                request_type=str(rag_result.get("query_type") or request_type),
+                retrieved_doc_ids=retrieved_doc_ids,
+                retrieved_sources=_extract_sources(documents),
+                documents_count=len(documents),
+                latency_ms=_latency_ms(started),
+                request_id=rid,
+                cache_hit=True,
+                rerank_applied=bool(rag_result.get("rerank_applied", False)),
+            )
+
+        generation = await generate_answer(
+            GenerationRequest(
+                query=request.query,
+                documents=documents,
+                config=dependencies.config,
+            ),
+            generate=legacy_generate,
+        )
+        generation_result = generation.payload
+        usage = _as_usage_dict(generation_result.get("usage_details"))
+        llm_model = _extract_llm_model(generation_result)
+
+        log_event(
+            "llm_completed",
+            request_id=rid,
+            route="rag_search",
+            request_type=request_type,
+            latency_ms=_latency_ms(started),
+            error_type=None,
+            llm_model=llm_model,
+            input_tokens=usage.get("input"),
+            output_tokens=usage.get("output"),
+        )
+
+        return AssistantResult(
+            response_text=generation.response_text,
+            route="rag_search",
+            request_type=str(rag_result.get("query_type") or request_type),
+            retrieved_doc_ids=retrieved_doc_ids,
+            retrieved_sources=_extract_sources(documents),
+            documents_count=len(documents),
+            latency_ms=_latency_ms(started),
+            error_type=None,
+            request_id=rid,
+            cache_hit=False,
+            llm_model=llm_model,
+            llm_call_count=1,
+            rerank_applied=bool(rag_result.get("rerank_applied", False)),
+        )
+    except Exception as exc:
+        result = AssistantResult(
+            response_text="Сервис временно недоступен. Пожалуйста, повторите через минуту.",
+            route="error",
+            request_type="",
+            latency_ms=_latency_ms(started),
+            error_type="dependency_failed",
+            error_message=str(exc),
+            request_id=rid,
+        )
+        log_event(
+            "dependency_failed",
+            request_id=rid,
+            route=result.route,
+            request_type=result.request_type,
+            latency_ms=result.latency_ms,
+            error_type=result.error_type,
+        )
+        return result
+
+
+def _latency_ms(started: float) -> float:
+    return round((time.perf_counter() - started) * 1000, 3)
+
+
+def _coerce_user_id(value: str) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _as_document_list(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _extract_doc_ids(documents: list[dict[str, Any]]) -> list[str]:
+    ids: list[str] = []
+    for doc in documents:
+        metadata = doc.get("metadata") if isinstance(doc.get("metadata"), dict) else {}
+        candidate = (
+            metadata.get("source_id")
+            or metadata.get("doc_id")
+            or metadata.get("id")
+            or doc.get("source_id")
+            or doc.get("doc_id")
+            or doc.get("id")
+        )
+        if candidate is not None:
+            ids.append(str(candidate))
+    return ids
+
+
+def _extract_sources(documents: list[dict[str, Any]]) -> list[dict[str, str]]:
+    sources: list[dict[str, str]] = []
+    for doc in documents:
+        metadata = doc.get("metadata") if isinstance(doc.get("metadata"), dict) else {}
+        source: dict[str, str] = {}
+        title = metadata.get("title") or metadata.get("source") or doc.get("title")
+        url = metadata.get("url") or doc.get("url")
+        if title is not None:
+            source["title"] = str(title)
+        if url is not None:
+            source["url"] = str(url)
+        if source:
+            sources.append(source)
+    return sources
+
+
+def _as_usage_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _extract_llm_model(generation_result: dict[str, Any]) -> str | None:
+    model = generation_result.get("llm_provider_model") or generation_result.get("model")
+    return str(model) if model else None
+
+
+__all__ = ["run_assistant_pipeline"]

--- a/src/runtime/pipeline/rag.py
+++ b/src/runtime/pipeline/rag.py
@@ -1,0 +1,22 @@
+"""Runtime RAG pipeline seam.
+
+This module is the canonical runtime-facing entrypoint for RAG retrieval during
+the monolith-core migration. It delegates to the legacy Telegram implementation
+until CORE-005 can move the full implementation without changing retrieval
+behaviour.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+
+async def rag_pipeline(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    """Run the current RAG pipeline through the runtime-owned seam."""
+
+    legacy = importlib.import_module("telegram_bot.agents.rag_pipeline").rag_pipeline
+    return await legacy(*args, **kwargs)
+
+
+__all__ = ["rag_pipeline"]

--- a/telegram_bot/assistant_core_adapter.py
+++ b/telegram_bot/assistant_core_adapter.py
@@ -1,0 +1,80 @@
+"""Telegram adapter helpers for the assistant core rollout.
+
+CORE-008 keeps these helpers isolated so the production text path can switch to
+``src.core.run_assistant_request`` in a controlled follow-up without mixing
+Telegram rendering with runtime RAG ownership.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from src.core import (
+    AssistantResult,
+    CoreDependencies,
+    UserContext,
+    run_assistant_request,
+)
+
+
+CORE_ENTRYPOINT_ENV = "ASSISTANT_CORE_ENTRYPOINT_ENABLED"
+
+
+def core_entrypoint_enabled() -> bool:
+    """Return whether Telegram should use the assistant core entrypoint."""
+
+    return os.getenv(CORE_ENTRYPOINT_ENV, "0").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def build_user_context(
+    *,
+    user_id: int | str | None,
+    session_id: str | None,
+    role: str = "client",
+    filters: dict[str, Any] | None = None,
+    language: str = "ru",
+) -> UserContext:
+    """Build the transport-neutral context passed from Telegram into the core."""
+
+    return UserContext(
+        user_id=str(user_id or ""),
+        session_id=session_id or "",
+        role=role,
+        filters=filters,
+        language=language,
+    )
+
+
+async def run_core_text_request(
+    *,
+    query: str,
+    collection: str,
+    user_context: UserContext,
+    dependencies: CoreDependencies,
+    request_id: str | None = None,
+) -> AssistantResult:
+    """Call the assistant core from Telegram adapter code."""
+
+    return await run_assistant_request(
+        query,
+        collection=collection,
+        user_context=user_context,
+        request_id=request_id,
+        dependencies=dependencies,
+    )
+
+
+def response_text_for_telegram(result: AssistantResult) -> str:
+    """Return the user-visible Telegram text for a core result."""
+
+    return result.response_text
+
+
+__all__ = [
+    "CORE_ENTRYPOINT_ENV",
+    "build_user_context",
+    "core_entrypoint_enabled",
+    "response_text_for_telegram",
+    "run_core_text_request",
+]

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -68,6 +68,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from langgraph.errors import GraphRecursionError
 
 from src.retrieval.topic_classifier import get_query_topic_hint
+from src.runtime.grounding.policy import get_grounding_mode
 
 from . import (
     _bot_error_classification,  # #1265 Slice 1 PR-3: extracted error-classification helpers
@@ -125,7 +126,6 @@ from .services.cache_policy import (
     resolve_semantic_cache_signature,
 )
 from .services.forum_bridge import ForumBridge
-from .services.grounding_policy import get_grounding_mode
 from .services.handoff_state import HandoffData, HandoffState
 from .services.query_filter_signal import detect_filter_sensitive_query
 from .services.redis_monitor import RedisHealthMonitor

--- a/telegram_bot/pipelines/client.py
+++ b/telegram_bot/pipelines/client.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from src.observability_payloads import build_safe_input_payload
 from src.retrieval.topic_classifier import get_query_topic_hint
+from src.runtime.grounding.policy import get_grounding_mode
 from telegram_bot.agents.rag_pipeline import rag_pipeline
 from telegram_bot.graph.nodes.respond import _MAX_SOURCES, format_sources
 from telegram_bot.observability import get_client, observe, propagate_attributes
@@ -25,7 +26,6 @@ from telegram_bot.services.cache_policy import (
     resolve_semantic_cache_signature,
 )
 from telegram_bot.services.generate_response import generate_response
-from telegram_bot.services.grounding_policy import get_grounding_mode
 from telegram_bot.services.history_service import HistoryService
 from telegram_bot.services.telegram_formatting import send_html_messages
 from telegram_bot.services.types import PipelineResult

--- a/telegram_bot/services/cache_policy.py
+++ b/telegram_bot/services/cache_policy.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from time import time
 from typing import Any
 
-from telegram_bot.services.grounding_policy import semantic_cache_safe_reuse_allowed
+from src.runtime.grounding.policy import semantic_cache_safe_reuse_allowed
 from telegram_bot.services.query_filter_signal import build_filter_signature
 
 

--- a/telegram_bot/services/generate_response.py
+++ b/telegram_bot/services/generate_response.py
@@ -12,6 +12,11 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any
 
+from src.runtime.grounding.policy import (
+    build_safe_fallback_response,
+    is_strict_grounding_safe,
+    should_safe_fallback,
+)
 from telegram_bot.integrations.prompt_manager import (
     get_prompt,
     get_prompt_with_config,
@@ -23,11 +28,6 @@ from telegram_bot.integrations.prompt_templates import (
 )
 from telegram_bot.observability import get_client, observe
 from telegram_bot.services.coverage_mode import detect_coverage_mode
-from telegram_bot.services.grounding_policy import (
-    build_safe_fallback_response,
-    is_strict_grounding_safe,
-    should_safe_fallback,
-)
 from telegram_bot.services.metrics import PipelineMetrics
 from telegram_bot.services.response_style_detector import ResponseStyleDetector
 from telegram_bot.services.telegram_formatting import (

--- a/tests/contract/test_core_e2e_direct_entrypoint_contract.py
+++ b/tests/contract/test_core_e2e_direct_entrypoint_contract.py
@@ -1,0 +1,26 @@
+"""Contract: core live E2E must exercise the assistant core directly."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CORE_LIVE_TEST = REPO_ROOT / "tests" / "e2e" / "test_core_live_ingest_answer.py"
+
+
+def test_core_live_e2e_uses_run_assistant_request_directly() -> None:
+    text = CORE_LIVE_TEST.read_text(encoding="utf-8")
+    assert "run_assistant_request" in text
+    assert "from src.core.assistant import" in text or "from src.core import" in text
+
+
+def test_core_live_e2e_does_not_import_telegram_adapter() -> None:
+    text = CORE_LIVE_TEST.read_text(encoding="utf-8")
+    assert "import telegram_bot" not in text
+    assert "from telegram_bot" not in text
+
+
+if __name__ == "__main__":
+    test_core_live_e2e_uses_run_assistant_request_directly()
+    test_core_live_e2e_does_not_import_telegram_adapter()

--- a/tests/contract/test_runtime_no_telegram_bot_coupling_contract.py
+++ b/tests/contract/test_runtime_no_telegram_bot_coupling_contract.py
@@ -1,0 +1,135 @@
+"""Contract: ratchet dynamic ``telegram_bot`` coupling under ``src.core``/``src.runtime``.
+
+The static layering contract already blocks ``import telegram_bot`` statements
+under ``src``. This contract covers the remaining runtime-coupling seam: string
+literals such as ``importlib.import_module("telegram_bot...")`` and default
+factory specs that still point back to the Telegram adapter package during the
+monolith-core migration.
+
+The allowlist is intentionally small and must shrink as CORE-004/CORE-005 move
+generation/RAG ownership into ``src.runtime`` and CORE-010 removes transitional
+shims/defaults.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ALLOWLIST_PATH = REPO_ROOT / "tests" / "data" / "known_runtime_telegram_bot_couplings.json"
+GUARDED_ROOTS = (REPO_ROOT / "src" / "core", REPO_ROOT / "src" / "runtime")
+
+
+def _load_allowlist() -> dict[str, list[str]]:
+    payload = json.loads(ALLOWLIST_PATH.read_text(encoding="utf-8"))
+    return {path: sorted(values) for path, values in payload.items()}
+
+
+def _docstring_nodes(tree: ast.AST) -> set[ast.Constant]:
+    out: set[ast.Constant] = set()
+    for node in ast.walk(tree):
+        body = getattr(node, "body", None)
+        if not isinstance(body, list) or not body:
+            continue
+        first = body[0]
+        if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant):
+            if isinstance(first.value.value, str):
+                out.add(first.value)
+    return out
+
+
+def _string_values(value: Any) -> list[str]:
+    if isinstance(value, str) and "telegram_bot." in value:
+        return [value]
+    return []
+
+
+def _collect_runtime_couplings() -> dict[str, list[str]]:
+    out: dict[str, set[str]] = {}
+    for root in GUARDED_ROOTS:
+        for path in sorted(root.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            docstrings = _docstring_nodes(tree)
+            values: set[str] = set()
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Constant) and node not in docstrings:
+                    values.update(_string_values(node.value))
+                elif isinstance(node, ast.JoinedStr):
+                    # Dynamic f-strings containing telegram_bot are forbidden even
+                    # if the exact final module path is not statically knowable.
+                    literal_parts = [
+                        part.value
+                        for part in node.values
+                        if isinstance(part, ast.Constant) and isinstance(part.value, str)
+                    ]
+                    joined = "".join(literal_parts)
+                    values.update(_string_values(joined))
+            if values:
+                out[path.relative_to(REPO_ROOT).as_posix()] = values
+    return {path: sorted(values) for path, values in out.items()}
+
+
+def test_no_new_files_add_runtime_telegram_bot_coupling() -> None:
+    current = _collect_runtime_couplings()
+    allowlist = _load_allowlist()
+    new_files = sorted(set(current) - set(allowlist))
+    assert not new_files, (
+        "CORE-003: new file(s) under src/core or src/runtime contain executable "
+        "telegram_bot.* string coupling. Move the shared code under src.runtime or "
+        f"explicitly justify a temporary allowlist entry. New files: {new_files}"
+    )
+
+
+def test_existing_runtime_telegram_bot_coupling_does_not_grow() -> None:
+    current = _collect_runtime_couplings()
+    allowlist = _load_allowlist()
+    grown: dict[str, list[str]] = {}
+    for path, allowed_values in allowlist.items():
+        added = sorted(set(current.get(path, [])) - set(allowed_values))
+        if added:
+            grown[path] = added
+    assert not grown, (
+        "CORE-003: existing runtime coupling file(s) added new telegram_bot.* "
+        f"strings. Added values: {grown}"
+    )
+
+
+def test_runtime_telegram_bot_coupling_allowlist_has_no_stale_files() -> None:
+    current = _collect_runtime_couplings()
+    allowlist = _load_allowlist()
+    stale = sorted(set(allowlist) - set(current))
+    assert not stale, (
+        "CORE-003: allowlist contains file(s) that no longer have executable "
+        f"telegram_bot.* string coupling. Remove stale entries: {stale}"
+    )
+
+
+def test_runtime_telegram_bot_coupling_allowlist_matches_current_values() -> None:
+    current = _collect_runtime_couplings()
+    allowlist = _load_allowlist()
+    drift: dict[str, dict[str, list[str]]] = {}
+    for path, allowed_values in allowlist.items():
+        if path not in current:
+            continue
+        current_set = set(current[path])
+        allowed_set = set(allowed_values)
+        if current_set != allowed_set:
+            drift[path] = {
+                "extra_in_allowlist": sorted(allowed_set - current_set),
+                "missing_from_allowlist": sorted(current_set - allowed_set),
+            }
+    assert not drift, (
+        "CORE-003: runtime coupling allowlist drift detected. Update the JSON "
+        f"to match current executable telegram_bot.* strings exactly: {drift}"
+    )
+
+
+if __name__ == "__main__":
+    test_no_new_files_add_runtime_telegram_bot_coupling()
+    test_existing_runtime_telegram_bot_coupling_does_not_grow()
+    test_runtime_telegram_bot_coupling_allowlist_has_no_stale_files()
+    test_runtime_telegram_bot_coupling_allowlist_matches_current_values()

--- a/tests/data/known_runtime_telegram_bot_couplings.json
+++ b/tests/data/known_runtime_telegram_bot_couplings.json
@@ -1,0 +1,9 @@
+{
+  "src/core/assistant.py": [
+    "telegram_bot.agents.rag_pipeline",
+    "telegram_bot.services.generate_response"
+  ],
+  "src/runtime/graph/builder.py": [
+    "telegram_bot.graph.graph:build_graph"
+  ]
+}

--- a/tests/data/known_runtime_telegram_bot_couplings.json
+++ b/tests/data/known_runtime_telegram_bot_couplings.json
@@ -1,9 +1,11 @@
 {
-  "src/core/assistant.py": [
-    "telegram_bot.agents.rag_pipeline",
-    "telegram_bot.services.generate_response"
-  ],
   "src/runtime/graph/builder.py": [
     "telegram_bot.graph.graph:build_graph"
+  ],
+  "src/runtime/pipeline/assistant_pipeline.py": [
+    "telegram_bot.services.generate_response"
+  ],
+  "src/runtime/pipeline/rag.py": [
+    "telegram_bot.agents.rag_pipeline"
   ]
 }

--- a/tests/unit/core/test_assistant_entrypoint.py
+++ b/tests/unit/core/test_assistant_entrypoint.py
@@ -33,6 +33,26 @@ def test_module_imports_no_telegram_or_fastapi() -> None:
         assert forbidden not in mod_src.__dict__, f"src.core.assistant must not import {forbidden}"
 
 
+def test_core_public_contract_imports() -> None:
+    """src.core should re-export every public assistant contract."""
+    from src.core import (
+        AssistantError,
+        AssistantRequest,
+        AssistantResult,
+        CoreDependencies,
+        CrmAction,
+        UserContext,
+    )
+    from src.core import contracts
+
+    assert AssistantError is contracts.AssistantError
+    assert AssistantRequest is contracts.AssistantRequest
+    assert AssistantResult is contracts.AssistantResult
+    assert CoreDependencies is contracts.CoreDependencies
+    assert CrmAction is contracts.CrmAction
+    assert UserContext is contracts.UserContext
+
+
 # =============================================================================
 # UserContext
 # =============================================================================
@@ -80,6 +100,51 @@ class TestUserContext:
         assert is_dataclass(UserContext)
         assert not hasattr(UserContext, "model_validate")
         assert "pydantic" not in UserContext.__module__
+
+
+# =============================================================================
+# AssistantRequest
+# =============================================================================
+
+
+class TestAssistantRequest:
+    """Tests for the AssistantRequest dataclass."""
+
+    def test_creation_with_required_fields(self) -> None:
+        """AssistantRequest should accept query and collection with safe defaults."""
+        from src.core import AssistantRequest, UserContext
+
+        request = AssistantRequest(query="hello", collection="kb")
+
+        assert request.query == "hello"
+        assert request.collection == "kb"
+        assert isinstance(request.user_context, UserContext)
+        assert request.request_id == ""
+
+    def test_custom_context_and_request_id(self) -> None:
+        """AssistantRequest should carry caller-provided context and request_id."""
+        from src.core import AssistantRequest, UserContext
+
+        ctx = UserContext(user_id="u-1", session_id="s-1", filters={"city": "Sofia"})
+        request = AssistantRequest(
+            query="q",
+            collection="c",
+            user_context=ctx,
+            request_id="req-1",
+        )
+
+        assert request.user_context is ctx
+        assert request.request_id == "req-1"
+        assert request.user_context.filters == {"city": "Sofia"}
+
+    def test_importable_from_core_and_assistant_modules(self) -> None:
+        """AssistantRequest should be available from both public core surfaces."""
+        from src.core import AssistantRequest as FromCore
+        from src.core.assistant import AssistantRequest as FromAssistant
+        from src.core.contracts import AssistantRequest as FromContracts
+
+        assert FromCore is FromContracts
+        assert FromAssistant is FromContracts
 
 
 # =============================================================================

--- a/tests/unit/runtime/test_assistant_pipeline.py
+++ b/tests/unit/runtime/test_assistant_pipeline.py
@@ -1,0 +1,68 @@
+"""Tests for the runtime assistant pipeline seam."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+
+async def test_run_assistant_pipeline_returns_assistant_result(monkeypatch) -> None:
+    from src.core import AssistantRequest, CoreDependencies, UserContext
+    from src.runtime.pipeline.assistant_pipeline import run_assistant_pipeline
+
+    async def fake_rag_pipeline(**kwargs):
+        return {
+            "documents": [
+                {
+                    "content": "fact",
+                    "metadata": {
+                        "source_id": "doc-1",
+                        "title": "Doc 1",
+                        "url": "fixture://doc-1",
+                    },
+                }
+            ],
+            "cache_hit": False,
+            "query_type": "GENERAL",
+            "rerank_applied": True,
+        }
+
+    async def fake_generate_response(**kwargs):
+        return {
+            "response": "answer",
+            "llm_provider_model": "fake-model",
+            "usage_details": {"input": 1, "output": 2},
+        }
+
+    classify_mod = types.ModuleType("src.runtime.graph.nodes.classify")
+    classify_mod.classify_query = lambda query: "GENERAL"
+    generate_mod = types.ModuleType("telegram_bot.services.generate_response")
+    generate_mod.generate_response = fake_generate_response
+
+    monkeypatch.setitem(sys.modules, "src.runtime.graph.nodes.classify", classify_mod)
+    monkeypatch.setitem(sys.modules, "telegram_bot.services.generate_response", generate_mod)
+    monkeypatch.setattr(
+        "src.runtime.pipeline.assistant_pipeline.rag_pipeline",
+        fake_rag_pipeline,
+    )
+
+    result = await run_assistant_pipeline(
+        AssistantRequest(
+            query="q",
+            collection="c",
+            user_context=UserContext(user_id="42", session_id="s"),
+            request_id="req-1",
+        ),
+        dependencies=CoreDependencies(
+            cache=object(),
+            embeddings=object(),
+            sparse_embeddings=object(),
+            qdrant=object(),
+        ),
+    )
+
+    assert result.response_text == "answer"
+    assert result.route == "rag_search"
+    assert result.retrieved_doc_ids == ["doc-1"]
+    assert result.retrieved_sources == [{"title": "Doc 1", "url": "fixture://doc-1"}]
+    assert result.llm_model == "fake-model"

--- a/tests/unit/runtime/test_generation_service.py
+++ b/tests/unit/runtime/test_generation_service.py
@@ -1,0 +1,31 @@
+"""Tests for the runtime generation seam."""
+
+from __future__ import annotations
+
+
+async def test_generate_answer_uses_transport_free_request_contract() -> None:
+    from src.runtime.generation import GenerationRequest, generate_answer
+
+    captured = {}
+
+    async def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return {"response": "hello", "llm_provider_model": "fake"}
+
+    result = await generate_answer(
+        GenerationRequest(
+            query="q",
+            documents=[{"text": "fact"}],
+            grounding_mode="strict",
+            grade_confidence=0.7,
+            config=object(),
+        ),
+        generate=fake_generate,
+    )
+
+    assert result.response_text == "hello"
+    assert captured["query"] == "q"
+    assert captured["documents"] == [{"text": "fact"}]
+    assert captured["grounding_mode"] == "strict"
+    assert captured["grade_confidence"] == 0.7
+    assert "message" not in captured

--- a/tests/unit/runtime/test_grounding_policy.py
+++ b/tests/unit/runtime/test_grounding_policy.py
@@ -1,0 +1,56 @@
+"""Tests for the canonical runtime grounding policy module."""
+
+from __future__ import annotations
+
+
+def test_telegram_grounding_policy_is_compatibility_shim() -> None:
+    """Old Telegram file should re-export the canonical runtime functions.
+
+    Load the shim file directly so this lightweight test does not import the
+    heavy ``telegram_bot.services`` package initializer.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    from src.runtime.grounding import policy as canonical
+
+    shim_path = Path("telegram_bot/services/grounding_policy.py")
+    spec = importlib.util.spec_from_file_location("_grounding_policy_shim", shim_path)
+    assert spec is not None
+    assert spec.loader is not None
+    shim = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(shim)
+
+    assert shim.get_grounding_mode is canonical.get_grounding_mode
+    assert shim.is_high_risk_grounding_request is canonical.is_high_risk_grounding_request
+    assert shim.is_strict_grounding_safe is canonical.is_strict_grounding_safe
+    assert shim.semantic_cache_safe_reuse_allowed is canonical.semantic_cache_safe_reuse_allowed
+    assert shim.should_safe_fallback is canonical.should_safe_fallback
+    assert shim.build_safe_fallback_response is canonical.build_safe_fallback_response
+
+
+def test_grounding_policy_behavior_is_preserved() -> None:
+    """Canonical runtime policy should preserve strict/normal decisions."""
+    from src.runtime.grounding.policy import (
+        build_safe_fallback_response,
+        get_grounding_mode,
+        semantic_cache_safe_reuse_allowed,
+        should_safe_fallback,
+    )
+
+    assert get_grounding_mode(query_type="FAQ", topic_hint="legal") == "strict"
+    assert get_grounding_mode(query_type="GENERAL", topic_hint=None) == "normal"
+    assert should_safe_fallback(
+        grounding_mode="strict",
+        documents=[{"text": "fact"}],
+        sources_enabled=True,
+        grade_confidence=0.1,
+    )
+    assert not semantic_cache_safe_reuse_allowed(
+        grounding_mode="strict",
+        grounded=True,
+        legal_answer_safe=True,
+        semantic_cache_safe_reuse=False,
+        safe_fallback_used=False,
+    )
+    assert "Не могу дать надежный ответ" in build_safe_fallback_response([])

--- a/tests/unit/telegram_bot/test_assistant_core_adapter.py
+++ b/tests/unit/telegram_bot/test_assistant_core_adapter.py
@@ -1,0 +1,38 @@
+"""Tests for Telegram assistant-core adapter helpers."""
+
+from __future__ import annotations
+
+
+def test_build_user_context_is_transport_neutral() -> None:
+    from telegram_bot.assistant_core_adapter import build_user_context
+
+    ctx = build_user_context(
+        user_id=42,
+        session_id="s-1",
+        role="manager",
+        filters={"city": "Sofia"},
+    )
+
+    assert ctx.user_id == "42"
+    assert ctx.session_id == "s-1"
+    assert ctx.role == "manager"
+    assert ctx.filters == {"city": "Sofia"}
+    assert ctx.language == "ru"
+
+
+def test_core_entrypoint_flag_defaults_off(monkeypatch) -> None:
+    from telegram_bot.assistant_core_adapter import (
+        CORE_ENTRYPOINT_ENV,
+        core_entrypoint_enabled,
+    )
+
+    monkeypatch.delenv(CORE_ENTRYPOINT_ENV, raising=False)
+
+    assert not core_entrypoint_enabled()
+
+
+def test_response_text_for_telegram_returns_core_text() -> None:
+    from src.core import AssistantResult
+    from telegram_bot.assistant_core_adapter import response_text_for_telegram
+
+    assert response_text_for_telegram(AssistantResult(response_text="hello")) == "hello"


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Summary

Rebases and merges the monolith-core implementation from PR #2381 (`codex/find-current-codex-version`) onto current `dev`, resolving the conflict, so it can land cleanly.

Implements the first slice of milestone #25 (Stabilize Core Monolith):
- `src/core/contracts.py` — public assistant contracts (`AssistantRequest/Result`, `UserContext`, `CoreDependencies`, `CrmAction`, `AssistantError`) → **CORE-001**
- `src/runtime/grounding/policy.py` → **CORE-002**
- `src/runtime/generation/*` (`GenerationRequest`, `generate_answer`) → **CORE-004**
- `src/runtime/pipeline/rag.py` — runtime RAG seam (importlib shim to legacy) → **CORE-005**
- `src/runtime/pipeline/assistant_pipeline.py` — `run_assistant_pipeline` orchestration → **CORE-006**
- `telegram_bot/assistant_core_adapter.py` — adapter behind `ASSISTANT_CORE_ENTRYPOINT_ENABLED` → **CORE-008**
- `tests/contract/test_runtime_no_telegram_bot_coupling_contract.py` + allowlist → **CORE-003**
- Companion design docs + unit/contract tests.

## Conflict resolution

Single conflict in `docs/designs/README.md`. Resolved to keep our consolidated `monolith-core-plan.md` as the source of truth while listing #2381's companion docs and the lean-core audit doc. All other 29 files auto-merged.

## Verification

- No leftover conflict markers (repo-wide check).
- All changed/added Python files pass `py_compile`.
- 30 files changed vs `dev`.

## Open question (ADR 0015 — decision #0)

`run_assistant_pipeline` is assembled as a procedural path (classify -> rag -> legacy `generate_response`), not a `create_agent` wrapper. Per `monolith-core-plan.md` §5.2 this is the canonical-text-path decision that should be confirmed; tracked as a follow-up, not a blocker for landing these seams.

## PR guardrails

Regression guardrail: New runtime seams are additive and delegate to the existing legacy implementation via shims; behavior is unchanged until the `ASSISTANT_CORE_ENTRYPOINT_ENABLED` flag is enabled.
Checks run: py_compile on all changed files; CI Lint/Semgrep/Secret Scan/Lockfile/Compose; Fast/Heavy contract tests via CI lane.
No regression test: Added unit + contract tests for the new modules (`tests/unit/runtime/*`, `tests/contract/test_runtime_no_telegram_bot_coupling_contract.py`).