### PR TITLE
Mark optional test surfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: help install install-dev install-all lint format type-check security compile-python test test-full test-cov clean all-checks \
 	test-preflight test-smoke test-load-eviction \
+	test-telegram-adapter test-api-adapter test-ingest-extra test-voice-extra test-eval-extra test-observability-extra test-optional-surfaces \
 	smoke-fast smoke-zoo \
 	monitoring-up monitoring-down monitoring-logs monitoring-status monitoring-test-alert \
 	ingest-dir ingest-status ingest-services \
@@ -59,18 +60,13 @@ CORE_LIVE_PYTEST := $(UV_RUN_NO_SYNC) pytest $(CORE_LIVE_TEST_PATH) -v --tb=shor
 PYTEST_REQUIRES_EXTRAS_IGNORE := $(addprefix --ignore=, \
 	tests/unit/test_document_parser.py \
 	tests/unit/test_evaluator.py \
-	tests/unit/evaluation/test_ragas_evaluation.py \
+	tests/unit/test_ragas_evaluation.py \
 	tests/unit/api \
-	tests/unit/voice/test_sip_setup.py \
-	tests/unit/voice/test_voice_agent.py \
-	tests/unit/ingestion/test_cocoindex_init.py \
-	tests/unit/ingestion/test_qdrant_hybrid_target.py \
-	tests/unit/ingestion/test_qdrant_hybrid_target_helpers.py \
-	tests/unit/ingestion/test_qdrant_hybrid_target_state_paths.py \
-	tests/unit/ingestion/test_target_sync_execution.py \
-	tests/unit/ingestion/test_unified_cli.py \
-	tests/unit/ingestion/test_unified_flow.py \
-	tests/unit/ingestion/test_unified_flow_wiring.py)
+	tests/unit/evaluation \
+	tests/unit/ingestion \
+	tests/unit/observability \
+	tests/unit/voice)
+
 
 help: ## Show this help message
 	@echo "$(BLUE)Contextual RAG v$(PROJECT_VERSION) - Development Commands$(NC)"
@@ -197,10 +193,11 @@ all-checks: lint type-check security ## Run all code quality checks
 # TESTING
 # =============================================================================
 
-test: ## Run fast deterministic PR/local gate (unit + critical graph paths)
-	@echo "$(BLUE)Running fast test gate (unit + graph_paths)...$(NC)"
-	PYTHONDONTWRITEBYTECODE=1 $(UV_RUN_NO_SYNC) --python $(PYTHON_VERSION) pytest tests/unit/ tests/integration/test_graph_paths.py $(PYTEST_REQUIRES_EXTRAS_IGNORE) $(PYTEST_PARALLEL_ARGS) -q --timeout=30 -m "not legacy_api and not requires_extras and not slow"
-	@echo "$(GREEN)✓ Fast test gate complete$(NC)"
+test: ## Run deterministic core PR/local gate (core + graph paths)
+	@echo "$(BLUE)Running deterministic core gate (test-core + graph_paths)...$(NC)"
+	$(MAKE) test-core
+	PYTHONDONTWRITEBYTECODE=1 $(UV_RUN_NO_SYNC) --python $(PYTHON_VERSION) pytest tests/integration/test_graph_paths.py -q --timeout=30 -m "not legacy_api and not requires_extras and not slow"
+	@echo "$(GREEN)✓ Deterministic core gate complete$(NC)"
 
 test-core: ## Run monolith core-required tests only (local/manual)
 	@echo "$(BLUE)Running monolith core test gate...$(NC)"
@@ -210,8 +207,47 @@ test-core: ## Run monolith core-required tests only (local/manual)
 	  tests/contract/test_runtime_no_telegram_bot_coupling_contract.py \
 	  tests/contract/test_layering_no_telegram_bot_imports_contract.py \
 	  tests/contract/test_langfuse_optional_core_contract.py \
+	  --ignore=tests/unit/core/test_pipeline.py \
 	  -q --timeout=30 -m "not requires_extras and not slow"
 	@echo "$(GREEN)✓ Monolith core test gate complete$(NC)"
