### PR TITLE
Enforce runtime/adapter boundary; typed CoreDependencies, AssistantApp, telemetry, and runtime-owned graph default

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -45,9 +45,13 @@ src.retrieval ✗ telegram_bot
 providers     ✗ src.runtime
 ```
 
-### Current violations (being resolved)
+### Current migration debt
 
-See `tests/data/known_runtime_telegram_bot_couplings.json`.
+`tests/data/known_runtime_telegram_bot_couplings.json` is now the target state
+`{}`: `src.core` and `src.runtime` must not contain dynamic `telegram_bot.*`
+string coupling. Existing adapter-to-runtime imports are tracked separately as
+incremental migration debt; new adapter behavior should enter through
+`src.core`.
 Track: #2478, #2486, #2489.
 
 ---
@@ -108,12 +112,22 @@ These are implementation details. They must not call back into `src.runtime`.
 2. **Core generation does not accept Telegram `message`.** Generation returns
    data; the adapter sends messages.
 3. **Observability is optional.** Product JSON logs are required. Langfuse,
-   OTel, Sentry, Prometheus are optional diagnostic layers.
+   OTel, Sentry, Prometheus are optional diagnostic layers. Core/runtime code
+   emits telemetry through an injected `CoreDependencies.telemetry` listener or
+   standard Python logging fallback, not through adapter-global loggers.
 4. **`create_agent` is adapter-only.** Per ADR-0019, `create_agent` is not the
    owner of the core text RAG path. It remains useful for Telegram/voice
    adapter conversational shell behavior.
 5. **No dynamic `telegram_bot.*` imports in `src.core` or `src.runtime`.**
    Track: `tests/data/known_runtime_telegram_bot_couplings.json`.
+6. **Runtime graph defaults stay runtime-owned.** Adapter-specific graph assembly
+   must be selected explicitly with `RAG_GRAPH_FACTORY=module:attribute`;
+   `src.runtime.graph.builder.DEFAULT_FACTORY_SPEC` must not point at
+   `telegram_bot`.
+7. **Core dependencies are protocol typed.** `CoreDependencies` fields describe
+   cache, embedding, Qdrant, reranker, LLM, CRM, and telemetry contracts via
+   structural protocols so adapters do not leak concrete client ownership into
+   the SDK boundary.
 
 ---
 
@@ -126,6 +140,7 @@ tests/contract/test_runtime_no_telegram_bot_coupling_contract.py
 tests/contract/test_layering_no_telegram_bot_imports_contract.py
 tests/contract/test_langfuse_optional_core_contract.py
 tests/contract/test_service_dependency_markers_contract.py
+tests/contract/test_architecture_layer_law_contract.py
 ```
 
 ### Target

--- a/src/README.md
+++ b/src/README.md
@@ -34,11 +34,24 @@ Contains all non-transport logic: document ingestion, vector search, model conte
 | `utils/` | Shared helpers |
 | `voice/` | LiveKit voice agent and SIP setup (deferred by default) |
 
-## Boundaries
+## Architecture Law
 
-- **Shared/domain `src/` modules should stay Telegram-agnostic.** `src/api/` is an explicit adapter exception: it reuses the Telegram LangGraph pipeline (graph, state, observability, scoring) until that pipeline is extracted into a shared location.
+`src/` follows the repository architecture law documented in [`../ARCHITECTURE.md`](../ARCHITECTURE.md):
+
+```text
+External adapters -> src.core -> src.runtime -> providers / clients
+providers / clients -X-> src.runtime
+src.runtime -X-> telegram_bot
+CRM writes -> HITL confirmation required
+```
+
+Practical rules for this tree:
+
+- **`src.core/` owns the public SDK boundary.** Adapters pass request context, config, and typed `CoreDependencies` into core entrypoints instead of wiring low-level runtime dependencies themselves.
+- **`src.runtime/` owns assistant orchestration and must stay adapter-agnostic.** It may call neutral `src.services` clients and provider protocols, but it must not import or dynamically resolve `telegram_bot.*`.
+- **Providers and clients do not call runtime orchestration.** Shared clients under `src/services/` and provider wrappers stay reusable below runtime.
 - **Ingestion determinism and resumability** are owned by `src/ingestion/` and `src/ingestion/unified/`. Do not change manifest identity, hashing, or collection semantics without careful review.
-- **LangGraph state contracts** are defined in `telegram_bot/graph/state.py`; `src/api/` reuses the same pipeline but does not redefine state shapes.
+- **CRM writes require HITL.** Core/runtime may propose CRM actions, but adapters must require explicit confirmation before side effects.
 
 ## Related Runtime Services
 
@@ -59,6 +72,7 @@ pytest src/retrieval/ src/ingestion/unified/ src/api/
 
 ## See Also
 
+- [`../ARCHITECTURE.md`](../ARCHITECTURE.md) — Layer dependency rules
 - [`../telegram_bot/README.md`](../telegram_bot/README.md) — Telegram transport layer
 - [`../DOCKER.md`](../DOCKER.md) — Docker orchestration and service dependencies
 - [`../docs/LOCAL-DEVELOPMENT.md`](../docs/LOCAL-DEVELOPMENT.md) — Local setup and validation ladder

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -4,8 +4,16 @@ from .contracts import (
     AssistantError,
     AssistantRequest,
     AssistantResult,
+    CacheProvider,
     CoreDependencies,
     CrmAction,
+    CrmClientProtocol,
+    EmbeddingProvider,
+    LLMProvider,
+    QdrantClientProtocol,
+    RerankerProvider,
+    SparseEmbeddingProvider,
+    TelemetryLogger,
     UserContext,
 )
 
