### PR TITLE
CORE-021: route graph retrieval callers

### DIFF
--- a/src/runtime/retrieval/service.py
+++ b/src/runtime/retrieval/service.py
@@ -31,6 +31,9 @@ class VectorRetrievalRequest:
     return_meta: bool = False
     dense_weight: float | None = None
     sparse_weight: float | None = None
+    prefetch_multiplier: int | None = None
+    group_by: str | None = None
+    group_size: int | None = None
 
 
 @dataclass(frozen=True)
@@ -71,6 +74,12 @@ class RetrievalService:
             search_kwargs["dense_weight"] = request.dense_weight
         if request.sparse_weight is not None:
             search_kwargs["sparse_weight"] = request.sparse_weight
+        if request.prefetch_multiplier is not None:
+            search_kwargs["prefetch_multiplier"] = request.prefetch_multiplier
+        if request.group_by is not None:
+            search_kwargs["group_by"] = request.group_by
+        if request.group_size is not None:
+            search_kwargs["group_size"] = request.group_size
 
         has_colbert_search = callable(getattr(self._qdrant, "hybrid_search_rrf_colbert", None))
         if request.colbert_query and has_colbert_search:

--- a/telegram_bot/graph/nodes/retrieve.py
+++ b/telegram_bot/graph/nodes/retrieve.py
@@ -1,8 +1,8 @@
 """Retrieve node for RAG LangGraph pipeline.
 
-Performs hybrid RRF search via QdrantService with search cache integration.
-Uses direct Qdrant SDK (NOT langchain_qdrant) for full control over
-prefetch, FusionQuery, and ColBERT reranking.
+Performs hybrid RRF search through the runtime RetrievalService seam with
+search cache integration. The underlying Qdrant gateway still owns prefetch,
+FusionQuery, and ColBERT reranking details.
 """
 
 from __future__ import annotations
@@ -13,6 +13,7 @@ import logging
 import time
 from typing import Any
 
+from src.runtime.retrieval import RetrievalService, VectorRetrievalRequest
 from telegram_bot.observability import get_client, observe
 from telegram_bot.services.coverage_mode import cap_results_per_doc, detect_coverage_mode
 from telegram_bot.services.metrics import PipelineMetrics
