### PR TITLE
Make broad unit optional lanes explicit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help install install-dev install-all lint format type-check security compile-python test test-full test-cov clean all-checks \
 	test-preflight test-smoke test-load-eviction \
-	test-telegram-adapter test-api-adapter test-ingest-extra test-voice-extra test-eval-extra test-observability-extra test-optional-surfaces \
+	test-telegram-adapter test-api-adapter test-providers-extra test-legacy-graph-extra test-ingest-extra test-voice-extra test-eval-extra test-observability-extra test-optional-surfaces \
 	smoke-fast smoke-zoo \
 	monitoring-up monitoring-down monitoring-logs monitoring-status monitoring-test-alert \
 	ingest-dir ingest-status ingest-services \
@@ -66,6 +66,59 @@ PYTEST_REQUIRES_EXTRAS_IGNORE := $(addprefix --ignore=, \
 	tests/unit/ingestion \
 	tests/unit/observability \
 	tests/unit/voice)
+# Explicit owner lanes for tests excluded from the lean broad unit lane.
+# Keep these variables in sync with the matching opt-in targets below.
+PYTEST_TELEGRAM_ADAPTER_PATHS := \
+	tests/unit/agents \
+	tests/unit/dialogs \
+	tests/unit/handlers \
+	tests/unit/keyboards \
+	tests/unit/middlewares \
+	tests/unit/pipelines \
+	tests/unit/services/test_catalog_rendering.py \
+	tests/unit/services/test_catalog_session.py \
+	tests/unit/services/test_draft_streamer_removed.py \
+	tests/unit/services/test_favorites_service.py \
+	tests/unit/services/test_kommo_models.py
+PYTEST_TELEGRAM_ADAPTER_ROOT_TESTS := \
+	tests/unit/test_*bot*.py \
+	tests/unit/test_bot*.py \
+	tests/unit/test_*callback*.py \
+	tests/unit/test_*catalog*.py \
+	tests/unit/test_*feedback*.py \
+	tests/unit/test_*handoff*.py \
+	tests/unit/test_*i18n*.py \
+	tests/unit/test_*menu*.py \
+	tests/unit/test_*preflight*.py \
+	tests/unit/test_*middlewares*.py \
+	tests/unit/test_agent_streaming.py \
+	tests/unit/test_card_context.py \
+	tests/unit/test_cmd_call.py \
+	tests/unit/test_docker_static_validation*.py \
+	tests/unit/test_error_handler.py \
+	tests/unit/test_feedback.py \
+	tests/unit/test_kommo_token_seed.py \
+	tests/unit/test_main.py \
+	tests/unit/test_perf_fixes.py \
+	tests/unit/test_results_pagination_bugs.py \
+	tests/unit/test_send_property_card.py \
+	tests/unit/test_thread_routing.py \
+	tests/unit/test_topic_service_init.py
+PYTEST_TELEGRAM_ADAPTER_IGNORE_GLOB := $(addprefix --ignore-glob=,$(PYTEST_TELEGRAM_ADAPTER_ROOT_TESTS))
+PYTEST_PROVIDER_CONTEXTUALIZATION_PATHS := \
+	tests/unit/contextualization \
+	tests/unit/test_claude_contextualizer.py \
+	tests/unit/test_contextualization_batch.py
+# Temporary #2526 partition only: these legacy graph/langgraph tests are owned
+# by the explicit lane below until the #2495 graph/API rewrite retargets them.
+PYTEST_LEGACY_GRAPH_PATHS := \
+	tests/unit/graph \
+	tests/unit/integrations \
+	tests/unit/test_latency_units.py
+PYTEST_OPTIONAL_ADAPTER_IGNORE := $(addprefix --ignore=,$(PYTEST_TELEGRAM_ADAPTER_PATHS))
+PYTEST_OPTIONAL_ADAPTER_IGNORE_GLOB := $(PYTEST_TELEGRAM_ADAPTER_IGNORE_GLOB)
+PYTEST_OPTIONAL_PROVIDER_IGNORE := $(addprefix --ignore=,$(PYTEST_PROVIDER_CONTEXTUALIZATION_PATHS) $(PYTEST_LEGACY_GRAPH_PATHS))
+
 
 
 help: ## Show this help message
