### PR TITLE
refactor(deps): make heavy observability deps optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "aiohttp",
     "requests",
     "qdrant-client>=1.17.1",  # Vector database client (v1.17+ for weighted RRF, relevance feedback)
-    "langfuse>=4.0.0,<5.0",  # Native v4 observability migration
     # Voyage AI is OPTIONAL (#1773): not used by default bot/retrieval runtime.
     # Install via `uv sync --extra voyage` only for legacy GDrive ingestion or
     # contextualized-embedding paths.
@@ -39,16 +38,7 @@ dependencies = [
     # CheckpointerKind config flag) only when the Postgres path is actually wired.
     "langgraph-checkpoint-redis>=0.3.6",  # Redis checkpointer for LangGraph (0.3.0 fixes HumanMessage serialization #128)
     "langmem>=0.0.30",                    # SummarizationNode for conversation compression
-    # Scheduled nurturing + analytics (#390)
-    "apscheduler>=3.11.2,<4.0",           # Async job scheduling (v3 API)
     "phonenumbers>=9.0.25",
-    # Observability (#2060 / umbrella #1417 — Sentry-compatible error tracking).
-    # sentry-sdk powers the optional Bugsink/Sentry-Cloud integration in
-    # src/observability_sentry.py. It silently no-ops when SENTRY_DSN is unset.
-    "sentry-sdk>=2.0,<3.0",
-    # Direct root constraints to fix Dependabot alerts #50, #52-#55, #60, #66-#69
-    "pillow>=12.2.0",
-    "gradio>=6.7.0",
     "litellm>=1.0.0",
 ]
 
@@ -71,6 +61,24 @@ docs = [
     "mkdocs>=1.6.0",         # Documentation generator
     "mkdocs-material>=9.5.0",# Material theme
     "mkdocstrings[python]>=0.25.0",  # Auto API docs
+]
+
+
+# Optional observability listeners and error tracking
+observability = [
+    "langfuse>=4.0.0,<5.0",
+    "sentry-sdk>=2.0,<3.0",
+]
+
+# Optional scheduled nurturing / analytics jobs
+scheduling = [
+    "apscheduler>=3.11.2,<4.0",
+]
+
+# Optional heavyweight UI/media dependencies
+ui = [
+    "pillow>=12.2.0",
+    "gradio>=6.7.0",
 ]
 
 # Mini App (Telegram Web App — FastAPI backend)