@@ -64,7 +65,7 @@ async def retrieve_node(
     Flow:
       1. Check search cache (by embedding prefix + filters)
       2. If miss: get sparse embedding (cached or compute)
-      3. Call qdrant.hybrid_search_rrf()
+      3. Call RetrievalService.retrieve_vectors()
       4. Cache results
 
     Args:
@@ -254,38 +255,45 @@ async def retrieve_node(
             sparse_vector = await sparse_embeddings.aembed_query(query)
             await cache.store_sparse_embedding(query, sparse_vector)
 
-    # Step 3: Hybrid search via Qdrant SDK
+    # Step 3: Hybrid search via the shared runtime retrieval seam
+    retrieval = RetrievalService(qdrant=qdrant)
     if needs_coverage:
-        qdrant_result = await qdrant.hybrid_search_rrf(
-            dense_vector=dense_vector,
-            sparse_vector=sparse_vector,
-            filters=retrieval_filters,
-            top_k=10,
-            prefetch_multiplier=7,
-            group_by="metadata.doc_id",
-            group_size=2,
-            return_meta=True,
+        qdrant_result = await retrieval.retrieve_vectors(
+            VectorRetrievalRequest(
+                dense_vector=dense_vector,
+                sparse_vector=sparse_vector,
+                filters=retrieval_filters,
+                top_k=10,
+                prefetch_multiplier=7,
+                group_by="metadata.doc_id",
+                group_size=2,
+                return_meta=True,
+            )
         )
         rerank_applied = False
     elif colbert_query and _has_colbert_search:
         # 3-stage: dense+sparse -> RRF -> ColBERT MaxSim (server-side)
-        qdrant_result = await qdrant.hybrid_search_rrf_colbert(
-            dense_vector=dense_vector,
-            sparse_vector=sparse_vector,
-            colbert_query=colbert_query,
-            filters=retrieval_filters,
-            top_k=top_k,
-            return_meta=True,
+        qdrant_result = await retrieval.retrieve_vectors(
+            VectorRetrievalRequest(
+                dense_vector=dense_vector,
+                sparse_vector=sparse_vector,
+                colbert_query=colbert_query,
+                filters=retrieval_filters,
+                top_k=top_k,
+                return_meta=True,
+            )
         )
         rerank_applied = True
     else:
         # 2-stage fallback: dense+sparse -> RRF
-        qdrant_result = await qdrant.hybrid_search_rrf(
-            dense_vector=dense_vector,
-            sparse_vector=sparse_vector,
-            filters=retrieval_filters,
-            top_k=top_k,
-            return_meta=True,
+        qdrant_result = await retrieval.retrieve_vectors(
+            VectorRetrievalRequest(
+                dense_vector=dense_vector,
+                sparse_vector=sparse_vector,
+                filters=retrieval_filters,
+                top_k=top_k,
+                return_meta=True,
+            )
         )
         rerank_applied = False
     if isinstance(qdrant_result, tuple) and len(qdrant_result) == 2:

--- a/telegram_bot/graph/tools/retrieve.py
+++ b/telegram_bot/graph/tools/retrieve.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field, create_model
 
+from src.runtime.retrieval import RetrievalService, VectorRetrievalRequest
 from telegram_bot.agents.tooling import BaseTool, tool
 
 
@@ -74,9 +75,8 @@ def make_retrieve_tool(
     """Return a ``BaseTool`` wrapping hybrid retrieval.
 
     Args:
-        qdrant: Object exposing ``hybrid_search_rrf_colbert(dense_query=,
-            sparse_query=, colbert_query=, k=)`` — typically the production
-            ``src.runtime.services.qdrant.QdrantService`` instance.
+        qdrant: Object exposing the ``src.runtime.services.qdrant.QdrantService``
+            hybrid retrieval methods used by ``src.runtime.retrieval.RetrievalService``.
         embed_query: Async callable that returns an object with ``dense``,
             ``sparse`` and ``colbert`` attributes (the unified query
             embeddings bundle used by the rest of the runtime).
@@ -101,11 +101,14 @@ def make_retrieve_tool(
             return []
 
         try:
-            response = await qdrant.hybrid_search_rrf_colbert(
-                dense_query=getattr(embeddings, "dense", None),
-                sparse_query=getattr(embeddings, "sparse", None),
-                colbert_query=getattr(embeddings, "colbert", None),
-                k=k,
+            retrieval = RetrievalService(qdrant=qdrant)
+            response = await retrieval.retrieve_vectors(
+                VectorRetrievalRequest(
+                    dense_vector=getattr(embeddings, "dense", None) or [],
+                    sparse_vector=getattr(embeddings, "sparse", None),
+                    colbert_query=getattr(embeddings, "colbert", None),
+                    top_k=k,
+                )
             )
         except Exception:
             logger.warning("retrieve_documents: qdrant search failed", exc_info=True)

--- a/tests/unit/graph/test_retrieve_node.py
+++ b/tests/unit/graph/test_retrieve_node.py
@@ -3,22 +3,21 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from langgraph.runtime import Runtime
 
 from telegram_bot.graph.nodes.retrieve import retrieve_node
 from telegram_bot.graph.state import make_initial_state
 
 
-def _make_runtime(cache=None, sparse_embeddings=None, qdrant=None, embeddings=None) -> Runtime:
-    """Create a Runtime with GraphContext for retrieve_node tests."""
-    return Runtime(
-        context={
-            "cache": cache,
-            "sparse_embeddings": sparse_embeddings,
-            "qdrant": qdrant,
-            "embeddings": embeddings,
-        }
-    )
+def _make_runtime(cache=None, sparse_embeddings=None, qdrant=None, embeddings=None):
+    """Create a minimal runtime context for retrieve_node tests."""
+    runtime = MagicMock()
+    runtime.context = {
+        "cache": cache,
+        "sparse_embeddings": sparse_embeddings,
+        "qdrant": qdrant,
+        "embeddings": embeddings,
+    }
+    return runtime
 
 
 _OK_META = {"backend_error": False, "error_type": None, "error_message": None}
@@ -957,3 +956,106 @@ class TestRetrieveNodeBundle:
         store_call = cache.store_search_results.await_args
         profile = store_call.kwargs.get("filters") or store_call.args[1]
         assert profile["mode"] == "colbert"
+
+
+class TestRetrieveNodeRetrievalServiceSeam:
+    """Focused seam tests for #2406 Telegram retrieval routing."""
+
+    async def test_rrf_path_calls_retrieval_service_retrieve_vectors(self) -> None:
+        state = make_initial_state(user_id=1, session_id="s1", query="ordinary query")
+        state["query_type"] = "GENERAL"
+        state["query_embedding"] = [0.1] * 1024
+        state["filters"] = {"city": "Sofia"}
+        sparse = {"indices": [1], "values": [0.5]}
+
+        cache = AsyncMock()
+        cache.get_search_results = AsyncMock(return_value=None)
+        cache.get_sparse_embedding = AsyncMock(return_value=sparse)
+        cache.store_search_results = AsyncMock()
+        qdrant = MagicMock()
+
+        service = MagicMock()
+        service.retrieve_vectors = AsyncMock(return_value=(_make_docs(2), _OK_META))
+        with patch("telegram_bot.graph.nodes.retrieve.RetrievalService", return_value=service):
+            result = await retrieve_node(
+                state,
+                _make_runtime(cache=cache, sparse_embeddings=AsyncMock(), qdrant=qdrant),
+                top_k=7,
+            )
+
+        service.retrieve_vectors.assert_awaited_once()
+        request = service.retrieve_vectors.await_args.args[0]
+        assert request.dense_vector == state["query_embedding"]
+        assert request.sparse_vector == sparse
+        assert request.filters == state["filters"]
+        assert request.top_k == 7
+        assert request.return_meta is True
+        assert request.colbert_query is None
+        assert result["rerank_applied"] is False
+
+    async def test_colbert_path_calls_retrieval_service_retrieve_vectors(self) -> None:
+        colbert_query = [[0.2, 0.3]]
+        state = make_initial_state(user_id=1, session_id="s1", query="semantic query")
+        state["query_type"] = "GENERAL"
+        state["query_embedding"] = [0.1] * 1024
+        state["colbert_query"] = colbert_query
+        sparse = {"indices": [2], "values": [0.7]}
+
+        cache = AsyncMock()
+        cache.get_search_results = AsyncMock(return_value=None)
+        cache.get_sparse_embedding = AsyncMock(return_value=sparse)
+        cache.store_search_results = AsyncMock()
+        qdrant = MagicMock()
+        qdrant.hybrid_search_rrf_colbert = AsyncMock()
+
+        service = MagicMock()
+        service.retrieve_vectors = AsyncMock(return_value=(_make_docs(1), _OK_META))
+        with patch("telegram_bot.graph.nodes.retrieve.RetrievalService", return_value=service):
+            result = await retrieve_node(
+                state,
+                _make_runtime(cache=cache, sparse_embeddings=AsyncMock(), qdrant=qdrant),
+                top_k=9,
+            )
+
+        service.retrieve_vectors.assert_awaited_once()
+        request = service.retrieve_vectors.await_args.args[0]
+        assert request.dense_vector == state["query_embedding"]
+        assert request.sparse_vector == sparse
+        assert request.colbert_query == colbert_query
+        assert request.top_k == 9
+        assert request.return_meta is True
+        assert result["rerank_applied"] is True
+
+    async def test_coverage_path_calls_retrieval_service_with_grouped_rrf(self) -> None:
+        state = make_initial_state(user_id=1, session_id="s1", query="перечисли все основания")
+        state["query_type"] = "GENERAL"
+        state["query_embedding"] = [0.1] * 1024
+        state["colbert_query"] = [[0.2, 0.3]]
+        sparse = {"indices": [3], "values": [0.9]}
+
+        cache = AsyncMock()
+        cache.get_search_results = AsyncMock(return_value=None)
+        cache.get_sparse_embedding = AsyncMock(return_value=sparse)
+        cache.store_search_results = AsyncMock()
+        qdrant = MagicMock()
+        qdrant.hybrid_search_rrf_colbert = AsyncMock()
+
+        service = MagicMock()
+        service.retrieve_vectors = AsyncMock(return_value=(_make_docs(3), _OK_META))
+        with patch("telegram_bot.graph.nodes.retrieve.RetrievalService", return_value=service):
+            result = await retrieve_node(
+                state,
+                _make_runtime(cache=cache, sparse_embeddings=AsyncMock(), qdrant=qdrant),
+                top_k=20,
+            )
+
+        service.retrieve_vectors.assert_awaited_once()
+        request = service.retrieve_vectors.await_args.args[0]
+        assert request.top_k == 10
+        assert request.prefetch_multiplier == 7
+        assert request.group_by == "metadata.doc_id"
+        assert request.group_size == 2
+        assert request.return_meta is True
+        assert request.colbert_query is None
+        assert result["needs_coverage"] is True
+        assert result["rerank_applied"] is False

--- a/tests/unit/graph/tools/test_retrieve_tool.py
+++ b/tests/unit/graph/tools/test_retrieve_tool.py
@@ -171,3 +171,67 @@ class TestRetrieveToolFailure:
         t = _make_tool(qdrant_raises=True)
         result = await t(query="test", k=5)
         assert result == []
+
+
+class TestRetrieveToolRetrievalServiceSeam:
+    @pytest.mark.asyncio
+    async def test_routes_through_retrieval_service_and_preserves_normalization(self):
+        class _ScoredPoint:
+            id = "pt1"
+            score = 0.8
+            payload = {"text": "doc content"}
+
+        async def embed(query: str):
+            emb = MagicMock()
+            emb.dense = [0.1, 0.2]
+            emb.sparse = {"indices": [1], "values": [0.5]}
+            emb.colbert = [[0.3, 0.4]]
+            return emb
+
+        service = MagicMock()
+        service.retrieve_vectors = AsyncMock(return_value=([_ScoredPoint()], {"total": 1}))
+        qdrant = MagicMock()
+
+        from telegram_bot.graph.tools import retrieve as retrieve_module
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(
+                retrieve_module,
+                "RetrievalService",
+                MagicMock(return_value=service),
+            )
+            tool = make_retrieve_tool(qdrant=qdrant, embed_query=embed)
+            result = await tool(query="test", k=3)
+
+        service.retrieve_vectors.assert_awaited_once()
+        request = service.retrieve_vectors.await_args.args[0]
+        assert request.dense_vector == [0.1, 0.2]
+        assert request.sparse_vector == {"indices": [1], "values": [0.5]}
+        assert request.colbert_query == [[0.3, 0.4]]
+        assert request.top_k == 3
+        assert result == [{"id": "pt1", "score": 0.8, "text": "doc content"}]
+
+    @pytest.mark.asyncio
+    async def test_retrieval_service_failure_returns_empty_list(self):
+        async def embed(query: str):
+            emb = MagicMock()
+            emb.dense = [0.1]
+            emb.sparse = None
+            emb.colbert = None
+            return emb
+
+        service = MagicMock()
+        service.retrieve_vectors = AsyncMock(side_effect=RuntimeError("qdrant failure"))
+
+        from telegram_bot.graph.tools import retrieve as retrieve_module
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(
+                retrieve_module,
+                "RetrievalService",
+                MagicMock(return_value=service),
+            )
+            tool = make_retrieve_tool(qdrant=MagicMock(), embed_query=embed)
+            result = await tool(query="test", k=5)
+
+        assert result == []

--- a/tests/unit/retrieval/test_runtime_retrieval_service.py
+++ b/tests/unit/retrieval/test_runtime_retrieval_service.py
@@ -168,6 +168,40 @@ async def test_retrieve_vectors_routes_precomputed_colbert_without_generation() 
 
 
 @pytest.mark.asyncio
+async def test_retrieve_vectors_forwards_rrf_grouping_options() -> None:
+    qdrant = RecordingQdrant()
+    service = RetrievalService(qdrant=qdrant)  # type: ignore[arg-type]
+
+    await service.retrieve_vectors(
+        VectorRetrievalRequest(
+            dense_vector=[0.1],
+            sparse_vector={"indices": [1], "values": [0.2]},
+            top_k=10,
+            return_meta=True,
+            prefetch_multiplier=7,
+            group_by="metadata.doc_id",
+            group_size=2,
+        )
+    )
+
+    assert qdrant.calls == [
+        (
+            "rrf",
+            {
+                "dense_vector": [0.1],
+                "sparse_vector": {"indices": [1], "values": [0.2]},
+                "filters": None,
+                "top_k": 10,
+                "return_meta": True,
+                "prefetch_multiplier": 7,
+                "group_by": "metadata.doc_id",
+                "group_size": 2,
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
 async def test_retrieve_requires_embeddings_for_query_vectorization() -> None:
     service = RetrievalService(qdrant=RecordingQdrant())  # type: ignore[arg-type]
 


### PR DESCRIPTION
## Issue / Mode
- Mode: PR Coordinator fix for existing PR #2569 only
- Issue: Refs #2406
- Base: `dev`
- Head: `worker-e-core-021-retrieval-callers`
- Queue guard: #2487 remains queued and was not started or touched.

## Summary
- Extended `VectorRetrievalRequest` so grouped/coverage RRF options can pass through the pure `src.runtime.retrieval` seam.
- Routed Telegram graph retrieve-node vector searches through `RetrievalService.retrieve_vectors()` while preserving cache, coverage grouping, ColBERT, metadata, and fallback behavior.
- Routed the retrieve-documents tool through `RetrievalService.retrieve_vectors()` instead of calling Qdrant directly.
- Added focused seam coverage proving Telegram node/tool callers invoke `RetrievalService.retrieve_vectors()` with the expected `VectorRetrievalRequest` shapes.

## Changed files / scope
- `src/runtime/retrieval/service.py`
- `telegram_bot/graph/nodes/retrieve.py`
- `telegram_bot/graph/tools/retrieve.py`
- `tests/unit/retrieval/test_runtime_retrieval_service.py`
- `tests/unit/graph/test_retrieve_node.py`
- `tests/unit/graph/tools/test_retrieve_tool.py`

## Duplicate PR preflight
- Re-checked #2406 is open and active; #2487 is open but queued.
- Searched open PRs targeting `dev` for #2406 / CORE-021 / RetrievalService / route graph retrieval callers terms.
- Only active PR found for this #2406 slice: #2569 (`worker-e-core-021-retrieval-callers`).

## TDD red/green notes
- Red / pre-fix gap: focused validation for `tests/unit/graph/test_retrieve_node.py` was blocked by a missing `langgraph` test import, and caller seam coverage only validated `VectorRetrievalRequest` option forwarding rather than Telegram caller routing.
- Green / post-fix: replaced the test-only `langgraph.runtime.Runtime` dependency with a minimal runtime-context test double and added node seam tests for non-cache RRF, ColBERT, and coverage paths.
- Green / post-fix: added retrieve-tool seam tests proving `make_retrieve_tool(...).retrieve_documents` routes through `RetrievalService.retrieve_vectors()`, preserves `VectorRetrievalRequest` dense/sparse/ColBERT/top_k values, normalizes returned scored-point-like objects, and returns `[]` on retrieval-service failure.

## Validation
- ✅ `uv run pytest -o addopts='' tests/unit/retrieval/test_runtime_retrieval_service.py tests/unit/graph/test_retrieve_node.py tests/unit/graph/tools/test_retrieve_tool.py -q` (`50 passed`)
- ✅ `make test-core` (`66 passed`)
- ✅ `make check` (Ruff passed; MyPy completed with existing annotation-unchecked notes only)
- ✅ `uv run pytest tests/integration/test_graph_paths.py -n auto --dist=worksteal -q` (`5 passed`)
- ✅ `uvx ruff check src/ telegram_bot/ mini_app/ services/ scripts/ --output-format=github`
- ✅ `uvx ruff format --target-version py312 --check src/ telegram_bot/ mini_app/ services/ scripts/` (`419 files already formatted`)
- ✅ `uv lock --locked`
- ⚠️ `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit` hit existing baseline failures outside this PR: broken markdown link in `archive/mini_app/frontend/README.md`, PR template field contract, and missing `voyage` optional extras in root/telegram pyprojects. It otherwise ran `3279 passed, 44 skipped` before reporting 4 unrelated failures.

## Skipped checks + reason
- Heavy/full/live Docker checks were not run; per repo policy they are manual-only unless explicitly requested.

## Failed checks triage
- `PYTEST_ADDOPTS='-n auto --dist=worksteal' make test-unit` failures are unrelated baseline/process/dependency issues and are outside the allowed #2406 scope for this PR:
  - `tests/unit/scripts/test_check_markdown_links.py::test_current_repository_markdown_links_are_valid` — `archive/mini_app/frontend/README.md` link to `../../DOCKER.md` resolves to missing `archive/DOCKER.md`.
  - `tests/unit/test_bug_class_registry_contract.py::test_pr_template_has_validation_and_runtime_fields` — `.github/pull_request_template.md` missing lightweight reviewer field `Checks run`.
  - `tests/unit/test_voyage_optional_imports.py::test_voyage_extra_declared_in_root_pyproject` — root `pyproject.toml` missing `voyage = [` optional extra.
  - `tests/unit/test_voyage_optional_imports.py::test_voyage_extra_declared_in_telegram_bot_pyproject` — `telegram_bot/pyproject.toml` missing `voyage = [` optional extra.

## Risk / rollback
- Risk: Low-medium. Runtime behavior is intended to be unchanged because `RetrievalService` delegates to the same Qdrant gateway methods and now forwards the coverage/grouping options needed by existing callers.
- Rollback: revert the commits in this PR to restore direct Telegram graph Qdrant calls and remove the added seam tests.

## Agent Handoff
- Status: clean; required CI and CodeQL are green on the validated commit.
- Base: `dev`
- Head: `worker-e-core-021-retrieval-callers`
- Validated commit: `93725df577c9e5efb371301f176b5f6aafa3a25e`
- Risk: Low-medium runtime seam change with focused caller-seam coverage.
- Failure class: `baseline_unrelated` for broad `make test-unit`; focused seam tests and required static checks passed on the validated commit.
- Validation checklist:
  - ✅ Focused retrieval/node/tool seam pytest passed on validated commit.
  - ✅ `make test-core` passed on validated commit.
  - ✅ `make check` passed on validated commit.
  - ⚠️ Broad `make test-unit` has unrelated baseline failures documented above.
  - ✅ Graph-path integration smoke passed on validated commit.
  - ✅ Required static/format/lock checks passed on validated commit.
- Findings:
  - #2406 is open and active.
  - #2487 remains queued and untouched.
  - Duplicate PR preflight found only #2569 for this #2406 slice.
  - Retrieval responsibilities route through `src.runtime.retrieval.RetrievalService` seams.
  - Generation remains owned outside `src.runtime.retrieval`.
  - No broad `rag_pipeline` rewrite and no #2406/#2487 mixing.
- Next action: ready for ORCH final review and human merge decision. Do not merge unless explicitly instructed.
