### PR TITLE
Unify retrieval and embeddings layer

### DIFF
--- a/src/adapters/embeddings/__init__.py
+++ b/src/adapters/embeddings/__init__.py
@@ -1,6 +1,12 @@
-"""Embeddings providers package."""
+"""Embedding provider adapters.
+
+The canonical application-facing embedding layer lives here. Runtime retrieval
+code should depend on these providers; low-level SDK clients stay in
+``src.services``.
+"""
 
 from src.adapters.embeddings.base import EmbeddingProvider
+from src.adapters.embeddings.bge_m3 import BgeM3EmbeddingProvider
 from src.adapters.embeddings.factory import get_embeddings_provider
 from src.adapters.embeddings.local_bge_m3 import LocalBgeM3Provider
 from src.adapters.embeddings.openai_embeddings import OpenAIEmbeddingProvider
@@ -8,6 +14,7 @@ from src.adapters.embeddings.service_bge_m3 import ServiceBgeM3Provider
 
 
 __all__ = [
+    "BgeM3EmbeddingProvider",
     "EmbeddingProvider",
     "LocalBgeM3Provider",
     "OpenAIEmbeddingProvider",

--- a/src/adapters/embeddings/base.py
+++ b/src/adapters/embeddings/base.py
@@ -2,10 +2,17 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from typing import Any
 
 
 class EmbeddingProvider(ABC):
-    """Abstract base class for embedding generation providers."""
+    """Abstract base class for embedding generation providers.
+
+    This is the canonical application-facing embedding adapter surface.
+    Low-level SDK clients (for example ``BGEM3Client``) should be wrapped by
+    implementations of this provider rather than used directly by retrieval
+    orchestration.
+    """
 
     @abstractmethod
     async def embed_texts(self, texts: Sequence[str]) -> list[list[float]]:
@@ -17,6 +24,25 @@ class EmbeddingProvider(ABC):
         Returns:
             A list of float lists, representing the dense embeddings.
         """
+
+    async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
+        """LangChain-compatible async dense document embedding alias."""
+        return await self.embed_texts(texts)
+
+    async def aembed_query(self, text: str) -> list[float]:
+        """Compute one dense query embedding."""
+        vectors = await self.embed_texts([text])
+        return vectors[0]
+
+    async def aembed_hybrid(self, text: str) -> tuple[list[float], dict[str, Any]]:
+        """Compute dense+sparse query vectors when supported by the provider."""
+        raise NotImplementedError(f"{type(self).__name__} does not provide hybrid embeddings")
+
+    async def aembed_hybrid_with_colbert(
+        self, text: str
+    ) -> tuple[list[float], dict[str, Any], list[list[float]]]:
+        """Compute dense+sparse+ColBERT query vectors when supported."""
+        raise NotImplementedError(f"{type(self).__name__} does not provide ColBERT embeddings")
 
     async def aclose(self) -> None:
         """Close any open resources (no-op by default)."""

--- a/src/adapters/embeddings/bge_m3.py
+++ b/src/adapters/embeddings/bge_m3.py
@@ -1,0 +1,120 @@
+"""Canonical BGE-M3 embedding provider adapter.
+
+This module owns the runtime-facing embedding provider surface.  It adapts the
+low-level :class:`src.services.bge_m3_client.BGEM3Client` HTTP SDK into the
+method shapes used by retrieval, semantic cache, and legacy LangChain shims.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+from typing import Any
+
+import httpx
+
+from src.adapters.embeddings.base import EmbeddingProvider
+from src.services.bge_m3_client import BGEM3Client
+
+
+class BgeM3EmbeddingProvider(EmbeddingProvider):
+    """BGE-M3 provider for dense, sparse, hybrid, and ColBERT query vectors.
+
+    ``BGEM3Client`` remains the low-level REST SDK.  This provider is the
+    canonical adapter layer consumed by runtime retrieval code and compatibility
+    wrappers, so callers do not need to know BGE-M3 endpoint details.
+    """
+
+    def __init__(
+        self,
+        client: BGEM3Client | None = None,
+        base_url: str | None = None,
+        timeout: float | httpx.Timeout | None = None,
+        batch_size: int = 32,
+        max_length: int = 512,
+    ) -> None:
+        url = base_url or os.getenv("BGE_M3_URL", "http://bge-m3:8000") or "http://bge-m3:8000"
+        self.base_url = url
+        self.timeout = timeout
+        self._client = client or BGEM3Client(
+            base_url=url,
+            timeout=timeout,
+            max_length=max_length,
+            batch_size=batch_size,
+        )
+
+    async def embed_texts(self, texts: Sequence[str]) -> list[list[float]]:
+        """Compute dense embeddings for a sequence of texts."""
+        return await self.aembed_documents(list(texts))
+
+    async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
+        """Compute dense document embeddings."""
+        if not texts:
+            return []
+        result = await self._client.encode_dense(texts)
+        return result.vectors
+
+    async def aembed_query(self, text: str) -> list[float]:
+        """Compute a dense query embedding."""
+        result = await self._client.encode_dense([text])
+        return result.vectors[0]
+
+    async def aembed_dense_query(self, text: str) -> tuple[list[float], float | None]:
+        """Compute a dense query embedding and expose BGE processing time."""
+        result = await self._client.encode_dense([text])
+        return result.vectors[0], result.processing_time
+
+    async def aembed_sparse_query(self, text: str) -> dict[str, Any]:
+        """Compute a sparse query vector."""
+        result = await self._client.encode_sparse([text])
+        return result.weights[0]
+
+    async def aembed_sparse_documents(self, texts: list[str]) -> list[dict[str, Any]]:
+        """Compute sparse document vectors."""
+        if not texts:
+            return []
+        result = await self._client.encode_sparse(texts)
+        return result.weights
+
+    async def aembed_hybrid(self, text: str) -> tuple[list[float], dict[str, Any]]:
+        """Compute dense and sparse query vectors in one provider call."""
+        result = await self._client.encode_hybrid([text])
+        return result.dense_vecs[0], result.lexical_weights[0]
+
+    async def aembed_hybrid_with_colbert(
+        self, text: str
+    ) -> tuple[list[float], dict[str, Any], list[list[float]]]:
+        """Compute dense, sparse, and ColBERT query vectors.
+
+        Prefer the BGE-M3 hybrid endpoint when it returns ColBERT vectors; fall
+        back to the dedicated ColBERT endpoint for older service builds.
+        """
+        result = await self._client.encode_hybrid([text])
+        dense = result.dense_vecs[0]
+        sparse = result.lexical_weights[0]
+
+        if result.colbert_vecs:
+            colbert = result.colbert_vecs[0]
+        else:
+            colbert_result = await self._client.encode_colbert([text])
+            colbert = colbert_result.colbert_vecs[0]
+
+        return dense, sparse, colbert
+
+    async def aembed_colbert_query(self, text: str) -> list[list[float]]:
+        """Compute ColBERT query token vectors."""
+        result = await self._client.encode_colbert([text])
+        return result.colbert_vecs[0]
+
+    async def aembed_hybrid_batch(
+        self, texts: list[str]
+    ) -> tuple[list[list[float]], list[dict[str, Any]]]:
+        """Compute dense and sparse vectors for a batch of texts."""
+        if not texts:
+            return [], []
+        result = await self._client.encode_hybrid(texts)
+        return result.dense_vecs, result.lexical_weights
+
+    async def aclose(self) -> None:
+        """Close the underlying BGE-M3 client."""
+        await self._client.aclose()

--- a/src/adapters/embeddings/factory.py
+++ b/src/adapters/embeddings/factory.py
@@ -3,6 +3,7 @@
 import os
 
 from src.adapters.embeddings.base import EmbeddingProvider
+from src.adapters.embeddings.bge_m3 import BgeM3EmbeddingProvider
 from src.adapters.embeddings.local_bge_m3 import LocalBgeM3Provider
 from src.adapters.embeddings.openai_embeddings import OpenAIEmbeddingProvider
 from src.adapters.embeddings.service_bge_m3 import ServiceBgeM3Provider
@@ -26,11 +27,11 @@ def get_embeddings_provider(provider_name: str | None = None) -> EmbeddingProvid
 
     if name == "local_bge_m3":
         return LocalBgeM3Provider()
-    if name == "service_bge_m3":
-        return ServiceBgeM3Provider()
+    if name in {"bge_m3", "service_bge_m3"}:
+        return BgeM3EmbeddingProvider() if name == "bge_m3" else ServiceBgeM3Provider()
     if name == "openai":
         return OpenAIEmbeddingProvider()
     raise ValueError(
         f"Unknown embeddings provider: '{name}'. Supported providers: "
-        "'local_bge_m3', 'service_bge_m3', 'openai'."
+        "'local_bge_m3', 'bge_m3', 'service_bge_m3', 'openai'."
     )

--- a/src/adapters/embeddings/local_bge_m3.py
+++ b/src/adapters/embeddings/local_bge_m3.py
@@ -80,14 +80,15 @@ class LocalBgeM3Provider(EmbeddingProvider):
 
             logger.info("Initializing local BGE-M3 model (singleton): %s", self.model_name)
 
-            def _load():
-                return BGEM3FlagModel(self.model_name, use_fp16=self.use_fp16)
-
             # asyncio.to_thread copies the current contextvars into the worker
             # thread (Langfuse/OTEL span context), unlike a bare
             # loop.run_in_executor(None, ...). See observability contextvars
             # contract.
-            _MODEL_INSTANCE = await asyncio.to_thread(_load)
+            _MODEL_INSTANCE = await asyncio.to_thread(
+                BGEM3FlagModel,
+                self.model_name,
+                use_fp16=self.use_fp16,
+            )
             logger.info("Local BGE-M3 model initialized successfully.")
             return _MODEL_INSTANCE
 
@@ -107,18 +108,15 @@ class LocalBgeM3Provider(EmbeddingProvider):
         sem = self._get_semaphore()
 
         async with sem:
-
-            def _encode():
-                # Encode returns dict with 'dense_vecs', 'lexical_weights', etc.
-                result = model.encode(
-                    list(texts),
-                    batch_size=self.batch_size,
-                    max_length=self.max_length,
-                )
-                dense_vecs = result["dense_vecs"]
-                # Convert list/numpy arrays to list of float lists
-                return [vec.tolist() if hasattr(vec, "tolist") else list(vec) for vec in dense_vecs]
-
+            # Encode returns dict with 'dense_vecs', 'lexical_weights', etc.
             # asyncio.to_thread propagates contextvars to the worker thread
             # (observability contextvars contract).
-            return await asyncio.to_thread(_encode)
+            result = await asyncio.to_thread(
+                model.encode,
+                list(texts),
+                batch_size=self.batch_size,
+                max_length=self.max_length,
+            )
+            dense_vecs = result["dense_vecs"]
+            # Convert list/numpy arrays to list of float lists.
+            return [vec.tolist() if hasattr(vec, "tolist") else list(vec) for vec in dense_vecs]

--- a/src/adapters/embeddings/service_bge_m3.py
+++ b/src/adapters/embeddings/service_bge_m3.py
@@ -1,26 +1,16 @@
-"""Embedding provider that calls an external BGE-M3 REST service."""
+"""Compatibility name for the canonical BGE-M3 embedding provider."""
 
-import os
-from collections.abc import Sequence
-
-from src.adapters.embeddings.base import EmbeddingProvider
+from src.adapters.embeddings.bge_m3 import BgeM3EmbeddingProvider
 from src.services.bge_m3_client import BGEM3Client
 
 
-class ServiceBgeM3Provider(EmbeddingProvider):
-    """Embedding provider that calls an external BGE-M3 REST service."""
+class ServiceBgeM3Provider(BgeM3EmbeddingProvider):
+    """Embedding provider that calls an external BGE-M3 REST service.
 
-    def __init__(self, client: BGEM3Client | None = None, base_url: str | None = None) -> None:
-        url = base_url or os.getenv("BGE_M3_URL", "http://bge-m3:8000") or "http://bge-m3:8000"
-        self._client = client or BGEM3Client(base_url=url)
+    Kept for existing ``service_bge_m3`` factory users.  New runtime retrieval
+    code should depend on :class:`BgeM3EmbeddingProvider` through the base
+    provider interface.
+    """
 
-    async def embed_texts(self, texts: Sequence[str]) -> list[list[float]]:
-        """Encode texts via external BGE-M3 service /encode/dense endpoint."""
-        if not texts:
-            return []
-        result = await self._client.encode_dense(list(texts))
-        return result.vectors
 
-    async def aclose(self) -> None:
-        """Close the underlying client."""
-        await self._client.aclose()
+__all__ = ["BGEM3Client", "ServiceBgeM3Provider"]

--- a/src/retrieval/README.md
+++ b/src/retrieval/README.md
@@ -1,17 +1,17 @@
 # src/retrieval/
 
-Search engine implementations for vector retrieval.
+Benchmark/evaluation search strategy implementations for vector retrieval.
 
 ## Purpose
 
-Execute hybrid and dense vector searches against Qdrant, with optional reranking. Consumes chunks produced by `src/ingestion/`.
+Keep synchronous retrieval strategies available for benchmarks, experiments, and evaluation. Production runtime retrieval composes `src.adapters.embeddings` with the canonical `src.runtime.services.qdrant.QdrantService` gateway through `src.runtime.retrieval`.
 
 ## Files
 
 | File | Purpose |
 |------|---------|
 | [`__init__.py`](./__init__.py) | Exports `create_search_engine` and search engine classes |
-| [`search_engines.py`](./search_engines.py) | 4 search variants: Baseline, HybridRRF, HybridRRFColBERT, DBSFColBERT |
+| [`search_engines.py`](./search_engines.py) | Benchmark/eval-only search variants: Baseline, HybridRRF, HybridRRFColBERT, DBSFColBERT |
 | [`search_engine_shared.py`](./search_engine_shared.py) | Shared primitives: sparse vector conversion, result shaping |
 | [`reranker.py`](./reranker.py) | Cross-encoder reranking (ms-marco-MiniLM, +10-15% NDCG) |
 | [`topic_classifier.py`](./topic_classifier.py) | Lightweight topic/doc-type classification for retrieval tuning |
@@ -29,12 +29,13 @@ Execute hybrid and dense vector searches against Qdrant, with optional reranking
 
 | Entrypoint | Role |
 |------------|------|
-| `src.retrieval.create_search_engine(settings)` | Factory that returns the configured engine |
+| `src.retrieval.create_search_engine(settings)` | Benchmark/eval factory that returns the configured engine |
 | `search_engines.py` engine classes | Direct instantiation for evaluation and testing |
 
 ## Boundaries
 
 - Retrieval code is **query-only**. It must not write to Qdrant or modify collections.
+- Production runtime retrieval should use `src.runtime.retrieval.RetrievalService`; `src/retrieval/search_engines.py` is benchmark/eval-only.
 - **Score shapes and payload fields** are coupled to `src/ingestion/unified/qdrant_writer.py`. If the ingestion payload contract changes, retrieval filters and result parsing may need updates.
 - `topic_classifier.py` is advisory only; retrieval must still work when classification returns `None`.
 

--- a/src/retrieval/search_engines.py
+++ b/src/retrieval/search_engines.py
@@ -1,4 +1,10 @@
-"""Search engine implementations for retrieval."""
+"""Benchmark/evaluation search strategies for retrieval.
+
+Production runtime code should use ``src.runtime.services.qdrant.QdrantService``
+as the canonical Qdrant SDK gateway and compose it through
+``src.runtime.retrieval``.  These synchronous engines remain for evaluation,
+experiments, and strategy tests.
+"""
 
 from abc import abstractmethod
 from collections.abc import Callable

--- a/src/runtime/integrations/embeddings.py
+++ b/src/runtime/integrations/embeddings.py
@@ -1,35 +1,25 @@
-"""BGE-M3 embedding wrappers for the runtime API.
+"""Runtime compatibility wrappers for embedding providers.
 
-Moved from ``telegram_bot/integrations/embeddings.py`` as the second slice
-of the reverse-layering fix tracked under #1948 / #2045 / #2049. The
-legacy ``telegram_bot.integrations.embeddings`` module is kept as a thin
-re-export so existing imports across the test suite, ``telegram_bot/``
-internals, and external consumers continue to work without churn.
-
-Provides BGEM3Embeddings (dense), BGEM3SparseEmbeddings (sparse), and
-BGEM3HybridEmbeddings (dense + sparse + optional ColBERT) that wrap the
-local BGE-M3 REST API for use in the imperative assistant pipeline.
-
-All HTTP communication delegates to BGEM3Client (unified SDK layer).
+The canonical embedding adapter layer is ``src.adapters.embeddings``. This
+module keeps the historical runtime class names used by legacy imports, but all
+BGE-M3 endpoint work is delegated to ``BgeM3EmbeddingProvider``.
+``BGEM3Client`` remains the low-level HTTP SDK.
 """
 
 from __future__ import annotations
 
 import asyncio
-import logging
 from typing import Any
 
 import httpx
 
+from src.adapters.embeddings.bge_m3 import BgeM3EmbeddingProvider
 from src.observability import observe
 from src.services.bge_m3_client import BGEM3Client
 
 
-logger = logging.getLogger(__name__)
-
-
 class BGEM3Embeddings:
-    """Embeddings wrapper for BGE-M3 /encode/dense endpoint."""
+    """Dense-embedding compatibility shim over the canonical BGE-M3 provider."""
 
     def __init__(
         self,
@@ -39,10 +29,12 @@ class BGEM3Embeddings:
         max_length: int = 512,
         *,
         client: BGEM3Client | None = None,
+        provider: BgeM3EmbeddingProvider | None = None,
     ) -> None:
         self.base_url = base_url
         self.timeout = timeout
-        self._client = client or BGEM3Client(
+        self._provider = provider or BgeM3EmbeddingProvider(
+            client=client,
             base_url=base_url,
             timeout=timeout,
             max_length=max_length,
@@ -51,14 +43,10 @@ class BGEM3Embeddings:
 
     @observe(name="bge-m3-dense-embed", capture_input=False, capture_output=False)
     async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
-        if not texts:
-            return []
-        result = await self._client.encode_dense(texts)
-        return result.vectors
+        return await self._provider.aembed_documents(texts)
 
     async def aembed_query(self, text: str) -> list[float]:
-        result = await self._client.encode_dense([text])
-        return result.vectors[0]
+        return await self._provider.aembed_query(text)
 
     def embed_documents(self, texts: list[str]) -> list[list[float]]:
         return asyncio.get_event_loop().run_until_complete(self.aembed_documents(texts))
@@ -66,9 +54,12 @@ class BGEM3Embeddings:
     def embed_query(self, text: str) -> list[float]:
         return asyncio.get_event_loop().run_until_complete(self.aembed_query(text))
 
+    async def aclose(self) -> None:
+        await self._provider.aclose()
+
 
 class BGEM3SparseEmbeddings:
-    """Sparse embeddings wrapper for BGE-M3 /encode/sparse endpoint."""
+    """Sparse-embedding compatibility shim over the canonical BGE-M3 provider."""
 
     def __init__(
         self,
@@ -77,10 +68,12 @@ class BGEM3SparseEmbeddings:
         max_length: int = 512,
         *,
         client: BGEM3Client | None = None,
+        provider: BgeM3EmbeddingProvider | None = None,
     ) -> None:
         self.base_url = base_url
         self.timeout = timeout
-        self._client = client or BGEM3Client(
+        self._provider = provider or BgeM3EmbeddingProvider(
+            client=client,
             base_url=base_url,
             timeout=timeout,
             max_length=max_length,
@@ -88,24 +81,18 @@ class BGEM3SparseEmbeddings:
 
     @observe(name="bge-m3-sparse-embed", capture_input=False, capture_output=False)
     async def aembed_query(self, text: str) -> dict[str, Any]:
-        result = await self._client.encode_sparse([text])
-        return result.weights[0]
+        return await self._provider.aembed_sparse_query(text)
 
     @observe(name="bge-m3-sparse-embed-batch", capture_input=False, capture_output=False)
     async def aembed_documents(self, texts: list[str]) -> list[dict[str, Any]]:
-        if not texts:
-            return []
-        result = await self._client.encode_sparse(texts)
-        return result.weights
+        return await self._provider.aembed_sparse_documents(texts)
+
+    async def aclose(self) -> None:
+        await self._provider.aclose()
 
 
 class BGEM3HybridEmbeddings:
-    """Combined dense+sparse(+ColBERT) embedding via BGE-M3 /encode/hybrid.
-
-    Single HTTP call returns dense and sparse vectors, and may also return
-    ColBERT token vectors when the endpoint supports it.
-    Uses shared httpx.AsyncClient for connection pooling.
-    """
+    """Hybrid/ColBERT compatibility shim over the canonical BGE-M3 provider."""
 
     def __init__(
         self,
@@ -114,8 +101,10 @@ class BGEM3HybridEmbeddings:
         max_length: int = 512,
         *,
         client: BGEM3Client | None = None,
+        provider: BgeM3EmbeddingProvider | None = None,
     ) -> None:
-        self._client = client or BGEM3Client(
+        self._provider = provider or BgeM3EmbeddingProvider(
+            client=client,
             base_url=base_url,
             timeout=timeout,
             max_length=max_length,
@@ -123,60 +112,38 @@ class BGEM3HybridEmbeddings:
 
     @observe(name="bge-m3-dense-query-embed", capture_input=False, capture_output=False)
     async def aembed_dense_query(self, text: str) -> tuple[list[float], float | None]:
-        """Embed query text via /encode/dense, returning (dense_vector, processing_time)."""
-        result = await self._client.encode_dense([text])
-        return result.vectors[0], result.processing_time
+        """Embed query text via BGE-M3, returning ``(dense_vector, processing_time)``."""
+        return await self._provider.aembed_dense_query(text)
 
     @observe(name="bge-m3-hybrid-embed", capture_input=False, capture_output=False)
     async def aembed_hybrid(self, text: str) -> tuple[list[float], dict[str, Any]]:
-        """Embed text via /encode/hybrid, returning (dense, sparse)."""
-        result = await self._client.encode_hybrid([text])
-        return result.dense_vecs[0], result.lexical_weights[0]
+        """Embed text, returning ``(dense, sparse)``."""
+        return await self._provider.aembed_hybrid(text)
 
     @observe(name="bge-m3-hybrid-colbert-embed", capture_input=False, capture_output=False)
     async def aembed_hybrid_with_colbert(
         self, text: str
     ) -> tuple[list[float], dict[str, Any], list[list[float]]]:
-        """Embed text returning (dense, sparse, colbert_query_vectors).
-
-        Tries to get all three from /encode/hybrid in one call.
-        Falls back to separate /encode/colbert if hybrid doesn't return colbert_vecs.
-        """
-        result = await self._client.encode_hybrid([text])
-        dense = result.dense_vecs[0]
-        sparse = result.lexical_weights[0]
-
-        if result.colbert_vecs:
-            colbert = result.colbert_vecs[0]
-        else:
-            colbert_result = await self._client.encode_colbert([text])
-            colbert = colbert_result.colbert_vecs[0]
-
-        return dense, sparse, colbert
+        """Embed text, returning ``(dense, sparse, colbert_query_vectors)``."""
+        return await self._provider.aembed_hybrid_with_colbert(text)
 
     @observe(name="bge-m3-colbert-query-embed", capture_input=False, capture_output=False)
     async def aembed_colbert_query(self, text: str) -> list[list[float]]:
-        """Embed text via /encode/colbert, returning query token vectors only."""
-        result = await self._client.encode_colbert([text])
-        return result.colbert_vecs[0]
+        """Embed text, returning ColBERT query token vectors only."""
+        return await self._provider.aembed_colbert_query(text)
 
     @observe(name="bge-m3-hybrid-embed-batch", capture_input=False, capture_output=False)
     async def aembed_hybrid_batch(
         self, texts: list[str]
     ) -> tuple[list[list[float]], list[dict[str, Any]]]:
-        """Batch embed via /encode/hybrid."""
-        if not texts:
-            return [], []
-        result = await self._client.encode_hybrid(texts)
-        return result.dense_vecs, result.lexical_weights
+        """Batch embed dense and sparse vectors."""
+        return await self._provider.aembed_hybrid_batch(texts)
 
     async def aembed_query(self, text: str) -> list[float]:
         dense, _ = await self.aembed_hybrid(text)
         return dense
 
     async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
-        if not texts:
-            return []
         dense_vecs, _ = await self.aembed_hybrid_batch(texts)
         return dense_vecs
 
@@ -187,7 +154,7 @@ class BGEM3HybridEmbeddings:
         return asyncio.get_event_loop().run_until_complete(self.aembed_query(text))
 
     async def aclose(self) -> None:
-        await self._client.aclose()
+        await self._provider.aclose()
 
 
 __all__ = [

--- a/src/runtime/retrieval/__init__.py
+++ b/src/runtime/retrieval/__init__.py
@@ -1,0 +1,10 @@
+"""Pure runtime retrieval services.
+
+Retrieval services compose the embedding provider layer with the canonical
+Qdrant SDK gateway. They do not generate answers.
+"""
+
+from src.runtime.retrieval.service import RetrievalRequest, RetrievalService
+
+
+__all__ = ["RetrievalRequest", "RetrievalService"]

--- a/src/runtime/retrieval/service.py
+++ b/src/runtime/retrieval/service.py
@@ -1,0 +1,79 @@
+"""Pure retrieval service boundary for runtime RAG.
+
+This module creates the seam requested by #2406: retrieval owns query
+vectorization plus Qdrant lookup, while answer generation stays outside this
+package.  It intentionally delegates algorithms to the existing Qdrant gateway
+instead of changing ranking behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from src.adapters.embeddings.base import EmbeddingProvider
+from src.runtime.services.qdrant import QdrantService, SearchReturn
+
+
+@dataclass(frozen=True)
+class RetrievalRequest:
+    """Input contract for pure retrieval."""
+
+    query: str
+    filters: dict[str, Any] | None = None
+    top_k: int = 5
+    return_meta: bool = False
+
+
+class RetrievalService:
+    """Compose embeddings and Qdrant into a generation-free retrieval layer."""
+
+    def __init__(self, *, embeddings: EmbeddingProvider, qdrant: QdrantService) -> None:
+        self._embeddings = embeddings
+        self._qdrant = qdrant
+
+    async def retrieve(self, request: RetrievalRequest) -> SearchReturn:
+        """Retrieve documents for a query without invoking answer generation.
+
+        The preferred path asks the embedding provider for dense+sparse+ColBERT
+        vectors and uses the canonical ``QdrantService`` ColBERT/RRF gateway.
+        Providers without ColBERT support fall back to dense+sparse RRF, and
+        dense-only providers fall back to dense search through RRF with no
+        sparse vector.
+        """
+        colbert_vectors: tuple[list[float], dict[str, Any], list[list[float]]] | None = None
+        try:
+            colbert_vectors = await self._embeddings.aembed_hybrid_with_colbert(request.query)
+        except NotImplementedError:
+            colbert_vectors = None
+
+        if colbert_vectors is not None:
+            dense, sparse, colbert = colbert_vectors
+            return await self._qdrant.hybrid_search_rrf_colbert(
+                dense_vector=dense,
+                sparse_vector=sparse,
+                colbert_query=colbert,
+                filters=request.filters,
+                top_k=request.top_k,
+                return_meta=request.return_meta,
+            )
+
+        hybrid_vectors: tuple[list[float], dict[str, Any]] | None = None
+        try:
+            hybrid_vectors = await self._embeddings.aembed_hybrid(request.query)
+        except NotImplementedError:
+            hybrid_vectors = None
+
+        if hybrid_vectors is not None:
+            dense, sparse = hybrid_vectors
+        else:
+            dense = await self._embeddings.aembed_query(request.query)
+            sparse = None
+
+        return await self._qdrant.hybrid_search_rrf(
+            dense_vector=dense,
+            sparse_vector=sparse,
+            filters=request.filters,
+            top_k=request.top_k,
+            return_meta=request.return_meta,
+        )

--- a/src/runtime/services/qdrant.py
+++ b/src/runtime/services/qdrant.py
@@ -1,4 +1,4 @@
-"""Qdrant service with Query API, Score Boosting, and MMR (canonical home, #2047).
+"""Canonical runtime Qdrant SDK gateway with Query API, Score Boosting, and MMR.
 
 Moved from ``telegram_bot/services/qdrant.py`` as part of the
 reverse-layering fix tracked under #1948 / #2047 / #2049. The legacy
@@ -29,7 +29,7 @@ SearchReturn = SearchResults | tuple[SearchResults, dict[str, Any]]
 
 
 class QdrantService:
-    """Smart Gateway for Qdrant with advanced search features.
+    """Canonical runtime Qdrant SDK gateway with advanced search features.
 
     Provides:
     - Hybrid search with RRF fusion (dense + sparse)

--- a/tests/unit/integrations/test_embeddings.py
+++ b/tests/unit/integrations/test_embeddings.py
@@ -1,6 +1,6 @@
-"""Tests for BGE-M3 LangChain embedding wrappers.
+"""Tests for BGE-M3 runtime embedding compatibility shims.
 
-Wrappers delegate to BGEM3Client; tests mock at the httpx level.
+Wrappers delegate through BgeM3EmbeddingProvider; tests mock at the httpx level.
 """
 
 from __future__ import annotations
@@ -9,8 +9,8 @@ from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
-from langchain_core.embeddings import Embeddings
 
+from src.adapters.embeddings.bge_m3 import BgeM3EmbeddingProvider
 from telegram_bot.integrations.embeddings import (
     BGEM3Embeddings,
     BGEM3HybridEmbeddings,
@@ -19,9 +19,9 @@ from telegram_bot.integrations.embeddings import (
 
 
 class TestBGEM3Embeddings:
-    def test_inherits_from_embeddings(self):
+    def test_uses_provider_backed_shim(self):
         emb = BGEM3Embeddings(base_url="http://fake:8000")
-        assert isinstance(emb, Embeddings)
+        assert isinstance(emb._provider, BgeM3EmbeddingProvider)
 
     async def test_aembed_query(self):
         mock_response = httpx.Response(
@@ -187,10 +187,14 @@ class TestBGEM3HybridEmbeddings:
         )
         with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response):
             emb = BGEM3HybridEmbeddings(base_url="http://fake:8000")
+            provider = emb._provider
+            client = provider._client
             await emb.aembed_hybrid("test1")
             await emb.aembed_hybrid("test2")
-            # Same BGEM3Client instance used
-            assert emb._client is not None
+            # Same provider and BGEM3Client instances are reused.
+            assert isinstance(provider, BgeM3EmbeddingProvider)
+            assert emb._provider is provider
+            assert emb._provider._client is client
 
     async def test_aembed_query_delegates_to_hybrid(self):
         """aembed_query returns only dense part from hybrid call."""
@@ -362,7 +366,7 @@ class TestBGEM3HybridTimeout:
     async def test_timeout_configuration(self, kwargs, expected_read, expected_connect):
         """Timeout is configured correctly (default granular or custom override)."""
         emb = BGEM3HybridEmbeddings(base_url="http://fake:8000", **kwargs)
-        # Access internal BGEM3Client's httpx client
-        client = await emb._client._get_client()
+        # Access internal BGEM3Client through the provider-backed shim.
+        client = await emb._provider._client._get_client()
         assert client.timeout.read == expected_read
         assert client.timeout.connect == expected_connect

--- a/tests/unit/retrieval/test_bge_m3_embedding_provider.py
+++ b/tests/unit/retrieval/test_bge_m3_embedding_provider.py
@@ -1,0 +1,69 @@
+"""Tests for the canonical BGE-M3 embedding adapter."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.adapters.embeddings.bge_m3 import BgeM3EmbeddingProvider
+from src.services.bge_m3_client import ColbertResult, DenseResult, HybridResult, SparseResult
+
+
+@pytest.mark.asyncio
+async def test_bge_provider_delegates_dense_documents_to_client() -> None:
+    client = AsyncMock()
+    client.encode_dense.return_value = DenseResult(vectors=[[0.1], [0.2]], processing_time=0.4)
+    provider = BgeM3EmbeddingProvider(client=client)
+
+    assert await provider.embed_texts(["a", "b"]) == [[0.1], [0.2]]
+    client.encode_dense.assert_awaited_once_with(["a", "b"])
+
+
+@pytest.mark.asyncio
+async def test_bge_provider_uses_hybrid_colbert_when_available() -> None:
+    client = AsyncMock()
+    client.encode_hybrid.return_value = HybridResult(
+        dense_vecs=[[0.1]],
+        lexical_weights=[{"indices": [1], "values": [0.5]}],
+        colbert_vecs=[[[0.2, 0.3]]],
+    )
+    provider = BgeM3EmbeddingProvider(client=client)
+
+    assert await provider.aembed_hybrid_with_colbert("q") == (
+        [0.1],
+        {"indices": [1], "values": [0.5]},
+        [[0.2, 0.3]],
+    )
+    client.encode_hybrid.assert_awaited_once_with(["q"])
+    client.encode_colbert.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bge_provider_falls_back_to_colbert_endpoint_when_hybrid_omits_it() -> None:
+    client = AsyncMock()
+    client.encode_hybrid.return_value = HybridResult(
+        dense_vecs=[[0.1]],
+        lexical_weights=[{"indices": [1], "values": [0.5]}],
+        colbert_vecs=None,
+    )
+    client.encode_colbert.return_value = ColbertResult(colbert_vecs=[[[0.9]]])
+    provider = BgeM3EmbeddingProvider(client=client)
+
+    assert await provider.aembed_hybrid_with_colbert("q") == (
+        [0.1],
+        {"indices": [1], "values": [0.5]},
+        [[0.9]],
+    )
+    client.encode_hybrid.assert_awaited_once_with(["q"])
+    client.encode_colbert.assert_awaited_once_with(["q"])
+
+
+@pytest.mark.asyncio
+async def test_bge_provider_sparse_helpers_delegate_to_client() -> None:
+    client = AsyncMock()
+    client.encode_sparse.return_value = SparseResult(weights=[{"indices": [2], "values": [0.8]}])
+    provider = BgeM3EmbeddingProvider(client=client)
+
+    assert await provider.aembed_sparse_query("q") == {"indices": [2], "values": [0.8]}
+    client.encode_sparse.assert_awaited_once_with(["q"])

--- a/tests/unit/retrieval/test_runtime_retrieval_service.py
+++ b/tests/unit/retrieval/test_runtime_retrieval_service.py
@@ -1,0 +1,131 @@
+"""Tests for the pure runtime retrieval boundary."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.adapters.embeddings.base import EmbeddingProvider
+from src.runtime.retrieval import RetrievalRequest, RetrievalService
+
+
+class HybridColbertEmbeddings(EmbeddingProvider):
+    async def embed_texts(self, texts):  # pragma: no cover - not used in this path
+        return [[0.0] for _ in texts]
+
+    async def aembed_hybrid_with_colbert(self, text: str):
+        assert text == "hello"
+        return [0.1], {"indices": [1], "values": [0.5]}, [[0.2, 0.3]]
+
+
+class DenseOnlyEmbeddings(EmbeddingProvider):
+    async def embed_texts(self, texts):
+        return [[0.7] for _ in texts]
+
+
+class RecordingQdrant:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def hybrid_search_rrf_colbert(self, **kwargs):
+        self.calls.append(("colbert", kwargs))
+        return [{"id": "colbert"}]
+
+    async def hybrid_search_rrf(self, **kwargs):
+        self.calls.append(("rrf", kwargs))
+        return [{"id": "rrf"}]
+
+
+@pytest.mark.asyncio
+async def test_retrieve_prefers_hybrid_colbert_provider_path() -> None:
+    qdrant = RecordingQdrant()
+    service = RetrievalService(embeddings=HybridColbertEmbeddings(), qdrant=qdrant)  # type: ignore[arg-type]
+
+    result = await service.retrieve(
+        RetrievalRequest(query="hello", filters={"topic": "docs"}, top_k=3, return_meta=True)
+    )
+
+    assert result == [{"id": "colbert"}]
+    assert qdrant.calls == [
+        (
+            "colbert",
+            {
+                "dense_vector": [0.1],
+                "sparse_vector": {"indices": [1], "values": [0.5]},
+                "colbert_query": [[0.2, 0.3]],
+                "filters": {"topic": "docs"},
+                "top_k": 3,
+                "return_meta": True,
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_retrieve_falls_back_to_dense_only_rrf_path() -> None:
+    qdrant = RecordingQdrant()
+    service = RetrievalService(embeddings=DenseOnlyEmbeddings(), qdrant=qdrant)  # type: ignore[arg-type]
+
+    result = await service.retrieve(RetrievalRequest(query="plain"))
+
+    assert result == [{"id": "rrf"}]
+    assert qdrant.calls == [
+        (
+            "rrf",
+            {
+                "dense_vector": [0.7],
+                "sparse_vector": None,
+                "filters": None,
+                "top_k": 5,
+                "return_meta": False,
+            },
+        )
+    ]
+
+
+class HybridOnlyEmbeddings(EmbeddingProvider):
+    async def embed_texts(self, texts):  # pragma: no cover - not used in this path
+        return [[0.0] for _ in texts]
+
+    async def aembed_hybrid(self, text: str):
+        assert text == "hybrid"
+        return [0.4], {"indices": [4], "values": [0.4]}
+
+
+class ColbertQdrantNotImplemented(RecordingQdrant):
+    async def hybrid_search_rrf_colbert(self, **kwargs):
+        raise NotImplementedError("qdrant colbert path is misconfigured")
+
+
+@pytest.mark.asyncio
+async def test_retrieve_uses_hybrid_rrf_when_colbert_embedding_is_unavailable() -> None:
+    qdrant = RecordingQdrant()
+    service = RetrievalService(embeddings=HybridOnlyEmbeddings(), qdrant=qdrant)  # type: ignore[arg-type]
+
+    result = await service.retrieve(RetrievalRequest(query="hybrid", top_k=2))
+
+    assert result == [{"id": "rrf"}]
+    assert qdrant.calls == [
+        (
+            "rrf",
+            {
+                "dense_vector": [0.4],
+                "sparse_vector": {"indices": [4], "values": [0.4]},
+                "filters": None,
+                "top_k": 2,
+                "return_meta": False,
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_retrieve_does_not_swallow_qdrant_not_implemented_errors() -> None:
+    service = RetrievalService(
+        embeddings=HybridColbertEmbeddings(),
+        qdrant=ColbertQdrantNotImplemented(),  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(NotImplementedError, match="qdrant colbert path"):
+        await service.retrieve(RetrievalRequest(query="hello"))


### PR DESCRIPTION
## Issue / Mode
- Mode: Issue Executor (Worker D — Retrieval/Embeddings cleanup)
- Issues: Closes #2475, Closes #2476; Refs #2406
- Base: `dev`
- Head: `runtime/clarify-retrieval-embedding-boundaries`

## Summary
- Adds `BgeM3EmbeddingProvider` as the canonical BGE-M3 adapter in `src.adapters.embeddings`, keeping `BGEM3Client` as the low-level transport and `ServiceBgeM3Provider` as a compatibility name.
- Converts runtime embedding classes into provider-backed compatibility shims instead of duplicate endpoint wrappers.
- Adds a pure `src.runtime.retrieval` service seam that composes embeddings with canonical `QdrantService` without owning answer generation.
- Marks `src/retrieval/search_engines.py` as benchmark/eval strategy code and documents runtime retrieval ownership.
- Removes the nested `_load` / `_encode` functions from `LocalBgeM3Provider` while preserving `asyncio.to_thread` behavior.

## Changed files / scope
- `src/adapters/embeddings/__init__.py`
- `src/adapters/embeddings/base.py`
- `src/adapters/embeddings/bge_m3.py`
- `src/adapters/embeddings/factory.py`
- `src/adapters/embeddings/local_bge_m3.py`
- `src/adapters/embeddings/service_bge_m3.py`
- `src/retrieval/README.md`
- `src/retrieval/search_engines.py`
- `src/runtime/integrations/embeddings.py`
- `src/runtime/retrieval/__init__.py`
- `src/runtime/retrieval/service.py`
- `src/runtime/services/qdrant.py`
- `tests/unit/retrieval/test_bge_m3_embedding_provider.py`
- `tests/unit/integrations/test_embeddings.py`
- `tests/unit/retrieval/test_runtime_retrieval_service.py`

## Duplicate PR preflight
- Checked open PRs for #2475, #2476, #2406, and retrieval/embeddings keywords.
- No duplicate open implementation PR was found for this exact Worker D scope.
- Rebased this PR branch onto fresh `origin/dev` and removed process/control-plane contamination; current diff is limited to retrieval/embeddings runtime scope.

## Validation
- ✅ `uvx ruff check src/ telegram_bot/ mini_app/ services/ scripts/ --output-format=github`
- ✅ `uvx ruff format --target-version py312 --check src/ telegram_bot/ mini_app/ services/ scripts/`
- ✅ `uv lock --locked`
- ✅ `uv run --no-sync pytest -o addopts='' tests/unit/integrations/test_embeddings.py tests/unit/retrieval/ tests/unit/services/test_bge_m3_client.py -q` (`139 passed`)
- ✅ `uv run --no-sync pytest -o addopts='' tests/unit/retrieval/ -q` (`84 passed`)
- ✅ `uv run --no-sync pytest -o addopts='' tests/unit/services/test_bge_m3_client.py -q` (`32 passed`)

## Skipped checks + reason
- No heavy/full suites run; per repo policy, full/heavy tests are manual-only unless explicitly requested.

## Failed checks triage
- ⚠️ `make test-core` currently fails during collection on missing optional `groq` dependency in `tests/unit/core/test_pipeline.py`, before reaching this PR's runtime retrieval tests.
- Classification: environment / optional dependency baseline outside this PR's changed subsystem. Focused retrieval/BGE-M3 checks and exact static CI-equivalent commands passed.

## Risk / rollback
- Risk: Medium. This changes embedding/retrieval wiring, but keeps compatibility class names and delegates to existing BGE-M3/Qdrant primitives without changing ranking algorithms.
- Rollback: revert this PR commit to restore previous runtime embedding wrappers and remove the new `src.runtime.retrieval` seam.

## Follow-up issues
- #2406 remains the broader Phase E migration to move `rag_pipeline()` orchestration onto the pure retrieval service after generation ownership is fully separated.

## Audit blocker closure
- Closed audit blocker: `tests/unit/integrations/test_embeddings.py` now asserts provider-backed runtime embedding shims instead of LangChain inheritance/direct `_client` access.
- The test now checks `BgeM3EmbeddingProvider`, provider/client reuse via `emb._provider`, and timeout inspection via `emb._provider._client._get_client()`.

## Agent Handoff
- Status: clean / ready_for_review
- Base: `dev`
- Head: `runtime/clarify-retrieval-embedding-boundaries`
- Validated commit: `789a3af23aaedaaa0c03b9a70024ff237c008509`
- GitHub required checks: completed / green
- Risk: Medium runtime boundary change
- Failure class: optional dependency baseline for `make test-core` (`groq` missing during collection)
- Validation checklist:
  - [x] Fresh `origin/dev` fetched and branch rebased
  - [x] AGENTS.md read
  - [x] `docs/engineering/gh-pr-review.md` read
  - [x] PR diff checked for control-plane contamination
  - [x] Exact static CI-equivalent commands run locally
  - [x] Focused retrieval and BGE-M3 tests run locally
  - [x] GitHub required checks completed / green
- Findings:
  - Current diff is constrained to retrieval/embeddings files and focused tests.
  - GitHub required checks completed and are green on validated commit `789a3af23aaedaaa0c03b9a70024ff237c008509`.
- Next action: ready for review; rerun validation only if the branch changes again.
