### PR TITLE
PROCESS: require coverage-preservation map before test deletion

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,6 +28,26 @@ Skipped:
 Reason for skipped checks:
 -
 
+## coverage-preservation map
+Required before deleting, moving, skipping, xfail-ing, retargeting, or weakening
+tests. Delete this section only when no tests are deleted or weakened.
+
+- deleted test path:
+- old assertion / behavior / contract:
+- whether behavior still exists on current `dev`:
+- current adjacent surfaces checked:
+- replacement or preserved coverage:
+- focused validation command:
+- follow-up issue if coverage is intentionally deferred:
+
+Loop-break ownership:
+- worker prompt:
+- TDD/focused tests:
+- PR body:
+- reviewer:
+- no-code closeout:
+- orchestrator close decision:
+
 ## Risk / rollback
 -
 

--- a/docs/engineering/codex-web-prompt.md
+++ b/docs/engineering/codex-web-prompt.md
@@ -103,6 +103,35 @@ When validation fails, classify before fixing:
 
 Never expand a PR just to make a broad suite green unless the user explicitly asks for a baseline cleanup PR.
 
+## Test Coverage Preservation Guard
+
+Before deleting, moving, skipping, xfail-ing, retargeting, or weakening any
+test, the worker prompt owner must require a coverage-preservation map in the PR
+body. The map must prove whether the old assertion / behavior / contract still
+exists on current `dev`, which current adjacent surfaces were checked, and
+which replacement or preserved coverage keeps the behavior tested.
+
+Loop-break ownership:
+- worker prompt: require the coverage-preservation map before test deletion or
+  weakening work starts;
+- TDD/focused tests: prove replacement coverage with a focused validation
+  command, or keep the PR blocked;
+- PR body: record the map fields and any intentionally deferred coverage;
+- reviewer: reject missing or vague maps before approving;
+- no-code closeout: may close only when the map proves no code/test change is
+  needed;
+- orchestrator close decision: may close the issue only after merge or accepted
+  no-code evidence references the map.
+
+Required map fields:
+- deleted test path;
+- old assertion / behavior / contract;
+- whether behavior still exists on current `dev`;
+- current adjacent surfaces checked;
+- replacement or preserved coverage;
+- focused validation command;
+- follow-up issue if coverage is intentionally deferred.
+
 ## Pre-PR Validation Loop
 
 Before opening or marking a PR ready:

--- a/docs/engineering/gh-pr-review.md
+++ b/docs/engineering/gh-pr-review.md
@@ -195,6 +195,26 @@ If adjacent tests assert the old contract, classify the finding as `stale_test` 
 
 Focused validation must include the retargeted adjacent test file. The PR body `Changed files / scope`, `Validation`, and Agent Handoff must also include the retargeted test file before status can become `clean`.
 
+### Coverage-preservation map guard
+
+Before approving any PR that is deleting, moving, skipping, xfail-ing,
+retargeting, or weakening tests, the reviewer must require a
+coverage-preservation map in the PR
+body. The map must include: deleted test path; old assertion / behavior /
+contract; whether behavior still exists on current `dev`; current adjacent
+surfaces checked; replacement or preserved coverage; focused validation command;
+and follow-up issue if coverage is intentionally deferred.
+
+Loop-break ownership:
+- worker prompt: tells the worker to prepare the map before test deletion or
+  weakening;
+- TDD/focused tests: demonstrates replacement coverage with focused validation;
+- PR body: stores the coverage-preservation map evidence;
+- reviewer: blocks vague, incomplete, or missing maps;
+- no-code closeout: needs explicit evidence that no test/code change is needed;
+- orchestrator close decision: can close only after merge or accepted no-code
+  map evidence.
+
 ### Validation by risk
 
 | Risk | Examples | Validation |

--- a/tests/unit/test_agents_contract.py
+++ b/tests/unit/test_agents_contract.py
@@ -68,3 +68,39 @@ def test_codex_web_prompt_requires_validation_matrix() -> None:
     assert "Required Validation Matrix" in text
     assert "make test-core" in text
     assert "make test-contract" in text