@@ -129,7 +137,7 @@ voyage = [
 
 # All optional dependencies
 all = [
-    "contextual-rag[docs,voice,eval,ingest,ml-local,voyage]",
+    "contextual-rag[docs,voice,eval,ingest,ml-local,voyage,observability,scheduling,ui]",
 ]
 
 # =============================================================================
@@ -155,6 +163,15 @@ dev = [
     "telethon>=1.42.0",
     "pytest-split>=0.11.0",
     "fakeredis>=2.26.0",
+    # Static-analysis support for optional surfaces moved out of base deps.
+    # These stay dev-only so `uv sync --no-dev` keeps the runtime dependency diet.
+    "langfuse>=4.0.0,<5.0",
+    "sentry-sdk>=2.0,<3.0",
+    "apscheduler>=3.11.2,<4.0",
+    "pillow>=12.2.0",
+    "gradio>=6.7.0",
+    "fastapi>=0.115.0",
+    "uvicorn>=0.30.0",
 ]
 
 # =============================================================================

--- a/telegram_bot/pyproject.toml
+++ b/telegram_bot/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "tenacity>=8.2.0",
     "cachetools>=5.3.0",
     "python-dotenv>=1.0.0",
-    "langfuse>=4.0.0,<5.0",
     "openai>=1.10.0",
     "langchain>=1.2",  # create_agent, ToolRuntime, middleware
     "langchain-core>=1.2",
@@ -32,9 +31,7 @@ dependencies = [
     "fluentogram>=1.1.8",
     "fluent-compiler>=1.1",
     "asyncpg>=0.31.0",
-    "apscheduler>=3.11.2,<4.0",
     "phonenumbers>=9.0.25",
-    "sentry-sdk>=2.0,<3.0",
     "uvicorn>=0.30.0",
 ]
 
@@ -45,8 +42,15 @@ dependencies = [
 voyage = [
     "voyageai>=0.3.0",
 ]
+observability = [
+    "langfuse>=4.0.0,<5.0",
+    "sentry-sdk>=2.0,<3.0",
+]
+scheduling = [
+    "apscheduler>=3.11.2,<4.0",
+]
 all = [
-    "rag-telegram-bot[voyage]",
+    "rag-telegram-bot[voyage,observability,scheduling]",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/telegram_bot/uv.lock
+++ b/telegram_bot/uv.lock
@@ -2051,7 +2051,6 @@ source = { editable = "." }
 dependencies = [
     { name = "aiogram" },
     { name = "aiogram-dialog" },
-    { name = "apscheduler" },
     { name = "asyncpg" },
     { name = "cachetools" },
     { name = "fluent-compiler" },
@@ -2061,7 +2060,6 @@ dependencies = [
     { name = "langchain" },
     { name = "langchain-core" },
     { name = "langchain-openai" },
-    { name = "langfuse" },
     { name = "langgraph" },
     { name = "langgraph-checkpoint-redis" },
     { name = "langmem" },
@@ -2072,14 +2070,23 @@ dependencies = [
     { name = "qdrant-client" },
     { name = "redis" },
     { name = "redisvl" },
-    { name = "sentry-sdk" },
     { name = "tenacity" },
     { name = "uvicorn" },
 ]
 
 [package.optional-dependencies]
 all = [
+    { name = "apscheduler" },
+    { name = "langfuse" },
+    { name = "sentry-sdk" },
     { name = "voyageai" },
+]
+observability = [
+    { name = "langfuse" },
+    { name = "sentry-sdk" },
+]
+scheduling = [
+    { name = "apscheduler" },
 ]
 voyage = [
     { name = "voyageai" },
@@ -2089,7 +2096,7 @@ voyage = [
 requires-dist = [
     { name = "aiogram", specifier = ">=3.15.0" },
     { name = "aiogram-dialog", specifier = ">=2.4.0" },
-    { name = "apscheduler", specifier = ">=3.11.2,<4.0" },
+    { name = "apscheduler", marker = "extra == 'scheduling'", specifier = ">=3.11.2,<4.0" },
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "cachetools", specifier = ">=5.3.0" },
     { name = "fluent-compiler", specifier = ">=1.1" },
@@ -2099,7 +2106,7 @@ requires-dist = [
     { name = "langchain", specifier = ">=1.2" },
     { name = "langchain-core", specifier = ">=1.2" },
     { name = "langchain-openai", specifier = ">=0.3.0" },
-    { name = "langfuse", specifier = ">=4.0.0,<5.0" },
+    { name = "langfuse", marker = "extra == 'observability'", specifier = ">=4.0.0,<5.0" },
     { name = "langgraph", specifier = ">=1.1.6,<2.0" },
     { name = "langgraph-checkpoint-redis", specifier = ">=0.2.0" },
     { name = "langmem", specifier = ">=0.0.30" },
@@ -2108,15 +2115,15 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "qdrant-client", specifier = ">=1.14.0" },
-    { name = "rag-telegram-bot", extras = ["voyage"], marker = "extra == 'all'" },
+    { name = "rag-telegram-bot", extras = ["voyage", "observability", "scheduling"], marker = "extra == 'all'" },
     { name = "redis", specifier = ">=5.0.0" },
     { name = "redisvl", specifier = ">=0.3.0" },
-    { name = "sentry-sdk", specifier = ">=2.0,<3.0" },
+    { name = "sentry-sdk", marker = "extra == 'observability'", specifier = ">=2.0,<3.0" },
     { name = "tenacity", specifier = ">=8.2.0" },
     { name = "uvicorn", specifier = ">=0.30.0" },
     { name = "voyageai", marker = "extra == 'voyage'", specifier = ">=0.3.0" },
 ]
-provides-extras = ["voyage", "all"]
+provides-extras = ["voyage", "observability", "scheduling", "all"]
 
 [[package]]
 name = "redis"

--- a/tests/contract/test_optional_heavy_dependencies_contract.py
+++ b/tests/contract/test_optional_heavy_dependencies_contract.py
@@ -1,0 +1,55 @@
+"""Contract: DEPS-7 keeps heavy/observability packages out of base deps."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ROOT_PYPROJECT = ROOT / "pyproject.toml"
+TELEGRAM_PYPROJECT = ROOT / "telegram_bot" / "pyproject.toml"
+OPTIONAL_PACKAGES = {
+    "gradio",
+    "pillow",
+    "apscheduler",
+    "sentry-sdk",
+    "langfuse",
+}
+
+
+def _load(path: Path) -> dict:
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def _package_name(requirement: str) -> str:
+    return (
+        requirement.split("[", 1)[0]
+        .split("<", 1)[0]
+        .split(">", 1)[0]
+        .split("=", 1)[0]
+        .strip()
+        .lower()
+    )
+
+
+def test_root_base_dependencies_exclude_optional_heavy_packages() -> None:
+    deps = {_package_name(dep) for dep in _load(ROOT_PYPROJECT)["project"]["dependencies"]}
+    assert deps.isdisjoint(OPTIONAL_PACKAGES)
+
+
+def test_telegram_base_dependencies_exclude_optional_heavy_packages() -> None:
+    deps = {_package_name(dep) for dep in _load(TELEGRAM_PYPROJECT)["project"]["dependencies"]}
+    assert deps.isdisjoint(OPTIONAL_PACKAGES)
+
+
+def test_root_extras_keep_optional_dependency_targets() -> None:
+    optional = _load(ROOT_PYPROJECT)["project"].get("optional-dependencies", {})
+    flattened = {_package_name(dep) for deps in optional.values() for dep in deps}
+    assert flattened >= OPTIONAL_PACKAGES
+
+
+def test_telegram_extras_keep_observability_targets() -> None:
+    optional = _load(TELEGRAM_PYPROJECT)["project"].get("optional-dependencies", {})
+    flattened = {_package_name(dep) for deps in optional.values() for dep in deps}
+    assert {"langfuse", "sentry-sdk", "apscheduler"} <= flattened

--- a/uv.lock
+++ b/uv.lock
@@ -296,15 +296,6 @@ wheels = [
 ]
 
 [[package]]
-name = "asgiref"
-version = "3.11.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
-]
-
-[[package]]
 name = "astroid"
 version = "4.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -837,15 +828,12 @@ dependencies = [
     { name = "aiogram-dialog" },
     { name = "aiohttp" },
     { name = "anthropic" },
-    { name = "apscheduler" },
     { name = "asyncpg" },
     { name = "cachetools" },
     { name = "fluentogram" },
-    { name = "gradio" },
     { name = "groq" },
     { name = "instructor" },
     { name = "langchain-core" },
-    { name = "langfuse" },
     { name = "langgraph" },
     { name = "langgraph-checkpoint-redis" },
     { name = "langmem" },
@@ -853,14 +841,12 @@ dependencies = [
     { name = "numpy" },
     { name = "openai" },
     { name = "phonenumbers" },
-    { name = "pillow" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "qdrant-client" },
     { name = "redis" },
     { name = "redisvl" },
     { name = "requests" },
-    { name = "sentry-sdk" },
     { name = "tenacity" },
     { name = "typing-extensions" },
     { name = "uvloop" },
@@ -868,6 +854,7 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "apscheduler" },
     { name = "cocoindex" },
     { name = "datasets" },
     { name = "docling" },
@@ -876,7 +863,9 @@ all = [
     { name = "fastapi", version = "0.136.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "fastembed" },
     { name = "flagembedding" },
+    { name = "gradio" },
     { name = "httpx" },
+    { name = "langfuse" },
     { name = "livekit" },
     { name = "livekit-agents", extra = ["silero", "turn-detector"] },
     { name = "livekit-plugins-elevenlabs" },
@@ -887,10 +876,12 @@ all = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
     { name = "pandas" },
+    { name = "pillow" },
     { name = "pymupdf" },
     { name = "ragas" },
     { name = "scipy" },
     { name = "sentence-transformers" },
+    { name = "sentry-sdk" },
     { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (platform_machine != 'x86_64' and sys_platform == 'darwin')" },
     { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or sys_platform != 'darwin'" },
     { name = "torchvision", version = "0.26.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (platform_machine != 'x86_64' and sys_platform == 'darwin')" },
@@ -932,6 +923,17 @@ ml-local = [
     { name = "torchvision", version = "0.26.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or sys_platform != 'darwin'" },
     { name = "transformers" },
 ]
+observability = [
+    { name = "langfuse" },
+    { name = "sentry-sdk" },
+]
+scheduling = [
+    { name = "apscheduler" },
+]
+ui = [
+    { name = "gradio" },
+    { name = "pillow" },
+]
 voice = [
     { name = "fastapi", version = "0.129.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "fastapi", version = "0.136.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
@@ -950,11 +952,17 @@ voyage = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "apscheduler" },
     { name = "bandit" },
     { name = "click" },
     { name = "fakeredis" },
+    { name = "fastapi", version = "0.129.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "fastapi", version = "0.136.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "gradio" },
+    { name = "langfuse" },
     { name = "mypy" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "pillow" },
     { name = "pre-commit" },
     { name = "pylint" },
     { name = "pytest" },
@@ -965,7 +973,9 @@ dev = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "sentry-sdk" },
     { name = "telethon" },
+    { name = "uvicorn" },
     { name = "vulture" },
 ]
 
@@ -975,11 +985,11 @@ requires-dist = [
     { name = "aiogram-dialog", specifier = "==2.6.0" },
     { name = "aiohttp" },
     { name = "anthropic" },
-    { name = "apscheduler", specifier = ">=3.11.2,<4.0" },
+    { name = "apscheduler", marker = "extra == 'scheduling'", specifier = ">=3.11.2,<4.0" },
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "cachetools", specifier = ">=5.0.0" },
     { name = "cocoindex", marker = "extra == 'ingest'", specifier = ">=0.3.28" },
-    { name = "contextual-rag", extras = ["docs", "voice", "eval", "ingest", "ml-local", "voyage"], marker = "extra == 'all'" },
+    { name = "contextual-rag", extras = ["docs", "voice", "eval", "ingest", "ml-local", "voyage", "observability", "scheduling", "ui"], marker = "extra == 'all'" },
     { name = "datasets", marker = "extra == 'eval'", specifier = ">=3.0.0" },
     { name = "docling", marker = "extra == 'ingest'", specifier = ">=2.94.0" },
     { name = "docling-core", marker = "extra == 'ingest'", specifier = ">=2.74.1" },
@@ -988,13 +998,13 @@ requires-dist = [
     { name = "fastembed", marker = "extra == 'ingest'", specifier = ">=0.7.4" },
     { name = "flagembedding", marker = "extra == 'ml-local'" },
     { name = "fluentogram", specifier = ">=1.2.0" },
-    { name = "gradio", specifier = ">=6.7.0" },
+    { name = "gradio", marker = "extra == 'ui'", specifier = ">=6.7.0" },
     { name = "groq" },
     { name = "httpx", marker = "extra == 'mini-app'", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'voice'", specifier = ">=0.27.0" },
     { name = "instructor", specifier = ">=1.7.0" },
     { name = "langchain-core", specifier = ">=1.2" },
-    { name = "langfuse", specifier = ">=4.0.0,<5.0" },
+    { name = "langfuse", marker = "extra == 'observability'", specifier = ">=4.0.0,<5.0" },
     { name = "langgraph", specifier = ">=1.0.3,<2.0" },
     { name = "langgraph-checkpoint-redis", specifier = ">=0.3.6" },
     { name = "langmem", specifier = ">=0.0.30" },
@@ -1012,7 +1022,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", marker = "extra == 'voice'", specifier = ">=1.39.0" },
     { name = "pandas", marker = "extra == 'eval'", specifier = ">=2.0.0" },
     { name = "phonenumbers", specifier = ">=9.0.25" },
-    { name = "pillow", specifier = ">=12.2.0" },
+    { name = "pillow", marker = "extra == 'ui'", specifier = ">=12.2.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pymupdf", marker = "extra == 'ingest'", specifier = ">=1.26.0" },
     { name = "python-dotenv" },
@@ -1023,7 +1033,7 @@ requires-dist = [
     { name = "requests" },
     { name = "scipy", marker = "extra == 'ml-local'" },
     { name = "sentence-transformers", marker = "extra == 'ml-local'" },
-    { name = "sentry-sdk", specifier = ">=2.0,<3.0" },
+    { name = "sentry-sdk", marker = "extra == 'observability'", specifier = ">=2.0,<3.0" },
     { name = "tenacity", specifier = ">=8.2.0" },
     { name = "torch", marker = "extra == 'ml-local'", specifier = ">=2.0.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torchvision", marker = "extra == 'ml-local'", specifier = ">=0.15.0", index = "https://download.pytorch.org/whl/cpu" },
@@ -1034,15 +1044,20 @@ requires-dist = [
     { name = "uvloop", specifier = ">=0.21.0" },
     { name = "voyageai", marker = "extra == 'voyage'", specifier = ">=0.3.0" },
 ]
-provides-extras = ["ml-local", "docs", "mini-app", "voice", "docling", "ingest", "eval", "voyage", "all"]
+provides-extras = ["ml-local", "docs", "observability", "scheduling", "ui", "mini-app", "voice", "docling", "ingest", "eval", "voyage", "all"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "apscheduler", specifier = ">=3.11.2,<4.0" },
     { name = "bandit", specifier = ">=1.7.9" },
     { name = "click", specifier = ">=8.1.7" },
     { name = "fakeredis", specifier = ">=2.26.0" },
+    { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "gradio", specifier = ">=6.7.0" },
+    { name = "langfuse", specifier = ">=4.0.0,<5.0" },
     { name = "mypy", specifier = ">=1.11.0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.39.0" },
+    { name = "pillow", specifier = ">=12.2.0" },
     { name = "pre-commit", specifier = ">=3.8.0" },
     { name = "pylint", specifier = ">=3.2.0" },
     { name = "pytest", specifier = ">=8.3.0" },
@@ -1053,7 +1068,9 @@ dev = [
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.6.0" },
+    { name = "sentry-sdk", specifier = ">=2.0,<3.0" },
     { name = "telethon", specifier = ">=1.42.0" },
+    { name = "uvicorn", specifier = ">=0.30.0" },
     { name = "vulture", specifier = ">=2.11" },
 ]
 
@@ -4257,53 +4274,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-instrumentation"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "packaging" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/41/0f/7e6b713ac117c1f5e4e3300748af699b9902a2e5e34c9cf443dde25a01fa/opentelemetry_instrumentation-0.60b1.tar.gz", hash = "sha256:57ddc7974c6eb35865af0426d1a17132b88b2ed8586897fee187fd5b8944bd6a", size = 31706, upload-time = "2025-12-11T13:36:42.515Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/d2/6788e83c5c86a2690101681aeef27eeb2a6bf22df52d3f263a22cee20915/opentelemetry_instrumentation-0.60b1-py3-none-any.whl", hash = "sha256:04480db952b48fb1ed0073f822f0ee26012b7be7c3eac1a3793122737c78632d", size = 33096, upload-time = "2025-12-11T13:35:33.067Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-asgi"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "asgiref" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/77/db/851fa88db7441da82d50bd80f2de5ee55213782e25dc858e04d0c9961d60/opentelemetry_instrumentation_asgi-0.60b1.tar.gz", hash = "sha256:16bfbe595cd24cda309a957456d0fc2523f41bc7b076d1f2d7e98a1ad9876d6f", size = 26107, upload-time = "2025-12-11T13:36:47.015Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/76/1fb94367cef64420d2171157a6b9509582873bd09a6afe08a78a8d1f59d9/opentelemetry_instrumentation_asgi-0.60b1-py3-none-any.whl", hash = "sha256:d48def2dbed10294c99cfcf41ebbd0c414d390a11773a41f472d20000fcddc25", size = 16933, upload-time = "2025-12-11T13:35:40.462Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-fastapi"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-instrumentation-asgi" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/e7/e7e5e50218cf488377209d85666b182fa2d4928bf52389411ceeee1b2b60/opentelemetry_instrumentation_fastapi-0.60b1.tar.gz", hash = "sha256:de608955f7ff8eecf35d056578346a5365015fd7d8623df9b1f08d1c74769c01", size = 24958, upload-time = "2025-12-11T13:36:59.35Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/cc/6e808328ba54662e50babdcab21138eae4250bc0fddf67d55526a615a2ca/opentelemetry_instrumentation_fastapi-0.60b1-py3-none-any.whl", hash = "sha256:af94b7a239ad1085fc3a820ecf069f67f579d7faf4c085aaa7bd9b64eafc8eaf", size = 13478, upload-time = "2025-12-11T13:36:00.811Z" },
-]
-
-[[package]]
 name = "opentelemetry-proto"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4340,15 +4310,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
-]
-
-[[package]]
-name = "opentelemetry-util-http"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/50/fc/c47bb04a1d8a941a4061307e1eddfa331ed4d0ab13d8a9781e6db256940a/opentelemetry_util_http-0.60b1.tar.gz", hash = "sha256:0d97152ca8c8a41ced7172d29d3622a219317f74ae6bb3027cfbdcf22c3cc0d6", size = 11053, upload-time = "2025-12-11T13:37:25.115Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/5c/d3f1733665f7cd582ef0842fb1d2ed0bc1fba10875160593342d22bba375/opentelemetry_util_http-0.60b1-py3-none-any.whl", hash = "sha256:66381ba28550c91bee14dcba8979ace443444af1ed609226634596b4b0faf199", size = 8947, upload-time = "2025-12-11T13:36:37.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Move Langfuse, Sentry, APScheduler, Pillow, and Gradio out of base dependencies into optional extras.
- Add root extras for observability, scheduling, and UI dependency groups, and include them in the all extra.
- Add telegram_bot observability/scheduling extras and keep all extra opt-in complete.
- Add a DEPS-7 contract that prevents these packages from returning to base deps.

Closes #2431

## Testing
- PYTEST_ADDOPTS='' uv run --no-sync pytest tests/contract/test_optional_heavy_dependencies_contract.py -q
- uv run --no-sync ruff check tests/contract/test_optional_heavy_dependencies_contract.py --fix
- uv run --no-sync ruff check tests/contract/test_optional_heavy_dependencies_contract.py
- git diff --check
- uv lock --check
- make check (ruff passes; mypy fails on existing errors outside this change)