### PR TITLE
Remove remaining runtime Telegram allowlist entries

### DIFF
--- a/src/runtime/graph/builder.py
+++ b/src/runtime/graph/builder.py
@@ -3,17 +3,14 @@
 Before this module, ``src/api/main.py`` opened its FastAPI ``lifespan``
 with::
 
-    from telegram_bot.graph.graph import build_graph
+    from adapter.graph.graph import build_graph
 
-That static import was the last entry in
-``tests/data/known_layering_violations.json`` and the last reason
-``src/`` could not be shipped without ``telegram_bot/`` mounted next to
-it.
+That static import pattern was the last reason ``src/`` could not be
+shipped without an adapter package mounted next to it.
 
 This module replaces that static import with a string-based resolution:
 
-* ``RAG_GRAPH_FACTORY`` (default ``telegram_bot.graph.graph:build_graph``)
-  points at a ``module:attribute`` callable.
+* ``RAG_GRAPH_FACTORY`` points at a ``module:attribute`` callable.
 * :func:`resolve_pipeline_factory` imports the module via
   :func:`importlib.import_module` (a string call, not an ``import``
   statement) and returns the attribute.
@@ -21,8 +18,8 @@ This module replaces that static import with a string-based resolution:
   ``ast.Import`` / ``ast.ImportFrom`` nodes only, so the dynamic resolve
   does not register as a violation.
 
-The default still points at the bot's existing ``build_graph`` so
-production behaviour is unchanged. Tests and alternative deployments
+The default now raises a clear error because runtime code must not
+default back to the Telegram adapter. Tests and alternative deployments
 override the env var to inject their own factory without touching
 ``src/api/``.
 """
@@ -39,12 +36,11 @@ from typing import Any, cast
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_FACTORY_SPEC = "telegram_bot.graph.graph:build_graph"
+DEFAULT_FACTORY_SPEC = "src.runtime.graph.builder:_raise_missing_pipeline_factory"
 """Default ``module:attribute`` factory spec.
 
-The bot's ``build_graph`` is the canonical pipeline factory; ``src/api``
-and ``mini_app`` consume it via this seam so they remain free of any
-static ``from telegram_bot ...`` import.
+Runtime no longer owns a default graph factory. Set ``RAG_GRAPH_FACTORY``
+explicitly when this legacy resolver is used.
 """
 
 ENV_VAR = "RAG_GRAPH_FACTORY"
@@ -66,6 +62,14 @@ def reset_pipeline_factory_cache() -> None:
     therefore see a fresh resolution on every call.
     """
 