@@ -213,7 +266,8 @@ test-core: ## Run monolith core-required tests only (local/manual)
 
 test-telegram-adapter: ## Run Telegram adapter unit tests explicitly
 	@echo "$(BLUE)Running Telegram adapter tests...$(NC)"
-	PYTHONDONTWRITEBYTECODE=1 $(UV_RUN_NO_SYNC) --python $(PYTHON_VERSION) pytest tests/unit/agents/ tests/unit/dialogs/ tests/unit/handlers/ tests/unit/middlewares/ tests/unit/pipelines/ tests/unit/test_bot*.py tests/unit/test_main.py tests/unit/test_middlewares_impl.py -q --timeout=30 -m "not legacy_api and not requires_extras and not slow"
+	uv sync --extra telegram --all-groups
+	PYTHONDONTWRITEBYTECODE=1 uv run pytest $(PYTEST_TELEGRAM_ADAPTER_PATHS) $(PYTEST_TELEGRAM_ADAPTER_ROOT_TESTS) -q --timeout=30 -m "not legacy_api and not requires_extras and not slow"
 	@echo "$(GREEN)✓ Telegram adapter tests complete$(NC)"
 
 test-api-adapter: ## Run API adapter unit tests explicitly
@@ -221,6 +275,18 @@ test-api-adapter: ## Run API adapter unit tests explicitly
 	uv sync --extra mini-app --all-groups
 	PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/unit/api/ -q --timeout=30
 	@echo "$(GREEN)✓ API adapter tests complete$(NC)"
+
+test-providers-extra: ## Run optional provider/contextualization tests explicitly
+	@echo "$(BLUE)Running providers-extra tests...$(NC)"
+	uv sync --extra providers --all-groups
+	PYTHONDONTWRITEBYTECODE=1 uv run pytest $(PYTEST_PROVIDER_CONTEXTUALIZATION_PATHS) -q --timeout=30 -m "not legacy_api and not slow"
+	@echo "$(GREEN)✓ Providers-extra tests complete$(NC)"
+
+test-legacy-graph-extra: ## Run temporary legacy graph/langgraph lane (#2495 follow-up) explicitly
+	@echo "$(BLUE)Running legacy graph-extra tests...$(NC)"
+	uv sync --extra providers --extra telegram --all-groups
+	PYTHONDONTWRITEBYTECODE=1 uv run pytest $(PYTEST_LEGACY_GRAPH_PATHS) -q --timeout=30 -m "not legacy_api and not slow"
+	@echo "$(GREEN)✓ Legacy graph-extra tests complete$(NC)"
 
 test-ingest-extra: ## Run optional ingestion-extra tests explicitly
 	@echo "$(BLUE)Running ingestion-extra tests...$(NC)"
@@ -246,7 +312,7 @@ test-observability-extra: ## Run optional observability-extra tests explicitly
 	PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/unit/observability/ -q --timeout=30
 	@echo "$(GREEN)✓ Observability-extra tests complete$(NC)"
 
-test-optional-surfaces: test-api-adapter test-ingest-extra test-voice-extra test-eval-extra test-observability-extra ## Run optional surface lanes explicitly
+test-optional-surfaces: test-api-adapter test-providers-extra test-legacy-graph-extra test-ingest-extra test-voice-extra test-eval-extra test-observability-extra ## Run optional surface lanes explicitly
 	@echo "$(GREEN)✓ Optional surface lanes complete$(NC)"
 
 test-full: ## Run full test suite with hybrid parallelism (all tiers)