+
+test-telegram-adapter: ## Run Telegram adapter unit tests explicitly
+	@echo "$(BLUE)Running Telegram adapter tests...$(NC)"
+	PYTHONDONTWRITEBYTECODE=1 $(UV_RUN_NO_SYNC) --python $(PYTHON_VERSION) pytest tests/unit/agents/ tests/unit/dialogs/ tests/unit/handlers/ tests/unit/middlewares/ tests/unit/pipelines/ tests/unit/test_bot*.py tests/unit/test_main.py tests/unit/test_middlewares_impl.py -q --timeout=30 -m "not legacy_api and not requires_extras and not slow"
+	@echo "$(GREEN)✓ Telegram adapter tests complete$(NC)"
+
+test-api-adapter: ## Run API adapter unit tests explicitly
+	@echo "$(BLUE)Running API adapter tests...$(NC)"
+	uv sync --extra mini-app --all-groups
+	PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/unit/api/ -q --timeout=30
+	@echo "$(GREEN)✓ API adapter tests complete$(NC)"
+
+test-ingest-extra: ## Run optional ingestion-extra tests explicitly
+	@echo "$(BLUE)Running ingestion-extra tests...$(NC)"
+	uv sync --extra ingest --all-groups
+	PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/unit/ingestion/ -q --timeout=30
+	@echo "$(GREEN)✓ Ingestion-extra tests complete$(NC)"
+
+test-voice-extra: ## Run optional voice-extra tests explicitly
+	@echo "$(BLUE)Running voice-extra tests...$(NC)"
+	uv sync --extra voice --all-groups
+	PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/unit/voice/ -q --timeout=30
+	@echo "$(GREEN)✓ Voice-extra tests complete$(NC)"
+
+test-eval-extra: ## Run optional evaluation-extra tests explicitly
+	@echo "$(BLUE)Running evaluation-extra tests...$(NC)"
+	uv sync --extra eval --all-groups
+	PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/unit/evaluation/ -q --timeout=30
+	@echo "$(GREEN)✓ Evaluation-extra tests complete$(NC)"
+
+test-observability-extra: ## Run optional observability-extra tests explicitly
+	@echo "$(BLUE)Running observability-extra tests...$(NC)"
+	uv sync --extra observability --all-groups
+	PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/unit/observability/ -q --timeout=30
+	@echo "$(GREEN)✓ Observability-extra tests complete$(NC)"
+
+test-optional-surfaces: test-api-adapter test-ingest-extra test-voice-extra test-eval-extra test-observability-extra ## Run optional surface lanes explicitly
+	@echo "$(GREEN)✓ Optional surface lanes complete$(NC)"
 
 test-full: ## Run full test suite with hybrid parallelism (all tiers)
 	@echo "$(BLUE)Running full test suite...$(NC)"

--- a/docs/engineering/test-writing-guide.md
+++ b/docs/engineering/test-writing-guide.md
@@ -106,9 +106,11 @@ Do not add Telegram, Mini App, voice, ingestion, eval, or legacy graph tests to 
 ## Minimal Verification For Test Changes
 - Focused run for touched files first:
   - `uv run pytest <path/to/test_file.py> -q`
-- Then run repository baseline:
-  - `make check`
-  - `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
+- Then run the deterministic repository gate:
+  - `make test`
+- Run `make test-contract` when changing contract surfaces.
+- Run `make test-unit` or explicit optional-surface targets only when the touched
+  area requires that broader/local coverage.
 - If skipping a relevant check, document it explicitly in the report.
 
 ## References

--- a/docs/engineering/test-writing-guide.md
+++ b/docs/engineering/test-writing-guide.md
@@ -60,12 +60,18 @@ It should cover only:
 
 Do not add Telegram, Mini App, voice, ingestion, eval, or legacy graph tests to `test-core`.
 
-### Local fast lane
-- The local fast lane runs `tests/unit/` and critical graph-path integration via
-  `make test` with `-m "not legacy_api and not requires_extras and not slow"`.
-- Keep new fast-lane tests free of `pytest.mark.slow`, `pytest.mark.requires_extras`,
-  and any marker that would exclude them from that expression.
-- Fast tests must not require Docker or live services.
+### Deterministic core lane
+- `make test` is the PR/local deterministic core gate: it runs `make test-core`
+  plus the no-service graph-path integration check.
+- `make test` must not collect the broad `tests/unit/` tree, because that tree
+  includes optional Telegram, API, voice, ingestion, evaluation, observability,
+  and service-adapter tests.
+- Optional surfaces that need extras or adapter SDKs must be marked with
+  `pytest.mark.requires_extras` and run through their explicit Make targets.
+- Keep new core-lane tests free of `pytest.mark.slow`, `pytest.mark.requires_extras`,
+  and any marker that would exclude them from `-m "not legacy_api and not requires_extras and not slow"`.
+- Core-lane tests must not require Docker, live services, optional extras, or
+  adapter SDKs.
 - Core changes should prefer `make test-core` first.
 - Adapter/service changes should run their explicit lane in addition to `make test-core`.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,20 +27,25 @@ tests/
 ## Test Tiers
 
 ### Local-fast checks (no Docker required)
-These are the default gate for PRs and local development.
+`make test` is the deterministic default gate for PRs and local development.
+It runs the monolith core lane plus the critical no-service graph-path
+integration check. The full `tests/unit/` tree is a separate local/manual lane
+because it includes optional adapter and extra-dependency surfaces.
 
 | Tier | Location | What it proves | Typical duration |
 |------|----------|----------------|------------------|
-| Unit | `tests/unit/` | Isolated logic with mocks/fakes | Seconds |
+| Core unit | `tests/unit/core/`, `tests/unit/runtime/` | Core/runtime logic with mocks/fakes | Seconds |
+| Critical graph paths | `tests/integration/test_graph_paths.py` | No-service graph routing paths | Seconds |
 | Contract | `tests/contract/` | Trace/schema contracts via static analysis | Seconds |
 
 ### Tier to command / CI mapping
 
 | What | Scope | Coverage threshold |
 |------|-------|--------------------|
-| `make test` | unit + critical graph paths (`tests/unit/`, `tests/integration/test_graph_paths.py`) | none |
+| `make test` | deterministic core gate (`make test-core`, `tests/integration/test_graph_paths.py`) | none |
+| `make test-unit` | broad unit lane (`tests/unit/`) excluding optional markers/paths | none |
 | `make test-contract` | contract only (`tests/contract/`) | none |
-| Local PR readiness | `make check && make test && make test-contract` | coverage remains a separate `make test-cov` check |
+| Local PR readiness | focused checks + `make test`; run `make test-contract` when contract surfaces changed | coverage remains a separate `make test-cov` check |
 
 ### Heavy / runtime checks (services or credentials required)
 Run these selectively, not on every save.
@@ -79,6 +84,7 @@ PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit
 
 ### Optional surface lanes (explicit opt-in)
 ```bash
