### PR TITLE
Fix #2488 remove Mini App dead Kommo helper

### DIFF
--- a/mini_app/api.py
+++ b/mini_app/api.py
@@ -39,7 +39,7 @@ def _build_kommo_client(*, redis_client: Any) -> Any | None:
     """Construct a ``KommoClient`` from environment, or ``None`` if Kommo
     is not configured.
 
-    Pre-#2212 ``mini_app/phone.py::get_kommo_client()`` called
+    Pre-#2212 Mini App phone submission constructed
     ``KommoClient()`` with no args — every Mini App phone submission
     raised ``TypeError`` because the SDK requires keyword-only
     ``subdomain`` and ``token_store``. This helper centralises the

--- a/mini_app/phone.py
+++ b/mini_app/phone.py
@@ -39,19 +39,6 @@ class PhoneRequest(BaseModel):
         return normalized
 
 
-def get_kommo_client():
-    """Get Kommo client (lazy import).
-
-    Deprecated since #2212: kept for backward compat with callers that
-    haven't migrated to dependency injection. New callers must construct
-    a :class:`KommoClient` via ``mini_app.api._build_kommo_client(...)``
-    in the FastAPI ``lifespan`` and pass it explicitly to
-    :func:`submit_phone`.
-    """
-    from src.services.kommo_client import KommoClient  # type: ignore[import-untyped]
-
-    return KommoClient()
-
 
 @observe(name="miniapp-kommo-create-lead", capture_input=False, capture_output=False)
 async def submit_phone(request: PhoneRequest, *, client: Any | None = None) -> dict:

--- a/mini_app/phone.py
+++ b/mini_app/phone.py
@@ -39,7 +39,6 @@ class PhoneRequest(BaseModel):
         return normalized
 
 
-
 @observe(name="miniapp-kommo-create-lead", capture_input=False, capture_output=False)
 async def submit_phone(request: PhoneRequest, *, client: Any | None = None) -> dict:
     """Submit phone to CRM.

--- a/tests/contract/test_2488_miniapp_dead_code_contract.py
+++ b/tests/contract/test_2488_miniapp_dead_code_contract.py
@@ -1,0 +1,16 @@
+"""Contract for #2488 Mini App dead-code cleanup."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_miniapp_deprecated_get_kommo_client_removed() -> None:
+    tree = ast.parse((ROOT / "mini_app" / "phone.py").read_text(encoding="utf-8"))
+    names = {node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)}
+
+    assert "get_kommo_client" not in names

--- a/tests/unit/mini_app/test_phone_kommo_di.py
+++ b/tests/unit/mini_app/test_phone_kommo_di.py
@@ -1,6 +1,6 @@
 """Mini App phone -> Kommo DI contract (#2212 / Epic C).
 
-Pre-#2212 ``mini_app/phone.py::get_kommo_client()`` constructed
+Pre-#2212 Mini App phone submission constructed
 ``KommoClient()`` with no args. ``KommoClient.__init__`` requires
 ``subdomain`` and ``token_store`` (kw-only), so every call raised
 ``TypeError``. The Mini App phone submission emitted a Langfuse span


### PR DESCRIPTION
## Summary
- Refs #2488 by removing the deprecated unused `mini_app.phone.get_kommo_client` helper.
- Updates Mini App comments/tests to describe the DI path without referencing the removed helper.
- Adds a contract test so the helper stays removed.

## Tests
- `/workspace/rag/.venv/bin/python -m pytest tests/contract/test_2488_miniapp_dead_code_contract.py tests/unit/mini_app/test_phone_kommo_di.py -q`
- `/workspace/rag/.venv/bin/python -m ruff check mini_app/phone.py mini_app/api.py tests/unit/mini_app/test_phone_kommo_di.py tests/contract/test_2488_miniapp_dead_code_contract.py`

## Skipped tests
- Frontend checks skipped: this PR does not touch `mini_app/frontend`.
- `make test-full` skipped: heavy/manual-only full gate per repo policy.

## Agent Handoff

Status: merged
Base: dev
Head: fix/2488-miniapp-dead-kommo-helper
Validated commit: 01487f8649466e809e7f5573679b8550bb0f4ff6
Risk: test
Failure class: none

## Validation

- [x] Required GitHub checks: green (Secret Scan, Semgrep, Lint, Lockfile Check, Compose Config)
- [x] Focused validation: passed (git diff --check origin/dev..HEAD; uvx ruff check src/ telegram_bot/ mini_app/ services/ scripts/ --output-format=github; uvx ruff format --target-version py312 --check src/ telegram_bot/ mini_app/ services/ scripts/; uv run pytest tests/contract/test_2488_miniapp_dead_code_contract.py tests/unit/mini_app/test_phone_kommo_di.py -q; make test-core)
- [x] make test-core: passed
- [x] Optional/heavy checks: failed/skipped (Fast Tests and Heavy Contract Tests are optional diagnostics per gh-pr-review policy; ignored for merge)

## Findings

- None

## Next action

Merged into dev by codex-web.