@@ -266,12 +332,12 @@ test-cov: ## Run tests with coverage
 
 test-unit: ## Run broad unit test lane locally in parallel
 	@echo "$(BLUE)Running broad unit tests...$(NC)"
-	PYTHONDONTWRITEBYTECODE=1 $(UV_RUN_NO_SYNC) --python $(PYTHON_VERSION) pytest tests/unit/ $(PYTEST_REQUIRES_EXTRAS_IGNORE) $(PYTEST_PARALLEL_ARGS) -q --timeout=30 -m "not legacy_api and not requires_extras and not slow"
+	PYTHONDONTWRITEBYTECODE=1 $(UV_RUN_NO_SYNC) --python $(PYTHON_VERSION) pytest tests/unit/ $(PYTEST_REQUIRES_EXTRAS_IGNORE) $(PYTEST_OPTIONAL_ADAPTER_IGNORE) $(PYTEST_OPTIONAL_ADAPTER_IGNORE_GLOB) $(PYTEST_OPTIONAL_PROVIDER_IGNORE) $(PYTEST_PARALLEL_ARGS) -q --timeout=30 -m "not legacy_api and not requires_extras and not slow"
 	@echo "$(GREEN)✓ Broad unit tests complete$(NC)"
 
 test-unit-loadscope: ## Run unit tests with loadscope (faster fixture reuse locally)
 	@echo "$(BLUE)Running unit tests (loadscope)...$(NC)"
-	PYTHONDONTWRITEBYTECODE=1 $(UV_RUN_NO_SYNC) --python $(PYTHON_VERSION) pytest tests/unit/ $(PYTEST_REQUIRES_EXTRAS_IGNORE) -n auto --dist=loadscope -q --timeout=30 -m "not legacy_api and not requires_extras and not slow"
+	PYTHONDONTWRITEBYTECODE=1 $(UV_RUN_NO_SYNC) --python $(PYTHON_VERSION) pytest tests/unit/ $(PYTEST_REQUIRES_EXTRAS_IGNORE) $(PYTEST_OPTIONAL_ADAPTER_IGNORE) $(PYTEST_OPTIONAL_ADAPTER_IGNORE_GLOB) $(PYTEST_OPTIONAL_PROVIDER_IGNORE) -n auto --dist=loadscope -q --timeout=30 -m "not legacy_api and not requires_extras and not slow"
 	@echo "$(GREEN)✓ Unit tests (loadscope) complete$(NC)"
 
 test-unit-full: ## Run all unit tests including optional-dep tests (nightly/main)
@@ -298,12 +364,12 @@ test-benchmark: ## Run benchmark suite with the live ColBERT gate enabled (#1618
 
 test-fast: ## Run unit tests in parallel (honours $(PYTEST_PARALLEL_ARGS))
 	@echo "$(BLUE)Running unit tests in parallel...$(NC)"
-	PYTHONDONTWRITEBYTECODE=1 $(UV_RUN_NO_SYNC) --python $(PYTHON_VERSION) pytest tests/unit/ $(PYTEST_REQUIRES_EXTRAS_IGNORE) $(PYTEST_PARALLEL_ARGS) -q --timeout=30 -m "not legacy_api and not requires_extras and not slow"
+	PYTHONDONTWRITEBYTECODE=1 $(UV_RUN_NO_SYNC) --python $(PYTHON_VERSION) pytest tests/unit/ $(PYTEST_REQUIRES_EXTRAS_IGNORE) $(PYTEST_OPTIONAL_ADAPTER_IGNORE) $(PYTEST_OPTIONAL_ADAPTER_IGNORE_GLOB) $(PYTEST_OPTIONAL_PROVIDER_IGNORE) $(PYTEST_PARALLEL_ARGS) -q --timeout=30 -m "not legacy_api and not requires_extras and not slow"
 	@echo "$(GREEN)✓ Parallel tests complete$(NC)"
 
 test-all-fast: ## Run unit tests + critical graph-path integration tests in parallel (no smoke; smoke needs live services via 'make test-smoke')
 	@echo "$(BLUE)Running unit + critical graph-path integration tests in parallel...$(NC)"
