### PR TITLE
fix(ci): repair red dev baseline blocking all open PRs

### DIFF
--- a/docs/engineering/bot-inert-paths-inventory-2026-05.md
+++ b/docs/engineering/bot-inert-paths-inventory-2026-05.md
@@ -98,4 +98,4 @@ the deletion in `tests/contract/test_dead_code_audit_2026_05_contract.py`.
 - Parent: [#1978](https://github.com/yastman/rag/issues/1978).
 - Companion docs: [`dead-code-audit-2026-05.md`](dead-code-audit-2026-05.md),
   `scripts-inventory-2026-05.md` (delivered separately under #1997).
-- Contract test: [`tests/contract/test_dead_code_audit_2026_05_contract.py`](../../tests/contract/test_dead_code_audit_2026_05_contract.py).
+- Contract test: `tests/contract/test_dead_code_audit_2026_05_contract.py` (removed during the 2026-05 contract simplification).

--- a/docs/engineering/compat-exports-decision-2026-05.md
+++ b/docs/engineering/compat-exports-decision-2026-05.md
@@ -87,7 +87,7 @@ PR should:
    `src/_compat.py` and the `from src._compat import …` lines at the
    top of each affected `__init__.py`.
 5. Pin the deletions in
-   [`tests/contract/test_dead_code_audit_2026_05_contract.py`](../../tests/contract/test_dead_code_audit_2026_05_contract.py)
+   `tests/contract/test_dead_code_audit_2026_05_contract.py` (removed during the 2026-05 contract simplification)
    so the shims do not accidentally come back.
 
 Suggested PR cuts (one per row, smallest blast radius first):

--- a/docs/engineering/dead-code-audit-2026-05.md
+++ b/docs/engineering/dead-code-audit-2026-05.md
@@ -53,7 +53,7 @@ the fourth is either "no" or "the tests test only this dead symbol".
 
 The legacy ingestion modules called out in the issue
 (`src/ingestion/docling_client.py`, `src/ingestion/service.py`) are already
-guarded by [`tests/contract/test_legacy_ingestion_removed_contract.py`](../../tests/contract/test_legacy_ingestion_removed_contract.py)
+guarded by `tests/contract/test_legacy_ingestion_removed_contract.py` (removed during the 2026-05 contract simplification)
 with documented `KNOWN_LIVE_CALLERS`, so they are intentionally retained
 until those callers migrate. No new action here; tracked under #1532.
 
@@ -84,4 +84,4 @@ the follow-up issue.
 - Methodology cross-link:
   [`docs/engineering/repo-hygiene-runbook.md`](repo-hygiene-runbook.md)
 - Contract test:
-  [`tests/contract/test_dead_code_audit_2026_05_contract.py`](../../tests/contract/test_dead_code_audit_2026_05_contract.py)
+  `tests/contract/test_dead_code_audit_2026_05_contract.py` (removed during the 2026-05 contract simplification)

--- a/docs/engineering/scripts-inventory-2026-05.md
+++ b/docs/engineering/scripts-inventory-2026-05.md
@@ -129,5 +129,5 @@ them under a Makefile target so they regain a documented caller.
 - Companion docs: [`dead-code-audit-2026-05.md`](dead-code-audit-2026-05.md),
   [`scripts/README.md`](../../scripts/README.md),
   [`script-native-migration-matrix.md`](script-native-migration-matrix.md).
-- Contract test: [`tests/contract/test_dead_code_audit_2026_05_contract.py`](../../tests/contract/test_dead_code_audit_2026_05_contract.py)
+- Contract test: `tests/contract/test_dead_code_audit_2026_05_contract.py` (removed during the 2026-05 contract simplification)
   (extend with the deletion pinned by this PR).

--- a/src/runtime/generation/__init__.py
+++ b/src/runtime/generation/__init__.py
@@ -3,4 +3,5 @@
 from .contracts import GenerationCallable, GenerationRequest, GenerationResult
 from .service import generate_answer
 
+
 __all__ = ["GenerationCallable", "GenerationRequest", "GenerationResult", "generate_answer"]

--- a/src/runtime/grounding/__init__.py
+++ b/src/runtime/grounding/__init__.py
@@ -12,6 +12,7 @@ from .policy import (
     should_safe_fallback,
 )
 
+
 __all__ = [
     "STRICT_GROUNDING_CONFIDENCE_THRESHOLD",
     "STRICT_QUERY_TYPES",

--- a/src/runtime/pipeline/rag.py
+++ b/src/runtime/pipeline/rag.py
@@ -18,13 +18,12 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import importlib.util
 import logging
 import time
 from collections.abc import Callable
-from typing import Any, TypeVar, cast
-
-import importlib.util
 from pathlib import Path
+from typing import Any, TypeVar, cast
 
 
 _T = TypeVar("_T")
@@ -69,7 +68,12 @@ def _load_observe() -> Callable[..., Callable[[_T], _T]]:
 
 
 def _get_client() -> Any:
-    return _load_telegram_attr("telegram_bot.observability", "get_client")
+    # ``telegram_bot.observability.get_client`` is the Langfuse ``get_client``
+    # factory; it must be *called* to obtain the client instance that exposes
+    # ``update_current_span``. Returning the factory itself caused
+    # ``AttributeError: 'function' object has no attribute 'update_current_span'``
+    # whenever the runtime pipeline recorded a span (e.g. miniapp path).
+    return _load_telegram_attr("telegram_bot.observability", "get_client")()
 
 
 def _cache_policy_attr(name: str) -> Any:

--- a/telegram_bot/agents/rag_tool.py
+++ b/telegram_bot/agents/rag_tool.py
@@ -20,8 +20,8 @@ from langgraph.runtime import Runtime
 
 from src.runtime.graph.nodes.classify import classify_query
 from src.runtime.graph.nodes.guard import guard_node
-from telegram_bot.agents.context import get_bot_context
 from src.runtime.pipeline.rag import rag_pipeline
+from telegram_bot.agents.context import get_bot_context
 from telegram_bot.observability import get_client, observe
 from telegram_bot.pipelines.state_contract import PreAgentStateContract
 from telegram_bot.scoring import write_langfuse_scores

--- a/telegram_bot/services/grounding_policy.py
+++ b/telegram_bot/services/grounding_policy.py
@@ -18,6 +18,7 @@ from src.runtime.grounding.policy import (
     should_safe_fallback,
 )
 
+
 __all__ = [
     "STRICT_GROUNDING_CONFIDENCE_THRESHOLD",
     "STRICT_QUERY_TYPES",

--- a/tests/contract/test_error_contract.py
+++ b/tests/contract/test_error_contract.py
@@ -45,6 +45,10 @@ ERROR_SPAN_ALLOWLIST: dict[str, list[str]] = {
     "telegram_bot/services/generate_response.py": ["ERROR", "WARNING"],
     "telegram_bot/services/qdrant.py": ["ERROR", "WARNING"],
     "src/runtime/services/qdrant.py": ["ERROR", "WARNING"],
+    # SDK-native runtime pipeline — curated ERROR spans on the embedding,
+    # rerank (ColBERT) and rewrite (LLM) failure paths inside ``except``
+    # blocks; mirrors the telegram_bot pipeline counterparts (core migration).
+    "src/runtime/pipeline/rag.py": ["ERROR"],
     "telegram_bot/services/history_service.py": ["ERROR"],
     "telegram_bot/middlewares/error_handler.py": ["ERROR"],
     # CRM callback handlers — exception path of CRM dialog/wrapper spans

--- a/tests/unit/agents/test_rag_pipeline.py
+++ b/tests/unit/agents/test_rag_pipeline.py
@@ -532,7 +532,7 @@ async def test_hybrid_retrieve_emits_topic_relax_trace_markers(mock_cache, mock_
     )
     mock_lf = MagicMock()
 
-    with patch("telegram_bot.agents.rag_pipeline.get_client", return_value=mock_lf):
+    with patch("src.runtime.pipeline.rag.get_client", return_value=mock_lf):
         result = await _hybrid_retrieve(
             "виды внж в болгарии?",
             [0.1] * 1024,
@@ -1360,7 +1360,7 @@ async def test_skip_rewrite_bypasses_rewrite_loop(
 
     with (
         patch(
-            "telegram_bot.agents.rag_pipeline._rewrite_query",
+            "src.runtime.pipeline.rag._rewrite_query",
             new_callable=AsyncMock,
         ) as mock_rewrite,
         patch.dict("os.environ", {"MAX_REWRITE_ATTEMPTS": "1"}),
@@ -1404,7 +1404,7 @@ async def test_skip_rewrite_false_allows_rewrite(
 
     with (
         patch(
-            "telegram_bot.agents.rag_pipeline._rewrite_query",
+            "src.runtime.pipeline.rag._rewrite_query",
             new=AsyncMock(return_value=mock_rewrite_result),
         ) as mock_rewrite,
         patch.dict("os.environ", {"MAX_REWRITE_ATTEMPTS": "1"}),

--- a/tests/unit/contextualization/test_base.py
+++ b/tests/unit/contextualization/test_base.py
@@ -15,7 +15,7 @@ from src.contextualization.base import ContextualizedChunk, ContextualizeProvide
 class TestContextualizedChunkCreation:
     """Tests for ContextualizedChunk dataclass creation."""
 
-    def test_creation_with_required_fields(self):
+    def test_chunk_creation_with_required_fields(self):
         """Test chunk creation with only required fields."""
         chunk = ContextualizedChunk(
             original_text="Test text",

--- a/tests/unit/test_bot_deeplink.py
+++ b/tests/unit/test_bot_deeplink.py
@@ -289,7 +289,7 @@ async def test_run_miniapp_rag_success(mock_config):
 
     with (
         patch(
-            "telegram_bot.agents.rag_pipeline.rag_pipeline",
+            "src.runtime.pipeline.rag.rag_pipeline",
             new_callable=AsyncMock,
             return_value={"documents": [{"text": "doc1"}]},
         ),
@@ -316,7 +316,7 @@ async def test_run_miniapp_rag_error_sends_fallback(mock_config):
     bot.bot = AsyncMock()
 
     with patch(
-        "telegram_bot.agents.rag_pipeline.rag_pipeline",
+        "src.runtime.pipeline.rag.rag_pipeline",
         new_callable=AsyncMock,
         side_effect=RuntimeError("Pipeline crashed"),
     ):
@@ -333,7 +333,7 @@ async def test_run_miniapp_rag_no_documents(mock_config):
     bot.bot = AsyncMock()
 
     with patch(
-        "telegram_bot.agents.rag_pipeline.rag_pipeline",
+        "src.runtime.pipeline.rag.rag_pipeline",
         new_callable=AsyncMock,
         return_value={"documents": []},
     ):

--- a/tests/unit/test_observability_span_metadata.py
+++ b/tests/unit/test_observability_span_metadata.py
@@ -121,7 +121,10 @@ class TestRAGPipelineSpanMetadata:
 
     @pytest.fixture(scope="class")
     def rag_spans(self):
-        path = REPO_ROOT / "telegram_bot" / "agents" / "rag_pipeline.py"
+        # The RAG pipeline observe-decorated spans live in the runtime module
+        # since the core migration; telegram_bot/agents/rag_pipeline.py is now a
+        # thin compatibility shim.
+        path = REPO_ROOT / "src" / "runtime" / "pipeline" / "rag.py"
         return _collect_observe_decorators(path)
 
     def test_grade_documents_has_evaluator_type(self, rag_spans):


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yastman :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Why

The `dev` base branch is **red**, which cascades into every open PR (#2438–#2443 etc.) — they can never go green until `dev` is fixed. Root causes:

| Failing check | Root cause |
|---|---|
| **Lint** | `ruff` `I001` import-sort errors in 5 files |
| **Heavy Contract Tests** | `src/runtime/pipeline/rag.py` ERROR spans not in `ERROR_SPAN_ALLOWLIST` |
| **Heavy Contract Tests** | duplicate test name `test_creation_with_required_fields` (#1539 ratchet) |
| **Fast Tests** | dead relative links in `docs/engineering/*` to deleted contract test files |
| **Fast Tests** (runtime) | `get_client()` returned the Langfuse factory, not the client → `AttributeError: 'function' object has no attribute 'update_current_span'` |

## What

- **ruff**: auto-fix `I001` import ordering in 5 files (`ruff check`/`format --check` both pass).
- **error-contract**: allowlist `src/runtime/pipeline/rag.py` ERROR spans — the embedding / ColBERT rerank / LLM rewrite failure paths inside `except` blocks, mirroring the already-allowlisted `telegram_bot` counterparts.
- **runtime rag**: `_get_client()` now *calls* `telegram_bot.observability.get_client()` to return the client instance (verified against the Langfuse Python SDK: `get_client()` returns the `Langfuse` client which exposes `update_current_span(*, output, metadata, version, status_message, level)`).
- **tests**: rename the duplicate to `test_chunk_creation_with_required_fields`.
- **docs**: de-link 5 references to deleted `*_2026_05_contract.py` test files (kept as inline code + "removed" note).

## Verification (local, py3.12)

- `ruff check` + `ruff format --check`: clean (405 files)
- `pytest tests/contract/test_error_contract.py`: 323 passed
- `pytest tests/unit/scripts/test_check_markdown_links.py`: passed
- `pytest tests/contract/test_no_new_duplicate_test_names.py`: passed
- `scripts/check_unique_test_names.py` + `scripts/check_markdown_links.py`: OK

## Note on direction

Per the plan to strip Langfuse from core and run a clean Python monolith (**DEPS-OBS1/2/3 — #2434/#2435/#2436**), the observability span code touched here (`get_client`, `ERROR_SPAN_ALLOWLIST`) is slated for removal. These are **interim** fixes to get `dev` and the open PRs green now; the allowlist entry and `get_client` shim will be deleted once the observability removal lands.