### PR TITLE
ci: add worker pack rules, validation matrix, PR template, and prompt contract tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,48 +1,32 @@
-## Summary
+## Issue
+Fixes #
 
-What does this PR do and why?
+## Mode
+- [ ] Issue Executor
+- [ ] PR Coordinator
+- [ ] Audit Planner
+- [ ] Worker Pack item: issue ___ of ___
 
 ## Scope
+Changed files:
+-
 
-- [ ] Bug fix
-- [ ] Feature
-- [ ] Refactor
-- [ ] Documentation / portfolio cleanup
-- [ ] Infrastructure / deploy
+Out of scope:
+-
 
-## Files touched
+## Duplicate PR preflight
+- [ ] Searched open PRs for this issue number/title
+- Existing PRs found: none / #____
 
-List the main files or modules changed (one per line):
-- `...`
+## Validation
+Ran:
+-
 
-## Validation / Checks Run
+Skipped:
+-
 
-Checks run (paste the command and output summary):
-> ___________
+Reason for skipped checks:
+-
 
-If any check was skipped, state the reason explicitly:
-> ___________
-
-## Runtime Impact
-
-Does this change affect Docker Compose, k8s manifests, service startup, or production deploy?
-
-- [ ] No runtime impact
-- [ ] Compose file change (`compose.yml`, `compose.dev.yml`)
-- [ ] Dockerfile or build change
-- [ ] k8s manifest change
-- [ ] Environment variable or secret contract change
-- [ ] Database migration or collection schema change
-
-If runtime-impacting, note the verification you ran (e.g., `COMPOSE_FILE=compose.yml:compose.dev.yml docker compose --compatibility config --services`):
-> ___________
-
-## Screenshots / Demo
-
-If this PR changes UI, Telegram flows, or visual output, attach screenshots or a short demo.
-
-## Reviewer Notes
-
-- Anything non-obvious about the implementation?
-- Any trade-offs or follow-up work?
-- Relevant docs: [`docs/review/ACCESS_FOR_REVIEWERS.md`](../docs/review/ACCESS_FOR_REVIEWERS.md), [`docs/engineering/test-writing-guide.md`](../docs/engineering/test-writing-guide.md), [`DOCKER.md`](../DOCKER.md), [`tests/README.md`](../tests/README.md)
+## Risk / rollback
+-

--- a/docs/engineering/codex-web-prompt.md
+++ b/docs/engineering/codex-web-prompt.md
@@ -15,6 +15,25 @@ Codex Web должен безопасно работать с репозитор
 - Не менять `.github/workflows/*`, если issue прямо этого не требует.
 - Если workflow-файл всё же нужен, сначала проверить, что токен имеет `workflow` scope.
 
+## 0.1 Worker Pack / Batch Mode
+
+A worker may receive a pack of 2-5 related issues for context locality and reduced ramp-up time.
+
+Important:
+- A worker pack is a queue, not a PR scope.
+- Default rule remains: one issue = one branch = one PR.
+- Process issues in the pack sequentially unless explicitly instructed otherwise.
+- Do not combine multiple issues into one PR unless:
+  1. the user explicitly requests one PR,
+  2. all issues are part of the same atomic change,
+  3. there is no existing open PR for any included issue,
+  4. the PR body explains why the issues are inseparable.
+- If issue B depends on issue A, create a stacked PR:
+  issue A -> branch A -> PR A
+  issue B -> branch B based on branch A -> PR B
+- If an open PR already exists for an issue, do not create a duplicate PR.
+  Switch to PR Coordinator mode for that issue and report the existing PR.
+
 ## 1. Issue Executor
 - Прочитать body issue и актуальные audit docs перед изменениями.
 - Создать ветку от актуального `dev`.
@@ -29,6 +48,33 @@ Codex Web должен безопасно работать с репозитор
   - изменённые файлы
   - выполненные тесты
   - skipped tests с причиной
+
+### Preflight checklist (before coding each issue in a worker pack)
+
+Before coding each issue in a worker pack:
+- Search open PRs for `Fixes #ISSUE`, `Closes #ISSUE`, issue number, and title keywords.
+- If an open PR exists, stop this issue and report:
+  - existing PR number
+  - overlap
+  - whether to review, rebase, or close duplicate work
+- Confirm the target branch:
+  - normal PR base = dev
+  - stacked PR base = previous open PR branch, with reason in PR body
+
+## Required Validation Matrix
+
+| Changed area | Required local validation before ready PR |
+|---|---|
+| Any Python code | `make pre-push` or `uv run ruff check <changed files>` + format check |
+| `src/core/**` | `make test-core` |
+| `src/runtime/**` | `make test-core` + targeted runtime tests |
+| `tests/contract/**` or architecture rules | `make test-contract` |
+| `telegram_bot/**` | nearest override applies: `make check` and `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`, or document why skipped |
+| observability/logging | targeted product event / observability tests |
+| docs only | markdown/link checks if available; otherwise state docs-only validation |
+
+A PR must not be marked ready if static CI-equivalent checks fail locally.
+If checks cannot be run, keep the PR draft or document skipped checks and risk.
 
 ## 2. PR Coordinator
 - Используется только для ревью существующих PR и подготовки к merge.

--- a/tests/unit/test_agents_contract.py
+++ b/tests/unit/test_agents_contract.py
@@ -48,3 +48,23 @@ def test_repo_hygiene_runbook_documents_worktree_start_rule() -> None:
     assert "Before Starting New Work" in text
     assert "make git-hygiene" in text
     assert "git worktree add .worktrees/<branch>" in text
+
+
+def test_codex_web_prompt_defines_worker_pack_as_queue() -> None:
+    text = Path("docs/engineering/codex-web-prompt.md").read_text(encoding="utf-8")
+    assert "Worker Pack" in text
+    assert "queue, not a PR scope" in text
+    assert "one issue = one branch = one PR" in text
+
+
+def test_codex_web_prompt_requires_duplicate_pr_preflight() -> None:
+    text = Path("docs/engineering/codex-web-prompt.md").read_text(encoding="utf-8")
+    assert "Search open PRs" in text
+    assert "do not create a duplicate PR" in text
+
+
+def test_codex_web_prompt_requires_validation_matrix() -> None:
+    text = Path("docs/engineering/codex-web-prompt.md").read_text(encoding="utf-8")
+    assert "Required Validation Matrix" in text
+    assert "make test-core" in text
+    assert "make test-contract" in text


### PR DESCRIPTION
## Issue
Relates to codex-web workflow hardening

## Mode
- [x] Audit Planner

## Scope
Changed files:
- `docs/engineering/codex-web-prompt.md` — Worker Pack section, preflight checklist, validation matrix
- `.github/pull_request_template.md` — structured template with duplicate PR preflight
- `tests/unit/test_agents_contract.py` — contract tests for prompt policy phrases

## Duplicate PR preflight
- [x] Searched open PRs for this issue number/title
- Existing PRs found: none

## Validation
Ran:
- `uv run pytest tests/unit/test_agents_contract.py -v` — 8/8 passed
- pre-commit hooks (ruff, lint, format, gitleaks) — all passed

Skipped:
- full test suite (docs/prompt-only change)

## Risk / rollback
- Low risk: docs + template + contract tests only, no runtime code changed