-	PYTHONDONTWRITEBYTECODE=1 $(UV_RUN_NO_SYNC) --python $(PYTHON_VERSION) pytest tests/unit/ tests/integration/test_graph_paths.py $(PYTEST_REQUIRES_EXTRAS_IGNORE) $(PYTEST_PARALLEL_ARGS) -q --timeout=30 -m "not legacy_api and not requires_extras and not slow"
+	PYTHONDONTWRITEBYTECODE=1 $(UV_RUN_NO_SYNC) --python $(PYTHON_VERSION) pytest tests/unit/ tests/integration/test_graph_paths.py $(PYTEST_REQUIRES_EXTRAS_IGNORE) $(PYTEST_OPTIONAL_ADAPTER_IGNORE) $(PYTEST_OPTIONAL_ADAPTER_IGNORE_GLOB) $(PYTEST_OPTIONAL_PROVIDER_IGNORE) $(PYTEST_PARALLEL_ARGS) -q --timeout=30 -m "not legacy_api and not requires_extras and not slow"
 	@echo "$(GREEN)✓ All fast tests complete$(NC)"
 
 test-lf: ## Run only last failed tests (parallel)
@@ -318,7 +384,7 @@ test-ff: ## Run failed first, then rest
 
 test-profile: ## Profile slowest tests (find bottlenecks) — measures the same lane as test-unit
 	@echo "$(BLUE)Profiling slow tests...$(NC)"
-	PYTHONDONTWRITEBYTECODE=1 $(UV_RUN_NO_SYNC) --python $(PYTHON_VERSION) pytest tests/unit/ $(PYTEST_REQUIRES_EXTRAS_IGNORE) $(PYTEST_PARALLEL_ARGS) --durations=20 --durations-min=0.5 -q --timeout=30 -m "not legacy_api and not requires_extras and not slow"
+	PYTHONDONTWRITEBYTECODE=1 $(UV_RUN_NO_SYNC) --python $(PYTHON_VERSION) pytest tests/unit/ $(PYTEST_REQUIRES_EXTRAS_IGNORE) $(PYTEST_OPTIONAL_ADAPTER_IGNORE) $(PYTEST_OPTIONAL_ADAPTER_IGNORE_GLOB) $(PYTEST_OPTIONAL_PROVIDER_IGNORE) $(PYTEST_PARALLEL_ARGS) --durations=20 --durations-min=0.5 -q --timeout=30 -m "not legacy_api and not requires_extras and not slow"
 	@echo "$(GREEN)✓ Profile complete$(NC)"
 
 test-integration: ## Run graph path integration tests (no Docker, ~5s)

--- a/tests/README.md
+++ b/tests/README.md
@@ -43,7 +43,7 @@ because it includes optional adapter and extra-dependency surfaces.
 | What | Scope | Coverage threshold |
 |------|-------|--------------------|
 | `make test` | deterministic core gate (`make test-core`, `tests/integration/test_graph_paths.py`) | none |
-| `make test-unit` | broad unit lane (`tests/unit/`) excluding optional markers/paths | none |
+| `make test-unit` | broad unit lane (`tests/unit/`) excluding optional markers and explicit optional adapter/provider paths | none |
 | `make test-contract` | contract only (`tests/contract/`) | none |
 | Local PR readiness | focused checks + `make test`; run `make test-contract` when contract surfaces changed | coverage remains a separate `make test-cov` check |
 
@@ -86,12 +86,23 @@ PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit
 ```bash
 make test-telegram-adapter
 make test-api-adapter
+make test-providers-extra
+make test-legacy-graph-extra
 make test-ingest-extra
 make test-voice-extra
 make test-eval-extra
 make test-observability-extra
 make test-optional-surfaces
 ```
