### PR TITLE
fix(typing/attribute-error): fix mypy return type in rag.py and narrow metadata type in assistant_pipeline.py

### DIFF
--- a/src/runtime/pipeline/assistant_pipeline.py
+++ b/src/runtime/pipeline/assistant_pipeline.py
@@ -159,7 +159,8 @@ def _as_document_list(value: Any) -> list[dict[str, Any]]:
 def _extract_doc_ids(documents: list[dict[str, Any]]) -> list[str]:
     ids: list[str] = []
     for doc in documents:
-        metadata = doc.get("metadata") if isinstance(doc.get("metadata"), dict) else {}
+        meta_val = doc.get("metadata")
+        metadata = meta_val if isinstance(meta_val, dict) else {}
         candidate = (
             metadata.get("source_id")
             or metadata.get("doc_id")
@@ -176,7 +177,8 @@ def _extract_doc_ids(documents: list[dict[str, Any]]) -> list[str]:
 def _extract_sources(documents: list[dict[str, Any]]) -> list[dict[str, str]]:
     sources: list[dict[str, str]] = []
     for doc in documents:
-        metadata = doc.get("metadata") if isinstance(doc.get("metadata"), dict) else {}
+        meta_val = doc.get("metadata")
+        metadata = meta_val if isinstance(meta_val, dict) else {}
         source: dict[str, str] = {}
         title = metadata.get("title") or metadata.get("source") or doc.get("title")
         url = metadata.get("url") or doc.get("url")

--- a/src/runtime/pipeline/rag.py
+++ b/src/runtime/pipeline/rag.py
@@ -18,13 +18,12 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import importlib.util
 import logging
 import time
 from collections.abc import Callable
-from typing import Any, TypeVar, cast
-
-import importlib.util
 from pathlib import Path
+from typing import Any, TypeVar, cast
 
 
 _T = TypeVar("_T")
@@ -63,7 +62,10 @@ def _identity_observe(*args: Any, **kwargs: Any) -> Callable[[_T], _T]:
 
 def _load_observe() -> Callable[..., Callable[[_T], _T]]:
     try:
-        return _load_telegram_attr("telegram_bot.observability", "observe")
+        return cast(
+            Callable[..., Callable[[_T], _T]],
+            _load_telegram_attr("telegram_bot.observability", "observe"),
+        )
     except Exception:  # pragma: no cover - import-safety fallback for lightweight tooling
         return _identity_observe
 


### PR DESCRIPTION
Fixes typing and AttributeError vulnerabilities in runtime pipelines (#2416).