+
+
+def _raise_missing_pipeline_factory(**_kwargs: Any) -> Any:
+    """Raise when the deprecated resolver is used without an explicit factory."""
+    raise PipelineFactoryError(
+        f"{ENV_VAR} must be set when using src.runtime.graph.builder; "
+        "the runtime package no longer defaults to an adapter-owned graph."
+    )
 
 def resolve_pipeline_factory() -> Callable[..., Any]:
     """Return the configured pipeline factory callable.

--- a/src/runtime/pipeline/rag.py
+++ b/src/runtime/pipeline/rag.py
@@ -18,24 +18,45 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-import importlib.util
 import logging
 import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, TypeVar, cast
 
+from src.observability import get_client as _observability_get_client
+from src.observability import observe
+from src.runtime.graph.config import GraphConfig
+from src.runtime.services.cache_policy import (
+    SEMANTIC_CACHE_SCHEMA_VERSION,
+    build_cacheability_decision,
+    is_contextual_query,
+    maybe_store_semantic_response,
+    resolve_semantic_cache_signature,
+)
+from src.runtime.services.metrics import record_pipeline_event
+from src.runtime.services.query_filter_signal import detect_filter_sensitive_query
+from src.runtime.services.query_preprocessor import QueryPreprocessor, expand_short_query
+from src.runtime.services.rag_core import (
+    CACHEABLE_QUERY_TYPES,
+    check_semantic_cache,
+    compute_query_embedding,
+    perform_rerank,
+    rewrite_query_via_llm,
+)
+from src.runtime.services.rag_core import (
+    build_retrieved_context as _build_retrieved_context,
+)
+from src.runtime.services.small_to_big import SmallToBigMode, SmallToBigService
+from src.services.bge_m3_query_bundle import BgeM3QueryVectorBundle
+
 
 _T = TypeVar("_T")
 
 
-def _load_telegram_attr(module_name: str, attr_name: str) -> Any:
-    import importlib
-
-    return getattr(importlib.import_module(module_name), attr_name)
-
-
 def _load_topic_classifier_attr(attr_name: str) -> Any:
+    import importlib.util
+
     module_path = Path(__file__).resolve().parents[2] / "retrieval" / "topic_classifier.py"
     spec = importlib.util.spec_from_file_location("_runtime_topic_classifier", module_path)
     if spec is None or spec.loader is None:
@@ -60,129 +81,31 @@ def _identity_observe(*args: Any, **kwargs: Any) -> Callable[[_T], _T]:
     return decorator
 
 
-def _load_observe() -> Callable[..., Callable[[_T], _T]]:
-    try:
-        return cast(
-            Callable[..., Callable[[_T], _T]],
-            _load_telegram_attr("telegram_bot.observability", "observe"),
-        )
-    except Exception:  # pragma: no cover - import-safety fallback for lightweight tooling
-        return _identity_observe
+def get_client() -> Any:
+    return _observability_get_client()
 
 
-def _get_client() -> Any:
-    # ``telegram_bot.observability.get_client`` is the Langfuse ``get_client``
-    # factory; it must be *called* to obtain the client instance that exposes
-    # ``update_current_span``. Returning the factory itself caused
-    # ``AttributeError: 'function' object has no attribute 'update_current_span'``
-    # whenever the runtime pipeline recorded a span (e.g. miniapp path).
-    return _load_telegram_attr("telegram_bot.observability", "get_client")()
+def _graph_config_from_env() -> GraphConfig:
+    return GraphConfig.from_env()
 
 
-def _cache_policy_attr(name: str) -> Any:
-    return _load_telegram_attr("telegram_bot.services.cache_policy", name)
-
-
-def _graph_config_from_env() -> Any:
-    graph_config = _load_telegram_attr("telegram_bot.graph.config", "GraphConfig")
-    return graph_config.from_env()
-
-
-def _bge_m3_query_bundle_cls() -> Any:
-    return _load_telegram_attr(
-        "telegram_bot.services.bge_m3_query_bundle",
-        "BgeM3QueryVectorBundle",
-    )
+def _bge_m3_query_bundle_cls() -> type[BgeM3QueryVectorBundle]:
+    return BgeM3QueryVectorBundle
 
 
 def _small_to_big_attr(name: str) -> Any:
-    return _load_telegram_attr("telegram_bot.services.small_to_big", name)
+    return {
+        "SmallToBigMode": SmallToBigMode,
+        "SmallToBigService": SmallToBigService,
+    }[name]
 
 
-def _rag_core_attr(name: str) -> Any:
-    return _load_telegram_attr("telegram_bot.services.rag_core", name)
-
-
-def _record_pipeline_event(*args: Any, **kwargs: Any) -> Any:
-    record = _load_telegram_attr("telegram_bot.services.metrics", "record_pipeline_event")
-    return record(*args, **kwargs)
-
-
-def _detect_filter_sensitive_query(*args: Any, **kwargs: Any) -> Any:
-    return _load_telegram_attr(
-        "telegram_bot.services.query_filter_signal",
-        "detect_filter_sensitive_query",
-    )(*args, **kwargs)
-
-
-def _expand_short_query(*args: Any, **kwargs: Any) -> Any:
-    return _load_telegram_attr("telegram_bot.services.query_preprocessor", "expand_short_query")(
-        *args,
-        **kwargs,
-    )
-
-
-def _new_query_preprocessor() -> Any:
-    cls = _load_telegram_attr("telegram_bot.services.query_preprocessor", "QueryPreprocessor")
-    return cls()
-
-
-observe = _load_observe()
-
-
-def get_client() -> Any:
-    # ``_get_client()`` already returns the Langfuse client instance (it calls
-    # the ``telegram_bot.observability.get_client`` factory), so this wrapper
-    # must NOT call the result again.
-    return _get_client()
-
-
-SEMANTIC_CACHE_SCHEMA_VERSION = "v8"
-
-
-def build_cacheability_decision(*args: Any, **kwargs: Any) -> Any:
-    return _cache_policy_attr("build_cacheability_decision")(*args, **kwargs)
-
-
-def is_contextual_query(*args: Any, **kwargs: Any) -> Any:
-    return _cache_policy_attr("is_contextual_query")(*args, **kwargs)
-
-
-def maybe_store_semantic_response(*args: Any, **kwargs: Any) -> Any:
-    return _cache_policy_attr("maybe_store_semantic_response")(*args, **kwargs)
-
-
-def resolve_semantic_cache_signature(*args: Any, **kwargs: Any) -> Any:
-    return _cache_policy_attr("resolve_semantic_cache_signature")(*args, **kwargs)
-
-
-def check_semantic_cache(*args: Any, **kwargs: Any) -> Any:
-    return _rag_core_attr("check_semantic_cache")(*args, **kwargs)
-
-
-def compute_query_embedding(*args: Any, **kwargs: Any) -> Any:
-    return _rag_core_attr("compute_query_embedding")(*args, **kwargs)
-
-
-def perform_rerank(*args: Any, **kwargs: Any) -> Any:
-    return _rag_core_attr("perform_rerank")(*args, **kwargs)
-
-
-def rewrite_query_via_llm(*args: Any, **kwargs: Any) -> Any:
-    return _rag_core_attr("rewrite_query_via_llm")(*args, **kwargs)
-
-
-def _build_retrieved_context(*args: Any, **kwargs: Any) -> Any:
-    return _rag_core_attr("build_retrieved_context")(*args, **kwargs)
+def _new_query_preprocessor() -> QueryPreprocessor:
+    return QueryPreprocessor()
 
 
 def _cacheable_query_types() -> set[str]:
-    return set(_rag_core_attr("CACHEABLE_QUERY_TYPES"))
-
-
-record_pipeline_event = _record_pipeline_event
-detect_filter_sensitive_query = _detect_filter_sensitive_query
-expand_short_query = _expand_short_query
+    return set(CACHEABLE_QUERY_TYPES)
 
 
 logger = logging.getLogger(__name__)

--- a/tests/data/known_runtime_telegram_bot_couplings.json
+++ b/tests/data/known_runtime_telegram_bot_couplings.json
@@ -1,16 +1,1 @@
-{
-  "src/runtime/graph/builder.py": [
-    "telegram_bot.graph.graph:build_graph"
-  ],
-  "src/runtime/pipeline/rag.py": [
-    "telegram_bot.graph.config",
-    "telegram_bot.observability",
-    "telegram_bot.services.bge_m3_query_bundle",
-    "telegram_bot.services.cache_policy",
-    "telegram_bot.services.metrics",
-    "telegram_bot.services.query_filter_signal",
-    "telegram_bot.services.query_preprocessor",
-    "telegram_bot.services.rag_core",
-    "telegram_bot.services.small_to_big"
-  ]
-}
+{}

--- a/tests/unit/runtime/graph/test_builder.py
+++ b/tests/unit/runtime/graph/test_builder.py
@@ -3,8 +3,7 @@
 Closes the final layering offender for #1948: ``src/api/main.py`` previously
 hard-imported ``telegram_bot.graph.graph.build_graph`` inside its FastAPI
 ``lifespan``. The new builder resolves the factory dynamically through
-``RAG_GRAPH_FACTORY`` (default ``telegram_bot.graph.graph:build_graph``),
-which is a string spec — no static ``from telegram_bot ...`` import remains
+``RAG_GRAPH_FACTORY``. There is no adapter-owned default, so no static import remains
 under ``src/`` once ``src/api/main.py`` is rewired.
 
 Tests cover the resolver only. The actual ``build_graph`` implementation is
@@ -37,29 +36,21 @@ def _install_stub_module(name: str, factory: object) -> None:
     sys.modules[name] = module
 
 
-def test_resolve_pipeline_factory_uses_default_spec(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Default spec is ``telegram_bot.graph.graph:build_graph`` per the
-    canonical bot wiring; we install a stub at that location so the test
-    has no transitive ML imports.
-    """
+def test_resolve_pipeline_factory_default_requires_explicit_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default spec must not point back to an adapter-owned graph factory."""
     monkeypatch.delenv("RAG_GRAPH_FACTORY", raising=False)
-
-    def _fake_build_graph(*args: object, **kwargs: object) -> str:
-        return "fake-graph"
-
-    fake_module = types.ModuleType("telegram_bot.graph.graph")
-    fake_module.build_graph = _fake_build_graph  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "telegram_bot.graph.graph", fake_module)
 
     factory = builder.resolve_pipeline_factory()
 
-    assert factory is _fake_build_graph
-    assert factory() == "fake-graph"
+    with pytest.raises(builder.PipelineFactoryError, match="must be set"):
+        factory()
 
 
 def test_resolve_pipeline_factory_honours_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
     """``RAG_GRAPH_FACTORY`` overrides the default; this is the seam that
