### PR TITLE
ci: make trusted-heavy workflow_dispatch-only and document manual workflow policy

### DIFF
--- a/.github/workflows/trusted-heavy.yml
+++ b/.github/workflows/trusted-heavy.yml
@@ -1,8 +1,6 @@
 name: Trusted Heavy Checks
 
 on:
-  pull_request:
-    branches: [main, dev]
   workflow_dispatch:
 
 permissions:

--- a/docs/engineering/codex-web-prompt.md
+++ b/docs/engineering/codex-web-prompt.md
@@ -109,14 +109,17 @@ If checks cannot be run, keep the PR draft or document skipped checks and risk.
 
 ## 5. Политика тестов
 - GitHub required CI = hygiene/static only:
-  - Secret Scan
-  - Semgrep
-  - Ruff lint/format
-  - uv lock
-  - Compose config
+  - `ci.yml`: Secret Scan, Semgrep, Ruff lint/format, uv lock, Compose config
+  - `codeql.yml`: security analysis
+- Manual-only workflows (must not block PRs):
+  - `core-tests.yml`
+  - `trusted-heavy.yml`
+  - `nightly-heavy.yml`
 - Python tests = local/manual или workflow_dispatch.
 - `make test-core` = локальная core-проверка без heavy lanes.
 - Heavy / nightly tests = только manual.
+- Workers must not wait for manual workflows unless explicitly asked.
+- Workers must still document local tests / skipped tests in PR body.
 
 ## 6. Режимы запуска Codex Web
 - Focused tests: по diff-файлам PR/issue.


### PR DESCRIPTION
## Issue
Prevent trusted-heavy from auto-running on PRs even if re-enabled in GitHub UI.

## Scope
Changed files:
- `.github/workflows/trusted-heavy.yml` — removed `pull_request` trigger, kept `workflow_dispatch` only
- `docs/engineering/codex-web-prompt.md` — documented all manual-only workflows

## Validation
- YAML syntax check passed (pre-commit)
- No Python changes, no tests needed

## Risk / rollback
Low risk: workflow config + docs only. Revert to restore PR trigger.