### PR TITLE
Wire API queries through assistant core

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,4 +1,4 @@
-"""FastAPI RAG API — wrapper around LangGraph pipeline.
+"""FastAPI RAG API — wrapper around the assistant core.
 
 Exposes POST /query for synchronous RAG queries and GET /health for readiness.
 """
@@ -10,13 +10,13 @@ import os
 import re
 import time
 import uuid
+from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
 from typing import Any, cast
 
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
-from langgraph.errors import GraphRecursionError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from src.api.schemas import QueryRequest, QueryResponse
@@ -33,16 +33,8 @@ _LANGFUSE_TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Initialize and teardown pipeline services.
-
-    The pipeline factory is resolved through :mod:`src.runtime.graph.builder`
-    (env var ``RAG_GRAPH_FACTORY``, default ``telegram_bot.graph.graph:build_graph``).
-    The dynamic resolution is the seam introduced for #1948: it removes the
-    last static ``from telegram_bot ...`` import under ``src/`` so the API
-    can be shipped without ``telegram_bot/`` next to it, while production
-    behaviour stays unchanged.
-    """
-    from src.runtime.graph.builder import build_pipeline
+    """Initialize and teardown assistant-core services."""
+    from src.core import CoreDependencies
     from src.runtime.graph.config import GraphConfig
     from src.runtime.integrations.cache import CacheLayerManager
     from src.runtime.services.qdrant import QdrantService
@@ -76,17 +68,18 @@ async def lifespan(app: FastAPI):
 
     llm = cfg.create_llm()
 