-    lets ``src/api/main.py`` stay free of any static telegram_bot import.
+    lets legacy callers provide an explicit factory.
     """
 
     def _custom(*args: object, **kwargs: object) -> str:


### PR DESCRIPTION
## Summary
- Fixes #2478.
- Removes remaining executable runtime `telegram_bot.*` string couplings from `src/runtime/pipeline/rag.py` by importing runtime/core services directly.
- Changes the legacy graph builder default so runtime no longer defaults to an adapter-owned graph factory.
- Shrinks `tests/data/known_runtime_telegram_bot_couplings.json` to `{}`.

## Stack
- Base branch: `codex/2486-break-generation-cycle` because #2478 depends on #2486 removing the assistant-pipeline generation cycle first.

## Changed files
- `src/runtime/pipeline/rag.py`
- `src/runtime/graph/builder.py`
- `tests/data/known_runtime_telegram_bot_couplings.json`
- `tests/unit/runtime/graph/test_builder.py`

## Tests
- `uv run ruff check src/runtime/pipeline/rag.py src/runtime/graph/builder.py tests/unit/runtime/graph/test_builder.py tests/contract/test_runtime_no_telegram_bot_coupling_contract.py`
- `uv run pytest tests/contract/test_runtime_no_telegram_bot_coupling_contract.py tests/unit/runtime/graph/test_builder.py -q`

## Skipped
- Full/heavy suites skipped per Codex Web focused-test policy for this runtime coupling ratchet slice.