+
+Broad-unit exclusions are not silent coverage drops:
+
+| Owner lane | Excluded from `make test-unit` | Why |
+|---|---|---|
+| `make test-telegram-adapter` | Telegram adapter directories and root Telegram adapter test selectors | Requires the optional `telegram` extra (`aiogram`, `aiogram-dialog`, `asyncpg`) or Telegram bot import surface. |
+| `make test-providers-extra` | `tests/unit/contextualization/` and root contextualization provider tests | Requires optional provider SDKs (`anthropic`, `groq`). |
+| `make test-legacy-graph-extra` | `tests/unit/graph/`, `tests/unit/integrations/`, and root LangGraph runtime tests | Temporary #2526 partition for stale legacy graph/LangGraph coverage; this is not the #2495 graph/API rewrite. |
+
 
 ### Focused run (preferred while developing)
 ```bash

--- a/tests/contract/test_core_gate_optional_surfaces_contract.py
+++ b/tests/contract/test_core_gate_optional_surfaces_contract.py
@@ -27,9 +27,13 @@ OPTIONAL_SURFACE_TOKENS = (
     "tests/unit/ingestion",
     "tests/unit/evaluation",
     "tests/unit/observability",
+    "tests/unit/contextualization",
+    "tests/unit/graph",
     "tests/unit/mini_app",
     "test-telegram-adapter",
     "test-api-adapter",
+    "test-providers-extra",
+    "test-legacy-graph-extra",
     "test-ingest-extra",
     "test-voice-extra",
     "test-eval-extra",
@@ -39,6 +43,8 @@ OPTIONAL_SURFACE_TOKENS = (
 OPTIONAL_TARGETS = (
     "test-telegram-adapter",
     "test-api-adapter",
+    "test-providers-extra",
+    "test-legacy-graph-extra",
     "test-ingest-extra",
     "test-voice-extra",
     "test-eval-extra",
@@ -126,3 +132,32 @@ def test_langfuse_baseline_diagnostics_are_not_required_gate_dependencies() -> N
         assert offenders == [], (
             f"{target!r} must not depend on optional Langfuse diagnostics: {offenders}"
         )
+
+
+def test_broad_unit_exclusions_are_owned_by_explicit_lanes() -> None:
+    text = _makefile_text()
+
+    owner_vars = {
+        "PYTEST_TELEGRAM_ADAPTER_PATHS": "test-telegram-adapter",
+        "PYTEST_TELEGRAM_ADAPTER_ROOT_TESTS": "test-telegram-adapter",
+        "PYTEST_PROVIDER_CONTEXTUALIZATION_PATHS": "test-providers-extra",
+        "PYTEST_LEGACY_GRAPH_PATHS": "test-legacy-graph-extra",
+    }
+    broad_body = _target_body(text, "test-unit")
+
+    for var_name, owner_target in owner_vars.items():
+        var_ref = f"$({var_name})"
+        assert var_ref in text, f"{var_name} must remain defined in Makefile"
+        assert var_ref in _target_body(text, owner_target), (
+            f"{var_name} must be assigned to explicit owner lane {owner_target}"
+        )
+
+    telegram_body = _target_body(text, "test-telegram-adapter")
+    assert "--ignore" not in telegram_body
+    assert "$(PYTEST_TELEGRAM_ADAPTER_IGNORE_GLOB)" not in telegram_body
+
+    assert "$(PYTEST_OPTIONAL_ADAPTER_IGNORE)" in broad_body
+    assert "$(PYTEST_OPTIONAL_ADAPTER_IGNORE_GLOB)" in broad_body
+    assert "$(PYTEST_OPTIONAL_PROVIDER_IGNORE)" in broad_body
+    assert "$(PYTEST_TELEGRAM_ADAPTER_IGNORE_GLOB)" in text
+    assert "$(PYTEST_LEGACY_GRAPH_PATHS)" in _target_body(text, "test-legacy-graph-extra")


### PR DESCRIPTION
## Issue / Mode
- Issue: Fixes #2526 only.
- Mode: PR Coordinator follow-up for existing PR #2560.
- Base branch: `dev`.
- Out of scope: #2495 graph/API rewrite; #2551 launch issue closure; merge.

## Changed files / scope
- `Makefile`: keeps `make test-unit` lean by excluding optional/stale import-heavy lanes through owner variables, not ad-hoc hidden drops.
- `Makefile`: split Telegram root test selectors from broad-lane ignore selectors: `PYTEST_TELEGRAM_ADAPTER_ROOT_TESTS` is runnable, while `PYTEST_TELEGRAM_ADAPTER_IGNORE_GLOB` is only used by broad unit ignores.
- `Makefile`: `test-telegram-adapter` now runs `$(PYTEST_TELEGRAM_ADAPTER_PATHS) $(PYTEST_TELEGRAM_ADAPTER_ROOT_TESTS)` and does not pass `--ignore-glob` selectors.
- `Makefile`: `test-providers-extra` owns only provider/contextualization tests and was validated directly.
- `Makefile`: `test-legacy-graph-extra` remains a temporary explicit legacy graph/LangGraph lane for #2526 partitioning; this documents ownership without rewriting/deleting graph tests or starting #2495.
- `tests/contract/test_core_gate_optional_surfaces_contract.py`: pins optional targets and verifies broad-unit exclusions are assigned to explicit owner lanes; it now rejects satisfying Telegram owner-lane coverage through ignore flags.
- `tests/README.md`: documents owner lanes for broad-unit exclusions and clarifies the legacy graph lane is a temporary #2526 partition, not the #2495 rewrite.

## Duplicate PR preflight
- Reused existing PR #2560: https://github.com/yastman/rag/pull/2560.
- No duplicate PR was created.
- PR base/head verified as `dev` ← `codex/2526-broad-unit-lane`.

## Validation
Validated on commit `b7f64f84fd94029a76775b9a52ad5d1813c519a5`.

Passed:
- `git diff --check`
- `uv run --no-sync --python 3.12 pytest tests/contract/test_core_gate_optional_surfaces_contract.py tests/unit/test_dependency_extras_contract.py -q` (`10 passed`)
- `make test-providers-extra` (`139 passed, 18 deselected`)
- `make test-core` (`66 passed`)
- `uvx ruff check src/ telegram_bot/ mini_app/ services/ scripts/ --output-format=github`
- `uvx ruff format --target-version py312 --check src/ telegram_bot/ mini_app/ services/ scripts/`
- `uv lock --locked`

Failed with classified baseline/optional failures:
- `make test-telegram-adapter`
  - Result: collection failed with 10 import errors.
  - First error group: `tests/unit/agents/*` imports `langchain` / `langchain_core`, which are not in the current project optional extras or lockfile.
  - Classification: `optional_dependency_or_legacy_baseline`, not PR-caused by this selector fix. The command now proves the root Telegram selectors are runnable selectors and are no longer re-ignored by `test-telegram-adapter`.
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit`
  - Result: `4 failed, 3278 passed, 44 skipped`.
  - Classification: `stale_legacy_baseline`, not PR-caused; the PR removes optional/stub collection noise and leaves actionable legacy/baseline assertions.

## Skipped checks + reason
- `make test-optional-surfaces` was intentionally skipped. It is an aggregate optional lane that now includes multiple extras and the temporary legacy graph lane; direct validation of the changed/new owner lanes was run/classified via `make test-telegram-adapter` and `make test-providers-extra`.
- `make test-legacy-graph-extra` was not run to avoid expanding #2526 into #2495 graph/API rewrite validation. The lane is explicit owner mapping for excluded legacy graph tests and is documented as temporary #2495 follow-up.
- `make test-full` was not run per heavy-suite policy and worker instructions.

## Failed checks triage
`make test-telegram-adapter` representative failures:
- `tests/unit/agents/middleware/test_classify_middleware.py` — `ModuleNotFoundError: No module named 'langchain'`.
- `tests/unit/agents/test_crm_tools.py` and similar agent tests — `ModuleNotFoundError: No module named 'langchain_core'`.
- Classification: `optional_dependency_or_legacy_baseline`; the PR does not add optional dependencies blindly.

`PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit` remaining failures:
- `tests/unit/test_bug_class_registry_contract.py::test_pr_template_has_validation_and_runtime_fields` — `stale_legacy_baseline`; expects legacy PR-template headings in a process/control-plane file outside #2526 scope.
- `tests/unit/scripts/test_check_markdown_links.py::test_current_repository_markdown_links_are_valid` — `stale_legacy_baseline`; archive Mini App README links to missing `archive/DOCKER.md` outside #2526 scope.
- `tests/unit/test_voyage_optional_imports.py::test_voyage_extra_declared_in_root_pyproject` — `stale_legacy_baseline`; expects removed `voyage` extra outside #2526 scope.
- `tests/unit/test_voyage_optional_imports.py::test_voyage_extra_declared_in_telegram_bot_pyproject` — `stale_legacy_baseline`; expects removed `voyage` extra outside #2526 scope.

## Risk / rollback
- Risk: test-gate partitioning. Coverage is preserved through explicit owner lanes rather than broad-unit collection.
- Rollback: revert this PR to restore the previous broad-unit collection and optional target shape.

## Follow-up issues / known baselines
- #2495 remains the follow-up owner for graph/API rewrite work. This PR only creates a temporary explicit legacy graph lane; it does not rewrite/delete graph tests.
- Follow-up recommended for Telegram/agent tests that still require removed or untracked LangChain/LangGraph dependencies.
- Follow-up recommended for stale broad-unit baseline assertions listed above: PR-template contract, archive README link, and removed `voyage` extra assertions.

## Agent Handoff

Status: blocked-on-known-baseline
Base: dev
Head: codex/2526-broad-unit-lane
Validated commit: b7f64f84fd94029a76775b9a52ad5d1813c519a5
Risk: test
Failure class: optional_dependency_or_legacy_baseline / stale_legacy_baseline

## Validation checklist

- [x] Focused contract validation passed.
- [x] Telegram selector blocker fixed: owner lane uses runnable root selectors, not `--ignore-glob` flags.
- [x] New provider target validated directly.
- [x] `make test-core` passed.
- [x] Static CI-equivalent commands passed.
- [x] Broad unit lane no longer fails mainly on optional dependency/stub collection noise.
- [ ] `make test-telegram-adapter` fully green — blocked by LangChain/LangGraph optional dependency/legacy baseline errors.
- [ ] Broad unit lane fully green — blocked by known/actionable stale baselines above.

## Findings

- Every new broad-unit exclusion is assigned to an explicit owner lane:
  - Telegram adapter paths and root runnable selectors → `make test-telegram-adapter`.
  - Provider/contextualization paths → `make test-providers-extra`.
  - Legacy graph/LangGraph paths → `make test-legacy-graph-extra` as a temporary #2495 follow-up lane.
- `test-telegram-adapter` no longer uses ignore flags to satisfy ownership; it now attempts to collect/run the root Telegram adapter selectors and exposes the next dependency/baseline group.
- `test-providers-extra` is split from legacy graph coverage to avoid confusing #2526 provider optionalization with #2495 graph/API rewrite.
- #2495 is safe to launch after #2560 merges from a sequencing perspective, but only if the orchestrator explicitly relaunches it.

## Next action

- Re-check PR head is `b7f64f84fd94029a76775b9a52ad5d1813c519a5` and required GitHub checks are green after the amended push.
- Review/merge decision should account for documented `make test-telegram-adapter` optional dependency/legacy baseline errors and `make test-unit` stale baseline failures.
- Do not merge unless explicitly instructed.

