### PR TITLE
Break runtime generation adapter cycle

### DIFF
--- a/src/runtime/pipeline/assistant_pipeline.py
+++ b/src/runtime/pipeline/assistant_pipeline.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import importlib
 import time
 from typing import Any
 
@@ -31,10 +30,7 @@ async def run_assistant_pipeline(
     ctx = request.user_context or UserContext()
 
     try:
-        classify_query = importlib.import_module("src.runtime.graph.nodes.classify").classify_query
-        legacy_generate = importlib.import_module(
-            "telegram_bot.services.generate_response"
-        ).generate_response
+        from src.runtime.graph.nodes.classify import classify_query
 
         request_type = classify_query(request.query)
         state_contract: dict[str, Any] | None = {"filters": ctx.filters} if ctx.filters else None
@@ -93,7 +89,6 @@ async def run_assistant_pipeline(
                 grade_confidence=grade_confidence,
                 config=dependencies.config,
             ),
-            generate=legacy_generate,
         )
         generation_result = generation.payload
         usage = _as_usage_dict(generation_result.get("usage_details"))

--- a/tests/data/known_runtime_telegram_bot_couplings.json
+++ b/tests/data/known_runtime_telegram_bot_couplings.json
@@ -2,9 +2,6 @@
   "src/runtime/graph/builder.py": [
     "telegram_bot.graph.graph:build_graph"
   ],
-  "src/runtime/pipeline/assistant_pipeline.py": [
-    "telegram_bot.services.generate_response"
-  ],
   "src/runtime/pipeline/rag.py": [
     "telegram_bot.graph.config",
     "telegram_bot.observability",

--- a/tests/unit/core/test_assistant_entrypoint.py
+++ b/tests/unit/core/test_assistant_entrypoint.py
@@ -539,19 +539,23 @@ class TestRunAssistantRequestRuntime:
                 "query_type": "GENERAL",
             }
         )
+        from src.runtime.generation import GenerationResult
+
         gen = AsyncMock(
-            return_value={
-                "response": "Sunny Beach Studio is available for 110000 EUR.",
-                "llm_provider_model": "gpt-4o-mini",
-                "usage_details": {"input": 10, "output": 12},
-            }
+            return_value=GenerationResult(
+                payload={
+                    "response": "Sunny Beach Studio is available for 110000 EUR.",
+                    "llm_provider_model": "gpt-4o-mini",
+                    "usage_details": {"input": 10, "output": 12},
+                }
+            )
         )
         deps = self._deps()
 
         with (
             patch("src.runtime.graph.nodes.classify.classify_query", return_value="GENERAL"),
             patch("src.runtime.pipeline.assistant_pipeline.rag_pipeline", rag),
-            patch("telegram_bot.services.generate_response.generate_response", gen),
+            patch("src.runtime.pipeline.assistant_pipeline.generate_answer", gen),
         ):
             result = await run_assistant_request(
                 "Найди студию у моря до 120000",
@@ -578,8 +582,9 @@ class TestRunAssistantRequestRuntime:
         assert rag_kwargs["state_contract"]["filters"] == {"city": "Sunny Beach"}
 
         gen.assert_awaited_once()
-        assert gen.await_args.kwargs["query"] == "Найди студию у моря до 120000"
-        assert gen.await_args.kwargs["documents"] == docs
+        generation_request = gen.await_args.args[0]
+        assert generation_request.query == "Найди студию у моря до 120000"
+        assert generation_request.documents == docs
 
         assert result.route == "rag_search"
         assert result.error_type is None
@@ -612,7 +617,7 @@ class TestRunAssistantRequestRuntime:
         with (
             patch("src.runtime.graph.nodes.classify.classify_query", return_value="FAQ"),
             patch("src.runtime.pipeline.assistant_pipeline.rag_pipeline", rag),
-            patch("telegram_bot.services.generate_response.generate_response", gen),
+            patch("src.runtime.pipeline.assistant_pipeline.generate_answer", gen),
         ):
             result = await run_assistant_request(
                 "Какие условия рассрочки?",
@@ -661,12 +666,14 @@ class TestRunAssistantRequestRuntime:
                 "query_type": "GENERAL",
             }
         )
