### PR TITLE
Deps: guard against KFP and Kubernetes packages

### DIFF
--- a/docs/review/kfp-kubernetes-dependency-audit-2450.md
+++ b/docs/review/kfp-kubernetes-dependency-audit-2450.md
@@ -1,0 +1,27 @@
+# KFP / Kubernetes dependency audit (#2450)
+
+## Result
+
+The root application does not declare or lock Kubeflow Pipelines or Kubernetes
+Python clients.
+
+## Direct dependency check
+
+The following packages are absent from `pyproject.toml` direct runtime,
+optional, and development dependencies:
+
+- `kfp`
+- `kfp-kubernetes`
+- `kfp-pipeline-spec`
+- `kfp-server-api`
+- `kubernetes`
+
+## Lockfile check
+
+The same package names are absent from `uv.lock`, so they are not currently
+pulled into the resolved root environment as transitive dependencies.
+
+## Runtime import check
+
+Static import scanning found no runtime imports of `kfp` or `kubernetes` under
+`src/` or `telegram_bot/`.

--- a/tests/unit/test_kfp_kubernetes_dependency_contract.py
+++ b/tests/unit/test_kfp_kubernetes_dependency_contract.py
@@ -1,0 +1,62 @@
+"""Regression guard for removed KFP/Kubernetes dependencies (#2450)."""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import tomllib
+
+
+PYPROJECT = Path("pyproject.toml")
+LOCKFILE = Path("uv.lock")
+RUNTIME_ROOTS = [Path("src"), Path("telegram_bot")]
+FORBIDDEN = {"kfp", "kfp-kubernetes", "kfp-pipeline-spec", "kfp-server-api", "kubernetes"}
+
+
+def _dependency_names() -> set[str]:
+    project = tomllib.loads(PYPROJECT.read_text())
+    names: set[str] = set()
+
+    def add(deps: list[str]) -> None:
+        for dep in deps:
+            match = re.match(r"([A-Za-z0-9_.-]+)", dep)
+            assert match, f"Could not parse dependency {dep!r}"
+            names.add(match.group(1).lower().replace("_", "-"))
+
+    add(project["project"].get("dependencies", []))
+    for deps in project["project"].get("optional-dependencies", {}).values():
+        add(deps)
+    for deps in project.get("dependency-groups", {}).values():
+        add(deps)
+    return names
+
+
+def test_kfp_kubernetes_are_not_declared_dependencies() -> None:
+    assert _dependency_names().isdisjoint(FORBIDDEN)
+
+
+def test_kfp_kubernetes_are_not_locked() -> None:
+    text = LOCKFILE.read_text()
+    for package in FORBIDDEN:
+        assert f'name = "{package}"' not in text
+
+
+def test_runtime_code_does_not_import_kfp_or_kubernetes() -> None:
+    offenders: list[str] = []
+    for root in RUNTIME_ROOTS:
+        for path in root.rglob("*.py"):
+            if any(part in {".venv", "__pycache__"} for part in path.parts):
+                continue
+            tree = ast.parse(path.read_text(), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    names = {alias.name.split(".", 1)[0] for alias in node.names}
+                elif isinstance(node, ast.ImportFrom) and node.module:
+                    names = {node.module.split(".", 1)[0]}
+                else:
+                    continue
+                if names & {"kfp", "kubernetes"}:
+                    offenders.append(f"{path}:{node.lineno}")
+    assert not offenders


### PR DESCRIPTION
## Summary
- Documents that KFP/Kubernetes packages are absent from direct dependencies, lockfile resolution, and runtime imports.
- Adds a regression test to keep KFP/Kubernetes packages out of root dependencies and runtime code.
- Regenerates/checks the root lockfile with no package changes needed.

Closes #2450

## Testing
- `uv lock`
- `uv run pytest tests/unit/test_kfp_kubernetes_dependency_contract.py -q`
- `uv lock --locked`