### PR TITLE
Fix #2491 production test import hygiene

### DIFF
--- a/tests/contract/test_src_no_tests_imports_contract.py
+++ b/tests/contract/test_src_no_tests_imports_contract.py
@@ -1,0 +1,33 @@
+"""Contract: production ``src`` modules must not import test code (#2491)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+
+
+def test_src_modules_do_not_import_tests_package() -> None:
+    violations: dict[str, list[str]] = {}
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        modules: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                if module == "tests" or module.startswith("tests."):
+                    modules.add(module)
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    name = alias.name
+                    if name == "tests" or name.startswith("tests."):
+                        modules.add(name)
+        if modules:
+            violations[path.relative_to(REPO_ROOT).as_posix()] = sorted(modules)
+
+    assert not violations, f"Production src modules must not import tests: {violations}"


### PR DESCRIPTION
## Summary
- Fixes #2491 by adding a contract test that scans every Python module under `src/` and fails on `tests` / `tests.*` imports.
- Confirms the current production tree has zero direct test-package imports.

## Tests
- `uv run pytest tests/contract/test_src_no_tests_imports_contract.py -q`
- `uv run ruff check tests/contract/test_src_no_tests_imports_contract.py`

## Skipped tests
- `make test-full` skipped: heavy/manual-only full gate per repo policy.

## Agent Handoff

Status: merged
Base: dev
Head: fix/2491-production-test-import-hygiene
Validated commit: 4cfe5c34d2ce318ff7f53114018b14031337bc3c
Risk: test
Failure class: none

## Validation

- [x] Required GitHub checks: green (Secret Scan, Semgrep, Lint, Lockfile Check, Compose Config)
- [x] Focused validation: passed (git diff --check origin/dev..HEAD; uvx ruff check src/ telegram_bot/ mini_app/ services/ scripts/ --output-format=github; uvx ruff format --target-version py312 --check src/ telegram_bot/ mini_app/ services/ scripts/; uv run pytest tests/contract/test_src_no_tests_imports_contract.py -q; make test-core)
- [x] make test-core: passed
- [x] Optional/heavy checks: failed/skipped (Fast Tests and Heavy Contract Tests are optional diagnostics per gh-pr-review policy; ignored for merge)

## Findings

- None

## Next action

Merged into dev by codex-web.