-    graph = build_pipeline(
+    core_dependencies = CoreDependencies(
         cache=cache,
         embeddings=embeddings,
         sparse_embeddings=sparse_embeddings,
         qdrant=qdrant,
         reranker=None,
         llm=llm,
-        message=None,
+        config=cfg,
     )
 
-    app.state.graph = graph
+    app.state.core_dependencies = core_dependencies
+    app.state.collection_name = cfg.qdrant_collection
     app.state.cache = cache
     app.state.qdrant = qdrant
     app.state.embeddings = embeddings
@@ -316,7 +309,7 @@ def _normalize_langfuse_trace_id(trace_id: str | None) -> str | None:
 
 @app.post("/query", response_model=QueryResponse)
 async def query(req: QueryRequest) -> QueryResponse:
-    """Run a RAG query through the LangGraph pipeline."""
+    """Run a RAG query through the assistant core."""
     normalized_trace_id = _normalize_langfuse_trace_id(req.langfuse_trace_id)
     if normalized_trace_id:
         return await _query_with_explicit_trace(req, langfuse_trace_id=normalized_trace_id)
@@ -348,25 +341,20 @@ async def _query_with_explicit_trace(
 
 
 async def _execute_query(req: QueryRequest) -> QueryResponse:
-    """Run a RAG query through the LangGraph pipeline."""
+    """Run a RAG query through the assistant core."""
+    from src.core import UserContext
+    from src.core import run_assistant_request as core_run_assistant_request
     from src.observability import get_client, propagate_attributes
-    from src.runtime.graph.state import make_initial_state
     from src.scoring import write_langfuse_scores
 
     start = time.perf_counter()
-
     session_id = req.session_id or f"api-{req.user_id}"
-    state = make_initial_state(
-        user_id=req.user_id,
-        session_id=session_id,
-        query=req.query,
-    )
-    state["max_rewrite_attempts"] = int(getattr(app.state, "max_rewrite_attempts", 1))
+    request_id = uuid.uuid4().hex
 
     trace_kwargs: dict[str, Any] = {
         "session_id": session_id,
         "user_id": str(req.user_id),
-        "metadata": {"source": req.channel},
+        "metadata": {"source": req.channel, "request_id": request_id},
         "tags": ["api", "rag", req.channel],
         # Keep Langfuse request metadata attached to the top-level API
         # observation. DEPS-OBS1 removes monolith OTEL auto-propagation, so
@@ -376,51 +364,35 @@ async def _execute_query(req: QueryRequest) -> QueryResponse:
     }
 
     with propagate_attributes(**trace_kwargs):
-        try:
-            result = await app.state.graph.ainvoke(state)
-        except GraphRecursionError:
-            elapsed_ms = (time.perf_counter() - start) * 1000
-            fallback_response = (
-                "Запрос слишком сложный — достигнут лимит обработки. Попробуйте упростить его."
-            )
-            lf = get_client()
-            if lf is not None:
-                lf.update_current_span(
-                    input=build_safe_input_payload(
-                        content_type="api", text=req.query, route="rag-api-query"
-                    ),
-                    output=build_safe_output_payload(
-                        answer_text=fallback_response,
-                        chunks_count=1,
-                        fallback_reason="recursion_limit",
-                    ),
-                    metadata={
-                        "source": req.channel,
-                        "query_type": "ERROR",
-                        "error_reason": "recursion_limit",
-                    },
-                )
-                fallback_result: dict[str, Any] = {
-                    "input_type": "api",
-                    "query_type": "ERROR",
-                    "pipeline_wall_ms": elapsed_ms,
-                    "e2e_latency_ms": elapsed_ms,
-                    "user_perceived_wall_ms": elapsed_ms,
-                    "cache_hit": False,
-                    "search_results_count": 0,
-                    "rerank_applied": False,
-                    "response": fallback_response,
-                }
-                write_langfuse_scores(lf, fallback_result)
-            return QueryResponse(
-                response=fallback_response,
-                query_type="ERROR",
-                cache_hit=False,
-                documents_count=0,
-                rerank_applied=False,
-                latency_ms=round(elapsed_ms, 1),
-                context=[],
-            )
+        run_assistant_request = cast(Callable[..., Awaitable[Any]], core_run_assistant_request)
+        assistant_result = await run_assistant_request(
+            req.query,
+            collection=str(getattr(app.state, "collection_name", "")),
+            user_context=UserContext(
+                user_id=str(req.user_id),
+                session_id=session_id,
+                role="client",
+            ),
+            request_id=request_id,
+            dependencies=app.state.core_dependencies,
+        )
+
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        result: dict[str, Any] = {
+            "input_type": "api",
+            "query_type": assistant_result.request_type,
+            "pipeline_wall_ms": elapsed_ms,
+            "e2e_latency_ms": elapsed_ms,
+            "user_perceived_wall_ms": elapsed_ms,
+            "cache_hit": assistant_result.cache_hit,
+            "search_results_count": assistant_result.documents_count,
+            "rerank_applied": assistant_result.rerank_applied,
+            "response": assistant_result.response_text,
+            "retrieved_context": assistant_result.retrieved_sources,
+            "llm_provider_model": assistant_result.llm_model,
+            "llm_call_count": assistant_result.llm_call_count,
+            "latency_stages": {},
+        }
 
         lf = get_client()
         if lf is not None:
@@ -429,31 +401,26 @@ async def _execute_query(req: QueryRequest) -> QueryResponse:
                     content_type="api", text=req.query, route="rag-api-query"
                 ),
                 output=build_safe_output_payload(
-                    answer_text=result.get("response", ""),
+                    answer_text=assistant_result.response_text,
                     chunks_count=1,
-                    sources_count=result.get("search_results_count", 0),
+                    sources_count=assistant_result.documents_count,
+                    fallback_reason=assistant_result.error_type,
                 ),
                 metadata={
                     "source": req.channel,
-                    "query_type": result.get("query_type", ""),
+                    "query_type": assistant_result.request_type,
+                    "route": assistant_result.route,
+                    "error_type": assistant_result.error_type,
                 },
             )
