### PR TITLE
fix(types): clear Telegram MyPy baseline (#2525)

### DIFF
--- a/telegram_bot/callback_data.py
+++ b/telegram_bot/callback_data.py
@@ -5,34 +5,34 @@ from __future__ import annotations
 from aiogram.filters.callback_data import CallbackData
 
 
-class FeedbackCB(CallbackData, prefix="fb"):
+class FeedbackCB(CallbackData, prefix="fb"):  # type: ignore[call-arg]  # aiogram CallbackData accepts prefix at runtime
     """Feedback like/dislike/done callback data."""
 
     action: str  # "like", "dislike", "done"
     trace_id: str = ""
 
 
-class FeedbackReasonCB(CallbackData, prefix="fbr"):
+class FeedbackReasonCB(CallbackData, prefix="fbr"):  # type: ignore[call-arg]  # aiogram CallbackData accepts prefix at runtime
     """Feedback dislike reason callback data."""
 
     code: str
     trace_id: str
 
 
-class FavoriteCB(CallbackData, prefix="fav"):
+class FavoriteCB(CallbackData, prefix="fav"):  # type: ignore[call-arg]  # aiogram CallbackData accepts prefix at runtime
     """Favorites add/remove/viewing callback data."""
 
     action: str  # "add", "remove", "viewing", "viewing_all"
     apartment_id: str = ""
 
 
-class ResultsCB(CallbackData, prefix="results"):
+class ResultsCB(CallbackData, prefix="results"):  # type: ignore[call-arg]  # aiogram CallbackData accepts prefix at runtime
     """Property results pagination callback data."""
 
     action: str  # "more", "refine", "viewing"
 
 
-class DemoCB(CallbackData, prefix="demo"):
+class DemoCB(CallbackData, prefix="demo"):  # type: ignore[call-arg]  # aiogram CallbackData accepts prefix at runtime
     """Demo flow callback data."""
 
     action: str  # "apartments", "example"

--- a/telegram_bot/dialogs/filter_dialog.py
+++ b/telegram_bot/dialogs/filter_dialog.py
@@ -133,7 +133,7 @@ def _callback_intent_id(callback_data: str | None) -> str | None:
         return None
     with contextlib.suppress(Exception):
         intent_id, _ = remove_intent_id(callback_data)
-        return intent_id
+        return intent_id if isinstance(intent_id, str) else None
     return None
 
 

--- a/telegram_bot/services/forum_bridge.py
+++ b/telegram_bot/services/forum_bridge.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+from typing import cast
 
 from aiogram import Bot
 
@@ -31,7 +32,7 @@ class ForumBridge:
         raw_name = f"{client_name} — {goal}"
         name = _truncate_topic_name(raw_name)
         topic = await self._bot.create_forum_topic(chat_id=self._group_id, name=name)
-        return topic.message_thread_id
+        return cast(int, topic.message_thread_id)
 
     async def post_context_pack(
         self,

--- a/telegram_bot/services/topic_manager.py
+++ b/telegram_bot/services/topic_manager.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 
 if TYPE_CHECKING:
@@ -60,7 +60,7 @@ class TopicManager:
         await self._redis.set(fwd, tid, ex=_TOPIC_TTL)
         await self._redis.set(self._rev_key(chat_id, tid), expert_id, ex=_TOPIC_TTL)
         logger.info("Created topic %d for expert=%s chat=%d", tid, expert_id, chat_id)
-        return tid
+        return cast(int, tid)
 
     async def get_expert_for_topic(self, chat_id: int, topic_id: int) -> str | None:
         """Reverse lookup: topic_id → expert_id."""


### PR DESCRIPTION
## Agent Handoff

Issue: #2525
Base: dev
Head: codex/2525-telegram-mypy-baseline
Head SHA: 8c9649b

## Summary
- Added localized aiogram CallbackData MyPy suppressions for the runtime-supported `prefix` subclass keyword, because the installed type surface reports it as an object `__init_subclass__` call-arg.
- Cast forum topic `message_thread_id` values to `int` at the Telegram service boundary.
- Guarded aiogram-dialog `remove_intent_id()` output before returning `str | None`.

## Current MyPy failures before
`make check` on current dev failed in MyPy with:
- `telegram_bot/callback_data.py:8`: Unexpected keyword argument `prefix` for `__init_subclass__` of `object` [call-arg]
- `telegram_bot/callback_data.py:15`: Unexpected keyword argument `prefix` for `__init_subclass__` of `object` [call-arg]
- `telegram_bot/callback_data.py:22`: Unexpected keyword argument `prefix` for `__init_subclass__` of `object` [call-arg]
- `telegram_bot/callback_data.py:29`: Unexpected keyword argument `prefix` for `__init_subclass__` of `object` [call-arg]
- `telegram_bot/callback_data.py:35`: Unexpected keyword argument `prefix` for `__init_subclass__` of `object` [call-arg]
- `telegram_bot/services/forum_bridge.py:34`: Returning Any from function declared to return `int` [no-any-return]
- `telegram_bot/services/topic_manager.py:63`: Returning Any from function declared to return `int` [no-any-return]
- `src/runtime/retrieval/service.py:71`: Incompatible types in assignment (expression has type `None`, variable has type `dict[str, Any]`) [assignment]
- `src/evaluation/generate_test_queries.py:135`: `object` has no attribute `chat` [attr-defined]
- `telegram_bot/dialogs/filter_dialog.py:136`: Returning Any from function declared to return `str | None` [no-any-return]

Note: the current dev output differs from the issue body by adding two non-Telegram failures in `src/runtime/retrieval/service.py` and `src/evaluation/generate_test_queries.py`; those are intentionally left for #2474 follow-up.

## Current MyPy failures after
`uv run --frozen mypy src/ telegram_bot/ services/ scripts/ --ignore-missing-imports --no-error-summary` no longer reports the #2525 Telegram findings. Remaining distinct failures:
- `src/runtime/retrieval/service.py:71`: Incompatible types in assignment (expression has type `None`, variable has type `dict[str, Any]`) [assignment]
- `src/evaluation/generate_test_queries.py:135`: `object` has no attribute `chat` [attr-defined]

## Validation
- PASS: `uv run --frozen mypy src/ telegram_bot/ services/ scripts/ --ignore-missing-imports --no-error-summary` cleared the #2525 Telegram findings; exits non-zero only for the two distinct non-Telegram failures listed above.
- WARN: `make check` still fails in MyPy on the two distinct non-Telegram failures above; tracked for #2474 pass.
- PASS: `uvx ruff check src/ telegram_bot/ mini_app/ services/ scripts/ --output-format=github`
- PASS: `uvx ruff format --target-version py312 --check src/ telegram_bot/ mini_app/ services/ scripts/`
- PASS: `uv lock --locked`
- WARN: `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit` failed on existing broad unit baseline/import-environment issues (for example missing `langchain`/`langchain_core`) and many unrelated tests; no targeted runtime behavior was changed.

## Changed files
- `telegram_bot/callback_data.py`
- `telegram_bot/dialogs/filter_dialog.py`
- `telegram_bot/services/forum_bridge.py`
- `telegram_bot/services/topic_manager.py`

Fixes #2525
