### PR TITLE
Keep Langfuse diagnostics optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,10 +286,10 @@ test-unit-extras: ## Run optional-extra unit tests only
 	PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/unit/ -n auto --dist=worksteal -q --timeout=30 -m "requires_extras"
 	@echo "$(GREEN)✓ Optional-extra unit tests complete$(NC)"
 
-test-contract: ## Run trace contract tests (static analysis, no Docker)
-	@echo "$(BLUE)Running trace contract tests...$(NC)"
+test-contract: ## Run static contract tests (no Docker; optional SDK lanes excluded by markers)
+	@echo "$(BLUE)Running static contract tests...$(NC)"
 	PYTHONDONTWRITEBYTECODE=1 $(UV_RUN_NO_SYNC) pytest tests/contract/ -n auto --dist=worksteal -q --timeout=30
-	@echo "$(GREEN)Trace contract tests complete$(NC)"
+	@echo "$(GREEN)Static contract tests complete$(NC)"
 
 test-benchmark: ## Run benchmark suite with the live ColBERT gate enabled (#1618)
 	@echo "$(BLUE)Running benchmark suite with RUN_BENCHMARK_TESTS=1...$(NC)"
@@ -1078,7 +1078,7 @@ endif
 		--output=reports/baseline-$(shell date +%Y%m%d-%H%M%S).html
 	@echo "$(GREEN)Report saved to reports/$(NC)"
 
-baseline-check: baseline-compile baseline-smoke ## Quick baseline check (smoke + compare with main)
+baseline-check: baseline-compile baseline-smoke ## Optional Langfuse baseline check (smoke + compare with main)
 	@echo "$(BLUE)Comparing with main baseline...$(NC)"
 	make baseline-compare BASELINE_TAG=main-latest CURRENT_SESSION=$(BASELINE_SESSION)
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -140,10 +140,14 @@ make eval-rag-quick          # 10-sample subset
 make eval-rag-full           # RAGAS + DeepEval
 ```
 
-### Baseline / observability
+### Optional baseline / observability
+These Langfuse-backed diagnostics are explicit operator lanes. They are not part
+of `make test`, `make test-core`, or the required static gates, and they should
+only be run when the optional observability stack is available.
+
 ```bash
-make baseline-smoke          # smoke with Langfuse tracing
-make baseline-compare        # compare against a baseline tag
+make baseline-smoke          # optional smoke with Langfuse tracing
+make baseline-compare        # optional compare against a baseline tag
 ```
 
 ### Compose validation (for runtime-impacting changes)

--- a/tests/contract/test_core_gate_optional_surfaces_contract.py
+++ b/tests/contract/test_core_gate_optional_surfaces_contract.py
@@ -45,6 +45,16 @@ OPTIONAL_TARGETS = (
     "test-observability-extra",
     "test-optional-surfaces",
 )
+OPTIONAL_OBSERVABILITY_DIAGNOSTIC_TARGETS = (
+    "baseline-smoke",
+    "baseline-load",
+    "baseline-check",
+)
+REQUIRED_GATE_TARGETS = (
+    "test",
+    "test-core",
+    "test-contract",
+)
 
 
 def _makefile_text() -> str:
@@ -96,3 +106,23 @@ def test_optional_surface_targets_are_explicit() -> None:
     for target in OPTIONAL_TARGETS:
         body = _target_body(text, target)
         assert "pytest" in body or target == "test-optional-surfaces"
+
+
+def test_langfuse_baseline_diagnostics_are_not_required_gate_dependencies() -> None:
+    """Langfuse-backed baseline checks remain explicit optional diagnostics."""
+
+    text = _makefile_text()
+
+    for target in OPTIONAL_OBSERVABILITY_DIAGNOSTIC_TARGETS:
+        assert re.search(rf"^{re.escape(target)}:", text, re.MULTILINE), (
+            f"Makefile must keep {target!r} as an explicit opt-in diagnostic target."
+        )
+
+    for target in REQUIRED_GATE_TARGETS:
+        body = _target_body(text, target)
+        offenders = [
+            optional for optional in OPTIONAL_OBSERVABILITY_DIAGNOSTIC_TARGETS if optional in body
+        ]
+        assert offenders == [], (
+            f"{target!r} must not depend on optional Langfuse diagnostics: {offenders}"
+        )


### PR DESCRIPTION
## Issue / Mode
- Issue Executor mode for #2452.
- Base branch: `dev`.
- Launch issue #2552 is coordination-only and is not closed by this PR.
- Fixes #2452.

## Changed files / Scope
- `Makefile`: clarifies `test-contract` as static contracts rather than trace contracts, and labels `baseline-check` as an optional Langfuse diagnostic lane.
- `tests/README.md`: documents Langfuse-backed baseline diagnostics as optional operator lanes, outside `make test`, `make test-core`, and required static gates.
- `tests/contract/test_core_gate_optional_surfaces_contract.py`: adds a contract that `baseline-smoke`, `baseline-load`, and `baseline-check` remain explicit opt-in diagnostics and are not dependencies of required gates.

## Validation
Passed:
- `uv run --no-sync ruff check tests/contract/test_core_gate_optional_surfaces_contract.py`
- `uv run --no-sync ruff format --check tests/contract/test_core_gate_optional_surfaces_contract.py`
- `uv run --no-sync --python 3.12 pytest tests/contract/test_core_gate_optional_surfaces_contract.py tests/contract/test_langfuse_optional_core_contract.py tests/contract/test_obsolete_observability_assets_removed_contract.py -q`
- `make test-core`

Warnings / baseline failures:
- `make test-contract` was attempted and still fails on existing baseline/environment issues outside this PR scope: missing optional `asyncpg` and `aiogram`, existing `test_no_get_event_loop` allowlist drift in `src/runtime/integrations/embeddings.py`, and unrelated Telegram extraction parity contract failures. The focused touched observability/core-gate contracts pass.

## Skipped checks + reason
- Optional Langfuse baseline diagnostics (`make baseline-smoke`, `make baseline-load`, `make baseline-check`) were not run because this PR only ensures they remain explicit opt-in lanes and the local environment does not provide the optional observability stack.
- Full optional observability lane was not run because no SDK behavior or optional unit tests changed.

## Remaining #2496 scope
- #2496 should be launched next as a focused no/low-code verification or cleanup pass over `tests/unit/observability/` and any remaining trace-validator test assets.
- Current evidence: graceful-degradation contracts remain in core/contract lanes, while SDK-backed observability unit tests are already behind `pytest.mark.requires_extras` and `make test-observability-extra`.

## Handoff
- Base: `dev`.
- Head: `worker-c-observability-2452`.
- Head SHA: `438d560`.
- #2452 can be closed by this PR if reviewers agree the remaining optional-diagnostics contract/documentation guard completes the re-scoped cleanup.