+make test-telegram-adapter
 make test-api-adapter
 make test-ingest-extra
 make test-voice-extra

--- a/tests/README.md
+++ b/tests/README.md
@@ -67,14 +67,24 @@ Canonical E2E placement:
 make check
 ```
 
-### Fast test gate (unit + critical graph paths)
+### Deterministic core gate (core + critical graph paths)
 ```bash
 make test
 ```
 
-### Core unit tests (parallel, default local gate)
+### Broad unit lane (local/manual)
 ```bash
 PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit
+```
+
+### Optional surface lanes (explicit opt-in)
+```bash
+make test-api-adapter
+make test-ingest-extra
+make test-voice-extra
+make test-eval-extra
+make test-observability-extra
+make test-optional-surfaces
 ```
 
 ### Focused run (preferred while developing)

--- a/tests/contract/test_core_gate_optional_surfaces_contract.py
+++ b/tests/contract/test_core_gate_optional_surfaces_contract.py
@@ -1,0 +1,98 @@
+"""Contract: the deterministic core gate must not collect optional surfaces.
+
+Optional surface tests remain first-class, but they depend on extras or adapter
+SDKs that are intentionally absent from the lean core install. ``make test`` is
+therefore limited to the core gate plus the no-service graph-path check, and
+optional surfaces must be run through explicit opt-in Make targets.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MAKEFILE = REPO_ROOT / "Makefile"
+OPTIONAL_REQUIRES_EXTRAS_DIRS = (
+    Path("tests/unit/voice"),
+    Path("tests/unit/ingestion"),
+    Path("tests/unit/evaluation"),
+    Path("tests/unit/observability"),
+)
+OPTIONAL_SURFACE_TOKENS = (
+    "pytest tests/unit/",
+    "tests/unit/api",
+    "tests/unit/voice",
+    "tests/unit/ingestion",
+    "tests/unit/evaluation",
+    "tests/unit/observability",
+    "tests/unit/mini_app",
+    "test-telegram-adapter",
+    "test-api-adapter",
+    "test-ingest-extra",
+    "test-voice-extra",
+    "test-eval-extra",
+    "test-observability-extra",
+    "test-optional-surfaces",
+)
+OPTIONAL_TARGETS = (
+    "test-telegram-adapter",
+    "test-api-adapter",
+    "test-ingest-extra",
+    "test-voice-extra",
+    "test-eval-extra",
+    "test-observability-extra",
+    "test-optional-surfaces",
+)
+
+
+def _makefile_text() -> str:
+    return MAKEFILE.read_text(encoding="utf-8")
+
+
+def _target_body(text: str, target: str) -> str:
+    pattern = re.compile(rf"^{re.escape(target)}:.*?\n", re.MULTILINE)
+    match = pattern.search(text)
+    assert match is not None, f"Makefile must define {target!r}"
+
+    body_lines: list[str] = []
+    for line in text[match.end() :].splitlines():
+        if line and not line.startswith(("\t", " ", "\\")):
+            break
+        body_lines.append(line)
+    return "\n".join(body_lines)
+
+
+def test_make_test_is_deterministic_core_gate_not_broad_unit_collection() -> None:
+    body = _target_body(_makefile_text(), "test")
+
+    assert "$(MAKE) test-core" in body
+    assert "tests/integration/test_graph_paths.py" in body
+    assert "pytest tests/unit/" not in body
+
+
+def test_make_test_does_not_run_optional_surface_paths_or_targets() -> None:
+    body = _target_body(_makefile_text(), "test")
+
+    offenders = [token for token in OPTIONAL_SURFACE_TOKENS if token in body]
+    assert offenders == []
+
+
+def test_optional_surface_files_use_registered_requires_extras_marker() -> None:
+    missing: list[str] = []
+    for rel_dir in OPTIONAL_REQUIRES_EXTRAS_DIRS:
+        for test_file in sorted((REPO_ROOT / rel_dir).glob("test*.py")):
+            text = test_file.read_text(encoding="utf-8")
+            if "pytestmark" not in text or "pytest.mark.requires_extras" not in text:
+                missing.append(str(test_file.relative_to(REPO_ROOT)))
+
+    assert missing == []
+
+
+def test_optional_surface_targets_are_explicit() -> None:
+    text = _makefile_text()
+
+    for target in OPTIONAL_TARGETS:
+        body = _target_body(text, target)
+        assert "pytest" in body or target == "test-optional-surfaces"

--- a/tests/unit/core/test_pipeline.py
+++ b/tests/unit/core/test_pipeline.py
@@ -7,6 +7,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+
+pytestmark = pytest.mark.requires_extras
+
 # Stubs for pymupdf/docling are installed via conftest.py pytest_configure (#611).
 from src.core.pipeline import RAGPipeline, RAGResult
 

--- a/tests/unit/evaluation/test_config_snapshot.py
+++ b/tests/unit/evaluation/test_config_snapshot.py
@@ -12,6 +12,9 @@ from src.evaluation.config_snapshot import (
 )
 
 
+pytestmark = pytest.mark.requires_extras
+
+
 class TestGetConfigHash:
     def test_returns_12_char_hex_string(self):
         result = get_config_hash()

--- a/tests/unit/evaluation/test_create_golden_set.py
+++ b/tests/unit/evaluation/test_create_golden_set.py
@@ -5,6 +5,11 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+
+pytestmark = pytest.mark.requires_extras
+
 
 def _run_and_capture() -> dict:
     """Run create_golden_test_set with a mocked open and return the written JSON."""

--- a/tests/unit/evaluation/test_evaluate_with_ragas.py
+++ b/tests/unit/evaluation/test_evaluate_with_ragas.py
@@ -14,6 +14,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+pytestmark = pytest.mark.requires_extras
+
+
+
 # Mock heavy dependencies before importing the module under test
 _mock_modules = {
     "datasets": MagicMock(),

--- a/tests/unit/evaluation/test_extract_ground_truth.py
+++ b/tests/unit/evaluation/test_extract_ground_truth.py
@@ -3,6 +3,11 @@
 
 from unittest.mock import MagicMock, mock_open, patch
 
+import pytest
+
+
+pytestmark = pytest.mark.requires_extras
+
 
 class TestExtractArticles:
     """Tests for extract_articles function."""

--- a/tests/unit/evaluation/test_generate_test_queries.py
+++ b/tests/unit/evaluation/test_generate_test_queries.py
@@ -13,6 +13,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+pytestmark = pytest.mark.requires_extras
+
+
+
 # Mock heavy dependencies before importing
 # Note: We don't mock 'aiohttp' or 'requests' in sys.modules because they're used
 # by httpx internally and mocking them causes test pollution in other test modules.

--- a/tests/unit/evaluation/test_goldset_sync.py
+++ b/tests/unit/evaluation/test_goldset_sync.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from scripts.eval.goldset_sync import load_ground_truth, sync_to_langfuse
+
+
+pytestmark = pytest.mark.requires_extras
 
 
 def test_load_ground_truth_returns_samples():

--- a/tests/unit/evaluation/test_run_ab_test.py
+++ b/tests/unit/evaluation/test_run_ab_test.py
@@ -11,6 +11,9 @@ import pytest
 from src.evaluation.run_ab_test import convert_numpy, determine_conclusion, print_metrics
 
 
+pytestmark = pytest.mark.requires_extras
+
+
 class TestConvertNumpy:
     """Tests for convert_numpy helper function."""
 

--- a/tests/unit/evaluation/test_run_experiment.py
+++ b/tests/unit/evaluation/test_run_experiment.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
+
+pytestmark = pytest.mark.requires_extras
+
 
 def test_build_rag_task_returns_callable():
     from scripts.eval.run_experiment import build_rag_task

--- a/tests/unit/evaluation/test_search_engines_eval.py
+++ b/tests/unit/evaluation/test_search_engines_eval.py
@@ -16,6 +16,9 @@ from src.retrieval.search_engine_shared import (
 from src.utils.serialization import convert_to_python_types as shared_convert
 
 
+pytestmark = pytest.mark.requires_extras
+
+
 class TestConvertToPythonTypes:
     """Tests for convert_to_python_types helper function."""
 

--- a/tests/unit/evaluation/test_search_engines_rerank.py
+++ b/tests/unit/evaluation/test_search_engines_rerank.py
@@ -6,6 +6,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+pytestmark = pytest.mark.requires_extras
+
+
 def _make_flag_embedding_mock():
     """Return a sys.modules patch dict that provides FlagEmbedding.FlagReranker."""
     mock_reranker_cls = MagicMock()

--- a/tests/unit/evaluation/test_smoke_test.py
+++ b/tests/unit/evaluation/test_smoke_test.py
@@ -12,7 +12,12 @@ from __future__ import annotations
 
 import sys
 
+import pytest
+
 from src.evaluation.smoke_test import SLO_THRESHOLDS, SMOKE_QUERIES, run_smoke_test
+
+
+pytestmark = pytest.mark.requires_extras
 
 
 class TestSmokeQueries:

--- a/tests/unit/evaluation/test_sparse_vector_name_contract.py
+++ b/tests/unit/evaluation/test_sparse_vector_name_contract.py
@@ -31,6 +31,10 @@ from pathlib import Path
 import pytest
 
 
+pytestmark = pytest.mark.requires_extras
+
+
+
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 # Modules that issue Qdrant queries against the canonical collection

--- a/tests/unit/ingestion/test_apartment_flow.py
+++ b/tests/unit/ingestion/test_apartment_flow.py
@@ -1,7 +1,12 @@
 """Tests for apartment ingestion flow — text serialization and embedding prep."""
 
+import pytest
+
 from src.ingestion.apartments.flow import format_apartment_text
 from telegram_bot.services.apartment_models import ApartmentRecord
+
+
+pytestmark = pytest.mark.requires_extras
 
 
 class TestFormatApartmentText:

--- a/tests/unit/ingestion/test_apartment_runner.py
+++ b/tests/unit/ingestion/test_apartment_runner.py
@@ -4,8 +4,13 @@ import csv
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from src.ingestion.apartments.runner import IncrementalApartmentIngester
 from src.services.bge_m3_client import HybridResult
+
+
+pytestmark = pytest.mark.requires_extras
 
 
 def _write_csv(rows: list[dict], path: Path) -> None:

--- a/tests/unit/ingestion/test_apartment_source.py
+++ b/tests/unit/ingestion/test_apartment_source.py
@@ -3,7 +3,12 @@
 import csv
 from pathlib import Path
 
+import pytest
+
 from src.ingestion.apartments.source import parse_apartment_row, row_change_key
+
+
+pytestmark = pytest.mark.requires_extras
 
 
 def _write_csv(rows: list[dict], path: Path) -> None:

--- a/tests/unit/ingestion/test_colbert_backfill.py
+++ b/tests/unit/ingestion/test_colbert_backfill.py
@@ -10,6 +10,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+pytestmark = pytest.mark.requires_extras
+
+
 def _record(
     point_id: int | str,
     *,

--- a/tests/unit/ingestion/test_contextual_integration.py
+++ b/tests/unit/ingestion/test_contextual_integration.py
@@ -1,5 +1,7 @@
 """Integration tests for Contextual Retrieval pipeline."""
 
+import pytest
+
 from src.ingestion import (
     ContextualChunk,
     ContextualDocument,
@@ -7,6 +9,9 @@ from src.ingestion import (
     load_contextual_json,
 )
 from src.ingestion.chunker import Chunk
+
+
+pytestmark = pytest.mark.requires_extras
 
 
 class TestContextualPipeline:

--- a/tests/unit/ingestion/test_docling_client.py
+++ b/tests/unit/ingestion/test_docling_client.py
@@ -1,4 +1,8 @@
 """Tests for Docling-serve HTTP client helpers."""
+import pytest
+
+
+pytestmark = pytest.mark.requires_extras
 
 
 def test_build_chunking_form_data_omits_invalid_tokenizer_word():

--- a/tests/unit/ingestion/test_docling_native.py
+++ b/tests/unit/ingestion/test_docling_native.py
@@ -27,6 +27,10 @@ import pytest
 from src.ingestion.docling_native import NativeDoclingAdapter
 
 
+pytestmark = pytest.mark.requires_extras
+
+
+
 # ---------------------------------------------------------------------------
 # Test scaffolding
 # ---------------------------------------------------------------------------

--- a/tests/unit/ingestion/test_hybrid_chunker.py
+++ b/tests/unit/ingestion/test_hybrid_chunker.py
@@ -27,6 +27,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+pytestmark = pytest.mark.requires_extras
+
+
+
 # ---------------------------------------------------------------------------
 # make_hybrid_chunker
 # ---------------------------------------------------------------------------

--- a/tests/unit/ingestion/test_manifest_copy_rename.py
+++ b/tests/unit/ingestion/test_manifest_copy_rename.py
@@ -21,6 +21,9 @@ import pytest
 from src.ingestion.unified.manifest import GDriveManifest
 
 
+pytestmark = pytest.mark.requires_extras
+
+
 class TestCopyVsRenameDetection:
     """Verify that copies get distinct file_ids and renames reuse the old one."""
 

--- a/tests/unit/ingestion/test_observability.py
+++ b/tests/unit/ingestion/test_observability.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from src.ingestion.unified.observability import update_ingestion_trace
+
+
+pytestmark = pytest.mark.requires_extras
 
 
 def test_update_ingestion_trace_uses_observation_updates() -> None:

--- a/tests/unit/ingestion/test_payload_contract.py
+++ b/tests/unit/ingestion/test_payload_contract.py
@@ -6,8 +6,13 @@ from __future__ import annotations
 import threading
 from unittest.mock import MagicMock
 
+import pytest
+
 from src.ingestion.unified.qdrant_writer import QdrantHybridWriter
 from telegram_bot.services.bge_m3_client import HybridResult
+
+
+pytestmark = pytest.mark.requires_extras
 
 
 class TestPayloadContract:

--- a/tests/unit/ingestion/test_qdrant_writer_atomic_replace.py
+++ b/tests/unit/ingestion/test_qdrant_writer_atomic_replace.py
@@ -25,6 +25,10 @@ from qdrant_client.models import HasIdCondition
 from src.ingestion.unified.qdrant_writer import QdrantHybridWriter
 
 
+pytestmark = pytest.mark.requires_extras
+
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/unit/ingestion/test_qdrant_writer_behavior.py
+++ b/tests/unit/ingestion/test_qdrant_writer_behavior.py
@@ -18,6 +18,10 @@ from src.ingestion.unified.qdrant_writer import QdrantHybridWriter
 from src.services.bge_m3_client import HybridResult
 
 
+pytestmark = pytest.mark.requires_extras
+
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/unit/ingestion/test_state_manager_async.py
+++ b/tests/unit/ingestion/test_state_manager_async.py
@@ -12,6 +12,10 @@ import pytest
 from src.ingestion.unified.state_manager import FileState, UnifiedStateManager
 
 
+pytestmark = pytest.mark.requires_extras
+
+
+
 @pytest.fixture
 def mock_pool():
     """Create a mock asyncpg pool."""

--- a/tests/unit/ingestion/test_state_manager_behavior.py
+++ b/tests/unit/ingestion/test_state_manager_behavior.py
@@ -19,6 +19,10 @@ import pytest
 from src.ingestion.unified.state_manager import UnifiedStateManager
 
 
+pytestmark = pytest.mark.requires_extras
+
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/tests/unit/ingestion/test_state_manager_sync.py
+++ b/tests/unit/ingestion/test_state_manager_sync.py
@@ -3,6 +3,11 @@
 
 import asyncio
 
+import pytest
+
+
+pytestmark = pytest.mark.requires_extras
+
 
 class TestStateManagerSyncMethods:
     """Verify sync methods exist and are not coroutines."""

--- a/tests/unit/ingestion/test_state_manager_transitions.py
+++ b/tests/unit/ingestion/test_state_manager_transitions.py
@@ -14,6 +14,10 @@ import pytest
 from src.ingestion.unified.state_manager import UnifiedStateManager
 
 
+pytestmark = pytest.mark.requires_extras
+
+
+
 @pytest.fixture
 def mock_pool() -> AsyncMock:
     pool = AsyncMock()

--- a/tests/unit/ingestion/test_unified_config.py
+++ b/tests/unit/ingestion/test_unified_config.py
@@ -3,7 +3,12 @@
 
 from pathlib import Path
 
+import pytest
+
 from src.ingestion.unified.config import UnifiedConfig
+
+
+pytestmark = pytest.mark.requires_extras
 
 
 class TestManifestDir:

--- a/tests/unit/ingestion/test_unified_manifest.py
+++ b/tests/unit/ingestion/test_unified_manifest.py
@@ -9,6 +9,9 @@ import pytest
 from src.ingestion.unified.manifest import GDriveManifest, compute_content_hash_from_bytes
 
 
+pytestmark = pytest.mark.requires_extras
+
+
 class TestComputeContentHash:
     """Test compute_content_hash_from_bytes()."""
 

--- a/tests/unit/ingestion/test_unified_metrics.py
+++ b/tests/unit/ingestion/test_unified_metrics.py
@@ -14,6 +14,9 @@ from src.ingestion.unified.metrics import (
 )
 
 
+pytestmark = pytest.mark.requires_extras
+
+
 class TestIngestionMetrics:
     """Test IngestionMetrics dataclass."""
 

--- a/tests/unit/observability/test_litellm_model_capture.py
+++ b/tests/unit/observability/test_litellm_model_capture.py
@@ -25,6 +25,10 @@ from __future__ import annotations
 import inspect
 
 import langfuse.openai
+import pytest
+
+
+pytestmark = pytest.mark.requires_extras
 
 
 class TestLangfuseOpenAISourceCodeContract:

--- a/tests/unit/observability/test_observability_payloads.py
+++ b/tests/unit/observability/test_observability_payloads.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import pytest
+
 from telegram_bot.observability_payloads import (
     build_safe_input_payload,
     build_safe_output_payload,
 )
+
+
+pytestmark = pytest.mark.requires_extras
 
 
 def test_build_safe_input_payload_masks_and_hashes_text() -> None:

--- a/tests/unit/observability/test_score_coverage.py
+++ b/tests/unit/observability/test_score_coverage.py
@@ -15,6 +15,10 @@ from unittest.mock import MagicMock
 import pytest
 
 
+pytestmark = pytest.mark.requires_extras
+
+
+
 _TRACE_ID = "trace-coverage-001"
 
 _FULL_RESULT: dict = {

--- a/tests/unit/observability/test_trace_contracts.py
+++ b/tests/unit/observability/test_trace_contracts.py
@@ -15,6 +15,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+pytestmark = pytest.mark.requires_extras
+
+
+
 _TRACE_ID = "trace-contract-abc"
 
 # Minimal state dict that exercises all 13 core RAG scores.

--- a/tests/unit/observability/test_trace_resilience.py
+++ b/tests/unit/observability/test_trace_resilience.py
@@ -16,6 +16,10 @@ from unittest.mock import MagicMock
 import pytest
 
 
+pytestmark = pytest.mark.requires_extras
+
+
+
 _TRACE_ID = "trace-resilience-001"
 
 _MINIMAL_RESULT: dict = {

--- a/tests/unit/observability/test_tracing_context.py
+++ b/tests/unit/observability/test_tracing_context.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from telegram_bot.tracing_context import classify_action, make_session_id
+
+
+pytestmark = pytest.mark.requires_extras
 
 
 class TestMakeSessionId:

--- a/tests/unit/voice/test_rag_api_client.py
+++ b/tests/unit/voice/test_rag_api_client.py
@@ -7,6 +7,9 @@ import pytest
 from src.voice.rag_api_client import RagApiClient, RagApiClientError, RagQueryRequest
 
 
+pytestmark = pytest.mark.requires_extras
+
+
 def test_query_request_payload_includes_optional_trace_id():
     req = RagQueryRequest(
         query="test",

--- a/tests/unit/voice/test_transcript_store.py
+++ b/tests/unit/voice/test_transcript_store.py
@@ -3,7 +3,12 @@
 import uuid
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from src.voice.schemas import CallRequest, CallResponse, CallStatus, TranscriptEntry
+
+
+pytestmark = pytest.mark.requires_extras
 
 
 def test_call_request_schema():

--- a/tests/unit/voice/test_voice_healthcheck.py
+++ b/tests/unit/voice/test_voice_healthcheck.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import pytest
+
 from src.voice.healthcheck import _cmdline_matches_voice_agent
+
+
+pytestmark = pytest.mark.requires_extras
 
 
 def test_cmdline_matches_voice_agent_start_process() -> None:

--- a/tests/unit/voice/test_voice_observability.py
+++ b/tests/unit/voice/test_voice_observability.py
@@ -8,12 +8,17 @@ import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from src.voice.observability import (
     build_voice_trace_metadata,
     trace_voice_session,
     update_voice_trace,
     voice_session_id,
 )
+
+
+pytestmark = pytest.mark.requires_extras
 
 
 def test_voice_session_id_handles_missing_call_id() -> None:

--- a/tests/unit/voice/test_voice_schemas.py
+++ b/tests/unit/voice/test_voice_schemas.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import pytest
+
 from src.voice.schemas import CallRequest, CallResponse, CallStatus, TranscriptEntry
+
+
+pytestmark = pytest.mark.requires_extras
 
 
 def test_call_request_defaults_lead_data_to_empty_dict() -> None:


### PR DESCRIPTION
## Issue / Mode
- PR Coordinator mode for existing PR #2530 only.
- Addresses #2494: move optional/service tests out of the default/core gate while preserving explicit opt-in lanes.
- Partially addresses #2496 only for the optional observability lane: SDK/heavy observability tests live behind an explicit target, while core graceful-degradation/optional Langfuse contracts stay in the core/contract surface.
- #2495 is out of scope/out of order for this PR; no graph/API rewrite was performed.
- #2497 is out of scope/out of order for this PR; no archive/delete work was performed.

## Changed files / Scope
- `Makefile`: `make test` is now a deterministic core gate that runs `make test-core` plus `tests/integration/test_graph_paths.py`; it does not collect the whole `tests/unit/` tree.
- `Makefile`: explicit optional opt-in targets are present for Telegram adapter, API adapter, ingestion extra, voice extra, evaluation extra, observability extra, and aggregate optional surfaces.
- `tests/contract/test_core_gate_optional_surfaces_contract.py`: pins the default gate shape, verifies optional paths are excluded from default/core collection, verifies registered marker usage, and verifies explicit optional targets exist.
- `tests/unit/core/test_pipeline.py`: remains outside `test-core` and is marked with the existing `requires_extras` marker because it is a legacy optional RAG pipeline test that imports optional provider/ingestion surfaces at collection time.
- `tests/unit/voice/`, `tests/unit/ingestion/`, `tests/unit/evaluation/`, and `tests/unit/observability/`: optional dependency tests use the existing registered `pytest.mark.requires_extras` marker.
- `tests/README.md` and `docs/engineering/test-writing-guide.md`: updated to match the current Makefile lanes: deterministic `make test`, separate broad unit lane, and explicit optional-surface targets.
- Mini App unit tests/target were not restored because current `dev` already removed/moved those tests; this PR does not reintroduce them.

## Duplicate PR preflight
- Reused existing PR #2530: https://github.com/yastman/rag/pull/2530.
- Verified open PR search for `2494` and optional-surface wording; no new PR was created.
- Current head branch remains `work` targeting `dev`.

## Validation
Validated on commit `195ba939a6e8dd0d5ba23db8cd67ff83cc6c9f7c`.

Passed:
- `apt-get update && apt-get install -y gh`
- `gh --version`
- `gh auth status --hostname github.com`
- `git fetch origin --prune`
- `git checkout work`
- `git reset --hard origin/work`
- `git rebase origin/dev`
- `gh auth setup-git --hostname github.com && git push origin work --force-with-lease`
- `uv run --no-sync ruff check tests/contract/test_core_gate_optional_surfaces_contract.py tests/unit/core/test_pipeline.py`
- `uv run --no-sync --python 3.12 pytest tests/contract/test_core_gate_optional_surfaces_contract.py -q`
- `make test-core`
- `make test`
- `gh pr checks 2530 --repo yastman/rag --required`

## Skipped checks + reason
- No Mini App optional lane was run because current `dev` no longer has the Mini App unit-test target/tests in this scope.
- Optional surface lanes were not run as merge-required validation; this PR only makes them explicit opt-in lanes and keeps default/core validation deterministic.

## Failed checks triage
- `make test-contract` was attempted and still fails on existing baseline issues outside this PR scope:
  - missing optional/runtime imports in the lean environment, including `asyncpg`;
  - existing `test_no_get_event_loop` allowlist/runtime embedding line drift;
  - unrelated Telegram bot extraction/parity contract failures.
- These failures are not fixed here because this PR is limited to Worker E optional-surface lane coordination and must not broaden into unrelated contract/runtime rewrites.

## Follow-up issues
- #2495: graph/API rewrite remains out of scope/out of order.
- #2497: archive/delete work remains out of scope/out of order.
- #2496: only the optional observability lane slice is handled here; broader observability cleanup remains follow-up work.

## Risk / rollback
- Risk: test-gate behavior change. The default local `make test` lane is intentionally narrower and deterministic.
- Rollback: revert this PR to restore the prior Makefile/test-lane behavior and marker/doc changes.

## Agent Handoff

Status: clean
Base: dev
Head: work
Validated commit: 195ba939a6e8dd0d5ba23db8cd67ff83cc6c9f7c
Risk: test
Failure class: env_failure

## Validation checklist

- [x] Required GitHub checks: green on current head
- [x] Focused validation: passed
- [x] make test-core: passed
- [x] make test: passed
- [x] Optional/heavy checks: `make test-contract` attempted; failed on known unrelated baseline/env issues described above

## Findings

- No PR-scope blockers found after rebase and focused validation.
- Remote PR body must be treated as the source of truth; it was re-read after update and verified against the current head.

## Next action

- Re-check that PR head is still `195ba939a6e8dd0d5ba23db8cd67ff83cc6c9f7c`.
- If head changed, rerun relevant validation.
- If unchanged and required GitHub checks remain green, continue with review/decision.
- Do not merge unless explicitly instructed.