-        # Set wall-time fields so write_langfuse_scores reports real latency
-        elapsed_ms = (time.perf_counter() - start) * 1000
-        result["pipeline_wall_ms"] = elapsed_ms
-        result["e2e_latency_ms"] = elapsed_ms
-        summarize_s = result.get("latency_stages", {}).get("summarize", 0)
-        result["user_perceived_wall_ms"] = elapsed_ms - (summarize_s * 1000)
-
-        # Write Langfuse scores for observability parity with bot
-        write_langfuse_scores(lf, result)
+            write_langfuse_scores(lf, result)
 
     return QueryResponse(
-        response=result.get("response", ""),
-        query_type=result.get("query_type", ""),
-        cache_hit=result.get("cache_hit", False),
-        documents_count=result.get("search_results_count", 0),
-        rerank_applied=result.get("rerank_applied", False),
+        response=assistant_result.response_text,
+        query_type=assistant_result.request_type,
+        cache_hit=assistant_result.cache_hit,
+        documents_count=assistant_result.documents_count,
+        rerank_applied=assistant_result.rerank_applied,
         latency_ms=round(elapsed_ms, 1),
-        context=result.get("retrieved_context", []),
+        context=assistant_result.retrieved_sources,
     )

--- a/tests/unit/api/test_rag_api_runtime.py
+++ b/tests/unit/api/test_rag_api_runtime.py
@@ -19,6 +19,7 @@ pytestmark = pytest.mark.requires_extras
 
 from src.api.main import app, generic_error_handler, lifespan, query
 from src.api.schemas import QueryRequest, QueryResponse
+from src.core import AssistantResult
 
 
 def _response_content(response) -> dict:
@@ -42,30 +43,52 @@ class _DummyGraph:
         }
 
 
-async def test_query_applies_max_rewrite_attempts_from_app_state() -> None:
-    graph = _DummyGraph()
-    app.state.graph = graph
-    app.state.max_rewrite_attempts = 3
 
+
+def _set_core_state() -> object:
+    deps = object()
+    app.state.core_dependencies = deps
+    app.state.collection_name = "test_collection"
+    return deps
+
+
+def _assistant_result(**overrides) -> AssistantResult:
+    data = {
+        "response_text": "ok",
+        "request_type": "GENERAL",
+        "documents_count": 0,
+        "cache_hit": False,
+        "rerank_applied": False,
+        "retrieved_sources": [],
+        "route": "rag_search",
+    }
+    data.update(overrides)
+    return AssistantResult(**data)
+
+async def test_query_calls_assistant_core_with_api_context() -> None:
+    deps = _set_core_state()
     lf = MagicMock()
     lf.update_current_span = MagicMock()
 
     with (
         patch("src.observability.propagate_attributes", return_value=nullcontext()),
         patch("src.observability.get_client", return_value=lf),
+        patch("src.core.run_assistant_request", new=AsyncMock(return_value=_assistant_result())) as mock_run,
     ):
-        await query(QueryRequest(query="test", user_id=1))
+        await query(QueryRequest(query="test", user_id=1, session_id="sess-1"))
 
-    assert graph.last_state is not None
-    assert graph.last_state["max_rewrite_attempts"] == 3
+    mock_run.assert_awaited_once()
+    call = mock_run.await_args
+    assert call.args == ("test",)
+    assert call.kwargs["collection"] == "test_collection"
+    assert call.kwargs["dependencies"] is deps
+    assert call.kwargs["user_context"].user_id == "1"
+    assert call.kwargs["user_context"].session_id == "sess-1"
 
 
 async def test_query_writes_langfuse_scores() -> None:
     """POST /query must call write_langfuse_scores for score parity with bot."""
-    graph = _DummyGraph()
-    app.state.graph = graph
-    app.state.max_rewrite_attempts = 1
-
+    _set_core_state()
     lf = MagicMock()
     lf.update_current_span = MagicMock()
     lf.score_current_trace = MagicMock()
@@ -73,23 +96,20 @@ async def test_query_writes_langfuse_scores() -> None:
     with (
         patch("src.observability.propagate_attributes", return_value=nullcontext()),
         patch("src.observability.get_client", return_value=lf),
+        patch("src.core.run_assistant_request", new=AsyncMock(return_value=_assistant_result())),
         patch("src.scoring.write_langfuse_scores") as mock_write_scores,
     ):
         await query(QueryRequest(query="test", user_id=1))
 
