### PR TITLE
CORE-021: Route RAG retrieval through runtime seam

### DIFF
--- a/src/runtime/pipeline/rag.py
+++ b/src/runtime/pipeline/rag.py
@@ -27,6 +27,7 @@ from typing import Any, TypeVar
 
 from src.observability import get_client, observe
 from src.runtime.graph.config import GraphConfig
+from src.runtime.retrieval import RetrievalService, VectorRetrievalRequest
 from src.runtime.services.cache_policy import (
     SEMANTIC_CACHE_SCHEMA_VERSION,
     build_cacheability_decision,
@@ -99,6 +100,7 @@ def _cacheable_query_types() -> set[str]:
 
 logger = logging.getLogger(__name__)
 
+
 # top_k=7 for reranking. Standard in literature; balances latency vs recall for
 # reranking candidate pool. 3 was too restrictive — comprehensive queries
 # (e.g. list all ВНЖ types) were losing chunks.
@@ -148,8 +150,10 @@ async def _execute_qdrant_retrieval(
     sparse_weight: float,
 ) -> tuple[list[dict[str, Any]], dict[str, Any], bool]:
     has_colbert_search = callable(getattr(qdrant, "hybrid_search_rrf_colbert", None))
-    if colbert_query and has_colbert_search:
-        result = await qdrant.hybrid_search_rrf_colbert(
+    colbert_used = bool(colbert_query and has_colbert_search)
+    retrieval = RetrievalService(qdrant=qdrant)
+    result = await retrieval.retrieve_vectors(
+        VectorRetrievalRequest(
             dense_vector=dense_vector,
             sparse_vector=sparse_vector,
             colbert_query=colbert_query,
@@ -159,18 +163,7 @@ async def _execute_qdrant_retrieval(
             top_k=top_k,
             return_meta=True,
         )
-        colbert_used = True
-    else:
-        result = await qdrant.hybrid_search_rrf(
-            dense_vector=dense_vector,
-            sparse_vector=sparse_vector,
-            filters=filters,
-            dense_weight=dense_weight,
-            sparse_weight=sparse_weight,
-            top_k=top_k,
-            return_meta=True,
-        )
-        colbert_used = False
+    )
 
     if isinstance(result, tuple) and len(result) == 2:
         results, search_meta = result

--- a/src/runtime/retrieval/__init__.py
+++ b/src/runtime/retrieval/__init__.py
@@ -4,7 +4,7 @@ Retrieval services compose the embedding provider layer with the canonical
 Qdrant SDK gateway. They do not generate answers.
 """
 
-from src.runtime.retrieval.service import RetrievalRequest, RetrievalService
+from src.runtime.retrieval.service import RetrievalRequest, RetrievalService, VectorRetrievalRequest
 
 
-__all__ = ["RetrievalRequest", "RetrievalService"]
+__all__ = ["RetrievalRequest", "RetrievalService", "VectorRetrievalRequest"]

--- a/src/runtime/retrieval/service.py
+++ b/src/runtime/retrieval/service.py
@@ -16,6 +16,24 @@ from src.runtime.services.qdrant import QdrantService, SearchReturn
 
 
 @dataclass(frozen=True)
+class VectorRetrievalRequest:
+    """Pre-vectorized retrieval request used by cache-aware orchestration.
+
+    This contract keeps Qdrant search selection inside the pure retrieval
+    boundary even when the caller already owns embedding/cache decisions.
+    """
+
+    dense_vector: list[float]
+    sparse_vector: Any = None
+    colbert_query: list[list[float]] | None = None
+    filters: dict[str, Any] | None = None
+    top_k: int = 5
+    return_meta: bool = False
+    dense_weight: float | None = None
+    sparse_weight: float | None = None
+
+
+@dataclass(frozen=True)
 class RetrievalRequest:
     """Input contract for pure retrieval."""
 
@@ -28,9 +46,40 @@ class RetrievalRequest:
 class RetrievalService:
     """Compose embeddings and Qdrant into a generation-free retrieval layer."""
 
-    def __init__(self, *, embeddings: EmbeddingProvider, qdrant: QdrantService) -> None:
+    def __init__(
+        self, *, embeddings: EmbeddingProvider | None = None, qdrant: QdrantService
+    ) -> None:
         self._embeddings = embeddings
         self._qdrant = qdrant
+
+    async def retrieve_vectors(self, request: VectorRetrievalRequest) -> SearchReturn:
+        """Retrieve documents for already-computed query vectors.
+
+        Cache-aware pipelines may compute or reuse query vectors before the
+        Qdrant call.  They still route the actual retrieval operation through
+        this service so the RAG orchestrator does not own Qdrant search-method
+        selection or answer generation.
+        """
+        search_kwargs: dict[str, Any] = {
+            "dense_vector": request.dense_vector,
+            "sparse_vector": request.sparse_vector,
+            "filters": request.filters,
+            "top_k": request.top_k,
+            "return_meta": request.return_meta,
+        }
+        if request.dense_weight is not None:
+            search_kwargs["dense_weight"] = request.dense_weight
+        if request.sparse_weight is not None:
+            search_kwargs["sparse_weight"] = request.sparse_weight
+
+        has_colbert_search = callable(getattr(self._qdrant, "hybrid_search_rrf_colbert", None))
+        if request.colbert_query and has_colbert_search:
+            return await self._qdrant.hybrid_search_rrf_colbert(
+                **search_kwargs,
+                colbert_query=request.colbert_query,
+            )
+
+        return await self._qdrant.hybrid_search_rrf(**search_kwargs)
 
     async def retrieve(self, request: RetrievalRequest) -> SearchReturn:
         """Retrieve documents for a query without invoking answer generation.
@@ -41,6 +90,10 @@ class RetrievalService:
         dense-only providers fall back to dense search through RRF with no
         sparse vector.
         """
+        if self._embeddings is None:
+            raise RuntimeError("RetrievalService.retrieve requires an embedding provider")
+
+        sparse: dict[str, Any] | None
         colbert_vectors: tuple[list[float], dict[str, Any], list[list[float]]] | None = None
         try:
             colbert_vectors = await self._embeddings.aembed_hybrid_with_colbert(request.query)
@@ -49,13 +102,15 @@ class RetrievalService:
 
         if colbert_vectors is not None:
             dense, sparse, colbert = colbert_vectors
-            return await self._qdrant.hybrid_search_rrf_colbert(
-                dense_vector=dense,
-                sparse_vector=sparse,
-                colbert_query=colbert,
-                filters=request.filters,
-                top_k=request.top_k,
-                return_meta=request.return_meta,
+            return await self.retrieve_vectors(
+                VectorRetrievalRequest(
+                    dense_vector=dense,
+                    sparse_vector=sparse,
+                    colbert_query=colbert,
+                    filters=request.filters,
+                    top_k=request.top_k,
+                    return_meta=request.return_meta,
+                )
             )
 
         hybrid_vectors: tuple[list[float], dict[str, Any]] | None = None
@@ -70,10 +125,12 @@ class RetrievalService:
             dense = await self._embeddings.aembed_query(request.query)
             sparse = None
 
-        return await self._qdrant.hybrid_search_rrf(
-            dense_vector=dense,
-            sparse_vector=sparse,
-            filters=request.filters,
-            top_k=request.top_k,
-            return_meta=request.return_meta,
+        return await self.retrieve_vectors(
+            VectorRetrievalRequest(
+                dense_vector=dense,
+                sparse_vector=sparse,
+                filters=request.filters,
+                top_k=request.top_k,
+                return_meta=request.return_meta,
+            )
         )

--- a/tests/unit/retrieval/test_runtime_retrieval_service.py
+++ b/tests/unit/retrieval/test_runtime_retrieval_service.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 
 from src.adapters.embeddings.base import EmbeddingProvider
-from src.runtime.retrieval import RetrievalRequest, RetrievalService
+from src.runtime.retrieval import RetrievalRequest, RetrievalService, VectorRetrievalRequest
 
 
 class HybridColbertEmbeddings(EmbeddingProvider):
@@ -128,4 +128,48 @@ async def test_retrieve_does_not_swallow_qdrant_not_implemented_errors() -> None
     )
 
     with pytest.raises(NotImplementedError, match="qdrant colbert path"):
+        await service.retrieve(RetrievalRequest(query="hello"))
+
+
+@pytest.mark.asyncio
+async def test_retrieve_vectors_routes_precomputed_colbert_without_generation() -> None:
+    qdrant = RecordingQdrant()
+    service = RetrievalService(qdrant=qdrant)  # type: ignore[arg-type]
+
+    result = await service.retrieve_vectors(
+        VectorRetrievalRequest(
+            dense_vector=[0.9],
+            sparse_vector={"indices": [9], "values": [0.9]},
+            colbert_query=[[0.8]],
+            filters={"city": "Sunny Beach"},
+            top_k=7,
+            return_meta=True,
+            dense_weight=0.4,
+            sparse_weight=0.6,
+        )
+    )
+
+    assert result == [{"id": "colbert"}]
+    assert qdrant.calls == [
+        (
+            "colbert",
+            {
+                "dense_vector": [0.9],
+                "sparse_vector": {"indices": [9], "values": [0.9]},
+                "filters": {"city": "Sunny Beach"},
+                "top_k": 7,
+                "return_meta": True,
+                "dense_weight": 0.4,
+                "sparse_weight": 0.6,
+                "colbert_query": [[0.8]],
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_retrieve_requires_embeddings_for_query_vectorization() -> None:
+    service = RetrievalService(qdrant=RecordingQdrant())  # type: ignore[arg-type]
+
+    with pytest.raises(RuntimeError, match="requires an embedding provider"):
         await service.retrieve(RetrievalRequest(query="hello"))


### PR DESCRIPTION
## Issue / Mode
- Mode: Issue Executor (Worker H — Retrieval Phase E)
- Issue: Refs #2406
- Base: `dev`
- Head: `worker-h-core-021-retrieval-phase-e`

## Summary
- Added a `VectorRetrievalRequest` contract to the pure `src.runtime.retrieval` service so cache-aware orchestration can reuse precomputed dense/sparse/ColBERT vectors without owning Qdrant method selection.
- Routed the legacy `rag_pipeline` Qdrant execution helper through `RetrievalService.retrieve_vectors()` while preserving existing cache, grading, rewrite, rerank, and generation behavior.
- Kept answer generation owned by `src.runtime.generation.generate_answer`; this PR only advances the retrieval boundary and does not close the broader Phase E migration.
- Added focused retrieval-service tests for pre-vectorized ColBERT retrieval and for requiring an embedding provider on query-vectorizing retrieval.

## Changed files
- `src/runtime/retrieval/service.py`
- `src/runtime/retrieval/__init__.py`
- `src/runtime/pipeline/rag.py`
- `tests/unit/retrieval/test_runtime_retrieval_service.py`

## Duplicate PR preflight
- Checked open PRs via GitHub search for `#2406`, `CORE-021`, `Retrieval service`, and `rag_pipeline generation_service`.
- No duplicate open PR was found.
- Confirmed #2406 is open.

## Validation
- ✅ `uv run --no-sync pytest -o addopts='' tests/unit/retrieval/test_runtime_retrieval_service.py -q` (`6 passed`)
- ✅ `make test-core` (`66 passed`)
- ✅ `uvx ruff check src/ telegram_bot/ mini_app/ services/ scripts/ --output-format=github`
- ✅ `uvx ruff format --target-version py312 --check src/ telegram_bot/ mini_app/ services/ scripts/`
- ✅ `uv lock --locked`

## Skipped checks
- Heavy/full suites were not run; per repo policy they are manual-only unless explicitly requested.

## Boundary changed
- `rag_pipeline` still handles cache/rewrite/rerank orchestration, but the actual Qdrant retrieval operation now flows through `src.runtime.retrieval.RetrievalService`.
- Generation remains outside retrieval and continues through `src.runtime.generation.generate_answer` from the assistant pipeline.

## Issue status
- #2406 is advanced to the next minimal Phase E step after #2528.
- #2406 is not fully closed by this PR; legacy callers and broader old `rag_pipeline` decomposition remain follow-up work.

## Agent Handoff
- Status: code/CI merge-ready; Agent Handoff refreshed after latest head update.
- Base: `dev` at `c228cea1ed997c261e55bf923d3d9c0b2dd012b0`.
- Head: `worker-h-core-021-retrieval-phase-e`.
- Validated commit: `c4742bbd8a39908f4f8a2e312e48b096cf1c1d03`.
- Rebase/conflicts: rebase completed without conflicts; scope unchanged.
- GitHub checks: completed / green on validated commit `c4742bbd8a39908f4f8a2e312e48b096cf1c1d03`.
- Stale validation rerun:
  - ✅ `make test-core` (`66 passed`)
  - ✅ `uv run --no-sync pytest -o addopts='' tests/unit/retrieval/test_runtime_retrieval_service.py -q` (`6 passed`)
  - ✅ `uvx ruff check src/ telegram_bot/ mini_app/ services/ scripts/ --output-format=github`
  - ✅ `uvx ruff format --target-version py312 --check src/ telegram_bot/ mini_app/ services/ scripts/`
  - ✅ `uv lock --locked`
