### PR TITLE
Update orchestrator skill loop and test-audit guardrails

### DIFF
--- a/docs/engineering/orchestrator-playbook.md
+++ b/docs/engineering/orchestrator-playbook.md
@@ -24,6 +24,30 @@ Was this a code bug, a validation gap, a PR process failure, or a prompt failure
 
 If the root cause is process/prompt-related, propose a concrete update to the relevant prompt, skill, PR template, or contract test.
 
+## Self-Updating Skill Loop
+
+When the orchestrator finds a new recurring bug, it must turn that bug into a durable rule and open a separate process PR to update the right skill file.
+
+Route the rule by ownership:
+
+```text
+orchestrator coordination bug -> docs/engineering/orchestrator-playbook.md
+worker execution bug -> docs/engineering/codex-web-prompt.md
+PR review / gatekeeper bug -> docs/engineering/gh-pr-review.md
+PR body / handoff bug -> .github/pull_request_template.md or reviewer skill
+must-never-repeat invariant -> tests/unit/test_agents_contract.py
+```
+
+Rules:
+
+```text
+- Do not bury process fixes inside unrelated runtime PRs.
+- If a worker bug is found during review, keep the feature PR focused and create a separate process PR.
+- If multiple orchestrators are active, each may create a process PR; the human merges the chosen one into dev.
+- The process PR must describe the original failure, the new rule, and which skill owns it.
+- If the rule should never regress, add or request an agent contract test.
+```
+
 ---
 
 ## Role Separation
@@ -378,8 +402,9 @@ When a process mistake happens:
 
 ```text
 - identify root cause
-- write prompt improvement
-- decide whether to update worker prompt, reviewer skill, PR template, or contract tests
+- choose the owning skill: orchestrator, worker, PR reviewer, PR template, or contract test
+- create or request a separate process PR updating that skill
+- keep runtime feature PRs free of unrelated process edits
 ```
 
 ---