+
+
+def test_test_deletion_requires_coverage_preservation_map() -> None:
+    worker = Path("docs/engineering/codex-web-prompt.md").read_text(encoding="utf-8")
+    reviewer = Path("docs/engineering/gh-pr-review.md").read_text(encoding="utf-8")
+    template = Path(".github/pull_request_template.md").read_text(encoding="utf-8")
+
+    combined_guidance = "\n".join([worker, reviewer, template])
+
+    assert "coverage-preservation map" in worker
+    assert "coverage-preservation map" in reviewer
+    assert "coverage-preservation map" in template
+
+    for action in ("deleting", "moving", "skipping", "xfail-ing", "retargeting", "weakening"):
+        assert action in combined_guidance
+
+    for required_field in (
+        "deleted test path",
+        "old assertion / behavior / contract",
+        "whether behavior still exists on current `dev`",
+        "current adjacent surfaces checked",
+        "replacement or preserved coverage",
+        "focused validation command",
+        "follow-up issue if coverage is intentionally deferred",
+    ):
+        assert required_field in template
+
+    for owner in (
+        "worker prompt",
+        "TDD/focused tests",
+        "PR body",
+        "reviewer",
+        "no-code closeout",
+        "orchestrator close decision",
+    ):
+        assert owner in combined_guidance


### PR DESCRIPTION
## Issue / Mode
- Fixes #2568
- Mode: Issue Executor for process/docs/contract PR
- Primary doc: `docs/engineering/orchestrator-playbook.md`

## Changed files / Scope
- `.github/pull_request_template.md`: adds required coverage-preservation map section for test deletion/weakening PR bodies.
- `docs/engineering/codex-web-prompt.md`: adds worker-owned guardrail and loop-break ownership for coverage-preservation maps.
- `docs/engineering/gh-pr-review.md`: adds reviewer gate for missing/vague coverage-preservation maps.
- `tests/unit/test_agents_contract.py`: adds must-never-repeat contract assertion.

Runtime behavior changes are out of scope and were not made.

## Duplicate PR preflight
Searched open PRs before creating this branch/PR:
- `#2568`: none
- `Fixes #2568`: none
- `Closes #2568`: none
- `coverage-preservation map`: none

## TDD / contract-first evidence
- Red step: added `test_test_deletion_requires_coverage_preservation_map` before docs/template changes.
  - `uv run pytest -o addopts='' tests/unit/test_agents_contract.py -q` failed with `AssertionError: assert 'coverage-preservation map' in template`.
- Green step after docs/template changes:
  - `uv run pytest -o addopts='' tests/unit/test_agents_contract.py -q` passed: `9 passed in 2.11s`.

## Validation
Ran:
- `git diff --check` — passed.
- `uv run pytest -o addopts='' tests/unit/test_agents_contract.py -q` — passed, `9 passed in 2.11s`.

## Skipped checks + reason
- Broader Python suites skipped: process/docs/contract-only change; focused contract test covers the touched invariant.
- Direct `pytest tests/unit/test_agents_contract.py -q` was attempted but local global pytest fails before collection with unsupported repo addopts (`--dist=worksteal`); `uv run pytest -o addopts='' ...` was used as the focused repo-managed validation command.

## Risk / rollback
- Risk: low; changes are process docs/template and static contract coverage only.
- Rollback: revert this commit to remove the guardrail and contract assertion.

## Follow-up issues
- None. #2565 is already completed/closed for concrete coverage restoration; this PR only adds the durable process guardrail for #2568.

## Agent Handoff
- Status: ready for orchestrator review
- Base: `dev`
- Head: `process/2568-coverage-preservation-map`
- Validated commit: `ffd248b50f81a4f5c601fee1804ed669bf3749b3`
- Risk: low process/docs/contract-only
- Failure class: process guardrail / test deletion coverage-preservation gap
- Validation checklist:
  - `git diff --check` passed
  - `uv run pytest -o addopts='' tests/unit/test_agents_contract.py -q` passed
  - broad suites skipped as out of scope
- Findings: durable guardrail now requires a coverage-preservation map before deleting, moving, skipping, xfail-ing, retargeting, or weakening tests, with explicit loop-break ownership.
- Next action: orchestrator review; #2568 can close after merge if review accepts this process guardrail.
