### PR TITLE
fix(types): clear current core MyPy errors (#2474)

### DIFF
--- a/src/evaluation/generate_test_queries.py
+++ b/src/evaluation/generate_test_queries.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, Field
 from qdrant_client import QdrantClient, models
 
 from src.config import Settings
-from src.runtime.llm import create_litellm_chat_client
+from src.runtime.llm import LiteLLMChatClient, create_litellm_chat_client
 
 
 class GeneratedQueries(BaseModel):
@@ -94,7 +94,7 @@ def fetch_article_texts(collection_name: str, article_numbers: list[str]) -> dic
 
 
 async def generate_queries_for_article(
-    client: object, model: str, article_num: str, article_text: str
+    client: LiteLLMChatClient, model: str, article_num: str, article_text: str
 ) -> list[dict]:
     """
     Generate 3 types of queries for a single article.


### PR DESCRIPTION
## Agent Handoff

Issue: #2474
Base: `dev`
Head: `codex/2474-current-mypy-baseline`
Head SHA: `5fa1312ac21baa47ee9fbe76c87abf9a7d9aeb36`

## Refresh after #2547
- #2547 was merged into `dev` at `f4911a57a3ba516486980a66707f38cc746ae67c`.
- This branch was rebased onto refreshed `origin/dev`.
- The duplicate retrieval hunk was removed/reset to `dev`.
- Current PR diff is intentionally limited to `src/evaluation/generate_test_queries.py`.

## Summary
- Typed the synthetic query generation helper with the concrete `LiteLLMChatClient` so MyPy can see the OpenAI-shaped `.chat.completions.create(...)` surface.

## Current scope
- Leaves the retrieval-service change owned by merged PR #2547.
- Leaves optional/test-surface marker work out of scope.
- Fixes only the remaining `src/evaluation/generate_test_queries.py` type issue for #2474.

## Changed files
- `src/evaluation/generate_test_queries.py`

## Validation after refresh
- ✅ `uv run --no-sync mypy src/evaluation/generate_test_queries.py --ignore-missing-imports --no-error-summary`
- ✅ `uvx ruff check src/evaluation/generate_test_queries.py --output-format=github`
- ✅ `uvx ruff format --target-version py312 --check src/evaluation/generate_test_queries.py`
- ✅ `uvx ruff check src/ telegram_bot/ mini_app/ services/ scripts/ --output-format=github`
- ✅ `uvx ruff format --target-version py312 --check src/ telegram_bot/ mini_app/ services/ scripts/`
- ✅ `uv lock --locked`

## CI status
- GitHub required checks and CodeQL are completed / green on `5fa1312ac21baa47ee9fbe76c87abf9a7d9aeb36`.

Fixes #2474
