### PR TITLE
fix(bot): add polling lock release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@
 # Configurable container names & thresholds
 REDIS_CONTAINER ?= dev_redis_1
 POLLING_LOCK_KEY ?= telegram-bot:polling
+RELEASE_POLLING_LOCK_FORCE ?= 0
 EXPECTED_MAXMEMORY_SAMPLES ?= 10
 PROJECT_VERSION := $(shell sed -n 's/^version = "\([^"]*\)"/\1/p' pyproject.toml | head -n 1)
 K3S_IMAGE_REGISTRY ?= ghcr.io/yastman
@@ -771,6 +772,21 @@ release-polling-lock:  ## Delete the local Redis Telegram polling lock after con
 	@$(ENV_LOAD) \
 	container="$${REDIS_CONTAINER:-$(REDIS_CONTAINER)}"; \
 	key="$${POLLING_LOCK_KEY:-$(POLLING_LOCK_KEY)}"; \
+	force="$${RELEASE_POLLING_LOCK_FORCE:-$(RELEASE_POLLING_LOCK_FORCE)}"; \
+	if [ "$$force" != "1" ] && [ "$$force" != "true" ]; then \
+		running_bot_containers="$$(docker ps --filter name=bot --format '{{.Names}}' | tr '\n' ' ')"; \
+		if [ -n "$$running_bot_containers" ]; then \
+			echo "$(RED)Refusing to release polling lock while bot container(s) are running: $$running_bot_containers$(NC)"; \
+			echo "$(YELLOW)Stop the bot first, or set RELEASE_POLLING_LOCK_FORCE=1 for an emergency override.$(NC)"; \
+			exit 1; \
+		fi; \
+		native_bot_pids="$$(if command -v pgrep >/dev/null 2>&1; then pgrep -f 'python.*-m telegram_bot[.]main' || true; fi)"; \
+		if [ -n "$$native_bot_pids" ]; then \
+			echo "$(RED)Refusing to release polling lock while native bot process(es) are running: $$native_bot_pids$(NC)"; \
+			echo "$(YELLOW)Stop make run-bot first, or set RELEASE_POLLING_LOCK_FORCE=1 for an emergency override.$(NC)"; \
+			exit 1; \
+		fi; \
+	fi; \
 	if ! docker inspect "$$container" >/dev/null 2>&1; then \
 		container="$$(docker ps --filter name=redis -q | head -1)"; \
 	fi; \

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@
 	test-contract \
 	preflight-bot \
 	preflight-qdrant \
+	release-polling-lock \
 	docs-check \
 	remote-docker-status remote-compose-config remote-docker-ps remote-env-sync remote-env-check \
 	remote-active-up remote-core-up remote-core-ps remote-core-logs remote-core-health remote-core-env-check \
@@ -19,6 +20,7 @@
 
 # Configurable container names & thresholds
 REDIS_CONTAINER ?= dev_redis_1
+POLLING_LOCK_KEY ?= telegram-bot:polling
 EXPECTED_MAXMEMORY_SAMPLES ?= 10
 PROJECT_VERSION := $(shell sed -n 's/^version = "\([^"]*\)"/\1/p' pyproject.toml | head -n 1)
 K3S_IMAGE_REGISTRY ?= ghcr.io/yastman
@@ -752,7 +754,7 @@ qa: all-checks test ## Full quality assurance
 # Local Development (compose.yml + compose.dev.yml via COMPOSE_FILE env)
 # =============================================================================
 
-.PHONY: local-up local-up-ingest local-down local-logs local-ps local-build local-redis-recreate run-bot bot
+.PHONY: local-up local-up-ingest local-down local-logs local-ps local-build local-redis-recreate release-polling-lock run-bot bot
 LOCAL_SERVICES := postgres redis qdrant bge-m3 litellm
 LOCAL_INGEST_SERVICES := docling
 LOCAL_ALL_SERVICES := $(LOCAL_SERVICES) $(LOCAL_INGEST_SERVICES)
@@ -764,6 +766,33 @@ local-up:  ## Start local Docker services (bot runs via make run-bot)
 local-up-ingest:  ## Start local services + docling for ingestion workflows
 	$(LOCAL_COMPOSE_CMD) up -d $(LOCAL_ALL_SERVICES)
 	@echo "$(GREEN)✓ Local services + docling started$(NC)"
