### PR TITLE
chore(cleanup): remove verified dead code

### DIFF
--- a/docs/engineering/dependency-audits/dead-code-cleanup-2458.md
+++ b/docs/engineering/dependency-audits/dead-code-cleanup-2458.md
@@ -1,0 +1,28 @@
+# DEPS-15 dead-code cleanup audit
+
+This audit verifies candidate symbols with repository-wide `rg` reference checks
+before removal. Mini App candidates remain blocked by #2430. Langfuse/OTel
+helpers that still have active imports or tests remain in place until #2434 and
+#2435 land.
+
+Removed in this slice:
+
+| Symbol | File | Verification result |
+|---|---|---|
+| `find_merged_branches` | `scripts/archive/git_hygiene.py` | Only the definition existed. |
+| `find_no_upstream_branches` | `scripts/archive/git_hygiene.py` | Only the definition existed. |
+| `find_stale_worktrees` | `scripts/archive/git_hygiene.py` | Only the definition existed. |
+| `fix_merged_branches` | `scripts/archive/git_hygiene.py` | Only the compatibility shim existed. |
+| `_resolve` | `src/observability_sentry.py` | Only the private definition existed; resolver-specific helpers remain used. |
+| `embed_queries_sync` | `src/models/contextualized_embedding.py` | Only the sync-wrapper definition existed. |
+
+Kept after verification:
+
+- `rag_task` is used by `scripts/run_experiment.py` when creating the dataset
+  run task.
+- `traced_pipeline`, `is_endpoint_reachable`, and `disable_otel_exporter` still
+  have active imports/tests.
+- `reset_pipeline_factory_cache` and `mark_processing_sync` are covered by unit
+  tests and remain public test/reset helpers.
+- Docling `chunk_document`, `convert_file`, and `health_check` remain part of
+  the ingestion compatibility/export surface.

--- a/scripts/archive/git_hygiene.py
+++ b/scripts/archive/git_hygiene.py
@@ -475,56 +475,6 @@ def find_transient_files() -> list[str]:
 
 
 # ---------------------------------------------------------------------------
-# Backward-compat helpers (kept so external callers/tests stay green)
-# ---------------------------------------------------------------------------
-
-
-def find_merged_branches() -> list[str]:
-    """Backward-compat: list of branch names eligible for safe deletion."""
-    fetch_remote_state()
-    current = _current_branch()
-    worktrees = collect_worktrees()
-    branches = classify_branches(
-        collect_branches(base=base_branch, current=current, worktrees=worktrees),
-        base=base_branch,
-    )
-    return [b.name for b in branches if b.category == "safe-to-delete"]
-
-
-def find_no_upstream_branches() -> list[str]:
-    """Backward-compat: branches without upstream tracking."""
-    raw = _run(
-        [
-            "git",
-            "for-each-ref",
-            "--format=%(refname:short) %(upstream)",
-            "refs/heads/",
-        ],
-        check=False,
-    )
-    if not raw:
-        return []
-    out: list[str] = []
-    for line in raw.splitlines():
-        parts = line.split(maxsplit=1)
-        branch = parts[0]
-        upstream = parts[1] if len(parts) > 1 else ""
-        if not upstream:
-            out.append(branch)
-    return out
-
-
-def find_stale_worktrees() -> list[dict[str, str]]:
-    """Backward-compat: dicts of ``{path, reason}`` for any non-safe worktree."""
-    worktrees = collect_worktrees()
-    out: list[dict[str, str]] = []
-    for wt in worktrees:
-        if wt.category != "safe":
-            out.append({"path": wt.path, "reason": ", ".join(wt.reasons) or "unknown"})
-    return out
-
-
-# ---------------------------------------------------------------------------
 # Report assembly
 # ---------------------------------------------------------------------------
 
@@ -620,18 +570,6 @@ def fix_safe_branches(
         elif not quiet:
             print(f"  FAILED to delete {branch.name}: {result.stderr.strip()}")
     return deleted
-
-
-# Backward-compat shim: existing tests/code may call ``fix_merged_branches``.
-def fix_merged_branches(
-    branches: list[str], *, dry_run: bool = False, quiet: bool = False
-) -> list[str]:
-    """Backward-compatible shim accepting plain branch names."""
-    return fix_safe_branches(
-        [BranchInfo(name=b, category="safe-to-delete") for b in branches],
-        dry_run=dry_run,
-        quiet=quiet,
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/models/contextualized_embedding.py
+++ b/src/models/contextualized_embedding.py
@@ -378,7 +378,3 @@ class ContextualizedEmbeddingService:
     def embed_query_sync(self, query: str) -> list[float]:
         """Sync wrapper for embed_query."""
         return asyncio.run(self.embed_query(query))
-
-    def embed_queries_sync(self, queries: list[str]) -> list[list[float]]:
-        """Sync wrapper for embed_queries."""
-        return asyncio.run(self.embed_queries(queries))

--- a/src/observability_sentry.py
+++ b/src/observability_sentry.py
@@ -93,15 +93,6 @@ _initialized = False
 _skip_logged = False
 
 
-def _resolve(value: str | None, env_name: str, default: str | None = None) -> str | None:
-    """Return *value* when set, else env var, else default. Strips whitespace."""
-    candidate = value if value is not None else os.getenv(env_name, "")
-    candidate = (candidate or "").strip()
-    if candidate:
-        return candidate
-    return default
-
-
 def _resolve_dsn(explicit: str | None) -> str | None:
     """Return a non-blank DSN or ``None``."""
     candidate = explicit if explicit is not None else os.getenv("SENTRY_DSN", "")

--- a/tests/contract/test_dead_code_cleanup_contract.py
+++ b/tests/contract/test_dead_code_cleanup_contract.py
@@ -1,0 +1,32 @@
+"""Contracts for DEPS-15 verified dead-code removals."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REMOVED_SYMBOLS = {
+    "scripts/archive/git_hygiene.py": {
+        "find_merged_branches",
+        "find_no_upstream_branches",
+        "find_stale_worktrees",
+        "fix_merged_branches",
+    },
+    "src/observability_sentry.py": {"_resolve"},
+    "src/models/contextualized_embedding.py": {"embed_queries_sync"},
+}
+
+
+def _function_names(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text())
+    return {node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)}
+
+
+def test_verified_dead_code_symbols_are_removed() -> None:
+    existing = {
+        file: sorted(symbols & _function_names(ROOT / file))
+        for file, symbols in REMOVED_SYMBOLS.items()
+    }
+    assert existing == {file: [] for file in REMOVED_SYMBOLS}


### PR DESCRIPTION
Closes #2458.

## Summary
- remove verified-unused archive git hygiene compatibility shims
- remove unused private Sentry resolver and contextualized embedding sync wrapper
- add a DEPS-15 audit note and contract to keep the removed symbols from coming back

## Notes
- Mini App candidates remain blocked by #2430.
- Langfuse/OTel candidates with active imports/tests remain blocked by #2434/#2435.
- Other candidates with active references or public compatibility exports were kept and documented.

## Validation
- uv run --no-sync ruff check tests/contract/test_dead_code_cleanup_contract.py scripts/archive/git_hygiene.py src/observability_sentry.py src/models/contextualized_embedding.py --fix
- PYTEST_ADDOPTS='' uv run --no-sync pytest -o addopts='' tests/contract/test_dead_code_cleanup_contract.py tests/unit/scripts/test_git_hygiene.py tests/unit/test_contextualized_embeddings.py tests/unit/observability/test_sentry_init.py -q
- uv lock --check
- git diff --check