### PR TITLE
docs(deps): audit Boto3 and Google Cloud dependencies

### DIFF
--- a/docs/engineering/dependency-audits/boto-google-cloud-deps.md
+++ b/docs/engineering/dependency-audits/boto-google-cloud-deps.md
@@ -1,0 +1,43 @@
+# Boto3 / Google Cloud dependency audit (DEPS-9)
+
+## Scope
+
+This audit covers the root and Telegram dependency surfaces for the packages
+listed in #2451:
+
+- `boto3`
+- `botocore`
+- `google-cloud-storage`
+- `google-auth`
+- `google-cloud-core`
+- `google-crc32c`
+- `google-resumable-media`
+- `googleapis-common-protos`
+
+## Findings
+
+The application code does not import Boto3, Botocore, Google Cloud Storage, or
+Google Auth directly from `src/` or `telegram_bot/`.
+
+After DEPS-8 removed root `docling-serve[ui]` from the application dependency
+extra, the root lockfile no longer contains these service-only packages:
+
+- `boto3`
+- `botocore`
+- `google-cloud-storage`
+- `google-auth`
+- `google-cloud-core`
+- `google-crc32c`
+- `google-resumable-media`
+
+`googleapis-common-protos` may still appear while OpenTelemetry exporter packages
+remain in the root or Telegram lockfiles. Its parents are OTel exporters (`opentelemetry-exporter-otlp-proto-http` and, in the root lock, `opentelemetry-exporter-otlp-proto-grpc`), not Boto3 or Google Cloud Storage runtime code. That remaining transitive dependency
+is owned by the OTel removal path (#2434 / PR #2447), not by a Boto/GCS direct
+usage path.
+
+## Guardrail
+
+`tests/contract/test_boto_google_cloud_dependency_audit_contract.py` prevents
+these packages from returning as direct dependencies or direct runtime imports,
+and keeps the only temporary `googleapis-common-protos` allowance tied to OTel
+exporter parents.

--- a/tests/contract/test_boto_google_cloud_dependency_audit_contract.py
+++ b/tests/contract/test_boto_google_cloud_dependency_audit_contract.py
@@ -1,0 +1,99 @@
+"""Contract: DEPS-9 keeps Boto3/GCS packages out of runtime dependencies."""
+
+from __future__ import annotations
+
+import ast
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ROOT_LOCK = ROOT / "uv.lock"
+TELEGRAM_LOCK = ROOT / "telegram_bot" / "uv.lock"
+AUDIT_DOC = ROOT / "docs" / "engineering" / "dependency-audits" / "boto-google-cloud-deps.md"
+FORBIDDEN_DIRECT_PACKAGES = {
+    "boto3",
+    "botocore",
+    "google-cloud-storage",
+    "google-auth",
+    "google-cloud-core",
+    "google-crc32c",
+    "google-resumable-media",
+}
+GOOGLEAPIS_COMMON_PROTOS = "googleapis-common-protos"
+ALLOWED_GOOGLEAPIS_PARENTS = {
+    "opentelemetry-exporter-otlp-proto-grpc",
+    "opentelemetry-exporter-otlp-proto-http",
+}
+RUNTIME_DIRS = (ROOT / "src", ROOT / "telegram_bot")
+
+
+def _load_toml(path: Path) -> dict:
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def _lock_package_names(path: Path) -> set[str]:
+    data = _load_toml(path)
+    return {package["name"] for package in data.get("package", [])}
+
+
+def _reverse_lock_dependencies(path: Path) -> dict[str, set[str]]:
+    data = _load_toml(path)
+    reverse: dict[str, set[str]] = {}
+    for package in data.get("package", []):
+        parent = package["name"]
+        for dep in package.get("dependencies", []) or []:
+            reverse.setdefault(dep["name"], set()).add(parent)
+    return reverse
+
+
+def _project_dependencies(path: Path) -> set[str]:
+    data = _load_toml(path)
+    deps = data["project"].get("dependencies", [])
+    return {dep.split("[", 1)[0].split("<", 1)[0].split(">", 1)[0].split("=", 1)[0].lower() for dep in deps}
+
+
+def test_root_and_telegram_base_deps_do_not_include_boto_or_gcs_packages() -> None:
+    for pyproject in (ROOT / "pyproject.toml", ROOT / "telegram_bot" / "pyproject.toml"):
+        deps = _project_dependencies(pyproject)
+        assert deps.isdisjoint(FORBIDDEN_DIRECT_PACKAGES | {GOOGLEAPIS_COMMON_PROTOS})
+
+
+def test_root_lock_excludes_boto_and_google_cloud_storage_packages() -> None:
+    packages = _lock_package_names(ROOT_LOCK)
+    assert packages.isdisjoint(FORBIDDEN_DIRECT_PACKAGES)
+
+
+def test_googleapis_common_protos_is_only_transitive_from_otel_exporters_when_present() -> None:
+    for lock_path in (ROOT_LOCK, TELEGRAM_LOCK):
+        packages = _lock_package_names(lock_path)
+        if GOOGLEAPIS_COMMON_PROTOS not in packages:
+            continue
+        parents = _reverse_lock_dependencies(lock_path).get(GOOGLEAPIS_COMMON_PROTOS, set())
+        assert parents
+        assert parents <= ALLOWED_GOOGLEAPIS_PARENTS
+
+
+def test_runtime_code_does_not_import_boto_or_google_cloud_modules() -> None:
+    violations: list[str] = []
+    for base in RUNTIME_DIRS:
+        for py_file in base.rglob("*.py"):
+            rel = py_file.relative_to(ROOT)
+            tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(rel))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    for alias in node.names:
+                        if alias.name in {"boto3", "botocore"} or alias.name.startswith(("google.cloud", "google.auth")):
+                            violations.append(f"{rel}:{node.lineno} imports {alias.name}")
+                elif isinstance(node, ast.ImportFrom):
+                    module = node.module or ""
+                    if module in {"boto3", "botocore"} or module.startswith(("google.cloud", "google.auth")):
+                        violations.append(f"{rel}:{node.lineno} imports from {module}")
+    assert violations == []
+
+
+def test_dependency_audit_document_records_transitive_owner() -> None:
+    text = AUDIT_DOC.read_text(encoding="utf-8")
+    assert "docling-serve[ui]" in text
+    assert "opentelemetry-exporter-otlp-proto-http" in text
+    assert "PR #2447" in text