-    # write_langfuse_scores must be called with (lf_client, result_state)
     mock_write_scores.assert_called_once()
     call_args = mock_write_scores.call_args
-    assert call_args[0][0] is lf  # first arg: langfuse client
-    assert isinstance(call_args[0][1], dict)  # second arg: result dict
+    assert call_args[0][0] is lf
+    assert isinstance(call_args[0][1], dict)
 
 
 async def test_query_updates_current_observation_and_propagates_api_attributes() -> None:
     """POST /query must propagate correlating attrs and update the active root observation."""
-    graph = _DummyGraph()
-    app.state.graph = graph
-    app.state.max_rewrite_attempts = 1
-
+    _set_core_state()
     lf = MagicMock()
     lf.update_current_span = MagicMock()
 
@@ -98,27 +118,26 @@ async def test_query_updates_current_observation_and_propagates_api_attributes()
             "src.observability.propagate_attributes", return_value=nullcontext()
         ) as mock_propagate,
         patch("src.observability.get_client", return_value=lf),
+        patch("src.core.run_assistant_request", new=AsyncMock(return_value=_assistant_result())),
     ):
         await query(QueryRequest(query="test", user_id=42, session_id="sess-1", channel="voice"))
 
-    mock_propagate.assert_called_once_with(
-        session_id="sess-1",
-        user_id="42",
-        metadata={"source": "voice"},
-        tags=["api", "rag", "voice"],
-        as_baggage=True,
-    )
+    call_kwargs = mock_propagate.call_args.kwargs
+    assert call_kwargs["session_id"] == "sess-1"
+    assert call_kwargs["user_id"] == "42"
+    assert call_kwargs["metadata"]["source"] == "voice"
+    assert "request_id" in call_kwargs["metadata"]
+    assert call_kwargs["tags"] == ["api", "rag", "voice"]
+    assert call_kwargs["as_baggage"] is True
     lf.update_current_span.assert_called_once()
     call_kwargs = lf.update_current_span.call_args.kwargs
-    # Safe input payload
     input_payload = call_kwargs["input"]
     assert isinstance(input_payload, dict)
     assert input_payload["content_type"] == "api"
     assert "query_preview" in input_payload
     assert "query_hash" in input_payload
     assert input_payload["query_len"] == 4
-    assert "test" not in input_payload  # raw text must not be present
-    # Safe output payload
+    assert "test" not in input_payload
     output_payload = call_kwargs["output"]
     assert isinstance(output_payload, dict)
     assert "answer_preview" in output_payload
@@ -126,8 +145,9 @@ async def test_query_updates_current_observation_and_propagates_api_attributes()
     assert output_payload["answer_len"] == 2
     assert output_payload["chunks_count"] == 1
     assert output_payload["delivery_status"] == "sent"
-    assert "ok" not in output_payload  # raw response must not be present
-    assert call_kwargs["metadata"] == {"source": "voice", "query_type": "GENERAL"}
+    assert "ok" not in output_payload
+    assert call_kwargs["metadata"]["source"] == "voice"
+    assert call_kwargs["metadata"]["query_type"] == "GENERAL"
 
 
 async def test_query_propagates_explicit_langfuse_trace_id() -> None:
@@ -179,20 +199,15 @@ async def test_lifespan_respects_rerank_provider_none() -> None:
 
     fake_cache = AsyncMock()
     fake_qdrant = AsyncMock()
