### PR TITLE
Refactor generate_answer_stream safe fallback helper

### DIFF
--- a/src/runtime/generation/service.py
+++ b/src/runtime/generation/service.py
@@ -583,6 +583,77 @@ async def generate_answer(
     )
 
 
+def _apply_stream_safe_fallback(
+    *,
+    request: GenerationRequest,
+    metadata_out: dict[str, Any],
+    docs: list[dict[str, Any]],
+    style_info: Any,
+    lf_client: Any | None,
+    dyn: dict[str, Any],
+    extra: dict[str, Any],
+    t0: float,
+    needs_coverage: bool,
+    coverage_reason: str | None,
+) -> str:
+    """Apply the pre-stream strict-grounding safe fallback branch."""
+    elapsed = time.monotonic() - t0
+    with contextlib.suppress(Exception):
+        dyn["PipelineMetrics"].get().record("generate", elapsed * 1000)
+    answer = extra.get("build_fallback_response", _build_fallback_response)(docs)
+    current_latency = request.latency_stages or {}
+    _update_current_span(
+        lf_client,
+        output={
+            "response_length": len(answer),
+            "llm_provider_model": "safe_fallback",
+            "fallback_used": False,
+            "safe_fallback_used": True,
+            "grounded": False,
+            "response_sent": False,
+            "needs_coverage": needs_coverage,
+            "coverage_mode": "exhaustive_list" if needs_coverage else "default",
+            "coverage_reason": coverage_reason,
+        },
+    )
+    metadata_out.update(
+        _ensure_generation_signal_defaults(
+            {
+                "response": answer,
+                "response_sent": False,
+                "sent_message": None,
+                "llm_provider_model": "safe_fallback",
+                "llm_ttft_ms": 0.0,
+                "llm_response_duration_ms": elapsed * 1000,
+                "llm_stream_only_ttft_ms": None,
+                "llm_ttft_drift_ms": None,
+                "llm_call_count": max(0, int(request.llm_call_count)),
+                "latency_stages": {**current_latency, "generate": elapsed},
+                "llm_decode_ms": None,
+                "llm_tps": None,
+                "llm_queue_ms": None,
+                "llm_timeout": False,
+                "llm_stream_recovery": False,
+                "streaming_enabled": True,
+                "response_style": style_info.style,
+                "response_difficulty": style_info.difficulty,
+                "response_style_reasoning": style_info.reasoning,
+                "answer_words": len(answer.split()),
+                "answer_chars": len(answer),
+                "answer_to_question_ratio": len(answer.split()) / max(style_info.word_count, 1),
+                "response_policy_mode": "safe_fallback",
+                "grounding_mode": request.grounding_mode,
+                "safe_fallback_used": True,
+                "grounded": False,
+                "legal_answer_safe": False,
+                "semantic_cache_safe_reuse": False,
+                "needs_coverage": needs_coverage,
+            }
+        )
+    )
+    return answer
+
+
 async def generate_answer_stream(
     request: GenerationRequest,
     metadata_out: dict[str, Any],
@@ -653,59 +724,17 @@ async def generate_answer_stream(
         grade_confidence=request.grade_confidence,
         legal_answer_safe=legal_answer_safe,
     ):
-        elapsed = time.monotonic() - t0
-        with contextlib.suppress(Exception):
-            dyn["PipelineMetrics"].get().record("generate", elapsed * 1000)
-        answer = extra.get("build_fallback_response", _build_fallback_response)(docs)
-        current_latency = request.latency_stages or {}
-        _update_current_span(
-            lf_client,
-            output={
-                "response_length": len(answer),
-                "llm_provider_model": "safe_fallback",
-                "fallback_used": False,
-                "safe_fallback_used": True,
-                "grounded": False,
-                "response_sent": False,
-                "needs_coverage": needs_coverage,
-                "coverage_mode": "exhaustive_list" if needs_coverage else "default",
-                "coverage_reason": coverage_reason,
-            },
-        )
-        metadata_out.update(
-            _ensure_generation_signal_defaults(
-                {
-                    "response": answer,
-                    "response_sent": False,
-                    "sent_message": None,
-                    "llm_provider_model": "safe_fallback",
-                    "llm_ttft_ms": 0.0,
-                    "llm_response_duration_ms": elapsed * 1000,
-                    "llm_stream_only_ttft_ms": None,
-                    "llm_ttft_drift_ms": None,
-                    "llm_call_count": max(0, int(request.llm_call_count)),
-                    "latency_stages": {**current_latency, "generate": elapsed},
-                    "llm_decode_ms": None,
-                    "llm_tps": None,
-                    "llm_queue_ms": None,
-                    "llm_timeout": False,
-                    "llm_stream_recovery": False,
-                    "streaming_enabled": True,
-                    "response_style": style_info.style,
-                    "response_difficulty": style_info.difficulty,
-                    "response_style_reasoning": style_info.reasoning,
-                    "answer_words": len(answer.split()),
-                    "answer_chars": len(answer),
-                    "answer_to_question_ratio": len(answer.split()) / max(style_info.word_count, 1),
-                    "response_policy_mode": "safe_fallback",
-                    "grounding_mode": request.grounding_mode,
-                    "safe_fallback_used": True,
-                    "grounded": False,
-                    "legal_answer_safe": False,
-                    "semantic_cache_safe_reuse": False,
-                    "needs_coverage": needs_coverage,
-                }
-            )
+        answer = _apply_stream_safe_fallback(
+            request=request,
+            metadata_out=metadata_out,
+            docs=docs,
+            style_info=style_info,
+            lf_client=lf_client,
+            dyn=dyn,
+            extra=extra,
+            t0=t0,
+            needs_coverage=needs_coverage,
+            coverage_reason=coverage_reason,
         )
         yield answer
         return

--- a/tests/unit/runtime/test_generation_service_stream.py
+++ b/tests/unit/runtime/test_generation_service_stream.py
@@ -1,0 +1,100 @@
+"""Focused tests for runtime generation streaming helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.runtime.generation.contracts import GenerationRequest
+from src.runtime.generation.service import generate_answer_stream
+from src.runtime.services.coverage_mode import CoverageDecision
+from src.runtime.services.response_style_detector import StyleInfo
+
+
+class _StyleDetector:
+    def detect(self, query: str) -> StyleInfo:
+        return StyleInfo(
+            style="balanced",
+            difficulty="medium",
+            reasoning="test_style",
+            word_count=len(query.split()),
+        )
+
+
+class _Metrics:
+    def __init__(self) -> None:
+        self.record = MagicMock()
+
+
+class _PipelineMetrics:
+    metric = _Metrics()
+
+    @classmethod
+    def get(cls) -> _Metrics:
+        return cls.metric
+
+
+@pytest.mark.asyncio
+async def test_generate_answer_stream_safe_fallback_preserves_metadata_and_skips_llm() -> None:
+    config = MagicMock()
+    config.show_sources = True
+    config.response_style_enabled = False
+    config.response_style_shadow_mode = False
+    config.generate_max_tokens = 128
+    config.domain = "недвижимость"
+    config.create_llm = MagicMock()
+
+    lf_client = MagicMock()
+    metadata_out: dict[str, object] = {}
+    fallback_answer = "Не могу дать надежный ответ по найденному контексту."
+    _PipelineMetrics.metric = _Metrics()
+
+    request = GenerationRequest(
+        query="Можно ли получить ВНЖ?",
+        documents=[],
+        raw_messages=[{"role": "user", "content": "Можно ли получить ВНЖ?"}],
+        latency_stages={"retrieve": 0.25},
+        llm_call_count=2,
+        grounding_mode="strict",
+        grade_confidence=0.1,
+        config=config,
+        extra_kwargs={
+            "lf_client": lf_client,
+            "style_detector": _StyleDetector(),
+            "detect_coverage_mode": lambda _query: CoverageDecision(False, None),
+            "PipelineMetrics": _PipelineMetrics,
+            "build_fallback_response": lambda _docs: fallback_answer,
+        },
+    )
+
+    chunks = [chunk async for chunk in generate_answer_stream(request, metadata_out)]
+
+    assert chunks == [fallback_answer]
+    assert metadata_out["response"] == fallback_answer
+    assert metadata_out["safe_fallback_used"] is True
+    assert metadata_out["grounded"] is False
+    assert metadata_out["legal_answer_safe"] is False
+    assert metadata_out["semantic_cache_safe_reuse"] is False
+    assert metadata_out["streaming_enabled"] is True
+    assert metadata_out["llm_call_count"] == 2
+    assert metadata_out["latency_stages"]["retrieve"] == 0.25  # type: ignore[index]
+    assert "generate" in metadata_out["latency_stages"]  # type: ignore[operator]
+    assert metadata_out["needs_coverage"] is False
+    assert metadata_out["response_style"] == "balanced"
+    assert metadata_out["response_difficulty"] == "medium"
+    assert metadata_out["response_style_reasoning"] == "test_style"
+    assert metadata_out["response_policy_mode"] == "safe_fallback"
+    assert metadata_out["llm_provider_model"] == "safe_fallback"
+
+    span_outputs = [
+        call.kwargs["output"]
+        for call in lf_client.update_current_span.call_args_list
+        if "output" in call.kwargs
+    ]
+    assert span_outputs[-1]["safe_fallback_used"] is True
+    assert span_outputs[-1]["grounded"] is False
+    assert span_outputs[-1]["llm_provider_model"] == "safe_fallback"
+    assert span_outputs[-1]["needs_coverage"] is False
+    _PipelineMetrics.metric.record.assert_called_once()
+    config.create_llm.assert_not_called()


### PR DESCRIPTION
## Issue / Mode
- Mode: Issue Executor with Audit Planner preflight
- Issue: Refs #2487
- Base: `dev`
- Head: `worker-e2-2487-stream-safe-fallback-helper`
- Scope: first small generation-service slice only; this PR does not touch `_handle_query_supervisor` or broadly refactor `generate_answer` / `generate_answer_stream`.

## Changed files / scope
- `src/runtime/generation/service.py`
- `tests/unit/runtime/test_generation_service_stream.py`

## Duplicate PR preflight
- Confirmed #2487 is open.
- Searched open PRs targeting `dev` for `2487`, `Refactor complexity hotspots`, `_handle_query_supervisor`, `generate_answer`, and `generate_answer_stream`.
- No duplicate open PRs found before starting this branch.

## TDD red/green notes
- Red/characterization target: the streaming strict-grounding safe-fallback path lacked focused direct coverage at the runtime generation seam.
- Added `tests/unit/runtime/test_generation_service_stream.py::test_generate_answer_stream_safe_fallback_preserves_metadata_and_skips_llm` to characterize existing behavior before the extraction.
- Green/refactor: extracted the pre-stream safe-fallback branch into `_apply_stream_safe_fallback()` while preserving yielded text, metadata shape, Langfuse span output fields, PipelineMetrics recording, and the no-LLM-stream-start invariant.

## Validation
- ✅ `uv run pytest -o addopts='' tests/unit/runtime/test_generation_service_stream.py tests/unit/services/test_generate_response.py -q` (`49 passed`)
- ✅ `make test-core` (`67 passed`)
- ✅ `uvx ruff check src/ telegram_bot/ mini_app/ services/ scripts/ --output-format=github`
- ✅ `uvx ruff format --target-version py312 --check src/ telegram_bot/ mini_app/ services/ scripts/` (`419 files already formatted`)
- ✅ `uv lock --locked`

## Skipped checks + reason
- Heavy/full/live test suites were not run; this PR changes one focused `src/runtime/generation` helper extraction and follows the repo policy to avoid heavy suites unless explicitly requested.
- `make test-unit` was not run because this PR does not touch Telegram adapter files and focused runtime generation coverage plus `make test-core` were the required local validations for this slice.

## Failed checks triage
- No PR-caused local validation failures observed.

## Risk / rollback
- Risk: Low. This is a behavior-preserving extraction of the pre-stream safe-fallback branch in `generate_answer_stream` with focused characterization coverage.
- Rollback: revert this single commit to inline the safe-fallback branch again.

## Closure note
- This is a partial #2487 slice. It uses `Refs #2487`, not `Fixes #2487`.
- Do not close #2487 from this PR; `_handle_query_supervisor` and `generate_answer` remain out of scope.

## Agent Handoff
- Status: clean pending GitHub CI on the pushed head.
- Base: `dev`
- Head: `worker-e2-2487-stream-safe-fallback-helper`
- Validated commit: `afcfaf669fabec73f99d9c064018ca584f8bc79f`
- Risk: Low behavior-preserving helper extraction.
- Failure class: none observed locally.
- Validation checklist:
  - ✅ Focused runtime generation tests passed.
  - ✅ `make test-core` passed.
  - ✅ Static CI-equivalent Ruff/format/lock checks passed.
- Findings:
  - #2487 is open.
  - No duplicate open PR found for #2487 preflight terms.
  - Scope is limited to `generate_answer_stream` pre-stream safe-fallback helper extraction.
  - #2487 should remain open after merge because this is not full acceptance completion.
- Next action: wait for required GitHub checks; merge into `dev` only if CI/CodeQL and mergeability are clean.