--- a/docs/engineering/orchestrator-playbook.md
+++ b/docs/engineering/orchestrator-playbook.md
@@ -48,6 +48,176 @@ Rules:
 - If the rule should never regress, add or request an agent contract test.
 ```
 
+## Worker Prompt Writing
+
+The orchestrator writes task prompts for Codex Web workers. A new orchestrator should be able to read this playbook and produce a complete copy-paste prompt without needing hidden context.
+
+Choose the mode and skill first:
+
+```text
+existing PR review/fix -> PR Coordinator -> docs/engineering/gh-pr-review.md
+new issue implementation -> Issue Executor -> docs/engineering/codex-web-prompt.md
+process/skill update -> process PR -> this playbook + skill-maintenance-guardrails.md
+audit only / planning -> Audit Planner -> this playbook
+```
+
+A worker prompt must include:
+
+```text
+Mode / skill:
+- Which mode to use.
+- Which skill/doc to follow.
+- Whether to create a new PR, update an existing PR, or only audit.
+
+Context:
+- Repo, base branch, issue/PR number, branch if known.
+- What the orchestrator already verified.
+- Current blockers/findings.
+
+Source of truth:
+- Issue body.
+- Recent issue comments.
+- Linked audit docs.
+- PR review comments or Agent Handoff.
+
+Scope:
+- Exact files/subsystems to change.
+- Exact behavior to preserve.
+- What counts as done.
+
+Non-scope / forbidden:
+- No unrelated refactors.
+- No workflow/process/control-plane edits in runtime PRs.
+- No broad dependency changes unless explicitly in scope.
+- Do not merge unless explicitly instructed.
+
+Tasks:
+1. Concrete ordered steps.
+2. Required searches/preflights.
+3. Required code/docs/test changes.
+
+Validation:
+- Exact focused commands to run.
+- Exact CI-equivalent static commands when needed.
+- Explicit skipped checks wording if Docker/K8s/secrets are unavailable.
+
+Handoff:
+- PR URL.
+- Base/head/head SHA.
+- Tests run/skipped.
+- Blockers.
+- Follow-up issues.
+- Agent Handoff with Validated commit.
+
+Skill update hook:
+- If the worker discovers a recurring process bug, do not fix the skill inside the runtime PR.
+- Report the proposed owner and rule text so the orchestrator can open a separate process PR.
+```
+
+Copyable default worker prompt shape:
+
+```text
+Ты работаешь в repo `yastman/rag`.
+
+Mode / skill:
+- Use <Issue Executor | PR Coordinator | Audit Planner>.
+- Follow `<skill/doc path>`.
+- Base branch is `dev`.
+- Do not merge unless explicitly instructed.
+
+Context:
+- Issue/PR: <number and title>.
+- Current branch/head if applicable: <branch/sha>.
+- Relevant findings: <short bullets>.
+
+Source of truth:
+- Read the issue body.
+- Read recent issue comments.
+- Read linked audit docs: <paths or none>.
+- If issue comments re-scope the issue, use the latest re-scope and document stale checklist items.
+
+Scope:
+- Change only: <files/subsystems>.
+- Preserve: <contracts/behavior>.
+- Done means: <acceptance criteria>.
+
+Non-scope / forbidden:
+- Do not create duplicate PRs.
+- Do not touch process/control-plane files unless this is a process PR.
+- Do not broaden into unrelated baseline cleanup.
+- Do not skip/delete/weaken tests to pass.
+
+Tasks:
+1. <step>
+2. <step>
+3. <step>
+
+Validation:
+Run:
+```bash
+<focused commands>
+```
+
+If Python paths changed, also run:
+```bash
+uvx ruff check src/ telegram_bot/ mini_app/ services/ scripts/ --output-format=github
+uvx ruff format --target-version py312 --check src/ telegram_bot/ mini_app/ services/ scripts/
+uv lock --locked
+```
+
+If Docker/K8s/live services are unavailable, document exactly what was skipped and why.
+
+Handoff:
+Update PR body/comment with:
+- Status
+- Base
+- Head
+- Validated commit
+- Risk
+- Failure class
+- Validation checklist
+- Findings
+- Next action
+```
+
+Example PR Coordinator prompt:
+
+```text
+Ты работаешь в repo `yastman/rag`.
+
+Mode / skill:
+- Use PR Coordinator mode.
+- Follow `docs/engineering/gh-pr-review.md`.
+- Update existing PR #<number>; do not create a duplicate PR.
+- Do not merge unless explicitly instructed.
+
+Context:
+- PR #<number>: <title>.
+- Base must be `dev`.
+- Current blockers from orchestrator review:
+  - <blocker 1>
+  - <blocker 2>
+
+Source of truth:
+- Read PR body, comments, labels, changed files, and Agent Handoff.
+- Read related issues and recent issue comments.
+- If issue comments re-scope the work, use the latest re-scope.
+
+Tasks:
+1. Rebase on current `origin/dev` if stale.
+2. Fix only the listed blockers.
+3. Add or update focused tests for changed behavior.
+4. Update PR body with complete Agent Handoff.
+5. Report remaining blockers instead of broadening scope.
+
+Validation:
+Run focused tests for touched files plus required static checks.
+Report skipped Docker/K8s/live checks with reason.
+
+Handoff:
+Return PR URL, head SHA, validation results, skipped checks, findings, and next action.
+```
+
 ---
 
 ## Role Separation


### PR DESCRIPTION
## Summary
- Updates orchestrator process docs.
- Adds self-updating skill loop.
- Adds worker prompt writing template for Codex Web tasks.
- Adds broad-suite failure audit guardrail: broad `make test` failures must be grouped, classified, and linked to issues instead of summarized vaguely.

## Validation
- Docs-only connector update; local checks not run.

## Agent Handoff
Status: ready_for_review
Base: dev
Head: skill-updates
Validated commit: 39fb9dbdd29659c86640c2c6e6516cd972b63be0
Risk: docs
Failure class: none