@@ -13,6 +21,14 @@ from .contracts import (
 def __getattr__(name: str) -> object:
     """Load runtime-bearing exports lazily to keep core contracts import-safe."""
 
+    if name == "AssistantApp":
+        from .app import AssistantApp
+
+        return AssistantApp
+    if name == "DependencyBuilder":
+        from .app import DependencyBuilder
+
+        return DependencyBuilder
     if name == "run_assistant_request":
         from .assistant import run_assistant_request
 
@@ -25,12 +41,22 @@ def __getattr__(name: str) -> object:
 
 
 __all__ = [
+    "AssistantApp",
     "AssistantError",
     "AssistantRequest",
     "AssistantResult",
+    "CacheProvider",
     "CoreDependencies",
     "CrmAction",
+    "CrmClientProtocol",
+    "DependencyBuilder",
+    "EmbeddingProvider",
+    "LLMProvider",
+    "QdrantClientProtocol",
     "RAGPipeline",
+    "RerankerProvider",
+    "SparseEmbeddingProvider",
+    "TelemetryLogger",
     "UserContext",
     "run_assistant_request",
 ]

--- a/src/core/app.py
+++ b/src/core/app.py
@@ -1,0 +1,78 @@
+"""Assistant SDK application builder."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from src.core.assistant import run_assistant_request
+from src.core.contracts import AssistantResult, CoreDependencies, UserContext
+
+
+DependencyBuilder = Callable[[object | None], CoreDependencies]
+
+
+@dataclass(slots=True)
+class AssistantApp:
+    """Encapsulated assistant application for adapters and SDK callers.
+
+    Adapters should construct this app from configuration or an explicit
+    dependency builder, then call ``run_text``. That keeps concrete dependency
+    wiring behind the core SDK boundary instead of spreading low-level runtime
+    clients through transport code.
+    """
+
+    config: object | None = None
+    dependencies: CoreDependencies | None = None
+
+    @classmethod
+    def from_dependencies(
+        cls,
+        dependencies: CoreDependencies,
+        *,
+        config: object | None = None,
+    ) -> AssistantApp:
+        """Build an app from an already prepared dependency bundle."""
+
+        return cls(config=config, dependencies=dependencies)
+
+    @classmethod
+    def from_config(
+        cls,
+        config: object | None = None,
+        *,
+        dependency_builder: DependencyBuilder | None = None,
+    ) -> AssistantApp:
+        """Build an app from config, optionally using a dependency builder.
+
+        When no builder is supplied the app remains in skeleton mode; this is
+        useful for import-only SDK tests and documentation examples that should
+        not initialize live Qdrant, LLM, embedding, or cache clients.
+        """
+
+        dependencies = dependency_builder(config) if dependency_builder is not None else None
+        return cls(config=config, dependencies=dependencies)
+
+    async def run_text(
+        self,
+        query: str,
+        *,
+        collection: str,
+        user_context: UserContext | None = None,
+        request_id: str | None = None,
+        dependencies: CoreDependencies | None = None,
+        **_: Any,
+    ) -> AssistantResult:
+        """Run one text request through the core assistant entrypoint."""
+
+        return await run_assistant_request(
+            query,
+            collection=collection,
+            user_context=user_context,
+            request_id=request_id,
+            dependencies=dependencies or self.dependencies,
+        )
+
+
+__all__ = ["AssistantApp", "DependencyBuilder"]

--- a/src/core/assistant.py
+++ b/src/core/assistant.py
@@ -13,8 +13,8 @@ from src.core.contracts import (
     CrmAction,
     UserContext,
 )
+from src.core.telemetry import emit_product_event
 from src.runtime.pipeline.assistant_pipeline import run_assistant_pipeline
-from src.utils.product_events import log_event
 
 
 async def run_assistant_request(
@@ -33,7 +33,8 @@ async def run_assistant_request(
 
     rid = request_id or str(uuid4())
 
-    log_event("assistant_request_started", request_id=rid, route="unknown")
+    telemetry = dependencies.telemetry if dependencies is not None else None
+    emit_product_event(telemetry, "assistant_request_started", request_id=rid, route="unknown")
 
     if dependencies is None:
         await asyncio.sleep(0)
@@ -47,7 +48,8 @@ async def run_assistant_request(
             error_message="Assistant core is in skeleton mode and does not execute live services.",
         )
 
-        log_event(
+        emit_product_event(
+            telemetry,
             "assistant_request_completed",
             request_id=result.request_id,
             route=result.route,
@@ -66,7 +68,8 @@ async def run_assistant_request(
     )
     result = await run_assistant_pipeline(request, dependencies=dependencies)
 
-    log_event(
+    emit_product_event(
+        telemetry,
         "assistant_request_completed",
         request_id=result.request_id,
         route=result.route,

--- a/src/core/contracts.py
+++ b/src/core/contracts.py
@@ -36,27 +36,25 @@ class AssistantRequest:
 class CacheProvider(Protocol):
     """Semantic cache dependency used by the runtime RAG path."""
 
-    async def check_semantic(self, *args: Any, **kwargs: Any) -> dict[str, Any] | None: ...
-
-    async def store(self, *args: Any, **kwargs: Any) -> Any: ...
+    async def check_semantic(self, *args: Any, **kwargs: Any) -> Any: ...
 
 
 class EmbeddingProvider(Protocol):
     """Dense embedding dependency used by core/runtime."""
 
-    async def embed_texts(self, texts: list[str]) -> list[list[float]]: ...
+    async def aembed_query(self, text: str) -> list[float]: ...
 
 
 class SparseEmbeddingProvider(Protocol):
     """Sparse embedding dependency used by core/runtime."""
 
-    async def embed_sparse(self, texts: list[str]) -> list[dict[str, Any]]: ...
+    async def aembed_query(self, text: str) -> dict[str, Any]: ...
 
 
 class QdrantClientProtocol(Protocol):
     """Vector search dependency used by core/runtime."""
 
-    async def hybrid_search_rrf(self, *args: Any, **kwargs: Any) -> list[dict[str, Any]]: ...
+    async def hybrid_search_rrf(self, *args: Any, **kwargs: Any) -> Any: ...
 
 
 class RerankerProvider(Protocol):

--- a/src/core/contracts.py
+++ b/src/core/contracts.py
@@ -9,7 +9,7 @@ them in lightweight tests and tooling.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Protocol
 
 
 @dataclass
@@ -33,17 +33,69 @@ class AssistantRequest:
     request_id: str = ""
 
 
+class CacheProvider(Protocol):
+    """Semantic cache dependency used by the runtime RAG path."""
+
+    async def check_semantic(self, *args: Any, **kwargs: Any) -> dict[str, Any] | None: ...
+
+    async def store(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
+class EmbeddingProvider(Protocol):
+    """Dense embedding dependency used by core/runtime."""
+
+    async def embed_texts(self, texts: list[str]) -> list[list[float]]: ...
+
+
+class SparseEmbeddingProvider(Protocol):
+    """Sparse embedding dependency used by core/runtime."""
+
+    async def embed_sparse(self, texts: list[str]) -> list[dict[str, Any]]: ...
+
+
+class QdrantClientProtocol(Protocol):
+    """Vector search dependency used by core/runtime."""
+
+    async def hybrid_search_rrf(self, *args: Any, **kwargs: Any) -> list[dict[str, Any]]: ...
+
+
+class RerankerProvider(Protocol):
+    """Optional reranking dependency used by core/runtime."""
+
+    async def rerank(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
+class LLMProvider(Protocol):
+    """Optional language-model dependency used by core/runtime."""
+
+    async def generate(self, *args: Any, **kwargs: Any) -> str: ...
+
+
+class CrmClientProtocol(Protocol):
+    """Optional CRM dependency; implementations must keep writes behind HITL."""
+
+    async def propose_action(self, *args: Any, **kwargs: Any) -> CrmAction | None: ...
+
+
+class TelemetryLogger(Protocol):
+    """SDK-friendly telemetry callback surface for product events."""
+
+    def log_event(self, event: str, **fields: Any) -> None: ...
+
+
 @dataclass
 class CoreDependencies:
     """Runtime collaborators required to execute the existing RAG path."""
 
-    cache: Any
-    embeddings: Any
-    sparse_embeddings: Any
-    qdrant: Any
-    reranker: Any | None = None
-    llm: Any | None = None
-    config: Any | None = None
+    cache: CacheProvider
+    embeddings: EmbeddingProvider
+    sparse_embeddings: SparseEmbeddingProvider
+    qdrant: QdrantClientProtocol
+    reranker: RerankerProvider | None = None
+    llm: LLMProvider | None = None
+    config: object | None = None
+    crm: CrmClientProtocol | None = None
+    telemetry: TelemetryLogger | None = None
 
 
 @dataclass
@@ -88,7 +140,15 @@ __all__ = [
     "AssistantError",
     "AssistantRequest",
     "AssistantResult",
+    "CacheProvider",
     "CoreDependencies",
     "CrmAction",
+    "CrmClientProtocol",
+    "EmbeddingProvider",
+    "LLMProvider",
+    "QdrantClientProtocol",
+    "RerankerProvider",
+    "SparseEmbeddingProvider",
+    "TelemetryLogger",
     "UserContext",
 ]

--- a/src/core/telemetry.py
+++ b/src/core/telemetry.py
@@ -5,24 +5,32 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from src.utils.product_events import log_event as _product_log_event
 
-_LOGGER = logging.getLogger("src.core.telemetry")
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def emit_product_event(telemetry: object | None, event: str, **fields: Any) -> None:
-    """Emit a product event via an injected listener or standard logging.
+    """Emit a product event via an injected listener or safe JSON-log fallback.
 
-    The SDK core no longer imports the repository-level ``log_event`` helper
-    directly. Host applications can pass ``CoreDependencies.telemetry`` with a
-    ``log_event(event, **fields)`` method; otherwise events are emitted through
-    Python's standard logging with sanitized structured extras.
+    Host applications can pass ``CoreDependencies.telemetry`` with a
+    ``log_event(event, **fields)`` method. Listener failures are fail-open: the
+    assistant request path must continue, and the event falls back to the
+    existing product log helper so allowlist-based PII/secret filtering remains
+    in force.
     """
 
     if telemetry is not None:
-        log_event = getattr(telemetry, "log_event", None)
-        if callable(log_event):
-            log_event(event, **fields)
-            return
+        telemetry_log_event = getattr(telemetry, "log_event", None)
+        if callable(telemetry_log_event):
+            try:
+                telemetry_log_event(event, **fields)
+                return
+            except Exception:
+                _LOGGER.warning(
+                    "Telemetry listener failed; falling back to product event log",
+                    exc_info=True,
+                )
 
-    extra = {"event": event, **fields}
-    _LOGGER.info(event, extra=extra)
+    _product_log_event(event, **fields)

--- a/src/core/telemetry.py
+++ b/src/core/telemetry.py
@@ -1,0 +1,28 @@
+"""SDK-friendly telemetry dispatch for core/runtime product events."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+
+_LOGGER = logging.getLogger("src.core.telemetry")
+
+
+def emit_product_event(telemetry: object | None, event: str, **fields: Any) -> None:
+    """Emit a product event via an injected listener or standard logging.
+
+    The SDK core no longer imports the repository-level ``log_event`` helper
+    directly. Host applications can pass ``CoreDependencies.telemetry`` with a
+    ``log_event(event, **fields)`` method; otherwise events are emitted through
+    Python's standard logging with sanitized structured extras.
+    """
+
+    if telemetry is not None:
+        log_event = getattr(telemetry, "log_event", None)
+        if callable(log_event):
+            log_event(event, **fields)
+            return
+
+    extra = {"event": event, **fields}
+    _LOGGER.info(event, extra=extra)

--- a/src/runtime/graph/builder.py
+++ b/src/runtime/graph/builder.py
@@ -1,30 +1,9 @@
 """Pipeline factory resolver — the seam that closes #1948.
 
 Before this module, ``src/api/main.py`` opened its FastAPI ``lifespan``
-with::
-
-    from telegram_bot.graph.graph import build_graph
-
-That static import was the last entry in
-``tests/data/known_layering_violations.json`` and the last reason
-``src/`` could not be shipped without ``telegram_bot/`` mounted next to
-it.
-
-This module replaces that static import with a string-based resolution:
-
-* ``RAG_GRAPH_FACTORY`` (default ``telegram_bot.graph.graph:build_graph``)
-  points at a ``module:attribute`` callable.
-* :func:`resolve_pipeline_factory` imports the module via
-  :func:`importlib.import_module` (a string call, not an ``import``
-  statement) and returns the attribute.
-* The layering contract test (#1948) scans the AST for
-  ``ast.Import`` / ``ast.ImportFrom`` nodes only, so the dynamic resolve
-  does not register as a violation.
-
-The default still points at the bot's existing ``build_graph`` so
-production behaviour is unchanged. Tests and alternative deployments
-override the env var to inject their own factory without touching
-``src/api/``.
+with a direct adapter import. This resolver keeps API/runtime code on a
+runtime-owned default factory while still allowing adapters to override the
+factory with ``RAG_GRAPH_FACTORY=some.module:factory``.
 """
 
 from __future__ import annotations
@@ -39,12 +18,11 @@ from typing import Any, cast
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_FACTORY_SPEC = "telegram_bot.graph.graph:build_graph"
+DEFAULT_FACTORY_SPEC = "src.runtime.graph.graph:build_graph"
 """Default ``module:attribute`` factory spec.
 
-The bot's ``build_graph`` is the canonical pipeline factory; ``src/api``
-and ``mini_app`` consume it via this seam so they remain free of any
-static ``from telegram_bot ...`` import.
+Runtime-owned default pipeline factory. Adapters may override this with
+their own ``module:attribute`` spec at process startup.
 """
 
 ENV_VAR = "RAG_GRAPH_FACTORY"

--- a/src/runtime/graph/graph.py
+++ b/src/runtime/graph/graph.py
@@ -1,0 +1,34 @@
+"""Runtime-owned graph factory surface.
+
+The reusable runtime package must not point back to the Telegram adapter as its
+factory default. This module provides the neutral default import target for
+``src.runtime.graph.builder``. Adapter-specific graph assembly can still be
+selected explicitly with ``RAG_GRAPH_FACTORY``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class RuntimeGraphFactoryUnavailable(RuntimeError):
+    """Raised when the neutral runtime factory is called without an adapter."""
+
+
+def build_graph(**kwargs: Any) -> Any:
+    """Build the default runtime graph.
+
+    The legacy LangGraph graph still has transport-specific nodes. Until those
+    nodes are fully migrated into ``src.runtime.graph.nodes``, callers that need
+    the adapter graph must set ``RAG_GRAPH_FACTORY`` explicitly. Keeping this
+    neutral callable in ``src.runtime`` removes the runtime -> adapter default
+    dependency while preserving the builder's import contract.
+    """
+
+    raise RuntimeGraphFactoryUnavailable(
+        "The default runtime graph factory is intentionally adapter-neutral. "
+        "Set RAG_GRAPH_FACTORY to an application graph factory to build a graph."
+    )
+
+
+__all__ = ["RuntimeGraphFactoryUnavailable", "build_graph"]

--- a/src/runtime/pipeline/assistant_pipeline.py
+++ b/src/runtime/pipeline/assistant_pipeline.py
@@ -11,11 +11,11 @@ from src.core.contracts import (
     CoreDependencies,
     UserContext,
 )
+from src.core.telemetry import emit_product_event
 from src.retrieval.topic_classifier import get_query_topic_hint
 from src.runtime.generation import GenerationRequest, generate_answer
 from src.runtime.grounding.policy import get_grounding_mode
 from src.runtime.pipeline.rag import rag_pipeline
-from src.core.telemetry import emit_product_event
 
 
 async def run_assistant_pipeline(

--- a/src/runtime/pipeline/assistant_pipeline.py
+++ b/src/runtime/pipeline/assistant_pipeline.py
@@ -15,7 +15,7 @@ from src.retrieval.topic_classifier import get_query_topic_hint
 from src.runtime.generation import GenerationRequest, generate_answer
 from src.runtime.grounding.policy import get_grounding_mode
 from src.runtime.pipeline.rag import rag_pipeline
-from src.utils.product_events import log_event
+from src.core.telemetry import emit_product_event
 
 
 async def run_assistant_pipeline(
@@ -53,7 +53,8 @@ async def run_assistant_pipeline(
 
         documents = _as_document_list(rag_result.get("documents"))
         retrieved_doc_ids = _extract_doc_ids(documents)
-        log_event(
+        emit_product_event(
+            dependencies.telemetry,
             "search_completed",
             request_id=rid,
             route="cache_hit" if rag_result.get("cache_hit") else "rag_search",
@@ -94,7 +95,8 @@ async def run_assistant_pipeline(
         usage = _as_usage_dict(generation_result.get("usage_details"))
         llm_model = _extract_llm_model(generation_result)
 
-        log_event(
+        emit_product_event(
+            dependencies.telemetry,
             "llm_completed",
             request_id=rid,
             route="rag_search",
@@ -132,7 +134,8 @@ async def run_assistant_pipeline(
             error_message=str(exc),
             request_id=rid,
         )
-        log_event(
+        emit_product_event(
+            dependencies.telemetry,
             "dependency_failed",
             request_id=rid,
             route=result.route,

--- a/src/runtime/pipeline/rag.py
+++ b/src/runtime/pipeline/rag.py
@@ -25,17 +25,31 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, TypeVar, cast
 
+from src.observability import get_client, observe
+from src.runtime.graph.config import GraphConfig
+from src.runtime.services.cache_policy import (
+    SEMANTIC_CACHE_SCHEMA_VERSION,
+    build_cacheability_decision,
+    is_contextual_query,
+    maybe_store_semantic_response,
+    resolve_semantic_cache_signature,
+)
+from src.runtime.services.metrics import record_pipeline_event
 from src.runtime.services.query_filter_signal import detect_filter_sensitive_query
 from src.runtime.services.query_preprocessor import QueryPreprocessor, expand_short_query
+from src.runtime.services.rag_core import (
+    CACHEABLE_QUERY_TYPES,
+    build_retrieved_context,
+    check_semantic_cache,
+    compute_query_embedding,
+    perform_rerank,
+    rewrite_query_via_llm,
+)
+from src.runtime.services.small_to_big import SmallToBigMode, SmallToBigService
+from src.services.bge_m3_query_bundle import BgeM3QueryVectorBundle
 
 
 _T = TypeVar("_T")
-
-
-def _load_telegram_attr(module_name: str, attr_name: str) -> Any:
-    import importlib
-
-    return getattr(importlib.import_module(module_name), attr_name)
 
 
 def _load_topic_classifier_attr(attr_name: str) -> Any:
@@ -63,112 +77,24 @@ def _identity_observe(*args: Any, **kwargs: Any) -> Callable[[_T], _T]:
     return decorator
 
 
-def _load_observe() -> Callable[..., Callable[[_T], _T]]:
-    try:
-        return cast(
-            Callable[..., Callable[[_T], _T]],
-            _load_telegram_attr("telegram_bot.observability", "observe"),
-        )
-    except Exception:  # pragma: no cover - import-safety fallback for lightweight tooling
-        return _identity_observe
-
-
-def _get_client() -> Any:
-    # ``telegram_bot.observability.get_client`` is the Langfuse ``get_client``
-    # factory; it must be *called* to obtain the client instance that exposes
-    # ``update_current_span``. Returning the factory itself caused
-    # ``AttributeError: 'function' object has no attribute 'update_current_span'``
-    # whenever the runtime pipeline recorded a span (e.g. miniapp path).
-    return _load_telegram_attr("telegram_bot.observability", "get_client")()
-
-
-def _cache_policy_attr(name: str) -> Any:
-    return _load_telegram_attr("telegram_bot.services.cache_policy", name)
-
-
 def _graph_config_from_env() -> Any:
-    graph_config = _load_telegram_attr("telegram_bot.graph.config", "GraphConfig")
-    return graph_config.from_env()
+    return GraphConfig.from_env()
 
 
 def _bge_m3_query_bundle_cls() -> Any:
-    return _load_telegram_attr(
-        "telegram_bot.services.bge_m3_query_bundle",
-        "BgeM3QueryVectorBundle",
-    )
-
-
-def _small_to_big_attr(name: str) -> Any:
-    return _load_telegram_attr("telegram_bot.services.small_to_big", name)
-
-
-def _rag_core_attr(name: str) -> Any:
-    return _load_telegram_attr("telegram_bot.services.rag_core", name)
-
-
-def _record_pipeline_event(*args: Any, **kwargs: Any) -> Any:
-    record = _load_telegram_attr("telegram_bot.services.metrics", "record_pipeline_event")
-    return record(*args, **kwargs)
+    return BgeM3QueryVectorBundle
 
 
 def _new_query_preprocessor() -> QueryPreprocessor:
     return QueryPreprocessor()
 
 
-observe = _load_observe()
-
-
-def get_client() -> Any:
-    # ``_get_client()`` already returns the Langfuse client instance (it calls
-    # the ``telegram_bot.observability.get_client`` factory), so this wrapper
-    # must NOT call the result again.
-    return _get_client()
-
-
-SEMANTIC_CACHE_SCHEMA_VERSION = "v8"
-
-
-def build_cacheability_decision(*args: Any, **kwargs: Any) -> Any:
-    return _cache_policy_attr("build_cacheability_decision")(*args, **kwargs)
-
-
-def is_contextual_query(*args: Any, **kwargs: Any) -> Any:
-    return _cache_policy_attr("is_contextual_query")(*args, **kwargs)
-
-
-def maybe_store_semantic_response(*args: Any, **kwargs: Any) -> Any:
-    return _cache_policy_attr("maybe_store_semantic_response")(*args, **kwargs)
-
-
-def resolve_semantic_cache_signature(*args: Any, **kwargs: Any) -> Any:
-    return _cache_policy_attr("resolve_semantic_cache_signature")(*args, **kwargs)
-
-
-def check_semantic_cache(*args: Any, **kwargs: Any) -> Any:
-    return _rag_core_attr("check_semantic_cache")(*args, **kwargs)
-
-
-def compute_query_embedding(*args: Any, **kwargs: Any) -> Any:
-    return _rag_core_attr("compute_query_embedding")(*args, **kwargs)
-
-
-def perform_rerank(*args: Any, **kwargs: Any) -> Any:
-    return _rag_core_attr("perform_rerank")(*args, **kwargs)
-
-
-def rewrite_query_via_llm(*args: Any, **kwargs: Any) -> Any:
-    return _rag_core_attr("rewrite_query_via_llm")(*args, **kwargs)
-
-
 def _build_retrieved_context(*args: Any, **kwargs: Any) -> Any:
-    return _rag_core_attr("build_retrieved_context")(*args, **kwargs)
+    return build_retrieved_context(*args, **kwargs)
 
 
 def _cacheable_query_types() -> set[str]:
-    return set(_rag_core_attr("CACHEABLE_QUERY_TYPES"))
-
-
-record_pipeline_event = _record_pipeline_event
+    return set(CACHEABLE_QUERY_TYPES)
 
 
 logger = logging.getLogger(__name__)
@@ -1544,13 +1470,10 @@ async def _expand_small_to_big(
     Qdrant document, replaces each doc's ``text`` with expanded context.
     Failures are logged but never crash the pipeline.
     """
-    small_to_big_mode = _small_to_big_attr("SmallToBigMode")
-    small_to_big_service = _small_to_big_attr("SmallToBigService")
-
-    if config.small_to_big_mode == small_to_big_mode.OFF or not final_docs:
+    if config.small_to_big_mode == SmallToBigMode.OFF or not final_docs:
         return
     try:
-        stb = small_to_big_service(
+        stb = SmallToBigService(
             client=qdrant.client,
             collection_name=qdrant.collection_name,
             max_expanded_chunks=config.max_expanded_chunks,

--- a/src/runtime/pipeline/rag.py
+++ b/src/runtime/pipeline/rag.py
@@ -23,7 +23,7 @@ import logging
 import time
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar
 
 from src.observability import get_client, observe
 from src.runtime.graph.config import GraphConfig
@@ -1185,10 +1185,17 @@ async def rag_pipeline(
         )
     semantic_cache_already_checked = semantic_cache_prechecked
     # Embedding of cache_key — kept separately for _cache_store so rewrites don't overwrite it
-    cache_embedding = cast(list[float] | None, cache_result.get("query_embedding"))
+    cache_embedding_value = cache_result.get("query_embedding")
+    cache_embedding: list[float] | None = (
+        cache_embedding_value if isinstance(cache_embedding_value, list) else None
+    )
     cache_sparse: Any = cache_result.get("sparse_embedding")
-    latency_stages = cast(dict[str, float], cache_result["latency_stages"])
-    colbert_query = cast(list[list[float]] | None, cache_result.get("colbert_query"))
+    latency_stages_value = cache_result.get("latency_stages")
+    latency_stages = latency_stages_value if isinstance(latency_stages_value, dict) else {}
+    colbert_query_value = cache_result.get("colbert_query")
+    colbert_query: list[list[float]] | None = (
+        colbert_query_value if isinstance(colbert_query_value, list) else None
+    )
     embeddings_cache_hit = bool(cache_result.get("embeddings_cache_hit", False))
 
     if cache_result.get("embedding_error"):

--- a/telegram_bot/assistant_core_adapter.py
+++ b/telegram_bot/assistant_core_adapter.py
@@ -15,7 +15,7 @@ from src.core import (
     CoreDependencies,
     UserContext,
 )
-from src.core.assistant import run_assistant_request
+from src.core.app import AssistantApp
 
 
 CORE_ENTRYPOINT_ENV = "ASSISTANT_CORE_ENTRYPOINT_ENABLED"
@@ -56,12 +56,12 @@ async def run_core_text_request(
 ) -> AssistantResult:
     """Call the assistant core from Telegram adapter code."""
 
-    return await run_assistant_request(
+    app = AssistantApp.from_dependencies(dependencies)
+    return await app.run_text(
         query,
         collection=collection,
         user_context=user_context,
         request_id=request_id,
-        dependencies=dependencies,
     )
 
 

--- a/tests/contract/test_architecture_layer_law_contract.py
+++ b/tests/contract/test_architecture_layer_law_contract.py
@@ -1,0 +1,60 @@
+"""Contract: enforce the modular-monolith architecture law.
+
+The full adapter migration is incremental, but the reusable layers must not gain
+new reverse dependencies. These checks cover rules that can be enforced without
+allowlists: provider/client code must not import runtime orchestration, and the
+runtime graph builder default must stay runtime-owned rather than adapter-owned.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from src.runtime.graph import builder
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROVIDER_CLIENT_ROOTS = (
+    REPO_ROOT / "src" / "services",
+    REPO_ROOT / "src" / "providers",
+)
+
+
+def _imports_runtime(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module == "src.runtime" or module.startswith("src.runtime."):
+                found.add(module)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "src.runtime" or alias.name.startswith("src.runtime."):
+                    found.add(alias.name)
+    return found
+
+
+def test_provider_and_client_layers_do_not_import_runtime() -> None:
+    violations: dict[str, list[str]] = {}
+    for root in PROVIDER_CLIENT_ROOTS:
+        if not root.exists():
+            continue
+        for path in sorted(root.rglob("*.py")):
+            imports = _imports_runtime(path)
+            if imports:
+                violations[path.relative_to(REPO_ROOT).as_posix()] = sorted(imports)
+
+    assert not violations, (
+        "Architecture law: providers/clients are below runtime and must not "
+        f"import src.runtime orchestration. Violations: {violations}"
+    )
+
+
+def test_runtime_graph_default_factory_is_runtime_owned() -> None:
+    assert builder.DEFAULT_FACTORY_SPEC.startswith("src.runtime."), (
+        "Architecture law: runtime graph default must be runtime-owned; adapters "
+        "can opt in with RAG_GRAPH_FACTORY but src.runtime must not default to one."
+    )
+    assert "telegram_bot" not in builder.DEFAULT_FACTORY_SPEC

--- a/tests/contract/test_langfuse_optional_core_contract.py
+++ b/tests/contract/test_langfuse_optional_core_contract.py
@@ -12,7 +12,9 @@ CORE_RUNTIME_DIRS = [REPO_ROOT / "src" / "core", REPO_ROOT / "src" / "runtime"]
 
 
 def test_core_and_runtime_do_not_import_langfuse_modules() -> None:
-    missing_roots = [str(path.relative_to(REPO_ROOT)) for path in CORE_RUNTIME_DIRS if not path.is_dir()]
+    missing_roots = [
+        str(path.relative_to(REPO_ROOT)) for path in CORE_RUNTIME_DIRS if not path.is_dir()
+    ]
     assert missing_roots == [], f"contract scan roots do not exist: {missing_roots}"
 
     violations: list[str] = []

--- a/tests/contract/test_no_kfp_kubernetes_root_dependency_contract.py
+++ b/tests/contract/test_no_kfp_kubernetes_root_dependency_contract.py
@@ -34,7 +34,14 @@ def _package_names_from_lock(path: Path) -> set[str]:
 
 
 def _package_name(requirement: str) -> str:
-    return requirement.split("[", 1)[0].split("<", 1)[0].split(">", 1)[0].split("=", 1)[0].strip().lower()
+    return (
+        requirement.split("[", 1)[0]
+        .split("<", 1)[0]
+        .split(">", 1)[0]
+        .split("=", 1)[0]
+        .strip()
+        .lower()
+    )
 
 
 def test_root_lock_does_not_include_kfp_or_kubernetes_packages() -> None:

--- a/tests/data/known_runtime_telegram_bot_couplings.json
+++ b/tests/data/known_runtime_telegram_bot_couplings.json
@@ -1,14 +1,1 @@
-{
-  "src/runtime/graph/builder.py": [
-    "telegram_bot.graph.graph:build_graph"
-  ],
-  "src/runtime/pipeline/rag.py": [
-    "telegram_bot.graph.config",
-    "telegram_bot.observability",
-    "telegram_bot.services.bge_m3_query_bundle",
-    "telegram_bot.services.cache_policy",
-    "telegram_bot.services.metrics",
-    "telegram_bot.services.rag_core",
-    "telegram_bot.services.small_to_big"
-  ]
-}
+{}

--- a/tests/unit/api/test_rag_api_runtime.py
+++ b/tests/unit/api/test_rag_api_runtime.py
@@ -57,7 +57,9 @@ async def test_query_calls_assistant_core_with_api_context() -> None:
     with (
         patch("src.observability.propagate_attributes", return_value=nullcontext()),
         patch("src.observability.get_client", return_value=lf),
-        patch("src.core.run_assistant_request", new=AsyncMock(return_value=_assistant_result())) as mock_run,
+        patch(
+            "src.core.run_assistant_request", new=AsyncMock(return_value=_assistant_result())
+        ) as mock_run,
     ):
         await query(QueryRequest(query="test", user_id=1, session_id="sess-1"))
 

--- a/tests/unit/core/test_assistant_entrypoint.py
+++ b/tests/unit/core/test_assistant_entrypoint.py
@@ -668,7 +668,11 @@ class TestRunAssistantRequestRuntime:
         )
         from src.runtime.generation import GenerationResult
 
-        gen = AsyncMock(return_value=GenerationResult(payload={"response": "answer", "llm_provider_model": "test-model"}))
+        gen = AsyncMock(
+            return_value=GenerationResult(
+                payload={"response": "answer", "llm_provider_model": "test-model"}
+            )
+        )
 
         with (
             patch("src.runtime.graph.nodes.classify.classify_query", return_value="GENERAL"),

--- a/tests/unit/core/test_telemetry.py
+++ b/tests/unit/core/test_telemetry.py
@@ -1,0 +1,118 @@
+"""Tests for core telemetry event dispatch."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import pytest
+
+
+class _FakeCache:
+    async def check_semantic(self, *args: object, **kwargs: object) -> dict[str, Any] | None:
+        return None
+
+
+class _FakeEmbeddings:
+    async def aembed_query(self, text: str) -> list[float]:
+        return [0.0]
+
+
+class _FakeSparseEmbeddings:
+    async def aembed_query(self, text: str) -> dict[str, Any]:
+        return {}
+
+
+class _FakeQdrant:
+    async def hybrid_search_rrf(self, *args: object, **kwargs: object) -> list[dict[str, Any]]:
+        return []
+
+
+class _FailingTelemetry:
+    def log_event(self, event: str, **fields: object) -> None:
+        raise RuntimeError("listener down")
+
+
+def _format_record(record: logging.LogRecord) -> dict[str, Any]:
+    from src.utils.product_events import ProductEventsFormatter
+
+    return json.loads(ProductEventsFormatter().format(record))
+
+
+def _product_records(records: list[logging.LogRecord]) -> list[logging.LogRecord]:
+    return [record for record in records if record.name == "src.utils.product_events"]
+
+
+def test_emit_product_event_fallback_filters_unknown_fields(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from src.core.telemetry import emit_product_event
+
+    with caplog.at_level(logging.INFO, logger="src.utils.product_events"):
+        emit_product_event(None, "some_event", request_id="abc", secret_field="SEKRET")
+
+    product_records = _product_records(caplog.records)
+    assert len(product_records) == 1
+
+    data = _format_record(product_records[0])
+    assert data["event"] == "some_event"
+    assert data["request_id"] == "abc"
+    assert "secret_field" not in data
+
+
+def test_emit_product_event_fallback_preserves_falsy_values(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from src.core.telemetry import emit_product_event
+
+    with caplog.at_level(logging.INFO, logger="src.utils.product_events"):
+        emit_product_event(None, "llm_completed", input_tokens=0, error_type=None)
+
+    product_records = _product_records(caplog.records)
+    assert len(product_records) == 1
+
+    data = _format_record(product_records[0])
+    assert data["event"] == "llm_completed"
+    assert data["input_tokens"] == 0
+    assert data["error_type"] is None
+
+
+async def test_run_assistant_request_fail_opens_when_telemetry_listener_raises(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from src.core.assistant import run_assistant_request
+    from src.core.contracts import CoreDependencies
+
+    deps = CoreDependencies(
+        cache=_FakeCache(),
+        embeddings=_FakeEmbeddings(),
+        sparse_embeddings=_FakeSparseEmbeddings(),
+        qdrant=_FakeQdrant(),
+        telemetry=_FailingTelemetry(),
+    )
+
+    with caplog.at_level(logging.INFO):
+        result = await run_assistant_request(
+            "hello",
+            collection="test",
+            request_id="telemetry-fail-open",
+            dependencies=deps,
+        )
+
+    assert result.request_id == "telemetry-fail-open"
+    assert result.error_type == "dependency_failed"
+
+    product_events = [
+        getattr(record, "event", None)
+        for record in _product_records(caplog.records)
+        if hasattr(record, "event")
+    ]
+    assert "assistant_request_started" in product_events
+    assert "assistant_request_completed" in product_events
+    assert any(
+        record.levelno == logging.WARNING
+        and record.name == "src.core.telemetry"
+        and "Telemetry listener failed" in record.getMessage()
+        for record in caplog.records
+    )

--- a/tests/unit/graph/test_metrics_instrumentation.py
+++ b/tests/unit/graph/test_metrics_instrumentation.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from langgraph.runtime import Runtime
+
 from telegram_bot.graph.nodes.cache import cache_check_node
 from telegram_bot.graph.nodes.generate import generate_node
 from telegram_bot.graph.nodes.rerank import rerank_node

--- a/tests/unit/handlers/test_demo_transcribe_litellm_routing.py
+++ b/tests/unit/handlers/test_demo_transcribe_litellm_routing.py
@@ -6,9 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 
 class TestTranscribeVoiceOpenAIRouting:
-    async def test_transcribe_voice_default_client_uses_openai_api_key(
-        self, monkeypatch
-    ) -> None:
+    async def test_transcribe_voice_default_client_uses_openai_api_key(self, monkeypatch) -> None:
         import openai
 
         from telegram_bot.handlers.demo_handler import transcribe_voice
@@ -37,9 +35,7 @@ class TestTranscribeVoiceOpenAIRouting:
         assert result == "привет"
         assert created.get("kwargs", {}).get("api_key") == "test-key"
 
-    async def test_transcribe_voice_default_client_falls_back_to_dev_key(
-        self, monkeypatch
-    ) -> None:
+    async def test_transcribe_voice_default_client_falls_back_to_dev_key(self, monkeypatch) -> None:
         import openai
 
         from telegram_bot.handlers.demo_handler import transcribe_voice

--- a/tests/unit/runtime/graph/test_builder.py
+++ b/tests/unit/runtime/graph/test_builder.py
@@ -3,9 +3,8 @@
 Closes the final layering offender for #1948: ``src/api/main.py`` previously
 hard-imported ``telegram_bot.graph.graph.build_graph`` inside its FastAPI
 ``lifespan``. The new builder resolves the factory dynamically through
-``RAG_GRAPH_FACTORY`` (default ``telegram_bot.graph.graph:build_graph``),
-which is a string spec — no static ``from telegram_bot ...`` import remains
-under ``src/`` once ``src/api/main.py`` is rewired.
+``RAG_GRAPH_FACTORY`` (default ``src.runtime.graph.graph:build_graph``),
+which keeps the runtime default owned by ``src.runtime``.
 
 Tests cover the resolver only. The actual ``build_graph`` implementation is
 exercised by the existing graph-level tests; here we use a tiny stub module
@@ -38,23 +37,14 @@ def _install_stub_module(name: str, factory: object) -> None:
 
 
 def test_resolve_pipeline_factory_uses_default_spec(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Default spec is ``telegram_bot.graph.graph:build_graph`` per the
-    canonical bot wiring; we install a stub at that location so the test
-    has no transitive ML imports.
-    """
+    """Default spec resolves to the runtime-owned graph factory."""
     monkeypatch.delenv("RAG_GRAPH_FACTORY", raising=False)
 
-    def _fake_build_graph(*args: object, **kwargs: object) -> str:
-        return "fake-graph"
-
-    fake_module = types.ModuleType("telegram_bot.graph.graph")
-    fake_module.build_graph = _fake_build_graph  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "telegram_bot.graph.graph", fake_module)
+    from src.runtime.graph.graph import build_graph
 
     factory = builder.resolve_pipeline_factory()
 
-    assert factory is _fake_build_graph
-    assert factory() == "fake-graph"
+    assert factory is build_graph
 
 
 def test_resolve_pipeline_factory_honours_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -78,8 +68,8 @@ def test_resolve_pipeline_factory_resolves_each_call(monkeypatch: pytest.MonkeyP
     """The resolver does NOT cache: a re-``patch`` of the target attribute
     must be observed on the next ``resolve_pipeline_factory`` call. This
     is the behaviour ``tests/unit/api/test_rag_api_runtime.py`` relies on
-    when it ``patch``-es ``telegram_bot.graph.graph.build_graph`` from a
-    fresh test that runs after this module has already resolved once.
+    when it patches a configured graph factory from a fresh test that runs
+    after this module has already resolved once.
     """
     fake_module = types.ModuleType("tests._fake_pipeline_recheck")
 

--- a/tests/unit/telegram_bot/test_assistant_core_adapter.py
+++ b/tests/unit/telegram_bot/test_assistant_core_adapter.py
@@ -2,6 +2,28 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+
+class _FakeCache:
+    async def check_semantic(self, *args: object, **kwargs: object) -> dict[str, Any] | None:
+        return None
+
+
+class _FakeEmbeddings:
+    async def aembed_query(self, text: str) -> list[float]:
+        return [0.0]
+
+
+class _FakeSparseEmbeddings:
+    async def aembed_query(self, text: str) -> dict[str, Any]:
+        return {}
+
+
+class _FakeQdrant:
+    async def hybrid_search_rrf(self, *args: object, **kwargs: object) -> list[dict[str, Any]]:
+        return []
+
 
 def test_build_user_context_is_transport_neutral() -> None:
     from telegram_bot.assistant_core_adapter import build_user_context
@@ -36,3 +58,52 @@ def test_response_text_for_telegram_returns_core_text() -> None:
     from telegram_bot.assistant_core_adapter import response_text_for_telegram
 
     assert response_text_for_telegram(AssistantResult(response_text="hello")) == "hello"
+
+
+async def test_run_core_text_request_uses_assistant_app(monkeypatch) -> None:
+    from unittest.mock import AsyncMock
+
+    import telegram_bot.assistant_core_adapter as adapter
+    from src.core import AssistantResult, CoreDependencies, UserContext
+
+    dependencies = CoreDependencies(
+        cache=_FakeCache(),
+        embeddings=_FakeEmbeddings(),
+        sparse_embeddings=_FakeSparseEmbeddings(),
+        qdrant=_FakeQdrant(),
+    )
+    user_context = UserContext(user_id="u-1", session_id="s-1")
+    run_text = AsyncMock(return_value=AssistantResult(response_text="ok"))
+
+    class FakeAssistantApp:
+        async def run_text(self, *args, **kwargs):
+            return await run_text(*args, **kwargs)
+
+    seen = {}
+
+    def from_dependencies(deps):
+        seen["dependencies"] = deps
+        return FakeAssistantApp()
+
+    monkeypatch.setattr(
+        adapter.AssistantApp,
+        "from_dependencies",
+        staticmethod(from_dependencies),
+    )
+
+    result = await adapter.run_core_text_request(
+        query="hello",
+        collection="collection-a",
+        user_context=user_context,
+        dependencies=dependencies,
+        request_id="req-1",
+    )
+
+    assert result.response_text == "ok"
+    assert seen["dependencies"] is dependencies
+    run_text.assert_awaited_once_with(
+        "hello",
+        collection="collection-a",
+        user_context=user_context,
+        request_id="req-1",
+    )

--- a/tests/unit/test_cloud_dependency_contract.py
+++ b/tests/unit/test_cloud_dependency_contract.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import ast
 import re
-from pathlib import Path
-
 import tomllib
+from pathlib import Path
 
 
 PYPROJECT = Path("pyproject.toml")
@@ -76,11 +75,8 @@ def test_runtime_code_does_not_import_cloud_storage_sdks() -> None:
                 elif isinstance(node, ast.ImportFrom) and node.module:
                     imported = {node.module}
                 if any(
-                    name == "boto3"
-                    or name == "botocore"
-                    or name == "google.cloud"
-                    or name.startswith("google.cloud.")
-                    or name.startswith("google.auth")
+                    name in {"boto3", "botocore", "google.cloud"}
+                    or name.startswith(("google.cloud.", "google.auth"))
                     for name in imported
                 ):
                     offenders.append(f"{path}:{node.lineno}")

--- a/tests/unit/test_dependency_extras_contract.py
+++ b/tests/unit/test_dependency_extras_contract.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import re
-from pathlib import Path
-
 import tomllib
+from pathlib import Path
 
 
 PYPROJECT = Path("pyproject.toml")
@@ -69,9 +68,7 @@ def test_optional_extras_cover_platform_surfaces() -> None:
     """Optional extras should make each non-core surface explicit."""
     extras = _project()["project"]["optional-dependencies"]
 
-    assert {"aiogram", "aiogram-dialog", "fluentogram"}.issubset(
-        _dep_names(extras["telegram"])
-    )
+    assert {"aiogram", "aiogram-dialog", "fluentogram"}.issubset(_dep_names(extras["telegram"]))
     assert {"anthropic", "groq", "instructor"}.issubset(_dep_names(extras["providers"]))
     assert {"docling", "cocoindex", "pymupdf", "fastembed"}.issubset(
         _dep_names(extras["ingestion"])

--- a/tests/unit/test_kfp_kubernetes_dependency_contract.py
+++ b/tests/unit/test_kfp_kubernetes_dependency_contract.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import ast
 import re
-from pathlib import Path
-
 import tomllib
+from pathlib import Path
 
 
 PYPROJECT = Path("pyproject.toml")

--- a/tests/unit/test_makefile_contract.py
+++ b/tests/unit/test_makefile_contract.py
@@ -57,7 +57,7 @@ def test_release_polling_lock_target_exists_and_uses_rediscli_auth() -> None:
     block = block_match.group(0)
     assert "POLLING_LOCK_KEY" in block
     assert "REDISCLI_AUTH" in block, "target must not put Redis passwords on redis-cli -a argv"
-    assert "redis_exec DEL \"$$key\"" in block
+    assert 'redis_exec DEL "$$key"' in block
     assert "sh -c" not in block, "target should pass keys/passwords as docker exec args"
     assert "make run-bot" in block
 

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -761,7 +761,6 @@ class TestDisableOtelExporter:
         _disable_otel_exporter(shutdown=True)
 
 
-
 class TestInitializeLangfuseCallsDisableOtel:
     """Tests verifying _disable_otel_exporter() is called in all early-return paths."""
 

--- a/tests/unit/test_optional_observability_ui_dependency_contract.py
+++ b/tests/unit/test_optional_observability_ui_dependency_contract.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import re
+import tomllib
 from pathlib import Path
 
-import tomllib
 import yaml
 
 


### PR DESCRIPTION
## Issue / Mode

- Mode: Issue Executor / PR follow-up for architecture boundary work.
- Issues: #2478, #2477, #2404, #2480, #2407.
- Decision: keep #2521 as the active PR for the runtime/adapter boundary work; duplicate preflight found #2515 and it has been closed as superseded by #2521.

## Changed files

- Architecture/docs: `ARCHITECTURE.md`, `src/README.md`.
- Core SDK boundary: `src/core/__init__.py`, `src/core/app.py`, `src/core/assistant.py`, `src/core/contracts.py`, `src/core/telemetry.py`.
- Runtime boundary: `src/runtime/graph/builder.py`, `src/runtime/graph/graph.py`, `src/runtime/pipeline/assistant_pipeline.py`, `src/runtime/pipeline/rag.py`.
- Telegram adapter: `telegram_bot/assistant_core_adapter.py`.
- Contracts/tests: `tests/contract/test_architecture_layer_law_contract.py`, `tests/data/known_runtime_telegram_bot_couplings.json`, `tests/unit/core/test_telemetry.py`, `tests/unit/runtime/graph/test_builder.py`, `tests/unit/telegram_bot/test_assistant_core_adapter.py`, plus Ruff-only formatting/lint normalization in existing test files.

## Duplicate PR preflight

- Found duplicate/overlapping PR: #2515 (`Remove remaining runtime Telegram allowlist entries`).
- Resolution: closed #2515 as superseded by #2521 because #2521 targets `dev`, keeps the runtime Telegram allowlist at `{}`, includes the architecture boundary contract, typed `CoreDependencies`, telemetry fail-open behavior, and is now rebased on current `dev`.

## Ran tests

- ✅ `uv run ruff check .`
- ✅ `uv run ruff format --check .`
- ✅ `uv run pytest -o addopts='' tests/unit/core/test_telemetry.py tests/unit/telegram_bot/test_assistant_core_adapter.py tests/contract/test_runtime_no_telegram_bot_coupling_contract.py tests/contract/test_architecture_layer_law_contract.py -q`
- ✅ `uv run pyright src/core/telemetry.py src/core/assistant.py src/runtime/pipeline/assistant_pipeline.py tests/unit/core/test_telemetry.py tests/unit/telegram_bot/test_assistant_core_adapter.py`
- ⚠️ `make check` was run after rebasing. Ruff passed; MyPy failed on pre-existing unrelated Telegram typing findings (`telegram_bot/callback_data.py` `CallbackData(prefix=...)`, `forum_bridge.py`, `topic_manager.py`, `filter_dialog.py`). The previous PR-introduced `CoreDependencies`/`rag.py` MyPy findings were fixed before push.
- ⚠️ `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit` was run as requested. It failed in this local environment with broad-suite dependency/stub issues (`groq`, `aiogram_dialog`, `aiogram.fsm`) and many unrelated legacy failures; focused tests for this PR passed.

## Skipped tests + reason

- No requested follow-up check was intentionally skipped.
- Heavy/full E2E suites were not run because the Codex Web prompt says not to run heavy tests for issue executor work; the requested `make check` and `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit` were both attempted and documented above.

## Follow-up issues

- #2525 — TYPE-BASELINE: existing Telegram MyPy failures.
- #2526 — TEST-INFRA: unit suite missing optional deps groq / aiogram_dialog / aiogram.fsm.

## Risk / rollback

- Risk: `CoreDependencies` protocols and telemetry listener/fallback touch the core entrypoint path and adapter boundary. Focused telemetry, adapter, and runtime-coupling contract tests cover the changed behavior.
- Rollback: revert the two PR commits on `codex-723frc` (`Enforce architecture boundary law` and `Fix telemetry fallback and PR lint`) to restore the previous dynamic factory/default telemetry behavior.