+
+release-polling-lock:  ## Delete the local Redis Telegram polling lock after confirming no bot is alive
+	@$(ENV_LOAD) \
+	container="$${REDIS_CONTAINER:-$(REDIS_CONTAINER)}"; \
+	key="$${POLLING_LOCK_KEY:-$(POLLING_LOCK_KEY)}"; \
+	if ! docker inspect "$$container" >/dev/null 2>&1; then \
+		container="$$(docker ps --filter name=redis -q | head -1)"; \
+	fi; \
+	if [ -z "$$container" ]; then \
+		echo "$(RED)No Redis container found. Start services with 'make local-up' first.$(NC)"; \
+		exit 1; \
+	fi; \
+	redis_cli='redis-cli'; \
+	if [ -n "$${REDIS_PASSWORD:-}" ]; then \
+		redis_cli='env REDISCLI_AUTH='"'$$REDIS_PASSWORD'"' redis-cli'; \
+	fi; \
+	owner="$$(docker exec "$$container" sh -c "$$redis_cli GET '$$key'")"; \
+	pttl="$$(docker exec "$$container" sh -c "$$redis_cli PTTL '$$key'")"; \
+	if [ -z "$$owner" ]; then \
+		echo "$(GREEN)Polling lock '$$key' is already free in Redis container '$$container'.$(NC)"; \
+		exit 0; \
+	fi; \
+	echo "$(YELLOW)Deleting polling lock '$$key' from Redis container '$$container'.$(NC)"; \
+	echo "$(YELLOW)Owner: $$owner$(NC)"; \
+	echo "$(YELLOW)PTTL ms: $$pttl$(NC)"; \
+	docker exec "$$container" sh -c "$$redis_cli DEL '$$key'" >/dev/null; \
+	echo "$(GREEN)✓ Polling lock released. Run 'make run-bot' again.$(NC)"
 
 run-bot:  ## Run bot locally (requires: make local-up)
 	$(UV_RUN_NO_SYNC) --env-file "$$RAG_RUNTIME_ENV_FILE" python -m telegram_bot.main

--- a/Makefile
+++ b/Makefile
@@ -778,12 +778,15 @@ release-polling-lock:  ## Delete the local Redis Telegram polling lock after con
 		echo "$(RED)No Redis container found. Start services with 'make local-up' first.$(NC)"; \
 		exit 1; \
 	fi; \
-	redis_cli='redis-cli'; \
-	if [ -n "$${REDIS_PASSWORD:-}" ]; then \
-		redis_cli='env REDISCLI_AUTH='"'$$REDIS_PASSWORD'"' redis-cli'; \
-	fi; \
-	owner="$$(docker exec "$$container" sh -c "$$redis_cli GET '$$key'")"; \
-	pttl="$$(docker exec "$$container" sh -c "$$redis_cli PTTL '$$key'")"; \
+	redis_exec() { \
+		if [ -n "$${REDIS_PASSWORD:-}" ]; then \
+			docker exec -e REDISCLI_AUTH="$$REDIS_PASSWORD" "$$container" redis-cli "$$@"; \
+		else \
+			docker exec "$$container" redis-cli "$$@"; \
+		fi; \
+	}; \
+	owner="$$(redis_exec GET "$$key")"; \
+	pttl="$$(redis_exec PTTL "$$key")"; \
 	if [ -z "$$owner" ]; then \
 		echo "$(GREEN)Polling lock '$$key' is already free in Redis container '$$container'.$(NC)"; \
 		exit 0; \
@@ -791,7 +794,7 @@ release-polling-lock:  ## Delete the local Redis Telegram polling lock after con
 	echo "$(YELLOW)Deleting polling lock '$$key' from Redis container '$$container'.$(NC)"; \
 	echo "$(YELLOW)Owner: $$owner$(NC)"; \
 	echo "$(YELLOW)PTTL ms: $$pttl$(NC)"; \
-	docker exec "$$container" sh -c "$$redis_cli DEL '$$key'" >/dev/null; \
+	redis_exec DEL "$$key" >/dev/null; \
 	echo "$(GREEN)✓ Polling lock released. Run 'make run-bot' again.$(NC)"
 
 run-bot:  ## Run bot locally (requires: make local-up)