--- a/tests/contract/test_boto_google_cloud_dependency_audit_contract.py
+++ b/tests/contract/test_boto_google_cloud_dependency_audit_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import subprocess
 import tomllib
 from pathlib import Path
 
@@ -26,6 +27,7 @@ ALLOWED_GOOGLEAPIS_PARENTS = {
     "opentelemetry-exporter-otlp-proto-http",
 }
 RUNTIME_DIRS = (ROOT / "src", ROOT / "telegram_bot")
+RUNTIME_GIT_PATTERNS = ("src/**/*.py", "telegram_bot/**/*.py")
 
 
 def _load_toml(path: Path) -> dict:
@@ -50,7 +52,26 @@ def _reverse_lock_dependencies(path: Path) -> dict[str, set[str]]:
 def _project_dependencies(path: Path) -> set[str]:
     data = _load_toml(path)
     deps = data["project"].get("dependencies", [])
-    return {dep.split("[", 1)[0].split("<", 1)[0].split(">", 1)[0].split("=", 1)[0].lower() for dep in deps}
+    return {
+        dep.split("[", 1)[0].split("<", 1)[0].split(">", 1)[0].split("=", 1)[0].lower()
+        for dep in deps
+    }
+
+
+def _tracked_runtime_python_files() -> list[Path]:
+    for runtime_dir in RUNTIME_DIRS:
+        assert runtime_dir.is_dir(), f"runtime scan root does not exist: {runtime_dir}"
+
+    result = subprocess.run(
+        ["git", "ls-files", *RUNTIME_GIT_PATTERNS],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    files = [ROOT / line for line in result.stdout.splitlines() if line]
+    assert files, "runtime import contract did not find any tracked Python files"
+    return files
 
 
 def test_root_and_telegram_base_deps_do_not_include_boto_or_gcs_packages() -> None:
@@ -76,19 +97,22 @@ def test_googleapis_common_protos_is_only_transitive_from_otel_exporters_when_pr
 
 def test_runtime_code_does_not_import_boto_or_google_cloud_modules() -> None:
     violations: list[str] = []
-    for base in RUNTIME_DIRS:
-        for py_file in base.rglob("*.py"):
-            rel = py_file.relative_to(ROOT)
-            tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(rel))
-            for node in ast.walk(tree):
-                if isinstance(node, ast.Import):
-                    for alias in node.names:
-                        if alias.name in {"boto3", "botocore"} or alias.name.startswith(("google.cloud", "google.auth")):
-                            violations.append(f"{rel}:{node.lineno} imports {alias.name}")
-                elif isinstance(node, ast.ImportFrom):
-                    module = node.module or ""
-                    if module in {"boto3", "botocore"} or module.startswith(("google.cloud", "google.auth")):
-                        violations.append(f"{rel}:{node.lineno} imports from {module}")
+    for py_file in _tracked_runtime_python_files():
+        rel = py_file.relative_to(ROOT)
+        tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(rel))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name in {"boto3", "botocore"} or alias.name.startswith(
+                        ("google.cloud", "google.auth")
+                    ):
+                        violations.append(f"{rel}:{node.lineno} imports {alias.name}")
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                if module in {"boto3", "botocore"} or module.startswith(
+                    ("google.cloud", "google.auth")
+                ):
+                    violations.append(f"{rel}:{node.lineno} imports from {module}")
     assert violations == []
 
 


### PR DESCRIPTION
## Summary
- Document the DEPS-9 Boto3 / Google Cloud dependency audit after the DEPS-8 root Docling service-dependency cleanup.
- Add a contract that prevents Boto3, Botocore, and Google Cloud Storage/Auth packages from returning as direct runtime deps/imports.
- Allow temporary `googleapis-common-protos` only when it is transitive from OTel exporters, which is owned by the OTel removal path (#2434 / PR #2447).

Closes #2451

Depends on #2464

## Testing
- `uv run --no-sync ruff check tests/contract/test_boto_google_cloud_dependency_audit_contract.py --fix`
- `uv run --no-sync ruff check tests/contract/test_boto_google_cloud_dependency_audit_contract.py`
- `PYTEST_ADDOPTS='' uv run --no-sync pytest -o addopts='' tests/contract/test_boto_google_cloud_dependency_audit_contract.py -q`
- `uv lock --check`
- `git diff --check`