-        gen = AsyncMock(return_value={"response": "answer", "llm_provider_model": "test-model"})
+        from src.runtime.generation import GenerationResult
+
+        gen = AsyncMock(return_value=GenerationResult(payload={"response": "answer", "llm_provider_model": "test-model"}))
 
         with (
             patch("src.runtime.graph.nodes.classify.classify_query", return_value="GENERAL"),
             patch("src.runtime.pipeline.assistant_pipeline.rag_pipeline", rag),
-            patch("telegram_bot.services.generate_response.generate_response", gen),
+            patch("src.runtime.pipeline.assistant_pipeline.generate_answer", gen),
             caplog.at_level(logging.INFO, logger="src.utils.product_events"),
         ):
             await run_assistant_request(

--- a/tests/unit/runtime/test_assistant_pipeline.py
+++ b/tests/unit/runtime/test_assistant_pipeline.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import sys
 import types
 
+from src.runtime.generation import GenerationResult
+
 
 async def test_run_assistant_pipeline_returns_assistant_result(monkeypatch) -> None:
     from src.core import AssistantRequest, CoreDependencies, UserContext
@@ -27,23 +29,26 @@ async def test_run_assistant_pipeline_returns_assistant_result(monkeypatch) -> N
             "rerank_applied": True,
         }
 
-    async def fake_generate_response(**kwargs):
-        return {
-            "response": "answer",
-            "llm_provider_model": "fake-model",
-            "usage_details": {"input": 1, "output": 2},
-        }
+    async def fake_generate_answer(_request):
+        return GenerationResult(
+            payload={
+                "response": "answer",
+                "llm_provider_model": "fake-model",
+                "usage_details": {"input": 1, "output": 2},
+            }
+        )
 
     classify_mod = types.ModuleType("src.runtime.graph.nodes.classify")
     classify_mod.classify_query = lambda _: "GENERAL"
-    generate_mod = types.ModuleType("telegram_bot.services.generate_response")
-    generate_mod.generate_response = fake_generate_response
 
     monkeypatch.setitem(sys.modules, "src.runtime.graph.nodes.classify", classify_mod)
-    monkeypatch.setitem(sys.modules, "telegram_bot.services.generate_response", generate_mod)
     monkeypatch.setattr(
         "src.runtime.pipeline.assistant_pipeline.rag_pipeline",
         fake_rag_pipeline,
+    )
+    monkeypatch.setattr(
+        "src.runtime.pipeline.assistant_pipeline.generate_answer",
+        fake_generate_answer,
     )
 
     result = await run_assistant_pipeline(


### PR DESCRIPTION
## Summary
- Fixes #2486.
- Removes the runtime assistant pipeline's dynamic import of `telegram_bot.services.generate_response`.
- Lets `src.runtime.generation.generate_answer()` own generation execution directly after #2489 moved prompt policy into runtime.
- Ratchets `tests/data/known_runtime_telegram_bot_couplings.json` by removing the `src/runtime/pipeline/assistant_pipeline.py` entry.

## Changed files
- `src/runtime/pipeline/assistant_pipeline.py`
- `tests/data/known_runtime_telegram_bot_couplings.json`
- `tests/unit/core/test_assistant_entrypoint.py`
- `tests/unit/runtime/test_assistant_pipeline.py`

## Tests
- `uv run ruff check src/runtime/pipeline/assistant_pipeline.py tests/unit/core/test_assistant_entrypoint.py tests/unit/runtime/test_assistant_pipeline.py tests/contract/test_runtime_no_telegram_bot_coupling_contract.py`
- `uv run pytest tests/contract/test_runtime_no_telegram_bot_coupling_contract.py tests/unit/core/test_assistant_entrypoint.py::TestRunAssistantRequestRuntime tests/unit/runtime/test_assistant_pipeline.py -q`

## Skipped
- Full/heavy suites skipped per Codex Web focused-test policy for this single runtime generation-cycle slice.

## Agent Handoff

Status: merged
Base: dev
Head: codex/2486-break-generation-cycle
Validated commit: 9ad377209de4316c77da4b185fdb1d0abe5cf7e8
Risk: core
Failure class: none

## Validation

- [x] Required GitHub checks: green (Secret Scan, Semgrep, Lint, Lockfile Check, Compose Config)
- [x] Focused validation: passed (git diff --check origin/dev..HEAD; uvx ruff check src/ telegram_bot/ mini_app/ services/ scripts/ --output-format=github; uvx ruff format --target-version py312 --check src/ telegram_bot/ mini_app/ services/ scripts/; uv run pytest tests/unit/core/test_assistant_entrypoint.py tests/unit/runtime/test_assistant_pipeline.py tests/contract/test_runtime_no_telegram_bot_coupling_contract.py -q; make test-core)
- [x] make test-core: passed
- [x] Optional/heavy checks: failed/skipped (Fast Tests and Heavy Contract Tests are optional diagnostics per gh-pr-review policy; ignored for merge)

## Findings

- None

## Next action

Merged into dev by codex-web.