-    fake_graph = MagicMock()
-
     with (
-        patch("telegram_bot.graph.config.GraphConfig.from_env", return_value=fake_cfg),
-        patch("telegram_bot.integrations.cache.CacheLayerManager", return_value=fake_cache),
-        patch("telegram_bot.services.qdrant.QdrantService", return_value=fake_qdrant),
-        patch("telegram_bot.graph.graph.build_graph", return_value=fake_graph) as mock_build_graph,
-        patch("telegram_bot.services.colbert_reranker.ColbertRerankerService") as mock_colbert,
+        patch("src.runtime.graph.config.GraphConfig.from_env", return_value=fake_cfg),
+        patch("src.runtime.integrations.cache.CacheLayerManager", return_value=fake_cache),
+        patch("src.runtime.services.qdrant.QdrantService", return_value=fake_qdrant),
     ):
         async with lifespan(app):
             assert app.state.max_rewrite_attempts == 2
-
-    assert mock_build_graph.call_args.kwargs["reranker"] is None
-    mock_colbert.assert_not_called()
+            assert app.state.core_dependencies.reranker is None
+            assert app.state.collection_name == "test_collection"
 
 
 async def test_lifespan_keeps_colbert_runtime_server_side() -> None:
@@ -212,20 +227,15 @@ async def test_lifespan_keeps_colbert_runtime_server_side() -> None:
 
     fake_cache = AsyncMock()
     fake_qdrant = AsyncMock()
-    fake_graph = MagicMock()
-
     with (
-        patch("telegram_bot.graph.config.GraphConfig.from_env", return_value=fake_cfg),
-        patch("telegram_bot.integrations.cache.CacheLayerManager", return_value=fake_cache),
-        patch("telegram_bot.services.qdrant.QdrantService", return_value=fake_qdrant),
-        patch("telegram_bot.graph.graph.build_graph", return_value=fake_graph) as mock_build_graph,
-        patch("telegram_bot.services.colbert_reranker.ColbertRerankerService") as mock_colbert,
+        patch("src.runtime.graph.config.GraphConfig.from_env", return_value=fake_cfg),
+        patch("src.runtime.integrations.cache.CacheLayerManager", return_value=fake_cache),
+        patch("src.runtime.services.qdrant.QdrantService", return_value=fake_qdrant),
     ):
         async with lifespan(app):
             assert app.state.max_rewrite_attempts == 2
-
-    assert mock_build_graph.call_args.kwargs["reranker"] is None
-    mock_colbert.assert_not_called()
+            assert app.state.core_dependencies.reranker is None
+            assert app.state.collection_name == "test_collection"
 
 
 async def test_lifespan_unknown_rerank_provider_logs_and_closes_embeddings() -> None:
@@ -247,13 +257,10 @@ async def test_lifespan_unknown_rerank_provider_logs_and_closes_embeddings() -> 
 
     fake_cache = AsyncMock()
     fake_qdrant = AsyncMock()
-    fake_graph = MagicMock()
-
     with (
-        patch("telegram_bot.graph.config.GraphConfig.from_env", return_value=fake_cfg),
-        patch("telegram_bot.integrations.cache.CacheLayerManager", return_value=fake_cache),
-        patch("telegram_bot.services.qdrant.QdrantService", return_value=fake_qdrant),
-        patch("telegram_bot.graph.graph.build_graph", return_value=fake_graph),
+        patch("src.runtime.graph.config.GraphConfig.from_env", return_value=fake_cfg),
+        patch("src.runtime.integrations.cache.CacheLayerManager", return_value=fake_cache),
+        patch("src.runtime.services.qdrant.QdrantService", return_value=fake_qdrant),
         patch("src.api.main.logger.warning") as mock_warning,
     ):
         async with lifespan(app):
@@ -301,103 +308,97 @@ async def test_generic_error_handler_uses_langfuse_trace_id_when_available() -> 
     )
 
 
-async def test_query_returns_fallback_on_graph_recursion_error() -> None:
-    """GraphRecursionError must return a valid QueryResponse fallback, not 500."""
-    from langgraph.errors import GraphRecursionError
-
-    class _FailingGraph:
-        async def ainvoke(self, state: dict) -> dict:
-            raise GraphRecursionError("recursion limit exceeded")
-
-    app.state.graph = _FailingGraph()
-    app.state.max_rewrite_attempts = 1
-
+async def test_query_returns_core_error_response() -> None:
+    """Core errors should return a valid QueryResponse fallback, not 500."""
+    _set_core_state()
     lf = MagicMock()
     lf.update_current_span = MagicMock()
