### PR TITLE
docs: sync guardrails roadmap with current dev

### DIFF
--- a/docs/plans/open-issues-roadmap-2026-06-10.md
+++ b/docs/plans/open-issues-roadmap-2026-06-10.md
@@ -70,15 +70,15 @@ Issues:
 Execution plan:
 
 1. Finish the accepted “honest signal” split from #2324: `no_services` vs `requires_services`, fast-lane tests, nightly service checks, and non-silent nightly notifications.
-2. Make PR guardrails fail-closed for empty diffs and label-driven bugfix detection.
-3. Add or strengthen contextvars contracts around `asyncio.run` / `run_until_complete` with an explicit CLI allowlist.
+2. Treat the old `validate_pr_guardrails.py` / PR Guardrails fail-open plan as stale on current `dev`: CORE-011 removed that brittle custom check, so do not recreate it without a new native-first design.
+3. Keep observability/contextvars follow-up design-first: current `dev` has targeted ingestion thread-hop coverage, while broader `asyncio.run` / `run_until_complete` scanning is runtime-adjacent and needs an explicit allowlist before implementation.
 4. Implement branch-protection/required-check verification only after repository-owner approval, because that setting is outside the normal code patch path.
-5. Add dedup or recurrence detection only after the bug-class registry contract is stable.
+5. Add dedup or recurrence automation only after the bug-class registry and native issue-triage workflow are stable; do not add a custom nightly/BGE-M3 detector as a quick Worker P slice.
 
 Validation focus:
 
-- Fast local unit/static checks for guardrail scripts.
-- Contract tests for marker coverage and fail-closed behavior.
+- Fast local unit/static checks for any retained guardrail scripts; no new custom script should be introduced without `Native/tooling alternative considered:`.
+- Contract tests for marker coverage and any approved fail-closed behavior.
 - A documented manual verification step for GitHub branch protection.
 
 ### Wave 2 — Core architecture decisions and SDK boundaries
@@ -275,7 +275,8 @@ flowchart TD
 
 1. **PR 1: Backlog/guardrail normalization**
    - Update issue comments/labels for blockers and lanes.
-   - Add/adjust marker-contract tests and fail-closed PR guardrails from #2319/#2324.
+   - Add/adjust marker-contract tests from #2324.
+   - Do not reintroduce removed PR Guardrails from #2319 unless a new native-first design explicitly rejects GitHub-native/tooling alternatives.
    - Do not touch runtime simplification yet.
 
 2. **PR 2: SDK-friendly logging seam**


### PR DESCRIPTION
## Issue / Mode
- Refs #2324
- Mode: Audit Planner -> Issue Executor for one small docs/status cleanup
- Primary doc: `docs/engineering/orchestrator-playbook.md`

## Changed files / Scope
- `docs/plans/open-issues-roadmap-2026-06-10.md` only.
- Scope: update stale guardrails-roadmap execution text to match current `dev` and accepted #2319 blocker/no-code audit.
- Out of scope: branch protection changes, observability runtime scanners, `validate_pr_guardrails.py` reintroduction, dedup automation, runtime source changes, #2319 implementation.

## Duplicate PR preflight
Searched open PRs before this branch/PR:
- `#2324`: none
- `Fixes #2324`: none
- `Closes #2324`: none
- `roadmap guardrails`: none
- `validate_pr_guardrails`: none
- `PR Guardrails`: none
- `native-first`: none
- `branch protection`: none
- `dedup`: none

## Audit findings
- #2324 is still a valid umbrella, but the roadmap text in `docs/plans/open-issues-roadmap-2026-06-10.md` had stale execution guidance saying to make PR Guardrails fail-closed.
- Current `dev` removed `validate_pr_guardrails.py` / PR Guardrails under CORE-011, so the roadmap now says not to recreate that brittle custom check without a new native-first design.
- Branch protection remains owner/manual territory.
- Observability/contextvars remains design-first/runtime-adjacent.
- Dedup automation remains deferred until bug-class registry/native issue-triage workflow is stable.

## TDD / contract-first evidence
- Not applicable. This is a docs/status-only roadmap correction and no contract/process invariant file was changed.

## Validation
Ran:
- `git diff --check` — passed.

## Skipped checks + reason
- Contract tests skipped: no contract files changed.
- Python/script tests skipped: no Python or script files changed.
- Broad suites skipped: docs/status-only change.

## Risk / rollback
- Risk: low. Docs/status-only change to prevent workers from following stale PR Guardrails guidance.
- Rollback: revert the single commit to restore the prior roadmap wording.

## Follow-up issues
- #2324 should remain open as the guardrails umbrella.
- #2319 should remain open/decomposed for owner/admin branch protection, observability design, and dedup workflow decisions.

## Agent Handoff
- Status: ready for orchestrator review
- Base: `dev`
- Head: `audit/2324-roadmap-sync`
- Validated commit: `ee141c65bb8ac5b89b13408175434c1809c3d09f`
- Risk: low docs/status-only roadmap sync
- Failure class: stale roadmap/process guidance
- Validation checklist:
  - `git diff --check` passed
  - no contract/Python/script checks required
- Findings:
  - Current `dev` no longer has `validate_pr_guardrails.py`; roadmap text now reflects that PR Guardrails should not be reintroduced without native-first design.
  - Branch protection remains owner/manual.
  - Observability and dedup remain separate design-first/deferred tracks.
- Next action: orchestrator review; #2324 should not close after this PR because it is an umbrella/status sync only.
