### PR TITLE
Add self-updating skill guardrails

### DIFF
--- a/docs/engineering/skill-maintenance-guardrails.md
+++ b/docs/engineering/skill-maintenance-guardrails.md
@@ -1,0 +1,102 @@
+# Skill Maintenance Guardrails
+
+This document captures process bugs found during orchestrator review and turns them into reusable worker and reviewer rules.
+
+Use it when updating:
+
+- `docs/engineering/orchestrator-playbook.md`
+- `docs/engineering/codex-web-prompt.md`
+- `docs/engineering/gh-pr-review.md`
+- PR templates or agent contract tests
+
+---
+
+## 1. Orchestrator responsibility
+
+The orchestrator owns prompt and skill freshness.
+
+After every worker or reviewer failure, the orchestrator must classify the failure:
+
+```text
+code bug | validation gap | PR process failure | prompt/skill failure | contract-test gap
+```
+
+If the failure could repeat, the orchestrator must create a process PR or include a copyable prompt-improvement block that updates the right worker/reviewer/orchestrator skill.
+
+Do not hide these improvements inside unrelated runtime PRs. Process/control-plane changes belong in a separate process PR unless the user explicitly asked to include them.
+
+---
+
+## 2. Re-scoped issue source of truth
+
+When an issue body is stale but later comments or audit docs re-scope the work, use the latest re-scope as the source of truth.
+
+Before approving or assigning work for a re-scoped issue:
+
+1. Read the issue body.
+2. Read recent issue comments.
+3. Read linked audit docs if referenced.
+4. Classify old checklist items as `current`, `stale`, or `follow-up`.
+5. Require the worker/PR body to state which interpretation was used.
+
+A PR must not be accepted just because it satisfies an old issue body while ignoring newer issue comments.
+
+---
+
+## 3. Removed dependency / service reverse-search gate
+
+When removing a dependency, service, environment variable, endpoint, or config file, workers and reviewers must run reverse searches before the PR is marked ready.
+
+Minimum searches:
+
+```bash
+# Removed dependency
+rg -n "import <dep>|from <dep>|<dep>\." .
+
+# Removed service / endpoint / env / config
+rg -n "<SERVICE_NAME>|<HOST>:<PORT>|<ENV_VAR>|<old config path>|<old health endpoint>" .
+```
+
+Block the PR if any of these remain:
+
+- unconditional imports for a removed dependency;
+- active runtime/default/test paths pointing at a removed service endpoint;
+- docs claiming migration is complete while scripts/runbooks/tests still default to the removed surface;
+- lockfile/dependency removal without matching import cleanup.
+
+Allowed only with explicit documentation:
+
+- legacy opt-in compatibility paths;
+- historical docs that are clearly archived;
+- optional extras that still declare the dependency they import.
+
+---
+
+## 4. New central shim coverage
+
+When a worker introduces or changes a central compatibility shim, router, adapter, or facade, the PR must include direct unit tests for the shim itself, not only caller tests.
+
+Coverage must prove:
+
+- input translation into the downstream SDK/API contract;
+- dropping or preserving wrapper-only kwargs intentionally;
+- parsing/normalizing return values;
+- failure propagation to caller fallback paths;
+- at least one regression case for the bug that caused the shim.
+
+---
+
+## 5. PR body and handoff freshness
+
+A PR touched by a reviewer or worker must not be reported as ready unless the PR body contains:
+
+- duplicate PR preflight;
+- changed files / scope;
+- validation run on the current head;
+- skipped checks with reasons;
+- failed-check triage;
+- follow-up issues for intentionally deferred work;
+- risk / rollback;
+- Agent Handoff with `Validated commit` equal to current head.
+
+If the head changes after validation, validation is stale and must be rerun.


### PR DESCRIPTION
## Summary
- Adds shared skill-maintenance guardrails for orchestrator, worker, and reviewer process fixes.
- Updates `docs/engineering/orchestrator-playbook.md` with a self-updating skill loop: when a new recurring worker/reviewer/orchestrator bug is found, route it to the owning skill file and create a separate process PR.
- Documents reverse-search gates for removed dependencies/services, re-scoped issue handling, central shim test coverage, and handoff freshness.

## Changed files / Scope
- `docs/engineering/orchestrator-playbook.md`
- `docs/engineering/skill-maintenance-guardrails.md`

## Duplicate PR preflight
- Existing PR #2529 is runtime/dependency remediation, not a process-skill update.
- This PR is process/docs-only and intentionally separate to avoid control-plane contamination inside runtime PRs.

## Validation
- Docs-only connector update; local checks not run.

## Skipped checks + reason
- Local markdown checks not run: no local checkout in this connector workflow.
- Python tests not run: docs-only change.

## Failed checks triage
- None.

## Follow-up issues
- Optional follow-up: wire the same guardrails directly into `docs/engineering/codex-web-prompt.md` and `docs/engineering/gh-pr-review.md` if you want the worker/reviewer skills to carry duplicated local rules instead of relying on the orchestrator routing rule + shared guardrails doc.

## Risk / rollback
- Low risk. Rollback by reverting the docs-only commits.

## Agent Handoff

Status: ready_for_review
Base: dev
Head: skill-updates
Validated commit: d00558650150fa2e41749d79e0a586a27b84dfc9
Risk: docs
Failure class: none

## Validation

- [ ] Required GitHub checks: pending / not rechecked after latest docs commit
- [ ] Focused validation: skipped docs-only connector update
- [ ] make test-core: not required
- [ ] Optional/heavy checks: not required

## Findings

- Orchestrator now explicitly knows to patch the owning skill when it finds a new repeating bug.
- Runtime feature PRs must stay clean; skill updates go through separate process PRs.

## Next action

Review and merge PR #2541 if acceptable, then optionally add duplicated local rules to worker/reviewer skill files in a follow-up process PR.