### PR TITLE
Deps: keep observability and heavy UI optional

### DIFF
--- a/docs/review/observability-ui-optional-deps-2431.md
+++ b/docs/review/observability-ui-optional-deps-2431.md
@@ -1,0 +1,29 @@
+# Observability and heavy UI dependency audit (#2431)
+
+## Result
+
+The root runtime dependency set keeps observability and heavy UI packages out of
+base installs. They are available through explicit extras and development tools
+only.
+
+## Optional extras
+
+- `observability`: `langfuse`, `sentry-sdk`
+- `scheduling`: `apscheduler`
+- `ui`: `pillow`, `gradio`
+
+## Compose profile
+
+The self-hosted Langfuse stack remains profile-gated under the existing `ml`
+profile in `compose.dev.yml`:
+
+- `clickhouse`
+- `minio`
+- `redis-langfuse`
+- `langfuse-worker`
+- `langfuse`
+
+## Base install contract
+
+`uv sync --no-dev` should not install `langfuse`, `sentry-sdk`, `apscheduler`,
+`pillow`, or `gradio` unless an optional extra is selected.

--- a/tests/unit/test_optional_observability_ui_dependency_contract.py
+++ b/tests/unit/test_optional_observability_ui_dependency_contract.py
@@ -1,0 +1,51 @@
+"""Contracts for optional observability/heavy UI dependencies (#2431)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import tomllib
+import yaml
+
+
+PYPROJECT = Path("pyproject.toml")
+COMPOSE_DEV = Path("compose.dev.yml")
+HEAVY_OPTIONAL = {"gradio", "pillow", "apscheduler", "sentry-sdk", "langfuse"}
+
+
+def _dep_names(deps: list[str]) -> set[str]:
+    names: set[str] = set()
+    for dep in deps:
+        match = re.match(r"([A-Za-z0-9_.-]+)", dep)
+        assert match, f"Could not parse dependency {dep!r}"
+        names.add(match.group(1).lower().replace("_", "-"))
+    return names
+
+
+def _project() -> dict:
+    return tomllib.loads(PYPROJECT.read_text())
+
+
+def test_observability_and_heavy_ui_are_not_base_dependencies() -> None:
+    base = _dep_names(_project()["project"]["dependencies"])
+
+    assert base.isdisjoint(HEAVY_OPTIONAL)
+
+
+def test_observability_scheduling_and_ui_extras_own_heavy_deps() -> None:
+    extras = _project()["project"]["optional-dependencies"]
+
+    assert {"langfuse", "sentry-sdk"}.issubset(_dep_names(extras["observability"]))
+    assert {"apscheduler"}.issubset(_dep_names(extras["scheduling"]))
+    assert {"pillow", "gradio"}.issubset(_dep_names(extras["ui"]))
+
+
+def test_langfuse_self_host_services_stay_profile_gated() -> None:
+    compose = yaml.safe_load(COMPOSE_DEV.read_text())
+    services = compose["services"]
+    langfuse_stack = {"clickhouse", "minio", "redis-langfuse", "langfuse-worker", "langfuse"}
+
+    for service_name in langfuse_stack:
+        profiles = set(services[service_name].get("profiles", []))
+        assert "ml" in profiles, f"{service_name} must stay behind the ml profile"


### PR DESCRIPTION
## Summary
- Documents optional extras for Langfuse/Sentry, APScheduler, and Gradio/Pillow.
- Adds regression tests that heavy observability/UI packages stay out of base deps and behind extras.
- Verifies the Langfuse self-host compose services remain gated by the `ml` profile.

Closes #2431

## Testing
- `uv run pytest tests/unit/test_optional_observability_ui_dependency_contract.py -q`
- `uv sync --no-dev`
- `uv run --no-sync python - <<'PY' ...` base install absence smoke