+    core_error = _assistant_result(
+        response_text="Сервис временно недоступен.",
+        request_type="ERROR",
+        route="error",
+        error_type="dependency_failed",
+        documents_count=0,
+    )
 
     with (
         patch("src.observability.propagate_attributes", return_value=nullcontext()),
         patch("src.observability.get_client", return_value=lf),
+        patch("src.core.run_assistant_request", new=AsyncMock(return_value=core_error)),
         patch("src.scoring.write_langfuse_scores") as mock_write_scores,
     ):
         response = await query(QueryRequest(query="test", user_id=1))
 
     assert isinstance(response, QueryResponse)
-    assert "лимит" in response.response.lower() or "limit" in response.response.lower()
     assert response.query_type == "ERROR"
     assert response.documents_count == 0
     assert response.latency_ms >= 0
-    # Observability: span should still be updated and scores written
+    assert response.response
     lf.update_current_span.assert_called_once()
     mock_write_scores.assert_called_once()
 
 
-async def test_query_graph_recursion_error_preserves_trace_context() -> None:
-    """GraphRecursionError fallback should preserve trace/span behavior."""
-    from langgraph.errors import GraphRecursionError
-
-    class _FailingGraph:
-        async def ainvoke(self, state: dict) -> dict:
-            raise GraphRecursionError("recursion limit exceeded")
-
-    app.state.graph = _FailingGraph()
-    app.state.max_rewrite_attempts = 1
-
+async def test_query_core_error_preserves_trace_context() -> None:
+    """Core error fallback should preserve trace/span behavior."""
+    _set_core_state()
     lf = MagicMock()
     lf.update_current_span = MagicMock()
+    core_error = _assistant_result(
+        response_text="Сервис временно недоступен.",
+        request_type="ERROR",
+        route="error",
+        error_type="dependency_failed",
+        documents_count=0,
+    )
 
     with (
         patch("src.observability.propagate_attributes", return_value=nullcontext()),
         patch("src.observability.get_client", return_value=lf),
+        patch("src.core.run_assistant_request", new=AsyncMock(return_value=core_error)),
     ):
         await query(QueryRequest(query="complex", user_id=42, session_id="sess-1"))
 
     call_kwargs = lf.update_current_span.call_args.kwargs
-    # Safe input payload
     input_payload = call_kwargs["input"]
     assert isinstance(input_payload, dict)
     assert input_payload["content_type"] == "api"
     assert "query_preview" in input_payload
     assert "query_hash" in input_payload
     assert input_payload["query_len"] == 7
-    assert "complex" not in input_payload  # raw text must not be present
-    # Safe output payload with fallback_reason
+    assert "complex" not in input_payload
     output_payload = call_kwargs["output"]
     assert isinstance(output_payload, dict)
     assert "answer_preview" in output_payload
     assert "answer_hash" in output_payload
-    assert output_payload["fallback_reason"] == "recursion_limit"
+    assert output_payload["fallback_reason"] == "dependency_failed"
     assert output_payload["chunks_count"] == 1
     assert call_kwargs["metadata"]["source"] == "api"
     assert call_kwargs["metadata"]["query_type"] == "ERROR"
 
 