--- a/tests/unit/test_makefile_contract.py
+++ b/tests/unit/test_makefile_contract.py
@@ -57,7 +57,8 @@ def test_release_polling_lock_target_exists_and_uses_rediscli_auth() -> None:
     block = block_match.group(0)
     assert "POLLING_LOCK_KEY" in block
     assert "REDISCLI_AUTH" in block, "target must not put Redis passwords on redis-cli -a argv"
-    assert " DEL '$$key'" in block
+    assert "redis_exec DEL \"$$key\"" in block
+    assert "sh -c" not in block, "target should pass keys/passwords as docker exec args"
     assert "make run-bot" in block
 
 

--- a/tests/unit/test_makefile_contract.py
+++ b/tests/unit/test_makefile_contract.py
@@ -62,6 +62,23 @@ def test_release_polling_lock_target_exists_and_uses_rediscli_auth() -> None:
     assert "make run-bot" in block
 
 
+def test_release_polling_lock_requires_bot_not_running_unless_forced() -> None:
+    """The manual unlock target must not create a second live poller by default."""
+    text = _makefile_text()
+    assert "RELEASE_POLLING_LOCK_FORCE ?= 0" in text
+    block_match = re.search(
+        r"^release-polling-lock:.*?(?=^[A-Za-z0-9_.-]+:|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert block_match, "release-polling-lock target not found in Makefile"
+    block = block_match.group(0)
+    assert "docker ps --filter name=bot" in block
+    assert "telegram_bot[.]main" in block
+    assert "Refusing to release polling lock" in block
+    assert "RELEASE_POLLING_LOCK_FORCE=1" in block
+
+
 def test_release_polling_lock_is_phony() -> None:
     text = _makefile_text()
     phony_blocks = re.findall(r"^\.PHONY:.*(?:\\\n.*)*", text, re.MULTILINE)

--- a/tests/unit/test_makefile_contract.py
+++ b/tests/unit/test_makefile_contract.py
@@ -37,6 +37,37 @@ def test_redis_container_override_behavior_preserved() -> None:
     )
 
 
+def test_polling_lock_key_default_matches_bot_contract() -> None:
+    """The manual unlock target must use the canonical bot polling lock key."""
+    text = _makefile_text()
+    match = re.search(r"^POLLING_LOCK_KEY\s+\?=\s*(.+)$", text, re.MULTILINE)
+    assert match, "POLLING_LOCK_KEY default not found in Makefile"
+    assert match.group(1).strip() == "telegram-bot:polling"
+
+
+def test_release_polling_lock_target_exists_and_uses_rediscli_auth() -> None:
+    """Operators need a safe local workaround for stale Redis polling locks."""
+    text = _makefile_text()
+    block_match = re.search(
+        r"^release-polling-lock:.*?(?=^[A-Za-z0-9_.-]+:|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert block_match, "release-polling-lock target not found in Makefile"
+    block = block_match.group(0)
+    assert "POLLING_LOCK_KEY" in block
+    assert "REDISCLI_AUTH" in block, "target must not put Redis passwords on redis-cli -a argv"
+    assert " DEL '$$key'" in block
+    assert "make run-bot" in block
+
+
+def test_release_polling_lock_is_phony() -> None:
+    text = _makefile_text()
+    phony_blocks = re.findall(r"^\.PHONY:.*(?:\\\n.*)*", text, re.MULTILINE)
+    combined = " ".join(phony_blocks)
+    assert "release-polling-lock" in combined
+
+
 # --- #1282 Local services docling contract tests ---
 
 


### PR DESCRIPTION
## Summary
- Add a make release-polling-lock target for stale local Telegram polling locks.
- Keep the canonical telegram-bot:polling key configurable via POLLING_LOCK_KEY.
- Add Makefile contract coverage for the target and Redis password handling.

Closes #2347

## Testing
- make -n release-polling-lock
- PYTEST_ADDOPTS='' uv run --no-sync pytest tests/unit/test_makefile_contract.py -q
- git diff --check
- make check (fails on pre-existing mypy errors in src/runtime/generation/service.py and related files)