-async def test_query_graph_recursion_error_works_when_langfuse_disabled() -> None:
-    """Regression for #1606: GraphRecursionError fallback must not crash with
-    UnboundLocalError when Langfuse is disabled (get_client() returns None)."""
-    from langgraph.errors import GraphRecursionError
-
-    class _FailingGraph:
-        async def ainvoke(self, state: dict) -> dict:
-            raise GraphRecursionError("recursion limit exceeded")
-
-    app.state.graph = _FailingGraph()
-    app.state.max_rewrite_attempts = 1
+async def test_query_core_error_works_when_langfuse_disabled() -> None:
+    """Core error fallback must not crash when Langfuse is disabled."""
+    _set_core_state()
+    core_error = _assistant_result(
+        response_text="Сервис временно недоступен.",
+        request_type="ERROR",
+        route="error",
+        error_type="dependency_failed",
+        documents_count=0,
+    )
 
     with (
         patch("src.observability.propagate_attributes", return_value=nullcontext()),
         patch("src.observability.get_client", return_value=None),
+        patch("src.core.run_assistant_request", new=AsyncMock(return_value=core_error)),
         patch("src.scoring.write_langfuse_scores") as mock_write_scores,
     ):
         response = await query(QueryRequest(query="test", user_id=1))
 
-    # Must return a valid QueryResponse with the fallback message
     assert isinstance(response, QueryResponse)
     assert response.query_type == "ERROR"
     assert response.documents_count == 0
     assert response.cache_hit is False
     assert response.latency_ms >= 0
-    assert response.response  # non-empty fallback message
-    assert "лимит" in response.response.lower() or "limit" in response.response.lower()
-    # When Langfuse is disabled, scores must not be written
+    assert response.response
     mock_write_scores.assert_not_called()

--- a/tests/unit/api/test_rag_api_runtime.py
+++ b/tests/unit/api/test_rag_api_runtime.py
@@ -28,23 +28,6 @@ def _response_content(response) -> dict:
     return json.loads(response.body.decode("utf-8"))
 
 
-class _DummyGraph:
-    def __init__(self) -> None:
-        self.last_state: dict | None = None
-
-    async def ainvoke(self, state: dict) -> dict:
-        self.last_state = state
-        return {
-            "response": "ok",
-            "query_type": "GENERAL",
-            "cache_hit": False,
-            "search_results_count": 0,
-            "rerank_applied": False,
-        }
-
-
-
-
 def _set_core_state() -> object:
     deps = object()
     app.state.core_dependencies = deps
@@ -64,6 +47,7 @@ def _assistant_result(**overrides) -> AssistantResult:
     }
     data.update(overrides)
     return AssistantResult(**data)
+
 
 async def test_query_calls_assistant_core_with_api_context() -> None:
     deps = _set_core_state()


### PR DESCRIPTION
## Summary
- Fixes #2483.
- Replaces API lifespan graph construction with `CoreDependencies` construction.
- Routes `/query` through `src.core.run_assistant_request()` while preserving the existing response shape and observability score envelope.
- Updates API runtime tests to assert core entrypoint wiring.

## Changed files
- `src/api/main.py`
- `tests/unit/api/test_rag_api_runtime.py`

## Tests
- `uv run ruff check src/api/main.py tests/unit/api/test_rag_api_runtime.py`
- `uv run pytest tests/unit/api/test_rag_api_runtime.py -q`

## Skipped
- Full/heavy suites skipped per Codex Web focused-test policy for this API wiring slice.

## Agent Handoff

Status: merged
Base: dev
Head: codex/2483-api-core-entrypoint
Validated commit: ba962aae8fa7851342b974ee2f7a80d9217c765d
Risk: adapter
Failure class: none

## Validation

- [x] Required GitHub checks: green (Secret Scan, Semgrep, Lint, Lockfile Check, Compose Config)
- [x] Focused validation: passed (git diff --check origin/dev..HEAD; uvx ruff check src/ telegram_bot/ mini_app/ services/ scripts/ --output-format=github; uvx ruff format --target-version py312 --check src/ telegram_bot/ mini_app/ services/ scripts/; uv run pytest tests/unit/api/test_rag_api_runtime.py -q; make check)
- [x] make test-core: not required
- [x] Optional/heavy checks: failed/skipped (Fast Tests and Heavy Contract Tests are optional diagnostics per gh-pr-review policy; ignored for merge)

## Findings

- None

## Next action

Merged into dev by codex-web.
